### PR TITLE
feat(core): Detect embedded chat in v3 migration report (no-changelog)

### DIFF
--- a/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.rule-discovery.test.ts
+++ b/packages/cli/src/modules/breaking-changes/__tests__/breaking-changes.rule-discovery.test.ts
@@ -10,8 +10,8 @@ describe('Breaking change rules auto-discovery', () => {
 		const entries = metadata.getEntries();
 
 		expect(entries.filter((entry) => entry.version === 'v2')).toHaveLength(16);
-		expect(entries.filter((entry) => entry.version === 'v3')).toHaveLength(11);
-		expect(entries).toHaveLength(27);
+		expect(entries.filter((entry) => entry.version === 'v3')).toHaveLength(12);
+		expect(entries).toHaveLength(28);
 	});
 
 	it('should resolve all registered rules with valid metadata from the DI container', () => {

--- a/packages/cli/src/modules/breaking-changes/rules/index.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/index.ts
@@ -21,6 +21,7 @@ import './v2/workflow-hooks-deprecated.rule';
 
 // v3 rules
 import './v3/always-output-data-multi-output.rule';
+import './v3/chat-trigger-embedded-json.rule';
 import './v3/compression-node-limits.rule';
 import './v3/docker-only-deployment.rule';
 import './v3/execute-workflow-each-mode.rule';

--- a/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/chat-trigger-embedded-json.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/chat-trigger-embedded-json.rule.test.ts
@@ -1,0 +1,96 @@
+import { createNode, createWorkflow } from '../../../__tests__/test-helpers';
+import { ChatTriggerEmbeddedJsonRule } from '../chat-trigger-embedded-json.rule';
+
+const CHAT_TRIGGER = '@n8n/n8n-nodes-langchain.chatTrigger';
+const CHAT_TRIGGER_LEGACY = 'n8n-nodes-langchain.chatTrigger';
+
+describe('ChatTriggerEmbeddedJsonRule', () => {
+	let rule: ChatTriggerEmbeddedJsonRule;
+
+	beforeEach(() => {
+		rule = new ChatTriggerEmbeddedJsonRule();
+	});
+
+	describe('detectWorkflow()', () => {
+		it('should not be affected when there is no Chat Trigger node', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('HTTP', 'n8n-nodes-base.httpRequest'),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should not be affected when Chat Trigger uses hosted mode', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('Chat', CHAT_TRIGGER, { mode: 'hostedChat' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should not be affected when mode is unset (defaults to hosted)', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('Chat', CHAT_TRIGGER),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should detect Chat Trigger using embedded (webhook) mode', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('Chat', CHAT_TRIGGER, { mode: 'webhook' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].title).toContain('Chat');
+			expect(result.issues[0].level).toBe('warning');
+			expect(result.issues[0].nodeName).toBe('Chat');
+		});
+
+		it('should detect embedded mode on the legacy un-scoped node type', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('Chat', CHAT_TRIGGER_LEGACY, { mode: 'webhook' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].nodeName).toBe('Chat');
+		});
+
+		it('should flag only the embedded Chat Trigger when hosted and embedded coexist', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('Embedded', CHAT_TRIGGER, { mode: 'webhook' }),
+				createNode('Hosted', CHAT_TRIGGER, { mode: 'hostedChat' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].nodeName).toBe('Embedded');
+		});
+	});
+
+	describe('getRecommendations()', () => {
+		it('should recommend updating the embedded chat', async () => {
+			const recommendations = await rule.getRecommendations([]);
+
+			expect(recommendations).toHaveLength(1);
+			expect(recommendations[0].action).toContain('embedded chat');
+		});
+	});
+});

--- a/packages/cli/src/modules/breaking-changes/rules/v3/chat-trigger-embedded-json.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/chat-trigger-embedded-json.rule.ts
@@ -1,0 +1,74 @@
+import type { BreakingChangeAffectedWorkflow, BreakingChangeRecommendation } from '@n8n/api-types';
+import type { WorkflowEntity } from '@n8n/db';
+import { BreakingChangeRule } from '@n8n/decorators';
+import type { INode } from 'n8n-workflow';
+
+import type {
+	BreakingChangeRuleMetadata,
+	IBreakingChangeWorkflowRule,
+	WorkflowDetectionReport,
+} from '../../types';
+import { BreakingChangeCategory } from '../../types';
+
+// Chat Trigger is normalized to the scoped type, but legacy workflows may carry the un-scoped form.
+const CHAT_TRIGGER_NODE_TYPES = [
+	'@n8n/n8n-nodes-langchain.chatTrigger',
+	'n8n-nodes-langchain.chatTrigger',
+];
+// Embedded mode ('webhook') runs the widget/client on the customer's own site; 'hostedChat' (also
+// the default when unset) is served by n8n from the unpinned CDN and updates automatically.
+const EMBEDDED_MODE = 'webhook';
+
+@BreakingChangeRule({ version: 'v3' })
+export class ChatTriggerEmbeddedJsonRule implements IBreakingChangeWorkflowRule {
+	id = 'chat-trigger-embedded-json-v3';
+
+	getMetadata(): BreakingChangeRuleMetadata {
+		return {
+			version: 'v3',
+			title: 'Embedded chat now uses a JSON WebSocket message format',
+			description:
+				'The chat WebSocket now sends every frame as JSON. Embedded chats using an old @n8n/chat widget pinned to a specific version, or a custom chat client that reads the raw WebSocket, will not understand the new frames until updated. Chats embedded via the unpinned CDN script update automatically, and hosted chats served by n8n are unaffected.',
+			category: BreakingChangeCategory.workflow,
+			severity: 'low',
+			documentationUrl: 'https://www.npmjs.com/package/@n8n/chat',
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async getRecommendations(
+		_workflowResults: BreakingChangeAffectedWorkflow[],
+	): Promise<BreakingChangeRecommendation[]> {
+		return [
+			{
+				action: 'Update your embedded chat to support the JSON message format',
+				description:
+					'If you embed the @n8n/chat widget with a pinned version, update it to a version that supports the JSON WebSocket format. If you use a custom chat client, make sure it parses JSON frames. Embeds using the unpinned CDN script update automatically and need no action.',
+			},
+		];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async detectWorkflow(
+		_workflow: WorkflowEntity,
+		nodesGroupedByType: Map<string, INode[]>,
+	): Promise<WorkflowDetectionReport> {
+		const affectedNodes = CHAT_TRIGGER_NODE_TYPES.flatMap(
+			(type) => nodesGroupedByType.get(type) ?? [],
+		).filter((node) => node.parameters.mode === EMBEDDED_MODE);
+
+		if (affectedNodes.length === 0) return { isAffected: false, issues: [] };
+
+		return {
+			isAffected: true,
+			issues: affectedNodes.map((node) => ({
+				title: `Node '${node.name}' uses an embedded chat`,
+				description:
+					'This embedded chat now receives JSON WebSocket frames. Update a pinned @n8n/chat widget to a version that supports the JSON format, or ensure your custom chat client parses JSON frames. Unpinned CDN embeds update automatically.',
+				level: 'warning',
+				nodeId: node.id,
+				nodeName: node.name,
+			})),
+		};
+	}
+}


### PR DESCRIPTION
## Summary

Adds a v3 breaking-change rule to the migration report that flags workflows using a **Chat Trigger in Embedded Chat mode** (`mode: webhook`).

[PR #34247](https://github.com/n8n-io/n8n/pull/34247) changes the chat WebSocket to send JSON-only frames in v3. Consumers that only understand the old string sentinels break — specifically embedded chats running a **pinned old `@n8n/chat` widget** or a **custom raw-WebSocket client**. This rule surfaces those workflows so users know to update before upgrading.

Scope and framing decisions:
- **Embedded (`mode: webhook`) only.** Hosted Chat is served by n8n from the unpinned jsdelivr CDN and updates automatically; the editor panel bundles the widget from source. Both are safe, so flagging them would be noise. A missing `mode` defaults to `hostedChat` and is not flagged.
- **Low severity, advisory `warning`.** The embedded widget version is not knowable server-side (`@n8n/chat` exposes no runtime version and runs on the customer's own site), so the rule can only nudge, not verify. Unpinned CDN embeds update automatically and need no action.
- Matches both the scoped (`@n8n/n8n-nodes-langchain.chatTrigger`) and legacy un-scoped node type.


<img width="1430" height="382" alt="Bildschirmfoto 2026-07-21 um 10 12 46" src="https://github.com/user-attachments/assets/b34b08c0-a87c-469f-a5b6-12c508309f61" />


## How to test

1. Temporarily set `MIGRATION_REPORT_TARGET_VERSION = 'v3'` in `packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts` and rebuild `@n8n/api-types`.
2. Create a workflow with a **Chat Trigger** in **Embedded Chat** mode.
3. Open Settings → Migration Report (or `GET /breaking-changes/report?version=v3`) and confirm the workflow appears under rule `chat-trigger-embedded-json-v3` as a low-severity warning.
4. A **Hosted Chat** trigger should **not** appear under this rule.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to the v3 chat WebSocket JSON change: https://github.com/n8n-io/n8n/pull/34247 (NODE-4436)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34604">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

