### PR TITLE
fix(editor): Keep Switch fallback outputs available with unresolved expressions

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -1,6 +1,10 @@
 import type { IWorkflowDb } from '@/Interface';
 import type { WorkflowData } from '@n8n/rest-api-client/api/workflows';
-import { resolveParameter, useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
+import {
+	resolveParameter,
+	resolveRequiredParameters,
+	useWorkflowHelpers,
+} from '@/app/composables/useWorkflowHelpers';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -10,7 +14,12 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { createTestNode, createTestWorkflow, mockNodeTypeDescription } from '@/__tests__/mocks';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { CHAT_TRIGGER_NODE_TYPE, WEBHOOK_NODE_TYPE } from 'n8n-workflow';
-import type { AssignmentCollectionValue, IConnections, IRunData } from 'n8n-workflow';
+import type {
+	AssignmentCollectionValue,
+	IConnections,
+	INodeProperties,
+	IRunData,
+} from 'n8n-workflow';
 import * as apiWebhooks from '@n8n/rest-api-client/api/webhooks';
 import { mockedStore } from '@/__tests__/utils';
 import { SET_NODE_TYPE, SLACK_TRIGGER_NODE_TYPE } from '../constants';
@@ -1310,5 +1319,85 @@ describe(resolveParameter, () => {
 
 			expect(result?.params).toBeDefined();
 		});
+	});
+});
+
+describe('resolveRequiredParameters', () => {
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ stubActions: false }));
+	});
+
+	const createParameter = (loadOptionsDependsOn: string[]): INodeProperties => ({
+		displayName: 'Fallback Output',
+		name: 'fallbackOutput',
+		type: 'options',
+		default: 'none',
+		typeOptions: { loadOptionsDependsOn },
+	});
+
+	const createResolveContext = () => {
+		const workflowData = createTestWorkflow({
+			nodes: [createTestNode({ name: 'Switch' })],
+		});
+		const workflowDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId(workflowData.id),
+		);
+		workflowDocumentStore.hydrate(workflowData);
+
+		return {
+			workflowDocumentId: workflowDocumentStore.documentId,
+			opts: {
+				localResolve: true as const,
+				nodeName: 'Switch',
+				additionalKeys: {},
+			},
+		};
+	};
+
+	it('should preserve structure and resolve available leaves when an optional expression fails', async () => {
+		const { workflowDocumentId, opts } = createResolveContext();
+
+		const result = await resolveRequiredParameters(
+			createParameter(['rules.values']),
+			{
+				rules: {
+					values: [
+						{
+							conditions: {
+								leftValue: '={{ $json.missing.toUpperCase() }}',
+								rightValue: '={{ 2 + 2 }}',
+							},
+							outputKey: 'Matched',
+						},
+					],
+				},
+			},
+			workflowDocumentId,
+			opts,
+		);
+
+		expect(result).toEqual({
+			rules: {
+				values: [
+					{
+						conditions: { leftValue: null, rightValue: 4 },
+						outputKey: 'Matched',
+					},
+				],
+			},
+		});
+	});
+
+	it('should reject when a required parameter cannot be resolved', async () => {
+		const { workflowDocumentId, opts } = createResolveContext();
+
+		await expect(
+			resolveRequiredParameters(
+				createParameter(['rules']),
+				{ rules: '={{ $json.missing.toUpperCase() }}' },
+				workflowDocumentId,
+				opts,
+			),
+		).rejects.toThrow();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -15,7 +15,9 @@ import type {
 	IRunData,
 	IWebhookDescription,
 	IWorkflowDataProxyAdditionalKeys,
+	GenericValue,
 	NodeParameterValue,
+	NodeParameterValueType,
 } from 'n8n-workflow';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
@@ -275,6 +277,37 @@ export async function resolveParameter<T = IDataObject>(
 	) as T;
 }
 
+async function resolveParameterLeaves(
+	parameter: NodeParameterValueType,
+	workflowDocumentId: WorkflowDocumentId,
+	opts: ResolveParameterOptions | ExpressionLocalResolveContext,
+): Promise<GenericValue> {
+	if (Array.isArray(parameter)) {
+		return await Promise.all(
+			parameter.map(async (value) => await resolveParameterLeaves(value, workflowDocumentId, opts)),
+		);
+	}
+
+	if (parameter !== null && typeof parameter === 'object') {
+		const entries = await Promise.all(
+			Object.entries(parameter).map(
+				async ([name, value]): Promise<[string, GenericValue]> => [
+					name,
+					await resolveParameterLeaves(value, workflowDocumentId, opts),
+				],
+			),
+		);
+
+		return Object.fromEntries(entries);
+	}
+
+	try {
+		return await resolveParameter<GenericValue>(parameter, workflowDocumentId, opts);
+	} catch {
+		return null;
+	}
+}
+
 export async function resolveRequiredParameters(
 	currentParameter: INodeProperties,
 	parameters: INodeParameters,
@@ -285,7 +318,7 @@ export async function resolveRequiredParameters(
 
 	const entries = Object.entries(parameters);
 	const resolvedEntries = await Promise.all(
-		entries.map(async ([name, parameter]): Promise<[string, IDataObject | null]> => {
+		entries.map(async ([name, parameter]): Promise<[string, GenericValue]> => {
 			const required = loadOptionsDependsOn.has(name);
 
 			if (required) {
@@ -299,9 +332,10 @@ export async function resolveRequiredParameters(
 						name,
 						await resolveParameter(parameter as NodeParameterValue, workflowDocumentId, opts),
 					];
-				} catch (error) {
-					// ignore any expressions errors for non required parameters
-					return [name, null];
+				} catch {
+					// Load options may still need the parameter structure when a nested
+					// expression fails, so resolve a complex parameter recursively.
+					return [name, await resolveParameterLeaves(parameter, workflowDocumentId, opts)];
 				}
 			}
 		}),


### PR DESCRIPTION
## Summary

Previously, when any nested expression in a non-required node parameter could not be evaluated, the editor replaced the entire top-level parameter with null before requesting dynamic options from the backend

For the Switch node, an unavailable expression inside a routing rule caused the complete rules structure to be discarded. The backend therefore received no rules and could not generate numeric fallback options such as Output 0

This change preserves the existing fast path for parameters that resolve successfully. If resolving a non-required structured parameter fails, the editor now resolves each leaf independently. Unavailable expressions become null, while the surrounding structure and successfully resolved sibling values are retained

As a result, the backend still receives the Switch rule count and output names needed to generate fallback options. Required parameters continue to fail normally when they cannot be resolved.

Required parameter resolution continues to fail normally and wasn't touched, since even if the editor would walk the structure to resolve leaves separately, it would still throw in the end

## How to test

Use this workflow:
<details>

```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        0
      ],
      "id": "ad59225b-3e6f-48bb-9dcb-f08d98a05f14",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "rules": {
          "values": [
            {
              "conditions": {
                "options": {
                  "caseSensitive": true,
                  "leftValue": "",
                  "typeValidation": "strict",
                  "version": 3
                },
                "conditions": [
                  {
                    "id": "1ed7d7fd-d3a8-4276-8860-64ca898629db",
                    "leftValue": "1",
                    "rightValue": "2",
                    "operator": {
                      "type": "string",
                      "operation": "equals",
                      "name": "filter.operator.equals"
                    }
                  }
                ],
                "combinator": "and"
              }
            }
          ]
        },
        "options": {
          "fallbackOutput": "none"
        }
      },
      "type": "n8n-nodes-base.switch",
      "typeVersion": 3.4,
      "position": [
        208,
        0
      ],
      "id": "4dad60b6-1ca0-4d68-ab78-e372428abce5",
      "name": "Switch"
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Switch",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Switch": {
      "main": [
        []
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "3666feb8935111309be62e6408a792d5193270a7ad5d662c8c14af007da79d2f"
  }
}
```

</details>

1. Open the NDV
2. Verify that for "Fallback Output" parameter you have three options: "None", "Extra Output" and "Output 0"
3. Verify that in the call to `/dynamic-node-parameters/options` in network tab of devtools the request has a proper value for the `rules` parameter
4. Update one of the values in the rule to `{{ $json.foo }}` (expression mode). The load options should refresh, since the value changed
5. Verify that "Output 0" option is gone and the request to `/dynamic-node-parameters/options` has `rules: null` (pre-fix)
6. Checkout the fix branch, rebuild and restart n8n
7. Repeat the same steps as above
8. Now, when the rule has an expression, "Output 0" option should still be present. The request to `/dynamic-node-parameters/options` has `rules` with proper values, only the unresolved expression has a value of `null`, instead of the whole parameter

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5232

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34698">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

