### PR TITLE
docs(ai-builder): Add a source-linking provenance step to the eval-authoring skill (no-changelog)

### DIFF
--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -208,7 +208,9 @@ calibration you hand the driver the thread link + login to review the real build
    (or delete it once it's in the suite). Committing new case JSONs into the repo
    is no longer the approach. (Exception: seeded cases can't be pushed — a
    `seedFile`/`priorConversation` case stays committed JSON, a `seedThread` case is
-   a local throwaway; see [`case-shapes.md`](case-shapes.md).)
+   a local throwaway; see [`case-shapes.md`](case-shapes.md).) For a sourced case,
+   finish by **linking it to its source thread/finding** over the MCP — see
+   [Link the pushed case to its source](#link-the-pushed-case-to-its-source-provenance-step--always-do-this).
 
 `--iterations N` is available to measure flakiness (pass@k / pass^k) — reach for
 it when you suspect a case is non-deterministic or before promoting it to a
@@ -665,6 +667,35 @@ npx dotenvx run -f .env.eval -- pnpm eval:langtracer-push --suite workflow-build
   durable synthetic case as the artifact instead. A `seedFile`/`priorConversation`
   case isn't transient and has no suite home, so it's the one exception to
   "don't commit the JSON" — it lives as a committed artifact.
+
+### Link the pushed case to its source (provenance step — always do this)
+
+A sourced case that isn't linked back to the conversation/finding it encodes is
+an orphan: six months later nobody can tell what real failure it guards. The
+push CLI doesn't carry provenance, so after pushing, link the case over the
+lang-tracer MCP with one **`update_test_case`** call on the new case id (the
+push prints it):
+
+1. **`sourceThreadId`** — the source conversation's thread id (plus
+   **`sourceRunId`** when the case anchors to one specific run/step within it).
+   This is the DB-level link every by-version rollup, conversation float, and
+   `?sourceThreadId=` query joins on — the tags/description below are the
+   human-readable layer on top, not a substitute. The thread must already be
+   imported into lang-tracer (running `get_conversation_analysis` on it, as the
+   sourcing flow does, is enough); `source_kind` is derived server-side, and
+   the link is only editable on authored cases — promotion-recorded provenance
+   is immutable.
+2. **`expectedBehavior`** — the rule the case enforces, one paragraph — and
+   **`failurePattern`** — what actually happened in the source thread, with
+   turn references. Copy/adapt these from the analysis's `extractedCases`
+   entry when the case came from `get_conversation_analysis`.
+
+Then **`add_case_tags`** (additive; targets the LT-side `tags` array, not
+`evalTags`, so nothing round-trips into eval runs): add a capability tag (e.g.
+`instruction-persistence`). Tag normalization is aggressive (lowercase, kebab);
+colon-form tags get silently dropped. And keep the thread id + turn refs in
+the case `description` too (the drafter's habit of "Sourced from thread <id>"
+is the convention) — the description is the only field shown everywhere.
 
 ## Running
 

--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -23,8 +23,8 @@ exhaustive field reference; this skill is the opinionated *how*.
 > approach.** Author the file locally (uncommitted), calibrate it against a real
 > build, then **push it to a lang-tracer suite** with `eval:langtracer-push`
 > (see [Push to a lang-tracer suite](#push-to-a-lang-tracer-suite)) —
-> `--suite n8n-workflows` for the corpus n8n CI runs, or a capability suite
-> like `workflow-building` that runs on LangTracer's own automation.
+> `--suite baseline` for the consolidated corpus n8n CI runs, or a dedicated
+> capability suite like `agents`.
 > The suite is the home for the case; the eval CLI reads it back via
 > `--source langtracer`. You still write the JSON file — it's just the input to
 > the push, not a committed artifact.
@@ -383,7 +383,7 @@ What each piece is doing:
   misses the label filter. Keep the whole script in one turn and encode ordering
   inside it (don't fabricate assistant "done" turns to sequence steps — see
   [`case-shapes.md`](case-shapes.md)). `applies-each-change-when-asked` (in the
-  `n8n-workflows` LangTracer suite) is a good real example.
+  `baseline` LangTracer suite) is a good real example.
 - **`dataSetup` describes only what external services return.** That's the layer
   the harness controls (below).
 
@@ -632,9 +632,9 @@ drifted, leaves the rest unchanged, and never prunes. It's the inverse of
 ```bash
 cd packages/@n8n/instance-ai
 # preview first — no writes (use `npx dotenvx`; the bare `dotenvx` binary is usually not on PATH):
-npx dotenvx run -f .env.eval -- pnpm eval:langtracer-push --suite workflow-building --dry-run --changed
+npx dotenvx run -f .env.eval -- pnpm eval:langtracer-push --suite baseline --dry-run --changed
 # then push (drop --dry-run):
-npx dotenvx run -f .env.eval -- pnpm eval:langtracer-push --suite workflow-building --changed
+npx dotenvx run -f .env.eval -- pnpm eval:langtracer-push --suite baseline --changed
 ```
 
 - **Selectors** (at least one required — no accidental push-all): positional

--- a/.agents/skills/create-instance-ai-eval/case-shapes.md
+++ b/.agents/skills/create-instance-ai-eval/case-shapes.md
@@ -10,7 +10,7 @@ Example cases in the corpus get renamed and churned, so this file names as few
 cases as possible — search the LangTracer suite by tag/field instead (the
 `search_test_cases` MCP tool, or export the suite and grep). The one stable
 pointer worth naming: **`applies-each-change-when-asked`** (in the
-`n8n-workflows` suite) for a well-built director conversation.
+`baseline` suite) for a well-built director conversation.
 
 The schema
 ([`harness/schema.ts`](../../../packages/@n8n/instance-ai/evaluations/harness/schema.ts))

--- a/.agents/skills/create-instance-ai-eval/running-evals.md
+++ b/.agents/skills/create-instance-ai-eval/running-evals.md
@@ -54,7 +54,7 @@ inspection; `--iterations N` runs each case N times for pass@k / pass^k.
 | Source | When to use it |
 |---|---|
 | **`disk`** (default) | **Preferred for local development** — authoring and calibrating the case in front of you: drop the JSON into `data/workflows/`, `--filter` it, iterate. Also the only home of the `agents` tier and the seeded carve-out cases; since the corpus migration the directory holds only those, not the full suite. |
-| **`langtracer`** (`--source langtracer --suite n8n-workflows`) | Bigger runs (the full corpus or a whole tier), re-running specific cases that already live in the suite, and CI — which always runs this way. Needs `LANGTRACER_URL`/`LANGTRACER_API_KEY` in your env. |
+| **`langtracer`** (`--source langtracer --suite baseline`) | Bigger runs (the full corpus or a whole tier), re-running specific cases that already live in the suite, and CI — which always runs this way. Needs `LANGTRACER_URL`/`LANGTRACER_API_KEY` in your env. |
 
 ## Configuration & secrets
 
@@ -194,7 +194,7 @@ for low noise:
 # with your env loaded and LANGSMITH_API_KEY set, from packages/@n8n/instance-ai/
 # (--dataset/--baseline-prefix mirror CI's pins — langtracer mode otherwise
 # derives suite-scoped names and later runs would never find this baseline)
-pnpm eval:instance-ai --source langtracer --suite n8n-workflows \
+pnpm eval:instance-ai --source langtracer --suite baseline \
   --dataset instance-ai-workflow-evals --baseline-prefix instance-ai-baseline- \
   --experiment-name instance-ai-baseline --iterations 10
 ```

--- a/packages/@n8n/instance-ai/evaluations/__tests__/args.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/args.test.ts
@@ -145,9 +145,9 @@ describe('partialIsolationWarning', () => {
 
 describe('parseCliArgs --source langtracer dataset isolation', () => {
 	it('derives a suite-scoped dataset + baseline prefix by default', () => {
-		const args = parseCliArgs(['--source', 'langtracer', '--suite', 'n8n-workflows']);
-		expect(args.dataset).toBe('instance-ai-langtracer-n8n-workflows');
-		expect(args.baselinePrefix).toBe('instance-ai-langtracer-n8n-workflows-baseline-');
+		const args = parseCliArgs(['--source', 'langtracer', '--suite', 'my-suite']);
+		expect(args.dataset).toBe('instance-ai-langtracer-my-suite');
+		expect(args.baselinePrefix).toBe('instance-ai-langtracer-my-suite-baseline-');
 	});
 
 	it('does not derive in disk mode (defaults stay the shared cohort)', () => {
@@ -161,7 +161,7 @@ describe('parseCliArgs --source langtracer dataset isolation', () => {
 			'--source',
 			'langtracer',
 			'--suite',
-			'n8n-workflows',
+			'my-suite',
 			'--dataset',
 			'custom-ds',
 			'--baseline-prefix',

--- a/packages/cli/src/modules/mcp/evaluations/README.md
+++ b/packages/cli/src/modules/mcp/evaluations/README.md
@@ -99,7 +99,7 @@ always pass a dedicated `--dataset` and `--baseline-prefix`:
 LANGSMITH_API_KEY=ls__... dotenvx run -f .env.mcp-evals -- \
   pnpm --filter @n8n/instance-ai run eval:instance-ai \
   --base-url http://localhost:5678 \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   --tier mcp \
   --prebuilt-workflows /tmp/n8n-mcp-cohort/manifest.json \
   --dataset mcp-workflow-evals \
@@ -130,7 +130,7 @@ dataset and prefix (high `--iterations` for a low-noise reference point):
 LANGSMITH_API_KEY=ls__... dotenvx run -f .env.mcp-evals -- \
   pnpm --filter @n8n/instance-ai run eval:instance-ai \
   --base-url http://localhost:5678 \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   --tier mcp \
   --prebuilt-workflows /tmp/n8n-mcp-cohort/manifest.json \
   --dataset mcp-workflow-evals \
@@ -206,7 +206,7 @@ and stay in lockstep:
 ```bash
 # 1. Build the cohort — only mcp-tier cases
 dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:build-mcp-manifest \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   --tier mcp \
   -n 3 \
   -j 3 \
@@ -216,7 +216,7 @@ dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:build-m
 # 2. Evaluate the same cohort
 dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:instance-ai \
   --base-url http://localhost:5678 \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   --tier mcp \
   --prebuilt-workflows /tmp/n8n-mcp-cohort/manifest.json \
   --iterations 3 \
@@ -237,13 +237,13 @@ them; narrow its build set with positional slugs instead (e.g. append
 
 Without `--tier` or a positional slug, the build covers every test case in the
 source. The commands below pull the real corpus from LangTracer
-(`--source langtracer --suite n8n-workflows`); disk mode (`data/workflows/`)
+(`--source langtracer --suite baseline`); disk mode (`data/workflows/`)
 only holds the seeded carve-out cases. From the repo root, build five
 workflows per test case with five concurrent Claude Code builds:
 
 ```bash
 dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:build-mcp-manifest \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   -n 5 \
   -j 5 \
   --output-dir /tmp/n8n-mcp-cohort \
@@ -264,7 +264,7 @@ dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:build-m
   -j 5 \
   --output-dir /tmp/n8n-mcp-cohort \
   --mcp-server n8n-local \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   --model claude-opus-4-5
 ```
 
@@ -280,7 +280,7 @@ dotenvx run -f /path/to/n8n/.env.mcp-evals -- pnpm --dir /path/to/n8n \
   -j 5 \
   --mcp-server n8n-local \
   --project-id <n8n-project-id> \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   --build-cwd /path/to/mcp-workspace \
   --output-dir /tmp/n8n-mcp-skills-cohort
 ```
@@ -308,7 +308,7 @@ dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:build-m
   -j 5 \
   --output-dir /tmp/n8n-mcp-contact-form \
   --mcp-server n8n-local \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   contact-form-automation
 ```
 
@@ -325,7 +325,7 @@ concurrent eval workers:
 ```bash
 dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:instance-ai \
   --base-url http://localhost:5678 \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   --prebuilt-workflows /tmp/n8n-mcp-cohort/manifest.json \
   --iterations 5 \
   --concurrency 5 \
@@ -342,7 +342,7 @@ Use `--filter` with the same slug that was used during manifest generation:
 ```bash
 dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:instance-ai \
   --base-url http://localhost:5678 \
-  --source langtracer --suite n8n-workflows \
+  --source langtracer --suite baseline \
   --prebuilt-workflows /tmp/n8n-mcp-contact-form/manifest.json \
   --filter contact-form-automation \
   --iterations 5 \
@@ -352,7 +352,7 @@ dotenvx run -f .env.mcp-evals -- pnpm --filter @n8n/instance-ai run eval:instanc
 
 ## Adding a case to the `mcp` tier
 
-Test cases live in the LangTracer suite `n8n-workflows` — see
+Test cases live in the LangTracer suite `baseline` — see
 [Adding test cases](../../../../../@n8n/instance-ai/evaluations/README.md#adding-test-cases)
 for the full schema and authoring flow. To include a case in the MCP cohort,
 add `"mcp"` to its `datasets` array (in LangTracer for existing cases; in the


### PR DESCRIPTION
## Summary

The `create-instance-ai-eval` skill now finishes every sourced-case push with a provenance step: one `update_test_case` call setting `sourceThreadId` (and `sourceRunId` when the case anchors to a specific run) as the DB-level link — the field by-version rollups and `?sourceThreadId=` queries join on — plus `expectedBehavior`/`failurePattern` from the source finding, a capability tag, and the existing "Sourced from thread <id>" description convention as the human-readable layer.

**Merge ordering:** the skill text assumes the lang-tracer case-write API accepts `sourceThreadId`/`sourceRunId`. Hold this until the corresponding lang-tracer change is merged and deployed.

**Also in this PR:** the `n8n-workflows` / `workflow-building` LangTracer suites were consolidated into `baseline`, and #34402 updated the workflow yml defaults but not the docs. The second commit replaces the dead slugs across the skill and the MCP evals README (`packages/cli/src/modules/mcp/evaluations/README.md`, whose copy-paste commands currently fail with `suite "n8n-workflows" not found`), and renames the arbitrary suite fixture in `args.test.ts` so the old slug no longer greps anywhere.

## Related Linear tickets, Github issues, and Community forum posts

- n/a (skill/docs only; the API counterpart lives in the lang-tracer repo)

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [ ] Tests included
- [x] I acknowledge that this PR is my responsibility from creation through merge and release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34721">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
