### PR TITLE
fix(core): Resolve PostHog feature flags without emitting exposure events (no-changelog)

### DIFF
--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -1,7 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
 import { InstanceSettings } from 'n8n-core';
-import type { FeatureFlags } from 'n8n-workflow';
 import { PostHog } from 'posthog-node';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
@@ -9,13 +8,6 @@ import { mock } from 'vitest-mock-extended';
 import { PostHogClient } from '@/posthog';
 
 vi.mock('posthog-node');
-
-function mockEvaluatedFlags(flags: FeatureFlags) {
-	return {
-		keys: Object.keys(flags),
-		getFlag: (key: string) => flags[key],
-	};
-}
 
 describe('PostHog', () => {
 	const instanceId = 'test-id';
@@ -158,7 +150,7 @@ describe('PostHog', () => {
 
 			await ph.getFeatureFlags({ id: userId, createdAt });
 
-			expect(PostHog.prototype.evaluateFlags).toHaveBeenCalledWith(`${instanceId}#${userId}`, {
+			expect(PostHog.prototype.getAllFlags).toHaveBeenCalledWith(`${instanceId}#${userId}`, {
 				personProperties: {
 					created_at_timestamp: createdAt.getTime().toString(),
 				},
@@ -168,7 +160,7 @@ describe('PostHog', () => {
 
 		it('returns cached flags on second call', async () => {
 			const flags = { 'test-flag': true };
-			(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(mockEvaluatedFlags(flags));
+			(PostHog.prototype.getAllFlags as Mock).mockResolvedValue(flags);
 
 			const ph = new PostHogClient(instanceSettings, globalConfig);
 			await ph.init();
@@ -178,12 +170,12 @@ describe('PostHog', () => {
 
 			expect(first).toEqual(flags);
 			expect(second).toEqual(flags);
-			expect(PostHog.prototype.evaluateFlags).toHaveBeenCalledTimes(1);
+			expect(PostHog.prototype.getAllFlags).toHaveBeenCalledTimes(1);
 		});
 
 		it('refetches after cache expires', async () => {
 			const flags = { 'test-flag': true };
-			(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(mockEvaluatedFlags(flags));
+			(PostHog.prototype.getAllFlags as Mock).mockResolvedValue(flags);
 
 			const now = Date.now();
 			const spy = vi.spyOn(Date, 'now').mockReturnValue(now);
@@ -192,18 +184,18 @@ describe('PostHog', () => {
 			await ph.init();
 
 			await ph.getFeatureFlags({ id: userId, createdAt });
-			expect(PostHog.prototype.evaluateFlags).toHaveBeenCalledTimes(1);
+			expect(PostHog.prototype.getAllFlags).toHaveBeenCalledTimes(1);
 
 			spy.mockReturnValue(now + 10 * 60 * 1000 + 1);
 
 			await ph.getFeatureFlags({ id: userId, createdAt });
-			expect(PostHog.prototype.evaluateFlags).toHaveBeenCalledTimes(2);
+			expect(PostHog.prototype.getAllFlags).toHaveBeenCalledTimes(2);
 
 			spy.mockRestore();
 		});
 
 		it('does not cache empty results', async () => {
-			(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(mockEvaluatedFlags({}));
+			(PostHog.prototype.getAllFlags as Mock).mockResolvedValue({});
 
 			const ph = new PostHogClient(instanceSettings, globalConfig);
 			await ph.init();
@@ -211,7 +203,7 @@ describe('PostHog', () => {
 			await ph.getFeatureFlags({ id: userId, createdAt });
 			await ph.getFeatureFlags({ id: userId, createdAt });
 
-			expect(PostHog.prototype.evaluateFlags).toHaveBeenCalledTimes(2);
+			expect(PostHog.prototype.getAllFlags).toHaveBeenCalledTimes(2);
 		});
 
 		describe('env-var overrides', () => {
@@ -222,7 +214,7 @@ describe('PostHog', () => {
 			});
 
 			it('force-enables the eval-collections flag when N8N_EVAL_COLLECTIONS_ENABLED is set', async () => {
-				(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(mockEvaluatedFlags({}));
+				(PostHog.prototype.getAllFlags as Mock).mockResolvedValue({});
 				globalConfig.evaluation.collectionsEnabled = true;
 
 				const ph = new PostHogClient(instanceSettings, globalConfig);
@@ -234,9 +226,7 @@ describe('PostHog', () => {
 			});
 
 			it('leaves flags untouched when no override is configured', async () => {
-				(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(
-					mockEvaluatedFlags({ 'some-other-flag': true }),
-				);
+				(PostHog.prototype.getAllFlags as Mock).mockResolvedValue({ 'some-other-flag': true });
 
 				const ph = new PostHogClient(instanceSettings, globalConfig);
 				await ph.init();
@@ -247,7 +237,7 @@ describe('PostHog', () => {
 			});
 
 			it('falls back to env overrides when PostHog throws', async () => {
-				(PostHog.prototype.evaluateFlags as Mock).mockRejectedValue(new Error('posthog down'));
+				(PostHog.prototype.getAllFlags as Mock).mockRejectedValue(new Error('posthog down'));
 				globalConfig.evaluation.collectionsEnabled = true;
 
 				const ph = new PostHogClient(instanceSettings, globalConfig);

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -4,7 +4,7 @@ import type { PublicUser } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 import type { FeatureFlags, ITelemetryTrackProperties } from 'n8n-workflow';
-import type { PostHog, FeatureFlagEvaluations } from 'posthog-node';
+import type { PostHog } from 'posthog-node';
 
 /**
  * PostHog group type for instance-level properties.
@@ -128,33 +128,21 @@ export class PostHogClient {
 			return cached.flags;
 		}
 
-		const evaluatedFlags = await this.postHog.evaluateFlags(fullId, {
+		// getAllFlags is deprecated upstream but is the only API that resolves flags
+		// without firing a $feature_flag_called capture per flag per user
+		// (evaluateFlags/getFlag does), which pollutes experiment exposure analysis.
+		const flags = await this.postHog.getAllFlags(fullId, {
 			personProperties: {
 				created_at_timestamp: user.createdAt.getTime().toString(),
 			},
 			...(instanceId && { groups: { [POSTHOG_GROUP_TYPE_INSTANCE]: instanceId } }),
 		});
-		const flags = this.resolveFeatureFlagVariants(evaluatedFlags);
 
-		if (Object.keys(flags).length > 0) {
+		if (flags && Object.keys(flags).length > 0) {
 			this.flagsCache.set(fullId, { flags, expiresAt: Date.now() + FLAGS_CACHE_TTL_MS });
 		}
 
-		return flags;
-	}
-
-	private resolveFeatureFlagVariants(evaluatedFlags: FeatureFlagEvaluations): FeatureFlags {
-		const result: FeatureFlags = {};
-
-		if (!evaluatedFlags || !Array.isArray(evaluatedFlags.keys)) return result;
-
-		for (const key of evaluatedFlags.keys) {
-			try {
-				result[key] = evaluatedFlags.getFlag(key);
-			} catch {}
-		}
-
-		return result;
+		return flags ?? {};
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Backend flag resolution uses posthog-node's `evaluateFlags()` + per-flag
`getFlag()`, which emits a `$feature_flag_called` event for every flag on every
uncached evaluation. Server-side, that marks every logged-in user as "exposed"
to every flag and pollutes native experiment exposure analysis.

This switches to the bulk `getAllFlags()` API, which returns the same variant
values without emitting any exposure event (a near-restore of the pre-#30272
behaviour). Cache, TTL, instance-group support and env-var overrides are
unchanged.

## How to test

- Unit: `cd packages/cli && pnpm test src/posthog/__tests__/posthog.test.ts`
- Staging: confirm feature flags still resolve for logged-in users, and that
  flag resolution no longer emits `$feature_flag_called` events with
  `$lib=posthog-node`.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link the Linear ticket if one exists: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34560">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

