### PR TITLE
fix(editor): Stabilize icon picker scrolling

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.virtualization.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.virtualization.test.ts
@@ -47,6 +47,27 @@ const router = createRouter({
 });
 
 describe('IconPicker virtualization', () => {
+	it('reserves the estimated row height while lazy icons render', async () => {
+		const { getByTestId, findAllByTestId } = render(IconPicker, {
+			props: {
+				modelValue: { type: 'icon', value: 'icon-1' },
+				buttonTooltip: 'Select an icon',
+			},
+			global: {
+				plugins: [router],
+				stubs: ['N8nButton', 'N8nIcon'],
+			},
+		});
+
+		await fireEvent.click(getByTestId('icon-picker-button'));
+
+		const [icon] = await findAllByTestId('icon-picker-icon');
+		const row = icon.closest('[class*="iconGridRow"]');
+
+		expect(row).not.toBeNull();
+		expect(row).toHaveStyle({ minHeight: 'var(--height--md)' });
+	});
+
 	it('renders only visible icon rows in browse mode', async () => {
 		const { getByTestId } = render(IconPicker, {
 			props: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIconPicker/IconPicker.vue
@@ -42,6 +42,7 @@ defineOptions({ name: 'N8nIconPicker' });
 
 const SKIN_TONE_STORAGE_KEY = 'n8n-emoji-skin-tone';
 const VIRTUAL_ROW_SIZE = 32;
+const VIRTUAL_ROW_STYLE = { minHeight: 'var(--height--md)' };
 
 type Props = {
 	buttonTooltip: string;
@@ -358,7 +359,11 @@ function humanizeIconName(name: string): string {
 								{{ t(item.labelKey) }}
 							</div>
 						</div>
-						<div v-else-if="item.type === 'icon-row'" :class="$style.iconGridRow">
+						<div
+							v-else-if="item.type === 'icon-row'"
+							:class="$style.iconGridRow"
+							:style="VIRTUAL_ROW_STYLE"
+						>
 							<button
 								v-for="name in item.iconNames"
 								:key="name"
@@ -397,7 +402,11 @@ function humanizeIconName(name: string): string {
 								{{ t(item.labelKey) }}
 							</div>
 						</div>
-						<div v-else-if="item.type === 'emoji-row'" :class="$style.emojiGridRow">
+						<div
+							v-else-if="item.type === 'emoji-row'"
+							:class="$style.emojiGridRow"
+							:style="VIRTUAL_ROW_STYLE"
+						>
 							<button
 								v-for="emoji in item.emojis"
 								:key="emoji.u"


### PR DESCRIPTION
## Summary

- Keep virtualized icon and emoji rows stable while their assets load
- Add regression coverage for virtual row sizing

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-362

## Screenshot
<img width="465" height="458" alt="icon-picker" src="https://github.com/user-attachments/assets/02eb21a2-1993-4cfd-972e-99617d9de3d4" />

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR labeled for backporting if required.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34596">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

