### PR TITLE
fix(editor): Reconcile executing-node state on reconnect and tab-visibility regain (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/api/workflows.ts
+++ b/packages/frontend/editor-ui/src/app/api/workflows.ts
@@ -12,7 +12,7 @@ import type {
 } from '@/features/execution/executions/executions.types';
 import { DEFAULT_NEW_WORKFLOW_NAME, DEFAULT_SETTINGS } from '@/app/constants';
 import { isEmpty } from '@/app/utils/typesUtils';
-import type { ExecutionRedactionQueryDto } from '@n8n/api-types';
+import type { ExecutionLiveStatus, ExecutionRedactionQueryDto } from '@n8n/api-types';
 import type { IRestApiContext } from '@n8n/rest-api-client';
 import type {
 	ExecutionFilters,
@@ -143,6 +143,19 @@ export async function getExecutionData(
 		'GET',
 		`/executions/${executionId}`,
 		queryParams,
+	);
+}
+
+/**
+ * Live state of an execution (running node(s) + latest sequence number, or a
+ * finished/unknown marker), used to reconcile executing-node state after a push
+ * reconnect or tab-visibility regain (CAT-2895 Option B).
+ */
+export async function getExecutionLiveStatus(context: IRestApiContext, executionId: string) {
+	return await makeRestApiRequest<ExecutionLiveStatus>(
+		context,
+		'GET',
+		`/executions/${executionId}/live-status`,
 	);
 }
 

--- a/packages/frontend/editor-ui/src/app/composables/useExecutingNode.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExecutingNode.test.ts
@@ -103,6 +103,52 @@ describe('useExecutingNode composable', () => {
 		});
 	});
 
+	describe('reconcileExecutingNodes (reconnect / visibility ground-truth)', () => {
+		it('replaces the shown node(s) with ground truth in a single assignment', () => {
+			const { executingNode, addExecutingNode, reconcileExecutingNodes, lastAddedExecutingNode } =
+				useExecutingNode();
+
+			// A stale spinner is up (nodeA), but ground truth says nodeB is running.
+			addExecutingNode('nodeA', 0);
+			reconcileExecutingNodes(['nodeB'], 5);
+
+			expect(executingNode.value).toEqual(['nodeB']);
+			expect(lastAddedExecutingNode.value).toBe('nodeB');
+		});
+
+		it('holds a legitimately-nested parent + sub-node pair', () => {
+			const { executingNode, reconcileExecutingNodes, isNodeExecuting } = useExecutingNode();
+
+			reconcileExecutingNodes(['Agent', 'Sub Model'], 7);
+
+			expect(executingNode.value).toEqual(['Agent', 'Sub Model']);
+			expect(isNodeExecuting('Agent')).toBe(true);
+			expect(isNodeExecuting('Sub Model')).toBe(true);
+		});
+
+		it('seeds the sequence baseline so a replayed lower-sequence event is ignored afterwards', () => {
+			const { executingNode, addExecutingNode, reconcileExecutingNodes } = useExecutingNode();
+
+			reconcileExecutingNodes(['nodeB'], 5);
+			// A late/replayed push for the superseded nodeA (seq 5 <= 5) is ignored.
+			addExecutingNode('nodeA', 5);
+
+			expect(executingNode.value).toEqual(['nodeB']);
+		});
+
+		it('clears the spinner when ground truth reports no node in flight', () => {
+			const { executingNode, addExecutingNode, reconcileExecutingNodes, lastAddedExecutingNode } =
+				useExecutingNode();
+
+			addExecutingNode('nodeA', 0);
+			// Run is active but momentarily between nodes (empty `nodes`).
+			reconcileExecutingNodes([], 3);
+
+			expect(executingNode.value).toEqual([]);
+			expect(lastAddedExecutingNode.value).toBeNull();
+		});
+	});
+
 	it('tracks the last node that started executing', () => {
 		const { lastAddedExecutingNode, addExecutingNode } = useExecutingNode();
 		addExecutingNode('nodeA', 0);

--- a/packages/frontend/editor-ui/src/app/composables/useExecutingNode.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExecutingNode.ts
@@ -11,10 +11,13 @@ import { ref } from 'vue';
  * ignored, so a stale node can never overwrite the current one or leave several
  * spinners running at once.
  *
- * `executingNode` stays an array for its consumers' sake, but now holds at most
- * one entry. The counter restarts at 0 per run — and mid-run on a wait-node
- * resume — so a fresh event is also accepted whenever nothing is currently
- * shown, not only when it beats the last sequence number.
+ * `executingNode` stays an array for its consumers' sake. During live push it
+ * holds at most one entry; the counter restarts at 0 per run — and mid-run on a
+ * wait-node resume — so a fresh event is also accepted whenever nothing is
+ * currently shown, not only when it beats the last sequence number. On a
+ * reconnect/visibility reconcile (`reconcileExecutingNodes`) it is set from
+ * ground truth and may hold more than one entry — a parent node plus a sub-node
+ * executing inside it.
  */
 export function useExecutingNode() {
 	const executingNode = ref<string[]>([]);
@@ -42,6 +45,25 @@ export function useExecutingNode() {
 		}
 	}
 
+	/**
+	 * Replaces the shown executing node(s) with ground truth from the live-status
+	 * endpoint (push reconnect / tab-visibility regain — CAT-2895 Option B).
+	 *
+	 * Unlike `addExecutingNode`, this is not sequence-gated: ground truth always
+	 * wins. It seeds `latestSequenceNumber` from the endpoint so a late or
+	 * replayed push event carrying a lower number can't resurrect a superseded
+	 * spinner afterwards. The `nodes` array is written in a single assignment so
+	 * the stale→reconciled swap is one paint (no clear-then-set flicker), and it
+	 * may legitimately hold more than one entry — a parent node plus a sub-node
+	 * executing inside it. An empty array clears the spinner (the run is active
+	 * but momentarily between nodes).
+	 */
+	function reconcileExecutingNodes(nodes: string[], sequenceNumber: number) {
+		executingNode.value = nodes;
+		lastAddedExecutingNode.value = nodes.at(-1) ?? null;
+		latestSequenceNumber = sequenceNumber;
+	}
+
 	function clearNodeExecutionQueue() {
 		executingNode.value = [];
 		lastAddedExecutingNode.value = null;
@@ -57,6 +79,7 @@ export function useExecutingNode() {
 		lastAddedExecutingNode,
 		addExecutingNode,
 		removeExecutingNode,
+		reconcileExecutingNodes,
 		isNodeExecuting,
 		clearNodeExecutionQueue,
 	};

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -1,7 +1,9 @@
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import type { PushMessage } from '@n8n/api-types';
 
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
+import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
+import { useDocumentVisibility } from '@/app/composables/useDocumentVisibility';
 import {
 	builderCreditsUpdated,
 	testWebhookDeleted,
@@ -41,6 +43,32 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);
 
 	const removeEventListener = ref<(() => void) | null>(null);
+
+	/**
+	 * Reconcile the executing-node spinner against ground truth. A push reconnect
+	 * or a background tab regaining focus can have missed the terminal or
+	 * superseding node event that would have cleared or advanced the spinner
+	 * (CAT-2895 Option B). Resolve the document the user is currently viewing and
+	 * let the store fetch live status and reconcile (no-op unless a run is active).
+	 */
+	function reconcileExecutingNodeState() {
+		const store = useWorkflowExecutionStateStore(workflowDocumentStore.value.documentId);
+		void store.reconcileExecutingNodeState();
+	}
+
+	// On reconnect (isConnected false -> true): a dropped socket may have missed
+	// node events while down. The first connect is also a rising edge and is
+	// safely reconciled too (the store no-ops when no run is active).
+	watch(
+		() => pushStore.isConnected,
+		(isConnected, wasConnected) => {
+			if (isConnected && !wasConnected) reconcileExecutingNodeState();
+		},
+	);
+
+	// On tab-visibility regain: a suspended background tab can drop pushes without
+	// the socket ever closing, so reconnect alone would miss it.
+	useDocumentVisibility().onDocumentVisible(reconcileExecutingNodeState);
 
 	function initialize() {
 		removeEventListener.value = pushStore.addEventListener((message) => {

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
@@ -31,6 +31,12 @@ import {
 	type ExecutionSummary,
 } from 'n8n-workflow';
 import { IN_PROGRESS_EXECUTION_ID } from '@/app/constants/placeholders';
+import * as workflowsApi from '@/app/api/workflows';
+
+vi.mock('@/app/api/workflows', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@/app/api/workflows')>()),
+	getExecutionLiveStatus: vi.fn(),
+}));
 
 function makeExecution(overrides: Partial<IExecutionResponse> = {}): IExecutionResponse {
 	return createTestWorkflowExecutionResponse({
@@ -1486,6 +1492,124 @@ describe('workflowExecutionState.store', () => {
 			// The canvas projection sees exactly one running node.
 			expect(executionStateStore.executionRunningByNodeId.get('a-id')?.value).toBe(false);
 			expect(executionStateStore.executionRunningByNodeId.get('b-id')?.value).toBe(true);
+		});
+	});
+
+	// CAT-2895 Option B: after a push reconnect or a tab-visibility regain, the
+	// spinner is reconciled against ground truth from the live-status endpoint so
+	// a dropped node event can no longer leave a stale, wrong, or orphaned
+	// spinner. Driven through the store; the endpoint is mocked.
+	describe('reconcileExecutingNodeState', () => {
+		function addNode(
+			documentStore: ReturnType<typeof useWorkflowDocumentStore>,
+			id: string,
+			name: string,
+		) {
+			documentStore.addNode({
+				id,
+				name,
+				type: 'n8n-nodes-base.set',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			});
+		}
+
+		beforeEach(() => {
+			vi.mocked(workflowsApi.getExecutionLiveStatus).mockReset();
+		});
+
+		it('restores the correct running node after a dropped nodeExecuteAfter, then clears on genuine completion', async () => {
+			const id = createWorkflowDocumentId('wf-reconcile-after');
+			const store = useWorkflowExecutionStateStore(id);
+			store.setActiveExecutionId('exec-1');
+			// Node A's terminal `nodeExecuteAfter` was dropped, so its spinner is
+			// stuck even though Node B is the node actually running now.
+			store.executingNode.addExecutingNode('Node A', 0);
+
+			vi.mocked(workflowsApi.getExecutionLiveStatus).mockResolvedValue({
+				state: 'running',
+				nodes: ['Node B'],
+				sequenceNumber: 5,
+			});
+			await store.reconcileExecutingNodeState();
+
+			expect(store.executingNode.executingNode).toEqual(['Node B']);
+			expect(store.executingNode.isNodeExecuting('Node A')).toBe(false);
+
+			// The run then genuinely completes: the spinner clears, not left stale.
+			vi.mocked(workflowsApi.getExecutionLiveStatus).mockResolvedValue({ state: 'finished' });
+			await store.reconcileExecutingNodeState();
+
+			expect(store.executingNode.executingNode).toEqual([]);
+		});
+
+		it('reconciles to the node actually executing after a dropped nodeExecuteBefore, and seeds the sequence so a replayed stale event cannot resurrect it', async () => {
+			const id = createWorkflowDocumentId('wf-reconcile-before');
+			const store = useWorkflowExecutionStateStore(id);
+			store.setActiveExecutionId('exec-1');
+			// Node B's `nodeExecuteBefore` was dropped, so the spinner still shows the
+			// stale previous node (Node A).
+			store.executingNode.addExecutingNode('Node A', 0);
+
+			vi.mocked(workflowsApi.getExecutionLiveStatus).mockResolvedValue({
+				state: 'running',
+				nodes: ['Node B'],
+				sequenceNumber: 5,
+			});
+			await store.reconcileExecutingNodeState();
+
+			expect(store.executingNode.executingNode).toEqual(['Node B']);
+
+			// A late/replayed push for the superseded Node A (seq 0 <= seeded 5) must
+			// be ignored — the seed prevents it from resurrecting the old spinner.
+			store.executingNode.addExecutingNode('Node A', 0);
+			expect(store.executingNode.executingNode).toEqual(['Node B']);
+		});
+
+		it('shows both a parent and its sub-node after reconcile (agent + sub-node, no regression of scope-awareness)', async () => {
+			const id = createWorkflowDocumentId('wf-reconcile-nested');
+			const documentStore = useWorkflowDocumentStore(id);
+			const store = useWorkflowExecutionStateStore(id);
+			addNode(documentStore, 'agent-id', 'Agent');
+			addNode(documentStore, 'sub-id', 'Sub Model');
+			store.setActiveExecutionId('exec-1');
+
+			vi.mocked(workflowsApi.getExecutionLiveStatus).mockResolvedValue({
+				state: 'running',
+				nodes: ['Agent', 'Sub Model'],
+				sequenceNumber: 7,
+			});
+			await store.reconcileExecutingNodeState();
+
+			expect(store.executingNode.isNodeExecuting('Agent')).toBe(true);
+			expect(store.executingNode.isNodeExecuting('Sub Model')).toBe(true);
+			// The canvas projection sees both as running (the legitimately-nested pair).
+			expect(store.executionRunningByNodeId.get('agent-id')?.value).toBe(true);
+			expect(store.executionRunningByNodeId.get('sub-id')?.value).toBe(true);
+		});
+
+		it('keeps current state on unknown / 404 / fetch error (multi-main safety — never clears)', async () => {
+			const id = createWorkflowDocumentId('wf-reconcile-unknown');
+			const store = useWorkflowExecutionStateStore(id);
+			store.setActiveExecutionId('exec-1');
+			store.executingNode.addExecutingNode('Node A', 0);
+
+			// `unknown` (incl. a 404 from a main that does not hold the run): keep state.
+			vi.mocked(workflowsApi.getExecutionLiveStatus).mockResolvedValue({ state: 'unknown' });
+			await store.reconcileExecutingNodeState();
+			expect(store.executingNode.executingNode).toEqual(['Node A']);
+
+			// A fetch failure is treated the same way — never clear on uncertainty.
+			vi.mocked(workflowsApi.getExecutionLiveStatus).mockRejectedValue(new Error('network'));
+			await store.reconcileExecutingNodeState();
+			expect(store.executingNode.executingNode).toEqual(['Node A']);
+		});
+
+		it('is a no-op when no real execution is active (never calls the endpoint)', async () => {
+			const store = useWorkflowExecutionStateStore(createWorkflowDocumentId('wf-reconcile-idle'));
+			await store.reconcileExecutingNodeState();
+			expect(workflowsApi.getExecutionLiveStatus).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -27,6 +27,8 @@ import type {
 import { IN_PROGRESS_EXECUTION_ID } from '@/app/constants/placeholders';
 import { useExecutingNode } from '@/app/composables/useExecutingNode';
 import { useUIStore } from '@/app/stores/ui.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import * as workflowsApi from '@/app/api/workflows';
 import {
 	createExecutionDataId,
 	disposeExecutionDataStore,
@@ -886,6 +888,56 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			clearPopupWindowState();
 		}
 
+		/**
+		 * Reconciles the executing-node spinner against ground truth from the
+		 * live-status endpoint after a push reconnect or a tab-visibility regain
+		 * (CAT-2895 Option B). Under tab suspension or a dropped push, a terminal
+		 * `nodeExecuteAfter` or a superseding `nodeExecuteBefore` can be lost,
+		 * leaving a stale or wrong spinner; this restores the truth.
+		 *
+		 *  - `running`  -> set the executing node(s) from `nodes` and seed
+		 *                  `latestSequenceNumber` so a late/replayed push event
+		 *                  can't resurrect a superseded spinner.
+		 *  - `finished` -> clear the spinner (the run genuinely completed).
+		 *  - `unknown`  -> keep current state, never clear. Covers a 404 and the
+		 *                  multi-main case (run held by another main), where
+		 *                  clearing could hide a still-running node. A fetch error
+		 *                  is treated the same way — never clear on uncertainty.
+		 *
+		 * No-op unless a real execution id is active. Re-checks the active id after
+		 * the await so ground truth for a superseded run is never applied to a new
+		 * one.
+		 */
+		async function reconcileExecutingNodeState() {
+			const executionId = activeExecutionId.value;
+			if (typeof executionId !== 'string') return;
+
+			let status;
+			try {
+				status = await workflowsApi.getExecutionLiveStatus(
+					useRootStore().restApiContext,
+					executionId,
+				);
+			} catch {
+				// Treat any failure (incl. 404) like `unknown`: keep state, never clear.
+				return;
+			}
+
+			// A run may have superseded this one while the request was in flight.
+			if (activeExecutionId.value !== executionId) return;
+
+			switch (status.state) {
+				case 'running':
+					executingNode.reconcileExecutingNodes(status.nodes, status.sequenceNumber);
+					break;
+				case 'finished':
+					executingNode.clearNodeExecutionQueue();
+					break;
+				case 'unknown':
+					break;
+			}
+		}
+
 		return {
 			documentId,
 			workflowId,
@@ -956,6 +1008,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			renameActiveExecutionNode,
 			resetExecutionState,
 			markExecutionAsStopped,
+			reconcileExecutingNodeState,
 			// Events
 			onWorkflowExecutionStateChange: onWorkflowExecutionStateChange.on,
 		};

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/_canvasNodeStyles.scss
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/_canvasNodeStyles.scss
@@ -72,10 +72,21 @@
 
 @mixin status-running-animation {
 	animation: border-rotate 1.5s linear infinite;
+
+	// The colored running border is the status signal; only the rotation is
+	// decorative. Freezing the animation holds the conic gradient at its initial
+	// angle, so the border stays visible while the motion stops.
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 }
 
 @mixin status-waiting-animation {
 	animation: border-rotate 4.5s linear infinite;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 }
 
 // @keyframes names are scoped per CSS module, so every module that uses the


### PR DESCRIPTION
## Summary

Frontend half of CAT-2895 Option B (fast-follow to Option A, #34182). Option A shows only the latest executing node via a per-run `sequenceNumber`, but a dropped terminal `nodeExecuteAfter` or a superseding `nodeExecuteBefore` under tab-suspension / push-drop can leave a **stale** or **wrong** spinner.

This reconciles the executing-node spinner against ground truth from the live-status endpoint on **push reconnect** and on **tab-visibility regain**.

## What changed

- **REST client method** (`app/api/workflows.ts`): `getExecutionLiveStatus` hits `GET /rest/executions/:id/live-status`, consuming the `ExecutionLiveStatus` DTO from `@n8n/api-types` (no hand-rolled type).
- **Store reconcile** (`workflowExecutionState.store.ts`): `reconcileExecutingNodeState()` fetches live status for the active execution and maps it:
  - `running` → set executing node(s) from `nodes` and seed `latestSequenceNumber` so a late/replayed push event can't resurrect a superseded spinner.
  - `finished` → clear the spinner (run genuinely completed).
  - `unknown` / `404` / fetch error → keep current state, never clear (multi-main safety).
  - No-op unless a real execution id is active; re-checks the active id after the await so ground truth for a superseded run is never applied to a new one.
- **Composable** (`useExecutingNode.ts`): `reconcileExecutingNodes(nodes, sequenceNumber)` writes the array in a **single assignment** (stale→reconciled is one paint, no clear-then-set flicker) and may hold a legitimately-nested parent + sub-node pair.
- **Wiring** (`usePushConnection.ts`): reconcile on the reconnect rising edge (`isConnected` false→true) and on `visibilitychange` regain, resolving the document the user is currently viewing.
- **A11y** (`_canvasNodeStyles.scss`): guard the running/waiting node-border rotation with `prefers-reduced-motion: reduce`. B leans on this indicator harder (a nested pair can animate two borders at once), so bundling it here. Freezing the conic-gradient rotation holds the colored border at its initial angle — status preserved, motion stopped — matching the design-system motion-mixin pattern.

## Tests

Store-level (`workflowExecutionState.store.test.ts`) + composable-level (`useExecutingNode.test.ts`):

- Dropped `nodeExecuteAfter` + reconnect → spinner restored to the correct single node; cleared on genuine completion.
- Dropped `nodeExecuteBefore` + reconnect → reconciles to the node actually executing; sequence seeded so a replayed stale event can't resurrect it.
- Agent + sub-node → both parent and sub-node show after reconcile (canvas projection asserted).
- `unknown` / `404` / fetch error → keeps current state, never clears.
- No-op when no execution is active.

`pnpm test` (131 affected specs), `pnpm typecheck`, `pnpm lint` all green in `editor-ui`.

## Dependency / stacking

Stacked on the settled BE seam (N8N-82, #34661) — this PR's base is that branch so the `@n8n/api-types` DTO resolves and CI passes. Rebase onto `master` once #34661 merges.

## Known named gaps (not silently closed)

- **`unknown`-forever fog** (multi-main): "keep state, never clear" means a run riding another main leaves its spinner up indefinitely. Bounding that staleness (neutral "status unavailable" after N s + manual re-check) needs a product/scope call and is tracked separately — not implemented here.
- **Reduced-motion** (#3): now fixed here — see the A11y bullet above.
- **Nested** (parent-contains-sub-node) visual: the data path (the `nodes` array) is carried truthfully and both borders render; whether two rotating borders + the connecting edge read as *one nested unit* vs two competing signals at 320px is a taste call pending the live render pass (design QA).

Linear: https://linear.app/n8n/issue/N8N-83

## Review / Testing
- [ ] Manual (CAT-2895 repro): parallel tabs → navigate away 10s+ → return → spinner matches ground truth after reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34663">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


