### PR TITLE
fix(ai-builder): Detect datasets changes when re-pushing eval cases to LangTracer (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-push.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-push.test.ts
@@ -110,11 +110,42 @@ describe('planPush', () => {
 		expect(plan.toUpdate).toEqual([]);
 	});
 
-	it('ignores tags and datasets differences (the suite export does not round-trip them)', () => {
+	it('ignores tags differences (the suite export returns them empty)', () => {
 		const plan = planPush(
-			[item('c', { tags: ['build', 'ai'], datasets: ['full'] })],
-			// export comes back with empty tags and null datasets — must not count as a change
-			{ 'c.json': body({ tags: [], datasets: null }) },
+			[item('c', { tags: ['build', 'ai'] })],
+			{ 'c.json': body({ tags: [] }) },
+			{ c: 5 },
+		);
+		expect(plan.unchanged.map((c) => c.fileSlug)).toEqual(['c']);
+		expect(plan.toUpdate).toEqual([]);
+	});
+
+	it('treats a datasets difference as an update so tier edits re-sync', () => {
+		const plan = planPush(
+			[item('c', { datasets: ['mcp', 'pr', 'full'] })],
+			// the stored case lost its tiers (exported as null) — the push must restore them
+			{ 'c.json': body({ datasets: null }) },
+			{ c: 5 },
+		);
+		expect(plan.toUpdate).toHaveLength(1);
+		expect(plan.toUpdate[0].id).toBe(5);
+		expect(plan.unchanged).toEqual([]);
+	});
+
+	it('treats the default datasets as unchanged whether the export nulls or omits it', () => {
+		const omitted = body();
+		delete omitted.datasets;
+		for (const exported of [body({ datasets: null }), omitted]) {
+			const plan = planPush([item('c', { datasets: ['full'] })], { 'c.json': exported }, { c: 5 });
+			expect(plan.unchanged.map((c) => c.fileSlug)).toEqual(['c']);
+			expect(plan.toUpdate).toEqual([]);
+		}
+	});
+
+	it('ignores datasets ordering', () => {
+		const plan = planPush(
+			[item('c', { datasets: ['pr', 'full', 'mcp'] })],
+			{ 'c.json': body({ datasets: ['mcp', 'pr', 'full'] }) },
 			{ c: 5 },
 		);
 		expect(plan.unchanged.map((c) => c.fileSlug)).toEqual(['c']);

--- a/packages/@n8n/instance-ai/evaluations/langtracer/push.ts
+++ b/packages/@n8n/instance-ai/evaluations/langtracer/push.ts
@@ -7,6 +7,7 @@ import type { LangTracerUpdateCaseBody } from './client';
 import { normalizeExportedCase } from './normalize';
 import { unsupportedPushReason, type LangTracerCreateCaseBody } from './to-exported';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
+import { DEFAULT_DATASETS } from '../harness/schema';
 
 export interface PushPlan {
 	toCreate: WorkflowTestCaseWithFile[];
@@ -15,12 +16,12 @@ export interface PushPlan {
 	skipped: Array<{ fileSlug: string; reason: string }>;
 }
 
-/** Disk fields compared to decide create-vs-update. Deliberately EXCLUDES two
- *  fields that would make a re-push never converge (always "update"):
- *  - `tags` and `datasets`: the lang-tracer suite export does not round-trip these
- *    (tags come back empty, default `datasets` comes back null/omitted), so a diff
- *    on them always fires. They're still SENT on create so new cases carry them;
- *    edits to only tags/tier on an existing case aren't re-synced. */
+/** Disk fields compared to decide create-vs-update. Deliberately EXCLUDES `tags`:
+ *  the lang-tracer suite export returns them empty, so a diff on them would fire
+ *  on every case; they're still SENT on create so new cases carry them.
+ *  `datasets` IS compared — a tier edit must re-sync on push — but the export
+ *  omits (or nulls) the stored default, so `projectComparable` folds the default
+ *  to absent on both sides to keep re-pushes convergent. */
 const COMPARED_KEYS = [
 	'description',
 	'conversation',
@@ -30,6 +31,7 @@ const COMPARED_KEYS = [
 	'outcomeExpectations',
 	'messageBudget',
 	'credentials',
+	'datasets',
 	// Round-trips faithfully: PATCH /cases/:id reconciles scenario rows by name
 	// (lang-tracer #48) and the export emits them back in disk shape.
 	'executionScenarios',
@@ -104,6 +106,16 @@ function projectComparable(src: unknown): Record<string, unknown> {
 		// The export only emits `messageBudget` for multi-turn cases (it's ignored for
 		// single-turn auto-approve builds), so ignore it there to stay convergent.
 		if (key === 'messageBudget' && !isMultiTurn) continue;
+		// The loader defaults an absent disk `datasets` while the export omits (or
+		// nulls) the stored default — fold the default to absent on both sides, and
+		// compare order-insensitively since tiers are a set.
+		if (key === 'datasets') {
+			if (!Array.isArray(value)) continue;
+			const datasets = value.slice().sort();
+			if (canonicalize(datasets) === canonicalize([...DEFAULT_DATASETS].sort())) continue;
+			out[key] = datasets;
+			continue;
+		}
 		out[key] = value;
 	}
 	return out;


### PR DESCRIPTION
## Summary

The push planner deliberately excluded `datasets` from its create-vs-update comparison — calibrated back when the suite export did not round-trip the field. Consequence: a tier-only edit (or server-side loss of the tags) plans as "unchanged" and can never be re-synced by `eval:langtracer-push`.

This bit for real during the 2026-07-16 suite consolidation: 16 cases in the `baseline` suite lost their `datasets`, the PR eval gate silently shrank from 7 to 4 pr-tier cases, and re-pushing the correct files was a no-op until the planner was hand-patched.

The fix makes `datasets` a compared field while keeping re-pushes convergent:
- The loader defaults an absent disk `datasets` to `['full']` while the export omits (or nulls) the stored default — so the comparison folds the default to absent on **both** sides.
- Tiers are a set, so the comparison is order-insensitive.
- `tags` stays excluded — the export still returns it empty, so diffing it would fire on every case.

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm test evaluations/__tests__/langtracer-push.test.ts   # 17 tests, 4 new/updated for datasets semantics
```

Verified live against the `baseline` suite: a case whose stored copy lacks its tier tags now plans **update** (and the PATCH already carries `datasets`, so the push restores them); a case on default datasets plans **unchanged** instead of perma-updating (previously it would re-fire on every push once datasets were compared naively).

## Related Linear tickets, Github issues, and Community forum posts

No ticket — follow-up to the LangTracer baseline-suite consolidation recovery (2026-07-21).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

