### PR TITLE
feat(core): Add eligible-reviewer API types and reviewer ids to revie…

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -293,6 +293,7 @@ export {
 export type { EncryptionKeyResponseDto } from './encryption/encryption-key-response.dto';
 
 export { CreateWorkflowReviewRequestDto } from './workflow-reviews/create-workflow-review-request.dto';
+export { GetWorkflowReviewEligibleReviewersQueryDto } from './workflow-reviews/get-eligible-reviewers-query.dto';
 export { ListWorkflowReviewRequestsQueryDto } from './workflow-reviews/list-workflow-review-requests-query.dto';
 
 export { UpdateOtelSettingsDto } from './otel/update-otel-settings.dto';

--- a/packages/@n8n/api-types/src/dto/workflow-reviews/create-workflow-review-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-reviews/create-workflow-review-request.dto.ts
@@ -13,4 +13,6 @@ export class CreateWorkflowReviewRequestDto extends Z.class({
 			}),
 		)
 		.length(1),
+	// UI sends at most one reviewer for now; array for future multi-reviewer support (LIGO-601)
+	reviewerUserIds: z.array(z.string().min(1).max(36)).max(10).optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/workflow-reviews/create-workflow-review-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-reviews/create-workflow-review-request.dto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { n8nIdSchema } from '../../schemas/id.schema';
 import { Z } from '../../zod-class';
 
 export class CreateWorkflowReviewRequestDto extends Z.class({
@@ -8,11 +9,11 @@ export class CreateWorkflowReviewRequestDto extends Z.class({
 	workflows: z
 		.array(
 			z.object({
-				workflowId: z.string().min(1).max(36),
-				workflowVersionId: z.string().min(1).max(36),
+				workflowId: n8nIdSchema,
+				workflowVersionId: n8nIdSchema,
 			}),
 		)
 		.length(1),
 	// UI sends at most one reviewer for now; array for future multi-reviewer support (LIGO-601)
-	reviewerUserIds: z.array(z.string().min(1).max(36)).max(10).optional(),
+	reviewerUserIds: z.array(n8nIdSchema).max(10).optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/workflow-reviews/get-eligible-reviewers-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-reviews/get-eligible-reviewers-query.dto.ts
@@ -1,7 +1,6 @@
-import { z } from 'zod';
-
+import { n8nIdSchema } from '../../schemas/id.schema';
 import { Z } from '../../zod-class';
 
 export class GetWorkflowReviewEligibleReviewersQueryDto extends Z.class({
-	workflowId: z.string().min(1).max(36),
+	workflowId: n8nIdSchema,
 }) {}

--- a/packages/@n8n/api-types/src/dto/workflow-reviews/get-eligible-reviewers-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-reviews/get-eligible-reviewers-query.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class GetWorkflowReviewEligibleReviewersQueryDto extends Z.class({
+	workflowId: z.string().min(1).max(36),
+}) {}

--- a/packages/@n8n/api-types/src/dto/workflow-reviews/list-workflow-review-requests-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflow-reviews/list-workflow-review-requests-query.dto.ts
@@ -1,5 +1,4 @@
-import { z } from 'zod';
-
+import { n8nIdSchema } from '../../schemas/id.schema';
 import { workflowReviewRequestStateSchema } from '../../workflow-review-request-summary';
 import { Z } from '../../zod-class';
 import { paginationSchema } from '../pagination/pagination.dto';
@@ -7,6 +6,6 @@ import { paginationSchema } from '../pagination/pagination.dto';
 export class ListWorkflowReviewRequestsQueryDto extends Z.class({
 	...paginationSchema,
 	// Required until cross-workflow listing gets project-based access filtering (LIGO-597)
-	workflowId: z.string().min(1),
+	workflowId: n8nIdSchema,
 	state: workflowReviewRequestStateSchema.optional(),
 }) {}

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -13,6 +13,7 @@ export * from './instance-registry-types';
 export * from './redaction-enforcement';
 export * from './redaction-enforcement-floor';
 export * from './workflow-reviews-policy';
+export type * from './workflow-review-eligible-reviewer';
 export * from './workflow-review-request-summary';
 export {
 	chatHubConversationModelSchema,

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -121,6 +121,7 @@ export { FAVORITE_RESOURCE_TYPES } from './schemas/favorites.schema';
 export type { BannerName } from './schemas/banner-name.schema';
 export { ViewableMimeTypes } from './schemas/binary-data.schema';
 export { passwordSchema, createPasswordSchema } from './schemas/password.schema';
+export { n8nIdSchema } from './schemas/id.schema';
 export {
 	SYSTEM_RESOLVER_ID,
 	credentialResolverSchema,

--- a/packages/@n8n/api-types/src/schemas/id.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/id.schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+/**
+ * An entity id as exchanged over the API. 36 chars covers both id formats
+ * n8n uses: nanoid (16) for most resources and UUID (36) for users.
+ */
+export const n8nIdSchema = z.string().min(1).max(36);

--- a/packages/@n8n/api-types/src/workflow-review-eligible-reviewer.ts
+++ b/packages/@n8n/api-types/src/workflow-review-eligible-reviewer.ts
@@ -1,0 +1,12 @@
+// Not MinimalUser: its name fields are non-nullable, while the DB columns are nullable.
+export type WorkflowReviewEligibleReviewer = {
+	id: string;
+	email: string;
+	firstName: string | null;
+	lastName: string | null;
+};
+
+export type WorkflowReviewEligibleReviewersList = {
+	count: number;
+	data: WorkflowReviewEligibleReviewer[];
+};

--- a/packages/@n8n/api-types/src/workflow-review-eligible-reviewer.ts
+++ b/packages/@n8n/api-types/src/workflow-review-eligible-reviewer.ts
@@ -1,4 +1,6 @@
-// Not MinimalUser: its name fields are non-nullable, while the DB columns are nullable.
+// Deliberately not derived from a shared user type: MinimalUser wrongly claims
+// non-nullable names, userBaseSchema wrongly claims optional id/email — and this
+// type doubles as the boundary of what the endpoint may expose.
 export type WorkflowReviewEligibleReviewer = {
 	id: string;
 	email: string;

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -1,7 +1,12 @@
 import type { UsersListFilterDto } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import { PROJECT_OWNER_ROLE_SLUG, PROJECT_VIEWER_ROLE_SLUG } from '@n8n/permissions';
-import type { DeepPartial, EntityManager, SelectQueryBuilder } from '@n8n/typeorm';
+import type {
+	DeepPartial,
+	EntityManager,
+	FindOptionsWhere,
+	SelectQueryBuilder,
+} from '@n8n/typeorm';
 import { Brackets, DataSource, In, IsNull, Not, Repository } from '@n8n/typeorm';
 
 import { ApiKey, Project, ProjectRelation, User } from '../entities';
@@ -148,6 +153,44 @@ export class UserRepository extends Repository<User> {
 		// TODO: use a transactions
 		// This is blocked by TypeORM having concurrency issues with transactions
 		return await createInner(this.manager);
+	}
+
+	/**
+	 * Find enabled users whose global role or role on the given project is in
+	 * the given slug sets. Role slugs are passed in so this package stays
+	 * scope-agnostic; resolving scopes to roles is the caller's concern.
+	 *
+	 * Loads `role` and `authIdentities` because the `@AfterLoad` hook needs
+	 * both to compute `isPending` (a raw `password IS NOT NULL` filter would
+	 * wrongly drop SSO/LDAP users).
+	 */
+	async findEligibleByProjectOrGlobalRoles({
+		projectId,
+		projectRoleSlugs,
+		globalRoleSlugs,
+	}: {
+		projectId: string;
+		projectRoleSlugs: string[];
+		globalRoleSlugs: string[];
+	}): Promise<User[]> {
+		const where: Array<FindOptionsWhere<User>> = [];
+		if (globalRoleSlugs.length > 0) {
+			where.push({ disabled: false, role: { slug: In(globalRoleSlugs) } });
+		}
+		if (projectRoleSlugs.length > 0) {
+			where.push({
+				disabled: false,
+				projectRelations: { projectId, role: { slug: In(projectRoleSlugs) } },
+			});
+		}
+		if (where.length === 0) {
+			return [];
+		}
+
+		return await this.find({
+			where,
+			relations: { role: true, authIdentities: true },
+		});
 	}
 
 	/**

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -156,9 +156,8 @@ export class UserRepository extends Repository<User> {
 	}
 
 	/**
-	 * Find enabled users whose global role or role on the given project is in
-	 * the given slug sets. Role slugs are passed in so this package stays
-	 * scope-agnostic; resolving scopes to roles is the caller's concern.
+	 * Find enabled users whose global/project is in the given slug sets. Role slugs
+	 * are passed in so this package stays scope-agnostic.
 	 *
 	 * Loads `role` and `authIdentities` because the `@AfterLoad` hook needs
 	 * both to compute `isPending` (a raw `password IS NOT NULL` filter would

--- a/packages/@n8n/db/src/repositories/workflow-review-request-reviewer.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-review-request-reviewer.repository.ts
@@ -1,4 +1,5 @@
 import { Service } from '@n8n/di';
+import type { EntityManager } from '@n8n/typeorm';
 import { DataSource, In, Repository } from '@n8n/typeorm';
 
 import { WorkflowReviewRequestReviewer } from '../entities/workflow-review-request-reviewer.ee';
@@ -7,6 +8,30 @@ import { WorkflowReviewRequestReviewer } from '../entities/workflow-review-reque
 export class WorkflowReviewRequestReviewerRepository extends Repository<WorkflowReviewRequestReviewer> {
 	constructor(dataSource: DataSource) {
 		super(WorkflowReviewRequestReviewer, dataSource.manager);
+	}
+
+	/** Unlike `setReviewers`, this runs in the caller's transaction and only appends rows. */
+	async addReviewers(
+		input: {
+			workflowReviewRequestId: string;
+			userIds: string[];
+		},
+		trx?: EntityManager,
+	): Promise<WorkflowReviewRequestReviewer[]> {
+		const uniqueUserIds = [...new Set(input.userIds)];
+		if (uniqueUserIds.length === 0) {
+			return [];
+		}
+
+		const manager = trx ?? this.manager;
+		const entities = uniqueUserIds.map((userId) =>
+			this.create({
+				workflowReviewRequestId: input.workflowReviewRequestId,
+				userId,
+			}),
+		);
+
+		return await manager.save(WorkflowReviewRequestReviewer, entities);
 	}
 
 	async setReviewers(

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.service.test.ts
@@ -1,20 +1,23 @@
 import type {
 	CreateWorkflowReviewRequestDto,
+	GetWorkflowReviewEligibleReviewersQueryDto,
 	ListWorkflowReviewRequestsQueryDto,
 } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type {
+	AuthIdentity,
 	DbLockService,
 	Project,
 	SharedWorkflowRepository,
-	User,
+	UserRepository,
 	WorkflowEntity,
 	WorkflowReviewRequest,
 	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
+	WorkflowReviewRequestReviewerRepository,
 	WorkflowReviewRequestWorkflowRepository,
 } from '@n8n/db';
-import { DbLock } from '@n8n/db';
+import { DbLock, User } from '@n8n/db';
 import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
@@ -23,6 +26,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { RoleService } from '@/services/role.service';
 import type { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -30,6 +34,13 @@ import type { WorkflowHistoryService } from '@/workflows/workflow-history/workfl
 import { WorkflowReviewRequestService } from '../workflow-review-request.service';
 
 const user = mock<User>({ id: 'user-1' });
+
+/** Build a real `User` with `isPending` computed, as TypeORM does after load. */
+function loadedUser(fields: Partial<User> & { id: string; email: string }): User {
+	const loaded = Object.assign(new User(), { password: 'hashed', authIdentities: [], ...fields });
+	loaded.computeIsPending();
+	return loaded;
+}
 
 const dto: CreateWorkflowReviewRequestDto = {
 	title: 'Please review',
@@ -45,6 +56,9 @@ describe('WorkflowReviewRequestService', () => {
 	const requestRepository = mock<WorkflowReviewRequestRepository>();
 	const workflowRepository = mock<WorkflowReviewRequestWorkflowRepository>();
 	const authorRepository = mock<WorkflowReviewRequestAuthorRepository>();
+	const reviewerRepository = mock<WorkflowReviewRequestReviewerRepository>();
+	const userRepository = mock<UserRepository>();
+	const roleService = mock<RoleService>();
 	const dbLockService = mock<DbLockService>();
 	const collaborationService = mock<CollaborationService>();
 	const logger = mock<Logger>();
@@ -59,6 +73,9 @@ describe('WorkflowReviewRequestService', () => {
 		requestRepository,
 		workflowRepository,
 		authorRepository,
+		reviewerRepository,
+		userRepository,
+		roleService,
 		dbLockService,
 		collaborationService,
 	);
@@ -73,6 +90,24 @@ describe('WorkflowReviewRequestService', () => {
 	});
 
 	describe('create', () => {
+		const mockSuccessfulCreatePath = () => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(
+				mock<WorkflowEntity>({ isArchived: false }),
+			);
+			workflowHistoryService.findVersion.mockResolvedValue(mock());
+			sharedWorkflowRepository.getWorkflowOwningProject.mockResolvedValue(
+				mock<Project>({ id: 'project-1' }),
+			);
+			requestRepository.findOpenRequestForWorkflow.mockResolvedValue(null);
+			requestRepository.createRequest.mockResolvedValue(
+				mock<WorkflowReviewRequest>({
+					id: 'req-1',
+					createdAt: new Date('2024-01-01T00:00:00.000Z'),
+					updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+				}),
+			);
+		};
+
 		it('throws when the instance policy is disabled, before any lookup or lock', async () => {
 			workflowReviewPolicyService.get.mockResolvedValue({ enabled: false });
 
@@ -187,25 +222,80 @@ describe('WorkflowReviewRequestService', () => {
 			expect(authorRepository.addAuthor).not.toHaveBeenCalled();
 		});
 
-		describe('review state broadcast', () => {
-			const mockSuccessfulCreatePath = () => {
-				workflowFinderService.findWorkflowForUser.mockResolvedValue(
-					mock<WorkflowEntity>({ isArchived: false }),
-				);
-				workflowHistoryService.findVersion.mockResolvedValue(mock());
-				sharedWorkflowRepository.getWorkflowOwningProject.mockResolvedValue(
-					mock<Project>({ id: 'project-1' }),
-				);
-				requestRepository.findOpenRequestForWorkflow.mockResolvedValue(null);
-				requestRepository.createRequest.mockResolvedValue(
-					mock<WorkflowReviewRequest>({
-						id: 'req-1',
-						createdAt: new Date('2024-01-01T00:00:00.000Z'),
-						updatedAt: new Date('2024-01-01T00:00:00.000Z'),
-					}),
+		describe('reviewer assignment', () => {
+			const mockEligibleReviewers = (...ids: string[]) => {
+				roleService.rolesWithScope.mockResolvedValue(['some-role']);
+				userRepository.findEligibleByProjectOrGlobalRoles.mockResolvedValue(
+					ids.map((id) => loadedUser({ id, email: `${id}@n8n.io` })),
 				);
 			};
 
+			it('writes deduplicated reviewers in the same transaction as the request', async () => {
+				mockSuccessfulCreatePath();
+				mockEligibleReviewers('user-2', 'user-3');
+
+				await service.create(user, {
+					...dto,
+					reviewerUserIds: ['user-2', 'user-2', 'user-3'],
+				});
+
+				expect(reviewerRepository.addReviewers).toHaveBeenCalledWith(
+					{ workflowReviewRequestId: 'req-1', userIds: ['user-2', 'user-3'] },
+					tx,
+				);
+			});
+
+			it('rejects self-assignment before checking eligibility or taking the lock', async () => {
+				mockSuccessfulCreatePath();
+
+				await expect(service.create(user, { ...dto, reviewerUserIds: ['user-1'] })).rejects.toThrow(
+					BadRequestError,
+				);
+
+				expect(userRepository.findEligibleByProjectOrGlobalRoles).not.toHaveBeenCalled();
+				expect(dbLockService.withLock).not.toHaveBeenCalled();
+			});
+
+			it('rejects reviewers outside the eligible set before taking the lock, naming them', async () => {
+				mockSuccessfulCreatePath();
+				mockEligibleReviewers('user-2');
+
+				await expect(
+					service.create(user, { ...dto, reviewerUserIds: ['user-2', 'user-99'] }),
+				).rejects.toThrow('These users are not eligible to review this workflow: user-99');
+
+				expect(dbLockService.withLock).not.toHaveBeenCalled();
+			});
+
+			it('rejects a pending user as reviewer even when their role qualifies', async () => {
+				mockSuccessfulCreatePath();
+				roleService.rolesWithScope.mockResolvedValue(['some-role']);
+				userRepository.findEligibleByProjectOrGlobalRoles.mockResolvedValue([
+					loadedUser({ id: 'user-2', email: 'user-2@n8n.io', password: null }),
+				]);
+
+				await expect(service.create(user, { ...dto, reviewerUserIds: ['user-2'] })).rejects.toThrow(
+					BadRequestError,
+				);
+			});
+
+			it.each<[string, string[] | undefined]>([
+				['omitted', undefined],
+				['empty', []],
+			])(
+				'skips the eligibility lookup and the reviewer write when reviewers are %s',
+				async (_name, reviewerUserIds) => {
+					mockSuccessfulCreatePath();
+
+					await service.create(user, { ...dto, reviewerUserIds });
+
+					expect(userRepository.findEligibleByProjectOrGlobalRoles).not.toHaveBeenCalled();
+					expect(reviewerRepository.addReviewers).not.toHaveBeenCalled();
+				},
+			);
+		});
+
+		describe('review state broadcast', () => {
 			it('broadcasts exactly once after the lock resolves', async () => {
 				mockSuccessfulCreatePath();
 				let lockResolved = false;
@@ -253,6 +343,100 @@ describe('WorkflowReviewRequestService', () => {
 					expect.objectContaining({ workflowId: 'wf-1' }),
 				);
 			});
+		});
+	});
+
+	describe('getEligibleReviewers', () => {
+		const query = { workflowId: 'wf-1' } as GetWorkflowReviewEligibleReviewersQueryDto;
+
+		const mockEligibleLookupPath = () => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(mock<WorkflowEntity>());
+			sharedWorkflowRepository.getWorkflowOwningProject.mockResolvedValue(
+				mock<Project>({ id: 'project-1' }),
+			);
+			roleService.rolesWithScope.mockImplementation(async (namespace) =>
+				namespace === 'project'
+					? ['project:admin', 'project:editor', 'custom:reviewer']
+					: ['global:owner', 'global:admin'],
+			);
+		};
+
+		it('throws when the instance policy is disabled, before any lookup', async () => {
+			workflowReviewPolicyService.get.mockResolvedValue({ enabled: false });
+
+			await expect(service.getEligibleReviewers(user, query)).rejects.toThrow(ForbiddenError);
+
+			expect(workflowFinderService.findWorkflowForUser).not.toHaveBeenCalled();
+			expect(userRepository.findEligibleByProjectOrGlobalRoles).not.toHaveBeenCalled();
+		});
+
+		it('throws NotFoundError when the user lacks publish access to the workflow', async () => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(null);
+
+			await expect(service.getEligibleReviewers(user, query)).rejects.toThrow(NotFoundError);
+
+			expect(workflowFinderService.findWorkflowForUser).toHaveBeenCalledWith('wf-1', user, [
+				'workflow:publish',
+			]);
+			expect(userRepository.findEligibleByProjectOrGlobalRoles).not.toHaveBeenCalled();
+		});
+
+		it('throws NotFoundError when the workflow has no owning project', async () => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(mock<WorkflowEntity>());
+			sharedWorkflowRepository.getWorkflowOwningProject.mockResolvedValue(undefined);
+
+			await expect(service.getEligibleReviewers(user, query)).rejects.toThrow(NotFoundError);
+		});
+
+		it('queries users by the project and global role slugs granting workflow:publish', async () => {
+			mockEligibleLookupPath();
+			userRepository.findEligibleByProjectOrGlobalRoles.mockResolvedValue([]);
+
+			await service.getEligibleReviewers(user, query);
+
+			expect(userRepository.findEligibleByProjectOrGlobalRoles).toHaveBeenCalledWith({
+				projectId: 'project-1',
+				projectRoleSlugs: ['project:admin', 'project:editor', 'custom:reviewer'],
+				globalRoleSlugs: ['global:owner', 'global:admin'],
+			});
+		});
+
+		it('excludes the requester and pending users, and returns the rest sorted by email', async () => {
+			mockEligibleLookupPath();
+			userRepository.findEligibleByProjectOrGlobalRoles.mockResolvedValue([
+				loadedUser({ id: 'user-3', email: 'zoe@n8n.io', firstName: 'Zoe' }),
+				loadedUser({ id: 'user-1', email: 'requester@n8n.io' }),
+				loadedUser({ id: 'user-4', email: 'pending@n8n.io', password: null }),
+				loadedUser({ id: 'user-2', email: 'amy@n8n.io' }),
+			]);
+
+			const result = await service.getEligibleReviewers(user, query);
+
+			expect(result).toEqual({
+				count: 2,
+				data: [
+					{ id: 'user-2', email: 'amy@n8n.io', firstName: null, lastName: null },
+					{ id: 'user-3', email: 'zoe@n8n.io', firstName: 'Zoe', lastName: null },
+				],
+			});
+		});
+
+		it('does not misclassify an SSO user without a password as pending', async () => {
+			mockEligibleLookupPath();
+			userRepository.findEligibleByProjectOrGlobalRoles.mockResolvedValue([
+				loadedUser({
+					id: 'user-sso',
+					email: 'sso@n8n.io',
+					password: null,
+					authIdentities: [mock<AuthIdentity>({ providerType: 'ldap' })],
+				}),
+			]);
+
+			const result = await service.getEligibleReviewers(user, query);
+
+			expect(result.data).toEqual([
+				{ id: 'user-sso', email: 'sso@n8n.io', firstName: null, lastName: null },
+			]);
 		});
 	});
 

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-requests.controller.integration.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-requests.controller.integration.test.ts
@@ -11,10 +11,11 @@ import type { Project, User } from '@n8n/db';
 import {
 	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
+	WorkflowReviewRequestReviewerRepository,
 	WorkflowReviewRequestWorkflowRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { createMember, createOwner } from '@test-integration/db/users';
+import { createAdmin, createMember, createOwner, createUser } from '@test-integration/db/users';
 import { createWorkflowHistoryItem } from '@test-integration/db/workflow-history';
 import type { SuperAgentTest } from '@test-integration/types';
 import * as utils from '@test-integration/utils';
@@ -36,12 +37,14 @@ let memberAgent: SuperAgentTest;
 let requestRepository: WorkflowReviewRequestRepository;
 let workflowRepository: WorkflowReviewRequestWorkflowRepository;
 let authorRepository: WorkflowReviewRequestAuthorRepository;
+let reviewerRepository: WorkflowReviewRequestReviewerRepository;
 let policyService: WorkflowReviewPolicyService;
 
 beforeAll(() => {
 	requestRepository = Container.get(WorkflowReviewRequestRepository);
 	workflowRepository = Container.get(WorkflowReviewRequestWorkflowRepository);
 	authorRepository = Container.get(WorkflowReviewRequestAuthorRepository);
+	reviewerRepository = Container.get(WorkflowReviewRequestReviewerRepository);
 	policyService = Container.get(WorkflowReviewPolicyService);
 });
 
@@ -118,6 +121,69 @@ describe('POST /workflow-review-requests', () => {
 			workflowReviewRequestId: requests[0].id,
 			userId: owner.id,
 		});
+	});
+
+	test('persists deduplicated reviewer rows together with the request', async () => {
+		const { workflow, versionId } = await createReviewableWorkflow();
+		const reviewer = await createAdmin();
+
+		await ownerAgent
+			.post('/workflow-review-requests')
+			.send({
+				title: 'With a reviewer',
+				workflows: [{ workflowId: workflow.id, workflowVersionId: versionId }],
+				reviewerUserIds: [reviewer.id, reviewer.id],
+			})
+			.expect(201);
+
+		const reviewerRows = await reviewerRepository.find();
+		expect(reviewerRows).toHaveLength(1);
+		expect(reviewerRows[0]).toMatchObject({ userId: reviewer.id });
+	});
+
+	test('returns 400 when the requester assigns themselves as reviewer', async () => {
+		const { workflow, versionId } = await createReviewableWorkflow();
+
+		await ownerAgent
+			.post('/workflow-review-requests')
+			.send({
+				title: 'x',
+				workflows: [{ workflowId: workflow.id, workflowVersionId: versionId }],
+				reviewerUserIds: [owner.id],
+			})
+			.expect(400);
+
+		expect(await requestRepository.find()).toHaveLength(0);
+	});
+
+	test('returns 400 for an ineligible reviewer and writes nothing', async () => {
+		const { workflow, versionId } = await createReviewableWorkflow();
+
+		// A plain member has no publish rights on the owner's personal project
+		await ownerAgent
+			.post('/workflow-review-requests')
+			.send({
+				title: 'x',
+				workflows: [{ workflowId: workflow.id, workflowVersionId: versionId }],
+				reviewerUserIds: [member.id],
+			})
+			.expect(400);
+
+		expect(await requestRepository.find()).toHaveLength(0);
+		expect(await reviewerRepository.find()).toHaveLength(0);
+	});
+
+	test('returns 400 for more than 10 reviewer ids', async () => {
+		const { workflow, versionId } = await createReviewableWorkflow();
+
+		await ownerAgent
+			.post('/workflow-review-requests')
+			.send({
+				title: 'x',
+				workflows: [{ workflowId: workflow.id, workflowVersionId: versionId }],
+				reviewerUserIds: Array.from({ length: 11 }, (_, i) => `user-${i}`),
+			})
+			.expect(400);
 	});
 
 	test('returns 400 when the workflows array is empty', async () => {
@@ -396,6 +462,137 @@ describe('POST /workflow-review-requests', () => {
 				title: 'x',
 				workflows: [{ workflowId: 'wf-1', workflowVersionId: 'version-1' }],
 			})
+			.expect(403);
+
+		testServer.license.enable('feat:workflowReviews');
+	});
+});
+
+describe('GET /workflow-review-requests/eligible-reviewers', () => {
+	test('returns publish-capable project and instance users, excluding everyone else', async () => {
+		const project = await createTeamProject('team', owner);
+		// The requester holds workflow:publish through project:editor
+		await linkUserToProject(member, project, 'project:editor');
+
+		const projectAdmin = await createUser();
+		await linkUserToProject(projectAdmin, project, 'project:admin');
+		const projectEditor = await createUser();
+		await linkUserToProject(projectEditor, project, 'project:editor');
+		const globalAdmin = await createAdmin();
+
+		const projectViewer = await createUser();
+		await linkUserToProject(projectViewer, project, 'project:viewer');
+		const disabledEditor = await createUser({ disabled: true });
+		await linkUserToProject(disabledEditor, project, 'project:editor');
+		const pendingEditor = await createUser({ password: null });
+		await linkUserToProject(pendingEditor, project, 'project:editor');
+		await createUser(); // unrelated member
+
+		const workflow = await createWorkflow({}, project);
+
+		const response = await memberAgent
+			.get('/workflow-review-requests/eligible-reviewers')
+			.query({ workflowId: workflow.id })
+			.expect(200);
+
+		expect(response.body.data.count).toBe(4);
+		const ids = response.body.data.data.map((reviewer: { id: string }) => reviewer.id);
+		expect(ids.sort()).toEqual(
+			[owner.id, projectAdmin.id, projectEditor.id, globalAdmin.id].sort(),
+		);
+	});
+
+	test('returns a user holding both a project and a global qualifying role only once', async () => {
+		const project = await createTeamProject('team', owner);
+		await linkUserToProject(member, project, 'project:editor');
+		const globalAdmin = await createAdmin();
+		await linkUserToProject(globalAdmin, project, 'project:admin');
+		const workflow = await createWorkflow({}, project);
+
+		const response = await memberAgent
+			.get('/workflow-review-requests/eligible-reviewers')
+			.query({ workflowId: workflow.id })
+			.expect(200);
+
+		const ids = response.body.data.data.filter(
+			(reviewer: { id: string }) => reviewer.id === globalAdmin.id,
+		);
+		expect(ids).toHaveLength(1);
+	});
+
+	test('exposes only id, email, and names for each reviewer', async () => {
+		const globalAdmin = await createAdmin();
+		const { workflow } = await createReviewableWorkflow();
+
+		const response = await ownerAgent
+			.get('/workflow-review-requests/eligible-reviewers')
+			.query({ workflowId: workflow.id })
+			.expect(200);
+
+		expect(response.body.data.data).toEqual([
+			{
+				id: globalAdmin.id,
+				email: globalAdmin.email,
+				firstName: globalAdmin.firstName,
+				lastName: globalAdmin.lastName,
+			},
+		]);
+	});
+
+	test('returns only instance-level reviewers for a personal-project workflow', async () => {
+		const globalAdmin = await createAdmin();
+		const { workflow } = await createReviewableWorkflow();
+
+		const response = await ownerAgent
+			.get('/workflow-review-requests/eligible-reviewers')
+			.query({ workflowId: workflow.id })
+			.expect(200);
+
+		// The requesting owner is excluded; the plain member holds no publish rights
+		expect(response.body.data.count).toBe(1);
+		expect(response.body.data.data[0].id).toBe(globalAdmin.id);
+	});
+
+	test('returns 400 without a workflowId', async () => {
+		await ownerAgent.get('/workflow-review-requests/eligible-reviewers').expect(400);
+	});
+
+	test('returns 404 when the member has no access to the workflow', async () => {
+		const { workflow } = await createReviewableWorkflow();
+
+		await memberAgent
+			.get('/workflow-review-requests/eligible-reviewers')
+			.query({ workflowId: workflow.id })
+			.expect(404);
+	});
+
+	test('returns 404 for a project:viewer (lacks workflow:publish)', async () => {
+		const project = await createTeamProject('team', owner);
+		await linkUserToProject(member, project, 'project:viewer');
+		const workflow = await createWorkflow({}, project);
+
+		await memberAgent
+			.get('/workflow-review-requests/eligible-reviewers')
+			.query({ workflowId: workflow.id })
+			.expect(404);
+	});
+
+	test('returns 403 when the instance policy is disabled', async () => {
+		const { workflow } = await createReviewableWorkflow();
+		await policyService.set(false);
+
+		await ownerAgent
+			.get('/workflow-review-requests/eligible-reviewers')
+			.query({ workflowId: workflow.id })
+			.expect(403);
+	});
+
+	test('returns 403 when the license lacks feat:workflowReviews', async () => {
+		testServer.license.disable('feat:workflowReviews');
+
+		await ownerAgent
+			.get('/workflow-review-requests/eligible-reviewers')
+			.query({ workflowId: 'wf-1' })
 			.expect(403);
 
 		testServer.license.enable('feat:workflowReviews');

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
@@ -48,12 +48,6 @@ export class WorkflowReviewRequestService {
 		private readonly collaborationService: CollaborationService,
 	) {}
 
-	/**
-	 * Users who may review workflows of the given project: anyone whose project
-	 * role on it or global role grants `workflow:publish` (covers custom roles
-	 * via the role cache), excluding deactivated users, pending users, and the
-	 * requester.
-	 */
 	private async findEligibleReviewers(projectId: string, excludeUserId: string): Promise<User[]> {
 		const [projectRoleSlugs, globalRoleSlugs] = await Promise.all([
 			this.roleService.rolesWithScope('project', ['workflow:publish']),

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
@@ -1,6 +1,8 @@
 import type {
 	CreateWorkflowReviewRequestDto,
+	GetWorkflowReviewEligibleReviewersQueryDto,
 	ListWorkflowReviewRequestsQueryDto,
+	WorkflowReviewEligibleReviewersList,
 	WorkflowReviewRequestList,
 	WorkflowReviewRequestSummary,
 } from '@n8n/api-types';
@@ -9,8 +11,10 @@ import {
 	DbLock,
 	DbLockService,
 	SharedWorkflowRepository,
+	UserRepository,
 	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
+	WorkflowReviewRequestReviewerRepository,
 	WorkflowReviewRequestWorkflowRepository,
 	type User,
 } from '@n8n/db';
@@ -21,6 +25,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { RoleService } from '@/services/role.service';
 import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -36,9 +41,35 @@ export class WorkflowReviewRequestService {
 		private readonly workflowReviewRequestRepository: WorkflowReviewRequestRepository,
 		private readonly workflowReviewRequestWorkflowRepository: WorkflowReviewRequestWorkflowRepository,
 		private readonly workflowReviewRequestAuthorRepository: WorkflowReviewRequestAuthorRepository,
+		private readonly workflowReviewRequestReviewerRepository: WorkflowReviewRequestReviewerRepository,
+		private readonly userRepository: UserRepository,
+		private readonly roleService: RoleService,
 		private readonly dbLockService: DbLockService,
 		private readonly collaborationService: CollaborationService,
 	) {}
+
+	/**
+	 * Users who may review workflows of the given project: anyone whose project
+	 * role on it or global role grants `workflow:publish` (covers custom roles
+	 * via the role cache), excluding deactivated users, pending users, and the
+	 * requester.
+	 */
+	private async findEligibleReviewers(projectId: string, excludeUserId: string): Promise<User[]> {
+		const [projectRoleSlugs, globalRoleSlugs] = await Promise.all([
+			this.roleService.rolesWithScope('project', ['workflow:publish']),
+			this.roleService.rolesWithScope('global', ['workflow:publish']),
+		]);
+
+		const users = await this.userRepository.findEligibleByProjectOrGlobalRoles({
+			projectId,
+			projectRoleSlugs,
+			globalRoleSlugs,
+		});
+
+		return users
+			.filter((user) => !user.isPending && user.id !== excludeUserId)
+			.sort((a, b) => a.email.localeCompare(b.email));
+	}
 
 	async list(
 		user: User,
@@ -69,6 +100,41 @@ export class WorkflowReviewRequestService {
 				decision: request.decision,
 				createdAt: request.createdAt.toISOString(),
 				updatedAt: request.updatedAt.toISOString(),
+			})),
+		};
+	}
+
+	async getEligibleReviewers(
+		user: User,
+		query: GetWorkflowReviewEligibleReviewersQueryDto,
+	): Promise<WorkflowReviewEligibleReviewersList> {
+		const policy = await this.workflowReviewPolicyService.get();
+		if (!policy.enabled) {
+			throw new ForbiddenError('Workflow reviews are not enabled for this instance');
+		}
+
+		const workflow = await this.workflowFinderService.findWorkflowForUser(query.workflowId, user, [
+			'workflow:publish',
+		]);
+		if (!workflow) {
+			throw new NotFoundError('Could not find workflow');
+		}
+
+		const project = await this.sharedWorkflowRepository.getWorkflowOwningProject(query.workflowId);
+		if (!project) {
+			throw new NotFoundError('Could not find workflow');
+		}
+
+		const reviewers = await this.findEligibleReviewers(project.id, user.id);
+
+		// No pagination: the set is bounded by the project's members plus instance admins
+		return {
+			count: reviewers.length,
+			data: reviewers.map((reviewer) => ({
+				id: reviewer.id,
+				email: reviewer.email,
+				firstName: reviewer.firstName ?? null,
+				lastName: reviewer.lastName ?? null,
 			})),
 		};
 	}
@@ -109,6 +175,24 @@ export class WorkflowReviewRequestService {
 			throw new NotFoundError('Could not find workflow');
 		}
 
+		const reviewerUserIds = [...new Set(dto.reviewerUserIds ?? [])];
+		if (reviewerUserIds.length > 0) {
+			if (reviewerUserIds.includes(user.id)) {
+				throw new BadRequestError('You cannot assign yourself as a reviewer');
+			}
+
+			const eligibleIds = new Set(
+				(await this.findEligibleReviewers(project.id, user.id)).map((reviewer) => reviewer.id),
+			);
+			// The requester can already enumerate the eligible set, so listing ids leaks nothing
+			const ineligibleIds = reviewerUserIds.filter((id) => !eligibleIds.has(id));
+			if (ineligibleIds.length > 0) {
+				throw new BadRequestError(
+					`These users are not eligible to review this workflow: ${ineligibleIds.join(', ')}`,
+				);
+			}
+		}
+
 		const request = await this.dbLockService.withLock(
 			DbLock.WORKFLOW_REVIEW_REQUEST_CREATE,
 			async (tx) => {
@@ -147,6 +231,13 @@ export class WorkflowReviewRequestService {
 					{ workflowReviewRequestId: created.id, userId: user.id },
 					tx,
 				);
+
+				if (reviewerUserIds.length > 0) {
+					await this.workflowReviewRequestReviewerRepository.addReviewers(
+						{ workflowReviewRequestId: created.id, userIds: reviewerUserIds },
+						tx,
+					);
+				}
 
 				return created;
 			},

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-requests.controller.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-requests.controller.ts
@@ -1,4 +1,8 @@
-import { CreateWorkflowReviewRequestDto, ListWorkflowReviewRequestsQueryDto } from '@n8n/api-types';
+import {
+	CreateWorkflowReviewRequestDto,
+	GetWorkflowReviewEligibleReviewersQueryDto,
+	ListWorkflowReviewRequestsQueryDto,
+} from '@n8n/api-types';
 import { AuthenticatedRequest } from '@n8n/db';
 import { Body, Get, Licensed, Post, Query, RestController } from '@n8n/decorators';
 import { Response } from 'express';
@@ -17,6 +21,18 @@ export class WorkflowReviewRequestsController {
 		@Query query: ListWorkflowReviewRequestsQueryDto,
 	) {
 		return await this.workflowReviewRequestService.list(req.user, query);
+	}
+
+	// Routes register in declaration order — keep this above any future `GET /:id`
+	// so 'eligible-reviewers' is not captured as an id
+	@Get('/eligible-reviewers')
+	@Licensed('feat:workflowReviews')
+	async getEligibleReviewers(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Query query: GetWorkflowReviewEligibleReviewersQueryDto,
+	) {
+		return await this.workflowReviewRequestService.getEligibleReviewers(req.user, query);
 	}
 
 	@Post('/')

--- a/packages/frontend/@n8n/design-system/src/components/N8nUserSelect/UserSelect.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nUserSelect/UserSelect.vue
@@ -17,6 +17,8 @@ interface UserSelectProps {
 	remote?: boolean;
 	remoteMethod?: (query: string) => void;
 	loading?: boolean;
+	/** Set to false to keep the dropdown in the local stacking context, e.g. inside N8nDialog */
+	teleported?: boolean;
 }
 
 const props = withDefaults(defineProps<UserSelectProps>(), {
@@ -26,6 +28,7 @@ const props = withDefaults(defineProps<UserSelectProps>(), {
 	currentUserId: '',
 	remote: false,
 	loading: false,
+	teleported: true,
 });
 
 const emit = defineEmits<{
@@ -101,7 +104,7 @@ const getLabel = (user: IUser) =>
 		:filter-method="setFilter"
 		:placeholder="placeholder || t('nds.userSelect.selectUser')"
 		:default-first-option="true"
-		teleported
+		:teleported="teleported"
 		:popper-class="$style.limitPopperWidth"
 		:no-data-text="t('nds.userSelect.noMatchingUsers')"
 		:size="size"

--- a/packages/frontend/@n8n/design-system/src/v2/components/Checkbox/Checkbox.test.ts
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Checkbox/Checkbox.test.ts
@@ -5,6 +5,31 @@ import Checkbox from './Checkbox.vue';
 
 describe('v2/components/Checkbox', () => {
 	describe('rendering', () => {
+		it('should forward attributes without Vue warnings', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			try {
+				const wrapper = render(Checkbox, {
+					attrs: {
+						class: 'custom-checkbox',
+						'aria-describedby': 'checkbox-description',
+					},
+				});
+
+				const warnings = warnSpy.mock.calls.flat().join(' ');
+				expect(warnings).not.toContain(
+					'toRefs() expects a reactive object but received a plain one',
+				);
+				expect(wrapper.container.firstElementChild).toHaveClass('custom-checkbox');
+				expect(wrapper.container.querySelector('[role="checkbox"]')).toHaveAttribute(
+					'aria-describedby',
+					'checkbox-description',
+				);
+			} finally {
+				warnSpy.mockRestore();
+			}
+		});
+
 		it('should render unchecked by default', () => {
 			const wrapper = render(Checkbox);
 			const checkbox = wrapper.container.querySelector('[role="checkbox"]');

--- a/packages/frontend/@n8n/design-system/src/v2/components/Checkbox/Checkbox.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Checkbox/Checkbox.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactiveOmit, reactivePick } from '@vueuse/core';
+import { reactivePick } from '@vueuse/core';
 import { CheckboxIndicator, CheckboxRoot, Label, Primitive, useForwardProps } from 'reka-ui';
 import { computed, useAttrs, useId } from 'vue';
 
@@ -20,8 +20,11 @@ const modelValue = defineModel<boolean>({ default: undefined });
 const computedValue = computed(() => (props.indeterminate ? 'indeterminate' : modelValue.value));
 
 const attrs = useAttrs();
-const primitiveClass = computed(() => attrs.class);
-const rootAttrs = computed(() => reactiveOmit(attrs, ['class']));
+const getRootAttrs = () => {
+	const rootAttrs = { ...attrs };
+	delete rootAttrs.class;
+	return rootAttrs;
+};
 
 function onUpdate(value: boolean | 'indeterminate') {
 	// @ts-expect-error - 'target' does not exist in type 'EventInit'
@@ -31,14 +34,10 @@ function onUpdate(value: boolean | 'indeterminate') {
 </script>
 
 <template>
-	<Primitive
-		:as
-		:class="[$style.checkbox, primitiveClass]"
-		:data-disabled="disabled ? '' : undefined"
-	>
+	<Primitive :as :class="[$style.checkbox, attrs.class]" :data-disabled="disabled ? '' : undefined">
 		<CheckboxRoot
 			:id="uuid"
-			v-bind="{ ...rootProps, ...rootAttrs }"
+			v-bind="{ ...rootProps, ...getRootAttrs() }"
 			:model-value="computedValue"
 			:name="name"
 			:disabled="disabled"

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4442,6 +4442,8 @@
 	"workflowReviews.submitForReview.ariaDescription": "Enter a title and optional description for this workflow review.",
 	"workflowReviews.submitForReview.reviewTitle.label": "Review title",
 	"workflowReviews.submitForReview.description.label": "Description",
+	"workflowReviews.submitForReview.reviewer.label": "Reviewer",
+	"workflowReviews.submitForReview.reviewer.placeholder": "Search users...",
 	"workflowReviews.submitForReview.submit": "Submit",
 	"workflowReviews.submitForReview.error.title": "Workflow couldn't be submitted for review",
 	"workflowReviews.submitForReview.error.save": "Save the workflow and try again.",

--- a/packages/frontend/editor-ui/src/app/composables/useKeybindings.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useKeybindings.test.ts
@@ -85,6 +85,29 @@ describe('useKeybindings', () => {
 		document.body.removeChild(input);
 	});
 
+	it('should not call handler when focus is inside a dialog', async () => {
+		const handler = vi.fn();
+		const keymap = ref({ enter: handler });
+
+		useKeybindings(keymap);
+
+		// A modal dialog (e.g. N8nDialog) portals its content to the body and owns
+		// keyboard input while open, so a focused button inside it must not fire
+		// canvas shortcuts that also listen on `document`.
+		const dialog = document.createElement('div');
+		dialog.setAttribute('role', 'dialog');
+		const button = document.createElement('button');
+		dialog.appendChild(button);
+		document.body.appendChild(dialog);
+		button.focus();
+
+		const event = new KeyboardEvent('keydown', { key: 'Enter' });
+		document.dispatchEvent(event);
+
+		expect(handler).not.toHaveBeenCalled();
+		document.body.removeChild(dialog);
+	});
+
 	it('should not call handler if disabled', async () => {
 		const handler = vi.fn();
 		const keymap = ref({ a: handler });

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.test.ts
@@ -6,7 +6,10 @@ import { waitFor } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { useReviewRequiredStore } from '@/features/workflow-reviews/reviewRequired.store';
 import { useWorkflowReviewStatusStore } from '@/features/workflow-reviews/reviewStatus.store';
-import { createWorkflowReviewRequest } from '@/features/workflow-reviews/workflowReviews.api';
+import {
+	createWorkflowReviewRequest,
+	fetchEligibleReviewers,
+} from '@/features/workflow-reviews/workflowReviews.api';
 import WorkflowSubmitForReviewDialog from './WorkflowSubmitForReviewDialog.vue';
 
 const mockShowError = vi.fn();
@@ -17,6 +20,7 @@ vi.mock('@/app/composables/useToast', () => ({
 
 vi.mock('@/features/workflow-reviews/workflowReviews.api', () => ({
 	createWorkflowReviewRequest: vi.fn(),
+	fetchEligibleReviewers: vi.fn(),
 	fetchWorkflowReviewRequests: vi.fn().mockResolvedValue({ count: 0, data: [] }),
 }));
 
@@ -53,6 +57,10 @@ describe('WorkflowSubmitForReviewDialog', () => {
 			decision: 'pending',
 			createdAt: '2024-01-01T00:00:00.000Z',
 			updatedAt: '2024-01-01T00:00:00.000Z',
+		});
+		vi.mocked(fetchEligibleReviewers).mockResolvedValue({
+			count: 1,
+			data: [{ id: 'reviewer-1', email: 'reviewer@n8n.io', firstName: 'Rae', lastName: 'Viewer' }],
 		});
 	});
 
@@ -95,6 +103,56 @@ describe('WorkflowSubmitForReviewDialog', () => {
 		expect(fetchStatusSpy).toHaveBeenCalledWith('workflow-1');
 		expect(emitted('submitted')).toHaveLength(1);
 		expect(emitted('update:open')).toContainEqual([false]);
+	});
+
+	it('loads the eligible reviewers when the dialog opens', async () => {
+		await renderDialog();
+
+		expect(fetchEligibleReviewers).toHaveBeenCalledWith(expect.any(Object), {
+			workflowId: 'workflow-1',
+		});
+	});
+
+	it('sends the selected reviewer with the submission', async () => {
+		const { getByTestId, getByRole, baseElement } = await renderDialog();
+
+		await userEvent.click(getByRole('combobox'));
+		await waitFor(() => expect(getByRole('listbox')).toBeInTheDocument());
+		const option = baseElement.querySelector('#user-select-option-id-reviewer-1');
+		expect(option).not.toBeNull();
+		await userEvent.click(option as HTMLElement);
+
+		await userEvent.type(getByTestId('workflow-review-title-input'), 'Review payments');
+		await userEvent.click(getByTestId('workflow-review-submit-button'));
+
+		await waitFor(() => {
+			expect(createWorkflowReviewRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({ reviewerUserIds: ['reviewer-1'] }),
+			);
+		});
+	});
+
+	it('omits the reviewer list from the submission when none is selected', async () => {
+		const { getByTestId } = await renderDialog();
+
+		await userEvent.type(getByTestId('workflow-review-title-input'), 'Review payments');
+		await userEvent.click(getByTestId('workflow-review-submit-button'));
+
+		await waitFor(() => expect(createWorkflowReviewRequest).toHaveBeenCalledOnce());
+		expect(vi.mocked(createWorkflowReviewRequest).mock.calls[0][1].reviewerUserIds).toBeUndefined();
+	});
+
+	it('still allows submission when loading the reviewers fails', async () => {
+		vi.mocked(fetchEligibleReviewers).mockRejectedValue(new Error('nope'));
+		const { getByTestId, emitted } = await renderDialog();
+
+		await userEvent.type(getByTestId('workflow-review-title-input'), 'Review payments');
+		await userEvent.click(getByTestId('workflow-review-submit-button'));
+
+		await waitFor(() => expect(createWorkflowReviewRequest).toHaveBeenCalledOnce());
+		expect(emitted('submitted')).toHaveLength(1);
+		expect(mockShowError).not.toHaveBeenCalled();
 	});
 
 	it('keeps the dialog open and preference enabled when an open review conflicts', async () => {

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
@@ -73,7 +73,6 @@ const loadEligibleReviewers = async () => {
 		});
 		eligibleReviewers.value = data;
 	} catch {
-		// The reviewer field is optional — on failure it stays empty and never blocks submission
 		eligibleReviewers.value = [];
 	} finally {
 		isLoadingReviewers.value = false;
@@ -151,8 +150,6 @@ const submit = async () => {
 		isSubmitting.value = false;
 	}
 };
-
-// TODO(LIGO-601): allow editing the notify list after the review request is created
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { WorkflowReviewEligibleReviewer } from '@n8n/api-types';
 import { ResponseError } from '@n8n/rest-api-client';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import {
@@ -6,8 +7,11 @@ import {
 	N8nCallout,
 	N8nDialog,
 	N8nDialogFooter,
+	N8nIcon,
 	N8nInput,
 	N8nInputLabel,
+	N8nUserSelect,
+	type IUser,
 } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue';
@@ -15,7 +19,10 @@ import { computed, nextTick, ref, useTemplateRef, watch } from 'vue';
 import { useToast } from '@/app/composables/useToast';
 import { useReviewRequiredStore } from '@/features/workflow-reviews/reviewRequired.store';
 import { useWorkflowReviewStatusStore } from '@/features/workflow-reviews/reviewStatus.store';
-import { createWorkflowReviewRequest } from '@/features/workflow-reviews/workflowReviews.api';
+import {
+	createWorkflowReviewRequest,
+	fetchEligibleReviewers,
+} from '@/features/workflow-reviews/workflowReviews.api';
 
 const REVIEW_TITLE_MAX_LENGTH = 128;
 const REVIEW_DESCRIPTION_MAX_LENGTH = 512;
@@ -42,11 +49,36 @@ const description = ref('');
 const isSubmitting = ref(false);
 const hasConflict = ref(false);
 const existingReviewRequestId = ref<string>();
+const selectedReviewerId = ref('');
+const eligibleReviewers = ref<WorkflowReviewEligibleReviewer[]>([]);
+const isLoadingReviewers = ref(false);
 const titleInput = useTemplateRef<InstanceType<typeof N8nInput>>('titleInput');
 
 const isSubmitDisabled = computed(
 	() => isSubmitting.value || reviewTitle.value.trim().length === 0,
 );
+
+const reviewerOptions = computed<IUser[]>(() =>
+	eligibleReviewers.value.map((reviewer) => ({
+		...reviewer,
+		fullName: [reviewer.firstName, reviewer.lastName].filter(Boolean).join(' ') || undefined,
+	})),
+);
+
+const loadEligibleReviewers = async () => {
+	isLoadingReviewers.value = true;
+	try {
+		const { data } = await fetchEligibleReviewers(rootStore.restApiContext, {
+			workflowId: props.workflowId,
+		});
+		eligibleReviewers.value = data;
+	} catch {
+		// The reviewer field is optional — on failure it stays empty and never blocks submission
+		eligibleReviewers.value = [];
+	} finally {
+		isLoadingReviewers.value = false;
+	}
+};
 
 watch(
 	() => props.open,
@@ -57,6 +89,9 @@ watch(
 		description.value = '';
 		hasConflict.value = false;
 		existingReviewRequestId.value = undefined;
+		selectedReviewerId.value = '';
+		eligibleReviewers.value = [];
+		void loadEligibleReviewers();
 	},
 );
 
@@ -92,6 +127,7 @@ const submit = async () => {
 			title: reviewTitle.value.trim(),
 			description: trimmedDescription || undefined,
 			workflows: [{ workflowId: props.workflowId, workflowVersionId }],
+			reviewerUserIds: selectedReviewerId.value ? [selectedReviewerId.value] : undefined,
 		});
 
 		reviewRequiredStore.setReviewRequired(props.workflowId, false);
@@ -116,7 +152,7 @@ const submit = async () => {
 	}
 };
 
-// TODO(LIGO-600, LIGO-601): add Reviewer selection (N8nUserSelect) once eligible-reviewers + notify-list endpoints exist
+// TODO(LIGO-601): allow editing the notify list after the review request is created
 </script>
 
 <template>
@@ -159,6 +195,26 @@ const submit = async () => {
 					data-test-id="workflow-review-description-input"
 				/>
 			</N8nInputLabel>
+			<hr :class="$style.divider" />
+			<N8nInputLabel
+				input-name="workflow-review-reviewer"
+				:label="i18n.baseText('workflowReviews.submitForReview.reviewer.label')"
+			>
+				<N8nUserSelect
+					id="workflow-review-reviewer"
+					v-model="selectedReviewerId"
+					:users="reviewerOptions"
+					:loading="isLoadingReviewers"
+					:placeholder="i18n.baseText('workflowReviews.submitForReview.reviewer.placeholder')"
+					:teleported="false"
+					clearable
+					data-test-id="workflow-review-reviewer-select"
+				>
+					<template #prefix>
+						<N8nIcon icon="search" />
+					</template>
+				</N8nUserSelect>
+			</N8nInputLabel>
 			<N8nCallout v-if="hasConflict" theme="danger" data-test-id="workflow-review-conflict-error">
 				{{ i18n.baseText('workflowReviews.submitForReview.error.conflict') }}
 			</N8nCallout>
@@ -192,5 +248,12 @@ const submit = async () => {
 	flex-direction: column;
 	gap: var(--spacing--xs);
 	margin-top: var(--spacing--xs);
+}
+
+.divider {
+	width: 100%;
+	margin: 0;
+	border: none;
+	border-top: var(--border);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/workflowReviews.api.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/workflowReviews.api.ts
@@ -1,4 +1,5 @@
 import type {
+	WorkflowReviewEligibleReviewersList,
 	WorkflowReviewRequestList,
 	WorkflowReviewRequestState,
 	WorkflowReviewRequestSummary,
@@ -12,6 +13,7 @@ export interface CreateWorkflowReviewRequestPayload {
 		workflowId: string;
 		workflowVersionId: string;
 	}>;
+	reviewerUserIds?: string[];
 }
 
 export async function fetchWorkflowReviewRequests(
@@ -22,6 +24,18 @@ export async function fetchWorkflowReviewRequests(
 		context,
 		'GET',
 		'/workflow-review-requests',
+		{ ...query },
+	);
+}
+
+export async function fetchEligibleReviewers(
+	context: IRestApiContext,
+	query: { workflowId: string },
+): Promise<WorkflowReviewEligibleReviewersList> {
+	return await makeRestApiRequest<WorkflowReviewEligibleReviewersList>(
+		context,
+		'GET',
+		'/workflow-review-requests/eligible-reviewers',
 		{ ...query },
 	);
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
@@ -430,6 +430,7 @@ export function shouldIgnoreCanvasShortcut(el: Element): boolean {
 	return (
 		['INPUT', 'TEXTAREA'].includes(el.tagName) ||
 		el.closest('[contenteditable]') !== null ||
+		el.closest('[role="dialog"]') !== null ||
 		el.closest('.ignore-key-press-canvas') !== null
 	);
 }


### PR DESCRIPTION
## Summary

Lets a user optionally assign a reviewer when submitting a workflow for review.

## What changed

- **API types** — `WorkflowReviewEligibleReviewer(sList)` types, a `GetWorkflowReviewEligibleReviewersQueryDto`, and an optional `reviewerUserIds` on the create-review-request DTO.
- **Persistence** — `UserRepository.findEligibleByProjectOrGlobalRoles` (users whose global or project role grants a given scope) and `WorkflowReviewRequestReviewerRepository.addReviewers` (append reviewers inside the caller's transaction).
- **Backend** — `GET /workflow-review-requests/eligible-reviewers` plus reviewer validation/persistence on create. Eligible reviewers are derived from `workflow:publish`-granting roles, excluding the requester and deactivated/pending users.
- **Editor** — an optional reviewer picker (`N8nUserSelect`) in the submit-for-review dialog, backed by the new endpoint, plus a `teleported` prop on `N8nUserSelect` so its dropdown stays inside the dialog's stacking context.
- **Fix** — `N8nCheckbox` (v2) no longer emits the `toRefs() expects a reactive object` Vue warning; mirrors the earlier `N8nSwitch` fix.

## Screen recording

<details><summary>Details</summary>
<p>

https://github.com/user-attachments/assets/41c9864c-f966-4554-80b0-e93f9c6a7eb4

</p>
</details> 

## How to test

1. Enable workflow reviews, open a workflow, and submit it for review.
2. The dialog now shows a **Reviewer** picker listing eligible users (excluding yourself); selecting one persists it as a reviewer on the request.

## Notes for reviewers

- The `1784000000052-CreateWorkflowReviewRequestTables` migration was edited in place to give the author/reviewer junction tables composite primary keys (no `id`). Local dev DBs that ran the earlier version will have drifted and need a reset. Since the migration is unreleased this is fine for CI, but consider a follow-up if that's a concern.

## Related

https://linear.app/n8n/issue/LIGO-865

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34677">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

