### PR TITLE
refactor(editor): Unify decoupled stores on a shared ModalOpeners contract (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -654,6 +654,16 @@ export type Modals = {
 
 export type ModalKey = keyof Modals;
 
+/**
+ * The modal-opening capability. Stores that need to open modals depend on this
+ * pair (mirroring `ui.store`'s surface) and receive it via dependency injection,
+ * rather than importing `ui.store` directly. A consumer may use only a subset.
+ */
+export interface ModalOpeners {
+	openModal: (name: ModalKey) => void;
+	openModalWithData: (payload: { name: ModalKey; data: Record<string, unknown> }) => void;
+}
+
 // `ModalState` is owned by `@n8n/frontend-module-sdk`; re-exported here so existing
 // `@/Interface` importers stay unchanged.
 export type { ModalState };

--- a/packages/frontend/editor-ui/src/app/init.test.ts
+++ b/packages/frontend/editor-ui/src/app/init.test.ts
@@ -34,7 +34,7 @@ vi.mock('@/features/settings/users/users.store', () => ({
 		initialize: vi.fn(),
 		registerLoginHook: vi.fn(),
 		registerLogoutHook: vi.fn(),
-		registerModalOpener: vi.fn(),
+		registerModalOpeners: vi.fn(),
 		setUserQuota: vi.fn(),
 	}),
 }));
@@ -250,7 +250,7 @@ describe('Init', () => {
 			expect(versionsSpy).toHaveBeenCalled();
 			expect(usersStore.setUserQuota).toHaveBeenCalled();
 			// Modal openers are provided to the decoupled stores at bootstrap.
-			expect(usersStore.registerModalOpener).toHaveBeenCalled();
+			expect(usersStore.registerModalOpeners).toHaveBeenCalled();
 			expect(versionsStore.registerModalOpeners).toHaveBeenCalled();
 
 			await initializeAuthenticatedFeatures();

--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -126,11 +126,12 @@ export async function initializeAuthenticatedFeatures(
 
 	// Provide the modal-open actions to the stores that were decoupled from `ui.store`,
 	// so they can open modals without importing it.
-	usersStore.registerModalOpener(uiStore.openModal);
-	versionsStore.registerModalOpeners({
+	const modalOpeners = {
 		openModal: uiStore.openModal,
 		openModalWithData: uiStore.openModalWithData,
-	});
+	};
+	usersStore.registerModalOpeners(modalOpeners);
+	versionsStore.registerModalOpeners(modalOpeners);
 
 	if (!settingsStore.isPreviewMode) {
 		usersStore.setUserQuota(settingsStore.userManagement.quota);

--- a/packages/frontend/editor-ui/src/app/stores/versions.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/versions.store.test.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { useVersionsStore, type VersionsModalOpeners } from './versions.store';
+import { useVersionsStore } from './versions.store';
+import type { ModalOpeners } from '@/Interface';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import * as versionsApi from '@n8n/rest-api-client/api/versions';
 import type { IVersionNotificationSettings } from '@n8n/api-types';
@@ -74,8 +75,8 @@ const toast = useToast();
 
 // Recreated per test (see beforeEach) so call history never leaks between tests —
 // vi.restoreAllMocks() resets spies from vi.spyOn but not standalone vi.fn()s.
-let openModal: VersionsModalOpeners['openModal'];
-let openModalWithData: VersionsModalOpeners['openModalWithData'];
+let openModal: ModalOpeners['openModal'];
+let openModalWithData: ModalOpeners['openModalWithData'];
 
 describe('versions.store', () => {
 	beforeEach(() => {

--- a/packages/frontend/editor-ui/src/app/stores/versions.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/versions.store.ts
@@ -12,7 +12,7 @@ import { defineStore } from 'pinia';
 import type { NotificationHandle } from 'element-plus';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useToast } from '@/app/composables/useToast';
-import type { ModalKey } from '@/Interface';
+import type { ModalOpeners } from '@/Interface';
 import { computed, ref } from 'vue';
 import { useSettingsStore } from './settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
@@ -21,16 +21,6 @@ import { jsonParse } from 'n8n-workflow';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 
 type SetVersionParams = { versions: Version[]; currentVersion: string };
-
-/**
- * Modal-open actions this store needs. The concrete implementation lives in
- * `ui.store`; it is registered at app bootstrap via {@link useVersionsStore.registerModalOpeners}
- * so the store carries no dependency on `ui.store`.
- */
-export interface VersionsModalOpeners {
-	openModal: (name: ModalKey) => void;
-	openModalWithData: (payload: { name: ModalKey; data: Record<string, unknown> }) => void;
-}
 
 /**
  * Semantic versioning 2.0.0, Regex from https://semver.org/
@@ -73,12 +63,12 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 			);
 		}
 	};
-	const modalOpeners = ref<VersionsModalOpeners>({
+	const modalOpeners = ref<ModalOpeners>({
 		openModal: (name) => warnModalOpenerMissing(`openModal(${String(name)})`),
 		openModalWithData: (payload) =>
 			warnModalOpenerMissing(`openModalWithData(${String(payload.name)})`),
 	});
-	const registerModalOpeners = (openers: VersionsModalOpeners) => {
+	const registerModalOpeners = (openers: ModalOpeners) => {
 		modalOpeners.value = openers;
 	};
 	const readWhatsNewArticlesStorage = useStorage(LOCAL_STORAGE_READ_WHATS_NEW_ARTICLES);

--- a/packages/frontend/editor-ui/src/features/settings/users/users.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/users.store.test.ts
@@ -233,7 +233,7 @@ describe('users.store', () => {
 			setCurrentUser(usersStore);
 
 			const openModal = vi.fn();
-			usersStore.registerModalOpener(openModal);
+			usersStore.registerModalOpeners({ openModal, openModalWithData: vi.fn() });
 
 			await usersStore.showPersonalizationSurvey();
 
@@ -245,7 +245,7 @@ describe('users.store', () => {
 			setCurrentUser(usersStore);
 
 			const openModal = vi.fn();
-			usersStore.registerModalOpener(openModal);
+			usersStore.registerModalOpeners({ openModal, openModalWithData: vi.fn() });
 
 			await usersStore.showPersonalizationSurvey();
 
@@ -257,7 +257,7 @@ describe('users.store', () => {
 			enableSurvey();
 			setCurrentUser(usersStore);
 
-			// No registerModalOpener() — the default no-op opener must not break the flow.
+			// No registerModalOpeners() — the default no-op opener must not break the flow.
 			await expect(usersStore.showPersonalizationSurvey()).resolves.toBeUndefined();
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/settings/users/users.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/users.store.ts
@@ -24,7 +24,7 @@ import type {
 import { getPersonalizedNodeTypes } from './users.utils';
 import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import type { ModalKey } from '@/Interface';
+import type { ModalOpeners } from '@/Interface';
 import * as mfaApi from '@n8n/rest-api-client/api/mfa';
 import * as cloudApi from '@n8n/rest-api-client/api/cloudPlans';
 import * as invitationsApi from './invitation.api';
@@ -42,9 +42,6 @@ const _isAdmin = (user: IUserResponse | null) => user?.role === ROLE.Admin;
 export type LoginHook = (user: CurrentUserResponse) => void | Promise<void>;
 type LogoutHook = () => void | Promise<void>;
 
-/** Modal-open action this store needs, registered at app bootstrap (see app/init.ts). */
-export type OpenModalFn = (name: ModalKey) => void;
-
 export const useUsersStore = defineStore(STORES.USERS, () => {
 	const initialized = ref(false);
 	const currentUserId = ref<string | null>(null);
@@ -54,17 +51,24 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 	const loginHooks = ref<LoginHook[]>([]);
 	const logoutHooks = ref<LogoutHook[]>([]);
 
-	// Modal-open action, registered at app bootstrap (see app/init.ts). Until then it
-	// no-ops — warning in dev — so the store never reaches into `ui.store`.
-	const openModal = ref<OpenModalFn>((name) => {
+	// Modal-open actions, registered at app bootstrap (see app/init.ts). Until then
+	// they no-op — warning in dev — so the store never reaches into `ui.store`. Shares
+	// the `ModalOpeners` contract with the other decoupled stores; this store currently
+	// uses only `openModal`.
+	const warnModalOpenerMissing = (action: string) => {
 		if (import.meta.env.DEV) {
 			console.warn(
-				`[users.store] openModal(${String(name)}) called before a modal opener was registered; ignoring. Call registerModalOpener() at app bootstrap.`,
+				`[users.store] ${action} called before modal openers were registered; ignoring. Call registerModalOpeners() at app bootstrap.`,
 			);
 		}
+	};
+	const modalOpeners = ref<ModalOpeners>({
+		openModal: (name) => warnModalOpenerMissing(`openModal(${String(name)})`),
+		openModalWithData: (payload) =>
+			warnModalOpenerMissing(`openModalWithData(${String(payload.name)})`),
 	});
-	const registerModalOpener = (opener: OpenModalFn) => {
-		openModal.value = opener;
+	const registerModalOpeners = (openers: ModalOpeners) => {
+		modalOpeners.value = openers;
 	};
 
 	// Stores
@@ -389,7 +393,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 	const showPersonalizationSurvey = async () => {
 		const surveyEnabled = settingsStore.isPersonalizationSurveyEnabled;
 		if (surveyEnabled && currentUser.value && !currentUser.value.personalizationAnswers) {
-			openModal.value(PERSONALIZATION_MODAL_KEY);
+			modalOpeners.value.openModal(PERSONALIZATION_MODAL_KEY);
 		}
 	};
 
@@ -488,7 +492,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		logout,
 		registerLoginHook,
 		registerLogoutHook,
-		registerModalOpener,
+		registerModalOpeners,
 		createOwner,
 		validateSignupToken,
 		acceptInvitation,


### PR DESCRIPTION
## Summary

Follow-up to #34639 (merged). Unifies the two decoupled stores on a single shared modal-opener contract.

Before, `versions.store` took a `{ openModal, openModalWithData }` bag while `users.store` took a narrower single `openModal` function. This unifies both on a shared `ModalOpeners` interface, registered via `registerModalOpeners`.

- Adds `ModalOpeners` to `@/Interface`, next to `ModalKey`.
- `users.store`: `registerModalOpener(fn)` → `registerModalOpeners(bag)`. It uses only `openModal` today but shares the contract.
- `versions.store`: drops its local `VersionsModalOpeners` for the shared type.
- `app/init.ts`: registers one opener bag with both stores.

**Why now:** this surface goes `@n8n/stores`-public after N8N-69/70, and public signatures are expensive to change afterwards. Settling the shape pre-move means a future `openModalWithData` use in `users.store` is a zero-API-change internal edit rather than a breaking signature widening (or a bolted-on second register method). The one cost — `users.store` accepting an opener it doesn't yet call — is documented on the shared type as a capability a consumer may use a subset of.

No behaviour change.

## How to test

Refactor only — behaviour unchanged. Verify:

1. `cd packages/frontend/editor-ui && pnpm test src/app/stores/versions.store.test.ts src/features/settings/users/users.store.test.ts src/app/init.test.ts` — 62 tests pass. `pnpm typecheck` and `pnpm lint` clean.
2. In the app, the three modal paths still open: version-update toast → versions modal; what's-new callout → what's new modal; personalization survey for a first-time eligible user.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-79

Follow-up to #34639.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- N/A — internal refactor, no user-facing change. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34727">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

