### PR TITLE
fix(editor): Rename preview AI Agent node to V1

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2166,7 +2166,6 @@
 	"nodeCreator.nodeItem.triggerIconTitle": "Trigger Node",
 	"nodeCreator.nodeItem.aiIconTitle": "LangChain AI Node",
 	"nodeCreator.nodeItem.deprecated": "Deprecated",
-	"nodeCreator.nodeItem.deprecatingSoon": "Deprecating soon",
 	"nodeCreator.nodeItem.earlyPreview": "Early preview",
 	"nodeCreator.nodeItem.beta": "Beta",
 	"nodeCredentials.createNew": "Create new credential",

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.test.ts
@@ -76,7 +76,7 @@ describe('NodeItem', () => {
 			props: {
 				nodeType: mockSimplifiedNodeType({
 					name: MESSAGE_AN_AGENT_NODE_TYPE,
-					displayName: 'AI Agent',
+					displayName: 'AI Agent V1',
 					group: ['transform'],
 				}),
 			},

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/AgentsMode.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/AgentsMode.test.ts
@@ -57,7 +57,7 @@ const render = createComponentRenderer(AgentsMode);
 
 function pushAgentsViewStack() {
 	useViewStacks().pushViewStack({
-		title: 'AI Agent',
+		title: 'AI Agent V1',
 		hasSearch: true,
 		mode: 'agents',
 		items: [],

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.test.ts
@@ -42,7 +42,7 @@ function messageAnAgentElement(): NodeCreateElement {
 		subcategory: '*',
 		properties: mockSimplifiedNodeType({
 			name: MESSAGE_AN_AGENT_NODE_TYPE,
-			displayName: 'AI Agent',
+			displayName: 'AI Agent V1',
 			group: ['transform'],
 		}),
 	};
@@ -69,13 +69,13 @@ describe('NodesMode', () => {
 		const { emitted } = render({ pinia });
 		await nextTick();
 
-		await userEvent.click(screen.getByText('AI Agent'));
+		await userEvent.click(screen.getByText('AI Agent V1'));
 
 		expect(emitted('nodeTypeSelected')).toBeUndefined();
 
 		const activeStack = useViewStacks().activeViewStack;
 		expect(activeStack.mode).toBe('agents');
-		expect(activeStack.title).toBe('AI Agent');
+		expect(activeStack.title).toBe('AI Agent V1');
 		expect(activeStack.hasSearch).toBe(true);
 		expect(activeStack.rootView).toBe(REGULAR_NODE_CREATOR_VIEW);
 	});

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -897,7 +897,7 @@ describe('NodeCreator - utils', () => {
 		});
 	});
 
-	describe('finalizeItems - agent transition badges', () => {
+	describe('finalizeItems - agent badges', () => {
 		const makeAgentNode = (name: string, tag?: NodeCreatorTag) =>
 			mockNodeCreateElement(undefined, { name, ...(tag ? { tag } : {}) });
 
@@ -908,24 +908,15 @@ describe('NodeCreator - utils', () => {
 		};
 
 		it.each([AGENT_NODE_TYPE, AGENT_TOOL_NODE_TYPE])(
-			'should show Deprecating soon badge on %s when the agents module is active',
+			'should not show a transition badge on %s',
 			(nodeType) => {
 				mockSettingsStore(true);
-				const [result] = finalizeItems([makeAgentNode(nodeType)]) as NodeCreateElement[];
-				expect(result.properties.tag).toEqual({ type: 'info', text: 'Deprecating soon' });
-			},
-		);
-
-		it.each([AGENT_NODE_TYPE, AGENT_TOOL_NODE_TYPE])(
-			'should not show Deprecating soon badge on %s when the agents module is inactive',
-			(nodeType) => {
-				mockSettingsStore(false);
 				const [result] = finalizeItems([makeAgentNode(nodeType)]) as NodeCreateElement[];
 				expect(result.properties.tag).toBeUndefined();
 			},
 		);
 
-		it('should show Early preview badge on the Message an Agent node', () => {
+		it('should show Early preview badge on the AI Agent V1 node', () => {
 			mockSettingsStore(true);
 			const [result] = finalizeItems([
 				makeAgentNode(MESSAGE_AN_AGENT_NODE_TYPE),
@@ -1222,10 +1213,10 @@ describe('NodeCreator - utils', () => {
 			} as unknown as ReturnType<typeof useSettingsStore>);
 		});
 
-		// Both nodes display as "AI Agent"; the legacy agent carries the popularity
-		// factor, so the successor ranking first proves the boost outweighs it.
+		// The legacy node is an exact "AI Agent" match and carries the popularity factor,
+		// so the AI Agent V1 successor ranking first proves the boost outweighs both.
 		const legacyAgent = makeNode(AGENT_NODE_TYPE, 'AI Agent', ['agent']);
-		const messageAnAgent = makeNode(MESSAGE_AN_AGENT_NODE_TYPE, 'AI Agent', [
+		const messageAnAgent = makeNode(MESSAGE_AN_AGENT_NODE_TYPE, 'AI Agent V1', [
 			'agent',
 			'ai',
 			'sdk',
@@ -1233,7 +1224,7 @@ describe('NodeCreator - utils', () => {
 		]);
 		const popularity = { [AGENT_NODE_TYPE]: 98.2 };
 
-		it('should rank the Message an Agent node above the legacy agent despite its popularity', () => {
+		it('should rank the AI Agent V1 node above the legacy agent despite its popularity', () => {
 			const result = searchNodes('AI Agent', [legacyAgent, messageAnAgent], { popularity });
 			expect(result.map((item) => item.key)).toEqual([MESSAGE_AN_AGENT_NODE_TYPE, AGENT_NODE_TYPE]);
 		});

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
@@ -12,8 +12,6 @@ import type {
 	SubcategoryCreateElement,
 } from '@/Interface';
 import {
-	AGENT_NODE_TYPE,
-	AGENT_TOOL_NODE_TYPE,
 	AI_CATEGORY_AGENTS,
 	AI_CATEGORY_HUMAN_IN_THE_LOOP,
 	AI_CATEGORY_MCP_NODES,
@@ -45,7 +43,6 @@ import type { NodeViewItemSection } from './views/viewsData';
 import { stripToolSuffix, useAiGatewayStore } from '@/app/stores/aiGateway.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { AGENTS_MODULE_NAME } from '@/features/agents/constants';
 import type { NodeIconSource } from '@/app/utils/nodeIcon';
 import { SampleTemplates } from '@/features/workflows/templates/utils/workflowSamples';
 import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
@@ -453,15 +450,7 @@ function applyNodeTags(element: INodeCreateElement): INodeCreateElement {
 
 	if (element.properties.tag) return element;
 
-	if (
-		[AGENT_NODE_TYPE, AGENT_TOOL_NODE_TYPE].includes(element.properties.name) &&
-		useSettingsStore().isModuleActive(AGENTS_MODULE_NAME)
-	) {
-		element.properties.tag = {
-			type: 'info',
-			text: i18n.baseText('nodeCreator.nodeItem.deprecatingSoon'),
-		};
-	} else if (element.properties.name === MESSAGE_AN_AGENT_NODE_TYPE) {
+	if (element.properties.name === MESSAGE_AN_AGENT_NODE_TYPE) {
 		element.properties.tag = {
 			preview: true,
 			text: i18n.baseText('nodeCreator.nodeItem.earlyPreview'),

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
@@ -19,7 +19,7 @@ const getNodeType = vi.fn();
 const aiTransformNode = mockNodeTypeDescription({ name: AI_TRANSFORM_NODE_TYPE });
 const messageAnAgentNode = mockNodeTypeDescription({
 	name: MESSAGE_AN_AGENT_NODE_TYPE,
-	displayName: 'AI Agent',
+	displayName: 'AI Agent V1',
 	hidden: true,
 });
 

--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -9,7 +9,7 @@ import { MessageAnAgentV2 } from './v2/MessageAnAgentV2.node';
  * the `agentId` property, and (v1 only) the `listAgents` search method.
  */
 export const baseDescription: INodeTypeBaseDescription = {
-	displayName: 'AI Agent',
+	displayName: 'AI Agent V1',
 	name: 'messageAnAgent',
 	icon: 'node:ai-agent',
 	group: ['transform'],

--- a/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
@@ -683,6 +683,12 @@ describe('MessageAnAgent Node', () => {
 });
 
 describe('MessageAnAgent versioning', () => {
+	it('uses AI Agent V1 as the display and default name', () => {
+		expect(baseDescription.displayName).toBe('AI Agent V1');
+		expect(new MessageAnAgentV1(baseDescription).description.defaults.name).toBe('AI Agent V1');
+		expect(new MessageAnAgentV2(baseDescription).description.defaults.name).toBe('AI Agent V1');
+	});
+
 	it('exposes v1 and v2 with v2 as the default', () => {
 		const versioned = new MessageAnAgent();
 

--- a/packages/nodes-base/nodes/MessageAnAgent/shared.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/shared.ts
@@ -18,7 +18,7 @@ export const sharedVersionDescription: Pick<
 > = {
 	hidden: true,
 	defaults: {
-		name: 'AI Agent',
+		name: 'AI Agent V1',
 	},
 	codex: {
 		categories: ['AI'],


### PR DESCRIPTION
## Summary

Rename the preview AI Agent node to AI Agent V1 and remove the deprecation badge from the LangChain agent nodes. [AGENT-442](https://linear.app/n8n/issue/AGENT-442)

## Screenshot
<img width="770" height="322" alt="image" src="https://github.com/user-attachments/assets/0531835e-a3ea-4e6f-8b25-f216502dc340" />

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34714">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

