### PR TITLE
fix(editor): Fix an issue in some Safari versions that prevented copying invite links

### DIFF
--- a/packages/frontend/@n8n/composables/src/useClipboard.ts
+++ b/packages/frontend/@n8n/composables/src/useClipboard.ts
@@ -22,11 +22,12 @@ export function useClipboard({
 
 	// Find the correct navigator at copy-time so it works even when the
 	// pop-out window opens after the composable was created.
-	async function copy(value: string) {
+	async function copy(value: string | (() => Promise<string>)) {
 		const nav = popOutWindow?.value?.navigator;
 		if (nav?.clipboard) {
 			try {
-				await nav.clipboard.writeText(value);
+				const resolvedValue = typeof value === 'function' ? await value() : value;
+				await nav.clipboard.writeText(resolvedValue);
 				return;
 			} catch {
 				// Fall back to the core clipboard copy below.

--- a/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.test.ts
@@ -1,0 +1,120 @@
+import { createTestingPinia } from '@pinia/testing';
+import { waitFor, within } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { ROLE } from '@n8n/api-types';
+import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore, type MockedStore } from '@/__tests__/utils';
+import { INVITE_USER_MODAL_KEY } from '../users.constants';
+import type { IInviteResponse } from '../users.types';
+import InviteUsersModal from './InviteUsersModal.vue';
+import { useUsersStore } from '../users.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { useRolesStore } from '@/app/stores/roles.store';
+
+const ModalStub = {
+	template: `
+		<div>
+			<slot name="header" />
+			<slot name="title" />
+			<slot name="content" />
+			<slot name="footer" />
+		</div>
+	`,
+};
+
+const mockClipboard = {
+	copy: vi.fn(),
+};
+
+const mockToast = {
+	showMessage: vi.fn(),
+	showError: vi.fn(),
+};
+
+vi.mock('@/app/composables/useClipboard', () => ({
+	useClipboard: vi.fn(() => mockClipboard),
+}));
+
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: vi.fn(() => mockToast),
+}));
+
+vi.mock('@/app/composables/usePageRedirectionHelper', () => ({
+	usePageRedirectionHelper: vi.fn(() => ({ goToUpgrade: vi.fn() })),
+}));
+
+const global = {
+	stubs: {
+		Modal: ModalStub,
+	},
+};
+
+function makeUrlInvite(id: string, email: string): IInviteResponse {
+	return {
+		user: {
+			id,
+			email,
+			emailSent: false,
+			inviteAcceptUrl: `https://example.com/signup?inviterId=owner&inviteeId=${id}`,
+			role: ROLE.Member,
+		},
+	};
+}
+
+const renderModal = createComponentRenderer(InviteUsersModal);
+let pinia: ReturnType<typeof createTestingPinia>;
+let usersStore: MockedStore<typeof useUsersStore>;
+let settingsStore: MockedStore<typeof useSettingsStore>;
+let rolesStore: MockedStore<typeof useRolesStore>;
+
+describe('InviteUsersModal', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		pinia = createTestingPinia();
+
+		usersStore = mockedStore(useUsersStore);
+		settingsStore = mockedStore(useSettingsStore);
+		rolesStore = mockedStore(useRolesStore);
+
+		settingsStore.isSmtpSetup = false;
+		settingsStore.isChatFeatureEnabled = false;
+		settingsStore.isEnterpriseFeatureEnabled = {} as MockedStore<
+			typeof useSettingsStore
+		>['isEnterpriseFeatureEnabled'];
+		rolesStore.processedInstanceRoles = [];
+		rolesStore.customInstanceRoles = [];
+	});
+
+	it('copies a generated invite link via a deferred function on direct click', async () => {
+		const link = 'https://example.com/signup?token=generated-token';
+		usersStore.inviteUsers.mockResolvedValue([
+			makeUrlInvite('3', 'a@example.com'),
+			makeUrlInvite('4', 'b@example.com'),
+		]);
+		usersStore.generateInviteLink.mockResolvedValue({ link });
+
+		const { findByTestId, getAllByTestId, getByRole } = renderModal({
+			props: {
+				modalName: INVITE_USER_MODAL_KEY,
+				data: {},
+			},
+			global,
+			pinia,
+		});
+
+		// Enter two emails (no SMTP → URL invites) and submit.
+		const emailsInput = within(await findByTestId('emails')).getByRole('textbox');
+		await userEvent.type(emailsInput, 'a@example.com, b@example.com');
+		await userEvent.click(getByRole('button'));
+
+		const generateButtons = await waitFor(() => getAllByTestId('generate-invite-link-button'));
+		await userEvent.click(generateButtons[0]);
+
+		expect(usersStore.generateInviteLink).toHaveBeenCalledWith({ id: '3' });
+		await waitFor(async () => {
+			expect(mockClipboard.copy).toHaveBeenCalledWith(expect.any(Function));
+			const getLink = mockClipboard.copy.mock.calls.at(-1)![0];
+			await expect(getLink()).resolves.toBe(link);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.test.ts
@@ -31,7 +31,7 @@ const mockToast = {
 	showError: vi.fn(),
 };
 
-vi.mock('@/app/composables/useClipboard', () => ({
+vi.mock('@n8n/composables/useClipboard', () => ({
 	useClipboard: vi.fn(() => mockClipboard),
 }));
 

--- a/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.vue
@@ -8,6 +8,7 @@ import { EnterpriseEditionFeature, VALID_EMAIL_REGEX } from '@/app/constants';
 import { INVITE_USER_MODAL_KEY } from '../users.constants';
 import { ROLE } from '@n8n/api-types';
 import { useUsersStore } from '../users.store';
+import { copyInviteLink } from '../invite-link.utils';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRolesStore } from '@/app/stores/roles.store';
 import { createFormEventBus } from '@n8n/design-system/utils';
@@ -170,10 +171,7 @@ async function onSubmit() {
 		if (successfulUrlInvites.length) {
 			if (successfulUrlInvites.length === 1) {
 				try {
-					const url = await usersStore.generateInviteLink({
-						id: successfulUrlInvites[0].user.id,
-					});
-					void clipboard.copy(url.link);
+					await copyInviteLink(clipboard, usersStore, successfulUrlInvites[0].user.id);
 				} catch (error) {
 					showError(error, i18n.baseText('settings.users.inviteLinkError'));
 				}
@@ -255,8 +253,7 @@ async function onCopyInviteLink(user: IInviteResponse['user']) {
 	}
 
 	try {
-		const url = await usersStore.generateInviteLink({ id: user.id });
-		void clipboard.copy(url.link);
+		await copyInviteLink(clipboard, usersStore, user.id);
 		showCopyInviteLinkToast([]);
 	} catch (error) {
 		showError(error, i18n.baseText('settings.users.inviteLinkError'));

--- a/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.test.ts
@@ -1,0 +1,48 @@
+import { copyInviteLink } from './invite-link.utils';
+import type { useClipboard } from '@/app/composables/useClipboard';
+import type { useUsersStore } from './users.store';
+
+describe('copyInviteLink', () => {
+	const link = 'https://example.com/signup?token=generated-token';
+
+	function setup(generateInviteLink: ReturnType<typeof vi.fn>) {
+		const clipboard = { copy: vi.fn() } as unknown as ReturnType<typeof useClipboard>;
+		const usersStore = { generateInviteLink } as unknown as ReturnType<typeof useUsersStore>;
+		return { clipboard, usersStore };
+	}
+
+	it('calls generateInviteLink with the user id', async () => {
+		const generateInviteLink = vi.fn().mockResolvedValue({ link });
+		const { clipboard, usersStore } = setup(generateInviteLink);
+
+		await copyInviteLink(clipboard, usersStore, 'user-1');
+
+		expect(generateInviteLink).toHaveBeenCalledWith({ id: 'user-1' });
+	});
+
+	it('passes a promise-returning function to clipboard.copy that resolves to the link', async () => {
+		const generateInviteLink = vi.fn().mockResolvedValue({ link });
+		const { clipboard, usersStore } = setup(generateInviteLink);
+
+		await copyInviteLink(clipboard, usersStore, 'user-1');
+
+		expect(clipboard.copy).toHaveBeenCalledWith(expect.any(Function));
+		const getLink = (clipboard.copy as ReturnType<typeof vi.fn>).mock.calls.at(-1)![0];
+		await expect(getLink()).resolves.toBe(link);
+	});
+
+	it('propagates a rejection from generateInviteLink', async () => {
+		const error = new Error('Failed to generate link');
+		const generateInviteLink = vi.fn().mockRejectedValue(error);
+		const { clipboard, usersStore } = setup(generateInviteLink);
+		// Mimic useClipboard.copy resolving the promise-returning value, so a
+		// rejected invite surfaces to the caller's try/catch.
+		(clipboard.copy as ReturnType<typeof vi.fn>).mockImplementation(
+			async (value: string | (() => Promise<string>)) => {
+				if (typeof value === 'function') await value();
+			},
+		);
+
+		await expect(copyInviteLink(clipboard, usersStore, 'user-1')).rejects.toThrow(error);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.test.ts
@@ -1,5 +1,5 @@
 import { copyInviteLink } from './invite-link.utils';
-import type { useClipboard } from '@/app/composables/useClipboard';
+import type { useClipboard } from '@n8n/composables/useClipboard';
 import type { useUsersStore } from './users.store';
 
 describe('copyInviteLink', () => {

--- a/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
@@ -1,0 +1,21 @@
+import type { useClipboard } from '@/app/composables/useClipboard';
+import type { useUsersStore } from './users.store';
+
+/**
+ * Copies a freshly-generated invite link to the clipboard.
+ *
+ * The link is passed to `clipboard.copy` as a promise-returning function rather
+ * than an already-awaited string. vueuse 14+ writes via `navigator.clipboard.write`,
+ * which accepts a promise that resolves to the value; starting the copy synchronously
+ * inside the click handler keeps Safari's transient user-activation alive. Awaiting the
+ * network request first drops it, and Safari (26.5 / 27.0) then silently copies an empty
+ * string. See IAM-532.
+ */
+export async function copyInviteLink(
+	clipboard: ReturnType<typeof useClipboard>,
+	usersStore: ReturnType<typeof useUsersStore>,
+	userId: string,
+): Promise<void> {
+	const invite = usersStore.generateInviteLink({ id: userId });
+	await clipboard.copy(() => invite.then((res) => res.link));
+}

--- a/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
@@ -1,4 +1,4 @@
-import type { useClipboard } from '@/app/composables/useClipboard';
+import type { useClipboard } from '@n8n/composables/useClipboard';
 import type { useUsersStore } from './users.store';
 
 /**

--- a/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
@@ -17,5 +17,8 @@ export async function copyInviteLink(
 	userId: string,
 ): Promise<void> {
 	const invite = usersStore.generateInviteLink({ id: userId });
-	await clipboard.copy(async () => invite.then((res) => res.link));
+	await clipboard.copy(async () => {
+		const response = await invite;
+		return response.link;
+	});
 }

--- a/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
@@ -17,5 +17,5 @@ export async function copyInviteLink(
 	userId: string,
 ): Promise<void> {
 	const invite = usersStore.generateInviteLink({ id: userId });
-	await clipboard.copy(() => invite.then((res) => res.link));
+	await clipboard.copy(async () => invite.then((res) => res.link));
 }

--- a/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/invite-link.utils.ts
@@ -9,7 +9,7 @@ import type { useUsersStore } from './users.store';
  * which accepts a promise that resolves to the value; starting the copy synchronously
  * inside the click handler keeps Safari's transient user-activation alive. Awaiting the
  * network request first drops it, and Safari (26.5 / 27.0) then silently copies an empty
- * string. See IAM-532.
+ * string.
  */
 export async function copyInviteLink(
 	clipboard: ReturnType<typeof useClipboard>,

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.test.ts
@@ -135,6 +135,12 @@ describe('SettingsUsersView', () => {
 		mockIsVariantEnabled.mockReset();
 		mockIsVariantEnabled.mockReturnValue(false);
 
+		// Mimic useClipboard.copy resolving a promise-returning value, so a
+		// rejected invite-link fetch surfaces to the handler's try/catch.
+		mockClipboard.copy.mockImplementation(async (value: string | (() => Promise<string>)) => {
+			if (typeof value === 'function') await value();
+		});
+
 		renderComponent = createComponentRenderer(SettingsUsersView, {
 			pinia: createTestingPinia(),
 		});
@@ -555,10 +561,10 @@ describe('SettingsUsersView', () => {
 			emitters.settingsUsersTable.emit('action', { action: 'generateInviteLink', userId: '3' });
 
 			expect(usersStore.generateInviteLink).toHaveBeenCalledWith({ id: '3' });
-			await waitFor(() => {
-				expect(mockClipboard.copy).toHaveBeenCalledWith(
-					'https://example.com/signup?token=generated-token',
-				);
+			await waitFor(async () => {
+				expect(mockClipboard.copy).toHaveBeenCalledWith(expect.any(Function));
+				const getLink = mockClipboard.copy.mock.calls.at(-1)![0];
+				await expect(getLink()).resolves.toBe('https://example.com/signup?token=generated-token');
 				expect(mockToast.showToast).toHaveBeenCalledWith({
 					type: 'success',
 					title: expect.any(String),

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
@@ -19,6 +19,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRolesStore } from '@/app/stores/roles.store';
 import { useUsersStore } from '../users.store';
+import { copyInviteLink } from '../invite-link.utils';
 import { useSSOStore } from '@/features/settings/sso/sso.store';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { useClipboard } from '@n8n/composables/useClipboard';
@@ -255,8 +256,7 @@ async function onGenerateInviteLink(userId: string) {
 	try {
 		const user = usersStore.usersList.state.items.find((u) => u.id === userId);
 		if (user) {
-			const url = await usersStore.generateInviteLink({ id: userId });
-			void clipboard.copy(url.link);
+			await copyInviteLink(clipboard, usersStore, userId);
 
 			showToast({
 				type: 'success',


### PR DESCRIPTION
## Summary
In some versions of Safari (confirmed in at least 26.5 and 27.0-beta, although not reproducible in 26.5.2) the 'copy invite link' buttons report success when clicked, but nothing is actually copied to the clipboard. Whilst it is possible that this is Safari regression there is nothing in any of their patch notes to suggest it is something they intentionally fixed so it makes sense for us to find a method that works everywhere.

Due to a recent upgrade to `vueuse` version 14, we are now able to pass functions that resolve asynchronous promises to the clipboards `copy` method. This allows us to work around a Safari-specific issue where they require the clipboard action to be taken quickly after the users click event (~5s) - because the 'copy' function is called immediatel, the value can then take longer to resolve without issue (note: this does fix the issue even though our invite link request takes far less than 5s to resolve, hence the theory it could be a Safari regression).

This PR adds support for those resolving functions in the internal `useClipboard` composable. For the special case of the pop-out nav, which still uses `writeText` (which does _not_ support the async resolver function) we await the promise first before copying it.

A small utility method was added to handle the logic for copying the invite links as it is shared in 2 locations, and to make it easier to document with a comment.

Confirmed working in:
- Safari 26.5
- Safari 26.5.2
- Chrome 150.0.7871.115
- Firefox 152.0.6
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
1. Go to the users settings page
2. invite a user
3. (if email is not configured on instance) click 'copy invite link' in the modal and see that it was copied to your clipboard
4. In the users table click the 3 dots menu icon and click 'copy invite link' and see that it was copied to your clipboard.
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-532/community-issue-safari-generate-invite-link-copies-empty-clipboard
Closes #28058
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34620">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->