### PR TITLE
docs: Warn when pnpm nathan combines enterprise and AI features (no-changelog)

### DIFF
--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -11,6 +11,8 @@
 //   node scripts/nathan.mjs deploy my-branch --license pro2
 //   node scripts/nathan.mjs deploy master test-ai --ai
 //
+// Note: enterprise (--license) and AI (--ai) features cannot be used together.
+//
 // Needs a token in ~/.n8n/dev/nathan-token — on first run it links you to a form to
 // get one and saves it there. A public tunnel is opened via `npx localtunnel`.
 import http from 'node:http';
@@ -132,6 +134,13 @@ if (!token) {
 if (!token) process.exit(1);
 
 const text = process.argv.slice(2).join(' ').trim() || 'help';
+const args = process.argv.slice(2);
+const hasEnterprise = args.some(
+	(a) => a === '--license' || a.startsWith('--license=') || a === '--enterprise',
+);
+if (args.includes('--ai') && hasEnterprise) {
+	console.error('⚠️  Enterprise (--license/--enterprise) and --ai cannot be used together; the deploy may not behave as expected.\n');
+}
 const isLocal = text.startsWith('local');
 const slackTarget = process.env.NATHAN_SLACK_CHANNEL
 	? `Slack channel ${process.env.NATHAN_SLACK_CHANNEL}`

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -11,7 +11,7 @@
 //   node scripts/nathan.mjs deploy my-branch --license pro2
 //   node scripts/nathan.mjs deploy master test-ai --ai
 //
-// Note: enterprise (--license) and AI (--ai) features cannot be used together.
+// Note: --license enterprise and AI (--ai) features cannot be used together.
 //
 // Needs a token in ~/.n8n/dev/nathan-token — on first run it links you to a form to
 // get one and saves it there. A public tunnel is opened via `npx localtunnel`.
@@ -136,10 +136,10 @@ if (!token) process.exit(1);
 const text = process.argv.slice(2).join(' ').trim() || 'help';
 const args = process.argv.slice(2);
 const hasEnterprise = args.some(
-	(a) => a === '--license' || a.startsWith('--license=') || a === '--enterprise',
+	(a, i) => a === '--license=enterprise' || (a === '--license' && args[i + 1] === 'enterprise'),
 );
 if (args.includes('--ai') && hasEnterprise) {
-	console.error('⚠️  Enterprise (--license/--enterprise) and --ai cannot be used together; the deploy may not behave as expected.\n');
+	console.error('⚠️  --license enterprise and --ai cannot be used together; the deploy may not behave as expected.\n');
 }
 const isLocal = text.startsWith('local');
 const slackTarget = process.env.NATHAN_SLACK_CHANNEL


### PR DESCRIPTION
## Summary

The `pnpm nathan` deploy-bot CLI (`scripts/nathan.mjs`) accepts both enterprise (`--license`/`--enterprise`) and AI (`--ai`) flags, but these features cannot be used together on a deployed instance. This documents the incompatibility in the usage comment and logs a warning to stderr when both are passed, so a misconfigured deploy is flagged instead of failing silently.

## How to test

Run `node scripts/nathan.mjs deploy master test-ai --ai --license pro2` (or with `--enterprise`) and confirm the warning is printed. Run with only `--ai` or only `--license`/`--enterprise` and confirm no warning appears.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-662

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34716">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

