### PR TITLE
fix(ai-builder): Scope user-proxy decisions to the conversation moment (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
@@ -9,7 +9,12 @@
 import type { CapturedEvent } from '../types';
 import { UserProxyLlm } from '../utils/user-proxy';
 import type { UserProxyAgent } from '../utils/user-proxy/agent';
-import type { Decision } from '../utils/user-proxy/tools';
+import {
+	confirmationDecisionSchema,
+	userTurnDecisionSchema,
+	type Decision,
+	type ProxyDecisionMode,
+} from '../utils/user-proxy/tools';
 
 // ---------------------------------------------------------------------------
 // FakeAgent — programmable agent for tests
@@ -17,6 +22,7 @@ import type { Decision } from '../utils/user-proxy/tools';
 
 class FakeAgent implements UserProxyAgent {
 	readonly prompts: string[] = [];
+	readonly modes: ProxyDecisionMode[] = [];
 	private queue: Array<Decision | undefined | Error> = [];
 
 	enqueue(...decisions: Array<Decision | undefined | Error>): void {
@@ -24,8 +30,9 @@ class FakeAgent implements UserProxyAgent {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
-	async decide(userPrompt: string): Promise<Decision | undefined> {
+	async decide(userPrompt: string, mode: ProxyDecisionMode): Promise<Decision | undefined> {
 		this.prompts.push(userPrompt);
+		this.modes.push(mode);
 		const next = this.queue.shift();
 		if (next instanceof Error) throw next;
 		return next;
@@ -217,6 +224,7 @@ describe('UserProxyLlm.respondToConfirmation', () => {
 			expect(response.answers).toEqual([{ questionId: 'q1', selectedOptions: ['#general'] }]);
 		}
 		expect(agent.callCount).toBe(1);
+		expect(agent.modes[0]).toBe('confirmation');
 	});
 
 	it('routes ask-user questions to the agent even when scripted user turns remain (no deterministic shortcut)', async () => {
@@ -577,9 +585,9 @@ describe('UserProxyLlm.respondToConfirmation', () => {
 		expect(response.kind).toBe('approval');
 	});
 
-	it('falls back to the permissive payload when the agent picks a between-run action', async () => {
+	it('falls back to the permissive payload when the agent picks a user-turn action', async () => {
 		const agent = new FakeAgent();
-		// declare_done is a between-run action, invalid as a confirmation response.
+		// declare_done is a user-turn action, invalid as a confirmation response.
 		agent.enqueue({ action: 'declare_done' });
 		const proxy = new UserProxyLlm({
 			conversation: [{ role: 'user', text: 'go' }],
@@ -700,6 +708,7 @@ describe('UserProxyLlm.decideFollowUp', () => {
 		}
 		expect(proxy.getMessagesSent()).toBe(1);
 		expect(agent.callCount).toBe(1);
+		expect(agent.modes[0]).toBe('user-turn');
 	});
 
 	it('invokes the agent on every follow-up — no verbatim shortcut for short scripts', async () => {
@@ -811,6 +820,37 @@ describe('UserProxyLlm.decideFollowUp', () => {
 		const third = await proxy.decideFollowUp();
 		expect(third.kind).toBe('done');
 		expect(proxy.getMessagesSent()).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Mode-scoped decision schemas
+// ---------------------------------------------------------------------------
+
+describe('mode-scoped decision schemas', () => {
+	it('user-turn schema does not offer confirmation actions', () => {
+		expect(
+			userTurnDecisionSchema.safeParse({
+				action: 'approve_or_reject',
+				approved: false,
+				userInput: 'two changes first',
+			}).success,
+		).toBe(false);
+		expect(
+			userTurnDecisionSchema.safeParse({ action: 'send_follow_up_message', message: 'hi' }).success,
+		).toBe(true);
+		expect(userTurnDecisionSchema.safeParse({ action: 'declare_done' }).success).toBe(true);
+	});
+
+	it('confirmation schema does not offer user-turn actions', () => {
+		expect(
+			confirmationDecisionSchema.safeParse({ action: 'send_follow_up_message', message: 'hi' })
+				.success,
+		).toBe(false);
+		expect(confirmationDecisionSchema.safeParse({ action: 'declare_done' }).success).toBe(false);
+		expect(
+			confirmationDecisionSchema.safeParse({ action: 'approve_or_reject', approved: true }).success,
+		).toBe(true);
 	});
 });
 

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/agent.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/agent.ts
@@ -1,5 +1,12 @@
 import { SYSTEM_PROMPT } from './prompts';
-import { decisionSchema, TOOL_DESCRIPTIONS, type Decision } from './tools';
+import {
+	CONFIRMATION_TOOL_DESCRIPTIONS,
+	confirmationDecisionSchema,
+	USER_TURN_TOOL_DESCRIPTIONS,
+	userTurnDecisionSchema,
+	type Decision,
+	type ProxyDecisionMode,
+} from './tools';
 import { createEvalAgent } from '../../../src/utils/eval-agents';
 import type { EvalLogger } from '../../harness/logger';
 
@@ -9,19 +16,22 @@ export interface UserProxyAgentConfig {
 }
 
 export interface UserProxyAgent {
-	decide(userPrompt: string): Promise<Decision | undefined>;
+	decide(userPrompt: string, mode: ProxyDecisionMode): Promise<Decision | undefined>;
 }
 
 export function createUserProxyAgent(config: UserProxyAgentConfig = {}): UserProxyAgent {
-	const instructions = `${SYSTEM_PROMPT}\n\n${TOOL_DESCRIPTIONS}`;
-
 	return {
-		async decide(userPrompt: string): Promise<Decision | undefined> {
+		async decide(userPrompt: string, mode: ProxyDecisionMode): Promise<Decision | undefined> {
+			// The schema handed to the model is the action menu for this moment in
+			// the conversation — actions that cannot function now are not offered.
+			const schema = mode === 'user-turn' ? userTurnDecisionSchema : confirmationDecisionSchema;
+			const toolDescriptions =
+				mode === 'user-turn' ? USER_TURN_TOOL_DESCRIPTIONS : CONFIRMATION_TOOL_DESCRIPTIONS;
 			const agent = createEvalAgent('eval-user-proxy', {
 				...(config.modelId ? { model: config.modelId } : {}),
-				instructions,
+				instructions: `${SYSTEM_PROMPT}\n\n${toolDescriptions}`,
 				cache: true,
-			}).structuredOutput(decisionSchema);
+			}).structuredOutput(schema);
 
 			try {
 				const result = await agent.generate(userPrompt);

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
@@ -143,7 +143,7 @@ export class UserProxyLlm {
 		}
 
 		const prompt = buildConfirmationPrompt(this.promptContext(), event);
-		const decision = await this.agent.decide(prompt);
+		const decision = await this.agent.decide(prompt, 'confirmation');
 		if (!decision) {
 			this.logger?.warn(`[user-proxy] no decision; event=${summarizeEvent(event)}`);
 			this.bumpStat('fallback-no-decision');
@@ -203,10 +203,15 @@ export class UserProxyLlm {
 		}
 
 		const prompt = buildFollowUpPrompt(this.promptContext());
-		const decision = await this.agent.decide(prompt);
+		const decision = await this.agent.decide(prompt, 'user-turn');
 		if (!decision) {
 			const [next] = this.remainingUserScriptTurns();
-			if (!next || hasStageDirection(next.text)) return { kind: 'done' };
+			if (!next || hasStageDirection(next.text)) {
+				this.logger?.warn(
+					'[user-proxy] no user-turn decision and no plain scripted turn to fall back to — ending conversation',
+				);
+				return { kind: 'done' };
+			}
 			const scriptedMessage = this.consumeNextRemainingUserScriptTurn();
 			if (!scriptedMessage) return { kind: 'done' };
 			this.messagesSent++;
@@ -219,6 +224,13 @@ export class UserProxyLlm {
 			this.messagesSent++;
 			this.actualTranscript.push({ role: 'user', text: message });
 			return { kind: 'followUp', message };
+		}
+		if (decision.action !== 'declare_done') {
+			// The user-turn schema offers only the two actions above, so this only
+			// fires for injected test agents or schema drift — never drop it silently.
+			this.logger?.warn(
+				`[user-proxy] user-turn decision returned confirmation-only action=${decision.action} — treating as done`,
+			);
 		}
 		return { kind: 'done' };
 	}

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/prompts.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/prompts.ts
@@ -60,7 +60,7 @@ A "configure your workflow" / setup-wizard card (it lists nodes that need creden
 
 ## Pushing back on plans and summaries
 
-When the agent shows a plan, summary, or "here's what I'll build" preview, **audit it against the script**. The agent is designed to make assumptions rather than ask, so its plan often omits or substitutes things the user actually stated in the script.
+When the agent shows a plan, summary, or "here's what I'll build" preview, **audit it against the script**. The agent is designed to make assumptions rather than ask, so its plan often omits or substitutes things the user actually stated in the script. A plan can arrive as a plan-review widget (respond with the approval action) or as plain text with the agent waiting for a typed reply (respond with a chat message on the user's turn) — audit and push back the same way in both cases.
 
 Reject when the plan misses any of the following from the script:
 - **Concrete values** — channel IDs, table names, URLs, schedules, specific node configurations. Example: "Use #engineering (C04ENGINEER1), not the generic channel you picked."
@@ -93,7 +93,7 @@ export function buildConfirmationPrompt(ctx: PromptContext, event: CapturedEvent
 		formatScriptSection(ctx),
 		formatTranscriptSection(ctx),
 		formatEventSection(event),
-		'Pick one action to respond to this confirmation as the user.',
+		'A widget is on screen: the agent paused mid-run and is waiting for the user to respond to the event above. Pick one action to respond to this confirmation as the user.',
 	].join('\n\n');
 }
 
@@ -101,11 +101,10 @@ export function buildFollowUpPrompt(ctx: PromptContext): string {
 	return [
 		formatScriptSection(ctx),
 		formatTranscriptSection(ctx),
-		'The agent has just finished a run. Decide what the user would say next.',
-		'',
-		"Pick `send_follow_up_message` when the agent asked a question (in its last response) or stalled and needs unblocking. If the script answers the question, deliver that answer with concrete values verbatim. If the script doesn't cover it and credentials aren't involved, give a brief plausible reply.",
+		"It is now the user's turn: the agent finished its run and is waiting, and no widget is on screen. Decide what the user does — send a chat message or end the conversation.",
+		'Pick `send_follow_up_message` when the agent\'s last response leaves anything open — it asked a question, requested approval, presented a plan to react to, or stalled and needs unblocking. Approving or rejecting a plan the agent presented in plain text IS a follow-up message (e.g. "No — two changes first: …" / "Yes, go ahead."). If the script answers the open point, deliver it with concrete values verbatim; if the script doesn\'t cover it and credentials aren\'t involved, give a brief plausible reply.',
 		'If a stage direction tells the user to keep requesting changes or stay in the conversation, pick `send_follow_up_message` with the NEXT change — even after a successful build — until the change list is exhausted.',
-		'Pick `declare_done` when the agent finished a build, approved/rejected a plan appropriately, or otherwise has no open thread for the user to respond to. The script is a reference, not a checklist — late script content gets surfaced via plan rejection (or an explicit keep-going direction), not unsolicited follow-ups.',
+		'Pick `declare_done` only when the agent has no open thread for the user — never while it is waiting for an answer or an approval. The script is a reference, not a checklist — late script content gets surfaced by pushing back on the plan (or an explicit keep-going direction), not unsolicited follow-ups.',
 	].join('\n\n');
 }
 

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
@@ -16,37 +16,77 @@ const answerSchema = z.object({
 	skipped: z.boolean().optional(),
 });
 
+const answerQuestionsDecisionSchema = z.object({
+	action: z.literal('answer_questions'),
+	answers: z.array(answerSchema),
+});
+
+const applySetupWizardDecisionSchema = z.object({
+	action: z.literal('apply_setup_wizard'),
+	// JSON-encoded object mapping setup node name -> parameter map. Emitted as a string
+	// because Anthropic structured output rejects nested z.record schemas.
+	nodeParametersJson: z.string(),
+});
+
+const approveOrRejectDecisionSchema = z.object({
+	action: z.literal('approve_or_reject'),
+	approved: z.boolean(),
+	userInput: z.string().optional(),
+});
+
+const respondToDomainAccessDecisionSchema = z.object({
+	action: z.literal('respond_to_domain_access'),
+	response: z.enum(['allow_once', 'allow_all', 'deny']),
+});
+
+const pickResourceDecisionSchema = z.object({
+	action: z.literal('pick_resource_decision'),
+	decision: z.string(),
+});
+
+const sendFollowUpMessageDecisionSchema = z.object({
+	action: z.literal('send_follow_up_message'),
+	message: z.string(),
+});
+
+const declareDoneDecisionSchema = z.object({
+	action: z.literal('declare_done'),
+});
+
+/**
+ * The two moments the proxy is asked to decide, each with its own action menu:
+ *  - `confirmation` — the agent paused mid-run to show a widget; the proxy must
+ *    respond to that widget.
+ *  - `user-turn` — the agent's run finished with nothing pending; the turn passed
+ *    to the user, who either types a chat message or ends the conversation.
+ * The schema handed to the model per mode IS the action menu — actions that
+ * cannot function at that moment are not offered at all.
+ */
+export type ProxyDecisionMode = 'confirmation' | 'user-turn';
+
+export const confirmationDecisionSchema = z.discriminatedUnion('action', [
+	answerQuestionsDecisionSchema,
+	applySetupWizardDecisionSchema,
+	approveOrRejectDecisionSchema,
+	respondToDomainAccessDecisionSchema,
+	pickResourceDecisionSchema,
+]);
+
+export const userTurnDecisionSchema = z.discriminatedUnion('action', [
+	sendFollowUpMessageDecisionSchema,
+	declareDoneDecisionSchema,
+]);
+
+/** Full union — the type every decision consumer handles. Agents are only ever
+ *  offered the mode-scoped subsets above. */
 export const decisionSchema = z.discriminatedUnion('action', [
-	z.object({
-		action: z.literal('answer_questions'),
-		answers: z.array(answerSchema),
-	}),
-	z.object({
-		action: z.literal('apply_setup_wizard'),
-		// JSON-encoded object mapping setup node name -> parameter map. Emitted as a string
-		// because Anthropic structured output rejects nested z.record schemas.
-		nodeParametersJson: z.string(),
-	}),
-	z.object({
-		action: z.literal('approve_or_reject'),
-		approved: z.boolean(),
-		userInput: z.string().optional(),
-	}),
-	z.object({
-		action: z.literal('respond_to_domain_access'),
-		response: z.enum(['allow_once', 'allow_all', 'deny']),
-	}),
-	z.object({
-		action: z.literal('pick_resource_decision'),
-		decision: z.string(),
-	}),
-	z.object({
-		action: z.literal('send_follow_up_message'),
-		message: z.string(),
-	}),
-	z.object({
-		action: z.literal('declare_done'),
-	}),
+	answerQuestionsDecisionSchema,
+	applySetupWizardDecisionSchema,
+	approveOrRejectDecisionSchema,
+	respondToDomainAccessDecisionSchema,
+	pickResourceDecisionSchema,
+	sendFollowUpMessageDecisionSchema,
+	declareDoneDecisionSchema,
 ]);
 
 export type Decision = z.infer<typeof decisionSchema>;
@@ -63,21 +103,23 @@ export interface SetupWizardParseContext {
 // Tool descriptions — bundled with the prompt so the model picks the right action
 // ---------------------------------------------------------------------------
 
-export const TOOL_DESCRIPTIONS = `Available actions:
+export const CONFIRMATION_TOOL_DESCRIPTIONS = `Available actions — confirmation responses. A widget is on screen: the agent paused mid-run and is waiting for the user to respond to the event shown in this prompt. Pick the action that matches the widget:
 
 - answer_questions(answers[]): The agent fired an ask-user confirmation (inputType=questions). Answer every question with a plausible value — stated → implied → invented. Invent rather than skip. Set skipped=true only when the question has no plausible answer of any shape, OR when a [stage direction] in the script tells the user to decline or withhold that value — in that case you MUST set skipped=true with an empty selectedOptions and pick NO option (not even one that looks standard or obvious); picking a value defeats the test.
 
 - apply_setup_wizard(nodeParametersJson): The agent fired a setup-wizard / "configure your workflow" setup card with placeholder parameters. Emit a JSON string that decodes to { "<setup node name>": { "<paramName>": <value>, ... }, ... }. Fill every non-credential placeholder with a plausible value — stated → implied → invented. Never set credentials. This is the ONLY correct way to fill a setup card — do NOT answer it with answer_questions. To deliberately leave a value unset (e.g. a stage direction says the user skips it), dismiss the whole card with approve_or_reject(approved=false) instead of filling it.
 
-- approve_or_reject(approved, userInput?): The agent showed a plan (plan-review) or asked an open free-text question (inputType=text). Approve if the plan matches user intent; reject with reason if it diverges.
+- approve_or_reject(approved, userInput?): A plan-review or free-text confirmation widget is on screen (the event's inputType is plan-review or text). Approve if the plan matches user intent; reject with reason if it diverges. This action only exists as a response to such a widget.
 
 - respond_to_domain_access(response): The agent is asking for domain access permissions. Pick allow_once, allow_all, or deny. Default to allow_all unless the user would deny.
 
-- pick_resource_decision(decision): The agent is asking the user to pick a gateway resource access option. Pick the option the user would choose.
+- pick_resource_decision(decision): The agent is asking the user to pick a gateway resource access option. Pick the option the user would choose.`;
 
-- send_follow_up_message(message): Between-run decision. Send the user's next message — use when the user would continue.
+export const USER_TURN_TOOL_DESCRIPTIONS = `Available actions — it is the user's turn. The agent finished its run, no widget is on screen, and the chat input is waiting. The user either types a message or ends the conversation:
 
-- declare_done(): Between-run decision. Signal that the user has gotten what they wanted and the conversation ends.`;
+- send_follow_up_message(message): Send the user's next chat message. Everything the user wants to say right now goes here — including answering a question the agent asked in plain text, and approving or rejecting a plan the agent presented in plain text ("No — two changes first: …" or "Yes, go ahead." ARE follow-up messages).
+
+- declare_done(): The user got what they wanted (or has nothing left to say) and walks away; the conversation ends. Never pick this while the agent is waiting for an answer.`;
 
 // ---------------------------------------------------------------------------
 // Decision → InstanceAiConfirmRequest encoders
@@ -85,7 +127,7 @@ export const TOOL_DESCRIPTIONS = `Available actions:
 
 /**
  * Encode a confirmation-response action into an InstanceAiConfirmRequest.
- * Returns null for between-run actions (send_follow_up_message, declare_done),
+ * Returns null for user-turn actions (send_follow_up_message, declare_done),
  * which the caller routes separately.
  */
 export function encodeConfirmationDecision(


### PR DESCRIPTION
## Summary

The eval user-proxy (the LLM simulating the user in multi-turn workflow evals) picked its response as structured output against a single schema offering **all seven actions at every decision point**. At the **user-turn** moment — the agent's run finished, no widget on screen, the user must type or leave — only `send_follow_up_message` / `declare_done` can function. But the proxy, primed by its own plan-pushback guidance, regularly answered a *plain-text* plan with `approve_or_reject(approved=false, userInput="…full rejection…")`. `decideFollowUp()` silently mapped any non-follow-up action to "done": the composed rejection was discarded, the conversation ended with the builder still awaiting approval, no workflow was built, and every unit failed with "no rejection occurred".

This is the dominant flake of `revises-plan-after-rejection` (LangTracer case #209): ~8% of PR-gate iterations across its lifetime died this way (e.g. the 1/3 run on #34658), and a local N=5 reproduced it in 4/5 iterations.

The fix makes each decision call declare its conversation moment, and the moment picks both the schema and the tool descriptions — the schema the model sees IS its action menu, so out-of-context actions cannot be returned at all:

- `ProxyDecisionMode = 'confirmation' | 'user-turn'`; `UserProxyAgent.decide(prompt, mode)`.
- `confirmation` offers the five widget actions; `user-turn` offers the two chat actions.
- Tool descriptions split per mode; `approve_or_reject` is re-bound to widget events (its old wording — "asked an open free-text question" — actively described the no-widget situation and invited the mislabel).
- The user-turn prompt teaches the key mapping: approving/rejecting a plan presented in plain text IS the next chat message.
- The two remaining silent conversation exits (LLM error with no usable scripted fallback; a non-user-turn action from an injected agent) now log warnings.

**Validation** — `revises-plan-after-rejection`, N=5 against a local backend, direct loop, before → after on the same recipe:

| | before | after |
|---|---|---|
| successful builds | 1/5 | 4/5 |
| trials passing (5 units × 5 iters) | 5/25 (20%) | 18/25 (72%) |
| proxy decisions silently dropped | 4 | 0 |

After the fix the case exercises its actual premise in both channels: widget plan rejections (including holding firm on a re-presented plan) and typed rejections/approvals at the user-turn. The two non-perfect iterations were a local network outage (now loudly logged) and the builder substituting a Google Sheets polling trigger for the pinned Schedule Trigger (case-content variance, unrelated to the proxy).

Eval-harness only — no server/runtime code is touched.

## How to test

- `pnpm vitest run evaluations/__tests__/user-proxy.test.ts` in `packages/@n8n/instance-ai` (33 tests; new pins assert each mode's schema rejects the other mode's actions and that call sites pass the right mode).
- End to end: `pnpm eval:instance-ai --source langtracer --suite baseline --filter revises-plan-after-rejection --base-url <local n8n> --iterations 5 --verbose` — text-plan iterations should show `[multi-turn] Sending follow-up: <rejection>` instead of ending with the builder awaiting approval.

## Related Linear tickets, Github issues, and Community forum posts

No ticket — diagnosed from the eval gate flag on #34658 (`revises-plan-after-rejection` 1/3, "no rejection of the plan at all").

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

