### PR TITLE
feat(core): Add agent-evals PostHog feature flag and gating (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -272,6 +272,13 @@ export interface FrontendSettings {
 		 * `084_eval_collections` flag would otherwise never resolve.
 		 */
 		collectionsEnabled: boolean;
+		/**
+		 * Operator override (`N8N_AGENT_EVALS_ENABLED`) that force-enables the
+		 * agent-evals surface. Surfaced here so the frontend gate works even when
+		 * the in-browser PostHog client is disabled (telemetry off), where the
+		 * `101_agent_evals` flag would otherwise never resolve.
+		 */
+		agentEvalsEnabled: boolean;
 	};
 
 	/** Backend modules that were initialized during startup. */

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -550,6 +550,8 @@ export {
 	type EvalVersionsResponse,
 } from './schemas/eval-collections.schema';
 
+export { AGENT_EVALS_FLAG } from './schemas/agent-evals.schema';
+
 export {
 	aiInsightsStatusSchema,
 	aiInsightsPayloadSchema,

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -1,0 +1,7 @@
+// PostHog rollout flag id gating the agent-evals feature surface. Every new
+// agent-eval endpoint + frontend entry point consults this; the flag-off
+// cohort sees no agent-eval surface at all. Single source of truth shared
+// between FE and BE so the two cannot drift. Follows the `NNN_<feature>`
+// numeric-prefix convention used by every other n8n PostHog flag (next
+// available after `100_n8n_credits_credential_selection`).
+export const AGENT_EVALS_FLAG = '101_agent_evals';

--- a/packages/@n8n/config/src/configs/evaluation.config.ts
+++ b/packages/@n8n/config/src/configs/evaluation.config.ts
@@ -22,4 +22,23 @@ export class EvaluationConfig {
 	 */
 	@Env('N8N_EVAL_COLLECTIONS_ENABLED')
 	collectionsEnabled: boolean = false;
+
+	/**
+	 * Force-enable the agent-evals feature surface.
+	 *
+	 * Acts as an operator-level override of the `101_agent_evals` PostHog
+	 * rollout flag. When `true`, every agent-eval endpoint + frontend entry
+	 * point is available regardless of PostHog cohort. When `false` (default),
+	 * PostHog remains the source of truth.
+	 *
+	 * Useful for:
+	 * - Local development without PostHog wiring.
+	 * - QA environments that need the feature on for a smoke run.
+	 * - Self-hosted deployments that want the feature without PostHog.
+	 *
+	 * Cannot force-disable: setting this to `false` falls back to PostHog,
+	 * not a kill-switch. Use PostHog itself to disable a rolled-out flag.
+	 */
+	@Env('N8N_AGENT_EVALS_ENABLED')
+	agentEvalsEnabled: boolean = false;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -466,6 +466,7 @@ describe('GlobalConfig', () => {
 		},
 		evaluation: {
 			collectionsEnabled: false,
+			agentEvalsEnabled: false,
 		},
 		generic: {
 			timezone: 'America/New_York',

--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -219,6 +219,7 @@ describe('PostHog', () => {
 				// Mutated per test; reset so test ordering doesn't leak override
 				// state into unrelated cases.
 				globalConfig.evaluation.collectionsEnabled = false;
+				globalConfig.evaluation.agentEvalsEnabled = false;
 			});
 
 			it('force-enables the eval-collections flag when N8N_EVAL_COLLECTIONS_ENABLED is set', async () => {
@@ -256,6 +257,30 @@ describe('PostHog', () => {
 				const flags = await ph.getFeatureFlags({ id: userId, createdAt });
 
 				expect(flags).toEqual({ '084_eval_collections': true });
+			});
+
+			it('force-enables the agent-evals flag when N8N_AGENT_EVALS_ENABLED is set', async () => {
+				(PostHog.prototype.evaluateFlags as Mock).mockResolvedValue(mockEvaluatedFlags({}));
+				globalConfig.evaluation.agentEvalsEnabled = true;
+
+				const ph = new PostHogClient(instanceSettings, globalConfig);
+				await ph.init();
+
+				const flags = await ph.getFeatureFlags({ id: userId, createdAt });
+
+				expect(flags).toMatchObject({ '101_agent_evals': true });
+			});
+
+			it('falls back to the agent-evals override when PostHog throws', async () => {
+				(PostHog.prototype.evaluateFlags as Mock).mockRejectedValue(new Error('posthog down'));
+				globalConfig.evaluation.agentEvalsEnabled = true;
+
+				const ph = new PostHogClient(instanceSettings, globalConfig);
+				await ph.init();
+
+				const flags = await ph.getFeatureFlags({ id: userId, createdAt });
+
+				expect(flags).toEqual({ '101_agent_evals': true });
 			});
 		});
 	});

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -1,4 +1,4 @@
-import { EVAL_COLLECTIONS_FLAG } from '@n8n/api-types';
+import { AGENT_EVALS_FLAG, EVAL_COLLECTIONS_FLAG } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
 import type { PublicUser } from '@n8n/db';
 import { Service } from '@n8n/di';
@@ -167,6 +167,9 @@ export class PostHogClient {
 		const overrides: FeatureFlags = {};
 		if (this.globalConfig.evaluation.collectionsEnabled) {
 			overrides[EVAL_COLLECTIONS_FLAG] = true;
+		}
+		if (this.globalConfig.evaluation.agentEvalsEnabled) {
+			overrides[AGENT_EVALS_FLAG] = true;
 		}
 		return Object.keys(overrides).length === 0 ? flags : { ...flags, ...overrides };
 	}

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -420,6 +420,7 @@ export class FrontendService {
 			evaluation: {
 				quota: this.licenseState.getMaxWorkflowsWithEvaluations(),
 				collectionsEnabled: this.globalConfig.evaluation.collectionsEnabled,
+				agentEvalsEnabled: this.globalConfig.evaluation.agentEvalsEnabled,
 			},
 			activeModules: this.moduleRegistry.getActiveModules(),
 			canvasOnly: this.globalConfig.canvasOnly,

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -184,6 +184,7 @@ export const defaultSettings: FrontendSettings = {
 	evaluation: {
 		quota: 0,
 		collectionsEnabled: false,
+		agentEvalsEnabled: false,
 	},
 	activeModules: [],
 	canvasOnly: false,

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useAgentEvalsFlag.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useAgentEvalsFlag.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { useAgentEvalsFlag } from './useAgentEvalsFlag';
+
+const settingsState = { agentEvalsEnabled: false };
+const posthogState = { enabled: false };
+
+vi.mock('@/app/stores/settings.store', () => ({
+	useSettingsStore: () => ({
+		settings: { evaluation: { agentEvalsEnabled: settingsState.agentEvalsEnabled } },
+	}),
+}));
+
+vi.mock('@/app/stores/posthog.store', () => ({
+	usePostHog: () => ({ isFeatureEnabled: () => posthogState.enabled }),
+}));
+
+describe('useAgentEvalsFlag', () => {
+	it('is enabled via the backend operator override even when PostHog is off', () => {
+		// The telemetry-off case: the in-browser PostHog client never initializes,
+		// so the flag must come from the settings-provided override.
+		settingsState.agentEvalsEnabled = true;
+		posthogState.enabled = false;
+
+		expect(useAgentEvalsFlag().value).toBe(true);
+	});
+
+	it('is enabled via the PostHog cohort flag when the override is off', () => {
+		settingsState.agentEvalsEnabled = false;
+		posthogState.enabled = true;
+
+		expect(useAgentEvalsFlag().value).toBe(true);
+	});
+
+	it('is disabled when neither signal is set', () => {
+		settingsState.agentEvalsEnabled = false;
+		posthogState.enabled = false;
+
+		expect(useAgentEvalsFlag().value).toBe(false);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useAgentEvalsFlag.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useAgentEvalsFlag.ts
@@ -1,0 +1,29 @@
+import { AGENT_EVALS_FLAG } from '@n8n/api-types';
+import { computed } from 'vue';
+
+import { usePostHog } from '@/app/stores/posthog.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
+
+/**
+ * Frontend gate for the agent-evals feature surface, matching the
+ * `101_agent_evals` flag the backend consults to gate its routes. It combines
+ * two independent signals:
+ *
+ *  - `settings.evaluation.agentEvalsEnabled` — the backend-provided operator
+ *    override (`N8N_AGENT_EVALS_ENABLED`). Delivered in the settings payload,
+ *    so it works even when the in-browser PostHog client never initializes
+ *    (telemetry off), where the flag would otherwise stay false.
+ *  - the PostHog client flag — carries per-cohort rollout when telemetry is on.
+ *
+ * Coerces to a strict boolean so `v-if="isAgentEvalsEnabled"` never
+ * undefined-flickers during the initial flag-fetch frame.
+ */
+export const useAgentEvalsFlag = () => {
+	const postHog = usePostHog();
+	const settingsStore = useSettingsStore();
+	return computed(
+		() =>
+			settingsStore.settings.evaluation?.agentEvalsEnabled === true ||
+			postHog.isFeatureEnabled(AGENT_EVALS_FLAG) === true,
+	);
+};


### PR DESCRIPTION
## Summary

Scaffolds the `101_agent_evals` PostHog feature flag that will gate every future agent-eval surface, so all later Phase-0 work can land **dark** on `master`. Nothing user-visible ships here — this PR only wires the flag and its gating helpers.

It mirrors the existing `084_eval_collections` flag pattern exactly:

- **Flag key single-sourced** in `@n8n/api-types` — `AGENT_EVALS_FLAG = '101_agent_evals'` (`schemas/agent-evals.schema.ts`), re-exported from the package index. `101` is the next-free numeric prefix (highest existing real flag is `100_n8n_credits_credential_selection`).
- **Operator override** in `@n8n/config` — `EvaluationConfig.agentEvalsEnabled` (`@Env('N8N_AGENT_EVALS_ENABLED')`, default `false`). Force-enable only; `false` defers to PostHog (not a kill-switch).
- **Backend gating** — the override is surfaced in the frontend-settings payload (`evaluation.agentEvalsEnabled`, populated by `FrontendService`) and force-enables the flag server-side in `PostHogClient.applyEnvOverrides()`.
- **Frontend gate** — `useAgentEvalsFlag` composable = settings override **OR** PostHog client flag, so the gate still works when telemetry (and thus the in-browser PostHog client) is disabled.

Default **off** in every path. No consumer references the flag yet.

## How to test

There is no user-visible surface yet, so testing is limited to confirming the gate resolves correctly:

1. **Default (off):** with no env override and no PostHog cohort, `useAgentEvalsFlag()` resolves `false` and `settings.evaluation.agentEvalsEnabled` is `false`.
2. **Operator override:** boot with `N8N_AGENT_EVALS_ENABLED=true`. The `/settings` payload returns `evaluation.agentEvalsEnabled: true`, the PostHog client reports `101_agent_evals: true`, and `useAgentEvalsFlag()` resolves `true` even with telemetry disabled.
3. **PostHog cohort:** with the env override off but the `101_agent_evals` flag enabled for the instance/user in PostHog, the FE gate resolves `true` via the PostHog client.

Automated coverage:

```bash
pnpm --filter @n8n/config test config.test.ts
pnpm --filter n8n test src/posthog/__tests__/posthog.test.ts
pnpm --filter n8n-editor-ui test useAgentEvalsFlag.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-283

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

