### PR TITLE
fix(core): Include RFC 9207 iss parameter on OAuth authorization error redirects

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.controller.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.controller.api.test.ts
@@ -5,6 +5,7 @@ import { Container } from '@n8n/di';
 
 import { JwtService } from '@/services/jwt.service';
 import { ProtectedResourceRegistry } from '@/services/protected-resource.registry';
+import { UrlService } from '@/services/url.service';
 import { createOwner, createMember } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
 
@@ -285,6 +286,9 @@ describe('POST /rest/consent/approve', () => {
 		expect(redirectUrl.searchParams.get('code')).toBeTruthy();
 		expect(redirectUrl.searchParams.get('code')?.length).toBeGreaterThan(32);
 		expect(redirectUrl.searchParams.get('state')).toBe('test-state');
+		expect(redirectUrl.searchParams.get('iss')).toBe(
+			Container.get(UrlService).getInstanceBaseUrl(),
+		);
 	});
 
 	test('should handle consent denial and return error redirect URL', async () => {
@@ -304,6 +308,9 @@ describe('POST /rest/consent/approve', () => {
 		expect(redirectUrl.searchParams.get('error')).toBe('access_denied');
 		expect(redirectUrl.searchParams.get('error_description')).toBeTruthy();
 		expect(redirectUrl.searchParams.get('state')).toBe('test-state');
+		expect(redirectUrl.searchParams.get('iss')).toBe(
+			Container.get(UrlService).getInstanceBaseUrl(),
+		);
 	});
 
 	test('should clear session cookie after processing consent', async () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts
@@ -9,6 +9,7 @@ import { setupTestServer } from '@test-integration/utils';
 
 import { SUPPORTED_SCOPES } from '@/modules/mcp/mcp-protected-resource';
 import { McpSettingsService } from '@/modules/mcp/mcp.settings.service';
+import { UrlService } from '@/services/url.service';
 
 import { OAuthServerConfig } from '../oauth-server.config';
 import type { OAuthController as OAuthControllerClass } from '../oauth.controller';
@@ -394,6 +395,36 @@ describe('GET /mcp-oauth/authorize', () => {
 		expect(response.statusCode).not.toBe(403);
 		expect([302, 400, 401]).toContain(response.statusCode);
 	});
+
+	// RFC 9207: `iss` is required on every authorization response — including
+	// the SDK's own request-validation error redirects — because the metadata
+	// advertises `authorization_response_iss_parameter_supported`.
+	test.each(['/mcp-oauth/authorize', '/oauth/authorize'])(
+		'should include the iss parameter on error redirects from %s',
+		async (authorizePath) => {
+			const registerResponse = await testServer.restlessAgent.post('/mcp-oauth/register').send({
+				client_name: 'Error Redirect Client',
+				redirect_uris: ['https://example.com/callback'],
+				grant_types: ['authorization_code'],
+				token_endpoint_auth_method: 'none',
+			});
+
+			const response = await testServer.restlessAgent.get(authorizePath).query({
+				client_id: registerResponse.body.client_id,
+				redirect_uri: 'https://example.com/callback',
+				response_type: 'code',
+				// missing code_challenge → SDK redirects back with an error
+			});
+
+			expect(response.statusCode).toBe(302);
+			const redirectUrl = new URL(response.headers.location);
+			expect(redirectUrl.origin + redirectUrl.pathname).toBe('https://example.com/callback');
+			expect(redirectUrl.searchParams.get('error')).toBe('invalid_request');
+			expect(redirectUrl.searchParams.get('iss')).toBe(
+				Container.get(UrlService).getInstanceBaseUrl(),
+			);
+		},
+	);
 });
 
 describe('POST /mcp-oauth/token', () => {
@@ -601,6 +632,9 @@ describe('Full authorization-code flow (PKCE)', () => {
 		const code = redirectUrl.searchParams.get('code');
 		expect(code).toBeTruthy();
 		expect(redirectUrl.searchParams.get('state')).toBe('flow-state');
+		expect(redirectUrl.searchParams.get('iss')).toBe(
+			Container.get(UrlService).getInstanceBaseUrl(),
+		);
 
 		// 4. Token exchange
 		const tokenResponse = await testServer.restlessAgent

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts
@@ -399,32 +399,29 @@ describe('GET /mcp-oauth/authorize', () => {
 	// RFC 9207: `iss` is required on every authorization response — including
 	// the SDK's own request-validation error redirects — because the metadata
 	// advertises `authorization_response_iss_parameter_supported`.
-	test.each(['/mcp-oauth/authorize', '/oauth/authorize'])(
-		'should include the iss parameter on error redirects from %s',
-		async (authorizePath) => {
-			const registerResponse = await testServer.restlessAgent.post('/mcp-oauth/register').send({
-				client_name: 'Error Redirect Client',
-				redirect_uris: ['https://example.com/callback'],
-				grant_types: ['authorization_code'],
-				token_endpoint_auth_method: 'none',
-			});
+	test('should include the iss parameter on error redirects', async () => {
+		const registerResponse = await testServer.restlessAgent.post('/mcp-oauth/register').send({
+			client_name: 'Error Redirect Client',
+			redirect_uris: ['https://example.com/callback'],
+			grant_types: ['authorization_code'],
+			token_endpoint_auth_method: 'none',
+		});
 
-			const response = await testServer.restlessAgent.get(authorizePath).query({
-				client_id: registerResponse.body.client_id,
-				redirect_uri: 'https://example.com/callback',
-				response_type: 'code',
-				// missing code_challenge → SDK redirects back with an error
-			});
+		const response = await testServer.restlessAgent.get('/mcp-oauth/authorize').query({
+			client_id: registerResponse.body.client_id,
+			redirect_uri: 'https://example.com/callback',
+			response_type: 'code',
+			// missing code_challenge → SDK redirects back with an error
+		});
 
-			expect(response.statusCode).toBe(302);
-			const redirectUrl = new URL(response.headers.location);
-			expect(redirectUrl.origin + redirectUrl.pathname).toBe('https://example.com/callback');
-			expect(redirectUrl.searchParams.get('error')).toBe('invalid_request');
-			expect(redirectUrl.searchParams.get('iss')).toBe(
-				Container.get(UrlService).getInstanceBaseUrl(),
-			);
-		},
-	);
+		expect(response.statusCode).toBe(302);
+		const redirectUrl = new URL(response.headers.location);
+		expect(redirectUrl.origin + redirectUrl.pathname).toBe('https://example.com/callback');
+		expect(redirectUrl.searchParams.get('error')).toBe('invalid_request');
+		expect(redirectUrl.searchParams.get('iss')).toBe(
+			Container.get(UrlService).getInstanceBaseUrl(),
+		);
+	});
 });
 
 describe('POST /mcp-oauth/token', () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.helpers.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.helpers.test.ts
@@ -184,4 +184,37 @@ describe('OAuthHelpers', () => {
 			expect(new URL(result).searchParams.get('iss')).toBe(issuer);
 		});
 	});
+
+	describe('appendIssuerParam', () => {
+		it('should append iss to an absolute URL without one', () => {
+			const result = OAuthHelpers.appendIssuerParam('https://example.com/callback', issuer);
+
+			expect(new URL(result).searchParams.get('iss')).toBe(issuer);
+		});
+
+		it('should preserve existing query parameters', () => {
+			const result = OAuthHelpers.appendIssuerParam(
+				'https://example.com/callback?error=invalid_request&state=state-xyz',
+				issuer,
+			);
+
+			const url = new URL(result);
+			expect(url.searchParams.get('error')).toBe('invalid_request');
+			expect(url.searchParams.get('state')).toBe('state-xyz');
+			expect(url.searchParams.get('iss')).toBe(issuer);
+		});
+
+		it('should not overwrite an existing iss parameter', () => {
+			const result = OAuthHelpers.appendIssuerParam(
+				'https://example.com/callback?iss=https%3A%2F%2Fother.example.com',
+				issuer,
+			);
+
+			expect(new URL(result).searchParams.get('iss')).toBe('https://other.example.com');
+		});
+
+		it('should return relative URLs unchanged', () => {
+			expect(OAuthHelpers.appendIssuerParam('/oauth/consent', issuer)).toBe('/oauth/consent');
+		});
+	});
 });

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.helpers.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.helpers.test.ts
@@ -185,15 +185,15 @@ describe('OAuthHelpers', () => {
 		});
 	});
 
-	describe('appendIssuerParam', () => {
-		it('should append iss to an absolute URL without one', () => {
-			const result = OAuthHelpers.appendIssuerParam('https://example.com/callback', issuer);
+	describe('setIssuerParam', () => {
+		it('should set iss on an absolute URL without one', () => {
+			const result = OAuthHelpers.setIssuerParam('https://example.com/callback', issuer);
 
 			expect(new URL(result).searchParams.get('iss')).toBe(issuer);
 		});
 
 		it('should preserve existing query parameters', () => {
-			const result = OAuthHelpers.appendIssuerParam(
+			const result = OAuthHelpers.setIssuerParam(
 				'https://example.com/callback?error=invalid_request&state=state-xyz',
 				issuer,
 			);
@@ -204,17 +204,18 @@ describe('OAuthHelpers', () => {
 			expect(url.searchParams.get('iss')).toBe(issuer);
 		});
 
-		it('should not overwrite an existing iss parameter', () => {
-			const result = OAuthHelpers.appendIssuerParam(
+		it('should replace a pre-existing iss parameter with the server issuer', () => {
+			const result = OAuthHelpers.setIssuerParam(
 				'https://example.com/callback?iss=https%3A%2F%2Fother.example.com',
 				issuer,
 			);
 
-			expect(new URL(result).searchParams.get('iss')).toBe('https://other.example.com');
+			expect(new URL(result).searchParams.get('iss')).toBe(issuer);
+			expect(new URL(result).searchParams.getAll('iss')).toHaveLength(1);
 		});
 
 		it('should return relative URLs unchanged', () => {
-			expect(OAuthHelpers.appendIssuerParam('/oauth/consent', issuer)).toBe('/oauth/consent');
+			expect(OAuthHelpers.setIssuerParam('/oauth/consent', issuer)).toBe('/oauth/consent');
 		});
 	});
 });

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -27,6 +27,7 @@ const oauthServerService = Container.get(OAuthServerService);
 const globalConfig = Container.get(GlobalConfig);
 const oauthServerConfig = Container.get(OAuthServerConfig);
 const logger = Container.get(Logger);
+const urlService = Container.get(UrlService);
 
 /**
  * Pre-check guard for the unauthenticated DCR endpoint. Short-circuits with
@@ -70,9 +71,7 @@ const oauthClientLimitGuard: RequestHandler = async (_req, res, next) => {
 const rfc9207IssuerParam: RequestHandler = (_req, res, next) => {
 	const originalLocation = res.location.bind(res);
 	res.location = (url: string) =>
-		originalLocation(
-			OAuthHelpers.appendIssuerParam(url, Container.get(UrlService).getInstanceBaseUrl()),
-		);
+		originalLocation(OAuthHelpers.appendIssuerParam(url, urlService.getInstanceBaseUrl()));
 	next();
 };
 

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -71,7 +71,7 @@ const oauthClientLimitGuard: RequestHandler = async (_req, res, next) => {
 const rfc9207IssuerParam: RequestHandler = (_req, res, next) => {
 	const originalLocation = res.location.bind(res);
 	res.location = (url: string) =>
-		originalLocation(OAuthHelpers.appendIssuerParam(url, urlService.getInstanceBaseUrl()));
+		originalLocation(OAuthHelpers.setIssuerParam(url, urlService.getInstanceBaseUrl()));
 	next();
 };
 

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -21,6 +21,7 @@ import { UrlService } from '@/services/url.service';
 import { OAuthServerConfig } from './oauth-server.config';
 import { OAuthServerService } from './oauth-server.service';
 import { buildOAuthClientLimitReachedMessage } from './oauth.errors';
+import { OAuthHelpers } from './oauth.helpers';
 
 const oauthServerService = Container.get(OAuthServerService);
 const globalConfig = Container.get(GlobalConfig);
@@ -54,6 +55,27 @@ const oauthClientLimitGuard: RequestHandler = async (_req, res, next) => {
 	next();
 };
 
+/**
+ * The SDK's authorization handler redirects request-validation errors (e.g.
+ * missing `code_challenge`) back to the client without the RFC 9207 `iss`
+ * parameter, while our metadata advertises
+ * `authorization_response_iss_parameter_supported`. Wrap `res.location`
+ * (which `res.redirect` sets its target through) so every absolute-URL
+ * redirect from the authorize route carries `iss` matching the advertised
+ * issuer. Internal relative redirects (consent screen) pass through
+ * untouched. Remove once `@modelcontextprotocol/sdk` ships
+ * `authorizationHandler({ issuerUrl })` (on upstream main, unreleased as of
+ * 1.29.0) and the catalog version is bumped past it.
+ */
+const rfc9207IssuerParam: RequestHandler = (_req, res, next) => {
+	const originalLocation = res.location.bind(res);
+	res.location = (url: string) =>
+		originalLocation(
+			OAuthHelpers.appendIssuerParam(url, Container.get(UrlService).getInstanceBaseUrl()),
+		);
+	next();
+};
+
 // Built once and mounted under both the legacy `/mcp-oauth/*` paths (existing
 // DCR clients hold them in their stored discovery metadata) and the neutral
 // `/oauth/*` paths that future, non-MCP protected resources will advertise.
@@ -79,6 +101,7 @@ const sharedEndpointRouters = (basePath: '/mcp-oauth' | '/oauth'): StaticRouterM
 		path: `${basePath}/authorize`,
 		router: authorizeRouter,
 		skipAuth: true,
+		middlewares: [rfc9207IssuerParam],
 		ipRateLimit: createIpRateLimit(
 			oauthServerConfig.rateLimitAuthorize,
 			5 * Time.minutes.toMilliseconds,

--- a/packages/cli/src/modules/oauth-server/oauth.helpers.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.helpers.ts
@@ -47,4 +47,19 @@ export class OAuthHelpers {
 		targetUrl.searchParams.set('iss', issuer);
 		return targetUrl.toString();
 	}
+
+	/**
+	 * Append the RFC 9207 `iss` parameter to an absolute redirect URL when
+	 * missing. Relative URLs (internal redirects, e.g. to the consent screen)
+	 * are returned unchanged.
+	 */
+	static appendIssuerParam(url: string, issuer: string): string {
+		if (!URL.canParse(url)) return url;
+
+		const targetUrl = new URL(url);
+		if (!targetUrl.searchParams.has('iss')) {
+			targetUrl.searchParams.set('iss', issuer);
+		}
+		return targetUrl.toString();
+	}
 }

--- a/packages/cli/src/modules/oauth-server/oauth.helpers.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.helpers.ts
@@ -49,17 +49,17 @@ export class OAuthHelpers {
 	}
 
 	/**
-	 * Append the RFC 9207 `iss` parameter to an absolute redirect URL when
-	 * missing. Relative URLs (internal redirects, e.g. to the consent screen)
-	 * are returned unchanged.
+	 * Set the RFC 9207 `iss` parameter on an absolute redirect URL, replacing
+	 * any pre-existing value (e.g. one baked into the client's registered
+	 * redirect URI) so the response always asserts this server's identity.
+	 * Relative URLs (internal redirects, e.g. to the consent screen) are
+	 * returned unchanged.
 	 */
-	static appendIssuerParam(url: string, issuer: string): string {
+	static setIssuerParam(url: string, issuer: string): string {
 		if (!URL.canParse(url)) return url;
 
 		const targetUrl = new URL(url);
-		if (!targetUrl.searchParams.has('iss')) {
-			targetUrl.searchParams.set('iss', issuer);
-		}
+		targetUrl.searchParams.set('iss', issuer);
 		return targetUrl.toString();
 	}
 }


### PR DESCRIPTION
## Summary

The OAuth authorization-server metadata advertises `authorization_response_iss_parameter_supported: true`, but redirects emitted internally by the MCP SDK's `authorizationHandler` (request-validation errors, e.g. a missing `code_challenge`) did not carry the RFC 9207 `iss` parameter. Strict clients such as Codex CLI reject any authorization response without `iss`, failing the flow with `Authorization server response missing required issuer`.

The consent approve/deny redirects already include `iss`; the SDK's error redirects were the remaining gap. The installed SDK (1.26.0) has no issuer option, and no published version does yet (upstream added `authorizationHandler({ issuerUrl })` on main only, unreleased as of 1.29.0).

This PR adds:

- `OAuthHelpers.appendIssuerParam(url, issuer)`: appends `iss` to absolute URLs when missing; relative URLs (internal consent redirect) pass through unchanged.
- A `rfc9207IssuerParam` middleware on both `/mcp-oauth/authorize` and `/oauth/authorize` mounts that wraps `res.location` (which `res.redirect` funnels through), so every redirect to the client's callback carries `iss` matching the advertised issuer. It can be removed once the SDK ships `issuerUrl` support.

Supersedes #34503. Credit to @sabih-haider1 for the initial diagnosis and fix proposal there.

## How to test

1. Start n8n and register an OAuth client via dynamic client registration:
   ```bash
   curl -s -X POST http://localhost:5678/mcp-oauth/register -H 'Content-Type: application/json' \
     -d '{"client_name":"t","redirect_uris":["http://localhost:8976/callback"],"grant_types":["authorization_code"],"token_endpoint_auth_method":"none"}'
   ```
2. Send an authorize request without `code_challenge`:
   ```bash
   curl -s -o /dev/null -D - "http://localhost:5678/mcp-oauth/authorize?client_id=<client_id>&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Fcallback&response_type=code"
   ```
3. The 302 `Location` header now contains `error=invalid_request` and `iss=<instance base URL>`, matching the `issuer` from `/.well-known/oauth-authorization-server`. Before this change the `iss` parameter was absent.
4. Full-flow check with a strict RFC 9207 client:
   ```bash
   codex mcp add n8n_official --url http://localhost:5678/mcp-server/http
   codex mcp login n8n_official
   ```
5. Run the module test suite: `pnpm --filter=n8n test src/modules/oauth-server/`

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-5611
- https://linear.app/n8n/issue/GHC-8998
- Closes #34489

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34751">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

