### PR TITLE
feat(core): Add workflow.deactivate external hook

### DIFF
--- a/packages/cli/src/errors/response-errors/workflow-deactivation-bad-request.error.ts
+++ b/packages/cli/src/errors/response-errors/workflow-deactivation-bad-request.error.ts
@@ -1,0 +1,15 @@
+import { BadRequestError } from './bad-request.error';
+
+/**
+ * Error thrown when a workflow fails to deactivate, e.g. because a
+ * `workflow.deactivate` external hook rejected the operation.
+ */
+export class WorkflowDeactivationBadRequestError extends BadRequestError {
+	constructor(
+		message: string,
+		readonly meta: { nodeId?: string; validationError?: boolean; description?: string } = {},
+	) {
+		super(message);
+		this.name = 'WorkflowDeactivationBadRequestError';
+	}
+}

--- a/packages/cli/src/errors/response-errors/workflow-deactivation-bad-request.error.ts
+++ b/packages/cli/src/errors/response-errors/workflow-deactivation-bad-request.error.ts
@@ -7,7 +7,7 @@ import { BadRequestError } from './bad-request.error';
 export class WorkflowDeactivationBadRequestError extends BadRequestError {
 	constructor(
 		message: string,
-		readonly meta: { nodeId?: string; validationError?: boolean; description?: string } = {},
+		readonly meta: { description?: string } = {},
 	) {
 		super(message);
 		this.name = 'WorkflowDeactivationBadRequestError';

--- a/packages/cli/src/external-hooks.ts
+++ b/packages/cli/src/external-hooks.ts
@@ -71,6 +71,7 @@ type ExternalHooksMap = {
 	'workflow.create': [createdWorkflow: IWorkflowBase];
 	'workflow.afterCreate': [createdWorkflow: IWorkflowBase];
 	'workflow.activate': [updatedWorkflow: IWorkflowBase];
+	'workflow.deactivate': [deactivatedWorkflow: IWorkflowBase];
 	'workflow.update': [updatedWorkflow: IWorkflowBase];
 	'workflow.afterUpdate': [updatedWorkflow: IWorkflowBase];
 	'workflow.delete': [workflowId: string];

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -22,6 +22,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 import { WorkflowActivationBadRequestError } from '@/errors/response-errors/workflow-activation-bad-request.error';
+import { WorkflowDeactivationBadRequestError } from '@/errors/response-errors/workflow-deactivation-bad-request.error';
 import type { EventService } from '@/events/event.service';
 import type { ExternalHooks } from '@/external-hooks';
 import type { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
@@ -1257,6 +1258,49 @@ describe('WorkflowService', () => {
 			);
 			// in-memory teardown is left to the leader, not run here
 			expect(activeWorkflowManagerMock.remove).not.toHaveBeenCalled();
+		});
+
+		test('deactivation blocked by hook leaves the workflow published', async () => {
+			const workflow = makeWorkflowEntity({ activeVersionId: PREVIOUS_VERSION_ID });
+			workflowFinderServiceMock.findWorkflowForUser.mockResolvedValue(workflow);
+
+			externalHooksMock.run.mockRejectedValue(new Error('Code freeze in effect'));
+
+			const user = mock<User>();
+
+			await expect(workflowService.deactivateWorkflow(user, WORKFLOW_ID)).rejects.toBeInstanceOf(
+				WorkflowDeactivationBadRequestError,
+			);
+
+			expect(workflow.active).toBe(true);
+			expect(workflow.activeVersionId).toBe(PREVIOUS_VERSION_ID);
+			expect(activeWorkflowManagerMock.remove).not.toHaveBeenCalled();
+			expect(workflowRepositoryMock.update).not.toHaveBeenCalled();
+			expect(workflowPublishHistoryRepositoryMock.addRecord).not.toHaveBeenCalled();
+		});
+
+		test('hook receives the workflow being deactivated', async () => {
+			const workflow = makeWorkflowEntity({ activeVersionId: PREVIOUS_VERSION_ID });
+			workflowFinderServiceMock.findWorkflowForUser.mockResolvedValue(workflow);
+
+			externalHooksMock.run.mockResolvedValue(undefined);
+
+			const user = mock<User>();
+
+			await workflowService.deactivateWorkflow(user, WORKFLOW_ID);
+
+			expect(externalHooksMock.run).toHaveBeenCalledWith('workflow.deactivate', [workflow]);
+		});
+
+		test('does not run the hook when the workflow is already inactive', async () => {
+			const workflow = makeWorkflowEntity({ active: false, activeVersionId: null });
+			workflowFinderServiceMock.findWorkflowForUser.mockResolvedValue(workflow);
+
+			const user = mock<User>();
+
+			await workflowService.deactivateWorkflow(user, WORKFLOW_ID);
+
+			expect(externalHooksMock.run).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -988,7 +988,6 @@ export class WorkflowService {
 			await this.externalHooks.run('workflow.deactivate', [workflow]);
 		} catch (error) {
 			throw new WorkflowDeactivationBadRequestError(ensureError(error).message, {
-				nodeId: getErrorNodeId(error),
 				description: getErrorDescription(error),
 			});
 		}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -32,6 +32,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WorkflowActivationBadRequestError } from '@/errors/response-errors/workflow-activation-bad-request.error';
+import { WorkflowDeactivationBadRequestError } from '@/errors/response-errors/workflow-deactivation-bad-request.error';
 import { WorkflowValidationError } from '@/errors/response-errors/workflow-validation.error';
 import { WorkflowHistoryVersionNotFoundError } from '@/errors/workflow-history-version-not-found.error';
 import { EventService } from '@/events/event.service';
@@ -981,6 +982,15 @@ export class WorkflowService {
 
 		if (options?.expectedChecksum) {
 			await this._detectConflicts(workflow, options.expectedChecksum);
+		}
+
+		try {
+			await this.externalHooks.run('workflow.deactivate', [workflow]);
+		} catch (error) {
+			throw new WorkflowDeactivationBadRequestError(ensureError(error).message, {
+				nodeId: getErrorNodeId(error),
+				description: getErrorDescription(error),
+			});
 		}
 
 		if (this.globalConfig.workflows.useWorkflowPublicationService) {


### PR DESCRIPTION
## Summary

Adds a `workflow.deactivate` backend external hook (usable via `EXTERNAL_HOOK_FILES`), mirroring the existing `workflow.activate` hook.

The hook fires in `deactivateWorkflow` **before** any destructive state change, so a hook that throws aborts the deactivation and leaves the workflow published. 

A rejection is surfaced as a new `WorkflowDeactivationBadRequestError` (mirroring `WorkflowActivationBadRequestError`).

Scope notes:
- The hook runs only in the explicit `deactivateWorkflow` (unpublish) path. It intentionally does **not** fire during the version swap inside `activateWorkflow`, where the workflow never goes offline and `workflow.activate` already guards the transition first.
- Payload matches `workflow.activate` exactly: `[deactivatedWorkflow: IWorkflowBase]`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-2994
- Documentation included in https://github.com/n8n-io/n8n-docs/pull/5077

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

