### PR TITLE
fix(core): Normalize workflow rollup timestamps

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/workflow-statistics.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow-statistics.repository.test.ts
@@ -1,0 +1,54 @@
+import type { GlobalConfig } from '@n8n/config';
+import type { DataSource } from '@n8n/typeorm';
+import { mock } from 'vitest-mock-extended';
+
+import { WorkflowStatistics } from '../../entities';
+import { StatisticsNames } from '../../entities/types-db';
+import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
+import { WorkflowStatisticsRepository } from '../workflow-statistics.repository';
+
+describe('WorkflowStatisticsRepository', () => {
+	const entityManager = mockEntityManager(WorkflowStatistics);
+	const repository = new WorkflowStatisticsRepository(
+		entityManager.connection as unknown as DataSource,
+		mock<GlobalConfig>({ database: { type: 'postgresdb', tablePrefix: '' } }),
+	);
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		Object.assign(entityManager.connection.driver, {
+			escape: vi.fn((identifier: string) => `"${identifier}"`),
+		});
+	});
+
+	it.each([
+		['a Date', new Date('2026-07-21T16:33:00.000Z')],
+		// Regression for #34669: raw Postgres timestamps are not always parsed into Date objects.
+		['an ISO timestamp string', '2026-07-21T16:33:00.000Z'],
+	])('converts firstEvent from %s to epoch milliseconds', async (_, firstEvent) => {
+		entityManager.query.mockResolvedValueOnce([
+			{
+				delta_rows: 1,
+				workflowId: 'workflow-id',
+				name: StatisticsNames.productionSuccess,
+				inserted: true,
+				workflowName: 'Workflow',
+				firstEvent,
+			},
+		]);
+
+		const result = await repository.rollupIncrements(entityManager, 100);
+
+		expect(result).toEqual({
+			increments: 1,
+			firstOccurrences: [
+				{
+					name: StatisticsNames.productionSuccess,
+					workflowId: 'workflow-id',
+					workflowName: 'Workflow',
+					firstEventMs: 1_784_651_580_000,
+				},
+			],
+		});
+	});
+});

--- a/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-statistics.repository.ts
@@ -35,7 +35,7 @@ type FoldRow = {
 	name: StatisticsNames;
 	inserted: boolean;
 	workflowName: string | null;
-	firstEvent: Date; // timestamptz -> pg driver parses to a JS Date
+	firstEvent: Date | string;
 };
 
 @Service()
@@ -203,7 +203,7 @@ export class WorkflowStatisticsRepository extends Repository<WorkflowStatistics>
 				name: r.name,
 				workflowId: r.workflowId,
 				workflowName: r.workflowName,
-				firstEventMs: r.firstEvent.getTime(),
+				firstEventMs: new Date(r.firstEvent).getTime(),
 			}));
 
 		return { increments: rows[0].delta_rows, firstOccurrences };


### PR DESCRIPTION
## Summary

Normalizes the PostgreSQL workflow statistics rollup's `firstEvent` value before converting it to epoch milliseconds.

PostgreSQL query results can provide this timestamp as either a JavaScript `Date` or an ISO timestamp string. Calling `.getTime()` directly on the latter causes the rollup to fail repeatedly.

This change:

- updates the fold-row type to represent both possible timestamp forms;
- normalizes `firstEvent` through the `Date` constructor;
- adds regression coverage for both `Date` and ISO timestamp string results.

The regression test reproduces the reported `r.firstEvent.getTime is not a function` exception without the fix.

## How to test

From `packages/@n8n/db`:

```bash
pnpm test src/repositories/__tests__/workflow-statistics.repository.test.ts
pnpm lint
pnpm typecheck
```

Results:

- focused regression test: 2 tests passed;
- package lint: passed;
- package typecheck: passed.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #34669

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs are not affected by this internal timestamp normalization.
- [x] Tests included.
- [ ] Backport labels can be selected by maintainers if appropriate.

## 🤖 PR Summary generated by AI

- Normalize workflow statistics rollup timestamps returned as either `Date` objects or ISO strings.
- Add regression coverage that reproduces the original exception and verifies both timestamp representations.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34670">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

