### PR TITLE
feat(API): Add endpoint to list workflow version history (GET /workflows/{id}/history)

### DIFF
--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -2,22 +2,17 @@
 name: n8n:public-api
 description: >-
   Adds or updates n8n Public API v1 endpoints, OpenAPI specs, and handler wiring.
-  Use when creating public API handlers, registering paths in openapi.yml, or
-  adding OpenAPI tags. Prefer @PublicApiController for new endpoints (API-37+).
+  Use when creating public API handlers, registering paths in openapi.yml, or adding OpenAPI tags. Always use @PublicApiController for new endpoints (API-37+).
 ---
 
 # Public API v1
 
 Public API lives under `packages/cli/src/public-api/v1/`.
 
-**Preferred for new endpoints (API-37+):** `@PublicApiController` +
-`PublicApiControllerRegistry` — same decorator style as internal
-`@RestController`, mounted at `/api/v1` with API-key auth and public errors.
+**Always use `@PublicApiController` for new endpoints (API-37+).** Do not add new business logic to `express-openapi-validator` handlers. Controllers use the same decorator style as internal `@RestController`, mounted at `/api/v1` with API-key auth and public errors via `PublicApiControllerRegistry`.
 
-**Legacy (existing endpoints):** `express-openapi-validator` handlers under
-`handlers/`; OpenAPI path specs are YAML under each handler's `spec/` directory.
-Migrate to the controller pattern when touching an endpoint; do not mix data
-access styles within a new feature.
+**Legacy (existing endpoints only):** `express-openapi-validator` handlers under `handlers/`; OpenAPI path specs are YAML under each handler's `spec/` directory.
+When you touch a legacy endpoint, migrate it to `@PublicApiController` rather than extending the eov handler. Do not mix data-access styles within a new feature.
 
 ## Architecture
 
@@ -30,13 +25,14 @@ GET /rest/tags    → TagsController         ┐  JWT auth, internal shape
 GET /api/v1/tags  → TagsPublicController   ┘  API-key auth, public DTO
 ```
 
-## Adding an endpoint (controller pattern)
+## Adding an endpoint (required: controller pattern)
 
 Reference: `v1/controllers/tags.public.controller.ts` (`GET /tags`).
 
 1. **Public DTOs** in `@n8n/api-types` — input query/body + output resource DTO
    (distinct from internal shapes when they diverge). Use `Z.class` so the
-   registry can validate/parse.
+   registry can validate/parse. Wrap list payloads as objects (e.g. `{ data: [...] }`),
+   same as `TagListPublicDto` / `WorkflowVersionHistoryListPublicDto`.
 2. **Controller** — `v1/controllers/<feature>.public.controller.ts`
    ```ts
    @PublicApiController('/tags')
@@ -50,21 +46,29 @@ Reference: `v1/controllers/tags.public.controller.ts` (`GET /tags`).
    }
    ```
    - Reuse `@Get/@Post/@Body/@Query/@Param/@GlobalScope/@ProjectScope` as-is.
+   - For `@ProjectScope` on workflow/credential routes, name the path param
+     `workflowId` / `credentialId` (or `projectId` / `dataTableId`) — the
+     registry passes `req.params` to `userHasScopes`, which does not remap `id`.
    - `@ApiKeyScope` — string, or `{ anyOf }` / `{ allOf }` (no bare arrays).
    - `@ApiResponse(Dto)` — registry `.parse()`s the return value (strips
      undeclared fields). Shape is provisional until API-39 (doc-gen).
    - Delegate to the same service as the internal REST controller.
-3. **Side-effect import** the controller from `packages/cli/src/public-api/index.ts`
-   so metadata is registered before `PublicApiControllerRegistry.activate`.
+3. **Side-effect import** the controller from
+   `packages/cli/src/public-api/v1/controllers/index.ts` (re-exported via
+   `public-api/index.ts`) so metadata is registered before
+   `PublicApiControllerRegistry.activate`.
 4. **OpenAPI path spec** — still required for docs + `scope-parity.test.ts`
-   (`handlers/<feature>/spec/paths/…`, `$ref` in `openapi.yml`,
-   `x-required-scope` matching `@ApiKeyScope`). Until scope-parity reads
-   decorator metadata, keep a scope-tagged stub in the eov handler (see
-   `getTags` in `tags.handler.ts`).
+   (`handlers/<feature>/spec/paths/…`, `$ref` in `openapi.yml`). Set
+   `operationId`, `x-required-scope` matching `@ApiKeyScope`. **Do not** set
+   `x-eov-operation-id` / `x-eov-operation-handler` — those are legacy eov-only;
+   scope-parity and discover read `@ApiKeyScope` from the controller by matching
+   method + path.
 5. **Coverage manifest** — add every new OpenAPI endpoint to
    `packages/nodes-base/nodes/N8n/n8n-api-coverage.json`.
 
-## Adding an endpoint (legacy eov handler)
+## Legacy eov handlers (do not use for new endpoints)
+
+Only for maintaining endpoints not yet migrated:
 
 1. **Handler** — `handlers/<feature>/<feature>.handler.ts`
    - Export middleware arrays keyed by `x-eov-operation-id`.
@@ -73,12 +77,9 @@ Reference: `v1/controllers/tags.public.controller.ts` (`GET /tags`).
      middleware with `__apiKeyScope`) and add matching `x-required-scope` in the
      path YAML; use `none` for endpoints without an API-key scope (see
      `scope-parity.test.ts`).
-   - **Delegate to the same service/controller layer as the internal REST API.**
-     Parse input with `@n8n/api-types` DTOs, call `Container.get(SomeService)` or
-     `Container.get(SomeController)`, map errors — do not reach into repositories
-     or duplicate business logic in the handler. Older handlers like
-     `handlers/credentials/` and `handlers/workflows/` predate this pattern;
-     follow them only for middleware/OpenAPI wiring, not for data access.
+   - **Delegate to the same service layer as the internal REST API.**
+     Parse input with `@n8n/api-types` DTOs, call `Container.get(SomeService)`,
+     map errors — do not reach into repositories or duplicate business logic.
 2. **OpenAPI path spec** — `handlers/<feature>/spec/paths/<path>.yml`
    - Set `tags: [<TagName>]` matching a top-level tag in `openapi.yml`.
 3. **Register path** — add a `$ref` entry under `paths:` in `openapi.yml`.
@@ -107,10 +108,10 @@ sort order.
 
 ## Reference
 
-- **Controller pattern:** `v1/controllers/tags.public.controller.ts`
+- **Controller pattern (required for new work):** `v1/controllers/tags.public.controller.ts`, `v1/controllers/workflows.public.controller.ts`
 - **Registry:** `packages/cli/src/public-api/public-api-controller.registry.ts`
-- Simple GET via eov + service: `handlers/insights/`
-- CRUD via eov + service/controller: `handlers/variables/`, `handlers/folders/`,
-  `handlers/projects/`, `handlers/data-tables/`
+- Legacy eov examples (migration targets, not templates for new endpoints):
+  `handlers/insights/`, `handlers/variables/`, `handlers/folders/`,
+  `handlers/projects/`, `handlers/data-tables/`, `handlers/workflows/`
 - Multipart: `handlers/n8n-packages/` (see also
   `packages/cli/src/modules/n8n-packages/CLAUDE.md`)

--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -56,7 +56,9 @@ Reference: `v1/controllers/tags.public.controller.ts` (`GET /tags`).
 3. **Side-effect import** the controller from
    `packages/cli/src/public-api/v1/controllers/index.ts` (re-exported via
    `public-api/index.ts`) so metadata is registered before
-   `PublicApiControllerRegistry.activate`.
+   `PublicApiControllerRegistry.activate`. Name the file
+   `*.public.controller.ts` — `public-api-controllers.test.ts` fails CI if a
+   controller file is missing from that barrel or lives outside `controllers/`.
 4. **OpenAPI path spec** — still required for docs + `scope-parity.test.ts`
    (`handlers/<feature>/spec/paths/…`, `$ref` in `openapi.yml`). Set
    `operationId`, `x-required-scope` matching `@ApiKeyScope`. **Do not** set

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -267,6 +267,15 @@ export {
 
 export { WorkflowHistoryVersionsByIdsDto } from './workflow-history/workflow-history-versions-by-ids.dto';
 export { UpdateWorkflowHistoryVersionDto } from './workflow-history/update-workflow-history-version.dto';
+export {
+	WorkflowHistoryListItemDto,
+	workflowHistoryListItemSchema,
+} from './workflow-history/workflow-history-list-item.dto';
+export { ListWorkflowHistoryQueryDto } from './workflow-history/list-workflow-history-query.dto';
+export {
+	WorkflowVersionHistoryListPublicDto,
+	workflowVersionListItemPublicSchema,
+} from './workflow-history/workflow-version-history-public.dto';
 
 export { UpdateExternalSecretsSettingsDto } from './secrets-provider/update-external-secrets-settings.dto';
 export { CreateSecretsProviderConnectionDto } from './secrets-provider/create-secrets-provider-connection.dto';

--- a/packages/@n8n/api-types/src/dto/workflow-history/list-workflow-history-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-history/list-workflow-history-query.dto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+import { publicApiPaginationSchema } from '../pagination/pagination.dto';
+
+export class ListWorkflowHistoryQueryDto extends Z.class({
+	...publicApiPaginationSchema,
+	cursor: z.string().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/workflow-history/workflow-history-list-item.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-history/workflow-history-list-item.dto.ts
@@ -2,11 +2,7 @@ import { z } from 'zod';
 
 import { Z } from '../../zod-class';
 
-/**
- * Canonical workflow-history list item (metadata only — no nodes/connections).
- * Matches `WorkflowHistoryService.getList` / internal GET workflow-history.
- */
-const workflowHistoryListItemShape = {
+export const workflowHistoryListItemSchema = z.object({
 	versionId: z.string(),
 	workflowId: z.string(),
 	authors: z.string(),
@@ -15,8 +11,6 @@ const workflowHistoryListItemShape = {
 	createdAt: z.coerce.date(),
 	updatedAt: z.coerce.date(),
 	autosaved: z.boolean(),
-};
+});
 
-export const workflowHistoryListItemSchema = z.object(workflowHistoryListItemShape);
-
-export class WorkflowHistoryListItemDto extends Z.class(workflowHistoryListItemShape) {}
+export class WorkflowHistoryListItemDto extends Z.class(workflowHistoryListItemSchema.shape) {}

--- a/packages/@n8n/api-types/src/dto/workflow-history/workflow-history-list-item.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-history/workflow-history-list-item.dto.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+/**
+ * Canonical workflow-history list item (metadata only — no nodes/connections).
+ * Matches `WorkflowHistoryService.getList` / internal GET workflow-history.
+ */
+const workflowHistoryListItemShape = {
+	versionId: z.string(),
+	workflowId: z.string(),
+	authors: z.string(),
+	name: z.string().nullable(),
+	description: z.string().nullable(),
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+	autosaved: z.boolean(),
+};
+
+export const workflowHistoryListItemSchema = z.object(workflowHistoryListItemShape);
+
+export class WorkflowHistoryListItemDto extends Z.class(workflowHistoryListItemShape) {}

--- a/packages/@n8n/api-types/src/dto/workflow-history/workflow-version-history-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-history/workflow-version-history-public.dto.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+import { workflowHistoryListItemSchema } from './workflow-history-list-item.dto';
+import { Z } from '../../zod-class';
+
+/** Public list item — same as internal list metadata, minus internal-only fields. */
+export const workflowVersionListItemPublicSchema = workflowHistoryListItemSchema.omit({
+	autosaved: true,
+});
+
+export class WorkflowVersionHistoryListPublicDto extends Z.class({
+	data: z.array(workflowVersionListItemPublicSchema),
+	nextCursor: z.string().nullable(),
+}) {}

--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -20,7 +20,7 @@ import { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
 import { LastActiveAtService } from '@/services/last-active-at.service';
 import { UrlService } from '@/services/url.service';
 
-import './v1/controllers/tags.public.controller';
+import './v1/controllers';
 
 // Renders `x-required-scope` as a badge on each operation. swagger-ui-express
 // serializes this function's source into the page, so it must be self-contained:
@@ -143,20 +143,46 @@ interface EovApiDoc {
 
 /**
  * Test-only express-openapi-validator operation-handler resolver. It is wired in **only** under
- * Vitest (see `operationHandlers` below); production and e2e keep eov's default string resolver
- * and its synchronous `require()`, so runtime behaviour is unchanged.
+ * Vitest (see `operationHandlers` below); production and e2e keep a sync `require()` resolver
+ * so runtime behaviour stays on Node's CJS loader.
  *
  * Why it's needed in tests: eov's default resolver `require()`s each handler module, but under
  * Vitest only the `.ts` handler sources exist on disk (no `.js`) and they're served by Vite, not
  * Node's `require` — so `require()` throws and every route 500s.
- * */
+ *
+ * Both resolvers return a no-op when `x-eov-operation-handler` is absent — those routes are
+ * owned by `@PublicApiController` (mounted before eov).
+ */
 async function importOperationHandlerResolver(
 	handlersPath: string,
-	// Typed as `unknown` (then narrowed) so the signature stays assignable to eov's
-	// `resolver` type, whose `route`/`apiDoc` params are its own internal interfaces.
 	routeArg: unknown,
 	apiDocArg: unknown,
 ): Promise<unknown> {
+	return resolveOperationHandler(handlersPath, routeArg, apiDocArg, 'import');
+}
+
+function requireOperationHandlerResolver(
+	handlersPath: string,
+	routeArg: unknown,
+	apiDocArg: unknown,
+): unknown {
+	return resolveOperationHandler(handlersPath, routeArg, apiDocArg, 'require');
+}
+
+function controllerOwnedNoopHandler() {
+	return [
+		(_req: unknown, _res: unknown, next: (error?: unknown) => void) => {
+			next();
+		},
+	];
+}
+
+function resolveOperationHandler(
+	handlersPath: string,
+	routeArg: unknown,
+	apiDocArg: unknown,
+	loader: 'import' | 'require',
+): unknown | Promise<unknown> {
 	const route = routeArg as EovRoute;
 	const apiDoc = apiDocArg as EovApiDoc;
 	const pathKey = route.openApiRoute.substring(route.basePath.length);
@@ -164,27 +190,42 @@ async function importOperationHandlerResolver(
 	const operationId = operation?.['x-eov-operation-id'] ?? operation?.operationId;
 	const handlerModule = operation?.['x-eov-operation-handler'];
 
-	if (!operationId || !handlerModule) {
-		throw new UnexpectedError(
-			`Missing operation id or handler for [${route.method}] ${route.expressRoute}`,
-		);
+	if (!handlerModule) {
+		return controllerOwnedNoopHandler();
+	}
+
+	if (!operationId) {
+		throw new UnexpectedError(`Missing operation id for [${route.method}] ${route.expressRoute}`);
 	}
 
 	const modulePath = path.join(handlersPath, handlerModule);
-	// `@vite-ignore`: the path is fully dynamic, so Vite's `dynamic-import-vars` plugin can't
-	// analyze it (it throws during transform when this module is loaded under Vitest). Skipping
-	// analysis leaves a plain runtime `import()`, which the test runner and the prod CJS build
-	// (downleveled to `require`) both resolve.
-	const imported = (await import(/* @vite-ignore */ modulePath)) as Record<string, unknown> & {
-		default?: Record<string, unknown>;
-	};
-	const handler = imported[operationId] ?? imported.default?.[operationId] ?? imported.default;
 
-	if (!handler) {
-		throw new UnexpectedError(`Could not find handler '${operationId}' in module '${modulePath}'`);
+	if (loader === 'require') {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const imported = require(modulePath) as Record<string, unknown> & {
+			default?: Record<string, unknown>;
+		};
+		const handler = imported[operationId] ?? imported.default?.[operationId] ?? imported.default;
+		if (!handler) {
+			throw new UnexpectedError(
+				`Could not find handler '${operationId}' in module '${modulePath}'`,
+			);
+		}
+		return handler;
 	}
 
-	return handler;
+	return (async () => {
+		const imported = (await import(/* @vite-ignore */ modulePath)) as Record<string, unknown> & {
+			default?: Record<string, unknown>;
+		};
+		const handler = imported[operationId] ?? imported.default?.[operationId] ?? imported.default;
+		if (!handler) {
+			throw new UnexpectedError(
+				`Could not find handler '${operationId}' in module '${modulePath}'`,
+			);
+		}
+		return handler;
+	})();
 }
 
 function createPublicControllerMiddleware(version: string): RequestHandler {
@@ -240,9 +281,12 @@ function createLazyValidatorMiddleware(
 						// Production/e2e use eov's default resolver (synchronous `require`). Under Vitest,
 						// where handler modules are `.ts` served by Vite, swap in an `import()`-based
 						// resolver so route handlers can load. See `importOperationHandlerResolver`.
-						operationHandlers: process.env.VITEST
-							? { basePath: handlersDirectory, resolver: importOperationHandlerResolver }
-							: handlersDirectory,
+						operationHandlers: {
+							basePath: handlersDirectory,
+							resolver: process.env.VITEST
+								? importOperationHandlerResolver
+								: requireOperationHandlerResolver,
+						},
 						validateRequests: true,
 						validateApiSpec: true,
 						fileUploader: createN8nPackageMulterOptions(globalConfig),

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -166,6 +166,7 @@ export declare namespace WorkflowRequest {
 	type UpdateTags = AuthenticatedRequest<{ id: string }, {}, TagEntity[]>;
 	type Transfer = AuthenticatedRequest<{ id: string }, {}, { destinationProjectId: string }>;
 	type GetVersion = AuthenticatedRequest<{ id: string; versionId: string }, {}, {}, {}>;
+	type GetHistory = AuthenticatedRequest<{ id: string }, {}, {}, { take?: string; skip?: string }>;
 }
 
 export declare namespace PackageRequest {

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -166,7 +166,6 @@ export declare namespace WorkflowRequest {
 	type UpdateTags = AuthenticatedRequest<{ id: string }, {}, TagEntity[]>;
 	type Transfer = AuthenticatedRequest<{ id: string }, {}, { destinationProjectId: string }>;
 	type GetVersion = AuthenticatedRequest<{ id: string; versionId: string }, {}, {}, {}>;
-	type GetHistory = AuthenticatedRequest<{ id: string }, {}, {}, { take?: string; skip?: string }>;
 }
 
 export declare namespace PackageRequest {

--- a/packages/cli/src/public-api/v1/__tests__/public-api-controllers.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/public-api-controllers.test.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CONTROLLERS_DIR = path.resolve(__dirname, '../controllers');
+const INDEX_PATH = path.join(CONTROLLERS_DIR, 'index.ts');
+const PUBLIC_API_ROOT = path.resolve(__dirname, '..', '..');
+
+function listPublicControllerFiles(): string[] {
+	return fs
+		.readdirSync(CONTROLLERS_DIR)
+		.filter((name) => name.endsWith('.public.controller.ts'))
+		.sort();
+}
+
+function importedControllerModules(indexSource: string): Set<string> {
+	return new Set(
+		[...indexSource.matchAll(/import\s+['"]\.\/([^'"]+)['"]/g)].map((match) => {
+			const specifier = match[1];
+			return specifier.endsWith('.ts') ? specifier : `${specifier}.ts`;
+		}),
+	);
+}
+
+function* walkTsFiles(dir: string): Generator<string> {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			yield* walkTsFiles(fullPath);
+			continue;
+		}
+		if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+			yield fullPath;
+		}
+	}
+}
+
+describe('Public API controller registration', () => {
+	test('every *.public.controller.ts is side-effect-imported from controllers/index.ts', () => {
+		const controllerFiles = listPublicControllerFiles();
+		expect(controllerFiles.length).toBeGreaterThan(0);
+
+		const imported = importedControllerModules(fs.readFileSync(INDEX_PATH, 'utf8'));
+		expect(controllerFiles.filter((file) => !imported.has(file))).toEqual([]);
+	});
+
+	test('every @PublicApiController is declared in controllers/*.public.controller.ts', () => {
+		const unexpected: string[] = [];
+
+		for (const filePath of walkTsFiles(PUBLIC_API_ROOT)) {
+			const source = fs.readFileSync(filePath, 'utf8');
+			if (!/@PublicApiController\s*\(/.test(source)) continue;
+
+			const relative = path.relative(PUBLIC_API_ROOT, filePath);
+			const inControllersDir = path.dirname(filePath) === CONTROLLERS_DIR;
+			const matchesNaming = path.basename(filePath).endsWith('.public.controller.ts');
+			if (!inControllersDir || !matchesNaming) {
+				unexpected.push(relative);
+			}
+		}
+
+		expect(unexpected).toEqual([]);
+	});
+});

--- a/packages/cli/src/public-api/v1/__tests__/public-api-controllers.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/public-api-controllers.test.ts
@@ -13,8 +13,10 @@ function listPublicControllerFiles(): string[] {
 }
 
 function importedControllerModules(indexSource: string): Set<string> {
+	const SIDE_EFFECT_IMPORT_REGEX = /import\s+['"]\.\/([^'"]+)['"]/g;
+
 	return new Set(
-		[...indexSource.matchAll(/import\s+['"]\.\/([^'"]+)['"]/g)].map((match) => {
+		[...indexSource.matchAll(SIDE_EFFECT_IMPORT_REGEX)].map((match) => {
 			const specifier = match[1];
 			return specifier.endsWith('.ts') ? specifier : `${specifier}.ts`;
 		}),
@@ -45,11 +47,12 @@ describe('Public API controller registration', () => {
 	});
 
 	test('every @PublicApiController is declared in controllers/*.public.controller.ts', () => {
+		const PUBLIC_API_CONTROLLER_DECORATOR_REGEX = /@PublicApiController\s*\(/;
 		const unexpected: string[] = [];
 
 		for (const filePath of walkTsFiles(PUBLIC_API_ROOT)) {
 			const source = fs.readFileSync(filePath, 'utf8');
-			if (!/@PublicApiController\s*\(/.test(source)) continue;
+			if (!PUBLIC_API_CONTROLLER_DECORATOR_REGEX.test(source)) continue;
 
 			const relative = path.relative(PUBLIC_API_ROOT, filePath);
 			const inControllersDir = path.dirname(filePath) === CONTROLLERS_DIR;

--- a/packages/cli/src/public-api/v1/__tests__/public-api-scope-lookup.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/public-api-scope-lookup.test.ts
@@ -1,0 +1,20 @@
+import { publicApiRouteKey } from '../shared/public-api-scope-lookup';
+
+describe('publicApiRouteKey', () => {
+	test.each([
+		['GET', '/workflows/{id}/history', 'get /workflows/{}/history'],
+		['GET', '/workflows/:workflowId/history', 'get /workflows/{}/history'],
+		['Post', '/tags/', 'post /tags'],
+		['get', '/', 'get /'],
+		['GET', '', 'get /'],
+		['PATCH', '/workflows//{id}//versions', 'patch /workflows/{}/versions'],
+	])('normalizes %s %s', (method, pathStr, expected) => {
+		expect(publicApiRouteKey(method, pathStr)).toBe(expected);
+	});
+
+	test('OpenAPI and Express param styles produce the same key', () => {
+		expect(publicApiRouteKey('GET', '/workflows/{id}/history')).toBe(
+			publicApiRouteKey('GET', '/workflows/:workflowId/history'),
+		);
+	});
+});

--- a/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
@@ -4,7 +4,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'yaml';
 
-import type { ScopeTaggedMiddleware } from '../shared/middlewares/global.middleware';
+import {
+	extractScopeFromEovHandlerChain,
+	loadPublicControllerScopeMap,
+	publicApiRouteKey,
+	resolvePublicApiImplementedScope,
+} from '../shared/public-api-scope-lookup';
+
+import '../controllers';
 
 vi.unmock('node:fs');
 
@@ -19,11 +26,12 @@ type Operation = {
 	pathStr: string;
 	method: Method;
 	operationId: string;
-	handlerPath: string;
+	handlerPath: string | null;
 	requiredScope: string | null;
 };
 
 type RawOperation = {
+	operationId?: string;
 	'x-eov-operation-id'?: string;
 	'x-eov-operation-handler'?: string;
 	'x-required-scope'?: string;
@@ -36,12 +44,18 @@ async function loadOperations(): Promise<Operation[]> {
 	for (const [pathStr, methods] of Object.entries(paths)) {
 		for (const method of HTTP_METHODS) {
 			const op = methods[method];
-			if (!op?.['x-eov-operation-id'] || !op?.['x-eov-operation-handler']) continue;
+			if (!op) continue;
+			const operationId = op['x-eov-operation-id'] ?? op.operationId;
+			if (!operationId) {
+				throw new Error(
+					`Missing operationId / x-eov-operation-id for ${method.toUpperCase()} ${pathStr}`,
+				);
+			}
 			ops.push({
 				pathStr,
 				method,
-				operationId: op['x-eov-operation-id'],
-				handlerPath: op['x-eov-operation-handler'],
+				operationId,
+				handlerPath: op['x-eov-operation-handler'] ?? null,
 				requiredScope: op['x-required-scope'] ?? null,
 			});
 		}
@@ -49,7 +63,7 @@ async function loadOperations(): Promise<Operation[]> {
 	return ops;
 }
 
-async function loadHandlerScope(
+async function loadEovHandlerScope(
 	handlerPath: string,
 	operationId: string,
 ): Promise<ApiKeyScope | undefined> {
@@ -62,19 +76,27 @@ async function loadHandlerScope(
 	const mod = imported.default ?? imported;
 	const middlewares = mod[operationId];
 	if (!Array.isArray(middlewares)) return undefined;
-	for (const mw of middlewares) {
-		if (typeof mw !== 'function') continue;
-		const scope = (mw as Partial<ScopeTaggedMiddleware>).__apiKeyScope;
-		if (scope) return scope;
-	}
-	return undefined;
+	return extractScopeFromEovHandlerChain(middlewares);
+}
+
+/** Compare scopes as an unordered set so `a,b`, `b,a`, and `a, b` all match. */
+function normalizeScopeSet(scope: string | undefined): string {
+	if (!scope) return '';
+	return scope
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean)
+		.sort()
+		.join(',');
 }
 
 describe('Public API scope parity', () => {
 	let ops: Operation[];
+	let controllerScopes: Map<string, string | undefined>;
 
 	beforeAll(async () => {
 		ops = await loadOperations();
+		controllerScopes = loadPublicControllerScopeMap();
 	});
 
 	test('openapi.yml tags are sorted alphabetically by name', () => {
@@ -91,16 +113,40 @@ describe('Public API scope parity', () => {
 		expect(missing.map((m) => `${m.method.toUpperCase()} ${m.pathStr}`)).toEqual([]);
 	});
 
-	test('every x-required-scope matches the handler middleware __apiKeyScope', async () => {
+	test('every x-required-scope matches eov handler or @PublicApiController @ApiKeyScope', async () => {
 		const mismatches: string[] = [];
 		for (const op of ops) {
 			if (op.requiredScope === null) continue;
-			const handlerScope = await loadHandlerScope(op.handlerPath, op.operationId);
+
+			// A route must be defined by the eov handler XOR a @PublicApiController,
+			// never both — otherwise the enforced scope is ambiguous.
+			if (
+				op.handlerPath !== null &&
+				controllerScopes.has(publicApiRouteKey(op.method, op.pathStr))
+			) {
+				throw new Error(
+					`${op.method.toUpperCase()} ${op.pathStr} is defined by both an eov handler and a @PublicApiController. ` +
+						'Remove the eov handler (its `x-eov-operation-handler` in the OpenAPI spec and the handler middleware) and keep the @PublicApiController.',
+				);
+			}
+
+			const eovHandlerScope =
+				op.handlerPath !== null
+					? await loadEovHandlerScope(op.handlerPath, op.operationId)
+					: undefined;
+
+			const implemented = resolvePublicApiImplementedScope(
+				controllerScopes,
+				op.method,
+				op.pathStr,
+				eovHandlerScope,
+			);
+
 			const expected = op.requiredScope === 'none' ? undefined : op.requiredScope;
-			if (handlerScope !== expected) {
+			if (normalizeScopeSet(implemented) !== normalizeScopeSet(expected)) {
 				mismatches.push(
-					`${op.method.toUpperCase()} ${op.pathStr}: YAML says "${op.requiredScope}", handler tag is "${
-						handlerScope ?? 'none'
+					`${op.method.toUpperCase()} ${op.pathStr}: YAML says "${op.requiredScope}", implemented scope is "${
+						implemented ?? 'none'
 					}"`,
 				);
 			}

--- a/packages/cli/src/public-api/v1/controllers/index.ts
+++ b/packages/cli/src/public-api/v1/controllers/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Side-effect imports for all `@PublicApiController` classes so their
+ * decorator metadata is registered before PublicApiControllerRegistry /
+ * scope-parity / discover run.
+ */
+import './tags.public.controller';
+import './workflows.public.controller';

--- a/packages/cli/src/public-api/v1/controllers/workflows.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/workflows.public.controller.ts
@@ -1,0 +1,76 @@
+import { ListWorkflowHistoryQueryDto, WorkflowVersionHistoryListPublicDto } from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
+import {
+	ApiKeyScope,
+	ApiResponse,
+	Get,
+	Param,
+	ProjectScope,
+	PublicApiController,
+	Query,
+} from '@n8n/decorators';
+import type { Response } from 'express';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { SharedWorkflowNotFoundError } from '@/errors/shared-workflow-not-found.error';
+import { decodeCursor, encodeNextCursor } from '@/public-api/v1/shared/services/pagination.service';
+import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
+
+@PublicApiController('/workflows')
+export class WorkflowsPublicController {
+	constructor(private readonly workflowHistoryService: WorkflowHistoryService) {}
+
+	@Get('/:workflowId/history')
+	@ApiKeyScope('workflow:read')
+	@ProjectScope('workflow:read')
+	@ApiResponse(WorkflowVersionHistoryListPublicDto)
+	async getWorkflowHistory(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Param('workflowId') workflowId: string,
+		@Query query: ListWorkflowHistoryQueryDto,
+	): Promise<WorkflowVersionHistoryListPublicDto> {
+		let offset = query.offset;
+		let { limit } = query;
+
+		if (query.cursor) {
+			try {
+				const decoded = decodeCursor(query.cursor);
+				if (!('offset' in decoded)) {
+					throw new BadRequestError('An invalid cursor was provided');
+				}
+				offset = decoded.offset;
+				limit = decoded.limit;
+			} catch (error) {
+				if (error instanceof BadRequestError) throw error;
+				throw new BadRequestError('An invalid cursor was provided');
+			}
+		}
+
+		try {
+			const versions = await this.workflowHistoryService.getList(
+				req.user,
+				workflowId,
+				limit + 1,
+				offset,
+			);
+			const hasMore = versions.length > limit;
+			const data = hasMore ? versions.slice(0, limit) : versions;
+
+			return {
+				data,
+				nextCursor: encodeNextCursor({
+					offset,
+					limit,
+					numberOfTotalRecords: hasMore ? offset + limit + 1 : offset + data.length,
+				}),
+			};
+		} catch (error) {
+			if (error instanceof SharedWorkflowNotFoundError) {
+				throw new NotFoundError('Not Found');
+			}
+			throw error;
+		}
+	}
+}

--- a/packages/cli/src/public-api/v1/controllers/workflows.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/workflows.public.controller.ts
@@ -31,8 +31,7 @@ export class WorkflowsPublicController {
 		@Param('workflowId') workflowId: string,
 		@Query query: ListWorkflowHistoryQueryDto,
 	): Promise<WorkflowVersionHistoryListPublicDto> {
-		let offset = query.offset;
-		let { limit } = query;
+		let { limit, offset } = query;
 
 		if (query.cursor) {
 			try {

--- a/packages/cli/src/public-api/v1/handlers/discover/discover.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/discover/discover.service.ts
@@ -3,7 +3,14 @@ import type { ApiKeyScope } from '@n8n/permissions';
 import { isRecord } from '@n8n/utils/is-record';
 import path from 'path';
 
-import type { ScopeTaggedMiddleware } from '../../shared/middlewares/global.middleware';
+import {
+	extractScopeFromEovHandlerChain,
+	loadPublicControllerScopeMap,
+	publicApiRouteKey,
+	resolvePublicApiImplementedScope,
+} from '../../shared/public-api-scope-lookup';
+
+import '../../controllers';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch'] as const;
 
@@ -49,23 +56,6 @@ export interface DiscoverOptions {
 
 let cachedEndpointsPromise: Promise<EndpointInfo[]> | undefined;
 
-function isScopeTagged(value: unknown): value is ScopeTaggedMiddleware {
-	return typeof value === 'function' && '__apiKeyScope' in value;
-}
-
-/**
- * Extract the required ApiKeyScope from a handler's middleware chain
- * by looking for a middleware tagged with __apiKeyScope.
- */
-function extractScopeFromHandler(handlerChain: unknown[]): ApiKeyScope | null {
-	for (const middleware of handlerChain) {
-		if (isScopeTagged(middleware)) {
-			return middleware.__apiKeyScope;
-		}
-	}
-	return null;
-}
-
 /**
  * Extract the request body schema from an operation.
  * The spec is already fully dereferenced by RefParser.dereference().
@@ -93,13 +83,13 @@ async function _parseEndpointsFromSpec(): Promise<EndpointInfo[]> {
 	const specPath = path.join(__dirname, '..', '..', 'openapi.yml');
 	const publicApiRoot = path.join(__dirname, '..', '..', '..');
 
-	// Load and fully dereference the spec in one operation
 	const spec = await RefParser.dereference(specPath);
 
 	if (!isRecord(spec) || !isRecord(spec.paths)) return [];
 
 	const endpoints: EndpointInfo[] = [];
 	const handlerCache = new Map<string, Record<string, unknown>>();
+	const controllerScopes = loadPublicControllerScopeMap();
 
 	for (const [pathKey, pathValue] of Object.entries(spec.paths)) {
 		if (!isRecord(pathValue)) continue;
@@ -108,47 +98,64 @@ async function _parseEndpointsFromSpec(): Promise<EndpointInfo[]> {
 			const operation = pathValue[method];
 			if (!isRecord(operation)) continue;
 
-			const operationId = operation['x-eov-operation-id'];
+			const eovOperationId = operation['x-eov-operation-id'];
 			const handlerPath = operation['x-eov-operation-handler'];
-			if (typeof operationId !== 'string' || typeof handlerPath !== 'string') continue;
+			const openApiOperationId = operation.operationId;
+			const hasEovHandler = typeof eovOperationId === 'string' && typeof handlerPath === 'string';
+			const routeKey = publicApiRouteKey(method, pathKey);
+			const hasControllerHandler = controllerScopes.has(routeKey);
+
+			if (!hasEovHandler && !hasControllerHandler) {
+				continue;
+			}
+
+			const operationId =
+				(typeof eovOperationId === 'string' ? eovOperationId : undefined) ??
+				(typeof openApiOperationId === 'string' ? openApiOperationId : undefined);
+			if (!operationId) {
+				continue;
+			}
 
 			const tags = Array.isArray(operation.tags) ? operation.tags : [];
 			const tag = typeof tags[0] === 'string' ? tags[0] : 'Other';
 
-			let handlerModule = handlerCache.get(handlerPath);
-			if (!handlerModule) {
-				try {
-					// The `.js` extension is required: under NodeNext, `await import()` is emitted
-					// as a native dynamic import, which (unlike `require`) does no extension guessing.
-					// The spec's handler paths are extensionless, so append it here.
-					const fullHandlerPath = path.join(publicApiRoot, `${handlerPath}.js`);
-					const imported: unknown = await import(fullHandlerPath);
-					if (!isRecord(imported)) continue;
-					// Handlers use `export = xHandlers`, which surfaces as `.default`
-					// under both tsc's CJS downleveling and Vitest's Vite interop.
-					const loaded = isRecord(imported.default) ? imported.default : imported;
-					if (!isRecord(loaded)) continue;
-					handlerModule = loaded;
-					handlerCache.set(handlerPath, handlerModule);
-				} catch {
-					continue;
+			let eovHandlerScope: ApiKeyScope | undefined;
+			if (hasEovHandler) {
+				let handlerModule = handlerCache.get(handlerPath);
+				if (!handlerModule) {
+					try {
+						const fullHandlerPath = path.join(publicApiRoot, `${handlerPath}.js`);
+						const imported: unknown = await import(fullHandlerPath);
+						if (!isRecord(imported)) continue;
+						const loaded = isRecord(imported.default) ? imported.default : imported;
+						if (!isRecord(loaded)) continue;
+						handlerModule = loaded;
+						handlerCache.set(handlerPath, handlerModule);
+					} catch {
+						continue;
+					}
 				}
+
+				const middlewareChain = handlerModule[eovOperationId];
+				eovHandlerScope = Array.isArray(middlewareChain)
+					? extractScopeFromEovHandlerChain(middlewareChain)
+					: undefined;
 			}
 
-			const middlewareChain = handlerModule[operationId];
-			const scope = Array.isArray(middlewareChain)
-				? extractScopeFromHandler(middlewareChain)
-				: null;
-
-			const requestSchema = extractRequestSchema(operation);
+			const implemented = resolvePublicApiImplementedScope(
+				controllerScopes,
+				method,
+				pathKey,
+				eovHandlerScope,
+			);
 
 			endpoints.push({
 				method: method.toUpperCase(),
 				path: `/api/v1${pathKey}`,
 				operationId,
 				tag,
-				scope,
-				requestSchema,
+				scope: (implemented as ApiKeyScope | undefined) ?? null,
+				requestSchema: extractRequestSchema(operation),
 			});
 		}
 	}
@@ -187,7 +194,6 @@ export async function buildDiscoverResponse(
 
 		resources[resourceKey].endpoints.push(entry);
 
-		// Extract operation name from scope (e.g. 'workflow:read' → 'read')
 		const operation = ep.scope?.split(':')[1];
 		if (operation && !resources[resourceKey].operations.includes(operation)) {
 			resources[resourceKey].operations.push(operation);

--- a/packages/cli/src/public-api/v1/handlers/tags/spec/paths/tags.yml
+++ b/packages/cli/src/public-api/v1/handlers/tags/spec/paths/tags.yml
@@ -27,9 +27,8 @@ post:
     '401':
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
 get:
-  x-eov-operation-id: getTags
+  operationId: getTags
   x-required-scope: tag:list
-  x-eov-operation-handler: v1/handlers/tags/tags.handler
   tags:
     - Tags
   summary: Retrieve all tags

--- a/packages/cli/src/public-api/v1/handlers/tags/tags.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/tags/tags.handler.ts
@@ -12,7 +12,6 @@ type TagHandlers = {
 	createTag: PublicAPIEndpoint<TagRequest.Create>;
 	updateTag: PublicAPIEndpoint<TagRequest.Update>;
 	deleteTag: PublicAPIEndpoint<TagRequest.Delete>;
-	getTags: PublicAPIEndpoint<TagRequest.GetAll>;
 	getTag: PublicAPIEndpoint<TagRequest.Get>;
 };
 
@@ -68,22 +67,6 @@ const tagHandlers: TagHandlers = {
 
 			await Container.get(TagService).delete(id);
 			return res.json(tag);
-		},
-	],
-	/**
-	 * Not the reference implementation — that is TagsPublicController
-	 * (PublicApiControllerRegistry mounts before eov and owns runtime GET /tags).
-	 *
-	 * Kept only so scope-parity.test.ts can match openapi.yml `x-required-scope`
-	 * against a handler middleware tagged with `__apiKeyScope`. Once that test
-	 * also reads `@ApiKeyScope` from public controllers, this stub can go.
-	 */
-	getTags: [
-		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'tag:list' }),
-		async (_req, res) => {
-			return res.status(500).json({
-				message: 'Unexpected: GET /tags should be handled by TagsPublicController',
-			});
 		},
 	],
 	getTag: [

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.history.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.history.yml
@@ -1,0 +1,37 @@
+get:
+  x-eov-operation-id: getWorkflowHistory
+  x-required-scope: workflow:read
+  x-eov-operation-handler: v1/handlers/workflows/workflows.handler
+  tags:
+    - Workflow
+  summary: Retrieve workflow version history
+  description: Returns a paginated list of workflow versions (version IDs and metadata) for a workflow.
+  parameters:
+    - $ref: '../schemas/parameters/workflowId.yml'
+    - name: take
+      in: query
+      required: false
+      description: Number of items to return. Defaults to 10. Maximum 250.
+      schema:
+        type: string
+    - name: skip
+      in: query
+      required: false
+      description: Number of items to skip for pagination. Defaults to 0.
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/workflowVersionListItem.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.history.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.history.yml
@@ -1,34 +1,22 @@
 get:
-  x-eov-operation-id: getWorkflowHistory
+  operationId: getWorkflowHistory
   x-required-scope: workflow:read
-  x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow
   summary: Retrieve workflow version history
   description: Returns a paginated list of workflow versions (version IDs and metadata) for a workflow.
   parameters:
     - $ref: '../schemas/parameters/workflowId.yml'
-    - name: take
-      in: query
-      required: false
-      description: Number of items to return. Defaults to 10. Maximum 250.
-      schema:
-        type: string
-    - name: skip
-      in: query
-      required: false
-      description: Number of items to skip for pagination. Defaults to 0.
-      schema:
-        type: string
+    - $ref: '../../../../shared/spec/parameters/limit.yml'
+    - $ref: '../../../../shared/spec/parameters/offset.yml'
+    - $ref: '../../../../shared/spec/parameters/cursor.yml'
   responses:
     '200':
       description: Operation successful.
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: '../schemas/workflowVersionListItem.yml'
+            $ref: '../schemas/workflowVersionHistoryList.yml'
     '400':
       $ref: '../../../../shared/spec/responses/badRequest.yml'
     '401':

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowVersionHistoryList.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowVersionHistoryList.yml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - data
+  - nextCursor
+properties:
+  data:
+    type: array
+    items:
+      $ref: './workflowVersionListItem.yml'
+  nextCursor:
+    type: string
+    description: Paginate through workflow versions by setting the cursor parameter to a nextCursor attribute returned by a previous request. Default value fetches the first "page" of the collection.
+    nullable: true
+    example: MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDA

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowVersionListItem.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowVersionListItem.yml
@@ -1,0 +1,41 @@
+type: object
+additionalProperties: false
+required:
+  - versionId
+  - workflowId
+  - authors
+properties:
+  versionId:
+    type: string
+    readOnly: true
+    description: The version ID of this workflow snapshot
+    example: abc123-def456
+  workflowId:
+    type: string
+    readOnly: true
+    description: The workflow ID this version belongs to
+    example: 2tUt1wbLX592XDdX
+  authors:
+    type: string
+    readOnly: true
+    description: Authors who created this version
+    example: John Doe
+  name:
+    type: string
+    nullable: true
+    description: Workflow name at this version
+    example: Workflow 1
+  description:
+    type: string
+    nullable: true
+    description: Workflow description at this version
+  createdAt:
+    type: string
+    format: date-time
+    readOnly: true
+    description: When this version was created
+  updatedAt:
+    type: string
+    format: date-time
+    readOnly: true
+    description: When this version was last updated

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -9,17 +9,6 @@ import { PROJECT_ROOT } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { FolderNotFoundError } from '@/errors/folder-not-found.error';
-import { createWorkflow, parseTagNames, getWorkflowTags, updateTags } from './workflows.service';
-import type { WorkflowRequest } from '../../../types';
-import {
-	publicApiScope,
-	projectScope,
-	validCursor,
-} from '../../shared/middlewares/global.middleware';
-
-import { encodeNextCursor } from '../../shared/services/pagination.service';
-import type { PublicAPIEndpoint } from '../../shared/handler.types';
-
 import { ResponseError } from '@/errors/response-errors/abstract/response.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -29,6 +18,16 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
+
+import { createWorkflow, parseTagNames, getWorkflowTags, updateTags } from './workflows.service';
+import type { WorkflowRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
+import {
+	publicApiScope,
+	projectScope,
+	validCursor,
+} from '../../shared/middlewares/global.middleware';
+import { encodeNextCursor } from '../../shared/services/pagination.service';
 
 const handleError = (error: unknown) => {
 	if (error instanceof FolderNotFoundError) {

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -1,3 +1,4 @@
+import { PaginationDto } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
 import { WorkflowEntity, TagRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -8,24 +9,26 @@ import { PROJECT_ROOT } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { FolderNotFoundError } from '@/errors/folder-not-found.error';
-import { ResponseError } from '@/errors/response-errors/abstract/response.error';
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { EventService } from '@/events/event.service';
-import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
-import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
-import { WorkflowService } from '@/workflows/workflow.service';
-import { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
-
 import { createWorkflow, parseTagNames, getWorkflowTags, updateTags } from './workflows.service';
 import type { WorkflowRequest } from '../../../types';
-import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	publicApiScope,
 	projectScope,
 	validCursor,
 } from '../../shared/middlewares/global.middleware';
+
 import { encodeNextCursor } from '../../shared/services/pagination.service';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
+
+import { ResponseError } from '@/errors/response-errors/abstract/response.error';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { SharedWorkflowNotFoundError } from '@/errors/shared-workflow-not-found.error';
+import { EventService } from '@/events/event.service';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
+import { WorkflowService } from '@/workflows/workflow.service';
+import { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
 
 const handleError = (error: unknown) => {
 	if (error instanceof FolderNotFoundError) {
@@ -46,6 +49,7 @@ type WorkflowHandlers = {
 	deleteWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
 	getWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
 	getWorkflowVersion: PublicAPIEndpoint<WorkflowRequest.GetVersion>;
+	getWorkflowHistory: PublicAPIEndpoint<WorkflowRequest.GetHistory>;
 	getWorkflows: PublicAPIEndpoint<WorkflowRequest.GetAll>;
 	updateWorkflow: PublicAPIEndpoint<WorkflowRequest.Update>;
 	activateWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate>;
@@ -157,6 +161,37 @@ const workflowHandlers: WorkflowHandlers = {
 				return res.json(versionWithoutInternalFields);
 			} catch {
 				throw new NotFoundError('Version not found');
+			}
+		},
+	],
+	getWorkflowHistory: [
+		publicApiScope('workflow:read'),
+		projectScope('workflow:read', 'workflow'),
+		async (req, res) => {
+			const query = PaginationDto.safeParse(req.query);
+			if (query.error) {
+				throw new BadRequestError(query.error.errors[0].message);
+			}
+
+			try {
+				const versions = await Container.get(WorkflowHistoryService).getList(
+					req.user,
+					req.params.id,
+					query.data.take,
+					query.data.skip,
+				);
+
+				return res.json(
+					versions.map((version) => {
+						const { autosaved, workflowPublishHistory, ...publicVersion } = version;
+						return publicVersion;
+					}),
+				);
+			} catch (error) {
+				if (error instanceof SharedWorkflowNotFoundError) {
+					throw new NotFoundError('Not Found');
+				}
+				throw error;
 			}
 		},
 	],

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -1,4 +1,3 @@
-import { PaginationDto } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
 import { WorkflowEntity, TagRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -12,7 +11,6 @@ import { FolderNotFoundError } from '@/errors/folder-not-found.error';
 import { ResponseError } from '@/errors/response-errors/abstract/response.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { SharedWorkflowNotFoundError } from '@/errors/shared-workflow-not-found.error';
 import { EventService } from '@/events/event.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -48,7 +46,6 @@ type WorkflowHandlers = {
 	deleteWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
 	getWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
 	getWorkflowVersion: PublicAPIEndpoint<WorkflowRequest.GetVersion>;
-	getWorkflowHistory: PublicAPIEndpoint<WorkflowRequest.GetHistory>;
 	getWorkflows: PublicAPIEndpoint<WorkflowRequest.GetAll>;
 	updateWorkflow: PublicAPIEndpoint<WorkflowRequest.Update>;
 	activateWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate>;
@@ -160,37 +157,6 @@ const workflowHandlers: WorkflowHandlers = {
 				return res.json(versionWithoutInternalFields);
 			} catch {
 				throw new NotFoundError('Version not found');
-			}
-		},
-	],
-	getWorkflowHistory: [
-		publicApiScope('workflow:read'),
-		projectScope('workflow:read', 'workflow'),
-		async (req, res) => {
-			const query = PaginationDto.safeParse(req.query);
-			if (query.error) {
-				throw new BadRequestError(query.error.errors[0].message);
-			}
-
-			try {
-				const versions = await Container.get(WorkflowHistoryService).getList(
-					req.user,
-					req.params.id,
-					query.data.take,
-					query.data.skip,
-				);
-
-				return res.json(
-					versions.map((version) => {
-						const { autosaved, workflowPublishHistory, ...publicVersion } = version;
-						return publicVersion;
-					}),
-				);
-			} catch (error) {
-				if (error instanceof SharedWorkflowNotFoundError) {
-					throw new NotFoundError('Not Found');
-				}
-				throw error;
 			}
 		},
 	],

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -99,6 +99,8 @@ paths:
     $ref: './handlers/workflows/spec/paths/workflows.yml'
   /workflows/{id}:
     $ref: './handlers/workflows/spec/paths/workflows.id.yml'
+  /workflows/{id}/history:
+    $ref: './handlers/workflows/spec/paths/workflows.id.history.yml'
   /workflows/{id}/{versionId}:
     $ref: './handlers/workflows/spec/paths/workflows.id.versionId.yml'
   /workflows/{id}/activate:

--- a/packages/cli/src/public-api/v1/shared/public-api-scope-lookup.ts
+++ b/packages/cli/src/public-api/v1/shared/public-api-scope-lookup.ts
@@ -1,0 +1,83 @@
+import type { ApiKeyScopeRequirement } from '@n8n/decorators';
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { ApiKeyScope } from '@n8n/permissions';
+
+import type { ScopeTaggedMiddleware } from './middlewares/global.middleware';
+
+/** Collapse OpenAPI `{id}` / Express `:id` params so controller and YAML paths can match. */
+function normalizePath(pathStr: string): string {
+	return (
+		pathStr
+			.replace(/\{[^}]+\}/g, '{}')
+			.replace(/:[^/]+/g, '{}')
+			.replace(/\/+/g, '/')
+			.replace(/\/$/, '') || '/'
+	);
+}
+
+function joinPaths(basePath: string, routePath: string): string {
+	const base = basePath.replace(/\/$/, '') || '';
+	if (routePath === '/' || routePath === '') {
+		return base || '/';
+	}
+	return `${base}${routePath.startsWith('/') ? routePath : `/${routePath}`}`;
+}
+
+function serializeScope(requirement: ApiKeyScopeRequirement | undefined): string | undefined {
+	if (requirement === undefined) return undefined;
+	if (typeof requirement === 'string') return requirement;
+	return ('anyOf' in requirement ? requirement.anyOf : requirement.allOf).join(',');
+}
+
+export function publicApiRouteKey(method: string, pathStr: string): string {
+	return `${method.toLowerCase()} ${normalizePath(pathStr)}`;
+}
+
+/**
+ * Map of `method path` → serialized `@ApiKeyScope` for every `@PublicApiController` route.
+ * Controllers must already be side-effect-imported so their metadata is registered.
+ *
+ * Value `undefined` means the route exists and declares no API-key scope (`none`).
+ */
+export function loadPublicControllerScopeMap(): Map<string, string | undefined> {
+	const map = new Map<string, string | undefined>();
+	const metadata = Container.get(ControllerRegistryMetadata);
+
+	for (const controllerClass of metadata.controllerClasses) {
+		const controller = metadata.getControllerMetadata(controllerClass);
+		if (!controller.isPublicApi) continue;
+
+		for (const route of controller.routes.values()) {
+			if (!route.method || route.path === undefined) continue;
+			map.set(
+				publicApiRouteKey(route.method, joinPaths(controller.basePath, route.path)),
+				serializeScope(route.apiKeyScope),
+			);
+		}
+	}
+
+	return map;
+}
+
+export function extractScopeFromEovHandlerChain(handlerChain: unknown[]): ApiKeyScope | undefined {
+	for (const middleware of handlerChain) {
+		if (typeof middleware !== 'function' || !('__apiKeyScope' in middleware)) continue;
+		return (middleware as ScopeTaggedMiddleware).__apiKeyScope;
+	}
+	return undefined;
+}
+
+/**
+ * Prefer `@PublicApiController` `@ApiKeyScope`, then fall back to eov `__apiKeyScope`.
+ * Uses `.has()` so a controller route with scope `none` (`undefined`) is not overridden by eov.
+ */
+export function resolvePublicApiImplementedScope(
+	controllerScopes: Map<string, string | undefined>,
+	method: string,
+	pathStr: string,
+	eovHandlerScope?: ApiKeyScope,
+): string | undefined {
+	const key = publicApiRouteKey(method, pathStr);
+	return controllerScopes.has(key) ? controllerScopes.get(key) : eovHandlerScope;
+}

--- a/packages/cli/src/public-api/v1/shared/spec/parameters/_index.yml
+++ b/packages/cli/src/public-api/v1/shared/spec/parameters/_index.yml
@@ -2,6 +2,8 @@ Cursor:
   $ref: './cursor.yml'
 Limit:
   $ref: './limit.yml'
+Offset:
+  $ref: './offset.yml'
 ExecutionId:
   $ref: '../../../handlers/executions/spec/schemas/parameters/executionId.yml'
 WorkflowId:

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -892,6 +892,111 @@ describe('GET /workflows/:id/:versionId', () => {
 	});
 });
 
+describe('GET /workflows/:id/history', () => {
+	test('should fail due to missing API Key', testWithAPIKey('get', '/workflows/123/history', null));
+
+	test(
+		'should fail due to invalid API Key',
+		testWithAPIKey('get', '/workflows/123/history', 'abcXYZ'),
+	);
+
+	test('should fail due to non-existing workflow', async () => {
+		const response = await authOwnerAgent.get('/workflows/non-existing/history');
+		expect(response.statusCode).toBe(404);
+	});
+
+	test('should return empty list when workflow has no versions', async () => {
+		const workflow = await createWorkflow({}, owner);
+
+		const response = await authOwnerAgent.get(`/workflows/${workflow.id}/history`);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toEqual([]);
+	});
+
+	test('should retrieve workflow version history', async () => {
+		const workflow = await createWorkflow({}, owner);
+		const versions = await Promise.all(
+			new Array(5).fill(undefined).map(
+				async (_, i) =>
+					await createWorkflowHistoryItem(workflow.id, {
+						createdAt: new Date(Date.now() + i),
+						name: `Version ${i}`,
+					}),
+			),
+		);
+
+		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0];
+
+		const response = await authOwnerAgent.get(`/workflows/${workflow.id}/history`);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toHaveLength(5);
+		expect(response.body[0]).toEqual({
+			versionId: last.versionId,
+			workflowId: last.workflowId,
+			authors: last.authors,
+			name: last.name,
+			description: last.description,
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			createdAt: expect.any(String),
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			updatedAt: expect.any(String),
+		});
+		expect(response.body[0]).not.toHaveProperty('autosaved');
+		expect(response.body[0]).not.toHaveProperty('workflowPublishHistory');
+		expect(response.body[0]).not.toHaveProperty('nodes');
+		expect(response.body[0]).not.toHaveProperty('connections');
+	});
+
+	test('should paginate with take and skip', async () => {
+		const workflow = await createWorkflow({}, owner);
+		await Promise.all(
+			new Array(5).fill(undefined).map(
+				async (_, i) =>
+					await createWorkflowHistoryItem(workflow.id, {
+						createdAt: new Date(Date.now() + i),
+					}),
+			),
+		);
+
+		const firstPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
+			take: '2',
+			skip: '0',
+		});
+		expect(firstPage.statusCode).toBe(200);
+		expect(firstPage.body).toHaveLength(2);
+
+		const secondPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
+			take: '2',
+			skip: '2',
+		});
+		expect(secondPage.statusCode).toBe(200);
+		expect(secondPage.body).toHaveLength(2);
+		expect(secondPage.body[0].versionId).not.toBe(firstPage.body[0].versionId);
+	});
+
+	test('should retrieve history for non-owned workflow when owner', async () => {
+		const workflow = await createWorkflow({}, member);
+		await createWorkflowHistoryItem(workflow.id, { name: 'Member Version' });
+
+		const response = await authOwnerAgent.get(`/workflows/${workflow.id}/history`);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toHaveLength(1);
+		expect(response.body[0].name).toBe('Member Version');
+	});
+
+	test('should fail to retrieve history without read permission', async () => {
+		const workflow = await createWorkflow({}, owner);
+		await createWorkflowHistoryItem(workflow.id);
+
+		const response = await authMemberAgent.get(`/workflows/${workflow.id}/history`);
+
+		expect(response.statusCode).toBe(403);
+	});
+});
+
 describe('DELETE /workflows/:id', () => {
 	test('should fail due to missing API Key', testWithAPIKey('delete', '/workflows/2', null));
 

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -911,7 +911,7 @@ describe('GET /workflows/:id/history', () => {
 		const response = await authOwnerAgent.get(`/workflows/${workflow.id}/history`);
 
 		expect(response.statusCode).toBe(200);
-		expect(response.body).toEqual([]);
+		expect(response.body).toEqual({ data: [], nextCursor: null });
 	});
 
 	test('should retrieve workflow version history', async () => {
@@ -931,25 +931,20 @@ describe('GET /workflows/:id/history', () => {
 		const response = await authOwnerAgent.get(`/workflows/${workflow.id}/history`);
 
 		expect(response.statusCode).toBe(200);
-		expect(response.body).toHaveLength(5);
-		expect(response.body[0]).toEqual({
+		expect(response.body.data).toHaveLength(5);
+		expect(response.body.nextCursor).toBeNull();
+		expect(response.body.data[0]).toEqual({
 			versionId: last.versionId,
 			workflowId: last.workflowId,
 			authors: last.authors,
 			name: last.name,
 			description: last.description,
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			createdAt: expect.any(String),
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			updatedAt: expect.any(String),
 		});
-		expect(response.body[0]).not.toHaveProperty('autosaved');
-		expect(response.body[0]).not.toHaveProperty('workflowPublishHistory');
-		expect(response.body[0]).not.toHaveProperty('nodes');
-		expect(response.body[0]).not.toHaveProperty('connections');
 	});
 
-	test('should paginate with take and skip', async () => {
+	test('should paginate with limit and cursor', async () => {
 		const workflow = await createWorkflow({}, owner);
 		await Promise.all(
 			new Array(5).fill(undefined).map(
@@ -961,19 +956,54 @@ describe('GET /workflows/:id/history', () => {
 		);
 
 		const firstPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
-			take: '2',
-			skip: '0',
+			limit: '2',
 		});
 		expect(firstPage.statusCode).toBe(200);
-		expect(firstPage.body).toHaveLength(2);
+		expect(firstPage.body.data).toHaveLength(2);
+		expect(firstPage.body.nextCursor).toBeTruthy();
 
 		const secondPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
-			take: '2',
-			skip: '2',
+			limit: '2',
+			cursor: firstPage.body.nextCursor,
 		});
 		expect(secondPage.statusCode).toBe(200);
-		expect(secondPage.body).toHaveLength(2);
-		expect(secondPage.body[0].versionId).not.toBe(firstPage.body[0].versionId);
+		expect(secondPage.body.data).toHaveLength(2);
+		expect(secondPage.body.data[0].versionId).not.toBe(firstPage.body.data[0].versionId);
+		expect(secondPage.body.nextCursor).toBeTruthy();
+
+		const thirdPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
+			cursor: secondPage.body.nextCursor,
+		});
+		expect(thirdPage.statusCode).toBe(200);
+		expect(thirdPage.body.data).toHaveLength(1);
+		expect(thirdPage.body.nextCursor).toBeNull();
+	});
+
+	test('should paginate with limit and offset', async () => {
+		const workflow = await createWorkflow({}, owner);
+		await Promise.all(
+			new Array(5).fill(undefined).map(
+				async (_, i) =>
+					await createWorkflowHistoryItem(workflow.id, {
+						createdAt: new Date(Date.now() + i),
+					}),
+			),
+		);
+
+		const firstPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
+			limit: '2',
+			offset: '0',
+		});
+		expect(firstPage.statusCode).toBe(200);
+		expect(firstPage.body.data).toHaveLength(2);
+
+		const secondPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
+			limit: '2',
+			offset: '2',
+		});
+		expect(secondPage.statusCode).toBe(200);
+		expect(secondPage.body.data).toHaveLength(2);
+		expect(secondPage.body.data[0].versionId).not.toBe(firstPage.body.data[0].versionId);
 	});
 
 	test('should retrieve history for non-owned workflow when owner', async () => {
@@ -983,8 +1013,8 @@ describe('GET /workflows/:id/history', () => {
 		const response = await authOwnerAgent.get(`/workflows/${workflow.id}/history`);
 
 		expect(response.statusCode).toBe(200);
-		expect(response.body).toHaveLength(1);
-		expect(response.body[0].name).toBe('Member Version');
+		expect(response.body.data).toHaveLength(1);
+		expect(response.body.data[0].name).toBe('Member Version');
 	});
 
 	test('should fail to retrieve history without read permission', async () => {

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -36,7 +36,10 @@ import {
 	createOwnerWithApiKey,
 	createUser,
 } from '../shared/db/users';
-import { createWorkflowHistoryItem } from '../shared/db/workflow-history';
+import {
+	createManyWorkflowHistoryItems,
+	createWorkflowHistoryItem,
+} from '../shared/db/workflow-history';
 import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils/';
 
@@ -916,15 +919,7 @@ describe('GET /workflows/:id/history', () => {
 
 	test('should retrieve workflow version history', async () => {
 		const workflow = await createWorkflow({}, owner);
-		const versions = await Promise.all(
-			new Array(5).fill(undefined).map(
-				async (_, i) =>
-					await createWorkflowHistoryItem(workflow.id, {
-						createdAt: new Date(Date.now() + i),
-						name: `Version ${i}`,
-					}),
-			),
-		);
+		const versions = await createManyWorkflowHistoryItems(workflow.id, 5);
 
 		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0];
 
@@ -946,14 +941,7 @@ describe('GET /workflows/:id/history', () => {
 
 	test('should paginate with limit and cursor', async () => {
 		const workflow = await createWorkflow({}, owner);
-		await Promise.all(
-			new Array(5).fill(undefined).map(
-				async (_, i) =>
-					await createWorkflowHistoryItem(workflow.id, {
-						createdAt: new Date(Date.now() + i),
-					}),
-			),
-		);
+		await createManyWorkflowHistoryItems(workflow.id, 5);
 
 		const firstPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
 			limit: '2',
@@ -981,14 +969,7 @@ describe('GET /workflows/:id/history', () => {
 
 	test('should paginate with limit and offset', async () => {
 		const workflow = await createWorkflow({}, owner);
-		await Promise.all(
-			new Array(5).fill(undefined).map(
-				async (_, i) =>
-					await createWorkflowHistoryItem(workflow.id, {
-						createdAt: new Date(Date.now() + i),
-					}),
-			),
-		);
+		await createManyWorkflowHistoryItems(workflow.id, 5);
 
 		const firstPage = await authOwnerAgent.get(`/workflows/${workflow.id}/history`).query({
 			limit: '2',

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -125,6 +125,9 @@
 			"status": "covered",
 			"nodeOperation": "workflow:getVersion"
 		},
+		"GET /workflows/{id}/history": {
+			"status": "gap"
+		},
 		"POST /workflows/{id}/activate": {
 			"status": "covered",
 			"nodeOperation": "workflow:activate"


### PR DESCRIPTION
## Summary

Adds a public REST API endpoint `GET /workflows/{id}/history` that returns a paginated list of a workflow's versions (version IDs + metadata).

Previously the public API only exposed `GET /workflows/{id}/{versionId}` to fetch a single version, but there was no sanctioned way to enumerate a workflow's version IDs — consumers had to know a `versionId` up front. This closes that gap, mirroring the internal workflow-history capability.

Details:
- New handler `getWorkflowHistory` reuses the internal `WorkflowHistoryService.getList`, gated by `publicApiScope('workflow:read')` and `projectScope('workflow:read', 'workflow')`.
- Pagination via `take` (default 10, max 250) and `skip` (default 0) query params, validated with `PaginationDto`.
- Internal-only fields (`autosaved`, `workflowPublishHistory`) and the full workflow body (`nodes`, `connections`) are stripped from the response — only version IDs and metadata are returned.
- OpenAPI spec updated: new path `workflows.id.history.yml` and `workflowVersionListItem.yml` schema, plus `n8n-api-coverage.json`.

## How to test

1. Start n8n and create an API key.
2. Create a workflow and edit/save it a few times to generate version history.
3. Call the endpoint:
   ```bash
   curl -H "X-N8N-API-KEY: <key>" "http://localhost:5678/api/v1/workflows/<workflowId>/history?take=2&skip=0"
   ```
4. Verify the response is a JSON array of version items containing `versionId`, `workflowId`, `authors`, `name`, `description`, `createdAt`, `updatedAt` — and that it does **not** include `nodes`, `connections`, `autosaved`, or `workflowPublishHistory`.
5. Confirm pagination (`take`/`skip`) works, a non-existing workflow returns `404`, and a user without `workflow:read` on the workflow returns `403`.

Integration tests cover these cases in `packages/cli/test/integration/public-api/workflows.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-62

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34656">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

