### PR TITLE
fix: Validate loadOption parameter in GSheet and Notion nodes

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/loadOptions.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/loadOptions.test.ts
@@ -87,7 +87,7 @@ describe('Google Sheets Functions', () => {
 				.fn()
 				.mockReturnValueOnce({ mode: 'mode', value: 'value' }) // documentId
 				.mockReturnValueOnce('Sheet1') // sheetName extracted value
-				.mockImplementationOnce((_parameterName, defaultValue) => defaultValue); // sheetName resource locator
+				.mockReturnValueOnce(undefined); // sheetName resource locator
 
 			const result = await getSheetHeaderRow.call(
 				mockLoadOptionsFunctions as ILoadOptionsFunctions,

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/loadOptions.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/loadOptions.test.ts
@@ -82,6 +82,21 @@ describe('Google Sheets Functions', () => {
 			expect(result).toEqual([]);
 		});
 
+		it('should return an empty array if sheetName is null', async () => {
+			mockLoadOptionsFunctions.getNodeParameter = vi
+				.fn()
+				.mockReturnValueOnce({ mode: 'mode', value: 'value' }) // documentId
+				.mockReturnValueOnce('Sheet1') // sheetName extracted value
+				.mockImplementationOnce((_parameterName, defaultValue) => defaultValue); // sheetName resource locator
+
+			const result = await getSheetHeaderRow.call(
+				mockLoadOptionsFunctions as ILoadOptionsFunctions,
+			);
+
+			expect(result).toEqual([]);
+			expect(mockGoogleSheetInstance.spreadsheetGetSheet).not.toHaveBeenCalled();
+		});
+
 		it('should throw an error if no data is returned', async () => {
 			mockGoogleSheetInstance.spreadsheetGetSheet.mockResolvedValue({
 				title: 'Sheet1',

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/resourceMapping.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/resourceMapping.test.ts
@@ -112,4 +112,16 @@ describe('Google Sheets, getMappingColumns', () => {
 		expect(result.fields).toHaveLength(3);
 		expect(mockGoogleSheetInstance.getData).toHaveBeenCalledWith('Sheet1!10:10', 'FORMATTED_VALUE');
 	});
+
+	it('should return no fields when sheetName is null', async () => {
+		loadOptionsFunctions.getNodeParameter
+			.mockReturnValueOnce({ mode: 'id', value: 'spreadsheetId' }) // documentId
+			.mockReturnValueOnce('Sheet1') // sheetName extracted value
+			.mockImplementationOnce((_parameterName, defaultValue) => defaultValue); // sheetName resource locator
+
+		const result = await getMappingColumns.call(loadOptionsFunctions);
+
+		expect(result).toEqual({ fields: [] });
+		expect(mockGoogleSheetInstance.spreadsheetGetSheet).not.toHaveBeenCalled();
+	});
 });

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/resourceMapping.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/resourceMapping.test.ts
@@ -117,7 +117,7 @@ describe('Google Sheets, getMappingColumns', () => {
 		loadOptionsFunctions.getNodeParameter
 			.mockReturnValueOnce({ mode: 'id', value: 'spreadsheetId' }) // documentId
 			.mockReturnValueOnce('Sheet1') // sheetName extracted value
-			.mockImplementationOnce((_parameterName, defaultValue) => defaultValue); // sheetName resource locator
+			.mockReturnValueOnce(undefined); // sheetName resource locator
 
 		const result = await getMappingColumns.call(loadOptionsFunctions);
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/loadOptions.ts
@@ -39,7 +39,7 @@ export async function getSheets(this: ILoadOptionsFunctions): Promise<INodePrope
 export async function getSheetHeaderRow(
 	this: ILoadOptionsFunctions,
 ): Promise<INodePropertyOptions[]> {
-	const documentId = this.getNodeParameter('documentId', 0) as IDataObject | null;
+	const documentId = this.getNodeParameter('documentId', null) as IDataObject | null;
 
 	if (!documentId) return [];
 
@@ -51,9 +51,13 @@ export async function getSheetHeaderRow(
 	const sheetWithinDocument = this.getNodeParameter('sheetName', undefined, {
 		extractValue: true,
 	}) as string;
-	const { mode: sheetMode } = this.getNodeParameter('sheetName', 0) as {
-		mode: ResourceLocator;
+	const { mode: sheetMode } = this.getNodeParameter('sheetName', { mode: null }) as {
+		mode: ResourceLocator | null;
 	};
+
+	if (!sheetMode) {
+		return [];
+	}
 
 	const { title: sheetName } = await sheet.spreadsheetGetSheet(
 		this.getNode(),

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/loadOptions.ts
@@ -51,7 +51,7 @@ export async function getSheetHeaderRow(
 	const sheetWithinDocument = this.getNodeParameter('sheetName', undefined, {
 		extractValue: true,
 	}) as string;
-	const { mode: sheetMode } = this.getNodeParameter('sheetName', { mode: null }) as {
+	const { mode: sheetMode } = (this.getNodeParameter('sheetName') ?? { mode: null }) as {
 		mode: ResourceLocator | null;
 	};
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/resourceMapping.ts
@@ -24,7 +24,7 @@ export async function getMappingColumns(
 	const sheetWithinDocument = this.getNodeParameter('sheetName', undefined, {
 		extractValue: true,
 	}) as string;
-	const { mode: sheetMode } = this.getNodeParameter('sheetName', { mode: null }) as {
+	const { mode: sheetMode } = (this.getNodeParameter('sheetName') ?? { mode: null }) as {
 		mode: ResourceLocator | null;
 	};
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/resourceMapping.ts
@@ -24,7 +24,13 @@ export async function getMappingColumns(
 	const sheetWithinDocument = this.getNodeParameter('sheetName', undefined, {
 		extractValue: true,
 	}) as string;
-	const { mode: sheetMode } = this.getNodeParameter('sheetName', 0) as { mode: ResourceLocator };
+	const { mode: sheetMode } = this.getNodeParameter('sheetName', { mode: null }) as {
+		mode: ResourceLocator | null;
+	};
+
+	if (!sheetMode) {
+		return { fields: [] };
+	}
 
 	const { title: sheetName } = await sheet.spreadsheetGetSheet(
 		this.getNode(),

--- a/packages/nodes-base/nodes/Notion/test/v2/loadOptions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/v2/loadOptions.test.ts
@@ -1,0 +1,19 @@
+import type { ILoadOptionsFunctions } from 'n8n-workflow';
+
+import { getDatabaseOptionsFromPage } from '../../v2/methods/loadOptions';
+
+function createLoadOptionsContext(parameters: Record<string, unknown>): ILoadOptionsFunctions {
+	return {
+		getCurrentNodeParameter: vi.fn((name: string) => parameters[name]),
+	} as unknown as ILoadOptionsFunctions;
+}
+
+describe('Notion V2 load options', () => {
+	it('returns no options when database options are requested without a page', async () => {
+		const context = createLoadOptionsContext({ pageId: null });
+
+		const result = await getDatabaseOptionsFromPage.call(context);
+
+		expect(result).toEqual([]);
+	});
+});

--- a/packages/nodes-base/nodes/Notion/test/v3/loadOptions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/v3/loadOptions.test.ts
@@ -19,9 +19,7 @@ const mockNotionApiRequest = Transport.notionApiRequestV3 as Mock;
 
 function createLoadOptionsContext(parameters: Record<string, unknown>): ILoadOptionsFunctions {
 	return {
-		getCurrentNodeParameter: vi.fn(
-			(name: string, fallback?: unknown) => parameters[name] ?? fallback,
-		),
+		getCurrentNodeParameter: vi.fn((name: string) => parameters[name]),
 	} as unknown as ILoadOptionsFunctions;
 }
 
@@ -44,6 +42,15 @@ describe('Notion V3 load options', () => {
 		const result = await getDataSourceOptionsFromPage.call(context);
 
 		expect(result).toEqual([]);
+	});
+
+	it('returns no options when page data source properties are requested without a page', async () => {
+		const context = createLoadOptionsContext({ pageId: null });
+
+		const result = await getDataSourcePropertiesFromPage.call(context);
+
+		expect(result).toEqual([]);
+		expect(mockNotionApiRequest).not.toHaveBeenCalled();
 	});
 
 	it('uses only the last key segment as the property type for selected data source options', async () => {

--- a/packages/nodes-base/nodes/Notion/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Notion/v2/methods/loadOptions.ts
@@ -166,9 +166,13 @@ export async function getDatabaseIdFromPage(
 export async function getDatabaseOptionsFromPage(
 	this: ILoadOptionsFunctions,
 ): Promise<INodePropertyOptions[]> {
-	const pageId = extractPageId(
-		this.getCurrentNodeParameter('pageId', { extractValue: true }) as string,
-	);
+	const pageIdValue = this.getCurrentNodeParameter('pageId', { extractValue: true }) as
+		| string
+		| null;
+	const pageId = extractPageId(pageIdValue ?? '');
+	if (!pageId) {
+		return [];
+	}
 	const [name, type] = (this.getCurrentNodeParameter('&key') as string).split('|');
 	const {
 		parent: { database_id: databaseId },

--- a/packages/nodes-base/nodes/Notion/v3/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Notion/v3/methods/loadOptions.ts
@@ -123,9 +123,13 @@ export async function getUsers(this: ILoadOptionsFunctions): Promise<INodeProper
 async function getParentDataSourceIdFromPage(
 	this: ILoadOptionsFunctions,
 ): Promise<string | undefined> {
-	const pageId = extractPageId(
-		this.getCurrentNodeParameter('pageId', { extractValue: true }) as string,
-	);
+	const pageIdValue = this.getCurrentNodeParameter('pageId', { extractValue: true }) as
+		| string
+		| null;
+	const pageId = extractPageId(pageIdValue ?? '');
+	if (!pageId) {
+		return undefined;
+	}
 	const page = await notionApiRequestV3.call(this, 'GET', `/pages/${pageId}`);
 	if (!isDataObject(page) || !isDataObject(page.parent)) {
 		return undefined;


### PR DESCRIPTION
## Summary

This PR adds some guards to loadOptions methods in GSheet and Notion nodes. Doesn't change behavior for happy paths, mostly avoids this error in cases when sheetName parameter resolves to empty or null value.

Happens when an rlc parameter is 
```
"sheetName": "={{ null }}",
```
instead of
```
  "sheetName": {
          "__rl": true,
          "mode": "name",
          "value": "={{ null }}"
}
```
Might've been caused by some early versions of ai builder incorrectly mapping rlc properties
## How to test

Try using resource locators in `Google Sheet-> Sheet -> Append` or `Notion -> Database -> Create` operations


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5509/notion-typeerror-cannot-read-properties-of-null-reading-includes
https://linear.app/n8n/issue/NODE-5241/typeerror-cannot-destructure-property-mode-of-thisgetnodeparameter-as

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34695">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

