### PR TITLE
feat(Microsoft Excel SharePoint Node): Enable use as an AI agent tool (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/MicrosoftExcelSharePoint.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/MicrosoftExcelSharePoint.node.ts
@@ -32,6 +32,9 @@ export class MicrosoftExcelSharePoint implements INodeType {
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],
 		hidden: true,
+		// The generated Tool variant inherits `hidden`, so both stay out of the
+		// panel until launch; removing `hidden` exposes node and tool together.
+		usableAsTool: true,
 		// Legacy credentials deliberately excluded: the SharePoint one targets
 		// the old _api host (not Graph); the Excel one has no Sites.* scopes.
 		credentials: [

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/MicrosoftExcelSharePoint.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/MicrosoftExcelSharePoint.node.test.ts
@@ -20,8 +20,26 @@ describe('MicrosoftExcelSharePoint (hidden shell)', () => {
 		expect(node.description.displayName).not.toBe(oneDriveNode.description.displayName);
 	});
 
-	it('should not be exposed as an AI tool yet', () => {
+	it('should be exposed as an AI tool', () => {
 		expect(node.description.version).toBe(1);
-		expect(node.description.usableAsTool).toBeUndefined();
+		expect(node.description.usableAsTool).toBe(true);
+	});
+
+	it('describes every operation for a model choosing between tools', () => {
+		const operationProperties = node.description.properties.filter(
+			(property) => property.name === 'operation',
+		);
+
+		expect(operationProperties.length).toBeGreaterThan(0);
+		for (const property of operationProperties) {
+			for (const option of property.options ?? []) {
+				if (!('value' in option)) continue;
+				expect(option.description, `operation ${String(option.value)}`).toMatch(/\w+/);
+				expect(
+					(option as { action?: string }).action,
+					`operation ${String(option.value)} action`,
+				).toMatch(/\w+/);
+			}
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Enables the (still hidden, pre-launch) Microsoft Excel (SharePoint) node as an AI agent tool, matching the OneDrive Excel node.

- `usableAsTool: true` on the node description. The generated `microsoftExcelSharePointTool` variant inherits `hidden`, so both the node and its tool stay out of the panel until the launch ticket removes the flag — then both appear together (a comment records this).
- The shell test's "not exposed as an AI tool yet" guard flips to assert the flag, and a new test pins the second acceptance criterion: every operation carries a non-empty description and action, so the tool's operation list reads sensibly to a model choosing between tools.

Note: the AC's "agent reads rows and appends rows through the tool (faked replies)" cannot currently be written as an automated test — tool-variant generation lives in the CLI layer (`cli/src/tool-generation`), and no test harness today can host a converted `*Tool` node inside an agent workflow (existing agent integration tests use standalone tool nodes like Calculator). The operations themselves are already proven against faked Graph replies by the node's unit tests; the agent-loop check is a runtime verification, suggested for the launch ticket's real-tenant pass.

## How to test

`cd packages/nodes-base && pnpm vitest run nodes/Microsoft/ExcelSharePoint/test` — 194 tests, all green. For the live check: unhide the node locally, build an AI Agent workflow with the Microsoft Excel (SharePoint) tool, and have the agent read and append rows.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-209

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (Node still hidden; docs PR for the node is held for launch.)
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

