### PR TITLE
fix(core): Advertise OAuth protected-resource metadata URL on MCP server 401 responses

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp-protected-resource.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-protected-resource.test.ts
@@ -75,6 +75,30 @@ describe('McpProtectedResource', () => {
 		});
 	});
 
+	describe('getProtectedResourceMetadataUrl', () => {
+		it('should insert the well-known prefix before the resource path (RFC 9728)', () => {
+			urlService.getInstanceBaseUrl.mockReturnValue('https://n8n.example.com');
+			expect(resource.getProtectedResourceMetadataUrl()).toBe(
+				'https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http',
+			);
+		});
+
+		it('should preserve a subpath in the base URL', () => {
+			urlService.getInstanceBaseUrl.mockReturnValue('https://example.com/n8n');
+			expect(resource.getProtectedResourceMetadataUrl()).toBe(
+				'https://example.com/.well-known/oauth-protected-resource/n8n/mcp-server/http',
+			);
+		});
+
+		it('should derive from the configured MCP base URL when set', () => {
+			urlService.getInstanceBaseUrl.mockReturnValue('https://n8n.example.com');
+			mcpConfig.baseUrl = 'https://n8n-mcp.example.com';
+			expect(resource.getProtectedResourceMetadataUrl()).toBe(
+				'https://n8n-mcp.example.com/.well-known/oauth-protected-resource/mcp-server/http',
+			);
+		});
+	});
+
 	describe('getAudiences', () => {
 		it('should accept the canonical resource URL and the legacy audience', () => {
 			urlService.getInstanceBaseUrl.mockReturnValue('https://n8n.example.com');

--- a/packages/cli/src/modules/mcp/__tests__/mcp-server-middleware.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-server-middleware.service.test.ts
@@ -51,6 +51,9 @@ describe('McpServerMiddlewareService', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mcpProtectedResource.getResourceUrl.mockReturnValue('https://n8n.example.com/mcp-server/http');
+		mcpProtectedResource.getProtectedResourceMetadataUrl.mockReturnValue(
+			'https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http',
+		);
 	});
 
 	describe('getUserForToken', () => {
@@ -158,7 +161,10 @@ describe('McpServerMiddlewareService', () => {
 
 			await middleware(req, res, next);
 
-			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+			expect(res.header).toHaveBeenCalledWith(
+				'WWW-Authenticate',
+				'Bearer realm="n8n MCP Server", resource_metadata="https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http"',
+			);
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({
 				message: 'Unauthorized: Authorization header not sent',
@@ -185,7 +191,10 @@ describe('McpServerMiddlewareService', () => {
 
 			await middleware(req, res, next);
 
-			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+			expect(res.header).toHaveBeenCalledWith(
+				'WWW-Authenticate',
+				'Bearer realm="n8n MCP Server", resource_metadata="https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http"',
+			);
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({
 				message: 'Unauthorized: Invalid authorization header format - Missing Bearer prefix',
@@ -212,7 +221,10 @@ describe('McpServerMiddlewareService', () => {
 
 			await middleware(req, res, next);
 
-			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+			expect(res.header).toHaveBeenCalledWith(
+				'WWW-Authenticate',
+				'Bearer realm="n8n MCP Server", resource_metadata="https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http"',
+			);
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({
 				message: 'Unauthorized: Invalid authorization header format - Malformed Bearer token',
@@ -357,7 +369,10 @@ describe('McpServerMiddlewareService', () => {
 
 			await middleware(req, res, next);
 
-			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+			expect(res.header).toHaveBeenCalledWith(
+				'WWW-Authenticate',
+				'Bearer realm="n8n MCP Server", resource_metadata="https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http"',
+			);
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({ message: 'Unauthorized' });
 			expect(next).not.toHaveBeenCalled();
@@ -382,7 +397,10 @@ describe('McpServerMiddlewareService', () => {
 
 			await middleware(req, res, next);
 
-			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+			expect(res.header).toHaveBeenCalledWith(
+				'WWW-Authenticate',
+				'Bearer realm="n8n MCP Server", resource_metadata="https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http"',
+			);
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({
 				message: 'Unauthorized: Authorization header not sent',
@@ -412,7 +430,10 @@ describe('McpServerMiddlewareService', () => {
 
 			await middleware(req, res, next);
 
-			expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+			expect(res.header).toHaveBeenCalledWith(
+				'WWW-Authenticate',
+				'Bearer realm="n8n MCP Server", resource_metadata="https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http"',
+			);
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(res.send).toHaveBeenCalledWith({ message: 'Unauthorized' });
 			expect(next).not.toHaveBeenCalled();

--- a/packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts
@@ -22,6 +22,7 @@ mcpServerMiddlewareService.getAuthMiddleware.mockReturnValue(mockAuthMiddleware)
 Container.set(McpServerMiddlewareService, mcpServerMiddlewareService);
 
 import { McpConfig } from '../mcp.config';
+import { McpProtectedResource } from '../mcp-protected-resource';
 import type { McpController as McpControllerType, FlushableResponse } from '../mcp.controller';
 import { McpService } from '../mcp.service';
 import { McpSettingsService } from '../mcp.settings.service';
@@ -64,6 +65,13 @@ describe('McpController', () => {
 		resolveMcpAppsVariant: vi.fn(),
 	} as unknown as McpService;
 	const mcpSettingsService = { getEnabled: vi.fn() } as unknown as McpSettingsService;
+	const mcpProtectedResource = {
+		getProtectedResourceMetadataUrl: vi
+			.fn()
+			.mockReturnValue(
+				'https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http',
+			),
+	} as unknown as McpProtectedResource;
 
 	beforeEach(async () => {
 		vi.clearAllMocks();
@@ -81,6 +89,7 @@ describe('McpController', () => {
 		Container.set(Telemetry, telemetry);
 		Container.set(McpService, mcpService);
 		Container.set(McpSettingsService, mcpSettingsService);
+		Container.set(McpProtectedResource, mcpProtectedResource);
 		// Real repositories can't be auto-constructed by DI without a DataSource.
 		Container.set(ApiKeyRepository, mock<ApiKeyRepository>());
 
@@ -281,7 +290,10 @@ describe('McpController', () => {
 
 		await controller.discoverAuthSchemeHead(req, res);
 
-		expect(res.header).toHaveBeenCalledWith('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+		expect(res.header).toHaveBeenCalledWith(
+			'WWW-Authenticate',
+			'Bearer realm="n8n MCP Server", resource_metadata="https://n8n.example.com/.well-known/oauth-protected-resource/mcp-server/http"',
+		);
 		expect(res.status).toHaveBeenCalledWith(401);
 		expect(res.end).toHaveBeenCalled();
 	});

--- a/packages/cli/src/modules/mcp/mcp-protected-resource.ts
+++ b/packages/cli/src/modules/mcp/mcp-protected-resource.ts
@@ -82,6 +82,17 @@ export class McpProtectedResource implements ProtectedResource {
 	}
 
 	/**
+	 * RFC 9728 §3.1 metadata URL for this resource: `/.well-known/
+	 * oauth-protected-resource` with the resource's path inserted after it.
+	 * Advertised in `WWW-Authenticate: resource_metadata=...` on 401s so clients
+	 * discover the metadata directly instead of guessing the well-known path.
+	 */
+	getProtectedResourceMetadataUrl(): string {
+		const url = new URL(this.getResourceUrl());
+		return `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`;
+	}
+
+	/**
 	 * Canonical resource URL first, then the instance-base-URL-derived one when
 	 * a dedicated MCP base URL is configured — clients connecting through the
 	 * main hostname (and tokens minted before the config change) must keep

--- a/packages/cli/src/modules/mcp/mcp-server-middleware.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-server-middleware.service.ts
@@ -125,8 +125,11 @@ export class McpServerMiddlewareService {
 
 	private responseWithUnauthorized(res: Response, req: Request, context?: TelemetryAuthContext) {
 		this.trackUnauthorizedEvent(req, context);
-		// RFC 6750 Section 3: Include WWW-Authenticate header for 401 responses
-		res.header('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+		// RFC 6750 Section 3 / RFC 9728 Section 5.1: include the WWW-Authenticate
+		// header on 401s, advertising the protected-resource metadata URL so
+		// clients discover it directly instead of guessing the well-known path.
+		const prmUrl = this.mcpProtectedResource.getProtectedResourceMetadataUrl();
+		res.header('WWW-Authenticate', `Bearer realm="n8n MCP Server", resource_metadata="${prmUrl}"`);
 		res.status(401).send({
 			message: `${UNAUTHORIZED_ERROR_MESSAGE}${context?.error_details ? ': ' + context.error_details : ''}`,
 		});

--- a/packages/cli/src/modules/mcp/mcp.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.controller.ts
@@ -7,6 +7,7 @@ import { ErrorReporter } from 'n8n-core';
 
 import { Telemetry } from '@/telemetry';
 
+import { McpProtectedResource } from './mcp-protected-resource';
 import { McpServerMiddlewareService } from './mcp-server-middleware.service';
 import { McpConfig } from './mcp.config';
 import {
@@ -34,6 +35,7 @@ export class McpController {
 		private readonly mcpSettingsService: McpSettingsService,
 		private readonly telemetry: Telemetry,
 		private readonly logger: Logger,
+		private readonly mcpProtectedResource: McpProtectedResource,
 	) {}
 
 	// Add CORS headers helper
@@ -66,7 +68,8 @@ export class McpController {
 	})
 	async discoverAuthSchemeHead(_req: Request, res: Response) {
 		this.setCorsHeaders(res);
-		res.header('WWW-Authenticate', 'Bearer realm="n8n MCP Server"');
+		const prmUrl = this.mcpProtectedResource.getProtectedResourceMetadataUrl();
+		res.header('WWW-Authenticate', `Bearer realm="n8n MCP Server", resource_metadata="${prmUrl}"`);
 		res.status(401).end();
 	}
 


### PR DESCRIPTION
## Summary

The instance MCP server (`/mcp-server/http`) returns `401` with a
`WWW-Authenticate: Bearer realm="n8n MCP Server"` header, but **without** an
RFC 9728 `resource_metadata` parameter. Because clients get no pointer to the
protected-resource metadata document, a spec-compliant OAuth client (built on
`@modelcontextprotocol/sdk`) must *guess* the well-known metadata URL — and in
some topologies (e.g. the MCP server presented at the root of a tunnel/proxy
host) it probes only the origin-level `/.well-known/oauth-protected-resource`,
which historically fell through to the SPA catch-all and broke discovery.

The MCP **Trigger** node already advertises `resource_metadata` on its 401s
(`n8n-oauth2-auth.ts`). This PR brings the instance MCP server to parity.

**Changes:**
- Add `McpProtectedResource.getProtectedResourceMetadataUrl()` — builds the
  RFC 9728 §3.1 metadata URL by inserting `/.well-known/oauth-protected-resource`
  before the resource's path, derived from the canonical resource URL (so it
  honours a dedicated MCP base URL / split-hostname deployments).
- Emit `resource_metadata="…"` in the `WWW-Authenticate` header at both 401
  sites: the auth middleware (`McpServerMiddlewareService`) and the
  `HEAD /mcp-server/http` auth-scheme discovery probe (`McpController`).

Compliant clients now use the advertised metadata URL directly instead of
guessing the well-known path. This is the RFC-preferred discovery mechanism and
complements #33776 (which handles clients that ignore the header).

## How to test

1. Start n8n with the MCP server enabled.
2. `curl -i -X HEAD https://<instance>/mcp-server/http` → `401` with
   `WWW-Authenticate: Bearer realm="n8n MCP Server", resource_metadata="https://<instance>/.well-known/oauth-protected-resource/mcp-server/http"`.
3. Same header on an unauthenticated `POST /mcp-server/http`.
4. Fetching that advertised URL returns the RFC 9728 JSON metadata document.

## Related Linear tickets, Github issues, and Community forum posts

Related to https://linear.app/n8n/issue/IAM-1016 and #33776.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34571">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

