### PR TITLE
fix(editor-ui): refresh credential issues after workflow import

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -5355,6 +5355,42 @@ describe('useCanvasOperations', () => {
 			);
 		});
 
+		it('re-evaluates credential issues after importing non-trigger nodes', async () => {
+			vi.mocked(workflowDocumentStoreInstance.createWorkflowObject).mockImplementation(
+				(nodes, connections) =>
+					createTestWorkflowObject({
+						nodes: nodes as INodeUi[],
+						connections,
+					}),
+			);
+
+			const updateNodesCredentialsIssuesSpy = vi.fn();
+			const nodeHelpersOriginal = nodeHelpers.useNodeHelpers();
+			vi.spyOn(nodeHelpers, 'useNodeHelpers').mockImplementation(() => ({
+				...nodeHelpersOriginal,
+				updateNodesCredentialsIssues: updateNodesCredentialsIssuesSpy,
+			}));
+
+			const canvasOperations = useCanvasOperations();
+			await canvasOperations.importWorkflowData(
+				{
+					nodes: [
+						createTestNode({
+							id: 'imported-1',
+							name: 'Imported Node',
+							type: SET_NODE_TYPE,
+							typeVersion: 1,
+							position: [100, 100],
+						}),
+					],
+					connections: {},
+				},
+				'file',
+			);
+
+			await waitFor(() => expect(updateNodesCredentialsIssuesSpy).toHaveBeenCalled());
+		});
+
 		it('should track telemetry when trackEvents is true (default)', async () => {
 			const telemetry = useTelemetry();
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -3039,6 +3039,17 @@ export function useCanvasOperations() {
 				{ setStateDirty, trackHistory },
 			);
 
+			// Imported nodes can carry credentials by name or stale ids.
+			// Re-match and re-evaluate credential issues after all nodes are on canvas,
+			// so imported workflows don't show transient missing-credential warnings.
+			for (const importedNode of importResult.nodes ?? []) {
+				const currentNode = workflowDocumentStore.value.getNodeById(importedNode.id);
+				if (currentNode) {
+					nodeHelpers.matchCredentials(currentNode);
+				}
+			}
+			nodeHelpers.updateNodesCredentialsIssues();
+
 			if (ownsImportBulk) {
 				historyStore.stopRecordingUndo();
 			}


### PR DESCRIPTION
## Summary
- Re-match credentials for imported nodes after import insertion completes
- Recompute credential issues immediately after import
- Add regression coverage for non-trigger imports to ensure credential issue refresh happens without opening NDV

## Problem
Imported workflows could show stale missing-credential indicators until a node dialog was opened.

## Root cause
Credential issues were not always re-evaluated after import completed, so imported node credential state could remain stale.

## Test plan
- Added unit test in useCanvasOperations import suite for non-trigger import credential issue refresh
- Local execution in this environment is blocked by engine mismatch (repo requires Node >= 22.22 and pnpm >= 10.22.0; environment has Node 22.21.1 and pnpm 10.3.0)

Closes #34640


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34641">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

