### PR TITLE
fix(editor): Keep chat typing indicator visible until response arrives

### DIFF
--- a/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
@@ -127,6 +127,28 @@ describe('ChatInput', () => {
 		expect(global.WebSocket).toHaveBeenCalledWith(expect.stringContaining('executionId=exec-123'));
 	});
 
+	it('keeps waitingForResponse true after setting up the WebSocket connection', () => {
+		// The initial sendMessage clears waitingForResponse on `executionStarted`;
+		// the connection setup must re-enable it so the typing indicator stays up
+		// until the first bot frame arrives over the socket.
+		// The shared vi.fn mock doesn't return its object from `new`, so use a
+		// class that returns a captured instance (same pattern as the frame tests).
+		const ws = { send: vi.fn(), onmessage: null, onclose: null };
+		class FakeWebSocket {
+			constructor() {
+				return ws;
+			}
+		}
+		// @ts-expect-error - mock WebSocket
+		global.WebSocket = FakeWebSocket;
+		wrapper = mount(Input);
+		wrapper.vm.chatStore.waitingForResponse.value = false;
+
+		wrapper.vm.setupWebsocketConnection('exec-123');
+
+		expect(wrapper.vm.chatStore.waitingForResponse.value).toBe(true);
+	});
+
 	it('handles WebSocket messages correctly', async () => {
 		const mockWs = {
 			send: vi.fn(),

--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -167,6 +167,10 @@ function setupWebsocketConnection(executionId: string, resumeToken?: string) {
 				resumeToken,
 			);
 			chatStore.ws = new WebSocket(wsUrl);
+			// Keep the typing indicator up while the execution runs: the initial
+			// sendMessage cleared it on `executionStarted`, and the first bot frame
+			// (or socket close) below will clear it again.
+			chatStore.waitingForResponse.value = true;
 			// The first heartbeat locks the protocol: a pre-v3 server sends the string
 			// `n8n|heartbeat`, a v3 server sends `{type:'heartbeat'}`. Once legacy mode is
 			// locked, JSON that merely looks like a control frame is a chat message.


### PR DESCRIPTION
## Summary

When the Chat Trigger's Response Mode is **"Using Response Nodes"** (which drives the chat over a WebSocket), the typing indicator ("..." dots) only showed for a split second on the **first** message, even when the response took much longer to arrive. Follow-up messages behaved correctly.

Previous behaviour: on the first message the flow goes through `chatStore.sendMessage()`, which sets `waitingForResponse = true` (indicator shown), then receives `executionStarted: true` from the quick "start execution" call and sets `waitingForResponse = false` again. The WebSocket is then opened in `setupWebsocketConnection()`, but nothing re-enabled the indicator, so it stayed hidden while the agent was still working. Follow-up messages go through `respondToChatNode()`, which explicitly re-enables it — hence they were unaffected.

This change re-enables `waitingForResponse` right after the WebSocket is established, so the indicator stays visible until the first bot frame arrives (the existing message and socket-close handlers already clear it). A regression test was added in `Input.spec.ts`.

> [!NOTE]
> The hosted chat page (`/webhook/<id>/chat`) loads `@n8n/chat` from jsdelivr (the latest published npm version), not the bundled build, so this fix only reaches the hosted page once `@n8n/chat` is republished to npm. The canvas/editor chat picks it up immediately (bundled from workspace source). Verified locally on both.

## How to test

1. Create a workflow: **Chat Trigger** (Response Mode = "Using Response Nodes") → **AI Agent** → **Respond to Chat** node.
2. Open the chat and send the **first** message.
3. Expected: the typing indicator stays visible for the full duration of the response, not just a split second.
4. Send follow-up messages and confirm the indicator still behaves correctly (unchanged).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2660

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
