### PR TITLE
feat(core): Nest delegated sub-agent spans under the parent agent trace

### DIFF
--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -153,6 +153,8 @@
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-async-hooks": "^2.7.1",
     "@pinecone-database/pinecone": "catalog:",
     "@qdrant/js-client-rest": "catalog:",
     "@supabase/supabase-js": "catalog:",

--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -146,6 +146,7 @@ export { evaluate } from './sdk/evaluate';
 export type { DatasetRow, EvaluateConfig } from './sdk/evaluate';
 export * as evals from './evals/index';
 export { Telemetry } from './sdk/telemetry';
+export { deriveSubAgentTelemetry } from './runtime/telemetry/sub-agent-telemetry';
 export { LangSmithTelemetry } from './integrations/langsmith';
 export type { LangSmithTelemetryConfig } from './integrations/langsmith';
 export { Agent } from './sdk/agent';

--- a/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
@@ -437,6 +437,33 @@ describe('createDelegateSubAgentTool', () => {
 		expect(runSubAgent.mock.calls[0]?.[0]).not.toHaveProperty('parentResourceId');
 		expect(runSubAgent.mock.calls[0]?.[0]).not.toHaveProperty('parentAbortSignal');
 		expect(runSubAgent.mock.calls[0]?.[0]).not.toHaveProperty('parentExecutionCounter');
+		expect(runSubAgent.mock.calls[0]?.[0]).not.toHaveProperty('parentTelemetry');
+	});
+
+	it('forwards the parent telemetry from the tool context to the runner callback', async () => {
+		const runSubAgent = vi
+			.fn<DelegateSubAgentRunner>()
+			.mockResolvedValue({ status: 'completed', taskPath: '/root/research_api', answer: 'done' });
+		const tool = createDelegateSubAgentTool({ runSubAgent });
+		const parentTelemetry = {
+			enabled: true,
+			recordInputs: true,
+			recordOutputs: true,
+			integrations: [],
+			functionId: 'parent-agent',
+		};
+
+		await tool.handler?.(input, {
+			runId: 'parent-run-1',
+			parentTelemetry,
+		});
+
+		expect(runSubAgent).toHaveBeenCalledWith(
+			expect.objectContaining({ parentTelemetry }),
+			expect.objectContaining({
+				runInlineSubAgent: expect.any(Function),
+			}),
+		);
 	});
 
 	it('forwards the parent run abort signal to the runner callback', async () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/runtime-telemetry.otel.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/runtime-telemetry.otel.test.ts
@@ -1,0 +1,85 @@
+import { trace } from '@opentelemetry/api';
+
+import { OtelTestProvider } from './support/otel-test-provider';
+import type { BuiltTelemetry } from '../../types/telemetry';
+import type { AgentRuntimeConfig } from '../loop/agent-runtime';
+import { RuntimeTelemetry } from '../telemetry/runtime-telemetry';
+
+const TEST_TRACER_NAME = 'runtime-telemetry-otel-test';
+
+function builtTelemetry(overrides: Partial<BuiltTelemetry> = {}): BuiltTelemetry {
+	return {
+		enabled: true,
+		recordInputs: true,
+		recordOutputs: true,
+		integrations: [],
+		tracer: trace.getTracer(TEST_TRACER_NAME),
+		...overrides,
+	};
+}
+
+// Deliberately does not mock '@opentelemetry/api' or the tracer:
+// runtime-telemetry.test.ts already covers the branching logic against a
+// stubbed tracer. This file proves the real OTel path end-to-end — that a
+// top-level run's root span really starts a new trace even inside an active
+// ambient span, and a sub-agent run (rootAnchored: false) really nests under
+// one, exactly as TRUST-308 requires.
+describe('RuntimeTelemetry.withRootSpan (real OTel provider)', () => {
+	it('anchors a top-level run as its own root, ignoring an active ambient span', async () => {
+		const otel = OtelTestProvider.create();
+		try {
+			const config = { name: 'parent-agent' } as AgentRuntimeConfig;
+			const runtimeTelemetry = new RuntimeTelemetry(config);
+			const tracer = trace.getTracer(TEST_TRACER_NAME);
+
+			await tracer.startActiveSpan('ambient-span', async (ambientSpan) => {
+				await runtimeTelemetry.withRootSpan(
+					'generate',
+					{ telemetry: builtTelemetry() },
+					'run-1',
+					async () => await Promise.resolve('ok'),
+				);
+				ambientSpan.end();
+			});
+
+			const spans = otel.getFinishedSpans();
+			const rootSpan = spans.find((span) => span.name === 'parent-agent.generate');
+			const ambientSpan = spans.find((span) => span.name === 'ambient-span');
+			expect(rootSpan).toBeDefined();
+			expect(ambientSpan).toBeDefined();
+			expect(rootSpan?.parentSpanContext).toBeUndefined();
+			expect(rootSpan?.spanContext().traceId).not.toBe(ambientSpan?.spanContext().traceId);
+		} finally {
+			await otel.shutdown();
+		}
+	});
+
+	it('nests a sub-agent run (rootAnchored: false) under the active parent tool-call span', async () => {
+		const otel = OtelTestProvider.create();
+		try {
+			const config = { name: 'child-agent' } as AgentRuntimeConfig;
+			const runtimeTelemetry = new RuntimeTelemetry(config);
+			const tracer = trace.getTracer(TEST_TRACER_NAME);
+
+			await tracer.startActiveSpan('execute_tool delegate_subagent', async (toolSpan) => {
+				await runtimeTelemetry.withRootSpan(
+					'generate',
+					{ telemetry: builtTelemetry({ rootAnchored: false }) },
+					'run-2',
+					async () => await Promise.resolve('ok'),
+				);
+				toolSpan.end();
+			});
+
+			const spans = otel.getFinishedSpans();
+			const childSpan = spans.find((span) => span.name === 'child-agent.generate');
+			const toolSpan = spans.find((span) => span.name === 'execute_tool delegate_subagent');
+			expect(childSpan).toBeDefined();
+			expect(toolSpan).toBeDefined();
+			expect(childSpan?.parentSpanContext?.spanId).toBe(toolSpan?.spanContext().spanId);
+			expect(childSpan?.spanContext().traceId).toBe(toolSpan?.spanContext().traceId);
+		} finally {
+			await otel.shutdown();
+		}
+	});
+});

--- a/packages/@n8n/agents/src/runtime/__tests__/runtime-telemetry.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/runtime-telemetry.test.ts
@@ -127,6 +127,69 @@ describe('RuntimeTelemetry.withRootSpan()', () => {
 		expect(span.end).toHaveBeenCalledTimes(1);
 	});
 
+	it('omits root when rootAnchored is false, so the span nests under the ambient context', async () => {
+		const span = fakeSpan();
+		const tracer = fakeTracer(span);
+		const telemetry = builtTelemetry({ tracer, rootAnchored: false });
+		const config = { name: 'sub-agent' } as AgentRuntimeConfig;
+		const runtimeTelemetry = new RuntimeTelemetry(config);
+
+		await runtimeTelemetry.withRootSpan(
+			'generate',
+			{ telemetry },
+			'run-1',
+			async () => await Promise.resolve('ok'),
+		);
+
+		const [, options] = tracer.startActiveSpan.mock.calls[0];
+		expect(options).not.toHaveProperty('root');
+		expect((options as { attributes?: unknown }).attributes).toBeDefined();
+		expect(span.end).toHaveBeenCalledTimes(1);
+	});
+
+	it('still skips span creation entirely when runtimeRootSpanEnabled is false, even if rootAnchored is also false', async () => {
+		const tracer = fakeTracer(fakeSpan());
+		const telemetry = builtTelemetry({
+			tracer,
+			runtimeRootSpanEnabled: false,
+			rootAnchored: false,
+		});
+		const config = { name: 'sub-agent' } as AgentRuntimeConfig;
+		const runtimeTelemetry = new RuntimeTelemetry(config);
+
+		await expect(
+			runtimeTelemetry.withRootSpan(
+				'generate',
+				{ telemetry },
+				'run-1',
+				async () => await Promise.resolve('ok'),
+			),
+		).resolves.toBe('ok');
+		expect(tracer.startActiveSpan).not.toHaveBeenCalled();
+	});
+
+	it('tags sub-agent metadata (e.g. source: sub-agent) onto the span attributes like any other metadata key', async () => {
+		const tracer = fakeTracer(fakeSpan());
+		const telemetry = builtTelemetry({
+			tracer,
+			rootAnchored: false,
+			metadata: { thread_id: 'thread-abc', source: 'sub-agent' },
+		});
+		const config = { name: 'sub-agent' } as AgentRuntimeConfig;
+		const runtimeTelemetry = new RuntimeTelemetry(config);
+
+		await runtimeTelemetry.withRootSpan(
+			'generate',
+			{ telemetry },
+			'run-1',
+			async () => await Promise.resolve('ok'),
+		);
+
+		const [, options] = tracer.startActiveSpan.mock.calls[0];
+		const attributes = (options as { attributes: Record<string, unknown> }).attributes;
+		expect(attributes).toMatchObject({ 'ai.telemetry.metadata.source': 'sub-agent' });
+	});
+
 	it('passes links through to the tracer only when provided', async () => {
 		const tracer = fakeTracer(fakeSpan());
 		const telemetry = builtTelemetry({ tracer });

--- a/packages/@n8n/agents/src/runtime/__tests__/support/otel-test-provider.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/support/otel-test-provider.ts
@@ -1,0 +1,56 @@
+import { context, trace } from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import {
+	BasicTracerProvider,
+	InMemorySpanExporter,
+	SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
+
+/**
+ * Disposable OTel test harness. Sets up an in-memory tracer that captures
+ * spans for assertion, plus a real async-hooks context manager so parent/child
+ * span nesting is preserved across `await` boundaries (without it, every span
+ * looks like a root regardless of `startActiveSpan` nesting, since the default
+ * no-op context manager never tracks an "active" context).
+ *
+ * Usage:
+ *   const otel = OtelTestProvider.create();
+ *   // ... run code that creates spans ...
+ *   expect(otel.getFinishedSpans()).toHaveLength(1);
+ *   otel.reset(); // between tests
+ *   await otel.shutdown(); // cleanup
+ */
+export class OtelTestProvider {
+	private constructor(
+		private readonly provider: BasicTracerProvider,
+		private readonly exporter: InMemorySpanExporter,
+		private readonly contextManager: AsyncHooksContextManager,
+	) {}
+
+	static create(): OtelTestProvider {
+		const exporter = new InMemorySpanExporter();
+		const provider = new BasicTracerProvider({
+			spanProcessors: [new SimpleSpanProcessor(exporter)],
+		});
+		trace.setGlobalTracerProvider(provider);
+		const contextManager = new AsyncHooksContextManager().enable();
+		context.setGlobalContextManager(contextManager);
+		return new OtelTestProvider(provider, exporter, contextManager);
+	}
+
+	getFinishedSpans() {
+		return this.exporter.getFinishedSpans();
+	}
+
+	reset() {
+		this.exporter.reset();
+	}
+
+	async shutdown() {
+		this.exporter.reset();
+		await this.provider.shutdown();
+		this.contextManager.disable();
+		trace.disable();
+		context.disable();
+	}
+}

--- a/packages/@n8n/agents/src/runtime/telemetry/__tests__/sub-agent-telemetry.test.ts
+++ b/packages/@n8n/agents/src/runtime/telemetry/__tests__/sub-agent-telemetry.test.ts
@@ -1,0 +1,45 @@
+import type { BuiltTelemetry } from '../../../types/telemetry';
+import { deriveSubAgentTelemetry } from '../sub-agent-telemetry';
+
+function builtTelemetry(overrides: Partial<BuiltTelemetry> = {}): BuiltTelemetry {
+	return {
+		enabled: true,
+		recordInputs: true,
+		recordOutputs: true,
+		integrations: [],
+		...overrides,
+	};
+}
+
+describe('deriveSubAgentTelemetry()', () => {
+	it('returns undefined when the parent has no telemetry', () => {
+		expect(deriveSubAgentTelemetry(undefined)).toBeUndefined();
+	});
+
+	it('clears functionId, sets rootAnchored: false, and tags source: sub-agent while preserving other metadata', () => {
+		const tracer = { startActiveSpan: () => {} };
+		const parentTelemetry = builtTelemetry({
+			tracer,
+			functionId: 'parent-agent',
+			metadata: { agent_id: 'agent-1', thread_id: 'thread-1' },
+		});
+
+		const derived = deriveSubAgentTelemetry(parentTelemetry);
+
+		expect(derived).toEqual({
+			...parentTelemetry,
+			functionId: undefined,
+			metadata: { agent_id: 'agent-1', thread_id: 'thread-1', source: 'sub-agent' },
+			rootAnchored: false,
+		});
+		expect(derived?.tracer).toBe(tracer);
+	});
+
+	it('overrides an existing source in metadata to sub-agent', () => {
+		const parentTelemetry = builtTelemetry({ metadata: { source: 'workflow' } });
+
+		const derived = deriveSubAgentTelemetry(parentTelemetry);
+
+		expect(derived?.metadata).toEqual({ source: 'sub-agent' });
+	});
+});

--- a/packages/@n8n/agents/src/runtime/telemetry/runtime-telemetry.ts
+++ b/packages/@n8n/agents/src/runtime/telemetry/runtime-telemetry.ts
@@ -170,8 +170,6 @@ export class RuntimeTelemetry {
 		options: ExecutionOptions | undefined,
 		runId: string,
 		fn: () => Promise<T>,
-		// Seam for TRUST-308 (nesting delegated sub-agent spans under the parent
-		// agent trace) — unused today, every root span is self-contained.
 		links?: OpaqueSpanLink[],
 	): Promise<T> {
 		const t = this.resolve(options);
@@ -183,9 +181,13 @@ export class RuntimeTelemetry {
 		return await t.tracer.startActiveSpan(
 			spanName,
 			{
-				// Self-contained trace regardless of ambient context, so the span
-				// tree's shape is identical no matter how the agent was invoked.
-				root: true,
+				// Self-contained trace regardless of ambient context by default, so
+				// a top-level agent run's span tree is identical no matter how it was
+				// invoked. `rootAnchored: false` (set by `deriveSubAgentTelemetry` for
+				// delegated sub-agent runs) omits `root` instead, so the span nests
+				// under whatever OTel context is already active — the parent's
+				// delegate-tool-call span, when run in-process inside it.
+				...(t.rootAnchored === false ? {} : { root: true }),
 				...(links?.length ? { links } : {}),
 				attributes: this.buildTelemetryRootAttributes(t, spanName, runId),
 			},

--- a/packages/@n8n/agents/src/runtime/telemetry/sub-agent-telemetry.ts
+++ b/packages/@n8n/agents/src/runtime/telemetry/sub-agent-telemetry.ts
@@ -1,0 +1,27 @@
+import type { BuiltTelemetry } from '../../types/telemetry';
+
+/**
+ * Derives a delegated sub-agent's telemetry from its parent's live, resolved
+ * `BuiltTelemetry` (e.g. `ToolContext.parentTelemetry`), so the child shares
+ * the parent's tracer and nests under the parent's delegate-tool-call span
+ * instead of starting a separate root trace.
+ *
+ * Returns undefined when the parent has none — an untraced parent run must
+ * not cause its sub-agent to accidentally start its own root trace.
+ *
+ * `functionId` is cleared so `RuntimeTelemetry.resolve()` re-stamps it with
+ * the child runtime's own name instead of keeping the parent's (the parent
+ * telemetry object arrives already stamped, since it was resolved for the
+ * parent's own run before being handed to the tool).
+ */
+export function deriveSubAgentTelemetry(
+	parentTelemetry: BuiltTelemetry | undefined,
+): BuiltTelemetry | undefined {
+	if (!parentTelemetry) return undefined;
+	return {
+		...parentTelemetry,
+		functionId: undefined,
+		metadata: { ...parentTelemetry.metadata, source: 'sub-agent' },
+		rootAnchored: false,
+	};
+}

--- a/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
+++ b/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../types/sdk/agent';
 import type { AgentMessage } from '../../types/sdk/message';
 import type { BuiltProviderTool, BuiltTool, ToolContext } from '../../types/sdk/tool';
+import type { BuiltTelemetry } from '../../types/telemetry';
 
 export const DELEGATE_SUB_AGENT_TOOL_NAME = 'delegate_subagent';
 export const INLINE_SUB_AGENT_ID = 'inline';
@@ -129,6 +130,13 @@ export interface DelegateSubAgentRequest extends DelegateSubAgentInput {
 	parentAbortSignal?: AbortSignal;
 	/** Parent aggregate execution counter (`ctx.executionCounter`) for inline child accounting. */
 	parentExecutionCounter?: AgentExecutionCounter;
+	/**
+	 * Parent's live, resolved telemetry (`ctx.parentTelemetry`). Hosts derive the
+	 * child's own telemetry from this (see `deriveSubAgentTelemetry`) so the
+	 * sub-agent shares the parent's tracer and nests under the parent's
+	 * delegate-tool-call span instead of starting a separate root trace.
+	 */
+	parentTelemetry?: BuiltTelemetry;
 	/** How many siblings the parent already spawned before this one (0-based). */
 	childCount: number;
 	/** Effective policy for this delegation. */
@@ -459,6 +467,7 @@ async function handleDelegateSubAgent(
 			...(ctx.executionCounter !== undefined
 				? { parentExecutionCounter: ctx.executionCounter }
 				: {}),
+			...(ctx.parentTelemetry !== undefined ? { parentTelemetry: ctx.parentTelemetry } : {}),
 			...(options.policy !== undefined ? { policy: options.policy } : {}),
 		};
 

--- a/packages/@n8n/agents/src/sdk/__tests__/inline-sub-agent-tools.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/inline-sub-agent-tools.test.ts
@@ -13,10 +13,12 @@ import {
 } from '../../runtime/tools/delegate-sub-agent-tool';
 import { WRITE_TODOS_TOOL_NAME } from '../../runtime/tools/write-todos-tool';
 import type { BuiltProviderTool, BuiltTool } from '../../types';
+import type { BuiltTelemetry } from '../../types/telemetry';
 import { Agent, filterInlineSubAgentTools } from '../agent';
 
 const runtimeConfigs: Array<Record<string, unknown>> = [];
 const runtimeGenerateResults: Array<Record<string, unknown>> = [];
+const runtimeGenerateOptions: Array<Record<string, unknown>> = [];
 
 function makeGenerateSuccess(): Record<string, unknown> {
 	return {
@@ -42,7 +44,8 @@ vi.mock('../../runtime/loop/agent-runtime', async (importOriginal) => {
 				runtimeConfigs.push(config);
 			}
 
-			async generate() {
+			async generate(_prompt: string, options?: Record<string, unknown>) {
+				runtimeGenerateOptions.push(options ?? {});
 				return await Promise.resolve(runtimeGenerateResults.shift() ?? makeGenerateSuccess());
 			}
 
@@ -77,6 +80,7 @@ type AgentWithInlineRunner = {
 		deferredTools: BuiltTool[];
 		modelConfig: string;
 		tools: BuiltTool[];
+		telemetry?: BuiltTelemetry;
 		inlineSubAgentBlockedTools?: string[];
 		inlineSubAgentModelsByDifficulty?: Partial<Record<'low' | 'medium' | 'high', string>>;
 		resolveInlineSubAgentProviderTools?: InlineSubAgentProviderToolsResolver;
@@ -85,6 +89,7 @@ type AgentWithInlineRunner = {
 
 function createInlineRunner(options: {
 	tools?: BuiltTool[];
+	telemetry?: BuiltTelemetry;
 	inlineSubAgentBlockedTools?: string[];
 	inlineSubAgentModelsByDifficulty?: Partial<Record<'low' | 'medium' | 'high', string>>;
 	resolveInlineSubAgentProviderTools?: InlineSubAgentProviderToolsResolver;
@@ -94,10 +99,21 @@ function createInlineRunner(options: {
 		deferredTools: [],
 		modelConfig: 'openai/gpt-4o-mini',
 		tools: options.tools ?? [makeTool('lookup')],
+		telemetry: options.telemetry,
 		inlineSubAgentBlockedTools: options.inlineSubAgentBlockedTools,
 		inlineSubAgentModelsByDifficulty: options.inlineSubAgentModelsByDifficulty,
 		resolveInlineSubAgentProviderTools: options.resolveInlineSubAgentProviderTools,
 	});
+}
+
+function builtTelemetry(overrides: Partial<BuiltTelemetry> = {}): BuiltTelemetry {
+	return {
+		enabled: true,
+		recordInputs: true,
+		recordOutputs: true,
+		integrations: [],
+		...overrides,
+	};
 }
 
 function providerToolNames(runtimeConfig: Record<string, unknown> | undefined): string[] {
@@ -111,6 +127,7 @@ describe('inline sub-agent tool filtering', () => {
 	beforeEach(() => {
 		runtimeConfigs.length = 0;
 		runtimeGenerateResults.length = 0;
+		runtimeGenerateOptions.length = 0;
 	});
 
 	it.each([
@@ -349,6 +366,65 @@ describe('inline sub-agent tool filtering', () => {
 		expect(runtimeConfigs).toHaveLength(2);
 		expect(resolveInlineSubAgentProviderTools).toHaveBeenCalledWith('anthropic/claude-sonnet-4-5');
 		expect(providerToolNames(runtimeConfigs[1])).toEqual(['anthropic.web_search_20250305']);
+	});
+
+	it('derives the child telemetry from the live per-request parentTelemetry, not build-time telemetry', async () => {
+		const parentTelemetry = builtTelemetry({
+			functionId: 'parent-agent',
+			metadata: { thread_id: 't1' },
+		});
+		const runner = createInlineRunner({});
+
+		await runner({
+			subAgentId: INLINE_SUB_AGENT_ID,
+			taskName: 'research',
+			goal: 'Find the answer',
+			taskPath: '/root/research',
+			childCount: 0,
+			parentTelemetry,
+		});
+
+		const expectedTelemetry = {
+			...parentTelemetry,
+			functionId: undefined,
+			metadata: { thread_id: 't1', source: 'sub-agent' },
+			rootAnchored: false,
+		};
+		expect(runtimeConfigs).toHaveLength(1);
+		expect(runtimeConfigs[0]?.telemetry).toEqual(expectedTelemetry);
+		expect(runtimeGenerateOptions).toHaveLength(1);
+		expect(runtimeGenerateOptions[0]?.telemetry).toEqual(expectedTelemetry);
+	});
+
+	it('falls back to build-time telemetry when the request has no parentTelemetry', async () => {
+		const buildTimeTelemetry = builtTelemetry({ functionId: 'build-time' });
+		const runner = createInlineRunner({ telemetry: buildTimeTelemetry });
+
+		await runner({
+			subAgentId: INLINE_SUB_AGENT_ID,
+			taskName: 'research',
+			goal: 'Find the answer',
+			taskPath: '/root/research',
+			childCount: 0,
+		});
+
+		expect(runtimeConfigs[0]?.telemetry).toBe(buildTimeTelemetry);
+		expect(runtimeGenerateOptions[0]?.telemetry).toBe(buildTimeTelemetry);
+	});
+
+	it('omits telemetry entirely when neither parentTelemetry nor build-time telemetry is set', async () => {
+		const runner = createInlineRunner({});
+
+		await runner({
+			subAgentId: INLINE_SUB_AGENT_ID,
+			taskName: 'research',
+			goal: 'Find the answer',
+			taskPath: '/root/research',
+			childCount: 0,
+		});
+
+		expect(runtimeConfigs[0]).not.toHaveProperty('telemetry');
+		expect(runtimeGenerateOptions[0]).not.toHaveProperty('telemetry');
 	});
 });
 

--- a/packages/@n8n/agents/src/sdk/agent.ts
+++ b/packages/@n8n/agents/src/sdk/agent.ts
@@ -16,6 +16,7 @@ import type { FetchFn } from '../runtime/model/model-factory';
 import { mergeProviderOptions } from '../runtime/model/prompt-cache';
 import { AgentEventBus } from '../runtime/state/event-bus';
 import { RunStateManager } from '../runtime/state/run-state';
+import { deriveSubAgentTelemetry } from '../runtime/telemetry/sub-agent-telemetry';
 import {
 	LOAD_TOOL_TOOL_NAME,
 	SEARCH_TOOLS_TOOL_NAME,
@@ -1113,6 +1114,7 @@ export class Agent implements BuiltAgent, AgentBuilder {
 			const childThinkingConfig = shouldInheritThinking(options.modelConfig, childModelConfig)
 				? this.thinkingConfig
 				: undefined;
+			const telemetry = deriveSubAgentTelemetry(request.parentTelemetry) ?? options.telemetry;
 			const childRuntime = new AgentRuntime({
 				name: `${this.name}:${request.taskName}`,
 				model: childModelConfig,
@@ -1129,7 +1131,7 @@ export class Agent implements BuiltAgent, AgentBuilder {
 				promptCaching: this.promptCachingConfig,
 				checkpointStorage: this.checkpointStore,
 				...(childThinkingConfig !== undefined ? { thinking: childThinkingConfig } : {}),
-				...(options.telemetry !== undefined ? { telemetry: options.telemetry } : {}),
+				...(telemetry !== undefined ? { telemetry } : {}),
 				...(options.toolCallConcurrency !== undefined
 					? { toolCallConcurrency: options.toolCallConcurrency }
 					: {}),
@@ -1140,7 +1142,7 @@ export class Agent implements BuiltAgent, AgentBuilder {
 					...(request.parentAbortSignal !== undefined
 						? { abortSignal: request.parentAbortSignal }
 						: {}),
-					...(options.telemetry !== undefined ? { telemetry: options.telemetry } : {}),
+					...(telemetry !== undefined ? { telemetry } : {}),
 					...(request.parentExecutionCounter !== undefined
 						? { executionCounter: request.parentExecutionCounter }
 						: {}),

--- a/packages/@n8n/agents/src/types/telemetry.ts
+++ b/packages/@n8n/agents/src/types/telemetry.ts
@@ -34,6 +34,14 @@ export interface BuiltTelemetry {
 	readonly recordOutputs: boolean;
 	/** Whether AgentRuntime should add a generic chain span around generate/stream loops. */
 	readonly runtimeRootSpanEnabled?: boolean;
+	/**
+	 * Whether the runtime's root span anchors a new trace (`root: true`) or
+	 * nests under the ambient active OTel context. Defaults to `true`
+	 * (self-contained trace). Set to `false` by `deriveSubAgentTelemetry` for
+	 * delegated sub-agent runs, so their span nests under the parent's
+	 * delegate-tool-call span instead of starting a separate trace.
+	 */
+	readonly rootAnchored?: boolean;
 	/** Integrations are pre-wrapped with redaction if .redact() was set at build time. */
 	readonly integrations: TelemetryIntegration[];
 	readonly tracer?: OpaqueTracer;

--- a/packages/cli/src/modules/agents/sub-agents/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/cli/src/modules/agents/sub-agents/__tests__/delegate-sub-agent-tool.test.ts
@@ -174,6 +174,48 @@ describe('createN8nDelegateSubAgentTool', () => {
 		);
 	});
 
+	it('forwards the parent telemetry from the tool context to the foreground runner', async () => {
+		const tool = createN8nDelegateSubAgentTool({
+			runner,
+			sourcesById: { 'agent-2': source },
+			projectId,
+			credentialProvider,
+		});
+		const parentTelemetry = {
+			enabled: true,
+			recordInputs: true,
+			recordOutputs: true,
+			integrations: [],
+			functionId: 'parent-agent',
+		};
+
+		await tool.handler?.(
+			{ subAgentId: 'agent-2', taskName: 'Research API', goal: 'Find behavior.' },
+			{ runId: 'parent-run-1', parentTelemetry },
+		);
+
+		expect(runner.runForeground).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({ telemetry: parentTelemetry }),
+		);
+	});
+
+	it('omits telemetry from the runner context when the parent run has none', async () => {
+		const tool = createN8nDelegateSubAgentTool({
+			runner,
+			sourcesById: { 'agent-2': source },
+			projectId,
+			credentialProvider,
+		});
+
+		await tool.handler?.(
+			{ subAgentId: 'agent-2', taskName: 'Research API', goal: 'Find behavior.' },
+			{ runId: 'parent-run-1' },
+		);
+
+		expect(runner.runForeground.mock.calls[0]?.[1]).not.toHaveProperty('telemetry');
+	});
+
 	it('selects a configured n8n agent source by subAgentId', async () => {
 		const selectedSource: SubAgentSource = { agentId: 'agent-2' };
 		const tool = createN8nDelegateSubAgentTool({

--- a/packages/cli/src/modules/agents/sub-agents/__tests__/sub-agent-foreground-runner.test.ts
+++ b/packages/cli/src/modules/agents/sub-agents/__tests__/sub-agent-foreground-runner.test.ts
@@ -1,6 +1,7 @@
 import {
 	DELEGATED_CHILD_SUSPEND_UNSUPPORTED_MESSAGE,
 	type BuiltAgent,
+	type BuiltTelemetry,
 	type CredentialProvider,
 	type StreamChunk,
 	type StreamResult,
@@ -359,6 +360,45 @@ describe('SubAgentForegroundRunner', () => {
 			expect.any(String),
 			expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
 		);
+	});
+
+	it('derives sub-agent telemetry from the parent context and passes it to the child stream', async () => {
+		const parentTelemetry: BuiltTelemetry = {
+			enabled: true,
+			recordInputs: true,
+			recordOutputs: true,
+			integrations: [],
+			functionId: 'parent-agent',
+			metadata: { agent_id: 'agent-1', thread_id: 'parent-thread-1' },
+		};
+
+		await runner.runForeground(spawnRequest, {
+			projectId,
+			credentialProvider,
+			telemetry: parentTelemetry,
+		});
+
+		expect(childAgent.stream).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				telemetry: {
+					...parentTelemetry,
+					functionId: undefined,
+					metadata: { agent_id: 'agent-1', thread_id: 'parent-thread-1', source: 'sub-agent' },
+					rootAnchored: false,
+				},
+			}),
+		);
+	});
+
+	it('omits telemetry from the child stream call when the parent context has none', async () => {
+		await runner.runForeground(spawnRequest, {
+			projectId,
+			credentialProvider,
+		});
+
+		const options = childAgent.stream.mock.calls[0]?.[1];
+		expect(options).not.toHaveProperty('telemetry');
 	});
 });
 

--- a/packages/cli/src/modules/agents/sub-agents/delegate-sub-agent-tool.ts
+++ b/packages/cli/src/modules/agents/sub-agents/delegate-sub-agent-tool.ts
@@ -83,6 +83,7 @@ export function createN8nDelegateSubAgentTool(options: CreateN8nDelegateSubAgent
 					...(request.parentAbortSignal !== undefined
 						? { abortSignal: request.parentAbortSignal }
 						: {}),
+					...(request.parentTelemetry !== undefined ? { telemetry: request.parentTelemetry } : {}),
 				},
 			);
 

--- a/packages/cli/src/modules/agents/sub-agents/sub-agent-foreground-runner.ts
+++ b/packages/cli/src/modules/agents/sub-agents/sub-agent-foreground-runner.ts
@@ -1,9 +1,11 @@
 import {
 	assertSubAgentTaskPath,
 	DELEGATED_CHILD_SUSPEND_UNSUPPORTED_MESSAGE,
+	deriveSubAgentTelemetry,
 	renderDelegateSubAgentPrompt,
 	type AgentExecutionCounter,
 	type AgentMessage,
+	type BuiltTelemetry,
 	type CredentialProvider,
 	type GenerateResult,
 	type SubAgentTaskPath,
@@ -31,6 +33,12 @@ export interface SubAgentForegroundRunContext {
 	executionCounter?: AgentExecutionCounter;
 	/** Parent run's abort signal — cancelling the parent cancels this child. */
 	abortSignal?: AbortSignal;
+	/**
+	 * Parent's live, resolved telemetry, forwarded per-request. Derived (via
+	 * `deriveSubAgentTelemetry`) into the child's own telemetry so it shares the
+	 * parent's tracer and nests under the parent's delegate-tool-call span.
+	 */
+	telemetry?: BuiltTelemetry;
 	/**
 	 * Interactive n8n user of the delegating parent run; used to filter the
 	 * sub-agent's node/workflow tools by their access. Absent when the parent
@@ -115,11 +123,13 @@ export class SubAgentForegroundRunner {
 
 		// Abort the child when the parent run is cancelled.
 		const abortSignal = context.abortSignal;
+		const telemetry = deriveSubAgentTelemetry(context.telemetry);
 
 		const prompt = renderDelegateSubAgentPrompt(request);
 		try {
 			const resultStream = await agent.stream(prompt, {
 				...(abortSignal !== undefined ? { abortSignal } : {}),
+				...(telemetry !== undefined ? { telemetry } : {}),
 				persistence: {
 					resourceId,
 					threadId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1002,6 +1002,12 @@ importers:
       '@n8n/vitest-config':
         specifier: workspace:*
         version: link:../vitest-config
+      '@opentelemetry/api':
+        specifier: 1.9.0
+        version: 1.9.0
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.0)
       '@pinecone-database/pinecone':
         specifier: 'catalog:'
         version: 5.1.2


### PR DESCRIPTION
## Summary

A delegated sub-agent runs inside the parent's tool call and should appear nested under the parent trace, not as a separate root. Before this change, `RuntimeTelemetry.withRootSpan` unconditionally passed `root: true` to the OTel tracer, so every sub-agent run — inline or delegated to a configured sub-agent — started a brand new trace instead of nesting under the parent's `execute_tool` span.

This PR:
- Adds `BuiltTelemetry.rootAnchored` (default `true`) and makes `withRootSpan` only set `root: true` when it isn't explicitly `false`, so a sub-agent's span nests under whatever OTel context is already active.
- Adds `deriveSubAgentTelemetry()`, which derives a sub-agent's telemetry from its parent's live, resolved telemetry: shares the parent's tracer, tags `source: 'sub-agent'`, sets `rootAnchored: false`. Returns `undefined` when the parent has no telemetry, so an untraced parent never causes its sub-agent to accidentally start its own root trace.
- Threads `ctx.parentTelemetry` (already available on `ToolContext`, but previously unused) through `DelegateSubAgentRequest`, so both delegation paths can derive from it.
- Fixes two related propagation gaps found while implementing this:
  - The SDK's inline sub-agent runner (`sdk/agent.ts`) was only inheriting telemetry configured at `Agent.build()` time, which n8n's CLI never sets — inline sub-agents had **zero** tracing before this change, not just unnested tracing.
  - The CLI's `SubAgentForegroundRunner` (used for delegation to a configured sub-agent) never passed any telemetry at all to the child run.

Builds on #34460 (already merged), which added the underlying `withRootSpan`/`withToolSpan` OTel span mechanism this PR makes conditional.

## How to test

With `N8N_AGENTS_TRACING_ENABLED=true` and an OTel exporter configured (e.g. console or OTLP), run an agent that delegates to a sub-agent (either `subAgentId: "inline"` or a configured sub-agent) via the `delegate_subagent` tool, and inspect the resulting trace:
- One trace: parent root → `execute_tool delegate_subagent` → sub-agent `generate`/`stream` span(s) nested beneath, tagged `source: sub-agent` in metadata.
- The sub-agent's span never appears as a separate root trace.

Unit tests cover this directly and can be run without any live OTel backend:
```bash
# SDK-level: mocked-tracer + real in-memory OTel provider tests proving actual span nesting
cd packages/@n8n/agents && pnpm test runtime-telemetry.test.ts runtime-telemetry.otel.test.ts sub-agent-telemetry.test.ts delegate-sub-agent-tool.test.ts inline-sub-agent-tools.test.ts

# CLI-level: telemetry threading through the foreground runner and delegate tool wiring
cd packages/cli && pnpm test sub-agent-foreground-runner.test.ts delegate-sub-agent-tool.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-308

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->