### PR TITLE
fix(core): Classify masked Instance AI stream failures as quota exhaustion via credit re-check

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-files.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-files.test.ts
@@ -1,3 +1,4 @@
+import { isQuotaExhaustedError } from '../../stream/map-chunk';
 import type { WorkspaceFileTarget } from '../workspace-files';
 import { readWorkspaceFile, writeWorkspaceFile, writeWorkspaceFileMap } from '../workspace-files';
 
@@ -233,6 +234,43 @@ describe('workspace-files', () => {
 
 		expect(writeFile).toHaveBeenCalledTimes(3);
 		expect(executeCommand).toHaveBeenCalledTimes(3);
+	});
+
+	it('keeps a classifiable quota error as cause when both write paths fail', async () => {
+		const quotaError = () =>
+			Object.assign(new Error('Have reached end of quota'), {
+				statusCode: 403,
+				errorCode: 'quota_exhausted',
+			});
+		const commandError = quotaError();
+		const writeFile = vi.fn(async () => await Promise.reject(quotaError()));
+		const executeCommand = vi.fn(async () => await Promise.reject(commandError));
+		const target: WorkspaceFileTarget = { filesystem: { writeFile }, sandbox: { executeCommand } };
+
+		const thrown: unknown = await writeWorkspaceFile(target, '/tmp/a.txt', 'alpha', {
+			logger: createLogger(),
+		}).catch((error: unknown) => error);
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).cause).toBe(commandError);
+		expect(isQuotaExhaustedError(thrown)).toBe(true);
+	});
+
+	it('keeps a classifiable quota error as cause on the command-only write path', async () => {
+		const commandError = Object.assign(new Error('Have reached end of quota'), {
+			statusCode: 403,
+			errorCode: 'quota_exhausted',
+		});
+		const executeCommand = vi.fn(async () => await Promise.reject(commandError));
+		const target: WorkspaceFileTarget = { sandbox: { executeCommand } };
+
+		const thrown: unknown = await writeWorkspaceFile(target, '/tmp/a.txt', 'alpha', {
+			logger: createLogger(),
+		}).catch((error: unknown) => error);
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).cause).toBe(commandError);
+		expect(isQuotaExhaustedError(thrown)).toBe(true);
 	});
 
 	it('logs successful command fallback at warn level', async () => {

--- a/packages/@n8n/instance-ai/src/workspace/workspace-files.ts
+++ b/packages/@n8n/instance-ai/src/workspace/workspace-files.ts
@@ -120,8 +120,12 @@ export async function writeWorkspaceFile(
 				});
 				return;
 			} catch (fallbackError) {
+				// Keep the underlying error as `cause`: quota-exhausted proxy failures
+				// carry their machine-readable code there, which terminal-error
+				// classification reads to surface the out-of-credits message.
 				throw new Error(
 					`Failed to write ${label.toLowerCase()} "${filePath}": ${formatErrorForLog(error)}; command fallback failed: ${formatErrorForLog(fallbackError)}`,
+					{ cause: fallbackError },
 				);
 			}
 		}
@@ -132,6 +136,7 @@ export async function writeWorkspaceFile(
 	} catch (error) {
 		throw new Error(
 			`Failed to write ${label.toLowerCase()} "${filePath}": ${formatErrorForLog(error)}`,
+			{ cause: error },
 		);
 	}
 }

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.errorMessage.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.errorMessage.test.ts
@@ -1,4 +1,12 @@
-import { getUserFacingErrorMessage } from '../instance-ai.service';
+import type { User } from '@n8n/db';
+import { isQuotaExhaustedError } from '@n8n/instance-ai';
+
+import {
+	getUserFacingErrorMessage,
+	isMaskedStreamFailure,
+	InstanceAiService,
+	QuotaExhaustedStreamError,
+} from '../instance-ai.service';
 
 describe('getUserFacingErrorMessage', () => {
 	it('maps a sandbox "Endpoint not allowed" failure to a clear, retryable message', () => {
@@ -27,5 +35,103 @@ describe('getUserFacingErrorMessage', () => {
 		expect(getUserFacingErrorMessage(new Error('Have reached end of quota'))).toBe(
 			'Something went wrong before I could finish that response. Please try again.',
 		);
+	});
+});
+
+function createNoOutputGeneratedError(): Error {
+	const error = new Error('No output generated. Check the stream for errors.');
+	error.name = 'AI_NoOutputGeneratedError';
+	return error;
+}
+
+describe('isMaskedStreamFailure', () => {
+	it('matches the ai-sdk zero-steps flush wrapper by name', () => {
+		expect(isMaskedStreamFailure(createNoOutputGeneratedError())).toBe(true);
+	});
+
+	it('matches undici mid-stream termination', () => {
+		expect(isMaskedStreamFailure(new TypeError('terminated'))).toBe(true);
+	});
+
+	it('does not match other errors', () => {
+		expect(isMaskedStreamFailure(new TypeError('kaboom'))).toBe(false);
+		expect(isMaskedStreamFailure(new Error('terminated'))).toBe(false);
+		expect(isMaskedStreamFailure(undefined)).toBe(false);
+		expect(isMaskedStreamFailure('terminated')).toBe(false);
+	});
+});
+
+describe('reclassifyMaskedStreamFailure', () => {
+	type ReclassifyInternals = {
+		reclassifyMaskedStreamFailure: (
+			error: unknown,
+			user: User,
+			context: { threadId: string; runId: string },
+		) => Promise<unknown>;
+		modelService: {
+			getCredits: ReturnType<typeof vi.fn>;
+		};
+		logger: { debug: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn> };
+	};
+
+	const user = { id: 'user-1' } as User;
+	const context = { threadId: 'thread-1', runId: 'run-1' };
+
+	function createService(
+		getCredits: () => Promise<{ creditsQuota: number; creditsClaimed: number }>,
+	): ReclassifyInternals {
+		const service = Object.create(InstanceAiService.prototype) as unknown as ReclassifyInternals;
+		service.modelService = { getCredits: vi.fn(getCredits) };
+		service.logger = { debug: vi.fn(), info: vi.fn() };
+		return service;
+	}
+
+	it('substitutes a quota-exhausted error for a masked failure when credits are used up', async () => {
+		const service = createService(async () => ({ creditsQuota: 100, creditsClaimed: 100 }));
+		const masked = createNoOutputGeneratedError();
+
+		const resolved = await service.reclassifyMaskedStreamFailure(masked, user, context);
+
+		expect(resolved).toBeInstanceOf(QuotaExhaustedStreamError);
+		expect(isQuotaExhaustedError(resolved)).toBe(true);
+		expect(getUserFacingErrorMessage(resolved).toLowerCase()).toContain('credits');
+		expect((resolved as Error).cause).toBe(masked);
+	});
+
+	it('keeps the original error when credits remain', async () => {
+		const service = createService(async () => ({ creditsQuota: 100, creditsClaimed: 40 }));
+		const masked = new TypeError('terminated');
+
+		await expect(service.reclassifyMaskedStreamFailure(masked, user, context)).resolves.toBe(
+			masked,
+		);
+	});
+
+	it('keeps the original error on the unlimited-credits sentinel', async () => {
+		const service = createService(async () => ({ creditsQuota: -1, creditsClaimed: 0 }));
+		const masked = new TypeError('terminated');
+
+		await expect(service.reclassifyMaskedStreamFailure(masked, user, context)).resolves.toBe(
+			masked,
+		);
+	});
+
+	it('keeps the original error when the credit re-check fails', async () => {
+		const service = createService(async () => {
+			throw new Error('service unavailable');
+		});
+		const masked = createNoOutputGeneratedError();
+
+		await expect(service.reclassifyMaskedStreamFailure(masked, user, context)).resolves.toBe(
+			masked,
+		);
+	});
+
+	it('does not re-check credits for non-masked errors', async () => {
+		const service = createService(async () => ({ creditsQuota: 100, creditsClaimed: 100 }));
+		const error = new Error('kaboom');
+
+		await expect(service.reclassifyMaskedStreamFailure(error, user, context)).resolves.toBe(error);
+		expect(service.modelService.getCredits).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -332,6 +332,37 @@ export function getUserFacingErrorMessage(error: unknown): string {
 	return 'Something went wrong before I could finish that response. Please try again.';
 }
 
+/**
+ * Masked terminal failures whose real cause is unrecoverable from the error
+ * object: the ai-sdk's flush wrapper when zero steps were recorded (created
+ * without `cause`), and undici's `TypeError: terminated` when the upstream
+ * connection is killed mid-stream. When the credit wall hits at the model call
+ * instead of the token endpoint, the run dies with one of these rather than a
+ * classified quota error — see `reclassifyMaskedStreamFailure`.
+ */
+export function isMaskedStreamFailure(error: unknown): error is Error {
+	if (!(error instanceof Error)) return false;
+	if (error.name === 'AI_NoOutputGeneratedError') return true;
+	return error.name === 'TypeError' && error.message === 'terminated';
+}
+
+/**
+ * Substituted for a masked stream failure once the credit re-check confirms
+ * the user is out of credits. Carries the machine-readable quota code so the
+ * run is classified exactly like a quota error surfaced by the proxy (credits
+ * message + structured `errorCode`, not reported to Sentry), and keeps the
+ * masked original as `cause` for tracing and telemetry.
+ */
+export class QuotaExhaustedStreamError extends UserError {
+	readonly errorCode = 'quota_exhausted';
+
+	constructor(maskedError: Error) {
+		super(`AI credits exhausted (${maskedError.name}: ${maskedError.message})`, {
+			cause: maskedError,
+		});
+	}
+}
+
 function createInertAbortSignal(): AbortSignal {
 	return new AbortController().signal;
 }
@@ -747,6 +778,39 @@ export class InstanceAiService {
 	/** Get current credit usage from the AI service proxy. */
 	async getCredits(user: User): Promise<{ creditsQuota: number; creditsClaimed: number }> {
 		return await this.modelService.getCredits(user);
+	}
+
+	/**
+	 * When the credit wall hits at the model call (rather than the token
+	 * endpoint at sandbox start), the proxy failure surfaces as a masked
+	 * generic error. For those signatures, re-check the user's remaining
+	 * credits and substitute a quota-exhausted error so the run resolves to
+	 * the credits message instead of a generic failure. Best-effort: any
+	 * re-check failure keeps the original error, so genuinely unexplained
+	 * stream deaths stay visible.
+	 */
+	private async reclassifyMaskedStreamFailure(
+		error: unknown,
+		user: User,
+		context: { threadId: string; runId: string },
+	): Promise<unknown> {
+		if (!isMaskedStreamFailure(error)) return error;
+		try {
+			const { creditsQuota, creditsClaimed } = await this.modelService.getCredits(user);
+			// A negative quota is the unlimited sentinel (e.g. proxy disabled).
+			if (creditsQuota < 0 || creditsClaimed < creditsQuota) return error;
+		} catch (creditsError) {
+			this.logger.debug('Masked stream failure credit re-check failed; keeping original error', {
+				error: getErrorMessage(creditsError),
+				...context,
+			});
+			return error;
+		}
+		this.logger.info('Reclassified masked stream failure as quota-exhausted', {
+			maskedError: getErrorMessage(error),
+			...context,
+		});
+		return new QuotaExhaustedStreamError(error);
 	}
 
 	isEnabled(): boolean {
@@ -3672,9 +3736,13 @@ export class InstanceAiService {
 			}
 
 			const outputText = await (result.text ?? Promise.resolve(''));
+			const terminalError =
+				result.status === 'errored'
+					? await this.reclassifyMaskedStreamFailure(result.error, user, { threadId, runId })
+					: undefined;
 			if (result.status === 'errored') {
 				this.instanceAiErrorReporter.report(
-					result.error ?? new Error('Instance AI stream errored'),
+					terminalError ?? new Error('Instance AI stream errored'),
 					{
 						component: 'instance-ai-stream',
 						threadId,
@@ -3688,9 +3756,9 @@ export class InstanceAiService {
 				);
 			}
 			const userFacingErrorMessage =
-				result.status === 'errored' ? getUserFacingErrorMessage(result.error) : undefined;
+				result.status === 'errored' ? getUserFacingErrorMessage(terminalError) : undefined;
 			const userFacingErrorCode =
-				result.status === 'errored' ? getUserFacingErrorCode(result.error) : undefined;
+				result.status === 'errored' ? getUserFacingErrorCode(terminalError) : undefined;
 			if (runControl.shouldEmitTerminalOutcome(result.stopReason)) {
 				await this.terminalOutcome.evaluateTerminalResponse(threadId, runId, result.status, {
 					messageGroupId,
@@ -3731,8 +3799,8 @@ export class InstanceAiService {
 				...(result.status === 'errored'
 					? {
 							errorInfo: {
-								errorMessage: result.error
-									? getErrorMessage(result.error)
+								errorMessage: terminalError
+									? getErrorMessage(terminalError)
 									: 'Instance AI stream errored',
 								errorSource: 'stream' as const,
 							},
@@ -3817,9 +3885,13 @@ export class InstanceAiService {
 				return;
 			}
 
-			const errorMessage = getErrorMessage(error);
-			const userFacingErrorMessage = getUserFacingErrorMessage(error);
-			const userFacingErrorCode = getUserFacingErrorCode(error);
+			const terminalError = await this.reclassifyMaskedStreamFailure(error, user, {
+				threadId,
+				runId,
+			});
+			const errorMessage = getErrorMessage(terminalError);
+			const userFacingErrorMessage = getUserFacingErrorMessage(terminalError);
+			const userFacingErrorCode = getUserFacingErrorCode(terminalError);
 
 			const errCtx: InstanceAiObservabilityContext = {
 				threadId,
@@ -3834,7 +3906,10 @@ export class InstanceAiService {
 				error: errorMessage,
 				...buildInstanceAiObservabilityContext(errCtx),
 			});
-			this.instanceAiErrorReporter.report(error, { component: 'instance-ai-run', ...errCtx });
+			this.instanceAiErrorReporter.report(terminalError, {
+				component: 'instance-ai-run',
+				...errCtx,
+			});
 			await this.terminalOutcome.evaluateTerminalResponse(threadId, runId, 'errored', {
 				messageGroupId,
 				correlationId: messageId,
@@ -4821,9 +4896,16 @@ export class InstanceAiService {
 
 			const outputText = await (result.text ?? Promise.resolve(''));
 			const messageGroupId = this.tracing.getMessageGroupId(opts.runId);
+			const terminalError =
+				result.status === 'errored'
+					? await this.reclassifyMaskedStreamFailure(result.error, opts.user, {
+							threadId: opts.threadId,
+							runId: opts.runId,
+						})
+					: undefined;
 			if (result.status === 'errored') {
 				this.instanceAiErrorReporter.report(
-					result.error ?? new Error('Instance AI resumed stream errored'),
+					terminalError ?? new Error('Instance AI resumed stream errored'),
 					{
 						component: 'instance-ai-stream',
 						threadId: opts.threadId,
@@ -4836,9 +4918,9 @@ export class InstanceAiService {
 				);
 			}
 			const userFacingErrorMessage =
-				result.status === 'errored' ? getUserFacingErrorMessage(result.error) : undefined;
+				result.status === 'errored' ? getUserFacingErrorMessage(terminalError) : undefined;
 			const userFacingErrorCode =
-				result.status === 'errored' ? getUserFacingErrorCode(result.error) : undefined;
+				result.status === 'errored' ? getUserFacingErrorCode(terminalError) : undefined;
 			if (runControl.shouldEmitTerminalOutcome(result.stopReason)) {
 				await this.terminalOutcome.evaluateTerminalResponse(
 					opts.threadId,
@@ -4885,8 +4967,8 @@ export class InstanceAiService {
 				...(result.status === 'errored'
 					? {
 							errorInfo: {
-								errorMessage: result.error
-									? getErrorMessage(result.error)
+								errorMessage: terminalError
+									? getErrorMessage(terminalError)
 									: 'Instance AI resumed stream errored',
 								errorSource: 'stream' as const,
 							},
@@ -4968,9 +5050,13 @@ export class InstanceAiService {
 				return;
 			}
 
-			const errorMessage = getErrorMessage(error);
-			const userFacingErrorMessage = getUserFacingErrorMessage(error);
-			const userFacingErrorCode = getUserFacingErrorCode(error);
+			const terminalError = await this.reclassifyMaskedStreamFailure(error, opts.user, {
+				threadId: opts.threadId,
+				runId: opts.runId,
+			});
+			const errorMessage = getErrorMessage(terminalError);
+			const userFacingErrorMessage = getUserFacingErrorMessage(terminalError);
+			const userFacingErrorCode = getUserFacingErrorCode(terminalError);
 
 			const messageGroupId = this.tracing.getMessageGroupId(opts.runId);
 			const errCtx: InstanceAiObservabilityContext = {
@@ -4985,7 +5071,10 @@ export class InstanceAiService {
 				error: errorMessage,
 				...buildInstanceAiObservabilityContext(errCtx),
 			});
-			this.instanceAiErrorReporter.report(error, { component: 'instance-ai-run', ...errCtx });
+			this.instanceAiErrorReporter.report(terminalError, {
+				component: 'instance-ai-run',
+				...errCtx,
+			});
 			await this.terminalOutcome.evaluateTerminalResponse(opts.threadId, opts.runId, 'errored', {
 				messageGroupId,
 				errorMessage: userFacingErrorMessage,


### PR DESCRIPTION
## Summary

When a trial user's credit wall hits at the **model call** or during **sandbox workspace setup** (instead of the token endpoint at sandbox start), the run's terminal error is a masked generic wrapper. Users then see "Something went wrong before I could finish that response" instead of the credits message, and Sentry accumulates unclassifiable umbrella issues (>89% trial plan, almost exactly one event per account).

Three masked shapes are handled:

**1. `AI_NoOutputGeneratedError`** ([INSTANCE-BACKEND-2671](https://n8nio.sentry.io/issues/7572379754/)) — the ai-sdk's flush wrapper, created without `cause` when zero steps were recorded.
**2. `TypeError: terminated`** ([INSTANCE-BACKEND-26SE](https://n8nio.sentry.io/issues/7603998719/) + two sibling groupings) — undici killing the fetch when the proxy connection dies mid-stream.

For these two the real cause is unrecoverable from the error object, so when a run ends with one of them the service re-checks the user's remaining credits and, if exhausted, substitutes a `QuotaExhaustedStreamError` (a `UserError` carrying `errorCode: 'quota_exhausted'` and the masked original as `cause`) before any classification or reporting happens:

- The user gets the "You've run out of AI credits" message and structured `errorCode`, same as the sandbox-start path.
- `UserError` defaults to level `info` / `shouldReport: false`, so the occurrence is no longer reported to Sentry (independently of the guard in INS-937, which additionally short-circuits it once merged).
- The non-quota residue keeps flowing through untouched, so genuinely unexplained stream deaths stay visible in Sentry.

The re-check reuses `InstanceAiModelService.getCredits` (retry + proxy-disabled unlimited sentinel already handled) and fails open: if the credits fetch fails, the original error is kept. Non-masked errors never trigger the fetch. All four terminal classification sites are covered (stream-errored + exception catch, on both the initial-run and resumed-run paths).

**3. `Failed to write runtime skill file ...: Have reached end of quota`** ([INSTANCE-BACKEND-262N](https://n8nio.sentry.io/issues/7546970867/), ~2.5k events / ~1.75k users, ~90% trial) — the credit wall hitting at sandbox workspace setup. Every Daytona call in proxy mode mints a token via `getInstanceAiApiProxyToken`, which throws `AIServiceAPIResponseError` **with** `errorCode: 'quota_exhausted'` when credits are out, but `writeWorkspaceFile` flattened it into a plain `Error` message, destroying the machine-readable code. Here no re-check is needed: the second commit preserves the underlying error as `cause`, which `isQuotaExhaustedError` already walks, so the existing terminal classification surfaces the credits message deterministically. As a bonus, the SDK error carries `level: 'warning'` for 4xx, and the core `ErrorReporter` already drops events whose `cause` has warning/info level, so the quota occurrences stop reaching Sentry while 5xx-caused write failures (e.g. Cloudflare 524, INSTANCE-BACKEND-26VG) keep their current visibility.

## How to test

1. On an instance with the AI service proxy enabled, exhaust the account's AI credits.
2. Start an assistant run that reaches the model call (the wall must hit mid-run, not at sandbox start), or one that materializes workspace skills after the wall.
3. The run should finish with the "You've run out of AI credits" message and `errorCode: quota_exhausted` instead of the generic "Something went wrong" message.

Unit tests cover the signature detection, the substitution round-trip through the real `isQuotaExhaustedError` classifier, the unlimited-credits sentinel, the fail-open path, that non-masked errors skip the re-check, and that the workspace-file write wrappers keep a classifiable quota cause on both write paths:

```
cd packages/cli && pnpm test instance-ai.service.errorMessage
cd packages/@n8n/instance-ai && pnpm test workspace-files
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-938

Also addresses the classification gap behind https://linear.app/n8n/issue/N8N-10485 (auto-filed for INSTANCE-BACKEND-262N).

Sentry: [AI_NoOutputGeneratedError (INSTANCE-BACKEND-2671)](https://n8nio.sentry.io/issues/7572379754/), [TypeError: terminated (INSTANCE-BACKEND-26SE)](https://n8nio.sentry.io/issues/7603998719/), [skill-file write quota (INSTANCE-BACKEND-262N)](https://n8nio.sentry.io/issues/7546970867/)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)