### PR TITLE
feat(Gmail Node): Add warning notice when Simplify is disabled

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -17,6 +17,7 @@ import {
 	prepareQuery,
 	simplifyOutput,
 } from './GenericFunctions';
+import { simplifyMemoryNotice } from './utils/descriptions';
 import type {
 	GmailTriggerFilters,
 	GmailTriggerOptions,
@@ -113,9 +114,10 @@ export class GmailTrigger implements INodeType {
 					'Whether to return a simplified version of the response instead of the raw data',
 				builderHint: {
 					propertyHint:
-						'Set to false when the email body is needed for AI analysis, summarization, or content processing. When true, only returns snippet (preview text). When false, returns full email with {id, threadId, labelIds, headers, html, text, textAsHtml, subject, date, to, from, messageId, replyTo}.',
+						'Keep true by default. When true, returns lightweight metadata (id, threadId, labels, subject, from, to, snippet). When false, fetches and parses the full raw email (adds html, text, textAsHtml, headers, attachments), which uses much more memory and is a common cause of out-of-memory crashes. Only set false when the email body is actually required.',
 				},
 			},
+			simplifyMemoryNotice({ displayOptions: { show: { simple: [false] } } }),
 			{
 				displayName: 'Max Emails per Poll',
 				name: 'maxResults',

--- a/packages/nodes-base/nodes/Google/Gmail/utils/descriptions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/utils/descriptions.ts
@@ -1,0 +1,12 @@
+import type { IDisplayOptions, INodeProperties } from 'n8n-workflow';
+
+export const simplifyMemoryNotice = ({
+	displayOptions,
+}: { displayOptions?: IDisplayOptions } = {}): INodeProperties => ({
+	displayName:
+		'Simplify already returns the key fields most workflows need. The full response is much larger and can cause out-of-memory errors. Only turn Simplify off if you need the raw email body, attachments or other fields not available in the simplified response.',
+	name: 'simplifyMemoryNotice',
+	type: 'notice',
+	default: '',
+	displayOptions,
+});

--- a/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
@@ -1,6 +1,7 @@
 import { SEND_AND_WAIT_OPERATION, type INodeProperties } from 'n8n-workflow';
 
 import { appendAttributionOption } from '../../../../utils/descriptions';
+import { simplifyMemoryNotice } from '../utils/descriptions';
 
 export const messageOperations: INodeProperties[] = [
 	{
@@ -299,7 +300,14 @@ export const messageFields: INodeProperties[] = [
 		},
 		default: true,
 		description: 'Whether to return a simplified version of the response instead of the raw data',
+		builderHint: {
+			propertyHint:
+				'Keep true by default. When true, returns lightweight metadata (labels, subject, from, to, snippet). When false, fetches and parses the full raw email (adds html, text, textAsHtml, headers, attachments), which uses much more memory and is a common cause of out-of-memory crashes. Only set false when the email body is actually required, e.g. for AI classification, summarization, or content processing.',
+		},
 	},
+	simplifyMemoryNotice({
+		displayOptions: { show: { operation: ['get'], resource: ['message'], simple: [false] } },
+	}),
 	{
 		displayName: 'Options',
 		name: 'options',
@@ -381,7 +389,14 @@ export const messageFields: INodeProperties[] = [
 		},
 		default: true,
 		description: 'Whether to return a simplified version of the response instead of the raw data',
+		builderHint: {
+			propertyHint:
+				'Keep true by default. When true, returns lightweight metadata (labels, subject, from, to, snippet) per message. When false, fetches and parses the full raw email for every message (adds html, text, textAsHtml, headers, attachments), which uses much more memory and is a common cause of out-of-memory crashes. Only set false when the email body is actually required, e.g. for AI classification, summarization, or content processing.',
+		},
 	},
+	simplifyMemoryNotice({
+		displayOptions: { show: { operation: ['getAll'], resource: ['message'], simple: [false] } },
+	}),
 	{
 		displayName:
 			'Fetching a lot of messages may take a long time. Consider using filters to speed things up',

--- a/packages/nodes-base/nodes/Google/Gmail/v2/ThreadDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/ThreadDescription.ts
@@ -1,5 +1,7 @@
 import type { INodeProperties } from 'n8n-workflow';
 
+import { simplifyMemoryNotice } from '../utils/descriptions';
+
 export const threadOperations: INodeProperties[] = [
 	{
 		displayName: 'Operation',
@@ -240,7 +242,14 @@ export const threadFields: INodeProperties[] = [
 		},
 		default: true,
 		description: 'Whether to return a simplified version of the response instead of the raw data',
+		builderHint: {
+			propertyHint:
+				'Keep true by default. When true, returns lightweight metadata (labels, subject, from, to, snippet) for each message in the thread. When false, fetches and parses the full raw thread (adds html, text, textAsHtml, headers, attachments for every message), which uses much more memory and is a common cause of out-of-memory crashes. Only set false when the email body is actually required, e.g. for AI classification, summarization, or content processing.',
+		},
 	},
+	simplifyMemoryNotice({
+		displayOptions: { show: { operation: ['get'], resource: ['thread'], simple: [false] } },
+	}),
 	{
 		displayName: 'Options',
 		name: 'options',


### PR DESCRIPTION
## Summary

Disabling Simplify on the Gmail node fetches and parses the full raw email, which uses much more memory and is a frequent cause of crashes (especially the Gmail Trigger).

This PR adds a warning notice that appears directly below the Simplify toggle when it is turned off

<img width="1020" height="1412" alt="image" src="https://github.com/user-attachments/assets/8ba5b7e2-764c-41c5-aeb8-ac6c54ce962b" />

The `builderHint` was also updated so the AI builder keeps Simplify enabled unless the full email is needed.

**How to test:** open a Gmail Trigger (or Gmail node with Message → Get / Get Many, Thread → Get), turn Simplify off, and check the notice appears below the toggle; turn it back on and it disappears.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5411

## Review / Merge checklist

- [ ] PR title and summary are descriptive. (conventions)
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34611">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

