### PR TITLE
feat(editor): Expose `AuthenticationMethod` as a runtime import from `@n8n/api-types` (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -29,7 +29,15 @@ export interface ITelemetrySettings {
 	config?: ITelemetryClientConfig;
 }
 
-export type AuthenticationMethod = 'email' | 'ldap' | 'saml' | 'oidc' | 'token-exchange';
+export const AuthenticationMethod = {
+	Email: 'email',
+	Ldap: 'ldap',
+	Saml: 'saml',
+	Oidc: 'oidc',
+	TokenExchange: 'token-exchange',
+} as const;
+
+export type AuthenticationMethod = (typeof AuthenticationMethod)[keyof typeof AuthenticationMethod];
 
 export interface IUserManagementSettings {
 	quota: number;

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -3,7 +3,7 @@ export type * from './datetime';
 export * from './dto';
 export type * from './push';
 export type * from './scaling';
-export type * from './frontend-settings';
+export * from './frontend-settings';
 export type * from './user';
 export type * from './api-keys';
 export type * from './community-node-types';


### PR DESCRIPTION
## Summary

Converts the `AuthenticationMethod` contract in `@n8n/api-types` from a type-only union into a runtime value plus a derived type, so the authentication-method values become importable at runtime rather than type-only.

- **`src/frontend-settings.ts`** — `AuthenticationMethod` is now a `const` object (`as const`) with a same-name derived type. The derived type is identical to the previous union (`'email' | 'ldap' | 'saml' | 'oidc' | 'token-exchange'`), so existing type consumers are unaffected.
- **`src/index.ts`** — the barrel re-export for `frontend-settings` changes from `export type *` to `export *`, so the runtime value survives the package boundary under `isolatedModules` / `verbatimModuleSyntax` (a plain `const` object has no inlining semantics to erase, unlike a `const enum`). `frontend-settings.ts` has no other runtime-value exports, so this does not broaden the barrel's runtime surface beyond this one symbol.
- Adds the previously-missing `token-exchange` value to the shared contract.

This unblocks removing the duplicate front-end `const enum` (`UserManagementAuthenticationMethod`) in `editor-ui` and importing the shared contract instead. That consumer migration is a separate follow-up and is intentionally **not** included here — this PR is the export-shape change only.

## How to test

- `pnpm build --filter=@n8n/api-types` builds green.
- `pnpm --filter @n8n/api-types typecheck` and `pnpm --filter @n8n/api-types lint` pass.
- The built `dist/frontend-settings.js` emits the runtime `AuthenticationMethod` object (including `TokenExchange: 'token-exchange'`) and `dist/index.js` re-exports it — confirming the value is importable at runtime from the package root.

## Related Linear tickets, Github issues, and Community forum posts

Part of the frontend store modularization work; unblocks moving `settings.store` / `roles.store` into `@n8n/stores`.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — N/A: internal shared-types surface, no user-facing docs impact.
- [x] Tests included. — No runtime logic is added; the change is a type→`const` contract shape whose value/type sync is guaranteed by `tsc` and verified by the build. Consumer migration and its tests land with the follow-up.
- [ ] PR Labeled with a backport label — not an urgent fix.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34559">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

