### PR TITLE
feat(core): Add live execution status endpoint for reconnect reconcile (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/executions/execution-live-status-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/executions/execution-live-status-response.dto.ts
@@ -1,0 +1,52 @@
+/**
+ * Live state of an execution, used by the editor to reconcile executing-node
+ * state after a push reconnect or a background-tab visibility regain
+ * (CAT-2895 Option B). The frontend restores the correct spinner from a
+ * `running` response, clears it on `finished`, and — critically — keeps its
+ * current state on `unknown`.
+ *
+ * The three states never collapse: `unknown` (this main cannot resolve the
+ * execution's live state) must not be reported as `finished`, otherwise the
+ * frontend would clear a spinner for a run that may still be executing —
+ * exactly the stale-spinner bug this seam exists to fix.
+ */
+export type ExecutionLiveStatus =
+	| {
+			/** The execution is running on the main process that served this request. */
+			state: 'running';
+			/**
+			 * Nodes currently in flight — a `nodeExecuteBefore` has fired without a
+			 * matching `nodeExecuteAfter`. Ground truth from the execution lifecycle,
+			 * never a guess or a stale value. Usually holds exactly one node; may hold
+			 * more than one while a sub-node executes inside a still-running parent
+			 * node (both have an open start). Empty while the execution is active but
+			 * momentarily between nodes (e.g. a waiting execution).
+			 */
+			nodes: string[];
+			/**
+			 * Latest node-event sequence number emitted for this execution segment,
+			 * mirroring the `sequenceNumber` on the `nodeExecuteBefore` /
+			 * `nodeExecuteAfter` push events. Seeds the frontend's
+			 * `latestSequenceNumber` so late or out-of-order push events are ignored.
+			 * `-1` when no node event has fired yet this segment (matches the
+			 * frontend's default), which also resets across a waiting-execution resume.
+			 */
+			sequenceNumber: number;
+	  }
+	| {
+			/**
+			 * The execution has reached a terminal status (success, error, crashed or
+			 * canceled). The frontend clears any executing-node spinner.
+			 */
+			state: 'finished';
+	  }
+	| {
+			/**
+			 * The main process serving this request cannot resolve the execution's
+			 * live state — it does not hold the run. In queue mode (multi-main, out of
+			 * scope for v1) the run may be executing on another main whose in-flight
+			 * node state is not visible here. The frontend keeps its current state and
+			 * must not clear the spinner on this.
+			 */
+			state: 'unknown';
+	  };

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -280,6 +280,7 @@ export {
 	ExecutionRedactionQueryDtoSchema,
 	type ExecutionRedactionQueryDto,
 } from './executions/execution-redaction-query.dto';
+export type { ExecutionLiveStatus } from './executions/execution-live-status-response.dto';
 
 export { VersionSinceDateQueryDto } from './instance-version-history/version-since-date-query.dto';
 export { VersionQueryDto } from './instance-version-history/version-query.dto';

--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -543,4 +543,78 @@ describe('ActiveExecutions', () => {
 			);
 		});
 	});
+
+	describe('node execution state tracking (CAT-2895)', () => {
+		test('starts with no in-flight nodes and a sentinel sequence number', async () => {
+			const executionId = await activeExecutions.add(executionData);
+
+			expect(activeExecutions.getNodeExecutionState(executionId)).toEqual({
+				nodes: [],
+				sequenceNumber: -1,
+			});
+		});
+
+		test('tracks in-flight nodes and the latest sequence number', async () => {
+			const executionId = await activeExecutions.add(executionData);
+
+			activeExecutions.reportNodeExecuteBefore(executionId, 'Agent', 0);
+			expect(activeExecutions.getNodeExecutionState(executionId)).toEqual({
+				nodes: ['Agent'],
+				sequenceNumber: 0,
+			});
+
+			// A sub-node executing inside a still-running parent: both are in flight.
+			activeExecutions.reportNodeExecuteBefore(executionId, 'Model', 1);
+			expect(activeExecutions.getNodeExecutionState(executionId)).toEqual({
+				nodes: ['Agent', 'Model'],
+				sequenceNumber: 1,
+			});
+
+			activeExecutions.reportNodeExecuteAfter(executionId, 'Model', 2);
+			expect(activeExecutions.getNodeExecutionState(executionId)).toEqual({
+				nodes: ['Agent'],
+				sequenceNumber: 2,
+			});
+
+			activeExecutions.reportNodeExecuteAfter(executionId, 'Agent', 3);
+			expect(activeExecutions.getNodeExecutionState(executionId)).toEqual({
+				nodes: [],
+				sequenceNumber: 3,
+			});
+		});
+
+		test('keeps the highest sequence number seen', async () => {
+			const executionId = await activeExecutions.add(executionData);
+
+			activeExecutions.reportNodeExecuteBefore(executionId, 'A', 5);
+			activeExecutions.reportNodeExecuteBefore(executionId, 'B', 2);
+
+			expect(activeExecutions.getNodeExecutionState(executionId)?.sequenceNumber).toBe(5);
+		});
+
+		test('returns undefined for an execution this process does not hold', () => {
+			expect(activeExecutions.getNodeExecutionState('does-not-exist')).toBeUndefined();
+		});
+
+		test('report methods are a no-op for an unknown execution', () => {
+			expect(() =>
+				activeExecutions.reportNodeExecuteBefore('does-not-exist', 'A', 0),
+			).not.toThrow();
+			expect(() => activeExecutions.reportNodeExecuteAfter('does-not-exist', 'A', 1)).not.toThrow();
+		});
+
+		test('resets tracking per segment when a waiting execution resumes', async () => {
+			const executionId = await activeExecutions.add(executionData);
+			activeExecutions.reportNodeExecuteBefore(executionId, 'A', 4);
+			activeExecutions.setStatus(executionId, 'waiting');
+
+			// Resuming rebuilds the execution entry with a fresh counter.
+			await activeExecutions.add(executionData, executionId);
+
+			expect(activeExecutions.getNodeExecutionState(executionId)).toEqual({
+				nodes: [],
+				sequenceNumber: -1,
+			});
+		});
+	});
 });

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -151,6 +151,10 @@ export class ActiveExecutions {
 			status: executionStatus,
 			responsePromise: resumingExecution?.responsePromise,
 			httpResponse: executionData.httpResponse ?? undefined,
+			// Live node tracking resets per segment — a resume rebuilds the push
+			// hooks and restarts the sequence counter at 0 (CAT-2895).
+			runningNodes: new Set<string>(),
+			latestNodeExecuteSequenceNumber: -1,
 		};
 		this.activeExecutions[executionId] = execution;
 
@@ -310,6 +314,51 @@ export class ActiveExecutions {
 
 	getStatus(executionId: string): ExecutionStatus {
 		return this.getExecutionOrFail(executionId).status;
+	}
+
+	/**
+	 * Record that a node started executing (CAT-2895). Called from the push hook,
+	 * so the reconnect-reconcile endpoint can report which node(s) are in flight.
+	 * No-op if this process does not hold the execution.
+	 */
+	reportNodeExecuteBefore(executionId: string, nodeName: string, sequenceNumber: number): void {
+		const execution = this.activeExecutions[executionId];
+		if (!execution) return;
+		execution.runningNodes.add(nodeName);
+		execution.latestNodeExecuteSequenceNumber = Math.max(
+			execution.latestNodeExecuteSequenceNumber,
+			sequenceNumber,
+		);
+	}
+
+	/**
+	 * Record that a node finished executing (CAT-2895). Counterpart to
+	 * {@link reportNodeExecuteBefore}. No-op if this process does not hold the
+	 * execution.
+	 */
+	reportNodeExecuteAfter(executionId: string, nodeName: string, sequenceNumber: number): void {
+		const execution = this.activeExecutions[executionId];
+		if (!execution) return;
+		execution.runningNodes.delete(nodeName);
+		execution.latestNodeExecuteSequenceNumber = Math.max(
+			execution.latestNodeExecuteSequenceNumber,
+			sequenceNumber,
+		);
+	}
+
+	/**
+	 * Live in-flight node state for the reconnect-reconcile endpoint (CAT-2895),
+	 * or `undefined` if this process does not hold the execution.
+	 */
+	getNodeExecutionState(
+		executionId: string,
+	): { nodes: string[]; sequenceNumber: number } | undefined {
+		const execution = this.activeExecutions[executionId];
+		if (!execution) return undefined;
+		return {
+			nodes: [...execution.runningNodes],
+			sequenceNumber: execution.latestNodeExecuteSequenceNumber,
+		};
 	}
 
 	setResponseMode(executionId: string, responseMode: WebhookResponseMode): void {

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -23,6 +23,7 @@ import type {
 } from 'n8n-workflow';
 import { runDataAttemptedDynamicCredentials, runDataUsedDynamicCredentials } from 'n8n-workflow';
 
+import { ActiveExecutions } from '@/active-executions';
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import type { RedactableExecution } from '@/executions/execution-redaction';
@@ -267,6 +268,7 @@ function hookFunctionsPush(
 	if (!pushRef) return;
 	const logger = Container.get(Logger);
 	const pushInstance = Container.get(Push);
+	const activeExecutions = Container.get(ActiveExecutions);
 	const redactionProxy = Container.get(ExecutionRedactionServiceProxy);
 	const userRepository = Container.get(UserRepository);
 
@@ -299,13 +301,18 @@ function hookFunctionsPush(
 			workflowId: this.workflowData.id,
 		});
 
+		const sequenceNumber = nodeEventSequence++;
 		pushInstance.send(
 			{
 				type: 'nodeExecuteBefore',
-				data: { executionId, nodeName, sequenceNumber: nodeEventSequence++, data },
+				data: { executionId, nodeName, sequenceNumber, data },
 			},
 			pushRef,
 		);
+
+		// Mirror the pushed node state into ActiveExecutions so the
+		// reconnect-reconcile endpoint can report in-flight nodes (CAT-2895).
+		activeExecutions.reportNodeExecuteBefore(executionId, nodeName, sequenceNumber);
 	});
 	hooks.addHandler('nodeExecuteAfter', async function (nodeName, data, executionData) {
 		const { executionId } = this;
@@ -319,19 +326,23 @@ function hookFunctionsPush(
 		const itemCountByConnectionType = getItemCountByConnectionType(data?.data);
 		const { data: _, ...taskData } = data;
 
+		const sequenceNumber = nodeEventSequence++;
 		pushInstance.send(
 			{
 				type: 'nodeExecuteAfter',
 				data: {
 					executionId,
 					nodeName,
-					sequenceNumber: nodeEventSequence++,
+					sequenceNumber,
 					itemCountByConnectionType,
 					data: taskData,
 				},
 			},
 			pushRef,
 		);
+
+		// Mirror the pushed node state into ActiveExecutions (CAT-2895).
+		activeExecutions.reportNodeExecuteAfter(executionId, nodeName, sequenceNumber);
 
 		// Fail-closed redaction: if user cannot be resolved, skip the data push
 		// entirely rather than sending unredacted data to the client.

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -1,6 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type {
+	IExecutionBase,
 	IExecutionDb,
 	IExecutionResponse,
 	ExecutionRepository,
@@ -854,6 +855,62 @@ describe('ExecutionService', () => {
 			const result = await executionService.getExecutedVersions(workflowId);
 
 			expect(result).toEqual([]);
+		});
+	});
+
+	describe('getLiveStatus', () => {
+		const accessibleWorkflowIds = ['wf-1'];
+
+		it('returns running with in-flight nodes and the latest sequence number', async () => {
+			executionRepository.findIfAccessible.mockResolvedValue(
+				mock<IExecutionBase>({ status: 'running' }),
+			);
+			activeExecutions.getNodeExecutionState.mockReturnValue({
+				nodes: ['Agent', 'Model'],
+				sequenceNumber: 4,
+			});
+
+			const result = await executionService.getLiveStatus('123', accessibleWorkflowIds);
+
+			expect(result).toEqual({ state: 'running', nodes: ['Agent', 'Model'], sequenceNumber: 4 });
+			expect(executionRepository.findIfAccessible).toHaveBeenCalledWith(
+				'123',
+				accessibleWorkflowIds,
+			);
+		});
+
+		it('returns finished for a terminal persisted status not held by this main', async () => {
+			executionRepository.findIfAccessible.mockResolvedValue(
+				mock<IExecutionBase>({ status: 'success' }),
+			);
+			activeExecutions.getNodeExecutionState.mockReturnValue(undefined);
+
+			const result = await executionService.getLiveStatus('123', accessibleWorkflowIds);
+
+			expect(result).toEqual({ state: 'finished' });
+		});
+
+		it('returns unknown for a non-terminal execution this main does not hold (single-main scope)', async () => {
+			// Running per the shared DB, but absent from this main's ActiveExecutions:
+			// in queue mode it is executing on another main. The single-main v1 seam
+			// does not perform a cross-main lookup — it reports unknown so the editor
+			// keeps its current state rather than clearing the spinner.
+			executionRepository.findIfAccessible.mockResolvedValue(
+				mock<IExecutionBase>({ status: 'running' }),
+			);
+			activeExecutions.getNodeExecutionState.mockReturnValue(undefined);
+
+			const result = await executionService.getLiveStatus('123', accessibleWorkflowIds);
+
+			expect(result).toEqual({ state: 'unknown' });
+		});
+
+		it('throws NotFoundError for an absent or inaccessible execution', async () => {
+			executionRepository.findIfAccessible.mockResolvedValue(undefined);
+
+			await expect(executionService.getLiveStatus('123', accessibleWorkflowIds)).rejects.toThrow(
+				NotFoundError,
+			);
 		});
 	});
 });

--- a/packages/cli/src/executions/__tests__/executions.controller.test.ts
+++ b/packages/cli/src/executions/__tests__/executions.controller.test.ts
@@ -31,6 +31,36 @@ describe('ExecutionsController', () => {
 		});
 	});
 
+	describe('getLiveStatus', () => {
+		it('should 400 when execution id is not a number', async () => {
+			const req = mock<ExecutionRequest.GetLiveStatus>({ params: { id: 'test' } });
+
+			await expect(executionsController.getLiveStatus(req)).rejects.toThrow(BadRequestError);
+		});
+
+		it('should 404 when the user has no accessible workflows', async () => {
+			const req = mock<ExecutionRequest.GetLiveStatus>({ params: { id: '123' } });
+			workflowSharingService.getSharedWorkflowIds.mockResolvedValue([]);
+
+			await expect(executionsController.getLiveStatus(req)).rejects.toThrow(NotFoundError);
+		});
+
+		it('should delegate to the execution service with the accessible workflow ids', async () => {
+			const req = mock<ExecutionRequest.GetLiveStatus>({ params: { id: '123' } });
+			workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1']);
+			executionService.getLiveStatus.mockResolvedValue({
+				state: 'running',
+				nodes: ['Agent'],
+				sequenceNumber: 2,
+			});
+
+			const result = await executionsController.getLiveStatus(req);
+
+			expect(result).toEqual({ state: 'running', nodes: ['Agent'], sequenceNumber: 2 });
+			expect(executionService.getLiveStatus).toHaveBeenCalledWith('123', ['wf-1']);
+		});
+	});
+
 	describe('getMany', () => {
 		const NO_EXECUTIONS = {
 			count: 0,

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -1,4 +1,4 @@
-import { ExecutionRedactionQueryDtoSchema } from '@n8n/api-types';
+import { ExecutionRedactionQueryDtoSchema, type ExecutionLiveStatus } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import type {
@@ -200,6 +200,49 @@ export class ExecutionService {
 			data: stringify(processedExecution.data),
 			dataTooLargeToDisplay: execution.dataTooLargeToDisplay,
 		};
+	}
+
+	/**
+	 * Live state of an execution for the editor's reconnect-reconcile seam
+	 * (CAT-2895 Option B). Resolves from this main's in-memory `ActiveExecutions`
+	 * (authoritative for a run executing here) plus the persisted status.
+	 *
+	 * Single-main scope: an execution this main does not hold is reported as
+	 * `unknown` rather than `finished`, so the editor keeps its current state
+	 * instead of clearing the spinner on a state we cannot confirm. In queue mode
+	 * a run may execute on another main, whose in-flight node state is not visible
+	 * here — see N8N-20 for the multi-main follow-up.
+	 */
+	async getLiveStatus(
+		executionId: string,
+		accessibleWorkflowIds: string[],
+	): Promise<ExecutionLiveStatus> {
+		// Access boundary: not found / not accessible is a 404, same as `findOne`.
+		const execution = await this.executionRepository.findIfAccessible(
+			executionId,
+			accessibleWorkflowIds,
+		);
+		if (!execution) throw new NotFoundError('Execution not found');
+
+		// Held by this main → authoritative in-flight node state.
+		const liveState = this.activeExecutions.getNodeExecutionState(executionId);
+		if (liveState) {
+			return {
+				state: 'running',
+				nodes: liveState.nodes,
+				sequenceNumber: liveState.sequenceNumber,
+			};
+		}
+
+		// Not held here. `finished` only when the persisted status is terminal;
+		// otherwise `unknown` — the run is executing elsewhere (queue mode) and we
+		// must not guess a node or report it as finished.
+		const terminalStatuses: ExecutionStatus[] = ['success', 'error', 'crashed', 'canceled'];
+		if (terminalStatuses.includes(execution.status)) {
+			return { state: 'finished' };
+		}
+
+		return { state: 'unknown' };
 	}
 
 	async getLastSuccessfulExecution(

--- a/packages/cli/src/executions/execution.types.ts
+++ b/packages/cli/src/executions/execution.types.ts
@@ -45,6 +45,8 @@ export declare namespace ExecutionRequest {
 
 	type GetOne = AuthenticatedRequest<RouteParams.ExecutionId>;
 
+	type GetLiveStatus = AuthenticatedRequest<RouteParams.ExecutionId>;
+
 	type GetVersions = AuthenticatedRequest<{ workflowId: string }>;
 
 	type Delete = AuthenticatedRequest<{}, {}, BodyParams.DeleteFilter>;

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -97,6 +97,24 @@ export class ExecutionsController {
 			: await this.executionService.findOne(req, workflowIds);
 	}
 
+	/**
+	 * Live state of an execution (running node(s) + latest sequence number, or a
+	 * finished/unknown marker) so the editor can reconcile executing-node state
+	 * after a push reconnect or tab-visibility regain (CAT-2895 Option B).
+	 */
+	@Get('/:id/live-status')
+	async getLiveStatus(req: ExecutionRequest.GetLiveStatus) {
+		if (!isPositiveInteger(req.params.id)) {
+			throw new BadRequestError('Execution ID is not a number');
+		}
+
+		const workflowIds = await this.getAccessibleWorkflowIds(req.user, 'workflow:read');
+
+		if (workflowIds.length === 0) throw new NotFoundError('Execution not found');
+
+		return await this.executionService.getLiveStatus(req.params.id, workflowIds);
+	}
+
 	@Post('/:id/stop')
 	async stop(req: ExecutionRequest.Stop) {
 		const workflowIds = await this.getAccessibleWorkflowIds(req.user, 'workflow:execute');

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -142,6 +142,18 @@ export interface IExecutingWorkflowData {
 	responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>;
 	workflowExecution?: PCancelable<IRun>;
 	status: ExecutionStatus;
+	/**
+	 * Nodes with an open `nodeExecuteBefore` (started, not yet finished), so the
+	 * reconnect-reconcile endpoint can report what is executing right now
+	 * (CAT-2895). Populated only when the run pushes to an editor session; reset
+	 * per segment, so a waiting-execution resume starts empty.
+	 */
+	runningNodes: Set<string>;
+	/**
+	 * Latest node-event sequence number emitted this segment, mirroring the push
+	 * `sequenceNumber`. `-1` until the first node event fires.
+	 */
+	latestNodeExecuteSequenceNumber: number;
 }
 
 export interface IActiveDirectorySettings {


### PR DESCRIPTION
## Summary

Backend read seam for CAT-2895 **Option B** (reconcile executing-node state on push reconnect / tab-visibility regain). Fast-follow to Option A (#34182), which added a per-run `sequenceNumber` to node push events and made the editor render only the latest node.

Option A still leaves gaps: a missed terminal event (spinner sticks) or a dropped `nodeExecuteBefore` (spinner stuck on the wrong node) after a suspended background tab. The editor fix reconciles on reconnect, but needs an authoritative "what is executing right now" source to reconcile against — which did not exist. Mid-run node state is not persisted (`saveExecutionProgress` defaults to `false`), and the per-run sequence counter lived only inside the push emit closure. This PR lands that source.

**New endpoint:** `GET /rest/executions/:id/live-status` → `ExecutionLiveStatus`

```ts
type ExecutionLiveStatus =
  | { state: 'running'; nodes: string[]; sequenceNumber: number }
  | { state: 'finished' }
  | { state: 'unknown' };
```

Design notes:

- **Three states never collapse.** `unknown` (this main cannot resolve the run's live state) is never reported as `finished`, so the editor never clears a spinner on a state we cannot confirm. Encoded structurally as a discriminated union: `finished`/`unknown` carry no node data, so a stale/guessed node cannot be emitted.
- **`nodes` is the honest in-flight set** — nodes with an open `nodeExecuteBefore` (started, not yet finished). Usually one; may be more than one while a sub-node runs inside a still-running parent (both have an open start). Ground truth from the execution lifecycle, never a guess.
- **`sequenceNumber`** mirrors the push `nodeExecuteBefore`/`nodeExecuteAfter` counter and seeds the editor's `latestSequenceNumber` (default `-1`, per segment) so late/out-of-order push events are ignored.
- **Single-main scope (v1).** State is resolved from this main's in-memory `ActiveExecutions` plus the persisted status. A run this main does not hold (queue mode / multi-main) returns `unknown`; the cross-main lookup over the Redis push relay is a documented follow-up on the parent ticket.
- Access control matches `GET /executions/:id` — `workflow:read`-scoped accessible workflow ids; a not-found / inaccessible id is a `404`.

## How to test

Automated (from `packages/cli`):

```bash
pnpm test src/__tests__/active-executions.test.ts \
          src/executions/__tests__/execution.service.test.ts \
          src/executions/__tests__/executions.controller.test.ts
```

Covers node-state tracking (add / remove / latest sequence number / per-segment reset) and the `running` (mid-node) / `finished` / `unknown` / absent-or-inaccessible cases, with the single-main scope asserted.

Manual (single-main / regular mode):

1. Open a workflow in the editor and start a manual execution long enough to observe a node running.
2. `GET /rest/executions/{activeExecutionId}/live-status` mid-run → `{ state: 'running', nodes: [...], sequenceNumber: n }`.
3. After it completes → `{ state: 'finished' }`.
4. For an id this instance never held / does not exist → `404` (and, in queue mode for a run on another main, `{ state: 'unknown' }`).

No frontend changes here — the editor reconcile is the fast-follow that consumes this contract.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/N8N-82
- Parent: https://linear.app/n8n/issue/N8N-20
- Fast-follow to Option A: #34182

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34661">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

