### PR TITLE
fix(core): Redact a sub-workflow's own execution record per its own policy

### DIFF
--- a/packages/@n8n/decorators/src/context-establishment/context-establishment-hook-metadata.ts
+++ b/packages/@n8n/decorators/src/context-establishment/context-establishment-hook-metadata.ts
@@ -8,6 +8,18 @@ type ContextEstablishmentHookOptions = {
 	 * trigger node type (i.e. `isApplicableToTriggerNode` is not consulted).
 	 */
 	alwaysExecute: boolean;
+
+	/**
+	 * If true, the hook is also re-run for sub-workflow executions, which otherwise
+	 * inherit their parent's context verbatim. Opt in only when the hook must
+	 * re-derive context from the child workflow itself (e.g. its redaction policy).
+	 *
+	 * Sub-executions pass no trigger items and ignore any the hook returns — the
+	 * child keeps the input it inherited from its parent — so such a hook must
+	 * derive its result from the workflow/inherited context, not from trigger data,
+	 * and must not overwrite context the child legitimately inherited.
+	 */
+	runForSubExecution?: boolean;
 };
 
 /**
@@ -105,6 +117,12 @@ export class ContextEstablishmentHookMetadata {
 	getGlobalClasses() {
 		return [...this.contextEstablishmentHooks.values()]
 			.filter((entry) => entry.options?.alwaysExecute ?? false)
+			.map((entry) => entry.class);
+	}
+
+	getSubExecutionClasses() {
+		return [...this.contextEstablishmentHooks.values()]
+			.filter((entry) => entry.options?.runForSubExecution ?? false)
 			.map((entry) => entry.class);
 	}
 }

--- a/packages/cli/src/modules/redaction/__tests__/redaction-context-hook.integration.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction-context-hook.integration.test.ts
@@ -8,9 +8,11 @@ import {
 } from 'n8n-core';
 import {
 	createRunExecutionData,
+	type IExecutionContext,
 	type INode,
 	type IRunExecutionData,
 	type IWorkflowExecuteAdditionalData,
+	type RelatedExecution,
 	type Workflow,
 	type WorkflowSettings,
 } from 'n8n-workflow';
@@ -136,6 +138,69 @@ describe('RedactionContextHook integration with establishExecutionContext', () =
 			production: false,
 			manual: false,
 			source: 'workflow',
+		});
+	});
+
+	describe('sub-workflow execution (child re-runs the hook against the inherited snapshot)', () => {
+		const establishSubWorkflow = async (
+			floor: 'off' | 'production' | 'all',
+			childPolicy: WorkflowSettings.RedactionPolicy | undefined,
+			inheritedRedaction: IExecutionContext['redaction'],
+		) => {
+			enforcementService.get.mockResolvedValue(floor);
+
+			const parentExecution: RelatedExecution = {
+				executionId: 'parent-execution-id',
+				workflowId: 'parent-workflow-id',
+				executionContext: {
+					version: 1,
+					establishedAt: 1_000,
+					source: 'manual',
+					redaction: inheritedRedaction,
+				},
+			};
+
+			const childWorkflow = buildWorkflow(childPolicy);
+			const runExecutionData = buildRunExecutionData();
+			runExecutionData.parentExecution = parentExecution;
+
+			await establishExecutionContext(
+				childWorkflow,
+				runExecutionData,
+				additionalData,
+				'integrated',
+			);
+
+			return runExecutionData.executionData!.runtimeData!.redaction;
+		};
+
+		it("redacts the child's own record from its own policy when the parent redacts nothing", async () => {
+			// Core IAM-1049 case: policy'd child, policy-less parent, floor off.
+			expect(
+				await establishSubWorkflow('off', 'all', { version: 2, production: false, manual: false }),
+			).toEqual({ version: 2, production: true, manual: true, source: 'workflow' });
+		});
+
+		it("preserves top-down escalation: policy-less child inherits the parent's redaction", async () => {
+			expect(
+				await establishSubWorkflow('off', 'none', { version: 2, production: true, manual: true }),
+			).toEqual({ version: 2, production: true, manual: true, source: 'workflow' });
+		});
+
+		it('merges child and parent strictest-per-channel', async () => {
+			expect(
+				await establishSubWorkflow('off', 'non-manual', {
+					version: 2,
+					production: false,
+					manual: true,
+				}),
+			).toEqual({ version: 2, production: true, manual: true, source: 'workflow' });
+		});
+
+		it('still enforces the instance floor on the child record', async () => {
+			expect(
+				await establishSubWorkflow('all', 'none', { version: 2, production: false, manual: false }),
+			).toEqual({ version: 2, production: true, manual: true, source: 'instance' });
 		});
 	});
 

--- a/packages/cli/src/modules/redaction/__tests__/redaction-context-hook.integration.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction-context-hook.integration.test.ts
@@ -67,6 +67,8 @@ describe('RedactionContextHook integration with establishExecutionContext', () =
 
 		const hookRegistry = mock<ExecutionContextHookRegistry>();
 		hookRegistry.getGlobalHooks.mockReturnValue([hook]);
+		// The redaction hook opts into re-running for sub-workflow executions too.
+		hookRegistry.getSubExecutionHooks.mockReturnValue([hook]);
 
 		const executionContextService = new ExecutionContextService(
 			mock(),

--- a/packages/cli/src/modules/redaction/__tests__/redaction-context-hook.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction-context-hook.test.ts
@@ -1,6 +1,6 @@
 import type { RedactionFloor } from '@n8n/api-types';
 import type { ContextEstablishmentOptions } from '@n8n/decorators';
-import type { Workflow, WorkflowSettings } from 'n8n-workflow';
+import type { IRedactionSetting, Workflow, WorkflowSettings } from 'n8n-workflow';
 import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
 
@@ -13,11 +13,15 @@ describe('RedactionContextHook', () => {
 
 	const buildOptions = (
 		workflowRedactionPolicy?: WorkflowSettings.RedactionPolicy,
+		inheritedRedaction?: IRedactionSetting,
 	): ContextEstablishmentOptions =>
 		mock<ContextEstablishmentOptions>({
 			workflow: mock<Workflow>({
 				settings: { redactionPolicy: workflowRedactionPolicy },
 			}),
+			// Real object (not a deep mock) so `context.redaction` is deterministic:
+			// absent for root executions, the inherited parent snapshot for sub-workflows.
+			context: { version: 1, establishedAt: 0, source: 'manual', redaction: inheritedRedaction },
 		});
 
 	const setFloor = (floor: RedactionFloor) => {
@@ -159,6 +163,64 @@ describe('RedactionContextHook', () => {
 			const result = await hook.execute(buildOptions('manual-only'));
 
 			expect(result.contextUpdate!.redaction).toMatchObject({ source: 'workflow' });
+		});
+	});
+
+	describe('sub-workflow inherited snapshot (strictest-per-channel merge)', () => {
+		const v2 = (production: boolean, manual: boolean): IRedactionSetting => ({
+			version: 2,
+			production,
+			manual,
+		});
+
+		it("captures a policy'd child's own redaction even when the parent redacts nothing", async () => {
+			// The core IAM-1049 fix: a child with its own policy called by a policy-less
+			// parent must redact its own record. Inherited snapshot = nothing redacted.
+			setFloor('off');
+
+			const result = await hook.execute(buildOptions('all', v2(false, false)));
+
+			expect(result).toEqual(expectChannels(true, true));
+		});
+
+		it("preserves top-down escalation: a policy-less child inherits the parent's redaction", async () => {
+			setFloor('off');
+
+			const result = await hook.execute(buildOptions('none', v2(true, true)));
+
+			expect(result).toEqual(expectChannels(true, true));
+		});
+
+		it('merges per channel: child redacts production, parent redacts manual', async () => {
+			setFloor('off');
+
+			const result = await hook.execute(buildOptions('non-manual', v2(false, true)));
+
+			expect(result).toEqual(expectChannels(true, true));
+		});
+
+		it('is a no-op when neither the child, the floor, nor the parent redact', async () => {
+			setFloor('off');
+
+			const result = await hook.execute(buildOptions('none', v2(false, false)));
+
+			expect(result).toEqual(expectChannels(false, false));
+		});
+
+		it('folds in a legacy V1 inherited snapshot (policy enum)', async () => {
+			setFloor('off');
+
+			const result = await hook.execute(buildOptions('none', { version: 1, policy: 'non-manual' }));
+
+			expect(result).toEqual(expectChannels(true, false));
+		});
+
+		it('still applies the instance floor on top of an inherited snapshot', async () => {
+			setFloor('all');
+
+			const result = await hook.execute(buildOptions('none', v2(false, false)));
+
+			expect(result).toEqual(expectChannels(true, true, 'instance'));
 		});
 	});
 

--- a/packages/cli/src/modules/redaction/redaction-context-hook.ts
+++ b/packages/cli/src/modules/redaction/redaction-context-hook.ts
@@ -5,7 +5,7 @@ import {
 	HookDescription,
 	IContextEstablishmentHook,
 } from '@n8n/decorators';
-import { policyToChannels, type RedactionSource } from 'n8n-workflow';
+import { policyToChannels, redactionSettingToChannels, type RedactionSource } from 'n8n-workflow';
 
 import { InstanceRedactionEnforcementService } from './instance-redaction-enforcement.service';
 
@@ -32,15 +32,22 @@ export class RedactionContextHook implements IContextEstablishmentHook {
 	 * The instance floor is a minimum, not an override: each channel is redacted when
 	 * the workflow setting redacts it OR the floor enforces it (strictest-per-channel).
 	 * A workflow can be equal to or stricter than the floor, never weaker.
+	 *
+	 * For a sub-workflow the context also carries the snapshot inherited from the
+	 * parent execution; it is folded in the same way, so the child's own record is
+	 * redacted per its own policy while still inheriting the parent's redaction
+	 * (top-down escalation). Root executions carry no inherited snapshot, so it is
+	 * a no-op there.
 	 */
 	async execute(options: ContextEstablishmentOptions): Promise<ContextEstablishmentResult> {
 		const floor = await this.instanceRedactionEnforcementService.get();
 		const workflow = policyToChannels(options.workflow.settings?.redactionPolicy ?? 'none');
+		const inherited = redactionSettingToChannels(options.context?.redaction);
 
 		const floorEnforcesProduction = floor !== 'off';
 		const floorEnforcesManual = floor === 'all';
 
-		const manual = workflow.manual || floorEnforcesManual;
+		const manual = workflow.manual || floorEnforcesManual || inherited.manual;
 		// Manual redaction implies production redaction (IAM-697 + floor normalization
 		// already guarantee this; the clamp keeps the captured snapshot valid regardless).
 		//
@@ -50,12 +57,16 @@ export class RedactionContextHook implements IContextEstablishmentHook {
 		// such a workflow therefore redact production data that the old `manual-only`
 		// resolution left revealable. This is the intended fail-safe direction of the
 		// manual-implies-production invariant; past executions keep their V1 snapshot.
-		const production = workflow.production || floorEnforcesProduction || manual;
+		const production =
+			workflow.production || floorEnforcesProduction || manual || inherited.production;
 
 		// Attribution: `'instance'` when the floor enforced redaction the workflow did
 		// not ask for, `'workflow'` otherwise. The workflow's manual-implies-production
 		// clamp is workflow-side, so a manual-only workflow that produces production
-		// redaction is still attributed to the workflow, not the floor.
+		// redaction is still attributed to the workflow, not the floor. Redaction a
+		// sub-workflow inherited from its parent alone is left attributed to the
+		// workflow (there is no `'parent'` source); `source` is telemetry only and
+		// does not affect reveal permissions, which read the channels.
 		const floorRaisedTheBar =
 			(floorEnforcesProduction && !workflow.production) ||
 			(floorEnforcesManual && !workflow.manual);

--- a/packages/cli/src/modules/redaction/redaction-context-hook.ts
+++ b/packages/cli/src/modules/redaction/redaction-context-hook.ts
@@ -11,6 +11,9 @@ import { InstanceRedactionEnforcementService } from './instance-redaction-enforc
 
 @ContextEstablishmentHook({
 	alwaysExecute: true,
+	// Also re-run for sub-workflows so a child's own execution record captures its
+	// own redaction policy, merged with the inherited parent snapshot (see execute()).
+	runForSubExecution: true,
 })
 export class RedactionContextHook implements IContextEstablishmentHook {
 	constructor(

--- a/packages/core/src/execution-engine/__tests__/execution-context-hook-service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context-hook-service.test.ts
@@ -463,4 +463,50 @@ describe('ExecutionContextHookRegistry', () => {
 			expect(registry.getGlobalHooks()).toEqual([]);
 		});
 	});
+
+	describe('sub-execution hooks', () => {
+		it('exposes hooks decorated with runForSubExecution: true via getSubExecutionHooks()', async () => {
+			@ContextEstablishmentHook({ alwaysExecute: true, runForSubExecution: true })
+			class SubExecutionHook implements IContextEstablishmentHook {
+				hookDescription = { name: 'test.sub-execution' };
+				async execute(_options: ContextEstablishmentOptions): Promise<ContextEstablishmentResult> {
+					return {};
+				}
+				isApplicableToTriggerNode(_nodeType: string): boolean {
+					return false;
+				}
+			}
+
+			await registry.init();
+
+			const subHooks = registry.getSubExecutionHooks();
+			expect(subHooks).toHaveLength(1);
+			expect(subHooks[0]).toBeInstanceOf(SubExecutionHook);
+		});
+
+		it('does not expose a global hook that did not opt into sub-execution', async () => {
+			@ContextEstablishmentHook({ alwaysExecute: true })
+			// @ts-expect-error - Class is used via decorator side-effect
+			class GlobalOnlyHook implements IContextEstablishmentHook {
+				hookDescription = { name: 'test.global-only' };
+				async execute(_options: ContextEstablishmentOptions): Promise<ContextEstablishmentResult> {
+					return {};
+				}
+				isApplicableToTriggerNode(_nodeType: string): boolean {
+					return false;
+				}
+			}
+
+			await registry.init();
+
+			expect(registry.getGlobalHooks()).toHaveLength(1);
+			expect(registry.getSubExecutionHooks()).toEqual([]);
+		});
+
+		it('returns an empty array when no hooks are registered at all', async () => {
+			await registry.init();
+
+			expect(registry.getSubExecutionHooks()).toEqual([]);
+		});
+	});
 });

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -74,6 +74,7 @@ describe('ExecutionContextService', () => {
 		mockRegistry = {
 			getHookByName: vi.fn(),
 			getGlobalHooks: vi.fn().mockReturnValue([]),
+			getSubExecutionHooks: vi.fn().mockReturnValue([]),
 		} as unknown as Mocked<ExecutionContextHookRegistry>;
 
 		mockCipher = {
@@ -452,8 +453,8 @@ describe('ExecutionContextService', () => {
 			source: null,
 		};
 
-		it('returns the inherited context untouched (no round-trip) when no global hooks exist', async () => {
-			mockRegistry.getGlobalHooks.mockReturnValue([]);
+		it('returns the inherited context untouched (no round-trip) when no sub-execution hooks exist', async () => {
+			mockRegistry.getSubExecutionHooks.mockReturnValue([]);
 			const inherited: IExecutionContext = {
 				version: 1,
 				establishedAt: 100,
@@ -468,14 +469,14 @@ describe('ExecutionContextService', () => {
 			expect(mockCipher.encryptV2).not.toHaveBeenCalled();
 		});
 
-		it('runs global hooks with no trigger items, merges contextUpdate, and ignores returned items', async () => {
-			const globalHook = mock<IContextEstablishmentHook>();
-			globalHook.execute.mockResolvedValue({
+		it('runs sub-execution hooks with no trigger items, merges contextUpdate, and ignores returned items', async () => {
+			const subExecutionHook = mock<IContextEstablishmentHook>();
+			subExecutionHook.execute.mockResolvedValue({
 				// Items a hook returns must not leak into a sub-execution.
 				triggerItems: [{ json: { stripped: true } }],
 				contextUpdate: { redaction: { version: 2, production: true, manual: true } },
 			});
-			mockRegistry.getGlobalHooks.mockReturnValue([globalHook]);
+			mockRegistry.getSubExecutionHooks.mockReturnValue([subExecutionHook]);
 			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
 
 			const inherited: IExecutionContext = {
@@ -487,7 +488,7 @@ describe('ExecutionContextService', () => {
 
 			const result = await service.augmentSubExecutionContext(mockWorkflow, startItem, inherited);
 
-			expect(globalHook.execute).toHaveBeenCalledWith(
+			expect(subExecutionHook.execute).toHaveBeenCalledWith(
 				expect.objectContaining({
 					triggerNode: startItem.node,
 					workflow: mockWorkflow,

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -445,6 +445,63 @@ describe('ExecutionContextService', () => {
 		});
 	});
 
+	describe('augmentSubExecutionContext()', () => {
+		const startItem: IExecuteData = {
+			node: { name: 'Execute Workflow Trigger', parameters: {} } as INode,
+			data: { main: [[{ json: { fromParent: true } }]] },
+			source: null,
+		};
+
+		it('returns the inherited context untouched (no round-trip) when no global hooks exist', async () => {
+			mockRegistry.getGlobalHooks.mockReturnValue([]);
+			const inherited: IExecutionContext = {
+				version: 1,
+				establishedAt: 100,
+				source: 'trigger',
+				credentials: 'inherited-encrypted-creds',
+			};
+
+			const result = await service.augmentSubExecutionContext(mockWorkflow, startItem, inherited);
+
+			expect(result).toBe(inherited);
+			expect(mockCipher.decryptV2).not.toHaveBeenCalled();
+			expect(mockCipher.encryptV2).not.toHaveBeenCalled();
+		});
+
+		it('runs global hooks with no trigger items, merges contextUpdate, and ignores returned items', async () => {
+			const globalHook = mock<IContextEstablishmentHook>();
+			globalHook.execute.mockResolvedValue({
+				// Items a hook returns must not leak into a sub-execution.
+				triggerItems: [{ json: { stripped: true } }],
+				contextUpdate: { redaction: { version: 2, production: true, manual: true } },
+			});
+			mockRegistry.getGlobalHooks.mockReturnValue([globalHook]);
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
+
+			const inherited: IExecutionContext = {
+				version: 1,
+				establishedAt: 100,
+				source: 'trigger',
+				redaction: { version: 2, production: false, manual: false },
+			};
+
+			const result = await service.augmentSubExecutionContext(mockWorkflow, startItem, inherited);
+
+			expect(globalHook.execute).toHaveBeenCalledWith(
+				expect.objectContaining({
+					triggerNode: startItem.node,
+					workflow: mockWorkflow,
+					triggerItems: null,
+					context: expect.objectContaining({
+						redaction: { version: 2, production: false, manual: false },
+					}),
+					options: {},
+				}),
+			);
+			expect(result.redaction).toEqual({ version: 2, production: true, manual: true });
+		});
+	});
+
 	describe('augmentExecutionContextWithHooks()', () => {
 		const createMockStartItem = (
 			contextEstablishmentHooks?: unknown,

--- a/packages/core/src/execution-engine/__tests__/execution-context.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.test.ts
@@ -730,6 +730,98 @@ describe('establishExecutionContext', () => {
 		});
 	});
 
+	describe('sub-workflow re-runs global context hooks against the inherited context', () => {
+		let mockExecutionContextService: ReturnType<typeof mock<ExecutionContextService>>;
+
+		const buildSubWorkflowRunData = (withStartItem = true) =>
+			createRunExecutionData({
+				startData: {},
+				resultData: { runData: {} },
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: withStartItem
+						? [
+								{
+									node: mock<INode>({
+										name: 'Execute Workflow Trigger',
+										type: 'n8n-nodes-base.executeWorkflowTrigger',
+									}),
+									data: { main: [[{ json: { fromParent: true } }]] },
+									source: null,
+								},
+							]
+						: [],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+				},
+				parentExecution: {
+					executionId: 'parent-execution-id',
+					workflowId: 'parent-workflow-id',
+					executionContext: {
+						version: 1,
+						establishedAt: 1000,
+						source: 'manual',
+						redaction: { version: 2, production: false, manual: false },
+					},
+				},
+			});
+
+		beforeEach(() => {
+			mockExecutionContextService = mock<ExecutionContextService>();
+			Container.set(ExecutionContextService, mockExecutionContextService);
+		});
+
+		afterEach(() => {
+			Container.reset();
+		});
+
+		it('passes the inherited context to augmentSubExecutionContext and assigns its result', async () => {
+			const runExecutionData = buildSubWorkflowRunData();
+			const rederived: IExecutionContext = {
+				version: 1,
+				establishedAt: 2000,
+				source: 'integrated',
+				parentExecutionId: 'parent-execution-id',
+				redaction: { version: 2, production: true, manual: true, source: 'workflow' },
+			};
+			mockExecutionContextService.augmentSubExecutionContext.mockResolvedValue(rederived);
+
+			await establishExecutionContext(
+				mockWorkflow,
+				runExecutionData,
+				mockAdditionalData,
+				'integrated',
+			);
+
+			expect(mockExecutionContextService.augmentSubExecutionContext).toHaveBeenCalledWith(
+				mockWorkflow,
+				runExecutionData.executionData!.nodeExecutionStack[0],
+				expect.objectContaining({
+					parentExecutionId: 'parent-execution-id',
+					redaction: { version: 2, production: false, manual: false },
+				}),
+			);
+			expect(runExecutionData.executionData!.runtimeData).toBe(rederived);
+		});
+
+		it('skips augmentation when the child sub-execution has no start item', async () => {
+			const runExecutionData = buildSubWorkflowRunData(false);
+
+			await establishExecutionContext(
+				mockWorkflow,
+				runExecutionData,
+				mockAdditionalData,
+				'integrated',
+			);
+
+			expect(mockExecutionContextService.augmentSubExecutionContext).not.toHaveBeenCalled();
+			expect(runExecutionData.executionData!.runtimeData!.parentExecutionId).toBe(
+				'parent-execution-id',
+			);
+		});
+	});
+
 	describe('error workflow context inheritance', () => {
 		it('should inherit context from start item metadata', async () => {
 			const parentContext: IExecutionContext = {

--- a/packages/core/src/execution-engine/execution-context-hook-registry.service.ts
+++ b/packages/core/src/execution-engine/execution-context-hook-registry.service.ts
@@ -13,6 +13,7 @@ import { Container, Service } from '@n8n/di';
 export class ExecutionContextHookRegistry {
 	private hookMap: Map<string, IContextEstablishmentHook> = new Map();
 	private globalHook: Set<IContextEstablishmentHook> = new Set();
+	private subExecutionHook: Set<IContextEstablishmentHook> = new Set();
 
 	constructor(
 		private readonly executionContextHookMetadata: ContextEstablishmentHookMetadata,
@@ -33,9 +34,11 @@ export class ExecutionContextHookRegistry {
 	async init() {
 		this.hookMap.clear();
 		this.globalHook.clear();
+		this.subExecutionHook.clear();
 
 		const hookClasses = this.executionContextHookMetadata.getClasses();
 		const globalHookClasses = this.executionContextHookMetadata.getGlobalClasses();
+		const subExecutionHookClasses = this.executionContextHookMetadata.getSubExecutionClasses();
 		this.logger.debug(`Registering ${hookClasses.length} execution context hooks.`);
 
 		for (const hookClass of hookClasses) {
@@ -70,6 +73,9 @@ export class ExecutionContextHookRegistry {
 			this.hookMap.set(hook.hookDescription.name, hook);
 			if (globalHookClasses.includes(hookClass)) {
 				this.globalHook.add(hook);
+			}
+			if (subExecutionHookClasses.includes(hookClass)) {
+				this.subExecutionHook.add(hook);
 			}
 		}
 	}
@@ -110,5 +116,15 @@ export class ExecutionContextHookRegistry {
 
 	getGlobalHooks(): IContextEstablishmentHook[] {
 		return Array.from(this.globalHook);
+	}
+
+	/**
+	 * Returns hooks that opted into re-running for sub-workflow executions via
+	 * `runForSubExecution`. These re-derive the child's own context on top of the
+	 * inherited parent context (e.g. capturing the child workflow's redaction
+	 * policy on its own execution record).
+	 */
+	getSubExecutionHooks(): IContextEstablishmentHook[] {
+		return Array.from(this.subExecutionHook);
 	}
 }

--- a/packages/core/src/execution-engine/execution-context.service.ts
+++ b/packages/core/src/execution-engine/execution-context.service.ts
@@ -73,6 +73,49 @@ export class ExecutionContextService {
 		return deepMerge(baseContext, contextToMerge);
 	}
 
+	/**
+	 * Re-runs the global context hooks for a sub-workflow that inherited its
+	 * parent's context, so the child's own execution record reflects context
+	 * derived from the child workflow (e.g. its redaction policy) instead of only
+	 * the parent's.
+	 *
+	 * Unlike {@link augmentExecutionContextWithHooks}, trigger items are not
+	 * re-processed: the child inherits the parent's (already stripped) input, so
+	 * hooks run with `triggerItems: null` and any items they return are ignored.
+	 * Hooks that only act on trigger items (e.g. credential stripping) are
+	 * therefore no-ops here; hooks that derive context from the workflow (e.g.
+	 * redaction) still contribute. Node-specific hooks are not run.
+	 *
+	 * Returns the (re-encrypted) context, or the inherited context untouched when
+	 * no global hooks are registered.
+	 */
+	async augmentSubExecutionContext(
+		workflow: Workflow,
+		startItem: IExecuteData,
+		contextToAugment: IExecutionContext,
+	): Promise<IExecutionContext> {
+		const globalHooks = this.executionContextHookRegistry.getGlobalHooks();
+		if (globalHooks.length === 0) return contextToAugment;
+
+		let context = await this.decryptExecutionContext(contextToAugment);
+
+		for (const globalHook of globalHooks) {
+			const result = await globalHook.execute({
+				triggerNode: startItem.node,
+				workflow,
+				triggerItems: null,
+				context,
+				options: {},
+			});
+
+			if (result.contextUpdate) {
+				context = this.mergeExecutionContexts(context, result.contextUpdate);
+			}
+		}
+
+		return await this.encryptExecutionContext(context);
+	}
+
 	// startItem is mutated to reflect any changes to trigger items made by the hooks
 	async augmentExecutionContextWithHooks(
 		workflow: Workflow,

--- a/packages/core/src/execution-engine/execution-context.service.ts
+++ b/packages/core/src/execution-engine/execution-context.service.ts
@@ -74,33 +74,32 @@ export class ExecutionContextService {
 	}
 
 	/**
-	 * Re-runs the global context hooks for a sub-workflow that inherited its
+	 * Re-runs the sub-execution context hooks for a sub-workflow that inherited its
 	 * parent's context, so the child's own execution record reflects context
 	 * derived from the child workflow (e.g. its redaction policy) instead of only
 	 * the parent's.
 	 *
-	 * Unlike {@link augmentExecutionContextWithHooks}, trigger items are not
-	 * re-processed: the child inherits the parent's (already stripped) input, so
-	 * hooks run with `triggerItems: null` and any items they return are ignored.
-	 * Hooks that only act on trigger items (e.g. credential stripping) are
-	 * therefore no-ops here; hooks that derive context from the workflow (e.g.
-	 * redaction) still contribute. Node-specific hooks are not run.
+	 * Only hooks that opted in via `runForSubExecution` run here — not every global
+	 * hook — so a hook must consciously declare that it is safe to re-run for
+	 * children. Trigger items are not re-processed: the child inherits the parent's
+	 * (already stripped) input, so hooks run with `triggerItems: null` and any items
+	 * they return are ignored. Node-specific hooks are not run.
 	 *
 	 * Returns the (re-encrypted) context, or the inherited context untouched when
-	 * no global hooks are registered.
+	 * no sub-execution hooks are registered.
 	 */
 	async augmentSubExecutionContext(
 		workflow: Workflow,
 		startItem: IExecuteData,
 		contextToAugment: IExecutionContext,
 	): Promise<IExecutionContext> {
-		const globalHooks = this.executionContextHookRegistry.getGlobalHooks();
-		if (globalHooks.length === 0) return contextToAugment;
+		const subExecutionHooks = this.executionContextHookRegistry.getSubExecutionHooks();
+		if (subExecutionHooks.length === 0) return contextToAugment;
 
 		let context = await this.decryptExecutionContext(contextToAugment);
 
-		for (const globalHook of globalHooks) {
-			const result = await globalHook.execute({
+		for (const subExecutionHook of subExecutionHooks) {
+			const result = await subExecutionHook.execute({
 				triggerNode: startItem.node,
 				workflow,
 				triggerItems: null,

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -2,9 +2,9 @@ import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import { type IRunExecutionData, type Workflow, type WorkflowExecuteMode } from 'n8n-workflow';
 
-import { ExecutionContextService } from './execution-context.service';
-
 import { assertExecutionDataExists, type PreExecutionAdditionalData } from '@/utils/assertions';
+
+import { ExecutionContextService } from './execution-context.service';
 
 /**
  * Establishes the execution context for a workflow run.

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
-import { type WorkflowExecuteMode, type IRunExecutionData, type Workflow } from 'n8n-workflow';
-
-import { assertExecutionDataExists, type PreExecutionAdditionalData } from '@/utils/assertions';
+import { type IRunExecutionData, type Workflow, type WorkflowExecuteMode } from 'n8n-workflow';
 
 import { ExecutionContextService } from './execution-context.service';
+
+import { assertExecutionDataExists, type PreExecutionAdditionalData } from '@/utils/assertions';
 
 /**
  * Establishes the execution context for a workflow run.
@@ -141,6 +141,19 @@ export const establishExecutionContext = async (
 			...executionData.runtimeData,
 			parentExecutionId: runExecutionData.parentExecution.executionId,
 		};
+
+		// The child inherits the parent's context, but its OWN execution record must
+		// still reflect context derived from the child workflow — most importantly
+		// its redaction policy (a policy'd child called by a policy-less parent must
+		// redact its own record). Re-run the global context hooks against the
+		// inherited context so they can merge with it (redaction escalates
+		// strictest-per-channel; the parent's top-down escalation is preserved).
+		const [subExecutionStartItem] = executionData.nodeExecutionStack;
+		if (subExecutionStartItem) {
+			executionData.runtimeData = await Container.get(
+				ExecutionContextService,
+			).augmentSubExecutionContext(workflow, subExecutionStartItem, executionData.runtimeData);
+		}
 		return;
 	}
 

--- a/packages/workflow/src/redaction-channels.ts
+++ b/packages/workflow/src/redaction-channels.ts
@@ -1,3 +1,4 @@
+import type { IRedactionSetting } from './execution-context';
 import type { WorkflowSettings } from './interfaces';
 
 /**
@@ -41,4 +42,18 @@ export function channelsToPolicy({
 	if (production) return 'non-manual';
 	if (manual) return 'all';
 	return 'none';
+}
+
+/**
+ * Reads the per-channel redaction from a captured snapshot, normalizing the V1
+ * (single policy enum) and V2 (per-channel booleans) shapes. An absent snapshot
+ * means nothing is redacted.
+ */
+export function redactionSettingToChannels(
+	redaction: IRedactionSetting | undefined,
+): RedactionChannels {
+	if (!redaction) return { production: false, manual: false };
+	if (redaction.version === 2)
+		return { production: redaction.production, manual: redaction.manual };
+	return policyToChannels(redaction.policy);
 }

--- a/packages/workflow/test/redaction-channels.test.ts
+++ b/packages/workflow/test/redaction-channels.test.ts
@@ -1,5 +1,9 @@
 import type { WorkflowSettings } from '../src/interfaces';
-import { channelsToPolicy, policyToChannels } from '../src/redaction-channels';
+import {
+	channelsToPolicy,
+	policyToChannels,
+	redactionSettingToChannels,
+} from '../src/redaction-channels';
 
 describe('redaction-channels', () => {
 	describe('policyToChannels', () => {
@@ -37,6 +41,26 @@ describe('redaction-channels', () => {
 	describe('round-trip for invariant-respecting policies', () => {
 		it.each(['none', 'non-manual', 'all'] as const)('policy %s survives a round-trip', (policy) => {
 			expect(channelsToPolicy(policyToChannels(policy))).toBe(policy);
+		});
+	});
+
+	describe('redactionSettingToChannels', () => {
+		it('returns no redaction for an absent snapshot', () => {
+			expect(redactionSettingToChannels(undefined)).toEqual({ production: false, manual: false });
+		});
+
+		it('reads V2 per-channel booleans directly', () => {
+			expect(redactionSettingToChannels({ version: 2, production: true, manual: false })).toEqual({
+				production: true,
+				manual: false,
+			});
+		});
+
+		it('projects a V1 policy enum onto channels', () => {
+			expect(redactionSettingToChannels({ version: 1, policy: 'all' })).toEqual({
+				production: true,
+				manual: true,
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

A sub-workflow that inherits its parent's execution context returned before the
context hooks ran, so its own execution record carried the **parent's** redaction
snapshot instead of its own. A workflow with a redaction policy, run as a child of
a policy-less parent, was therefore served **unredacted** on its own execution row.

This re-runs the global context hooks for sub-executions against the inherited
context (with no trigger items, so credential stripping stays a no-op and the child
keeps its inherited input). `RedactionContextHook` now folds the inherited snapshot
in strictest-per-channel, so the child's record reflects its own policy while
preserving the parent's top-down escalation and the instance floor.

## How to test

1. On a licensed instance (data redaction), create sub-workflow `C` with policy
   "redact all executions"; confirm a direct manual run of `C` is redacted.
2. Create parent workflow `P` (no redaction policy): manual trigger → Execute
   Sub-workflow → `C`. Run `P`.
3. As a user with `execution:read`, open `C`'s own execution with data — it is now
   redacted (previously fully readable).
4. Unit tests:
   - `cd packages/workflow && pnpm test redaction-channels.test.ts`
   - `cd packages/core && pnpm test execution-context`
   - `cd packages/cli && pnpm test redaction-context-hook`

## Related Linear tickets

- https://linear.app/n8n/issue/IAM-1049

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34621">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

