### PR TITLE
chore(core): Allow known file extensions in import-x/extensions rule (no-changelog)

### DIFF
--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -45,7 +45,19 @@ export default defineConfig(
 			// TODO: Remove this
 			'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],
 			'import-x/no-cycle': 'warn',
-			'import-x/extensions': 'warn',
+			'import-x/extensions': [
+				'warn',
+				'never',
+				{
+					pathGroupOverrides: [
+						{
+							pattern:
+								'**/*.{service,controller,registry,repository,entity,dto,middleware,module,strategy,handler,helper,error,request,response,mapper,schema,types,constants,config,util,utils}',
+							action: 'ignore',
+						},
+					],
+				},
+			],
 			'import-x/order': 'warn',
 			'no-ex-assign': 'warn',
 			'no-case-declarations': 'warn',


### PR DESCRIPTION
## Summary

Updates the `import-x/extensions` ESLint rule in `packages/cli` so that imports of files matching a known set of layer suffixes (`service`, `controller`, `registry`, `repository`, `entity`, `dto`, `middleware`, `module`, `strategy`, `handler`, `helper`, `error`, `request`, `response`, `mapper`, `schema`, `types`, `constants`, `config`, `util`/`utils`) are ignored by the extension check.

Previously the rule was set to a bare `'warn'`, which produced noisy warnings on these imports. The rule now uses `'never'` with `pathGroupOverrides` to silence the warning for these known file patterns while keeping the check active elsewhere.

## How to test

Run lint in the `cli` package and confirm the previously-noisy `import-x/extensions` warnings are gone:

```bash
cd packages/cli && pnpm lint
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-86

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

