### PR TITLE
chore: Fix e2e tests

### DIFF
--- a/packages/workflow/test/application-error.test.ts
+++ b/packages/workflow/test/application-error.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationError as ErrorsApplicationError } from '@n8n/errors';
 
-import { ApplicationError } from 'n8n-workflow';
+import { ApplicationError } from '../src';
 
 // This file is the compatibility boundary, exempt from the `no-application-error` lint rule.
 describe('ApplicationError compatibility shim', () => {

--- a/packages/workflow/tsconfig.json
+++ b/packages/workflow/tsconfig.json
@@ -5,7 +5,6 @@
 		"noUncheckedIndexedAccess": false,
 		"types": ["vite/client", "vitest/globals"],
 		"paths": {
-			"n8n-workflow": ["./src/index.ts"],
 			"esprima-next": ["./node_modules/esprima-next/dist/esm/esprima"]
 		}
 	},


### PR DESCRIPTION
## Summary

The fixes the e2e test compilation, by removing the self reference in the workflow tsconfig.


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

