### PR TITLE
fix(editor): Reconcile canvas execution state on push reconnect

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
@@ -11,24 +11,24 @@ import {
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import type { PushHandlerOptions } from './types';
 
-export async function executionRecovered(
-	{ data }: ExecutionRecovered,
-	options: PushHandlerOptions,
-) {
+/**
+ * Re-fetches an execution from the server and reconciles this document's canvas
+ * state to that server truth: renders the final run data and clears the
+ * running/spinner state via `setRunExecutionData`.
+ *
+ * Shared by the `executionRecovered` push handler (server-side crash recovery
+ * on startup) and the push-reconnect reconciliation path (an execution that
+ * finished while the client was disconnected, so its `executionFinished` push
+ * was never delivered). Callers are responsible for confirming that
+ * `executionId` is the run this document should reconcile.
+ */
+export async function reconcileFinishedExecution(executionId: string, options: PushHandlerOptions) {
 	const { documentId, suppressExecutionSuccessToasts, suppressExecutionErrorToasts } = options;
-	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 	const uiStore = useUIStore();
-
-	// Only recover the execution this document is tracking. A mismatch (including
-	// the no-active-execution case, where activeExecutionId is undefined) means
-	// the event belongs to another execution and must be ignored.
-	if (workflowExecutionStateStore.activeExecutionId !== data.executionId) {
-		return;
-	}
 
 	uiStore.setProcessingExecutionResults(true);
 
-	const execution = await fetchExecutionData(data.executionId, documentId);
+	const execution = await fetchExecutionData(executionId, documentId);
 	if (!execution) {
 		uiStore.setProcessingExecutionResults(false);
 		return;
@@ -56,4 +56,20 @@ export async function executionRecovered(
 	}
 
 	setRunExecutionData(execution, runExecutionData, documentId);
+}
+
+export async function executionRecovered(
+	{ data }: ExecutionRecovered,
+	options: PushHandlerOptions,
+) {
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(options.documentId);
+
+	// Only recover the execution this document is tracking. A mismatch (including
+	// the no-active-execution case, where activeExecutionId is undefined) means
+	// the event belongs to another execution and must be ignored.
+	if (workflowExecutionStateStore.activeExecutionId !== data.executionId) {
+		return;
+	}
+
+	await reconcileFinishedExecution(data.executionId, options);
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/index.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/index.ts
@@ -6,6 +6,7 @@ export * from './nodeDescriptionUpdated';
 export * from './nodeExecuteAfter';
 export * from './nodeExecuteAfterData';
 export * from './nodeExecuteBefore';
+export * from './reconcileOnReconnect';
 export * from './reloadNodeType';
 export * from './removeNodeType';
 export * from './sendConsoleMessage';

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reconcileOnReconnect.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reconcileOnReconnect.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+import type { Router } from 'vue-router';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { createRunExecutionData } from 'n8n-workflow';
+import type { ExecutionSummary } from 'n8n-workflow';
+
+import { reconcileExecutionStateOnReconnect } from './reconcileOnReconnect';
+import { getActiveExecutions } from '@/app/api/workflows';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
+import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
+import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import type { IWorkflowDb } from '@/Interface';
+import type { PushHandlerOptions } from './types';
+
+// Derives the workflow id from the route; resolve it directly without a router.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: () => ({ showMessage: vi.fn(), showError: vi.fn() }),
+}));
+
+vi.mock('@/app/composables/useDocumentTitle', () => ({
+	useDocumentTitle: () => ({ setDocumentTitle: vi.fn() }),
+}));
+
+vi.mock('@/app/api/workflows', () => ({
+	getActiveExecutions: vi.fn(),
+}));
+
+const getActiveExecutionsMock = vi.mocked(getActiveExecutions);
+
+const workflowId = '1';
+const documentId = createWorkflowDocumentId(workflowId);
+const options: PushHandlerOptions = {
+	router: mock<Router>(),
+	documentId,
+};
+
+function startRunningExecution(executionId: string) {
+	const executionStateStore = useWorkflowExecutionStateStore(documentId);
+	useExecutionDataStore(createExecutionDataId(executionId)).setExecution(
+		mock<IExecutionResponse>({
+			id: executionId,
+			workflowId,
+			status: 'running',
+			finished: false,
+			data: { resultData: { runData: {} } },
+		}),
+	);
+	executionStateStore.setActiveExecutionId(executionId);
+	return executionStateStore;
+}
+
+function makeFinishedExecution(executionId: string): IExecutionResponse {
+	const nodeName = 'Trigger';
+	return {
+		id: executionId,
+		workflowId,
+		finished: true,
+		mode: 'manual',
+		status: 'success',
+		startedAt: new Date(),
+		createdAt: new Date(),
+		workflowData: mock<IWorkflowDb>({ id: workflowId, nodes: [], connections: {} }),
+		data: createRunExecutionData({
+			resultData: {
+				lastNodeExecuted: nodeName,
+				runData: {
+					[nodeName]: [
+						{
+							executionStatus: 'success',
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+							data: { main: [[{ json: { ok: true } }]] },
+						},
+					],
+				},
+			},
+		}),
+	};
+}
+
+describe('reconcileExecutionStateOnReconnect', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setActivePinia(createTestingPinia({ stubActions: false }));
+		useWorkflowDocumentStore(documentId).setName('My Workflow');
+	});
+
+	it('clears the stranded spinner when the tracked run finished server-side while disconnected', async () => {
+		const executionId = 'exec-finished-offline';
+		const executionStateStore = startRunningExecution(executionId);
+		expect(executionStateStore.isWorkflowRunning).toBe(true);
+
+		// Server no longer lists the execution as active — it finished while the
+		// client was disconnected, so its `executionFinished` push was dropped.
+		getActiveExecutionsMock.mockResolvedValue([]);
+		vi.spyOn(useWorkflowsStore(), 'fetchExecutionDataById').mockResolvedValue(
+			makeFinishedExecution(executionId),
+		);
+
+		await reconcileExecutionStateOnReconnect(options);
+
+		expect(getActiveExecutionsMock).toHaveBeenCalledWith(expect.anything(), {
+			workflowId,
+			status: ['new', 'running', 'waiting'],
+		});
+		// State reconciled to server truth: spinner cleared, final run displayed.
+		expect(executionStateStore.isWorkflowRunning).toBe(false);
+		expect(executionStateStore.activeExecutionId).toBeUndefined();
+		expect(executionStateStore.displayedExecutionId).toBe(executionId);
+	});
+
+	it('leaves a genuinely running execution untouched on reconnect', async () => {
+		const executionId = 'exec-still-running';
+		const executionStateStore = startRunningExecution(executionId);
+
+		// Server still reports the execution as active.
+		getActiveExecutionsMock.mockResolvedValue([mock<ExecutionSummary>({ id: executionId })]);
+		const fetchSpy = vi.spyOn(useWorkflowsStore(), 'fetchExecutionDataById');
+
+		await reconcileExecutionStateOnReconnect(options);
+
+		expect(executionStateStore.isWorkflowRunning).toBe(true);
+		expect(executionStateStore.activeExecutionId).toBe(executionId);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when no active execution is being tracked', async () => {
+		const executionStateStore = useWorkflowExecutionStateStore(documentId);
+		expect(executionStateStore.activeExecutionId).toBeUndefined();
+
+		await reconcileExecutionStateOnReconnect(options);
+
+		expect(getActiveExecutionsMock).not.toHaveBeenCalled();
+	});
+
+	it('does not reconcile a pending run whose backend id is not yet known', async () => {
+		const executionStateStore = useWorkflowExecutionStateStore(documentId);
+		executionStateStore.setActiveExecutionId(null);
+
+		await reconcileExecutionStateOnReconnect(options);
+
+		expect(getActiveExecutionsMock).not.toHaveBeenCalled();
+		expect(executionStateStore.activeExecutionId).toBeNull();
+	});
+
+	it('leaves the canvas untouched when the active-executions request fails', async () => {
+		const executionId = 'exec-network-error';
+		const executionStateStore = startRunningExecution(executionId);
+
+		getActiveExecutionsMock.mockRejectedValue(new Error('network down'));
+		const fetchSpy = vi.spyOn(useWorkflowsStore(), 'fetchExecutionDataById');
+
+		await reconcileExecutionStateOnReconnect(options);
+
+		expect(executionStateStore.isWorkflowRunning).toBe(true);
+		expect(executionStateStore.activeExecutionId).toBe(executionId);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reconcileOnReconnect.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reconcileOnReconnect.test.ts
@@ -95,6 +95,24 @@ function makeFinishedExecution(executionId: string): IExecutionResponse {
 	};
 }
 
+function makeWaitingExecution(executionId: string): IExecutionResponse {
+	const data = createRunExecutionData({ resultData: { runData: {} } });
+	// A run parked into wait server-side carries `waitTill` on its run data; the
+	// reconciliation routes this through the wait branch (mirrors the push path).
+	data.waitTill = new Date('2999-01-01T00:00:00.000Z');
+	return {
+		id: executionId,
+		workflowId,
+		finished: false,
+		mode: 'manual',
+		status: 'waiting',
+		startedAt: new Date(),
+		createdAt: new Date(),
+		workflowData: mock<IWorkflowDb>({ id: workflowId, nodes: [], connections: {} }),
+		data,
+	};
+}
+
 describe('reconcileExecutionStateOnReconnect', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -118,9 +136,33 @@ describe('reconcileExecutionStateOnReconnect', () => {
 
 		expect(getActiveExecutionsMock).toHaveBeenCalledWith(expect.anything(), {
 			workflowId,
-			status: ['new', 'running', 'waiting'],
+			status: ['new', 'running'],
 		});
 		// State reconciled to server truth: spinner cleared, final run displayed.
+		expect(executionStateStore.isWorkflowRunning).toBe(false);
+		expect(executionStateStore.activeExecutionId).toBeUndefined();
+		expect(executionStateStore.displayedExecutionId).toBe(executionId);
+	});
+
+	it('clears the stranded spinner when the tracked run parked into wait while disconnected', async () => {
+		const executionId = 'exec-parked-offline';
+		const executionStateStore = startRunningExecution(executionId);
+		expect(executionStateStore.isWorkflowRunning).toBe(true);
+
+		// `waiting` runs are excluded from the active-status query, so the server
+		// does not return the parked run — its `waitTill` push was dropped.
+		getActiveExecutionsMock.mockResolvedValue([]);
+		vi.spyOn(useWorkflowsStore(), 'fetchExecutionDataById').mockResolvedValue(
+			makeWaitingExecution(executionId),
+		);
+
+		await reconcileExecutionStateOnReconnect(options);
+
+		expect(getActiveExecutionsMock).toHaveBeenCalledWith(expect.anything(), {
+			workflowId,
+			status: ['new', 'running'],
+		});
+		// Reconciled to the wait state: spinner cleared, wait execution displayed.
 		expect(executionStateStore.isWorkflowRunning).toBe(false);
 		expect(executionStateStore.activeExecutionId).toBeUndefined();
 		expect(executionStateStore.displayedExecutionId).toBe(executionId);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reconcileOnReconnect.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reconcileOnReconnect.ts
@@ -1,0 +1,67 @@
+import type { ExecutionStatus } from 'n8n-workflow';
+
+import { getActiveExecutions } from '@/app/api/workflows';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
+import { reconcileFinishedExecution } from './executionRecovered';
+import type { PushHandlerOptions } from './types';
+
+/**
+ * Server-side statuses that still count as an in-flight run. If the execution
+ * this document is tracking is not returned under one of these, it has reached
+ * a terminal state on the server.
+ */
+const ACTIVE_EXECUTION_STATUSES: ExecutionStatus[] = ['new', 'running', 'waiting'];
+
+/**
+ * Reconciles the canvas execution state against server truth after a push
+ * reconnect.
+ *
+ * If the client disconnects across the moment a run finishes (or a single
+ * `executionFinished` frame is lost), that push is never delivered and the
+ * canvas is stranded showing a running spinner. On reconnect we ask the server
+ * which executions are still active for this workflow; if the one this document
+ * is tracking is no longer among them, it finished while we were away, so we
+ * re-fetch it and render the final state — which also clears the spinner.
+ *
+ * A run that is genuinely still executing server-side is left untouched, so
+ * live execution rendering during a normal, uninterrupted run is unaffected.
+ */
+export async function reconcileExecutionStateOnReconnect(options: PushHandlerOptions) {
+	const { documentId } = options;
+	const rootStore = useRootStore();
+	const executionStateStore = useWorkflowExecutionStateStore(documentId);
+	const { activeExecutionId, workflowId } = executionStateStore;
+
+	// Only a run tracked by a concrete backend id can strand. A pending run
+	// (`null`, id not yet assigned) has nothing to query, and an idle document
+	// (`undefined`) has nothing to reconcile.
+	if (typeof activeExecutionId !== 'string' || !executionStateStore.isWorkflowRunning) {
+		return;
+	}
+
+	let isStillActive: boolean;
+	try {
+		const activeExecutions = await getActiveExecutions(rootStore.restApiContext, {
+			workflowId,
+			status: ACTIVE_EXECUTION_STATUSES,
+		});
+		isStillActive = activeExecutions.some((execution) => execution.id === activeExecutionId);
+	} catch {
+		// Could not confirm server state; leave the canvas untouched rather than
+		// risk clearing a genuinely running execution.
+		return;
+	}
+
+	if (isStillActive) {
+		return;
+	}
+
+	// A new run may have started while the request was in flight. Only reconcile
+	// if this document is still tracking the same finished execution.
+	if (executionStateStore.activeExecutionId !== activeExecutionId) {
+		return;
+	}
+
+	await reconcileFinishedExecution(activeExecutionId, options);
+}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reconcileOnReconnect.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reconcileOnReconnect.ts
@@ -7,22 +7,26 @@ import { reconcileFinishedExecution } from './executionRecovered';
 import type { PushHandlerOptions } from './types';
 
 /**
- * Server-side statuses that still count as an in-flight run. If the execution
- * this document is tracking is not returned under one of these, it has reached
- * a terminal state on the server.
+ * Server-side statuses for which the canvas should keep rendering a live,
+ * executing run. `waiting` is deliberately excluded: a run that parks into wait
+ * server-side (`data.waitTill`) sends its own push, so a disconnect across that
+ * transition strands the running spinner just like a dropped finish. Excluding
+ * `waiting` routes such a run through reconciliation, where the re-fetched
+ * execution hits the existing waitTill branch and renders the wait state.
  */
-const ACTIVE_EXECUTION_STATUSES: ExecutionStatus[] = ['new', 'running', 'waiting'];
+const RUNNING_EXECUTION_STATUSES: ExecutionStatus[] = ['new', 'running'];
 
 /**
  * Reconciles the canvas execution state against server truth after a push
  * reconnect.
  *
- * If the client disconnects across the moment a run finishes (or a single
- * `executionFinished` frame is lost), that push is never delivered and the
- * canvas is stranded showing a running spinner. On reconnect we ask the server
- * which executions are still active for this workflow; if the one this document
- * is tracking is no longer among them, it finished while we were away, so we
- * re-fetch it and render the final state — which also clears the spinner.
+ * If the client disconnects across the moment a run finishes or parks into wait
+ * (or a single `executionFinished` frame is lost), that push is never delivered
+ * and the canvas is stranded showing a running spinner. On reconnect we ask the
+ * server which executions are still actively running for this workflow; if the
+ * one this document is tracking is no longer among them, it finished or parked
+ * while we were away, so we re-fetch it and render the final/wait state — which
+ * also clears the spinner.
  *
  * A run that is genuinely still executing server-side is left untouched, so
  * live execution rendering during a normal, uninterrupted run is unaffected.
@@ -44,7 +48,7 @@ export async function reconcileExecutionStateOnReconnect(options: PushHandlerOpt
 	try {
 		const activeExecutions = await getActiveExecutions(rootStore.restApiContext, {
 			workflowId,
-			status: ACTIVE_EXECUTION_STATUSES,
+			status: RUNNING_EXECUTION_STATUSES,
 		});
 		isStillActive = activeExecutions.some((execution) => execution.id === activeExecutionId);
 	} catch {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
@@ -2,20 +2,26 @@ import { usePushConnection } from '@/app/composables/usePushConnection';
 import {
 	testWebhookReceived,
 	builderCreditsUpdated,
+	reconcileExecutionStateOnReconnect,
 } from '@/app/composables/usePushConnection/handlers';
 import type { TestWebhookReceived } from '@n8n/api-types/push/webhook';
 import type { BuilderCreditsPushMessage } from '@n8n/api-types/push/builder-credits';
 import { useRouter } from 'vue-router';
 import type { OnPushMessageHandler } from '@/app/stores/pushConnection.store';
 import { createPinia, setActivePinia } from 'pinia';
+import { nextTick, ref } from 'vue';
 
 const removeEventListener = vi.fn();
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const addEventListener = vi.fn((_handler: OnPushMessageHandler) => removeEventListener);
+const isConnected = ref(false);
 
 vi.mock('@/app/stores/pushConnection.store', () => ({
 	usePushConnectionStore: () => ({
 		addEventListener,
+		get isConnected() {
+			return isConnected.value;
+		},
 	}),
 }));
 
@@ -36,6 +42,7 @@ vi.mock('@/app/composables/usePushConnection/handlers', () => ({
 	workflowPartiallyActivated: vi.fn(),
 	executionFinished: vi.fn(),
 	executionRecovered: vi.fn(),
+	reconcileExecutionStateOnReconnect: vi.fn(),
 	workflowActivated: vi.fn(),
 	workflowDeactivated: vi.fn(),
 	collaboratorsChanged: vi.fn(),
@@ -57,11 +64,19 @@ describe('usePushConnection composable', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		isConnected.value = false;
 
 		setActivePinia(createPinia());
 
 		const router = useRouter();
 		pushConnection = usePushConnection({ router });
+	});
+
+	afterEach(() => {
+		// The composable is created outside a component scope in these tests, so
+		// its reconnect watcher isn't auto-disposed — stop it to prevent leaking
+		// watchers across tests that share the module-level `isConnected` ref.
+		pushConnection.terminate();
 	});
 
 	it('should register an event listener on initialize', () => {
@@ -127,5 +142,59 @@ describe('usePushConnection composable', () => {
 		// Verify that the correct handler was called.
 		expect(builderCreditsUpdated).toHaveBeenCalledTimes(1);
 		expect(builderCreditsUpdated).toHaveBeenCalledWith(testEvent);
+	});
+
+	describe('execution state reconciliation on reconnect', () => {
+		it('should not reconcile on the initial connect', async () => {
+			pushConnection.initialize();
+
+			isConnected.value = true;
+			await nextTick();
+
+			expect(reconcileExecutionStateOnReconnect).not.toHaveBeenCalled();
+		});
+
+		it('should reconcile execution state on reconnect', async () => {
+			pushConnection.initialize();
+
+			// Initial connect, then a drop and a reconnect.
+			isConnected.value = true;
+			await nextTick();
+			isConnected.value = false;
+			await nextTick();
+			isConnected.value = true;
+			await nextTick();
+
+			expect(reconcileExecutionStateOnReconnect).toHaveBeenCalledTimes(1);
+			expect(reconcileExecutionStateOnReconnect).toHaveBeenCalledWith(expect.any(Object));
+		});
+
+		it('should treat a connection already established at setup as the initial connect', async () => {
+			isConnected.value = true;
+			pushConnection.initialize();
+
+			// A drop and reconnect after an already-live connection is a reconnect.
+			isConnected.value = false;
+			await nextTick();
+			isConnected.value = true;
+			await nextTick();
+
+			expect(reconcileExecutionStateOnReconnect).toHaveBeenCalledTimes(1);
+		});
+
+		it('should stop reconciling after terminate', async () => {
+			pushConnection.initialize();
+
+			isConnected.value = true;
+			await nextTick();
+			pushConnection.terminate();
+
+			isConnected.value = false;
+			await nextTick();
+			isConnected.value = true;
+			await nextTick();
+
+			expect(reconcileExecutionStateOnReconnect).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -1,9 +1,10 @@
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import type { PushMessage } from '@n8n/api-types';
 
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import {
 	builderCreditsUpdated,
+	reconcileExecutionStateOnReconnect,
 	testWebhookDeleted,
 	testWebhookReceived,
 	reloadNodeType,
@@ -25,7 +26,10 @@ import {
 	workflowSettingsUpdated,
 } from '@/app/composables/usePushConnection/handlers';
 import type { PushHandlerOptions } from '@/app/composables/usePushConnection/handlers/types';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	injectWorkflowDocumentStore,
+	type WorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useEditorContext } from '@/app/composables/useEditorContext';
 import { createEventQueue } from '@n8n/utils/create-event-queue';
 import type { useRouter } from 'vue-router';
@@ -41,31 +45,68 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);
 
 	const removeEventListener = ref<(() => void) | null>(null);
+	let stopConnectionWatcher: (() => void) | null = null;
+	/**
+	 * Whether this composable instance has observed a live connection yet. The
+	 * first connect is the initial one (nothing to reconcile); only subsequent
+	 * connects are reconnects. A connection already established at setup time
+	 * counts as the first, so the next transition to connected is a reconnect.
+	 */
+	let hasConnected = false;
+
+	/**
+	 * Build the handler options for a push event. Resolves the current workflow
+	 * document by default so handlers always act on the workflow the user is
+	 * viewing, even as they navigate. The reconnect path pins the document
+	 * resolved at reconnect time so a navigation during the async reconcile
+	 * can't retarget it.
+	 */
+	function buildHandlerOptions(
+		documentId: WorkflowDocumentId = workflowDocumentStore.value.documentId,
+	): PushHandlerOptions {
+		return {
+			router,
+			documentId,
+			suppressExecutionSuccessToasts: !executionSuccessToasts.value,
+			suppressExecutionErrorToasts: !executionErrorToasts.value,
+		};
+	}
 
 	function initialize() {
 		removeEventListener.value = pushStore.addEventListener((message) => {
 			enqueue(message);
 		});
+
+		// Reconcile canvas execution state on reconnect: a run that finished
+		// server-side while the client was disconnected drops its
+		// `executionFinished` push and strands the spinner until reconciled.
+		hasConnected = pushStore.isConnected;
+		stopConnectionWatcher = watch(
+			() => pushStore.isConnected,
+			(isConnected) => {
+				if (!isConnected) return;
+				if (!hasConnected) {
+					hasConnected = true;
+					return;
+				}
+				void reconcileExecutionStateOnReconnect(buildHandlerOptions());
+			},
+		);
 	}
 
 	function terminate() {
 		if (typeof removeEventListener.value === 'function') {
 			removeEventListener.value();
 		}
+		stopConnectionWatcher?.();
+		stopConnectionWatcher = null;
 	}
 
 	/**
 	 * Process received push message event by calling the correct handler
 	 */
 	async function processEvent(event: PushMessage) {
-		// Resolve the current workflow document per event so handlers always act on
-		// the workflow the user is currently viewing, even as they navigate.
-		const options: PushHandlerOptions = {
-			router,
-			documentId: workflowDocumentStore.value.documentId,
-			suppressExecutionSuccessToasts: !executionSuccessToasts.value,
-			suppressExecutionErrorToasts: !executionErrorToasts.value,
-		};
+		const options = buildHandlerOptions();
 
 		switch (event.type) {
 			case 'testWebhookDeleted':


### PR DESCRIPTION
## Summary

Lane 1 of N8N-61 (sub-issue of N8N-43). When the push connection drops across the moment a workflow run finishes — the client disconnects as the run completes, or a single `executionFinished` frame is lost — that push is never delivered. The canvas is left stranded showing a running spinner until a manual refresh, navigation, or Stop.

This reconciles canvas execution state on push **reconnect**. It is orthogonal to the event-ordering fix in #34182 (that fix assumes the events arrive; this one addresses the events not arriving).

## How it works

On reconnect (`pushConnection.store` `isConnected` transitioning back to connected, covering both WebSocket and SSE transports):

1. If this document is tracking a live run by a concrete backend id, ask the server which executions are still active for the workflow via the existing `GET /executions` (`getActiveExecutions`) — no new API.
2. If the tracked execution is **no longer** in the active set, it finished while the client was disconnected → re-fetch it and render the final state (success/error/waiting), which also clears the spinner.
3. If it **is** still active, leave the canvas untouched — live rendering during a normal, uninterrupted run is unaffected.

The server-truth reconciliation is shared with the existing `executionRecovered` handler via an extracted `reconcileFinishedExecution` helper, so the reconnect path renders the true final result rather than merely blanking the spinner.

Guards: the initial connect is skipped (only reconnects reconcile); a pending run (`null` id) or idle document is a no-op; the request failing leaves the canvas untouched rather than risk clearing a genuinely running execution; and execution identity is re-checked after the async request so a run started meanwhile is never clobbered.

## Acceptance criteria

- [x] After a push reconnect, canvas execution state matches server truth — a run that finished server-side while disconnected no longer shows a stranded spinner.
- [x] No regression to live execution rendering during a normal, uninterrupted run (still-active runs are left untouched).
- [x] Regression test: disconnect across `executionFinished` → reconnect → spinner cleared / state reconciled (`reconcileOnReconnect.test.ts`).

## Testing

- New `reconcileOnReconnect.test.ts` (5 tests): finished-while-disconnected clears the spinner and reconciles to the final execution; genuinely-running run untouched; idle/pending no-op; request failure leaves canvas untouched.
- `usePushConnection.test.ts` extended (wiring): reconnect triggers reconciliation, initial connect does not, an already-established connection at setup counts as initial, and reconciliation stops after `terminate`.
- Full push-connection suite green (107 tests); `pnpm typecheck` clean.

Boundary: Lane 1 only. Does not touch Lane 2 (stale-state backstop) or Lane 3 (backend push durability).

Linear: https://linear.app/n8n/issue/N8N-61

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34573">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

