### PR TITLE
fix(editor): Manage and other permissions checkboxs stuck in half-selected state during member selection

### DIFF
--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -110,6 +110,7 @@ export const API_KEY_RESOURCES = {
 } as const;
 
 export const GLOBAL_OWNER_ROLE_SLUG = 'global:owner';
+export const GLOBAL_ADMIN_ROLE_SLUG = 'global:admin';
 export const GLOBAL_CHAT_USER_ROLE_SLUG = 'global:chatUser';
 export const PROJECT_OWNER_ROLE_SLUG = 'project:personalOwner';
 export const PROJECT_ADMIN_ROLE_SLUG = 'project:admin';

--- a/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.vue
@@ -6,6 +6,7 @@ import { MODAL_CONFIRM, VIEWS } from '@/app/constants';
 import { useRolesStore } from '@/app/stores/roles.store';
 import { N8nButton, N8nHeading, N8nTabs, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
+import { GLOBAL_ADMIN_ROLE_SLUG } from '@n8n/permissions';
 import { computed, toRaw } from 'vue';
 import { useRouter } from 'vue-router';
 
@@ -58,8 +59,14 @@ const editorLabels = computed<RoleEditorLabels>(() => ({
 	create: i18n.baseText('projectRoles.create'),
 }));
 
-// System roles populate the preset buttons (clicking copies their scopes).
-const presetRoles = computed(() => rolesStore.processedInstanceRoles.filter((r) => r.systemRole));
+// Only the Admin system role is offered as a preset (clicking copies its scopes).
+// Member and Chat User presets were removed since their scopes are too limited
+// to be useful starting points for a custom role.
+const presetRoles = computed(() =>
+	rolesStore.processedInstanceRoles.filter(
+		(r) => r.systemRole && r.slug === GLOBAL_ADMIN_ROLE_SLUG,
+	),
+);
 
 function onBackClick() {
 	void router.push({ name: VIEWS.ROLES_SETTINGS, query: { tab: 'instance' } });

--- a/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.vue
@@ -60,8 +60,6 @@ const editorLabels = computed<RoleEditorLabels>(() => ({
 }));
 
 // Only the Admin system role is offered as a preset (clicking copies its scopes).
-// Member and Chat User presets were removed since their scopes are too limited
-// to be useful starting points for a custom role.
 const presetRoles = computed(() =>
 	rolesStore.processedInstanceRoles.filter(
 		(r) => r.systemRole && r.slug === GLOBAL_ADMIN_ROLE_SLUG,


### PR DESCRIPTION
## Summary

Custom instance role editor offered "Member" and "Chat User" as preset
buttons alongside "Admin". Clicking them copied a partial subset of scopes
onto the form, which left several checkboxes (e.g. "Manage") stuck in an
indeterminate/half-selected state — since those roles don't grant the full
scope group for options like tags, variables, or users.

This PR removes the Member and Chat User presets from the custom instance
role editor, leaving only Admin, whose scopes fully resolve every option
group and never leaves checkboxes half-selected.

## How to test

1. Go to **Settings → Roles → Instance roles** and click **Add role**.
2. Confirm only the **Admin** preset button is shown (no **Member** or **Chat User** buttons).
3. Click **Admin** and confirm all applicable scope checkboxes resolve to a fully checked (not indeterminate) state.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-960

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

