### PR TITLE
refactor(editor): Decouple useExternalHooks for package use (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/composables/src/useExternalHooks.test.ts
+++ b/packages/frontend/@n8n/composables/src/useExternalHooks.test.ts
@@ -1,0 +1,74 @@
+import { render } from '@testing-library/vue';
+import { defineComponent, h } from 'vue';
+
+import {
+	setExternalHooks,
+	ExternalHooksKey,
+	useExternalHooks,
+	type ExternalHooks,
+} from './useExternalHooks';
+
+function createExternalHooks(): ExternalHooks {
+	return {
+		run: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+describe('useExternalHooks', () => {
+	afterEach(() => {
+		setExternalHooks(undefined);
+	});
+
+	it('returns a no-op runner when nothing is registered', async () => {
+		const externalHooks = useExternalHooks();
+		// `run` resolves to a no-op; calling must not throw and must be awaitable.
+		await expect(externalHooks.run('app.mount')).resolves.toBeUndefined();
+	});
+
+	it('returns the registered runner from any context', async () => {
+		const registered = createExternalHooks();
+		setExternalHooks(registered);
+
+		const externalHooks = useExternalHooks();
+		await externalHooks.run('app.mount', { foo: 'bar' });
+
+		expect(externalHooks).toBe(registered);
+		expect(registered.run).toHaveBeenCalledWith('app.mount', { foo: 'bar' });
+	});
+
+	it('prefers a component-provided runner over the registered one', () => {
+		const registered = createExternalHooks();
+		const provided = createExternalHooks();
+		setExternalHooks(registered);
+
+		let resolved: ExternalHooks | undefined;
+		const Consumer = defineComponent({
+			setup() {
+				resolved = useExternalHooks();
+				return () => h('div');
+			},
+		});
+
+		render(Consumer, { global: { provide: { [ExternalHooksKey as symbol]: provided } } });
+
+		expect(resolved).toBe(provided);
+		expect(resolved).not.toBe(registered);
+	});
+
+	it('falls back to the registered runner inside a component without a provided key', () => {
+		const registered = createExternalHooks();
+		setExternalHooks(registered);
+
+		let resolved: ExternalHooks | undefined;
+		const Consumer = defineComponent({
+			setup() {
+				resolved = useExternalHooks();
+				return () => h('div');
+			},
+		});
+
+		render(Consumer);
+
+		expect(resolved).toBe(registered);
+	});
+});

--- a/packages/frontend/@n8n/composables/src/useExternalHooks.ts
+++ b/packages/frontend/@n8n/composables/src/useExternalHooks.ts
@@ -1,0 +1,60 @@
+import { hasInjectionContext, inject, type InjectionKey } from 'vue';
+
+/**
+ * The external-hooks contract consumed across the frontend. External hooks are
+ * an extension point: enterprise/embed builds register handlers on
+ * `window.n8nExternalHooks`, and `run` dispatches a named event to them.
+ *
+ * This package owns the *type* only; the concrete runner lives in the
+ * application (`editor-ui`) and is registered at bootstrap via
+ * {@link setExternalHooks} / provided through {@link ExternalHooksKey}. Keeping
+ * the contract here lets `useExternalHooks` return a working runner without the
+ * package importing application code (notably the webhooks store).
+ *
+ * The contract is intentionally loose (`eventName: string`, `metadata:
+ * unknown`): the strongly-typed event map stays in `editor-ui`, and the
+ * application's public wrapper preserves per-event type-checking for call
+ * sites that import it directly.
+ */
+export interface ExternalHooks {
+	run(eventName: string, metadata?: unknown): Promise<void>;
+}
+
+/**
+ * Injection key for the external-hooks runner. The application may provide it
+ * (e.g. a pop-out window with its own runner); `useExternalHooks` reads it when
+ * called inside an injection context and otherwise falls back to the registered
+ * singleton.
+ */
+export const ExternalHooksKey: InjectionKey<ExternalHooks> = Symbol('ExternalHooks');
+
+/**
+ * Null-object runner used when no concrete runner has been registered (e.g. in
+ * tests, or before bootstrap). External hooks are best-effort and must never
+ * throw or block the UI, so `run` resolves to a no-op.
+ */
+const noopExternalHooks: ExternalHooks = {
+	async run() {},
+};
+
+let registeredExternalHooks: ExternalHooks | undefined;
+
+/**
+ * Register the application's external-hooks runner. Called once at bootstrap by
+ * `editor-ui` so package-side `useExternalHooks` can resolve it from any
+ * context, including outside of component setup (routers, stores, plain
+ * modules).
+ */
+export function setExternalHooks(instance: ExternalHooks | undefined): void {
+	registeredExternalHooks = instance;
+}
+
+/**
+ * Returns the active external-hooks runner. Resolution order: a
+ * component-provided runner (via {@link ExternalHooksKey}), then the
+ * app-registered singleton (via {@link setExternalHooks}), then a no-op fallback.
+ */
+export function useExternalHooks(): ExternalHooks {
+	const injected = hasInjectionContext() ? inject(ExternalHooksKey, null) : null;
+	return injected ?? registeredExternalHooks ?? noopExternalHooks;
+}

--- a/packages/frontend/editor-ui/src/app/composables/useExternalHooks.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExternalHooks.ts
@@ -6,11 +6,14 @@ import type {
 	ExtractExternalHooksMethodPayloadFromKey,
 } from '@/app/types/externalHooks';
 import { useWebhooksStore } from '@/app/stores/webhooks.store';
+import { setExternalHooks } from '@n8n/composables/useExternalHooks';
 
-export async function runExternalHook<T extends ExternalHooksKey>(
-	eventName: T,
-	metadata?: ExtractExternalHooksMethodPayloadFromKey<T>,
-) {
+/**
+ * Concrete runner. Loosely typed to match the `@n8n/composables` contract so it
+ * can be registered for package-side consumers; the exported {@link runExternalHook}
+ * wrapper below re-adds per-event type-checking for direct call sites.
+ */
+async function runExternalHookInternal(eventName: string, metadata?: unknown): Promise<void> {
 	if (!window.n8nExternalHooks) {
 		return;
 	}
@@ -31,6 +34,18 @@ export async function runExternalHook<T extends ExternalHooksKey>(
 		}
 	}
 }
+
+export async function runExternalHook<T extends ExternalHooksKey>(
+	eventName: T,
+	metadata?: ExtractExternalHooksMethodPayloadFromKey<T>,
+): Promise<void> {
+	await runExternalHookInternal(eventName, metadata);
+}
+
+// Register the concrete runner so package-side `useExternalHooks`
+// (`@n8n/composables`) can resolve it from any context. Runs on first import;
+// `editor-ui` imports this module during bootstrap, before any consumer runs.
+setExternalHooks({ run: runExternalHookInternal });
 
 export function useExternalHooks() {
 	return {


### PR DESCRIPTION
## Summary

Inverts the external-hooks dependency so `useExternalHooks` can be consumed from `@n8n/composables` without pulling the `editor-ui` webhooks store into the package. This unblocks moving `useToast` into `@n8n/composables` (item G).

Mirrors the `useTelemetry` dependency inversion in #34635 — same provide/inject + registered-singleton + no-op-fallback pattern — rather than reinventing it.

**Mechanism (invert / inject):**
- `@n8n/composables/useExternalHooks` owns a loose `ExternalHooks` contract (`run(eventName: string, metadata?: unknown)`), an injection key, a `setExternalHooks` singleton setter, and a resolver. Resolution order: component-provided (via `ExternalHooksKey`) → app-registered singleton → no-op fallback (best-effort; never throws or blocks the UI).
- `editor-ui` keeps the concrete runner (`window.n8nExternalHooks` dispatch + `webhooks.store`) and registers it via `setExternalHooks(...)` on module load, which happens during bootstrap before any consumer runs.
- The public `runExternalHook` / `useExternalHooks` exports in `editor-ui` keep their **strongly-typed, per-event** signatures, so all ~40 existing call sites compile unchanged with no loss of type safety. The strongly-typed event map stays in `editor-ui`; only the package boundary is loose.

The webhooks store never enters the package. Net app-side change is +19/-4 LOC plus the new package composable.

**Scope note:** deliberately did *not* extract `webhooks.store` — that is a full store migration (it transitively depends on the excluded in-flight `workflowDocument.store`) and out of scope here. Inversion is the minimal cut. The `provide` path via `ExternalHooksKey` is wired in the resolver and covered by tests for future multi-instance needs (e.g. pop-out windows), but no bootstrap `provide` call is added yet since there is no current multi-runner requirement — the module-load singleton is the active mechanism.

## How to test

Frontend-only refactor; no runtime behavior change. Verified locally:

- `@n8n/composables`: `pnpm test useExternalHooks` → 4/4 pass; `pnpm typecheck` + `pnpm lint` clean.
- `editor-ui`: `pnpm typecheck` → 0 errors; affected suites green (`useRunWorkflow`, `useWorkflowActivate`, `usePinnedData`, `useNodeExecution`, `NodeExecuteButton`, `useToast` → 154/154 pass).

External hooks continue to no-op when `window.n8nExternalHooks` is absent (default OSS case) and dispatch to registered handlers when present, exactly as before.

## Related Linear tickets, Github issues, and Community forum posts

Builds on the pattern from #34635.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34705">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

