### PR TITLE
feat(core): Add advanced HITL telemetry events for the Gmail node (no-changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -3756,5 +3756,43 @@ describe('TelemetryEventRelay', () => {
 			expect(props).not.toHaveProperty('is_authorized');
 			expect(props).toMatchObject({ node_type: 'n8n-nodes-base.gmail', is_approved: false });
 		});
+
+		it('should forward `response_mode` and `advanced_email` for email nodes', () => {
+			const event: RelayEventMap['hitl-response-actioned'] = {
+				nodeType: 'n8n-nodes-base.gmail',
+				approved: true,
+				authorized: undefined,
+				response_mode: 'direct_link',
+				advanced_email: true,
+				executionId: 'exec1',
+				workflowId: 'wf1',
+			};
+
+			eventService.emit('hitl-response-actioned', event);
+
+			const props = vi.mocked(telemetry.track).mock.calls[0][1];
+			expect(props).toMatchObject({
+				node_type: 'n8n-nodes-base.gmail',
+				is_approved: true,
+				response_mode: 'direct_link',
+				is_advanced_email: true,
+			});
+		});
+
+		it('should omit `response_mode` and `is_advanced_email` when absent (chat nodes)', () => {
+			const event: RelayEventMap['hitl-response-actioned'] = {
+				nodeType: 'n8n-nodes-base.slack',
+				approved: true,
+				authorized: false,
+				executionId: 'exec1',
+				workflowId: 'wf1',
+			};
+
+			eventService.emit('hitl-response-actioned', event);
+
+			const props = vi.mocked(telemetry.track).mock.calls[0][1];
+			expect(props).not.toHaveProperty('response_mode');
+			expect(props).not.toHaveProperty('is_advanced_email');
+		});
 	});
 });

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -3718,5 +3718,43 @@ describe('TelemetryEventRelay', () => {
 				is_authorized: false,
 			});
 		});
+
+		it('should forward a truthy `authorized` as `is_authorized`', () => {
+			const event: RelayEventMap['hitl-response-actioned'] = {
+				nodeType: 'n8n-nodes-base.slack',
+				approved: true,
+				authorized: true,
+				executionId: 'exec1',
+				workflowId: 'wf1',
+			};
+
+			eventService.emit('hitl-response-actioned', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('Advanced HITL response actioned', {
+				node_type: 'n8n-nodes-base.slack',
+				is_approved: true,
+				is_authorized: true,
+			});
+		});
+
+		it('should omit `is_authorized` when `authorized` is undefined (email nodes)', () => {
+			const event: RelayEventMap['hitl-response-actioned'] = {
+				nodeType: 'n8n-nodes-base.gmail',
+				approved: false,
+				authorized: undefined,
+				executionId: 'exec1',
+				workflowId: 'wf1',
+			};
+
+			eventService.emit('hitl-response-actioned', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'Advanced HITL response actioned',
+				expect.anything(),
+			);
+			const props = vi.mocked(telemetry.track).mock.calls[0][1];
+			expect(props).not.toHaveProperty('is_authorized');
+			expect(props).toMatchObject({ node_type: 'n8n-nodes-base.gmail', is_approved: false });
+		});
 	});
 });

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -223,11 +223,15 @@ export class TelemetryEventRelay extends EventRelay {
 		approved,
 		authorized,
 	}: RelayEventMap['hitl-response-actioned']) {
-		this.telemetry.track('Advanced HITL response actioned', {
+		const props: { node_type: string; is_approved: boolean; is_authorized?: boolean } = {
 			node_type: nodeType,
 			is_approved: approved,
-			is_authorized: authorized,
-		});
+		};
+		// Email nodes cannot identify the responder, so they omit `authorized`.
+		if (authorized !== undefined) {
+			props.is_authorized = authorized;
+		}
+		this.telemetry.track('Advanced HITL response actioned', props);
 	}
 
 	// #endregion

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -222,14 +222,29 @@ export class TelemetryEventRelay extends EventRelay {
 		nodeType,
 		approved,
 		authorized,
+		response_mode,
+		advanced_email,
 	}: RelayEventMap['hitl-response-actioned']) {
-		const props: { node_type: string; is_approved: boolean; is_authorized?: boolean } = {
+		const props: {
+			node_type: string;
+			is_approved: boolean;
+			is_authorized?: boolean;
+			response_mode?: string;
+			is_advanced_email?: boolean;
+		} = {
 			node_type: nodeType,
 			is_approved: approved,
 		};
 		// Email nodes cannot identify the responder, so they omit `authorized`.
 		if (authorized !== undefined) {
 			props.is_authorized = authorized;
+		}
+		// The following two are only set by email nodes; chat nodes omit them.
+		if (response_mode !== undefined) {
+			props.response_mode = response_mode;
+		}
+		if (advanced_email !== undefined) {
+			props.is_advanced_email = advanced_email;
 		}
 		this.telemetry.track('Advanced HITL response actioned', props);
 	}

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -157,7 +157,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 		return this.webhookData.webhookDescription.name;
 	}
 
-	logHitlResponse(payload: { approved: boolean; authorized: boolean }) {
+	logHitlResponse(payload: { approved: boolean; authorized?: boolean }) {
 		this.additionalData.logHitlResponse?.({
 			...payload,
 			nodeType: this.node.type,

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -6,6 +6,7 @@ import type {
 	CredentialCheckResult,
 	ICredentialDataDecryptedObject,
 	IDataObject,
+	HitlResponseTelemetryPayload,
 	IExecuteData,
 	INode,
 	INodeExecutionData,
@@ -157,7 +158,12 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 		return this.webhookData.webhookDescription.name;
 	}
 
-	logHitlResponse(payload: { approved: boolean; authorized?: boolean }) {
+	logHitlResponse(
+		payload: Pick<
+			HitlResponseTelemetryPayload,
+			'approved' | 'authorized' | 'response_mode' | 'advanced_email'
+		>,
+	) {
 		this.additionalData.logHitlResponse?.({
 			...payload,
 			nodeType: this.node.type,

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry.test.ts
@@ -256,6 +256,54 @@ describe('telemetry', () => {
 			});
 		});
 
+		it('tracks the enable event when Gmail advancedEmail is turned on', () => {
+			const trackSpy = vi.spyOn(telemetry, 'track');
+
+			telemetry.trackNodeParametersValuesChange('n8n-nodes-base.gmail', {
+				name: 'parameters.advancedEmail',
+				value: true,
+			});
+
+			expect(trackSpy).toHaveBeenCalledWith('User enabled advanced HITL', {
+				node_type: 'n8n-nodes-base.gmail',
+			});
+		});
+
+		it('tracks the enable event when Gmail confirmationPage is turned on', () => {
+			const trackSpy = vi.spyOn(telemetry, 'track');
+
+			telemetry.trackNodeParametersValuesChange('n8n-nodes-base.gmail', {
+				name: 'parameters.confirmationPage',
+				value: true,
+			});
+
+			expect(trackSpy).toHaveBeenCalledWith('User enabled advanced HITL', {
+				node_type: 'n8n-nodes-base.gmail',
+			});
+		});
+
+		it('does not track the enable event when a Gmail toggle is turned off', () => {
+			const trackSpy = vi.spyOn(telemetry, 'track');
+
+			telemetry.trackNodeParametersValuesChange('n8n-nodes-base.gmail', {
+				name: 'parameters.confirmationPage',
+				value: false,
+			});
+
+			expect(trackSpy).not.toHaveBeenCalledWith('User enabled advanced HITL', expect.anything());
+		});
+
+		it('does not track the enable event for a non-mapped Gmail parameter', () => {
+			const trackSpy = vi.spyOn(telemetry, 'track');
+
+			telemetry.trackNodeParametersValuesChange('n8n-nodes-base.gmail', {
+				name: 'parameters.subject',
+				value: true,
+			});
+
+			expect(trackSpy).not.toHaveBeenCalledWith('User enabled advanced HITL', expect.anything());
+		});
+
 		it('does not track the enable event when the toggle is turned off', () => {
 			const trackSpy = vi.spyOn(telemetry, 'track');
 

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
@@ -7,6 +7,7 @@ import type { IUpdateInformation } from '@/Interface';
 import type { RudderStack } from './telemetry.types';
 import {
 	APPEND_ATTRIBUTION_DEFAULT_PATH,
+	GOOGLE_GMAIL_NODE_TYPE,
 	MICROSOFT_TEAMS_NODE_TYPE,
 	SLACK_NODE_TYPE,
 	TELEGRAM_NODE_TYPE,
@@ -212,11 +213,12 @@ export class Telemetry {
 			}
 
 			// Advanced HITL (one-tap approval) opt-in toggles, tracked per node.
-			const advancedHitlPathMap: { [key: string]: string } = {
-				[SLACK_NODE_TYPE]: 'parameters.captureResponder',
-				[TELEGRAM_NODE_TYPE]: 'parameters.chatApproval',
+			const advancedHitlPathMap: { [key: string]: string[] } = {
+				[SLACK_NODE_TYPE]: ['parameters.captureResponder'],
+				[TELEGRAM_NODE_TYPE]: ['parameters.chatApproval'],
+				[GOOGLE_GMAIL_NODE_TYPE]: ['parameters.advancedEmail', 'parameters.confirmationPage'],
 			};
-			if (change.name === advancedHitlPathMap[nodeType] && change.value === true) {
+			if (advancedHitlPathMap[nodeType]?.includes(change.name) && change.value === true) {
 				this.track('User enabled advanced HITL', { node_type: nodeType });
 			}
 		}

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -724,7 +724,11 @@ describe('Send and Wait utils tests', () => {
 					webhookResponse: expect.any(String),
 					workflowData: [[{ json: { data: { approved: true, respondedAt: expect.any(String) } } }]],
 				});
-				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({ approved: true });
+				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({
+					approved: true,
+					response_mode: 'confirmation_page',
+					advanced_email: false,
+				});
 			});
 
 			it('should log a declined HITL response on POST when the option is enabled', async () => {
@@ -740,7 +744,32 @@ describe('Send and Wait utils tests', () => {
 
 				await sendAndWaitWebhook.call(mockWebhookFunctions);
 
-				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({ approved: false });
+				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({
+					approved: false,
+					response_mode: 'confirmation_page',
+					advanced_email: false,
+				});
+			});
+
+			it('should record advanced_email on the confirmation-page POST when advanced email is also on', async () => {
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'POST',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'true' },
+				} as unknown as Request);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: true,
+					advancedEmail: true,
+				});
+
+				await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({
+					approved: true,
+					response_mode: 'confirmation_page',
+					advanced_email: true,
+				});
 			});
 
 			it('should not log a HITL response on POST when the option is disabled', async () => {
@@ -795,6 +824,105 @@ describe('Send and Wait utils tests', () => {
 					webhookResponse: expect.any(String),
 					workflowData: [[{ json: { data: { approved: true, respondedAt: expect.any(String) } } }]],
 				});
+				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
+			});
+
+			it('should log a direct-link HITL response on GET for advanced email without a confirmation page', async () => {
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'GET',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'true' },
+				} as unknown as Request);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: false,
+					advancedEmail: true,
+				});
+
+				await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({
+					approved: true,
+					response_mode: 'direct_link',
+					advanced_email: true,
+				});
+			});
+
+			it('should log a declined direct-link HITL response on GET for advanced email', async () => {
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'GET',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'false' },
+				} as unknown as Request);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: false,
+					advancedEmail: true,
+				});
+
+				await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({
+					approved: false,
+					response_mode: 'direct_link',
+					advanced_email: true,
+				});
+			});
+
+			it('should not log a direct-link response on GET when advanced email is off', async () => {
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'GET',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'true' },
+				} as unknown as Request);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: false,
+					advancedEmail: false,
+				});
+
+				await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
+			});
+
+			it('should not double-log on the confirmation-page GET when advanced email is also on', async () => {
+				const send = vi.fn();
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'GET',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'true' },
+				} as unknown as Request);
+				mockWebhookFunctions.getResponseObject.mockReturnValue({ send } as unknown as Response);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: true,
+					advancedEmail: true,
+				});
+
+				const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				expect(result).toEqual({ noWebhookResponse: true });
+				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
+			});
+
+			it('should not log a direct-link response on GET for a non-Gmail node', async () => {
+				mockWebhookFunctions.getNode.mockReturnValue({
+					type: 'n8n-nodes-base.microsoftOutlook',
+				} as any);
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'GET',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'true' },
+				} as unknown as Request);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: false,
+					advancedEmail: true,
+				});
+
+				await sendAndWaitWebhook.call(mockWebhookFunctions);
+
 				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
 			});
 

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -651,6 +651,11 @@ describe('Send and Wait utils tests', () => {
 				);
 			};
 
+			beforeEach(() => {
+				// HITL response logging is gated to Gmail for now.
+				mockWebhookFunctions.getNode.mockReturnValue({ type: 'n8n-nodes-base.gmail' } as any);
+			});
+
 			it('should render confirmation page on GET when the option is enabled', async () => {
 				const send = vi.fn();
 				mockWebhookFunctions.getRequestObject.mockReturnValue({
@@ -747,6 +752,25 @@ describe('Send and Wait utils tests', () => {
 				mockParams({
 					responseType: 'approval',
 					confirmationPage: false,
+				});
+
+				await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
+			});
+
+			it('should not log a HITL response on POST for a non-Gmail node', async () => {
+				mockWebhookFunctions.getNode.mockReturnValue({
+					type: 'n8n-nodes-base.microsoftOutlook',
+				} as any);
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'POST',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'true' },
+				} as unknown as Request);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: true,
 				});
 
 				await sendAndWaitWebhook.call(mockWebhookFunctions);

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -675,6 +675,7 @@ describe('Send and Wait utils tests', () => {
 				expect(page).toContain('Yes, approve');
 				expect(page).toContain('Approval required');
 				expect(page).toContain('Please review the request');
+				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
 			});
 
 			it('should use the disapprove label on the confirmation page when approved=false', async () => {
@@ -718,6 +719,39 @@ describe('Send and Wait utils tests', () => {
 					webhookResponse: expect.any(String),
 					workflowData: [[{ json: { data: { approved: true, respondedAt: expect.any(String) } } }]],
 				});
+				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({ approved: true });
+			});
+
+			it('should log a declined HITL response on POST when the option is enabled', async () => {
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'POST',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'false' },
+				} as unknown as Request);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: true,
+				});
+
+				await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				expect(mockWebhookFunctions.logHitlResponse).toHaveBeenCalledWith({ approved: false });
+			});
+
+			it('should not log a HITL response on POST when the option is disabled', async () => {
+				mockWebhookFunctions.getRequestObject.mockReturnValue({
+					method: 'POST',
+					headers: { 'user-agent': 'Mozilla/5.0 (Macintosh) Firefox/128.0' },
+					query: { approved: 'true' },
+				} as unknown as Request);
+				mockParams({
+					responseType: 'approval',
+					confirmationPage: false,
+				});
+
+				await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
 			});
 
 			it('should record the response on GET when the option is disabled', async () => {
@@ -737,6 +771,7 @@ describe('Send and Wait utils tests', () => {
 					webhookResponse: expect.any(String),
 					workflowData: [[{ json: { data: { approved: true, respondedAt: expect.any(String) } } }]],
 				});
+				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
 			});
 
 			it('should return noWebhookResponse for bot user-agent on POST', async () => {
@@ -759,6 +794,7 @@ describe('Send and Wait utils tests', () => {
 
 				expect(send).toHaveBeenCalledWith('');
 				expect(result).toEqual({ noWebhookResponse: true });
+				expect(mockWebhookFunctions.logHitlResponse).not.toHaveBeenCalled();
 			});
 
 			it('should escape HTML in the confirmation page content', async () => {

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -7,7 +7,12 @@ import type {
 	INodeProperties,
 	IWebhookFunctions,
 } from 'n8n-workflow';
-import { NodeOperationError, SEND_AND_WAIT_OPERATION, updateDisplayOptions } from 'n8n-workflow';
+import {
+	GMAIL_NODE_TYPE,
+	NodeOperationError,
+	SEND_AND_WAIT_OPERATION,
+	updateDisplayOptions,
+} from 'n8n-workflow';
 
 import { cssVariables } from '../../nodes/Form/cssVariables';
 import { formFieldsProperties } from '../../nodes/Form/Form.node';
@@ -506,7 +511,7 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 	}
 
 	// Advanced HITL: the confirmation-page POST is the actioned response.
-	if (confirmationPage && method === 'POST') {
+	if (confirmationPage && method === 'POST' && this.getNode().type === GMAIL_NODE_TYPE) {
 		this.logHitlResponse({ approved });
 	}
 

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -505,6 +505,11 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 		return { noWebhookResponse: true };
 	}
 
+	// Advanced HITL: the confirmation-page POST is the actioned response.
+	if (confirmationPage && method === 'POST') {
+		this.logHitlResponse({ approved });
+	}
+
 	return {
 		webhookResponse: ACTION_RECORDED_PAGE,
 		workflowData: [[{ json: { data: { approved, respondedAt: new Date().toISOString() } } }]],

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -510,9 +510,17 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 		return { noWebhookResponse: true };
 	}
 
-	// Advanced HITL: the confirmation-page POST is the actioned response.
-	if (confirmationPage && method === 'POST' && this.getNode().type === GMAIL_NODE_TYPE) {
-		this.logHitlResponse({ approved });
+	// Advanced HITL telemetry for the Gmail node — fired only for the advanced
+	// toggles (confirmation page, or advanced email's one-click links.)
+	const advancedEmail = this.getNodeParameter('advancedEmail', false) as boolean;
+	const isConfirmationPagePost = confirmationPage && method === 'POST';
+	const isDirectLinkGet = !confirmationPage && method === 'GET' && advancedEmail;
+	if ((isConfirmationPagePost || isDirectLinkGet) && this.getNode().type === GMAIL_NODE_TYPE) {
+		this.logHitlResponse({
+			approved,
+			response_mode: isConfirmationPagePost ? 'confirmation_page' : 'direct_link',
+			advanced_email: advancedEmail,
+		});
 	}
 
 	return {

--- a/packages/workflow/src/constants.ts
+++ b/packages/workflow/src/constants.ts
@@ -53,6 +53,7 @@ export const MICROSOFT_AGENT365_TRIGGER_NODE_TYPE =
 export const SCHEDULE_TRIGGER_NODE_TYPE = 'n8n-nodes-base.scheduleTrigger';
 export const DATA_TABLE_NODE_TYPE = 'n8n-nodes-base.dataTable';
 export const DATA_TABLE_TOOL_NODE_TYPE = 'n8n-nodes-base.dataTableTool';
+export const GMAIL_NODE_TYPE = 'n8n-nodes-base.gmail';
 
 export const STARTING_NODE_TYPES = [
 	MANUAL_TRIGGER_NODE_TYPE,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1470,7 +1470,7 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	getWebhookName(): string;
 	validateCookieAuth(cookieValue: string): Promise<IUser>;
 	/** Emits telemetry for an advanced HITL response actioned via this webhook. */
-	logHitlResponse(payload: { approved: boolean; authorized: boolean }): void;
+	logHitlResponse(payload: { approved: boolean; authorized?: boolean }): void;
 	nodeHelpers: NodeHelperFunctions;
 	helpers: RequestHelperFunctions & BaseHelperFunctions & BinaryHelperFunctions;
 }
@@ -3486,8 +3486,12 @@ export type HitlResponseTelemetryPayload = {
 	nodeType: string;
 	/** The decision the responder made. */
 	approved: boolean;
-	/** Whether the responder was on the node's approver allow-list (empty list = anyone). */
-	authorized: boolean;
+	/**
+	 * Whether the responder was on the node's approver allow-list (empty list = anyone).
+	 * Only chat nodes set this; email/confirmation-page nodes cannot identify the
+	 * responder and omit it.
+	 */
+	authorized?: boolean;
 	executionId?: string;
 	workflowId?: string;
 };

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1470,7 +1470,12 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	getWebhookName(): string;
 	validateCookieAuth(cookieValue: string): Promise<IUser>;
 	/** Emits telemetry for an advanced HITL response actioned via this webhook. */
-	logHitlResponse(payload: { approved: boolean; authorized?: boolean }): void;
+	logHitlResponse(
+		payload: Pick<
+			HitlResponseTelemetryPayload,
+			'approved' | 'authorized' | 'response_mode' | 'advanced_email'
+		>,
+	): void;
 	nodeHelpers: NodeHelperFunctions;
 	helpers: RequestHelperFunctions & BaseHelperFunctions & BinaryHelperFunctions;
 }
@@ -3492,6 +3497,13 @@ export type HitlResponseTelemetryPayload = {
 	 * responder and omit it.
 	 */
 	authorized?: boolean;
+	/**
+	 * How an email responder actioned the request: `confirmation_page` (the
+	 * double-confirm POST) or `direct_link` (a one-click email button GET). Only
+	 * email nodes set this; chat nodes omit it.
+	 */
+	response_mode?: 'confirmation_page' | 'direct_link';
+	advanced_email?: boolean;
 	executionId?: string;
 	workflowId?: string;
 };


### PR DESCRIPTION
## Summary

Follow-up to ENT-166 (Slack + Telegram advanced-HITL telemetry, #34225). Adds the same two telemetry events for the **Gmail** node's advanced HITL.

- **Enable event** — `User enabled advanced HITL` `{ node_type }`, fired from the editor when the user turns on the Gmail advanced-HITL section (either the `advancedEmail` or the `confirmationPage` toggle).
- **Actioned event** — `Advanced HITL response actioned` `{ node_type, is_approved, response_mode, is_advanced_email }`, fired when a Gmail advanced-HITL approval is actioned. Gmail carries **node + outcome only** — email cannot identify the responder, so there is no `is_authorized` property.
  - `response_mode` — how the response arrived: `confirmation_page` (the double-confirm POST) or `direct_link` (a one-click email button GET).
  - `is_advanced_email` — whether the advanced email delivery options (CC/BCC, sender name, reply threading) were enabled. Orthogonal to `response_mode`; it's a composition setting, not a response path.

Standard send-and-wait (neither advanced toggle on) fires no new events.

### How it's wired
- `HitlResponseTelemetryPayload.authorized` is now optional, and gains `response_mode` and `advanced_email`; the telemetry relay omits `is_authorized` / `response_mode` / `is_advanced_email` when unset.
- `logHitlResponse` is now typed via `Pick<HitlResponseTelemetryPayload, …>` so the inline shapes track the shared payload type instead of duplicating it.
- The Gmail webhook logs both response paths: the confirmation-page POST, and the advanced-email one-click GET — the latter mirrors the enable event so `advancedEmail`-only setups are no longer a blind spot in the funnel.
- Frontend enable-map widened to accept multiple param names per node.

### Accepted trade-offs
- Enabling **both** Gmail toggles fires the enable event twice (per-toggle-flip, consistent with how Slack/Telegram fire on each flip-to-true). Count events, not unique nodes, in analysis.


## Related

- Linear: https://linear.app/n8n/issue/ENT-231
- Parent: ENT-166 (#34225), ENT-162 (#34255)

## Review / testing

- Unit tests added/updated in `nodes-base` (sendAndWait util), `cli` (telemetry relay), and `editor-ui` (telemetry plugin). All green locally.

######

[skip changelog]


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34554">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
