### PR TITLE
feat(Webhook Node): Add condition-based Only Run If filtering

### DIFF
--- a/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
@@ -12,7 +12,9 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	Workflow,
 } from 'n8n-workflow';
-import type { Mock } from 'vitest';
+import { WorkflowExpression } from 'n8n-workflow';
+import { Webhook as WebhookNode } from 'n8n-nodes-base/nodes/Webhook/Webhook.node';
+import type { Mock, MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { WebhookNotFoundError } from '@/errors/response-errors/webhook-not-found.error';
@@ -578,6 +580,165 @@ describe('LiveWebhooks', () => {
 			await expect(
 				liveWebhooks.executeWebhook(buildRequest(), mock<Response>()),
 			).resolves.toBeDefined();
+		});
+	});
+
+	describe('isolate acquisition strategy', () => {
+		let acquireSpy: MockInstance;
+		let releaseSpy: MockInstance;
+
+		beforeEach(() => {
+			acquireSpy = vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate');
+			releaseSpy = vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate');
+		});
+
+		afterEach(() => {
+			acquireSpy.mockRestore();
+			releaseSpy.mockRestore();
+		});
+
+		const buildNode = (
+			parameters: INode['parameters'],
+			type = 'n8n-nodes-base.webhook',
+		): INode => ({
+			id: 'webhook-node-1',
+			name: NODE_NAME,
+			type,
+			typeVersion: 2.1,
+			position: [0, 0],
+			parameters,
+		});
+
+		const runWebhookWithNode = async (node: INode) => {
+			// Plain objects, not vitest-mock-extended deep mocks: the deep-mock
+			// proxy fabricates a `toJSON` function on nested objects, which makes
+			// `deepCopy` (used by parameter normalization in the Workflow
+			// constructor) collapse the node parameters to undefined.
+			const activeVersion = {
+				versionId: 'v1',
+				workflowId: WORKFLOW_ID,
+				nodes: [node],
+				connections: {},
+				authors: 'test-user',
+			} as unknown as WorkflowHistory;
+			const workflowEntity = {
+				id: WORKFLOW_ID,
+				name: 'Test Workflow',
+				active: true,
+				activeVersionId: activeVersion.versionId,
+				nodes: [node],
+				connections: {},
+				staticData: {},
+				settings: {},
+				activeVersion,
+				shared: [{ role: 'workflow:owner', project: { id: 'project-1', projectRelations: [] } }],
+			} as unknown as WorkflowEntity;
+			const request = setupExecuteWebhookMocks(workflowEntity);
+			// Use the real Webhook node description so the Workflow constructor's
+			// parameter normalization keeps the parameters under test (the shared
+			// mock declares `properties: []`, which would strip them all).
+			nodeTypes.getByNameAndVersion.mockReturnValue(new WebhookNode() as unknown as INodeType);
+			await liveWebhooks.executeWebhook(request, mock<Response>());
+		};
+
+		const simpleConditions = {
+			options: { caseSensitive: true, leftValue: '', typeValidation: 'loose', version: 2 },
+			combinator: 'and',
+			conditions: [
+				{
+					id: '1',
+					leftValue: '={{ $json.body.campaign_id }}',
+					rightValue: 'match-me',
+					operator: { type: 'string', operation: 'equals' },
+				},
+			],
+		};
+
+		it('skips acquisition for a webhook node without expressions', async () => {
+			await runWebhookWithNode(buildNode({ path: WEBHOOK_PATH, httpMethod: 'GET', options: {} }));
+
+			expect(acquireSpy).not.toHaveBeenCalled();
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('skips acquisition for simple "Only Run If" conditions on the webhook node', async () => {
+			await runWebhookWithNode(
+				buildNode({
+					path: WEBHOOK_PATH,
+					httpMethod: 'GET',
+					onlyRunIfMode: 'conditions',
+					onlyRunIfConditions: simpleConditions,
+					options: {},
+				}),
+			);
+
+			expect(acquireSpy).not.toHaveBeenCalled();
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('acquires when a parameter contains an expression', async () => {
+			await runWebhookWithNode(
+				buildNode({
+					path: WEBHOOK_PATH,
+					httpMethod: 'GET',
+					options: { responseData: '={{ $json.body.answer }}' },
+				}),
+			);
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('acquires when an "Only Run If" condition needs the expression engine', async () => {
+			const complexConditions = {
+				...simpleConditions,
+				conditions: [
+					{
+						...simpleConditions.conditions[0],
+						leftValue: '={{ $json.body.campaign_id.toUpperCase() }}',
+					},
+				],
+			};
+			await runWebhookWithNode(
+				buildNode({
+					path: WEBHOOK_PATH,
+					httpMethod: 'GET',
+					onlyRunIfMode: 'conditions',
+					onlyRunIfConditions: complexConditions,
+					options: {},
+				}),
+			);
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('acquires in expression mode', async () => {
+			await runWebhookWithNode(
+				buildNode({
+					path: WEBHOOK_PATH,
+					httpMethod: 'GET',
+					onlyRunIfMode: 'expression',
+					onlyRunIfExpression: '={{ $json.body.x === 1 }}',
+					options: {},
+				}),
+			);
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('always acquires for non-webhook node types, even without expressions', async () => {
+			await runWebhookWithNode(
+				buildNode(
+					{
+						path: WEBHOOK_PATH,
+						httpMethod: 'GET',
+						options: {},
+					},
+					'n8n-nodes-base.formTrigger',
+				),
+			);
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -3,7 +3,12 @@ import { WorkflowsConfig } from '@n8n/config';
 import { WorkflowRepository, type WorkflowEntity, type WorkflowHistory } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { Response } from 'express';
-import { Workflow, CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+import {
+	Workflow,
+	CHAT_TRIGGER_NODE_TYPE,
+	WEBHOOK_NODE_TYPE,
+	matchSimpleRequestFieldPath,
+} from 'n8n-workflow';
 import type { INode, IWebhookData, IHttpRequestMethods, IWorkflowBase } from 'n8n-workflow';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -25,6 +30,38 @@ import type {
 	WebhookAccessControlOptions,
 	WebhookRequest,
 } from './webhook.types';
+
+/**
+ * Whether handling a webhook request for this start node needs an isolate
+ * acquired for the duration of the request. Only the base Webhook node can
+ * skip it — its webhook phase is fully first-party code that evaluates no
+ * user expressions unless the node parameters contain one: description
+ * templates run as trusted (in-process) and "Only Run If" conditions made of
+ * simple request-field references are resolved natively. Every other node
+ * type acquires upfront, since its webhook code may evaluate expressions the
+ * parameter scan cannot see.
+ */
+function webhookPhaseNeedsIsolate(node: INode): boolean {
+	if (node.type !== WEBHOOK_NODE_TYPE) return true;
+	const scan = (value: unknown, inNativeConditions: boolean): boolean => {
+		if (typeof value === 'string') {
+			return (
+				value.startsWith('=') &&
+				!(inNativeConditions && matchSimpleRequestFieldPath(value) !== null)
+			);
+		}
+		if (Array.isArray(value)) {
+			return value.some((item) => scan(item, inNativeConditions));
+		}
+		if (value !== null && typeof value === 'object') {
+			return Object.entries(value).some(([key, item]) =>
+				scan(item, inNativeConditions || key === 'onlyRunIfConditions'),
+			);
+		}
+		return false;
+	};
+	return scan(node.parameters, false);
+}
 
 /**
  * Service for handling the execution of live webhooks, i.e. webhooks
@@ -131,7 +168,12 @@ export class LiveWebhooks implements IWebhookManager {
 			projectId: ownerProjectId,
 		});
 
-		await workflow.expression.acquireIsolate();
+		// Skip acquiring an isolate when the webhook phase provably evaluates no
+		// user expressions. `releaseIsolate()` is a no-op when nothing was acquired.
+		const startNode = workflow.getNode(webhook.node);
+		if (startNode === null || webhookPhaseNeedsIsolate(startNode)) {
+			await workflow.expression.acquireIsolate();
+		}
 		try {
 			const webhookData = this.webhookService
 				.getNodeWebhooks(workflow, workflow.getNode(webhook.node) as INode, additionalData)

--- a/packages/cli/src/webhooks/webhook-execution-context.ts
+++ b/packages/cli/src/webhooks/webhook-execution-context.ts
@@ -24,13 +24,15 @@ export class WebhookExecutionContext {
 
 	/**
 	 * Evaluates a simple expression from the webhook description.
+	 * Description templates are trusted (node-author code), so they run on the
+	 * in-process engine and need no isolate.
 	 */
 	evaluateSimpleWebhookDescriptionExpression<T extends boolean | number | string | unknown[]>(
 		propertyName: keyof IWebhookDescription,
 		executeData?: IExecuteData,
 		defaultValue?: T,
 	): T | undefined {
-		return this.workflow.expression.getSimpleParameterValue(
+		return this.workflow.expression.getTrustedSimpleParameterValue(
 			this.workflowStartNode,
 			this.webhookData.webhookDescription[propertyName],
 			this.executionMode,
@@ -48,7 +50,7 @@ export class WebhookExecutionContext {
 		executeData?: IExecuteData,
 		defaultValue?: T,
 	): T | undefined {
-		return this.workflow.expression.getComplexParameterValue(
+		return this.workflow.expression.getTrustedComplexParameterValue(
 			this.workflowStartNode,
 			this.webhookData.webhookDescription[propertyName],
 			this.executionMode,

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -1045,7 +1045,7 @@ function evaluateResponseOptions(
 	//check if response mode should be set automatically, e.g. multipage form
 	const responseMode =
 		autoDetectResponseMode(workflowStartNode, workflow, req.method) ??
-		(workflow.expression.getSimpleParameterValue(
+		(workflow.expression.getTrustedSimpleParameterValue(
 			workflowStartNode,
 			webhookData.webhookDescription.responseMode,
 			executionMode,
@@ -1054,7 +1054,7 @@ function evaluateResponseOptions(
 			'onReceived',
 		) as WebhookResponseMode);
 
-	const responseCode = workflow.expression.getSimpleParameterValue(
+	const responseCode = workflow.expression.getTrustedSimpleParameterValue(
 		workflowStartNode,
 		webhookData.webhookDescription.responseCode as string,
 		executionMode,
@@ -1066,7 +1066,7 @@ function evaluateResponseOptions(
 	// This parameter is used for two different purposes:
 	// 1. as arbitrary string input defined in the workflow in the "respond immediately" mode,
 	// 2. as well as WebhookResponseData config in all the other modes
-	const responseData = workflow.expression.getComplexParameterValue(
+	const responseData = workflow.expression.getTrustedComplexParameterValue(
 		workflowStartNode,
 		webhookData.webhookDescription.responseData,
 		executionMode,
@@ -1080,21 +1080,21 @@ function evaluateResponseOptions(
 	// We can unify the behavior in the next major release and get rid of this flag
 	const checkAllMainOutputs = workflowStartNode.type === CHAT_TRIGGER_NODE_TYPE;
 
-	const responsePropertyName = workflow.expression.getSimpleParameterValue(
+	const responsePropertyName = workflow.expression.getTrustedSimpleParameterValue(
 		workflowStartNode,
 		webhookData.webhookDescription.responsePropertyName,
 		executionMode,
 		additionalKeys,
 	) as string | undefined;
 
-	const responseContentType = workflow.expression.getSimpleParameterValue(
+	const responseContentType = workflow.expression.getTrustedSimpleParameterValue(
 		workflowStartNode,
 		webhookData.webhookDescription.responseContentType,
 		executionMode,
 		additionalKeys,
 	) as string | undefined;
 
-	const responseBinaryPropertyName = workflow.expression.getSimpleParameterValue(
+	const responseBinaryPropertyName = workflow.expression.getTrustedSimpleParameterValue(
 		workflowStartNode,
 		webhookData.webhookDescription.responseBinaryPropertyName,
 		executionMode,
@@ -1130,7 +1130,7 @@ async function parseRequestBody(
 	const nodeVersion = workflowStartNode.typeVersion;
 	if (nodeVersion === 1) {
 		// binaryData option is removed in versions higher than 1
-		binaryData = workflow.expression.getSimpleParameterValue(
+		binaryData = workflow.expression.getTrustedSimpleParameterValue(
 			workflowStartNode,
 			'={{$parameter["options"]["binaryData"]}}',
 			executionMode,

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -279,7 +279,7 @@ export class WebhookService {
 				continue;
 			}
 
-			let nodeWebhookPath = workflow.expression.getSimpleParameterValue(
+			let nodeWebhookPath = workflow.expression.getTrustedSimpleParameterValue(
 				node,
 				webhookDescription.path,
 				mode,
@@ -301,7 +301,7 @@ export class WebhookService {
 				nodeWebhookPath = nodeWebhookPath.slice(0, -1);
 			}
 
-			const isFullPath: boolean = workflow.expression.getSimpleParameterValue(
+			const isFullPath: boolean = workflow.expression.getTrustedSimpleParameterValue(
 				node,
 				webhookDescription.isFullPath,
 				'internal',
@@ -309,7 +309,7 @@ export class WebhookService {
 				undefined,
 				false,
 			) as boolean;
-			const restartWebhook: boolean = workflow.expression.getSimpleParameterValue(
+			const restartWebhook: boolean = workflow.expression.getTrustedSimpleParameterValue(
 				node,
 				webhookDescription.restartWebhook,
 				'internal',
@@ -325,7 +325,7 @@ export class WebhookService {
 				restartWebhook,
 			);
 
-			const webhookMethods = workflow.expression.getSimpleParameterValue(
+			const webhookMethods = workflow.expression.getTrustedSimpleParameterValue(
 				node,
 				webhookDescription.httpMethod,
 				mode,

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
@@ -80,6 +80,7 @@ describe('HookContext', () => {
 		nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
 		expression.getParameterValue.mockImplementation((value) => value);
 		expression.getSimpleParameterValue.mockImplementation((_, value) => value);
+		expression.getTrustedSimpleParameterValue.mockImplementation((_, value) => value);
 	});
 
 	describe('getActivationMode', () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/webhook-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/webhook-helper-functions.test.ts
@@ -128,7 +128,7 @@ describe('Webhook Helper Functions', () => {
 			nodeType.description.webhooks = [webhookDescription];
 			nodeTypes.getByNameAndVersion.mockReturnValueOnce(nodeType);
 
-			expression.getSimpleParameterValue.mockImplementation((_node, parameterValue) => {
+			expression.getTrustedSimpleParameterValue.mockImplementation((_node, parameterValue) => {
 				if (parameterValue === 'webhook') return webhookPath;
 				return parameterValue;
 			});
@@ -144,7 +144,7 @@ describe('Webhook Helper Functions', () => {
 			);
 
 			expect(result).toEqual(expected);
-			expect(expression.getSimpleParameterValue).toHaveBeenCalled();
+			expect(expression.getTrustedSimpleParameterValue).toHaveBeenCalled();
 		});
 	});
 
@@ -179,7 +179,7 @@ describe('Webhook Helper Functions', () => {
 			});
 			nodeType.description.webhooks = [webhookDescription];
 			nodeTypes.getByNameAndVersion.mockReturnValueOnce(nodeType);
-			expression.getSimpleParameterValue.mockImplementation((_node, parameterValue) =>
+			expression.getTrustedSimpleParameterValue.mockImplementation((_node, parameterValue) =>
 				parameterValue === 'mcp' ? 'mcp' : parameterValue,
 			);
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/webhook-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/webhook-helper-functions.ts
@@ -49,7 +49,7 @@ export function getNodeWebhookUrl(
 		baseUrl = isTest === true ? additionalData.webhookTestBaseUrl : additionalData.webhookBaseUrl;
 	}
 
-	const path = workflow.expression.getSimpleParameterValue(
+	const path = workflow.expression.getTrustedSimpleParameterValue(
 		node,
 		webhookDescription.path,
 		mode,
@@ -57,7 +57,7 @@ export function getNodeWebhookUrl(
 	);
 	if (path === undefined) return;
 
-	const isFullPath: boolean = workflow.expression.getSimpleParameterValue(
+	const isFullPath: boolean = workflow.expression.getTrustedSimpleParameterValue(
 		node,
 		webhookDescription.isFullPath,
 		mode,

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -9,6 +9,7 @@ import type {
 	INodeTypeDescription,
 	IWebhookResponseData,
 	INodeProperties,
+	FilterValue,
 } from 'n8n-workflow';
 import { BINARY_ENCODING, NodeOperationError, Node } from 'n8n-workflow';
 import { pipeline } from 'stream/promises';
@@ -21,6 +22,9 @@ import {
 	defaultWebhookDescription,
 	httpMethodsProperty,
 	inboundTriggerAuthenticationBuilderHint,
+	onlyRunIfConditionsProperty,
+	onlyRunIfExpressionProperty,
+	onlyRunIfModeProperty,
 	optionsProperty,
 	responseBinaryPropertyNameProperty,
 	responseCodeOption,
@@ -33,6 +37,7 @@ import { WebhookAuthorizationError } from './error';
 import {
 	checkResponseModeConfiguration,
 	configuredOutputs,
+	evaluateOnlyRunIfConditions,
 	handleFormData,
 	isIpAllowed,
 	setupOutputConnection,
@@ -185,6 +190,9 @@ export class Webhook extends Node {
 			},
 			responseDataProperty,
 			responseBinaryPropertyNameProperty,
+			onlyRunIfModeProperty,
+			onlyRunIfConditionsProperty,
+			onlyRunIfExpressionProperty,
 			{
 				displayName:
 					'If you are sending back a response, add a "Content-Type" response header with the appropriate value to avoid unexpected behavior',
@@ -253,17 +261,44 @@ export class Webhook extends Node {
 		}
 
 		const node = context.getNode();
-		const rawOptions = node.parameters?.options as { onlyRunIf?: unknown } | undefined;
-		const rawOnlyRunIf = rawOptions?.onlyRunIf;
-		if (typeof rawOnlyRunIf === 'string' && rawOnlyRunIf.startsWith('=')) {
-			try {
-				const result = context.evaluateExpression(rawOnlyRunIf.slice(1), 0);
-				if (!result) return {};
-			} catch (error) {
-				context.logger.warn(
-					`Webhook "Only Run If" expression failed to evaluate; allowing request through. ${(error as Error).message}`,
-					{ nodeName: node.name },
-				);
+		// Read "Only Run If" configuration from the raw parameters: resolving it
+		// via getNodeParameter would evaluate the contained expressions through
+		// the expression engine, defeating the native fast path.
+		const onlyRunIfMode = (node.parameters?.onlyRunIfMode as string) ?? 'all';
+		if (onlyRunIfMode === 'conditions') {
+			const rawConditions = node.parameters?.onlyRunIfConditions as FilterValue | undefined;
+			if (rawConditions?.conditions?.length) {
+				try {
+					const pass = evaluateOnlyRunIfConditions(context, rawConditions, {
+						body: req.body,
+						headers: req.headers,
+						params: req.params,
+						query: req.query,
+					} as unknown as IDataObject);
+					if (!pass) return {};
+				} catch (error) {
+					context.logger.warn(
+						`Webhook "Only Run If" conditions failed to evaluate; allowing request through. ${(error as Error).message}`,
+						{ nodeName: node.name },
+					);
+				}
+			}
+		} else {
+			const rawOptions = node.parameters?.options as { onlyRunIf?: unknown } | undefined;
+			const rawOnlyRunIf =
+				onlyRunIfMode === 'expression'
+					? node.parameters?.onlyRunIfExpression
+					: rawOptions?.onlyRunIf;
+			if (typeof rawOnlyRunIf === 'string' && rawOnlyRunIf.startsWith('=')) {
+				try {
+					const result = context.evaluateExpression(rawOnlyRunIf.slice(1), 0);
+					if (!result) return {};
+				} catch (error) {
+					context.logger.warn(
+						`Webhook "Only Run If" expression failed to evaluate; allowing request through. ${(error as Error).message}`,
+						{ nodeName: node.name },
+					);
+				}
 			}
 		}
 

--- a/packages/nodes-base/nodes/Webhook/description.ts
+++ b/packages/nodes-base/nodes/Webhook/description.ts
@@ -243,6 +243,71 @@ export const responseBinaryPropertyNameProperty: INodeProperties = {
 	description: 'Name of the binary property to return',
 };
 
+export const onlyRunIfModeProperty: INodeProperties = {
+	displayName: 'Only Run Workflow If',
+	name: 'onlyRunIfMode',
+	type: 'options',
+	options: [
+		{
+			name: 'Always',
+			value: 'all',
+			description: 'Run the workflow for every incoming request',
+		},
+		{
+			name: 'Conditions Match',
+			value: 'conditions',
+			description:
+				'Run only when the request matches simple conditions on its fields. Checked natively, without the expression sandbox — fastest option for busy endpoints.',
+		},
+		{
+			name: 'Expression Is True',
+			value: 'expression',
+			description: 'Run only when a full expression evaluates to true',
+		},
+	],
+	default: 'all',
+	description:
+		'Whether to filter incoming requests before running the workflow. Requests that do not match receive a 200 response and no execution is created.',
+};
+
+export const onlyRunIfConditionsProperty: INodeProperties = {
+	displayName: 'Conditions',
+	name: 'onlyRunIfConditions',
+	type: 'filter',
+	default: {},
+	typeOptions: {
+		filter: {
+			caseSensitive: true,
+			typeValidation: 'loose',
+			version: 2,
+		},
+	},
+	displayOptions: {
+		show: {
+			onlyRunIfMode: ['conditions'],
+		},
+	},
+	// eslint-disable-next-line n8n-nodes-base/node-param-description-miscased-json
+	description:
+		'Reference request fields with <code>{{ $json.body.field }}</code>, <code>{{ $json.headers[\'name\'] }}</code>, <code>{{ $json.query.param }}</code>. Simple field references like these are checked natively, without running the expression sandbox.',
+};
+
+export const onlyRunIfExpressionProperty: INodeProperties = {
+	displayName: 'Expression',
+	name: 'onlyRunIfExpression',
+	type: 'string',
+	default: '',
+	placeholder: "{{ $json.body.campaign_id === 'user-research-invite' }}",
+	displayOptions: {
+		show: {
+			onlyRunIfMode: ['expression'],
+		},
+	},
+	// eslint-disable-next-line n8n-nodes-base/node-param-description-miscased-json
+	description:
+		'Expression evaluated against the incoming request. The workflow will run only if the expression returns true. <code>$json</code> exposes the request as <code>{ body, headers, params, query }</code>. If the expression fails to evaluate, the request is allowed through and the error is logged.',
+};
+
 export const optionsProperty: INodeProperties = {
 	displayName: 'Options',
 	name: 'options',

--- a/packages/nodes-base/nodes/Webhook/description.ts
+++ b/packages/nodes-base/nodes/Webhook/description.ts
@@ -289,7 +289,7 @@ export const onlyRunIfConditionsProperty: INodeProperties = {
 	},
 	// eslint-disable-next-line n8n-nodes-base/node-param-description-miscased-json
 	description:
-		'Reference request fields with <code>{{ $json.body.field }}</code>, <code>{{ $json.headers[\'name\'] }}</code>, <code>{{ $json.query.param }}</code>. Simple field references like these are checked natively, without running the expression sandbox.',
+		"Reference request fields with <code>{{ $json.body.field }}</code>, <code>{{ $json.headers['name'] }}</code>, <code>{{ $json.query.param }}</code>. Simple field references like these are checked natively, without running the expression sandbox.",
 };
 
 export const onlyRunIfExpressionProperty: INodeProperties = {

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -284,4 +284,136 @@ describe('Test Webhook Node', () => {
 			expect(context.evaluateExpression).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('onlyRunIf modes', () => {
+		const node = new Webhook();
+		let context: ReturnType<typeof mock<IWebhookFunctions>>;
+		let req: ReturnType<typeof mock<Request>>;
+
+		const conditionsFor = (rightValue: string) => ({
+			options: { caseSensitive: true, leftValue: '', typeValidation: 'loose', version: 2 },
+			combinator: 'and',
+			conditions: [
+				{
+					id: '1',
+					leftValue: '={{ $json.body.campaign_id }}',
+					rightValue,
+					operator: { type: 'string', operation: 'equals' },
+				},
+			],
+		});
+
+		const setup = (parameters: Record<string, unknown>) => {
+			context = mock<IWebhookFunctions>({ nodeHelpers: mock(), logger: mock() });
+			req = mock<Request>();
+
+			context.getRequestObject.mockReturnValue(req);
+			context.getResponseObject.mockReturnValue(mock<Response>());
+			context.getChildNodes.mockReturnValue([]);
+			context.getNode.mockReturnValue({
+				type: 'n8n-nodes-base.webhook',
+				typeVersion: 2,
+				name: 'Webhook',
+				parameters,
+			} as any);
+			context.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'options') return (parameters.options as object) ?? {};
+				if (paramName === 'responseMode') return 'onReceived';
+				if (paramName === 'httpMethod') return 'POST';
+				return undefined;
+			});
+
+			req.headers = { 'content-type': 'application/json' };
+			req.params = {};
+			req.query = {};
+			req.body = { campaign_id: 'match-me' };
+			Object.defineProperty(req, 'ips', { value: [], configurable: true });
+			Object.defineProperty(req, 'ip', { value: '127.0.0.1', configurable: true });
+		};
+
+		afterEach(() => vi.clearAllMocks());
+
+		it('runs the workflow when simple conditions match, without the expression engine', async () => {
+			setup({ onlyRunIfMode: 'conditions', onlyRunIfConditions: conditionsFor('match-me') });
+
+			const result = await node.webhook(context);
+
+			expect(result.workflowData).toBeDefined();
+			expect(context.evaluateExpression).not.toHaveBeenCalled();
+		});
+
+		it('skips execution when simple conditions do not match', async () => {
+			setup({ onlyRunIfMode: 'conditions', onlyRunIfConditions: conditionsFor('other') });
+
+			const result = await node.webhook(context);
+
+			expect(result).toEqual({});
+			expect(context.evaluateExpression).not.toHaveBeenCalled();
+		});
+
+		it('runs the workflow when the conditions list is empty', async () => {
+			setup({
+				onlyRunIfMode: 'conditions',
+				onlyRunIfConditions: { ...conditionsFor('x'), conditions: [] },
+			});
+
+			const result = await node.webhook(context);
+
+			expect(result.workflowData).toBeDefined();
+		});
+
+		it('ignores the legacy options.onlyRunIf when conditions mode is active', async () => {
+			setup({
+				onlyRunIfMode: 'conditions',
+				onlyRunIfConditions: conditionsFor('match-me'),
+				options: { onlyRunIf: '={{ false }}' },
+			});
+
+			const result = await node.webhook(context);
+
+			expect(result.workflowData).toBeDefined();
+			expect(context.evaluateExpression).not.toHaveBeenCalled();
+		});
+
+		it('allows the request through and warns when condition evaluation throws', async () => {
+			const strict = conditionsFor('match-me');
+			strict.options.typeValidation = 'strict';
+			strict.conditions[0].operator = { type: 'number', operation: 'equals' };
+			setup({ onlyRunIfMode: 'conditions', onlyRunIfConditions: strict });
+
+			const result = await node.webhook(context);
+
+			expect(result.workflowData).toBeDefined();
+			expect(context.logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Only Run If'),
+				expect.objectContaining({ nodeName: 'Webhook' }),
+			);
+		});
+
+		it('evaluates onlyRunIfExpression in expression mode', async () => {
+			setup({
+				onlyRunIfMode: 'expression',
+				onlyRunIfExpression: "={{ $json.body.campaign_id === 'match-me' }}",
+			});
+			context.evaluateExpression.mockReturnValue(false);
+
+			const result = await node.webhook(context);
+
+			expect(result).toEqual({});
+			expect(context.evaluateExpression).toHaveBeenCalledWith(
+				"{{ $json.body.campaign_id === 'match-me' }}",
+				0,
+			);
+		});
+
+		it('still evaluates the legacy options.onlyRunIf in the default mode', async () => {
+			setup({ options: { onlyRunIf: '={{ false }}' } });
+			context.evaluateExpression.mockReturnValue(false);
+
+			const result = await node.webhook(context);
+
+			expect(result).toEqual({});
+			expect(context.evaluateExpression).toHaveBeenCalledWith('{{ false }}', 0);
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Webhook/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/utils.test.ts
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 import {
 	UnexpectedError,
+	type FilterValue,
 	type IWebhookFunctions,
 	type INodeExecutionData,
 	type IDataObject,
@@ -13,6 +14,7 @@ import type { WebhookParameters } from '../utils';
 import {
 	checkResponseModeConfiguration,
 	configuredOutputs,
+	evaluateOnlyRunIfConditions,
 	generateBasicAuthToken,
 	generateFormPostBasicAuthToken,
 	getResponseCode,
@@ -878,6 +880,209 @@ describe('Auth token generation', () => {
 
 			expect(token1).not.toBe(token2);
 			expect(token1).not.toBe(token3);
+		});
+	});
+
+	describe('evaluateOnlyRunIfConditions', () => {
+		const requestJson: IDataObject = {
+			body: { campaign_id: 'match-me', count: '42', tags: ['a', 'b'], contact: { id: 'c1' } },
+			headers: { 'x-api-key': 'secret', 'content-type': 'application/json' },
+			params: { segment: 'eu' },
+			query: { debug: 'true' },
+		};
+
+		let context: ReturnType<typeof mock<IWebhookFunctions>>;
+		beforeEach(() => {
+			context = mock<IWebhookFunctions>();
+		});
+
+		const filterOptions = {
+			caseSensitive: true,
+			leftValue: '',
+			typeValidation: 'loose',
+			version: 2,
+		} as const;
+
+		const makeFilter = (
+			conditions: FilterValue['conditions'],
+			combinator: FilterValue['combinator'] = 'and',
+		): FilterValue => ({
+			options: { ...filterOptions },
+			combinator,
+			conditions,
+		});
+
+		it('resolves a simple body field reference natively (no expression engine)', () => {
+			const pass = evaluateOnlyRunIfConditions(
+				context,
+				makeFilter([
+					{
+						id: '1',
+						leftValue: '={{ $json.body.campaign_id }}',
+						rightValue: 'match-me',
+						operator: { type: 'string', operation: 'equals' },
+					},
+				]),
+				requestJson,
+			);
+			expect(pass).toBe(true);
+			expect(context.evaluateExpression).not.toHaveBeenCalled();
+		});
+
+		it('returns false when the condition does not match', () => {
+			const pass = evaluateOnlyRunIfConditions(
+				context,
+				makeFilter([
+					{
+						id: '1',
+						leftValue: '={{ $json.body.campaign_id }}',
+						rightValue: 'other',
+						operator: { type: 'string', operation: 'equals' },
+					},
+				]),
+				requestJson,
+			);
+			expect(pass).toBe(false);
+			expect(context.evaluateExpression).not.toHaveBeenCalled();
+		});
+
+		it('resolves bracket paths into headers natively', () => {
+			const pass = evaluateOnlyRunIfConditions(
+				context,
+				makeFilter([
+					{
+						id: '1',
+						leftValue: "={{ $json.headers['x-api-key'] }}",
+						rightValue: 'secret',
+						operator: { type: 'string', operation: 'equals' },
+					},
+				]),
+				requestJson,
+			);
+			expect(pass).toBe(true);
+			expect(context.evaluateExpression).not.toHaveBeenCalled();
+		});
+
+		it('supports exists / notExists on missing fields', () => {
+			const exists = (leftValue: string, operation: 'exists' | 'notExists') =>
+				evaluateOnlyRunIfConditions(
+					context,
+					makeFilter([
+						{
+							id: '1',
+							leftValue,
+							rightValue: '',
+							operator: { type: 'string', operation, singleValue: true },
+						},
+					]),
+					requestJson,
+				);
+			expect(exists('={{ $json.body.campaign_id }}', 'exists')).toBe(true);
+			expect(exists('={{ $json.body.nope }}', 'exists')).toBe(false);
+			expect(exists('={{ $json.body.nope.deep }}', 'notExists')).toBe(true);
+		});
+
+		it('coerces string numbers under loose type validation', () => {
+			const pass = evaluateOnlyRunIfConditions(
+				context,
+				makeFilter([
+					{
+						id: '1',
+						leftValue: '={{ $json.body.count }}',
+						rightValue: 40,
+						operator: { type: 'number', operation: 'gt' },
+					},
+				]),
+				requestJson,
+			);
+			expect(pass).toBe(true);
+		});
+
+		it('combines conditions with AND and OR', () => {
+			const matching: FilterValue['conditions'][number] = {
+				id: '1',
+				leftValue: '={{ $json.body.campaign_id }}',
+				rightValue: 'match-me',
+				operator: { type: 'string', operation: 'equals' },
+			};
+			const failing: FilterValue['conditions'][number] = {
+				id: '2',
+				leftValue: '={{ $json.query.debug }}',
+				rightValue: 'false',
+				operator: { type: 'string', operation: 'equals' },
+			};
+			expect(
+				evaluateOnlyRunIfConditions(context, makeFilter([matching, failing], 'and'), requestJson),
+			).toBe(false);
+			expect(
+				evaluateOnlyRunIfConditions(context, makeFilter([matching, failing], 'or'), requestJson),
+			).toBe(true);
+		});
+
+		it('uses literal values without touching the expression engine', () => {
+			const pass = evaluateOnlyRunIfConditions(
+				context,
+				makeFilter([
+					{
+						id: '1',
+						leftValue: 'static',
+						rightValue: 'static',
+						operator: { type: 'string', operation: 'equals' },
+					},
+				]),
+				requestJson,
+			);
+			expect(pass).toBe(true);
+			expect(context.evaluateExpression).not.toHaveBeenCalled();
+		});
+
+		it('falls back to the expression engine for complex expressions', () => {
+			context.evaluateExpression.mockReturnValue('MATCH-ME');
+			const pass = evaluateOnlyRunIfConditions(
+				context,
+				makeFilter([
+					{
+						id: '1',
+						leftValue: '={{ $json.body.campaign_id.toUpperCase() }}',
+						rightValue: 'MATCH-ME',
+						operator: { type: 'string', operation: 'equals' },
+					},
+				]),
+				requestJson,
+			);
+			expect(pass).toBe(true);
+			expect(context.evaluateExpression).toHaveBeenCalledWith(
+				'{{ $json.body.campaign_id.toUpperCase() }}',
+				0,
+			);
+		});
+
+		it('applies defaults when filter options are missing', () => {
+			const filter = {
+				combinator: 'and',
+				conditions: [
+					{
+						id: '1',
+						leftValue: '={{ $json.body.campaign_id }}',
+						rightValue: 'match-me',
+						operator: { type: 'string', operation: 'equals' },
+					},
+				],
+			} as unknown as FilterValue;
+			expect(evaluateOnlyRunIfConditions(context, filter, requestJson)).toBe(true);
+		});
+
+		it('propagates filter errors (caller decides the failure policy)', () => {
+			const filter = makeFilter([
+				{
+					id: '1',
+					leftValue: '={{ $json.body.contact }}',
+					rightValue: 42,
+					operator: { type: 'number', operation: 'equals' },
+				},
+			]);
+			filter.options.typeValidation = 'strict';
+			expect(() => evaluateOnlyRunIfConditions(context, filter, requestJson)).toThrow();
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Webhook/utils.ts
+++ b/packages/nodes-base/nodes/Webhook/utils.ts
@@ -2,7 +2,12 @@ import { formatPemBlock } from '@n8n/utils/format-pem-block';
 import basicAuth from 'basic-auth';
 import { rm } from 'fs/promises';
 import jwt from 'jsonwebtoken';
-import { WorkflowConfigurationError } from 'n8n-workflow';
+import {
+	executeFilter,
+	matchSimpleRequestFieldPath,
+	resolveRequestFieldPath,
+	WorkflowConfigurationError,
+} from 'n8n-workflow';
 import type {
 	IWebhookFunctions,
 	INodeExecutionData,
@@ -10,6 +15,8 @@ import type {
 	ICredentialDataDecryptedObject,
 	MultiPartFormData,
 	INode,
+	FilterValue,
+	NodeParameterValue,
 } from 'n8n-workflow';
 import * as a from 'node:assert';
 import { createHmac, timingSafeEqual } from 'node:crypto';
@@ -85,6 +92,47 @@ export const configuredOutputs = (parameters: WebhookParameters) => {
 
 	return outputs;
 };
+
+/**
+ * Evaluates "Only Run If" filter conditions against the incoming request.
+ * Simple `{{ $json.<path> }}` references are resolved natively; anything more
+ * complex falls back to the expression engine (which acquires an isolate when
+ * the VM engine is enabled).
+ */
+export function evaluateOnlyRunIfConditions(
+	context: IWebhookFunctions,
+	rawFilter: FilterValue,
+	requestJson: IDataObject,
+): boolean {
+	const resolveValue = (
+		value: NodeParameterValue | NodeParameterValue[],
+	): NodeParameterValue | NodeParameterValue[] => {
+		if (typeof value !== 'string' || !value.startsWith('=')) return value;
+		const path = matchSimpleRequestFieldPath(value);
+		if (path !== null) return resolveRequestFieldPath(requestJson, path) as NodeParameterValue;
+		return context.evaluateExpression(value.slice(1), 0) as NodeParameterValue;
+	};
+
+	const conditions = (rawFilter.conditions ?? []).map((condition) => ({
+		...condition,
+		leftValue: resolveValue(condition.leftValue),
+		rightValue: resolveValue(condition.rightValue),
+	}));
+
+	return executeFilter(
+		{
+			combinator: rawFilter.combinator ?? 'and',
+			options: rawFilter.options ?? {
+				caseSensitive: true,
+				leftValue: '',
+				typeValidation: 'loose',
+				version: 2,
+			},
+			conditions,
+		},
+		{ itemIndex: 0 },
+	);
+}
 
 export const setupOutputConnection = (
 	ctx: IWebhookFunctions,

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -285,6 +285,29 @@ export class Expression {
 		return false;
 	}
 
+	/**
+	 * Set when the next evaluated template is trusted (authored by node/n8n
+	 * code, not by a user). Consumed by the first evaluation and NOT inherited
+	 * by nested evaluations (e.g. user expressions resolved through
+	 * `$parameter`), which stay on the sandboxed engine.
+	 */
+	private trustedTemplateRequested = false;
+
+	/**
+	 * Run `fn` marking the first template it evaluates as trusted: it is
+	 * evaluated with the in-process (legacy) engine even when the VM engine is
+	 * enabled, so it needs no isolate. Only use for templates defined in node
+	 * descriptions (e.g. `webhookDescription` fields) — never for user input.
+	 */
+	runAsTrustedTemplate<T>(fn: () => T): T {
+		this.trustedTemplateRequested = true;
+		try {
+			return fn();
+		} finally {
+			this.trustedTemplateRequested = false;
+		}
+	}
+
 	async releaseIsolate(): Promise<void> {
 		if (Expression.vmEvaluator) await Expression.vmEvaluator.release(this);
 	}
@@ -539,6 +562,12 @@ export class Expression {
 			return parameterValue;
 		}
 
+		// Consume the trusted-template flag at entry so that nested evaluations
+		// triggered while rendering (e.g. user expressions resolved via
+		// `$parameter`) do not inherit it and stay on the sandboxed engine.
+		const trustedTemplate = this.trustedTemplateRequested;
+		this.trustedTemplateRequested = false;
+
 		// Is an expression
 
 		// Remove the equal sign
@@ -561,7 +590,7 @@ export class Expression {
 
 		Expression.initializeGlobalContext(data);
 
-		const usingVm = Expression.shouldUseVm();
+		const usingVm = Expression.shouldUseVm() && !trustedTemplate;
 
 		// Expression extensions — only attached for the legacy engine.
 		//
@@ -608,7 +637,7 @@ export class Expression {
 
 		// Execute the expression
 		const extendedExpression = extendSyntax(parameterValue);
-		const returnValue = this.renderExpression(extendedExpression, data);
+		const returnValue = this.renderExpression(extendedExpression, data, trustedTemplate);
 		if (typeof returnValue === 'function') {
 			if (returnValue.name === 'DateTime')
 				throw new UserError('this is a DateTime, please access its methods');
@@ -625,9 +654,11 @@ export class Expression {
 		return returnValue;
 	}
 
-	private renderExpression(expression: string, data: IWorkflowDataProxyData) {
-		// Use VM evaluator if engine is set to 'vm' and we're not in the browser
-		if (Expression.expressionEngine === 'vm' && !IS_FRONTEND) {
+	private renderExpression(expression: string, data: IWorkflowDataProxyData, trustedTemplate = false) {
+		// Use VM evaluator if engine is set to 'vm' and we're not in the browser.
+		// Trusted templates (node-description code) skip the VM and run on the
+		// in-process engine — they need no isolate.
+		if (!trustedTemplate && Expression.expressionEngine === 'vm' && !IS_FRONTEND) {
 			if (!Expression.vmEvaluator) {
 				throw new UnexpectedError(
 					'N8N_EXPRESSION_ENGINE=vm is enabled but VM evaluator is not initialized. Call Expression.initExpressionEngine() during application startup.',

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -92,6 +92,7 @@ export { ExpressionExtensions, type Alias, type AliasCompletion } from './extens
 export * as ExpressionParser from './extensions/expression-parser';
 export { NativeMethods } from './native-methods';
 export * from './node-parameters/filter-parameter';
+export * from './node-parameters/request-field-expression';
 export * from './node-parameters/parameter-type-validation';
 export * from './node-parameters/node-parameter-value-type-guard';
 export * from './node-parameters/path-utils';

--- a/packages/workflow/src/node-parameters/request-field-expression.ts
+++ b/packages/workflow/src/node-parameters/request-field-expression.ts
@@ -1,0 +1,37 @@
+/**
+ * Utilities for recognizing and resolving expressions that are a plain field
+ * reference into webhook request data, e.g. `={{ $json.body.campaign_id }}`
+ * or `={{ $json.headers['x-api-key'] }}`. Such references can be resolved
+ * natively — without the expression engine — which lets busy webhook
+ * endpoints filter requests without acquiring an isolate.
+ */
+
+import type { IDataObject } from '../interfaces';
+
+const SIMPLE_REQUEST_FIELD_RE =
+	/^=\s*\{\{\s*\$json((?:\.[A-Za-z_$][\w$]*|\[\s*(?:'[^']*'|"[^"]*"|\d+)\s*\])+)\s*\}\}\s*$/;
+
+/**
+ * Returns the `$json`-relative path (e.g. `.body.campaign_id`) if the given
+ * raw parameter value is a simple request-field reference, `null` otherwise.
+ */
+export function matchSimpleRequestFieldPath(value: string): string | null {
+	const match = SIMPLE_REQUEST_FIELD_RE.exec(value);
+	return match ? match[1] : null;
+}
+
+/**
+ * Resolves a path returned by `matchSimpleRequestFieldPath` against the
+ * request data (`{ body, headers, params, query }`). Returns `undefined` for
+ * missing segments, like optional chaining would.
+ */
+export function resolveRequestFieldPath(source: IDataObject, pathExpr: string): unknown {
+	const tokenRe = /\.([A-Za-z_$][\w$]*)|\[\s*(?:'([^']*)'|"([^"]*)"|(\d+))\s*\]/g;
+	let current: unknown = source;
+	for (const match of pathExpr.matchAll(tokenRe)) {
+		if (current === null || typeof current !== 'object') return undefined;
+		const key = match[1] ?? match[2] ?? match[3] ?? match[4] ?? '';
+		current = (current as IDataObject)[key];
+	}
+	return current;
+}

--- a/packages/workflow/src/node-parameters/request-field-expression.ts
+++ b/packages/workflow/src/node-parameters/request-field-expression.ts
@@ -23,13 +23,15 @@ export function matchSimpleRequestFieldPath(value: string): string | null {
 /**
  * Resolves a path returned by `matchSimpleRequestFieldPath` against the
  * request data (`{ body, headers, params, query }`). Returns `undefined` for
- * missing segments, like optional chaining would.
+ * nullish segments, like optional chaining would; property access on
+ * primitives (e.g. `.length` on a string) behaves like plain JS so results
+ * match what the expression engine would produce for the same reference.
  */
 export function resolveRequestFieldPath(source: IDataObject, pathExpr: string): unknown {
 	const tokenRe = /\.([A-Za-z_$][\w$]*)|\[\s*(?:'([^']*)'|"([^"]*)"|(\d+))\s*\]/g;
 	let current: unknown = source;
 	for (const match of pathExpr.matchAll(tokenRe)) {
-		if (current === null || typeof current !== 'object') return undefined;
+		if (current === null || current === undefined) return undefined;
 		const key = match[1] ?? match[2] ?? match[3] ?? match[4] ?? '';
 		current = (current as IDataObject)[key];
 	}

--- a/packages/workflow/src/workflow-expression.ts
+++ b/packages/workflow/src/workflow-expression.ts
@@ -217,6 +217,29 @@ export class WorkflowExpression {
 	}
 
 	/**
+	 * Same as `getSimpleParameterValue`, but the template itself is evaluated
+	 * with the in-process (legacy) engine even when the VM engine is enabled —
+	 * no isolate needed. Only for trusted, node-description-authored templates
+	 * (e.g. `webhookDescription` fields). User expressions nested inside the
+	 * template (resolved via `$parameter`) still run on the sandboxed engine.
+	 */
+	getTrustedSimpleParameterValue(
+		...args: Parameters<WorkflowExpression['getSimpleParameterValue']>
+	): ReturnType<WorkflowExpression['getSimpleParameterValue']> {
+		return this.expression.runAsTrustedTemplate(() => this.getSimpleParameterValue(...args));
+	}
+
+	/**
+	 * Trusted-template variant of `getComplexParameterValue` — see
+	 * `getTrustedSimpleParameterValue`.
+	 */
+	getTrustedComplexParameterValue(
+		...args: Parameters<WorkflowExpression['getComplexParameterValue']>
+	): ReturnType<WorkflowExpression['getComplexParameterValue']> {
+		return this.expression.runAsTrustedTemplate(() => this.getComplexParameterValue(...args));
+	}
+
+	/**
 	 * Resolves value of complex parameter. But does not work for workflow-data.
 	 */
 	getComplexParameterValue(

--- a/packages/workflow/test/node-parameters/request-field-expression.test.ts
+++ b/packages/workflow/test/node-parameters/request-field-expression.test.ts
@@ -1,0 +1,140 @@
+import type { IDataObject } from '../../src/interfaces';
+import {
+	matchSimpleRequestFieldPath,
+	resolveRequestFieldPath,
+} from '../../src/node-parameters/request-field-expression';
+
+describe('matchSimpleRequestFieldPath', () => {
+	test.each<[string, string]>([
+		// dot notation
+		['={{ $json.body.campaign_id }}', '.body.campaign_id'],
+		['={{$json.body.x}}', '.body.x'],
+		['={{ $json.query.a.b.c.d.e }}', '.query.a.b.c.d.e'],
+		['={{ $json.body._private }}', '.body._private'],
+		['={{ $json.body.$dollar }}', '.body.$dollar'],
+		['={{ $json.body.x1 }}', '.body.x1'],
+		// bracket notation
+		["={{ $json.headers['x-api-key'] }}", ".headers['x-api-key']"],
+		['={{ $json.headers["x-api-key"] }}', '.headers["x-api-key"]'],
+		["={{ $json['body']['x'] }}", "['body']['x']"],
+		["={{ $json.body['content type'] }}", ".body['content type']"],
+		["={{ $json.body[''] }}", ".body['']"],
+		['={{ $json.body[0] }}', '.body[0]'],
+		['={{ $json.body.items[0] }}', '.body.items[0]'],
+		['={{ $json.body.items[12].id }}', '.body.items[12].id'],
+		["={{ $json.body[ 'spaced' ] }}", ".body[ 'spaced' ]"],
+		// mixed quoting: double quotes inside single-quoted key and vice versa
+		['={{ $json.body[\'say "hi"\'] }}', '.body[\'say "hi"\']'],
+		["={{ $json.body[\"it's\"] }}", '.body["it\'s"]'],
+		// whitespace tolerance around the template
+		['=  {{ $json.body.x }}  ', '.body.x'],
+		['={{$json.body.x }}', '.body.x'],
+		['={{ $json.body.x}}', '.body.x'],
+		['=\n{{ $json.body.x }}\n', '.body.x'],
+	])('should match %j and return the path %j', (value, expected) => {
+		expect(matchSimpleRequestFieldPath(value)).toBe(expected);
+	});
+
+	test.each<[string]>([
+		// not an expression at all
+		[''],
+		['='],
+		['hello'],
+		['{{ $json.body.x }}'],
+		// bare $json without a path
+		['={{ $json }}'],
+		['={{ $json. }}'],
+		// anything computed
+		['={{ $json.body.x.toUpperCase() }}'],
+		["={{ $json.body.x === 'y' }}"],
+		['={{ $json.body.a + $json.body.b }}'],
+		['={{ !$json.body.flag }}'],
+		// other context variables
+		['={{ $now }}'],
+		['={{ $env.FOO }}'],
+		['={{ $node.body.x }}'],
+		['={{ $jsonx.body.x }}'],
+		['={{ $JSON.body.x }}'],
+		// extra content around the template
+		['={{ $json.body.x }} suffix'],
+		['prefix {{ $json.body.x }}'],
+		['={{ $json.a }}{{ $json.b }}'],
+		// malformed paths
+		['={{ $json..x }}'],
+		['={{ $json.body.x. }}'],
+		['={{ $json.body.1x }}'],
+		['={{ $json.body.café }}'],
+		['={{ $json.body[x] }}'],
+		['={{ $json.body[-1] }}'],
+		['={{ $json.body[1.5] }}'],
+		["={{ $json.body['unclosed] }}"],
+		['={{ $json.body[\'mixed"] }}'],
+		// optional chaining is not a plain reference
+		['={{ $json.body?.x }}'],
+	])('should not match %j', (value) => {
+		expect(matchSimpleRequestFieldPath(value)).toBeNull();
+	});
+});
+
+describe('resolveRequestFieldPath', () => {
+	const source: IDataObject = {
+		body: {
+			contact: { id: 42 },
+			items: ['first', 'second'],
+			flag: null,
+			count: 7,
+			enabled: false,
+			empty: '',
+			zero: 0,
+			'content type': 'application/json',
+			'0': 'zero-key',
+		},
+		headers: { 'x-api-key': 'secret' },
+		params: {},
+		query: { a: { b: { c: 'deep' } } },
+	};
+
+	test.each<[string, unknown]>([
+		// dot notation
+		['.body.contact.id', 42],
+		['.query.a.b.c', 'deep'],
+		['.headers', source.headers],
+		// bracket notation, both quote styles
+		[".headers['x-api-key']", 'secret'],
+		['.headers["x-api-key"]', 'secret'],
+		["['body']['contact']['id']", 42],
+		[".body['content type']", 'application/json'],
+		["[ 'body' ][ 'count' ]", 7],
+		// array indexing
+		['.body.items[0]', 'first'],
+		['.body.items[1]', 'second'],
+		["['body']['0']", 'zero-key'],
+		// falsy values survive the walk
+		['.body.flag', null],
+		['.body.enabled', false],
+		['.body.empty', ''],
+		['.body.zero', 0],
+		// missing segments resolve to undefined, like optional chaining
+		['.body.missing', undefined],
+		['.body.missing.deeper', undefined],
+		['.missing[0].x', undefined],
+		['.body.items[9]', undefined],
+		[".body['']", undefined],
+		// walking through a non-object stops with undefined instead of throwing
+		['.body.flag.nested', undefined],
+		['.body.count.nested', undefined],
+		['.body.empty.nested', undefined],
+		['.headers["x-api-key"].length', undefined],
+	])('should resolve %j to %j', (pathExpr, expected) => {
+		expect(resolveRequestFieldPath(source, pathExpr)).toEqual(expected);
+	});
+
+	it('should return the source itself for an empty path', () => {
+		expect(resolveRequestFieldPath(source, '')).toBe(source);
+	});
+
+	it("should not throw when reading ['__proto__'] or ['constructor']", () => {
+		expect(() => resolveRequestFieldPath(source, ".body['__proto__']")).not.toThrow();
+		expect(() => resolveRequestFieldPath(source, ".body['constructor']['constructor']")).not.toThrow();
+	});
+});

--- a/packages/workflow/test/node-parameters/request-field-expression.test.ts
+++ b/packages/workflow/test/node-parameters/request-field-expression.test.ts
@@ -120,11 +120,15 @@ describe('resolveRequestFieldPath', () => {
 		['.missing[0].x', undefined],
 		['.body.items[9]', undefined],
 		[".body['']", undefined],
-		// walking through a non-object stops with undefined instead of throwing
-		['.body.flag.nested', undefined],
+		// property access on primitives behaves like plain JS
+		['.headers["x-api-key"].length', 'secret'.length],
+		['.body.items.length', 2],
+		// missing properties of primitives resolve to undefined
 		['.body.count.nested', undefined],
 		['.body.empty.nested', undefined],
-		['.headers["x-api-key"].length', undefined],
+		// nullish segments stop the walk with undefined instead of throwing
+		['.body.flag.nested', undefined],
+		['.body.flag.nested.deeper', undefined],
 	])('should resolve %j to %j', (pathExpr, expected) => {
 		expect(resolveRequestFieldPath(source, pathExpr)).toEqual(expected);
 	});

--- a/packages/workflow/test/trusted-template.test.ts
+++ b/packages/workflow/test/trusted-template.test.ts
@@ -1,0 +1,152 @@
+import * as Helpers from './helpers';
+import { Workflow } from '../src/workflow';
+
+// Tests for trusted-template evaluation (`Expression.runAsTrustedTemplate`,
+// `WorkflowExpression.getTrusted{Simple,Complex}ParameterValue`).
+//
+// Trusted templates are node-description-authored (e.g. `webhookDescription`
+// fields such as `={{$parameter["responseMode"]}}`). They are evaluated with
+// the in-process (legacy) engine even when the VM engine is enabled, so they
+// need no isolate. The security invariant is that trust applies to the FIRST
+// rendered template only: user-authored expressions resolved while rendering
+// (via `$parameter`) must still go through the sandboxed VM engine.
+//
+// This file runs under both vitest projects (legacy-engine and vm-engine, see
+// vitest.config.ts). VM-only assertions are gated with `it.runIf(isVm)` —
+// they prove sandbox routing by the fact that a VM evaluation without an
+// acquired isolate throws, while a trusted (legacy-routed) one succeeds.
+
+const isVm = process.env.N8N_EXPRESSION_ENGINE === 'vm';
+
+describe('trusted template evaluation', () => {
+	// `test.set` declares two string properties: value1 (plain value here)
+	// and value2 (holding a user-authored expression here).
+	const workflow = new Workflow({
+		id: '1',
+		nodes: [
+			{
+				name: 'Webhook',
+				typeVersion: 1,
+				type: 'test.set',
+				id: 'webhook-1',
+				position: [0, 0],
+				parameters: {
+					value1: 'hello',
+					value2: '={{ 1 + 1 }}',
+				},
+			},
+		],
+		connections: {},
+		active: false,
+		nodeTypes: Helpers.NodeTypes(),
+	});
+	const node = workflow.getNode('Webhook')!;
+	const expression = workflow.expression;
+
+	// NOTE: no `acquireIsolate()` in the outer scope — proving that trusted
+	// templates evaluate without one is the point of this suite.
+
+	describe('without an acquired isolate', () => {
+		it('evaluates a trusted template reading a plain parameter', () => {
+			const result = expression.getTrustedSimpleParameterValue(
+				node,
+				'={{ $parameter["value1"] }}',
+				'internal',
+				{},
+			);
+			expect(result).toBe('hello');
+		});
+
+		it('evaluates a trusted template with an inlined function body', () => {
+			// Mirrors real webhook descriptions like `={{(fn)($parameter)}}`
+			const result = expression.getTrustedSimpleParameterValue(
+				node,
+				'={{ (function (p) { return p.value1 + "!"; })($parameter) }}',
+				'internal',
+				{},
+			);
+			expect(result).toBe('hello!');
+		});
+
+		it('returns non-expression values as-is', () => {
+			expect(expression.getTrustedSimpleParameterValue(node, 'plain-string', 'internal', {})).toBe(
+				'plain-string',
+			);
+			expect(
+				expression.getTrustedSimpleParameterValue(node, undefined, 'internal', {}, undefined, true),
+			).toBe(true);
+		});
+
+		it.runIf(isVm)('untrusted evaluation still requires an isolate under the VM engine', () => {
+			expect(() =>
+				expression.getSimpleParameterValue(node, '={{ $parameter["value1"] }}', 'internal', {}),
+			).toThrow();
+		});
+
+		it.runIf(isVm)('user expressions nested in a trusted template do NOT inherit trust', () => {
+			// `$parameter["value2"]` resolves a user-authored `={{ 1 + 1 }}`.
+			// That nested evaluation must run on the VM engine, which fails here
+			// because no isolate is acquired (the failure surfaces as a nullish
+			// result). If the trusted flag were inherited, the nested expression
+			// would evaluate in-process and return 2 — see the acquired-isolate
+			// suite below for the positive case.
+			const result = expression.getTrustedSimpleParameterValue(
+				node,
+				'={{ $parameter["value2"] }}',
+				'internal',
+				{},
+			);
+			expect([null, undefined]).toContain(result);
+		});
+
+		it.runIf(isVm)('trust is consumed by a single call and does not leak to later ones', () => {
+			expression.getTrustedSimpleParameterValue(node, '={{ $parameter["value1"] }}', 'internal', {});
+			expect(() =>
+				expression.getSimpleParameterValue(node, '={{ $parameter["value1"] }}', 'internal', {}),
+			).toThrow();
+		});
+
+		it.runIf(isVm)('trust does not linger when the trusted value is not an expression', () => {
+			expression.getTrustedSimpleParameterValue(node, 'plain-string', 'internal', {});
+			expect(() =>
+				expression.getSimpleParameterValue(node, '={{ $parameter["value1"] }}', 'internal', {}),
+			).toThrow();
+		});
+	});
+
+	describe('with an acquired isolate', () => {
+		beforeAll(async () => {
+			await expression.acquireIsolate();
+		});
+		afterAll(async () => {
+			await expression.releaseIsolate();
+		});
+
+		it('resolves user expressions nested in a trusted template (on the active engine)', () => {
+			const result = expression.getTrustedSimpleParameterValue(
+				node,
+				'={{ $parameter["value2"] }}',
+				'internal',
+				{},
+			);
+			expect(result).toBe(2);
+		});
+
+		it('trusted and untrusted evaluation produce identical results', () => {
+			const template = '={{ $parameter["value1"] }}';
+			expect(expression.getTrustedSimpleParameterValue(node, template, 'internal', {})).toEqual(
+				expression.getSimpleParameterValue(node, template, 'internal', {}),
+			);
+		});
+
+		it('getTrustedComplexParameterValue resolves object-returning templates', () => {
+			const result = expression.getTrustedComplexParameterValue(
+				node,
+				'={{ { nested: $parameter["value1"] } }}',
+				'internal',
+				{},
+			);
+			expect(result).toEqual({ nested: 'hello' });
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds a mode selector for **Only Run If** on the Webhook node:

- **Always** (default) — current behavior.
- **Conditions Match** — If-node-style filter over the request (`body`, `headers`, `params`, `query`). Plain field references like `{{ $json.body.campaign_id }}` are resolved natively, without the expression engine.
- **Expression Is True** — the existing expression behavior as a top-level parameter. Legacy `options.onlyRunIf` keeps working.

Under `N8N_EXPRESSION_ENGINE=vm`, every webhook request currently acquires an isolate even when nothing needs one. This PR skips the acquisition for the base Webhook node when its parameters provably contain no expressions, and evaluates trusted `webhookDescription` templates in-process (nested user expressions stay sandboxed). All other trigger types acquire eagerly as before. With conditions mode, filtered requests never touch the isolate pool — benchmarked at parity with the legacy engine on a single core, vs ~13 rps/core with expression mode. Legacy engine behavior is unchanged.

## How to test

1. Webhook node → set **Only Run If** to *Conditions Match*, add a condition like `{{ $json.body.campaign_id }}` equals `123`.
2. Activate, POST to the production URL: matches execute, non-matches get 200 with no execution.
3. Verify *Expression Is True* and legacy `options.onlyRunIf` still work.
4. Under `N8N_EXPRESSION_ENGINE=vm`, filtered requests in conditions mode perform no isolate acquisitions; any expression parameter on the node restores eager acquisition.

Unit tests cover the trusted templates, field matcher/resolver, acquisition strategy, and node modes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3756

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
