### PR TITLE
fix(Form Node): Properly handle quotes in Form Trigger Node name

### DIFF
--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -27,7 +27,12 @@ import {
 import { cssVariables } from './cssVariables';
 import { renderFormCompletion } from './utils/formCompletionUtils';
 import { getFormTriggerNode, renderFormNode } from './utils/formNodeUtils';
-import { parseFormFields, prepareFormReturnItem, validateFormPageAuth } from './utils/utils';
+import {
+	getNodeReference,
+	parseFormFields,
+	prepareFormReturnItem,
+	validateFormPageAuth,
+} from './utils/utils';
 
 const waitTimeProperties: INodeProperties[] = [
 	{
@@ -358,11 +363,7 @@ export class Form extends Node {
 
 		const trigger = getFormTriggerNode(context);
 
-		// JSON.stringify produces a properly-escaped JS string literal, so an
-		// adversarial trigger node name containing `'`, `\`, or `${}` can't
-		// break out of the expression. Critical for the auth gate below; safer
-		// than `'${trigger.name}'` even though n8n constrains node names.
-		const triggerRef = `$(${JSON.stringify(trigger.name)})`;
+		const triggerRef = getNodeReference(trigger.name);
 
 		const triggerAuth =
 			(context.evaluateExpression(`{{ ${triggerRef}.params.authentication }}`) as string) ?? 'none';
@@ -375,7 +376,7 @@ export class Form extends Node {
 		) as boolean | undefined;
 		const userForOutput = triggerIncludeUser === false ? undefined : authResult.authedUser;
 
-		const mode = context.evaluateExpression(`{{ $('${trigger.name}').first().json.formMode }}`) as
+		const mode = context.evaluateExpression(`{{ ${triggerRef}.first().json.formMode }}`) as
 			| 'test'
 			| 'production';
 
@@ -413,7 +414,7 @@ export class Form extends Node {
 		}
 
 		let useWorkflowTimezone = context.evaluateExpression(
-			`{{ $('${trigger.name}').params.options?.useWorkflowTimezone }}`,
+			`{{ ${triggerRef}.params.options?.useWorkflowTimezone }}`,
 		) as boolean;
 
 		if (useWorkflowTimezone === undefined && trigger?.typeVersion > 2) {

--- a/packages/nodes-base/nodes/Form/test/Form.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/Form.node.test.ts
@@ -3,9 +3,16 @@ import type {
 	IExecuteFunctions,
 	INode,
 	INodeExecutionData,
+	INodeTypes,
 	IWebhookFunctions,
 	IWorkflowSettings,
 	NodeTypeAndVersion,
+} from 'n8n-workflow';
+import {
+	createRunExecutionData,
+	FORM_NODE_TYPE,
+	FORM_TRIGGER_NODE_TYPE,
+	Workflow,
 } from 'n8n-workflow';
 import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
@@ -482,6 +489,202 @@ describe('Form Node', () => {
 				);
 			},
 		);
+	});
+
+	describe('node references with special characters', () => {
+		// intentionally have a string with special chars and interpolation-looking part
+		// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
+		const triggerName = '"Form\'s" \\ ${Trigger}';
+		const triggerNode = {
+			id: 'trigger-id',
+			name: triggerName,
+			type: FORM_TRIGGER_NODE_TYPE,
+			typeVersion: 2.6,
+			disabled: false,
+			position: [0, 0],
+			parameters: {
+				formTitle: 'Contact',
+				authentication: 'none',
+				options: {
+					buttonLabel: 'Continue',
+					appendAttribution: false,
+					includeUserInOutput: false,
+					useWorkflowTimezone: false,
+				},
+			},
+		} satisfies INode & NodeTypeAndVersion;
+		const formNode: INode = {
+			id: 'form-id',
+			name: 'Form',
+			type: FORM_NODE_TYPE,
+			typeVersion: 2.5,
+			position: [100, 0],
+			parameters: {},
+		};
+		const triggerOutput: INodeExecutionData = {
+			json: {
+				formMode: 'test',
+				formQueryParameters: { email: 'from-query@example.com' },
+			},
+			binary: {
+				attachment: {
+					data: 'ZmlsZSBjb250ZW50',
+					fileName: 'file.txt',
+					mimeType: 'text/plain',
+				},
+			},
+		};
+		const workflow = new Workflow({
+			id: 'workflow-id',
+			name: 'Form workflow',
+			nodes: [triggerNode, formNode],
+			connections: {
+				[triggerName]: {
+					main: [[{ node: formNode.name, type: 'main', index: 0 }]],
+				},
+			},
+			active: false,
+			nodeTypes: mock<INodeTypes>(),
+		});
+		const runExecutionData = createRunExecutionData({
+			resultData: {
+				runData: {
+					[triggerName]: [
+						{
+							startTime: 1,
+							executionTime: 1,
+							executionIndex: 0,
+							source: [],
+							data: { main: [[triggerOutput]] },
+						},
+					],
+				},
+			},
+		});
+
+		beforeAll(async () => await workflow.expression.acquireIsolate());
+		afterAll(async () => await workflow.expression.releaseIsolate());
+
+		const createContext = () => {
+			const context = mock<IWebhookFunctions>();
+			context.getNode.mockReturnValue(formNode);
+			context.getParentNodes.mockReturnValue([triggerNode]);
+			context.getWorkflowSettings.mockReturnValue({});
+			context.evaluateExpression.mockImplementation((expression) =>
+				workflow.expression.resolveSimpleParameterValue(
+					`=${expression}`,
+					{},
+					runExecutionData,
+					0,
+					0,
+					formNode.name,
+					[triggerOutput],
+					'manual',
+					{},
+				),
+			);
+			return context;
+		};
+
+		it('renders a page using the trigger configuration and output', async () => {
+			const context = createContext();
+			const response = mock<Response>();
+			context.getResponseObject.mockReturnValue(response);
+			context.getRequestObject.mockReturnValue({ method: 'GET' } as Request);
+			context.getNodeParameter.mockImplementation((name) => {
+				if (name === 'operation') return 'page';
+				if (name === 'defineForm') return 'fields';
+				if (name === 'formFields.values') return [{ fieldLabel: 'Email', fieldName: 'email' }];
+				if (name === 'options') return { formTitle: '', formDescription: '', buttonLabel: '' };
+				return undefined;
+			});
+
+			await form.webhook(context);
+
+			expect(response.render).toHaveBeenCalledWith(
+				'form-trigger',
+				expect.objectContaining({
+					formTitle: 'Contact',
+					buttonLabel: 'Continue',
+					appendAttribution: false,
+					formFields: [expect.objectContaining({ defaultValue: 'from-query@example.com' })],
+				}),
+			);
+		});
+
+		it('renders completion using the trigger configuration and binary output', async () => {
+			const context = createContext();
+			const response = mock<Response>();
+			context.getResponseObject.mockReturnValue(response);
+			context.getRequestObject.mockReturnValue({ method: 'GET' } as Request);
+			context.getNodeParameter.mockImplementation((name) => {
+				if (name === 'operation') return 'completion';
+				if (name === 'defineForm') return 'fields';
+				if (name === 'formFields.values') return [];
+				if (name === 'options') return { formTitle: '' };
+				if (name === 'respondWith') return 'returnBinary';
+				if (name === 'inputDataFieldName') return 'attachment';
+				return undefined;
+			});
+
+			await form.webhook(context);
+
+			expect(response.render).toHaveBeenCalledWith(
+				'form-trigger-completion',
+				expect.objectContaining({
+					formTitle: 'Contact',
+					appendAttribution: false,
+					responseBinary: encodeURIComponent(
+						JSON.stringify([
+							{
+								data: 'file content',
+								fileName: 'file.txt',
+								type: 'text/plain',
+							},
+						]),
+					),
+				}),
+			);
+		});
+
+		it('reads the form mode and timezone setting when processing a submission', async () => {
+			const now = new Date('2026-01-15T12:00:00.000Z');
+			vi.useFakeTimers();
+			vi.setSystemTime(now);
+			const context = createContext();
+			context.getResponseObject.mockReturnValue(mock<Response>());
+			context.getRequestObject.mockReturnValue({
+				method: 'POST',
+				contentType: 'multipart/form-data',
+			} as Request);
+			context.getBodyData.mockReturnValue({ data: { 'field-0': 'Ada' }, files: {} });
+			context.getTimezone.mockReturnValue('Pacific/Auckland');
+			context.getNodeParameter.mockImplementation((name) => {
+				if (name === 'operation') return 'page';
+				if (name === 'defineForm') return 'fields';
+				if (name === 'formFields.values') return [{ fieldLabel: 'Name', fieldName: 'name' }];
+				return undefined;
+			});
+
+			try {
+				const result = await form.webhook(context);
+
+				expect(result.workflowData).toEqual([
+					[
+						{
+							json: expect.objectContaining({
+								name: 'Ada',
+								formMode: 'test',
+								submittedAt: now.toISOString(),
+							}),
+						},
+					],
+				]);
+				expect(context.getTimezone).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
 	});
 
 	describe('webhook method - n8nUserAuth propagation', () => {

--- a/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
@@ -181,7 +181,7 @@ describe('formCompletionUtils', () => {
 				return params[parameterName];
 			});
 			mockWebhookFunctions.evaluateExpression.mockImplementation((expression) => {
-				if (expression === `{{ $('${trigger.name}').params.formTitle }}`) {
+				if (expression === `{{ $(${JSON.stringify(trigger.name)}).params.formTitle }}`) {
 					return "={{ $workflow.name.split('-')[0].trim() }}";
 				}
 				if (expression === "{{ $workflow.name.split('-')[0].trim() }}") return 'MyForm';
@@ -295,9 +295,9 @@ describe('formCompletionUtils', () => {
 			for (const parentNodes of parentNodesTestCases) {
 				mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodes);
 				mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
-					if (arg === `{{ $('${nodeNameWithFileToDownload}').first().binary }}`) {
+					if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 						return expectedBinaryResponse;
-					} else if (arg === `{{ $('${nodeNameWithFile}').first().binary }}`) {
+					} else if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
 						return { someData: {} };
 					} else {
 						return undefined;
@@ -359,9 +359,9 @@ describe('formCompletionUtils', () => {
 			for (const parentNodes of parentNodesTestCases) {
 				mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodes);
 				mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
-					if (arg === `{{ $('${nodeNameWithFileToDownload}').first().binary }}`) {
+					if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 						return expectedBinaryResponse;
-					} else if (arg === `{{ $('${nodeNameWithFile}').first().binary }}`) {
+					} else if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
 						return { someData: {} };
 					} else {
 						return undefined;
@@ -519,7 +519,7 @@ describe('formCompletionUtils', () => {
 
 			mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodesWithMultipleBinaryFiles);
 			mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
-				if (arg === `{{ $('${nodeNameWithFile}').first().binary }}`) {
+				if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
 					return expectedBinaryResponse;
 				} else {
 					return notExpectedBinaryResponse;
@@ -559,7 +559,7 @@ describe('formCompletionUtils', () => {
 			});
 			mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodesWithSingleNodeFile);
 			mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
-				if (arg === `{{ $('${nodeNameWithFileToDownload}').first().binary }}`) {
+				if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 					return expectedBinaryResponse;
 				}
 
@@ -604,7 +604,7 @@ describe('formCompletionUtils', () => {
 			});
 			mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodesWithSingleNodeFile);
 			mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
-				if (arg === `{{ $('${nodeNameWithFileToDownload}').first().binary }}`) {
+				if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 					return expectedBinaryResponse;
 				}
 

--- a/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
@@ -177,7 +177,7 @@ describe('formNodeUtils', () => {
 		const triggerName = 'triggerName';
 		webhookFunctions.evaluateExpression.mockImplementation((expression) => {
 			// The trigger stores the raw, unresolved expression string in its params.
-			if (expression === `{{ $('${triggerName}').params.formTitle }}`) {
+			if (expression === `{{ $(${JSON.stringify(triggerName)}).params.formTitle }}`) {
 				return "={{ $workflow.name.split('-')[0].trim() }}";
 			}
 			if (expression === "{{ $workflow.name.split('-')[0].trim() }}") {
@@ -209,7 +209,7 @@ describe('formNodeUtils', () => {
 		const triggerName = 'triggerName';
 		webhookFunctions.evaluateExpression.mockImplementation((expression) => {
 			// The trigger stores the raw, unresolved expression string in its params.
-			if (expression === `{{ $('${triggerName}').params.options?.buttonLabel }}`) {
+			if (expression === `{{ $(${JSON.stringify(triggerName)}).params.options?.buttonLabel }}`) {
 				return '={{ $workflow.name }}';
 			}
 			if (expression === '{{ $workflow.name }}') {
@@ -294,7 +294,7 @@ describe('formNodeUtils', () => {
 			webhookFunctions.getParentNodes.mockReturnValue(parentNodes);
 
 			webhookFunctions.evaluateExpression
-				.calledWith(`{{ $('${formTrigger1.name}').first() }}`)
+				.calledWith(`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`)
 				.mockReturnValue('success');
 
 			const result = getFormTriggerNode(webhookFunctions);
@@ -302,7 +302,7 @@ describe('formNodeUtils', () => {
 			expect(result).toBe(formTrigger1);
 			expect(webhookFunctions.getParentNodes).toHaveBeenCalledWith('currentNode');
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger1.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`,
 			);
 		});
 
@@ -324,22 +324,22 @@ describe('formNodeUtils', () => {
 			webhookFunctions.getParentNodes.mockReturnValue(parentNodes);
 
 			webhookFunctions.evaluateExpression
-				.calledWith(`{{ $('${formTrigger1.name}').first() }}`)
+				.calledWith(`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`)
 				.mockImplementation(() => {
 					throw new Error('Evaluation failed');
 				});
 			webhookFunctions.evaluateExpression
-				.calledWith(`{{ $('${formTrigger2.name}').first() }}`)
+				.calledWith(`{{ $(${JSON.stringify(formTrigger2.name)}).first() }}`)
 				.mockReturnValue('success');
 
 			const result = getFormTriggerNode(webhookFunctions);
 
 			expect(result).toBe(formTrigger2);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger1.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`,
 			);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger2.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger2.name)}).first() }}`,
 			);
 		});
 
@@ -387,10 +387,10 @@ describe('formNodeUtils', () => {
 			);
 
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger1.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`,
 			);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger2.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger2.name)}).first() }}`,
 			);
 		});
 
@@ -427,7 +427,7 @@ describe('formNodeUtils', () => {
 			webhookFunctions.getParentNodes.mockReturnValue(parentNodes);
 
 			webhookFunctions.evaluateExpression
-				.calledWith(`{{ $('${formTrigger.name}').first() }}`)
+				.calledWith(`{{ $(${JSON.stringify(formTrigger.name)}).first() }}`)
 				.mockReturnValue('success');
 
 			const result = getFormTriggerNode(webhookFunctions);
@@ -435,7 +435,7 @@ describe('formNodeUtils', () => {
 			expect(result).toBe(formTrigger);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledTimes(1);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger.name)}).first() }}`,
 			);
 		});
 	});

--- a/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
@@ -12,6 +12,7 @@ import {
 
 import {
 	generateFormUserAuthToken,
+	getNodeReference,
 	handleNewlines,
 	resolveRawData,
 	sanitizeCustomCss,
@@ -25,7 +26,7 @@ const getBinaryDataFromNode = (
 	context: IWebhookFunctions,
 	nodeName: string,
 ): IDataObject | undefined => {
-	return context.evaluateExpression(`{{ $('${nodeName}').first().binary }}`) as
+	return context.evaluateExpression(`{{ ${getNodeReference(nodeName)}.first().binary }}`) as
 		| IDataObject
 		| undefined;
 };
@@ -92,14 +93,15 @@ export const renderFormCompletion = async (
 		| 'showText'
 		| 'returnBinary';
 	const binary = respondWith === 'returnBinary' ? await binaryResponse(context) : [];
+	const triggerRef = getNodeReference(trigger.name);
 
 	let title = options.formTitle;
 	if (!title) {
-		title = context.evaluateExpression(`{{ $('${trigger?.name}').params.formTitle }}`) as string;
+		title = context.evaluateExpression(`{{ ${triggerRef}.params.formTitle }}`) as string;
 		title = resolveRawData(context, title);
 	}
 	const appendAttribution = context.evaluateExpression(
-		`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
+		`{{ ${triggerRef}.params.options?.appendAttribution === false ? false : true }}`,
 	) as boolean;
 
 	if (respondWith !== 'redirect' && !isFormHtmlSandboxingDisabled()) {

--- a/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
@@ -11,6 +11,7 @@ import {
 
 import {
 	generateFormUserAuthToken,
+	getNodeReference,
 	handleNewlines,
 	renderForm,
 	resolveRawData,
@@ -31,10 +32,11 @@ export const renderFormNode = async (
 		buttonLabel: string;
 		customCss?: string;
 	};
+	const triggerRef = getNodeReference(trigger.name);
 
 	let title = options.formTitle;
 	if (!title) {
-		title = context.evaluateExpression(`{{ $('${trigger?.name}').params.formTitle }}`) as string;
+		title = context.evaluateExpression(`{{ ${triggerRef}.params.formTitle }}`) as string;
 		title = resolveRawData(context, title);
 	}
 
@@ -43,14 +45,13 @@ export const renderFormNode = async (
 	let buttonLabel = options.buttonLabel;
 	if (!buttonLabel) {
 		buttonLabel =
-			(context.evaluateExpression(
-				`{{ $('${trigger?.name}').params.options?.buttonLabel }}`,
-			) as string) || 'Submit';
+			(context.evaluateExpression(`{{ ${triggerRef}.params.options?.buttonLabel }}`) as string) ||
+			'Submit';
 		buttonLabel = resolveRawData(context, buttonLabel);
 	}
 
 	const appendAttribution = context.evaluateExpression(
-		`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
+		`{{ ${triggerRef}.params.options?.appendAttribution === false ? false : true }}`,
 	) as boolean;
 
 	// Embed the form auth token so subsequent POSTs can re-authenticate the
@@ -103,7 +104,7 @@ export function getFormTriggerNode(context: IWebhookFunctions): NodeTypeAndVersi
 
 	for (const trigger of formTriggers) {
 		try {
-			context.evaluateExpression(`{{ $('${trigger.name}').first() }}`);
+			context.evaluateExpression(`{{ ${getNodeReference(trigger.name)}.first() }}`);
 		} catch (error) {
 			continue;
 		}

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -46,6 +46,8 @@ import type { FormTriggerData, FormField } from '../interfaces';
  */
 const FORM_USER_AUTH_TOKEN_TTL_SECONDS = 60 * 60;
 
+export const getNodeReference = (nodeName: string) => `$(${JSON.stringify(nodeName)})`;
+
 type FormUserAuthClaims = {
 	sub: string;
 	email: string;
@@ -585,8 +587,9 @@ export function renderForm({
 			(node) => node.type === FORM_TRIGGER_NODE_TYPE,
 		) as NodeTypeAndVersion;
 		try {
+			const triggerRef = getNodeReference(trigger.name);
 			const triggerQueryParameters = context.evaluateExpression(
-				`{{ $('${trigger?.name}').first().json.formQueryParameters }}`,
+				`{{ ${triggerRef}.first().json.formQueryParameters }}`,
 			) as IDataObject;
 
 			if (triggerQueryParameters) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

If you have a Form Trigger with `'` in the name, the workflow will fail at subsequent Form Nodes. It's due to the fact that under the hood the Form Node finds the Form Trigger using `$('<trigger name>')` syntax, which fails, because the name itself is enclosed in `'`. This PR fixes it by `JSON.stringify`ing the name first and then passing it into `$(...)`. This ensures that the name is a valid JS string. It was already implemented like that for some cases where the trigger is used in the expression, but not all. This PR updates the remaining places where it's done

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

Use this workflow:
```json
{
  "nodes": [
    {
      "parameters": {
        "formFields": {
          "values": [
            {
              "fieldLabel": "Text input"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.form",
      "typeVersion": 2.5,
      "position": [
        208,
        0
      ],
      "id": "33c55377-515a-472a-bcba-cc046b382c83",
      "name": "Form",
      "webhookId": "a619a9ae-f686-425e-b6cd-d93a45f33dca"
    },
    {
      "parameters": {
        "formTitle": "Test form title",
        "options": {}
      },
      "type": "n8n-nodes-base.formTrigger",
      "typeVersion": 2.6,
      "position": [
        0,
        0
      ],
      "id": "31e069c1-2587-4fe7-b254-0d103216a630",
      "name": "Form ' Trigger",
      "webhookId": "9b811e50-8a17-48ed-af2a-c9174446ae5f"
    }
  ],
  "connections": {
    "Form ' Trigger": {
      "main": [
        [
          {
            "node": "Form",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "3666feb8935111309be62e6408a792d5193270a7ad5d662c8c14af007da79d2f"
  }
}
```
Without a fix, it will fail before getting to the second node

After the fix, it should work. Also, the parameters that are retrieved from the trigger (like the form title) should be correct

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-5206/community-issue-forms-break-when-the-form-trigger-node-name-contains-a
Closes #31773

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

