### PR TITLE
fix(editor): Allow LDAP users to configure n8n 2FA in personal settings

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/auth/views/SettingsPersonalView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SettingsPersonalView.test.ts
@@ -162,6 +162,29 @@ describe('SettingsPersonalView', () => {
 		});
 	});
 
+	describe('when signed in via LDAP', () => {
+		beforeEach(() => {
+			vi.spyOn(ssoStore, 'isEnterpriseLdapEnabled', 'get').mockReturnValue(true);
+			vi.spyOn(settingsStore, 'isMfaFeatureEnabled', 'get').mockReturnValue(true);
+			usersStore.usersById[currentUser.id] = { ...currentUser, signInType: 'ldap' };
+		});
+
+		it('should let a member configure MFA while hiding password change', async () => {
+			vi.spyOn(usersStore, 'isInstanceOwner', 'get').mockReturnValue(false);
+
+			const { queryByTestId, getAllByRole } = renderComponent({ pinia });
+			await waitAllPromises();
+
+			// LDAP has no native 2FA, so n8n's own MFA stays configurable...
+			expect(queryByTestId('mfa-section')).toBeInTheDocument();
+			// ...but password/email remain managed externally.
+			expect(queryByTestId('change-password-link')).not.toBeInTheDocument();
+			expect(
+				getAllByRole('textbox').find((el) => el.getAttribute('type') === 'email'),
+			).toBeDisabled();
+		});
+	});
+
 	test.each([
 		['Default', ROLE.Default, false, 'Default role for new users'],
 		['Member', ROLE.Member, false, 'Create and manage own workflows and credentials'],

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SettingsPersonalView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SettingsPersonalView.vue
@@ -97,15 +97,17 @@ const isManagedByEnv = computed((): boolean => {
 	return currentUser.value?.isManagedByEnv ?? false;
 });
 
+const isLdapCurrentAuthMethod = computed((): boolean => {
+	return ssoStore.isEnterpriseLdapEnabled && currentUser.value?.signInType === 'ldap';
+});
+
 const isExternalAuthEnabled = computed((): boolean => {
-	const isLdapEnabled =
-		ssoStore.isEnterpriseLdapEnabled && currentUser.value?.signInType === 'ldap';
 	const isSamlEnabled = ssoStore.isSamlLoginEnabled && ssoStore.isDefaultAuthenticationSaml;
 	const isOidcEnabled =
 		ssoStore.isEnterpriseOidcEnabled &&
 		ssoStore.isOidcLoginEnabled &&
 		currentUser.value?.signInType === 'oidc';
-	return isLdapEnabled || isSamlEnabled || isOidcEnabled;
+	return isLdapCurrentAuthMethod.value || isSamlEnabled || isOidcEnabled;
 });
 
 const isPersonalSecurityEnabled = computed((): boolean => {
@@ -120,6 +122,18 @@ const mfaEnforced = computed((): boolean => {
 });
 const isMfaFeatureEnabled = computed((): boolean => {
 	return settingsStore.isMfaFeatureEnabled;
+});
+
+// Unlike SAML/OIDC, LDAP has no native 2FA, so n8n's own 2FA must stay
+// configurable for LDAP users even though password management is external.
+const canConfigureMfa = computed((): boolean => {
+	return (
+		isMfaFeatureEnabled.value && (isPersonalSecurityEnabled.value || isLdapCurrentAuthMethod.value)
+	);
+});
+
+const isSecuritySectionVisible = computed((): boolean => {
+	return !isManagedByEnv.value && (isPersonalSecurityEnabled.value || canConfigureMfa.value);
 });
 
 const hasAnyPersonalisationChanges = computed((): boolean => {
@@ -403,18 +417,18 @@ onBeforeUnmount(() => {
 				/>
 			</div>
 		</div>
-		<div v-if="isPersonalSecurityEnabled && !isManagedByEnv">
+		<div v-if="isSecuritySectionVisible">
 			<div class="mb-s">
 				<N8nHeading size="large">{{ i18n.baseText('settings.personal.security') }}</N8nHeading>
 			</div>
-			<div class="mb-s">
+			<div v-if="isPersonalSecurityEnabled" class="mb-s">
 				<N8nInputLabel :label="i18n.baseText('auth.password')">
 					<N8nLink data-test-id="change-password-link" @click="openPasswordModal">{{
 						i18n.baseText('auth.changePassword')
 					}}</N8nLink>
 				</N8nInputLabel>
 			</div>
-			<div v-if="isMfaFeatureEnabled" data-test-id="mfa-section">
+			<div v-if="canConfigureMfa" data-test-id="mfa-section">
 				<div class="mb-xs">
 					<N8nInputLabel :label="i18n.baseText('settings.personal.mfa.section.title')" />
 					<N8nText :bold="false" :class="$style.infoText">


### PR DESCRIPTION
## Summary

When LDAP authentication was enabled, the MFA section on the personal settings page shared the `isPersonalSecurityEnabled` gate with the password-change block, so it was hidden for non-owner LDAP users — even though enforced 2FA already worked for them. Unlike SAML/OIDC (which handle 2FA natively at the IdP), LDAP has no native 2FA, so n8n's own 2FA must stay self-configurable. This splits MFA visibility (`canConfigureMfa`) from the password/email gate: LDAP users can now enable 2FA themselves, while password/email remain externally managed. The backend already permitted this (no `signInType` gate on MFA enable/login), so the change is frontend-only.

## How to test

1. Configure LDAP authentication and log in as a non-owner LDAP user.
2. Open **Personal settings → Security**: the **Two-factor authentication** section is now visible and you can enable 2FA. The password-change link and email field remain hidden/disabled.
3. Log out and back in with LDAP credentials — you are prompted for the 2FA code.
4. Verify SAML/OIDC members still see no MFA section (2FA handled by the IdP).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1037

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34655">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

