### PR TITLE
fix(core): Strip null optional node fields from AI-generated workflows

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-source-compiler.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-source-compiler.test.ts
@@ -72,6 +72,95 @@ describe('compileWorkflowSource', () => {
 		);
 	});
 
+	it('strips null top-level node keys and coerces parameters to an object', async () => {
+		const workflow = {
+			name: 'JSON workflow',
+			nodes: [
+				{
+					id: 'http-1',
+					name: 'HTTP Request',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 4.2,
+					position: [0, 0] as [number, number],
+					parameters: null,
+					credentials: null,
+					webhookId: null,
+					notes: null,
+				},
+				{
+					id: 'slack-1',
+					name: 'Slack',
+					type: 'n8n-nodes-base.slack',
+					typeVersion: 2.2,
+					position: [200, 0] as [number, number],
+					parameters: {},
+					credentials: {
+						slackApi: { id: null, name: 'Slack account' },
+					},
+				},
+			],
+			connections: {},
+		};
+		const context = makeContext();
+
+		const result = await compileWorkflowSource(
+			context,
+			'src/workflows/json.workflow.json',
+			JSON.stringify(workflow),
+		);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		const httpNode = result.workflow.nodes[0];
+		expect(httpNode).not.toHaveProperty('credentials');
+		expect(httpNode).not.toHaveProperty('webhookId');
+		expect(httpNode).not.toHaveProperty('notes');
+		expect(httpNode?.parameters).toEqual({});
+
+		const slackNode = result.workflow.nodes[1];
+		expect(slackNode?.credentials).toEqual({
+			slackApi: { id: null, name: 'Slack account' },
+		});
+	});
+
+	it('strips null top-level node keys from sandbox build output', async () => {
+		const workflow = {
+			name: 'TS workflow',
+			nodes: [
+				{
+					id: 'manual-1',
+					name: 'Manual Trigger',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [0, 0] as [number, number],
+					parameters: {},
+					credentials: null,
+					webhookId: null,
+				},
+			],
+			connections: {},
+		};
+		vi.mocked(runInSandbox).mockResolvedValue({
+			exitCode: 0,
+			stdout: JSON.stringify({ success: true, workflow, warnings: [] }),
+			stderr: '',
+		});
+
+		const result = await compileWorkflowSource(
+			makeContext(),
+			'src/workflows/main.workflow.ts',
+			'workflow source',
+		);
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+
+		const node = result.workflow.nodes[0];
+		expect(node).not.toHaveProperty('credentials');
+		expect(node).not.toHaveProperty('webhookId');
+	});
+
 	it('runs TypeScript workflow sources through the sandbox tsx build runner', async () => {
 		const workflow = {
 			name: 'TS workflow',

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
@@ -2,6 +2,7 @@ import { createAbortError, isAbortError } from '@n8n/agents';
 import { getWorkspaceRoot } from '@n8n/agents/sandbox';
 import { isRecord } from '@n8n/utils/is-record';
 import { validateWorkflow, type WorkflowJSON } from '@n8n/workflow-sdk';
+import { normalizeNodeShape } from 'n8n-workflow';
 
 import { buildCredentialHostIndex, resolveCredentialByUrl } from './credential-url-resolver';
 import { detectArrayInputCollapse } from './detect-array-input-collapse';
@@ -65,27 +66,12 @@ export function isWorkflowJsonSourceFile(filePath: string): boolean {
 }
 
 /**
- * Normalizes compiled workflow nodes for INode persistence.
- *
- * Optional top-level INode fields must be omitted, never null. LLM-authored
- * WorkflowJSON and sandbox BUILD_MJS output can still carry `"credentials": null`
- * etc.; strip those before validation/persist. Nested nulls (e.g. credential id)
- * are preserved.
+ * Normalizes compiled workflow nodes for INode persistence via
+ * {@link normalizeNodeShape}. Nested nulls (e.g. credential id) are preserved.
  */
 function normalizeWorkflowNodes(json: WorkflowJSON): void {
-	for (const node of json.nodes ?? []) {
-		if (!isRecord(node)) continue;
-
-		for (const key of Object.keys(node)) {
-			if (node[key] === null) {
-				delete node[key];
-			}
-		}
-
-		if (!isRecord(node.parameters)) {
-			node.parameters = {};
-		}
-	}
+	if (!json.nodes) return;
+	json.nodes = json.nodes.map((node) => normalizeNodeShape(node));
 }
 
 function validateCompiledWorkflow(

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
@@ -64,8 +64,24 @@ export function isWorkflowJsonSourceFile(filePath: string): boolean {
 	return filePath.toLowerCase().endsWith('.json');
 }
 
-function normalizeWorkflowNodeParameters(json: WorkflowJSON): void {
+/**
+ * Normalizes compiled workflow nodes for INode persistence.
+ *
+ * Optional top-level INode fields must be omitted, never null. LLM-authored
+ * WorkflowJSON and sandbox BUILD_MJS output can still carry `"credentials": null`
+ * etc.; strip those before validation/persist. Nested nulls (e.g. credential id)
+ * are preserved.
+ */
+function normalizeWorkflowNodes(json: WorkflowJSON): void {
 	for (const node of json.nodes ?? []) {
+		if (!isRecord(node)) continue;
+
+		for (const key of Object.keys(node)) {
+			if (node[key] === null) {
+				delete node[key];
+			}
+		}
+
 		if (!isRecord(node.parameters)) {
 			node.parameters = {};
 		}
@@ -77,7 +93,7 @@ function validateCompiledWorkflow(
 	context: InstanceAiContext,
 	compilerWarnings: ValidationWarning[] = [],
 ): ValidationWarning[] {
-	normalizeWorkflowNodeParameters(json);
+	normalizeWorkflowNodes(json);
 
 	const schemaValidation = validateWorkflow(json, {
 		nodeTypesProvider: context.nodeTypesProvider,

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.test.ts
@@ -113,6 +113,58 @@ describe('jsonSerializer', () => {
 			expect(result.nodes[0]?.parameters).toEqual({});
 		});
 
+		it('omits null and undefined optional top-level node keys', () => {
+			const httpNode = node({
+				type: 'n8n-nodes-base.httpRequest',
+				version: 4.2,
+				config: {
+					name: 'HTTP Request',
+					notes: null as unknown as string,
+					webhookId: null as unknown as string,
+					executeOnce: null as unknown as boolean,
+					onError: null as unknown as 'continueRegularOutput',
+					credentials: {
+						httpBasicAuth: { id: null as unknown as string, name: 'Basic Auth' },
+					},
+				},
+			});
+			const stickyNote = {
+				id: 'sticky-1',
+				name: 'Sticky Note',
+				type: 'n8n-nodes-base.stickyNote',
+				version: '1',
+				config: {
+					_originalName: undefined,
+					parameters: {},
+				},
+			} as unknown as GraphNode['instance'];
+			const ctx = createMockSerializerContext({
+				nodes: new Map<string, GraphNode>([
+					['HTTP Request', { instance: httpNode, connections: new Map() }],
+					['Sticky Note', { instance: stickyNote, connections: new Map() }],
+				]),
+			});
+
+			const result = jsonSerializer.serialize(ctx);
+
+			for (const serializedNode of result.nodes) {
+				for (const [key, value] of Object.entries(serializedNode)) {
+					if (key === 'parameters') continue;
+					expect(value).not.toBeNull();
+					expect(value).not.toBeUndefined();
+				}
+			}
+
+			expect(result.nodes[0]).not.toHaveProperty('notes');
+			expect(result.nodes[0]).not.toHaveProperty('webhookId');
+			expect(result.nodes[0]).not.toHaveProperty('executeOnce');
+			expect(result.nodes[0]).not.toHaveProperty('onError');
+			expect(result.nodes[0]?.credentials).toEqual({
+				httpBasicAuth: { id: null, name: 'Basic Auth' },
+			});
+			expect(result.nodes[1]).not.toHaveProperty('name');
+		});
+
 		describe('node groups', () => {
 			it('omits nodeGroups when the context has none', () => {
 				const result = jsonSerializer.serialize(createMockSerializerContext());

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -35,6 +35,18 @@ const WEBHOOK_NODE_TYPES = new Set([
 	'@n8n/n8n-nodes-langchain.mcpTrigger',
 ]);
 
+/** Drop null/undefined optional top-level keys; `parameters` is always retained. */
+function omitNullishTopLevelNodeFields(node: NodeJSON): NodeJSON {
+	const cleaned = { ...node };
+	for (const key of Object.keys(cleaned) as Array<keyof NodeJSON>) {
+		if (key === 'parameters') continue;
+		if (cleaned[key] === null || cleaned[key] === undefined) {
+			delete cleaned[key];
+		}
+	}
+	return cleaned;
+}
+
 /**
  * Serialize a single node to NodeJSON format.
  */
@@ -159,7 +171,7 @@ function serializeNode(
 		n8nNode.extendsCredential = config.extendsCredential;
 	}
 
-	return n8nNode;
+	return omitNullishTopLevelNodeFields(n8nNode);
 }
 
 /**

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -4,7 +4,7 @@
  * Serializes workflows to n8n's standard JSON format.
  */
 
-import { deepCopy } from 'n8n-workflow';
+import { deepCopy, normalizeNodeShape } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
 
 import { foldLegacyErrorConnections } from '../../../types/base';
@@ -34,18 +34,6 @@ const WEBHOOK_NODE_TYPES = new Set([
 	'n8n-nodes-base.formTrigger',
 	'@n8n/n8n-nodes-langchain.mcpTrigger',
 ]);
-
-/** Drop null/undefined optional top-level keys; `parameters` is always retained. */
-function omitNullishTopLevelNodeFields(node: NodeJSON): NodeJSON {
-	const cleaned = { ...node };
-	for (const key of Object.keys(cleaned) as Array<keyof NodeJSON>) {
-		if (key === 'parameters') continue;
-		if (cleaned[key] === null || cleaned[key] === undefined) {
-			delete cleaned[key];
-		}
-	}
-	return cleaned;
-}
 
 /**
  * Serialize a single node to NodeJSON format.
@@ -171,7 +159,7 @@ function serializeNode(
 		n8nNode.extendsCredential = config.extendsCredential;
 	}
 
-	return omitNullishTopLevelNodeFields(n8nNode);
+	return normalizeNodeShape(n8nNode);
 }
 
 /**

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -15,6 +15,7 @@ import { createTestNode } from '@/__tests__/mocks';
 import type { INodeUi } from '@/Interface';
 import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants';
 import type { Workflow } from 'n8n-workflow';
+import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/nodeTypesUtils';
 
 // Instantiates a store that derives the workflow id from the route. These tests run
 // without a router, so resolve the id directly.
@@ -165,6 +166,7 @@ describe('useWorkflowUpdate', () => {
 			});
 			const nodeWithNulls = {
 				...newNode,
+				parameters: null,
 				credentials: null,
 				webhookId: null,
 				notes: null,
@@ -198,6 +200,7 @@ describe('useWorkflowUpdate', () => {
 				string,
 				unknown
 			>;
+			expect(addedNode.parameters).toEqual({});
 			expect(addedNode).not.toHaveProperty('credentials');
 			expect(addedNode).not.toHaveProperty('webhookId');
 			expect(addedNode).not.toHaveProperty('notes');
@@ -923,6 +926,52 @@ describe('useWorkflowUpdate', () => {
 				expect(mockCanvasOperations.addNodes).toHaveBeenCalledWith(
 					[
 						expect.objectContaining({
+							credentials: { httpBasicAuth: { id: 'cred-1', name: 'My Credential' } },
+						}),
+					],
+					expect.any(Object),
+				);
+			});
+
+			it('should coerce null parameters to {} before applying default credentials', async () => {
+				const nodeWithNullParams = {
+					...createTestNode({
+						id: 'node-1',
+						name: 'HTTP Request',
+						type: 'n8n-nodes-base.httpRequest',
+						credentials: undefined,
+					}),
+					parameters: null,
+					credentials: null,
+				};
+
+				const mockCredential = {
+					id: 'cred-1',
+					name: 'My Credential',
+					type: 'httpBasicAuth',
+				};
+
+				nodeTypesStore.getNodeType = vi.fn().mockReturnValue({
+					credentials: [{ name: 'httpBasicAuth' }],
+				});
+				credentialsStore.getCredentialsByType = vi.fn().mockReturnValue([mockCredential]);
+				vi.mocked(getMainAuthField).mockReturnValue({ name: 'authentication' } as never);
+				vi.mocked(getAuthTypeForNodeCredential).mockReturnValue({ value: 'basicAuth' } as never);
+
+				mockCanvasOperations.addNodes.mockResolvedValue([nodeWithNullParams as unknown as INodeUi]);
+
+				const { updateWorkflow } = useWorkflowUpdate();
+
+				const result = await updateWorkflow({
+					nodes: [nodeWithNullParams as unknown as INodeUi],
+					connections: {},
+				});
+
+				expect(result.success).toBe(true);
+				expect(mockCanvasOperations.addNodes).toHaveBeenCalledWith(
+					[
+						expect.objectContaining({
+							parameters: expect.objectContaining({ authentication: 'basicAuth' }),
 							credentials: { httpBasicAuth: { id: 'cred-1', name: 'My Credential' } },
 						}),
 					],

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -157,6 +157,57 @@ describe('useWorkflowUpdate', () => {
 			expect(builderStore.setBuilderMadeEdits).toHaveBeenCalledWith(true);
 		});
 
+		it('should strip null optional fields from incoming AI nodes before applying', async () => {
+			const newNode = createTestNode({
+				id: 'new-node-1',
+				name: 'New Node',
+				type: 'n8n-nodes-base.httpRequest',
+			});
+			const nodeWithNulls = {
+				...newNode,
+				credentials: null,
+				webhookId: null,
+				notes: null,
+				notesInFlow: null,
+				executeOnce: null,
+				retryOnFail: null,
+				alwaysOutputData: null,
+				onError: null,
+			};
+
+			mockCanvasOperations.addNodes.mockResolvedValue([newNode as INodeUi]);
+
+			const { updateWorkflow } = useWorkflowUpdate();
+
+			await updateWorkflow({
+				nodes: [nodeWithNulls as unknown as INodeUi],
+				connections: {},
+			});
+
+			expect(mockCanvasOperations.addNodes).toHaveBeenCalledWith(
+				[
+					expect.objectContaining({
+						id: 'new-node-1',
+						name: 'New Node',
+						type: 'n8n-nodes-base.httpRequest',
+					}),
+				],
+				expect.any(Object),
+			);
+			const addedNode = mockCanvasOperations.addNodes.mock.calls[0][0][0] as Record<
+				string,
+				unknown
+			>;
+			expect(addedNode).not.toHaveProperty('credentials');
+			expect(addedNode).not.toHaveProperty('webhookId');
+			expect(addedNode).not.toHaveProperty('notes');
+			expect(addedNode).not.toHaveProperty('notesInFlow');
+			expect(addedNode).not.toHaveProperty('executeOnce');
+			expect(addedNode).not.toHaveProperty('retryOnFail');
+			expect(addedNode).not.toHaveProperty('alwaysOutputData');
+			expect(addedNode).not.toHaveProperty('onError');
+		});
+
 		describe('node categorization', () => {
 			it('should add new nodes that do not exist in current workflow', async () => {
 				const newNode = createTestNode({

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -14,10 +14,9 @@ import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { mapLegacyConnectionsToCanvasConnections } from '@/features/workflows/canvas/canvas.utils';
-import { omitNullNodeFields } from '@/app/utils/nodes/nodeTransforms';
 import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/nodeTypesUtils';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
-import { NodeHelpers, type IConnections, type INode } from 'n8n-workflow';
+import { NodeHelpers, normalizeNodeShape, type IConnections, type INode } from 'n8n-workflow';
 import isEqual from 'lodash/isEqual';
 
 export interface UpdateWorkflowOptions {
@@ -343,10 +342,10 @@ export function useWorkflowUpdate() {
 		options?: UpdateWorkflowOptions,
 	): Promise<UpdateWorkflowResult> {
 		try {
-			// AI edit round-trips can emit optional INode fields as null; strip them so
+			// AI edit round-trips can emit optional INode fields as null; normalize so
 			// they never reach the canvas store or serializeNode (Object.keys(null)).
 			if (workflowData.nodes) {
-				workflowData.nodes = workflowData.nodes.map((node) => omitNullNodeFields(node));
+				workflowData.nodes = workflowData.nodes.map((node) => normalizeNodeShape(node));
 			}
 
 			// Apply default credentials to incoming nodes BEFORE adding to store

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -14,6 +14,7 @@ import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { mapLegacyConnectionsToCanvasConnections } from '@/features/workflows/canvas/canvas.utils';
+import { omitNullNodeFields } from '@/app/utils/nodes/nodeTransforms';
 import { getAuthTypeForNodeCredential, getMainAuthField } from '@/app/utils/nodeTypesUtils';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
 import { NodeHelpers, type IConnections, type INode } from 'n8n-workflow';
@@ -342,6 +343,12 @@ export function useWorkflowUpdate() {
 		options?: UpdateWorkflowOptions,
 	): Promise<UpdateWorkflowResult> {
 		try {
+			// AI edit round-trips can emit optional INode fields as null; strip them so
+			// they never reach the canvas store or serializeNode (Object.keys(null)).
+			if (workflowData.nodes) {
+				workflowData.nodes = workflowData.nodes.map((node) => omitNullNodeFields(node));
+			}
+
 			// Apply default credentials to incoming nodes BEFORE adding to store
 			setDefaultCredentialsOnNodes(workflowData.nodes ?? []);
 

--- a/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.test.ts
@@ -4,11 +4,7 @@ import { setActivePinia } from 'pinia';
 import { NodeHelpers } from 'n8n-workflow';
 import type { INodePropertyOptions, INodeTypeDescription } from 'n8n-workflow';
 
-import {
-	getParameterDisplayableOptions,
-	omitNullNodeFields,
-	serializeNode,
-} from './nodeTransforms';
+import { getParameterDisplayableOptions, serializeNode } from './nodeTransforms';
 import type { INodeUi } from '@/Interface';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
@@ -262,30 +258,6 @@ describe('getParameterDisplayableOptions', () => {
 	});
 });
 
-describe('omitNullNodeFields', () => {
-	it('removes null-valued keys and leaves other values intact', () => {
-		const result = omitNullNodeFields({
-			id: '1',
-			name: 'Node',
-			credentials: null,
-			webhookId: null,
-			parameters: {},
-			retryOnFail: false,
-			notes: undefined,
-		});
-
-		expect(result).toEqual({
-			id: '1',
-			name: 'Node',
-			parameters: {},
-			retryOnFail: false,
-			notes: undefined,
-		});
-		expect('credentials' in result).toBe(false);
-		expect('webhookId' in result).toBe(false);
-	});
-});
-
 describe('serializeNode', () => {
 	const nodeTypeProvider = { getNodeType: vi.fn().mockReturnValue(null) };
 
@@ -409,8 +381,19 @@ describe('serializeNode', () => {
 			{},
 			false,
 			false,
-			node,
+			expect.objectContaining({
+				id: 'id',
+				name: 'Test Node',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {},
+			}),
 			knownNodeType,
 		);
+		const normalizedNode = vi.mocked(NodeHelpers.getNodeParameters).mock.calls[0]?.[4] as Record<
+			string,
+			unknown
+		>;
+		expect(normalizedNode).not.toHaveProperty('credentials');
+		expect(normalizedNode).not.toHaveProperty('webhookId');
 	});
 });

--- a/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.test.ts
@@ -4,7 +4,11 @@ import { setActivePinia } from 'pinia';
 import { NodeHelpers } from 'n8n-workflow';
 import type { INodePropertyOptions, INodeTypeDescription } from 'n8n-workflow';
 
-import { getParameterDisplayableOptions, serializeNode } from './nodeTransforms';
+import {
+	getParameterDisplayableOptions,
+	omitNullNodeFields,
+	serializeNode,
+} from './nodeTransforms';
 import type { INodeUi } from '@/Interface';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
@@ -258,6 +262,30 @@ describe('getParameterDisplayableOptions', () => {
 	});
 });
 
+describe('omitNullNodeFields', () => {
+	it('removes null-valued keys and leaves other values intact', () => {
+		const result = omitNullNodeFields({
+			id: '1',
+			name: 'Node',
+			credentials: null,
+			webhookId: null,
+			parameters: {},
+			retryOnFail: false,
+			notes: undefined,
+		});
+
+		expect(result).toEqual({
+			id: '1',
+			name: 'Node',
+			parameters: {},
+			retryOnFail: false,
+			notes: undefined,
+		});
+		expect('credentials' in result).toBe(false);
+		expect('webhookId' in result).toBe(false);
+	});
+});
+
 describe('serializeNode', () => {
 	const nodeTypeProvider = { getNodeType: vi.fn().mockReturnValue(null) };
 
@@ -275,6 +303,7 @@ describe('serializeNode', () => {
 
 	beforeEach(() => {
 		nodeTypeProvider.getNodeType.mockReturnValue(null);
+		vi.mocked(NodeHelpers.getNodeParameters).mockReturnValue({});
 	});
 
 	it('passes parameters + credentials through when node type is unknown', () => {
@@ -318,5 +347,70 @@ describe('serializeNode', () => {
 		expect(resultWithout.continueOnFail).toBeUndefined();
 		expect(resultWithout.onError).toBeUndefined();
 		expect(resultWithout.notes).toBeUndefined();
+	});
+
+	it('does not throw and omits null optional fields when node type is unknown', () => {
+		const node = createNode({
+			credentials: null as unknown as INodeUi['credentials'],
+			webhookId: null as unknown as string,
+			notes: null as unknown as string,
+			notesInFlow: null as unknown as boolean,
+			executeOnce: null as unknown as boolean,
+			retryOnFail: null as unknown as boolean,
+			alwaysOutputData: null as unknown as boolean,
+			onError: null as unknown as INodeUi['onError'],
+		});
+
+		const result = serializeNode(nodeTypeProvider, node);
+
+		expect(result.credentials).toBeUndefined();
+		expect(result.webhookId).toBeUndefined();
+		expect(result.notes).toBeUndefined();
+		expect(result.notesInFlow).toBeUndefined();
+		expect(result.executeOnce).toBeUndefined();
+		expect(result.retryOnFail).toBeUndefined();
+		expect(result.alwaysOutputData).toBeUndefined();
+		expect(result.onError).toBeUndefined();
+		expect(result.parameters).toEqual({});
+	});
+
+	it('does not throw when a known node type has null credentials or parameters', () => {
+		const knownNodeType = {
+			name: 'n8n-nodes-base.httpRequest',
+			displayName: 'HTTP Request',
+			version: 1,
+			description: '',
+			defaults: { name: 'HTTP Request' },
+			inputs: ['main'],
+			outputs: ['main'],
+			properties: [],
+			group: ['transform'],
+			credentials: [{ name: 'httpBasicAuth', required: false }],
+		} as INodeTypeDescription;
+
+		nodeTypeProvider.getNodeType.mockReturnValue(knownNodeType);
+		vi.mocked(NodeHelpers.getNodeParameters).mockReturnValue({});
+
+		const node = createNode({
+			type: 'n8n-nodes-base.httpRequest',
+			credentials: null as unknown as INodeUi['credentials'],
+			parameters: null as unknown as INodeUi['parameters'],
+			webhookId: null as unknown as string,
+		});
+
+		expect(() => serializeNode(nodeTypeProvider, node)).not.toThrow();
+		const result = serializeNode(nodeTypeProvider, node);
+
+		expect(result.credentials).toBeUndefined();
+		expect(result.webhookId).toBeUndefined();
+		expect(result.parameters).toEqual({});
+		expect(NodeHelpers.getNodeParameters).toHaveBeenCalledWith(
+			knownNodeType.properties,
+			{},
+			false,
+			false,
+			node,
+			knownNodeType,
+		);
 	});
 });

--- a/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
@@ -12,7 +12,12 @@ import type {
 	FromAIArgument,
 	INodePropertyOptions,
 } from 'n8n-workflow';
-import { isHitlToolType, NodeHelpers, traverseNodeParameters } from 'n8n-workflow';
+import {
+	isHitlToolType,
+	NodeHelpers,
+	normalizeNodeShape,
+	traverseNodeParameters,
+} from 'n8n-workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { getCredentialTypeName, isCredentialOnlyNodeType } from '@/app/utils/credentialOnlyNodes';
 import { hasProxyAuth } from '@/app/utils/nodeTypesUtils';
@@ -163,29 +168,13 @@ export function getParameterDisplayableOptions(
 }
 
 /**
- * Drops null-valued keys from a node object.
- *
- * Optional INode fields are `.optional()`, never `.nullable()`. Sources such as
- * the AI Assistant edit round-trip can still emit `"credentials": null` etc.;
- * those are equivalent to the key being omitted and must be stripped before the
- * node is applied to the canvas or persisted.
- */
-export function omitNullNodeFields<T extends object>(node: T): T {
-	const cleaned = { ...node };
-	for (const key of Object.keys(cleaned) as Array<keyof T>) {
-		if (cleaned[key] === null) {
-			delete cleaned[key];
-		}
-	}
-	return cleaned;
-}
-
-/**
  * Serializes a node for persistence: strips transient UI state, resolves
  * default parameters via the node type definition, and retains only the
  * credentials that are currently displayable.
  */
 export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi): INodeUi {
+	node = normalizeNodeShape(node);
+
 	const skipKeys = [
 		'color',
 		'continueOnFail',
@@ -204,11 +193,9 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 	};
 
 	for (const key in node) {
-		// Skip nulls: optional INode fields must be omitted, never null (see omitNullNodeFields).
-		const value = (node as unknown as Record<string, unknown>)[key];
-		if (key.charAt(0) !== '_' && skipKeys.indexOf(key) === -1 && value !== null) {
+		if (key.charAt(0) !== '_' && skipKeys.indexOf(key) === -1) {
 			// @ts-ignore
-			nodeData[key] = value;
+			nodeData[key] = node[key];
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
@@ -163,6 +163,24 @@ export function getParameterDisplayableOptions(
 }
 
 /**
+ * Drops null-valued keys from a node object.
+ *
+ * Optional INode fields are `.optional()`, never `.nullable()`. Sources such as
+ * the AI Assistant edit round-trip can still emit `"credentials": null` etc.;
+ * those are equivalent to the key being omitted and must be stripped before the
+ * node is applied to the canvas or persisted.
+ */
+export function omitNullNodeFields<T extends object>(node: T): T {
+	const cleaned = { ...node };
+	for (const key of Object.keys(cleaned) as Array<keyof T>) {
+		if (cleaned[key] === null) {
+			delete cleaned[key];
+		}
+	}
+	return cleaned;
+}
+
+/**
  * Serializes a node for persistence: strips transient UI state, resolves
  * default parameters via the node type definition, and retains only the
  * credentials that are currently displayable.
@@ -186,15 +204,18 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 	};
 
 	for (const key in node) {
-		if (key.charAt(0) !== '_' && skipKeys.indexOf(key) === -1) {
+		// Skip nulls: optional INode fields must be omitted, never null (see omitNullNodeFields).
+		const value = (node as unknown as Record<string, unknown>)[key];
+		if (key.charAt(0) !== '_' && skipKeys.indexOf(key) === -1 && value !== null) {
 			// @ts-ignore
-			nodeData[key] = node[key];
+			nodeData[key] = value;
 		}
 	}
 
 	// Get the data of the node type that we can get the default values
 	// TODO: Later also has to care about the node-type-version as defaults could be different
 	const nodeType = nodeTypeProvider.getNodeType(node.type, node.typeVersion);
+	const nodeParametersInput = node.parameters ?? {};
 
 	if (nodeType !== null) {
 		const isCredentialOnly = isCredentialOnlyNodeType(nodeType.name);
@@ -207,7 +228,7 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 		// Node-Type is known so we can save the parameters correctly
 		const nodeParameters = NodeHelpers.getNodeParameters(
 			nodeType.properties,
-			node.parameters,
+			nodeParametersInput,
 			isCredentialOnly,
 			false,
 			node,
@@ -216,17 +237,23 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 		nodeData.parameters = nodeParameters !== null ? nodeParameters : {};
 
 		// Add the node credentials if there are some set and if they should be displayed
-		if (node.credentials !== undefined && nodeType.credentials !== undefined) {
+		if (
+			node.credentials !== undefined &&
+			node.credentials !== null &&
+			nodeType.credentials !== undefined
+		) {
 			const saveCredentials: INodeCredentials = {};
 			for (const nodeCredentialTypeName of Object.keys(node.credentials)) {
-				if (hasProxyAuth(node) || Object.keys(node.parameters).includes('genericAuthType')) {
+				if (hasProxyAuth(node) || Object.keys(nodeParametersInput).includes('genericAuthType')) {
 					saveCredentials[nodeCredentialTypeName] = node.credentials[nodeCredentialTypeName];
 					continue;
 				}
 
 				const credentialTypeDescription = nodeType.credentials
 					// filter out credentials with same name in different node versions
-					.filter((c) => NodeHelpers.displayParameterPath(node.parameters, c, '', node, nodeType))
+					.filter((c) =>
+						NodeHelpers.displayParameterPath(nodeParametersInput, c, '', node, nodeType),
+					)
 					.find((c) => c.name === nodeCredentialTypeName);
 
 				if (credentialTypeDescription === undefined) {
@@ -236,7 +263,7 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 
 				if (
 					!NodeHelpers.displayParameterPath(
-						node.parameters,
+						nodeParametersInput,
 						credentialTypeDescription,
 						'',
 						node,
@@ -256,9 +283,11 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 			}
 		}
 	} else {
-		// Node-Type is not known so save the data as it is
-		nodeData.credentials = node.credentials;
-		nodeData.parameters = node.parameters;
+		// Node-Type is not known so save the data as it is (omit nulls)
+		if (node.credentials !== undefined && node.credentials !== null) {
+			nodeData.credentials = node.credentials;
+		}
+		nodeData.parameters = nodeParametersInput;
 		if (nodeData.color !== undefined) {
 			nodeData.color = node.color;
 		}
@@ -271,11 +300,11 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 	if (node.continueOnFail === true) {
 		nodeData.continueOnFail = true;
 	}
-	if (node.onError !== 'stopWorkflow') {
+	if (node.onError !== undefined && node.onError !== null && node.onError !== 'stopWorkflow') {
 		nodeData.onError = node.onError;
 	}
 	// Save the notes only if when they contain data
-	if (![undefined, ''].includes(node.notes)) {
+	if (node.notes !== undefined && node.notes !== null && node.notes !== '') {
 		nodeData.notes = node.notes;
 	}
 

--- a/packages/workflow/src/schemas.ts
+++ b/packages/workflow/src/schemas.ts
@@ -499,3 +499,29 @@ export const INodeSchema: z.ZodType<INode> = z.object({
 });
 
 export const INodesSchema: z.ZodType<INode[]> = z.array(INodeSchema);
+
+/**
+ * Normalize a node to the {@link INodeSchema} persistence shape.
+ *
+ * Optional top-level INode fields are `.optional()`, never `.nullable()` — nullish
+ * values are omitted. `parameters` is required and always coerced to an object.
+ * Nested nulls (e.g. credential ids) are left intact.
+ */
+export function normalizeNodeShape<T extends object>(node: T): T {
+	const cleaned: Record<string, unknown> = { ...(node as Record<string, unknown>) };
+
+	for (const key of Object.keys(cleaned)) {
+		if (key === 'parameters') continue;
+		if (cleaned[key] === null || cleaned[key] === undefined) {
+			delete cleaned[key];
+		}
+	}
+
+	const parameters = cleaned.parameters;
+	cleaned.parameters =
+		parameters !== null && typeof parameters === 'object' && !Array.isArray(parameters)
+			? parameters
+			: {};
+
+	return cleaned as T;
+}

--- a/packages/workflow/src/schemas.ts
+++ b/packages/workflow/src/schemas.ts
@@ -469,7 +469,7 @@ export const INodeCredentialsSchema: z.ZodType<INodeCredentials> = z.record(
 	INodeCredentialsDetailsSchema,
 );
 
-export const INodeSchema: z.ZodType<INode> = z.object({
+const iNodeSchemaObject = z.object({
 	id: z.string(),
 	name: z.string(),
 	typeVersion: z.number(),
@@ -498,20 +498,29 @@ export const INodeSchema: z.ZodType<INode> = z.object({
 		.optional(),
 });
 
+export const INodeSchema: z.ZodType<INode> = iNodeSchemaObject;
+
 export const INodesSchema: z.ZodType<INode[]> = z.array(INodeSchema);
+
+/** Top-level keys that are `.optional()` but not `.nullable()` — nullish values must be omitted. */
+const optionalNonNullableINodeKeys: ReadonlySet<string> = new Set(
+	Object.entries(iNodeSchemaObject.shape)
+		.filter(([, field]) => field.isOptional() && !field.isNullable())
+		.map(([key]) => key),
+);
 
 /**
  * Normalize a node to the {@link INodeSchema} persistence shape.
  *
- * Optional top-level INode fields are `.optional()`, never `.nullable()` — nullish
- * values are omitted. `parameters` is required and always coerced to an object.
+ * Driven by INodeSchema: nullish values are omitted only for top-level keys marked
+ * `.optional()` and not `.nullable()`. Adding a `.nullable()` field preserves `null`
+ * for that key automatically. `parameters` is required and always coerced to an object.
  * Nested nulls (e.g. credential ids) are left intact.
  */
 export function normalizeNodeShape<T extends object>(node: T): T {
 	const cleaned: Record<string, unknown> = { ...(node as Record<string, unknown>) };
 
-	for (const key of Object.keys(cleaned)) {
-		if (key === 'parameters') continue;
+	for (const key of optionalNonNullableINodeKeys) {
 		if (cleaned[key] === null || cleaned[key] === undefined) {
 			delete cleaned[key];
 		}

--- a/packages/workflow/src/schemas.ts
+++ b/packages/workflow/src/schemas.ts
@@ -502,7 +502,7 @@ export const INodeSchema: z.ZodType<INode> = iNodeSchemaObject;
 
 export const INodesSchema: z.ZodType<INode[]> = z.array(INodeSchema);
 
-/** Top-level keys that are `.optional()` but not `.nullable()` — nullish values must be omitted. */
+/** Top-level keys that are `.optional()` but not `.nullable()` — `null` must be omitted. */
 const optionalNonNullableINodeKeys: ReadonlySet<string> = new Set(
 	Object.entries(iNodeSchemaObject.shape)
 		.filter(([, field]) => field.isOptional() && !field.isNullable())
@@ -512,16 +512,23 @@ const optionalNonNullableINodeKeys: ReadonlySet<string> = new Set(
 /**
  * Normalize a node to the {@link INodeSchema} persistence shape.
  *
- * Driven by INodeSchema: nullish values are omitted only for top-level keys marked
- * `.optional()` and not `.nullable()`. Adding a `.nullable()` field preserves `null`
- * for that key automatically. `parameters` is required and always coerced to an object.
- * Nested nulls (e.g. credential ids) are left intact.
+ * - `undefined` top-level values are always omitted (JSON has no undefined; e.g. sticky
+ *   notes may intentionally leave `name` unset).
+ * - `null` is omitted only for keys marked `.optional()` and not `.nullable()` on
+ *   INodeSchema. Adding a `.nullable()` field preserves `null` for that key.
+ * - `parameters` is required and always coerced to an object.
+ * - Nested nulls (e.g. credential ids) are left intact.
  */
 export function normalizeNodeShape<T extends object>(node: T): T {
 	const cleaned: Record<string, unknown> = { ...(node as Record<string, unknown>) };
 
-	for (const key of optionalNonNullableINodeKeys) {
-		if (cleaned[key] === null || cleaned[key] === undefined) {
+	for (const key of Object.keys(cleaned)) {
+		const value = cleaned[key];
+		if (value === undefined) {
+			delete cleaned[key];
+			continue;
+		}
+		if (value === null && optionalNonNullableINodeKeys.has(key)) {
 			delete cleaned[key];
 		}
 	}

--- a/packages/workflow/test/schemas.test.ts
+++ b/packages/workflow/test/schemas.test.ts
@@ -1,4 +1,4 @@
-import { INodeCredentialsDetailsSchema } from '../src/schemas';
+import { INodeCredentialsDetailsSchema, normalizeNodeShape } from '../src/schemas';
 
 describe('INodeCredentialsDetailsSchema', () => {
 	it('accepts AI Gateway-managed credential entries', () => {
@@ -15,5 +15,63 @@ describe('INodeCredentialsDetailsSchema', () => {
 		const result = INodeCredentialsDetailsSchema.parse({ id: 'cred-123', name: 'My credential' });
 
 		expect(result).toEqual({ id: 'cred-123', name: 'My credential' });
+	});
+});
+
+describe('normalizeNodeShape', () => {
+	it('omits nullish optional top-level keys and coerces parameters to an object', () => {
+		const result = normalizeNodeShape({
+			id: '1',
+			name: 'HTTP Request',
+			type: 'n8n-nodes-base.httpRequest',
+			typeVersion: 4.2,
+			position: [0, 0] as [number, number],
+			parameters: null,
+			credentials: null,
+			webhookId: null,
+			notes: undefined,
+			retryOnFail: false,
+		});
+
+		expect(result).toEqual({
+			id: '1',
+			name: 'HTTP Request',
+			type: 'n8n-nodes-base.httpRequest',
+			typeVersion: 4.2,
+			position: [0, 0],
+			parameters: {},
+			retryOnFail: false,
+		});
+		expect(result).not.toHaveProperty('credentials');
+		expect(result).not.toHaveProperty('webhookId');
+		expect(result).not.toHaveProperty('notes');
+	});
+
+	it('preserves nested nulls and existing parameter objects', () => {
+		const result = normalizeNodeShape({
+			id: '1',
+			name: 'Slack',
+			parameters: { channel: 'general' },
+			credentials: {
+				slackApi: { id: null, name: 'Slack account' },
+			},
+		});
+
+		expect(result.parameters).toEqual({ channel: 'general' });
+		expect(result.credentials).toEqual({
+			slackApi: { id: null, name: 'Slack account' },
+		});
+	});
+
+	it('coerces missing or non-object parameters to {}', () => {
+		expect(normalizeNodeShape({ id: '1' })).toEqual({ id: '1', parameters: {} });
+		expect(normalizeNodeShape({ id: '1', parameters: 'bad' })).toEqual({
+			id: '1',
+			parameters: {},
+		});
+		expect(normalizeNodeShape({ id: '1', parameters: ['bad'] })).toEqual({
+			id: '1',
+			parameters: {},
+		});
 	});
 });

--- a/packages/workflow/test/schemas.test.ts
+++ b/packages/workflow/test/schemas.test.ts
@@ -75,7 +75,7 @@ describe('normalizeNodeShape', () => {
 		});
 	});
 
-	it('does not strip nullish values for keys outside INodeSchema', () => {
+	it('does not strip null for keys outside INodeSchema', () => {
 		const result = normalizeNodeShape({
 			id: '1',
 			parameters: {},
@@ -94,5 +94,18 @@ describe('normalizeNodeShape', () => {
 		});
 
 		expect(result).toEqual({ id: null, name: null, parameters: {} });
+	});
+
+	it('always omits undefined top-level values, including required keys', () => {
+		const result = normalizeNodeShape({
+			id: '1',
+			name: undefined,
+			parameters: {},
+			notInSchema: undefined,
+		});
+
+		expect(result).toEqual({ id: '1', parameters: {} });
+		expect(result).not.toHaveProperty('name');
+		expect(result).not.toHaveProperty('notInSchema');
 	});
 });

--- a/packages/workflow/test/schemas.test.ts
+++ b/packages/workflow/test/schemas.test.ts
@@ -74,4 +74,25 @@ describe('normalizeNodeShape', () => {
 			parameters: {},
 		});
 	});
+
+	it('does not strip nullish values for keys outside INodeSchema', () => {
+		const result = normalizeNodeShape({
+			id: '1',
+			parameters: {},
+			credentials: null,
+			notInSchema: null,
+		});
+
+		expect(result).toEqual({ id: '1', parameters: {}, notInSchema: null });
+	});
+
+	it('does not strip null on required top-level keys', () => {
+		const result = normalizeNodeShape({
+			id: null,
+			name: null,
+			parameters: {},
+		});
+
+		expect(result).toEqual({ id: null, name: null, parameters: {} });
+	});
 });


### PR DESCRIPTION
## Summary

`INodeSchema` marks optional top-level node attributes (`credentials`, `webhookId`, `notes`, `onError`, ...) as `.optional()`, not `.nullable()`. They must be omitted when absent — never `null`.

Some touchpoints let `null` values pass through (AI-generated workflow JSON, the sandbox build output). When such a node reaches the editor, saving fails with `Cannot convert undefined or null to object`.

This PR strips null top-level node attributes at these places (nested nulls like `credentials.x.id: null` are left intact):

- `workflow-source-compiler.ts` (Instance AI) — normalizes every compiled workflow, both `.json` and sandbox-built sources
- `json-serializer.ts` (workflow SDK) — drops null/undefined optional keys when serializing nodes
- `useWorkflowUpdate.ts` (editor) — strips nulls before applying AI edits to the canvas
- `nodeTransforms.ts` (editor) — `serializeNode` skips null values instead of crashing on save

## How to test

1. Ask the AI Assistant to build or edit a workflow whose generated JSON contains `"credentials": null` on a node.
2. Let it apply to the canvas and save.
3. Save succeeds and the persisted nodes contain no null top-level keys.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-941
- Resolves community forum report: [Problem saving workflow after using n8n AI Assistant to rename nodes](https://community.n8n.io/t/problem-saving-workflow-after-using-n8n-ai-assistant-to-rename-nodes/303207)
- RESOLVES INS-941

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)