### PR TITLE
ci: Pin standalone package latest dist-tag to newest beta (no-changelog)

### DIFF
--- a/.github/scripts/set-latest-for-monorepo-packages.mjs
+++ b/.github/scripts/set-latest-for-monorepo-packages.mjs
@@ -1,6 +1,17 @@
+import semver from 'semver';
+
 import { getMonorepoProjects } from './pnpm-utils.mjs';
 
 const NPM_REGISTRY = 'https://registry.npmjs.org';
+
+// Standalone packages release from master out-of-sync with the main pipeline
+// (release-standalone-package.yml), so their `latest` follows the newest beta
+// on npm instead of the version recorded in the stable checkout.
+const STANDALONE_PACKAGES_FOLLOWING_BETA = new Set([
+	'@n8n/create-node',
+	'@n8n/eslint-plugin-community-nodes',
+	'@n8n/scan-community-package',
+]);
 
 /**
  * @param {string} name
@@ -23,6 +34,30 @@ async function setDistTag(name, version, tag, token) {
 	});
 }
 
+/** @param {string} name */
+async function getDistTags(name) {
+	const res = await fetch(`${NPM_REGISTRY}/-/package/${encodeURIComponent(name)}/dist-tags`);
+	if (!res.ok) {
+		throw new Error(`Failed to fetch dist-tags for ${name}: HTTP ${res.status}`);
+	}
+	return await res.json();
+}
+
+/**
+ * Resolve the version `latest` should point at, or null if no move is needed.
+ * Standalone packages follow the npm `beta` dist-tag; a standalone release
+ * from master may already have pushed `latest` past beta, so never downgrade.
+ * @param {import('./pnpm-utils.mjs').PnpmPackage} pkg
+ */
+export async function resolveLatestVersion(pkg) {
+	if (!STANDALONE_PACKAGES_FOLLOWING_BETA.has(pkg.name)) return pkg.version;
+
+	const tags = await getDistTags(pkg.name);
+	const target = tags.beta ?? pkg.version;
+	if (tags.latest && semver.gte(tags.latest, target)) return null;
+	return target;
+}
+
 async function setLatestForMonorepoPackages() {
 	const token = process.env.NPM_TOKEN;
 	if (!token) {
@@ -39,10 +74,15 @@ async function setLatestForMonorepoPackages() {
 	const failures = [];
 
 	for (const pkg of publishedPackages) {
-		const versionName = `${pkg.name}@${pkg.version}`;
-
 		try {
-			const res = await setDistTag(pkg.name, pkg.version, 'latest', token);
+			const version = await resolveLatestVersion(pkg);
+			if (version === null) {
+				console.log(`Skipped ${pkg.name}: latest is already at or ahead of beta`);
+				continue;
+			}
+
+			const versionName = `${pkg.name}@${version}`;
+			const res = await setDistTag(pkg.name, version, 'latest', token);
 
 			if (res.ok) {
 				console.log(`Set ${versionName} as latest`);
@@ -53,8 +93,8 @@ async function setLatestForMonorepoPackages() {
 			}
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			console.error(`Failed to set ${versionName} as latest: ${message}`);
-			failures.push(versionName);
+			console.error(`Failed to set latest for ${pkg.name}: ${message}`);
+			failures.push(pkg.name);
 		}
 	}
 

--- a/.github/scripts/set-latest-for-monorepo-packages.test.mjs
+++ b/.github/scripts/set-latest-for-monorepo-packages.test.mjs
@@ -1,0 +1,53 @@
+import { describe, it, before, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Run these tests by running
+ *
+ * node --test --experimental-test-module-mocks ./.github/scripts/set-latest-for-monorepo-packages.test.mjs
+ * */
+
+let resolveLatestVersion;
+before(async () => {
+	({ resolveLatestVersion } = await import('./set-latest-for-monorepo-packages.mjs'));
+});
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function mockDistTags(tags) {
+	globalThis.fetch = async () => ({ ok: true, json: async () => tags });
+}
+
+describe('resolveLatestVersion', () => {
+	it('uses the checkout version for regular monorepo packages', async () => {
+		globalThis.fetch = async () => {
+			throw new Error('should not fetch dist-tags for regular packages');
+		};
+		const version = await resolveLatestVersion({ name: '@n8n/config', version: '1.2.3' });
+		assert.equal(version, '1.2.3');
+	});
+
+	it('pins standalone packages to the beta dist-tag', async () => {
+		mockDistTags({ beta: '0.40.1', latest: '0.39.3' });
+		const version = await resolveLatestVersion({ name: '@n8n/create-node', version: '0.39.3' });
+		assert.equal(version, '0.40.1');
+	});
+
+	it('never downgrades latest below a newer standalone release', async () => {
+		mockDistTags({ beta: '0.40.1', latest: '0.41.0' });
+		const version = await resolveLatestVersion({ name: '@n8n/create-node', version: '0.39.3' });
+		assert.equal(version, null);
+	});
+
+	it('skips standalone packages without a beta tag when latest is current', async () => {
+		mockDistTags({ latest: '0.25.0' });
+		const version = await resolveLatestVersion({
+			name: '@n8n/eslint-plugin-community-nodes',
+			version: '0.25.0',
+		});
+		assert.equal(version, null);
+	});
+});

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -80,9 +80,12 @@ jobs:
 
   ensure-correct-latest-version-on-npm:
     name: Ensure correct latest version on npm
+    # Also runs on beta patches: standalone packages pin `latest` to the newest
+    # beta, so every beta publish needs a re-pin, not just stable promotions.
     if: |
       inputs.bump == 'minor' ||
-      (inputs.track == 'stable' && inputs.release_type != 'rc')
+      (inputs.track == 'stable' && inputs.release_type != 'rc') ||
+      (inputs.track == 'beta' && inputs.release_type != 'rc')
     uses: ./.github/workflows/release-set-stable-npm-packages-to-latest.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary

The `latest` npm dist-tag for the standalone packages `@n8n/create-node`, `@n8n/eslint-plugin-community-nodes`, and `@n8n/scan-community-package` keeps falling behind the newest published version: every release bumps and publishes them under the `beta` dist-tag, but `latest` is only re-pinned on stable promotion — and to the (older) version recorded in the `stable` checkout. As a result `npx @n8n/scan-community-package` and friends resolve outdated versions.

This PR makes `latest` for these three packages follow the newest `beta` release:

- `set-latest-for-monorepo-packages.mjs` now resolves the npm `beta` dist-tag for the three standalone packages and pins `latest` to that instead of the stable-checkout version. It never downgrades: if `latest` is already at or ahead of beta (e.g. after a standalone release from master, which publishes straight to `latest`), the package is skipped.
- The `ensure-correct-latest-version-on-npm` post-release job now also runs on beta releases, so `latest` catches up on every beta publish instead of waiting for the next stable promotion. For all other packages this extra run is an idempotent re-pin.

Backport labels are set because the set-latest workflow runs the script from the `refs/tags/stable` checkout — the new logic only takes effect once the `stable` tag advances past a commit containing it, so it needs to reach the release-candidate branches.

## How to test

- `cd .github/scripts && pnpm install --ignore-workspace && node --test --experimental-test-module-mocks ./set-latest-for-monorepo-packages.test.mjs` — covers regular-package passthrough, beta pinning, the downgrade guard, and the missing-beta fallback.
- Full workflow-scripts suite passes: `pnpm test` in `.github/scripts` (462/462).
- After this lands in the `stable` tag lineage, dispatching "Release: Set stable npm packages to latest" should move `latest` for the three packages to the version currently under `beta` (verify with `npm view @n8n/create-node dist-tags`).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-823

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34770">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

