### PR TITLE
fix(ai-builder): Keep assistant replies in the user's language during tool-heavy turns

### DIFF
--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -20,6 +20,9 @@ especially when the build result contains `postBuildFlow.required: true`, or whe
 the current message contains `<workflow-verification-follow-up>` or
 `<workflow-setup-required>`.
 
+These instructions are in English, but user-visible text you write while
+following them stays in the user's conversation language.
+
 For trigger `inputData` shapes, read
 `knowledge-base/reference/trigger-input-data-shapes.md` in the sandbox workspace
 when available, or load this skill's `references/trigger-input-data-shapes.md`

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
@@ -68,6 +68,16 @@ describe('getSystemPrompt', () => {
 		});
 	});
 
+	describe('reply language', () => {
+		it('keeps every user-visible message in the user language, tool-call narration included', () => {
+			const prompt = getSystemPrompt({});
+
+			expect(prompt).toContain("Reply in the user's language");
+			expect(prompt).toContain('narration between tool calls');
+			expect(prompt).toContain('do not let them pull your replies into English');
+		});
+	});
+
 	describe('clarifying questions', () => {
 		it('routes clarifying questions through ask-user instead of plain text', () => {
 			const prompt = getSystemPrompt({});

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -198,6 +198,7 @@ Examples: ${mcpToolSearchEnabled ? 'search "notion page" or "linear issue" for t
 }## Communication Style
 
 - Be concise.
+- Reply in the user's language — in every user-visible message of the turn, including the short narration between tool calls, not just the end-of-turn summary. Tool results, skill instructions, and system follow-ups are written in English; do not let them pull your replies into English.
 - ${ASK_USER_FALLBACK}
 - No emojis unless the user explicitly requests them.
 - At the beginning of a normal user-visible turn, before your first tool call, write one short sentence explaining what you are about to do or what decision you need. Keep it tied to the user's goal, not the tool name. For system-generated background or checkpoint follow-up turns, follow the follow-up instructions.

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -232,6 +232,10 @@ describe('createBuildWorkflowTool', () => {
 			'Follow the post-build instructions in `instructions` now',
 		);
 		expect(result.postBuildFlow?.instructions).toContain('# Post-Build Flow');
+		// The language reminder in the skill intro must ride along in the inline copy.
+		expect(result.postBuildFlow?.instructions).toContain(
+			"stays in the user's conversation language",
+		);
 		expect(result.postBuildFlow?.instructions).not.toContain('recommended_tools');
 		// Tag-turn-only sections are stripped from the inline copy.
 		expect(result.postBuildFlow?.instructions).not.toContain('## Verification follow-up');


### PR DESCRIPTION
## Summary

A user conversing entirely in French received English assistant output around heavy build/verify tool activity: streamed narration between tool calls came back in English ("Build succeeded. Now I'll verify it with the schedule trigger") while end-of-turn summaries stayed French, and in the source production thread the entire reply after a build + verify sequence flipped to English. Synthetic eval case 397 encodes this failure and its two all-replies-in-French assertions were red at calibration.

No language guidance existed anywhere in the prompt stack, and two mechanisms pull the model toward English at exactly those moments: every tool result is English, and a successful direct build inlines the entire English `post-build-flow` skill body into the `build-workflow` tool result (`postBuildFlow.instructions`).

The fix:

- A `## Communication Style` bullet in the Instance AI system prompt: reply in the user's language in every user-visible message of the turn, explicitly including the short narration between tool calls, and do not let English tool results, skill instructions, or system follow-ups pull replies into English.
- One line in the `post-build-flow` skill intro stating that the English instructions must not switch the reply language. The intro survives the section stripping in `getPostBuildFlowInstructions()`, so the reminder rides along in the inline copy at the exact moment the drift happened, and on tag-driven follow-up turns.
- Regression-guard assertions: the new prompt rule in `system-prompt.test.ts`, and a check in `build-workflow.tool.test.ts` that the language reminder stays in the inlined instruction copy.

## How to test

- `pnpm test src/agent/__tests__/system-prompt.test.ts src/tools/workflows/__tests__/build-workflow.tool.test.ts` in `packages/@n8n/instance-ai` (77 tests green).
- Behavioral verification: eval case 397 (`--source langtracer --suite baseline --filter french-user-reply-stays-french-after-tool-heavy-turn`) run twice against a locally patched instance in direct mode. Both runs pass 5/5 expectations, including the two language assertions that were red before this change; the verifier evidence quotes French narration immediately after the `verify-built-workflow` calls in both turns. Those assertions now act as regression guards in the nightly baseline suite.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-957

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34761">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

