### PR TITLE
feat(core): Rename package import CLI conflict-policy flag and default it to new-version (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
@@ -242,8 +242,12 @@ describe('ImportPackageRequestDto', () => {
 		}
 	});
 
-	it('rejects omitted workflowConflictPolicy', () => {
-		expect(ImportPackageRequestDto.safeParse({}).success).toBe(false);
+	it('defaults workflowConflictPolicy to "new-version" when omitted', () => {
+		const result = ImportPackageRequestDto.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.workflowConflictPolicy).toBe('new-version');
+		}
 	});
 
 	describe('workflowIdPolicy', () => {

--- a/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
@@ -71,7 +71,7 @@ export class ImportPackageRequestDto extends Z.class({
 		.default('id-only'),
 	credentialMissingMode: z.enum(['must-preexist', 'create-stub']).optional().default('create-stub'),
 	bindings: bindingsSchema,
-	workflowConflictPolicy: z.enum(['new-version', 'fail', 'skip']),
+	workflowConflictPolicy: z.enum(['new-version', 'fail', 'skip']).optional().default('new-version'),
 	workflowPublishingPolicy: z
 		.enum(['preserve-published-state', 'match-source', 'publish-all', 'unpublish-all'])
 		.optional()

--- a/packages/@n8n/cli/docs/commands/package.md
+++ b/packages/@n8n/cli/docs/commands/package.md
@@ -43,16 +43,16 @@ referenced sub-workflows must be in one of the exported projects.
 Import a `.n8np` archive into a project.
 
 ```bash
-n8n-cli package import --file=export.n8np --conflict-policy=fail
-n8n-cli package import --file=export.n8np --project=<id> --conflict-policy=new-version
-n8n-cli package import --file=export.n8np --conflict-policy=fail --credential-missing-mode=must-preexist
-n8n-cli package import --file=export.n8np --conflict-policy=fail --bindings='{"credentials":{"<sourceId>":"<targetId>"}}'
+n8n-cli package import --file=export.n8np
+n8n-cli package import --file=export.n8np --project=<id> --workflow-conflict-policy=skip
+n8n-cli package import --file=export.n8np --workflow-conflict-policy=fail --credential-missing-mode=must-preexist
+n8n-cli package import --file=export.n8np --workflow-conflict-policy=fail --bindings='{"credentials":{"<sourceId>":"<targetId>"}}'
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--file` | Path to the `.n8np` package file. (required) |
-| `--conflict-policy` | What to do when a workflow already exists by source ID: `new-version`, `fail`, or `skip`. (required) |
+| `--workflow-conflict-policy` | What to do when a workflow already exists by source ID: `new-version` (default), `fail`, or `skip`. |
 | `--project` | Target project ID. Defaults to your personal project. |
 | `--folder` | Target folder ID within the project. Defaults to the project root. |
 | `--workflow-publishing-policy` | Whether imported workflows end up published. `preserve-published-state` (instance default) never publishes drafts — an updated workflow is republished only when it was already published and the package workflow is published too; `match-source` follows the package workflow's published flag; `publish-all` publishes every imported workflow; `unpublish-all` leaves new workflows unpublished and unpublishes updated ones. |
@@ -69,7 +69,7 @@ n8n-cli package import --file=export.n8np --conflict-policy=fail --bindings='{"c
 Requires the API key to hold the `workflow:import` scope, plus `dataTable:create`
 when the package references data tables and `--data-table-missing-mode` is
 `create`. When the import is blocked — for example by a workflow conflict under
-`--conflict-policy=fail`, or by an unresolved credential under
+`--workflow-conflict-policy=fail`, or by an unresolved credential under
 `--credential-missing-mode=must-preexist`, or by a schema-incompatible data
 table — the command exits non-zero and lists the blocking issues. With the
 default `create-stub` mode, missing credentials are stubbed instead of blocking

--- a/packages/@n8n/cli/src/__tests__/package-import.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-import.test.ts
@@ -1,4 +1,4 @@
-import type { Config } from '@oclif/core';
+import { Config } from '@oclif/core';
 import * as fs from 'node:fs';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
@@ -7,11 +7,15 @@ import PackageImport from '../commands/package/import';
 
 vi.mock('node:fs');
 
+// Tests run with the package directory as cwd (see AGENTS.md), so this is the
+// @n8n/cli package root oclif needs to read the command manifest.
+const packageRoot = process.cwd();
+
 interface ImportFlags {
 	file: string;
 	project?: string;
 	folder?: string;
-	conflictPolicy: string;
+	workflowConflictPolicy?: string;
 	workflowPublishingPolicy?: string;
 	workflowIdPolicy?: string;
 	folderConflictPolicy?: string;
@@ -56,7 +60,7 @@ describe('package import command', () => {
 			file: '/tmp/export.n8np',
 			project: 'p-1',
 			folder: 'f-1',
-			conflictPolicy: 'fail',
+			workflowConflictPolicy: 'fail',
 			workflowPublishingPolicy: 'publish-all',
 			workflowIdPolicy: 'new',
 			folderConflictPolicy: 'merge',
@@ -103,5 +107,57 @@ describe('package import command', () => {
 			'unpublish-all',
 		]);
 		expect(flag.default).toBeUndefined();
+	});
+
+	// Real oclif parsing exercises the flag default and alias resolution, which
+	// the stubbed `parse` above cannot.
+	describe('workflow-conflict-policy flag resolution (real parse)', () => {
+		async function runWithArgv(argv: string[]) {
+			vi.mocked(fs.existsSync).mockReturnValue(true);
+			vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from([1, 2, 3]));
+
+			const config = await Config.load(packageRoot);
+			const command = new PackageImport(argv, config);
+			const internals = command as unknown as ImportInternals;
+			const importPackage = vi.fn().mockResolvedValue({ imported: true });
+			vi.spyOn(internals, 'getClient').mockReturnValue({
+				importPackage,
+			} as unknown as N8nClient);
+			vi.spyOn(internals, 'output').mockImplementation(() => {});
+
+			await command.run();
+			return importPackage;
+		}
+
+		it('applies the new-version default when the flag is omitted', async () => {
+			const importPackage = await runWithArgv(['--file=/tmp/export.n8np']);
+
+			expect(importPackage).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ workflowConflictPolicy: 'new-version' }),
+			);
+		});
+
+		it('resolves the --workflow-conflict-policy flag', async () => {
+			const importPackage = await runWithArgv([
+				'--file=/tmp/export.n8np',
+				'--workflow-conflict-policy=fail',
+			]);
+
+			expect(importPackage).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ workflowConflictPolicy: 'fail' }),
+			);
+		});
+
+		it('rejects the removed --conflict-policy flag', async () => {
+			const config = await Config.load(packageRoot);
+			const command = new PackageImport(
+				['--file=/tmp/export.n8np', '--conflict-policy=fail'],
+				config,
+			);
+
+			await expect(command.run()).rejects.toThrow(/Nonexistent flag.*conflict-policy/i);
+		});
 	});
 });

--- a/packages/@n8n/cli/src/commands/package/import.ts
+++ b/packages/@n8n/cli/src/commands/package/import.ts
@@ -9,10 +9,10 @@ export default class PackageImport extends BaseCommand {
 	static override description = 'Import an n8n package (.n8np) into a project';
 
 	static override examples = [
-		'<%= config.bin %> package import --file=export.n8np --conflict-policy=fail',
-		'<%= config.bin %> package import --file=export.n8np --project=<id> --conflict-policy=new-version',
-		'<%= config.bin %> package import --file=export.n8np --conflict-policy=fail --credential-missing-mode=must-preexist',
-		'<%= config.bin %> package import --file=export.n8np --conflict-policy=fail --bindings=\'{"credentials":{"<sourceId>":"<targetId>"}}\'',
+		'<%= config.bin %> package import --file=export.n8np',
+		'<%= config.bin %> package import --file=export.n8np --project=<id> --workflow-conflict-policy=skip',
+		'<%= config.bin %> package import --file=export.n8np --workflow-conflict-policy=fail --credential-missing-mode=must-preexist',
+		'<%= config.bin %> package import --file=export.n8np --workflow-conflict-policy=fail --bindings=\'{"credentials":{"<sourceId>":"<targetId>"}}\'',
 	];
 
 	static override flags = {
@@ -24,11 +24,11 @@ export default class PackageImport extends BaseCommand {
 		folder: Flags.string({
 			description: 'Target folder ID within the project (defaults to the project root)',
 		}),
-		conflictPolicy: Flags.string({
+		workflowConflictPolicy: Flags.string({
 			description: 'What to do when a workflow already exists in the target project',
 			options: ['new-version', 'fail', 'skip'],
-			required: true,
-			aliases: ['conflict-policy'],
+			default: 'new-version',
+			aliases: ['workflow-conflict-policy'],
 		}),
 		workflowPublishingPolicy: Flags.string({
 			description:
@@ -103,7 +103,7 @@ export default class PackageImport extends BaseCommand {
 					{
 						projectId: flags.project,
 						folderId: flags.folder,
-						workflowConflictPolicy: flags.conflictPolicy,
+						workflowConflictPolicy: flags.workflowConflictPolicy,
 						workflowPublishingPolicy: flags.workflowPublishingPolicy,
 						workflowIdPolicy: flags.workflowIdPolicy,
 						folderConflictPolicy: flags.folderConflictPolicy,

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -505,14 +505,21 @@ describe('n8n-packages handler', () => {
 			});
 		});
 
-		it('throws BadRequestError and emits validation when workflowConflictPolicy is missing', async () => {
+		it('defaults workflowConflictPolicy to new-version when the caller omits it', async () => {
+			const result = { package: {}, workflows: [], bindings: {}, credentials: {} };
+			mockService.importPackage.mockResolvedValue(result as never);
+			const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response;
+
 			const caught = await runImport(
 				makeImportRequest({ workflowConflictPolicy: undefined }, ['workflow:import']),
-				makeResponse(),
+				res,
 			);
 
-			expect(caught).toBeInstanceOf(BadRequestError);
-			expect(emittedEvent('n8n-package-import-failed')).toMatchObject({ reason: 'validation' });
+			expect(caught).toBeUndefined();
+			expect(mockService.importPackage).toHaveBeenCalledWith(
+				expect.objectContaining({ workflowConflictPolicy: 'new-version' }),
+			);
+			expect(mockEventService.emit).not.toHaveBeenCalled();
 		});
 
 		it('emits access-denied with projectId when the service rejects the target project as forbidden', async () => {


### PR DESCRIPTION
## Summary

Two DX improvements to the `n8n-cli package import` command:

- **Rename** the `--conflict-policy` flag to `--workflow-conflict-policy`, matching the public API parameter (`workflowConflictPolicy`).
- **Default** it to `new-version` and drop `required: true`, so the flag can now be omitted:

  ```bash
  n8n-cli package import --file=export.n8np
  ```

Both the CLI flag and the server DTO (`ImportPackageRequestDto.workflowConflictPolicy`) now default to `new-version`, so omitting the policy no longer errors — on the CLI or on a direct API call.

> The n8n package import/export feature is still in beta, so the flag rename (removal of the old `--conflict-policy` alias) is an accepted breaking change on the beta CLI surface.

## How to test

```bash
# Omitting the flag now works (defaults to new-version)
n8n-cli package import --file=export.n8np

# The renamed flag resolves
n8n-cli package import --file=export.n8np --workflow-conflict-policy=fail

# The old flag is rejected
n8n-cli package import --file=export.n8np --conflict-policy=fail   # -> Nonexistent flag
```

Unit tests: `cd packages/@n8n/cli && pnpm test package-import` (5 tests, incl. real oclif-parse coverage of the default, the renamed flag, and rejection of the removed one).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-859

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
