### PR TITLE
fix(Wikipedia Tool Node): Surface tool errors as actionable node errors

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWikipedia/ToolWikipedia.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWikipedia/ToolWikipedia.node.test.ts
@@ -1,9 +1,10 @@
 import { WikipediaQueryRun } from '@langchain/community/tools/wikipedia_query_run';
-import type {
-	IExecuteFunctions,
-	INode,
-	INodeExecutionData,
-	ISupplyDataFunctions,
+import {
+	NodeOperationError,
+	type IExecuteFunctions,
+	type INode,
+	type INodeExecutionData,
+	type ISupplyDataFunctions,
 } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
@@ -162,6 +163,65 @@ describe('ToolWikipedia', () => {
 				],
 			]);
 			expect(WikipediaQueryRun.prototype.invoke).toHaveBeenCalledTimes(1);
+		});
+
+		it('should wrap network errors in a warning-level NodeOperationError', async () => {
+			const node = new ToolWikipedia();
+			const inputData: INodeExecutionData[] = [{ json: { query: 'test' } }];
+
+			const mockExecute = mock<IExecuteFunctions>({
+				getInputData: vi.fn(() => inputData),
+				getNode: vi.fn(() => mock<INode>({ name: 'test wikipedia' })),
+			});
+
+			WikipediaQueryRun.prototype.invoke = vi
+				.fn()
+				.mockRejectedValue(new Error('Network response was not ok'));
+
+			const promise = node.execute.call(mockExecute);
+
+			await expect(promise).rejects.toThrow(NodeOperationError);
+			await expect(promise).rejects.toMatchObject({
+				message: 'Network response was not ok',
+				level: 'warning',
+			});
+		});
+
+		it('should keep programmer errors at error level', async () => {
+			const node = new ToolWikipedia();
+			const inputData: INodeExecutionData[] = [{ json: { query: 'test' } }];
+
+			const mockExecute = mock<IExecuteFunctions>({
+				getInputData: vi.fn(() => inputData),
+				getNode: vi.fn(() => mock<INode>({ name: 'test wikipedia' })),
+			});
+
+			WikipediaQueryRun.prototype.invoke = vi
+				.fn()
+				.mockRejectedValue(new TypeError('undefined is not a function'));
+
+			const promise = node.execute.call(mockExecute);
+
+			await expect(promise).rejects.toThrow(NodeOperationError);
+			await expect(promise).rejects.toMatchObject({
+				message: 'undefined is not a function',
+				level: 'error',
+			});
+		});
+
+		it('should rethrow n8n errors unchanged', async () => {
+			const node = new ToolWikipedia();
+			const inputData: INodeExecutionData[] = [{ json: { query: 'test' } }];
+
+			const mockExecute = mock<IExecuteFunctions>({
+				getInputData: vi.fn(() => inputData),
+				getNode: vi.fn(() => mock<INode>({ name: 'test wikipedia' })),
+			});
+
+			const originalError = new NodeOperationError(mock<INode>({ name: 'test wikipedia' }), 'boom');
+			WikipediaQueryRun.prototype.invoke = vi.fn().mockRejectedValue(originalError);
+
+			await expect(node.execute.call(mockExecute)).rejects.toBe(originalError);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWikipedia/ToolWikipedia.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWikipedia/ToolWikipedia.node.ts
@@ -1,7 +1,9 @@
 import { WikipediaQueryRun } from '@langchain/community/tools/wikipedia_query_run';
 import {
 	type IExecuteFunctions,
+	BaseError,
 	NodeConnectionTypes,
+	NodeOperationError,
 	type INodeType,
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
@@ -70,7 +72,23 @@ export class ToolWikipedia implements INodeType {
 			if (item === undefined) {
 				continue;
 			}
-			const result = await WikiTool.invoke(item.json);
+			let result: string;
+			try {
+				result = await WikiTool.invoke(item.json);
+			} catch (error) {
+				if (error instanceof BaseError) throw error;
+				// warning-level errors are user-facing and skipped by error reporting;
+				// keep programming errors at error level to preserve their visibility
+				const isProgrammerError =
+					error instanceof TypeError ||
+					error instanceof RangeError ||
+					error instanceof ReferenceError ||
+					error instanceof SyntaxError;
+				throw new NodeOperationError(this.getNode(), error as Error, {
+					itemIndex,
+					level: isProgrammerError ? 'error' : 'warning',
+				});
+			}
 			response.push({
 				json: { response: result },
 				pairedItem: { item: itemIndex },

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWikipedia/ToolWikipedia.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWikipedia/ToolWikipedia.node.ts
@@ -72,6 +72,7 @@ export class ToolWikipedia implements INodeType {
 			if (item === undefined) {
 				continue;
 			}
+
 			let result: string;
 			try {
 				result = await WikiTool.invoke(item.json);
@@ -89,6 +90,7 @@ export class ToolWikipedia implements INodeType {
 					level: isProgrammerError ? 'error' : 'warning',
 				});
 			}
+
 			response.push({
 				json: { response: result },
 				pairedItem: { item: itemIndex },


### PR DESCRIPTION
## Summary

The Wikipedia tool node's `execute()` invoked the langchain `WikipediaQueryRun` with no error handling, so failures of the Wikipedia API request (e.g. a network rejection or a non-OK response) propagated as raw `Error`s that surface as the non-actionable `Error: Error` in error tracking. This PR wraps the invocation so failures are thrown as `NodeOperationError` with the real message preserved: provider/network failures at `warning` level (treated as user-facing), programmer errors (`TypeError`, `RangeError`, `ReferenceError`, `SyntaxError`) kept at `error` level, and existing n8n errors rethrown unchanged. Mirrors the approach of #33508 for vector stores.

## How to test

Unit tests cover the change: `pnpm test ToolWikipedia` in `packages/@n8n/nodes-langchain` (network failure → warning-level `NodeOperationError`, programmer error → error level, n8n error passthrough). To reproduce manually, connect a Wikipedia tool to an AI Agent, run it while blocking access to `wikipedia.org`, and observe the tool error now carries the underlying message instead of a bare `Error`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2635

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

