### PR TITLE
fix(editor): Assign existing credentials to imported nodes instead of removing unknown ones

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -5624,7 +5624,7 @@ describe('useCanvasOperations', () => {
 			});
 		});
 
-		it('should keep credentials whose id is unknown as name-only when multiple existing credentials match the name', async () => {
+		it('should relink credentials whose id is unknown to the most recently updated credential matching the name', async () => {
 			vi.mocked(workflowDocumentStoreInstance.createWorkflowObject).mockImplementation(
 				(nodes, connections) =>
 					createTestWorkflowObject({
@@ -5635,12 +5635,23 @@ describe('useCanvasOperations', () => {
 
 			const credentialsStore = mockedStore(useCredentialsStore);
 			credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
-			credentialsStore.getCredentialsByType = vi
-				.fn()
-				.mockReturnValue([
-					mock<ICredentialsResponse>({ id: 'local-id-1', name: 'My OpenAI Cred' }),
-					mock<ICredentialsResponse>({ id: 'local-id-2', name: 'My OpenAI Cred' }),
-				]);
+			credentialsStore.getCredentialsByType = vi.fn().mockReturnValue([
+				mock<ICredentialsResponse>({
+					id: 'local-id-1',
+					name: 'My OpenAI Cred',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				}),
+				mock<ICredentialsResponse>({
+					id: 'local-id-2',
+					name: 'My OpenAI Cred',
+					updatedAt: '2024-06-01T00:00:00.000Z',
+				}),
+				mock<ICredentialsResponse>({
+					id: 'local-id-3',
+					name: 'Other OpenAI Cred',
+					updatedAt: '2024-12-01T00:00:00.000Z',
+				}),
+			]);
 
 			const addNodeSpy = vi.spyOn(workflowDocumentStoreInstance, 'addNode');
 
@@ -5661,7 +5672,54 @@ describe('useCanvasOperations', () => {
 
 			expect(addNodeSpy).toHaveBeenCalled();
 			expect(addNodeSpy.mock.calls[0][0].credentials).toEqual({
-				openAiApi: { id: null, name: 'My OpenAI Cred' },
+				openAiApi: { id: 'local-id-2', name: 'My OpenAI Cred' },
+			});
+		});
+
+		it('should relink credentials whose id and name are unknown to the most recently updated credential of the type', async () => {
+			vi.mocked(workflowDocumentStoreInstance.createWorkflowObject).mockImplementation(
+				(nodes, connections) =>
+					createTestWorkflowObject({
+						nodes: nodes as INodeUi[],
+						connections,
+					}),
+			);
+
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
+			credentialsStore.getCredentialsByType = vi.fn().mockReturnValue([
+				mock<ICredentialsResponse>({
+					id: 'local-id-1',
+					name: 'Old OpenAI Cred',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				}),
+				mock<ICredentialsResponse>({
+					id: 'local-id-2',
+					name: 'Recent OpenAI Cred',
+					updatedAt: '2024-06-01T00:00:00.000Z',
+				}),
+			]);
+
+			const addNodeSpy = vi.spyOn(workflowDocumentStoreInstance, 'addNode');
+
+			const canvasOperations = useCanvasOperations();
+			await canvasOperations.importWorkflowData(
+				{
+					nodes: [
+						createTestNode({
+							id: 'imported-1',
+							name: 'Imported Node',
+							credentials: { openAiApi: { id: 'foreign-instance-id', name: 'Unknown Cred' } },
+						}),
+					],
+					connections: {},
+				},
+				'file',
+			);
+
+			expect(addNodeSpy).toHaveBeenCalled();
+			expect(addNodeSpy.mock.calls[0][0].credentials).toEqual({
+				openAiApi: { id: 'local-id-2', name: 'Recent OpenAI Cred' },
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -5582,6 +5582,123 @@ describe('useCanvasOperations', () => {
 			});
 		});
 
+		it('should relink credentials whose id is unknown but whose name matches exactly one existing credential', async () => {
+			vi.mocked(workflowDocumentStoreInstance.createWorkflowObject).mockImplementation(
+				(nodes, connections) =>
+					createTestWorkflowObject({
+						nodes: nodes as INodeUi[],
+						connections,
+					}),
+			);
+
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
+			credentialsStore.getCredentialsByType = vi
+				.fn()
+				.mockImplementation((type: string) =>
+					type === 'openAiApi'
+						? [mock<ICredentialsResponse>({ id: 'local-id', name: 'My OpenAI Cred' })]
+						: [],
+				);
+
+			const addNodeSpy = vi.spyOn(workflowDocumentStoreInstance, 'addNode');
+
+			const canvasOperations = useCanvasOperations();
+			await canvasOperations.importWorkflowData(
+				{
+					nodes: [
+						createTestNode({
+							id: 'imported-1',
+							name: 'Imported Node',
+							credentials: { openAiApi: { id: 'foreign-instance-id', name: 'My OpenAI Cred' } },
+						}),
+					],
+					connections: {},
+				},
+				'file',
+			);
+
+			expect(addNodeSpy).toHaveBeenCalled();
+			expect(addNodeSpy.mock.calls[0][0].credentials).toEqual({
+				openAiApi: { id: 'local-id', name: 'My OpenAI Cred' },
+			});
+		});
+
+		it('should keep credentials whose id is unknown as name-only when multiple existing credentials match the name', async () => {
+			vi.mocked(workflowDocumentStoreInstance.createWorkflowObject).mockImplementation(
+				(nodes, connections) =>
+					createTestWorkflowObject({
+						nodes: nodes as INodeUi[],
+						connections,
+					}),
+			);
+
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
+			credentialsStore.getCredentialsByType = vi
+				.fn()
+				.mockReturnValue([
+					mock<ICredentialsResponse>({ id: 'local-id-1', name: 'My OpenAI Cred' }),
+					mock<ICredentialsResponse>({ id: 'local-id-2', name: 'My OpenAI Cred' }),
+				]);
+
+			const addNodeSpy = vi.spyOn(workflowDocumentStoreInstance, 'addNode');
+
+			const canvasOperations = useCanvasOperations();
+			await canvasOperations.importWorkflowData(
+				{
+					nodes: [
+						createTestNode({
+							id: 'imported-1',
+							name: 'Imported Node',
+							credentials: { openAiApi: { id: 'foreign-instance-id', name: 'My OpenAI Cred' } },
+						}),
+					],
+					connections: {},
+				},
+				'file',
+			);
+
+			expect(addNodeSpy).toHaveBeenCalled();
+			expect(addNodeSpy.mock.calls[0][0].credentials).toEqual({
+				openAiApi: { id: null, name: 'My OpenAI Cred' },
+			});
+		});
+
+		it('should remove credentials whose id and name are both unknown', async () => {
+			vi.mocked(workflowDocumentStoreInstance.createWorkflowObject).mockImplementation(
+				(nodes, connections) =>
+					createTestWorkflowObject({
+						nodes: nodes as INodeUi[],
+						connections,
+					}),
+			);
+
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialById = vi.fn().mockReturnValue(undefined);
+			credentialsStore.getCredentialsByType = vi.fn().mockReturnValue([]);
+
+			const addNodeSpy = vi.spyOn(workflowDocumentStoreInstance, 'addNode');
+
+			const canvasOperations = useCanvasOperations();
+			await canvasOperations.importWorkflowData(
+				{
+					nodes: [
+						createTestNode({
+							id: 'imported-1',
+							name: 'Imported Node',
+							credentials: { openAiApi: { id: 'foreign-instance-id', name: 'Unknown Cred' } },
+						}),
+					],
+					connections: {},
+				},
+				'file',
+			);
+
+			expect(addNodeSpy).toHaveBeenCalled();
+			expect(addNodeSpy.mock.calls[0][0].credentials).toEqual({});
+		});
+
 		it.each(UPDATE_WEBHOOK_ID_NODE_TYPES)(
 			'should regenerate webhook ids for node type "%s" on pasting into canvas and sync default paths',
 			async (type) => {

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2630,11 +2630,24 @@ export function useCanvasOperations() {
 		for (const node of workflow.nodes) {
 			if (!node.credentials) continue;
 
-			for (const [name, credential] of Object.entries(node.credentials)) {
+			for (const [type, credential] of Object.entries(node.credentials)) {
 				if (typeof credential === 'string' || credential.id === null) continue;
+				if (credentialsStore.getCredentialById(credential.id)) continue;
 
-				if (!credentialsStore.getCredentialById(credential.id)) {
-					delete node.credentials[name];
+				// The id is unknown locally, e.g. the workflow was exported from another
+				// instance. Fall back to matching by name before dropping the credential.
+				const nameMatches = credentialsStore
+					.getCredentialsByType(type)
+					.filter((cred) => cred.name === credential.name);
+
+				if (nameMatches.length === 1) {
+					node.credentials[type] = { id: nameMatches[0].id, name: nameMatches[0].name };
+				} else if (nameMatches.length > 1) {
+					// Ambiguous: keep it name-only so the existing "not identified" node
+					// issue prompts the user to pick one, instead of silently unsetting it.
+					node.credentials[type] = { id: null, name: credential.name };
+				} else {
+					delete node.credentials[type];
 				}
 			}
 		}

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -13,7 +13,10 @@ import type {
 	XYPosition,
 } from '@/Interface';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
-import type { IUsedCredential } from '@/features/credentials/credentials.types';
+import type {
+	ICredentialsResponse,
+	IUsedCredential,
+} from '@/features/credentials/credentials.types';
 import type { ITag } from '@n8n/rest-api-client/api/tags';
 import type { IWorkflowTemplate } from '@n8n/rest-api-client/api/templates';
 import type { WorkflowData, WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
@@ -2624,6 +2627,16 @@ export function useCanvasOperations() {
 	 * Import operations
 	 */
 
+	function mostRecentlyUpdatedCredential(
+		credentials: ICredentialsResponse[],
+	): ICredentialsResponse | undefined {
+		return credentials.reduce<ICredentialsResponse | undefined>(
+			(mostRecent, current) =>
+				mostRecent && mostRecent.updatedAt > current.updatedAt ? mostRecent : current,
+			undefined,
+		);
+	}
+
 	function removeUnknownCredentials(workflow: WorkflowDataUpdate) {
 		if (!workflow?.nodes) return;
 
@@ -2635,17 +2648,17 @@ export function useCanvasOperations() {
 				if (credentialsStore.getCredentialById(credential.id)) continue;
 
 				// The id is unknown locally, e.g. the workflow was exported from another
-				// instance. Fall back to matching by name before dropping the credential.
-				const nameMatches = credentialsStore
-					.getCredentialsByType(type)
-					.filter((cred) => cred.name === credential.name);
+				// instance. Prefer re-matching by name, then fall back to the most
+				// recently updated credential of the type. This mirrors the NDV's
+				// auto-select: without it the node would warn on canvas only until it
+				// is opened, at which point that same credential gets assigned anyway.
+				const candidates = credentialsStore.getCredentialsByType(type);
+				const nameMatches = candidates.filter((cred) => cred.name === credential.name);
+				const replacement =
+					mostRecentlyUpdatedCredential(nameMatches) ?? mostRecentlyUpdatedCredential(candidates);
 
-				if (nameMatches.length === 1) {
-					node.credentials[type] = { id: nameMatches[0].id, name: nameMatches[0].name };
-				} else if (nameMatches.length > 1) {
-					// Ambiguous: keep it name-only so the existing "not identified" node
-					// issue prompts the user to pick one, instead of silently unsetting it.
-					node.credentials[type] = { id: null, name: credential.name };
+				if (replacement) {
+					node.credentials[type] = { id: replacement.id, name: replacement.name };
 				} else {
 					delete node.credentials[type];
 				}


### PR DESCRIPTION
## Summary

When importing a workflow whose credential ids are not known to this instance (e.g. the JSON was exported from another instance), `removeUnknownCredentials` deleted the credential entries entirely. Imported nodes then showed a "missing credentials" warning until the NDV was opened, at which point the NDV's default credential selection assigned the most recently updated credential of the type and the warning disappeared. The canvas warning and the NDV were inconsistent: the warning claimed a problem that opening the node silently resolved.

This PR resolves the credential at import time instead, using the same semantics the NDV applies on open:

- Unknown id, local credential(s) of the same type and name exist: re-link to the most recently updated credential matching the name.
- Unknown id and no name match, but credentials of the type exist: assign the most recently updated credential of the type. This mirrors the NDV's "select most recent credential by default" behavior (`NodeCredentials.vue`), so the node never sits in a credential-less state that opening it would silently fix.
- No credentials of the type exist at all: the entry is removed as before, and the missing-credentials warning shows correctly since there is nothing to select.

Name matching on import is not new policy: legacy name-only credential formats (string or `id: null`) already skip removal and are re-linked by name via `matchCredentials`. This PR makes the modern `{id, name}` format consistent with that, and aligns the import result with what the NDV would produce anyway.

## How to test

1. Create a credential (e.g. OpenAI).
2. Import (paste or import from file) a workflow JSON where a node references a credential of that type with an id that does not exist on your instance, e.g.:
   ```json
   "credentials": { "openAiApi": { "id": "some-foreign-id", "name": "Some Cred Name" } }
   ```
3. Before this fix: the node shows a red missing-credentials warning, which disappears after opening and closing the node without any changes.
4. After this fix: no warning, and the node is linked to your existing credential immediately (by name when one matches, otherwise the most recently updated credential of the type).
5. Import a workflow referencing a credential of a type you have no credentials for: the credential is removed and the missing-credentials warning still shows, as expected.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-5618
- fixes #34640
- Supersedes #34641, which re-matches credentials only after `removeUnknownCredentials` has already deleted the entries, so it does not fix this case.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI