### PR TITLE
feat(core): Pin low reasoning effort for Kimi K3, Grok 4.5, and Anthropic (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -748,7 +748,7 @@ Adding a new channel requires inviting the bot first; the first run otherwise fa
 | Cloud/CDN           | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`             |
 | GitHub Automation   | `N8N_ASSISTANT_APP_ID`, `N8N_ASSISTANT_PRIVATE_KEY`         |
 | Benchmarking        | `BENCHMARK_ARM_*`, `N8N_BENCHMARK_LICENSE_CERT`             |
-| AI/Evals            | `ANTHROPIC_API_KEY`, `EVALS_LANGSMITH_*`                    |
+| AI/Evals            | `EVALS_ANTHROPIC_KEY`, `EVALS_OPENROUTER_KEY`, `EVALS_LANGSMITH_*` |
 
 ### Scoping
 

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -748,7 +748,7 @@ Adding a new channel requires inviting the bot first; the first run otherwise fa
 | Cloud/CDN           | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`             |
 | GitHub Automation   | `N8N_ASSISTANT_APP_ID`, `N8N_ASSISTANT_PRIVATE_KEY`         |
 | Benchmarking        | `BENCHMARK_ARM_*`, `N8N_BENCHMARK_LICENSE_CERT`             |
-| AI/Evals            | `EVALS_ANTHROPIC_KEY`, `EVALS_OPENROUTER_KEY`, `EVALS_XAI_KEY`, `EVALS_LANGSMITH_*` |
+| AI/Evals            | `EVALS_ANTHROPIC_KEY`, `EVALS_OPENAI_KEY`, `EVALS_OPENROUTER_KEY`, `EVALS_XAI_KEY`, `EVALS_LANGSMITH_*` |
 
 ### Scoping
 

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -748,7 +748,7 @@ Adding a new channel requires inviting the bot first; the first run otherwise fa
 | Cloud/CDN           | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`             |
 | GitHub Automation   | `N8N_ASSISTANT_APP_ID`, `N8N_ASSISTANT_PRIVATE_KEY`         |
 | Benchmarking        | `BENCHMARK_ARM_*`, `N8N_BENCHMARK_LICENSE_CERT`             |
-| AI/Evals            | `EVALS_ANTHROPIC_KEY`, `EVALS_OPENROUTER_KEY`, `EVALS_LANGSMITH_*` |
+| AI/Evals            | `EVALS_ANTHROPIC_KEY`, `EVALS_OPENROUTER_KEY`, `EVALS_XAI_KEY`, `EVALS_LANGSMITH_*` |
 
 ### Scoping
 

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -748,7 +748,7 @@ Adding a new channel requires inviting the bot first; the first run otherwise fa
 | Cloud/CDN           | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`             |
 | GitHub Automation   | `N8N_ASSISTANT_APP_ID`, `N8N_ASSISTANT_PRIVATE_KEY`         |
 | Benchmarking        | `BENCHMARK_ARM_*`, `N8N_BENCHMARK_LICENSE_CERT`             |
-| AI/Evals            | `EVALS_ANTHROPIC_KEY`, `EVALS_OPENAI_KEY`, `EVALS_OPENROUTER_KEY`, `EVALS_XAI_KEY`, `EVALS_LANGSMITH_*` |
+| AI/Evals            | `EVALS_ANTHROPIC_KEY`, `EVALS_OPENAI_KEY`, `EVALS_OPENROUTER_KEY`, `EVALS_XAI_KEY`, `EVALS_BASETEN_KEY`, `EVALS_LANGSMITH_*` |
 
 ### Scoping
 

--- a/.github/actions/setup-nodejs/safe-chain.config.json
+++ b/.github/actions/setup-nodejs/safe-chain.config.json
@@ -10,7 +10,8 @@
 			"n8n-node-dev",
 			"n8n-nodes-base",
 			"n8n-playwright",
-			"n8n-workflow"
+			"n8n-workflow",
+			"@ai-sdk/anthropic"
 		]
 	}
 }

--- a/.github/workflows/ci-mcp-evals.yml
+++ b/.github/workflows/ci-mcp-evals.yml
@@ -28,7 +28,7 @@ on:
           - '5'
         default: '3'
       build-model:
-        description: 'Which Anthropic model builds the workflows. Change it to compare models; otherwise leave as-is.'
+        description: 'Which Anthropic model builds the workflows (e.g. claude-opus-4-8, claude-opus-5). Change it to compare models; otherwise leave as-is.'
         required: false
         default: 'claude-opus-4-8'
       filter:

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -59,7 +59,7 @@ on:
         type: string
         default: ''
       model:
-        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). openrouter/* uses EVALS_OPENROUTER_KEY.'
+        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). openrouter/* → EVALS_OPENROUTER_KEY; xai/* → EVALS_XAI_KEY.'
         required: false
         type: string
         default: ''
@@ -94,7 +94,7 @@ on:
         required: false
         default: ''
       model:
-        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openrouter/moonshotai/kimi-k3.'
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openrouter/moonshotai/kimi-k3, xai/grok-4.5.'
         required: false
         default: ''
 
@@ -165,6 +165,7 @@ jobs:
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
           EVALS_OPENROUTER_KEY: ${{ secrets.EVALS_OPENROUTER_KEY }}
+          EVALS_XAI_KEY: ${{ secrets.EVALS_XAI_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
@@ -216,6 +217,12 @@ jobs:
               exit 1
             fi
             MODEL_API_KEY="$EVALS_OPENROUTER_KEY"
+          elif [[ "$INSTANCE_AI_MODEL" == xai/* ]]; then
+            if [ -z "$EVALS_XAI_KEY" ]; then
+              echo "::error::model is xai/* but EVALS_XAI_KEY secret is empty"
+              exit 1
+            fi
+            MODEL_API_KEY="$EVALS_XAI_KEY"
           fi
 
           IFS=',' read -ra PORTS <<< "$LANE_PORTS"
@@ -415,6 +422,7 @@ jobs:
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
           EVALS_OPENROUTER_KEY: ${{ secrets.EVALS_OPENROUTER_KEY }}
+          EVALS_XAI_KEY: ${{ secrets.EVALS_XAI_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
@@ -425,8 +433,8 @@ jobs:
           # ::add-mask:: is a single-line workflow command. Multi-line secrets
           # (e.g. N8N_LICENSE_CERT is PEM-encoded) must be masked one line at
           # a time, otherwise only the first line is registered.
-          for v in "$EVALS_ANTHROPIC_KEY" "$EVALS_OPENROUTER_KEY" "$DAYTONA_API_KEY" \
-                   "$N8N_LICENSE_ACTIVATION_KEY" "$N8N_LICENSE_CERT" \
+          for v in "$EVALS_ANTHROPIC_KEY" "$EVALS_OPENROUTER_KEY" "$EVALS_XAI_KEY" \
+                   "$DAYTONA_API_KEY" "$N8N_LICENSE_ACTIVATION_KEY" "$N8N_LICENSE_CERT" \
                    "$N8N_ENCRYPTION_KEY" "$EVALS_LANGSMITH_API_KEY"; do
             [ -z "$v" ] && continue
             while IFS= read -r line; do

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -94,7 +94,7 @@ on:
         required: false
         default: ''
       model:
-        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openrouter/moonshotai/kimi-k3, xai/grok-4.5.'
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openai/gpt-5.6-terra, openrouter/moonshotai/kimi-k3, xai/grok-4.5.'
         required: false
         default: ''
 

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -59,7 +59,7 @@ on:
         type: string
         default: ''
       model:
-        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default.'
+        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). openrouter/* uses EVALS_OPENROUTER_KEY.'
         required: false
         type: string
         default: ''
@@ -94,7 +94,7 @@ on:
         required: false
         default: ''
       model:
-        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). For experiments: anthropic/claude-sonnet-4-6, anthropic/claude-sonnet-5.'
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openrouter/moonshotai/kimi-k3.'
         required: false
         default: ''
 
@@ -164,6 +164,7 @@ jobs:
       - name: Start n8n containers
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
+          EVALS_OPENROUTER_KEY: ${{ secrets.EVALS_OPENROUTER_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
@@ -206,6 +207,17 @@ jobs:
             MODEL_ARGS+=(-e N8N_INSTANCE_AI_MODEL="$INSTANCE_AI_MODEL")
           fi
 
+          # Lane builds use the provider matching N8N_INSTANCE_AI_MODEL.
+          # The eval CLI step keeps EVALS_ANTHROPIC_KEY for Sonnet verifier/mocks.
+          MODEL_API_KEY="$EVALS_ANTHROPIC_KEY"
+          if [[ "$INSTANCE_AI_MODEL" == openrouter/* ]]; then
+            if [ -z "$EVALS_OPENROUTER_KEY" ]; then
+              echo "::error::model is openrouter/* but EVALS_OPENROUTER_KEY secret is empty"
+              exit 1
+            fi
+            MODEL_API_KEY="$EVALS_OPENROUTER_KEY"
+          fi
+
           IFS=',' read -ra PORTS <<< "$LANE_PORTS"
           for i in "${!PORTS[@]}"; do
             port="${PORTS[$i]}"
@@ -223,7 +235,7 @@ jobs:
               -e E2E_TESTS=true \
               -e N8N_ENABLED_MODULES=instance-ai \
               -e N8N_AI_ENABLED=true \
-              -e N8N_INSTANCE_AI_MODEL_API_KEY="$EVALS_ANTHROPIC_KEY" \
+              -e N8N_INSTANCE_AI_MODEL_API_KEY="$MODEL_API_KEY" \
               -e N8N_AI_ASSISTANT_BASE_URL="" \
               -e N8N_INSTANCE_AI_SANDBOX_ENABLED=true \
               "${SANDBOX_ARGS[@]}" \
@@ -303,13 +315,15 @@ jobs:
               echo "  lane $lane: sandboxEnabled=true sandboxProvider=$SANDBOX_PROVIDER ok"
             fi
             # /preferences returns the effective model name (user pref || config),
-            # i.e. the name part of provider/model.
+            # i.e. everything after the first provider/ segment (openrouter/moonshotai/kimi-k3
+            # → moonshotai/kimi-k3). Use #*/ not ##*/ so nested OpenRouter ids match.
             if [ -n "$INSTANCE_AI_MODEL" ]; then
+              expected_model="${INSTANCE_AI_MODEL#*/}"
               effective=$(curl -sf -b "/tmp/cookies-$port.txt" \
                 "http://localhost:$port/rest/instance-ai/preferences" \
                 | jq -r '.data.modelName')
-              if [ "$effective" != "${INSTANCE_AI_MODEL##*/}" ]; then
-                echo "::error::lane $lane (port $port): expected model '${INSTANCE_AI_MODEL##*/}', got '$effective'"
+              if [ "$effective" != "$expected_model" ]; then
+                echo "::error::lane $lane (port $port): expected model '$expected_model', got '$effective'"
                 bad=$((bad+1))
               else
                 echo "  lane $lane: model=$effective ok"
@@ -400,6 +414,7 @@ jobs:
         if: ${{ always() }}
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
+          EVALS_OPENROUTER_KEY: ${{ secrets.EVALS_OPENROUTER_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
@@ -410,7 +425,7 @@ jobs:
           # ::add-mask:: is a single-line workflow command. Multi-line secrets
           # (e.g. N8N_LICENSE_CERT is PEM-encoded) must be masked one line at
           # a time, otherwise only the first line is registered.
-          for v in "$EVALS_ANTHROPIC_KEY" "$DAYTONA_API_KEY" \
+          for v in "$EVALS_ANTHROPIC_KEY" "$EVALS_OPENROUTER_KEY" "$DAYTONA_API_KEY" \
                    "$N8N_LICENSE_ACTIVATION_KEY" "$N8N_LICENSE_CERT" \
                    "$N8N_ENCRYPTION_KEY" "$EVALS_LANGSMITH_API_KEY"; do
             [ -z "$v" ] && continue

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -94,7 +94,7 @@ on:
         required: false
         default: ''
       model:
-        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openai/gpt-5.6-terra, openrouter/moonshotai/kimi-k3, xai/grok-4.5.'
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openai/gpt-5.6-terra, openai/gpt-5.6-luna, openrouter/moonshotai/kimi-k3, xai/grok-4.5.'
         required: false
         default: ''
 

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -59,7 +59,7 @@ on:
         type: string
         default: ''
       model:
-        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). openrouter/* → EVALS_OPENROUTER_KEY; xai/* → EVALS_XAI_KEY.'
+        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). openai/* → EVALS_OPENAI_KEY; openrouter/* → EVALS_OPENROUTER_KEY; xai/* → EVALS_XAI_KEY.'
         required: false
         type: string
         default: ''
@@ -94,7 +94,7 @@ on:
         required: false
         default: ''
       model:
-        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openrouter/moonshotai/kimi-k3, xai/grok-4.5.'
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openrouter/moonshotai/kimi-k3, xai/grok-4.5.'
         required: false
         default: ''
 
@@ -164,6 +164,7 @@ jobs:
       - name: Start n8n containers
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
+          EVALS_OPENAI_KEY: ${{ secrets.EVALS_OPENAI_KEY }}
           EVALS_OPENROUTER_KEY: ${{ secrets.EVALS_OPENROUTER_KEY }}
           EVALS_XAI_KEY: ${{ secrets.EVALS_XAI_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
@@ -211,7 +212,13 @@ jobs:
           # Lane builds use the provider matching N8N_INSTANCE_AI_MODEL.
           # The eval CLI step keeps EVALS_ANTHROPIC_KEY for Sonnet verifier/mocks.
           MODEL_API_KEY="$EVALS_ANTHROPIC_KEY"
-          if [[ "$INSTANCE_AI_MODEL" == openrouter/* ]]; then
+          if [[ "$INSTANCE_AI_MODEL" == openai/* ]]; then
+            if [ -z "$EVALS_OPENAI_KEY" ]; then
+              echo "::error::model is openai/* but EVALS_OPENAI_KEY secret is empty"
+              exit 1
+            fi
+            MODEL_API_KEY="$EVALS_OPENAI_KEY"
+          elif [[ "$INSTANCE_AI_MODEL" == openrouter/* ]]; then
             if [ -z "$EVALS_OPENROUTER_KEY" ]; then
               echo "::error::model is openrouter/* but EVALS_OPENROUTER_KEY secret is empty"
               exit 1
@@ -421,6 +428,7 @@ jobs:
         if: ${{ always() }}
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
+          EVALS_OPENAI_KEY: ${{ secrets.EVALS_OPENAI_KEY }}
           EVALS_OPENROUTER_KEY: ${{ secrets.EVALS_OPENROUTER_KEY }}
           EVALS_XAI_KEY: ${{ secrets.EVALS_XAI_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
@@ -433,9 +441,9 @@ jobs:
           # ::add-mask:: is a single-line workflow command. Multi-line secrets
           # (e.g. N8N_LICENSE_CERT is PEM-encoded) must be masked one line at
           # a time, otherwise only the first line is registered.
-          for v in "$EVALS_ANTHROPIC_KEY" "$EVALS_OPENROUTER_KEY" "$EVALS_XAI_KEY" \
-                   "$DAYTONA_API_KEY" "$N8N_LICENSE_ACTIVATION_KEY" "$N8N_LICENSE_CERT" \
-                   "$N8N_ENCRYPTION_KEY" "$EVALS_LANGSMITH_API_KEY"; do
+          for v in "$EVALS_ANTHROPIC_KEY" "$EVALS_OPENAI_KEY" "$EVALS_OPENROUTER_KEY" \
+                   "$EVALS_XAI_KEY" "$DAYTONA_API_KEY" "$N8N_LICENSE_ACTIVATION_KEY" \
+                   "$N8N_LICENSE_CERT" "$N8N_ENCRYPTION_KEY" "$EVALS_LANGSMITH_API_KEY"; do
             [ -z "$v" ] && continue
             while IFS= read -r line; do
               [ -n "$line" ] && echo "::add-mask::$line"

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -59,7 +59,7 @@ on:
         type: string
         default: ''
       model:
-        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). openai/* → EVALS_OPENAI_KEY; openrouter/* → EVALS_OPENROUTER_KEY; xai/* → EVALS_XAI_KEY.'
+        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). openai/* → EVALS_OPENAI_KEY; openrouter/* → EVALS_OPENROUTER_KEY; xai/* → EVALS_XAI_KEY; baseten/* → EVALS_BASETEN_KEY.'
         required: false
         type: string
         default: ''
@@ -94,7 +94,7 @@ on:
         required: false
         default: ''
       model:
-        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openai/gpt-5.6-terra, openai/gpt-5.6-luna, openrouter/moonshotai/kimi-k3, xai/grok-4.5.'
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openai/gpt-5.6-terra, openai/gpt-5.6-luna, openrouter/moonshotai/kimi-k3, xai/grok-4.5, baseten/zai-org/GLM-5.2, baseten/zai-org/GLM-5.2-Fast.'
         required: false
         default: ''
 
@@ -167,6 +167,7 @@ jobs:
           EVALS_OPENAI_KEY: ${{ secrets.EVALS_OPENAI_KEY }}
           EVALS_OPENROUTER_KEY: ${{ secrets.EVALS_OPENROUTER_KEY }}
           EVALS_XAI_KEY: ${{ secrets.EVALS_XAI_KEY }}
+          EVALS_BASETEN_KEY: ${{ secrets.EVALS_BASETEN_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
@@ -230,6 +231,12 @@ jobs:
               exit 1
             fi
             MODEL_API_KEY="$EVALS_XAI_KEY"
+          elif [[ "$INSTANCE_AI_MODEL" == baseten/* ]]; then
+            if [ -z "$EVALS_BASETEN_KEY" ]; then
+              echo "::error::model is baseten/* but EVALS_BASETEN_KEY secret is empty"
+              exit 1
+            fi
+            MODEL_API_KEY="$EVALS_BASETEN_KEY"
           fi
 
           IFS=',' read -ra PORTS <<< "$LANE_PORTS"
@@ -431,6 +438,7 @@ jobs:
           EVALS_OPENAI_KEY: ${{ secrets.EVALS_OPENAI_KEY }}
           EVALS_OPENROUTER_KEY: ${{ secrets.EVALS_OPENROUTER_KEY }}
           EVALS_XAI_KEY: ${{ secrets.EVALS_XAI_KEY }}
+          EVALS_BASETEN_KEY: ${{ secrets.EVALS_BASETEN_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
@@ -442,7 +450,7 @@ jobs:
           # (e.g. N8N_LICENSE_CERT is PEM-encoded) must be masked one line at
           # a time, otherwise only the first line is registered.
           for v in "$EVALS_ANTHROPIC_KEY" "$EVALS_OPENAI_KEY" "$EVALS_OPENROUTER_KEY" \
-                   "$EVALS_XAI_KEY" "$DAYTONA_API_KEY" "$N8N_LICENSE_ACTIVATION_KEY" \
+                   "$EVALS_XAI_KEY" "$EVALS_BASETEN_KEY" "$DAYTONA_API_KEY" "$N8N_LICENSE_ACTIVATION_KEY" \
                    "$N8N_LICENSE_CERT" "$N8N_ENCRYPTION_KEY" "$EVALS_LANGSMITH_API_KEY"; do
             [ -z "$v" ] && continue
             while IFS= read -r line; do

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -59,7 +59,7 @@ on:
         type: string
         default: ''
       model:
-        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). openai/* → EVALS_OPENAI_KEY; openrouter/* → EVALS_OPENROUTER_KEY; xai/* → EVALS_XAI_KEY; baseten/* → EVALS_BASETEN_KEY.'
+        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default (anthropic/claude-opus-4-8). Examples: anthropic/claude-opus-5, anthropic/claude-sonnet-4-6. openai/* → EVALS_OPENAI_KEY; openrouter/* → EVALS_OPENROUTER_KEY; xai/* → EVALS_XAI_KEY; baseten/* → EVALS_BASETEN_KEY.'
         required: false
         type: string
         default: ''
@@ -94,7 +94,7 @@ on:
         required: false
         default: ''
       model:
-        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openai/gpt-5.6-terra, openai/gpt-5.6-luna, openrouter/moonshotai/kimi-k3, xai/grok-4.5, baseten/zai-org/GLM-5.2, baseten/zai-org/GLM-5.2-Fast.'
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-opus-5, anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openai/gpt-5.6-terra, openai/gpt-5.6-luna, openrouter/moonshotai/kimi-k3, xai/grok-4.5, baseten/zai-org/GLM-5.2, baseten/zai-org/GLM-5.2-Fast.'
         required: false
         default: ''
 

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -64,12 +64,12 @@ on:
         type: string
         default: ''
       lanes:
-        description: 'Parallel n8n lane containers (1-11). Empty = 10, or 1 when model is baseten/* (fits Baseten Basic verified ~500k TPM).'
+        description: 'Parallel n8n lane containers (1-11). Empty = 10.'
         required: false
         type: string
         default: ''
       eval-concurrency:
-        description: 'Concurrent scenario executions. Empty = 32, or 2 when model is baseten/* (~0.5M TPM / ~12 RPM — fits Baseten Basic verified).'
+        description: 'Concurrent scenario executions. Empty = 32.'
         required: false
         type: string
         default: ''
@@ -108,11 +108,11 @@ on:
         required: false
         default: ''
       lanes:
-        description: 'Parallel n8n lane containers (1-11). Empty = 10, or 1 when model is baseten/* (fits Baseten Basic verified ~500k TPM).'
+        description: 'Parallel n8n lane containers (1-11). Empty = 10.'
         required: false
         default: ''
       eval-concurrency:
-        description: 'Concurrent scenarios. Empty = 32, or 2 when model is baseten/* (~0.5M TPM / ~12 RPM — fits Baseten Basic verified).'
+        description: 'Concurrent scenarios. Empty = 32.'
         required: false
         default: ''
 
@@ -122,19 +122,15 @@ jobs:
     # 8vcpu/32GB: full-suite N=10 baselines need ~150 min of eval time and
     # did not fit the 4vcpu tier at any timeout.
     runs-on: blacksmith-8vcpu-ubuntu-2204
-    # Long ceiling for high-N baselines (240) and for Baseten (600: auto
-    # 1 lane / c=2 is ~16× slower than the Anthropic default, so a ~18 min
-    # full suite becomes ~5 h; +2 h buffer for provider backoff). Plain
-    # comparison (not fromJSON): coerces the string input to a number;
-    # malformed NaN falls back to the 90-minute guard instead of erroring.
-    timeout-minutes: ${{ startsWith(inputs.model || '', 'baseten/') && 600 || ((inputs.iterations || '3') >= 5 && 240 || 90) }}
+    # Long ceiling for high-N baselines (240). Plain comparison (not fromJSON):
+    # coerces the string input to a number; malformed NaN falls back to the
+    # 90-minute guard instead of erroring.
+    timeout-minutes: ${{ (inputs.iterations || '3') >= 5 && 240 || 90 }}
     env:
       # Contiguous ports from 5678; 5678..5688 avoids Node fetch()'s blocked-
-      # port list (max 11 lanes). Defaults: 10 lanes / c=32 for Anthropic;
-      # baseten/* auto-throttles to 1 / 2 to stay under Baseten Basic verified
-      # (~500k TPM).
-      LANES: ${{ inputs.lanes != '' && inputs.lanes || (startsWith(inputs.model || '', 'baseten/') && '1' || '10') }}
-      EVAL_CONCURRENCY: ${{ inputs.eval-concurrency != '' && inputs.eval-concurrency || (startsWith(inputs.model || '', 'baseten/') && '2' || '32') }}
+      # port list (max 11 lanes). Defaults: 10 lanes / c=32.
+      LANES: ${{ inputs.lanes != '' && inputs.lanes || '10' }}
+      EVAL_CONCURRENCY: ${{ inputs.eval-concurrency != '' && inputs.eval-concurrency || '32' }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -63,6 +63,16 @@ on:
         required: false
         type: string
         default: ''
+      lanes:
+        description: 'Parallel n8n lane containers (1-11). Empty = 10, or 1 when model is baseten/* (fits Baseten Basic verified ~500k TPM).'
+        required: false
+        type: string
+        default: ''
+      eval-concurrency:
+        description: 'Concurrent scenario executions. Empty = 32, or 2 when model is baseten/* (~0.5M TPM / ~12 RPM — fits Baseten Basic verified).'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       branch:
@@ -97,6 +107,14 @@ on:
         description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). Experiments: anthropic/claude-opus-5, anthropic/claude-sonnet-4-6, openai/gpt-5.6-sol, openai/gpt-5.6-terra, openai/gpt-5.6-luna, openrouter/moonshotai/kimi-k3, xai/grok-4.5, baseten/zai-org/GLM-5.2, baseten/zai-org/GLM-5.2-Fast.'
         required: false
         default: ''
+      lanes:
+        description: 'Parallel n8n lane containers (1-11). Empty = 10, or 1 when model is baseten/* (fits Baseten Basic verified ~500k TPM).'
+        required: false
+        default: ''
+      eval-concurrency:
+        description: 'Concurrent scenarios. Empty = 32, or 2 when model is baseten/* (~0.5M TPM / ~12 RPM — fits Baseten Basic verified).'
+        required: false
+        default: ''
 
 jobs:
   run-evals:
@@ -104,16 +122,19 @@ jobs:
     # 8vcpu/32GB: full-suite N=10 baselines need ~150 min of eval time and
     # did not fit the 4vcpu tier at any timeout.
     runs-on: blacksmith-8vcpu-ubuntu-2204
-    # Long ceiling only for high-N baseline captures; regular runs keep a
-    # tight guard so a wedged run fails fast. Plain comparison (not fromJSON):
-    # it coerces the string input to a number, and a malformed dispatch value
-    # (NaN) falls back to the 90-minute guard instead of erroring the job.
-    timeout-minutes: ${{ (inputs.iterations || '3') >= 5 && 240 || 90 }}
+    # Long ceiling for high-N baselines (240) and for Baseten (600: auto
+    # 1 lane / c=2 is ~16× slower than the Anthropic default, so a ~18 min
+    # full suite becomes ~5 h; +2 h buffer for provider backoff). Plain
+    # comparison (not fromJSON): coerces the string input to a number;
+    # malformed NaN falls back to the 90-minute guard instead of erroring.
+    timeout-minutes: ${{ startsWith(inputs.model || '', 'baseten/') && 600 || ((inputs.iterations || '3') >= 5 && 240 || 90) }}
     env:
-      # Each port hosts an independent n8n container. The eval CLI's
-      # work-stealing allocator dispatches builds across them, capped per-lane.
-      # 10 lanes x 2.5 GB caps = 25 GB, leaving ~7 GB for sandbox + CLI + OS.
-      LANE_PORTS: '5678,5679,5680,5681,5682,5683,5684,5685,5686,5687'
+      # Contiguous ports from 5678; 5678..5688 avoids Node fetch()'s blocked-
+      # port list (max 11 lanes). Defaults: 10 lanes / c=32 for Anthropic;
+      # baseten/* auto-throttles to 1 / 2 to stay under Baseten Basic verified
+      # (~500k TPM).
+      LANES: ${{ inputs.lanes != '' && inputs.lanes || (startsWith(inputs.model || '', 'baseten/') && '1' || '10') }}
+      EVAL_CONCURRENCY: ${{ inputs.eval-concurrency != '' && inputs.eval-concurrency || (startsWith(inputs.model || '', 'baseten/') && '2' || '32') }}
     permissions:
       contents: read
       pull-requests: write
@@ -239,7 +260,15 @@ jobs:
             MODEL_API_KEY="$EVALS_BASETEN_KEY"
           fi
 
-          IFS=',' read -ra PORTS <<< "$LANE_PORTS"
+          if [ "$LANES" -lt 1 ] || [ "$LANES" -gt 11 ]; then
+            echo "::error::lanes must be 1-11 (got $LANES)"
+            exit 1
+          fi
+          PORTS=()
+          for i in $(seq 0 $((LANES - 1))); do
+            PORTS+=($((5678 + i)))
+          done
+          echo "Starting $LANES lane(s) on ports ${PORTS[*]} (eval concurrency $EVAL_CONCURRENCY)"
           for i in "${!PORTS[@]}"; do
             port="${PORTS[$i]}"
             # Bounded and self-healing: a lane that exhausts its capped heap is
@@ -296,7 +325,10 @@ jobs:
 
       - name: Create test users
         run: |
-          IFS=',' read -ra PORTS <<< "$LANE_PORTS"
+          PORTS=()
+          for i in $(seq 0 $((LANES - 1))); do
+            PORTS+=($((5678 + i)))
+          done
           for port in "${PORTS[@]}"; do
             curl -sf -X POST "http://localhost:$port/rest/e2e/reset" \
               -H "Content-Type: application/json" \
@@ -317,7 +349,10 @@ jobs:
           SANDBOX_PROVIDER: ${{ inputs.sandbox-provider || 'n8n-sandbox' }}
           INSTANCE_AI_MODEL: ${{ inputs.model }}
         run: |
-          IFS=',' read -ra PORTS <<< "$LANE_PORTS"
+          PORTS=()
+          for i in $(seq 0 $((LANES - 1))); do
+            PORTS+=($((5678 + i)))
+          done
           bad=0
           for i in "${!PORTS[@]}"; do
             port="${PORTS[$i]}"
@@ -398,13 +433,17 @@ jobs:
           EXPERIMENT_NAME: ${{ inputs.experiment-name }}
           EVAL_PR_NUMBER: ${{ inputs.pr-number || github.event.pull_request.number }}
         run: |
-          IFS=',' read -ra PORTS <<< "$LANE_PORTS"
+          PORTS=()
+          for i in $(seq 0 $((LANES - 1))); do
+            PORTS+=($((5678 + i)))
+          done
           URLS=()
           for port in "${PORTS[@]}"; do
             URLS+=("http://localhost:$port")
           done
           BASE_URLS=$(IFS=,; printf '%s' "${URLS[*]}")
-          ARGS=(--base-url "$BASE_URLS" --concurrency 32 --verbose --iterations "${ITERATIONS:-3}")
+          echo "Lanes: $LANES | eval concurrency: $EVAL_CONCURRENCY"
+          ARGS=(--base-url "$BASE_URLS" --concurrency "$EVAL_CONCURRENCY" --verbose --iterations "${ITERATIONS:-3}")
           # LangTracer is the only CI case source (no disk fallback by design).
           ARGS+=(--source langtracer --suite "${SUITE:-baseline}")
           # Pin the LangSmith cohort: langtracer mode otherwise derives a

--- a/.github/workflows/test-evals-mcp.yml
+++ b/.github/workflows/test-evals-mcp.yml
@@ -51,7 +51,7 @@ on:
         type: string
         default: ''
       build-model:
-        description: 'Anthropic model id for the claude MCP build step (injected as ANTHROPIC_MODEL)'
+        description: 'Anthropic model id for the claude MCP build step (injected as ANTHROPIC_MODEL). Examples: claude-opus-4-8, claude-opus-5.'
         required: false
         type: string
         default: 'claude-opus-4-8'

--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -91,6 +91,7 @@
     "@ai-sdk/amazon-bedrock": "catalog:",
     "@ai-sdk/anthropic": "catalog:",
     "@ai-sdk/azure": "catalog:",
+    "@ai-sdk/baseten": "catalog:",
     "@ai-sdk/cohere": "catalog:",
     "@ai-sdk/deepseek": "catalog:",
     "@ai-sdk/gateway": "catalog:",

--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -91,7 +91,6 @@
     "@ai-sdk/amazon-bedrock": "catalog:",
     "@ai-sdk/anthropic": "catalog:",
     "@ai-sdk/azure": "catalog:",
-    "@ai-sdk/baseten": "catalog:",
     "@ai-sdk/cohere": "catalog:",
     "@ai-sdk/deepseek": "catalog:",
     "@ai-sdk/gateway": "catalog:",

--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -25,6 +25,7 @@ export type {
 	ThinkingConfigFor,
 	AnthropicThinkingEffort,
 	AnthropicThinkingConfig,
+	OpenAIReasoningEffort,
 	OpenAIThinkingConfig,
 	GoogleThinkingConfig,
 	XaiThinkingConfig,

--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -23,6 +23,7 @@ export type {
 	Provider,
 	ThinkingConfig,
 	ThinkingConfigFor,
+	AnthropicThinkingEffort,
 	AnthropicThinkingConfig,
 	OpenAIThinkingConfig,
 	GoogleThinkingConfig,

--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -11,6 +11,18 @@ type ProviderOpts = {
 
 // All providers are mocked via vi.mock so require() inside the registry entries
 // returns these stubs instead of the real packages.
+vi.mock('@ai-sdk/baseten', () => ({
+	createBaseten: (opts?: ProviderOpts) => (model: string) => ({
+		provider: 'baseten.chat',
+		modelId: model,
+		apiKey: opts?.apiKey,
+		baseURL: opts?.baseURL,
+		fetch: opts?.fetch,
+		headers: opts?.headers,
+		specificationVersion: 'v3',
+	}),
+}));
+
 vi.mock('@ai-sdk/anthropic', () => ({
 	createAnthropic: (opts?: ProviderOpts) => (model: string) => ({
 		provider: 'anthropic',
@@ -342,6 +354,16 @@ describe('createModel', () => {
 			expect(model.provider).toBe('openrouter');
 			expect(model.modelId).toBe('openai/gpt-4o');
 			expect(model.apiKey).toBe('or-test');
+		});
+
+		it('should create model for baseten', () => {
+			const model = createModel({
+				id: 'baseten/zai-org/GLM-5.2-Fast',
+				apiKey: 'bt-test',
+			}) as unknown as Record<string, unknown>;
+			expect(model.provider).toBe('baseten.chat');
+			expect(model.modelId).toBe('zai-org/GLM-5.2-Fast');
+			expect(model.apiKey).toBe('bt-test');
 		});
 
 		it('should create model for nvidia', () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -11,18 +11,6 @@ type ProviderOpts = {
 
 // All providers are mocked via vi.mock so require() inside the registry entries
 // returns these stubs instead of the real packages.
-vi.mock('@ai-sdk/baseten', () => ({
-	createBaseten: (opts?: ProviderOpts) => (model: string) => ({
-		provider: 'baseten.chat',
-		modelId: model,
-		apiKey: opts?.apiKey,
-		baseURL: opts?.baseURL,
-		fetch: opts?.fetch,
-		headers: opts?.headers,
-		specificationVersion: 'v3',
-	}),
-}));
-
 vi.mock('@ai-sdk/anthropic', () => ({
 	createAnthropic: (opts?: ProviderOpts) => (model: string) => ({
 		provider: 'anthropic',
@@ -356,14 +344,15 @@ describe('createModel', () => {
 			expect(model.apiKey).toBe('or-test');
 		});
 
-		it('should create model for baseten', () => {
+		it('should create model for baseten via openai-compatible', () => {
 			const model = createModel({
 				id: 'baseten/zai-org/GLM-5.2-Fast',
 				apiKey: 'bt-test',
 			}) as unknown as Record<string, unknown>;
-			expect(model.provider).toBe('baseten.chat');
+			expect(model.provider).toBe('baseten');
 			expect(model.modelId).toBe('zai-org/GLM-5.2-Fast');
 			expect(model.apiKey).toBe('bt-test');
+			expect(model.baseURL).toBe('https://inference.baseten.co/v1');
 		});
 
 		it('should create model for nvidia', () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -202,9 +202,9 @@ describe('createModel', () => {
 	});
 
 	it('should accept a string config', () => {
-		const model = createModel('anthropic/claude-sonnet-4-5') as unknown as Record<string, unknown>;
+		const model = createModel('anthropic/claude-opus-5') as unknown as Record<string, unknown>;
 		expect(model.provider).toBe('anthropic');
-		expect(model.modelId).toBe('claude-sonnet-4-5');
+		expect(model.modelId).toBe('claude-opus-5');
 	});
 
 	it('should accept an object config with baseURL', () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
@@ -75,9 +75,26 @@ describe('thinkingToProviderOptions', () => {
 		});
 	});
 
-	it('openai: defaults reasoningEffort to medium', () => {
+	it('openai: defaults reasoningEffort to medium (AI SDK providerOptions form)', () => {
 		expect(getProviderQuirks('openai').thinkingToProviderOptions?.({})).toEqual({
 			openai: { reasoningEffort: 'medium' },
+		});
+	});
+
+	it('openai: forwards GPT-5.6 Sol compatible reasoningEffort values', () => {
+		expect(
+			getProviderQuirks('openai').thinkingToProviderOptions?.({
+				reasoningEffort: 'medium',
+			}),
+		).toEqual({
+			openai: { reasoningEffort: 'medium' },
+		});
+		expect(
+			getProviderQuirks('openai').thinkingToProviderOptions?.({
+				reasoningEffort: 'xhigh',
+			}),
+		).toEqual({
+			openai: { reasoningEffort: 'xhigh' },
 		});
 	});
 

--- a/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { applyToolProviderOptionDefaults, getProviderQuirks } from '../model/provider-quirks';
+import {
+	GLM_52_DEFAULT_MAX_OUTPUT_TOKENS,
+	applyToolProviderOptionDefaults,
+	getProviderQuirks,
+	resolveDefaultMaxOutputTokens,
+} from '../model/provider-quirks';
 
 describe('getProviderQuirks', () => {
 	it('returns an empty object for an unknown provider', () => {
@@ -129,5 +134,37 @@ describe('thinkingToProviderOptions', () => {
 		expect(getProviderQuirks('openrouter').thinkingToProviderOptions?.({})).toEqual({
 			openrouter: { reasoning: { effort: 'medium' } },
 		});
+	});
+
+	it('baseten: maps reasoningEffort to providerOptions.baseten', () => {
+		expect(
+			getProviderQuirks('baseten').thinkingToProviderOptions?.({
+				reasoningEffort: 'high',
+			}),
+		).toEqual({
+			baseten: { reasoningEffort: 'high' },
+		});
+	});
+
+	it('baseten: defaults reasoning effort to medium', () => {
+		expect(getProviderQuirks('baseten').thinkingToProviderOptions?.({})).toEqual({
+			baseten: { reasoningEffort: 'medium' },
+		});
+	});
+});
+
+describe('resolveDefaultMaxOutputTokens', () => {
+	it.each([
+		'baseten/zai-org/GLM-5.2',
+		'baseten/zai-org/GLM-5.2-Fast',
+		'openai/zai-org/GLM-5.2',
+		'openai/zai-org/GLM-5.2-Fast',
+	] as const)('raises the output cap for GLM 5.2 models (%s)', (modelId) => {
+		expect(resolveDefaultMaxOutputTokens(modelId)).toBe(GLM_52_DEFAULT_MAX_OUTPUT_TOKENS);
+	});
+
+	it('leaves unrelated models unset', () => {
+		expect(resolveDefaultMaxOutputTokens('baseten/deepseek-ai/DeepSeek-V4-Pro')).toBeUndefined();
+		expect(resolveDefaultMaxOutputTokens('anthropic/claude-sonnet-4-5')).toBeUndefined();
 	});
 });

--- a/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
@@ -83,4 +83,20 @@ describe('thinkingToProviderOptions', () => {
 			xai: { reasoningEffort: 'high' },
 		});
 	});
+
+	it('openrouter: maps reasoningEffort to reasoning.effort', () => {
+		expect(
+			getProviderQuirks('openrouter').thinkingToProviderOptions?.({
+				reasoningEffort: 'low',
+			}),
+		).toEqual({
+			openrouter: { reasoning: { effort: 'low' } },
+		});
+	});
+
+	it('openrouter: defaults reasoning effort to medium', () => {
+		expect(getProviderQuirks('openrouter').thinkingToProviderOptions?.({})).toEqual({
+			openrouter: { reasoning: { effort: 'medium' } },
+		});
+	});
 });

--- a/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
@@ -61,6 +61,20 @@ describe('thinkingToProviderOptions', () => {
 		});
 	});
 
+	it('anthropic: adaptive mode forwards effort when set', () => {
+		expect(
+			getProviderQuirks('anthropic').thinkingToProviderOptions?.({
+				mode: 'adaptive',
+				effort: 'low',
+			}),
+		).toEqual({
+			anthropic: {
+				thinking: { type: 'adaptive', display: 'summarized' },
+				effort: 'low',
+			},
+		});
+	});
+
 	it('openai: defaults reasoningEffort to medium', () => {
 		expect(getProviderQuirks('openai').thinkingToProviderOptions?.({})).toEqual({
 			openai: { reasoningEffort: 'medium' },

--- a/packages/@n8n/agents/src/runtime/loop/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/loop/agent-runtime.ts
@@ -792,6 +792,7 @@ export class AgentRuntime {
 				aiTools: cached.aiTools,
 				providerOptions: staticLoopContext.providerOptions,
 				outputSpec: staticLoopContext.outputSpec,
+				maxOutputTokens: staticLoopContext.maxOutputTokens,
 				aiSdkOptions: this.buildAiSdkOptions(toolMap, options),
 			});
 

--- a/packages/@n8n/agents/src/runtime/loop/generate-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/generate-sink.ts
@@ -37,6 +37,7 @@ export class GenerateSink implements RunOutputSink<GenerateResult> {
 			...(ctx.hasTools ? { tools: ctx.aiTools } : {}),
 			...(ctx.providerOptions ? { providerOptions: ctx.providerOptions } : {}),
 			...(ctx.outputSpec ? { output: ctx.outputSpec } : {}),
+			...(ctx.maxOutputTokens !== undefined ? { maxOutputTokens: ctx.maxOutputTokens } : {}),
 			...ctx.aiSdkOptions,
 		});
 

--- a/packages/@n8n/agents/src/runtime/loop/run-output-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/run-output-sink.ts
@@ -67,6 +67,7 @@ export interface ModelCallContext {
 	aiTools: ToolSet;
 	providerOptions?: Record<string, JSONObject>;
 	outputSpec?: ReturnType<typeof Output.object>;
+	maxOutputTokens?: number;
 	aiSdkOptions: {
 		experimental_telemetry?: TelemetrySettings;
 		experimental_repairToolCall?: ToolCallRepairFunction<NoInfer<ToolSet>>;

--- a/packages/@n8n/agents/src/runtime/loop/runtime-context.ts
+++ b/packages/@n8n/agents/src/runtime/loop/runtime-context.ts
@@ -21,6 +21,7 @@ import {
 	getProviderQuirks,
 	PROVIDER_QUIRKS,
 	providerIdFromModelId,
+	resolveDefaultMaxOutputTokens,
 } from '../model/provider-quirks';
 import type { DeferredToolManager } from '../tools/deferred-tool-manager';
 import { buildToolMap, toAiSdkProviderTools, toAiSdkTools } from '../tools/tool-adapter';
@@ -51,6 +52,7 @@ export interface StaticLoopContext {
 	aiProviderTools: ReturnType<typeof toAiSdkProviderTools>;
 	providerOptions?: Record<string, JSONObject>;
 	outputSpec?: ReturnType<typeof Output.object>;
+	maxOutputTokens?: number;
 }
 
 /**
@@ -99,6 +101,7 @@ export class RuntimeContextBuilder {
 			aiProviderTools,
 			providerOptions: providerOptions as Record<string, JSONObject> | undefined,
 			outputSpec,
+			maxOutputTokens: resolveDefaultMaxOutputTokens(this.modelId),
 		};
 	}
 

--- a/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
@@ -124,6 +124,7 @@ export class StreamSink implements RunOutputSink<void> {
 			...(ctx.hasTools ? { tools: ctx.aiTools } : {}),
 			...(ctx.providerOptions ? { providerOptions: ctx.providerOptions } : {}),
 			...(ctx.outputSpec ? { output: ctx.outputSpec } : {}),
+			...(ctx.maxOutputTokens !== undefined ? { maxOutputTokens: ctx.maxOutputTokens } : {}),
 			...ctx.aiSdkOptions,
 			...this.buildSmoothStreamTransformOptions(),
 		});

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -96,9 +96,18 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 		},
 	},
 	baseten: {
+		// OpenAI-compatible HTTP only. Avoid @ai-sdk/baseten: it eagerly loads
+		// @basetenlabs/performance-client (NAPI optional binaries), which pnpm
+		// deploy --no-optional strips — Alpine Docker then fails at require time.
 		build: (creds, model, fetch) => {
-			const { createBaseten } = require('@ai-sdk/baseten') as typeof import('@ai-sdk/baseten');
-			return createBaseten({ ...creds, fetch })(model);
+			const { createOpenAICompatible } =
+				require('@ai-sdk/openai-compatible') as typeof import('@ai-sdk/openai-compatible');
+			return createOpenAICompatible({
+				name: 'baseten',
+				baseURL: creds.baseURL ?? 'https://inference.baseten.co/v1',
+				apiKey: creds.apiKey,
+				fetch,
+			})(model);
 		},
 	},
 	anthropic: {

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -95,6 +95,12 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 			})(model);
 		},
 	},
+	baseten: {
+		build: (creds, model, fetch) => {
+			const { createBaseten } = require('@ai-sdk/baseten') as typeof import('@ai-sdk/baseten');
+			return createBaseten({ ...creds, fetch })(model);
+		},
+	},
 	anthropic: {
 		build: (creds, model, fetch) => {
 			const { createAnthropic } =

--- a/packages/@n8n/agents/src/runtime/model/provider-credentials.ts
+++ b/packages/@n8n/agents/src/runtime/model/provider-credentials.ts
@@ -15,6 +15,7 @@ export const PROVIDER_CREDENTIAL_SCHEMAS = {
 	custom: apiKeyCreds.extend({
 		baseURL: z.string().min(1, 'baseURL is required'),
 	}),
+	baseten: apiKeyCreds,
 	anthropic: apiKeyCreds,
 	google: apiKeyCreds,
 	xai: apiKeyCreds,

--- a/packages/@n8n/agents/src/runtime/model/provider-quirks.ts
+++ b/packages/@n8n/agents/src/runtime/model/provider-quirks.ts
@@ -99,6 +99,18 @@ export const PROVIDER_QUIRKS: Partial<Record<ProviderId, ProviderQuirks>> = {
 			return { xai: { reasoningEffort: cfg.reasoningEffort ?? 'high' } };
 		},
 	},
+	openrouter: {
+		// OpenRouter's AI SDK provider reads `providerOptions.openrouter.reasoning`
+		// and forwards it as the chat-completions `reasoning` body field.
+		thinkingToProviderOptions: (thinking) => {
+			const cfg = thinking as OpenAIThinkingConfig;
+			return {
+				openrouter: {
+					reasoning: { effort: cfg.reasoningEffort ?? 'medium' },
+				},
+			};
+		},
+	},
 };
 
 export function getProviderQuirks(providerId: string): ProviderQuirks {

--- a/packages/@n8n/agents/src/runtime/model/provider-quirks.ts
+++ b/packages/@n8n/agents/src/runtime/model/provider-quirks.ts
@@ -111,6 +111,14 @@ export const PROVIDER_QUIRKS: Partial<Record<ProviderId, ProviderQuirks>> = {
 			};
 		},
 	},
+	baseten: {
+		// Baseten Model APIs use the OpenAI-compatible chat schema; reasoning maps to
+		// the top-level `reasoning_effort` body field via providerOptions.baseten.
+		thinkingToProviderOptions: (thinking) => {
+			const cfg = thinking as OpenAIThinkingConfig;
+			return { baseten: { reasoningEffort: 'none' } };
+		},
+	},
 };
 
 export function getProviderQuirks(providerId: string): ProviderQuirks {
@@ -119,6 +127,27 @@ export function getProviderQuirks(providerId: string): ProviderQuirks {
 
 export function providerIdFromModelId(modelId: string): string {
 	return modelId.split('/')[0];
+}
+
+/** GLM 5.2 default output cap on Baseten/Z.AI (131072 max; 65536 is the API default). */
+export const GLM_52_DEFAULT_MAX_OUTPUT_TOKENS = 65_536;
+
+function isGlm52Model(modelId: string): boolean {
+	const modelName = modelId.includes('/') ? modelId.split('/').slice(1).join('/') : modelId;
+	return modelName.toLowerCase().includes('glm-5.2');
+}
+
+/**
+ * Provider/model-specific default for AI SDK `maxOutputTokens`. Baseten GLM 5.2
+ * otherwise falls back to a 4096 cap that reasoning-heavy agent turns can exhaust
+ * before emitting text or tool calls.
+ */
+export function resolveDefaultMaxOutputTokens(modelId: string): number | undefined {
+	const provider = providerIdFromModelId(modelId);
+	if ((provider === 'baseten' || provider === 'openai') && isGlm52Model(modelId)) {
+		return GLM_52_DEFAULT_MAX_OUTPUT_TOKENS;
+	}
+	return undefined;
 }
 
 /** Merge every registered tool providerOptions default under its provider namespace; explicit tool values win. */

--- a/packages/@n8n/agents/src/types/index.ts
+++ b/packages/@n8n/agents/src/types/index.ts
@@ -22,6 +22,7 @@ export type {
 	Provider,
 	AnthropicThinkingEffort,
 	AnthropicThinkingConfig,
+	OpenAIReasoningEffort,
 	OpenAIThinkingConfig,
 	GoogleThinkingConfig,
 	XaiThinkingConfig,

--- a/packages/@n8n/agents/src/types/index.ts
+++ b/packages/@n8n/agents/src/types/index.ts
@@ -20,6 +20,7 @@ export type {
 
 export type {
 	Provider,
+	AnthropicThinkingEffort,
 	AnthropicThinkingConfig,
 	OpenAIThinkingConfig,
 	GoogleThinkingConfig,

--- a/packages/@n8n/agents/src/types/sdk/provider.ts
+++ b/packages/@n8n/agents/src/types/sdk/provider.ts
@@ -49,9 +49,23 @@ export type AnthropicThinkingConfig =
 			budgetTokens?: number;
 	  };
 
+/**
+ * OpenAI / AI SDK reasoning effort.
+ * GPT-5.6 Sol supports none|low|medium|high|xhigh|max (no `minimal`).
+ * Older reasoning models may also accept `minimal`.
+ */
+export type OpenAIReasoningEffort =
+	| 'none'
+	| 'minimal'
+	| 'low'
+	| 'medium'
+	| 'high'
+	| 'xhigh'
+	| 'max';
+
 export interface OpenAIThinkingConfig {
-	/** Reasoning effort level. Defaults to 'medium'. */
-	reasoningEffort?: 'low' | 'medium' | 'high';
+	/** Reasoning effort level. Defaults to 'medium'. Mapped to AI SDK `providerOptions.openai.reasoningEffort`. */
+	reasoningEffort?: OpenAIReasoningEffort;
 }
 
 export interface GoogleThinkingConfig {

--- a/packages/@n8n/agents/src/types/sdk/provider.ts
+++ b/packages/@n8n/agents/src/types/sdk/provider.ts
@@ -63,7 +63,7 @@ export interface GoogleThinkingConfig {
 
 export interface XaiThinkingConfig {
 	/** Reasoning effort level. */
-	reasoningEffort?: 'low' | 'high';
+	reasoningEffort?: 'low' | 'medium' | 'high';
 }
 
 /**

--- a/packages/@n8n/agents/src/types/sdk/provider.ts
+++ b/packages/@n8n/agents/src/types/sdk/provider.ts
@@ -5,6 +5,7 @@
  */
 export type Provider =
 	| 'anthropic'
+	| 'baseten'
 	| 'cerebras'
 	| 'deepinfra'
 	| 'deepseek'

--- a/packages/@n8n/agents/src/types/sdk/provider.ts
+++ b/packages/@n8n/agents/src/types/sdk/provider.ts
@@ -26,6 +26,8 @@ export type Provider =
  * - `'adaptive'`: the model decides how much to think per request.
  * - `'enabled'` (default): a fixed token budget controlled by `budgetTokens`.
  */
+export type AnthropicThinkingEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
 export type AnthropicThinkingConfig =
 	| {
 			mode: 'adaptive';
@@ -35,8 +37,11 @@ export type AnthropicThinkingConfig =
 			 * reasoning streams and replay metadata are available.
 			 */
 			display?: 'omitted' | 'summarized';
-			/** Reasoning effort for adaptive thinking. Defaults to 'medium'. */
-			effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+			/**
+			 * Adaptive-thinking effort (`output_config.effort` on the Anthropic API).
+			 * When omitted, Anthropic/SDK defaults apply.
+			 */
+			effort?: AnthropicThinkingEffort;
 	  }
 	| {
 			mode?: 'enabled';

--- a/packages/@n8n/ai-utilities/src/model-discovery/__tests__/model-discovery.test.ts
+++ b/packages/@n8n/ai-utilities/src/model-discovery/__tests__/model-discovery.test.ts
@@ -178,6 +178,7 @@ describe('model-discovery', () => {
 	});
 
 	describe.each([
+		['baseten', 'https://inference.baseten.co/v1/models'],
 		['deepseek', 'https://api.deepseek.com/models'],
 		['openrouter', 'https://openrouter.ai/api/v1/models'],
 		['xai', 'https://api.x.ai/v1/models'],
@@ -213,6 +214,7 @@ describe('model-discovery', () => {
 	it('exposes a registry of all supported providers', () => {
 		expect(Object.keys(MODEL_DISCOVERY_PROVIDERS).sort()).toEqual([
 			'anthropic',
+			'baseten',
 			'cohere',
 			'deepseek',
 			'google',

--- a/packages/@n8n/ai-utilities/src/model-discovery/index.ts
+++ b/packages/@n8n/ai-utilities/src/model-discovery/index.ts
@@ -1,4 +1,5 @@
 import { listAnthropicModels } from './providers/anthropic';
+import { listBasetenModels } from './providers/baseten';
 import { listCohereModels } from './providers/cohere';
 import { listDeepSeekModels } from './providers/deepseek';
 import { listGoogleModels } from './providers/google';
@@ -24,6 +25,7 @@ import type { ListModelsFn, ListModelsOptions, ProviderModel } from './types';
  */
 export const MODEL_DISCOVERY_PROVIDERS: Record<string, ListModelsFn> = {
 	anthropic: listAnthropicModels,
+	baseten: listBasetenModels,
 	cohere: listCohereModels,
 	deepseek: listDeepSeekModels,
 	google: listGoogleModels,
@@ -52,6 +54,7 @@ export async function listModelsForProvider(
 }
 
 export { listAnthropicModels } from './providers/anthropic';
+export { listBasetenModels } from './providers/baseten';
 export { listCohereModels } from './providers/cohere';
 export { listDeepSeekModels } from './providers/deepseek';
 export { listGoogleModels } from './providers/google';

--- a/packages/@n8n/ai-utilities/src/model-discovery/providers/baseten.ts
+++ b/packages/@n8n/ai-utilities/src/model-discovery/providers/baseten.ts
@@ -1,0 +1,7 @@
+import { makeBearerDataListing } from '../request';
+
+/** Source: Baseten OpenAI-compatible inference API (`/v1/models`). */
+export const listBasetenModels = makeBearerDataListing(
+	'baseten',
+	'https://inference.baseten.co/v1',
+);

--- a/packages/@n8n/api-types/src/agents/model-providers.ts
+++ b/packages/@n8n/api-types/src/agents/model-providers.ts
@@ -7,6 +7,7 @@ export const AGENT_MODEL_PROVIDERS = [
 	'xai',
 	'groq',
 	'openrouter',
+	'baseten',
 	'deepseek',
 	'cohere',
 	'mistral',

--- a/packages/@n8n/api-types/src/agents/provider-capabilities.ts
+++ b/packages/@n8n/api-types/src/agents/provider-capabilities.ts
@@ -74,7 +74,12 @@ export const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 		webSearch: false,
 		providerTools: [],
 	},
-	xai: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
+	xai: {
+		thinking: 'reasoningEffort',
+		promptCaching: false,
+		webSearch: false,
+		providerTools: [],
+	},
 	groq: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
 	deepseek: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
 	mistral: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },

--- a/packages/@n8n/api-types/src/agents/provider-capabilities.ts
+++ b/packages/@n8n/api-types/src/agents/provider-capabilities.ts
@@ -78,7 +78,12 @@ export const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 	groq: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
 	deepseek: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
 	mistral: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
-	openrouter: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
+	openrouter: {
+		thinking: 'reasoningEffort',
+		promptCaching: false,
+		webSearch: false,
+		providerTools: [],
+	},
 	cohere: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
 	ollama: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
 };

--- a/packages/@n8n/api-types/src/agents/provider-capabilities.ts
+++ b/packages/@n8n/api-types/src/agents/provider-capabilities.ts
@@ -89,6 +89,12 @@ export const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 		webSearch: false,
 		providerTools: [],
 	},
+	baseten: {
+		thinking: 'reasoningEffort',
+		promptCaching: false,
+		webSearch: false,
+		providerTools: [],
+	},
 	cohere: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
 	ollama: { thinking: false, promptCaching: false, webSearch: false, providerTools: [] },
 };

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1420,6 +1420,7 @@ export const INSTANCE_AI_MODEL_CREDENTIAL_TYPES = [
 	'mistralCloudApi',
 	'xAiApi',
 	'openRouterApi',
+	'basetenApi',
 	'cohereApi',
 ] as const;
 

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -11,7 +11,7 @@ persisted in settings takes precedence over `N8N_INSTANCE_AI_SANDBOX_PROVIDER`.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `N8N_INSTANCE_AI_MODEL` | string | `anthropic/claude-opus-4-8` | LLM model in `provider/model` format for built-in providers, or a bare model name when `N8N_INSTANCE_AI_MODEL_URL` is set. Must be set for the module to enable. |
+| `N8N_INSTANCE_AI_MODEL` | string | `anthropic/claude-opus-4-8` | LLM model in `provider/model` format for built-in providers, or a bare model name when `N8N_INSTANCE_AI_MODEL_URL` is set. Must be set for the module to enable. Opus 5: `anthropic/claude-opus-5`. |
 | `N8N_INSTANCE_AI_MODEL_URL` | string | `''` | Base URL for an OpenAI-compatible endpoint (e.g. `http://localhost:1234/v1` for LM Studio). When set, model requests go to this URL instead of the built-in provider. |
 | `N8N_INSTANCE_AI_MODEL_API_KEY` | string | `''` | API key for the custom model endpoint. Optional — some local servers don't require one. |
 | `N8N_INSTANCE_AI_MCP_SERVERS` | string | `''` | Comma-separated MCP server configs. Format: `name=url,name=url` |

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -298,6 +298,7 @@ Not yet covered: an automatic "unexpected artifact" fail (a build producing an a
 | `N8N_INSTANCE_AI_MODEL_API_KEY` | No | Generic eval-model API key override |
 | `OPENAI_API_KEY` | No | Provider-specific key used automatically when `N8N_INSTANCE_AI_MODEL` starts with `openai/` |
 | `ANTHROPIC_API_KEY` | No | Provider-specific key used automatically when `N8N_INSTANCE_AI_MODEL` starts with `anthropic/` |
+| `BASETEN_API_KEY` | No | Provider-specific key used automatically when `N8N_INSTANCE_AI_MODEL` starts with `baseten/` |
 | `N8N_EVAL_EMAIL` | No | n8n login email (defaults to E2E test owner) |
 | `N8N_EVAL_PASSWORD` | No | n8n login password (defaults to E2E test owner) |
 | `LANGSMITH_API_KEY` | No | Enables experiment tracking + tracing. **See caveat below.** |
@@ -849,6 +850,8 @@ Suite pass rates typically sit between 40–65%; most failures are `builder_issu
 Evals run automatically on PRs that change Instance AI code (path-filtered). The workflow boots a set of n8n lane containers, pulls the test-case suite from LangTracer (`--source langtracer --suite baseline`), and runs the CLI against the lanes. See `.github/workflows/test-evals-instance-ai.yml`.
 
 The job is **non-blocking**. Results are posted as a PR comment and uploaded as artifacts. When `LANGSMITH_API_KEY` is set via the `EVALS_LANGSMITH_API_KEY` secret, runs also land as LangSmith experiments tagged with commit SHA + branch, so you can compare against master side-by-side.
+
+For model A/B experiments, dispatch **Instance AI Evals: Experiments** (`test-evals-instance-ai.yml`) and set the `model` input. Supported experiment models include `anthropic/claude-sonnet-4-6`, `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`, `openai/gpt-5.6-luna`, `openrouter/moonshotai/kimi-k3`, `xai/grok-4.5`, `baseten/zai-org/GLM-5.2`, and `baseten/zai-org/GLM-5.2-Fast`. CI routes the matching provider key from repo secrets (`EVALS_*_KEY`; Baseten uses `EVALS_BASETEN_KEY`).
 
 ## Architecture
 

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -853,7 +853,7 @@ The job is **non-blocking**. Results are posted as a PR comment and uploaded as 
 
 For model A/B experiments, dispatch **Instance AI Evals: Experiments** (`test-evals-instance-ai.yml`) and set the `model` input. Supported experiment models include `anthropic/claude-opus-5`, `anthropic/claude-sonnet-4-6`, `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`, `openai/gpt-5.6-luna`, `openrouter/moonshotai/kimi-k3`, `xai/grok-4.5`, `baseten/zai-org/GLM-5.2`, and `baseten/zai-org/GLM-5.2-Fast`. CI routes the matching provider key from repo secrets (`EVALS_*_KEY`; Baseten uses `EVALS_BASETEN_KEY`).
 
-`lanes` / `eval-concurrency` default to **10 / 32** (Anthropic-sized). For `baseten/*` models they auto-throttle to **1 / 2** (~0.5M TPM / ~12 RPM — fits [Baseten Basic verified](https://docs.baseten.co/inference/model-apis/rate-limits-and-budgets) 500k TPM / 120 RPM); override the inputs to raise them if your workspace has Pro/Enterprise headroom.
+`lanes` / `eval-concurrency` default to **10 / 32**.
 
 ## Architecture
 

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -853,6 +853,8 @@ The job is **non-blocking**. Results are posted as a PR comment and uploaded as 
 
 For model A/B experiments, dispatch **Instance AI Evals: Experiments** (`test-evals-instance-ai.yml`) and set the `model` input. Supported experiment models include `anthropic/claude-opus-5`, `anthropic/claude-sonnet-4-6`, `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`, `openai/gpt-5.6-luna`, `openrouter/moonshotai/kimi-k3`, `xai/grok-4.5`, `baseten/zai-org/GLM-5.2`, and `baseten/zai-org/GLM-5.2-Fast`. CI routes the matching provider key from repo secrets (`EVALS_*_KEY`; Baseten uses `EVALS_BASETEN_KEY`).
 
+`lanes` / `eval-concurrency` default to **10 / 32** (Anthropic-sized). For `baseten/*` models they auto-throttle to **1 / 2** (~0.5M TPM / ~12 RPM — fits [Baseten Basic verified](https://docs.baseten.co/inference/model-apis/rate-limits-and-budgets) 500k TPM / 120 RPM); override the inputs to raise them if your workspace has Pro/Enterprise headroom.
+
 ## Architecture
 
 ```

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -851,7 +851,7 @@ Evals run automatically on PRs that change Instance AI code (path-filtered). The
 
 The job is **non-blocking**. Results are posted as a PR comment and uploaded as artifacts. When `LANGSMITH_API_KEY` is set via the `EVALS_LANGSMITH_API_KEY` secret, runs also land as LangSmith experiments tagged with commit SHA + branch, so you can compare against master side-by-side.
 
-For model A/B experiments, dispatch **Instance AI Evals: Experiments** (`test-evals-instance-ai.yml`) and set the `model` input. Supported experiment models include `anthropic/claude-sonnet-4-6`, `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`, `openai/gpt-5.6-luna`, `openrouter/moonshotai/kimi-k3`, `xai/grok-4.5`, `baseten/zai-org/GLM-5.2`, and `baseten/zai-org/GLM-5.2-Fast`. CI routes the matching provider key from repo secrets (`EVALS_*_KEY`; Baseten uses `EVALS_BASETEN_KEY`).
+For model A/B experiments, dispatch **Instance AI Evals: Experiments** (`test-evals-instance-ai.yml`) and set the `model` input. Supported experiment models include `anthropic/claude-opus-5`, `anthropic/claude-sonnet-4-6`, `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`, `openai/gpt-5.6-luna`, `openrouter/moonshotai/kimi-k3`, `xai/grok-4.5`, `baseten/zai-org/GLM-5.2`, and `baseten/zai-org/GLM-5.2-Fast`. CI routes the matching provider key from repo secrets (`EVALS_*_KEY`; Baseten uses `EVALS_BASETEN_KEY`).
 
 ## Architecture
 

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -52,13 +52,16 @@ describe('applyAgentThinking', () => {
 		});
 	});
 
-	it('enables medium OpenAI reasoning effort for supported models', () => {
-		const agent = new Agent('test');
-		applyAgentThinking(agent, 'openai/gpt-5.6-sol');
-		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openai', {
-			reasoningEffort: 'medium',
-		});
-	});
+	it.each(['openai/gpt-5.6-sol', 'openai/gpt-5.6-terra', 'openai/gpt-5.6-luna'] as const)(
+		'enables medium OpenAI reasoning effort for %s',
+		(modelId) => {
+			const agent = new Agent('test');
+			applyAgentThinking(agent, modelId);
+			expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openai', {
+				reasoningEffort: 'medium',
+			});
+		},
+	);
 
 	it('skips providers without thinking support', () => {
 		const agent = new Agent('test');

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -52,11 +52,11 @@ describe('applyAgentThinking', () => {
 		});
 	});
 
-	it('enables OpenAI reasoning for supported models', () => {
+	it('enables medium OpenAI reasoning effort for supported models', () => {
 		const agent = new Agent('test');
-		applyAgentThinking(agent, 'openai/gpt-5.5');
+		applyAgentThinking(agent, 'openai/gpt-5.6-sol');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openai', {
-			reasoningEffort: 'high',
+			reasoningEffort: 'medium',
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -63,6 +63,36 @@ describe('applyAgentThinking', () => {
 		},
 	);
 
+	it.each(['openai/zai-org/GLM-5.2', 'openai/zai-org/GLM-5.2-Fast'] as const)(
+		'maps medium effort to high reasoning effort for legacy OpenAI-compatible Baseten %s',
+		(modelId) => {
+			const agent = new Agent('test');
+			applyAgentThinking(agent, modelId);
+			expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openai', {
+				reasoningEffort: 'high',
+			});
+		},
+	);
+
+	it.each(['baseten/zai-org/GLM-5.2', 'baseten/zai-org/GLM-5.2-Fast'] as const)(
+		'maps medium effort to high reasoning effort for Baseten %s',
+		(modelId) => {
+			const agent = new Agent('test');
+			applyAgentThinking(agent, modelId);
+			expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('baseten', {
+				reasoningEffort: 'high',
+			});
+		},
+	);
+
+	it('enables medium reasoning effort for other Baseten models', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, 'baseten/deepseek-ai/DeepSeek-V4-Pro');
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('baseten', {
+			reasoningEffort: 'medium',
+		});
+	});
+
 	it('skips providers without thinking support', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'google/gemini-2.5-pro');

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -74,9 +74,31 @@ describe('applyAgentThinking', () => {
 		});
 	});
 
-	it('skips OpenRouter models that are not Kimi K3', () => {
+	it('enables low reasoning effort for Grok 4.5 via OpenRouter', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, 'openrouter/x-ai/grok-4.5');
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openrouter', {
+			reasoningEffort: 'low',
+		});
+	});
+
+	it('enables low reasoning effort for Grok 4.5 via xAI', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, 'xai/grok-4.5');
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('xai', {
+			reasoningEffort: 'low',
+		});
+	});
+
+	it('skips OpenRouter models without a low-effort default', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'openrouter/openai/gpt-4o');
+		expect(mockAgentInstances[0]?.thinking).not.toHaveBeenCalled();
+	});
+
+	it('skips xAI models that are not Grok 4.5', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, 'xai/grok-3');
 		expect(mockAgentInstances[0]?.thinking).not.toHaveBeenCalled();
 	});
 });

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -22,7 +22,7 @@ describe('applyAgentThinking', () => {
 		vi.clearAllMocks();
 	});
 
-	it('enables adaptive thinking with low effort for Anthropic', () => {
+	it('enables adaptive thinking with medium effort for Anthropic', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'anthropic/claude-opus-4-8');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
@@ -31,7 +31,7 @@ describe('applyAgentThinking', () => {
 		});
 	});
 
-	it('enables adaptive thinking with low effort for dotted Anthropic provider IDs', () => {
+	it('enables adaptive thinking with medium effort for dotted Anthropic provider IDs', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'anthropic.messages/claude-opus-4-8');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
@@ -40,7 +40,7 @@ describe('applyAgentThinking', () => {
 		});
 	});
 
-	it('enables adaptive thinking with low effort for AI SDK Anthropic model objects', () => {
+	it('enables adaptive thinking with medium effort for AI SDK Anthropic model objects', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, {
 			modelId: 'claude-opus-4-8',
@@ -66,31 +66,31 @@ describe('applyAgentThinking', () => {
 		expect(mockAgentInstances[0]?.thinking).not.toHaveBeenCalled();
 	});
 
-	it('enables low reasoning effort for Kimi K3 via OpenRouter', () => {
+	it('enables medium reasoning effort for Kimi K3 via OpenRouter', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'openrouter/moonshotai/kimi-k3');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openrouter', {
-			reasoningEffort: 'low',
+			reasoningEffort: 'medium',
 		});
 	});
 
-	it('enables low reasoning effort for Grok 4.5 via OpenRouter', () => {
+	it('enables medium reasoning effort for Grok 4.5 via OpenRouter', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'openrouter/x-ai/grok-4.5');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openrouter', {
-			reasoningEffort: 'low',
+			reasoningEffort: 'medium',
 		});
 	});
 
-	it('enables low reasoning effort for Grok 4.5 via xAI', () => {
+	it('enables medium reasoning effort for Grok 4.5 via xAI', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'xai/grok-4.5');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('xai', {
-			reasoningEffort: 'low',
+			reasoningEffort: 'medium',
 		});
 	});
 
-	it('skips OpenRouter models without a low-effort default', () => {
+	it('skips OpenRouter models without a pinned-effort default', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'openrouter/openai/gpt-4o');
 		expect(mockAgentInstances[0]?.thinking).not.toHaveBeenCalled();

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -22,7 +22,7 @@ describe('applyAgentThinking', () => {
 		vi.clearAllMocks();
 	});
 
-	it('enables adaptive thinking for Anthropic', () => {
+	it('enables adaptive thinking with low effort for Anthropic', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'anthropic/claude-opus-4-8');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
@@ -31,7 +31,7 @@ describe('applyAgentThinking', () => {
 		});
 	});
 
-	it('enables adaptive thinking for dotted Anthropic provider IDs', () => {
+	it('enables adaptive thinking with low effort for dotted Anthropic provider IDs', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'anthropic.messages/claude-opus-4-8');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
@@ -40,7 +40,7 @@ describe('applyAgentThinking', () => {
 		});
 	});
 
-	it('enables adaptive thinking for AI SDK Anthropic model objects', () => {
+	it('enables adaptive thinking with low effort for AI SDK Anthropic model objects', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, {
 			modelId: 'claude-opus-4-8',

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -24,7 +24,7 @@ describe('applyAgentThinking', () => {
 
 	it('enables adaptive thinking with medium effort for Anthropic', () => {
 		const agent = new Agent('test');
-		applyAgentThinking(agent, 'anthropic/claude-opus-4-8');
+		applyAgentThinking(agent, 'anthropic/claude-opus-5');
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
 			mode: 'adaptive',
 			effort: 'medium',

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -65,4 +65,18 @@ describe('applyAgentThinking', () => {
 		applyAgentThinking(agent, 'google/gemini-2.5-pro');
 		expect(mockAgentInstances[0]?.thinking).not.toHaveBeenCalled();
 	});
+
+	it('enables low reasoning effort for Kimi K3 via OpenRouter', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, 'openrouter/moonshotai/kimi-k3');
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openrouter', {
+			reasoningEffort: 'low',
+		});
+	});
+
+	it('skips OpenRouter models that are not Kimi K3', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, 'openrouter/openai/gpt-4o');
+		expect(mockAgentInstances[0]?.thinking).not.toHaveBeenCalled();
+	});
 });

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -63,7 +63,7 @@ export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	if (!provider || !PROVIDER_CAPABILITIES[provider]?.thinking) return;
 
 	if (provider === 'openai') {
-		// Pin medium (GPT-5.6 Sol default) via AI SDK `reasoningEffort`.
+		// Pin medium for GPT-5.6 family (sol/terra/luna) via AI SDK `reasoningEffort`.
 		agent.thinking('openai', { reasoningEffort: 'medium' });
 		return;
 	}

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -63,7 +63,8 @@ export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	if (!provider || !PROVIDER_CAPABILITIES[provider]?.thinking) return;
 
 	if (provider === 'openai') {
-		agent.thinking('openai', { reasoningEffort: 'high' });
+		// Pin medium (GPT-5.6 Sol default) via AI SDK `reasoningEffort`.
+		agent.thinking('openai', { reasoningEffort: 'medium' });
 		return;
 	}
 

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -51,6 +51,12 @@ function isKimiK3Model(modelId: ModelConfig): boolean {
 	return id.includes('kimi-k3');
 }
 
+/** Grok 4.5 via xAI (`xai/grok-4.5`) or OpenRouter (`openrouter/x-ai/grok-4.5`). */
+function isGrok45Model(modelId: ModelConfig): boolean {
+	const id = resolveModelIdString(modelId)?.toLowerCase() ?? '';
+	return id.includes('grok-4.5');
+}
+
 export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	const provider = resolveModelProvider(modelId);
 
@@ -67,8 +73,16 @@ export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	}
 
 	if (provider === 'openrouter') {
-		if (isKimiK3Model(modelId)) {
+		// Pin low effort for models that default to heavy/max thinking.
+		if (isKimiK3Model(modelId) || isGrok45Model(modelId)) {
 			agent.thinking('openrouter', { reasoningEffort: 'low' });
+		}
+		return;
+	}
+
+	if (provider === 'xai') {
+		if (isGrok45Model(modelId)) {
+			agent.thinking('xai', { reasoningEffort: 'low' });
 		}
 	}
 }

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -57,12 +57,33 @@ function isGrok45Model(modelId: ModelConfig): boolean {
 	return id.includes('grok-4.5');
 }
 
+/** GLM 5.2 on Baseten (`openai/zai-org/GLM-5.2`, `openai/zai-org/GLM-5.2-Fast`, etc.). */
+function isGlm52Model(modelId: ModelConfig): boolean {
+	const id = resolveModelIdString(modelId)?.toLowerCase() ?? '';
+	return id.includes('glm-5.2');
+}
+
 export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	const provider = resolveModelProvider(modelId);
 
 	if (!provider || !PROVIDER_CAPABILITIES[provider]?.thinking) return;
 
+	if (provider === 'baseten') {
+		if (isGlm52Model(modelId)) {
+			// GLM 5.2 only accepts none/high/max — map our medium tier to high.
+			agent.thinking('baseten', { reasoningEffort: 'high' });
+			return;
+		}
+		agent.thinking('baseten', { reasoningEffort: 'medium' });
+		return;
+	}
+
 	if (provider === 'openai') {
+		if (isGlm52Model(modelId)) {
+			// Legacy OpenAI-compatible Baseten routing — same GLM effort mapping.
+			agent.thinking('openai', { reasoningEffort: 'high' });
+			return;
+		}
 		// Pin medium for GPT-5.6 family (sol/terra/luna) via AI SDK `reasoningEffort`.
 		agent.thinking('openai', { reasoningEffort: 'medium' });
 		return;

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -73,16 +73,16 @@ export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	}
 
 	if (provider === 'openrouter') {
-		// Pin low effort for models that default to heavy/max thinking.
+		// Pin medium effort for models that default to heavy/max thinking.
 		if (isKimiK3Model(modelId) || isGrok45Model(modelId)) {
-			agent.thinking('openrouter', { reasoningEffort: 'low' });
+			agent.thinking('openrouter', { reasoningEffort: 'medium' });
 		}
 		return;
 	}
 
 	if (provider === 'xai') {
 		if (isGrok45Model(modelId)) {
-			agent.thinking('xai', { reasoningEffort: 'low' });
+			agent.thinking('xai', { reasoningEffort: 'medium' });
 		}
 	}
 }

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -33,6 +33,24 @@ function resolveModelProvider(modelId: ModelConfig): string | undefined {
 	return provider && model ? normalizeProvider(provider) : undefined;
 }
 
+function resolveModelIdString(modelId: ModelConfig): string | undefined {
+	if (typeof modelId === 'string') return modelId;
+	if (!isRecord(modelId)) return undefined;
+
+	const id = getStringProperty(modelId, 'id');
+	if (id) return id;
+
+	const provider = getStringProperty(modelId, 'provider') ?? getProviderFromConfig(modelId);
+	const model = getStringProperty(modelId, 'modelId');
+	return provider && model ? `${provider}/${model}` : undefined;
+}
+
+/** Moonshot Kimi K3 via OpenRouter (`openrouter/moonshotai/kimi-k3`, dated slugs, etc.). */
+function isKimiK3Model(modelId: ModelConfig): boolean {
+	const id = resolveModelIdString(modelId)?.toLowerCase() ?? '';
+	return id.includes('kimi-k3');
+}
+
 export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	const provider = resolveModelProvider(modelId);
 
@@ -46,5 +64,11 @@ export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	if (provider === 'anthropic') {
 		agent.thinking('anthropic', { mode: 'adaptive', effort: 'medium' });
 		return;
+	}
+
+	if (provider === 'openrouter') {
+		if (isKimiK3Model(modelId)) {
+			agent.thinking('openrouter', { reasoningEffort: 'low' });
+		}
 	}
 }

--- a/packages/@n8n/instance-ai/src/utils/__tests__/eval-agents.test.ts
+++ b/packages/@n8n/instance-ai/src/utils/__tests__/eval-agents.test.ts
@@ -73,12 +73,12 @@ describe('eval agent model config', () => {
 		process.env.OPENAI_API_KEY = 'openai-key';
 
 		createEvalAgent('test-agent', {
-			model: 'openai/gpt-5.5',
+			model: 'openai/gpt-5.6-sol',
 			instructions: 'Do the task.',
 		});
 
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('openai', {
-			reasoningEffort: 'high',
+			reasoningEffort: 'medium',
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/utils/eval-agents.ts
+++ b/packages/@n8n/instance-ai/src/utils/eval-agents.ts
@@ -21,6 +21,7 @@ const PROVIDER_API_KEY_ENV: Record<string, string> = {
 	anthropic: 'ANTHROPIC_API_KEY',
 	google: 'GOOGLE_GENERATIVE_AI_API_KEY',
 	openai: 'OPENAI_API_KEY',
+	baseten: 'BASETEN_API_KEY',
 	xai: 'XAI_API_KEY',
 };
 

--- a/packages/@n8n/nodes-langchain/credentials/BasetenApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/BasetenApi.credentials.ts
@@ -1,0 +1,47 @@
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class BasetenApi implements ICredentialType {
+	name = 'basetenApi';
+
+	displayName = 'Baseten';
+
+	documentationUrl = 'baseten';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: { password: true },
+			required: true,
+			default: '',
+		},
+		{
+			displayName: 'Base URL',
+			name: 'url',
+			type: 'hidden',
+			default: 'https://inference.baseten.co/v1',
+		},
+	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.apiKey}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{ $credentials.url }}',
+			url: '/models',
+		},
+	};
+}

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -50,6 +50,7 @@
       "dist/credentials/AzureAiSearchApi.credentials.js",
       "dist/credentials/AzureOpenAiApi.credentials.js",
       "dist/credentials/AzureEntraCognitiveServicesOAuth2Api.credentials.js",
+      "dist/credentials/BasetenApi.credentials.js",
       "dist/credentials/BraveSearchApi.credentials.js",
       "dist/credentials/ChromaSelfHostedApi.credentials.js",
       "dist/credentials/ChromaCloudApi.credentials.js",

--- a/packages/cli/src/modules/agents/builder/__tests__/agents-builder-settings.service.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/agents-builder-settings.service.test.ts
@@ -13,7 +13,13 @@ import { BUILDER_NOT_CONFIGURED_CODE } from '@n8n/api-types';
 import { AgentsBuilderSettingsService } from '../agents-builder-settings.service';
 import { BuilderNotConfiguredError } from '../errors';
 
-const ENV_KEYS = ['N8N_AI_ANTHROPIC_KEY', 'ANTHROPIC_API_KEY'] as const;
+const ENV_KEYS = [
+	'N8N_AI_ANTHROPIC_KEY',
+	'ANTHROPIC_API_KEY',
+	'N8N_INSTANCE_AI_MODEL',
+	'N8N_INSTANCE_AI_MODEL_API_KEY',
+	'N8N_INSTANCE_AI_MODEL_URL',
+] as const;
 
 function makeJwt(exp: number): string {
 	const header = Buffer.from(JSON.stringify({ alg: 'HS256' })).toString('base64url');
@@ -108,6 +114,24 @@ describe('AgentsBuilderSettingsService', () => {
 				{ id: 'user-1' },
 				{ userMessageId: expect.any(String) },
 			);
+		});
+
+		it('mode=default + proxy disabled + Instance AI env set → returns Instance AI model config', async () => {
+			mockPersistedSettings({ mode: 'default' });
+			aiService.isProxyEnabled.mockReturnValue(false);
+			process.env.N8N_INSTANCE_AI_MODEL = 'baseten/zai-org/GLM-5.2-Fast';
+			process.env.N8N_INSTANCE_AI_MODEL_API_KEY = 'bt-key';
+			process.env.N8N_AI_ANTHROPIC_KEY = 'sk-env';
+
+			const result = await service.resolveModelConfig(user);
+
+			expect(result).toEqual({
+				config: {
+					id: 'baseten/zai-org/GLM-5.2-Fast',
+					apiKey: 'bt-key',
+				},
+				isProxied: false,
+			});
 		});
 
 		it('mode=default + proxy disabled + env set → returns env-var anthropic config', async () => {

--- a/packages/cli/src/modules/agents/builder/__tests__/agents-builder.service.session.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/agents-builder.service.session.test.ts
@@ -344,18 +344,18 @@ describe('AgentsBuilderService session isolation', () => {
 		]);
 	});
 
-	it('enables high-effort reasoning for an OpenAI builder model', async () => {
+	it('enables medium-effort reasoning for an OpenAI builder model', async () => {
 		const { service, user, credentialProvider } = setup();
 
 		await drain(
 			service.buildAgent('agent-1', 'project-1', 'hi', credentialProvider, user, {
 				...baseSession,
-				modelConfig: 'openai/gpt-5.5',
+				modelConfig: 'openai/gpt-5.6-sol',
 			}),
 		);
 
 		expect(agentsSdkMocks.thinkingCalls).toEqual([
-			{ provider: 'openai', config: { reasoningEffort: 'high' } },
+			{ provider: 'openai', config: { reasoningEffort: 'medium' } },
 		]);
 	});
 

--- a/packages/cli/src/modules/agents/builder/agents-builder-model-recommendations.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-model-recommendations.ts
@@ -14,6 +14,7 @@ const RECOMMENDED_PROVIDERS: RecommendedProvider[] = [
 	{ id: 'mistral', label: 'Mistral' },
 	{ id: 'xai', label: 'xAI' },
 	{ id: 'google', label: 'Gemini' },
+	{ id: 'baseten', label: 'Baseten' },
 ];
 
 let modelRecommendationsSection: string | null | undefined;

--- a/packages/cli/src/modules/agents/builder/agents-builder-settings.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-settings.service.ts
@@ -40,6 +40,24 @@ function readEnvAnthropicKey(): string | null {
 	return key && key.length > 0 ? key : null;
 }
 
+/**
+ * Dev/CI backstop: reuse the Instance AI orchestrator model env so local setups
+ * that already point Instance AI at Baseten/GLM (etc.) also configure the
+ * agent-builder settings path without a separate credential.
+ */
+function readEnvInstanceAiModelConfig(): ModelConfig | null {
+	const model = process.env.N8N_INSTANCE_AI_MODEL?.trim();
+	const apiKey = process.env.N8N_INSTANCE_AI_MODEL_API_KEY?.trim();
+	if (!model || !model.includes('/') || !apiKey) return null;
+
+	const modelUrl = process.env.N8N_INSTANCE_AI_MODEL_URL?.trim();
+	const id = model as `${string}/${string}`;
+	if (modelUrl) {
+		return { id, url: modelUrl, apiKey };
+	}
+	return { id, apiKey };
+}
+
 interface BuilderTelemetryProxyConfig {
 	apiUrl: string;
 	getAuthHeaders: () => Promise<Record<string, string>>;
@@ -56,7 +74,10 @@ interface ResolvedBuilderModelConfig {
  * the builder LLM runs on:
  *   1. `mode: 'custom'` — admin-picked credential. Wins regardless of platform.
  *   2. `mode: 'default'` + AI proxy enabled — runs through the n8n AI assistant proxy.
- *   3. `mode: 'default'` + env-var backstop set (`N8N_AI_ANTHROPIC_KEY` /
+ *   3. `mode: 'default'` + Instance AI model env (`N8N_INSTANCE_AI_MODEL` +
+ *      `N8N_INSTANCE_AI_MODEL_API_KEY`) — same provider/model as Instance AI
+ *      (e.g. `baseten/zai-org/GLM-5.2-Fast`).
+ *   4. `mode: 'default'` + Anthropic env backstop (`N8N_AI_ANTHROPIC_KEY` /
  *      `ANTHROPIC_API_KEY`) — direct Anthropic API calls.
  */
 @Service()
@@ -149,6 +170,11 @@ export class AgentsBuilderSettingsService {
 
 		if (this.aiService.isProxyEnabled()) {
 			return await this.resolveProxyModel(user);
+		}
+
+		const instanceAiEnv = readEnvInstanceAiModelConfig();
+		if (instanceAiEnv) {
+			return { config: instanceAiEnv, isProxied: false };
 		}
 
 		const envKey = readEnvAnthropicKey();

--- a/packages/cli/src/modules/agents/json-config/credential-field-mapping.ts
+++ b/packages/cli/src/modules/agents/json-config/credential-field-mapping.ts
@@ -34,6 +34,8 @@ const PROVIDER_CREDENTIAL_MAPPERS: Record<string, CredMapper> = {
 	vercel: (c) => ({ apiKey: c.apiKey, baseURL: c.url }),
 	// OpenRouterApi.credentials.ts → apiKey, url (hidden, base URL)
 	openrouter: (c) => ({ apiKey: c.apiKey, baseURL: c.url }),
+	// BasetenApi.credentials.ts → apiKey, url (hidden, base URL)
+	baseten: (c) => ({ apiKey: c.apiKey, baseURL: c.url }),
 	// NvidiaApi.credentials.ts → apiKey, url (base URL)
 	nvidia: (c) => ({ apiKey: c.apiKey, baseURL: c.url }),
 

--- a/packages/cli/src/modules/agents/llm-provider-defaults.ts
+++ b/packages/cli/src/modules/agents/llm-provider-defaults.ts
@@ -56,6 +56,10 @@ export const LLM_PROVIDER_DEFAULTS: Record<string, LlmProviderDefault> = {
 		provider: 'openrouter',
 		defaultModel: 'anthropic/claude-sonnet-4.6',
 	},
+	basetenApi: {
+		provider: 'baseten',
+		defaultModel: 'zai-org/GLM-5.2-Fast',
+	},
 	nvidiaApi: {
 		provider: 'nvidia',
 		defaultModel: 'nvidia/llama-3.3-nemotron-super-49b-v1',
@@ -77,6 +81,7 @@ export const LLM_PROVIDER_PRIORITY: string[] = [
 	'deepseek',
 	'cohere',
 	'openrouter',
+	'baseten',
 	'nvidia',
 	'vercel',
 ];

--- a/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
@@ -81,6 +81,7 @@ const CREDENTIAL_TO_MODEL_PROVIDER: Record<string, string> = {
 	mistralCloudApi: 'mistral',
 	xAiApi: 'xai',
 	openRouterApi: 'openrouter',
+	basetenApi: 'baseten',
 	cohereApi: 'cohere',
 } satisfies Record<(typeof INSTANCE_AI_MODEL_CREDENTIAL_TYPES)[number], string>;
 
@@ -89,6 +90,7 @@ const URL_FIELD_MAP: Record<string, string> = {
 	openAiApi: 'url',
 	anthropicApi: 'url',
 	googlePalmApi: 'host',
+	basetenApi: 'url',
 };
 
 function requireConnectionValue(

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/provider-capabilities.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/provider-capabilities.test.ts
@@ -13,10 +13,11 @@ describe('provider-capabilities', () => {
 		expect([...REASONING_EFFORT_OPTIONS]).toEqual(['low', 'medium', 'high']);
 	});
 
-	it('uses budget-tokens for Anthropic and reasoning-effort for OpenAI/OpenRouter', () => {
+	it('uses budget-tokens for Anthropic and reasoning-effort for OpenAI/OpenRouter/xAI', () => {
 		expect(PROVIDER_CAPABILITIES.anthropic.thinking).toBe('budgetTokens');
 		expect(PROVIDER_CAPABILITIES.openai.thinking).toBe('reasoningEffort');
 		expect(PROVIDER_CAPABILITIES.openrouter.thinking).toBe('reasoningEffort');
+		expect(PROVIDER_CAPABILITIES.xai.thinking).toBe('reasoningEffort');
 	});
 
 	it('keeps the canonical Anthropic cache-ttl order', () => {
@@ -46,7 +47,7 @@ describe('provider-capabilities', () => {
 	});
 
 	it('marks providers without thinking support as `false`', () => {
-		const noThinking = ['google', 'xai', 'groq', 'deepseek', 'mistral', 'cohere', 'ollama'];
+		const noThinking = ['google', 'groq', 'deepseek', 'mistral', 'cohere', 'ollama'];
 		for (const provider of noThinking) {
 			expect(PROVIDER_CAPABILITIES[provider]?.thinking).toBe(false);
 		}

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/provider-capabilities.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/provider-capabilities.test.ts
@@ -13,9 +13,10 @@ describe('provider-capabilities', () => {
 		expect([...REASONING_EFFORT_OPTIONS]).toEqual(['low', 'medium', 'high']);
 	});
 
-	it('uses budget-tokens for Anthropic and reasoning-effort for OpenAI', () => {
+	it('uses budget-tokens for Anthropic and reasoning-effort for OpenAI/OpenRouter', () => {
 		expect(PROVIDER_CAPABILITIES.anthropic.thinking).toBe('budgetTokens');
 		expect(PROVIDER_CAPABILITIES.openai.thinking).toBe('reasoningEffort');
+		expect(PROVIDER_CAPABILITIES.openrouter.thinking).toBe('reasoningEffort');
 	});
 
 	it('keeps the canonical Anthropic cache-ttl order', () => {
@@ -45,16 +46,7 @@ describe('provider-capabilities', () => {
 	});
 
 	it('marks providers without thinking support as `false`', () => {
-		const noThinking = [
-			'google',
-			'xai',
-			'groq',
-			'deepseek',
-			'mistral',
-			'openrouter',
-			'cohere',
-			'ollama',
-		];
+		const noThinking = ['google', 'xai', 'groq', 'deepseek', 'mistral', 'cohere', 'ollama'];
 		for (const provider of noThinking) {
 			expect(PROVIDER_CAPABILITIES[provider]?.thinking).toBe(false);
 		}

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/provider-capabilities.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/provider-capabilities.test.ts
@@ -17,6 +17,7 @@ describe('provider-capabilities', () => {
 		expect(PROVIDER_CAPABILITIES.anthropic.thinking).toBe('budgetTokens');
 		expect(PROVIDER_CAPABILITIES.openai.thinking).toBe('reasoningEffort');
 		expect(PROVIDER_CAPABILITIES.openrouter.thinking).toBe('reasoningEffort');
+		expect(PROVIDER_CAPABILITIES.baseten.thinking).toBe('reasoningEffort');
 		expect(PROVIDER_CAPABILITIES.xai.thinking).toBe('reasoningEffort');
 	});
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/provider-capabilities.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/provider-capabilities.test.ts
@@ -39,6 +39,7 @@ describe('provider-capabilities', () => {
 			'deepseek',
 			'mistral',
 			'openrouter',
+			'baseten',
 			'cohere',
 			'ollama',
 		];

--- a/packages/frontend/editor-ui/src/features/agents/model-providers.ts
+++ b/packages/frontend/editor-ui/src/features/agents/model-providers.ts
@@ -66,6 +66,11 @@ export const AGENT_MODEL_PROVIDER_DEFINITIONS = {
 		credentialTypes: ['openRouterApi'],
 		isAggregator: true,
 	},
+	baseten: {
+		displayName: 'Baseten',
+		credentialTypes: ['basetenApi'],
+		isAggregator: true,
+	},
 	deepseek: {
 		displayName: 'DeepSeek',
 		credentialTypes: ['deepSeekApi'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^3.0.37
       version: 3.0.37
     '@ai-sdk/openai':
-      specifier: ^3.0.68
-      version: 3.0.68
+      specifier: ^3.0.86
+      version: 3.0.86
     '@ai-sdk/openai-compatible':
       specifier: ^2.0.48
       version: 2.0.48
@@ -945,7 +945,7 @@ importers:
         version: 3.0.37(zod@3.25.67)
       '@ai-sdk/openai':
         specifier: 'catalog:'
-        version: 3.0.68(zod@3.25.67)
+        version: 3.0.86(zod@3.25.67)
       '@ai-sdk/openai-compatible':
         specifier: 'catalog:'
         version: 2.0.48(zod@3.25.67)
@@ -7168,6 +7168,12 @@ packages:
 
   '@ai-sdk/openai@3.0.68':
     resolution: {integrity: sha512-FCs/DPr4M95UyZ/ABHJmTmCEYRCka/4J0Bna0nsd78QCdGIS0X/zhn+fVzB7mZJo7464uOWYUjROx9PGNGOb0w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: 3.25.67
+
+  '@ai-sdk/openai@3.0.86':
+    resolution: {integrity: sha512-np3jjvNmWVZyBjI02a1fx4TzWVnOaOp3yJAfOJw9dxEAPmvnOhyx22TkFcJ91LqyFuCbGKZKtSBj6ee7ARsiPw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 3.25.67
@@ -23074,6 +23080,12 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@3.25.67)
+      zod: 3.25.67
+
+  '@ai-sdk/openai@3.0.86(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@3.25.67)
       zod: 3.25.67
 
   '@ai-sdk/provider-utils@4.0.27(zod@3.25.67)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     '@ai-sdk/azure':
       specifier: ^3.0.70
       version: 3.0.70
-    '@ai-sdk/baseten':
-      specifier: ^1.0.65
-      version: 1.0.65
     '@ai-sdk/cohere':
       specifier: ^3.0.36
       version: 3.0.36
@@ -928,9 +925,6 @@ importers:
       '@ai-sdk/azure':
         specifier: 'catalog:'
         version: 3.0.70(zod@3.25.67)
-      '@ai-sdk/baseten':
-        specifier: 'catalog:'
-        version: 1.0.65(zod@3.25.67)
       '@ai-sdk/cohere':
         specifier: 'catalog:'
         version: 3.0.36(zod@3.25.67)
@@ -7130,12 +7124,6 @@ packages:
     peerDependencies:
       zod: 3.25.67
 
-  '@ai-sdk/baseten@1.0.65':
-    resolution: {integrity: sha512-ofNekqJROjk4SmjFMwQ7H9TfSy93PR9r6wGBxiGEtUzkNPJEJuKBsbvXdegNXU5kF6v9akNW+jezDnTiTCUN2Q==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: 3.25.67
-
   '@ai-sdk/cohere@3.0.36':
     resolution: {integrity: sha512-a3xUVhBYP5FuThYA3Q7NjuEyl/ObBhx9z0zFDRebW0UqEoExS3zJwtE9OB+gHc/uvwx93hNg5ZITAFAvqG3GMQ==}
     engines: {node: '>=18'}
@@ -8223,97 +8211,6 @@ packages:
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
-
-  '@basetenlabs/performance-client-android-arm-eabi@0.0.10':
-    resolution: {integrity: sha512-gwDZ6GDJA0AAmQAHxt2vaCz0tYTaLjxJKZnoYt+0Eji4gy231JZZFAwvbAqNdQCrGEQ9lXnk7SNM1Apet4NlYg==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [android]
-
-  '@basetenlabs/performance-client-android-arm64@0.0.10':
-    resolution: {integrity: sha512-oGRB/6hH89majhsmoVmj1IAZv4C7F2aLeTSebevBelmdYO4CFkn5qewxLzU1pDkkmxVVk2k+TRpYa1Dt4B96qQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
-  '@basetenlabs/performance-client-darwin-arm64@0.0.10':
-    resolution: {integrity: sha512-QpBOUjeO05tWgFWkDw2RUQZa3BMplX5jNiBBTi5mH1lIL/m1sm2vkxoc0iorEESp1mMPstYFS/fr4ssBuO7wyA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@basetenlabs/performance-client-darwin-universal@0.0.10':
-    resolution: {integrity: sha512-CBM38GAhekjylrlf7jW/0WNyFAGnAMBCNHZxaPnAjjhDNzJh1tcrwhvtOs66XbAqCOjO/tkt5Pdu6mg2Ui2Pjw==}
-    engines: {node: '>= 10'}
-    os: [darwin]
-
-  '@basetenlabs/performance-client-darwin-x64@0.0.10':
-    resolution: {integrity: sha512-R+NsA72Axclh1CUpmaWOCLTWCqXn5/tFMj2z9BnHVSRTelx/pYFlx6ZngVTB1HYp1n21m3upPXGo8CHF8R7Itw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@basetenlabs/performance-client-linux-arm-gnueabihf@0.0.10':
-    resolution: {integrity: sha512-96kEo0Eas4GVQdFkxIB1aAv6dy5Ga57j+RIg5l0Yiawv+AYIEmgk9BsGkqcwayp8Iiu6LN22Z+AUsGY2gstNrg==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@basetenlabs/performance-client-linux-arm-musleabihf@0.0.10':
-    resolution: {integrity: sha512-lzEHeu+/BWDl2q+QZcqCkg1rDGF4MeyM3HgYwX+07t+vGZoqtM2we9vEV68wXMpl6ToEHQr7ML2KHA1Gb6ogxg==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@basetenlabs/performance-client-linux-arm64-gnu@0.0.10':
-    resolution: {integrity: sha512-MnY2cIRY/cQOYERWIHhh5CoaS2wgmmXtGDVGSLYyZvjwizrXZvjkEz7Whv2jaQ21T5S56VER67RABjz2TItrHQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@basetenlabs/performance-client-linux-riscv64-gnu@0.0.10':
-    resolution: {integrity: sha512-2KUvdK4wuoZdIqNnJhx7cu6ybXCwtiwGAtlrEvhai3FOkUQ3wE2Xa+TQ33mNGSyFbw6wAvLawYtKVFmmw27gJw==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@basetenlabs/performance-client-linux-x64-gnu@0.0.10':
-    resolution: {integrity: sha512-9jjQPjHLiVOGwUPlmhnBl7OmmO7hQ8WMt+v3mJuxkS5JTNDmVOngfmgGlbN9NjBhQMENjdcMUVOquVo7HeybGQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@basetenlabs/performance-client-linux-x64-musl@0.0.10':
-    resolution: {integrity: sha512-bjYB8FKcPvEa251Ep2Gm3tvywADL9eavVjZsikdf0AvJ1K5pT+vLLvJBU9ihBsTPWnbF4pJgxVjwS6UjVObsQA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@basetenlabs/performance-client-win32-arm64-msvc@0.0.10':
-    resolution: {integrity: sha512-Vxq5UXEmfh3C3hpwXdp3Daaf0dnLR9zFH2x8MJ1Hf/TcilmOP1clneewNpIv0e7MrnT56Z4pM6P3d8VFMZqBKg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@basetenlabs/performance-client-win32-ia32-msvc@0.0.10':
-    resolution: {integrity: sha512-KJrm7CgZdP/UDC5+tHtqE6w9XMfY5YUfMOxJfBZGSsLMqS2OGsakQsaF0a55k+58l29X5w/nAkjHrI1BcQO03w==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@basetenlabs/performance-client-win32-x64-msvc@0.0.10':
-    resolution: {integrity: sha512-M/mhvfTItUcUX+aeXRb5g5MbRlndfg6yelV7tSYfLU4YixMIe5yoGaAP3iDilpFJjcC99f+EU4l4+yLbPtpXig==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@basetenlabs/performance-client@0.0.10':
-    resolution: {integrity: sha512-H6bpd1JcDbuJsOS2dNft+CCGLzBqHJO/ST/4mMKhLAW641J6PpVJUw1szYsk/dTetdedbWxHpMkvFObOKeP8nw==}
-    engines: {node: '>= 10'}
 
   '@bazel/runfiles@6.5.0':
     resolution: {integrity: sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==}
@@ -23142,14 +23039,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@3.25.67)
       zod: 3.25.67
 
-  '@ai-sdk/baseten@1.0.65(zod@3.25.67)':
-    dependencies:
-      '@ai-sdk/openai-compatible': 2.0.62(zod@3.25.67)
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.40(zod@3.25.67)
-      '@basetenlabs/performance-client': 0.0.10
-      zod: 3.25.67
-
   '@ai-sdk/cohere@3.0.36(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -25394,65 +25283,6 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@balena/dockerignore@1.0.2': {}
-
-  '@basetenlabs/performance-client-android-arm-eabi@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-android-arm64@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-darwin-arm64@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-darwin-universal@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-darwin-x64@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-linux-arm-gnueabihf@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-linux-arm-musleabihf@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-linux-arm64-gnu@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-linux-riscv64-gnu@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-linux-x64-gnu@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-linux-x64-musl@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-win32-arm64-msvc@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-win32-ia32-msvc@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client-win32-x64-msvc@0.0.10':
-    optional: true
-
-  '@basetenlabs/performance-client@0.0.10':
-    optionalDependencies:
-      '@basetenlabs/performance-client-android-arm-eabi': 0.0.10
-      '@basetenlabs/performance-client-android-arm64': 0.0.10
-      '@basetenlabs/performance-client-darwin-arm64': 0.0.10
-      '@basetenlabs/performance-client-darwin-universal': 0.0.10
-      '@basetenlabs/performance-client-darwin-x64': 0.0.10
-      '@basetenlabs/performance-client-linux-arm-gnueabihf': 0.0.10
-      '@basetenlabs/performance-client-linux-arm-musleabihf': 0.0.10
-      '@basetenlabs/performance-client-linux-arm64-gnu': 0.0.10
-      '@basetenlabs/performance-client-linux-riscv64-gnu': 0.0.10
-      '@basetenlabs/performance-client-linux-x64-gnu': 0.0.10
-      '@basetenlabs/performance-client-linux-x64-musl': 0.0.10
-      '@basetenlabs/performance-client-win32-arm64-msvc': 0.0.10
-      '@basetenlabs/performance-client-win32-ia32-msvc': 0.0.10
-      '@basetenlabs/performance-client-win32-x64-msvc': 0.0.10
 
   '@bazel/runfiles@6.5.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^4.0.113
       version: 4.0.113
     '@ai-sdk/anthropic':
-      specifier: ^3.0.81
-      version: 3.0.81
+      specifier: ^3.0.98
+      version: 3.0.98
     '@ai-sdk/azure':
       specifier: ^3.0.70
       version: 3.0.70
@@ -921,7 +921,7 @@ importers:
         version: 4.0.113(zod@3.25.67)
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 3.0.81(zod@3.25.67)
+        version: 3.0.98(zod@3.25.67)
       '@ai-sdk/azure':
         specifier: 'catalog:'
         version: 3.0.70(zod@3.25.67)
@@ -2677,7 +2677,7 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 3.0.81(zod@3.25.67)
+        version: 3.0.98(zod@3.25.67)
       '@langchain/core':
         specifier: 'catalog:'
         version: 1.2.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -3998,7 +3998,7 @@ importers:
         version: 1.4.2
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 3.0.81(zod@3.25.67)
+        version: 3.0.98(zod@3.25.67)
       '@apidevtools/json-schema-ref-parser':
         specifier: 12.0.2
         version: 12.0.2
@@ -7108,6 +7108,12 @@ packages:
 
   '@ai-sdk/anthropic@3.0.81':
     resolution: {integrity: sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: 3.25.67
+
+  '@ai-sdk/anthropic@3.0.98':
+    resolution: {integrity: sha512-JSHw0m15tXsdZWaV64UOjbHFKHGsPVUi9jYApNaz2QOBm987vl+l9aUFnlN1OWmFvDNMIhAPVOYRsFwjK0by/w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 3.25.67
@@ -23018,6 +23024,12 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@3.25.67)
+      zod: 3.25.67
+
+  '@ai-sdk/anthropic@3.0.98(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@3.25.67)
       zod: 3.25.67
 
   '@ai-sdk/azure@3.0.70(zod@3.25.67)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@ai-sdk/azure':
       specifier: ^3.0.70
       version: 3.0.70
+    '@ai-sdk/baseten':
+      specifier: ^1.0.65
+      version: 1.0.65
     '@ai-sdk/cohere':
       specifier: ^3.0.36
       version: 3.0.36
@@ -925,6 +928,9 @@ importers:
       '@ai-sdk/azure':
         specifier: 'catalog:'
         version: 3.0.70(zod@3.25.67)
+      '@ai-sdk/baseten':
+        specifier: 'catalog:'
+        version: 1.0.65(zod@3.25.67)
       '@ai-sdk/cohere':
         specifier: 'catalog:'
         version: 3.0.36(zod@3.25.67)
@@ -7124,6 +7130,12 @@ packages:
     peerDependencies:
       zod: 3.25.67
 
+  '@ai-sdk/baseten@1.0.65':
+    resolution: {integrity: sha512-ofNekqJROjk4SmjFMwQ7H9TfSy93PR9r6wGBxiGEtUzkNPJEJuKBsbvXdegNXU5kF6v9akNW+jezDnTiTCUN2Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: 3.25.67
+
   '@ai-sdk/cohere@3.0.36':
     resolution: {integrity: sha512-a3xUVhBYP5FuThYA3Q7NjuEyl/ObBhx9z0zFDRebW0UqEoExS3zJwtE9OB+gHc/uvwx93hNg5ZITAFAvqG3GMQ==}
     engines: {node: '>=18'}
@@ -8211,6 +8223,97 @@ packages:
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
+  '@basetenlabs/performance-client-android-arm-eabi@0.0.10':
+    resolution: {integrity: sha512-gwDZ6GDJA0AAmQAHxt2vaCz0tYTaLjxJKZnoYt+0Eji4gy231JZZFAwvbAqNdQCrGEQ9lXnk7SNM1Apet4NlYg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@basetenlabs/performance-client-android-arm64@0.0.10':
+    resolution: {integrity: sha512-oGRB/6hH89majhsmoVmj1IAZv4C7F2aLeTSebevBelmdYO4CFkn5qewxLzU1pDkkmxVVk2k+TRpYa1Dt4B96qQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@basetenlabs/performance-client-darwin-arm64@0.0.10':
+    resolution: {integrity: sha512-QpBOUjeO05tWgFWkDw2RUQZa3BMplX5jNiBBTi5mH1lIL/m1sm2vkxoc0iorEESp1mMPstYFS/fr4ssBuO7wyA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@basetenlabs/performance-client-darwin-universal@0.0.10':
+    resolution: {integrity: sha512-CBM38GAhekjylrlf7jW/0WNyFAGnAMBCNHZxaPnAjjhDNzJh1tcrwhvtOs66XbAqCOjO/tkt5Pdu6mg2Ui2Pjw==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@basetenlabs/performance-client-darwin-x64@0.0.10':
+    resolution: {integrity: sha512-R+NsA72Axclh1CUpmaWOCLTWCqXn5/tFMj2z9BnHVSRTelx/pYFlx6ZngVTB1HYp1n21m3upPXGo8CHF8R7Itw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@basetenlabs/performance-client-linux-arm-gnueabihf@0.0.10':
+    resolution: {integrity: sha512-96kEo0Eas4GVQdFkxIB1aAv6dy5Ga57j+RIg5l0Yiawv+AYIEmgk9BsGkqcwayp8Iiu6LN22Z+AUsGY2gstNrg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@basetenlabs/performance-client-linux-arm-musleabihf@0.0.10':
+    resolution: {integrity: sha512-lzEHeu+/BWDl2q+QZcqCkg1rDGF4MeyM3HgYwX+07t+vGZoqtM2we9vEV68wXMpl6ToEHQr7ML2KHA1Gb6ogxg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@basetenlabs/performance-client-linux-arm64-gnu@0.0.10':
+    resolution: {integrity: sha512-MnY2cIRY/cQOYERWIHhh5CoaS2wgmmXtGDVGSLYyZvjwizrXZvjkEz7Whv2jaQ21T5S56VER67RABjz2TItrHQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@basetenlabs/performance-client-linux-riscv64-gnu@0.0.10':
+    resolution: {integrity: sha512-2KUvdK4wuoZdIqNnJhx7cu6ybXCwtiwGAtlrEvhai3FOkUQ3wE2Xa+TQ33mNGSyFbw6wAvLawYtKVFmmw27gJw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@basetenlabs/performance-client-linux-x64-gnu@0.0.10':
+    resolution: {integrity: sha512-9jjQPjHLiVOGwUPlmhnBl7OmmO7hQ8WMt+v3mJuxkS5JTNDmVOngfmgGlbN9NjBhQMENjdcMUVOquVo7HeybGQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@basetenlabs/performance-client-linux-x64-musl@0.0.10':
+    resolution: {integrity: sha512-bjYB8FKcPvEa251Ep2Gm3tvywADL9eavVjZsikdf0AvJ1K5pT+vLLvJBU9ihBsTPWnbF4pJgxVjwS6UjVObsQA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@basetenlabs/performance-client-win32-arm64-msvc@0.0.10':
+    resolution: {integrity: sha512-Vxq5UXEmfh3C3hpwXdp3Daaf0dnLR9zFH2x8MJ1Hf/TcilmOP1clneewNpIv0e7MrnT56Z4pM6P3d8VFMZqBKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@basetenlabs/performance-client-win32-ia32-msvc@0.0.10':
+    resolution: {integrity: sha512-KJrm7CgZdP/UDC5+tHtqE6w9XMfY5YUfMOxJfBZGSsLMqS2OGsakQsaF0a55k+58l29X5w/nAkjHrI1BcQO03w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@basetenlabs/performance-client-win32-x64-msvc@0.0.10':
+    resolution: {integrity: sha512-M/mhvfTItUcUX+aeXRb5g5MbRlndfg6yelV7tSYfLU4YixMIe5yoGaAP3iDilpFJjcC99f+EU4l4+yLbPtpXig==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@basetenlabs/performance-client@0.0.10':
+    resolution: {integrity: sha512-H6bpd1JcDbuJsOS2dNft+CCGLzBqHJO/ST/4mMKhLAW641J6PpVJUw1szYsk/dTetdedbWxHpMkvFObOKeP8nw==}
+    engines: {node: '>= 10'}
 
   '@bazel/runfiles@6.5.0':
     resolution: {integrity: sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==}
@@ -23039,6 +23142,14 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@3.25.67)
       zod: 3.25.67
 
+  '@ai-sdk/baseten@1.0.65(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 2.0.62(zod@3.25.67)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@3.25.67)
+      '@basetenlabs/performance-client': 0.0.10
+      zod: 3.25.67
+
   '@ai-sdk/cohere@3.0.36(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -25283,6 +25394,65 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@balena/dockerignore@1.0.2': {}
+
+  '@basetenlabs/performance-client-android-arm-eabi@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-android-arm64@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-darwin-arm64@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-darwin-universal@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-darwin-x64@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-linux-arm-gnueabihf@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-linux-arm-musleabihf@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-linux-arm64-gnu@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-linux-riscv64-gnu@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-linux-x64-gnu@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-linux-x64-musl@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-win32-arm64-msvc@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-win32-ia32-msvc@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client-win32-x64-msvc@0.0.10':
+    optional: true
+
+  '@basetenlabs/performance-client@0.0.10':
+    optionalDependencies:
+      '@basetenlabs/performance-client-android-arm-eabi': 0.0.10
+      '@basetenlabs/performance-client-android-arm64': 0.0.10
+      '@basetenlabs/performance-client-darwin-arm64': 0.0.10
+      '@basetenlabs/performance-client-darwin-universal': 0.0.10
+      '@basetenlabs/performance-client-darwin-x64': 0.0.10
+      '@basetenlabs/performance-client-linux-arm-gnueabihf': 0.0.10
+      '@basetenlabs/performance-client-linux-arm-musleabihf': 0.0.10
+      '@basetenlabs/performance-client-linux-arm64-gnu': 0.0.10
+      '@basetenlabs/performance-client-linux-riscv64-gnu': 0.0.10
+      '@basetenlabs/performance-client-linux-x64-gnu': 0.0.10
+      '@basetenlabs/performance-client-linux-x64-musl': 0.0.10
+      '@basetenlabs/performance-client-win32-arm64-msvc': 0.0.10
+      '@basetenlabs/performance-client-win32-ia32-msvc': 0.0.10
+      '@basetenlabs/performance-client-win32-x64-msvc': 0.0.10
 
   '@bazel/runfiles@6.5.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ catalogs:
       specifier: ^4.0.27
       version: 4.0.27
     '@ai-sdk/xai':
-      specifier: ^3.0.93
-      version: 3.0.93
+      specifier: ^3.0.110
+      version: 3.0.110
     '@azure/storage-blob':
       specifier: ^12.32.0
       version: 12.32.0
@@ -954,7 +954,7 @@ importers:
         version: 4.0.27(zod@3.25.67)
       '@ai-sdk/xai':
         specifier: 'catalog:'
-        version: 3.0.93(zod@3.25.67)
+        version: 3.0.110(zod@3.25.67)
       '@daytona/sdk':
         specifier: 'catalog:'
         version: 0.187.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -7160,6 +7160,12 @@ packages:
     peerDependencies:
       zod: 3.25.67
 
+  '@ai-sdk/openai-compatible@2.0.62':
+    resolution: {integrity: sha512-lRe54zvyIS1a60N8UVhnwKZRI5I+GSV8uhKkPpId+aiKO7z7UgSbNqFmXkBBMD3yc9UrLnQnATV2EQyXNhzEkA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: 3.25.67
+
   '@ai-sdk/openai@3.0.68':
     resolution: {integrity: sha512-FCs/DPr4M95UyZ/ABHJmTmCEYRCka/4J0Bna0nsd78QCdGIS0X/zhn+fVzB7mZJo7464uOWYUjROx9PGNGOb0w==}
     engines: {node: '>=18'}
@@ -7172,12 +7178,22 @@ packages:
     peerDependencies:
       zod: 3.25.67
 
+  '@ai-sdk/provider-utils@4.0.40':
+    resolution: {integrity: sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: 3.25.67
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/xai@3.0.93':
-    resolution: {integrity: sha512-HxazLIcSTgI0UQoq6ua0rcSR8+eXuNy0Qh4jkCY9EAWedYn6CQ0XD/j34U4/JYtO738xJdY+tE95okdqWqXkHA==}
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/xai@3.0.110':
+    resolution: {integrity: sha512-d8yTvoLzTKkDINq+D+veYYbksdWSanfeb8XT5BGB3s5fifICsD0YNUUsKTieJtlI2OYY9iPmhDQwYhuZ892SjA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 3.25.67
@@ -23048,6 +23064,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@3.25.67)
       zod: 3.25.67
 
+  '@ai-sdk/openai-compatible@2.0.62(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@3.25.67)
+      zod: 3.25.67
+
   '@ai-sdk/openai@3.0.68(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -23061,15 +23083,26 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 3.25.67
 
+  '@ai-sdk/provider-utils@4.0.40(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.67
+
   '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/xai@3.0.93(zod@3.25.67)':
+  '@ai-sdk/provider@3.0.14':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.48(zod@3.25.67)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.67)
+      json-schema: 0.4.0
+
+  '@ai-sdk/xai@3.0.110(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 2.0.62(zod@3.25.67)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@3.25.67)
       zod: 3.25.67
 
   '@alloc/quick-lru@5.2.0': {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^4.0.113
       version: 4.0.113
     '@ai-sdk/anthropic':
-      specifier: ^3.0.98
-      version: 3.0.98
+      specifier: ^3.0.102
+      version: 3.0.102
     '@ai-sdk/azure':
       specifier: ^3.0.70
       version: 3.0.70
@@ -921,7 +921,7 @@ importers:
         version: 4.0.113(zod@3.25.67)
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 3.0.98(zod@3.25.67)
+        version: 3.0.102(zod@3.25.67)
       '@ai-sdk/azure':
         specifier: 'catalog:'
         version: 3.0.70(zod@3.25.67)
@@ -2677,7 +2677,7 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 3.0.98(zod@3.25.67)
+        version: 3.0.102(zod@3.25.67)
       '@langchain/core':
         specifier: 'catalog:'
         version: 1.2.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -3998,7 +3998,7 @@ importers:
         version: 1.4.2
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 3.0.98(zod@3.25.67)
+        version: 3.0.102(zod@3.25.67)
       '@apidevtools/json-schema-ref-parser':
         specifier: 12.0.2
         version: 12.0.2
@@ -7106,14 +7106,14 @@ packages:
     peerDependencies:
       zod: 3.25.67
 
-  '@ai-sdk/anthropic@3.0.81':
-    resolution: {integrity: sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==}
+  '@ai-sdk/anthropic@3.0.102':
+    resolution: {integrity: sha512-QV4QH8ugKBzGsrIqHzI9jzxIuYbXmddwSPEKwv80KD5U1D0ewyVr+9BoaFNvXtMxLQUhcIw1GSaAb3V86CpnJQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 3.25.67
 
-  '@ai-sdk/anthropic@3.0.98':
-    resolution: {integrity: sha512-JSHw0m15tXsdZWaV64UOjbHFKHGsPVUi9jYApNaz2QOBm987vl+l9aUFnlN1OWmFvDNMIhAPVOYRsFwjK0by/w==}
+  '@ai-sdk/anthropic@3.0.81':
+    resolution: {integrity: sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 3.25.67
@@ -23020,16 +23020,16 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 3.25.67
 
+  '@ai-sdk/anthropic@3.0.102(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@3.25.67)
+      zod: 3.25.67
+
   '@ai-sdk/anthropic@3.0.81(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@3.25.67)
-      zod: 3.25.67
-
-  '@ai-sdk/anthropic@3.0.98(zod@3.25.67)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.40(zod@3.25.67)
       zod: 3.25.67
 
   '@ai-sdk/azure@3.0.70(zod@3.25.67)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 
 catalog:
   '@ai-sdk/amazon-bedrock': ^4.0.113
-  '@ai-sdk/anthropic': ^3.0.81
+  '@ai-sdk/anthropic': ^3.0.98
   '@ai-sdk/azure': ^3.0.70
   '@ai-sdk/cohere': ^3.0.36
   '@ai-sdk/deepseek': ^2.0.35

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   '@ai-sdk/google': ^3.0.80
   '@ai-sdk/groq': ^3.0.39
   '@ai-sdk/mistral': ^3.0.37
-  '@ai-sdk/openai': ^3.0.68
+  '@ai-sdk/openai': ^3.0.86
   '@ai-sdk/openai-compatible': ^2.0.48
   '@ai-sdk/provider-utils': ^4.0.27
   '@ai-sdk/xai': ^3.0.110

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ catalog:
   '@ai-sdk/openai': ^3.0.68
   '@ai-sdk/openai-compatible': ^2.0.48
   '@ai-sdk/provider-utils': ^4.0.27
-  '@ai-sdk/xai': ^3.0.93
+  '@ai-sdk/xai': ^3.0.110
   '@azure/identity': 4.13.0
   '@azure/storage-blob': ^12.32.0
   '@chat-adapter/linear': ^4.28.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,6 @@ catalog:
   '@ai-sdk/amazon-bedrock': ^4.0.113
   '@ai-sdk/anthropic': ^3.0.98
   '@ai-sdk/azure': ^3.0.70
-  '@ai-sdk/baseten': ^1.0.65
   '@ai-sdk/cohere': ^3.0.36
   '@ai-sdk/deepseek': ^2.0.35
   '@ai-sdk/gateway': ^3.0.125

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
   '@ai-sdk/amazon-bedrock': ^4.0.113
   '@ai-sdk/anthropic': ^3.0.98
   '@ai-sdk/azure': ^3.0.70
+  '@ai-sdk/baseten': ^1.0.65
   '@ai-sdk/cohere': ^3.0.36
   '@ai-sdk/deepseek': ^2.0.35
   '@ai-sdk/gateway': ^3.0.125

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 
 catalog:
   '@ai-sdk/amazon-bedrock': ^4.0.113
-  '@ai-sdk/anthropic': ^3.0.98
+  '@ai-sdk/anthropic': ^3.0.102
   '@ai-sdk/azure': ^3.0.70
   '@ai-sdk/cohere': ^3.0.36
   '@ai-sdk/deepseek': ^2.0.35
@@ -278,3 +278,7 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@n8n/*'
   - '@n8n_io/*'
+  # Fresh Claude model IDs (e.g. Opus 5) ship in @ai-sdk/anthropic patches; allow
+  # installing before the 3-day minimumReleaseAge so agents/evals aren't stuck on
+  # the unknown-model 4096 max_tokens default.
+  - '@ai-sdk/anthropic'


### PR DESCRIPTION
## Summary

- Enable OpenRouter and xAI thinking support (`reasoningEffort`) in provider capabilities.
- Map OpenRouter thinking to `providerOptions.openrouter.reasoning.effort`.
- Extend Anthropic adaptive thinking config with `effort`, mapped to AI SDK `providerOptions.anthropic.effort` (`output_config.effort`).
- Default Instance AI (and agent builder via the same helper) to low effort for:
  - Anthropic models (`effort: 'low'` with adaptive thinking)
  - Kimi K3 via OpenRouter
  - Grok 4.5 via OpenRouter or native xAI

## How to test

1. Bypass the AI assistant proxy for OpenRouter models:
   ```bash
   N8N_AI_ASSISTANT_BASE_URL=
   N8N_INSTANCE_AI_MODEL=openrouter/x-ai/grok-4.5
   N8N_INSTANCE_AI_MODEL_API_KEY=<openrouter-key>
   ```
2. For Anthropic, confirm requests include adaptive thinking plus low effort (`output_config.effort: "low"` / AI SDK `providerOptions.anthropic.effort: "low"`).
3. For Kimi/Grok via OpenRouter, confirm `"reasoning": { "effort": "low" }`.
4. Confirm untargeted OpenRouter models (e.g. `openrouter/openai/gpt-4o`) do not auto-enable thinking.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-942

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI