### PR TITLE
feat: Allow custom OAuth scopes for Microsoft Azure Monitor, Dynamics, Graph Security and Azure Storage

### DIFF
--- a/packages/nodes-base/credentials/AzureStorageOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/AzureStorageOAuth2Api.credentials.ts
@@ -23,10 +23,42 @@ export class AzureStorageOAuth2Api implements ICredentialType {
 			default: '=https://{{ $self["account"] }}.blob.core.windows.net',
 		},
 		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: 'https://storage.azure.com/.default',
+			description: 'Scopes that should be enabled',
+		},
+		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: 'https://storage.azure.com/.default',
+			default:
+				'={{$self["customScopes"] ? $self["enabledScopes"] : "https://storage.azure.com/.default"}}',
 		},
 		{
 			displayName: 'Microsoft Graph API Base URL',

--- a/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
@@ -105,7 +105,8 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 			},
 		},
 		{
-			// The default scope is built from Grant Type and Resource, so it can't prefill this field
+			// The default scope is built from Grant Type and Resource, so it can't prefill
+			// this field — left blank, the computed default applies instead
 			displayName: 'Enabled Scopes',
 			name: 'enabledScopes',
 			type: 'string',
@@ -123,7 +124,7 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 			name: 'scope',
 			type: 'hidden',
 			default:
-				'={{$self["customScopes"] ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : "")}}',
+				'={{$self["customScopes"] && $self["enabledScopes"] ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : "")}}',
 		},
 		{
 			displayName: 'Authentication',

--- a/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
@@ -94,7 +94,7 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 		},
 		{
 			displayName:
-				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly. Use the <code>{resource}</code> placeholder to reference the Resource value above. With the Authorization Code grant, the default scope is empty — the resource travels as a query parameter instead.',
 			name: 'customScopesNotice',
 			type: 'notice',
 			default: '',
@@ -105,8 +105,6 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 			},
 		},
 		{
-			// The default scope is built from Grant Type and Resource, so it can't prefill
-			// this field — left blank, the computed default applies instead
 			displayName: 'Enabled Scopes',
 			name: 'enabledScopes',
 			type: 'string',
@@ -115,16 +113,16 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 					customScopes: [true],
 				},
 			},
-			default: '',
-			placeholder: 'e.g. https://api.loganalytics.azure.com/.default',
-			description: 'Scopes that should be enabled',
+			default: '{resource}/.default',
+			description:
+				'Scopes that should be enabled. Use <code>{resource}</code> as a placeholder that will be replaced with the Resource value.',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
 			default:
-				'={{$self["customScopes"] && $self["enabledScopes"] ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : "")}}',
+				'={{(($self["customScopes"] && $self["enabledScopes"]) ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? "{resource}/.default" : "")).replace(/\\{resource\\}/g, $self["resource"])}}',
 		},
 		{
 			displayName: 'Authentication',

--- a/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
@@ -86,11 +86,44 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 				'={{$self["grantType"] === "clientCredentials" ? "" : "resource=" + $self["resource"]}}',
 		},
 		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			// The default scope is built from Grant Type and Resource, so it can't prefill this field
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: '',
+			placeholder: 'e.g. https://api.loganalytics.azure.com/.default',
+			description: 'Scopes that should be enabled',
+		},
+		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
 			default:
-				'={{$self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : ""}}',
+				'={{$self["customScopes"] ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : "")}}',
 		},
 		{
 			displayName: 'Authentication',

--- a/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
@@ -118,11 +118,14 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 				'Scopes that should be enabled. Use <code>{resource}</code> as a placeholder that will be replaced with the Resource value.',
 		},
 		{
+			// The untouched prefill counts as "use the defaults" so toggling custom
+			// scopes on without edits stays a no-op under the Authorization Code
+			// grant too, where the default scope is deliberately empty
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
 			default:
-				'={{(($self["customScopes"] && $self["enabledScopes"]) ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? "{resource}/.default" : "")).replace(/\\{resource\\}/g, $self["resource"])}}',
+				'={{(($self["customScopes"] && $self["enabledScopes"] && $self["enabledScopes"] !== "{resource}/.default") ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? "{resource}/.default" : "")).replace(/\\{resource\\}/g, $self["resource"])}}',
 		},
 		{
 			displayName: 'Authentication',

--- a/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
@@ -121,7 +121,8 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 			},
 		},
 		{
-			// The default scope is built from Subdomain and Region, so it can't prefill this field
+			// The default scope is built from Subdomain and Region, so it can't prefill
+			// this field — left blank, the computed default applies instead
 			displayName: 'Enabled Scopes',
 			name: 'enabledScopes',
 			type: 'string',
@@ -139,7 +140,7 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 			name: 'scope',
 			type: 'hidden',
 			default:
-				'={{$self["customScopes"] ? $self["enabledScopes"] : "openid offline_access https://" + $self["subdomain"] + "." + $self["region"] + "/.default"}}',
+				'={{$self["customScopes"] && $self["enabledScopes"] ? $self["enabledScopes"] : "openid offline_access https://" + $self["subdomain"] + "." + $self["region"] + "/.default"}}',
 		},
 		{
 			displayName: 'Microsoft Graph API Base URL',

--- a/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
@@ -1,5 +1,7 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
+const defaultScopes = ['openid', 'offline_access', 'https://{subdomain}.{region}/.default'];
+
 export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 	name = 'microsoftDynamicsOAuth2Api';
 
@@ -110,7 +112,7 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 		},
 		{
 			displayName:
-				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly. Use the <code>{subdomain}</code> and <code>{region}</code> placeholders to reference the Subdomain and Region values above.',
 			name: 'customScopesNotice',
 			type: 'notice',
 			default: '',
@@ -121,8 +123,6 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 			},
 		},
 		{
-			// The default scope is built from Subdomain and Region, so it can't prefill
-			// this field — left blank, the computed default applies instead
 			displayName: 'Enabled Scopes',
 			name: 'enabledScopes',
 			type: 'string',
@@ -131,16 +131,18 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 					customScopes: [true],
 				},
 			},
-			default: '',
-			placeholder: 'e.g. openid offline_access https://organization.crm.dynamics.com/.default',
-			description: 'Scopes that should be enabled',
+			default: defaultScopes.join(' '),
+			description:
+				'Scopes that should be enabled. Use <code>{subdomain}</code> and <code>{region}</code> as placeholders that will be replaced with the Subdomain and Region values.',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
 			default:
-				'={{$self["customScopes"] && $self["enabledScopes"] ? $self["enabledScopes"] : "openid offline_access https://" + $self["subdomain"] + "." + $self["region"] + "/.default"}}',
+				'={{(($self["customScopes"] && $self["enabledScopes"]) ? $self["enabledScopes"] : "' +
+				defaultScopes.join(' ') +
+				'").replace(/\\{subdomain\\}/g, $self["subdomain"]).replace(/\\{region\\}/g, $self["region"])}}',
 		},
 		{
 			displayName: 'Microsoft Graph API Base URL',

--- a/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
@@ -102,10 +102,44 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 			],
 		},
 		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			// The default scope is built from Subdomain and Region, so it can't prefill this field
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: '',
+			placeholder: 'e.g. openid offline_access https://organization.crm.dynamics.com/.default',
+			description: 'Scopes that should be enabled',
+		},
+		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: '=openid offline_access https://{{$self.subdomain}}.{{$self.region}}/.default',
+			default:
+				'={{$self["customScopes"] ? $self["enabledScopes"] : "openid offline_access https://" + $self["subdomain"] + "." + $self["region"] + "/.default"}}',
 		},
 		{
 			displayName: 'Microsoft Graph API Base URL',

--- a/packages/nodes-base/credentials/MicrosoftGraphSecurityOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftGraphSecurityOAuth2Api.credentials.ts
@@ -1,5 +1,7 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
+const defaultScopes = ['SecurityEvents.ReadWrite.All', 'offline_access'];
+
 export class MicrosoftGraphSecurityOAuth2Api implements ICredentialType {
 	name = 'microsoftGraphSecurityOAuth2Api';
 
@@ -11,10 +13,42 @@ export class MicrosoftGraphSecurityOAuth2Api implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: defaultScopes.join(' '),
+			description: 'Scopes that should be enabled',
+		},
+		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: 'SecurityEvents.ReadWrite.All offline_access',
+			default:
+				'={{$self["customScopes"] ? $self["enabledScopes"] : "' + defaultScopes.join(' ') + '"}}',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/test/AzureStorageOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/AzureStorageOAuth2Api.credentials.test.ts
@@ -1,0 +1,24 @@
+import { AzureStorageOAuth2Api } from '../AzureStorageOAuth2Api.credentials';
+
+describe('AzureStorageOAuth2Api Credential', () => {
+	const credential = new AzureStorageOAuth2Api();
+	const property = (name: string) => credential.properties.find((p) => p.name === name);
+
+	it('should keep its metadata', () => {
+		expect(credential.name).toBe('azureStorageOAuth2Api');
+		expect(credential.extends).toEqual(['microsoftOAuth2Api']);
+	});
+
+	it('should offer custom scopes prefilled with the defaults', () => {
+		expect(property('customScopes')?.default).toBe(false);
+		expect(property('enabledScopes')?.displayOptions).toEqual({ show: { customScopes: [true] } });
+		expect(property('enabledScopes')?.default).toBe('https://storage.azure.com/.default');
+	});
+
+	it('should keep the scope hidden and default to the standard scopes when custom scopes are off', () => {
+		expect(property('scope')?.type).toBe('hidden');
+		expect(property('scope')?.default).toBe(
+			'={{$self["customScopes"] ? $self["enabledScopes"] : "https://storage.azure.com/.default"}}',
+		);
+	});
+});

--- a/packages/nodes-base/credentials/test/MicrosoftAzureMonitorOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftAzureMonitorOAuth2Api.credentials.test.ts
@@ -9,16 +9,16 @@ describe('MicrosoftAzureMonitorOAuth2Api Credential', () => {
 		expect(credential.extends).toEqual(['oAuth2Api']);
 	});
 
-	it('should offer custom scopes without a prefill, since the default is built from other fields', () => {
+	it('should offer custom scopes prefilled with the default as a placeholder token', () => {
 		expect(property('customScopes')?.default).toBe(false);
 		expect(property('enabledScopes')?.displayOptions).toEqual({ show: { customScopes: [true] } });
-		expect(property('enabledScopes')?.default).toBe('');
+		expect(property('enabledScopes')?.default).toBe('{resource}/.default');
 	});
 
-	it('should keep the scope hidden and build the standard scopes when custom scopes are off or left blank', () => {
+	it('should keep the scope hidden, substituting the token and falling back to the defaults when custom scopes are off or cleared', () => {
 		expect(property('scope')?.type).toBe('hidden');
 		expect(property('scope')?.default).toBe(
-			'={{$self["customScopes"] && $self["enabledScopes"] ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : "")}}',
+			'={{(($self["customScopes"] && $self["enabledScopes"]) ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? "{resource}/.default" : "")).replace(/\\{resource\\}/g, $self["resource"])}}',
 		);
 	});
 });

--- a/packages/nodes-base/credentials/test/MicrosoftAzureMonitorOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftAzureMonitorOAuth2Api.credentials.test.ts
@@ -15,10 +15,10 @@ describe('MicrosoftAzureMonitorOAuth2Api Credential', () => {
 		expect(property('enabledScopes')?.default).toBe('');
 	});
 
-	it('should keep the scope hidden and build the standard scopes from grant type and resource when custom scopes are off', () => {
+	it('should keep the scope hidden and build the standard scopes when custom scopes are off or left blank', () => {
 		expect(property('scope')?.type).toBe('hidden');
 		expect(property('scope')?.default).toBe(
-			'={{$self["customScopes"] ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : "")}}',
+			'={{$self["customScopes"] && $self["enabledScopes"] ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : "")}}',
 		);
 	});
 });

--- a/packages/nodes-base/credentials/test/MicrosoftAzureMonitorOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftAzureMonitorOAuth2Api.credentials.test.ts
@@ -1,0 +1,24 @@
+import { MicrosoftAzureMonitorOAuth2Api } from '../MicrosoftAzureMonitorOAuth2Api.credentials';
+
+describe('MicrosoftAzureMonitorOAuth2Api Credential', () => {
+	const credential = new MicrosoftAzureMonitorOAuth2Api();
+	const property = (name: string) => credential.properties.find((p) => p.name === name);
+
+	it('should keep its metadata', () => {
+		expect(credential.name).toBe('microsoftAzureMonitorOAuth2Api');
+		expect(credential.extends).toEqual(['oAuth2Api']);
+	});
+
+	it('should offer custom scopes without a prefill, since the default is built from other fields', () => {
+		expect(property('customScopes')?.default).toBe(false);
+		expect(property('enabledScopes')?.displayOptions).toEqual({ show: { customScopes: [true] } });
+		expect(property('enabledScopes')?.default).toBe('');
+	});
+
+	it('should keep the scope hidden and build the standard scopes from grant type and resource when custom scopes are off', () => {
+		expect(property('scope')?.type).toBe('hidden');
+		expect(property('scope')?.default).toBe(
+			'={{$self["customScopes"] ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : "")}}',
+		);
+	});
+});

--- a/packages/nodes-base/credentials/test/MicrosoftAzureMonitorOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftAzureMonitorOAuth2Api.credentials.test.ts
@@ -15,10 +15,10 @@ describe('MicrosoftAzureMonitorOAuth2Api Credential', () => {
 		expect(property('enabledScopes')?.default).toBe('{resource}/.default');
 	});
 
-	it('should keep the scope hidden, substituting the token and falling back to the defaults when custom scopes are off or cleared', () => {
+	it('should keep the scope hidden, substituting the token and falling back to the defaults when custom scopes are off, cleared, or untouched', () => {
 		expect(property('scope')?.type).toBe('hidden');
 		expect(property('scope')?.default).toBe(
-			'={{(($self["customScopes"] && $self["enabledScopes"]) ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? "{resource}/.default" : "")).replace(/\\{resource\\}/g, $self["resource"])}}',
+			'={{(($self["customScopes"] && $self["enabledScopes"] && $self["enabledScopes"] !== "{resource}/.default") ? $self["enabledScopes"] : ($self["grantType"] === "clientCredentials" ? "{resource}/.default" : "")).replace(/\\{resource\\}/g, $self["resource"])}}',
 		);
 	});
 });

--- a/packages/nodes-base/credentials/test/MicrosoftDynamicsOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftDynamicsOAuth2Api.credentials.test.ts
@@ -15,10 +15,10 @@ describe('MicrosoftDynamicsOAuth2Api Credential', () => {
 		expect(property('enabledScopes')?.default).toBe('');
 	});
 
-	it('should keep the scope hidden and build the standard scopes from subdomain and region when custom scopes are off', () => {
+	it('should keep the scope hidden and build the standard scopes when custom scopes are off or left blank', () => {
 		expect(property('scope')?.type).toBe('hidden');
 		expect(property('scope')?.default).toBe(
-			'={{$self["customScopes"] ? $self["enabledScopes"] : "openid offline_access https://" + $self["subdomain"] + "." + $self["region"] + "/.default"}}',
+			'={{$self["customScopes"] && $self["enabledScopes"] ? $self["enabledScopes"] : "openid offline_access https://" + $self["subdomain"] + "." + $self["region"] + "/.default"}}',
 		);
 	});
 });

--- a/packages/nodes-base/credentials/test/MicrosoftDynamicsOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftDynamicsOAuth2Api.credentials.test.ts
@@ -1,0 +1,24 @@
+import { MicrosoftDynamicsOAuth2Api } from '../MicrosoftDynamicsOAuth2Api.credentials';
+
+describe('MicrosoftDynamicsOAuth2Api Credential', () => {
+	const credential = new MicrosoftDynamicsOAuth2Api();
+	const property = (name: string) => credential.properties.find((p) => p.name === name);
+
+	it('should keep its metadata', () => {
+		expect(credential.name).toBe('microsoftDynamicsOAuth2Api');
+		expect(credential.extends).toEqual(['microsoftOAuth2Api']);
+	});
+
+	it('should offer custom scopes without a prefill, since the default is built from other fields', () => {
+		expect(property('customScopes')?.default).toBe(false);
+		expect(property('enabledScopes')?.displayOptions).toEqual({ show: { customScopes: [true] } });
+		expect(property('enabledScopes')?.default).toBe('');
+	});
+
+	it('should keep the scope hidden and build the standard scopes from subdomain and region when custom scopes are off', () => {
+		expect(property('scope')?.type).toBe('hidden');
+		expect(property('scope')?.default).toBe(
+			'={{$self["customScopes"] ? $self["enabledScopes"] : "openid offline_access https://" + $self["subdomain"] + "." + $self["region"] + "/.default"}}',
+		);
+	});
+});

--- a/packages/nodes-base/credentials/test/MicrosoftDynamicsOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftDynamicsOAuth2Api.credentials.test.ts
@@ -9,16 +9,18 @@ describe('MicrosoftDynamicsOAuth2Api Credential', () => {
 		expect(credential.extends).toEqual(['microsoftOAuth2Api']);
 	});
 
-	it('should offer custom scopes without a prefill, since the default is built from other fields', () => {
+	it('should offer custom scopes prefilled with the defaults as placeholder tokens', () => {
 		expect(property('customScopes')?.default).toBe(false);
 		expect(property('enabledScopes')?.displayOptions).toEqual({ show: { customScopes: [true] } });
-		expect(property('enabledScopes')?.default).toBe('');
+		expect(property('enabledScopes')?.default).toBe(
+			'openid offline_access https://{subdomain}.{region}/.default',
+		);
 	});
 
-	it('should keep the scope hidden and build the standard scopes when custom scopes are off or left blank', () => {
+	it('should keep the scope hidden, substituting the tokens and falling back to the defaults when custom scopes are off or cleared', () => {
 		expect(property('scope')?.type).toBe('hidden');
 		expect(property('scope')?.default).toBe(
-			'={{$self["customScopes"] && $self["enabledScopes"] ? $self["enabledScopes"] : "openid offline_access https://" + $self["subdomain"] + "." + $self["region"] + "/.default"}}',
+			'={{(($self["customScopes"] && $self["enabledScopes"]) ? $self["enabledScopes"] : "openid offline_access https://{subdomain}.{region}/.default").replace(/\\{subdomain\\}/g, $self["subdomain"]).replace(/\\{region\\}/g, $self["region"])}}',
 		);
 	});
 });

--- a/packages/nodes-base/credentials/test/MicrosoftGraphSecurityOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftGraphSecurityOAuth2Api.credentials.test.ts
@@ -1,0 +1,24 @@
+import { MicrosoftGraphSecurityOAuth2Api } from '../MicrosoftGraphSecurityOAuth2Api.credentials';
+
+describe('MicrosoftGraphSecurityOAuth2Api Credential', () => {
+	const credential = new MicrosoftGraphSecurityOAuth2Api();
+	const property = (name: string) => credential.properties.find((p) => p.name === name);
+
+	it('should keep its metadata', () => {
+		expect(credential.name).toBe('microsoftGraphSecurityOAuth2Api');
+		expect(credential.extends).toEqual(['microsoftOAuth2Api']);
+	});
+
+	it('should offer custom scopes prefilled with the defaults', () => {
+		expect(property('customScopes')?.default).toBe(false);
+		expect(property('enabledScopes')?.displayOptions).toEqual({ show: { customScopes: [true] } });
+		expect(property('enabledScopes')?.default).toBe('SecurityEvents.ReadWrite.All offline_access');
+	});
+
+	it('should keep the scope hidden and default to the standard scopes when custom scopes are off', () => {
+		expect(property('scope')?.type).toBe('hidden');
+		expect(property('scope')?.default).toBe(
+			'={{$self["customScopes"] ? $self["enabledScopes"] : "SecurityEvents.ReadWrite.All offline_access"}}',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds the established custom-scopes option to four Microsoft OAuth2 credentials, following the pattern already shipped for Microsoft To Do, OneDrive, Outlook, and SharePoint: a **Custom Scopes** toggle, a warning notice, and an **Enabled Scopes** field shown when the toggle is on, with the hidden `scope` property switching between the user's scopes and the credential's defaults.

Per credential:

- **Microsoft Graph Security** — defaults prefilled into Enabled Scopes (`SecurityEvents.ReadWrite.All offline_access`).
- **Azure Storage** — defaults prefilled (`https://storage.azure.com/.default`).
- **Microsoft Dynamics** — the default scope is built from Subdomain and Region, so Enabled Scopes can't be prefilled; it starts empty with a placeholder example, and the hidden fallback keeps building the same expression as before.
- **Microsoft Azure Monitor** — same situation (default built from Grant Type and Resource); empty with a placeholder, fallback expression unchanged.

`GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE` is deliberately **not** touched: these credentials keep `scope` hidden (computed by expression), and the OAuth service's reconnect cleanup should keep stripping stale saved scope values for hidden-scope credentials — matching the four Microsoft credentials that already shipped this pattern.

Each credential gets a compact test pinning the toggle, the Enabled Scopes default/prefill, and the exact hidden scope expression.

## Screenshots

### Microsoft Azure Monitor

<img width="1220" height="767" alt="image" src="https://github.com/user-attachments/assets/6f5b024b-4462-4435-a695-11e68c8324fd" />

### Microsoft Dynamics

<img width="1220" height="767" alt="image" src="https://github.com/user-attachments/assets/959a1e13-5ae5-4350-ab2e-747f9799ca5d" />

### Microsoft Graph Security

<img width="1220" height="767" alt="image" src="https://github.com/user-attachments/assets/172cb19f-14e1-4217-ba37-c66c2d381d21" />

### Azure Storage

<img width="1220" height="767" alt="image" src="https://github.com/user-attachments/assets/d46a1ef5-add8-4867-b800-694192c9bd74" />

## How to test

Unit tests: `cd packages/nodes-base && pnpm test credentials/test` (the four new `*.credentials.test.ts` files).

Manually: create each credential in the editor, flip **Custom Scopes** on, and check the notice + Enabled Scopes field appear (prefilled for Graph Security and Azure Storage, placeholder for Dynamics and Azure Monitor). Complete an OAuth connect with the toggle off to confirm default behaviour is unchanged, then with custom scopes to confirm the consent screen requests them.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-236
- https://linear.app/n8n/issue/ENT-237
- https://linear.app/n8n/issue/ENT-238
- https://linear.app/n8n/issue/ENT-239

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34612">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

