### PR TITLE
build(editor): Add Design System ESLint plugin (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-config/package.json
+++ b/packages/@n8n/eslint-config/package.json
@@ -59,5 +59,8 @@
   "peerDependencies": {
     "eslint": "catalog:"
   },
-  "license": "LicenseRef-n8n-sustainable-use"
+  "license": "LicenseRef-n8n-sustainable-use",
+  "dependencies": {
+    "@n8n/eslint-plugin-design-system": "workspace:*"
+  }
 }

--- a/packages/@n8n/eslint-config/src/configs/frontend.ts
+++ b/packages/@n8n/eslint-config/src/configs/frontend.ts
@@ -2,6 +2,7 @@ import { globalIgnores } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 import VuePlugin from 'eslint-plugin-vue';
 import eslintConfigPrettier from 'eslint-config-prettier/flat';
+import { configs as designSystemConfigs } from '@n8n/eslint-plugin-design-system';
 import globals from 'globals';
 import { baseConfig } from './base.js';
 
@@ -13,6 +14,7 @@ export const frontendConfig = tseslint.config(
 	globalIgnores(['**/*.js', '**/*.d.ts', 'vite.config.ts', '**/*.ts.snap']),
 	baseConfig,
 	VuePlugin.configs['flat/recommended'],
+	designSystemConfigs.recommended,
 	{
 		rules: {
 			'no-console': 'warn',

--- a/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
@@ -210,7 +210,7 @@ defineExpose({
 				:content="truncateBeforeLast(item.data.description, 320, 0)"
 				:class="ui.class"
 				placement="right"
-				:teleported="item.data?.descriptionTooltipTeleported ?? true"
+				teleported
 			>
 				<N8nIcon icon="info" size="medium" color="text-light" :class="$style.infoIcon" />
 			</N8nTooltip>

--- a/packages/frontend/@n8n/eslint-plugin-design-system/README.md
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/README.md
@@ -1,0 +1,21 @@
+# @n8n/eslint-plugin-design-system
+
+Internal ESLint rules for safe composition of n8n Design System components.
+
+Use ESLint rules to enforce Design System constraints that cannot be reliably enforced through:
+
+- The component API or implementation, such as safe defaults or restricting invalid prop combinations
+- Storybook documentation, such as “Do/Don’t” usage guidance
+- Established UI patterns and code review
+
+ESLint is appropriate when a constraint spans component composition or usage context and cannot be expressed through TypeScript or the component API.
+
+The recommended flat config enables all rules for Vue files and is included by `@n8n/eslint-config/frontend`.
+
+## Rules
+
+### `require-teleported-tooltip-in-dropdown`
+
+Requires `N8nTooltip` nested anywhere inside `N8nDropdownMenu` to keep teleportation enabled. Dropdown content clips overflow, so an inline tooltip can otherwise be cropped.
+
+The `teleported` prop may be omitted because it defaults to `true`, or it may be set explicitly to `true`. Dynamic values are rejected because they cannot guarantee teleportation.

--- a/packages/frontend/@n8n/eslint-plugin-design-system/eslint.config.mjs
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/eslint.config.mjs
@@ -1,0 +1,10 @@
+import { baseConfig } from '@n8n/eslint-config/base';
+import { defineConfig } from 'eslint/config';
+
+export default defineConfig(baseConfig, {
+	files: ['src/**/*.ts'],
+	rules: {
+		'@typescript-eslint/naming-convention': 'off',
+		'import-x/no-default-export': 'off',
+	},
+});

--- a/packages/frontend/@n8n/eslint-plugin-design-system/eslint.config.mjs
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/eslint.config.mjs
@@ -1,10 +1,8 @@
-import { baseConfig } from '@n8n/eslint-config/base';
-import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
 
-export default defineConfig(baseConfig, {
+export default tseslint.config(...tseslint.configs.recommended, {
 	files: ['src/**/*.ts'],
 	rules: {
 		'@typescript-eslint/naming-convention': 'off',
-		'import-x/no-default-export': 'off',
 	},
 });

--- a/packages/frontend/@n8n/eslint-plugin-design-system/package.json
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@n8n/eslint-plugin-design-system",
+  "private": true,
+  "type": "module",
+  "version": "0.0.1",
+  "main": "./dist/plugin.js",
+  "types": "./dist/plugin.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/plugin.d.ts",
+      "default": "./dist/plugin.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "build:unchecked": "tsc --project tsconfig.json --noCheck",
+    "clean": "rimraf dist .turbo",
+    "format": "biome format --write .",
+    "format:check": "biome ci .",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:dev": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@typescript-eslint/utils": "^8.35.0"
+  },
+  "devDependencies": {
+    "@n8n/typescript-config": "workspace:*",
+    "@n8n/vitest-config": "workspace:*",
+    "@types/eslint": "^9.6.1",
+    "@types/node": "catalog:",
+    "@typescript-eslint/rule-tester": "^8.35.0",
+    "@typescript/native": "catalog:typescript-tooling",
+    "rimraf": "catalog:",
+    "typescript": "catalog:typescript-tooling",
+    "vite": "catalog:",
+    "vitest": "catalog:",
+    "vue-eslint-parser": "^10.1.3"
+  },
+  "peerDependencies": {
+    "eslint": "catalog:"
+  },
+  "license": "LicenseRef-n8n-sustainable-use"
+}

--- a/packages/frontend/@n8n/eslint-plugin-design-system/package.json
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/package.json
@@ -36,6 +36,7 @@
     "@typescript/native": "catalog:typescript-tooling",
     "rimraf": "catalog:",
     "typescript": "catalog:typescript-tooling",
+    "typescript-eslint": "^8.35.0",
     "vite": "catalog:",
     "vitest": "catalog:",
     "vue-eslint-parser": "^10.1.3"

--- a/packages/frontend/@n8n/eslint-plugin-design-system/src/plugin.ts
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/src/plugin.ts
@@ -1,0 +1,31 @@
+import type { ESLint, Linter } from 'eslint';
+
+import pkg from '../package.json' with { type: 'json' };
+import { rules } from './rules/index.js';
+
+const plugin = {
+	meta: {
+		name: pkg.name,
+		version: pkg.version,
+		namespace: '@n8n/design-system',
+	},
+	// @ts-expect-error Rules type does not match for typescript-eslint and eslint
+	rules: rules as ESLint.Plugin['rules'],
+} satisfies ESLint.Plugin;
+
+const configs = {
+	recommended: {
+		files: ['**/*.vue'],
+		plugins: {
+			'@n8n/design-system': plugin,
+		},
+		rules: {
+			'@n8n/design-system/require-teleported-tooltip-in-dropdown': 'error',
+		},
+	},
+} satisfies Record<string, Linter.Config>;
+
+const pluginWithConfigs = { ...plugin, configs } satisfies ESLint.Plugin;
+
+export default pluginWithConfigs;
+export { configs, rules };

--- a/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/index.ts
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/index.ts
@@ -1,0 +1,7 @@
+import type { AnyRuleModule } from '@typescript-eslint/utils/ts-eslint';
+
+import { RequireTeleportedTooltipInDropdownRule } from './require-teleported-tooltip-in-dropdown.js';
+
+export const rules = {
+	'require-teleported-tooltip-in-dropdown': RequireTeleportedTooltipInDropdownRule,
+} satisfies Record<string, AnyRuleModule>;

--- a/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/require-teleported-tooltip-in-dropdown.test.ts
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/require-teleported-tooltip-in-dropdown.test.ts
@@ -1,0 +1,66 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import * as vueParser from 'vue-eslint-parser';
+
+import { RequireTeleportedTooltipInDropdownRule } from './require-teleported-tooltip-in-dropdown.js';
+
+const ruleTester = new RuleTester({
+	languageOptions: {
+		parser: vueParser,
+		parserOptions: {
+			ecmaVersion: 'latest',
+			sourceType: 'module',
+		},
+	},
+});
+
+const vue = (template: string) => `<template>${template}</template>`;
+
+ruleTester.run('require-teleported-tooltip-in-dropdown', RequireTeleportedTooltipInDropdownRule, {
+	valid: [
+		{
+			filename: 'Component.vue',
+			code: vue('<N8nDropdownMenu><N8nTooltip /></N8nDropdownMenu>'),
+		},
+		{
+			filename: 'Component.vue',
+			code: vue('<N8nDropdownMenu><N8nTooltip teleported /></N8nDropdownMenu>'),
+		},
+		{
+			filename: 'Component.vue',
+			code: vue('<N8nDropdownMenu><N8nTooltip teleported="true" /></N8nDropdownMenu>'),
+		},
+		{
+			filename: 'Component.vue',
+			code: vue('<N8nDropdownMenu><N8nTooltip :teleported="true" /></N8nDropdownMenu>'),
+		},
+		{
+			filename: 'Component.vue',
+			code: vue('<N8nTooltip :teleported="false" />'),
+		},
+		{
+			filename: 'Component.vue',
+			code: vue(
+				'<n8n-dropdown-menu><template #item-label><n8n-tooltip /></template></n8n-dropdown-menu>',
+			),
+		},
+	],
+	invalid: [
+		{
+			filename: 'Component.vue',
+			code: vue('<N8nDropdownMenu><N8nTooltip :teleported="false" /></N8nDropdownMenu>'),
+			errors: [{ messageId: 'requireTeleported' }],
+		},
+		{
+			filename: 'Component.vue',
+			code: vue(
+				'<N8nDropdownMenu><template #item-label><N8nTooltip :teleported="shouldTeleport" /></template></N8nDropdownMenu>',
+			),
+			errors: [{ messageId: 'requireTeleported' }],
+		},
+		{
+			filename: 'Component.vue',
+			code: vue('<n8n-dropdown-menu><n8n-tooltip :teleported="false" /></n8n-dropdown-menu>'),
+			errors: [{ messageId: 'requireTeleported' }],
+		},
+	],
+});

--- a/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/require-teleported-tooltip-in-dropdown.test.ts
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/require-teleported-tooltip-in-dropdown.test.ts
@@ -27,6 +27,10 @@ ruleTester.run('require-teleported-tooltip-in-dropdown', RequireTeleportedToolti
 		},
 		{
 			filename: 'Component.vue',
+			code: vue('<N8nDropdownMenu><N8nTooltip teleported="" /></N8nDropdownMenu>'),
+		},
+		{
+			filename: 'Component.vue',
 			code: vue('<N8nDropdownMenu><N8nTooltip teleported="true" /></N8nDropdownMenu>'),
 		},
 		{

--- a/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/require-teleported-tooltip-in-dropdown.ts
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/require-teleported-tooltip-in-dropdown.ts
@@ -35,7 +35,9 @@ const isTeleportedAttribute = (attribute: VAttribute | VDirective) => {
 
 const guaranteesTeleportation = (attribute: VAttribute | VDirective) => {
 	if (!attribute.directive) {
-		return attribute.value === null || attribute.value.value === 'true';
+		return (
+			attribute.value === null || attribute.value.value === '' || attribute.value.value === 'true'
+		);
 	}
 
 	const expression = attribute.value?.expression;

--- a/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/require-teleported-tooltip-in-dropdown.ts
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/src/rules/require-teleported-tooltip-in-dropdown.ts
@@ -1,0 +1,76 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import type { RuleListener } from '@typescript-eslint/utils/ts-eslint';
+import type { Node, VAttribute, VDirective, VElement } from 'vue-eslint-parser/ast/nodes';
+
+const TOOLTIP_NAMES = new Set(['N8nTooltip', 'n8n-tooltip']);
+const DROPDOWN_NAMES = new Set(['N8nDropdownMenu', 'n8n-dropdown-menu']);
+
+type TemplateVisitor = Record<string, (node: VElement) => void>;
+
+type VueParserServices = {
+	defineTemplateBodyVisitor: (visitor: TemplateVisitor) => RuleListener;
+};
+
+const isInsideDropdown = (node: VElement) => {
+	let parent: Node | null | undefined = node.parent;
+
+	while (parent) {
+		if (parent.type === 'VElement' && DROPDOWN_NAMES.has(parent.rawName)) return true;
+		parent = parent.parent;
+	}
+
+	return false;
+};
+
+const isTeleportedAttribute = (attribute: VAttribute | VDirective) => {
+	if (!attribute.directive) return attribute.key.name === 'teleported';
+
+	return (
+		attribute.key.name.name === 'bind' &&
+		attribute.key.argument?.type === 'VIdentifier' &&
+		attribute.key.argument.name === 'teleported'
+	);
+};
+
+const guaranteesTeleportation = (attribute: VAttribute | VDirective) => {
+	if (!attribute.directive) {
+		return attribute.value === null || attribute.value.value === 'true';
+	}
+
+	const expression = attribute.value?.expression;
+	return expression?.type === 'Literal' && expression.value === true;
+};
+
+export const RequireTeleportedTooltipInDropdownRule = ESLintUtils.RuleCreator.withoutDocs({
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Require tooltips inside dropdown menus to be teleported to avoid clipping',
+		},
+		messages: {
+			requireTeleported:
+				'N8nTooltip inside N8nDropdownMenu must be teleported to avoid being clipped by the menu.',
+		},
+		schema: [],
+	},
+	defaultOptions: [],
+	create(context) {
+		const parserServices = context.sourceCode.parserServices as unknown as VueParserServices;
+		if (!parserServices.defineTemplateBodyVisitor) return {};
+
+		return parserServices.defineTemplateBodyVisitor({
+			VElement(node) {
+				if (!TOOLTIP_NAMES.has(node.rawName) || !isInsideDropdown(node)) return;
+
+				const attribute = node.startTag.attributes.find(isTeleportedAttribute);
+				if (!attribute || guaranteesTeleportation(attribute)) return;
+
+				context.report({
+					node: attribute as unknown as TSESTree.Node,
+					messageId: 'requireTeleported',
+				});
+			},
+		});
+	},
+});

--- a/packages/frontend/@n8n/eslint-plugin-design-system/tsconfig.json
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@n8n/typescript-config/modern/tsconfig.go.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"types": ["vitest/globals", "node"]
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/packages/frontend/@n8n/eslint-plugin-design-system/vite.config.ts
+++ b/packages/frontend/@n8n/eslint-plugin-design-system/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig, mergeConfig } from 'vite';
+
+import { vitestConfig } from '@n8n/vitest-config/node';
+
+export default mergeConfig(defineConfig({}), vitestConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5440,6 +5440,9 @@ importers:
       typescript:
         specifier: catalog:typescript-tooling
         version: '@typescript/typescript6@6.0.2'
+      typescript-eslint:
+        specifier: ^8.35.0
+        version: 8.35.0(@typescript/typescript6@6.0.2)(eslint@9.29.0(jiti@2.6.1))
       vite:
         specifier: 'catalog:'
         version: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,6 +2350,9 @@ importers:
 
   packages/@n8n/eslint-config:
     dependencies:
+      '@n8n/eslint-plugin-design-system':
+        specifier: workspace:*
+        version: link:../../frontend/@n8n/eslint-plugin-design-system
       eslint:
         specifier: 'catalog:'
         version: 9.29.0(jiti@2.6.1)
@@ -5403,6 +5406,49 @@ importers:
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@6.0.2)
+
+  packages/frontend/@n8n/eslint-plugin-design-system:
+    dependencies:
+      '@typescript-eslint/utils':
+        specifier: ^8.35.0
+        version: 8.35.0(@typescript/typescript6@6.0.2)(eslint@9.29.0(jiti@2.6.1))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.29.0(jiti@2.6.1)
+    devDependencies:
+      '@n8n/typescript-config':
+        specifier: workspace:*
+        version: link:../../../@n8n/typescript-config
+      '@n8n/vitest-config':
+        specifier: workspace:*
+        version: link:../../../@n8n/vitest-config
+      '@types/eslint':
+        specifier: ^9.6.1
+        version: 9.6.1
+      '@types/node':
+        specifier: ^20.17.50
+        version: 20.19.41
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.35.0
+        version: 8.35.0(@typescript/typescript6@6.0.2)(eslint@9.29.0(jiti@2.6.1))
+      '@typescript/native':
+        specifier: catalog:typescript-tooling
+        version: typescript@7.0.2
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.0.1
+      typescript:
+        specifier: catalog:typescript-tooling
+        version: '@typescript/typescript6@6.0.2'
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
+      vue-eslint-parser:
+        specifier: ^10.1.3
+        version: 10.1.3(eslint@9.29.0(jiti@2.6.1))
 
   packages/frontend/@n8n/frontend-constants:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2300,6 +2300,9 @@ importers:
 
   packages/@n8n/eslint-config:
     dependencies:
+      '@n8n/eslint-plugin-design-system':
+        specifier: workspace:*
+        version: link:../../frontend/@n8n/eslint-plugin-design-system
       eslint:
         specifier: 'catalog:'
         version: 9.29.0(jiti@2.6.1)
@@ -5311,6 +5314,49 @@ importers:
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@6.0.2)
+
+  packages/frontend/@n8n/eslint-plugin-design-system:
+    dependencies:
+      '@typescript-eslint/utils':
+        specifier: ^8.35.0
+        version: 8.35.0(@typescript/typescript6@6.0.2)(eslint@9.29.0(jiti@2.6.1))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.29.0(jiti@2.6.1)
+    devDependencies:
+      '@n8n/typescript-config':
+        specifier: workspace:*
+        version: link:../../../@n8n/typescript-config
+      '@n8n/vitest-config':
+        specifier: workspace:*
+        version: link:../../../@n8n/vitest-config
+      '@types/eslint':
+        specifier: ^9.6.1
+        version: 9.6.1
+      '@types/node':
+        specifier: ^20.17.50
+        version: 20.19.41
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.35.0
+        version: 8.35.0(@typescript/typescript6@6.0.2)(eslint@9.29.0(jiti@2.6.1))
+      '@typescript/native':
+        specifier: catalog:typescript-tooling
+        version: typescript@7.0.2
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.0.1
+      typescript:
+        specifier: catalog:typescript-tooling
+        version: '@typescript/typescript6@6.0.2'
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
+      vue-eslint-parser:
+        specifier: ^10.1.3
+        version: 10.1.3(eslint@9.29.0(jiti@2.6.1))
 
   packages/frontend/@n8n/frontend-constants:
     devDependencies:
@@ -22477,8 +22523,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.8:
-    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
+  vue-component-type-helpers@3.3.9:
+    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -29400,7 +29446,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(utf-8-validate@5.0.10)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@6.0.2)
-      vue-component-type-helpers: 3.3.8
+      vue-component-type-helpers: 3.3.9
 
   '@stryker-mutator/api@9.6.1':
     dependencies:
@@ -42048,7 +42094,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.8: {}
+  vue-component-type-helpers@3.3.9: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@6.0.2)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5348,6 +5348,9 @@ importers:
       typescript:
         specifier: catalog:typescript-tooling
         version: '@typescript/typescript6@6.0.2'
+      typescript-eslint:
+        specifier: ^8.35.0
+        version: 8.35.0(@typescript/typescript6@6.0.2)(eslint@9.29.0(jiti@2.6.1))
       vite:
         specifier: 'catalog:'
         version: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)


### PR DESCRIPTION
## Summary

Add an internal `@n8n/eslint-plugin-design-system` package for Design System composition constraints.

- Add `require-teleported-tooltip-in-dropdown`, which prevents tooltips inside dropdown menus from opting out of teleportation and being clipped by menu overflow
- Enable the recommended Design System rules through the shared frontend ESLint configuration
- Update the two existing Editor UI violations found by the rule
- Document when a Design System constraint should become an ESLint rule

### Why?
This helps enforce rules for robust, correct UI that cannot be enforced by the initial DS component/consumer contract. 

This PR is part of an effort to reducing UI regression whilst keeping a steady velocity of necessary DS updates.

### When to add new rules
Rules should be added sparingly. 

Ideally we'd try enforcing constraints through other means first, such as:
- The component API, such as safe defaults or restricting invalid prop combinations
- Storybook documentation, such as “Do/Don’t” usage guidance
- Established UI patterns and code review

However this isn't alway possible. For example, this #34547 PR addresses the fact that `N8nTooltips` need to be teleported when the child of a `N8nDropdownMenu` sub-menu, to avoid menu overflow. Ideally we prefer to not overwrite the clipping styles as it'll break overflow scrolling and masking. However, it's unclear that you should teleport items to avoid clipping, and could miss this in testing quite easily.

Lint rules are appropriate when a constraint spans component composition or usage context and cannot be expressed through TypeScript or the component API.

## How to test

1. Run the plugin checks:
   - `pnpm --filter @n8n/eslint-plugin-design-system lint`
   - `pnpm --filter @n8n/eslint-plugin-design-system test`
   - `pnpm --filter @n8n/eslint-plugin-design-system typecheck`
2. Build the plugin and shared ESLint configuration:
   - `pnpm --filter @n8n/eslint-plugin-design-system build`
   - `pnpm --filter @n8n/eslint-config build`
3. Run ESLint against the folder menu consumers and confirm there are no Design System rule violations:
   - `cd packages/frontend/editor-ui && pnpm exec eslint src/features/core/folders/components/FolderBreadcrumbs.vue src/features/core/folders/components/FolderCard.vue --quiet`
4. To verify the rule reports invalid usage, temporarily set either tooltip to `:teleported=\"false\"` and rerun the command. ESLint should report `@n8n/design-system/require-teleported-tooltip-in-dropdown`.

## Related Linear tickets, Github issues, and Community forum posts

Part of [DS-593](https://linear.app/n8n/issue/DS-593/enact-policies-to-ensure-less-ui-regression)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34550">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->