### PR TITLE
fix(core): Preserve the underlying error as cause on Instance AI workspace file reads

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-files.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-files.test.ts
@@ -147,6 +147,36 @@ describe('workspace-files', () => {
 		expect(executeCommand).toHaveBeenCalledTimes(3);
 	});
 
+	it('keeps the underlying error as cause on exhausted transient filesystem reads', async () => {
+		const readError = new TransientWriteError('timeout');
+		const readFile = vi.fn(async () => await Promise.reject(readError));
+		const target: WorkspaceFileTarget = {
+			filesystem: { readFile, writeFile: vi.fn(async () => {}) },
+		};
+
+		const thrown: unknown = await readWorkspaceFile(target, '/tmp/manifest.json', {
+			logger: createLogger(),
+			retryBackoffBaseMs: 1,
+		}).catch((error: unknown) => error);
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).cause).toBe(readError);
+	});
+
+	it('keeps the underlying error as cause on exhausted transient command reads', async () => {
+		const commandError = new TransientWriteError('bad gateway');
+		const executeCommand = vi.fn(async () => await Promise.reject(commandError));
+		const target: WorkspaceFileTarget = { sandbox: { executeCommand } };
+
+		const thrown: unknown = await readWorkspaceFile(target, '/tmp/manifest.json', {
+			logger: createLogger(),
+			retryBackoffBaseMs: 1,
+		}).catch((error: unknown) => error);
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect((thrown as Error).cause).toBe(commandError);
+	});
+
 	it('writes via filesystem and supports batch writes', async () => {
 		const { target, writes } = createWorkspaceTarget(new Map());
 

--- a/packages/@n8n/instance-ai/src/workspace/workspace-files.ts
+++ b/packages/@n8n/instance-ai/src/workspace/workspace-files.ts
@@ -70,6 +70,7 @@ export async function readWorkspaceFile(
 			if (isTransientSandboxIoError(error)) {
 				throw new Error(
 					`Failed to read ${resourceLabel(options).toLowerCase()} "${filePath}": ${formatErrorForLog(error)}`,
+					{ cause: error },
 				);
 			}
 			options?.logger.debug(`${resourceLabel(options)} filesystem read missed`, {
@@ -88,6 +89,7 @@ export async function readWorkspaceFile(
 		if (isTransientSandboxIoError(error)) {
 			throw new Error(
 				`Failed to read ${resourceLabel(options).toLowerCase()} "${filePath}": ${formatErrorForLog(error)}`,
+				{ cause: error },
 			);
 		}
 		options?.logger.debug(`${resourceLabel(options)} command read missed`, {


### PR DESCRIPTION
## Summary

Follow-up to #34553, which added `{ cause }` to the `writeWorkspaceFile` error wrappers so quota-exhausted proxy failures stay classifiable. The `readWorkspaceFile` wrappers (filesystem path and sandbox-command path) still flattened the underlying provider error into the message string.

The concrete cost is visible in production: [INSTANCE-BACKEND-2756](https://n8nio.sentry.io/issues/INSTANCE-BACKEND-2756/) reads `Failed to read runtime skill file "...": [object Object]; status: 502`, a dead end with the real provider error lost. With `cause` attached:

- Sentry's LinkedErrors integration surfaces the full error chain on the event, so 5xx read failures become diagnosable.
- Benign throttling causes (429, which the SDK marks `level: warning`) are dropped by the core reporter's existing cause-level rule instead of reporting as errors.
- If read failures ever surface a classifiable quota code, terminal-error classification can walk the cause, same as writes.

Note the read paths only throw for transient errors (status 500+, 408, 429); non-transient failures still return `null` as before. Behavior is unchanged apart from the `cause` property.

## How to test

`pnpm test src/workspace/__tests__/workspace-files.test.ts` in `packages/@n8n/instance-ai`: two new tests assert the thrown wrapper keeps the underlying error as `cause` on both read paths, mirroring the write-path tests from #34553.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to https://linear.app/n8n/issue/INS-938 (no dedicated ticket).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34759">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

