### PR TITLE
fix(core): Prevent concurrent instance startups from racing database migrations

### DIFF
--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -1,14 +1,21 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
 import type { DatabaseConfig } from '@n8n/config';
-import { DataSource, type DataSourceOptions } from '@n8n/typeorm';
+import {
+	DataSource,
+	MigrationExecutor,
+	type DataSourceOptions,
+	type QueryRunner,
+} from '@n8n/typeorm';
 import type { ErrorReporter } from 'n8n-core';
 import { DbConnectionTimeoutError } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
 import type { Mock } from 'vitest';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
 import * as migrationHelper from '../../migrations/migration-helpers';
 import type { Migration } from '../../migrations/migration-types';
+import { DbLock } from '../../services/db-lock.service';
 import { DbConnection } from '../db-connection';
 import type { DbConnectionMetrics } from '../db-connection-metrics';
 import { DbConnectionMonitor } from '../db-connection-monitor';
@@ -19,6 +26,8 @@ vi.mock('@n8n/typeorm', async () => ({
 	...(await vi.importActual<typeof import('@n8n/typeorm')>('@n8n/typeorm')),
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	DataSource: vi.fn(),
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	MigrationExecutor: vi.fn(),
 }));
 
 vi.mock('../db-connection-monitor');
@@ -151,21 +160,83 @@ describe('DbConnection', () => {
 	});
 
 	describe('migrate', () => {
-		it('should wrap migrations and run them', async () => {
-			dataSource.runMigrations.mockResolvedValue([]);
+		const queryRunner = mock<QueryRunner>();
+		const migrationExecutor = mock<MigrationExecutor>();
+		// Mirrors migrate()'s derivation for the test's schema-less, prefix-less options
+		const expectedSubKey = createHash('sha256').update('public:').digest().readInt32BE(0);
+		const lockKeys = [DbLock.MIGRATIONS, expectedSubKey];
 
-			const wrapMigrationSpy = vi
-				.spyOn(migrationHelper, 'wrapMigration')
-				.mockImplementation(() => {});
+		beforeEach(() => {
+			dataSource.createQueryRunner.mockReturnValue(queryRunner);
+			queryRunner.query.mockResolvedValue([]);
+			vi.mocked(MigrationExecutor).mockImplementation(function () {
+				return migrationExecutor;
+			});
+			vi.spyOn(migrationHelper, 'wrapMigration').mockImplementation(() => {});
+		});
 
-			expect(dataSource.runMigrations).not.toHaveBeenCalled();
+		it('should wrap migrations and run them under a session advisory lock on postgres', async () => {
 			expect(dbConnection.connectionState.migrated).toBe(false);
 
 			await dbConnection.migrate();
 
-			expect(wrapMigrationSpy).toHaveBeenCalledTimes(2);
-			expect(dataSource.runMigrations).toHaveBeenCalledWith({ transaction: 'each' });
+			expect(migrationHelper.wrapMigration).toHaveBeenCalledTimes(2);
+			expect(queryRunner.startTransaction).toHaveBeenCalled();
+			expect(queryRunner.query).toHaveBeenCalledWith('SET LOCAL statement_timeout = 0');
+			expect(queryRunner.query).toHaveBeenCalledWith('SELECT pg_advisory_lock($1, $2)', lockKeys);
+			expect(queryRunner.commitTransaction).toHaveBeenCalled();
+			expect(MigrationExecutor).toHaveBeenCalledWith(dataSource, queryRunner);
+			expect(migrationExecutor.transaction).toBe('each');
+			expect(migrationExecutor.executePendingMigrations).toHaveBeenCalled();
+			expect(queryRunner.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1, $2)', lockKeys);
+			expect(queryRunner.release).toHaveBeenCalled();
 			expect(dbConnection.connectionState.migrated).toBe(true);
+		});
+
+		it('should release the lock and propagate migration errors', async () => {
+			migrationExecutor.executePendingMigrations.mockRejectedValue(new Error('migration failed'));
+
+			await expect(dbConnection.migrate()).rejects.toThrow('migration failed');
+
+			expect(queryRunner.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1, $2)', lockKeys);
+			expect(queryRunner.release).toHaveBeenCalled();
+			expect(dbConnection.connectionState.migrated).toBe(false);
+		});
+
+		it('should not unlock when lock acquisition fails, but still release the runner', async () => {
+			queryRunner.query.mockRejectedValueOnce(new Error('connection lost'));
+
+			await expect(dbConnection.migrate()).rejects.toThrow('connection lost');
+
+			expect(queryRunner.query).not.toHaveBeenCalledWith(
+				'SELECT pg_advisory_unlock($1, $2)',
+				expect.anything(),
+			);
+			expect(queryRunner.release).toHaveBeenCalled();
+			expect(dbConnection.connectionState.migrated).toBe(false);
+		});
+
+		it('should run migrations directly without the lock on sqlite', async () => {
+			connectionOptions.getOptions.mockReturnValue({
+				type: 'sqlite',
+				database: ':memory:',
+				migrations,
+			});
+			// options are @Memoized and read in the constructor — re-instantiate
+			const sqliteConnection = new DbConnection(
+				errorReporter,
+				connectionOptions,
+				databaseConfig,
+				logger,
+				dbConnectionMetrics,
+			);
+			dataSource.runMigrations.mockResolvedValue([]);
+
+			await sqliteConnection.migrate();
+
+			expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+			expect(dataSource.runMigrations).toHaveBeenCalledWith({ transaction: 'each' });
+			expect(sqliteConnection.connectionState.migrated).toBe(true);
 		});
 	});
 

--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
 import type { DatabaseConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import {
 	DataSource,
 	MigrationExecutor,
 	type DataSourceOptions,
+	type EntityManager,
 	type QueryRunner,
 } from '@n8n/typeorm';
 import type { ErrorReporter } from 'n8n-core';
@@ -15,7 +17,7 @@ import { mock, mockDeep } from 'vitest-mock-extended';
 
 import * as migrationHelper from '../../migrations/migration-helpers';
 import type { Migration } from '../../migrations/migration-types';
-import { DbLock } from '../../services/db-lock.service';
+import { DbLock, DbLockService } from '../../services/db-lock.service';
 import { DbConnection } from '../db-connection';
 import type { DbConnectionMetrics } from '../db-connection-metrics';
 import { DbConnectionMonitor } from '../db-connection-monitor';
@@ -160,48 +162,46 @@ describe('DbConnection', () => {
 	});
 
 	describe('migrate', () => {
+		const dbLockService = mock<DbLockService>();
 		const queryRunner = mock<QueryRunner>();
+		const tx = mock<EntityManager>({ queryRunner });
 		const migrationExecutor = mock<MigrationExecutor>();
 		// Mirrors migrate()'s derivation for the test's schema-less, prefix-less options
 		const expectedSubKey = createHash('sha256').update('public:').digest().readInt32BE(0);
-		const lockKeys = [DbLock.MIGRATIONS, expectedSubKey];
 
 		beforeEach(() => {
-			dataSource.createQueryRunner.mockReturnValue(queryRunner);
-			queryRunner.query.mockResolvedValue([]);
-			queryRunner.rollbackTransaction.mockResolvedValue();
+			Container.set(DbLockService, dbLockService);
+			dbLockService.withLock.mockImplementation(async (_lockId, fn) => await fn(tx));
+			tx.query.mockResolvedValue([]);
 			vi.mocked(MigrationExecutor).mockImplementation(function () {
 				return migrationExecutor;
 			});
 			vi.spyOn(migrationHelper, 'wrapMigration').mockImplementation(() => {});
 		});
 
-		it('should run migrations inside the advisory lock transaction on postgres', async () => {
+		it('should run migrations under the migration advisory lock on postgres', async () => {
 			expect(dbConnection.connectionState.migrated).toBe(false);
 
 			await dbConnection.migrate();
 
 			expect(migrationHelper.wrapMigration).toHaveBeenCalledTimes(2);
-			expect(queryRunner.startTransaction).toHaveBeenCalled();
-			expect(queryRunner.query).toHaveBeenCalledWith('SET LOCAL statement_timeout = 0');
-			expect(queryRunner.query).toHaveBeenCalledWith('SET LOCAL lock_timeout = 0');
-			expect(queryRunner.query).toHaveBeenCalledWith(
-				'SET LOCAL idle_in_transaction_session_timeout = 0',
-			);
-			expect(queryRunner.query).toHaveBeenCalledWith(
-				'SELECT pg_advisory_xact_lock($1, $2)',
-				lockKeys,
-			);
+			expect(dbLockService.withLock).toHaveBeenCalledWith(DbLock.MIGRATIONS, expect.any(Function), {
+				subKey: expectedSubKey,
+				waitIndefinitely: true,
+			});
 			expect(MigrationExecutor).toHaveBeenCalledWith(dataSource, queryRunner);
 			expect(migrationExecutor.transaction).toBe('none');
 			expect(migrationExecutor.executePendingMigrations).toHaveBeenCalled();
-			expect(queryRunner.commitTransaction).toHaveBeenCalled();
-			expect(queryRunner.rollbackTransaction).not.toHaveBeenCalled();
-			expect(queryRunner.release).toHaveBeenCalled();
 			expect(dbConnection.connectionState.migrated).toBe(true);
 		});
 
-		it('should restore the configured statement timeout after acquiring the lock', async () => {
+		it('should not override statement_timeout when none is configured', async () => {
+			await dbConnection.migrate();
+
+			expect(tx.query).not.toHaveBeenCalled();
+		});
+
+		it('should restore the configured statement timeout inside the lock transaction', async () => {
 			connectionOptions.getOptions.mockReturnValue({
 				...postgresOptions,
 				statementTimeout: 300_000,
@@ -216,30 +216,14 @@ describe('DbConnection', () => {
 
 			await connection.migrate();
 
-			const calls = queryRunner.query.mock.calls.map(([sql]) => sql);
-			const lockIdx = calls.indexOf('SELECT pg_advisory_xact_lock($1, $2)');
-			const restoreIdx = calls.indexOf('SET LOCAL statement_timeout = 300000');
-			expect(restoreIdx).toBeGreaterThan(lockIdx);
+			expect(tx.query).toHaveBeenCalledWith('SET LOCAL statement_timeout = 300000');
 		});
 
-		it('should roll back and propagate migration errors', async () => {
+		it('should propagate migration errors', async () => {
 			migrationExecutor.executePendingMigrations.mockRejectedValue(new Error('migration failed'));
 
 			await expect(dbConnection.migrate()).rejects.toThrow('migration failed');
 
-			expect(queryRunner.rollbackTransaction).toHaveBeenCalled();
-			expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
-			expect(queryRunner.release).toHaveBeenCalled();
-			expect(dbConnection.connectionState.migrated).toBe(false);
-		});
-
-		it('should roll back and release the runner when lock acquisition fails', async () => {
-			queryRunner.query.mockRejectedValueOnce(new Error('connection lost'));
-
-			await expect(dbConnection.migrate()).rejects.toThrow('connection lost');
-
-			expect(queryRunner.rollbackTransaction).toHaveBeenCalled();
-			expect(queryRunner.release).toHaveBeenCalled();
 			expect(dbConnection.connectionState.migrated).toBe(false);
 		});
 
@@ -261,7 +245,7 @@ describe('DbConnection', () => {
 
 			await sqliteConnection.migrate();
 
-			expect(dataSource.createQueryRunner).not.toHaveBeenCalled();
+			expect(dbLockService.withLock).not.toHaveBeenCalled();
 			expect(dataSource.runMigrations).toHaveBeenCalledWith({ transaction: 'each' });
 			expect(sqliteConnection.connectionState.migrated).toBe(true);
 		});

--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -169,13 +169,14 @@ describe('DbConnection', () => {
 		beforeEach(() => {
 			dataSource.createQueryRunner.mockReturnValue(queryRunner);
 			queryRunner.query.mockResolvedValue([]);
+			queryRunner.rollbackTransaction.mockResolvedValue();
 			vi.mocked(MigrationExecutor).mockImplementation(function () {
 				return migrationExecutor;
 			});
 			vi.spyOn(migrationHelper, 'wrapMigration').mockImplementation(() => {});
 		});
 
-		it('should wrap migrations and run them under a session advisory lock on postgres', async () => {
+		it('should run migrations inside the advisory lock transaction on postgres', async () => {
 			expect(dbConnection.connectionState.migrated).toBe(false);
 
 			await dbConnection.migrate();
@@ -183,35 +184,60 @@ describe('DbConnection', () => {
 			expect(migrationHelper.wrapMigration).toHaveBeenCalledTimes(2);
 			expect(queryRunner.startTransaction).toHaveBeenCalled();
 			expect(queryRunner.query).toHaveBeenCalledWith('SET LOCAL statement_timeout = 0');
-			expect(queryRunner.query).toHaveBeenCalledWith('SELECT pg_advisory_lock($1, $2)', lockKeys);
-			expect(queryRunner.commitTransaction).toHaveBeenCalled();
+			expect(queryRunner.query).toHaveBeenCalledWith(
+				'SET LOCAL idle_in_transaction_session_timeout = 0',
+			);
+			expect(queryRunner.query).toHaveBeenCalledWith(
+				'SELECT pg_advisory_xact_lock($1, $2)',
+				lockKeys,
+			);
 			expect(MigrationExecutor).toHaveBeenCalledWith(dataSource, queryRunner);
-			expect(migrationExecutor.transaction).toBe('each');
+			expect(migrationExecutor.transaction).toBe('none');
 			expect(migrationExecutor.executePendingMigrations).toHaveBeenCalled();
-			expect(queryRunner.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1, $2)', lockKeys);
+			expect(queryRunner.commitTransaction).toHaveBeenCalled();
+			expect(queryRunner.rollbackTransaction).not.toHaveBeenCalled();
 			expect(queryRunner.release).toHaveBeenCalled();
 			expect(dbConnection.connectionState.migrated).toBe(true);
 		});
 
-		it('should release the lock and propagate migration errors', async () => {
+		it('should restore the configured statement timeout after acquiring the lock', async () => {
+			connectionOptions.getOptions.mockReturnValue({
+				...postgresOptions,
+				statementTimeout: 300_000,
+			});
+			const connection = new DbConnection(
+				errorReporter,
+				connectionOptions,
+				databaseConfig,
+				logger,
+				dbConnectionMetrics,
+			);
+
+			await connection.migrate();
+
+			const calls = queryRunner.query.mock.calls.map(([sql]) => sql);
+			const lockIdx = calls.indexOf('SELECT pg_advisory_xact_lock($1, $2)');
+			const restoreIdx = calls.indexOf('SET LOCAL statement_timeout = 300000');
+			expect(restoreIdx).toBeGreaterThan(lockIdx);
+		});
+
+		it('should roll back and propagate migration errors', async () => {
 			migrationExecutor.executePendingMigrations.mockRejectedValue(new Error('migration failed'));
 
 			await expect(dbConnection.migrate()).rejects.toThrow('migration failed');
 
-			expect(queryRunner.query).toHaveBeenCalledWith('SELECT pg_advisory_unlock($1, $2)', lockKeys);
+			expect(queryRunner.rollbackTransaction).toHaveBeenCalled();
+			expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
 			expect(queryRunner.release).toHaveBeenCalled();
 			expect(dbConnection.connectionState.migrated).toBe(false);
 		});
 
-		it('should not unlock when lock acquisition fails, but still release the runner', async () => {
+		it('should roll back and release the runner when lock acquisition fails', async () => {
 			queryRunner.query.mockRejectedValueOnce(new Error('connection lost'));
 
 			await expect(dbConnection.migrate()).rejects.toThrow('connection lost');
 
-			expect(queryRunner.query).not.toHaveBeenCalledWith(
-				'SELECT pg_advisory_unlock($1, $2)',
-				expect.anything(),
-			);
+			expect(queryRunner.rollbackTransaction).toHaveBeenCalled();
 			expect(queryRunner.release).toHaveBeenCalled();
 			expect(dbConnection.connectionState.migrated).toBe(false);
 		});

--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -184,6 +184,7 @@ describe('DbConnection', () => {
 			expect(migrationHelper.wrapMigration).toHaveBeenCalledTimes(2);
 			expect(queryRunner.startTransaction).toHaveBeenCalled();
 			expect(queryRunner.query).toHaveBeenCalledWith('SET LOCAL statement_timeout = 0');
+			expect(queryRunner.query).toHaveBeenCalledWith('SET LOCAL lock_timeout = 0');
 			expect(queryRunner.query).toHaveBeenCalledWith(
 				'SET LOCAL idle_in_transaction_session_timeout = 0',
 			);

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -89,7 +89,7 @@ export class DbConnection {
 		const { dataSource, connectionState, options } = this;
 		(dataSource.options.migrations as Migration[]).forEach(wrapMigration);
 		if (options.type === 'postgres') {
-			await this.migrateWithAdvisoryLock(options.schema, options.entityPrefix);
+			await this.migrateWithAdvisoryLock(options);
 		} else {
 			// SQLite is single-instance, so concurrent migrations aren't possible.
 			await dataSource.runMigrations({ transaction: 'each' });
@@ -98,56 +98,69 @@ export class DbConnection {
 	}
 
 	/**
-	 * Runs migrations while holding a Postgres advisory lock, so instances
-	 * starting concurrently against one database migrate one at a time instead
-	 * of racing (deadlocks, `column ... already exists`, crash-looping pods).
+	 * Runs migrations while holding a transaction-scoped Postgres advisory lock
+	 * (`pg_advisory_xact_lock`), so instances starting concurrently against one
+	 * database migrate one at a time instead of racing (deadlocks,
+	 * `column ... already exists`, crash-looping pods).
 	 *
-	 * The lock and the migrations share a single pooled connection: holding the
-	 * lock on a second connection would deadlock startup when
-	 * `DB_POSTGRESDB_POOL_SIZE=1`. That rules out transaction-scoped locks
-	 * (`pg_advisory_xact_lock`) — an open lock transaction can't host the
-	 * per-migration transactions — so the lock is session-scoped: explicitly
-	 * released after migrating, and automatically released by the server if the
-	 * connection drops (e.g. the migrating instance crashes), letting a waiter
-	 * take over from the first unapplied migration.
+	 * The lock transaction hosts the migrations themselves, on a single pooled
+	 * connection: holding the lock on a second connection would deadlock startup
+	 * when `DB_POSTGRESDB_POOL_SIZE=1`. All pending migrations therefore commit
+	 * or roll back as one unit (instead of the previous per-migration commits),
+	 * and the lock's lifetime is exactly the transaction's — released on
+	 * commit/rollback, or by the server/pooler when the migrating instance dies,
+	 * so a crash can never leave the lock behind (also under PgBouncer, which
+	 * keeps server connections alive across client disconnects, where a
+	 * session-scoped lock could be orphaned).
 	 */
-	private async migrateWithAdvisoryLock(schema?: string, entityPrefix?: string) {
+	private async migrateWithAdvisoryLock(options: {
+		schema?: string;
+		entityPrefix?: string;
+		statementTimeout?: number;
+	}) {
 		const { dataSource } = this;
 		// Scoped by schema+prefix so co-hosted tenants in one database don't block each other.
 		const subKey = createHash('sha256')
-			.update(`${schema ?? 'public'}:${entityPrefix ?? ''}`)
+			.update(`${options.schema ?? 'public'}:${options.entityPrefix ?? ''}`)
 			.digest()
 			.readInt32BE(0);
-		const lockKeys = [DbLock.MIGRATIONS, subKey];
 		const queryRunner = dataSource.createQueryRunner();
-		let lockAcquired = false;
 		try {
 			this.logger.info('Acquiring database migration lock...');
-			// A waiter blocks inside pg_advisory_lock() — a single statement — so it
-			// must not be killed by the driver's statement_timeout (default 5 min).
-			// SET LOCAL confines the override to this transaction; the session-scoped
-			// lock itself survives the COMMIT.
 			await queryRunner.startTransaction();
-			await queryRunner.query('SET LOCAL statement_timeout = 0');
-			await queryRunner.query('SELECT pg_advisory_lock($1, $2)', lockKeys);
-			lockAcquired = true;
-			await queryRunner.commitTransaction();
-
-			const migrationExecutor = new MigrationExecutor(dataSource, queryRunner);
-			migrationExecutor.transaction = 'each';
-			await migrationExecutor.executePendingMigrations();
-		} finally {
-			// Explicit unlock before the connection returns to the pool. If it fails,
-			// the connection is broken and the server has already dropped the lock.
-			if (lockAcquired) {
-				await queryRunner
-					.query('SELECT pg_advisory_unlock($1, $2)', lockKeys)
-					.catch((error: unknown) =>
-						this.logger.warn(
-							`Failed to release database migration lock: ${ensureError(error).message}`,
-						),
+			try {
+				// A waiter blocks inside pg_advisory_xact_lock() — a single statement —
+				// so it must not be killed by the driver's statement_timeout (default
+				// 5 min). The transaction also idles between statements while migration
+				// JS runs, so it must not be reaped by an idle-in-transaction timeout.
+				// SET LOCAL confines both overrides to this transaction.
+				await queryRunner.query('SET LOCAL statement_timeout = 0');
+				await queryRunner.query('SET LOCAL idle_in_transaction_session_timeout = 0');
+				await queryRunner.query('SELECT pg_advisory_xact_lock($1, $2)', [
+					DbLock.MIGRATIONS,
+					subKey,
+				]);
+				if (options.statementTimeout) {
+					// Lock acquired — restore the driver's per-statement cap for the
+					// migration statements themselves.
+					await queryRunner.query(
+						`SET LOCAL statement_timeout = ${Number(options.statementTimeout)}`,
 					);
+				}
+
+				const migrationExecutor = new MigrationExecutor(dataSource, queryRunner);
+				// 'none': the executor manages no transactions and runs everything
+				// inside ours, tying the migrations' fate to the lock's.
+				migrationExecutor.transaction = 'none';
+				await migrationExecutor.executePendingMigrations();
+
+				await queryRunner.commitTransaction();
+			} catch (error) {
+				// Rethrow the original error even if the rollback itself fails.
+				await queryRunner.rollbackTransaction().catch(() => {});
+				throw error;
 			}
+		} finally {
 			await queryRunner.release();
 		}
 	}

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -98,20 +98,12 @@ export class DbConnection {
 	}
 
 	/**
-	 * Runs migrations while holding a transaction-scoped Postgres advisory lock
-	 * (`pg_advisory_xact_lock`), so instances starting concurrently against one
-	 * database migrate one at a time instead of racing (deadlocks,
-	 * `column ... already exists`, crash-looping pods).
-	 *
-	 * The lock transaction hosts the migrations themselves, on a single pooled
-	 * connection: holding the lock on a second connection would deadlock startup
-	 * when `DB_POSTGRESDB_POOL_SIZE=1`. All pending migrations therefore commit
-	 * or roll back as one unit (instead of the previous per-migration commits),
-	 * and the lock's lifetime is exactly the transaction's — released on
-	 * commit/rollback, or by the server/pooler when the migrating instance dies,
-	 * so a crash can never leave the lock behind (also under PgBouncer, which
-	 * keeps server connections alive across client disconnects, where a
-	 * session-scoped lock could be orphaned).
+	 * Runs all pending migrations inside a single transaction that also holds a
+	 * Postgres advisory lock, so concurrently starting instances migrate one at
+	 * a time and a crashed instance can never leave the lock behind (even behind
+	 * a pooler like PgBouncer). Sharing one connection between the lock and the
+	 * migrations keeps `DB_POSTGRESDB_POOL_SIZE=1` working; the trade-off is
+	 * that migrations commit or roll back as one unit.
 	 */
 	private async migrateWithAdvisoryLock(options: {
 		schema?: string;
@@ -129,34 +121,30 @@ export class DbConnection {
 			this.logger.info('Acquiring database migration lock...');
 			await queryRunner.startTransaction();
 			try {
-				// A waiter blocks inside pg_advisory_xact_lock() — a single statement —
-				// so it must not be killed by the driver's statement_timeout (default
-				// 5 min). The transaction also idles between statements while migration
-				// JS runs, so it must not be reaped by an idle-in-transaction timeout.
-				// SET LOCAL confines both overrides to this transaction.
+				// No timeout may kill the blocked lock wait or reap this transaction
+				// while it idles between migration statements.
 				await queryRunner.query('SET LOCAL statement_timeout = 0');
+				await queryRunner.query('SET LOCAL lock_timeout = 0');
 				await queryRunner.query('SET LOCAL idle_in_transaction_session_timeout = 0');
 				await queryRunner.query('SELECT pg_advisory_xact_lock($1, $2)', [
 					DbLock.MIGRATIONS,
 					subKey,
 				]);
 				if (options.statementTimeout) {
-					// Lock acquired — restore the driver's per-statement cap for the
-					// migration statements themselves.
+					// Restore the driver's per-statement cap for the migration statements
 					await queryRunner.query(
 						`SET LOCAL statement_timeout = ${Number(options.statementTimeout)}`,
 					);
 				}
 
 				const migrationExecutor = new MigrationExecutor(dataSource, queryRunner);
-				// 'none': the executor manages no transactions and runs everything
-				// inside ours, tying the migrations' fate to the lock's.
+				// 'none': the executor manages no transactions and runs inside ours
 				migrationExecutor.transaction = 'none';
 				await migrationExecutor.executePendingMigrations();
 
 				await queryRunner.commitTransaction();
 			} catch (error) {
-				// Rethrow the original error even if the rollback itself fails.
+				// Rethrow the original error even if the rollback itself fails
 				await queryRunner.rollbackTransaction().catch(() => {});
 				throw error;
 			}

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -16,7 +16,7 @@ import { DbConnectionOptions } from './db-connection-options';
 import { readPoolStats, type DbPoolStats } from './db-pool-stats';
 import { wrapMigration } from '../migrations/migration-helpers';
 import type { Migration } from '../migrations/migration-types';
-import { DbLock } from '../services/db-lock.service';
+import { DbLock, DbLockService } from '../services/db-lock.service';
 import { TransactionRunner } from '../services/transaction';
 import { TypeOrmTransactionRunner } from '../services/typeorm-transaction';
 
@@ -98,12 +98,11 @@ export class DbConnection {
 	}
 
 	/**
-	 * Runs all pending migrations inside a single transaction that also holds a
-	 * Postgres advisory lock, so concurrently starting instances migrate one at
-	 * a time and a crashed instance can never leave the lock behind (even behind
-	 * a pooler like PgBouncer). Sharing one connection between the lock and the
-	 * migrations keeps `DB_POSTGRESDB_POOL_SIZE=1` working; the trade-off is
-	 * that migrations commit or roll back as one unit.
+	 * Runs all pending migrations while holding a Postgres advisory lock, so
+	 * concurrently starting instances migrate one at a time. The migrations run
+	 * on the lock transaction's own connection, which keeps
+	 * `DB_POSTGRESDB_POOL_SIZE=1` working; the trade-off is that they commit or
+	 * roll back as one unit.
 	 */
 	private async migrateWithAdvisoryLock(options: {
 		schema?: string;
@@ -116,41 +115,21 @@ export class DbConnection {
 			.update(`${options.schema ?? 'public'}:${options.entityPrefix ?? ''}`)
 			.digest()
 			.readInt32BE(0);
-		const queryRunner = dataSource.createQueryRunner();
-		try {
-			this.logger.info('Acquiring database migration lock...');
-			await queryRunner.startTransaction();
-			try {
-				// No timeout may kill the blocked lock wait or reap this transaction
-				// while it idles between migration statements.
-				await queryRunner.query('SET LOCAL statement_timeout = 0');
-				await queryRunner.query('SET LOCAL lock_timeout = 0');
-				await queryRunner.query('SET LOCAL idle_in_transaction_session_timeout = 0');
-				await queryRunner.query('SELECT pg_advisory_xact_lock($1, $2)', [
-					DbLock.MIGRATIONS,
-					subKey,
-				]);
+		this.logger.info('Acquiring database migration lock...');
+		await Container.get(DbLockService).withLock(
+			DbLock.MIGRATIONS,
+			async (tx) => {
 				if (options.statementTimeout) {
 					// Restore the driver's per-statement cap for the migration statements
-					await queryRunner.query(
-						`SET LOCAL statement_timeout = ${Number(options.statementTimeout)}`,
-					);
+					await tx.query(`SET LOCAL statement_timeout = ${Number(options.statementTimeout)}`);
 				}
-
-				const migrationExecutor = new MigrationExecutor(dataSource, queryRunner);
-				// 'none': the executor manages no transactions and runs inside ours
+				const migrationExecutor = new MigrationExecutor(dataSource, tx.queryRunner);
+				// 'none': the executor manages no transactions and runs inside the lock's
 				migrationExecutor.transaction = 'none';
 				await migrationExecutor.executePendingMigrations();
-
-				await queryRunner.commitTransaction();
-			} catch (error) {
-				// Rethrow the original error even if the rollback itself fails
-				await queryRunner.rollbackTransaction().catch(() => {});
-				throw error;
-			}
-		} finally {
-			await queryRunner.release();
-		}
+			},
+			{ subKey, waitIndefinitely: true },
+		);
 	}
 
 	async close() {

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -2,10 +2,11 @@ import { Logger } from '@n8n/backend-common';
 import { DatabaseConfig } from '@n8n/config';
 import { Memoized } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
-import { DataSource } from '@n8n/typeorm';
+import { DataSource, MigrationExecutor } from '@n8n/typeorm';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { ErrorReporter } from 'n8n-core';
 import { DbConnectionTimeoutError } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
 import { setTimeout as setTimeoutP } from 'timers/promises';
 
 import { computeBackoff } from './backoff';
@@ -15,6 +16,7 @@ import { DbConnectionOptions } from './db-connection-options';
 import { readPoolStats, type DbPoolStats } from './db-pool-stats';
 import { wrapMigration } from '../migrations/migration-helpers';
 import type { Migration } from '../migrations/migration-types';
+import { DbLock } from '../services/db-lock.service';
 import { TransactionRunner } from '../services/transaction';
 import { TypeOrmTransactionRunner } from '../services/typeorm-transaction';
 
@@ -84,10 +86,70 @@ export class DbConnection {
 	}
 
 	async migrate() {
-		const { dataSource, connectionState } = this;
+		const { dataSource, connectionState, options } = this;
 		(dataSource.options.migrations as Migration[]).forEach(wrapMigration);
-		await dataSource.runMigrations({ transaction: 'each' });
+		if (options.type === 'postgres') {
+			await this.migrateWithAdvisoryLock(options.schema, options.entityPrefix);
+		} else {
+			// SQLite is single-instance, so concurrent migrations aren't possible.
+			await dataSource.runMigrations({ transaction: 'each' });
+		}
 		connectionState.migrated = true;
+	}
+
+	/**
+	 * Runs migrations while holding a Postgres advisory lock, so instances
+	 * starting concurrently against one database migrate one at a time instead
+	 * of racing (deadlocks, `column ... already exists`, crash-looping pods).
+	 *
+	 * The lock and the migrations share a single pooled connection: holding the
+	 * lock on a second connection would deadlock startup when
+	 * `DB_POSTGRESDB_POOL_SIZE=1`. That rules out transaction-scoped locks
+	 * (`pg_advisory_xact_lock`) — an open lock transaction can't host the
+	 * per-migration transactions — so the lock is session-scoped: explicitly
+	 * released after migrating, and automatically released by the server if the
+	 * connection drops (e.g. the migrating instance crashes), letting a waiter
+	 * take over from the first unapplied migration.
+	 */
+	private async migrateWithAdvisoryLock(schema?: string, entityPrefix?: string) {
+		const { dataSource } = this;
+		// Scoped by schema+prefix so co-hosted tenants in one database don't block each other.
+		const subKey = createHash('sha256')
+			.update(`${schema ?? 'public'}:${entityPrefix ?? ''}`)
+			.digest()
+			.readInt32BE(0);
+		const lockKeys = [DbLock.MIGRATIONS, subKey];
+		const queryRunner = dataSource.createQueryRunner();
+		let lockAcquired = false;
+		try {
+			this.logger.info('Acquiring database migration lock...');
+			// A waiter blocks inside pg_advisory_lock() — a single statement — so it
+			// must not be killed by the driver's statement_timeout (default 5 min).
+			// SET LOCAL confines the override to this transaction; the session-scoped
+			// lock itself survives the COMMIT.
+			await queryRunner.startTransaction();
+			await queryRunner.query('SET LOCAL statement_timeout = 0');
+			await queryRunner.query('SELECT pg_advisory_lock($1, $2)', lockKeys);
+			lockAcquired = true;
+			await queryRunner.commitTransaction();
+
+			const migrationExecutor = new MigrationExecutor(dataSource, queryRunner);
+			migrationExecutor.transaction = 'each';
+			await migrationExecutor.executePendingMigrations();
+		} finally {
+			// Explicit unlock before the connection returns to the pool. If it fails,
+			// the connection is broken and the server has already dropped the lock.
+			if (lockAcquired) {
+				await queryRunner
+					.query('SELECT pg_advisory_unlock($1, $2)', lockKeys)
+					.catch((error: unknown) =>
+						this.logger.warn(
+							`Failed to release database migration lock: ${ensureError(error).message}`,
+						),
+					);
+			}
+			await queryRunner.release();
+		}
 	}
 
 	async close() {

--- a/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
+++ b/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
@@ -67,6 +67,70 @@ describe('DbLockService', () => {
 			expect(mockTx.query).toHaveBeenCalledWith('SELECT pg_advisory_xact_lock($1)', [1001]);
 		});
 
+		it('should disable all lock-killing timeouts when waitIndefinitely is set', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = vi.fn().mockResolvedValue('result');
+
+			await service.withLock(1001, fn, { waitIndefinitely: true });
+
+			expect(mockTx.query).toHaveBeenCalledWith('SET LOCAL statement_timeout = 0');
+			expect(mockTx.query).toHaveBeenCalledWith('SET LOCAL lock_timeout = 0');
+			expect(mockTx.query).toHaveBeenCalledWith(
+				'SET LOCAL idle_in_transaction_session_timeout = 0',
+			);
+		});
+
+		it('should not touch statement timeouts without waitIndefinitely', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = vi.fn().mockResolvedValue('result');
+
+			await service.withLock(1001, fn);
+			await service.withLock(1001, fn, { timeoutMs: 5000 });
+
+			expect(mockTx.query).not.toHaveBeenCalledWith(expect.stringContaining('statement_timeout'));
+			expect(mockTx.query).not.toHaveBeenCalledWith(
+				expect.stringContaining('idle_in_transaction_session_timeout'),
+			);
+		});
+
+		it('should reject combining timeoutMs and waitIndefinitely at compile time', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = vi.fn().mockResolvedValue('result');
+
+			// @ts-expect-error timeoutMs and waitIndefinitely are mutually exclusive
+			await service.withLock(1001, fn, { timeoutMs: 5000, waitIndefinitely: true });
+		});
+
+		it('should use the two-key lock form when subKey is provided', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = vi.fn().mockResolvedValue('result');
+
+			const result = await service.withLock(1005, fn, { subKey: -12345 });
+
+			expect(result).toBe('result');
+			expect(mockTx.query).toHaveBeenCalledWith(
+				'SELECT pg_advisory_xact_lock($1, $2)',
+				[1005, -12345],
+			);
+			expect(fn).toHaveBeenCalledWith(mockTx);
+		});
+
+		it('should include both keys in the timeout error message when subKey is provided', async () => {
+			databaseConfig.type = 'postgresdb';
+			const fn = vi.fn();
+			const timeoutError = new QueryFailedError(
+				'SELECT pg_advisory_xact_lock($1, $2)',
+				[1005, -12345],
+				new Error('canceling statement due to lock timeout'),
+			);
+
+			mockTx.query.mockResolvedValueOnce(undefined).mockRejectedValueOnce(timeoutError);
+
+			await expect(service.withLock(1005, fn, { timeoutMs: 5000, subKey: -12345 })).rejects.toThrow(
+				/Timed out waiting for DbLock 1005:-12345 after 5000ms/,
+			);
+		});
+
 		it('should throw OperationalError when lock timeout is exceeded', async () => {
 			databaseConfig.type = 'postgresdb';
 			const fn = vi.fn();

--- a/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
+++ b/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
@@ -258,6 +258,35 @@ describe('DbLockService', () => {
 			expect(executionOrder).toEqual(['fn1-start', 'fn1-end', 'fn2-start']);
 		});
 
+		it('should scope the in-process mutex by subKey', async () => {
+			let resolveFirst!: () => void;
+			const firstBlocking = new Promise<void>((r) => {
+				resolveFirst = r;
+			});
+
+			const fn1 = vi.fn(async () => {
+				await firstBlocking;
+				return 'first';
+			});
+			const fn2 = vi.fn(async () => 'second');
+			const fn3 = vi.fn(async () => 'third');
+
+			const p1 = service.withLock(1001, fn1, { subKey: 1 });
+			// Different subKey — must not block
+			const p2 = service.withLock(1001, fn2, { subKey: 2 });
+			// Same subKey — must block until fn1 releases
+			const p3 = service.withLock(1001, fn3, { subKey: 1 });
+
+			await new Promise((r) => setImmediate(r));
+			expect(fn1).toHaveBeenCalled();
+			expect(fn2).toHaveBeenCalled();
+			expect(fn3).not.toHaveBeenCalled();
+
+			resolveFirst();
+			const results = await Promise.all([p1, p2, p3]);
+			expect(results).toEqual(['first', 'second', 'third']);
+		});
+
 		it('should not block different lockIds', async () => {
 			let resolveFirst!: () => void;
 			const firstBlocking = new Promise<void>((r) => {

--- a/packages/@n8n/db/src/services/db-lock.service.ts
+++ b/packages/@n8n/db/src/services/db-lock.service.ts
@@ -14,7 +14,7 @@ export const enum DbLock {
 	TRUSTED_KEY_REFRESH = 1002,
 	WORKFLOW_STATISTICS_ROLLUP = 1003,
 	WORKFLOW_REVIEW_REQUEST_CREATE = 1004,
-	/** Session-scoped (not xact-scoped), acquired directly by `DbConnection.migrate()` */
+	/** Acquired directly by `DbConnection.migrate()`, not through this service */
 	MIGRATIONS = 1005,
 	/** Reserved for integration tests — never use in production code */
 	TEST = 9999,

--- a/packages/@n8n/db/src/services/db-lock.service.ts
+++ b/packages/@n8n/db/src/services/db-lock.service.ts
@@ -14,13 +14,21 @@ export const enum DbLock {
 	TRUSTED_KEY_REFRESH = 1002,
 	WORKFLOW_STATISTICS_ROLLUP = 1003,
 	WORKFLOW_REVIEW_REQUEST_CREATE = 1004,
-	/** Acquired directly by `DbConnection.migrate()`, not through this service */
 	MIGRATIONS = 1005,
 	/** Reserved for integration tests — never use in production code */
 	TEST = 9999,
 }
 
 type ReleaseFn = () => void;
+
+/**
+ * `timeoutMs` and `waitIndefinitely` are mutually exclusive — passing both is
+ * a compile-time error.
+ */
+type WithLockOptions = { subKey?: number } & (
+	| { timeoutMs?: number; waitIndefinitely?: never }
+	| { timeoutMs?: never; waitIndefinitely?: boolean }
+);
 
 /**
  * Opaque ownership token created on lock acquisition. The release function
@@ -98,12 +106,18 @@ export class DbLockService {
 	 * or rolls back. Concurrent callers block until the lock is available.
 	 *
 	 * @param options.timeoutMs - Maximum time in milliseconds to wait for the lock.
-	 *   If not provided, waits indefinitely.
+	 *   If not provided, the wait is implicitly capped by the connection's
+	 *   `statement_timeout` on Postgres.
+	 * @param options.waitIndefinitely - Wait for the lock with no upper bound and
+	 *   keep the lock transaction alive however long `fn` takes. Mutually
+	 *   exclusive with `timeoutMs`.
+	 * @param options.subKey - Optional int32 second lock key (Postgres two-int
+	 *   advisory lock form), e.g. to scope a lock ID per tenant schema.
 	 */
 	async withLock<T>(
 		lockId: DbLock,
 		fn: (tx: EntityManager) => Promise<T>,
-		options?: { timeoutMs?: number },
+		options?: WithLockOptions,
 	): Promise<T> {
 		if (this.databaseConfig.type !== 'postgresdb') {
 			const release = await this.acquireLock(lockId, options?.timeoutMs);
@@ -119,13 +133,26 @@ export class DbLockService {
 				// SET doesn't support parameterized queries ($1) in Postgres.
 				// Number() coercion is safe here since timeoutMs is typed as number.
 				await tx.query(`SET LOCAL lock_timeout = '${Number(options.timeoutMs)}'`);
+			} else if (options?.waitIndefinitely) {
+				// A blocked lock acquisition is a single statement, so no statement or
+				// lock timeout may kill the wait, and no idle timeout may reap this
+				// transaction while it idles holding the lock.
+				await tx.query('SET LOCAL statement_timeout = 0');
+				await tx.query('SET LOCAL lock_timeout = 0');
+				await tx.query('SET LOCAL idle_in_transaction_session_timeout = 0');
 			}
+			const lockKeys = options?.subKey === undefined ? [lockId] : [lockId, options.subKey];
 			try {
-				await tx.query('SELECT pg_advisory_xact_lock($1)', [lockId]);
+				await tx.query(
+					lockKeys.length === 1
+						? 'SELECT pg_advisory_xact_lock($1)'
+						: 'SELECT pg_advisory_xact_lock($1, $2)',
+					lockKeys,
+				);
 			} catch (error) {
 				if (error instanceof QueryFailedError && error.message.includes('lock timeout')) {
 					throw new OperationalError(
-						`Timed out waiting for DbLock ${lockId} after ${options?.timeoutMs}ms`,
+						`Timed out waiting for DbLock ${lockKeys.join(':')} after ${options?.timeoutMs}ms`,
 						{ cause: error },
 					);
 				}

--- a/packages/@n8n/db/src/services/db-lock.service.ts
+++ b/packages/@n8n/db/src/services/db-lock.service.ts
@@ -14,6 +14,8 @@ export const enum DbLock {
 	TRUSTED_KEY_REFRESH = 1002,
 	WORKFLOW_STATISTICS_ROLLUP = 1003,
 	WORKFLOW_REVIEW_REQUEST_CREATE = 1004,
+	/** Session-scoped (not xact-scoped), acquired directly by `DbConnection.migrate()` */
+	MIGRATIONS = 1005,
 	/** Reserved for integration tests — never use in production code */
 	TEST = 9999,
 }

--- a/packages/@n8n/db/src/services/db-lock.service.ts
+++ b/packages/@n8n/db/src/services/db-lock.service.ts
@@ -43,6 +43,10 @@ interface LockState {
 	queue: Array<(token: OwnerToken) => void>;
 }
 
+/** Shared key derivation so SQLite mutexes scope by subKey like Postgres locks do */
+const lockKey = (lockId: number, subKey?: number) =>
+	subKey === undefined ? `${lockId}` : `${lockId}:${subKey}`;
+
 /**
  * Provides serialized execution of critical sections across concurrent
  * callers using database-level advisory locks (Postgres) or an in-process
@@ -91,7 +95,7 @@ interface LockState {
  */
 @Service()
 export class DbLockService {
-	private readonly locks = new Map<number, LockState>();
+	private readonly locks = new Map<string, LockState>();
 
 	constructor(
 		private readonly dataSource: DataSource,
@@ -110,9 +114,11 @@ export class DbLockService {
 	 *   `statement_timeout` on Postgres.
 	 * @param options.waitIndefinitely - Wait for the lock with no upper bound and
 	 *   keep the lock transaction alive however long `fn` takes. Mutually
-	 *   exclusive with `timeoutMs`.
+	 *   exclusive with `timeoutMs`. On SQLite the in-process mutex already waits
+	 *   indefinitely without `timeoutMs`.
 	 * @param options.subKey - Optional int32 second lock key (Postgres two-int
-	 *   advisory lock form), e.g. to scope a lock ID per tenant schema.
+	 *   advisory lock form), e.g. to scope a lock ID per tenant schema. Scopes
+	 *   the SQLite in-process mutex the same way.
 	 */
 	async withLock<T>(
 		lockId: DbLock,
@@ -120,7 +126,7 @@ export class DbLockService {
 		options?: WithLockOptions,
 	): Promise<T> {
 		if (this.databaseConfig.type !== 'postgresdb') {
-			const release = await this.acquireLock(lockId, options?.timeoutMs);
+			const release = await this.acquireLock(lockId, options?.timeoutMs, options?.subKey);
 			try {
 				return await this.dataSource.manager.transaction(async (tx) => await fn(tx));
 			} finally {
@@ -194,8 +200,12 @@ export class DbLockService {
 	 * Acquire the in-process lock, blocking until available.
 	 * Returns a one-shot release function bound to this specific acquisition.
 	 */
-	private async acquireLock(lockId: number, timeoutMs?: number): Promise<ReleaseFn> {
-		const lockState = this.getOrCreateLockState(lockId);
+	private async acquireLock(
+		lockId: number,
+		timeoutMs?: number,
+		subKey?: number,
+	): Promise<ReleaseFn> {
+		const lockState = this.getOrCreateLockState(lockId, subKey);
 
 		if (!lockState.held) {
 			const token: OwnerToken = {} as OwnerToken;
@@ -228,7 +238,9 @@ export class DbLockService {
 						lockState.queue.splice(idx, 1);
 					}
 					reject(
-						new OperationalError(`Timed out waiting for DbLock ${lockId} after ${timeoutMs}ms`),
+						new OperationalError(
+							`Timed out waiting for DbLock ${lockKey(lockId, subKey)} after ${timeoutMs}ms`,
+						),
 					);
 				}, timeoutMs);
 			}
@@ -283,11 +295,12 @@ export class DbLockService {
 		};
 	}
 
-	private getOrCreateLockState(lockId: number): LockState {
-		let lockState = this.locks.get(lockId);
+	private getOrCreateLockState(lockId: number, subKey?: number): LockState {
+		const key = lockKey(lockId, subKey);
+		let lockState = this.locks.get(key);
 		if (!lockState) {
 			lockState = { held: null, queue: [] };
-			this.locks.set(lockId, lockState);
+			this.locks.set(key, lockState);
 		}
 		return lockState;
 	}

--- a/packages/cli/test/integration/database/services/db-lock.service.test.ts
+++ b/packages/cli/test/integration/database/services/db-lock.service.test.ts
@@ -172,4 +172,70 @@ describe('DbLockService', () => {
 			expect(result).toBe('free');
 		});
 	});
+
+	describe('subKey scoping (Postgres)', () => {
+		it('should not block when the same lock ID is held with a different subKey', async () => {
+			if (!isPostgres) return;
+
+			let lockAcquired!: () => void;
+			const lockAcquiredPromise = new Promise<void>((resolve) => {
+				lockAcquired = resolve;
+			});
+
+			// Hold (TEST, 1) on the separate connection
+			const holdLockPromise = holdLockDs.manager.transaction(async (tx) => {
+				await tx.query('SELECT pg_advisory_xact_lock($1, $2)', [DbLock.TEST, 1]);
+				lockAcquired();
+				await sleep(500);
+			});
+
+			await lockAcquiredPromise;
+
+			// (TEST, 2) must be acquirable immediately — timeoutMs turns a wrongly
+			// blocking lock into a test failure instead of a hang
+			const result = await dbLockService.withLock(DbLock.TEST, async () => 'independent', {
+				subKey: 2,
+				timeoutMs: 200,
+			});
+			expect(result).toBe('independent');
+
+			await holdLockPromise;
+		});
+
+		it('should serialize callers on the same lock ID and subKey', async () => {
+			if (!isPostgres) return;
+
+			const executionOrder: string[] = [];
+
+			let lockAcquired!: () => void;
+			const lockAcquiredPromise = new Promise<void>((resolve) => {
+				lockAcquired = resolve;
+			});
+
+			const first = holdLockDs.manager.transaction(async (tx) => {
+				await tx.query('SELECT pg_advisory_xact_lock($1, $2)', [DbLock.TEST, 1]);
+				executionOrder.push('first:start');
+				lockAcquired();
+				await sleep(300);
+				executionOrder.push('first:end');
+				return 'first';
+			});
+
+			await lockAcquiredPromise;
+
+			const second = dbLockService.withLock(
+				DbLock.TEST,
+				async () => {
+					executionOrder.push('second:start');
+					return 'second';
+				},
+				{ subKey: 1, waitIndefinitely: true },
+			);
+
+			const results = await Promise.all([first, second]);
+
+			expect(results).toEqual(['first', 'second']);
+			expect(executionOrder).toEqual(['first:start', 'first:end', 'second:start']);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

When multiple instances (mains, workers, webhooks) start simultaneously against a shared Postgres, they race `runMigrations()` — on multi-pod deployments this causes deadlocks, `column ... already exists` errors, and crash-looping pods.

This PR serializes startup migrations behind a Postgres advisory lock: one instance migrates, the rest wait, then find nothing pending.

- `DbConnection.migrate()` (Postgres only) acquires the lock through `DbLockService.withLock(DbLock.MIGRATIONS, ...)` and runs all pending migrations inside the lock transaction, on its one pooled connection (`MigrationExecutor` in `'none'` mode bound to the transaction's query runner). SQLite is single-instance and stays lock-free.
- One connection means `DB_POSTGRESDB_POOL_SIZE=1` keeps working, and the lock's lifetime is exactly the transaction's — a crashed instance can never leave it behind, including behind PgBouncer (which keeps server connections alive across client disconnects and could orphan a session-scoped lock).
- `withLock` gains a `subKey` option (two-int lock form), derived here from `schema:entityPrefix` so co-hosted tenants in one database don't block each other.
- `withLock` also gains a `waitIndefinitely` option (mutually exclusive with `timeoutMs` at the type level) that disables `statement_timeout` / `lock_timeout` / `idle_in_transaction_session_timeout` for the lock transaction — no timeout by design, since timing out would recreate the crash-loop. The configured `statement_timeout` is restored for the migration statements themselves.

**Behavior change:** pending migrations now commit or roll back as one unit instead of per-migration (`transaction: 'each'`). No existing Postgres migration is non-transactional, so all can run inside one transaction.

## How to test

- Unit: `pnpm --filter=@n8n/db test` (`db-connection.test.ts`, `db-lock.service.test.ts`).
- Manual: point `DB_POSTGRESDB_*` at an empty database and start `n8n start` + `n8n worker` simultaneously — both log `Acquiring database migration lock...`, one runs all migrations, the other runs none, both boot clean. Also verified with `DB_POSTGRESDB_POOL_SIZE=1`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3797

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)