### PR TITLE
feat(Microsoft Excel (SharePoint) Node): Add Table Get Rows, Get Columns, and Lookup (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/MicrosoftExcelSharePoint.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/MicrosoftExcelSharePoint.node.ts
@@ -7,6 +7,9 @@ import type {
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import * as getAllTables from './actions/table/getAll.operation';
+import * as getTableColumns from './actions/table/getColumns.operation';
+import * as getTableRows from './actions/table/getRows.operation';
+import * as lookupTable from './actions/table/lookup.operation';
 import * as append from './actions/worksheet/append.operation';
 import * as clear from './actions/worksheet/clear.operation';
 import * as deleteWorksheet from './actions/worksheet/deleteWorksheet.operation';
@@ -148,10 +151,28 @@ export class MicrosoftExcelSharePoint implements INodeType {
 				},
 				options: [
 					{
+						name: 'Get Columns',
+						value: 'getColumns',
+						description: "Retrieve a list of the table's columns",
+						action: 'Get columns in table',
+					},
+					{
 						name: 'Get Many',
 						value: 'getAll',
 						description: "Retrieve a list of the workbook's tables",
 						action: 'Get many tables',
+					},
+					{
+						name: 'Get Rows',
+						value: 'getRows',
+						description: "Retrieve a list of the table's rows",
+						action: 'Get rows in table',
+					},
+					{
+						name: 'Lookup',
+						value: 'lookup',
+						description: 'Look for a specific column value and then return the matching row',
+						action: 'Look up column value in table',
 					},
 				],
 				default: 'getAll',
@@ -163,6 +184,9 @@ export class MicrosoftExcelSharePoint implements INodeType {
 			...readRows.description,
 			...getAllWorksheets.description,
 			...getAllTables.description,
+			...getTableColumns.description,
+			...getTableRows.description,
+			...lookupTable.description,
 		],
 	};
 
@@ -185,6 +209,15 @@ export class MicrosoftExcelSharePoint implements INodeType {
 		}
 		if (resource === 'table' && operation === 'getAll') {
 			return [await getAllTables.execute.call(this, items)];
+		}
+		if (resource === 'table' && operation === 'getColumns') {
+			return [await getTableColumns.execute.call(this, items)];
+		}
+		if (resource === 'table' && operation === 'getRows') {
+			return [await getTableRows.execute.call(this, items)];
+		}
+		if (resource === 'table' && operation === 'lookup') {
+			return [await lookupTable.execute.call(this, items)];
 		}
 
 		if (resource === 'worksheet' && operation === 'clear') {

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/table/getColumns.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/table/getColumns.operation.ts
@@ -9,41 +9,29 @@ import { updateDisplayOptions } from '@utils/utilities';
 
 import {
 	libraryRLC,
+	rawDataOutput,
 	returnAllAndLimit,
 	siteRLC,
+	tableRLC,
 	workbookRLC,
+	worksheetRLC,
 } from '../../descriptions/common.descriptions';
-import type { GraphListResponse, GraphTable } from '../../helpers/interfaces';
-import { resolveWorkbookRoot } from '../../helpers/utils';
-import { microsoftApiRequest, microsoftApiRequestAllItems } from '../../transport';
+import { fetchTableCollection, resolveTableEndpoint } from '../../helpers/tableRead';
 
 const properties: INodeProperties[] = [
 	siteRLC,
 	libraryRLC,
 	workbookRLC,
+	worksheetRLC,
+	tableRLC,
 	...returnAllAndLimit,
-	{
-		displayName: 'Options',
-		name: 'options',
-		type: 'collection',
-		placeholder: 'Add option',
-		default: {},
-		options: [
-			{
-				displayName: 'Fields',
-				name: 'fields',
-				type: 'string',
-				default: '',
-				description: 'Fields to include in the response. Separate multiple fields with a comma.',
-			},
-		],
-	},
+	...rawDataOutput,
 ];
 
 const displayOptions = {
 	show: {
 		resource: ['table'],
-		operation: ['getAll'],
+		operation: ['getColumns'],
 	},
 };
 
@@ -53,44 +41,36 @@ export async function execute(
 	this: IExecuteFunctions,
 	items: INodeExecutionData[],
 ): Promise<INodeExecutionData[]> {
-	// https://learn.microsoft.com/en-us/graph/api/workbook-list-tables
+	// https://learn.microsoft.com/en-us/graph/api/table-list-columns
 	const returnData: INodeExecutionData[] = [];
 
-	// Hoisted once for the whole run and passed into resolveWorkbookRoot below,
-	// so a pasted Workbook/Site address is resolved once, not once per item.
 	const workbookRootCache = new Map<string, string>();
 	const siteIdCache = new Map<string, string>();
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const returnAll = this.getNodeParameter('returnAll', i);
+			const rawData = this.getNodeParameter('rawData', i);
 			const options = this.getNodeParameter('options', i, {}) as { fields?: string };
 
 			const qs: IDataObject = {};
-			if (options.fields) {
+			if (rawData && options.fields) {
 				qs.$select = options.fields;
 			}
 
-			const workbookRoot = await resolveWorkbookRoot.call(this, i, workbookRootCache, siteIdCache);
-			const endpoint = `${workbookRoot}/workbook/tables`;
+			const tableEndpoint = await resolveTableEndpoint.call(
+				this,
+				i,
+				workbookRootCache,
+				siteIdCache,
+			);
+			const columns = await fetchTableCollection.call(this, i, `${tableEndpoint}/columns`, qs);
 
-			let responseData: GraphTable[];
-			if (returnAll) {
-				responseData = await (microsoftApiRequestAllItems<GraphTable>).call(this, endpoint, qs);
-			} else {
-				qs.$top = this.getNodeParameter('limit', i);
-				const response = await (microsoftApiRequest<GraphListResponse<GraphTable>>).call(
-					this,
-					'GET',
-					endpoint,
-					{},
-					qs,
-				);
-				responseData = response.value ?? [];
-			}
+			const output: IDataObject | IDataObject[] = rawData
+				? { [this.getNodeParameter('dataProperty', i) as string]: columns }
+				: columns.map((column) => ({ name: column.name }));
 
 			const executionData = this.helpers.constructExecutionMetaData(
-				this.helpers.returnJsonArray(responseData),
+				this.helpers.returnJsonArray(output),
 				{ itemData: { item: i } },
 			);
 			returnData.push.apply(returnData, executionData);

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/table/getRows.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/table/getRows.operation.ts
@@ -9,41 +9,35 @@ import { updateDisplayOptions } from '@utils/utilities';
 
 import {
 	libraryRLC,
+	rawDataOutput,
 	returnAllAndLimit,
 	siteRLC,
+	tableRLC,
 	workbookRLC,
+	worksheetRLC,
 } from '../../descriptions/common.descriptions';
-import type { GraphListResponse, GraphTable } from '../../helpers/interfaces';
-import { resolveWorkbookRoot } from '../../helpers/utils';
-import { microsoftApiRequest, microsoftApiRequestAllItems } from '../../transport';
+import type { GraphTableRow } from '../../helpers/tableRead';
+import {
+	fetchTableCollection,
+	fetchTableColumnNames,
+	resolveTableEndpoint,
+	rowsToObjects,
+} from '../../helpers/tableRead';
 
 const properties: INodeProperties[] = [
 	siteRLC,
 	libraryRLC,
 	workbookRLC,
+	worksheetRLC,
+	tableRLC,
 	...returnAllAndLimit,
-	{
-		displayName: 'Options',
-		name: 'options',
-		type: 'collection',
-		placeholder: 'Add option',
-		default: {},
-		options: [
-			{
-				displayName: 'Fields',
-				name: 'fields',
-				type: 'string',
-				default: '',
-				description: 'Fields to include in the response. Separate multiple fields with a comma.',
-			},
-		],
-	},
+	...rawDataOutput,
 ];
 
 const displayOptions = {
 	show: {
 		resource: ['table'],
-		operation: ['getAll'],
+		operation: ['getRows'],
 	},
 };
 
@@ -53,44 +47,44 @@ export async function execute(
 	this: IExecuteFunctions,
 	items: INodeExecutionData[],
 ): Promise<INodeExecutionData[]> {
-	// https://learn.microsoft.com/en-us/graph/api/workbook-list-tables
+	// https://learn.microsoft.com/en-us/graph/api/table-list-rows
 	const returnData: INodeExecutionData[] = [];
 
-	// Hoisted once for the whole run and passed into resolveWorkbookRoot below,
-	// so a pasted Workbook/Site address is resolved once, not once per item.
 	const workbookRootCache = new Map<string, string>();
 	const siteIdCache = new Map<string, string>();
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const returnAll = this.getNodeParameter('returnAll', i);
+			const rawData = this.getNodeParameter('rawData', i);
 			const options = this.getNodeParameter('options', i, {}) as { fields?: string };
 
 			const qs: IDataObject = {};
-			if (options.fields) {
+			if (rawData && options.fields) {
 				qs.$select = options.fields;
 			}
 
-			const workbookRoot = await resolveWorkbookRoot.call(this, i, workbookRootCache, siteIdCache);
-			const endpoint = `${workbookRoot}/workbook/tables`;
+			const tableEndpoint = await resolveTableEndpoint.call(
+				this,
+				i,
+				workbookRootCache,
+				siteIdCache,
+			);
+			const rows = await (fetchTableCollection<GraphTableRow>).call(
+				this,
+				i,
+				`${tableEndpoint}/rows`,
+				qs,
+			);
 
-			let responseData: GraphTable[];
-			if (returnAll) {
-				responseData = await (microsoftApiRequestAllItems<GraphTable>).call(this, endpoint, qs);
+			let output: IDataObject | IDataObject[];
+			if (rawData) {
+				output = { [this.getNodeParameter('dataProperty', i) as string]: rows };
 			} else {
-				qs.$top = this.getNodeParameter('limit', i);
-				const response = await (microsoftApiRequest<GraphListResponse<GraphTable>>).call(
-					this,
-					'GET',
-					endpoint,
-					{},
-					qs,
-				);
-				responseData = response.value ?? [];
+				output = rowsToObjects(await fetchTableColumnNames.call(this, tableEndpoint), rows);
 			}
 
 			const executionData = this.helpers.constructExecutionMetaData(
-				this.helpers.returnJsonArray(responseData),
+				this.helpers.returnJsonArray(output),
 				{ itemData: { item: i } },
 			);
 			returnData.push.apply(returnData, executionData);

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/table/lookup.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/table/lookup.operation.ts
@@ -1,0 +1,132 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import {
+	libraryRLC,
+	siteRLC,
+	tableRLC,
+	workbookRLC,
+	worksheetRLC,
+} from '../../descriptions/common.descriptions';
+import type { GraphTableRow } from '../../helpers/tableRead';
+import {
+	fetchTableColumnNames,
+	resolveTableEndpoint,
+	rowsToObjects,
+} from '../../helpers/tableRead';
+import { microsoftApiRequestAllItems } from '../../transport';
+
+const properties: INodeProperties[] = [
+	siteRLC,
+	libraryRLC,
+	workbookRLC,
+	worksheetRLC,
+	tableRLC,
+	{
+		displayName: 'Lookup Column',
+		name: 'lookupColumn',
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. Email',
+		required: true,
+		description: 'The name of the column in which to look for value',
+	},
+	{
+		displayName: 'Lookup Value',
+		name: 'lookupValue',
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. frank@example.com',
+		required: true,
+		description: 'The value to look for in column',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		default: {},
+		options: [
+			{
+				displayName: 'Return All Matches',
+				name: 'returnAllMatches',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to return every matching row instead of only the first one',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['table'],
+		operation: ['lookup'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	// https://learn.microsoft.com/en-us/graph/api/table-list-rows
+	const returnData: INodeExecutionData[] = [];
+
+	const workbookRootCache = new Map<string, string>();
+	const siteIdCache = new Map<string, string>();
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const lookupColumn = this.getNodeParameter('lookupColumn', i) as string;
+			const lookupValue = this.getNodeParameter('lookupValue', i) as string;
+			const options = this.getNodeParameter('options', i, {}) as { returnAllMatches?: boolean };
+
+			const tableEndpoint = await resolveTableEndpoint.call(
+				this,
+				i,
+				workbookRootCache,
+				siteIdCache,
+			);
+			const rows = await (microsoftApiRequestAllItems<GraphTableRow>).call(
+				this,
+				`${tableEndpoint}/rows`,
+			);
+			const columnNames = await fetchTableColumnNames.call(this, tableEndpoint);
+
+			if (!columnNames.includes(lookupColumn)) {
+				throw new NodeOperationError(
+					this.getNode(),
+					`Column ${lookupColumn} does not exist on the table selected`,
+					{ itemIndex: i },
+				);
+			}
+
+			const matches = rowsToObjects(columnNames, rows).filter(
+				(row) => row[lookupColumn]?.toString() === lookupValue,
+			);
+			// No match yields no output item, rather than the OneDrive node's
+			// single item with an undefined body.
+			const output = options.returnAllMatches ? matches : matches.slice(0, 1);
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(output),
+				{ itemData: { item: i } },
+			);
+			returnData.push.apply(returnData, executionData);
+		} catch (error) {
+			if (!this.continueOnFail()) throw error;
+
+			const executionErrorData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ error: error.message }),
+				{ itemData: { item: i } },
+			);
+			returnData.push.apply(returnData, executionErrorData);
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/descriptions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/descriptions/common.descriptions.ts
@@ -110,6 +110,78 @@ export const libraryRLC: INodeProperties = {
 	],
 };
 
+/** Return All / Limit pair shared by the list-shaped operations. */
+export const returnAllAndLimit: INodeProperties[] = [
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+			maxValue: 500,
+		},
+		default: 100,
+		description: 'Max number of results to return',
+	},
+];
+
+/** RAW passthrough switches shared by the table read operations. */
+export const rawDataOutput: INodeProperties[] = [
+	{
+		displayName: 'RAW Data',
+		name: 'rawData',
+		type: 'boolean',
+		default: false,
+		description:
+			'Whether the data should be returned RAW instead of parsed into keys according to their header',
+	},
+	{
+		displayName: 'Data Property',
+		name: 'dataProperty',
+		type: 'string',
+		default: 'data',
+		displayOptions: {
+			show: {
+				rawData: [true],
+			},
+		},
+		description: 'The name of the property into which to write the RAW data',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		default: {},
+		options: [
+			{
+				displayName: 'Fields',
+				name: 'fields',
+				type: 'string',
+				default: '',
+				description: 'Fields to include in the response. Separate multiple fields with a comma.',
+				displayOptions: {
+					show: {
+						'/rawData': [true],
+					},
+				},
+			},
+		],
+	},
+];
+
 export const worksheetRLC: INodeProperties = {
 	displayName: 'Sheet',
 	name: 'worksheet',

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
@@ -30,6 +30,18 @@ export const REQUIRED_PERMISSIONS: Record<string, { delegated: string; applicati
 		delegated: 'Sites.Read.All',
 		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
 	},
+	'table:getColumns': {
+		delegated: 'Sites.Read.All',
+		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
+	},
+	'table:getRows': {
+		delegated: 'Sites.Read.All',
+		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
+	},
+	'table:lookup': {
+		delegated: 'Sites.Read.All',
+		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
+	},
 };
 
 // A 404 can come from any of the location segments, so the message must not

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/tableRead.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/tableRead.ts
@@ -1,0 +1,74 @@
+import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
+
+import type { AuthContext, GraphListResponse } from './interfaces';
+import { resolveWorkbookRoot, validatePathSegment } from './utils';
+import { microsoftApiRequest, microsoftApiRequestAllItems } from '../transport';
+
+export type GraphTableRow = IDataObject & { values?: unknown[][] };
+
+/** The Graph root every table request hangs off: {workbook-root}/workbook/tables/{table}. */
+export async function resolveTableEndpoint(
+	this: IExecuteFunctions,
+	itemIndex: number,
+	workbookRootCache: Map<string, string>,
+	siteIdCache: Map<string, string>,
+): Promise<string> {
+	const workbookRoot = await resolveWorkbookRoot.call(
+		this,
+		itemIndex,
+		workbookRootCache,
+		siteIdCache,
+	);
+	const tableId = validatePathSegment(
+		this.getNode(),
+		'Table',
+		this.getNodeParameter('table', itemIndex, '', { extractValue: true }) as string,
+	);
+	return `${workbookRoot}/workbook/tables/${encodeURIComponent(tableId)}`;
+}
+
+/** One page capped by Limit, or every page when Return All is on. */
+export async function fetchTableCollection<T extends IDataObject = IDataObject>(
+	this: IExecuteFunctions,
+	itemIndex: number,
+	endpoint: string,
+	qs: IDataObject,
+): Promise<T[]> {
+	if (this.getNodeParameter('returnAll', itemIndex)) {
+		return await (microsoftApiRequestAllItems<T>).call(this, endpoint, qs);
+	}
+	const response = await (microsoftApiRequest<GraphListResponse<T>>).call(
+		this,
+		'GET',
+		endpoint,
+		{},
+		{ ...qs, $top: this.getNodeParameter('limit', itemIndex) },
+	);
+	return response.value ?? [];
+}
+
+/** Column names in table order — the keys the row objects are built with. */
+export async function fetchTableColumnNames(
+	this: AuthContext,
+	tableEndpoint: string,
+): Promise<string[]> {
+	const columns = await (microsoftApiRequestAllItems<IDataObject & { name?: string }>).call(
+		this,
+		`${tableEndpoint}/columns`,
+		{ $select: 'name' },
+	);
+	return columns.map((column) => String(column.name));
+}
+
+/** Zips each row's values with the column names — the OneDrive node's output shape. */
+export function rowsToObjects(columnNames: string[], rows: GraphTableRow[]): IDataObject[] {
+	return rows.map((row) => {
+		// Null prototype: column names come from the workbook, so a column named
+		// like an object internal must land as a plain own key.
+		const object: IDataObject = Object.create(null) as IDataObject;
+		columnNames.forEach((name, index) => {
+			object[name] = row.values?.[0]?.[index] as IDataObject[string];
+		});
+		return { ...object };
+	});
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/table/read.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/table/read.test.ts
@@ -1,0 +1,225 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { DeepMockProxy } from 'vitest-mock-extended';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import { MicrosoftExcelSharePoint } from '../../MicrosoftExcelSharePoint.node';
+import * as transport from '../../transport';
+import type * as _importType0 from '../../transport';
+
+// Real transport module except the network helpers (see table/getAll.test.ts
+// for why microsoftApiRequestAllItems is mocked alongside microsoftApiRequest).
+vi.mock('../../transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+		microsoftApiRequestAllItems: vi.fn(),
+	};
+});
+
+const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const TABLE_ENDPOINT = `/v1.0/sites/${encodeURIComponent(SITE_ID)}/drives/b!drive1/items/ITEM123/workbook/tables/%7BT1%7D`;
+// The OneDrive node's shapes: rows carry values[0], columns carry a name
+const ROWS = [
+	{ index: 0, values: [['Frank', 'frank@example.com']] },
+	{ index: 1, values: [['Dana', 'dana@example.com']] },
+];
+const COLUMNS = [{ name: 'Name' }, { name: 'Email' }];
+const ROW_OBJECTS = [
+	{ Name: 'Frank', Email: 'frank@example.com' },
+	{ Name: 'Dana', Email: 'dana@example.com' },
+];
+
+describe('Microsoft Excel (SharePoint) — Table: Get Rows, Get Columns, Lookup', () => {
+	let node: MicrosoftExcelSharePoint;
+	let ctx: DeepMockProxy<IExecuteFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+	const apiRequestAllItems = transport.microsoftApiRequestAllItems as Mock;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown) =>
+				(name in params ? params[name] : fallback) as never,
+		);
+	};
+
+	const byIdParams = {
+		resource: 'table',
+		workbook: { mode: 'id', value: 'ITEM123' },
+		site: { mode: 'id', value: SITE_ID },
+		library: { mode: 'id', value: 'b!drive1' },
+		worksheet: { mode: 'id', value: 'Sheet1' },
+		table: '{T1}',
+	};
+
+	// The rows request is the plain one ($top) or the return-all one; the
+	// columns fetch always goes through the return-all helper.
+	const mockRowsAndColumns = () => {
+		apiRequest.mockResolvedValue({ value: ROWS });
+		apiRequestAllItems.mockImplementation(async (endpoint: string) =>
+			endpoint.endsWith('/columns') ? COLUMNS : ROWS,
+		);
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		node = new MicrosoftExcelSharePoint();
+		ctx = mockDeep<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 1 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.helpers.returnJsonArray.mockImplementation((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		);
+		ctx.helpers.constructExecutionMetaData.mockImplementation((inputData, options) =>
+			inputData.map((data) => ({ ...data, pairedItem: options?.itemData })),
+		);
+	});
+
+	describe('getRows', () => {
+		it('maps each row to an object keyed by the column names, matching the OneDrive node', async () => {
+			setParams({ ...byIdParams, operation: 'getRows', returnAll: false, limit: 50 });
+			mockRowsAndColumns();
+
+			const result = await node.execute.call(ctx);
+
+			expect(apiRequest).toHaveBeenCalledWith('GET', `${TABLE_ENDPOINT}/rows`, {}, { $top: 50 });
+			expect(apiRequestAllItems).toHaveBeenCalledWith(`${TABLE_ENDPOINT}/columns`, {
+				$select: 'name',
+			});
+			expect(result[0].map((item) => item.json)).toEqual(ROW_OBJECTS);
+		});
+
+		it('fetches every row page when Return All is on', async () => {
+			setParams({ ...byIdParams, operation: 'getRows', returnAll: true });
+			mockRowsAndColumns();
+
+			const result = await node.execute.call(ctx);
+
+			expect(apiRequest).not.toHaveBeenCalled();
+			expect(apiRequestAllItems).toHaveBeenCalledWith(`${TABLE_ENDPOINT}/rows`, {});
+			expect(result[0].map((item) => item.json)).toEqual(ROW_OBJECTS);
+		});
+
+		it('passes the reply through untouched under the data property in RAW mode', async () => {
+			setParams({
+				...byIdParams,
+				operation: 'getRows',
+				returnAll: false,
+				limit: 100,
+				rawData: true,
+				dataProperty: 'raw',
+				options: { fields: 'index,values' },
+			});
+			apiRequest.mockResolvedValue({ value: ROWS });
+
+			const result = await node.execute.call(ctx);
+
+			expect(apiRequest).toHaveBeenCalledWith(
+				'GET',
+				`${TABLE_ENDPOINT}/rows`,
+				{},
+				{ $select: 'index,values', $top: 100 },
+			);
+			expect(apiRequestAllItems).not.toHaveBeenCalled();
+			expect(result[0]).toEqual([{ json: { raw: ROWS }, pairedItem: { item: 0 } }]);
+		});
+
+		it('keeps a column named like an object internal as a plain row key', async () => {
+			setParams({ ...byIdParams, operation: 'getRows', returnAll: false, limit: 50 });
+			apiRequest.mockResolvedValue({ value: [{ index: 0, values: [['x', 'y']] }] });
+			apiRequestAllItems.mockResolvedValue([{ name: '__proto__' }, { name: 'ok' }]);
+
+			const result = await node.execute.call(ctx);
+
+			expect(Object.getPrototypeOf(result[0][0].json)).toBe(Object.prototype);
+			expect(Object.keys(result[0][0].json)).toEqual(['__proto__', 'ok']);
+		});
+	});
+
+	describe('getColumns', () => {
+		it('returns the column names, matching the OneDrive node', async () => {
+			setParams({ ...byIdParams, operation: 'getColumns', returnAll: false, limit: 50 });
+			apiRequest.mockResolvedValue({ value: [...COLUMNS] });
+
+			const result = await node.execute.call(ctx);
+
+			expect(apiRequest).toHaveBeenCalledWith('GET', `${TABLE_ENDPOINT}/columns`, {}, { $top: 50 });
+			expect(result[0].map((item) => item.json)).toEqual([{ name: 'Name' }, { name: 'Email' }]);
+		});
+
+		it('passes the reply through untouched under the data property in RAW mode', async () => {
+			setParams({
+				...byIdParams,
+				operation: 'getColumns',
+				returnAll: true,
+				rawData: true,
+				dataProperty: 'data',
+			});
+			apiRequestAllItems.mockResolvedValue([...COLUMNS]);
+
+			const result = await node.execute.call(ctx);
+
+			expect(apiRequestAllItems).toHaveBeenCalledWith(`${TABLE_ENDPOINT}/columns`, {});
+			expect(result[0]).toEqual([{ json: { data: COLUMNS }, pairedItem: { item: 0 } }]);
+		});
+	});
+
+	describe('lookup', () => {
+		const lookupParams = {
+			...byIdParams,
+			operation: 'lookup',
+			lookupColumn: 'Email',
+			lookupValue: 'frank@example.com',
+		};
+		const FRANK_TWICE = [...ROWS, { index: 2, values: [['Frank again', 'frank@example.com']] }];
+
+		it('returns only the first match by default', async () => {
+			setParams(lookupParams);
+			apiRequestAllItems.mockImplementation(async (endpoint: string) =>
+				endpoint.endsWith('/columns') ? COLUMNS : FRANK_TWICE,
+			);
+
+			const result = await node.execute.call(ctx);
+
+			expect(result[0].map((item) => item.json)).toEqual([ROW_OBJECTS[0]]);
+		});
+
+		it('returns every match when Return All Matches is on', async () => {
+			setParams({ ...lookupParams, options: { returnAllMatches: true } });
+			apiRequestAllItems.mockImplementation(async (endpoint: string) =>
+				endpoint.endsWith('/columns') ? COLUMNS : FRANK_TWICE,
+			);
+
+			const result = await node.execute.call(ctx);
+
+			expect(result[0].map((item) => item.json)).toEqual([
+				ROW_OBJECTS[0],
+				{ Name: 'Frank again', Email: 'frank@example.com' },
+			]);
+		});
+
+		it('returns no items when nothing matches', async () => {
+			setParams({ ...lookupParams, lookupValue: 'nobody@example.com' });
+			apiRequestAllItems.mockImplementation(async (endpoint: string) =>
+				endpoint.endsWith('/columns') ? COLUMNS : ROWS,
+			);
+
+			const result = await node.execute.call(ctx);
+
+			expect(result[0]).toEqual([]);
+		});
+
+		it('names the missing column when it does not exist on the table', async () => {
+			setParams({ ...lookupParams, lookupColumn: 'Phone' });
+			apiRequestAllItems.mockImplementation(async (endpoint: string) =>
+				endpoint.endsWith('/columns') ? COLUMNS : ROWS,
+			);
+
+			await expect(node.execute.call(ctx)).rejects.toThrow(
+				'Column Phone does not exist on the table selected',
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/tableGetRows.sp.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/tableGetRows.sp.test.ts
@@ -1,0 +1,35 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+// SP smoke test: site/library/workbook by ID, signed in as the Service Principal
+// (app-only) credential. preAuthentication is a no-op in the harness since the
+// fixture already carries an accessToken, so `authenticate` attaches Bearer directly.
+const credentials = {
+	microsoftEntraServicePrincipalApi: {
+		accessToken: 'test-access-token',
+		authentication: 'clientSecret',
+		tenantId: '11111111-1111-1111-1111-111111111111',
+		clientId: '22222222-2222-2222-2222-222222222222',
+		clientSecret: 'test-client-secret',
+		graphApiBaseUrl: 'https://graph.microsoft.com',
+	},
+};
+
+describe('Microsoft Excel (SharePoint), Service Principal table => getRows smoke', () => {
+	const tablePath =
+		'/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123/workbook/tables/Table1';
+
+	nock('https://graph.microsoft.com')
+		.matchHeader('Authorization', 'Bearer test-access-token')
+		.get(`${tablePath}/rows`)
+		.query({ $top: '10' })
+		.reply(200, { value: [{ index: 0, values: [['Frank', 'frank@example.com']] }] })
+		.get(`${tablePath}/columns`)
+		.query({ $select: 'name', $top: '100' })
+		.reply(200, { value: [{ name: 'Name' }, { name: 'Email' }] });
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['tableGetRows.sp.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/tableGetRows.sp.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/tableGetRows.sp.workflow.json
@@ -1,0 +1,82 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "f1c3e440-8930-4c57-be62-3cf3fa801601",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "table",
+				"operation": "getRows",
+				"workbook": {
+					"__rl": true,
+					"mode": "id",
+					"value": "ITEM123"
+				},
+				"site": {
+					"__rl": true,
+					"mode": "id",
+					"value": "contoso.sharepoint.com,g1,g2"
+				},
+				"library": {
+					"__rl": true,
+					"mode": "id",
+					"value": "b!drive1"
+				},
+				"worksheet": {
+					"__rl": true,
+					"mode": "id",
+					"value": "Sheet1"
+				},
+				"table": {
+					"__rl": true,
+					"mode": "id",
+					"value": "Table1"
+				},
+				"returnAll": false,
+				"limit": 10,
+				"rawData": false,
+				"options": {}
+			},
+			"type": "n8n-nodes-base.microsoftExcelSharePoint",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "f1c3e440-8930-4c57-be62-3cf3fa801602",
+			"name": "Microsoft Excel (SharePoint)",
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "sp1",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Excel (SharePoint)",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Microsoft Excel (SharePoint)": [
+			{
+				"json": {
+					"Name": "Frank",
+					"Email": "frank@example.com"
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Part of the [Microsoft Excel (SharePoint) node](https://linear.app/n8n/issue/ENT-206) build. Adds the three table read operations — **Get Rows**, **Get Columns**, and **Lookup** — with output shapes matching the OneDrive Excel node.

- Get Rows: `GET …/workbook/tables/{table}/rows` with Return All / Limit; non-RAW output zips each row's values with the table's column names (fetched once per item), RAW passes the reply through under the chosen data property (with an optional `$select` fields option).
- Get Columns: same shape over `…/columns`; non-RAW returns `{ name }` per column, matching OneDrive.
- Lookup: fetches all rows, filters on the chosen column; first match by default, every match with Return All Matches; a missing column fails with a clear error naming it. One deliberate delta from OneDrive: no match yields no output item instead of a single item with an undefined body.
- Shared plumbing extracted rather than copied: `returnAllAndLimit` / `rawDataOutput` description blocks (Table — Get Many now reuses the former) and `resolveTableEndpoint` / `fetchTableCollection` helpers.
- Row objects are built on a null-prototype accumulator so a workbook column named like an object internal lands as a plain key (pinned by a test).

## How to test

```bash
cd packages/nodes-base
pnpm test nodes/Microsoft/ExcelSharePoint
```

Ten new unit cases cover the ACs (OneDrive-shape parity for rows/columns, RAW passthrough, lookup first/all/no-match/missing-column), plus a Service Principal harness smoke (`tableGetRows.sp.test.ts`, the `.sp.` convention).

The node is hidden until launch; to click through it, temporarily remove `hidden: true` in `MicrosoftExcelSharePoint.node.ts`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-206

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34576">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

