### PR TITLE
perf(editor): Skip client-side PostHog flag refetch when flags are bootstrapped (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -80,6 +80,7 @@ declare global {
 					api_host?: string;
 					autocapture?: boolean;
 					disable_session_recording?: boolean;
+					advanced_disable_feature_flags?: boolean;
 					debug?: boolean;
 					bootstrap?: {
 						distinctID?: string;

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
@@ -164,6 +164,30 @@ describe('Posthog store', () => {
 			);
 		});
 
+		it('disables client-side flag refetch when flags are bootstrapped', () => {
+			const posthog = usePostHog();
+			posthog.init({ test: 'variant' });
+
+			expect(window.posthog?.init).toHaveBeenCalledWith(
+				DEFAULT_POSTHOG_SETTINGS.apiKey,
+				expect.objectContaining({
+					advanced_disable_feature_flags: true,
+				}),
+			);
+		});
+
+		it('keeps client-side flag refetch when flags are not bootstrapped', () => {
+			const posthog = usePostHog();
+			posthog.init();
+
+			expect(window.posthog?.init).toHaveBeenCalledWith(
+				DEFAULT_POSTHOG_SETTINGS.apiKey,
+				expect.not.objectContaining({
+					advanced_disable_feature_flags: expect.anything(),
+				}),
+			);
+		});
+
 		it('should identify user', () => {
 			const posthog = usePostHog();
 			posthog.init();

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -192,6 +192,10 @@ export const usePostHog = defineStore('posthog', () => {
 				distinctID: distinctId,
 				featureFlags: evaluatedFeatureFlags,
 			};
+			// Flags are server-evaluated and bootstrapped; without this, identify()/group()
+			// in the loaded callback each trigger a billed /flags refetch of values the
+			// client already has.
+			options.advanced_disable_feature_flags = true;
 		}
 
 		window.posthog?.init(config.apiKey, {


### PR DESCRIPTION
## Summary

Feature flags are evaluated server-side and passed to posthog-js via `bootstrap`.
Despite that, the `identify()` and `group()` calls in the `loaded` callback each
trigger a client-side `/flags` refetch of values the client already has — the
dominant source of billed flag requests.

This sets `advanced_disable_feature_flags` only when bootstrap is populated, so
bootstrapped sessions stop refetching. The no-bootstrap fallback (client-side
evaluation) is left untouched, so users without server flags keep today's
behaviour. Adds the option to the hand-written posthog init-options type so it
compiles.

## How to test

- Unit: `cd packages/frontend/editor-ui && pnpm test src/app/stores/posthog.store.test.ts`
- Manual: open an editor session with bootstrapped flags, watch the network tab —
  no `/flags` request fires after `identify`/`group`, and
  `window.featureFlags.getAll()` is still populated.
- Smoke-test in staging that cloud session replay still records (remote config in
  modern posthog-js does not ride the flags fetch, but verify once).

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link the Linear ticket if one exists: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34562">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

