### PR TITLE
fix(editor): Update copy for executions tab empty state

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1330,6 +1330,8 @@
 	"executions.ExecutionStatus": "Execution status",
 	"executions.privateCredential.tooltip": "This execution ran using end-user credentials",
 	"executions.concurrency.docsLink": "https://docs.n8n.io/hosting/scaling/concurrency-control/",
+	"executions.empty.heading": "No executions yet",
+	"executions.empty.description": "Each run of a workflow is called an execution, and you'll see them listed here",
 	"executionDetails.additionalActions": "Additional Actions",
 	"executionDetails.confirmMessage.confirmButtonText": "Yes, delete",
 	"executionDetails.confirmMessage.headline": "Delete Execution?",

--- a/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListEmptyState.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListEmptyState.test.ts
@@ -12,6 +12,7 @@ describe('ResourcesListEmptyState', () => {
 		['variables', 'Create your first variable', 'Create variable'],
 		['dataTable', 'Create your first data table', 'Create data table'],
 		['workflows', 'Create your first automation', 'Create workflow'],
+		['executions', 'No executions yet', 'Create workflow'],
 		['agents', 'Create your first agent', 'Create agent'],
 	])('renders canonical heading and CTA for %s', (resourceKey, heading, cta) => {
 		const { getByText, getByRole } = renderComponent({ props: { resourceKey } });

--- a/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListEmptyState.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListEmptyState.vue
@@ -27,7 +27,7 @@ export const EMPTY_STATE_CONFIG = {
 		disabledTooltipKey: 'credentials.empty.button.disabled.tooltip',
 	},
 	executions: {
-		icon: 'workflow',
+		icon: 'history',
 		headingKey: 'executions.empty.heading',
 		descriptionKey: 'executions.empty.description',
 		ctaKey: 'projects.header.create.workflow',

--- a/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListEmptyState.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/ResourcesListEmptyState.vue
@@ -26,6 +26,13 @@ export const EMPTY_STATE_CONFIG = {
 		ctaKey: 'projects.header.create.credential',
 		disabledTooltipKey: 'credentials.empty.button.disabled.tooltip',
 	},
+	executions: {
+		icon: 'workflow',
+		headingKey: 'executions.empty.heading',
+		descriptionKey: 'executions.empty.description',
+		ctaKey: 'projects.header.create.workflow',
+		disabledTooltipKey: 'workflows.empty.button.disabled.tooltip',
+	},
 	variables: {
 		icon: 'variable',
 		headingKey: 'variables.empty.heading',

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.test.ts
@@ -66,14 +66,14 @@ describe('ExecutionsView', () => {
 		await waitAllPromises();
 	});
 
-	it('shows the workflows empty state when there are no workflows', async () => {
+	it('shows the executions empty state when there are no workflows', async () => {
 		workflowsListStore.hasFetchedAllWorkflows.mockReturnValue(true);
 
 		const { getByTestId, queryByTestId } = renderComponent();
 		await waitAllPromises();
 
 		const emptyState = getByTestId('empty-resources-list');
-		expect(within(emptyState).getByText('Create your first automation')).toBeVisible();
+		expect(within(emptyState).getByText('No executions yet')).toBeVisible();
 		expect(queryByTestId('global-executions-list-stub')).not.toBeInTheDocument();
 
 		await fireEvent.click(within(emptyState).getByRole('button', { name: 'Create workflow' }));

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
@@ -153,7 +153,7 @@ async function onExecutionStop() {
 		</template>
 		<div>
 			<ResourcesListEmptyState
-				resource-key="workflows"
+				resource-key="executions"
 				:button-disabled="readOnlyEnv || !projectPermissions.workflow.create"
 				:disabled-tooltip-text="
 					readOnlyEnv ? i18n.baseText('readOnlyEnv.cantAdd.workflow') : undefined


### PR DESCRIPTION
## Summary

Gives the **Executions** tab its own empty-state copy. Until now, when a project had no workflows, the Executions tab reused the generic workflows empty state ("Create your first automation"), which didn't explain what executions are.

| | Before | After |
|---|---|---|
| Icon | `workflow` | `history` (the icon already used for executions elsewhere, e.g. MCP access) |
| Heading | Create your first automation | No executions yet |
| Description | Build multi-step automations connecting your apps and services | Each run of a workflow is called an execution, and you'll see them listed here |
| CTA | Create workflow | Create workflow *(unchanged)* |

Implementation: adds an `executions` entry to `EMPTY_STATE_CONFIG` in `ResourcesListEmptyState.vue` (reusing the workflow-creation CTA and disabled tooltip, since running a workflow is how you get an execution) and switches `ExecutionsView.vue` to use it. New i18n keys `executions.empty.heading` / `executions.empty.description`.

## How to test

1. Open a project (or the Overview page) that has **no workflows**.
2. Go to the **Executions** tab.
3. Verify the empty state shows the new icon, heading, and description, and the **Create workflow** button still navigates to the new-workflow view.
4. With a role that can't create workflows (or a protected instance), verify the button is disabled with the existing tooltip.

<img width="1405" height="647" alt="image" src="https://github.com/user-attachments/assets/b67a0aee-8ac7-48d7-af90-e0c4e7d274cc" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GROP-99

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)