### PR TITLE
fix(core): Skip Sentry reports for Instance AI errors that self-declare a warning level

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-error-reporter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-error-reporter.service.test.ts
@@ -6,12 +6,13 @@ describe('InstanceAiErrorReporterService', () => {
 	function createService(): {
 		service: InstanceAiErrorReporterService;
 		errorReporter: { error: Mock };
-		logger: { error: Mock; info: Mock };
+		logger: { error: Mock; info: Mock; warn: Mock };
 	} {
 		const errorReporter = { error: vi.fn() };
-		const logger: { error: Mock; info: Mock; scoped: Mock } = {
+		const logger: { error: Mock; info: Mock; warn: Mock; scoped: Mock } = {
 			error: vi.fn(),
 			info: vi.fn(),
+			warn: vi.fn(),
 			scoped: vi.fn(),
 		};
 		logger.scoped.mockReturnValue(logger);
@@ -117,6 +118,40 @@ describe('InstanceAiErrorReporterService', () => {
 		).rejects.toBe(error);
 
 		expect(errorReporter.error).not.toHaveBeenCalled();
+	});
+
+	it('logs at warn level instead of reporting for errors that self-declare a warning level', () => {
+		const { service, errorReporter, logger } = createService();
+		const error = Object.assign(new Error('ThrottlerException: Too Many Requests'), {
+			level: 'warning',
+		});
+
+		service.beginRun('r');
+		service.report(error, {
+			component: 'instance-ai-run',
+			threadId: 't',
+			runId: 'r',
+		});
+
+		expect(errorReporter.error).not.toHaveBeenCalled();
+		expect(logger.error).not.toHaveBeenCalled();
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Instance AI warning-level error in instance-ai-run',
+			expect.objectContaining({ error, threadId: 't', runId: 'r' }),
+		);
+	});
+
+	it('still reports errors that declare an error level', () => {
+		const { service, errorReporter } = createService();
+		const error = Object.assign(new Error('Internal Server Error'), { level: 'error' });
+
+		service.report(error, {
+			component: 'instance-ai-run',
+			threadId: 't',
+			runId: 'r',
+		});
+
+		expect(errorReporter.error).toHaveBeenCalledTimes(1);
 	});
 
 	it('drops per-run dedup state after endRun', () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai-error-reporter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-error-reporter.service.ts
@@ -10,6 +10,16 @@ import {
 
 export type InstanceAiErrorReportContext = { component: string } & InstanceAiObservabilityContext;
 
+/**
+ * The ai-assistant-sdk vendors its own ApplicationError, so its client-level
+ * errors (4xx, `level: 'warning'`, e.g. throttling) fail the core reporter's
+ * instanceof check and would reach Sentry despite declaring themselves benign.
+ */
+function isSelfDeclaredWarning(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null || !('level' in error)) return false;
+	return error.level === 'warning' || error.level === 'info';
+}
+
 @Service()
 export class InstanceAiErrorReporterService {
 	private readonly logger: Logger;
@@ -44,6 +54,15 @@ export class InstanceAiErrorReporterService {
 			// Expected condition: the user ran out of AI credits and the run already
 			// surfaces it as `quota_exhausted`. Not worth a Sentry event.
 			this.logger.info(`Instance AI quota exhausted in ${context.component}`, {
+				component: context.component,
+				...observability,
+			});
+			return;
+		}
+
+		if (isSelfDeclaredWarning(error)) {
+			this.logger.warn(`Instance AI warning-level error in ${context.component}`, {
+				error,
 				component: context.component,
 				...observability,
 			});


### PR DESCRIPTION
## Summary

Follow-up to #34549. That PR's guard skips Sentry for quota-exhausted errors, but the same trial-heavy noise arrives in a second shape: the AI service's rate limiter answers token-minting bursts with HTTP 429 `ThrottlerException: Too Many Requests` ([INSTANCE-BACKEND-26KV](https://n8nio.sentry.io/issues/INSTANCE-BACKEND-26KV), ~310 events / ~305 users in the last 14 days, almost exactly one event per account).

The ai-assistant-sdk already classifies every 4xx response as `level: 'warning'` on the thrown `AIServiceAPIResponseError`, and the core `ErrorReporter` already honors that level both for n8n's own error classes and for wrapped SDK errors (the cause-level drop). But as a top-level exception the SDK error slips through: the SDK vendors its own `ApplicationError`, so the core reporter's `instanceof` check never sees the level and the event reports as a plain error.

This PR mirrors the core reporter's cause rule at the top level, scoped to the Instance AI reporter: if a reported error self-declares `level: 'warning'` or `'info'`, it is logged at warn level and skipped for Sentry. Errors declaring `level: 'error'` (5xx responses, e.g. proxy outages) keep reporting unchanged. This also covers the SDK's `AuthError` (license-validation noise) and any future warning-level SDK error.

The quota guard stays first so quota exhaustion keeps its specific info log; it also matches quota codes on wrapped causes, which carry no `level` of their own.

## How to test

```
cd packages/cli && pnpm test instance-ai-error-reporter
```

Unit tests cover: a warning-level error is logged at warn and not reported to Sentry, and an error that declares `level: 'error'` still reports.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-937

Sentry: [AIServiceAPIResponseError: ThrottlerException (INSTANCE-BACKEND-26KV)](https://n8nio.sentry.io/issues/INSTANCE-BACKEND-26KV)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

