### PR TITLE
fix(core): Fall back to the run's resolved model for AI Assistant verification LLM calls

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/reconcile-plan.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/reconcile-plan.ts
@@ -18,8 +18,17 @@ export async function reconcileStaleCredentialPlan(args: {
 	domainContext: NonNullable<OrchestrationContext['domainContext']>;
 	workflowTaskService: WorkflowTaskService;
 	logger: OrchestrationContext['logger'];
+	/** Host-resolved model used when no eval model API key is configured in the environment. */
+	fallbackModelConfig?: OrchestrationContext['modelId'];
 }): Promise<WorkflowBuildOutcome> {
-	const { buildOutcome, workflowId, domainContext, workflowTaskService, logger } = args;
+	const {
+		buildOutcome,
+		workflowId,
+		domainContext,
+		workflowTaskService,
+		logger,
+		fallbackModelConfig,
+	} = args;
 	// Reconciliation can change something only when the outcome holds mocked
 	// credentials or an AI root simulated for missing model credentials.
 	const hasMockedCredentials = Object.keys(buildOutcome.mockedCredentialsByNode ?? {}).length > 0;
@@ -32,7 +41,12 @@ export async function reconcileStaleCredentialPlan(args: {
 	try {
 		const workflow = await domainContext.workflowService.getAsWorkflowJSON(workflowId);
 		const availableCredentials = await buildCredentialMap(domainContext.credentialService);
-		const patch = await reconcileSimulationPlan({ buildOutcome, workflow, availableCredentials });
+		const patch = await reconcileSimulationPlan({
+			buildOutcome,
+			workflow,
+			availableCredentials,
+			fallbackModelConfig,
+		});
 		if (!patch) return buildOutcome;
 
 		await workflowTaskService.updateBuildOutcome(buildOutcome.workItemId, patch);

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
@@ -136,6 +136,7 @@ export function createVerifyBuiltWorkflowTool(context: OrchestrationContext) {
 				domainContext: target.domainContext,
 				workflowTaskService,
 				logger: context.logger,
+				fallbackModelConfig: context.modelId,
 			});
 
 			if (buildOutcome.nodeSimulationPlan === undefined) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/classify-node-destructiveness.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/classify-node-destructiveness.service.test.ts
@@ -201,6 +201,34 @@ describe('classifyNodesForSimulation', () => {
 		expect(mockCreateEvalAgent).toHaveBeenCalledTimes(1);
 	});
 
+	it('forwards the fallback model config to the LLM call', async () => {
+		setupAgentMock(
+			JSON.stringify({
+				Search: { verdict: 'execute', reason: 'POST to a search endpoint', confidence: 'high' },
+			}),
+		);
+		const fallbackModelConfig = {
+			id: 'anthropic/claude-opus-4-8' as const,
+			url: 'https://proxy.example.com/anthropic/v1',
+			apiKey: 'proxy-token',
+		};
+		await classifyNodesForSimulation({
+			workflow: chainWorkflow([
+				trigger,
+				{
+					name: 'Search',
+					type: 'n8n-nodes-base.httpRequest',
+					parameters: { method: 'POST', url: 'https://api.example.com/search' },
+				},
+			]),
+			fallbackModelConfig,
+		});
+		expect(mockCreateEvalAgent).toHaveBeenCalledWith(
+			'verification-destructiveness-classifier',
+			expect.objectContaining({ fallbackModelConfig }),
+		);
+	});
+
 	it('classifies IO-free Code nodes as execute deterministically', async () => {
 		const verdicts = await classify([
 			trigger,

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/generate-simulation-fixtures.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/generate-simulation-fixtures.service.test.ts
@@ -120,6 +120,42 @@ describe('generateSimulationFixtures', () => {
 		expect(result).toEqual({ A: [{}] });
 	});
 
+	it('warns on generation failure so the empty-fixture degrade is visible', async () => {
+		mockCreateEvalAgent.mockImplementation(() => {
+			throw new Error('Missing API key');
+		});
+		const warn = vi.fn();
+		const logger = { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() };
+		const result = await generateSimulationFixtures({
+			workflow: wf([{ name: 'A', type: 'n8n-nodes-base.slack' }]),
+			plan: [simulateVerdict('A')],
+			logger,
+		});
+		expect(result).toEqual({ A: [{}] });
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining('fixture generation failed'),
+			expect.objectContaining({ reason: 'generation_failed', nodeCount: 1 }),
+		);
+	});
+
+	it('forwards the fallback model config to the LLM call', async () => {
+		setupAgentMock(JSON.stringify({ A: [{ json: { ok: true } }] }));
+		const fallbackModelConfig = {
+			id: 'anthropic/claude-opus-4-8' as const,
+			url: 'https://proxy.example.com/anthropic/v1',
+			apiKey: 'proxy-token',
+		};
+		await generateSimulationFixtures({
+			workflow: wf([{ name: 'A', type: 'n8n-nodes-base.slack' }]),
+			plan: [simulateVerdict('A')],
+			fallbackModelConfig,
+		});
+		expect(mockCreateEvalAgent).toHaveBeenCalledWith(
+			'verification-simulation-fixtures',
+			expect.objectContaining({ fallbackModelConfig }),
+		);
+	});
+
 	it('strips markdown fences around the JSON output', async () => {
 		setupAgentMock('```json\n{"A":[{"json":{"ok":true}}]}\n```');
 		const result = await generateSimulationFixtures({

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/plan-verification-simulation.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/plan-verification-simulation.test.ts
@@ -62,6 +62,34 @@ describe('planVerificationSimulation — simulated trigger verdicts', () => {
 		mockGenerateFixtures.mockResolvedValue({});
 	});
 
+	it('forwards the fallback model config to classification and fixture generation', async () => {
+		const fallbackModelConfig = {
+			id: 'anthropic/claude-opus-4-8' as const,
+			url: 'https://proxy.example.com/anthropic/v1',
+			apiKey: 'proxy-token',
+		};
+		mockClassify.mockResolvedValue([
+			{
+				nodeName: 'Send It',
+				verdict: 'simulate',
+				reason: 'Sends a message',
+				confidence: 'high',
+				source: 'deterministic',
+			},
+		]);
+
+		await planVerificationSimulation({
+			workflow: wf([{ name: 'Send It', type: 'n8n-nodes-base.slack' }]),
+			workflowId: 'wf-1',
+			fallbackModelConfig,
+		});
+
+		expect(mockClassify).toHaveBeenCalledWith(expect.objectContaining({ fallbackModelConfig }));
+		expect(mockGenerateFixtures).toHaveBeenCalledWith(
+			expect.objectContaining({ fallbackModelConfig }),
+		);
+	});
+
 	it('injects a deterministic simulate verdict for non-deterministic triggers', async () => {
 		mockClassify.mockResolvedValue([executeVerdict('Fetch Rows')]);
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/apply-workflow-credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/apply-workflow-credentials.tool.ts
@@ -108,6 +108,7 @@ export function createApplyWorkflowCredentialsTool(context: OrchestrationContext
 					buildOutcome,
 					workflow: json,
 					availableCredentials,
+					fallbackModelConfig: context.modelId,
 				});
 				if (patch) {
 					await context.workflowTaskService.updateBuildOutcome(input.workItemId, {

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -761,6 +761,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						declaredOutputFixtures: compiled.declaredOutputFixtures,
 						workflowId: saved.id,
 						outputSchemaLookup: context.outputSchemaLookup,
+						fallbackModelConfig: context.modelId,
 						logger: context.logger,
 					});
 					const runId = buildContext?.runId ?? context.runId;

--- a/packages/@n8n/instance-ai/src/tools/workflows/classify-node-destructiveness.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/classify-node-destructiveness.service.ts
@@ -22,6 +22,7 @@ import type { IConnections } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { isTriggerNodeType } from './workflow-json-utils';
+import type { ModelConfig } from '../../types';
 import { HAIKU_MODEL } from '../../utils/eval-agents';
 import { generateValidatedJson } from '../../utils/generate-validated-json';
 import type { NodeSimulationVerdict } from '../../workflow-loop/workflow-loop-state';
@@ -32,6 +33,8 @@ export interface ClassifyNodesForSimulationInput {
 	workflow: WorkflowJSON;
 	/** Node names whose credentials were mocked — always simulated. */
 	mockedNodeNames?: string[];
+	/** Host-resolved model used when no eval model API key is configured in the environment. */
+	fallbackModelConfig?: ModelConfig;
 }
 
 const STICKY_NOTE_TYPE = 'n8n-nodes-base.stickyNote';
@@ -354,6 +357,7 @@ function formatNodeBlock(node: WorkflowNode & { name: string }): string {
 
 async function classifyAmbiguousNodes(
 	nodes: Array<WorkflowNode & { name: string }>,
+	fallbackModelConfig?: ModelConfig,
 ): Promise<NodeSimulationVerdict[]> {
 	const userText = [
 		'Classify the following n8n workflow nodes.',
@@ -368,6 +372,7 @@ async function classifyAmbiguousNodes(
 		instructions: SYSTEM_INSTRUCTIONS,
 		userText,
 		schema: LlmVerdictSchema,
+		fallbackModelConfig,
 	});
 	const parsed = result.ok ? result.data : undefined;
 
@@ -426,7 +431,7 @@ export async function classifyNodesForSimulation(
 		// retired, the plan is the only source of verification pin data, so a
 		// throw here would leave every node executing for real. Fail destructive.
 		try {
-			for (const verdict of await classifyAmbiguousNodes(ambiguous)) {
+			for (const verdict of await classifyAmbiguousNodes(ambiguous, input.fallbackModelConfig)) {
 				verdictByName.set(verdict.nodeName, verdict);
 			}
 		} catch {

--- a/packages/@n8n/instance-ai/src/tools/workflows/generate-simulation-fixtures.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/generate-simulation-fixtures.service.ts
@@ -32,6 +32,8 @@ import { getParentNodes, mapConnectionsByDestination, type IConnections } from '
 import { z } from 'zod';
 
 import { isTriggerNodeType } from './workflow-json-utils';
+import type { Logger } from '../../logger';
+import type { ModelConfig } from '../../types';
 import { SONNET_MODEL } from '../../utils/eval-agents';
 import { generateValidatedJson } from '../../utils/generate-validated-json';
 import type { NodeSimulationVerdict } from '../../workflow-loop/workflow-loop-state';
@@ -53,6 +55,9 @@ export interface GenerateSimulationFixturesInput {
 	 * structure instead of the model's guess at the service's response shape.
 	 */
 	outputSchemaLookup?: OutputSchemaLookup;
+	/** Host-resolved model used when no eval model API key is configured in the environment. */
+	fallbackModelConfig?: ModelConfig;
+	logger?: Logger;
 }
 
 // Loose on purpose: items may arrive `{json: {...}}`-wrapped, flat, or as an
@@ -196,8 +201,15 @@ export async function generateSimulationFixtures(
 		instructions: SYSTEM_INSTRUCTIONS,
 		userText,
 		schema: FixturesResponseSchema,
+		fallbackModelConfig: input.fallbackModelConfig,
 	});
-	if (!result.ok) return emptyFixtures(nodeNames);
+	if (!result.ok) {
+		input.logger?.warn('Simulation fixture generation failed; simulated nodes get empty items', {
+			reason: result.reason,
+			nodeCount: nodeNames.length,
+		});
+		return emptyFixtures(nodeNames);
+	}
 
 	// Shared normalization + envelope repair, matching the eval pin-data paths:
 	// wrap-or-passthrough items, then mechanically fix the two known LLM

--- a/packages/@n8n/instance-ai/src/tools/workflows/plan-verification-simulation.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/plan-verification-simulation.ts
@@ -22,6 +22,7 @@ import {
 } from './generate-simulation-fixtures.service';
 import { isMockableTriggerNodeType, isTriggerNodeType } from './workflow-json-utils';
 import type { Logger } from '../../logger';
+import type { ModelConfig } from '../../types';
 import type { NodeSimulationVerdict } from '../../workflow-loop/workflow-loop-state';
 
 export interface PlanVerificationSimulationInput {
@@ -37,6 +38,8 @@ export interface PlanVerificationSimulationInput {
 	workflowId: string;
 	/** Node output `__schema__` lookup used to shape generated fixtures. */
 	outputSchemaLookup?: OutputSchemaLookup;
+	/** Host-resolved model used when no eval model API key is configured in the environment. */
+	fallbackModelConfig?: ModelConfig;
 	logger?: Logger;
 }
 
@@ -255,13 +258,18 @@ export async function planVerificationSimulation({
 	declaredOutputFixtures,
 	workflowId,
 	outputSchemaLookup,
+	fallbackModelConfig,
 	logger,
 }: PlanVerificationSimulationInput): Promise<VerificationSimulationPlan> {
 	let nodeSimulationPlan: NodeSimulationVerdict[] | undefined;
 	let simulationFixtures: SimulationFixtures | undefined;
 	const declaredFixtures = nonEmptyDeclaredFixtures(declaredOutputFixtures);
 	try {
-		nodeSimulationPlan = await classifyNodesForSimulation({ workflow, mockedNodeNames });
+		nodeSimulationPlan = await classifyNodesForSimulation({
+			workflow,
+			mockedNodeNames,
+			fallbackModelConfig,
+		});
 		nodeSimulationPlan = withDeclaredOutputVerdicts(nodeSimulationPlan, declaredFixtures);
 		nodeSimulationPlan = withSimulatedTriggerVerdicts(nodeSimulationPlan, workflow);
 		nodeSimulationPlan = withSimulatedCredentiallessAiRootVerdicts(
@@ -280,6 +288,8 @@ export async function planVerificationSimulation({
 							workflow,
 							plan: planNeedingGeneratedFixtures,
 							outputSchemaLookup,
+							fallbackModelConfig,
+							logger,
 						})
 					: {};
 			const fixtures = { ...generatedFixtures, ...declaredFixtures };

--- a/packages/@n8n/instance-ai/src/tools/workflows/reconcile-simulation-plan.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/reconcile-simulation-plan.ts
@@ -20,6 +20,7 @@ import {
 	findCredentiallessAiRoots,
 } from './plan-verification-simulation';
 import type { CredentialMap } from './resolve-credentials';
+import type { ModelConfig } from '../../types';
 import type {
 	NodeSimulationVerdict,
 	WorkflowBuildOutcome,
@@ -75,8 +76,10 @@ export async function reconcileSimulationPlan(args: {
 	buildOutcome: WorkflowBuildOutcome;
 	workflow: WorkflowJSON;
 	availableCredentials: CredentialMap;
+	/** Host-resolved model used when no eval model API key is configured in the environment. */
+	fallbackModelConfig?: ModelConfig;
 }): Promise<SimulationPlanPatch | undefined> {
-	const { buildOutcome, workflow, availableCredentials } = args;
+	const { buildOutcome, workflow, availableCredentials, fallbackModelConfig } = args;
 
 	const mockedEntries = Object.entries(buildOutcome.mockedCredentialsByNode ?? {});
 	const satisfiedNames = new Set(
@@ -131,6 +134,7 @@ export async function reconcileSimulationPlan(args: {
 		const freshVerdicts = await classifyNodesForSimulation({
 			workflow: scopedWorkflow,
 			mockedNodeNames: remainingMockedNames,
+			fallbackModelConfig,
 		});
 		freshVerdictByName = new Map(freshVerdicts.map((verdict) => [verdict.nodeName, verdict]));
 	}

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -951,6 +951,13 @@ export interface InstanceAiContext {
 	 */
 	tracing?: InstanceAiTraceContext;
 	projectId?: string;
+	/**
+	 * Host-resolved model for the current run (proxy-managed on cloud). Domain
+	 * tools pass it as the fallback for utility LLM calls (simulation fixtures,
+	 * destructiveness classification), which otherwise resolve an eval model
+	 * from environment API keys that proxy-managed deployments don't have.
+	 */
+	modelId?: ModelConfig;
 	workflowService: InstanceAiWorkflowService;
 	executionService: InstanceAiExecutionService;
 	credentialService: InstanceAiCredentialService;

--- a/packages/@n8n/instance-ai/src/utils/__tests__/eval-agents.test.ts
+++ b/packages/@n8n/instance-ai/src/utils/__tests__/eval-agents.test.ts
@@ -81,4 +81,43 @@ describe('eval agent model config', () => {
 			reasoningEffort: 'high',
 		});
 	});
+
+	it('throws without env keys or a fallback model config', () => {
+		expect(() => createEvalAgent('test-agent', { instructions: 'Do the task.' })).toThrow(
+			/Missing API key/,
+		);
+	});
+
+	it('uses the fallback model config when no env API key is configured', () => {
+		const fallbackModelConfig = {
+			id: 'anthropic/claude-opus-4-8' as const,
+			url: 'https://proxy.example.com/anthropic/v1',
+			apiKey: 'proxy-token',
+		};
+
+		createEvalAgent('test-agent', {
+			instructions: 'Do the task.',
+			fallbackModelConfig,
+		});
+
+		expect(mockAgentInstances[0]?.model).toHaveBeenCalledWith(fallbackModelConfig);
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
+			mode: 'adaptive',
+		});
+	});
+
+	it('prefers env-based model resolution over the fallback', () => {
+		process.env.N8N_AI_ANTHROPIC_KEY = 'env-key';
+
+		createEvalAgent('test-agent', {
+			instructions: 'Do the task.',
+			fallbackModelConfig: { id: 'anthropic/claude-opus-4-8' as const, url: '', apiKey: 'jwt' },
+		});
+
+		expect(mockAgentInstances[0]?.model).toHaveBeenCalledWith({
+			id: 'anthropic/claude-sonnet-4-6',
+			apiKey: 'env-key',
+			url: undefined,
+		});
+	});
 });

--- a/packages/@n8n/instance-ai/src/utils/__tests__/generate-validated-json.test.ts
+++ b/packages/@n8n/instance-ai/src/utils/__tests__/generate-validated-json.test.ts
@@ -79,4 +79,23 @@ describe('generateValidatedJson', () => {
 		});
 		expect(await generate()).toEqual({ ok: false, reason: 'generation_failed' });
 	});
+
+	it('forwards the fallback model config to agent creation', async () => {
+		setupAgentMock('{"ok": true}');
+		const fallbackModelConfig = {
+			id: 'anthropic/claude-opus-4-8' as const,
+			url: 'https://proxy.example.com/anthropic/v1',
+			apiKey: 'proxy-token',
+		};
+		await generateValidatedJson('test-agent', {
+			instructions: 'instructions',
+			userText: 'do it',
+			schema,
+			fallbackModelConfig,
+		});
+		expect(mockCreateEvalAgent).toHaveBeenCalledWith(
+			'test-agent',
+			expect.objectContaining({ fallbackModelConfig }),
+		);
+	});
 });

--- a/packages/@n8n/instance-ai/src/utils/eval-agents.ts
+++ b/packages/@n8n/instance-ai/src/utils/eval-agents.ts
@@ -1,6 +1,6 @@
 /** Shared agent factory + helpers for eval LLM calls (hint generation, mock responses, pin data). */
 
-import { Agent, Tool, type GenerateResult } from '@n8n/agents';
+import { Agent, Tool, type GenerateResult, type ModelConfig } from '@n8n/agents';
 
 import { applyAgentThinking } from '../agent/apply-agent-thinking';
 
@@ -100,20 +100,34 @@ const CACHE_PROVIDER_OPTS = {
 	providerOptions: EPHEMERAL_CACHE,
 };
 
+/**
+ * Env-based tiered model when configured, otherwise the caller's fallback.
+ * Deployments where the model is managed outside the environment (e.g. the
+ * cloud AI service proxy) have no eval API key, so without a fallback every
+ * in-product eval call would fail before reaching the LLM.
+ */
+function resolveAgentModel(model?: string, fallbackModelConfig?: ModelConfig): ModelConfig {
+	try {
+		const { modelId, apiKey, url } = resolveEvalModelConfig(model);
+		return { id: modelId, apiKey, url };
+	} catch (error) {
+		if (fallbackModelConfig) return fallbackModelConfig;
+		throw error;
+	}
+}
+
 export function createEvalAgent(
 	name: string,
 	options: {
 		model?: string;
 		instructions: string;
 		cache?: boolean;
+		/** Host-resolved model used when no eval model API key is configured in the environment. */
+		fallbackModelConfig?: ModelConfig;
 	},
 ): Agent {
-	const { modelId, apiKey, url } = resolveEvalModelConfig(options.model);
-	const agent = new Agent(name).model({
-		id: modelId,
-		apiKey,
-		url,
-	});
+	const model = resolveAgentModel(options.model, options.fallbackModelConfig);
+	const agent = new Agent(name).model(model);
 
 	if (options.cache) {
 		agent.instructions(options.instructions, CACHE_PROVIDER_OPTS);
@@ -121,7 +135,7 @@ export function createEvalAgent(
 		agent.instructions(options.instructions);
 	}
 
-	applyAgentThinking(agent, modelId);
+	applyAgentThinking(agent, model);
 
 	return agent;
 }

--- a/packages/@n8n/instance-ai/src/utils/generate-validated-json.ts
+++ b/packages/@n8n/instance-ai/src/utils/generate-validated-json.ts
@@ -8,6 +8,7 @@
  * helper's own tests mock `eval-agents`.
  */
 
+import type { ModelConfig } from '@n8n/agents';
 import type { z } from 'zod';
 
 import { createEvalAgent, extractText } from './eval-agents';
@@ -25,6 +26,8 @@ export interface GenerateValidatedJsonOptions<T> {
 	instructions: string;
 	userText: string;
 	schema: z.ZodType<T>;
+	/** Host-resolved model used when no eval model API key is configured in the environment. */
+	fallbackModelConfig?: ModelConfig;
 }
 
 function stripMarkdownFences(text: string): string {
@@ -42,6 +45,7 @@ export async function generateValidatedJson<T>(
 		const llm = createEvalAgent(agentName, {
 			model: options.model,
 			instructions: options.instructions,
+			fallbackModelConfig: options.fallbackModelConfig,
 		});
 		const result = await llm.generate([
 			{ role: 'user' as const, content: [{ type: 'text' as const, text: options.userText }] },

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -3767,3 +3767,36 @@ describe('createContext — builder delegate telemetry', () => {
 		expect(delegate.listAgents).toHaveBeenCalledTimes(1);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// createContext — run model wiring
+// ---------------------------------------------------------------------------
+
+describe('createContext — run model wiring', () => {
+	const mockUser = { id: 'user-1', role: { slug: 'global:member' } } as unknown as User;
+
+	// Guards the one link of the INS-948 fix that instance-ai's own unit tests
+	// cannot see: the run's resolved (proxy-aware) model must land on the domain
+	// context, where simulation fixture/classifier LLM calls read it as their
+	// fallback on deployments without env model keys (cloud). Dropping this
+	// wiring regresses silently — every simulated node degrades back to a
+	// single empty pinned item.
+	it('copies the host-resolved modelId onto the context', () => {
+		const service = createAdapterWithGatewayMock(vi.fn());
+		const modelId = {
+			id: 'anthropic/claude-opus-4-8' as const,
+			url: 'https://proxy.example.com/anthropic/v1',
+			apiKey: 'proxy-token',
+		};
+
+		const context = service.createContext(mockUser, { modelId });
+
+		expect(context.modelId).toEqual(modelId);
+	});
+
+	it('leaves modelId undefined when the host does not resolve one', () => {
+		const service = createAdapterWithGatewayMock(vi.fn());
+
+		expect(service.createContext(mockUser).modelId).toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -41,6 +41,7 @@ import type {
 	EvaluationConfigSummary,
 	UpsertEvaluationConfigInput,
 	InstanceAiBuilderDelegate,
+	ModelConfig,
 } from '@n8n/instance-ai';
 import { braveSearch, searxngSearch, type WebSearchResponse } from '@n8n/ai-utilities';
 import {
@@ -295,6 +296,9 @@ export class InstanceAiAdapterService {
 			/** Per-user config-evals gate (via `isConfigEvalsEnabled`). Falsy →
 			 *  eval-config service/tool not wired. */
 			configEvalsEnabled?: boolean;
+			/** Host-resolved model for the run — fallback for utility LLM calls
+			 *  (simulation fixtures, destructiveness classification). */
+			modelId?: ModelConfig;
 		},
 	): InstanceAiContext {
 		const {
@@ -305,6 +309,7 @@ export class InstanceAiAdapterService {
 			credentialIdAllowlist,
 			agentId,
 			configEvalsEnabled,
+			modelId,
 		} = options ?? {};
 
 		// Record gateway availability once per context. Fire-and-forget: the
@@ -316,6 +321,7 @@ export class InstanceAiAdapterService {
 		return {
 			userId: user.id,
 			projectId,
+			modelId,
 			workflowService: this.createWorkflowAdapter(user, threadId, projectId),
 			executionService: this.createExecutionAdapter(user, pushRef, threadId),
 			credentialService: this.createCredentialAdapter(user, projectId, credentialIdAllowlist),

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1993,6 +1993,11 @@ export class InstanceAiService {
 		const { searchProxyConfig, tracingProxyConfig, tokenManager, proxyBaseUrl } =
 			proxyRunConfig ?? (await this.createProxyRunConfig(user));
 
+		const modelId =
+			proxyBaseUrl && tokenManager
+				? await this.modelService.resolveProxyModel(user, proxyBaseUrl, tokenManager)
+				: await this.modelService.resolveAgentModelConfig(user);
+
 		const configEvalsEnabled = await this.adapterService.isConfigEvalsEnabled(user);
 		const context = this.adapterService.createContext(user, {
 			searchProxyConfig,
@@ -2001,6 +2006,7 @@ export class InstanceAiService {
 			projectId: boundProjectId,
 			credentialIdAllowlist: this.evalCredentialAllowlists.get(threadId),
 			configEvalsEnabled,
+			modelId,
 		});
 
 		// Merge both local gateway and direct browser-use into a single
@@ -2094,11 +2100,6 @@ export class InstanceAiService {
 				status: localGatewayDisabledForUser ? 'disabled' : 'disconnected',
 			};
 		}
-
-		const modelId =
-			proxyBaseUrl && tokenManager
-				? await this.modelService.resolveProxyModel(user, proxyBaseUrl, tokenManager)
-				: await this.modelService.resolveAgentModelConfig(user);
 
 		const taskStorage = new ThreadTaskStorage(memory);
 		const iterationLog = this.dbIterationLogStorage;


### PR DESCRIPTION
## Summary

Post-build verification simulates nodes it must not execute for real (mocked credentials, destructive operations, non-mockable triggers) and pins LLM-generated mock output on them so downstream expressions resolve against realistic data. The two LLM helpers behind that, simulation fixture generation and destructiveness classification, resolved their model exclusively from environment API keys (`N8N_INSTANCE_AI_MODEL_API_KEY`, `N8N_AI_ANTHROPIC_KEY`, `ANTHROPIC_API_KEY`).

Deployments where the model is managed outside the environment have no such keys: the AI service proxy authenticates with short-lived per-user tokens, and self-hosted users can also configure the model through a credential instead of env vars. On those deployments `createEvalAgent` threw before ever reaching the LLM, `generateValidatedJson` swallowed the throw, and every simulated node was silently pinned with a single empty item (`[{}]`). Verification still "passed" but exercised no realistic data, and the logs panel showed "This is an item, but it's empty" for simulated nodes. This has been the case since node simulation shipped (#32209), and it also affects the trigger verification added in #33896: on such deployments, non-mockable triggers verify against an empty event payload.

Changes:

- `createEvalAgent` / `generateValidatedJson` accept a `fallbackModelConfig`, used only when env-based resolution finds no API key. Env keys keep precedence, so environments that set them (local dev, evals, e2e) behave exactly as before, including the Sonnet/Haiku model tiering.
- The run's host-resolved model (the same proxy-aware config the orchestrator runs on, resolved once at run setup) now travels on `InstanceAiContext.modelId` and is passed as that fallback by every simulation-planning entry point: the build tool, verify-time plan reconciliation, and `apply-workflow-credentials`.
- Fixture-generation failures now log a warning instead of degrading silently; the silence is why this went unnoticed.

**Model tiering note:** with env keys these calls keep their dedicated cheaper tiers (Sonnet for fixtures, Haiku for classification). In the fallback path they run on the run's model instead: the host-resolved config is a pre-bound model instance, only the host can mint models for other tiers on proxy-managed deployments, and the run's model is the only one guaranteed to be accepted by the deployment's auth path. Both calls run at most once per build (classification only when ambiguous nodes exist), so the cost delta is small relative to the build turn itself. Restoring the cheaper tiers on key-less deployments would need host-resolved tier-specific models and is left as a follow-up.

## How to test

- Unit coverage across the chain: `eval-agents` (fallback used without env keys, env precedence kept, throw preserved without either), `generate-validated-json`, the fixture/classifier services, the simulation planner, and a cli adapter test guarding that `createContext` copies the resolved model onto the domain context. All new tests were red-checked: with the source changes reverted they fail, with them they pass.
- Manual, env-keyed setup (regression check): with `ANTHROPIC_API_KEY` or `N8N_AI_ANTHROPIC_KEY` set, build a workflow that needs credentials you don't have and let verification run. Simulated node previews contain generated realistic items, as before.
- Manual, key-less setup (the fix): run an instance whose model is not configured via env API keys (model credential or a proxy-managed setup), repeat the same flow. Simulated nodes previously showed a single empty item in the logs panel; they now show realistic generated output, and a failure to generate logs a warning instead of passing silently.

Labeled `Backport to Beta`: the 2.32.x cherry-pick is clean (master and 2.32 match in these files), and stable receives the fix when 2.32 promotes. A stable (2.31.x) backport was considered and skipped: #33896 is not in 2.31, so the pick would conflict on the planner/fixture files and need a manual port against the older code, to gain only the days until the promotion.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-948

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (internal behavior, no user-facing docs impact)
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

