### PR TITLE
feat(Microsoft Excel (SharePoint) Node): Add the workbook dropdown (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/descriptions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/descriptions/common.descriptions.ts
@@ -1,15 +1,18 @@
 import type { INodeProperties } from 'n8n-workflow';
 
-// The Workbook/Site/Library searchable dropdowns arrive with the site/library
-// ticket, on these same fields. The Sheet and Table dropdowns are below.
-
 export const workbookRLC: INodeProperties = {
 	displayName: 'Workbook',
 	name: 'workbook',
 	type: 'resourceLocator',
 	required: true,
+	// URL stays the default: pasting a "Copy link" address is the primary path
+	// and needs no site or library chosen first.
 	default: { mode: 'url', value: '' },
-	description: 'Pick the workbook by URL (no site or library needed) or by ID',
+	description: 'Pick the workbook by URL (no site or library needed), from the list, or by ID',
+	typeOptions: {
+		// So the editor re-fetches the workbook list whenever the site or library changes.
+		loadOptionsDependsOn: ['site.value', 'library.value'],
+	},
 	modes: [
 		{
 			displayName: 'By URL',
@@ -30,6 +33,15 @@ export const workbookRLC: INodeProperties = {
 			],
 		},
 		{
+			displayName: 'From List',
+			name: 'list',
+			type: 'list',
+			typeOptions: {
+				searchListMethod: 'searchWorkbooks',
+				searchable: true,
+			},
+		},
+		{
 			displayName: 'By ID',
 			name: 'id',
 			type: 'string',
@@ -44,7 +56,7 @@ export const siteRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'list', value: '' },
 	description:
-		'The SharePoint site the workbook lives in. Only needed when the workbook is chosen by ID.',
+		'The SharePoint site the workbook lives in. Only needed when the workbook is chosen from the list or by ID.',
 	// Field-shape-compatible with the site-selection component SharePoint 2.0
 	// is building (ENT-182), so the two can converge later.
 	modes: [
@@ -87,7 +99,7 @@ export const libraryRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'list', value: '' },
 	description:
-		'The document library the workbook lives in. Only needed when the workbook is chosen by ID.',
+		'The document library the workbook lives in. Only needed when the workbook is chosen from the list or by ID.',
 	typeOptions: {
 		// So the editor re-fetches the library list whenever the chosen site changes.
 		loadOptionsDependsOn: ['site.value'],

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/methods/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/methods/index.ts
@@ -1,8 +1,9 @@
-import { getSheets, getTables, searchLibraries, searchSites } from './listSearch';
+import { getSheets, getTables, searchLibraries, searchSites, searchWorkbooks } from './listSearch';
 
 export const listSearch = {
 	searchSites,
 	searchLibraries,
+	searchWorkbooks,
 	getSheets,
 	getTables,
 };

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/methods/listSearch.ts
@@ -3,6 +3,7 @@ import type {
 	ILoadOptionsFunctions,
 	INodeListSearchItems,
 	INodeListSearchResult,
+	INodeParameterResourceLocator,
 } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
@@ -14,6 +15,9 @@ import { getExcelSharePointCredentialType, microsoftApiRequest } from '../transp
 
 type Site = IDataObject & { id?: string; displayName?: string; webUrl?: string };
 type Drive = IDataObject & { id?: string; name?: string; webUrl?: string };
+type DriveItem = IDataObject & { id?: string; name?: string; webUrl?: string; file?: IDataObject };
+
+const WORKBOOK_EXTENSIONS = ['.xlsx', '.xlsm'];
 
 /**
  * Fetches one page of a Graph collection. An explicit `paginationToken` (a
@@ -64,6 +68,21 @@ function driveToItem(drive: Drive): INodeListSearchItems {
 		value: String(drive.id),
 		url: drive.webUrl,
 	};
+}
+
+function workbookToItem(item: DriveItem): INodeListSearchItems {
+	return {
+		name: item.name ?? String(item.id),
+		value: String(item.id),
+		url: item.webUrl,
+	};
+}
+
+function isWorkbookFile(item: DriveItem): boolean {
+	const name = String(item.name ?? '').toLowerCase();
+	return (
+		item.file !== undefined && WORKBOOK_EXTENSIONS.some((extension) => name.endsWith(extension))
+	);
 }
 
 /**
@@ -133,6 +152,55 @@ export async function searchLibraries(
 	return {
 		results: toListItems(response.value, driveToItem),
 		paginationToken: response['@odata.nextLink'],
+	};
+}
+
+/**
+ * Finds workbooks in the chosen document library. Drive search matches on file
+ * content as well as names, so the reply is always trimmed to workbook files by
+ * extension; with nothing typed, the extensions themselves are the search terms
+ * (the OneDrive Excel node's trick).
+ *
+ * While a filter is typed the editor disables "load more" (see listSearchPage),
+ * so pages the trim empties are walked here until one holds a workbook or the
+ * listing ends.
+ */
+export async function searchWorkbooks(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+	paginationToken?: string,
+): Promise<INodeListSearchResult> {
+	const siteId = await resolveSiteId.call(this, 0);
+	const driveId = validatePathSegment(
+		this.getNode(),
+		'Library',
+		String(
+			(this.getNodeParameter('library', 0) as INodeParameterResourceLocator | undefined)?.value ??
+				'',
+		),
+	);
+
+	const typed = filter?.trim() ?? '';
+	const searchText = typed === '' ? WORKBOOK_EXTENSIONS.join(' OR ') : typed;
+	// Doubling any quote keeps the value inside Graph's q='…' literal
+	const resource = `/v1.0/sites/${encodeURIComponent(siteId)}/drives/${encodeURIComponent(driveId)}/root/search(q='${encodeURIComponent(searchText.replace(/'/g, "''"))}')`;
+
+	let nextLink = paginationToken;
+	let workbooks: DriveItem[] = [];
+	do {
+		const response = await (fetchPage<DriveItem>).call(
+			this,
+			resource,
+			{ $select: 'id,name,webUrl,file' },
+			nextLink,
+		);
+		workbooks = (response.value ?? []).filter(isWorkbookFile);
+		nextLink = response['@odata.nextLink'];
+	} while (typed !== '' && workbooks.length === 0 && nextLink !== undefined);
+
+	return {
+		results: toListItems(workbooks, workbookToItem),
+		paginationToken: nextLink,
 	};
 }
 

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/methods/listSearch.test.ts
@@ -4,9 +4,15 @@ import type { Mock } from 'vitest';
 import type { DeepMockProxy } from 'vitest-mock-extended';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
-import { libraryRLC, siteRLC } from '../../descriptions/common.descriptions';
+import { libraryRLC, siteRLC, workbookRLC } from '../../descriptions/common.descriptions';
 import { SERVICE_PRINCIPAL_AUTH } from '../../helpers/constants';
-import { getSheets, getTables, searchLibraries, searchSites } from '../../methods/listSearch';
+import {
+	getSheets,
+	getTables,
+	searchLibraries,
+	searchSites,
+	searchWorkbooks,
+} from '../../methods/listSearch';
 import { MicrosoftExcelSharePoint } from '../../MicrosoftExcelSharePoint.node';
 import * as transport from '../../transport';
 import type * as _importType0 from '../../transport';
@@ -229,6 +235,130 @@ describe('Microsoft Excel (SharePoint) — dropdown search methods', () => {
 		});
 	});
 
+	describe('searchWorkbooks', () => {
+		const libraryParams = {
+			authentication: 'microsoftOAuth2Api',
+			site: { mode: 'id', value: SITE_ID },
+			library: { mode: 'id', value: 'b!drive1' },
+		};
+		const searchPath = (q: string) =>
+			`/v1.0/sites/${encodeURIComponent(SITE_ID)}/drives/b!drive1/root/search(q='${q}')`;
+		const SELECT = { $select: 'id,name,webUrl,file' };
+		const BOOK = { id: 'wb1', name: 'Budget.xlsx', webUrl: 'https://c.sharepoint.com/b', file: {} };
+		const BOOK_ITEM = { name: 'Budget.xlsx', value: 'wb1', url: 'https://c.sharepoint.com/b' };
+
+		beforeEach(() => setParams(libraryParams));
+
+		it('searches the chosen library with the typed text', async () => {
+			apiRequest.mockResolvedValueOnce({ value: [BOOK] });
+
+			const result = await searchWorkbooks.call(ctx, 'budget');
+
+			expect(apiRequest).toHaveBeenCalledWith('GET', searchPath('budget'), {}, SELECT);
+			expect(result.results).toEqual([BOOK_ITEM]);
+		});
+
+		it('searches for the workbook extensions themselves when nothing is typed', async () => {
+			apiRequest.mockResolvedValueOnce({ value: [] });
+
+			await searchWorkbooks.call(ctx);
+
+			expect(apiRequest).toHaveBeenCalledWith('GET', searchPath('.xlsx%20OR%20.xlsm'), {}, SELECT);
+		});
+
+		it('shows only workbook files from a listing that mixes in other types', async () => {
+			apiRequest.mockResolvedValueOnce({
+				value: [
+					BOOK,
+					{ id: 'wb2', name: 'Macros.XLSM', file: {} },
+					{ id: 'doc1', name: 'Notes.docx', file: {} },
+					{ id: 'folder1', name: 'Archive.xlsx', folder: {} },
+					{ id: 'bak1', name: 'report.xlsx.bak', file: {} },
+				],
+			});
+
+			const result = await searchWorkbooks.call(ctx);
+
+			expect(result.results.map((item) => item.value)).toEqual(['wb1', 'wb2']);
+		});
+
+		it('doubles a quote in the typed text so it stays inside the search literal', async () => {
+			apiRequest.mockResolvedValueOnce({ value: [] });
+
+			await searchWorkbooks.call(ctx, "O'Brien");
+
+			expect(apiRequest).toHaveBeenCalledWith('GET', searchPath("O''Brien"), {}, SELECT);
+		});
+
+		it('hands back the next-page link and requests it exactly as returned', async () => {
+			const nextLink = 'https://graph.microsoft.com/v1.0/sites/s/drives/d/root/search?$skiptoken=a';
+			apiRequest.mockResolvedValueOnce({ value: [BOOK], '@odata.nextLink': nextLink });
+
+			const firstPage = await searchWorkbooks.call(ctx);
+			expect(firstPage.paginationToken).toBe(nextLink);
+
+			apiRequest.mockResolvedValueOnce({ value: [] });
+			const secondPage = await searchWorkbooks.call(ctx, undefined, nextLink);
+
+			expect(apiRequest).toHaveBeenLastCalledWith('GET', '', {}, {}, nextLink);
+			expect(secondPage.paginationToken).toBeUndefined();
+		});
+
+		it('keeps walking pages while a filter is typed until one holds a workbook', async () => {
+			const nextLink = 'https://graph.microsoft.com/v1.0/sites/s/drives/d/root/search?$skiptoken=b';
+			apiRequest
+				.mockResolvedValueOnce({
+					value: [{ id: 'doc1', name: 'Budget.docx', file: {} }],
+					'@odata.nextLink': nextLink,
+				})
+				.mockResolvedValueOnce({ value: [BOOK] });
+
+			const result = await searchWorkbooks.call(ctx, 'budget');
+
+			expect(apiRequest).toHaveBeenCalledTimes(2);
+			expect(apiRequest).toHaveBeenLastCalledWith('GET', '', {}, {}, nextLink);
+			expect(result.results).toEqual([BOOK_ITEM]);
+		});
+
+		it('does not auto-page without a filter, even when the trim empties the page', async () => {
+			const nextLink = 'https://graph.microsoft.com/v1.0/sites/s/drives/d/root/search?$skiptoken=c';
+			apiRequest.mockResolvedValueOnce({
+				value: [{ id: 'doc1', name: 'Notes.docx', file: {} }],
+				'@odata.nextLink': nextLink,
+			});
+
+			const result = await searchWorkbooks.call(ctx);
+
+			expect(apiRequest).toHaveBeenCalledTimes(1);
+			expect(result.results).toEqual([]);
+			expect(result.paginationToken).toBe(nextLink);
+		});
+
+		it('rejects when no Library has been chosen yet', async () => {
+			setParams({ ...libraryParams, library: { mode: 'id', value: '' } });
+
+			await expect(searchWorkbooks.call(ctx)).rejects.toThrow("The 'Library' parameter is empty");
+			expect(apiRequest).not.toHaveBeenCalled();
+		});
+
+		it('lists workbooks signed in as an app (Service Principal)', async () => {
+			const { microsoftApiRequest: realApiRequest } =
+				await vi.importActual<typeof _importType0>('../../transport');
+			apiRequest.mockImplementationOnce(realApiRequest);
+			ctx.getCredentials.mockResolvedValue({});
+			ctx.helpers.httpRequestWithAuthentication.mockResolvedValue({ value: [BOOK] });
+			setParams({ ...libraryParams, authentication: SERVICE_PRINCIPAL_AUTH });
+
+			const result = await searchWorkbooks.call(ctx);
+
+			expect(ctx.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+				SERVICE_PRINCIPAL_AUTH,
+				expect.objectContaining({ url: expect.stringContaining("/root/search(q='") }),
+			);
+			expect(result.results).toEqual([BOOK_ITEM]);
+		});
+	});
+
 	describe('getSheets', () => {
 		it('lists the sheets in the workbook', async () => {
 			setParams(byIdParams);
@@ -376,11 +506,22 @@ describe('Microsoft Excel (SharePoint) — dropdown search methods', () => {
 			expect(libraryRLC.default).toEqual({ mode: 'list', value: '' });
 		});
 
+		it('keeps URL as the default Workbook mode, with the list and ID modes alongside', () => {
+			expect(workbookRLC.modes?.map((mode) => mode.name)).toEqual(['url', 'list', 'id']);
+			expect(workbookRLC.modes?.[1].typeOptions?.searchListMethod).toBe('searchWorkbooks');
+			expect(workbookRLC.typeOptions?.loadOptionsDependsOn).toEqual([
+				'site.value',
+				'library.value',
+			]);
+			expect(workbookRLC.default).toEqual({ mode: 'url', value: '' });
+		});
+
 		it('is wired into the node as list-search methods', () => {
 			const node = new MicrosoftExcelSharePoint();
 
 			expect(node.methods?.listSearch?.searchSites).toBe(searchSites);
 			expect(node.methods?.listSearch?.searchLibraries).toBe(searchLibraries);
+			expect(node.methods?.listSearch?.searchWorkbooks).toBe(searchWorkbooks);
 			expect(node.methods?.listSearch?.getSheets).toBe(getSheets);
 			expect(node.methods?.listSearch?.getTables).toBe(getTables);
 		});


### PR DESCRIPTION
## Summary

Part of the [Microsoft Excel (SharePoint) node](https://linear.app/n8n/issue/ENT-204) build. Completes the three-level picker: a searchable **From List** mode on the Workbook field that finds workbooks inside the chosen document library, alongside the existing paste-a-URL (still the default) and By ID modes.

- `searchWorkbooks` list-search method: `GET /v1.0/sites/{site}/drives/{drive}/root/search(q='…')` through the shared transport; with nothing typed it searches for the workbook extensions themselves (the OneDrive node's trick); replies are always trimmed to `.xlsx`/`.xlsm` files because drive search also matches file content.
- While a filter is typed the editor disables "load more", so pages the trim empties are walked until one holds a workbook (same rationale as `listSearchPage`).
- Works under both sign-in methods — requests are site-rooted, so the OneDrive node's "an app can't search a personal drive" limitation doesn't apply.

## How to test

```bash
cd packages/nodes-base
pnpm test nodes/Microsoft/ExcelSharePoint/test/methods/listSearch.test.ts
```

Nine new cases cover the ticket's ACs: typed-text search, extension-only default search, mixed-listing trim (folders and non-workbook files dropped), quote escaping, verbatim next-page links, filtered page-walking, empty-library rejection, and an app-only (Service Principal) variant through the real transport.

The node is hidden until launch; to see the dropdown in the editor, temporarily remove `hidden: true` in `MicrosoftExcelSharePoint.node.ts` and add the node to a workflow.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-204

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

