### PR TITLE
fix(core): Redirect form-resume waiting requests to the form endpoint

### DIFF
--- a/packages/cli/src/webhooks/__tests__/slack-interaction-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/slack-interaction-webhooks.test.ts
@@ -45,6 +45,7 @@ describe('SlackInteractionWebhooks', () => {
 		mock(),
 		mock<InstanceSettings>({ hmacSignatureSecret: TEST_HMAC_SECRET }),
 		mock<EventService>(),
+		mock(),
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/webhooks/__tests__/telegram-interaction-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/telegram-interaction-webhooks.test.ts
@@ -27,6 +27,7 @@ describe('TelegramInteractionWebhooks', () => {
 			mock<WebhookService>(),
 			mockInstanceSettings,
 			mock<EventService>(),
+			mock(),
 		);
 		getWebhookExecutionData = vi.fn().mockResolvedValue({ noWebhookResponse: true });
 		// Stub the shared resume so these tests focus on parsing, verification, and routing.

--- a/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-forms.test.ts
@@ -38,6 +38,7 @@ describe('WaitingForms', () => {
 		mock(),
 		mockInstanceSettings,
 		mock(),
+		mock(),
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -510,6 +510,38 @@ describe('WaitingWebhooks', () => {
 
 			expect(res.redirect).not.toHaveBeenCalled();
 		});
+
+		it('does not redirect when the waiting endpoints are configured identically', async () => {
+			const identicalEndpointsConfig = mock<EndpointsConfig>({
+				webhookWaiting: 'webhook-waiting',
+				formWaiting: 'webhook-waiting',
+			});
+			const webhooksWithIdenticalEndpoints = new TestWaitingWebhooks(
+				mock(),
+				mock(),
+				executionPersistence,
+				mockWebhookService,
+				mockInstanceSettings,
+				mockEventService,
+				identicalEndpointsConfig,
+			);
+			executionPersistence.findSingleExecution.mockResolvedValue(
+				buildExecution({ nodeType: 'n8n-nodes-base.wait', nodeParameters: { resume: 'form' } }),
+			);
+			mockWebhookService.getNodeWebhooks.mockReturnValue([]);
+			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue({} as any);
+			const res = buildRes();
+			const req = mock<WaitingWebhookRequest>({
+				params: { path: 'exec-id', suffix: undefined },
+				method: 'GET',
+				originalUrl: '/webhook-waiting/exec-id?signature=abc',
+			});
+
+			await expect(webhooksWithIdenticalEndpoints.executeWebhook(req, res)).rejects.toThrowError(
+				NotFoundError,
+			);
+			expect(res.redirect).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('createWorkflow', () => {

--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -1,8 +1,9 @@
+import type { EndpointsConfig } from '@n8n/config';
 import type { IExecutionResponse } from '@n8n/db';
 import type express from 'express';
 import type { InstanceSettings } from 'n8n-core';
 import { WAITING_TOKEN_QUERY_PARAM } from 'n8n-core';
-import type { IWorkflowBase, Workflow } from 'n8n-workflow';
+import type { INodeParameters, IWorkflowBase, Workflow } from 'n8n-workflow';
 import { SEND_AND_WAIT_OPERATION } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
@@ -39,6 +40,10 @@ describe('WaitingWebhooks', () => {
 	const mockWebhookService = mock<WebhookService>();
 	const mockInstanceSettings = mock<InstanceSettings>({ hmacSignatureSecret: TEST_HMAC_SECRET });
 	const mockEventService = mock<EventService>();
+	const mockEndpointsConfig = mock<EndpointsConfig>({
+		webhookWaiting: 'webhook-waiting',
+		formWaiting: 'form-waiting',
+	});
 	const waitingWebhooks = new TestWaitingWebhooks(
 		mock(),
 		mock(),
@@ -46,6 +51,7 @@ describe('WaitingWebhooks', () => {
 		mockWebhookService,
 		mockInstanceSettings,
 		mockEventService,
+		mockEndpointsConfig,
 	);
 
 	beforeEach(() => {
@@ -369,6 +375,140 @@ describe('WaitingWebhooks', () => {
 			expect(mockJson).toHaveBeenCalledWith({ error: 'Invalid token' });
 			expect(mockRender).not.toHaveBeenCalled();
 			expect(result).toEqual({ noWebhookResponse: true });
+		});
+	});
+
+	describe('form-resume redirect to form-waiting', () => {
+		const buildExecution = (opts: { nodeType: string; nodeParameters?: INodeParameters }) =>
+			mock<IExecutionResponse>({
+				status: 'waiting',
+				finished: false,
+				data: {
+					resumeToken: undefined,
+					executionData: {
+						nodeExecutionStack: [
+							{
+								node: {
+									id: 'resume-node-id',
+									name: 'ResumeNode',
+									type: opts.nodeType,
+									parameters: opts.nodeParameters ?? {},
+									typeVersion: 1,
+									position: [0, 0],
+									disabled: false,
+								},
+								data: {},
+								source: null,
+							},
+						],
+					},
+					resultData: {
+						lastNodeExecuted: 'ResumeNode',
+						runData: {
+							ResumeNode: [{ startTime: 0, executionTime: 0, executionIndex: 0, source: [] }],
+						},
+						error: undefined,
+					},
+				},
+				workflowData: {
+					id: 'workflow1',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							id: 'resume-node-id',
+							name: 'ResumeNode',
+							type: opts.nodeType,
+							parameters: opts.nodeParameters ?? {},
+							typeVersion: 1,
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: true,
+					settings: {},
+					staticData: {},
+				},
+			});
+
+		const buildRes = () =>
+			mock<express.Response>({
+				redirect: vi.fn(),
+				status: vi.fn().mockReturnThis(),
+				json: vi.fn(),
+				render: vi.fn(),
+			});
+
+		it('redirects a Wait node resuming on form submission', async () => {
+			executionPersistence.findSingleExecution.mockResolvedValue(
+				buildExecution({ nodeType: 'n8n-nodes-base.wait', nodeParameters: { resume: 'form' } }),
+			);
+			const res = buildRes();
+			const req = mock<WaitingWebhookRequest>({
+				params: { path: 'exec-id', suffix: undefined },
+				method: 'GET',
+				originalUrl: '/webhook-waiting/exec-id?signature=abc',
+			});
+
+			const result = await waitingWebhooks.executeWebhook(req, res);
+
+			expect(res.redirect).toHaveBeenCalledWith(307, '/form-waiting/exec-id?signature=abc');
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('redirects a Form node', async () => {
+			executionPersistence.findSingleExecution.mockResolvedValue(
+				buildExecution({ nodeType: 'n8n-nodes-base.form' }),
+			);
+			const res = buildRes();
+			const req = mock<WaitingWebhookRequest>({
+				params: { path: 'exec-id', suffix: 'my-suffix' },
+				method: 'POST',
+				originalUrl: '/webhook-waiting/exec-id/my-suffix?signature=abc',
+			});
+
+			const result = await waitingWebhooks.executeWebhook(req, res);
+
+			expect(res.redirect).toHaveBeenCalledWith(
+				307,
+				'/form-waiting/exec-id/my-suffix?signature=abc',
+			);
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('does not redirect a Wait node resuming on webhook call', async () => {
+			executionPersistence.findSingleExecution.mockResolvedValue(
+				buildExecution({ nodeType: 'n8n-nodes-base.wait', nodeParameters: { resume: 'webhook' } }),
+			);
+			mockWebhookService.getNodeWebhooks.mockReturnValue([
+				{
+					httpMethod: 'GET',
+					path: '',
+					webhookDescription: {
+						restartWebhook: true,
+						httpMethod: 'GET',
+						name: 'default',
+						path: '',
+						nodeType: undefined,
+					} as any,
+				},
+			] as any);
+			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue({} as any);
+			vi.spyOn(WebhookHelpers, 'executeWebhook').mockImplementation(
+				async (_w, _wd, _wfd, _wsn, _m, _pr, _red, _eid, _req, _res, callback) => {
+					callback(null, { noWebhookResponse: true });
+					return undefined;
+				},
+			);
+			const res = buildRes();
+			const req = mock<WaitingWebhookRequest>({
+				params: { path: 'exec-id', suffix: undefined },
+				method: 'GET',
+				originalUrl: '/webhook-waiting/exec-id?signature=abc',
+			});
+
+			await waitingWebhooks.executeWebhook(req, res);
+
+			expect(res.redirect).not.toHaveBeenCalled();
 		});
 	});
 
@@ -1355,6 +1495,29 @@ describe('WaitingWebhooks', () => {
 			const result = await waitingWebhooks.executeWebhook(mockReq, createMockRes());
 
 			expect(result).toEqual({ noWebhookResponse: true });
+			expect(mockEventService.emit).not.toHaveBeenCalledWith(
+				'execution-resumed',
+				expect.anything(),
+			);
+		});
+
+		it('should not emit for form-resume execution (redirected, not resumed here)', async () => {
+			executionPersistence.findSingleExecution.mockResolvedValue(
+				createMockExecution({
+					nodeType: 'n8n-nodes-base.wait',
+					nodeName: 'WaitNode',
+					nodeId: 'node-id',
+					nodeParameters: { resume: 'form' },
+				}),
+			);
+
+			const mockReq = mock<WaitingWebhookRequest>({
+				params: { path: 'test-execution-id', suffix: undefined },
+				method: 'GET',
+				originalUrl: '/webhook-waiting/test-execution-id?signature=abc',
+			});
+			await waitingWebhooks.executeWebhook(mockReq, createMockRes());
+
 			expect(mockEventService.emit).not.toHaveBeenCalledWith(
 				'execution-resumed',
 				expect.anything(),

--- a/packages/cli/src/webhooks/waiting-forms.ts
+++ b/packages/cli/src/webhooks/waiting-forms.ts
@@ -3,12 +3,7 @@ import { Service } from '@n8n/di';
 import type express from 'express';
 import { getHtmlSandboxCSP, isFormHtmlSandboxingDisabled } from 'n8n-core';
 import type { IRunData } from 'n8n-workflow';
-import {
-	FORM_NODE_TYPE,
-	WAIT_NODE_TYPE,
-	WAITING_FORMS_EXECUTION_STATUS,
-	Workflow,
-} from 'n8n-workflow';
+import { FORM_NODE_TYPE, WAITING_FORMS_EXECUTION_STATUS, Workflow } from 'n8n-workflow';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -166,13 +161,8 @@ export class WaitingForms extends WaitingWebhooks {
 		let status: string = execution?.status ?? 'null';
 		const { node } = execution?.data.executionData?.nodeExecutionStack[0] ?? {};
 
-		if (node && status === 'waiting') {
-			if (node.type === FORM_NODE_TYPE) {
-				status = 'form-waiting';
-			}
-			if (node.type === WAIT_NODE_TYPE && node.parameters.resume === 'form') {
-				status = 'form-waiting';
-			}
+		if (node && status === 'waiting' && this.isFormResumeNode(node)) {
+			status = 'form-waiting';
 		}
 
 		applyCors(req, res);

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -1,14 +1,17 @@
 import { Logger } from '@n8n/backend-common';
+import { EndpointsConfig } from '@n8n/config';
 import type { IExecutionResponse } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { timingSafeEqual } from 'crypto';
 import type express from 'express';
 import { InstanceSettings, WAITING_TOKEN_QUERY_PARAM, validateUrlSignature } from 'n8n-core';
 import {
+	FORM_NODE_TYPE,
 	type INodes,
 	type IWorkflowBase,
 	NodeConnectionTypes,
 	SEND_AND_WAIT_OPERATION,
+	WAIT_NODE_TYPE,
 	Workflow,
 } from 'n8n-workflow';
 
@@ -48,6 +51,7 @@ export class WaitingWebhooks implements IWebhookManager {
 		private readonly webhookService: WebhookService,
 		protected readonly instanceSettings: InstanceSettings,
 		private readonly eventService: EventService,
+		private readonly endpointsConfig: EndpointsConfig,
 	) {}
 
 	// TODO: implement `getWebhookMethods` for CORS support
@@ -76,6 +80,43 @@ export class WaitingWebhooks implements IWebhookManager {
 					nodes[node].id === suffix && nodes[node].parameters.operation === SEND_AND_WAIT_OPERATION,
 			)
 		);
+	}
+
+	/**
+	 * A resume node that continues on form submission is served by the
+	 * `form-waiting` endpoint, not `webhook-waiting`. Users frequently reach for
+	 * `$execution.resumeUrl` (webhook-waiting) instead of `$execution.resumeFormUrl`,
+	 * which resolves to the wrong endpoint for these nodes.
+	 */
+	private isFormResumeExecution(execution: IExecutionResponse): boolean {
+		const lastNodeExecuted = execution.data.resultData?.lastNodeExecuted;
+		if (!lastNodeExecuted) {
+			return false;
+		}
+
+		const node = execution.workflowData?.nodes?.find((n) => n.name === lastNodeExecuted);
+		if (!node) {
+			return false;
+		}
+
+		return (
+			node.type === FORM_NODE_TYPE ||
+			(node.type === WAIT_NODE_TYPE && node.parameters.resume === 'form')
+		);
+	}
+
+	/**
+	 * Redirects a form-resume request that landed on `webhook-waiting` to the
+	 * equivalent `form-waiting` URL (preserving suffix and query params), so the
+	 * form renders and submits against the endpoint that actually serves it.
+	 * Uses 307 to preserve the request method for direct submissions.
+	 */
+	private redirectToFormWaiting(req: WaitingWebhookRequest, res: express.Response) {
+		const location = req.originalUrl.replace(
+			`/${this.endpointsConfig.webhookWaiting}/`,
+			`/${this.endpointsConfig.formWaiting}/`,
+		);
+		res.redirect(307, location);
 	}
 
 	// TODO: fix the type here - it should be execution workflowData
@@ -216,6 +257,11 @@ export class WaitingWebhooks implements IWebhookManager {
 
 		if (!execution) {
 			throw new NotFoundError(`The execution "${executionId}" does not exist.`);
+		}
+
+		if (!this.includeForms && this.isFormResumeExecution(execution)) {
+			this.redirectToFormWaiting(req, res);
+			return { noWebhookResponse: true };
 		}
 
 		if (execution.status === 'running') {

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -7,6 +7,7 @@ import type express from 'express';
 import { InstanceSettings, WAITING_TOKEN_QUERY_PARAM, validateUrlSignature } from 'n8n-core';
 import {
 	FORM_NODE_TYPE,
+	type INode,
 	type INodes,
 	type IWorkflowBase,
 	NodeConnectionTypes,
@@ -83,6 +84,17 @@ export class WaitingWebhooks implements IWebhookManager {
 	}
 
 	/**
+	 * Whether a node continues execution on form submission, and is therefore
+	 * served by the `form-waiting` endpoint rather than `webhook-waiting`.
+	 */
+	protected isFormResumeNode(node: Pick<INode, 'type' | 'parameters'>): boolean {
+		return (
+			node.type === FORM_NODE_TYPE ||
+			(node.type === WAIT_NODE_TYPE && node.parameters.resume === 'form')
+		);
+	}
+
+	/**
 	 * A resume node that continues on form submission is served by the
 	 * `form-waiting` endpoint, not `webhook-waiting`. Users frequently reach for
 	 * `$execution.resumeUrl` (webhook-waiting) instead of `$execution.resumeFormUrl`,
@@ -99,10 +111,7 @@ export class WaitingWebhooks implements IWebhookManager {
 			return false;
 		}
 
-		return (
-			node.type === FORM_NODE_TYPE ||
-			(node.type === WAIT_NODE_TYPE && node.parameters.resume === 'form')
-		);
+		return this.isFormResumeNode(node);
 	}
 
 	/**
@@ -110,13 +119,22 @@ export class WaitingWebhooks implements IWebhookManager {
 	 * equivalent `form-waiting` URL (preserving suffix and query params), so the
 	 * form renders and submits against the endpoint that actually serves it.
 	 * Uses 307 to preserve the request method for direct submissions.
+	 *
+	 * Returns `false` without redirecting when the rewritten URL is unchanged,
+	 * which happens if the two endpoints are configured identically (e.g. a
+	 * custom `N8N_ENDPOINT_WEBHOOK_WAIT` equal to the form-waiting endpoint).
+	 * Redirecting in that case would loop back to this same handler forever.
 	 */
-	private redirectToFormWaiting(req: WaitingWebhookRequest, res: express.Response) {
+	private redirectToFormWaiting(req: WaitingWebhookRequest, res: express.Response): boolean {
 		const location = req.originalUrl.replace(
 			`/${this.endpointsConfig.webhookWaiting}/`,
 			`/${this.endpointsConfig.formWaiting}/`,
 		);
+		if (location === req.originalUrl) {
+			return false;
+		}
 		res.redirect(307, location);
+		return true;
 	}
 
 	// TODO: fix the type here - it should be execution workflowData
@@ -259,8 +277,11 @@ export class WaitingWebhooks implements IWebhookManager {
 			throw new NotFoundError(`The execution "${executionId}" does not exist.`);
 		}
 
-		if (!this.includeForms && this.isFormResumeExecution(execution)) {
-			this.redirectToFormWaiting(req, res);
+		if (
+			!this.includeForms &&
+			this.isFormResumeExecution(execution) &&
+			this.redirectToFormWaiting(req, res)
+		) {
 			return { noWebhookResponse: true };
 		}
 

--- a/packages/testing/playwright/services/webhook-api-helper.ts
+++ b/packages/testing/playwright/services/webhook-api-helper.ts
@@ -12,6 +12,8 @@ interface TriggerOptions {
 	maxNotFoundRetries?: number;
 	/** Delay between 404 retries in ms. Default: 250 */
 	notFoundRetryDelayMs?: number;
+	/** Max redirects to follow. Set to 0 to observe a redirect response directly. */
+	maxRedirects?: number;
 }
 
 /** Triggers webhooks with retry for 404s (async registration) and connection errors. */
@@ -29,6 +31,7 @@ export class WebhookApiHelper {
 				method: options?.method ?? 'GET',
 				headers: options?.headers,
 				data: options?.data,
+				maxRedirects: options?.maxRedirects,
 				maxRetries: 3, // Playwright retry for connection errors
 			});
 

--- a/packages/testing/playwright/tests/e2e/api/wait-form-resume.spec.ts
+++ b/packages/testing/playwright/tests/e2e/api/wait-form-resume.spec.ts
@@ -61,6 +61,53 @@ test.describe(
 			});
 		});
 
+		test.describe('resume url endpoint redirect', () => {
+			test('should redirect a form-resume request from webhook-waiting to form-waiting', async ({
+				api,
+			}) => {
+				const { webhookPath, workflowId } =
+					await api.workflows.importWorkflowFromFile('wait-form-resume.json');
+
+				// Trigger workflow via webhook to reach waiting state
+				const triggerResponse = await api.webhooks.trigger(`/webhook/${webhookPath}`, {
+					method: 'POST',
+				});
+				expect(triggerResponse.ok()).toBe(true);
+
+				const execution = await api.workflows.waitForWorkflowStatus(workflowId, 'waiting');
+				expect(execution).toBeDefined();
+
+				// Read the signed form-waiting URL captured by the Set node
+				const fullExecution = await api.workflows.getExecution(execution.id);
+				const executionData = flatted.parse(fullExecution.data);
+				const formUrl = executionData.resultData.runData['Capture Form URL'][0].data.main[0][0].json
+					.formUrl as string;
+
+				// Simulate a user who used `$execution.resumeUrl` (webhook-waiting) instead of
+				// `$execution.resumeFormUrl`. Both carry the same opaque resume token, so
+				// rewriting the endpoint segment yields a valid webhook-waiting resume URL.
+				const webhookWaitingUrl = formUrl.replace('/form-waiting/', '/webhook-waiting/');
+				expect(webhookWaitingUrl).toContain('/webhook-waiting/');
+				const { pathname, search } = new URL(webhookWaitingUrl);
+				const resumePath = `${pathname}${search}`;
+
+				// Without following the redirect, the request is answered with a 307 to form-waiting
+				const redirectResponse = await api.webhooks.trigger(resumePath, {
+					maxRedirects: 0,
+					maxNotFoundRetries: 0,
+				});
+				expect(redirectResponse.status()).toBe(307);
+				const location = redirectResponse.headers().location;
+				expect(location).toContain('/form-waiting/');
+				expect(location).not.toContain('/webhook-waiting/');
+
+				// Following the redirect renders the form served by form-waiting
+				const formResponse = await api.webhooks.trigger(resumePath, { maxNotFoundRetries: 0 });
+				expect(formResponse.ok()).toBe(true);
+				expect(await formResponse.text()).toContain('Test Form');
+			});
+		});
+
 		test.describe('manual execution form popup', () => {
 			test('should open form when Wait node enters waiting state', async ({ n8n }) => {
 				await n8n.start.fromBlankCanvas();


### PR DESCRIPTION
## Summary

A Wait node set to **"On Form Submitted"** is served by the `form-waiting` endpoint, but users commonly send `{{ $execution.resumeUrl }}` (which points at `webhook-waiting`).

In manual/test mode the editor auto-opens the form via `resumeFormUrl`, so it works.
In production the `resumeUrl` link renders the form but the submit POST hits `webhook-waiting`, which has no matching form webhook → **404**.

This redirects (307) any form-resume request landing on `webhook-waiting` to the equivalent `form-waiting` URL, so the form renders and submits against the endpoint that serves it.

## How to test

1. Import the workflow below and **activate it** (the bug only shows in production, not test mode).
2. Call the production webhook URL (`.../webhook/repro-cat-3792`). The response returns the `resumeUrl`.
3. Open that URL, submit the form.
   - **Before:** POST to `/webhook-waiting/...` → 404.
   - **After:** 307 redirect to `/form-waiting/...` → submission succeeds.

<details>
<summary>Repro workflow JSON</summary>

```json
{
  "name": "Repro CAT-3792",
  "nodes": [
    {
      "parameters": { "httpMethod": "GET", "path": "repro-cat-3792", "responseMode": "responseNode", "options": {} },
      "id": "11111111-1111-1111-1111-111111111111",
      "name": "Webhook",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 2,
      "position": [0, 0],
      "webhookId": "repro-cat-3792"
    },
    {
      "parameters": { "respondWith": "text", "responseBody": "={{ $execution.resumeUrl }}", "options": {} },
      "id": "22222222-2222-2222-2222-222222222222",
      "name": "Respond with resumeUrl",
      "type": "n8n-nodes-base.respondToWebhook",
      "typeVersion": 1.1,
      "position": [220, 0]
    },
    {
      "parameters": {
        "resume": "form",
        "formTitle": "Repro form",
        "formFields": { "values": [{ "fieldLabel": "Your name", "fieldType": "text" }] },
        "options": {}
      },
      "id": "33333333-3333-3333-3333-333333333333",
      "name": "Wait (On Form Submitted)",
      "type": "n8n-nodes-base.wait",
      "typeVersion": 1.1,
      "position": [440, 0]
    }
  ],
  "connections": {
    "Webhook": { "main": [[{ "node": "Respond with resumeUrl", "type": "main", "index": 0 }]] },
    "Respond with resumeUrl": { "main": [[{ "node": "Wait (On Form Submitted)", "type": "main", "index": 0 }]] }
  },
  "settings": {},
  "active": false
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3792
- closes #34515

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34725">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

