### PR TITLE
refactor(core): Derive the publish target from the workflow, not the outbox record (no-changelog)

### DIFF
--- a/docs/generated/postgres-schema/README.md
+++ b/docs/generated/postgres-schema/README.md
@@ -115,7 +115,7 @@ Auto-generated from the PostgreSQL migrations in @n8n/db. Do not edit by hand.
 | [public.workflow_dependency](public.workflow_dependency.md) | 9 |  | BASE TABLE |
 | [public.workflow_entity](public.workflow_entity.md) | 20 |  | BASE TABLE |
 | [public.workflow_history](public.workflow_history.md) | 11 |  | BASE TABLE |
-| [public.workflow_publication_outbox](public.workflow_publication_outbox.md) | 7 |  | BASE TABLE |
+| [public.workflow_publication_outbox](public.workflow_publication_outbox.md) | 6 |  | BASE TABLE |
 | [public.workflow_publication_trigger_status](public.workflow_publication_trigger_status.md) | 8 |  | BASE TABLE |
 | [public.workflow_publish_history](public.workflow_publish_history.md) | 6 |  | BASE TABLE |
 | [public.workflow_published_version](public.workflow_published_version.md) | 4 |  | BASE TABLE |
@@ -1367,7 +1367,6 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   text errorMessage
   integer id
-  varchar_36_ publishedVersionId
   varchar_20_ status
   timestamp_3__with_time_zone updatedAt
   varchar_36_ workflowId

--- a/docs/generated/postgres-schema/public.workflow_publication_outbox.md
+++ b/docs/generated/postgres-schema/public.workflow_publication_outbox.md
@@ -7,7 +7,6 @@
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | errorMessage | text |  | true |  |  | Error details for surfacing failed publications to the user. |
 | id | integer |  | false |  |  |  |
-| publishedVersionId | varchar(36) |  | false |  |  | References workflow_history.versionId. |
 | status | varchar(20) |  | false |  |  |  |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | workflowId | varchar(36) |  | false |  |  | References workflow_entity.id. |
@@ -20,7 +19,6 @@
 | PK_b3e2eeee36a4bd044d56468d311 | PRIMARY KEY | PRIMARY KEY (id) |
 | workflow_publication_outbox_createdAt_not_null | n | NOT NULL "createdAt" |
 | workflow_publication_outbox_id_not_null | n | NOT NULL id |
-| workflow_publication_outbox_publishedVersionId_not_null | n | NOT NULL "publishedVersionId" |
 | workflow_publication_outbox_status_not_null | n | NOT NULL status |
 | workflow_publication_outbox_updatedAt_not_null | n | NOT NULL "updatedAt" |
 | workflow_publication_outbox_workflowId_not_null | n | NOT NULL "workflowId" |
@@ -42,7 +40,6 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   text errorMessage
   integer id
-  varchar_36_ publishedVersionId
   varchar_20_ status
   timestamp_3__with_time_zone updatedAt
   varchar_36_ workflowId

--- a/docs/generated/sqlite-schema/README.md
+++ b/docs/generated/sqlite-schema/README.md
@@ -115,7 +115,7 @@ Auto-generated from the SQLite migrations in @n8n/db. Do not edit by hand.
 | [workflow_dependency](workflow_dependency.md) | 9 |  | table |
 | [workflow_entity](workflow_entity.md) | 20 |  | table |
 | [workflow_history](workflow_history.md) | 11 |  | table |
-| [workflow_publication_outbox](workflow_publication_outbox.md) | 7 |  | table |
+| [workflow_publication_outbox](workflow_publication_outbox.md) | 6 |  | table |
 | [workflow_publication_trigger_status](workflow_publication_trigger_status.md) | 8 |  | table |
 | [workflow_publish_history](workflow_publish_history.md) | 6 |  | table |
 | [workflow_published_version](workflow_published_version.md) | 4 |  | table |
@@ -1356,7 +1356,6 @@ erDiagram
   datetime_3_ createdAt
   TEXT errorMessage
   INTEGER id
-  varchar_36_ publishedVersionId
   varchar_20_ status
   datetime_3_ updatedAt
   varchar_36_ workflowId

--- a/docs/generated/sqlite-schema/workflow_publication_outbox.md
+++ b/docs/generated/sqlite-schema/workflow_publication_outbox.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "workflow_publication_outbox" ("id" integer PRIMARY KEY NOT NULL, "workflowId" varchar(36) NOT NULL, "publishedVersionId" varchar(36) NOT NULL, "status" varchar(20) NOT NULL, "errorMessage" text, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "CHK_workflow_publication_outbox_status" CHECK ("status" IN ('pending', 'in_progress', 'completed', 'partial_success', 'failed')))
+CREATE TABLE "workflow_publication_outbox" ("id" integer PRIMARY KEY NOT NULL, "workflowId" varchar(36) NOT NULL, "status" varchar(20) NOT NULL, "errorMessage" text, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), CONSTRAINT "CHK_workflow_publication_outbox_status" CHECK (("status" IN ('pending', 'in_progress', 'completed', 'partial_success', 'failed'))))
 ```
 
 </details>
@@ -18,7 +18,6 @@ CREATE TABLE "workflow_publication_outbox" ("id" integer PRIMARY KEY NOT NULL, "
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 | errorMessage | TEXT |  | true |  |  |  |
 | id | INTEGER |  | false |  |  |  |
-| publishedVersionId | varchar(36) |  | false |  |  |  |
 | status | varchar(20) |  | false |  |  |  |
 | updatedAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 | workflowId | varchar(36) |  | false |  |  |  |
@@ -27,7 +26,7 @@ CREATE TABLE "workflow_publication_outbox" ("id" integer PRIMARY KEY NOT NULL, "
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
-| - | CHECK | CHECK ("status" IN ('pending', 'in_progress', 'completed', 'partial_success', 'failed')) |
+| - | CHECK | CHECK (("status" IN ('pending', 'in_progress', 'completed', 'partial_success', 'failed'))) |
 | id | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
@@ -46,7 +45,6 @@ erDiagram
   datetime_3_ createdAt
   TEXT errorMessage
   INTEGER id
-  varchar_36_ publishedVersionId
   varchar_20_ status
   datetime_3_ updatedAt
   varchar_36_ workflowId

--- a/packages/@n8n/api-types/src/schemas/workflow-publication-status.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/workflow-publication-status.schema.ts
@@ -12,8 +12,6 @@ export const WorkflowPublicationStatusSchema = z.object({
 	status: z.enum(['in_progress', 'published', 'partial', 'failed', 'not_published']),
 	// version whose triggers are currently registered; null if nothing is live
 	liveVersionId: z.string().nullable(),
-	// version being published right now; null unless status === 'in_progress'
-	pendingVersionId: z.string().nullable(),
 	triggers: z.array(
 		z.object({
 			nodeId: z.string(),

--- a/packages/@n8n/db/src/entities/index.ts
+++ b/packages/@n8n/db/src/entities/index.ts
@@ -51,7 +51,6 @@ import { WorkflowDependency } from './workflow-dependency-entity';
 import { WorkflowEntity } from './workflow-entity';
 import { WorkflowHistory } from './workflow-history';
 import {
-	UNPUBLISH_VERSION_SENTINEL,
 	WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxStatus,
 } from './workflow-publication-outbox';
@@ -121,7 +120,6 @@ export {
 	WorkflowHistory,
 	WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxStatus,
-	UNPUBLISH_VERSION_SENTINEL,
 	WorkflowPublicationTriggerStatus,
 	type WorkflowPublicationTriggerStatusType,
 	type WorkflowPublicationTriggerKind,

--- a/packages/@n8n/db/src/entities/workflow-publication-outbox.ts
+++ b/packages/@n8n/db/src/entities/workflow-publication-outbox.ts
@@ -2,14 +2,6 @@ import { Column, Entity, Index, PrimaryGeneratedColumn } from '@n8n/typeorm';
 
 import { WithTimestamps } from './abstract-entity';
 
-/**
- * `publishedVersionId` value for records enqueued to unpublish a workflow that
- * no longer has an `activeVersionId` to carry (the column is NOT NULL). Inert:
- * the applier dispatches an unpublish on the workflow's null `activeVersionId`
- * and never reads the record's version.
- */
-export const UNPUBLISH_VERSION_SENTINEL = '__unpublish__';
-
 export const WorkflowPublicationOutboxStatus = {
 	Pending: 'pending',
 	InProgress: 'in_progress',
@@ -32,9 +24,6 @@ export class WorkflowPublicationOutbox extends WithTimestamps {
 
 	@Column({ type: 'varchar', length: 36 })
 	workflowId: string;
-
-	@Column({ type: 'varchar', length: 36 })
-	publishedVersionId: string;
 
 	@Column({ type: 'varchar', length: 20 })
 	status: WorkflowPublicationOutboxStatus;

--- a/packages/@n8n/db/src/migrations/common/1784564167057-DropPublishedVersionIdFromWorkflowPublicationOutbox.ts
+++ b/packages/@n8n/db/src/migrations/common/1784564167057-DropPublishedVersionIdFromWorkflowPublicationOutbox.ts
@@ -1,0 +1,57 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+/**
+ * Outbox records are pure "reconcile this workflow" markers: the applier
+ * derives the publish target from `workflow_entity.activeVersionId` at claim
+ * time, so `publishedVersionId` is written by no code path and read by none.
+ * Dropping it needs no deprecation release: every writer of this table is
+ * gated behind `N8N_USE_WORKFLOW_PUBLICATION_SERVICE` (default off), so a
+ * same-schema image downgrade cannot break unflagged instances, and the few
+ * flagged ones are centrally managed and can `db:revert`.
+ *
+ * `workflow_publication_outbox` has no incoming foreign keys, so the SQLite
+ * table recreation behind `dropColumns`/`addColumns` cannot cascade into other
+ * tables.
+ */
+export class DropPublishedVersionIdFromWorkflowPublicationOutbox1784564167057
+	implements ReversibleMigration
+{
+	async up({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns('workflow_publication_outbox', ['publishedVersionId'], {
+			recreatesOnSqlite: true,
+		});
+	}
+
+	async down(ctx: MigrationContext) {
+		const {
+			schemaBuilder: { addColumns, addNotNull, column },
+		} = ctx;
+
+		await addColumns('workflow_publication_outbox', [column('publishedVersionId').varchar(36)], {
+			recreatesOnSqlite: true,
+		});
+		await this.backfillVersions(ctx);
+		await addNotNull('workflow_publication_outbox', 'publishedVersionId', {
+			recreatesOnSqlite: true,
+		});
+	}
+
+	/**
+	 * Restore the value the previous release would have written: the workflow's
+	 * `activeVersionId`, or the unpublish sentinel when the workflow is
+	 * unpublished or gone.
+	 */
+	private async backfillVersions({ escape, runQuery }: MigrationContext) {
+		const outbox = escape.tableName('workflow_publication_outbox');
+		const workflow = escape.tableName('workflow_entity');
+
+		await runQuery(
+			`UPDATE ${outbox}
+			 SET "publishedVersionId" = COALESCE(
+				 (SELECT w."activeVersionId" FROM ${workflow} w WHERE w."id" = ${outbox}."workflowId"),
+				 '__unpublish__'
+			 )
+			 WHERE "publishedVersionId" IS NULL`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -226,6 +226,7 @@ import { AddScheduledTaskDispatchedAt1784000000049 } from '../common/17840000000
 import { AddHostRunIdToInstanceAiCheckpoints1784000000050 } from '../common/1784000000050-AddHostRunIdToInstanceAiCheckpoints';
 import { BackfillInstanceAiEventLog1784000000051 } from '../common/1784000000051-BackfillInstanceAiEventLog';
 import { CreateWorkflowReviewRequestTables1784000000052 } from '../common/1784000000052-CreateWorkflowReviewRequestTables';
+import { DropPublishedVersionIdFromWorkflowPublicationOutbox1784564167057 } from '../common/1784564167057-DropPublishedVersionIdFromWorkflowPublicationOutbox';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -457,4 +458,5 @@ export const postgresMigrations: Migration[] = [
 	AddHostRunIdToInstanceAiCheckpoints1784000000050,
 	BackfillInstanceAiEventLog1784000000051,
 	CreateWorkflowReviewRequestTables1784000000052,
+	DropPublishedVersionIdFromWorkflowPublicationOutbox1784564167057,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -218,6 +218,7 @@ import { AddScheduledTaskDispatchedAt1784000000049 } from '../common/17840000000
 import { AddHostRunIdToInstanceAiCheckpoints1784000000050 } from '../common/1784000000050-AddHostRunIdToInstanceAiCheckpoints';
 import { BackfillInstanceAiEventLog1784000000051 } from '../common/1784000000051-BackfillInstanceAiEventLog';
 import { CreateWorkflowReviewRequestTables1784000000052 } from '../common/1784000000052-CreateWorkflowReviewRequestTables';
+import { DropPublishedVersionIdFromWorkflowPublicationOutbox1784564167057 } from '../common/1784564167057-DropPublishedVersionIdFromWorkflowPublicationOutbox';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -439,6 +440,7 @@ const sqliteMigrations: Migration[] = [
 	AddHostRunIdToInstanceAiCheckpoints1784000000050,
 	BackfillInstanceAiEventLog1784000000051,
 	CreateWorkflowReviewRequestTables1784000000052,
+	DropPublishedVersionIdFromWorkflowPublicationOutbox1784564167057,
 ];
 
 export { sqliteMigrations };

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -33,62 +33,60 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 	}
 
 	/**
-	 * Enqueue a publication for `workflowId`. If a pending record is already in
-	 * place for the same workflow, its `publishedVersionId` is updated in place,
-	 * superseding the previous requested version.
+	 * Enqueue a publication for `workflowId`. The record carries no target — it
+	 * marks the workflow as needing reconciliation, and the applier derives the
+	 * target from `workflow_entity.activeVersionId` at claim time. A pending
+	 * record already in place therefore already means "reconcile": the enqueue is
+	 * a no-op, and the applier's fresh read supersedes any earlier intent.
 	 *
-	 * A single atomic UPSERT on the partial unique index
-	 * (`workflowId` where `status = 'pending'`) guarantees at most one pending
-	 * record per workflow without an explicit transaction. Callers only need to
-	 * know the enqueue succeeded, so no row is returned.
+	 * A single atomic insert on the partial unique index (`workflowId` where
+	 * `status` is pending/in_progress) guarantees at most one pending record per
+	 * workflow without an explicit transaction. Nothing is inserted when the
+	 * workflow row no longer exists. Callers only need to know the enqueue
+	 * succeeded, so no row is returned.
 	 *
-	 * Pass `trx` to run the UPSERT inside an existing transaction, e.g. to make
-	 * the enqueue atomic with a `workflow_entity` update.
+	 * Pass `trx` to run the insert inside an existing transaction, e.g. to make
+	 * the enqueue atomic with the `workflow_entity` update it reacts to.
 	 */
-	async enqueue(
-		workflowId: string,
-		publishedVersionId: string,
-		trx?: EntityManager,
-	): Promise<void> {
+	async enqueue(workflowId: string, trx?: EntityManager): Promise<void> {
 		if (this.globalConfig.database.type === 'postgresdb') {
-			await this.enqueueWithPostgresUpsert(workflowId, publishedVersionId, trx ?? this.manager);
+			await this.enqueueWithPostgresUpsert(workflowId, trx ?? this.manager);
 			return;
 		}
 
-		await this.enqueueWithSqliteUpsert(workflowId, publishedVersionId, trx ?? this.manager);
+		await this.enqueueWithSqliteUpsert(workflowId, trx ?? this.manager);
 	}
 
-	private async enqueueWithPostgresUpsert(
-		workflowId: string,
-		publishedVersionId: string,
-		trx: EntityManager,
-	): Promise<void> {
+	private async enqueueWithPostgresUpsert(workflowId: string, trx: EntityManager): Promise<void> {
 		const tableName = this.getTableName('workflow_publication_outbox');
+		const workflowTableName = this.getTableName('workflow_entity');
 
 		// `createdAt`/`updatedAt` carry DB-level defaults, so the insert omits
-		// them; the conflict path bumps `updatedAt` explicitly.
+		// them. COALESCE only satisfies the NOT NULL column until it is dropped —
+		// the value is never read.
 		await trx.query(
 			`INSERT INTO ${tableName} ("workflowId", "publishedVersionId", "status")
-			 VALUES ($1, $2, '${Status.Pending}')
+			 SELECT w."id", COALESCE(w."activeVersionId", '${UNPUBLISH_VERSION_SENTINEL}'), '${Status.Pending}'
+			 FROM ${workflowTableName} w
+			 WHERE w."id" = $1
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
-			 DO UPDATE SET "publishedVersionId" = EXCLUDED."publishedVersionId", "updatedAt" = CURRENT_TIMESTAMP(3)`,
-			[workflowId, publishedVersionId],
+			 DO NOTHING`,
+			[workflowId],
 		);
 	}
 
-	private async enqueueWithSqliteUpsert(
-		workflowId: string,
-		publishedVersionId: string,
-		trx: EntityManager,
-	): Promise<void> {
+	private async enqueueWithSqliteUpsert(workflowId: string, trx: EntityManager): Promise<void> {
 		const tableName = this.getTableName('workflow_publication_outbox');
+		const workflowTableName = this.getTableName('workflow_entity');
 
 		await trx.query(
 			`INSERT INTO ${tableName} ("workflowId", "publishedVersionId", "status")
-			 VALUES (?, ?, '${Status.Pending}')
+			 SELECT w."id", COALESCE(w."activeVersionId", '${UNPUBLISH_VERSION_SENTINEL}'), '${Status.Pending}'
+			 FROM ${workflowTableName} w
+			 WHERE w."id" = ?
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
-			 DO UPDATE SET "publishedVersionId" = excluded."publishedVersionId", "updatedAt" = STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')`,
-			[workflowId, publishedVersionId],
+			 DO NOTHING`,
+			[workflowId],
 		);
 	}
 
@@ -133,7 +131,7 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 				 OR NOT EXISTS (SELECT 1 FROM ${triggerStatusTableName} ts WHERE ts."workflowId" = w."id")
 			 )
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
-			 DO UPDATE SET "publishedVersionId" = EXCLUDED."publishedVersionId", "updatedAt" = CURRENT_TIMESTAMP(3)`,
+			 DO NOTHING`,
 		);
 	}
 
@@ -157,7 +155,7 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 				 OR NOT EXISTS (SELECT 1 FROM ${triggerStatusTableName} ts WHERE ts."workflowId" = w."id")
 			 )
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
-			 DO UPDATE SET "publishedVersionId" = excluded."publishedVersionId", "updatedAt" = STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')`,
+			 DO NOTHING`,
 		);
 	}
 

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -5,7 +5,6 @@ import type { EntityManager } from '@n8n/typeorm';
 import { UnexpectedError } from 'n8n-workflow';
 
 import {
-	UNPUBLISH_VERSION_SENTINEL,
 	WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxStatus as Status,
 } from '../entities/workflow-publication-outbox';
@@ -61,12 +60,10 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		const tableName = this.getTableName('workflow_publication_outbox');
 		const workflowTableName = this.getTableName('workflow_entity');
 
-		// `createdAt`/`updatedAt` carry DB-level defaults, so the insert omits
-		// them. COALESCE only satisfies the NOT NULL column until it is dropped —
-		// the value is never read.
+		// `createdAt`/`updatedAt` carry DB-level defaults, so the insert omits them.
 		await trx.query(
-			`INSERT INTO ${tableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", COALESCE(w."activeVersionId", '${UNPUBLISH_VERSION_SENTINEL}'), '${Status.Pending}'
+			`INSERT INTO ${tableName} ("workflowId", "status")
+			 SELECT w."id", '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."id" = $1
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
@@ -80,8 +77,8 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		const workflowTableName = this.getTableName('workflow_entity');
 
 		await trx.query(
-			`INSERT INTO ${tableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", COALESCE(w."activeVersionId", '${UNPUBLISH_VERSION_SENTINEL}'), '${Status.Pending}'
+			`INSERT INTO ${tableName} ("workflowId", "status")
+			 SELECT w."id", '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."id" = ?
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
@@ -117,8 +114,8 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		const triggerStatusTableName = this.getTableName('workflow_publication_trigger_status');
 
 		await this.query(
-			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", w."activeVersionId", '${Status.Pending}'
+			`INSERT INTO ${outboxTableName} ("workflowId", "status")
+			 SELECT w."id", '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."activeVersionId" IS NOT NULL AND w."isArchived" = false
 			 AND (
@@ -141,8 +138,8 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		const triggerStatusTableName = this.getTableName('workflow_publication_trigger_status');
 
 		await this.query(
-			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", w."activeVersionId", '${Status.Pending}'
+			`INSERT INTO ${outboxTableName} ("workflowId", "status")
+			 SELECT w."id", '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."activeVersionId" IS NOT NULL AND w."isArchived" = 0
 			 AND (
@@ -163,10 +160,10 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 	 * Enqueue a pending publication record for each given workflow that still
 	 * exists, in a single statement. Used by reconciliation, which must be able to
 	 * enqueue whatever its detection returns — refusing a workflow here would
-	 * re-detect it on every pass forever. Published workflows are enqueued at
-	 * their canonical `activeVersionId`; unpublished (including archived) ones get
-	 * an unpublish record that clears their stale trigger-status rows. Idempotent
-	 * via the same partial-unique-index upsert as {@link enqueue}.
+	 * re-detect it on every pass forever — the applier resolves what to do (publish
+	 * the current `activeVersionId`, or unpublish and clear stale trigger-status
+	 * rows) at claim time. Idempotent via the same partial-unique-index upsert as
+	 * {@link enqueue}.
 	 */
 	async enqueueByWorkflowIds(workflowIds: string[]): Promise<void> {
 		if (workflowIds.length === 0) return;
@@ -183,20 +180,14 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		const outboxTableName = this.getTableName('workflow_publication_outbox');
 		const workflowTableName = this.getTableName('workflow_entity');
 
-		// COALESCE: an unpublished workflow has no `activeVersionId`, but the column
-		// is NOT NULL, so those records carry the unpublish sentinel. It is inert —
-		// the applier dispatches an unpublish on the workflow's null
-		// `activeVersionId` and never reads the record's version. (Mirrored in the
-		// sqlite variant below.)
-		//
-		// DO NOTHING, unlike `enqueue`: reconciliation's detection and this enqueue
+		// DO NOTHING, like `enqueue`: reconciliation's detection and this enqueue
 		// are two separate statements, so a publish/unpublish can commit a pending
 		// record in the gap between them (detection's in-flight exclusion saw an
 		// earlier snapshot). Such a record is at least as fresh as this statement's
 		// snapshot — overwriting it could roll the workflow back to a stale version.
 		await this.query(
-			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", COALESCE(w."activeVersionId", '${UNPUBLISH_VERSION_SENTINEL}'), '${Status.Pending}'
+			`INSERT INTO ${outboxTableName} ("workflowId", "status")
+			 SELECT w."id", '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."id" = ANY($1)
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
@@ -211,8 +202,8 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		const placeholders = workflowIds.map(() => '?').join(', ');
 
 		await this.query(
-			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", COALESCE(w."activeVersionId", '${UNPUBLISH_VERSION_SENTINEL}'), '${Status.Pending}'
+			`INSERT INTO ${outboxTableName} ("workflowId", "status")
+			 SELECT w."id", '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."id" IN (${placeholders})
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -1181,11 +1181,7 @@ describe('WorkflowService', () => {
 				expect.objectContaining({ active: true, activeVersionId: TARGET_VERSION_ID }),
 			);
 			// the outbox record is enqueued in the same transaction
-			expect(outboxRepositoryMock.enqueue).toHaveBeenCalledWith(
-				WORKFLOW_ID,
-				TARGET_VERSION_ID,
-				trx,
-			);
+			expect(outboxRepositoryMock.enqueue).toHaveBeenCalledWith(WORKFLOW_ID, trx);
 			// publish-history records (deactivated for the previous version, activated for the
 			// target) are written in the same transaction
 			expect(workflowPublishHistoryRepositoryMock.addRecord).toHaveBeenCalledWith(

--- a/packages/cli/src/workflows/publication/__tests__/publication-status-reporter.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/publication-status-reporter.test.ts
@@ -71,6 +71,7 @@ describe('PublicationStatusReporter', () => {
 	test('completed writes trigger rows, marks the record completed, and clears activation errors', async () => {
 		await reporter.report(makeRecord(), {
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'Webhook', status: 'activated', triggerKind: 'persisted' },
 				{ nodeId: 'b', nodeName: 'Schedule', status: 'activated', triggerKind: 'in-memory' },
@@ -195,6 +196,7 @@ describe('PublicationStatusReporter', () => {
 		await reporter.report(makeRecord(), {
 			type: 'failed',
 			error,
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'Webhook', status: 'activated', triggerKind: 'persisted' },
 				{
@@ -237,6 +239,7 @@ describe('PublicationStatusReporter', () => {
 	test('partial marks partial_success, writes all trigger rows, and pushes the failures without registering activation errors', async () => {
 		await reporter.report(makeRecord(), {
 			type: 'partial',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'Webhook', status: 'activated', triggerKind: 'persisted' },
 				{

--- a/packages/cli/src/workflows/publication/__tests__/publication-status-reporter.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/publication-status-reporter.test.ts
@@ -44,7 +44,6 @@ describe('PublicationStatusReporter', () => {
 		return {
 			id: 1,
 			workflowId: 'wf-1',
-			publishedVersionId: 'v-2',
 			status: 'in_progress',
 			errorMessage: null,
 			createdAt: new Date(),

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -37,7 +37,6 @@ describe('WorkflowPublicationApplier', () => {
 		return {
 			id: 1,
 			workflowId: 'wf-1',
-			publishedVersionId: 'v-2',
 			status: 'in_progress',
 			errorMessage: null,
 			createdAt: new Date(),
@@ -222,11 +221,11 @@ describe('WorkflowPublicationApplier', () => {
 		expect(workflowPublishedVersionRepository.setPublishedVersion).not.toHaveBeenCalled();
 	});
 
-	test("publishes the workflow's current active version, ignoring the version the record was enqueued with", async () => {
-		// The record only marks the workflow as needing reconciliation; the target
-		// is always the workflow's `activeVersionId` at apply time, so a record
-		// enqueued for a since-superseded version still applies the current one.
-		const result = await applier.apply(makeRecord({ publishedVersionId: 'v-stale' }));
+	test("derives the publish target from the workflow's activeVersionId at apply time", async () => {
+		// The record carries no target — it only marks the workflow as needing
+		// reconciliation. Whatever was current at enqueue time, the version that
+		// gets published is the one the workflow points at now.
+		const result = await applier.apply(makeRecord());
 
 		expect(result).toEqual({ type: 'completed', appliedVersionId: 'v-2', triggerStatuses: [] });
 		expect(workflowPublishedVersionRepository.setPublishedVersion).toHaveBeenCalledWith(

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -1,16 +1,15 @@
+import type { Logger } from '@n8n/backend-common';
 import type {
 	WorkflowEntity,
 	WorkflowHistory,
 	WorkflowPublicationOutbox,
 	WorkflowPublishedVersion as WorkflowPublishedVersionEntity,
 	WorkflowPublishedVersionRepository,
-	WorkflowHistoryRepository,
 	WorkflowRepository,
 } from '@n8n/db';
-import type { Logger } from '@n8n/backend-common';
-import { mock } from 'vitest-mock-extended';
 import type { INode } from 'n8n-workflow';
 import { WebhookPathTakenError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
 
 import { WorkflowPublicationApplier } from '@/workflows/publication/workflow-publication-applier';
 import type { WorkflowTriggerActivator } from '@/workflows/triggers/workflow-trigger-activator';
@@ -20,7 +19,6 @@ describe('WorkflowPublicationApplier', () => {
 	const logger = mock<Logger>();
 	logger.scoped.mockReturnValue(logger);
 	const workflowRepository = mock<WorkflowRepository>();
-	const workflowHistoryRepository = mock<WorkflowHistoryRepository>();
 	const workflowPublishedVersionRepository = mock<WorkflowPublishedVersionRepository>();
 	const workflowTriggerActivator = mock<WorkflowTriggerActivator>();
 	const workflowPublishedDataService = mock<WorkflowPublishedDataService>();
@@ -28,7 +26,6 @@ describe('WorkflowPublicationApplier', () => {
 	const applier = new WorkflowPublicationApplier(
 		logger,
 		workflowRepository,
-		workflowHistoryRepository,
 		workflowPublishedVersionRepository,
 		workflowTriggerActivator,
 		workflowPublishedDataService,
@@ -50,12 +47,18 @@ describe('WorkflowPublicationApplier', () => {
 	}
 
 	function makeWorkflow(overrides: Partial<WorkflowEntity> = {}): WorkflowEntity {
-		return {
+		const workflow = {
 			id: 'wf-1',
 			active: true,
 			activeVersionId: 'v-2',
 			...overrides,
 		} as WorkflowEntity;
+		// `resolveVersions` joins the `activeVersion` relation; keep it consistent
+		// with `activeVersionId` unless a test overrides it explicitly.
+		if (!('activeVersion' in overrides)) {
+			workflow.activeVersion = workflow.activeVersionId === 'v-2' ? newVersion : null;
+		}
+		return workflow;
 	}
 
 	function makeVersion(versionId: string): WorkflowHistory {
@@ -102,10 +105,10 @@ describe('WorkflowPublicationApplier', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		workflowRepository.findOneBy.mockResolvedValue(makeWorkflow({ activeVersionId: 'v-1' }));
+		// The publication target is the workflow's `activeVersionId`, not the record.
+		workflowRepository.findOne.mockResolvedValue(makeWorkflow({ activeVersionId: 'v-2' }));
 		workflowPublishedVersionRepository.findOne.mockResolvedValue(makePublishedVersion(oldVersion));
 		workflowPublishedVersionRepository.setPublishedVersion.mockResolvedValue(undefined);
-		workflowHistoryRepository.findOneBy.mockResolvedValue(newVersion);
 		workflowTriggerActivator.getEnabledTriggerNodes.mockReturnValue([]);
 		workflowTriggerActivator.getUnregisteredNonWebhookTriggerNodeIds.mockReturnValue(new Set());
 		workflowTriggerActivator.getNodesWithUnregisteredWebhooks.mockResolvedValue(new Set());
@@ -119,7 +122,7 @@ describe('WorkflowPublicationApplier', () => {
 	});
 
 	test('skips with workflow-not-found when the workflow is gone', async () => {
-		workflowRepository.findOneBy.mockResolvedValue(null);
+		workflowRepository.findOne.mockResolvedValue(null);
 
 		const result = await applier.apply(makeRecord());
 
@@ -131,7 +134,7 @@ describe('WorkflowPublicationApplier', () => {
 	describe('unpublish (activeVersionId is null)', () => {
 		// `activeVersionId` is the source of truth, not the deprecated `active` flag.
 		beforeEach(() => {
-			workflowRepository.findOneBy.mockResolvedValue(
+			workflowRepository.findOne.mockResolvedValue(
 				makeWorkflow({ active: true, activeVersionId: null }),
 			);
 		});
@@ -192,6 +195,7 @@ describe('WorkflowPublicationApplier', () => {
 				'wf-1',
 			);
 			expect(workflowPublishedVersionRepository.setPublishedVersion).not.toHaveBeenCalled();
+			// An unpublished workflow has no active version, so no history row is looked up.
 		});
 
 		test('propagates a teardown failure and leaves the mapping in place', async () => {
@@ -206,14 +210,29 @@ describe('WorkflowPublicationApplier', () => {
 		});
 	});
 
-	test('returns version-missing when the published version history row is gone', async () => {
-		workflowHistoryRepository.findOneBy.mockResolvedValue(null);
+	test('returns version-missing when the active version history row is gone', async () => {
+		// The workflow's `activeVersionId` points at a history row that no longer
+		// exists, so the joined `activeVersion` relation comes back empty.
+		workflowRepository.findOne.mockResolvedValue(makeWorkflow({ activeVersion: null }));
 
 		const result = await applier.apply(makeRecord());
 
 		expect(result).toEqual({ type: 'version-missing' });
 		expect(workflowTriggerActivator.getEnabledTriggerNodes).not.toHaveBeenCalled();
 		expect(workflowPublishedVersionRepository.setPublishedVersion).not.toHaveBeenCalled();
+	});
+
+	test("publishes the workflow's current active version, ignoring the version the record was enqueued with", async () => {
+		// The record only marks the workflow as needing reconciliation; the target
+		// is always the workflow's `activeVersionId` at apply time, so a record
+		// enqueued for a since-superseded version still applies the current one.
+		const result = await applier.apply(makeRecord({ publishedVersionId: 'v-stale' }));
+
+		expect(result).toEqual({ type: 'completed', appliedVersionId: 'v-2', triggerStatuses: [] });
+		expect(workflowPublishedVersionRepository.setPublishedVersion).toHaveBeenCalledWith(
+			'wf-1',
+			'v-2',
+		);
 	});
 
 	test('advances the published version and completes when no triggers changed', async () => {
@@ -224,6 +243,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 			],
@@ -259,6 +279,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'hook', nodeName: 'hook', status: 'activated', triggerKind: 'persisted' },
 				{ nodeId: 'poll', nodeName: 'poll', status: 'activated', triggerKind: 'in-memory' },
@@ -273,6 +294,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 				{ nodeId: 'b', nodeName: 'b', status: 'activated', triggerKind: 'in-memory' },
@@ -303,6 +325,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 			],
@@ -328,6 +351,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 			],
@@ -352,6 +376,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 			],
@@ -377,6 +402,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 				{ nodeId: 'b', nodeName: 'b', status: 'activated', triggerKind: 'in-memory' },
@@ -396,6 +422,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 			],
@@ -440,6 +467,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 			],
@@ -482,6 +510,7 @@ describe('WorkflowPublicationApplier', () => {
 		expect(result).toEqual({
 			type: 'failed',
 			error: expect.objectContaining({ message: 'registration failed' }),
+			appliedVersionId: 'v-2',
 		});
 		expect(workflowPublishedVersionRepository.setPublishedVersion).toHaveBeenCalledWith(
 			'wf-1',
@@ -501,6 +530,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'partial',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 				{
@@ -532,6 +562,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'partial',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 				{
@@ -563,6 +594,7 @@ describe('WorkflowPublicationApplier', () => {
 		expect(result).toEqual({
 			type: 'failed',
 			error,
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{
 					nodeId: 'b',
@@ -597,6 +629,7 @@ describe('WorkflowPublicationApplier', () => {
 			error: expect.objectContaining({
 				message: `Triggers failed to activate: "b": ${deterministic.message}; "c": third-party unavailable`,
 			}),
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{
 					nodeId: 'b',
@@ -630,6 +663,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'partial',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 				{
@@ -655,6 +689,7 @@ describe('WorkflowPublicationApplier', () => {
 
 		expect(result).toEqual({
 			type: 'completed',
+			appliedVersionId: 'v-2',
 			triggerStatuses: [
 				{ nodeId: 'a', nodeName: 'a', status: 'activated', triggerKind: 'in-memory' },
 			],

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -52,7 +52,6 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 		return {
 			id: 1,
 			workflowId: 'wf-1',
-			publishedVersionId: 'v-2',
 			status: 'in_progress',
 			errorMessage: null,
 			createdAt: new Date(),

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -66,7 +66,11 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 		vi.useFakeTimers();
 		tracing.startSpan.mockImplementation(async (_opts, spanCb) => await spanCb(mock<Span>()));
 		outboxRepository.claimNextPendingRecord.mockResolvedValue(null);
-		applier.apply.mockResolvedValue({ type: 'completed', triggerStatuses: [] });
+		applier.apply.mockResolvedValue({
+			type: 'completed',
+			appliedVersionId: 'v-1',
+			triggerStatuses: [],
+		});
 		reporter.report.mockResolvedValue(undefined);
 		consumer = createConsumer();
 	});
@@ -219,7 +223,7 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 				started.push(record.id);
 				startedSignals.get(record.id)!();
 				await new Promise<void>((resolve) => releases.set(record.id, resolve));
-				return { type: 'completed', triggerStatuses: [] };
+				return { type: 'completed', appliedVersionId: 'v-1', triggerStatuses: [] };
 			});
 
 			consumer.startPolling();
@@ -258,7 +262,7 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 				await new Promise<void>((resolve) => {
 					releaseApply = resolve;
 				});
-				return { type: 'completed', triggerStatuses: [] };
+				return { type: 'completed', appliedVersionId: 'v-1', triggerStatuses: [] };
 			});
 
 			consumer.startPolling();
@@ -288,7 +292,11 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 	describe('processRecord', () => {
 		test('applies the record then reports the result', async () => {
 			const record = makeRecord();
-			const result: PublicationResult = { type: 'completed', triggerStatuses: [] };
+			const result: PublicationResult = {
+				type: 'completed',
+				appliedVersionId: 'v-1',
+				triggerStatuses: [],
+			};
 			applier.apply.mockResolvedValue(result);
 
 			await consumer.processRecord(record);
@@ -343,11 +351,15 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 		}
 
 		test.each([
-			[{ type: 'completed', triggerStatuses: [] }, 'published', 'none'],
+			[{ type: 'completed', appliedVersionId: 'v-1', triggerStatuses: [] }, 'published', 'none'],
 			[{ type: 'unpublished' }, 'unpublished', 'none'],
 			[{ type: 'skipped', reason: 'workflow-not-found' }, 'skipped', 'workflow_not_found'],
 			[{ type: 'version-missing' }, 'failed', 'version_missing'],
-			[{ type: 'partial', triggerStatuses: [] }, 'partial_success', 'none'],
+			[
+				{ type: 'partial', appliedVersionId: 'v-1', triggerStatuses: [] },
+				'partial_success',
+				'none',
+			],
 			[{ type: 'failed', error: new Error('boom') }, 'failed', 'none'],
 		] as Array<[PublicationResult, string, string]>)(
 			'emits result=%o as result=%s reason=%s',
@@ -363,7 +375,11 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 		);
 
 		test('emits a failed outcome when the reporter throws', async () => {
-			applier.apply.mockResolvedValue({ type: 'completed', triggerStatuses: [] });
+			applier.apply.mockResolvedValue({
+				type: 'completed',
+				appliedVersionId: 'v-1',
+				triggerStatuses: [],
+			});
 			reporter.report.mockRejectedValue(new Error('db write failed'));
 
 			await consumer.processRecord(makeRecord());

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
@@ -26,7 +26,6 @@ describe('WorkflowPublicationStatusService', () => {
 		return {
 			id: 1,
 			workflowId: WORKFLOW_ID,
-			publishedVersionId: 'v-2',
 			status: 'completed',
 			errorMessage: null,
 			createdAt: new Date(),
@@ -66,7 +65,7 @@ describe('WorkflowPublicationStatusService', () => {
 	describe('first publish in flight (no rows; in-flight in_progress)', () => {
 		it('returns in_progress with a null live version', async () => {
 			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'in_progress', publishedVersionId: 'v-2' }),
+				makeOutbox({ status: 'in_progress' }),
 			);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
 
@@ -81,7 +80,7 @@ describe('WorkflowPublicationStatusService', () => {
 	describe('first publish pending (no rows; in-flight pending)', () => {
 		it('returns in_progress with a null live version', async () => {
 			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'pending', publishedVersionId: 'v-2' }),
+				makeOutbox({ status: 'pending' }),
 			);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
 
@@ -96,7 +95,7 @@ describe('WorkflowPublicationStatusService', () => {
 	describe('republish over live v1 (rows v1 all activated; in-flight in_progress record)', () => {
 		it('returns in_progress with live v1 and pending v2', async () => {
 			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'in_progress', publishedVersionId: 'v-2' }),
+				makeOutbox({ status: 'in_progress' }),
 			);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
 				makeRow({ versionId: 'v-1', status: 'activated' }),

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
@@ -59,13 +59,12 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('not_published');
 			expect(result.liveVersionId).toBeNull();
-			expect(result.pendingVersionId).toBeNull();
 			expect(result.triggers).toEqual([]);
 		});
 	});
 
 	describe('first publish in flight (no rows; in-flight in_progress)', () => {
-		it('returns in_progress with pending version and null live version', async () => {
+		it('returns in_progress with a null live version', async () => {
 			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
 				makeOutbox({ status: 'in_progress', publishedVersionId: 'v-2' }),
 			);
@@ -75,13 +74,12 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('in_progress');
 			expect(result.liveVersionId).toBeNull();
-			expect(result.pendingVersionId).toBe('v-2');
 			expect(result.triggers).toEqual([]);
 		});
 	});
 
 	describe('first publish pending (no rows; in-flight pending)', () => {
-		it('returns in_progress with pending version and null live version', async () => {
+		it('returns in_progress with a null live version', async () => {
 			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
 				makeOutbox({ status: 'pending', publishedVersionId: 'v-2' }),
 			);
@@ -91,12 +89,11 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('in_progress');
 			expect(result.liveVersionId).toBeNull();
-			expect(result.pendingVersionId).toBe('v-2');
 			expect(result.triggers).toEqual([]);
 		});
 	});
 
-	describe('republish over live v1 (rows v1 all activated; in-flight in_progress pubVer v2)', () => {
+	describe('republish over live v1 (rows v1 all activated; in-flight in_progress record)', () => {
 		it('returns in_progress with live v1 and pending v2', async () => {
 			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
 				makeOutbox({ status: 'in_progress', publishedVersionId: 'v-2' }),
@@ -109,7 +106,6 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('in_progress');
 			expect(result.liveVersionId).toBe('v-1');
-			expect(result.pendingVersionId).toBe('v-2');
 		});
 	});
 
@@ -125,7 +121,6 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('published');
 			expect(result.liveVersionId).toBe('v-2');
-			expect(result.pendingVersionId).toBeNull();
 		});
 	});
 
@@ -141,7 +136,6 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('partial');
 			expect(result.liveVersionId).toBe('v-2');
-			expect(result.pendingVersionId).toBeNull();
 		});
 	});
 
@@ -157,7 +151,6 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('failed');
 			expect(result.liveVersionId).toBeNull();
-			expect(result.pendingVersionId).toBeNull();
 		});
 	});
 
@@ -170,7 +163,6 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('not_published');
 			expect(result.liveVersionId).toBeNull();
-			expect(result.pendingVersionId).toBeNull();
 		});
 	});
 
@@ -183,7 +175,6 @@ describe('WorkflowPublicationStatusService', () => {
 
 			expect(result.status).toBe('not_published');
 			expect(result.liveVersionId).toBeNull();
-			expect(result.pendingVersionId).toBeNull();
 		});
 	});
 

--- a/packages/cli/src/workflows/publication/publication-result.ts
+++ b/packages/cli/src/workflows/publication/publication-result.ts
@@ -39,8 +39,12 @@ export type TriggerPublicationStatus =
  * the single place mapping outcomes to terminal statuses and side effects.
  */
 export type PublicationResult =
-	/** Triggers reconciled (or no change needed); the published version advanced. */
-	| { type: 'completed'; triggerStatuses: TriggerPublicationStatus[] }
+	/**
+	 * Triggers reconciled (or no change needed); the published version advanced to
+	 * `appliedVersionId` — the workflow's `activeVersionId` at apply time, which
+	 * is what the reporter stamps into trigger-status rows and UI pushes.
+	 */
+	| { type: 'completed'; appliedVersionId: string; triggerStatuses: TriggerPublicationStatus[] }
 	/**
 	 * The workflow was unpublished: the triggers of the previously published
 	 * version were torn down and the `workflow_published_version` mapping removed.
@@ -49,13 +53,23 @@ export type PublicationResult =
 	| { type: 'unpublished' }
 	/** No trigger work was required; the record is completed without changes. */
 	| { type: 'skipped'; reason: PublicationSkipReason }
-	/** The history row for the published version is gone; the record is failed. */
+	/** The history row for the workflow's active version is gone; the record is failed. */
 	| { type: 'version-missing' }
 	/**
-	 * The published version advanced and some triggers are running, but others
-	 * failed to register. The record is marked `partial_success` and the workflow
-	 * stays published (no auto-unpublish); per-trigger detail is in `triggerStatuses`.
+	 * The published version advanced to `appliedVersionId` and some triggers are
+	 * running, but others failed to register. The record is marked
+	 * `partial_success` and the workflow stays published (no auto-unpublish);
+	 * per-trigger detail is in `triggerStatuses`.
 	 */
-	| { type: 'partial'; triggerStatuses: TriggerPublicationStatus[] }
-	/** The publication failed; the record is failed and the error is reported. */
-	| { type: 'failed'; error: Error; triggerStatuses?: TriggerPublicationStatus[] };
+	| { type: 'partial'; appliedVersionId: string; triggerStatuses: TriggerPublicationStatus[] }
+	/**
+	 * The publication failed; the record is failed and the error is reported.
+	 * `triggerStatuses` (with the `appliedVersionId` they were attempted at) are
+	 * present when the failure happened after the version advanced.
+	 */
+	| {
+			type: 'failed';
+			error: Error;
+			appliedVersionId?: string;
+			triggerStatuses?: TriggerPublicationStatus[];
+	  };

--- a/packages/cli/src/workflows/publication/publication-status-reporter.ts
+++ b/packages/cli/src/workflows/publication/publication-status-reporter.ts
@@ -42,10 +42,10 @@ export class PublicationStatusReporter {
 	async report(record: WorkflowPublicationOutbox, result: PublicationResult): Promise<void> {
 		switch (result.type) {
 			case 'completed': {
-				await this.complete(record, this.toRows(record, result.triggerStatuses));
+				await this.complete(record, this.toRows(result.appliedVersionId, result.triggerStatuses));
 				this.pushStatus({
 					type: 'workflowActivated',
-					data: { workflowId: record.workflowId, activeVersionId: record.publishedVersionId },
+					data: { workflowId: record.workflowId, activeVersionId: result.appliedVersionId },
 				});
 				return;
 			}
@@ -69,7 +69,6 @@ export class PublicationStatusReporter {
 				const errorMessage = 'Published version not found';
 				this.logger.warn('Published version not found, marking outbox record as failed', {
 					workflowId: record.workflowId,
-					publishedVersionId: record.publishedVersionId,
 					outboxId: record.id,
 				});
 				await this.outboxRepository.markFailed(record.id, errorMessage);
@@ -78,12 +77,12 @@ export class PublicationStatusReporter {
 			}
 
 			case 'failed': {
-				const { triggerStatuses } = result;
+				const { triggerStatuses, appliedVersionId } = result;
 				await this.outboxRepository.manager.transaction(async (trx) => {
-					if (triggerStatuses) {
+					if (triggerStatuses && appliedVersionId) {
 						await this.triggerStatusRepository.replaceForWorkflow(
 							record.workflowId,
-							this.toRows(record, triggerStatuses),
+							this.toRows(appliedVersionId, triggerStatuses),
 							trx,
 						);
 					}
@@ -95,7 +94,7 @@ export class PublicationStatusReporter {
 			}
 
 			case 'partial': {
-				await this.reportPartial(record, result.triggerStatuses);
+				await this.reportPartial(record, result.appliedVersionId, result.triggerStatuses);
 				return;
 			}
 		}
@@ -109,6 +108,7 @@ export class PublicationStatusReporter {
 	 */
 	private async reportPartial(
 		record: WorkflowPublicationOutbox,
+		appliedVersionId: string,
 		triggerStatuses: TriggerPublicationStatus[],
 	): Promise<void> {
 		const failures = triggerStatuses.filter(
@@ -125,7 +125,7 @@ export class PublicationStatusReporter {
 		await this.outboxRepository.manager.transaction(async (trx) => {
 			await this.triggerStatusRepository.replaceForWorkflow(
 				record.workflowId,
-				this.toRows(record, triggerStatuses),
+				this.toRows(appliedVersionId, triggerStatuses),
 				trx,
 			);
 			await this.outboxRepository.markPartialSuccess(record.id, errorMessage, trx);
@@ -135,7 +135,7 @@ export class PublicationStatusReporter {
 			type: 'workflowPartiallyActivated',
 			data: {
 				workflowId: record.workflowId,
-				activeVersionId: record.publishedVersionId,
+				activeVersionId: appliedVersionId,
 				errorMessage,
 				failedNodes: failures.map((triggerStatus) => ({
 					nodeId: triggerStatus.nodeId,
@@ -146,14 +146,14 @@ export class PublicationStatusReporter {
 		});
 	}
 
-	/** Maps trigger publication statuses to repository row objects, stamping the published version. */
+	/** Maps trigger publication statuses to repository row objects, stamping the version they were applied at. */
 	private toRows(
-		record: WorkflowPublicationOutbox,
+		appliedVersionId: string,
 		statuses: TriggerPublicationStatus[],
 	): TriggerStatusRow[] {
 		return statuses.map((triggerStatus) => ({
 			nodeId: triggerStatus.nodeId,
-			versionId: record.publishedVersionId,
+			versionId: appliedVersionId,
 			status: triggerStatus.status,
 			triggerKind: triggerStatus.triggerKind,
 			errorMessage: triggerStatus.status === 'failed' ? triggerStatus.errorMessage : null,

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -2,7 +2,6 @@ import { Logger } from '@n8n/backend-common';
 import {
 	WorkflowEntity,
 	WorkflowHistory,
-	WorkflowHistoryRepository,
 	WorkflowPublicationOutbox,
 	WorkflowPublishedVersionRepository,
 	WorkflowRepository,
@@ -38,7 +37,6 @@ export class WorkflowPublicationApplier {
 	constructor(
 		private readonly logger: Logger,
 		private readonly workflowRepository: WorkflowRepository,
-		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
 		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
 		private readonly workflowTriggerActivator: WorkflowTriggerActivator,
 		private readonly workflowPublishedDataService: WorkflowPublishedDataService,
@@ -48,8 +46,12 @@ export class WorkflowPublicationApplier {
 
 	/**
 	 * Applies a single publication outbox record, dispatching to {@link publish}
-	 * (reconcile triggers to the requested version) or {@link unpublish} (tear the
-	 * published triggers down) based on the workflow's current state.
+	 * (reconcile triggers to the workflow's current `activeVersionId`) or
+	 * {@link unpublish} (tear the published triggers down) based on the workflow's
+	 * current state. The record carries no target of its own — it only marks the
+	 * workflow as needing reconciliation; the target is always derived fresh from
+	 * `workflow_entity`, so a record can never apply a version that has since been
+	 * superseded.
 	 *
 	 * The caller must uphold these invariants for `apply` to behave correctly:
 	 *
@@ -108,7 +110,7 @@ export class WorkflowPublicationApplier {
 			`Calculated trigger diff for workflow publication: ${toAdd.size} to add, ${toRemove.size} to remove`,
 			{
 				workflowId: record.workflowId,
-				publishedVersionId: record.publishedVersionId,
+				publishedVersionId: newVersion.versionId,
 				toAdd: Array.from(toAdd),
 				toRemove: Array.from(toRemove),
 			},
@@ -131,9 +133,10 @@ export class WorkflowPublicationApplier {
 		// No trigger changed: advance the published version and finish. Unchanged
 		// triggers keep running and re-read the new version on their next fire.
 		if (toAdd.size === 0 && toRemove.size === 0) {
-			await this.advancePublishedVersion(record);
+			await this.advancePublishedVersion(record.workflowId, newVersion.versionId);
 			return {
 				type: 'completed',
+				appliedVersionId: newVersion.versionId,
 				triggerStatuses: this.buildTriggerStatuses(desiredTriggerNodes, triggerKinds, {
 					activated: [],
 					failures: [],
@@ -148,23 +151,29 @@ export class WorkflowPublicationApplier {
 			await this.workflowTriggerActivator.deactivate(workflow, oldVersion, toRemove);
 		}
 
-		await this.advancePublishedVersion(record);
+		await this.advancePublishedVersion(record.workflowId, newVersion.versionId);
 
 		try {
 			if (toAdd.size > 0) {
 				const outcome = await this.workflowTriggerActivator.activate(workflow, newVersion, toAdd);
-				return this.classifyActivationOutcome(outcome, desiredTriggerNodes, triggerKinds);
+				return this.classifyActivationOutcome(
+					outcome,
+					desiredTriggerNodes,
+					triggerKinds,
+					newVersion.versionId,
+				);
 			}
 
 			if (toRemove.size > 0) {
 				await this.workflowTriggerActivator.updateTriggerCount(workflow, newVersion);
 			}
 		} catch (e) {
-			return { type: 'failed', error: ensureError(e) };
+			return { type: 'failed', error: ensureError(e), appliedVersionId: newVersion.versionId };
 		}
 
 		return {
 			type: 'completed',
+			appliedVersionId: newVersion.versionId,
 			triggerStatuses: this.buildTriggerStatuses(desiredTriggerNodes, triggerKinds, {
 				activated: [],
 				failures: [],
@@ -220,18 +229,26 @@ export class WorkflowPublicationApplier {
 		outcome: TriggerActivationOutcome,
 		desiredTriggerNodes: INode[],
 		triggerKinds: Map<INode['id'], WorkflowPublicationTriggerKind>,
+		appliedVersionId: string,
 	): PublicationResult {
 		const triggerStatuses = this.buildTriggerStatuses(desiredTriggerNodes, triggerKinds, outcome);
-		if (outcome.failures.length === 0) return { type: 'completed', triggerStatuses };
+		if (outcome.failures.length === 0) {
+			return { type: 'completed', appliedVersionId, triggerStatuses };
+		}
 
 		// Check whether this is a partial or full failure: If at least one trigger
 		// has been activated successfully, it's partial.
 		const hasRunningTrigger = triggerStatuses.some((s) => s.status === 'activated');
 		if (!hasRunningTrigger) {
-			return { type: 'failed', error: this.toActivationError(outcome.failures), triggerStatuses };
+			return {
+				type: 'failed',
+				error: this.toActivationError(outcome.failures),
+				appliedVersionId,
+				triggerStatuses,
+			};
 		}
 
-		return { type: 'partial', triggerStatuses };
+		return { type: 'partial', appliedVersionId, triggerStatuses };
 	}
 
 	/**
@@ -278,26 +295,32 @@ export class WorkflowPublicationApplier {
 
 	/**
 	 * Loads the workflow and the two versions whose triggers are diffed: the
-	 * version being published (`newVersion`, null if its history row no longer
-	 * exists) and the currently published version (`oldVersion`, null on a first
-	 * publication). The workflow is loaded independently of the published-version
-	 * mapping so a first publication (no mapping row yet) still resolves it.
+	 * version being published (`newVersion` — the workflow's `activeVersion`
+	 * relation, joined in the same query; null if the workflow is unpublished or
+	 * the history row no longer exists) and the currently published version
+	 * (`oldVersion`, null on a first publication). The workflow is loaded
+	 * independently of the published-version mapping so a first publication (no
+	 * mapping row yet) still resolves it.
 	 */
 	private async resolveVersions(record: WorkflowPublicationOutbox): Promise<{
 		workflow: WorkflowEntity | null;
 		oldVersion: WorkflowHistory | null;
 		newVersion: WorkflowHistory | null;
 	}> {
-		const [workflow, currentlyPublishedVersion, newVersion] = await Promise.all([
-			this.workflowRepository.findOneBy({ id: record.workflowId }),
+		const [workflow, currentlyPublishedVersion] = await Promise.all([
+			this.workflowRepository.findOne({
+				where: { id: record.workflowId },
+				relations: { activeVersion: true },
+				loadEagerRelations: false,
+			}),
 			this.workflowPublishedVersionRepository.findOne({
 				where: { workflowId: record.workflowId },
 				relations: { publishedVersion: true },
 				loadEagerRelations: false,
 			}),
-			this.workflowHistoryRepository.findOneBy({ versionId: record.publishedVersionId }),
 		]);
 
+		const newVersion = workflow?.activeVersion ?? null;
 		const oldVersion = currentlyPublishedVersion?.publishedVersion ?? null;
 
 		return { workflow, oldVersion, newVersion };
@@ -308,15 +331,12 @@ export class WorkflowPublicationApplier {
 	 * the new triggers so they execute the newly published version rather than
 	 * the previous one.
 	 */
-	private async advancePublishedVersion(record: WorkflowPublicationOutbox) {
+	private async advancePublishedVersion(workflowId: string, versionId: string) {
 		// Invalidate → write → refresh: with the cache empty across the write, reads
 		// fall through to the database (the source of truth) rather than ever serving
 		// a stale version, before the new version is cached again.
-		await this.workflowPublishedDataService.invalidateCache(record.workflowId);
-		await this.workflowPublishedVersionRepository.setPublishedVersion(
-			record.workflowId,
-			record.publishedVersionId,
-		);
-		await this.workflowPublishedDataService.refreshCache(record.workflowId);
+		await this.workflowPublishedDataService.invalidateCache(workflowId);
+		await this.workflowPublishedVersionRepository.setPublishedVersion(workflowId, versionId);
+		await this.workflowPublishedDataService.refreshCache(workflowId);
 	}
 }

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -110,7 +110,7 @@ export class WorkflowPublicationApplier {
 			`Calculated trigger diff for workflow publication: ${toAdd.size} to add, ${toRemove.size} to remove`,
 			{
 				workflowId: record.workflowId,
-				publishedVersionId: newVersion.versionId,
+				appliedVersionId: newVersion.versionId,
 				toAdd: Array.from(toAdd),
 				toRemove: Array.from(toRemove),
 			},

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -215,7 +215,6 @@ export class WorkflowPublicationOutboxConsumer {
 				attributes: {
 					...this.tracing.pickWorkflowAttributes({ id: record.workflowId }),
 					'n8n.publication.outbox_id': record.id,
-					'n8n.publication.published_version_id': record.publishedVersionId,
 				},
 			},
 			async (span) => {
@@ -235,7 +234,6 @@ export class WorkflowPublicationOutboxConsumer {
 					this.logger.debug('Started processing workflow publication outbox record', {
 						outboxId: record.id,
 						workflowId: record.workflowId,
-						publishedVersionId: record.publishedVersionId,
 					});
 
 					const startedAt = Date.now();
@@ -249,6 +247,12 @@ export class WorkflowPublicationOutboxConsumer {
 							type: 'failed',
 							error: new UnexpectedError(`Unexpected: ${cause.message}`, { cause }),
 						};
+					}
+
+					// Set post-apply: the record carries no target, so the version only
+					// exists once the applier has derived and applied it.
+					if ('appliedVersionId' in result && result.appliedVersionId) {
+						span.setAttribute('n8n.publication.applied_version_id', result.appliedVersionId);
 					}
 
 					let reporterFailed = false;

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -36,14 +36,13 @@ export class WorkflowPublicationStatusService {
 		}));
 
 		const isPublishing = inFlightPublication !== null;
-		const pendingVersionId = inFlightPublication?.publishedVersionId ?? null;
 
 		// The settled rows ARE the running triggers; if none are activated, nothing is live.
 		const activatedRow = currentTriggerStatuses.find((r) => r.status === 'activated');
 		const liveVersionId = activatedRow?.versionId ?? null;
 
 		const status = this.deriveStatus(isPublishing, currentTriggerStatuses);
-		return { status, liveVersionId, pendingVersionId, triggers };
+		return { status, liveVersionId, triggers };
 	}
 
 	private deriveStatus(

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -1433,7 +1433,7 @@ export class WorkflowService {
 				trx,
 			);
 
-			await this.outboxRepository.enqueue(workflowId, versionIdToActivate, trx);
+			await this.outboxRepository.enqueue(workflowId, trx);
 		});
 
 		// Wake the leader now that the record is committed, so it drains without
@@ -1474,7 +1474,7 @@ export class WorkflowService {
 				trx,
 			);
 
-			await this.outboxRepository.enqueue(workflowId, deactivatedVersionId, trx);
+			await this.outboxRepository.enqueue(workflowId, trx);
 
 			// Durable jobs are DB state, so their removal commits here rather than
 			// waiting on the leader's outbox handler: a lost hand-off would otherwise

--- a/packages/cli/test/integration/commands/start.cmd.test.ts
+++ b/packages/cli/test/integration/commands/start.cmd.test.ts
@@ -136,7 +136,7 @@ describe('Start.run() with workflow publication service', () => {
 		);
 
 		const outboxRepository = Container.get(WorkflowPublicationOutboxRepository);
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 
 		// What a follower's publish triggers on this (leader) instance via Redis.
 		// Re-emitted per retry: a wake-up that lands while a previous drain is

--- a/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
@@ -29,45 +29,65 @@ describe('WorkflowPublicationOutboxRepository', () => {
 	});
 
 	it('enqueues a pending record that can then be claimed', async () => {
-		await repository.enqueue('wf-1', 'v-1');
+		const workflow = await createActiveWorkflow();
+
+		await repository.enqueue(workflow.id);
 
 		const claimed = await repository.claimNextPendingRecord();
 
-		expect(claimed?.workflowId).toBe('wf-1');
-		expect(claimed?.publishedVersionId).toBe('v-1');
+		expect(claimed?.workflowId).toBe(workflow.id);
+		expect(claimed?.publishedVersionId).toBe(workflow.activeVersionId);
 		expect(claimed?.status).toBe('in_progress');
 
 		const claimedAgain = await repository.claimNextPendingRecord();
 		expect(claimedAgain).toBeNull();
 	});
 
-	it('supersedes an existing pending record when re-enqueued for the same workflow', async () => {
-		await repository.enqueue('wf-1', 'v-1');
-		await repository.enqueue('wf-1', 'v-2');
+	it('is a no-op when a pending record already exists', async () => {
+		const workflow = await createActiveWorkflow();
+		await repository.enqueue(workflow.id);
+		const [original] = await repository.find({ where: { status: 'pending' } });
 
-		const claimed = await repository.claimNextPendingRecord();
-		expect(claimed?.workflowId).toBe('wf-1');
-		expect(claimed?.publishedVersionId).toBe('v-2');
+		await repository.enqueue(workflow.id);
 
-		// Only one record ever existed for the workflow, so nothing else is pending.
-		const claimedAgain = await repository.claimNextPendingRecord();
-		expect(claimedAgain).toBeNull();
+		// The record is a pure "reconcile this workflow" marker: a pending one
+		// already means "reconcile", so the original row remains untouched.
+		const pending = await repository.find({ where: { status: 'pending' } });
+		expect(pending).toHaveLength(1);
+		expect(pending[0].id).toBe(original.id);
+	});
+
+	it('enqueues unpublished workflows with the sentinel and skips missing ones', async () => {
+		const unpublished = await createWorkflow(); // no activeVersionId
+
+		await repository.enqueue(unpublished.id);
+		await repository.enqueue('does-not-exist');
+
+		const pending = await repository.find({ where: { status: 'pending' } });
+		expect(pending).toHaveLength(1);
+		expect(pending[0]).toMatchObject({
+			workflowId: unpublished.id,
+			publishedVersionId: UNPUBLISH_VERSION_SENTINEL,
+		});
 	});
 
 	it('enqueues within a provided transaction and is visible once it commits', async () => {
+		const workflow = await createActiveWorkflow();
+
 		await repository.manager.transaction(async (trx) => {
-			await repository.enqueue('wf-1', 'v-1', trx);
+			await repository.enqueue(workflow.id, trx);
 		});
 
 		const claimed = await repository.claimNextPendingRecord();
-		expect(claimed?.workflowId).toBe('wf-1');
-		expect(claimed?.publishedVersionId).toBe('v-1');
+		expect(claimed?.workflowId).toBe(workflow.id);
 	});
 
 	it('discards the enqueued record when the surrounding transaction rolls back', async () => {
+		const workflow = await createActiveWorkflow();
+
 		await expect(
 			repository.manager.transaction(async (trx) => {
-				await repository.enqueue('wf-1', 'v-1', trx);
+				await repository.enqueue(workflow.id, trx);
 				throw new Error('rollback');
 			}),
 		).rejects.toThrow('rollback');
@@ -76,52 +96,57 @@ describe('WorkflowPublicationOutboxRepository', () => {
 	});
 
 	it('claims pending records in FIFO order', async () => {
-		await repository.enqueue('wf-1', 'v-1');
-		await repository.enqueue('wf-2', 'v-1');
+		const wf1 = await createActiveWorkflow();
+		const wf2 = await createActiveWorkflow();
+		await repository.enqueue(wf1.id);
+		await repository.enqueue(wf2.id);
 
 		const first = await repository.claimNextPendingRecord();
 		const second = await repository.claimNextPendingRecord();
 
-		expect(first?.workflowId).toBe('wf-1');
-		expect(second?.workflowId).toBe('wf-2');
+		expect(first?.workflowId).toBe(wf1.id);
+		expect(second?.workflowId).toBe(wf2.id);
 	});
 
 	it('does not claim a second record for a workflow already in progress', async () => {
-		// wf-1 is claimed (in progress), then a newer version is enqueued.
-		await repository.enqueue('wf-1', 'v-1');
+		// wf1 is claimed (in progress), then it is re-enqueued.
+		const wf1 = await createActiveWorkflow();
+		const wf2 = await createActiveWorkflow();
+		await repository.enqueue(wf1.id);
 		const inProgress = await repository.claimNextPendingRecord();
 		assert(inProgress);
-		await repository.enqueue('wf-1', 'v-2');
+		await repository.enqueue(wf1.id);
 
-		// A different workflow is claimable, but wf-1's new pending record is not
+		// A different workflow is claimable, but wf1's new pending record is not
 		// until its in-progress record is resolved.
-		await repository.enqueue('wf-2', 'v-1');
+		await repository.enqueue(wf2.id);
 		const claimed = await repository.claimNextPendingRecord();
-		expect(claimed?.workflowId).toBe('wf-2');
+		expect(claimed?.workflowId).toBe(wf2.id);
 		expect(await repository.claimNextPendingRecord()).toBeNull();
 
-		// Once wf-1's in-progress record completes, its pending record is claimable.
+		// Once wf1's in-progress record completes, its pending record is claimable.
 		await repository.markCompleted(inProgress.id);
 		const next = await repository.claimNextPendingRecord();
-		expect(next?.workflowId).toBe('wf-1');
-		expect(next?.publishedVersionId).toBe('v-2');
+		expect(next?.workflowId).toBe(wf1.id);
 	});
 
 	it('enqueues a fresh pending record once the previous one is no longer pending', async () => {
-		await repository.enqueue('wf-1', 'v-1');
+		const workflow = await createActiveWorkflow();
+		await repository.enqueue(workflow.id);
 		const claimed = await repository.claimNextPendingRecord();
 		assert(claimed);
 		await repository.markCompleted(claimed.id);
 
-		await repository.enqueue('wf-1', 'v-2');
+		await repository.enqueue(workflow.id);
 
 		const next = await repository.claimNextPendingRecord();
 		expect(next?.id).not.toBe(claimed.id);
-		expect(next?.publishedVersionId).toBe('v-2');
+		expect(next?.workflowId).toBe(workflow.id);
 	});
 
 	it('marks a claimed record as completed', async () => {
-		await repository.enqueue('wf-1', 'v-1');
+		const workflow = await createActiveWorkflow();
+		await repository.enqueue(workflow.id);
 		const claimed = await repository.claimNextPendingRecord();
 		assert(claimed);
 
@@ -133,7 +158,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 	});
 
 	it('marks a claimed record as failed and records the error', async () => {
-		await repository.enqueue('wf-1', 'v-1');
+		const workflow = await createActiveWorkflow();
+		await repository.enqueue(workflow.id);
 		const claimed = await repository.claimNextPendingRecord();
 		assert(claimed);
 
@@ -145,7 +171,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 	});
 
 	it('throws when transitioning a record that is not in progress', async () => {
-		await repository.enqueue('wf-1', 'v-1');
+		const workflow = await createActiveWorkflow();
+		await repository.enqueue(workflow.id);
 		const claimed = await repository.claimNextPendingRecord();
 		assert(claimed);
 		await repository.markCompleted(claimed.id);
@@ -157,7 +184,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 
 	describe('returnToPending', () => {
 		it('returns a claimed record to the queue so it can be claimed again', async () => {
-			await repository.enqueue('wf-1', 'v-1');
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id);
 			const claimed = await repository.claimNextPendingRecord();
 			assert(claimed);
 
@@ -168,27 +196,29 @@ describe('WorkflowPublicationOutboxRepository', () => {
 
 			const reclaimed = await repository.claimNextPendingRecord();
 			expect(reclaimed?.id).toBe(claimed.id);
-			expect(reclaimed?.publishedVersionId).toBe('v-1');
 		});
 
 		it('drops the claimed record when a newer pending record already supersedes it', async () => {
-			// wf-1 is claimed (in progress), then a newer version is enqueued as pending.
-			await repository.enqueue('wf-1', 'v-1');
+			// The workflow is claimed (in progress), then re-enqueued as pending.
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id);
 			const claimed = await repository.claimNextPendingRecord();
 			assert(claimed);
-			await repository.enqueue('wf-1', 'v-2');
+			await repository.enqueue(workflow.id);
 
 			await repository.returnToPending(claimed.id);
 
 			// The in-progress row is gone; only the superseding pending record remains.
 			expect(await repository.findOneBy({ id: claimed.id })).toBeNull();
 			const next = await repository.claimNextPendingRecord();
-			expect(next?.publishedVersionId).toBe('v-2');
+			expect(next?.workflowId).toBe(workflow.id);
+			expect(next?.id).not.toBe(claimed.id);
 			expect(await repository.claimNextPendingRecord()).toBeNull();
 		});
 
 		it('is a no-op when the record is no longer in progress', async () => {
-			await repository.enqueue('wf-1', 'v-1');
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id);
 			const claimed = await repository.claimNextPendingRecord();
 			assert(claimed);
 			await repository.markCompleted(claimed.id);
@@ -222,7 +252,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('reclaims a stale in_progress record', async () => {
-			await repository.enqueue('wf-1', 'v-1');
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id);
 			const claimed = await repository.claimNextPendingRecord();
 			assert(claimed);
 			await backdateUpdatedAt(claimed.id);
@@ -234,7 +265,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('does not reclaim a fresh in_progress record', async () => {
-			await repository.enqueue('wf-1', 'v-1');
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id);
 			const claimed = await repository.claimNextPendingRecord();
 			assert(claimed);
 
@@ -243,7 +275,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('bumps updatedAt on reclaim so it is not immediately reclaimable again', async () => {
-			await repository.enqueue('wf-1', 'v-1');
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id);
 			const claimed = await repository.claimNextPendingRecord();
 			assert(claimed);
 			await backdateUpdatedAt(claimed.id);
@@ -256,22 +289,22 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('reclaims the stale in_progress only, leaving a newer pending record untouched', async () => {
-			await repository.enqueue('wf-1', 'v-1');
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id);
 			const claimed = await repository.claimNextPendingRecord();
 			assert(claimed);
-			await repository.enqueue('wf-1', 'v-2');
+			await repository.enqueue(workflow.id);
 			await backdateUpdatedAt(claimed.id);
 
 			const reclaimed = await repository.claimNextPendingRecord();
 			expect(reclaimed?.id).toBe(claimed.id);
-			expect(reclaimed?.publishedVersionId).toBe('v-1');
 
 			// No second in_progress row was created; the pending record is untouched.
 			const inProgress = await repository.find({ where: { status: 'in_progress' } });
 			expect(inProgress).toHaveLength(1);
 			const pending = await repository.find({ where: { status: 'pending' } });
 			expect(pending).toHaveLength(1);
-			expect(pending[0].publishedVersionId).toBe('v-2');
+			expect(pending[0].id).not.toBe(claimed.id);
 		});
 	});
 
@@ -285,11 +318,9 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			);
 		};
 
-		const createTerminal = async (
-			workflowId: string,
-			outcome: 'completed' | 'failed' | 'partial',
-		) => {
-			await repository.enqueue(workflowId, 'v-1');
+		const createTerminal = async (outcome: 'completed' | 'failed' | 'partial') => {
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id);
 			const claimed = await repository.claimNextPendingRecord();
 			assert(claimed);
 			if (outcome === 'completed') await repository.markCompleted(claimed.id);
@@ -299,9 +330,9 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		};
 
 		it('deletes completed rows past the completed retention but keeps failed/partial of the same age (split retention)', async () => {
-			const completedId = await createTerminal('wf-1', 'completed');
-			const failedId = await createTerminal('wf-2', 'failed');
-			const partialId = await createTerminal('wf-3', 'partial');
+			const completedId = await createTerminal('completed');
+			const failedId = await createTerminal('failed');
+			const partialId = await createTerminal('partial');
 			await backdateUpdatedAt(completedId);
 			await backdateUpdatedAt(failedId);
 			await backdateUpdatedAt(partialId);
@@ -317,8 +348,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('deletes failed and partial rows once they pass the failed retention', async () => {
-			const failedId = await createTerminal('wf-1', 'failed');
-			const partialId = await createTerminal('wf-2', 'partial');
+			const failedId = await createTerminal('failed');
+			const partialId = await createTerminal('partial');
 			await backdateUpdatedAt(failedId);
 			await backdateUpdatedAt(partialId);
 
@@ -330,8 +361,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('keeps terminal rows that are still within their retention window', async () => {
-			const completedId = await createTerminal('wf-1', 'completed');
-			const failedId = await createTerminal('wf-2', 'failed');
+			const completedId = await createTerminal('completed');
+			const failedId = await createTerminal('failed');
 
 			// Just created, so within any positive retention window.
 			const deleted = await repository.deleteTerminalOlderThan(60, 60, 100);
@@ -342,8 +373,10 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('never deletes pending or in_progress rows', async () => {
-			await repository.enqueue('wf-1', 'v-1'); // stays pending
-			await repository.enqueue('wf-2', 'v-1');
+			const wf1 = await createActiveWorkflow();
+			const wf2 = await createActiveWorkflow();
+			await repository.enqueue(wf1.id);
+			await repository.enqueue(wf2.id); // stays pending; the claim takes wf1's older record
 			const inProgress = await repository.claimNextPendingRecord();
 			assert(inProgress);
 			await backdateUpdatedAt(inProgress.id);
@@ -356,11 +389,9 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('deletes at most batchSize rows per call and reports the count', async () => {
-			const ids: number[] = [];
 			for (let i = 0; i < 3; i++) {
-				const id = await createTerminal(`wf-${i}`, 'completed');
+				const id = await createTerminal('completed');
 				await backdateUpdatedAt(id);
-				ids.push(id);
 			}
 
 			const firstBatch = await repository.deleteTerminalOlderThan(60, 60, 2);
@@ -451,7 +482,9 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			// record is at least as fresh as reconciliation's snapshot and must win —
 			// overwriting it could roll the workflow back to a stale version.
 			const workflow = await createActiveWorkflow();
-			await repository.enqueue(workflow.id, 'v-concurrent');
+			await repository.enqueue(workflow.id);
+			// Marker version so an overwrite would be detectable.
+			await repository.update({ workflowId: workflow.id }, { publishedVersionId: 'v-concurrent' });
 
 			await repository.enqueueByWorkflowIds([workflow.id]);
 
@@ -597,6 +630,25 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			});
 			expect(pending).toHaveLength(1);
 			expect(pending[0].publishedVersionId).toBe(workflow.activeVersionId);
+		});
+
+		it('does not overwrite an existing pending record', async () => {
+			// A publish can commit a pending record mid-statement during the takeover
+			// scan; that record is fresher and must win. (The version column is
+			// vestigial now, but the DO NOTHING also stops pointless lock churn.)
+			const workflow = await createActiveWorkflow();
+			await recordTrigger(workflow, 'n1', 'in-memory');
+			await repository.enqueue(workflow.id);
+			// Marker version so an overwrite would be detectable.
+			await repository.update({ workflowId: workflow.id }, { publishedVersionId: 'v-existing' });
+
+			await repository.enqueueForLeaderHandoff();
+
+			const pending = await repository.find({
+				where: { workflowId: workflow.id, status: 'pending' },
+			});
+			expect(pending).toHaveLength(1);
+			expect(pending[0].publishedVersionId).toBe('v-existing');
 		});
 	});
 

--- a/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
@@ -1,6 +1,5 @@
 import { createActiveWorkflow, createWorkflow, testDb } from '@n8n/backend-test-utils';
 import { WorkflowsConfig } from '@n8n/config';
-import { UNPUBLISH_VERSION_SENTINEL } from '@n8n/db';
 import type { WorkflowPublicationTriggerKind } from '@n8n/db';
 import {
 	WorkflowPublicationOutboxRepository,
@@ -36,7 +35,6 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		const claimed = await repository.claimNextPendingRecord();
 
 		expect(claimed?.workflowId).toBe(workflow.id);
-		expect(claimed?.publishedVersionId).toBe(workflow.activeVersionId);
 		expect(claimed?.status).toBe('in_progress');
 
 		const claimedAgain = await repository.claimNextPendingRecord();
@@ -57,7 +55,7 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		expect(pending[0].id).toBe(original.id);
 	});
 
-	it('enqueues unpublished workflows with the sentinel and skips missing ones', async () => {
+	it('enqueues unpublished workflows and skips missing ones', async () => {
 		const unpublished = await createWorkflow(); // no activeVersionId
 
 		await repository.enqueue(unpublished.id);
@@ -65,10 +63,7 @@ describe('WorkflowPublicationOutboxRepository', () => {
 
 		const pending = await repository.find({ where: { status: 'pending' } });
 		expect(pending).toHaveLength(1);
-		expect(pending[0]).toMatchObject({
-			workflowId: unpublished.id,
-			publishedVersionId: UNPUBLISH_VERSION_SENTINEL,
-		});
+		expect(pending[0]).toMatchObject({ workflowId: unpublished.id });
 	});
 
 	it('enqueues within a provided transaction and is visible once it commits', async () => {
@@ -428,19 +423,18 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			const pending = await repository.find({ where: { status: 'pending' } });
 			expect(pending).toEqual(
 				expect.arrayContaining([
-					expect.objectContaining({ workflowId: wf1.id, publishedVersionId: wf1.activeVersionId }),
-					expect.objectContaining({ workflowId: wf3.id, publishedVersionId: wf3.activeVersionId }),
+					expect.objectContaining({ workflowId: wf1.id }),
+					expect.objectContaining({ workflowId: wf3.id }),
 				]),
 			);
 			expect(pending).toHaveLength(2);
 			expect(pending.map((record) => record.workflowId)).not.toContain(wf2.id);
 		});
 
-		it('enqueues unpublished and archived workflows with the unpublish sentinel so stale trigger-status rows can be healed', async () => {
+		it('enqueues unpublished and archived workflows so stale trigger-status rows can be healed', async () => {
 			// The reconciler enqueues whatever its detection query returns; refusing
-			// any of it here would re-detect the same workflow forever. The sentinel
-			// is inert — the applier dispatches an unpublish on the workflow's null
-			// `activeVersionId` and never reads the record's version.
+			// any of it here would re-detect the same workflow forever. The applier
+			// dispatches an unpublish on the workflow's null `activeVersionId`.
 			const unpublished = await createWorkflow(); // no activeVersionId
 			const archived = await createWorkflow();
 			await Container.get(WorkflowRepository).update(archived.id, { isArchived: true });
@@ -450,14 +444,8 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			const pending = await repository.find({ where: { status: 'pending' } });
 			expect(pending).toEqual(
 				expect.arrayContaining([
-					expect.objectContaining({
-						workflowId: unpublished.id,
-						publishedVersionId: UNPUBLISH_VERSION_SENTINEL,
-					}),
-					expect.objectContaining({
-						workflowId: archived.id,
-						publishedVersionId: UNPUBLISH_VERSION_SENTINEL,
-					}),
+					expect.objectContaining({ workflowId: unpublished.id }),
+					expect.objectContaining({ workflowId: archived.id }),
 				]),
 			);
 			expect(pending).toHaveLength(2);
@@ -473,26 +461,6 @@ describe('WorkflowPublicationOutboxRepository', () => {
 				where: { workflowId: workflow.id, status: 'pending' },
 			});
 			expect(pending).toHaveLength(1);
-			expect(pending[0].publishedVersionId).toBe(workflow.activeVersionId);
-		});
-
-		it('does not overwrite an existing pending record', async () => {
-			// Reconciliation's detection and its enqueue are two separate statements:
-			// a publish can commit a pending record in the gap between them. That
-			// record is at least as fresh as reconciliation's snapshot and must win —
-			// overwriting it could roll the workflow back to a stale version.
-			const workflow = await createActiveWorkflow();
-			await repository.enqueue(workflow.id);
-			// Marker version so an overwrite would be detectable.
-			await repository.update({ workflowId: workflow.id }, { publishedVersionId: 'v-concurrent' });
-
-			await repository.enqueueByWorkflowIds([workflow.id]);
-
-			const pending = await repository.find({
-				where: { workflowId: workflow.id, status: 'pending' },
-			});
-			expect(pending).toHaveLength(1);
-			expect(pending[0].publishedVersionId).toBe('v-concurrent');
 		});
 
 		it('is a no-op for an empty list', async () => {
@@ -594,7 +562,7 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			expect(await pendingWorkflowIds()).toEqual([workflow.id]);
 		});
 
-		it('enqueues at the active version', async () => {
+		it('enqueues a reconcile marker for the workflow', async () => {
 			const workflow = await createActiveWorkflow();
 			await recordTrigger(workflow, 'n1', 'in-memory');
 
@@ -602,7 +570,6 @@ describe('WorkflowPublicationOutboxRepository', () => {
 
 			const pending = await repository.find({ where: { status: 'pending' } });
 			expect(pending).toHaveLength(1);
-			expect(pending[0].publishedVersionId).toBe(workflow.activeVersionId);
 		});
 
 		it('skips inactive and archived workflows', async () => {
@@ -629,39 +596,19 @@ describe('WorkflowPublicationOutboxRepository', () => {
 				where: { workflowId: workflow.id, status: 'pending' },
 			});
 			expect(pending).toHaveLength(1);
-			expect(pending[0].publishedVersionId).toBe(workflow.activeVersionId);
-		});
-
-		it('does not overwrite an existing pending record', async () => {
-			// A publish can commit a pending record mid-statement during the takeover
-			// scan; that record is fresher and must win. (The version column is
-			// vestigial now, but the DO NOTHING also stops pointless lock churn.)
-			const workflow = await createActiveWorkflow();
-			await recordTrigger(workflow, 'n1', 'in-memory');
-			await repository.enqueue(workflow.id);
-			// Marker version so an overwrite would be detectable.
-			await repository.update({ workflowId: workflow.id }, { publishedVersionId: 'v-existing' });
-
-			await repository.enqueueForLeaderHandoff();
-
-			const pending = await repository.find({
-				where: { workflowId: workflow.id, status: 'pending' },
-			});
-			expect(pending).toHaveLength(1);
-			expect(pending[0].publishedVersionId).toBe('v-existing');
 		});
 	});
 
 	describe('getRecordStatsByStatus', () => {
 		it('returns the count and oldest createdAt grouped by status in one query', async () => {
 			await repository.insert([
-				{ workflowId: 'wf-1', publishedVersionId: 'v', status: 'pending' },
-				{ workflowId: 'wf-2', publishedVersionId: 'v', status: 'pending' },
-				{ workflowId: 'wf-3', publishedVersionId: 'v', status: 'in_progress' },
-				{ workflowId: 'wf-4', publishedVersionId: 'v', status: 'completed' },
-				{ workflowId: 'wf-5', publishedVersionId: 'v', status: 'completed' },
-				{ workflowId: 'wf-6', publishedVersionId: 'v', status: 'failed' },
-				{ workflowId: 'wf-7', publishedVersionId: 'v', status: 'partial_success' },
+				{ workflowId: 'wf-1', status: 'pending' },
+				{ workflowId: 'wf-2', status: 'pending' },
+				{ workflowId: 'wf-3', status: 'in_progress' },
+				{ workflowId: 'wf-4', status: 'completed' },
+				{ workflowId: 'wf-5', status: 'completed' },
+				{ workflowId: 'wf-6', status: 'failed' },
+				{ workflowId: 'wf-7', status: 'partial_success' },
 			]);
 
 			const all = await repository.find();

--- a/packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts
+++ b/packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts
@@ -142,7 +142,6 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 		await outboxRepo.save(
 			outboxRepo.create({
 				workflowId: wf.id,
-				publishedVersionId: 'v-pending',
 				status: 'pending',
 				errorMessage: null,
 			}),
@@ -150,7 +149,6 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 		await outboxRepo.save(
 			outboxRepo.create({
 				workflowId: wf.id,
-				publishedVersionId: 'v-in-progress',
 				status: 'in_progress',
 				errorMessage: null,
 			}),
@@ -159,7 +157,6 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 		const inFlight = await outboxRepo.findInFlightByWorkflowId(wf.id);
 		expect(inFlight).not.toBeNull();
 		expect(inFlight!.status).toBe('in_progress');
-		expect(inFlight!.publishedVersionId).toBe('v-in-progress');
 	});
 
 	it('findInFlightByWorkflowId ignores terminal records', async () => {
@@ -167,7 +164,6 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 		await outboxRepo.save(
 			outboxRepo.create({
 				workflowId: wf.id,
-				publishedVersionId: 'v1',
 				status: 'completed',
 				errorMessage: null,
 			}),
@@ -296,7 +292,6 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 			// the workflow anyway, so its triggers must not be reported.
 			const record = outboxRepo.create({
 				workflowId: workflow.id,
-				publishedVersionId: 'v1',
 				status: 'pending',
 				errorMessage: null,
 			});

--- a/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
@@ -121,8 +121,9 @@ describe('WorkflowPublicationOutboxConsumer (integration)', () => {
 			nodes: [unchanged, added],
 			connections: {},
 		});
+		await setActiveVersion(workflow.id, newVersionId);
 
-		await outboxRepository.enqueue(workflow.id, newVersionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 		expect(record).not.toBeNull();
 
@@ -163,7 +164,7 @@ describe('WorkflowPublicationOutboxConsumer (integration)', () => {
 		expect(presentResponse).toBeDefined();
 		expect(activeWorkflowTriggers.get(workflow.id)?.has(missing.id)).toBe(false);
 
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 
 		await consumer.processRecord(record!);
@@ -190,7 +191,7 @@ describe('WorkflowPublicationOutboxConsumer (integration)', () => {
 		const responseBefore = activeWorkflowTriggers.get(workflow.id)?.get(trigger.id);
 		expect(responseBefore).toBeDefined();
 
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 
 		await consumer.processRecord(record!);
@@ -245,8 +246,9 @@ describe('WorkflowPublicationOutboxConsumer (integration)', () => {
 			nodes: [trigger],
 			connections: {},
 		});
+		await setActiveVersion(workflow.id, newVersionId);
 
-		await outboxRepository.enqueue(workflow.id, newVersionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 
 		await consumer.processRecord(record!);

--- a/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
@@ -109,7 +109,7 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 
 		// Publish through the real pipeline so the trigger registers in memory and
 		// the reporter persists the `activated` trigger-status rows with kinds.
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 		await consumer.processRecord(record!);
 		expect(activeWorkflowTriggers.get(workflow.id)?.has(trigger.id)).toBe(true);
@@ -142,7 +142,7 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 
 		// Publish through the real pipeline so the reporter persists the
 		// `activated` trigger-status rows.
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 		await consumer.processRecord(record!);
 
@@ -172,7 +172,7 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
 		await setActiveVersion(workflow.id, workflow.versionId);
 
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 		await consumer.processRecord(record!);
 		expect(activeWorkflowTriggers.get(workflow.id)?.has(trigger.id)).toBe(true);
@@ -199,7 +199,7 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
 		await setActiveVersion(workflow.id, workflow.versionId);
 
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 		await consumer.processRecord(record!);
 
@@ -225,14 +225,14 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
 		await setActiveVersion(workflow.id, workflow.versionId);
 
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 		await consumer.processRecord(record!);
 
 		// Mid-unpublish: activeVersionId already cleared, pending record owns the
 		// teardown. Reconciliation must not race it.
 		await Container.get(WorkflowRepository).update(workflow.id, { activeVersionId: null });
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 
 		await reconciler.reconcile();
 
@@ -246,7 +246,7 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
 		await setActiveVersion(workflow.id, workflow.versionId);
 
-		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id);
 		const record = await outboxRepository.claimNextPendingRecord();
 		await consumer.processRecord(record!);
 		const registeredBefore = activeWorkflowTriggers.get(workflow.id)?.get(trigger.id);

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -543,7 +543,6 @@ describe('workflow publication outbox', () => {
 			const outboxRecord = await outboxRepository.findOne({
 				where: { workflowId: workflow.id },
 			});
-			expect(outboxRecord?.publishedVersionId).toBe(workflow.versionId);
 			expect(outboxRecord?.status).toBe('pending');
 
 			// Publication is async: the published version is advanced by the
@@ -554,7 +553,7 @@ describe('workflow publication outbox', () => {
 			expect(publishedVersion).toBeNull();
 		});
 
-		test('should supersede the pending outbox record when activating a new version', async () => {
+		test('should keep a single pending outbox record when activating a new version', async () => {
 			const owner = await createOwner();
 			const workflow = await createWorkflowWithHistory({}, owner);
 
@@ -567,9 +566,10 @@ describe('workflow publication outbox', () => {
 				versionId: newVersionId,
 			});
 
+			// The record is a reconcile marker: re-activating does not duplicate or
+			// rewrite it — the applier reads the new activeVersionId at claim time.
 			const outboxRecords = await outboxRepository.find({ where: { workflowId: workflow.id } });
 			expect(outboxRecords).toHaveLength(1);
-			expect(outboxRecords[0].publishedVersionId).toBe(newVersionId);
 			expect(outboxRecords[0].status).toBe('pending');
 
 			const updated = await workflowRepository.findOne({ where: { id: workflow.id } });
@@ -595,7 +595,6 @@ describe('workflow publication outbox', () => {
 			const outboxRecord = await outboxRepository.findOne({
 				where: { workflowId: workflow.id },
 			});
-			expect(outboxRecord?.publishedVersionId).toBe(workflow.versionId);
 			expect(outboxRecord?.status).toBe('pending');
 
 			// Mapping removal and trigger teardown are deferred to the consumer, so the
@@ -623,7 +622,6 @@ describe('workflow publication outbox', () => {
 			const outboxRecord = await outboxRepository.findOne({
 				where: { workflowId: workflow.id },
 			});
-			expect(outboxRecord?.publishedVersionId).toBe(workflow.versionId);
 			expect(outboxRecord?.status).toBe('pending');
 
 			// Mapping removal is deferred to the consumer.

--- a/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
@@ -76,7 +76,6 @@ describe('GET /workflows/:workflowId/publication-status', () => {
 		expect(res.body.data).toMatchObject({
 			status: 'partial',
 			liveVersionId: versionId,
-			pendingVersionId: null,
 			triggers: expect.arrayContaining([
 				expect.objectContaining({ nodeId: 'node-1', status: 'activated', errorMessage: null }),
 				expect.objectContaining({
@@ -97,7 +96,6 @@ describe('GET /workflows/:workflowId/publication-status', () => {
 		expect(res.body.data).toMatchObject({
 			status: 'not_published',
 			liveVersionId: null,
-			pendingVersionId: null,
 			triggers: [],
 		});
 	});

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowPublicationStatusSync.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowPublicationStatusSync.test.ts
@@ -36,7 +36,6 @@ function makeStatus(
 	return {
 		status,
 		liveVersionId: null,
-		pendingVersionId: null,
 		triggers,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -747,7 +747,6 @@ describe('useWorkflowsStore', () => {
 			const mockStatus: WorkflowPublicationStatus = {
 				status: 'published',
 				liveVersionId: 'pub-1',
-				pendingVersionId: null,
 				triggers: [],
 			};
 


### PR DESCRIPTION
## Summary

The publication outbox record used to carry the version to publish. This PR removes that: the record is now just a marker saying "reconcile workflow X", and the applier derives what to do from `workflow_entity` **at claim time** — publish the current `activeVersionId`, or unpublish when it's null.

Why: the record's version was a copy of state, and every copy of state can go stale. All the recent races in this area (the [`DO NOTHING` fix in #34443](https://github.com/n8n-io/n8n/pull/34443#discussion_r3613797155), CAT-3794, CAT-3795 Gap 1) were the same disease: a stale copied version getting applied or overwriting a fresher one. Deriving fresh removes the disease instead of treating symptoms. The unpublish path already worked this way — dispatch ignored the record and read the workflow — so this makes publish consistent with it. Design discussion: [CAT-3796](https://linear.app/n8n/issue/CAT-3796) (resolves the [question raised in #34443's review](https://github.com/n8n-io/n8n/pull/34443#discussion_r3614248289)).

Everything is behind `N8N_USE_WORKFLOW_PUBLICATION_SERVICE` (default off).

## How to review

**Commit by commit is the intended path** — each builds on the previous and is green on its own:

1. **`Derive the publish target from the workflow, not the record`** — the semantic core: the applier joins the workflow's `activeVersion` and publishes that; `PublicationResult` carries `appliedVersionId` so the reporter stamps trigger-status rows and UI pushes with what was *actually applied*.
2. **`Drop unused pendingVersionId from the publication status API`** — removes a response field nothing consumed; its source (the record's version) is going away.
3. **`Collapse all publication enqueues to reconcile markers`** — `enqueue()` loses its version parameter and all three enqueue paths become the same `INSERT … SELECT … ON CONFLICT DO NOTHING`; the old `DO UPDATE` supersede semantics now live in the applier's fresh read. Also closes CAT-3794.
4. **`Drop the outbox publishedVersionId column`** — migration (reversible, `down()` backfills from `workflow_entity`), entity field, the `__unpublish__` sentinel, and the claim-time span attribute (replaced by a post-apply `applied_version_id` from the result) all go.
5. **`test: Align workflow.service enqueue assertion with marker semantics`** — one assertion in a suite outside the publication directory.

Dropping the column needs no deprecation release: every writer of this table is flag-gated (default off), so a same-schema image downgrade can't break unflagged instances, and the few flagged ones (internal + cloud pilot) are centrally managed and can `db:revert`.

## How to test

Requires `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

- Unit + integration suites updated in lockstep (headline test: the applier publishes the workflow's *current* active version regardless of when the record was enqueued).
- Manual: publish a workflow, then publish a second version before the consumer claims (or while it's mid-apply) — the second version's triggers end up live and `workflow_published_version` points at it, with no transient window on the first version.
- The migration runs in every integration suite (`testDb.init`) on both SQLite and Postgres.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3796
Closes CAT-3794 (absorbed: leader-handoff enqueue race).
Follow-up to #34443 and #34454 (both merged).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (schema docs regenerated; no user-facing docs)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI