### PR TITLE
fix(HTTP Request Node): Include error body in continueOnFail mode

### DIFF
--- a/packages/@n8n/agents/src/runtime/tools/tool-call-executor.ts
+++ b/packages/@n8n/agents/src/runtime/tools/tool-call-executor.ts
@@ -1,10 +1,10 @@
+import { toJsonValue } from '@n8n/utils/json/to-json-value';
 import { zodToJsonSchema, type JsonSchema7Type } from 'zod-to-json-schema';
 
 import {
 	getInlineDelegateSubAgentToolOptions,
 	isDelegateSubAgentTool,
 } from './delegate-sub-agent-tool';
-import { toJsonValue } from '../json-value';
 import { DEFAULT_SUB_AGENT_MAX_CHILDREN } from './sub-agent-task-path';
 import { executeTool, isSuspendedToolResult, type SuspendedToolResult } from './tool-adapter';
 import { isAbortError, raceWithAbort } from '../../sdk/abort';

--- a/packages/@n8n/utils/src/json/to-json-value.test.ts
+++ b/packages/@n8n/utils/src/json/to-json-value.test.ts
@@ -1,0 +1,165 @@
+import { toJsonValue } from './to-json-value';
+
+describe('toJsonValue', () => {
+	describe('primitives', () => {
+		it.each([
+			['null', null, null],
+			['a string', 'hello', 'hello'],
+			['an empty string', '', ''],
+			['true', true, true],
+			['false', false, false],
+			['an integer', 42, 42],
+			['a float', 3.14, 3.14],
+			['zero', 0, 0],
+			['negative zero', -0, -0],
+		])('returns %s as-is', (_label, input, expected) => {
+			expect(toJsonValue(input)).toBe(expected);
+		});
+	});
+
+	describe('non-finite numbers', () => {
+		it.each([
+			['NaN', NaN],
+			['Infinity', Infinity],
+			['-Infinity', -Infinity],
+		])('returns null for %s', (_label, input) => {
+			expect(toJsonValue(input)).toBeNull();
+		});
+	});
+
+	describe('non-JSON types', () => {
+		it.each([
+			['undefined', undefined],
+			['a function', () => {}],
+			['a symbol', Symbol('test')],
+		])('returns null for %s', (_label, input) => {
+			expect(toJsonValue(input)).toBeNull();
+		});
+	});
+
+	it('converts bigint to string', () => {
+		expect(toJsonValue(BigInt(9007199254740991))).toBe('9007199254740991');
+	});
+
+	describe('Buffer', () => {
+		it('converts a Buffer to its string content', () => {
+			expect(toJsonValue(Buffer.from('hello'))).toBe('hello');
+		});
+
+		it('converts a Buffer containing JSON to its raw string (no parse)', () => {
+			const buf = Buffer.from('{"error":"Bad Request"}');
+			expect(toJsonValue(buf)).toBe('{"error":"Bad Request"}');
+		});
+
+		it('converts an empty Buffer to an empty string', () => {
+			expect(toJsonValue(Buffer.alloc(0))).toBe('');
+		});
+	});
+
+	describe('Date', () => {
+		it('converts a Date to ISO string', () => {
+			const date = new Date('2024-01-15T12:00:00.000Z');
+			expect(toJsonValue(date)).toBe('2024-01-15T12:00:00.000Z');
+		});
+	});
+
+	describe('Error', () => {
+		it('converts an Error to { name, message }', () => {
+			const error = new TypeError('something broke');
+			expect(toJsonValue(error)).toEqual({
+				name: 'TypeError',
+				message: 'something broke',
+			});
+		});
+	});
+
+	describe('arrays', () => {
+		it('converts a simple array', () => {
+			expect(toJsonValue([1, 'two', true, null])).toEqual([1, 'two', true, null]);
+		});
+
+		it('converts nested arrays', () => {
+			expect(toJsonValue([[1, 2], [3]])).toEqual([[1, 2], [3]]);
+		});
+
+		it('converts non-JSON items inside arrays to null', () => {
+			expect(toJsonValue([1, undefined, () => {}, 'ok'])).toEqual([1, null, null, 'ok']);
+		});
+
+		it('converts Buffers inside arrays', () => {
+			expect(toJsonValue([Buffer.from('a'), Buffer.from('b')])).toEqual(['a', 'b']);
+		});
+	});
+
+	describe('objects', () => {
+		it('converts a plain object', () => {
+			expect(toJsonValue({ a: 1, b: 'two' })).toEqual({ a: 1, b: 'two' });
+		});
+
+		it('converts nested objects', () => {
+			expect(toJsonValue({ a: { b: { c: 3 } } })).toEqual({ a: { b: { c: 3 } } });
+		});
+
+		it('converts non-JSON property values to null', () => {
+			expect(toJsonValue({ a: 1, fn: () => {}, b: undefined })).toEqual({
+				a: 1,
+				fn: null,
+				b: null,
+			});
+		});
+
+		it('converts Buffers inside objects', () => {
+			expect(toJsonValue({ data: Buffer.from('payload') })).toEqual({ data: 'payload' });
+		});
+	});
+
+	describe('circular references', () => {
+		it('replaces a self-referencing object with "[Circular]"', () => {
+			const obj: Record<string, unknown> = { a: 1 };
+			obj.self = obj;
+
+			expect(toJsonValue(obj)).toEqual({ a: 1, self: '[Circular]' });
+		});
+
+		it('replaces deep circular references', () => {
+			const a: Record<string, unknown> = {};
+			const b: Record<string, unknown> = { parent: a };
+			a.child = b;
+
+			expect(toJsonValue(a)).toEqual({
+				child: { parent: '[Circular]' },
+			});
+		});
+
+		it('does not flag shared (non-circular) references', () => {
+			const shared = { x: 1 };
+			const obj = { a: shared, b: shared };
+
+			expect(toJsonValue(obj)).toEqual({ a: { x: 1 }, b: { x: 1 } });
+		});
+	});
+
+	describe('mixed structures', () => {
+		it('handles a realistic HTTP error object', () => {
+			const error = {
+				statusCode: 400,
+				error: { message: 'Bad Request' },
+				response: {
+					data: Buffer.from('{"detail":"invalid"}'),
+					// eslint-disable-next-line @typescript-eslint/naming-convention
+					headers: { 'content-type': 'application/json' },
+				},
+			};
+
+			expect(toJsonValue(error)).toEqual({
+				statusCode: 400,
+				error: { message: 'Bad Request' },
+				response: {
+					data: '{"detail":"invalid"}',
+					// eslint-disable-next-line @typescript-eslint/naming-convention
+					headers: { 'content-type': 'application/json' },
+				},
+			});
+		});
+	});
+});

--- a/packages/@n8n/utils/src/json/to-json-value.test.ts
+++ b/packages/@n8n/utils/src/json/to-json-value.test.ts
@@ -111,6 +111,21 @@ describe('toJsonValue', () => {
 		it('converts Buffers inside objects', () => {
 			expect(toJsonValue({ data: Buffer.from('payload') })).toEqual({ data: 'payload' });
 		});
+
+		it('preserves a reserver __proto__ key as an own property', () => {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, n8n-local-rules/no-uncaught-json-parse
+			const input: Record<string, unknown> = JSON.parse('{"__proto__":{"inherited":"abc"}}');
+			const result = toJsonValue(input);
+
+			if (result === null || Array.isArray(result) || typeof result !== 'object') {
+				throw new Error('Expected an object');
+			}
+
+			expect(Object.hasOwn(result, '__proto__')).toBe(true);
+			expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+			expect(result.__proto__).toEqual({ inherited: 'abc' });
+			expect(result.inherited).toBeUndefined();
+		});
 	});
 
 	describe('circular references', () => {

--- a/packages/@n8n/utils/src/json/to-json-value.ts
+++ b/packages/@n8n/utils/src/json/to-json-value.ts
@@ -57,7 +57,12 @@ export function toJsonValue(value: unknown, seen = new WeakSet<object>()): JSONV
 		seen.add(value);
 		const result: JSONObject = {};
 		for (const [key, entryValue] of Object.entries(value)) {
-			result[key] = toJsonValue(entryValue, seen);
+			Object.defineProperty(result, key, {
+				value: toJsonValue(entryValue, seen),
+				enumerable: true,
+				writable: true,
+				configurable: true,
+			});
 		}
 		seen.delete(value);
 		return result;

--- a/packages/@n8n/utils/src/json/to-json-value.ts
+++ b/packages/@n8n/utils/src/json/to-json-value.ts
@@ -1,5 +1,18 @@
-import type { JSONObject, JSONValue } from '../types/utils/json';
+export type JSONValue = null | string | number | boolean | JSONObject | JSONArray;
 
+export type JSONObject = {
+	[key: string]: JSONValue | undefined;
+};
+
+export type JSONArray = JSONValue[];
+
+/**
+ * Recursively converts an arbitrary value into a JSON-safe representation.
+ *
+ * Handles `Buffer`, `Date`, `Error`, `bigint`, circular references, and
+ * non-finite numbers (`NaN`, `Infinity`). Values that have no JSON
+ * representation (`undefined`, functions, symbols) become `null`.
+ */
 export function toJsonValue(value: unknown, seen = new WeakSet<object>()): JSONValue {
 	if (value === null || typeof value === 'string' || typeof value === 'boolean') {
 		return value;
@@ -14,6 +27,10 @@ export function toJsonValue(value: unknown, seen = new WeakSet<object>()): JSONV
 	}
 
 	if (typeof value === 'bigint') {
+		return value.toString();
+	}
+
+	if (Buffer.isBuffer(value)) {
 		return value.toString();
 	}
 

--- a/packages/nodes-base/nodes/HttpRequest/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/HttpRequest.node.ts
@@ -31,6 +31,7 @@ export class HttpRequest extends VersionedNodeType {
 			4.2: new HttpRequestV3(baseDescription),
 			4.3: new HttpRequestV3(baseDescription),
 			4.4: new HttpRequestV3(baseDescription),
+			4.5: new HttpRequestV3(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/HttpRequest/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/HttpRequest.node.ts
@@ -15,7 +15,7 @@ export class HttpRequest extends VersionedNodeType {
 			group: ['output'],
 			subtitle: '={{$parameter["requestMethod"] + ": " + $parameter["url"]}}',
 			description: 'Makes an HTTP request and returns the response data',
-			defaultVersion: 4.4,
+			defaultVersion: 4.5,
 			builderHint: {
 				searchHint:
 					'Prefer dedicated integration nodes over HTTP Request — n8n has 400+ dedicated nodes (e.g. Gmail, Slack, Google Sheets, Notion, OpenAI, HubSpot, Jira, etc.) with built-in authentication, pre-configured parameters, better error handling, and easier maintenance. Only use HTTP Request when no dedicated node exists for the service, the user explicitly requests it, accessing a custom/internal API, or the dedicated node does not support the specific operation needed.',

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -73,7 +73,7 @@ export class HttpRequestV3 implements INodeType {
 		this.description = {
 			...baseDescription,
 			subtitle: '={{$parameter["method"] + ": " + $parameter["url"]}}',
-			version: [3, 4, 4.1, 4.2, 4.3, 4.4],
+			version: [3, 4, 4.1, 4.2, 4.3, 4.4, 4.5],
 			defaults: {
 				name: 'HTTP Request',
 				color: '#0004F5',
@@ -879,11 +879,15 @@ export class HttpRequestV3 implements INodeType {
 						returnItems.push({
 							json: {
 								error: responseData.reason,
-								details: createErrorDetails(
-									this.getNode(),
-									responseData.reason as JsonObject,
-									itemIndex,
-								),
+								...(nodeVersion >= 4.5
+									? {
+											details: createErrorDetails(
+												this.getNode(),
+												responseData.reason as JsonObject,
+												itemIndex,
+											),
+										}
+									: {}),
 							},
 							pairedItem: {
 								item: itemIndex,

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -49,6 +49,7 @@ import { mimeTypeFromResponse } from './utils/parse';
 import { configureResponseOptimizer } from '../shared/optimizeResponse';
 
 import { binaryToStringWithEncodingDetection } from './utils/buffer-decoding';
+import { createErrorDetails } from './utils/error-details';
 
 function toText<T>(data: T) {
 	if (typeof data === 'object' && data !== null) {
@@ -823,7 +824,7 @@ export class HttpRequestV3 implements INodeType {
 									secrets = getSecrets(credentials);
 								}
 								const sanitizedRequestOptions = sanitizeUiMessage(options, authKeys, secrets);
-								sanitizedRequests.push(sanitizedRequestOptions);
+								sanitizedRequests[itemIndex] = sanitizedRequestOptions;
 								this.sendMessageToUI(sanitizedRequestOptions);
 							} catch (e) {}
 						}),
@@ -878,6 +879,11 @@ export class HttpRequestV3 implements INodeType {
 						returnItems.push({
 							json: {
 								error: responseData.reason,
+								details: createErrorDetails(
+									this.getNode(),
+									responseData.reason as JsonObject,
+									itemIndex,
+								),
 							},
 							pairedItem: {
 								item: itemIndex,

--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/error-details.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/error-details.ts
@@ -1,0 +1,68 @@
+import { toJsonValue, type JSONValue } from '@n8n/utils/json/to-json-value';
+import { NodeApiError, LoggerProxy } from 'n8n-workflow';
+import type { IDataObject, INode, JsonObject } from 'n8n-workflow';
+
+/**
+ * Looks for body in the error object in the following order:
+ * 1. error.response.data
+ * 2. error.response.body
+ * 3. error.error - body is here, when legacy http handler is used
+ * 4. error.body
+ *
+ */
+function getResponseBody(error: JsonObject): unknown {
+	const response = error.response;
+	if (response !== null && typeof response === 'object' && !Array.isArray(response)) {
+		const responseData = response;
+		if (Object.hasOwn(responseData, 'data')) {
+			return responseData.data;
+		}
+		if (Object.hasOwn(responseData, 'body')) {
+			return responseData.body;
+		}
+	}
+
+	if (Object.hasOwn(error, 'error')) {
+		return error.error;
+	}
+	if (Object.hasOwn(error, 'body')) {
+		return error.body;
+	}
+
+	return undefined;
+}
+
+function parseErrorResponseBody(body: unknown): JSONValue {
+	const jsonSafeBody = toJsonValue(body);
+	if (typeof jsonSafeBody !== 'string') {
+		return jsonSafeBody;
+	}
+
+	try {
+		return toJsonValue(JSON.parse(jsonSafeBody));
+	} catch {
+		return jsonSafeBody;
+	}
+}
+
+export function createErrorDetails(
+	node: INode,
+	reason: JsonObject,
+	itemIndex: number,
+): IDataObject | null {
+	try {
+		const responseBody = parseErrorResponseBody(getResponseBody(reason));
+		const error = new NodeApiError(node, reason, { itemIndex });
+
+		return {
+			message: error.message,
+			...(error.description && { description: error.description }),
+			httpCode: error.httpCode,
+			body: responseBody,
+			context: error.context,
+		};
+	} catch (error) {
+		LoggerProxy.warn('Failed to parse error response body', { error });
+		return null;
+	}
+}

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -652,6 +652,12 @@ describe('HttpRequestV3', () => {
 	});
 
 	describe('Continued request errors', () => {
+		beforeEach(() => {
+			(executeFunctions.getNode as Mock).mockReturnValue({
+				typeVersion: 4.5,
+			});
+		});
+
 		it('should return null details if response parsing fails', () => {
 			const requestError: JsonObject = {};
 			Object.defineProperty(requestError, 'response', {

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -1,7 +1,13 @@
 import FormData from 'form-data';
-import type { IExecuteFunctions, INodeTypeBaseDescription } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	INodeTypeBaseDescription,
+	JsonObject,
+	JsonValue,
+} from 'n8n-workflow';
 
 import { HttpRequestV3 } from '../../V3/HttpRequestV3.node';
+import { createErrorDetails } from '../../V3/utils/error-details';
 import type { Mock } from 'vitest';
 
 describe('HttpRequestV3', () => {
@@ -642,6 +648,180 @@ describe('HttpRequestV3', () => {
 			const result = await node.execute.call(executeFunctions);
 
 			expect(result).toEqual([[{ json: {}, pairedItem: { item: 0 } }]]);
+		});
+	});
+
+	describe('Continued request errors', () => {
+		it('should return null details if response parsing fails', () => {
+			const requestError: JsonObject = {};
+			Object.defineProperty(requestError, 'response', {
+				get: () => {
+					throw new Error('Unable to read response');
+				},
+			});
+
+			expect(createErrorDetails(executeFunctions.getNode(), requestError, 0)).toBeNull();
+		});
+
+		it('should use the body from a legacy request error', () => {
+			const responseBody = { error: 'Bad Request' };
+			const requestError: JsonObject = {
+				statusCode: 400,
+				error: responseBody,
+				response: {
+					headers: { 'x-request-id': 'request-1' },
+					status: 400,
+				},
+			};
+
+			expect(createErrorDetails(executeFunctions.getNode(), requestError, 0)).toMatchObject({
+				httpCode: '400',
+				body: responseBody,
+				context: { itemIndex: 0 },
+			});
+		});
+
+		const errorResponseBodies: Array<{
+			name: string;
+			body: JsonValue | Buffer;
+			expectedBody: JsonValue;
+		}> = [
+			{
+				name: 'an object response body',
+				body: { error: 'Bad Request' },
+				expectedBody: { error: 'Bad Request' },
+			},
+			{
+				name: 'a JSON response body encoded as text',
+				body: '{"error":"Bad Request"}',
+				expectedBody: { error: 'Bad Request' },
+			},
+			{
+				name: 'a plain-text response body',
+				body: 'The supplied value is invalid',
+				expectedBody: 'The supplied value is invalid',
+			},
+			{
+				name: 'a Buffer-backed response body',
+				body: Buffer.from('{"error":"Bad Request"}'),
+				expectedBody: { error: 'Bad Request' },
+			},
+			{
+				name: 'a null response body',
+				body: null,
+				expectedBody: null,
+			},
+			{
+				name: 'an array response body',
+				body: ['Bad Request'],
+				expectedBody: ['Bad Request'],
+			},
+			{
+				name: 'an invalid JSON response body',
+				body: '{"error":"Bad Request"',
+				expectedBody: '{"error":"Bad Request"',
+			},
+		];
+
+		it.each(errorResponseBodies)(
+			'should expose $name without changing the legacy error',
+			async ({ body, expectedBody }) => {
+				(executeFunctions.getInputData as Mock).mockReturnValue([{ json: {} }]);
+				(executeFunctions.continueOnFail as Mock).mockReturnValue(true);
+				(executeFunctions.getNodeParameter as Mock).mockImplementation((paramName: string) => {
+					switch (paramName) {
+						case 'method':
+							return 'GET';
+						case 'url':
+							return baseUrl;
+						case 'authentication':
+							return 'none';
+						case 'options':
+							return options;
+						default:
+							return undefined;
+					}
+				});
+
+				const requestError = {
+					message: 'Request failed with status code 400',
+					name: 'RequestError',
+					status: 400,
+					statusCode: 400,
+					response: {
+						headers: { 'x-request-id': 'request-1' },
+						data: body,
+					},
+				};
+				(executeFunctions.helpers.request as Mock).mockRejectedValue(requestError);
+
+				const result = await node.execute.call(executeFunctions);
+				const expectedContext = {
+					itemIndex: 0,
+					...(body !== null &&
+						!Buffer.isBuffer(body) &&
+						!Array.isArray(body) &&
+						typeof body === 'object' && {
+							data: body,
+						}),
+				};
+
+				expect(result[0][0]).toMatchObject({
+					json: {
+						error: requestError,
+						details: {
+							httpCode: '400',
+							body: expectedBody,
+							context: expectedContext,
+						},
+					},
+					pairedItem: { item: 0 },
+				});
+			},
+		);
+
+		it('should retain the matching response body when requests complete out of order', async () => {
+			(executeFunctions.getInputData as Mock).mockReturnValue([{ json: {} }, { json: {} }]);
+			(executeFunctions.continueOnFail as Mock).mockReturnValue(true);
+			(executeFunctions.getNodeParameter as Mock).mockImplementation(
+				(paramName: string, itemIndex: number) => {
+					switch (paramName) {
+						case 'method':
+							return 'GET';
+						case 'url':
+							return `${baseUrl}/${itemIndex}`;
+						case 'authentication':
+							return 'none';
+						case 'options':
+							return options;
+						default:
+							return undefined;
+					}
+				},
+			);
+
+			(executeFunctions.helpers.request as Mock).mockImplementation(
+				async (requestOptions: { uri: string }) =>
+					await new Promise((_, reject) => {
+						const delay = requestOptions.uri.endsWith('/0') ? 10 : 0;
+						setTimeout(() => {
+							reject({
+								message: 'Request failed',
+								statusCode: 400,
+								response: { data: { request: requestOptions.uri } },
+							});
+						}, delay);
+					}),
+			);
+
+			const result = await node.execute.call(executeFunctions);
+
+			expect(result[0][0].json.details).toMatchObject({
+				body: { request: `${baseUrl}/0` },
+			});
+			expect(result[0][1].json.details).toMatchObject({
+				body: { request: `${baseUrl}/1` },
+			});
 		});
 	});
 

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -829,6 +829,52 @@ describe('HttpRequestV3', () => {
 				body: { request: `${baseUrl}/1` },
 			});
 		});
+
+		it('should retain the matching sanitized request when requests complete out of order', async () => {
+			(executeFunctions.getInputData as Mock).mockReturnValue([{ json: {} }, { json: {} }]);
+			(executeFunctions.continueOnFail as Mock).mockReturnValue(false);
+			(executeFunctions.getNodeParameter as Mock).mockImplementation(
+				(paramName: string, itemIndex: number) => {
+					switch (paramName) {
+						case 'method':
+							return 'GET';
+						case 'url':
+							return `${baseUrl}/${itemIndex}`;
+						case 'authentication':
+							return 'none';
+						case 'options':
+							return {
+								...options,
+								batching: { batch: { batchSize: 1, batchInterval: 0 } },
+							};
+						default:
+							return undefined;
+					}
+				},
+			);
+
+			const rejectRequests: Array<(error: Error) => void> = [];
+			(executeFunctions.helpers.request as Mock).mockImplementation(
+				async () =>
+					await new Promise((_, reject) => {
+						rejectRequests.push(reject);
+					}),
+			);
+
+			const execution = node.execute.call(executeFunctions);
+			const requestError = Object.assign(new Error('Request failed'), { statusCode: 400 });
+			rejectRequests[1](requestError);
+			rejectRequests[0](requestError);
+
+			await expect(execution).rejects.toMatchObject({
+				context: {
+					itemIndex: 0,
+					request: {
+						uri: `${baseUrl}/0`,
+					},
+				},
+			});
+		});
 	});
 
 	describe('Cross-Origin Redirects', () => {


### PR DESCRIPTION
## Summary

This PR updates HTTP Node to output `details` with response body parsed as object for easier programmatic access.

Additional change:
- changed `sanitizedRequests.push` to `sanitizedRequests[itemIndex] =` to prevent mixing order of responses

Considerations:
- not exposing request data to avoid showing credentials in output
- gracefully parsing body to support all possible formats
- the change only introduces a new field, but due to the node popularity made a minor version bump to be extra careful. 

<img width="736" height="464" alt="image" src="https://github.com/user-attachments/assets/29cfdbd1-9ca2-46bf-8fff-8f94813a46d8" />


## How to test

Use this test workflow and script to verify body parsing behavior

<details>
<summary>Workflow</summary>

```
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        592
      ],
      "id": "0a385dbb-9780-4bc8-aba6-12ec7a85e92f",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:5678/rest/workflows",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        -176
      ],
      "id": "86f5a975-fe11-4038-9e2a-92c8ac2f2659",
      "name": "HTTP Request",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/json",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        16
      ],
      "id": "14ee3de5-322b-48df-8b68-ec2c97cc8283",
      "name": "HTTP Request1",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/json-string",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        208
      ],
      "id": "58c342cd-41d2-4cd9-9a1c-9acd60451a70",
      "name": "HTTP Request2",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/text",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        400
      ],
      "id": "16144c08-7675-4d8f-bfdb-a045f08e67ad",
      "name": "HTTP Request3",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/invalid-json",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        592
      ],
      "id": "d91478d1-1250-452a-afce-b6b61622cec0",
      "name": "HTTP Request4",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/array",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        784
      ],
      "id": "48d7bd6f-e0f2-41ff-b13b-8c6d431176f7",
      "name": "HTTP Request5",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/null",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        976
      ],
      "id": "87cea2ac-8ad0-46bf-9e85-8671fbe3ed19",
      "name": "HTTP Request6",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/buffer",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        1168
      ],
      "id": "cb69d3ec-e86b-4b18-befb-7244c62e7990",
      "name": "HTTP Request7",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/no-body",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        224,
        1360
      ],
      "id": "59dca31f-ff1e-4c37-b0b1-b452fdb377f4",
      "name": "HTTP Request8",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/json",
        "options": {
          "response": {
            "response": {
              "neverError": true
            }
          }
        }
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        448,
        16
      ],
      "id": "9e5cce07-ff14-4fd5-9d23-426c4a689851",
      "name": "HTTP Request9"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/json",
        "options": {
          "response": {
            "response": {
              "neverError": true
            }
          }
        }
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        448,
        208
      ],
      "id": "678d6ee7-24a6-47de-a2ab-a47257027f9c",
      "name": "HTTP Request10",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/text",
        "options": {
          "response": {
            "response": {
              "neverError": true,
              "responseFormat": "text"
            }
          }
        }
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        448,
        400
      ],
      "id": "d8d0ae16-d7d0-4e8f-8d9e-0a5a88b5a611",
      "name": "HTTP Request11",
      "onError": "continueRegularOutput"
    },
    {
      "parameters": {
        "url": "http://127.0.0.1:8080/invalid-json",
        "options": {
          "response": {
            "response": {
              "neverError": true
            }
          }
        }
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.5,
      "position": [
        448,
        592
      ],
      "id": "52af8fcb-d162-4fb2-a46e-bddff2938abb",
      "name": "HTTP Request12",
      "onError": "continueRegularOutput"
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "HTTP Request",
            "type": "main",
            "index": 0
          },
          {
            "node": "HTTP Request1",
            "type": "main",
            "index": 0
          },
          {
            "node": "HTTP Request2",
            "type": "main",
            "index": 0
          },
          {
            "node": "HTTP Request3",
            "type": "main",
            "index": 0
          },
          {
            "node": "HTTP Request4",
            "type": "main",
            "index": 0
          },
          {
            "node": "HTTP Request5",
            "type": "main",
            "index": 0
          },
          {
            "node": "HTTP Request6",
            "type": "main",
            "index": 0
          },
          {
            "node": "HTTP Request7",
            "type": "main",
            "index": 0
          },
          {
            "node": "HTTP Request8",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "HTTP Request1": {
      "main": [
        [
          {
            "node": "HTTP Request9",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "HTTP Request2": {
      "main": [
        [
          {
            "node": "HTTP Request10",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "HTTP Request3": {
      "main": [
        [
          {
            "node": "HTTP Request11",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "HTTP Request4": {
      "main": [
        [
          {
            "node": "HTTP Request12",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "869de6ef8ff5644147e5589ff5c9f86171de90b2c3bb7db31c1025ea70eaa896"
  }
}
```

</details>


<details>
<summary>Script</summary>

```
const { createServer } = require('node:http');

const port = Number(process.env.PORT ?? 8080);

const errorResponses = {
	'/json': {
		contentType: 'application/json',
		body: JSON.stringify({ error: 'Bad Request', message: 'A JSON error response' }),
	},
	'/json-string': {
		contentType: 'text/plain',
		body: JSON.stringify({ error: 'Bad Request', message: 'JSON encoded as text' }),
	},
	'/text': {
		contentType: 'text/plain',
		body: 'Text error response',
	},
	'/invalid-json': {
		contentType: 'application/json',
		body: '{"error":"Bad Request"',
	},
	'/array': {
		contentType: 'application/json',
		body: JSON.stringify([{ error: 'Bad Request' }]),
	},
	'/null': {
		contentType: 'application/json',
		body: 'null',
	},
	'/no-body': {
		contentType: 'text/plain',
	},
	'/buffer': {
		contentType: 'application/json',
		body: Buffer.from(JSON.stringify({ error: 'Bad Request', message: 'A Buffer response' })),
	},
};

const server = createServer((request, response) => {
	const errorResponse = errorResponses[request.url ?? ''];

	if (!errorResponse) {
		response.writeHead(404, { 'content-type': 'application/json' });
		response.end(JSON.stringify({ error: 'Not Found' }));
		return;
	}

	response.writeHead(400, {
		'content-type': errorResponse.contentType,
		'x-error-format': request.url?.slice(1) ?? 'unknown',
	});
	response.end(errorResponse.body);
});

server.listen(port, () => {
	console.log(`Error response server listening on http://localhost:${port}`);
	console.log(`Available endpoints: ${Object.keys(errorResponses).join(', ')}`);
});

function shutdown() {
	server.close();
}

process.once('SIGINT', shutdown);
process.once('SIGTERM', shutdown);


```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5038/community-issue-http-request-node-in-some-cases-fails-to-display
closes #30316 


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34729">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

