### PR TITLE
fix(core): Fail fast with a node error when a Data Table node references a missing table

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-table-proxy.service.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-proxy.service.integration.test.ts
@@ -1,7 +1,8 @@
 import type { ListDataTableQueryDto } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
-import { testDb, testModules } from '@n8n/backend-test-utils';
+import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
 import type { Project, User } from '@n8n/db';
+import { Container } from '@n8n/di';
 import type {
 	AddDataTableColumnOptions,
 	INode,
@@ -10,6 +11,7 @@ import type {
 	UpsertDataTableRowOptions,
 	Workflow,
 } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -19,7 +21,8 @@ import type { OwnershipService } from '@/services/ownership.service';
 
 import type { DataTableAggregateService } from '../data-table-aggregate.service';
 import { DataTableProxyService } from '../data-table-proxy.service';
-import type { DataTableService } from '../data-table.service';
+import { DataTableService } from '../data-table.service';
+import { DataTableNotFoundError } from '../errors/data-table-not-found.error';
 
 const PROJECT_ID = 'project-id';
 
@@ -280,6 +283,77 @@ describe('DataTableProxyService', () => {
 			true,
 			true,
 		);
+	});
+
+	describe('getDataTableProxy existence validation', () => {
+		it('throws NodeOperationError when the data table does not exist in the project', async () => {
+			dataTableServiceMock.validateDataTableExists.mockRejectedValue(
+				new DataTableNotFoundError('missing-id'),
+			);
+
+			const promise = dataTableProxyService.getDataTableProxy(workflow, node, 'missing-id');
+
+			await expect(promise).rejects.toBeInstanceOf(NodeOperationError);
+			await expect(promise).rejects.toThrow("Data table with ID 'missing-id' could not be found");
+		});
+
+		it('validates existence against the resolved project', async () => {
+			await dataTableProxyService.getDataTableProxy(workflow, node, 'dataTable-id');
+
+			expect(dataTableServiceMock.validateDataTableExists).toHaveBeenCalledWith(
+				'dataTable-id',
+				PROJECT_ID,
+			);
+		});
+
+		it('rethrows non-not-found errors unwrapped', async () => {
+			const dbError = new Error('connection lost');
+			dataTableServiceMock.validateDataTableExists.mockRejectedValue(dbError);
+
+			await expect(
+				dataTableProxyService.getDataTableProxy(workflow, node, 'dataTable-id'),
+			).rejects.toBe(dbError);
+		});
+	});
+});
+
+describe('DataTableProxyService (with database)', () => {
+	const node = mock<INode>({ type: 'n8n-nodes-base.dataTable' });
+	const workflow = mock<Workflow>({ id: 'workflow-id' });
+
+	afterEach(async () => {
+		await testDb.truncate(['DataTable', 'DataTableColumn', 'Project', 'ProjectRelation']);
+	});
+
+	it('resolves the proxy when the data table exists in the project', async () => {
+		const project = await createTeamProject();
+		const table = await Container.get(DataTableService).createDataTable(project.id, {
+			name: 'Existing Table',
+			columns: [],
+		});
+
+		await expect(
+			Container.get(DataTableProxyService).getDataTableProxy(workflow, node, table.id, project.id),
+		).resolves.toBeDefined();
+	});
+
+	it('throws NodeOperationError when the table exists only in another project', async () => {
+		const projectA = await createTeamProject();
+		const projectB = await createTeamProject();
+		const table = await Container.get(DataTableService).createDataTable(projectB.id, {
+			name: 'Other Project Table',
+			columns: [],
+		});
+
+		const promise = Container.get(DataTableProxyService).getDataTableProxy(
+			workflow,
+			node,
+			table.id,
+			projectA.id,
+		);
+
+		await expect(promise).rejects.toBeInstanceOf(NodeOperationError);
+		await expect(promise).rejects.toThrow(table.id);
 	});
 });
 

--- a/packages/cli/src/modules/data-table/__tests__/data-table-proxy.service.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-proxy.service.integration.test.ts
@@ -22,7 +22,6 @@ import type { OwnershipService } from '@/services/ownership.service';
 import type { DataTableAggregateService } from '../data-table-aggregate.service';
 import { DataTableProxyService } from '../data-table-proxy.service';
 import { DataTableService } from '../data-table.service';
-import { DataTableNotFoundError } from '../errors/data-table-not-found.error';
 
 const PROJECT_ID = 'project-id';
 
@@ -286,26 +285,6 @@ describe('DataTableProxyService', () => {
 	});
 
 	describe('getDataTableProxy existence validation', () => {
-		it('throws NodeOperationError when the data table does not exist in the project', async () => {
-			dataTableServiceMock.validateDataTableExists.mockRejectedValue(
-				new DataTableNotFoundError('missing-id'),
-			);
-
-			const promise = dataTableProxyService.getDataTableProxy(workflow, node, 'missing-id');
-
-			await expect(promise).rejects.toBeInstanceOf(NodeOperationError);
-			await expect(promise).rejects.toThrow("Data table with ID 'missing-id' could not be found");
-		});
-
-		it('validates existence against the resolved project', async () => {
-			await dataTableProxyService.getDataTableProxy(workflow, node, 'dataTable-id');
-
-			expect(dataTableServiceMock.validateDataTableExists).toHaveBeenCalledWith(
-				'dataTable-id',
-				PROJECT_ID,
-			);
-		});
-
 		it('rethrows non-not-found errors unwrapped', async () => {
 			const dbError = new Error('connection lost');
 			dataTableServiceMock.validateDataTableExists.mockRejectedValue(dbError);

--- a/packages/cli/src/modules/data-table/data-table-proxy.service.ts
+++ b/packages/cli/src/modules/data-table/data-table-proxy.service.ts
@@ -99,8 +99,6 @@ export class DataTableProxyService implements DataTableProxyProvider {
 		this.validateRequest(node);
 		projectId = projectId ?? (await this.getProjectId(workflow));
 
-		// Fail fast with a node-scoped error: the referenced table may have been
-		// deleted, or skipped when the workflow was imported without its tables.
 		try {
 			await this.dataTableService.validateDataTableExists(dataTableId, projectId);
 		} catch (error) {

--- a/packages/cli/src/modules/data-table/data-table-proxy.service.ts
+++ b/packages/cli/src/modules/data-table/data-table-proxy.service.ts
@@ -22,6 +22,7 @@ import {
 	UpdateDataTableRowOptions,
 	UpsertDataTableRowOptions,
 	Workflow,
+	NodeOperationError,
 } from 'n8n-workflow';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -31,6 +32,7 @@ import { OwnershipService } from '@/services/ownership.service';
 
 import { DataTableAggregateService } from './data-table-aggregate.service';
 import { DataTableService } from './data-table.service';
+import { DataTableNotFoundError } from './errors/data-table-not-found.error';
 
 const ALLOWED_NODES = [
 	'n8n-nodes-base.dataTable',
@@ -96,6 +98,24 @@ export class DataTableProxyService implements DataTableProxyProvider {
 	): Promise<IDataTableProjectService> {
 		this.validateRequest(node);
 		projectId = projectId ?? (await this.getProjectId(workflow));
+
+		// Fail fast with a node-scoped error: the referenced table may have been
+		// deleted, or skipped when the workflow was imported without its tables.
+		try {
+			await this.dataTableService.validateDataTableExists(dataTableId, projectId);
+		} catch (error) {
+			if (error instanceof DataTableNotFoundError) {
+				throw new NodeOperationError(
+					node,
+					`Data table with ID '${dataTableId}' could not be found in this project`,
+					{
+						description:
+							'It may have been deleted, or skipped when the workflow was imported. Choose an existing data table in the node.',
+					},
+				);
+			}
+			throw error;
+		}
 
 		return this.makeDataTableOperations(projectId, dataTableId);
 	}

--- a/packages/cli/src/modules/data-table/data-table.service.ts
+++ b/packages/cli/src/modules/data-table/data-table.service.ts
@@ -688,7 +688,10 @@ export class DataTableService {
 		return validationResult.newValue as DataTableColumnJsType;
 	}
 
-	private async validateDataTableExists(dataTableId: string, projectId: string) {
+	/**
+	 * Performs no authorization — callers must pass an already-authorized `projectId`.
+	 */
+	async validateDataTableExists(dataTableId: string, projectId: string) {
 		const existingTable = await this.dataTableRepository.findOneBy({
 			id: dataTableId,
 			project: {

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-data-tables.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-data-tables.integration.test.ts
@@ -3,11 +3,15 @@ import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils'
 import type { Project, User } from '@n8n/db';
 import { FolderRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import type { INode, INodeParameterResourceLocator, Workflow } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
 import type { RelayEventMap } from '@/events/maps/relay.event-map';
 import { mockDataTableSizeValidator } from '@/modules/data-table/__tests__/test-helpers';
+import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { createFolder } from '@test-integration/db/folders';
@@ -555,6 +559,35 @@ describe('workflow package import — with data tables', () => {
 
 			expect(result.workflows).toHaveLength(1);
 			expect(await tablesInProject(project.id)).toHaveLength(0);
+		});
+
+		it("imported workflow's data table reference fails fast with a node error", async () => {
+			const table = serializedDataTable();
+			const { packageBuffer } = await buildDataTablePackage([table]);
+
+			const result = await importPackage({
+				user: owner,
+				projectId: project.id,
+				packageBuffer,
+				dataTableMissingMode: 'do-nothing',
+			});
+
+			// The imported node still points at the skipped table's id.
+			const imported = await workflowRepository.findOneOrFail({
+				where: { id: result.workflows[0].localId },
+			});
+			const reference = imported.nodes[0].parameters.dataTableId as INodeParameterResourceLocator;
+			expect(reference.value).toBe(table.id);
+
+			const promise = Container.get(DataTableProxyService).getDataTableProxy(
+				mock<Workflow>({ id: imported.id }),
+				mock<INode>({ type: 'n8n-nodes-base.dataTable' }),
+				reference.value as string,
+				project.id,
+			);
+
+			await expect(promise).rejects.toBeInstanceOf(NodeOperationError);
+			await expect(promise).rejects.toThrow(table.id);
 		});
 	});
 

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-data-tables.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-data-tables.integration.test.ts
@@ -572,7 +572,6 @@ describe('workflow package import — with data tables', () => {
 				dataTableMissingMode: 'do-nothing',
 			});
 
-			// The imported node still points at the skipped table's id.
 			const imported = await workflowRepository.findOneOrFail({
 				where: { id: result.workflows[0].localId },
 			});


### PR DESCRIPTION
## Summary

When importing a package with dataTableMissingMode=do-nothing, workflows containing Data Table nodes are imported and the nodes look correctly configured, but the referenced data table does not exist on the target. The node shows no error, and clicking "Execute step" runs endlessly.

`DataTableProxyService.getDataTableProxy` now validates that the referenced table exists in the resolved project before returning the operations proxy, and surfaces a `NodeOperationError` with a clear, actionable message:

> Data table with ID '<id>' could not be found in this project
> It may have been deleted, or skipped when the workflow was imported. Choose an existing data table in the node.

This guards every consumer that routes through the proxy provider — the Data Table node (and its Tool variant), Evaluation nodes, and the loadOptions/resource-mapper paths — and mirrors how missing credentials fail at helper-acquisition time with a `NodeOperationError` (`packages/core/src/execution-engine/node-execution-context/node-execution-context.ts`; see also `packages/cli/src/utils/object-to-error.ts`).

<img width="1506" height="738" alt="image" src="https://github.com/user-attachments/assets/476a09c8-f641-4d44-94a0-71a652332386" />

## How to test
Manual (ticket repro):
1. Export a workflow that references a data table (requires the `n8n-packages` module: `N8N_ENABLED_MODULES=n8n-packages`, plus the data-table module enabled).
2. Import the package into a project with no data tables, using `dataTableMissingMode=do-nothing` (public API or `n8n package import --data-table-missing-mode=do-nothing`).
3. Open the workflow and execute the Data Table node: it must fail immediately with "Data table with ID '…' could not be found in this project" instead of appearing to run endlessly.
4. Deleted-table variant: create a table, reference it in a node, delete the table, execute — same clear error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-847

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34610">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

