### PR TITLE
feat(core): Add N8N_SCHEDULER_MAX_ATTEMPTS to configure scheduler dead-letter threshold

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/scheduler.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/scheduler.config.test.ts
@@ -39,6 +39,7 @@ describe('SchedulerConfig', () => {
 			expect(scheduler.reaperTimeoutSeconds).toBe(60);
 			expect(scheduler.retentionTimeoutSeconds).toBe(5 * 60);
 			expect(scheduler.maxConcurrentPasses).toBe(10);
+			expect(scheduler.maxAttempts).toBe(5);
 		});
 	});
 
@@ -67,6 +68,7 @@ describe('SchedulerConfig', () => {
 			vi.stubEnv('N8N_SCHEDULER_REAPER_TIMEOUT', '45');
 			vi.stubEnv('N8N_SCHEDULER_RETENTION_TIMEOUT', '120');
 			vi.stubEnv('N8N_SCHEDULER_MAX_CONCURRENT_PASSES', '4');
+			vi.stubEnv('N8N_SCHEDULER_MAX_ATTEMPTS', '3');
 
 			const { scheduler } = Container.get(GlobalConfig);
 
@@ -85,6 +87,7 @@ describe('SchedulerConfig', () => {
 			expect(scheduler.reaperTimeoutSeconds).toBe(45);
 			expect(scheduler.retentionTimeoutSeconds).toBe(120);
 			expect(scheduler.maxConcurrentPasses).toBe(4);
+			expect(scheduler.maxAttempts).toBe(3);
 		});
 
 		it('should allow disabling the min-interval clamp with 0', () => {

--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -253,15 +253,11 @@ export class SchedulerConfig {
 	triggerNodeMode: 'legacy' | 'new' = 'legacy';
 
 	/**
-	 * How many times a scheduled run may be attempted before it is dead-lettered.
-	 * Defaults to 5. Must be greater than 0.
-	 *
-	 * Counted against every `running` reclaim, including one where the previous
-	 * attempt's lease simply expired before its handler ever started (a crash or
-	 * a missed tick, not a handler failure) as well as one where the handler ran
-	 * and errored. At 1 (the schema's own floor), a single such reclaim already
-	 * exhausts the budget and the occurrence is dead-lettered without its handler
-	 * ever having run once.
+	 * How many times a scheduled run may be reclaimed (for example after a crash)
+	 * or retried on error before it's given up on and dead-lettered. Defaults to
+	 * 5. Raise it on infrastructure prone to instance restarts or transient
+	 * errors, so a single crash doesn't drop a run; lower it to dead-letter and
+	 * move on sooner. Must be greater than 0.
 	 */
 	@Env('N8N_SCHEDULER_MAX_ATTEMPTS', positiveIntSchema)
 	maxAttempts: number = 5;

--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -251,4 +251,18 @@ export class SchedulerConfig {
 	 */
 	@Env('N8N_SCHEDULER_TRIGGER_NODE_MODE', z.enum(['legacy', 'new']))
 	triggerNodeMode: 'legacy' | 'new' = 'legacy';
+
+	/**
+	 * How many times a scheduled run may be attempted before it is dead-lettered.
+	 * Defaults to 5. Must be greater than 0.
+	 *
+	 * Counted against every `running` reclaim, including one where the previous
+	 * attempt's lease simply expired before its handler ever started (a crash or
+	 * a missed tick, not a handler failure) as well as one where the handler ran
+	 * and errored. At 1 (the schema's own floor), a single such reclaim already
+	 * exhausts the budget and the occurrence is dead-lettered without its handler
+	 * ever having run once.
+	 */
+	@Env('N8N_SCHEDULER_MAX_ATTEMPTS', positiveIntSchema)
+	maxAttempts: number = 5;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -463,6 +463,7 @@ describe('GlobalConfig', () => {
 			minIntervalSeconds: 0,
 			maxConcurrentPasses: 10,
 			triggerNodeMode: 'legacy',
+			maxAttempts: 5,
 		},
 		evaluation: {
 			collectionsEnabled: false,

--- a/packages/@n8n/db/src/repositories/__tests__/scheduled-job.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/scheduled-job.repository.test.ts
@@ -26,6 +26,7 @@ const newJob = (name: string): NewScheduledJob => ({
 	intervalSeconds: null,
 	fireAt: null,
 	nextRunAt: CLOCK,
+	maxAttempts: 5,
 });
 
 /** A chainable insert query-builder mock; `execute` is set per test. */

--- a/packages/@n8n/db/src/repositories/scheduled-job.repository.ts
+++ b/packages/@n8n/db/src/repositories/scheduled-job.repository.ts
@@ -15,7 +15,7 @@ export interface JobAdvance {
 	lastFiredAt: Date | null;
 }
 
-/** A job row to insert; bookkeeping columns take their schema defaults. */
+/** A job row to insert; remaining bookkeeping columns take their schema defaults. */
 export type NewScheduledJob = Pick<
 	ScheduledJob,
 	| 'name'
@@ -31,6 +31,7 @@ export type NewScheduledJob = Pick<
 	| 'intervalSeconds'
 	| 'fireAt'
 	| 'nextRunAt'
+	| 'maxAttempts'
 >;
 
 /** A changed schedule definition, plus the fresh clock it restarts from. */

--- a/packages/cli/src/scheduling/__tests__/durable-job-provisioner.test.ts
+++ b/packages/cli/src/scheduling/__tests__/durable-job-provisioner.test.ts
@@ -73,7 +73,7 @@ describe('DurableJobProvisioner', () => {
 			created: [],
 		}));
 		const globalConfig = mock<GlobalConfig>({
-			scheduler: { materializationWindowSeconds: 60 },
+			scheduler: { materializationWindowSeconds: 60, maxAttempts: 5 },
 			generic: { timezone: 'UTC' },
 		});
 		provisioner = new DurableJobProvisioner(
@@ -113,6 +113,7 @@ describe('DurableJobProvisioner', () => {
 					intervalSeconds: null,
 					fireAt: null,
 					nextRunAt: CLOCK,
+					maxAttempts: 5,
 				},
 			]);
 			expect(summary.inserted).toEqual([{ id: 100, name: 'wf:node:0' }]);
@@ -370,6 +371,7 @@ describe('DurableJobProvisioner', () => {
 					intervalSeconds: null,
 					fireAt: null,
 					nextRunAt: CLOCK,
+					maxAttempts: 5,
 					...columns,
 				},
 			]);

--- a/packages/cli/src/scheduling/durable-job-provisioner.ts
+++ b/packages/cli/src/scheduling/durable-job-provisioner.ts
@@ -78,7 +78,7 @@ export class DurableJobProvisioner {
 		private readonly dataSource: DataSource,
 		private readonly jobs: ScheduledJobRepository,
 		private readonly tasks: ScheduledTaskRepository,
-		globalConfig: GlobalConfig,
+		private readonly globalConfig: GlobalConfig,
 		tracing: Tracing,
 	) {
 		this.logger = this.logger.scoped('scheduler');
@@ -170,6 +170,7 @@ export class DurableJobProvisioner {
 								payload,
 								...scheduleColumns(job.schedule),
 								nextRunAt: job.firstRunAt,
+								maxAttempts: this.globalConfig.scheduler.maxAttempts,
 							}),
 						);
 						const ids = await this.jobs.insertMany(manager, rows);

--- a/packages/cli/test/integration/scheduling/scheduled-repositories.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduled-repositories.test.ts
@@ -97,6 +97,7 @@ describe('scheduled repositories', () => {
 		intervalSeconds: 60,
 		fireAt: null,
 		nextRunAt: secondsFromNow(-60),
+		maxAttempts: 1,
 		...overrides,
 	});
 

--- a/packages/cli/test/integration/scheduling/scheduler-execute.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduler-execute.test.ts
@@ -138,6 +138,35 @@ describe('scheduler execution over the storage bindings', () => {
 		expect(recovered.errorMessage).toBe('Lease expired before completion');
 	});
 
+	it('honours maxAttempts: dead-letters once reclaims exhaust the configured limit', async () => {
+		const job = await createJob({ maxAttempts: 3 });
+		const past = new Date(Date.now() - 60_000);
+		await taskRepo.save(
+			taskRepo.create({
+				jobId: job.id,
+				taskType: TASK_TYPE,
+				payload: {},
+				scheduledFor: past,
+				runAt: past,
+				status: 'running',
+				claimedBy: 'main-dead',
+				leaseExpiresAt: new Date(Date.now() - 1000),
+				leaseEpoch: 1,
+				// Already reclaimed twice; this expired lease is the 3rd and last attempt.
+				attempts: 2,
+				maxAttempts: 3,
+			}),
+		);
+
+		const result = await scheduler.reap();
+
+		expect(result).toEqual({ reclaimed: 0, deadLettered: 1 });
+		const failed = await taskRepo.findOneByOrFail({ jobId: job.id });
+		expect(failed.status).toBe('failed');
+		expect(failed.claimedBy).toBe('main-dead');
+		expect(failed.errorMessage).toBe('Lease expired before completion');
+	});
+
 	// Last on purpose: it stops the shared scheduler's executor.
 	it('releases claimed but unfired tasks on stop', async () => {
 		const job = await createJob();

--- a/packages/cli/test/integration/scheduling/scheduler-query-benchmarks.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduler-query-benchmarks.test.ts
@@ -463,6 +463,7 @@ describe.runIf(runBenchmarks)('durable scheduler query benchmarks', () => {
 					intervalSeconds: 60,
 					fireAt: null,
 					nextRunAt: secondsFromNow(3600),
+					maxAttempts: 1,
 				}));
 				const ids = await dataSource.transaction(
 					async (trx) => await jobRepository.insertMany(trx, newJobs),


### PR DESCRIPTION
## Summary

- Adds `N8N_SCHEDULER_MAX_ATTEMPTS` (`SchedulerConfig.maxAttempts`, default `5`) following the same pattern as the other `N8N_SCHEDULER_*` tunables.
- Plumbs it through `DurableJobProvisioner` into every inserted `scheduled_job` row's `maxAttempts` column.

Previously `maxAttempts` had no config surface at all: every job was created with the schema's hardcoded default of `1`, so a single lease-expiry reclaim (for example an instance crashing before the handler even started) was enough to dead-letter the occurrence permanently, with zero real handler failures involved.

Note: this doesn't fix the underlying conflation between delivery failures (lease expired before the handler ran) and execution failures (handler ran and errored) sharing the same counter and bound — raising the default just gives more headroom before that wall. Follow-up worth tracking separately.

## How to test

- `N8N_SCHEDULER_MAX_ATTEMPTS=3` (or leave unset for the new default of 5) with `N8N_SCHEDULER_ENABLED=true`, provision a Schedule Trigger, and confirm new `scheduled_job` rows carry `maxAttempts` accordingly.
- New test added in `scheduler-execute.test.ts`: `scheduler.reap()` dead-letters exactly when reclaims exhaust the configured `maxAttempts`, not before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3803

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34633">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


