### PR TITLE
fix(core): Skip reporting axios errors thrown as unhandled node errors

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute-node-error-reporting.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-node-error-reporting.test.ts
@@ -163,6 +163,17 @@ describe('WorkflowExecute node error forwarding to ErrorReporter', () => {
 		expect(reported).toBe(baseError);
 	});
 
+	it('should not report an axios error', async () => {
+		const axiosError = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
+			name: 'AxiosError',
+			isAxiosError: true,
+		});
+
+		await runWorkflowThatThrows(axiosError);
+
+		expect(mockErrorReporter.error).not.toHaveBeenCalled();
+	});
+
 	it('should not report an ApplicationError with no cause', async () => {
 		const plainAppError = new ApplicationError('plain operational error', { level: 'error' });
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
+import { isAxiosError } from '@n8n/backend-network';
 import { TOOL_EXECUTOR_NODE_NAME } from '@n8n/constants';
 import { Container } from '@n8n/di';
 import * as assert from 'assert/strict';
@@ -1976,7 +1977,9 @@ export class WorkflowExecute {
 								// BaseError subclasses specify shouldReport and level
 								// so always report and let beforeSend decide
 								toReport = error;
-							} else if (error instanceof Error) {
+							} else if (error instanceof Error && !isAxiosError(error)) {
+								// Axios errors are suppressed in ErrorReporter's beforeSend via the
+								// `isAxiosError` brand, which sanitizing below would strip - so skip them here
 								// Non-BaseError errors only report their class and call frames
 								// The full error is still stored in the execution resultData
 								// Stack frames are in the format `<name>: <message>\n<call frames>`


### PR DESCRIPTION
## Summary

Since #31628, unhandled third-party errors thrown during node execution are sanitized (class name + call frames only) before being forwarded to the error tracker. Sanitizing replaces the error with a plain `new Error(errorClass)`, which drops the `isAxiosError` brand that `ErrorReporter.beforeSend` uses to suppress axios errors — so raw axios throws from node execution started reaching Sentry as `AxiosError: AxiosError`.

This guards the sanitize-and-report branch in `WorkflowExecute` with `isAxiosError(error)`, skipping the report at the source and restoring the pre-#31628 suppression behavior. The error is still preserved in the execution's `resultData`, so user-facing visibility is unchanged.

## How to test

`cd packages/core && pnpm test workflow-execute-node-error-reporting` — includes a new test asserting that an error carrying the `isAxiosError` brand thrown from a node is not forwarded to `ErrorReporter`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3786

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->