### PR TITLE
fix(core): Surface HITL suspend/resume content in Instance AI trace turns

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -2478,25 +2478,6 @@ describe('InstanceAiService — suspended run user revalidation', () => {
 		expect(options.input).not.toHaveProperty('credentials');
 		expect((options.input as { resumeFields: string[] }).resumeFields).toContain('credentials');
 	});
-
-	it('truncates long free-text resume input for tracing', async () => {
-		const service = createSuspendedRunResumeService();
-		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1', disabled: false } as User);
-		const longUserInput = 'x'.repeat(3000);
-
-		await service.resumeSuspendedRun('user-1', 'req-1', {
-			approved: true,
-			userInput: longUserInput,
-		});
-
-		const [options] = service.tracing.createOrchestratorResumeTraceContext.mock.calls[0] as [
-			{ input: { userInput: string } },
-		];
-		expect(options.input.userInput).toHaveLength(2001);
-		expect(options.input.userInput.endsWith('…')).toBe(true);
-		const [, resumeDataArg] = service.processResumedStream.mock.calls[0] as [unknown, object];
-		expect(resumeDataArg).toMatchObject({ userInput: longUserInput });
-	});
 });
 
 describe('InstanceAiService — rebuildAgentForAutoSetupResume', () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -1828,6 +1828,16 @@ type SuspendedRunResumeServiceInternals = {
 		data: {
 			approved: boolean;
 			autoSetup?: { credentialType: string };
+			userInput?: string;
+			credentials?: Record<string, string>;
+			answers?: Array<{
+				questionId: string;
+				selectedOptions: string[];
+				customText?: string;
+				skipped?: boolean;
+			}>;
+			action?: 'apply' | 'test-trigger';
+			resourceDecision?: string;
 		},
 	) => Promise<{ ok: true; runId: string } | null>;
 	revalidateActiveUser: Mock<(...args: [string]) => Promise<User | null>>;
@@ -2442,6 +2452,51 @@ describe('InstanceAiService — suspended run user revalidation', () => {
 		expect(result).toEqual({ ok: true, runId: 'run-1' });
 		expect(service.rebuildAgentForAutoSetupResume).not.toHaveBeenCalled();
 	});
+
+	it('includes the substantive user response in the resume trace input', async () => {
+		const service = createSuspendedRunResumeService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1', disabled: false } as User);
+
+		await service.resumeSuspendedRun('user-1', 'req-1', {
+			approved: true,
+			userInput: 'Use the #alerts channel',
+			credentials: { slackApi: 'cred-1' },
+			answers: [{ questionId: 'q1', selectedOptions: ['Slack'], customText: 'prefer DMs' }],
+		});
+
+		expect(service.tracing.createOrchestratorResumeTraceContext).toHaveBeenCalledTimes(1);
+		const [options] = service.tracing.createOrchestratorResumeTraceContext.mock.calls[0] as [
+			{ input: object },
+		];
+		expect(options.input).toMatchObject({
+			requestId: 'req-1',
+			toolCallId: 'tool-call-1',
+			approved: true,
+			userInput: 'Use the #alerts channel',
+			answers: [{ questionId: 'q1', selectedOptions: ['Slack'], customText: 'prefer DMs' }],
+		});
+		expect(options.input).not.toHaveProperty('credentials');
+		expect((options.input as { resumeFields: string[] }).resumeFields).toContain('credentials');
+	});
+
+	it('truncates long free-text resume input for tracing', async () => {
+		const service = createSuspendedRunResumeService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1', disabled: false } as User);
+		const longUserInput = 'x'.repeat(3000);
+
+		await service.resumeSuspendedRun('user-1', 'req-1', {
+			approved: true,
+			userInput: longUserInput,
+		});
+
+		const [options] = service.tracing.createOrchestratorResumeTraceContext.mock.calls[0] as [
+			{ input: { userInput: string } },
+		];
+		expect(options.input.userInput).toHaveLength(2001);
+		expect(options.input.userInput.endsWith('…')).toBe(true);
+		const [, resumeDataArg] = service.processResumedStream.mock.calls[0] as [unknown, object];
+		expect(resumeDataArg).toMatchObject({ userInput: longUserInput });
+	});
 });
 
 describe('InstanceAiService — rebuildAgentForAutoSetupResume', () => {
@@ -2850,6 +2905,60 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			'agent-run-1:req-1',
 			[usageItem],
 			'suspended',
+		);
+	});
+
+	it('surfaces the user-facing suspend message in the suspension trace outputs', async () => {
+		const service = createTerminalGuardOrderService();
+		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);
+		const abortController = new AbortController();
+		vi.mocked(resumeAgentRun).mockResolvedValueOnce({
+			status: 'suspended',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve(''),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+			suspension: {
+				toolCallId: 'tool-call-1',
+				requestId: 'req-1',
+				toolName: 'ask-user',
+				suspendPayload: { requestId: 'req-1', message: 'Set up the slack channel' },
+			},
+		});
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: {},
+			},
+		);
+
+		expect(service.tracing.finalizeRunTracing).toHaveBeenCalledWith(
+			'run-1',
+			undefined,
+			expect.objectContaining({
+				status: 'suspended',
+				outputs: expect.objectContaining({
+					message: 'Set up the slack channel',
+					pendingToolCallId: 'tool-call-1',
+					toolName: 'ask-user',
+					requestId: 'req-1',
+				}),
+			}),
+		);
+		expect(service.tracing.maybeFinalizeRunTraceRoot).toHaveBeenCalledWith(
+			'run-1',
+			expect.objectContaining({
+				status: 'suspended',
+				outputs: expect.objectContaining({ message: 'Set up the slack channel' }),
+			}),
 		);
 	});
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -198,17 +198,10 @@ function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-const TRACE_TEXT_CAP = 2000;
-
-/** Bound free text destined for trace inputs/outputs; returns undefined for non-strings and empty strings. */
-function boundTraceText(value: unknown): string | undefined {
-	if (typeof value !== 'string' || value.length === 0) return undefined;
-	return value.length > TRACE_TEXT_CAP ? `${value.slice(0, TRACE_TEXT_CAP)}…` : value;
-}
-
 /** Root-run outputs for a suspended segment — keep the LangSmith turn readable (AGENT-371). */
 function buildSuspensionTraceOutputs(runId: string, suspension: SuspensionInfo | undefined) {
-	const message = boundTraceText(suspension?.suspendPayload.message);
+	const rawMessage = suspension?.suspendPayload.message;
+	const message = typeof rawMessage === 'string' && rawMessage ? rawMessage : undefined;
 	return {
 		status: 'suspended',
 		runId,
@@ -4548,21 +4541,10 @@ export class InstanceAiService {
 				toolCallId,
 				approved: data.approved,
 				resumeFields: Object.keys(resumeData),
-				...(boundTraceText(data.userInput) ? { userInput: boundTraceText(data.userInput) } : {}),
+				...(data.userInput ? { userInput: data.userInput } : {}),
 				...(data.action ? { action: data.action } : {}),
 				...(data.resourceDecision ? { resourceDecision: data.resourceDecision } : {}),
-				...(data.answers
-					? {
-							answers: data.answers.map((answer) => ({
-								questionId: answer.questionId,
-								selectedOptions: answer.selectedOptions,
-								...(boundTraceText(answer.customText)
-									? { customText: boundTraceText(answer.customText) }
-									: {}),
-								...(answer.skipped !== undefined ? { skipped: answer.skipped } : {}),
-							})),
-						}
-					: {}),
+				...(data.answers ? { answers: data.answers } : {}),
 			},
 			resumeReason: 'approval',
 			metadata: {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -92,6 +92,7 @@ import {
 	type ServiceProxyConfig,
 	type StreamableAgent,
 	type SuspendedRunState,
+	type SuspensionInfo,
 	type WorkflowBuildOutcome,
 	type WorkflowLoopWorkItemRecord,
 	type WorkflowSetupRoutingClaim,
@@ -195,6 +196,27 @@ import { formatPreviewSessionContext } from '../agents/builder/format-preview-co
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+const TRACE_TEXT_CAP = 2000;
+
+/** Bound free text destined for trace inputs/outputs; returns undefined for non-strings and empty strings. */
+function boundTraceText(value: unknown): string | undefined {
+	if (typeof value !== 'string' || value.length === 0) return undefined;
+	return value.length > TRACE_TEXT_CAP ? `${value.slice(0, TRACE_TEXT_CAP)}…` : value;
+}
+
+/** Root-run outputs for a suspended segment — keep the LangSmith turn readable (AGENT-371). */
+function buildSuspensionTraceOutputs(runId: string, suspension: SuspensionInfo | undefined) {
+	const message = boundTraceText(suspension?.suspendPayload.message);
+	return {
+		status: 'suspended',
+		runId,
+		...(suspension?.requestId ? { requestId: suspension.requestId } : {}),
+		...(suspension?.toolCallId ? { pendingToolCallId: suspension.toolCallId } : {}),
+		...(suspension?.toolName ? { toolName: suspension.toolName } : {}),
+		...(message ? { message } : {}),
+	};
 }
 
 /**
@@ -3621,15 +3643,7 @@ export class InstanceAiService {
 				// The tree is rebuilt from in-memory events and includes the
 				// confirmation-request data that the frontend needs.
 				await this.saveAgentTreeSnapshot(threadId, runId, snapshotStorage);
-				const suspensionOutputs = {
-					status: 'suspended',
-					runId,
-					...(result.suspension?.requestId ? { requestId: result.suspension.requestId } : {}),
-					...(result.suspension?.toolCallId
-						? { pendingToolCallId: result.suspension.toolCallId }
-						: {}),
-					...(result.suspension?.toolName ? { toolName: result.suspension.toolName } : {}),
-				};
+				const suspensionOutputs = buildSuspensionTraceOutputs(runId, result.suspension);
 				await this.tracing.finalizeRunTracing(runId, tracing, {
 					status: 'suspended',
 					outputs: suspensionOutputs,
@@ -4534,6 +4548,21 @@ export class InstanceAiService {
 				toolCallId,
 				approved: data.approved,
 				resumeFields: Object.keys(resumeData),
+				...(boundTraceText(data.userInput) ? { userInput: boundTraceText(data.userInput) } : {}),
+				...(data.action ? { action: data.action } : {}),
+				...(data.resourceDecision ? { resourceDecision: data.resourceDecision } : {}),
+				...(data.answers
+					? {
+							answers: data.answers.map((answer) => ({
+								questionId: answer.questionId,
+								selectedOptions: answer.selectedOptions,
+								...(boundTraceText(answer.customText)
+									? { customText: boundTraceText(answer.customText) }
+									: {}),
+								...(answer.skipped !== undefined ? { skipped: answer.skipped } : {}),
+							})),
+						}
+					: {}),
 			},
 			resumeReason: 'approval',
 			metadata: {
@@ -4774,15 +4803,7 @@ export class InstanceAiService {
 				// Persist the refreshed agent tree so repeated HITL waits
 				// survive page refresh after a resume as well.
 				await this.saveAgentTreeSnapshot(opts.threadId, opts.runId, opts.snapshotStorage);
-				const suspensionOutputs = {
-					status: 'suspended',
-					runId: opts.runId,
-					...(result.suspension?.requestId ? { requestId: result.suspension.requestId } : {}),
-					...(result.suspension?.toolCallId
-						? { pendingToolCallId: result.suspension.toolCallId }
-						: {}),
-					...(result.suspension?.toolName ? { toolName: result.suspension.toolName } : {}),
-				};
+				const suspensionOutputs = buildSuspensionTraceOutputs(opts.runId, result.suspension);
 				await this.tracing.finalizeRunTracing(opts.runId, opts.tracing, {
 					status: 'suspended',
 					outputs: suspensionOutputs,


### PR DESCRIPTION
## Summary

LangSmith's Thread → Turns view renders each trace's root run inputs/outputs as one conversational turn. For HITL-heavy Instance AI conversations, those turns were unreadable:

- **Resume turns (HUMAN side)** only carried plumbing (`requestId`, `toolCallId`, `approved`, `resumeFields`), so the bubble rendered a `toolu_…` tool-call id instead of what the user actually answered.
- **Suspended turns (ASSISTANT side)** only carried plumbing (`status`, `runId`, `requestId`, `pendingToolCallId`, `toolName`), not the question the assistant asked.

This predates the builder sub-agent work, but the agent-build question cascade makes nearly every turn of an agent-build conversation a suspend/resume, so the Turns view of those threads collapsed into ids.

This PR:

1. **Resume trace inputs** (`resumeSuspendedRun`): includes the substantive user response — `userInput`, `action`, `resourceDecision`, and a sanitized `answers` array — alongside the existing plumbing, so the HUMAN turn reads like the user's actual answer. `credentials`, `nodeCredentials`, and `nodeParameters` are never included.
2. **Suspension trace outputs** (both call sites): includes the user-facing `message` from the suspend payload (e.g. "Set up the slack channel"), so a turn that ends in a question reads as the assistant asking that question.

All free-text values are bounded to 2000 characters before being sent to tracing. The actual `resumeData` object that drives the agent resume is unchanged — only the trace-facing input/output shaping changed.

Result: Turns view now reads *build request → question → answer → next question → final response* instead of a wall of tool-call ids.

## How to test

1. Start an Instance AI conversation that triggers a HITL suspend/resume (e.g. ask the assistant to build a workflow that needs a credential, or use `ask-user` via the agent builder).
2. In LangSmith, open the thread and look at the Turns view.
3. Confirm the HUMAN turn for a resume shows the actual answer (not just a tool-call id), and the ASSISTANT turn for a suspension shows the question/message that was asked.
4. Confirm no `credentials`, `nodeCredentials`, or `nodeParameters` values appear in the traced resume input.

Unit tests cover the same behavior without a live LangSmith project — see `packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-371

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34599">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

