### PR TITLE
feat(editor): Add native PostHog exposure tracking to the PostHog store (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
@@ -264,6 +264,69 @@ describe('Posthog store', () => {
 			expect(posthog.getVariant('test')).toEqual('variant');
 		});
 
+		describe('trackExposure', () => {
+			it('fires the native exposure event for a resolved variant', () => {
+				const posthog = usePostHog();
+				posthog.init({ test: 'variant' });
+
+				posthog.trackExposure('test');
+
+				expect(window.posthog?.capture).toHaveBeenCalledWith('$feature_flag_called', {
+					$feature_flag: 'test',
+					$feature_flag_response: 'variant',
+				});
+			});
+
+			it('does not fire the exposure event twice for the same variant', () => {
+				const posthog = usePostHog();
+				posthog.init({ test: 'variant' });
+
+				posthog.trackExposure('test');
+				posthog.trackExposure('test');
+
+				expect(window.posthog?.capture).toHaveBeenCalledTimes(1);
+			});
+
+			it('re-fires the exposure event when the variant changes', () => {
+				const posthog = usePostHog();
+				posthog.init({ test: 'variant' });
+
+				posthog.trackExposure('test');
+				posthog.overrides.test = 'variant-2';
+				posthog.trackExposure('test');
+
+				expect(window.posthog?.capture).toHaveBeenCalledTimes(2);
+				expect(window.posthog?.capture).toHaveBeenLastCalledWith('$feature_flag_called', {
+					$feature_flag: 'test',
+					$feature_flag_response: 'variant-2',
+				});
+			});
+
+			it('skips flags with no variant or a disabled boolean flag', () => {
+				const posthog = usePostHog();
+				posthog.init({ enabled_flag: false });
+
+				posthog.trackExposure('missing_flag');
+				posthog.trackExposure('enabled_flag');
+
+				expect(window.posthog?.capture).not.toHaveBeenCalled();
+			});
+
+			it('re-fires the exposure event after reset clears the dedupe cache', () => {
+				const posthog = usePostHog();
+				posthog.overrides.test = 'variant';
+
+				posthog.trackExposure('test');
+				posthog.trackExposure('test');
+				expect(window.posthog?.capture).toHaveBeenCalledTimes(1);
+
+				posthog.reset();
+				posthog.trackExposure('test');
+
+				expect(window.posthog?.capture).toHaveBeenCalledTimes(2);
+			});
+		});
+
 		afterEach(() => {
 			resetStores();
 			window.localStorage.clear();

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -27,6 +27,7 @@ export const usePostHog = defineStore('posthog', () => {
 
 	const featureFlags: Ref<FeatureFlags | null> = ref(null);
 	const trackedDemoExp: Ref<FeatureFlags> = ref({});
+	const trackedExposures: Ref<FeatureFlags> = ref({});
 	const pendingFeatureFlagsEvaluation = ref(false);
 
 	const overrides: Ref<Record<string, string | boolean>> = ref({});
@@ -52,6 +53,7 @@ export const usePostHog = defineStore('posthog', () => {
 		window.posthog?.reset?.();
 		featureFlags.value = null;
 		trackedDemoExp.value = {};
+		trackedExposures.value = {};
 		pendingFeatureFlagsEvaluation.value = false;
 		clearFeatureFlagsWait();
 	};
@@ -238,6 +240,23 @@ export const usePostHog = defineStore('posthog', () => {
 		}
 	};
 
+	/**
+	 * Fires PostHog's native exposure event for an experiment so results can use
+	 * built-in exposure analysis. Uses getVariant() so the recorded variant is the
+	 * one the user actually experienced, including local overrides. Deduped per
+	 * flag+variant; cleared on reset().
+	 */
+	const trackExposure = (experiment: string) => {
+		const variant = getVariant(experiment);
+		if (variant === undefined || variant === false) return;
+		if (trackedExposures.value[experiment] === variant) return;
+		capture('$feature_flag_called', {
+			$feature_flag: experiment,
+			$feature_flag_response: variant,
+		});
+		trackedExposures.value[experiment] = variant;
+	};
+
 	return {
 		init,
 		isFeatureEnabled,
@@ -250,6 +269,7 @@ export const usePostHog = defineStore('posthog', () => {
 		groupIdentify,
 		setMetadata,
 		capture,
+		trackExposure,
 		overrides,
 	};
 });


### PR DESCRIPTION
## Summary

Adds `trackExposure(experiment)` to the PostHog store. It fires PostHog's native
`$feature_flag_called` exposure event for a given experiment, reading the variant
via `getVariant()` so the recorded value reflects what the user actually
experienced (including local overrides). It dedupes per flag+variant and clears
its dedupe cache on `reset()`.

This is the building block for moving experiments onto PostHog's built-in
exposure analysis. It intentionally does not wire any surfaces yet — adoption is
per-experiment follow-up.

## How to test

- Unit: `cd packages/frontend/editor-ui && pnpm test src/app/stores/posthog.store.test.ts`
- Manual: call `usePostHog().trackExposure('<flag>')` — a single
  `$feature_flag_called` (`$lib=web`) fires; repeat calls for the same variant do
  not duplicate; a variant change re-fires.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link the Linear ticket if one exists: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34561">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

