### PR TITLE
feat(API): Add workflow publish/unpublish public API endpoints

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.publish.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.publish.yml
@@ -1,0 +1,40 @@
+post:
+  x-eov-operation-id: publishWorkflow
+  x-required-scope: workflow:activate
+  x-eov-operation-handler: v1/handlers/workflows/workflows.handler
+  tags:
+    - Workflow
+  summary: Publish a workflow
+  description: Publish a workflow. In n8n v1, this action was termed activating a workflow.
+  parameters:
+    - $ref: '../schemas/parameters/workflowId.yml'
+  requestBody:
+    description: Optional parameters to publish the workflow.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            versionId:
+              type: string
+              description: The specific version ID to publish. If not provided, the latest version is used.
+            name:
+              type: string
+              description: Optional name for the workflow version during publication.
+            description:
+              type: string
+              description: Optional description for the workflow version during publication.
+    required: false
+  responses:
+    '200':
+      description: Workflow object
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/workflow.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.unpublish.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.unpublish.yml
@@ -1,0 +1,21 @@
+post:
+  x-eov-operation-id: unpublishWorkflow
+  x-required-scope: workflow:deactivate
+  x-eov-operation-handler: v1/handlers/workflows/workflows.handler
+  tags:
+    - Workflow
+  summary: Unpublish a workflow
+  description: Unpublish a workflow. In n8n v1, this action was termed deactivating a workflow.
+  parameters:
+    - $ref: '../schemas/parameters/workflowId.yml'
+  responses:
+    '200':
+      description: Workflow object
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/workflow.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -48,6 +48,8 @@ type WorkflowHandlers = {
 	getWorkflowVersion: PublicAPIEndpoint<WorkflowRequest.GetVersion>;
 	getWorkflows: PublicAPIEndpoint<WorkflowRequest.GetAll>;
 	updateWorkflow: PublicAPIEndpoint<WorkflowRequest.Update>;
+	publishWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate>;
+	unpublishWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate>;
 	activateWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate>;
 	deactivateWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate>;
 	getWorkflowTags: PublicAPIEndpoint<WorkflowRequest.GetTags>;
@@ -55,6 +57,46 @@ type WorkflowHandlers = {
 	archiveWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
 	unarchiveWorkflow: PublicAPIEndpoint<WorkflowRequest.Get>;
 };
+
+const publishWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate> = [
+	publicApiScope('workflow:activate'),
+	projectScope('workflow:publish', 'workflow'),
+	async (req, res) => {
+		const { id } = req.params;
+		const { versionId, name, description } = req.body;
+
+		try {
+			const workflow = await Container.get(WorkflowService).activateWorkflow(req.user, id, {
+				versionId,
+				name,
+				description,
+				source: 'api',
+			});
+
+			return res.json(workflow);
+		} catch (error) {
+			return handleError(error);
+		}
+	},
+];
+
+const unpublishWorkflow: PublicAPIEndpoint<WorkflowRequest.Activate> = [
+	publicApiScope('workflow:deactivate'),
+	projectScope('workflow:unpublish', 'workflow'),
+	async (req, res) => {
+		const { id } = req.params;
+
+		try {
+			const workflow = await Container.get(WorkflowService).deactivateWorkflow(req.user, id, {
+				source: 'api',
+			});
+
+			return res.json(workflow);
+		} catch (error) {
+			return handleError(error);
+		}
+	},
+];
 
 const workflowHandlers: WorkflowHandlers = {
 	createWorkflow: [
@@ -331,44 +373,11 @@ const workflowHandlers: WorkflowHandlers = {
 			}
 		},
 	],
-	activateWorkflow: [
-		publicApiScope('workflow:activate'),
-		projectScope('workflow:publish', 'workflow'),
-		async (req, res) => {
-			const { id } = req.params;
-			const { versionId, name, description } = req.body;
-
-			try {
-				const workflow = await Container.get(WorkflowService).activateWorkflow(req.user, id, {
-					versionId,
-					name,
-					description,
-					source: 'api',
-				});
-
-				return res.json(workflow);
-			} catch (error) {
-				return handleError(error);
-			}
-		},
-	],
-	deactivateWorkflow: [
-		publicApiScope('workflow:deactivate'),
-		projectScope('workflow:unpublish', 'workflow'),
-		async (req, res) => {
-			const { id } = req.params;
-
-			try {
-				const workflow = await Container.get(WorkflowService).deactivateWorkflow(req.user, id, {
-					source: 'api',
-				});
-
-				return res.json(workflow);
-			} catch (error) {
-				return handleError(error);
-			}
-		},
-	],
+	publishWorkflow,
+	unpublishWorkflow,
+	// `activate`/`deactivate` are legacy aliases; they share the exact same code path.
+	activateWorkflow: publishWorkflow,
+	deactivateWorkflow: unpublishWorkflow,
 	getWorkflowTags: [
 		publicApiScope('workflowTags:list'),
 		projectScope('workflow:read', 'workflow'),

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -111,6 +111,10 @@ paths:
     $ref: './handlers/workflows/spec/paths/workflows.id.activate.yml'
   /workflows/{id}/deactivate:
     $ref: './handlers/workflows/spec/paths/workflows.id.deactivate.yml'
+  /workflows/{id}/publish:
+    $ref: './handlers/workflows/spec/paths/workflows.id.publish.yml'
+  /workflows/{id}/unpublish:
+    $ref: './handlers/workflows/spec/paths/workflows.id.unpublish.yml'
   /workflows/{id}/archive:
     $ref: './handlers/workflows/spec/paths/workflows.id.archive.yml'
   /workflows/{id}/unarchive:

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1010,26 +1010,30 @@ describe('DELETE /workflows/:id', () => {
 	});
 });
 
-describe('POST /workflows/:id/activate', () => {
-	test('should fail due to missing API Key', testWithAPIKey('post', '/workflows/2/activate', null));
+// `/publish` is a canonical alias of `/activate` sharing the exact same handler
+describe.each(['activate', 'publish'])('POST /workflows/:id/%s', (action) => {
+	test(
+		'should fail due to missing API Key',
+		testWithAPIKey('post', `/workflows/2/${action}`, null),
+	);
 
 	test(
 		'should fail due to invalid API Key',
-		testWithAPIKey('post', '/workflows/2/activate', 'abcXYZ'),
+		testWithAPIKey('post', `/workflows/2/${action}`, 'abcXYZ'),
 	);
 
 	test('should fail due to non-existing workflow', async () => {
-		const response = await authOwnerAgent.post('/workflows/2/activate');
+		const response = await authOwnerAgent.post(`/workflows/2/${action}`);
 		expect(response.statusCode).toBe(404);
 	});
 
-	test('should fail due to trying to activate a workflow without any nodes', async () => {
+	test('should fail when the workflow has no nodes', async () => {
 		const workflow = await createWorkflowWithHistory({ nodes: [] }, owner);
-		const response = await authOwnerAgent.post(`/workflows/${workflow.id}/activate`);
+		const response = await authOwnerAgent.post(`/workflows/${workflow.id}/${action}`);
 		expect(response.statusCode).toBe(400);
 	});
 
-	test('should fail due to trying to activate a workflow without a trigger', async () => {
+	test('should fail when the workflow has no trigger', async () => {
 		const workflow = await createWorkflowWithHistory(
 			{
 				nodes: [
@@ -1045,14 +1049,14 @@ describe('POST /workflows/:id/activate', () => {
 			},
 			owner,
 		);
-		const response = await authOwnerAgent.post(`/workflows/${workflow.id}/activate`);
+		const response = await authOwnerAgent.post(`/workflows/${workflow.id}/${action}`);
 		expect(response.statusCode).toBe(400);
 	});
 
 	test('should set workflow as active', async () => {
 		const workflow = await createWorkflowWithTriggerAndHistory({}, member);
 
-		const response = await authMemberAgent.post(`/workflows/${workflow.id}/activate`);
+		const response = await authMemberAgent.post(`/workflows/${workflow.id}/${action}`);
 
 		expect(response.statusCode).toBe(200);
 
@@ -1095,10 +1099,10 @@ describe('POST /workflows/:id/activate', () => {
 		expect(await workflowRepository.isActive(workflow.id)).toBe(true);
 	});
 
-	test('should set activeVersionId when activating workflow', async () => {
+	test('should set activeVersionId', async () => {
 		const workflow = await createWorkflowWithTriggerAndHistory({}, member);
 
-		const response = await authMemberAgent.post(`/workflows/${workflow.id}/activate`);
+		const response = await authMemberAgent.post(`/workflows/${workflow.id}/${action}`);
 
 		expect(response.statusCode).toBe(200);
 		expect(response.body.active).toBe(true);
@@ -1121,7 +1125,7 @@ describe('POST /workflows/:id/activate', () => {
 	test('should set non-owned workflow as active when owner', async () => {
 		const workflow = await createWorkflowWithTriggerAndHistory({}, member);
 
-		const response = await authMemberAgent.post(`/workflows/${workflow.id}/activate`).expect(200);
+		const response = await authMemberAgent.post(`/workflows/${workflow.id}/${action}`).expect(200);
 
 		const {
 			id,
@@ -1184,7 +1188,7 @@ describe('POST /workflows/:id/activate', () => {
 
 		const workflow = await createWorkflowWithTriggerAndHistory({}, teamProject);
 
-		const response = await authMemberAgent.post(`/workflows/${workflow.id}/activate`);
+		const response = await authMemberAgent.post(`/workflows/${workflow.id}/${action}`);
 
 		expect(response.statusCode).toBe(403);
 
@@ -1194,29 +1198,30 @@ describe('POST /workflows/:id/activate', () => {
 	});
 });
 
-describe('POST /workflows/:id/deactivate', () => {
+// `/unpublish` is a canonical alias of `/deactivate` sharing the exact same handler
+describe.each(['deactivate', 'unpublish'])('POST /workflows/:id/%s', (action) => {
 	test(
 		'should fail due to missing API Key',
-		testWithAPIKey('post', '/workflows/2/deactivate', null),
+		testWithAPIKey('post', `/workflows/2/${action}`, null),
 	);
 
 	test(
 		'should fail due to invalid API Key',
-		testWithAPIKey('post', '/workflows/2/deactivate', 'abcXYZ'),
+		testWithAPIKey('post', `/workflows/2/${action}`, 'abcXYZ'),
 	);
 
 	test('should fail due to non-existing workflow', async () => {
-		const response = await authOwnerAgent.post('/workflows/2/deactivate');
+		const response = await authOwnerAgent.post(`/workflows/2/${action}`);
 		expect(response.statusCode).toBe(404);
 	});
 
-	test('should deactivate workflow', async () => {
+	test(`should ${action} workflow`, async () => {
 		const workflow = await createWorkflowWithTriggerAndHistory({}, member);
 
 		await authMemberAgent.post(`/workflows/${workflow.id}/activate`);
 
 		const workflowDeactivationResponse = await authMemberAgent.post(
-			`/workflows/${workflow.id}/deactivate`,
+			`/workflows/${workflow.id}/${action}`,
 		);
 
 		const {
@@ -1272,7 +1277,7 @@ describe('POST /workflows/:id/deactivate', () => {
 
 		expect(sharedWorkflow?.workflow.activeVersionId).toBe(workflow.versionId);
 
-		const deactivateResponse = await authMemberAgent.post(`/workflows/${workflow.id}/deactivate`);
+		const deactivateResponse = await authMemberAgent.post(`/workflows/${workflow.id}/${action}`);
 
 		expect(deactivateResponse.statusCode).toBe(200);
 		expect(deactivateResponse.body.active).toBe(false);
@@ -1302,7 +1307,7 @@ describe('POST /workflows/:id/deactivate', () => {
 
 		const workflow = await createActiveWorkflow({}, teamProject);
 
-		const response = await authMemberAgent.post(`/workflows/${workflow.id}/deactivate`);
+		const response = await authMemberAgent.post(`/workflows/${workflow.id}/${action}`);
 
 		expect(response.statusCode).toBe(403);
 
@@ -1317,7 +1322,7 @@ describe('POST /workflows/:id/deactivate', () => {
 		await authMemberAgent.post(`/workflows/${workflow.id}/activate`);
 
 		const workflowDeactivationResponse = await authMemberAgent.post(
-			`/workflows/${workflow.id}/deactivate`,
+			`/workflows/${workflow.id}/${action}`,
 		);
 
 		const {

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -133,6 +133,12 @@
 			"status": "covered",
 			"nodeOperation": "workflow:deactivate"
 		},
+		"POST /workflows/{id}/publish": {
+			"status": "gap"
+		},
+		"POST /workflows/{id}/unpublish": {
+			"status": "gap"
+		},
 		"POST /workflows/{id}/archive": {
 			"status": "gap"
 		},


### PR DESCRIPTION
Adds `POST /api/v1/workflows/{id}/publish` and `/unpublish` as canonical aliases of `/activate` and `/deactivate`, matching the publish/unpublish wording adopted internally. Same handler, same behaviour, same scopes — naming only.

- Reuses the existing activate/deactivate code path (no duplicated logic)
- `/publish` keeps the optional `versionId`, `name`, `description` body params
- `/activate` and `/deactivate` unchanged; their deprecation is tracked in API-7
- Node coverage manifest: new paths marked `gap` (the N8n node still calls `/activate` `/deactivate`)

Tests: activate/deactivate integration suites parametrized over both path pairs to prove equivalence.

https://linear.app/n8n/issue/API-8


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34745">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

