### PR TITLE
fix(core): Compile eval LLM-judge chat model at its current node version (no-changelog)

### DIFF
--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/workflow-compiler.service.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/workflow-compiler.service.test.ts
@@ -1,10 +1,59 @@
 import type { EvaluationConfig } from '@n8n/db';
-import type { IWorkflowBase } from 'n8n-workflow';
+import { createRequire } from 'module';
+import type {
+	INodeType,
+	INodeTypeDescription,
+	IWorkflowBase,
+	NodeLoadingDetails,
+} from 'n8n-workflow';
+import { join } from 'path';
+
+import type { NodeTypes } from '@/node-types';
 
 import { LlmJudgeProviderRegistry } from '../../llm-judge-provider-registry';
 import { WorkflowCompilerService } from '../workflow-compiler.service';
 
 const EVALUATION_TRIGGER_NODE_TYPE = 'n8n-nodes-base.evaluationTrigger';
+
+// Load the REAL chat-model node descriptions from the built @n8n/n8n-nodes-langchain
+// package (via absolute-path require, the same mechanism as test-integration's
+// loadNodesFromDist) so these tests bind to the actual node contract the compiler
+// introspects. If a provider node changes its version array or `@version`-gated
+// `model` shape, these tests reflect that change instead of passing against a stale
+// hand-authored replica. Requires the langchain package to be built.
+const nodeRequire = createRequire(__filename);
+const LANGCHAIN_DIR = join(__dirname, '../../../../../@n8n/nodes-langchain');
+
+function realNodeDescription(shortName: string): INodeTypeDescription {
+	const known = nodeRequire(join(LANGCHAIN_DIR, 'dist/known/nodes.json')) as Record<
+		string,
+		NodeLoadingDetails
+	>;
+	const info = known[shortName];
+	const nodeModule = nodeRequire(join(LANGCHAIN_DIR, info.sourcePath)) as Record<
+		string,
+		new () => INodeType
+	>;
+	return new nodeModule[info.className]().description;
+}
+
+// Anthropic exposes `model` as a resource locator on its current (default) version;
+// Ollama keeps it a plain options field on a single version. Any other provider is
+// absent here so the compiler exercises its introspection fallback.
+const ANTHROPIC_DESCRIPTION = realNodeDescription('lmChatAnthropic');
+const OLLAMA_DESCRIPTION = realNodeDescription('lmChatOllama');
+
+const nodeTypes = {
+	getByNameAndVersion: (nodeType: string) => {
+		if (nodeType === '@n8n/n8n-nodes-langchain.lmChatAnthropic') {
+			return { description: ANTHROPIC_DESCRIPTION };
+		}
+		if (nodeType === '@n8n/n8n-nodes-langchain.lmChatOllama') {
+			return { description: OLLAMA_DESCRIPTION };
+		}
+		throw new Error(`unknown node type ${nodeType}`);
+	},
+} as unknown as NodeTypes;
 
 function baseWorkflow(): IWorkflowBase {
 	return {
@@ -59,11 +108,32 @@ function baseConfig(): EvaluationConfig {
 	} as unknown as EvaluationConfig;
 }
 
+function llmJudgeConfig(provider: string, model: string): EvaluationConfig {
+	const config = baseConfig();
+	config.metrics = [
+		{
+			id: 'm-judge',
+			name: 'Correctness',
+			type: 'llm_judge',
+			config: {
+				preset: 'correctness',
+				prompt: 'Judge it',
+				provider,
+				credentialId: 'cred',
+				model,
+				outputType: 'numeric',
+				inputs: { actualAnswer: '={{ $json.a }}', expectedAnswer: '={{ $json.e }}' },
+			},
+		},
+	];
+	return config;
+}
+
 describe('WorkflowCompilerService', () => {
 	let compiler: WorkflowCompilerService;
 
 	beforeEach(() => {
-		compiler = new WorkflowCompilerService(new LlmJudgeProviderRegistry());
+		compiler = new WorkflowCompilerService(new LlmJudgeProviderRegistry(), nodeTypes);
 	});
 
 	it('injects __eval_trigger and leaves the user trigger intact, redirecting the edge to entry', () => {
@@ -172,7 +242,13 @@ describe('WorkflowCompilerService', () => {
 
 		const model = compiled.nodes.find((n) => n.name === '__eval_model_m-judge')!;
 		expect(model.type).toBe('@n8n/n8n-nodes-langchain.lmChatAnthropic');
-		expect(model.parameters.model).toBe('claude-sonnet-4-6');
+		expect(model.typeVersion).toBe(ANTHROPIC_DESCRIPTION.defaultVersion);
+		expect(model.parameters.model).toEqual({
+			__rl: true,
+			mode: 'list',
+			value: 'claude-sonnet-4-6',
+			cachedResultName: 'claude-sonnet-4-6',
+		});
 		expect(model.credentials).toEqual({ anthropicApi: { id: 'cred-anth', name: '' } });
 
 		expect(compiled.connections['__eval_model_m-judge']).toEqual({
@@ -204,6 +280,44 @@ describe('WorkflowCompilerService', () => {
 		const metric = compiled.nodes.find((n) => n.name === '__eval_metric_m-judge')!;
 		expect(metric.parameters).not.toHaveProperty('prompt');
 		expect(metric.parameters.metric).toBe('correctness');
+	});
+
+	describe('llm-judge chat-model sub-node shape', () => {
+		it('emits the sub-node at the provider default version with a resource-locator model when the node expects one', () => {
+			const compiled = compiler.compile(
+				baseWorkflow(),
+				llmJudgeConfig('@n8n/n8n-nodes-langchain.lmChatAnthropic', 'claude-sonnet-4-6'),
+			);
+			const model = compiled.nodes.find((n) => n.name === '__eval_model_m-judge')!;
+			expect(model.typeVersion).toBe(ANTHROPIC_DESCRIPTION.defaultVersion);
+			expect(model.parameters.model).toEqual({
+				__rl: true,
+				mode: 'list',
+				value: 'claude-sonnet-4-6',
+				cachedResultName: 'claude-sonnet-4-6',
+			});
+		});
+
+		it('emits a plain-string model at the provider default version when the node model is not a resource locator', () => {
+			const compiled = compiler.compile(
+				baseWorkflow(),
+				llmJudgeConfig('@n8n/n8n-nodes-langchain.lmChatOllama', 'llama3'),
+			);
+			const model = compiled.nodes.find((n) => n.name === '__eval_model_m-judge')!;
+			expect(model.typeVersion).toBe(OLLAMA_DESCRIPTION.version);
+			expect(model.parameters.model).toBe('llama3');
+		});
+
+		it('falls back to typeVersion 1 with a string model when the provider node type cannot be introspected', () => {
+			// lmChatOpenAi is a registered provider but absent from the node-type double.
+			const compiled = compiler.compile(
+				baseWorkflow(),
+				llmJudgeConfig('@n8n/n8n-nodes-langchain.lmChatOpenAi', 'gpt-4o'),
+			);
+			const model = compiled.nodes.find((n) => n.name === '__eval_model_m-judge')!;
+			expect(model.typeVersion).toBe(1);
+			expect(model.parameters.model).toBe('gpt-4o');
+		});
 	});
 
 	it('compiles a string_similarity metric to a setMetrics node with metric=stringSimilarity', () => {

--- a/packages/cli/src/evaluation.ee/test-runner/workflow-compiler.service.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/workflow-compiler.service.ts
@@ -5,6 +5,7 @@ import {
 	EVALUATION_NODE_TYPE,
 	EVALUATION_TRIGGER_NODE_TYPE,
 	NodeConnectionTypes,
+	NodeHelpers,
 	UserError,
 	deepCopy,
 } from 'n8n-workflow';
@@ -12,10 +13,14 @@ import type {
 	IConnection,
 	IConnections,
 	INode,
+	INodeParameterResourceLocator,
 	INodeParameters,
+	INodeTypeDescription,
 	IWorkflowBase,
 } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
+
+import { NodeTypes } from '@/node-types';
 
 import { isCoercibleBooleanExpression } from '../evaluation-config-validator';
 import { LlmJudgeProviderRegistry } from '../llm-judge-provider-registry';
@@ -40,7 +45,10 @@ type UserTriggerEdge = {
 
 @Service()
 export class WorkflowCompilerService {
-	constructor(private readonly providerRegistry: LlmJudgeProviderRegistry) {}
+	constructor(
+		private readonly providerRegistry: LlmJudgeProviderRegistry,
+		private readonly nodeTypes: NodeTypes,
+	) {}
 
 	compile(workflow: IWorkflowBase, config: EvaluationConfig): IWorkflowBase {
 		this.assertNoReservedNames(workflow);
@@ -352,20 +360,70 @@ export class WorkflowCompilerService {
 		metricY: number,
 	): INode[] {
 		if (metric.type !== 'llm_judge') return [];
+		const { typeVersion, model } = this.resolveChatModelShape(
+			metric.config.provider,
+			metric.config.model,
+		);
 		return [
 			{
 				id: nanoid(),
 				name: `__eval_model_${metric.id}`,
 				type: metric.config.provider,
-				typeVersion: 1,
+				typeVersion,
 				position: [metricX, metricY + MODEL_OFFSET_Y],
 				credentials: this.credentialsForProvider(
 					metric.config.provider,
 					metric.config.credentialId,
 				),
-				parameters: { model: metric.config.model },
+				parameters: { model },
 			},
 		];
+	}
+
+	/**
+	 * Shapes the judge's chat-model sub-node to the provider node's current definition
+	 * instead of pinning it to a legacy version: uses the node's default `typeVersion`
+	 * and emits `model` as a resource locator when that version's `model` property
+	 * expects one (a plain string otherwise). Falls back to the legacy v1 + string form
+	 * if the node type can't be introspected, so judging keeps working.
+	 */
+	private resolveChatModelShape(
+		provider: string,
+		modelId: string,
+	): { typeVersion: number; model: string | INodeParameterResourceLocator } {
+		const legacyShape = { typeVersion: 1, model: modelId };
+		try {
+			const description = this.nodeTypes.getByNameAndVersion(provider).description;
+			const typeVersion = Array.isArray(description.version)
+				? (description.defaultVersion ?? Math.max(...description.version))
+				: description.version;
+			if (!Number.isFinite(typeVersion)) return legacyShape;
+
+			return {
+				typeVersion,
+				model: this.modelExpectsResourceLocator(description, typeVersion)
+					? { __rl: true, mode: 'list', value: modelId, cachedResultName: modelId }
+					: modelId,
+			};
+		} catch {
+			return legacyShape;
+		}
+	}
+
+	/**
+	 * Whether the `model` property shown at `typeVersion` is a resource locator. Chat-model
+	 * nodes gate several `model` variants by `@version`, so pick the one that displays at
+	 * this version and read its declared type.
+	 */
+	private modelExpectsResourceLocator(
+		description: INodeTypeDescription,
+		typeVersion: number,
+	): boolean {
+		const modelProp = description.properties.find(
+			(p) =>
+				p.name === 'model' && NodeHelpers.displayParameter({}, p, { typeVersion }, description),
+		);
+		return modelProp?.type === 'resourceLocator';
 	}
 
 	private credentialsForProvider(provider: string, credentialId: string) {


### PR DESCRIPTION
## Summary

When an eval config is compiled for a run, the workflow compiler built the LLM-judge's chat-model sub-node against an **outdated schema**: it hardcoded `typeVersion: 1` and set `model` as a **plain string**. Current chat-model nodes default to a higher version and expect `model` as a **resource-locator object**, so the compiled judge sub-node was structurally off from the node's current contract — for **every** provider, pinned to its oldest version.

Judging still functioned today (v1 accepted a string `model` via backward-compat), but it was schema-incorrect and fragile: pinned to the oldest node version, off-contract with the node's model-selection shape, and liable to break if/when v1 is deprecated.

This affects all eval-config-compiled judges (the Instance AI path and the classic wizard path), behind the `084_eval_collections` flag.

### Fix

`WorkflowCompilerService.buildChatModelNodeIfNeeded` now **introspects the provider node type at compile time** (via the injected `NodeTypes` service):

- uses the node's **default `typeVersion`** instead of a hardcoded `1`, and
- shapes the `model` parameter by its declared type on that version — a **resource locator** (`{ __rl: true, mode: 'list', value, cachedResultName }`) when the version's `model` property is a `resourceLocator`, otherwise a plain string.

The correct version-gated `model` variant is resolved via the real `NodeHelpers.displayParameter`, so it adapts per provider automatically as nodes version up. If the node type can't be introspected, it falls back to the prior shape (`typeVersion: 1` + string model) so judging keeps working.

## How to test

Gated behind `084_eval_collections` — run n8n with `N8N_EVAL_COLLECTIONS_ENABLED=true`.

1. Create an eval config with an LLM-judge metric using a provider whose current node default uses a resource-locator model (e.g. **Anthropic Chat Model**, default v1.5).
2. Compile/run it and inspect the compiled judge chat-model sub-node: it should now be emitted at the provider's current default `typeVersion` with `model` as a resource-locator object (`{ __rl: true, mode: 'list', value: <modelId>, ... }`), not `typeVersion: 1` + a bare string.
3. A provider whose current default model is still a plain field (e.g. **Ollama**, v1) should emit a plain-string `model` at that version.

Automated coverage:

```bash
cd packages/cli
pnpm test src/evaluation.ee/test-runner/__tests__/workflow-compiler.service.test.ts
```

The new tests bind to the **real** `@n8n/n8n-nodes-langchain` node descriptions (Anthropic resource-locator @ default, Ollama string @ v1) run through the real `displayParameter`, plus the introspection-fallback path — so drift in a provider node's version/model shape surfaces here instead of passing silently.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-317

Related: https://linear.app/n8n/issue/TRUST-314 · https://linear.app/n8n/issue/TRUST-316

> **Follow-up (out of scope here):** two registered providers — Google Gemini (`lmChatGoogleGemini`) and Google Vertex (`lmChatGoogleVertex`) — name their model parameter `modelName`, not `model`. The compiler writes `parameters: { model: ... }` for all providers (unchanged by this PR), so for those two the configured model is silently ignored and the node's default is used. This is a pre-existing, separate bug from the typeVersion/resource-locator issue fixed here; worth a dedicated ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

