### PR TITLE
feat(ai-builder): Report per-case claude build cost for MCP eval builds (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/ARCHITECTURE.md
+++ b/packages/@n8n/instance-ai/evaluations/ARCHITECTURE.md
@@ -59,7 +59,8 @@ analytics pipeline reads them), the direct driver passes identity.
 - **`eval-pr-comment.md`** is posted verbatim by CI; the comment is found by its
   `### Instance AI Workflow Eval` prefix.
 - **LangSmith feedback keys** (`scenario_pass`, `failure_category`,
-  `evals.workflows.*`, `pass_at_k`, `pass_hat_k`) and the traced span names
+  `evals.workflows.*`, `pass_at_k`, `pass_hat_k` — plus `build_cost_usd` /
+  `build_turns` on `--build-via-mcp` rows) and the traced span names
   feed the LangSmith→BigQuery analytics.
 - **`pnpm eval:*` script names** are invoked by CI workflows and
   `run-eval-lanes.sh`.

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -441,6 +441,12 @@ How it differs from the manifest flow:
   `--keep-workflows`. Known limitation: cleanup keys off the `WORKFLOW_ID` trailer
   `claude` prints, so a build that times out or never emits the trailer can leave
   its workflow behind on the lane even though cleanup is on.
+- **Per-case spend reporting.** Each build's `claude` cost/turns (summed across
+  attempts — failed attempts cost money too) land as `build_cost_usd` /
+  `build_turns` row feedback in LangSmith and as `buildCostUsdPerRun` /
+  `buildTurnsPerRun` per case in `eval-results.json`, alongside the run-level
+  `summary.mcpBuild` totals. `pnpm eval:build-cost-report` joins these with an
+  AIA arm's backend-trace cost for builder cost comparisons.
 
 **Prerequisites**: `LANGSMITH_API_KEY` set — MCP builds only run on the
 LangSmith path, whose lane allocator caps builds at 4 per lane globally (the

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -445,9 +445,11 @@ How it differs from the manifest flow:
   attempts — failed attempts cost money too) land as `build_cost_usd` /
   `build_turns` row feedback in LangSmith and as `buildCostUsdPerRun` /
   `buildTurnsPerRun` per case in `eval-results.json`, alongside the run-level
-  `summary.mcpBuild` totals. For builder cost comparisons, the un-wired helper
-  `evaluations/cli/build-cost-report.ts` (run via `pnpm tsx`) joins these with
-  an AIA arm's backend-trace cost.
+  `summary.mcpBuild` totals. For builder cost comparisons across any runs
+  (MCP vs AIA, builder-model A/Bs), the un-wired helper
+  `evaluations/cli/build-cost-report.ts` (run via `pnpm tsx`, one `--results`
+  per arm) auto-detects each arm's cost source — these persisted fields, or
+  the backend build threads priced in LangSmith.
 
 **Prerequisites**: `LANGSMITH_API_KEY` set — MCP builds only run on the
 LangSmith path, whose lane allocator caps builds at 4 per lane globally (the

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -445,8 +445,9 @@ How it differs from the manifest flow:
   attempts — failed attempts cost money too) land as `build_cost_usd` /
   `build_turns` row feedback in LangSmith and as `buildCostUsdPerRun` /
   `buildTurnsPerRun` per case in `eval-results.json`, alongside the run-level
-  `summary.mcpBuild` totals. `pnpm eval:build-cost-report` joins these with an
-  AIA arm's backend-trace cost for builder cost comparisons.
+  `summary.mcpBuild` totals. For builder cost comparisons, the un-wired helper
+  `evaluations/cli/build-cost-report.ts` (run via `pnpm tsx`) joins these with
+  an AIA arm's backend-trace cost.
 
 **Prerequisites**: `LANGSMITH_API_KEY` set — MCP builds only run on the
 LangSmith path, whose lane allocator caps builds at 4 per lane globally (the

--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-cost-report.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-cost-report.test.ts
@@ -1,0 +1,251 @@
+import { jsonParse } from 'n8n-workflow';
+import { afterEach, vi } from 'vitest';
+
+import {
+	greenStats,
+	persistedSpendCosts,
+	renderMarkdown,
+	sumThreadCost,
+	threadJoinCosts,
+} from '../cli/build-cost-report';
+import type { ArmSummary, EvalResults, ReportTestCase } from '../cli/build-cost-report';
+
+const scenarioRun = (passed: boolean, incomplete = false) => ({ passed, incomplete });
+const expectation = (pass: boolean, incomplete = false) => ({ pass, incomplete });
+
+const testCase = (overrides: Partial<ReportTestCase> = {}): ReportTestCase => ({
+	name: 'case',
+	status: 'completed',
+	totalRuns: 3,
+	...overrides,
+});
+
+describe('greenStats', () => {
+	it.each([
+		{
+			label: 'every evaluated unit passing → all iterations green',
+			tc: testCase({
+				scenarios: [{ name: 's', runs: [scenarioRun(true), scenarioRun(true), scenarioRun(true)] }],
+			}),
+			expected: { green: 3, evaluated: 3 },
+		},
+		{
+			label: 'one failing scenario run reddens only its iteration',
+			tc: testCase({
+				scenarios: [
+					{ name: 's', runs: [scenarioRun(true), scenarioRun(false), scenarioRun(true)] },
+				],
+			}),
+			expected: { green: 2, evaluated: 3 },
+		},
+		{
+			label: 'a failing build expectation reddens an iteration whose scenarios passed',
+			tc: testCase({
+				totalRuns: 2,
+				scenarios: [{ name: 's', runs: [scenarioRun(true), scenarioRun(true)] }],
+				buildExpectationResultsPerRun: [[expectation(true)], [expectation(false)]],
+			}),
+			expected: { green: 1, evaluated: 2 },
+		},
+		{
+			label: 'incomplete units count neither way; only-incomplete iterations are not evaluated',
+			tc: testCase({
+				totalRuns: 2,
+				scenarios: [{ name: 's', runs: [scenarioRun(true), scenarioRun(false, true)] }],
+			}),
+			expected: { green: 1, evaluated: 1 },
+		},
+		{
+			label: 'build-only cases evaluate on expectations alone',
+			tc: testCase({
+				totalRuns: 2,
+				buildExpectationResultsPerRun: [
+					[expectation(true), expectation(true)],
+					[expectation(true), expectation(false)],
+				],
+			}),
+			expected: { green: 1, evaluated: 2 },
+		},
+		{
+			label: 'iterations with no verdicts at all are not evaluated',
+			tc: testCase({ totalRuns: 2 }),
+			expected: { green: 0, evaluated: 0 },
+		},
+		{
+			label: 'short scenario-run arrays and null expectation rows are skipped, not failed',
+			tc: testCase({
+				totalRuns: 3,
+				scenarios: [{ name: 's', runs: [scenarioRun(true)] }],
+				buildExpectationResultsPerRun: [null, [expectation(true)], null],
+			}),
+			expected: { green: 2, evaluated: 2 },
+		},
+	])('$label', ({ tc, expected }) => {
+		expect(greenStats(tc)).toEqual(expected);
+	});
+});
+
+describe('persistedSpendCosts', () => {
+	it('carries per-iteration spend through and means turns over known iterations', () => {
+		const results: EvalResults = {
+			totalRuns: 3,
+			testCases: [
+				testCase({
+					name: 'case-a',
+					testCaseFile: 'case-a.json',
+					buildCostUsdPerRun: [0.1, null, 0.3],
+					buildTurnsPerRun: [10, null, 20],
+					scenarios: [
+						{ name: 's', runs: [scenarioRun(true), scenarioRun(true), scenarioRun(false)] },
+					],
+				}),
+			],
+		};
+
+		const [caseCost] = persistedSpendCosts(results);
+
+		expect(caseCost.slug).toBe('case-a.json');
+		expect(caseCost.costPerIteration).toEqual([0.1, null, 0.3]);
+		expect(caseCost.meanTurns).toBe(15);
+		expect(caseCost.greenIterations).toBe(2);
+		expect(caseCost.evaluatedIterations).toBe(3);
+	});
+
+	it('records unknown cost (null), not $0, when no spend was persisted', () => {
+		const results: EvalResults = {
+			totalRuns: 2,
+			testCases: [testCase({ name: 'case-b', totalRuns: 2 })],
+		};
+
+		const [caseCost] = persistedSpendCosts(results);
+
+		expect(caseCost.costPerIteration).toEqual([null, null]);
+		expect(caseCost.meanTurns).toBeUndefined();
+	});
+});
+
+describe('LangSmith thread costs', () => {
+	const ls = { apiUrl: 'https://langsmith.test', headers: {} };
+
+	const stubRunsQuery = (runsByThread: Record<string, unknown[]>) => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn((_url: unknown, init?: RequestInit) => {
+				const body = typeof init?.body === 'string' ? init.body : '{}';
+				const { filter } = jsonParse<{ filter: string }>(body);
+				const threadId = /eq\(thread_id, "([^"]+)"\)/.exec(filter)?.[1] ?? '';
+				return { ok: true, status: 200, json: () => ({ runs: runsByThread[threadId] ?? [] }) };
+			}),
+		);
+	};
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	describe('sumThreadCost', () => {
+		it('returns null (unknown) for a thread with no runs in the project', async () => {
+			stubRunsQuery({});
+
+			expect(await sumThreadCost(ls, 'project-1', 'thread-x')).toBeNull();
+		});
+
+		it('sums cost, tokens and turns over the thread root runs', async () => {
+			stubRunsQuery({
+				'thread-x': [
+					{ id: 'r1', total_cost: 0.5, total_tokens: 100 },
+					{ id: 'r2', total_cost: 0.25, total_tokens: 50 },
+					{ id: 'r3', total_cost: null, total_tokens: null },
+				],
+			});
+
+			expect(await sumThreadCost(ls, 'project-1', 'thread-x')).toEqual({
+				costUsd: 0.75,
+				tokens: 150,
+				turns: 3,
+			});
+		});
+
+		it('warns when the page limit is hit so truncated totals are not silent', async () => {
+			stubRunsQuery({
+				'thread-x': Array.from({ length: 100 }, (_, i) => ({
+					id: `r${i}`,
+					total_cost: 0.01,
+					total_tokens: 10,
+				})),
+			});
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+			const cost = await sumThreadCost(ls, 'project-1', 'thread-x');
+
+			expect(cost?.turns).toBe(100);
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining('undercounted'));
+		});
+	});
+
+	describe('threadJoinCosts', () => {
+		it('sums resolved threads and records unresolved ones as unknown, not $0', async () => {
+			stubRunsQuery({
+				'thread-resolved': [
+					{ id: 'r1', total_cost: 0.5, total_tokens: 100 },
+					{ id: 'r2', total_cost: 0.25, total_tokens: 50 },
+				],
+			});
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			const results: EvalResults = {
+				totalRuns: 2,
+				testCases: [
+					testCase({
+						name: 'resolved',
+						totalRuns: 2,
+						threadIds: ['thread-resolved', null],
+						scenarios: [{ name: 's', runs: [scenarioRun(true), scenarioRun(true)] }],
+					}),
+					testCase({ name: 'unresolved', totalRuns: 1, threadIds: ['thread-missing'] }),
+				],
+			};
+
+			const [resolved, unresolved] = await threadJoinCosts(results, ls, 'project-1', 5);
+
+			expect(resolved.costPerIteration).toEqual([0.75, null]);
+			expect(resolved.meanTurns).toBe(2);
+			expect(resolved.meanTokens).toBe(150);
+			expect(unresolved.costPerIteration).toEqual([null]);
+			expect(unresolved.meanTurns).toBeUndefined();
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining('thread-missing'));
+		});
+	});
+});
+
+describe('renderMarkdown', () => {
+	it('renders unknown costs as — and keeps known means intact', () => {
+		const arms: ArmSummary[] = [
+			{
+				label: 'aia',
+				source: 'LangSmith thread pricing',
+				cases: [
+					{
+						slug: 'known-case',
+						costPerIteration: [0.2, 0.4],
+						meanTurns: 3,
+						greenIterations: 2,
+						evaluatedIterations: 2,
+					},
+					{
+						slug: 'unknown-case',
+						costPerIteration: [null],
+						greenIterations: 1,
+						evaluatedIterations: 1,
+					},
+				],
+			},
+		];
+
+		const markdown = renderMarkdown(arms);
+
+		expect(markdown).toContain('| known-case | $0.300 | 2/2 | 3.0 |');
+		expect(markdown).toContain('| unknown-case | — | 1/1 | — |');
+		expect(markdown).toContain('2 builds with cost');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
@@ -128,7 +128,12 @@ describe('createCasePipeline', () => {
 			reasoning: 'works',
 			workflowId: 'wf-exec',
 		} as never);
-		const cached: CachedBuild = { build: okBuild(), lane, buildDurationMs: 42 };
+		const cached: CachedBuild = {
+			build: okBuild(),
+			lane,
+			buildDurationMs: 42,
+			buildSpend: { costUsd: 0.42, turns: 6 },
+		};
 		const orchestrator = makeOrchestrator(cached);
 		const pipeline = createCasePipeline(makeDeps(orchestrator));
 
@@ -142,6 +147,9 @@ describe('createCasePipeline', () => {
 			scenarioWorkflowId: 'wf-exec',
 			nodeCount: 2,
 			buildDurationMs: 42,
+			// `claude` spend (--build-via-mcp) rides on every row of the case's build.
+			buildCostUsd: 0.42,
+			buildTurns: 6,
 		});
 		// Single-scenario case → this was the last row → artifacts deleted eagerly.
 		expect(vi.mocked(cleanupBuild)).toHaveBeenCalledTimes(1);

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -97,6 +97,8 @@ interface DispatcherView {
 			pass: boolean;
 			reason: string;
 		}> | null>;
+		buildCostUsdPerRun?: Array<number | null>;
+		buildTurnsPerRun?: Array<number | null>;
 		scenarios: Array<{
 			name: string;
 			passCount: number;
@@ -157,6 +159,10 @@ describe('eval-results.json — dispatcher contract', () => {
 			[{ expectation: 'sends a digest', pass: true, reason: 'digest node present' }],
 			[{ expectation: 'sends a digest', pass: false, reason: 'digest node missing' }],
 		]);
+		// Spend arrays are `--build-via-mcp`-only — absent when no iteration
+		// recorded `claude` spend, so non-MCP dispatcher output is unchanged.
+		expect(tc).not.toHaveProperty('buildCostUsdPerRun');
+		expect(tc).not.toHaveProperty('buildTurnsPerRun');
 
 		// Scenario blocks serialize under the flat `scenarios` key with a flat
 		// `name` — the shape the dispatcher's fallback reader consumes today.
@@ -175,5 +181,29 @@ describe('eval-results.json — dispatcher contract', () => {
 			rootCause: 'mock returned an empty page',
 			execErrors: ['HTTP 500 from the mocked API'],
 		});
+	});
+
+	it('serializes per-iteration `claude` build spend when a run recorded it', () => {
+		const evaluation = aggregateResults(
+			[[{ ...iteration1(), buildCostUsd: 0.31, buildTurns: 5 }], [iteration2()]],
+			2,
+		);
+		const dir = mkdtempSync(join(tmpdir(), 'eval-results-contract-'));
+		const { jsonPath } = writeEvalResults(
+			evaluation,
+			1234,
+			dir,
+			'exp-dispatcher-contract',
+			undefined,
+			undefined,
+			new Map([[testCase, 'daily-digest']]),
+			undefined,
+			undefined,
+		);
+		const report = jsonParse<DispatcherView>(readFileSync(jsonPath, 'utf8'));
+
+		const tc = report.testCases[0];
+		expect(tc.buildCostUsdPerRun).toEqual([0.31, null]);
+		expect(tc.buildTurnsPerRun).toEqual([5, null]);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
@@ -258,6 +258,41 @@ describe('buildWorkflowViaMcp', () => {
 		expect(result.failureReason).toBeUndefined();
 		expect(vi.mocked(spawn)).toHaveBeenCalledTimes(1);
 	});
+
+	it('sums cost, turns and duration across attempts — failed attempts cost money too', async () => {
+		let call = 0;
+		spawnReturning(() => {
+			const child = new FakeChild(1234);
+			call++;
+			const session =
+				call === 1
+					? {
+							result: 'built something, forgot the id',
+							total_cost_usd: 0.1,
+							num_turns: 2,
+							duration_ms: 1000,
+						}
+					: {
+							result: 'done\nWORKFLOW_ID=wf42',
+							total_cost_usd: 0.25,
+							num_turns: 5,
+							duration_ms: 3000,
+						};
+			setImmediate(() => {
+				child.stdout.emit('data', Buffer.from(JSON.stringify(session)));
+				child.emit('close', 0, null);
+			});
+			return child;
+		});
+
+		const result = await buildWorkflowViaMcp(buildOpts());
+
+		expect(result.workflowId).toBe('wf42');
+		expect(result.cost).toBeCloseTo(0.35);
+		expect(result.turns).toBe(7);
+		expect(result.durationMs).toBe(4000);
+		expect(vi.mocked(spawn)).toHaveBeenCalledTimes(2);
+	});
 });
 
 describe('stageLaneMcpConfig', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -135,6 +135,32 @@ describe('reshapeLangSmithRuns', () => {
 		expect(tc.buildError).toBe('Build failed: agent produced no workflow');
 	});
 
+	it('carries `claude` build spend from any row of the case (first defined wins)', () => {
+		const cases = [withFile('airtable', [scenario('s1'), scenario('s2')])];
+		const rows = [
+			row(
+				{ testCaseFile: 'airtable', scenarioName: 's1', _iteration: 0 },
+				{ buildSuccess: true, passed: true, score: 1, reasoning: 'ok' },
+			),
+			row(
+				{ testCaseFile: 'airtable', scenarioName: 's2', _iteration: 0 },
+				{
+					buildSuccess: true,
+					passed: true,
+					score: 1,
+					reasoning: 'ok',
+					buildCostUsd: 0.37,
+					buildTurns: 6,
+				},
+			),
+		];
+
+		const result = reshapeLangSmithRuns(rows, cases, 1, new Map(), new Map(), undefined);
+
+		expect(result[0][0].buildCostUsd).toBe(0.37);
+		expect(result[0][0].buildTurns).toBe(6);
+	});
+
 	it('attaches build-expectation verdicts by iteration:fileSlug even with no threadId (prebuilt/MCP path)', () => {
 		// Prebuilt/MCP builds have no threadId. Transcript stays threadId-gated (so it
 		// remains undefined here), but outcome-expectation verdicts must still attach via

--- a/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
@@ -64,8 +64,8 @@ const evalResultsSchema = z.object({
 	testCases: z.array(testCaseSchema),
 });
 
-type EvalResults = z.infer<typeof evalResultsSchema>;
-type ReportTestCase = z.infer<typeof testCaseSchema>;
+export type EvalResults = z.infer<typeof evalResultsSchema>;
+export type ReportTestCase = z.infer<typeof testCaseSchema>;
 
 // ---------------------------------------------------------------------------
 // LangSmith REST (raw fetch + zod — keeps cost fields typed without SDK casts)
@@ -145,13 +145,17 @@ interface ThreadCost {
 	turns: number;
 }
 
+const RUNS_QUERY_LIMIT = 100;
+
 /** Sum a thread's root runs (one per turn); roots aggregate their children,
- *  so this is the thread's whole backend LLM spend. */
-async function sumThreadCost(
+ *  so this is the thread's whole backend LLM spend. Null when the thread has
+ *  no runs in the project — an unknown cost, not a $0 build (wrong
+ *  --trace-project, or the trace hasn't landed yet). */
+export async function sumThreadCost(
 	ls: LangSmithConfig,
 	projectId: string,
 	threadId: string,
-): Promise<ThreadCost> {
+): Promise<ThreadCost | null> {
 	const res = await lsFetch(`${ls.apiUrl}/api/v1/runs/query`, {
 		method: 'POST',
 		headers: ls.headers,
@@ -159,7 +163,7 @@ async function sumThreadCost(
 			session: [projectId],
 			is_root: true,
 			filter: `eq(thread_id, "${threadId}")`,
-			limit: 100,
+			limit: RUNS_QUERY_LIMIT,
 			select: ['id', 'total_cost', 'total_tokens'],
 		}),
 	});
@@ -167,6 +171,12 @@ async function sumThreadCost(
 		throw new Error(`LangSmith runs/query failed: ${res.status} ${await res.text()}`);
 	}
 	const { runs } = lsRunsQuerySchema.parse(await res.json());
+	if (runs.length === 0) return null;
+	if (runs.length === RUNS_QUERY_LIMIT) {
+		console.warn(
+			`thread ${threadId}: hit the runs/query page limit (${RUNS_QUERY_LIMIT}) — cost may be undercounted`,
+		);
+	}
 	return {
 		costUsd: runs.reduce((sum, r) => sum + (r.total_cost ?? 0), 0),
 		tokens: runs.reduce((sum, r) => sum + (r.total_tokens ?? 0), 0),
@@ -178,9 +188,9 @@ async function sumThreadCost(
 // Per-case aggregation
 // ---------------------------------------------------------------------------
 
-interface CaseCost {
+export interface CaseCost {
 	slug: string;
-	/** Build cost per iteration; null when unknown (no thread / no spend recorded). */
+	/** Build cost per iteration; null when unknown (no thread, unresolved thread, or no spend recorded). */
 	costPerIteration: Array<number | null>;
 	/** MCP: `claude` turns; AIA: root runs (build turns). Mean over known iterations. */
 	meanTurns?: number;
@@ -196,7 +206,7 @@ function caseSlug(tc: ReportTestCase): string {
 
 /** An iteration is green when every evaluated unit of it passed (scenario runs
  *  plus build-expectation verdicts; incomplete units don't count either way). */
-function greenStats(tc: ReportTestCase): { green: number; evaluated: number } {
+export function greenStats(tc: ReportTestCase): { green: number; evaluated: number } {
 	let green = 0;
 	let evaluated = 0;
 	for (let i = 0; i < tc.totalRuns; i++) {
@@ -228,7 +238,7 @@ function median(values: number[]): number | undefined {
 }
 
 /** Arm whose cost the harness persisted per case (`--build-via-mcp` runs). */
-function persistedSpendCosts(results: EvalResults): CaseCost[] {
+export function persistedSpendCosts(results: EvalResults): CaseCost[] {
 	return results.testCases.map((tc) => {
 		const { green, evaluated } = greenStats(tc);
 		const turns = (tc.buildTurnsPerRun ?? []).filter((t): t is number => t !== null);
@@ -244,7 +254,7 @@ function persistedSpendCosts(results: EvalResults): CaseCost[] {
 
 /** Arm whose builder ran in the n8n backend (AIA): sum each case's build
  *  threads from the LangSmith trace project. */
-async function threadJoinCosts(
+export async function threadJoinCosts(
 	results: EvalResults,
 	ls: LangSmithConfig,
 	projectId: string,
@@ -265,7 +275,14 @@ async function threadJoinCosts(
 		const resolved = await Promise.all(
 			batch.map(async (l) => ({ l, cost: await sumThreadCost(ls, projectId, l.threadId) })),
 		);
-		for (const { l, cost } of resolved) costs.set(`${l.caseIndex}:${l.iteration}`, cost);
+		for (const { l, cost } of resolved) {
+			if (cost) costs.set(`${l.caseIndex}:${l.iteration}`, cost);
+			else {
+				console.warn(
+					`thread ${l.threadId}: no runs in the trace project — wrong --trace-project or trace not landed; cost recorded as unknown`,
+				);
+			}
+		}
 	}
 
 	return results.testCases.map((tc, caseIndex) => {
@@ -292,7 +309,7 @@ async function threadJoinCosts(
 // Rendering
 // ---------------------------------------------------------------------------
 
-interface ArmSummary {
+export interface ArmSummary {
 	label: string;
 	/** Where this arm's dollars came from — rendered so mixed-source tables stay honest. */
 	source: string;
@@ -327,7 +344,7 @@ function armTotals(arm: ArmSummary): string[] {
 	];
 }
 
-function renderMarkdown(arms: ArmSummary[]): string {
+export function renderMarkdown(arms: ArmSummary[]): string {
 	const lines: string[] = ['# Build-cost report — builder arms compared', ''];
 	for (const arm of arms) {
 		lines.push(`- **${arm.label}** (${arm.source}): ${armTotals(arm).join(', ')}`);
@@ -408,13 +425,17 @@ function loadResults(path: string): EvalResults {
 async function main(): Promise<void> {
 	const flags = parseFlags(process.argv.slice(2));
 	const traceProject = single(flags, 'trace-project') ?? 'instance-ai-evals';
-	const concurrency = Number(single(flags, 'concurrency') ?? '3');
+	const concurrency = Math.max(1, Math.floor(Number(single(flags, 'concurrency'))) || 3);
 
 	const probeThread = single(flags, 'probe-thread');
 	if (probeThread) {
 		const ls = await langsmithConfig();
 		const projectId = await resolveTraceProjectId(ls, traceProject);
 		const cost = await sumThreadCost(ls, projectId, probeThread);
+		if (!cost) {
+			console.log(`thread ${probeThread}: no runs found in trace project "${traceProject}"`);
+			return;
+		}
 		console.log(
 			`thread ${probeThread}: ${cost.turns} turns, ${cost.tokens.toLocaleString()} tokens, ${fmtUsd(cost.costUsd)}`,
 		);
@@ -465,7 +486,9 @@ async function main(): Promise<void> {
 	console.log(`Report written to ${outPath}`);
 }
 
-main().catch((error: unknown) => {
-	console.error(error instanceof Error ? error.message : String(error));
-	process.exitCode = 1;
-});
+if (require.main === module) {
+	main().catch((error: unknown) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	});
+}

--- a/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
@@ -86,6 +86,20 @@ interface LangSmithConfig {
 	headers: Record<string, string>;
 }
 
+/** LangSmith request with 429/5xx backoff — a full-run join fires ~100 queries,
+ *  which trips the API's rate limit without pacing. Honors Retry-After. */
+async function lsFetch(url: string, init: RequestInit): Promise<Response> {
+	let delayMs = 2_000;
+	for (let attempt = 1; ; attempt++) {
+		const res = await fetch(url, init);
+		if (res.ok || attempt >= 6 || (res.status !== 429 && res.status < 500)) return res;
+		const retryAfter = Number(res.headers.get('retry-after'));
+		const waitMs = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1_000 : delayMs;
+		await new Promise((resolve) => setTimeout(resolve, waitMs));
+		delayMs = Math.min(delayMs * 2, 30_000);
+	}
+}
+
 async function langsmithConfig(): Promise<LangSmithConfig> {
 	const { apiUrl, apiKey } = configFor();
 	if (!apiKey) {
@@ -105,9 +119,12 @@ async function langsmithConfig(): Promise<LangSmithConfig> {
 }
 
 async function resolveTraceProjectId(ls: LangSmithConfig, projectName: string): Promise<string> {
-	const res = await fetch(`${ls.apiUrl}/api/v1/sessions?name=${encodeURIComponent(projectName)}`, {
-		headers: ls.headers,
-	});
+	const res = await lsFetch(
+		`${ls.apiUrl}/api/v1/sessions?name=${encodeURIComponent(projectName)}`,
+		{
+			headers: ls.headers,
+		},
+	);
 	if (!res.ok) {
 		throw new Error(`LangSmith sessions lookup failed: ${res.status} ${await res.text()}`);
 	}
@@ -135,7 +152,7 @@ async function sumThreadCost(
 	projectId: string,
 	threadId: string,
 ): Promise<ThreadCost> {
-	const res = await fetch(`${ls.apiUrl}/api/v1/runs/query`, {
+	const res = await lsFetch(`${ls.apiUrl}/api/v1/runs/query`, {
 		method: 'POST',
 		headers: ls.headers,
 		body: JSON.stringify({
@@ -391,7 +408,7 @@ function loadResults(path: string): EvalResults {
 async function main(): Promise<void> {
 	const flags = parseFlags(process.argv.slice(2));
 	const traceProject = single(flags, 'trace-project') ?? 'instance-ai-evals';
-	const concurrency = Number(single(flags, 'concurrency') ?? '5');
+	const concurrency = Number(single(flags, 'concurrency') ?? '3');
 
 	const probeThread = single(flags, 'probe-thread');
 	if (probeThread) {

--- a/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
@@ -1,28 +1,29 @@
 // ---------------------------------------------------------------------------
-// Build-cost comparison report: MCP (`claude` via --build-via-mcp) vs AIA
-// (internal builder) arms of the same suite.
+// Build-cost comparison report across eval runs ("arms") — one arm per
+// eval-results.json, any pairing: MCP vs AIA, AIA vs AIA (builder-model A/Bs),
+// MCP vs MCP (ANTHROPIC_MODEL A/Bs), or a single arm alone.
 //
-// Joins, per case:
-//   - MCP arm: per-iteration `claude` spend persisted in eval-results.json
-//     (`buildCostUsdPerRun` / `buildTurnsPerRun`).
-//   - AIA arm: per-iteration backend builder cost summed from LangSmith —
-//     each case's threadIds resolve to root runs (one per build turn) in the
+// The cost source is auto-detected per file:
+//   - `buildCostUsdPerRun` present → persisted `claude` spend
+//     (--build-via-mcp runs; attempts summed).
+//   - non-null `threadIds` → backend builder cost summed from LangSmith:
+//     each case's threads resolve to root runs (one per build turn) in the
 //     backend trace project (default `instance-ai-evals`, eval workspace),
 //     whose `total_cost` LangSmith prices cache-aware from the traced usage.
-//   - Both arms: per-iteration green verdicts (every evaluated scenario run
-//     and build expectation passed) → cost per green iteration.
+// Every arm also gets per-iteration green verdicts (every evaluated scenario
+// run and build expectation passed) → cost per green iteration.
 //
 // Usage — deliberately not wired into package.json (an experiment-time tool,
 // used rarely); invoke via tsx from packages/@n8n/instance-ai:
 //   dotenvx run -f ../../../.env.local -- pnpm tsx evaluations/cli/build-cost-report.ts \
-//     --aia-results <aia-run>/eval-results.json \
-//     --mcp-results <mcp-run>/eval-results.json \
+//     --results <mcp-run>/eval-results.json --results <aia-run>/eval-results.json \
+//     [--label mcp-opus48 --label aia-opus48] \
 //     [--trace-project instance-ai-evals] [--out build-cost-report.md]
 //
-// Either arm may be omitted to report on one arm alone. `--probe-thread <id>`
-// skips the report and prints one thread's cost — a connectivity spot-check.
-// Reads LANGSMITH_ENDPOINT / LANGSMITH_API_KEY and pins reads to the eval
-// workspace (Staging) exactly like the harness does.
+// Labels default to each run's experimentName. `--probe-thread <id>` skips the
+// report and prints one thread's cost — a connectivity spot-check. Reads
+// LANGSMITH_ENDPOINT / LANGSMITH_API_KEY and pins reads to the eval workspace
+// (Staging) exactly like the harness does.
 // ---------------------------------------------------------------------------
 
 import { jsonParse } from 'n8n-workflow';
@@ -209,7 +210,8 @@ function median(values: number[]): number | undefined {
 	return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
 }
 
-function mcpCaseCosts(results: EvalResults): CaseCost[] {
+/** Arm whose cost the harness persisted per case (`--build-via-mcp` runs). */
+function persistedSpendCosts(results: EvalResults): CaseCost[] {
 	return results.testCases.map((tc) => {
 		const { green, evaluated } = greenStats(tc);
 		const turns = (tc.buildTurnsPerRun ?? []).filter((t): t is number => t !== null);
@@ -223,7 +225,9 @@ function mcpCaseCosts(results: EvalResults): CaseCost[] {
 	});
 }
 
-async function aiaCaseCosts(
+/** Arm whose builder ran in the n8n backend (AIA): sum each case's build
+ *  threads from the LangSmith trace project. */
+async function threadJoinCosts(
 	results: EvalResults,
 	ls: LangSmithConfig,
 	projectId: string,
@@ -273,7 +277,8 @@ async function aiaCaseCosts(
 
 interface ArmSummary {
 	label: string;
-	experimentName?: string;
+	/** Where this arm's dollars came from — rendered so mixed-source tables stay honest. */
+	source: string;
 	cases: CaseCost[];
 }
 
@@ -308,9 +313,7 @@ function armTotals(arm: ArmSummary): string[] {
 function renderMarkdown(arms: ArmSummary[]): string {
 	const lines: string[] = ['# Build-cost report — builder arms compared', ''];
 	for (const arm of arms) {
-		lines.push(
-			`- **${arm.label}**: ${arm.experimentName ?? '(unnamed experiment)'} — ${armTotals(arm).join(', ')}`,
-		);
+		lines.push(`- **${arm.label}** (${arm.source}): ${armTotals(arm).join(', ')}`);
 	}
 	lines.push('');
 
@@ -347,8 +350,9 @@ function renderMarkdown(arms: ArmSummary[]): string {
 	}
 	lines.push('');
 	lines.push(
-		'_Cost sources differ by arm: MCP is `claude`-billed `total_cost_usd` (attempts summed);' +
-			' AIA is LangSmith cache-aware pricing over the build thread’s root runs._',
+		'_Cost sources are listed per arm above: persisted `claude` spend is Anthropic-billed' +
+			' `total_cost_usd` (attempts summed); thread pricing is LangSmith cache-aware pricing' +
+			' over the build thread’s root runs. Comparable at list price, not identical accountants._',
 	);
 	return lines.join('\n');
 }
@@ -357,8 +361,8 @@ function renderMarkdown(arms: ArmSummary[]): string {
 // CLI
 // ---------------------------------------------------------------------------
 
-function parseFlags(argv: string[]): Map<string, string> {
-	const flags = new Map<string, string>();
+function parseFlags(argv: string[]): Map<string, string[]> {
+	const flags = new Map<string, string[]>();
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
 		if (!arg.startsWith('--')) continue;
@@ -366,10 +370,18 @@ function parseFlags(argv: string[]): Map<string, string> {
 		if (value === undefined || value.startsWith('--')) {
 			throw new Error(`Flag ${arg} needs a value`);
 		}
-		flags.set(arg.slice(2), value);
+		const key = arg.slice(2);
+		const values = flags.get(key);
+		if (values) values.push(value);
+		else flags.set(key, [value]);
 		i++;
 	}
 	return flags;
+}
+
+/** Last occurrence wins for flags that only make sense once. */
+function single(flags: Map<string, string[]>, key: string): string | undefined {
+	return flags.get(key)?.at(-1);
 }
 
 function loadResults(path: string): EvalResults {
@@ -378,10 +390,10 @@ function loadResults(path: string): EvalResults {
 
 async function main(): Promise<void> {
 	const flags = parseFlags(process.argv.slice(2));
-	const traceProject = flags.get('trace-project') ?? 'instance-ai-evals';
-	const concurrency = Number(flags.get('concurrency') ?? '5');
+	const traceProject = single(flags, 'trace-project') ?? 'instance-ai-evals';
+	const concurrency = Number(single(flags, 'concurrency') ?? '5');
 
-	const probeThread = flags.get('probe-thread');
+	const probeThread = single(flags, 'probe-thread');
 	if (probeThread) {
 		const ls = await langsmithConfig();
 		const projectId = await resolveTraceProjectId(ls, traceProject);
@@ -392,40 +404,45 @@ async function main(): Promise<void> {
 		return;
 	}
 
-	const aiaPath = flags.get('aia-results');
-	const mcpPath = flags.get('mcp-results');
-	if (!aiaPath && !mcpPath) {
-		throw new Error('Pass --aia-results and/or --mcp-results (or --probe-thread <id>).');
+	const resultPaths = flags.get('results') ?? [];
+	const labels = flags.get('label') ?? [];
+	if (resultPaths.length === 0) {
+		throw new Error(
+			'Pass --results <eval-results.json> (repeatable, one per arm) or --probe-thread <id>.',
+		);
 	}
 
+	// LangSmith access is resolved once, lazily — only when some arm needs the
+	// thread join (a persisted-spend-only comparison runs without credentials).
+	let ls: LangSmithConfig | undefined;
+	let projectId: string | undefined;
+
 	const arms: ArmSummary[] = [];
-	if (aiaPath) {
-		const results = loadResults(aiaPath);
-		const ls = await langsmithConfig();
-		const projectId = await resolveTraceProjectId(ls, traceProject);
-		arms.push({
-			label: 'AIA',
-			experimentName: results.experimentName ?? undefined,
-			cases: await aiaCaseCosts(results, ls, projectId, concurrency),
-		});
-	}
-	if (mcpPath) {
-		const results = loadResults(mcpPath);
-		const withCost = results.testCases.filter((tc) => tc.buildCostUsdPerRun !== undefined);
-		if (withCost.length === 0) {
-			console.warn(
-				'MCP results carry no buildCostUsdPerRun — re-run the MCP arm on a build that persists per-case spend.',
-			);
+	for (let i = 0; i < resultPaths.length; i++) {
+		const results = loadResults(resultPaths[i]);
+		const label = labels[i] ?? results.experimentName ?? `arm${String(i + 1)}`;
+		const hasPersistedSpend = results.testCases.some((tc) => tc.buildCostUsdPerRun !== undefined);
+		const hasThreads = results.testCases.some((tc) =>
+			(tc.threadIds ?? []).some((id) => id !== null),
+		);
+		if (hasPersistedSpend) {
+			arms.push({ label, source: 'persisted `claude` spend', cases: persistedSpendCosts(results) });
+		} else if (hasThreads) {
+			ls ??= await langsmithConfig();
+			projectId ??= await resolveTraceProjectId(ls, traceProject);
+			arms.push({
+				label,
+				source: 'LangSmith thread pricing',
+				cases: await threadJoinCosts(results, ls, projectId, concurrency),
+			});
+		} else {
+			console.warn(`${resultPaths[i]}: no buildCostUsdPerRun and no threadIds — pass data only.`);
+			arms.push({ label, source: 'no cost source', cases: persistedSpendCosts(results) });
 		}
-		arms.push({
-			label: 'MCP',
-			experimentName: results.experimentName ?? undefined,
-			cases: mcpCaseCosts(results),
-		});
 	}
 
 	const markdown = renderMarkdown(arms);
-	const outPath = flags.get('out') ?? 'build-cost-report.md';
+	const outPath = single(flags, 'out') ?? 'build-cost-report.md';
 	writeFileSync(outPath, markdown);
 	for (const arm of arms) console.log(`${arm.label}: ${armTotals(arm).join(', ')}`);
 	console.log(`Report written to ${outPath}`);

--- a/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
@@ -12,8 +12,9 @@
 //   - Both arms: per-iteration green verdicts (every evaluated scenario run
 //     and build expectation passed) → cost per green iteration.
 //
-// Usage:
-//   dotenvx run -f ../../../.env.local -- pnpm eval:build-cost-report \
+// Usage — deliberately not wired into package.json (an experiment-time tool,
+// used rarely); invoke via tsx from packages/@n8n/instance-ai:
+//   dotenvx run -f ../../../.env.local -- pnpm tsx evaluations/cli/build-cost-report.ts \
 //     --aia-results <aia-run>/eval-results.json \
 //     --mcp-results <mcp-run>/eval-results.json \
 //     [--trace-project instance-ai-evals] [--out build-cost-report.md]

--- a/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-cost-report.ts
@@ -1,0 +1,436 @@
+// ---------------------------------------------------------------------------
+// Build-cost comparison report: MCP (`claude` via --build-via-mcp) vs AIA
+// (internal builder) arms of the same suite.
+//
+// Joins, per case:
+//   - MCP arm: per-iteration `claude` spend persisted in eval-results.json
+//     (`buildCostUsdPerRun` / `buildTurnsPerRun`).
+//   - AIA arm: per-iteration backend builder cost summed from LangSmith —
+//     each case's threadIds resolve to root runs (one per build turn) in the
+//     backend trace project (default `instance-ai-evals`, eval workspace),
+//     whose `total_cost` LangSmith prices cache-aware from the traced usage.
+//   - Both arms: per-iteration green verdicts (every evaluated scenario run
+//     and build expectation passed) → cost per green iteration.
+//
+// Usage:
+//   dotenvx run -f ../../../.env.local -- pnpm eval:build-cost-report \
+//     --aia-results <aia-run>/eval-results.json \
+//     --mcp-results <mcp-run>/eval-results.json \
+//     [--trace-project instance-ai-evals] [--out build-cost-report.md]
+//
+// Either arm may be omitted to report on one arm alone. `--probe-thread <id>`
+// skips the report and prints one thread's cost — a connectivity spot-check.
+// Reads LANGSMITH_ENDPOINT / LANGSMITH_API_KEY and pins reads to the eval
+// workspace (Staging) exactly like the harness does.
+// ---------------------------------------------------------------------------
+
+import { jsonParse } from 'n8n-workflow';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { z } from 'zod';
+
+import { configFor, resolveEvalWorkspaceId } from '../harness/langsmith-seed';
+
+// ---------------------------------------------------------------------------
+// eval-results.json (only the fields this report needs; unknown keys ignored)
+// ---------------------------------------------------------------------------
+
+const unitVerdictSchema = z.object({
+	pass: z.boolean(),
+	incomplete: z.boolean().optional(),
+});
+
+const scenarioRunSchema = z.object({
+	passed: z.boolean(),
+	incomplete: z.boolean().optional(),
+});
+
+const testCaseSchema = z.object({
+	name: z.string(),
+	testCaseFile: z.string().nullish(),
+	status: z.string(),
+	totalRuns: z.number(),
+	threadIds: z.array(z.string().nullable()).optional(),
+	buildCostUsdPerRun: z.array(z.number().nullable()).optional(),
+	buildTurnsPerRun: z.array(z.number().nullable()).optional(),
+	buildExpectationResultsPerRun: z.array(z.array(unitVerdictSchema).nullable()).optional(),
+	scenarios: z.array(z.object({ name: z.string(), runs: z.array(scenarioRunSchema) })).optional(),
+});
+
+const evalResultsSchema = z.object({
+	experimentName: z.string().nullish(),
+	totalRuns: z.number(),
+	testCases: z.array(testCaseSchema),
+});
+
+type EvalResults = z.infer<typeof evalResultsSchema>;
+type ReportTestCase = z.infer<typeof testCaseSchema>;
+
+// ---------------------------------------------------------------------------
+// LangSmith REST (raw fetch + zod — keeps cost fields typed without SDK casts)
+// ---------------------------------------------------------------------------
+
+const lsProjectSchema = z.object({ id: z.string(), name: z.string() });
+const lsRunsQuerySchema = z.object({
+	runs: z.array(
+		z.object({
+			total_cost: z.number().nullish(),
+			total_tokens: z.number().nullish(),
+		}),
+	),
+});
+
+interface LangSmithConfig {
+	apiUrl: string;
+	headers: Record<string, string>;
+}
+
+async function langsmithConfig(): Promise<LangSmithConfig> {
+	const { apiUrl, apiKey } = configFor();
+	if (!apiKey) {
+		throw new Error(
+			'LANGSMITH_API_KEY is not set — the AIA arm needs LangSmith access to sum builder cost.',
+		);
+	}
+	const workspaceId = await resolveEvalWorkspaceId();
+	return {
+		apiUrl,
+		headers: {
+			'x-api-key': apiKey,
+			'Content-Type': 'application/json',
+			...(workspaceId ? { 'X-Tenant-Id': workspaceId } : {}),
+		},
+	};
+}
+
+async function resolveTraceProjectId(ls: LangSmithConfig, projectName: string): Promise<string> {
+	const res = await fetch(`${ls.apiUrl}/api/v1/sessions?name=${encodeURIComponent(projectName)}`, {
+		headers: ls.headers,
+	});
+	if (!res.ok) {
+		throw new Error(`LangSmith sessions lookup failed: ${res.status} ${await res.text()}`);
+	}
+	const projects = z.array(lsProjectSchema).parse(await res.json());
+	const match = projects.find((p) => p.name === projectName);
+	if (!match) {
+		throw new Error(
+			`Trace project "${projectName}" not found in the eval workspace — is this the right tenant/workspace?`,
+		);
+	}
+	return match.id;
+}
+
+interface ThreadCost {
+	costUsd: number;
+	tokens: number;
+	/** Root runs in the thread — one per build turn. */
+	turns: number;
+}
+
+/** Sum a thread's root runs (one per turn); roots aggregate their children,
+ *  so this is the thread's whole backend LLM spend. */
+async function sumThreadCost(
+	ls: LangSmithConfig,
+	projectId: string,
+	threadId: string,
+): Promise<ThreadCost> {
+	const res = await fetch(`${ls.apiUrl}/api/v1/runs/query`, {
+		method: 'POST',
+		headers: ls.headers,
+		body: JSON.stringify({
+			session: [projectId],
+			is_root: true,
+			filter: `eq(thread_id, "${threadId}")`,
+			limit: 100,
+			select: ['id', 'total_cost', 'total_tokens'],
+		}),
+	});
+	if (!res.ok) {
+		throw new Error(`LangSmith runs/query failed: ${res.status} ${await res.text()}`);
+	}
+	const { runs } = lsRunsQuerySchema.parse(await res.json());
+	return {
+		costUsd: runs.reduce((sum, r) => sum + (r.total_cost ?? 0), 0),
+		tokens: runs.reduce((sum, r) => sum + (r.total_tokens ?? 0), 0),
+		turns: runs.length,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Per-case aggregation
+// ---------------------------------------------------------------------------
+
+interface CaseCost {
+	slug: string;
+	/** Build cost per iteration; null when unknown (no thread / no spend recorded). */
+	costPerIteration: Array<number | null>;
+	/** MCP: `claude` turns; AIA: root runs (build turns). Mean over known iterations. */
+	meanTurns?: number;
+	/** AIA only: mean tokens per build. */
+	meanTokens?: number;
+	greenIterations: number;
+	evaluatedIterations: number;
+}
+
+function caseSlug(tc: ReportTestCase): string {
+	return tc.testCaseFile ?? tc.name;
+}
+
+/** An iteration is green when every evaluated unit of it passed (scenario runs
+ *  plus build-expectation verdicts; incomplete units don't count either way). */
+function greenStats(tc: ReportTestCase): { green: number; evaluated: number } {
+	let green = 0;
+	let evaluated = 0;
+	for (let i = 0; i < tc.totalRuns; i++) {
+		const verdicts: boolean[] = [];
+		for (const scenario of tc.scenarios ?? []) {
+			const run = scenario.runs[i];
+			if (run && !run.incomplete) verdicts.push(run.passed);
+		}
+		for (const verdict of tc.buildExpectationResultsPerRun?.[i] ?? []) {
+			if (!verdict.incomplete) verdicts.push(verdict.pass);
+		}
+		if (verdicts.length === 0) continue;
+		evaluated++;
+		if (verdicts.every(Boolean)) green++;
+	}
+	return { green, evaluated };
+}
+
+function mean(values: number[]): number | undefined {
+	if (values.length === 0) return undefined;
+	return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function median(values: number[]): number | undefined {
+	if (values.length === 0) return undefined;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function mcpCaseCosts(results: EvalResults): CaseCost[] {
+	return results.testCases.map((tc) => {
+		const { green, evaluated } = greenStats(tc);
+		const turns = (tc.buildTurnsPerRun ?? []).filter((t): t is number => t !== null);
+		return {
+			slug: caseSlug(tc),
+			costPerIteration: tc.buildCostUsdPerRun ?? Array.from({ length: tc.totalRuns }, () => null),
+			meanTurns: mean(turns),
+			greenIterations: green,
+			evaluatedIterations: evaluated,
+		};
+	});
+}
+
+async function aiaCaseCosts(
+	results: EvalResults,
+	ls: LangSmithConfig,
+	projectId: string,
+	concurrency: number,
+): Promise<CaseCost[]> {
+	// Flatten (case, iteration, threadId) so the thread queries can run in
+	// fixed-size batches regardless of how threads distribute across cases.
+	const lookups: Array<{ caseIndex: number; iteration: number; threadId: string }> = [];
+	results.testCases.forEach((tc, caseIndex) => {
+		(tc.threadIds ?? []).forEach((threadId, iteration) => {
+			if (threadId) lookups.push({ caseIndex, iteration, threadId });
+		});
+	});
+
+	const costs = new Map<string, ThreadCost>();
+	for (let i = 0; i < lookups.length; i += concurrency) {
+		const batch = lookups.slice(i, i + concurrency);
+		const resolved = await Promise.all(
+			batch.map(async (l) => ({ l, cost: await sumThreadCost(ls, projectId, l.threadId) })),
+		);
+		for (const { l, cost } of resolved) costs.set(`${l.caseIndex}:${l.iteration}`, cost);
+	}
+
+	return results.testCases.map((tc, caseIndex) => {
+		const { green, evaluated } = greenStats(tc);
+		const perIteration = Array.from({ length: tc.totalRuns }, (_, iteration) => {
+			const cost = costs.get(`${caseIndex}:${iteration}`);
+			return cost ? cost.costUsd : null;
+		});
+		const known = Array.from({ length: tc.totalRuns }, (_, iteration) =>
+			costs.get(`${caseIndex}:${iteration}`),
+		).filter((c): c is ThreadCost => c !== undefined);
+		return {
+			slug: caseSlug(tc),
+			costPerIteration: perIteration,
+			meanTurns: mean(known.map((c) => c.turns)),
+			meanTokens: mean(known.map((c) => c.tokens)),
+			greenIterations: green,
+			evaluatedIterations: evaluated,
+		};
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+interface ArmSummary {
+	label: string;
+	experimentName?: string;
+	cases: CaseCost[];
+}
+
+function knownCosts(arm: ArmSummary): number[] {
+	return arm.cases.flatMap((c) => c.costPerIteration.filter((v): v is number => v !== null));
+}
+
+function fmtUsd(value: number | undefined | null): string {
+	return value === undefined || value === null ? '—' : `$${value.toFixed(3)}`;
+}
+
+function fmtNum(value: number | undefined, digits = 1): string {
+	return value === undefined ? '—' : value.toFixed(digits);
+}
+
+function armTotals(arm: ArmSummary): string[] {
+	const costs = knownCosts(arm);
+	const green = arm.cases.reduce((sum, c) => sum + c.greenIterations, 0);
+	const evaluated = arm.cases.reduce((sum, c) => sum + c.evaluatedIterations, 0);
+	const total = costs.reduce((a, b) => a + b, 0);
+	return [
+		`${arm.cases.length} cases`,
+		`${costs.length} builds with cost`,
+		`total ${fmtUsd(total)}`,
+		`mean/build ${fmtUsd(mean(costs))}`,
+		`median/build ${fmtUsd(median(costs))}`,
+		`green ${green}/${evaluated} iterations`,
+		`cost per green iteration ${green > 0 ? fmtUsd(total / green) : '—'}`,
+	];
+}
+
+function renderMarkdown(arms: ArmSummary[]): string {
+	const lines: string[] = ['# Build-cost report — builder arms compared', ''];
+	for (const arm of arms) {
+		lines.push(
+			`- **${arm.label}**: ${arm.experimentName ?? '(unnamed experiment)'} — ${armTotals(arm).join(', ')}`,
+		);
+	}
+	lines.push('');
+
+	const slugs = [...new Set(arms.flatMap((arm) => arm.cases.map((c) => c.slug)))].sort();
+	const byArm = arms.map((arm) => new Map(arm.cases.map((c) => [c.slug, c])));
+
+	const header = ['case'];
+	for (const arm of arms) {
+		header.push(`${arm.label} $/build`, `${arm.label} green`, `${arm.label} turns`);
+		if (arm.cases.some((c) => c.meanTokens !== undefined)) header.push(`${arm.label} tokens`);
+	}
+	lines.push(`| ${header.join(' | ')} |`);
+	lines.push(`|${header.map(() => '---').join('|')}|`);
+
+	for (const slug of slugs) {
+		const row = [slug];
+		for (let a = 0; a < arms.length; a++) {
+			const c = byArm[a].get(slug);
+			if (!c) {
+				row.push('missing', '—', '—');
+				if (arms[a].cases.some((x) => x.meanTokens !== undefined)) row.push('—');
+				continue;
+			}
+			row.push(
+				fmtUsd(mean(c.costPerIteration.filter((v): v is number => v !== null))),
+				`${c.greenIterations}/${c.evaluatedIterations}`,
+				fmtNum(c.meanTurns),
+			);
+			if (arms[a].cases.some((x) => x.meanTokens !== undefined)) {
+				row.push(c.meanTokens === undefined ? '—' : Math.round(c.meanTokens).toLocaleString());
+			}
+		}
+		lines.push(`| ${row.join(' | ')} |`);
+	}
+	lines.push('');
+	lines.push(
+		'_Cost sources differ by arm: MCP is `claude`-billed `total_cost_usd` (attempts summed);' +
+			' AIA is LangSmith cache-aware pricing over the build thread’s root runs._',
+	);
+	return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseFlags(argv: string[]): Map<string, string> {
+	const flags = new Map<string, string>();
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (!arg.startsWith('--')) continue;
+		const value = argv[i + 1];
+		if (value === undefined || value.startsWith('--')) {
+			throw new Error(`Flag ${arg} needs a value`);
+		}
+		flags.set(arg.slice(2), value);
+		i++;
+	}
+	return flags;
+}
+
+function loadResults(path: string): EvalResults {
+	return evalResultsSchema.parse(jsonParse(readFileSync(path, 'utf8')));
+}
+
+async function main(): Promise<void> {
+	const flags = parseFlags(process.argv.slice(2));
+	const traceProject = flags.get('trace-project') ?? 'instance-ai-evals';
+	const concurrency = Number(flags.get('concurrency') ?? '5');
+
+	const probeThread = flags.get('probe-thread');
+	if (probeThread) {
+		const ls = await langsmithConfig();
+		const projectId = await resolveTraceProjectId(ls, traceProject);
+		const cost = await sumThreadCost(ls, projectId, probeThread);
+		console.log(
+			`thread ${probeThread}: ${cost.turns} turns, ${cost.tokens.toLocaleString()} tokens, ${fmtUsd(cost.costUsd)}`,
+		);
+		return;
+	}
+
+	const aiaPath = flags.get('aia-results');
+	const mcpPath = flags.get('mcp-results');
+	if (!aiaPath && !mcpPath) {
+		throw new Error('Pass --aia-results and/or --mcp-results (or --probe-thread <id>).');
+	}
+
+	const arms: ArmSummary[] = [];
+	if (aiaPath) {
+		const results = loadResults(aiaPath);
+		const ls = await langsmithConfig();
+		const projectId = await resolveTraceProjectId(ls, traceProject);
+		arms.push({
+			label: 'AIA',
+			experimentName: results.experimentName ?? undefined,
+			cases: await aiaCaseCosts(results, ls, projectId, concurrency),
+		});
+	}
+	if (mcpPath) {
+		const results = loadResults(mcpPath);
+		const withCost = results.testCases.filter((tc) => tc.buildCostUsdPerRun !== undefined);
+		if (withCost.length === 0) {
+			console.warn(
+				'MCP results carry no buildCostUsdPerRun — re-run the MCP arm on a build that persists per-case spend.',
+			);
+		}
+		arms.push({
+			label: 'MCP',
+			experimentName: results.experimentName ?? undefined,
+			cases: mcpCaseCosts(results),
+		});
+	}
+
+	const markdown = renderMarkdown(arms);
+	const outPath = flags.get('out') ?? 'build-cost-report.md';
+	writeFileSync(outPath, markdown);
+	for (const arm of arms) console.log(`${arm.label}: ${armTotals(arm).join(', ')}`);
+	console.log(`Report written to ${outPath}`);
+}
+
+main().catch((error: unknown) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
@@ -411,11 +411,11 @@ where <id> is the workflowId returned by create_workflow_from_code. Emit it verb
 export interface McpBuildResult {
 	/** The created workflow's id, or null if every attempt failed. */
 	workflowId: string | null;
-	/** Anthropic spend for the last attempt (USD). */
+	/** Anthropic spend summed across every attempt (USD) — failed attempts cost money too. */
 	cost: number;
-	/** Assistant turns in the last attempt. */
+	/** Assistant turns summed across every attempt. */
 	turns: number;
-	/** Wall-clock of the last attempt (ms). */
+	/** `claude` wall-clock summed across every attempt (ms). */
 	durationMs: number;
 	/** Path to the last attempt's captured `claude` output, for post-mortem. */
 	logFile: string | null;
@@ -446,9 +446,11 @@ export async function buildWorkflowViaMcp(opts: {
 	const userMessage = buildUserMessage(conversation, settings);
 
 	let workflowId: string | null = null;
-	let lastSession: ClaudeSession | undefined;
 	let lastLogFile: string | null = null;
 	let failureReason: string | undefined;
+	let totalCostUsd = 0;
+	let totalTurns = 0;
+	let totalDurationMs = 0;
 
 	for (let attempt = 1; attempt <= settings.maxAttempts; attempt++) {
 		const ts = new Date().toISOString().replace(/[:.]/g, '-');
@@ -464,7 +466,9 @@ export async function buildWorkflowViaMcp(opts: {
 			allowedTools,
 			logFile,
 		);
-		lastSession = session;
+		totalCostUsd += session?.total_cost_usd ?? 0;
+		totalTurns += session?.num_turns ?? 0;
+		totalDurationMs += session?.duration_ms ?? 0;
 		const id = session?.result ? tailWorkflowId(session.result) : null;
 		if (id) {
 			workflowId = id;
@@ -504,9 +508,9 @@ export async function buildWorkflowViaMcp(opts: {
 
 	return {
 		workflowId,
-		cost: lastSession?.total_cost_usd ?? 0,
-		turns: lastSession?.num_turns ?? 0,
-		durationMs: lastSession?.duration_ms ?? 0,
+		cost: totalCostUsd,
+		turns: totalTurns,
+		durationMs: totalDurationMs,
 		logFile: lastLogFile,
 		failureReason: workflowId ? undefined : failureReason,
 	};

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -64,8 +64,8 @@ export interface Lane {
 }
 
 /** One `claude` build's Anthropic spend (`--build-via-mcp` only). Mirrors
- *  McpBuildResult: the numbers cover the LAST attempt, so totals are a lower
- *  bound when retries happened (same semantics as the manifest flow's stats). */
+ *  McpBuildResult: cost and turns are summed across every attempt of the
+ *  build, so totals are the run's true spend (failed attempts cost money too). */
 export interface McpBuildSpend {
 	costUsd: number;
 	turns: number;
@@ -203,6 +203,9 @@ export interface CachedBuild {
 	build: BuildResult;
 	lane: LaneState;
 	buildDurationMs: number;
+	/** `claude` spend for this case's build (`--build-via-mcp` only) — feeds the
+	 *  per-row build_cost_usd/build_turns feedback and eval-results.json. */
+	buildSpend?: McpBuildSpend;
 }
 
 export interface BuildOrchestratorDeps {
@@ -349,6 +352,9 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 				const lane = await allocator.acquire(fileSlug);
 				const start = Date.now();
 				let build: BuildResult;
+				// Local collector so this case's spend stays attributable to its own
+				// rows; drained into the run-wide record right after the build.
+				const caseSpend: McpBuildSpend[] = [];
 				try {
 					build = await buildWorkflowViaMcpOnLane({
 						lane: lane.runner,
@@ -358,7 +364,7 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 						args,
 						logDir: mcpBuildLogDir ?? process.cwd(),
 						logger,
-						buildSpend: mcpBuildSpend,
+						buildSpend: caseSpend,
 					});
 				} finally {
 					// Release as soon as the build (incl. fetch-back) is done — the
@@ -366,6 +372,7 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 					// holding the slot through it would idle the lane's build capacity.
 					allocator.release(lane, fileSlug);
 				}
+				mcpBuildSpend.push(...caseSpend);
 				{
 					const transient = await isTransportFailure(build, lane);
 					if (!build.success) build.transportFailure = transient;
@@ -388,7 +395,9 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 						logger,
 					});
 				}
-				return { build, lane, buildDurationMs };
+				// One collector entry per buildWorkflowViaMcpOnLane call (attempts are
+				// summed inside buildWorkflowViaMcp), so [0] is this build's whole spend.
+				return { build, lane, buildDurationMs, buildSpend: caseSpend[0] };
 			}
 			const prebuiltId = pickPrebuiltWorkflowId(prebuiltManifest, fileSlug, iteration);
 			if (prebuiltId !== undefined) {

--- a/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
@@ -174,8 +174,15 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 			build,
 			lane: builtOnLane,
 			buildDurationMs,
+			buildSpend,
 		} = await getOrBuild(iteration, inputs.testCaseFile);
 		const cacheKey = `${String(iteration)}:${inputs.testCaseFile}`;
+		// `claude` spend for this case's build (--build-via-mcp only). Rides on
+		// every row of the case like buildDurationMs — dedupe per (iteration, case)
+		// when summing (persist takes the first defined value per iteration).
+		const buildSpendFields = buildSpend
+			? { buildCostUsd: buildSpend.costUsd, buildTurns: buildSpend.turns }
+			: {};
 
 		// Agent-anchored build: scenarios target the agent and a missing workflow is
 		// not a build failure (helper workflows are its tools) — mirrors the direct loop.
@@ -211,6 +218,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				...(outcome.incomplete ? { incomplete: true } : {}),
 				execErrors: [],
 				buildDurationMs,
+				...buildSpendFields,
 				execDurationMs: 0,
 				nodeCount: build.workflowJsons[0]?.nodes.length ?? 0,
 				threadId: build.threadId,
@@ -233,6 +241,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 					build.seedingFailed || build.transportFailure ? 'framework_issue' : 'build_failure',
 				execErrors: build.error ? [build.error] : [],
 				buildDurationMs,
+				...buildSpendFields,
 				execDurationMs: 0,
 				nodeCount: 0,
 				threadId: build.threadId,
@@ -291,6 +300,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 						failureCategory: 'framework_issue',
 						execErrors: [errorMessage],
 						buildDurationMs,
+						...buildSpendFields,
 						execDurationMs: Date.now() - agentExecStart,
 						nodeCount: 0,
 						threadId: build.threadId,
@@ -315,6 +325,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				...(agentResult.incomplete ? { incomplete: true } : {}),
 				execErrors: agentResult.agentEvalResult?.errors ?? [],
 				buildDurationMs,
+				...buildSpendFields,
 				execDurationMs: Date.now() - agentExecStart,
 				nodeCount: 0,
 				threadId: build.threadId,
@@ -352,6 +363,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				failureCategory: 'framework_issue',
 				execErrors: [reason],
 				buildDurationMs,
+				...buildSpendFields,
 				execDurationMs: 0,
 				nodeCount: build.workflowJsons[0]?.nodes.length ?? 0,
 				threadId: build.threadId,
@@ -404,6 +416,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 						rootCause: classified.rootCause,
 						execErrors: [errorMessage],
 						buildDurationMs,
+						...buildSpendFields,
 						execDurationMs: Date.now() - execStart,
 						nodeCount,
 						threadId: build.threadId,
@@ -434,6 +447,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				execErrors: result.evalResult?.errors ?? [],
 				evalResult: result.evalResult,
 				buildDurationMs,
+				...buildSpendFields,
 				execDurationMs,
 				nodeCount,
 				threadId: build.threadId,

--- a/packages/@n8n/instance-ai/evaluations/run/langsmith-driver.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/langsmith-driver.ts
@@ -174,6 +174,16 @@ export async function runWithLangSmith(config: RunConfig): Promise<{
 		if (output.buildDurationMs !== undefined) {
 			feedback.push({ key: 'build_duration_s', score: output.buildDurationMs / 1000 });
 		}
+		// `claude` build spend (--build-via-mcp only). Like build_duration_s the
+		// value repeats on every row of the case's build, so the LangSmith column
+		// mean is per-row; sum true spend per (iteration, case) from
+		// eval-results.json (buildCostUsdPerRun) instead of over rows.
+		if (output.buildCostUsd !== undefined) {
+			feedback.push({ key: 'build_cost_usd', score: output.buildCostUsd });
+		}
+		if (output.buildTurns !== undefined) {
+			feedback.push({ key: 'build_turns', score: output.buildTurns });
+		}
 		// Deterministic conversation counter (per evals rubric) — a navigation/feature
 		// signal for the HOW judges, not a gating check.
 		if (output.planRejections !== undefined) {

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -32,8 +32,8 @@ import { caseDisplayPrompt } from '../utils/conversation-text';
 /**
  * Sum per-build `claude` spend into run-level numbers, or undefined when no
  * MCP builds were recorded (so non-MCP runs add nothing to their outputs).
- * Last-attempt semantics (see McpBuildSpend): totals are a lower bound when
- * builds were retried.
+ * Each entry already sums every attempt of its build (see McpBuildSpend), so
+ * the totals are the run's true spend.
  */
 export function summarizeMcpBuildSpend(
 	spend: McpBuildSpend[] | undefined,
@@ -429,6 +429,15 @@ export function writeEvalResults(
 				passHatK: terminalRate(ea.passHatK),
 			})),
 			threadIds: tc.runs.map((run) => run.threadId ?? null),
+			// `claude` build spend per iteration (--build-via-mcp only) — the
+			// dedupe-safe source for per-case cost (LangSmith feedback repeats the
+			// value on every row of a case's build).
+			...(tc.runs.some((run) => run.buildCostUsd !== undefined)
+				? {
+						buildCostUsdPerRun: tc.runs.map((run) => run.buildCostUsd ?? null),
+						buildTurnsPerRun: tc.runs.map((run) => run.buildTurns ?? null),
+					}
+				: {}),
 			scenarios: tc.executionScenarios.map((sa) => ({
 				name: sa.scenario.name,
 				passCount: sa.passCount,

--- a/packages/@n8n/instance-ai/evaluations/run/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reshape.ts
@@ -69,6 +69,11 @@ const targetOutputSchema = z.object({
 	agentContext: z.string().optional(),
 	/** Only set on the scenario that initiated the build. */
 	buildDurationMs: z.number().optional(),
+	/** `claude` build spend in USD (--build-via-mcp only). Repeats on every row
+	 *  of the case's build — dedupe per (iteration, case) when summing. */
+	buildCostUsd: z.number().optional(),
+	/** Assistant turns across the `claude` build's attempts (--build-via-mcp only). */
+	buildTurns: z.number().optional(),
 	execDurationMs: z.number().default(0),
 	nodeCount: z.number().default(0),
 	/** The thread id used during the build — keys the LangSmith trace lookup. */
@@ -253,6 +258,8 @@ export function reshapeLangSmithRuns(
 			let workflowChecks: CheckOutcome[] | undefined;
 			let workflowJson: WorkflowResponse | undefined;
 			let buildTrace: BuildTrace | undefined;
+			let buildCostUsd: number | undefined;
+			let buildTurns: number | undefined;
 
 			for (const scenario of testCase.executionScenarios ?? []) {
 				const run = byKey.get(`${String(iter)}/${fileSlug}/${scenario.name}`);
@@ -276,6 +283,9 @@ export function reshapeLangSmithRuns(
 				if (output.workflowChecks && !workflowChecks) workflowChecks = output.workflowChecks;
 				if (output.workflowJson && !workflowJson) workflowJson = output.workflowJson;
 				if (output.buildTrace && !buildTrace) buildTrace = output.buildTrace;
+				// Every row of the case repeats the build's spend — first defined wins.
+				buildCostUsd ??= output.buildCostUsd;
+				buildTurns ??= output.buildTurns;
 				executionScenarioResults.push({
 					scenario,
 					success: output.passed,
@@ -305,6 +315,8 @@ export function reshapeLangSmithRuns(
 					workflowChecks = output.workflowChecks;
 					workflowJson = output.workflowJson;
 					buildTrace = output.buildTrace;
+					buildCostUsd = output.buildCostUsd;
+					buildTurns = output.buildTurns;
 				}
 			}
 
@@ -325,6 +337,8 @@ export function reshapeLangSmithRuns(
 				workflowChecks,
 				workflowJson,
 				buildTrace,
+				buildCostUsd,
+				buildTurns,
 				n8nBaseUrl,
 				runDebug: threadId ? runDebugByThreadId.get(threadId) : undefined,
 			});

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -310,6 +310,10 @@ export interface WorkflowTestCaseResult {
 	workflowChecks?: CheckOutcome[];
 	/** Captured build-time sub-agent/tool activity for builder debugging. */
 	buildTrace?: BuildTrace;
+	/** `claude` build spend in USD for this iteration's build (--build-via-mcp only). */
+	buildCostUsd?: number;
+	/** Assistant turns across the `claude` build's attempts (--build-via-mcp only). */
+	buildTurns?: number;
 	/** Per-expectation verdicts from the build-expectations judge. Aggregated as
 	 *  scoring units alongside execution scenarios. */
 	buildExpectationResults?: BuildExpectationResult[];

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -20,7 +20,6 @@
     "eval:pairwise": "tsx evaluations/cli/pairwise.ts",
     "eval:pairwise:report": "tsx evaluations/cli/report.ts",
     "eval:pairwise:compare": "tsx evaluations/cli/compare-pairwise.ts",
-    "eval:build-cost-report": "tsx evaluations/cli/build-cost-report.ts",
     "eval:subagent": "tsx evaluations/subagent/cli.ts",
     "eval:computer-use": "tsx evaluations/computer-use/cli.ts",
     "eval:discovery": "tsx evaluations/discovery/cli.ts",

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -20,6 +20,7 @@
     "eval:pairwise": "tsx evaluations/cli/pairwise.ts",
     "eval:pairwise:report": "tsx evaluations/cli/report.ts",
     "eval:pairwise:compare": "tsx evaluations/cli/compare-pairwise.ts",
+    "eval:build-cost-report": "tsx evaluations/cli/build-cost-report.ts",
     "eval:subagent": "tsx evaluations/subagent/cli.ts",
     "eval:computer-use": "tsx evaluations/computer-use/cli.ts",
     "eval:discovery": "tsx evaluations/discovery/cli.ts",


### PR DESCRIPTION
## Summary

Per-case builder cost for `--build-via-mcp` eval runs, plus a cross-arm cost report — groundwork for the MCP (Claude Code) vs AIA builder cost comparison on the `model-comparison` LangTracer suite.

- `buildWorkflowViaMcp` now sums `claude` cost/turns/duration across **every attempt** (run totals were a documented last-attempt lower bound; failed attempts cost money too).
- Each build's spend rides the row outputs (`buildCostUsd`/`buildTurns`, same pattern as `buildDurationMs`) → new per-row LangSmith feedback `build_cost_usd` / `build_turns`.
- `eval-results.json` gains per-case `buildCostUsdPerRun` / `buildTurnsPerRun` — conditional, absent on non-MCP runs, so dispatcher output is unchanged (contract test extended).
- New `evaluations/cli/build-cost-report.ts`: arm-agnostic cost comparison across eval runs — one repeatable `--results <eval-results.json>` per arm (optional `--label`), cost source auto-detected per file (`buildCostUsdPerRun` → persisted `claude` spend; non-null `threadIds` → LangSmith thread pricing over the `instance-ai-evals` trace project). Missing traces count as **unknown**, never $0; LangSmith calls retry 429/5xx with backoff. **Deliberately not wired into package.json** — an experiment-time tool; invoke via `pnpm tsx evaluations/cli/build-cost-report.ts`.

**Merge intent:** durable instrumentation — every future `--build-via-mcp` run reports per-case cost; run totals become true spend; feedback keys feed the LS→BQ analytics.

**History note:** originally stacked on `trust-261-eval-harness-hardening-pr-c`; rebased onto `master` after #34747's squash-merge, so the diff is exactly the 5 commits of this PR.

## How to test

- `pnpm test mcp-builder.test.ts case-pipeline.test.ts reshape.test.ts eval-results-dispatcher-contract.test.ts build-cost-report.test.ts` — 93 tests across the touched files (incl. 14 table-driven report tests).
- **Validated at scale**: full `model-comparison` wave, both arms, 31 cases × 3 iterations (runs [30009318629](https://github.com/n8n-io/n8n/actions/runs/30009318629) / [30009320648](https://github.com/n8n-io/n8n/actions/runs/30009320648)) — `build_cost_usd`/`build_turns` verified on every MCP experiment row (values match the artifact exactly), per-case arrays present, and the report joined 84 MCP builds + 80 AIA thread costs (4 timed-out builds correctly reported as unknown).
- Spot-check: `dotenvx run -f ../../../.env.local -- pnpm tsx evaluations/cli/build-cost-report.ts --probe-thread <threadId>`.

Known gap: the orchestrator's spend-capture glue (local collector → `CachedBuild.buildSpend`) has no direct unit test — it would need a `cli/mcp-builder` module-mock scaffold in `build-orchestrator.test.ts`; both ends of the chain are covered (builder summation, pipeline row attachment, reshape, persist), and the full wave exercised it live.

## Related Linear tickets, Github issues, and Community forum posts

None — supports the MCP-vs-AIA builder cost comparison experiment.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (in-repo: evaluations README + ARCHITECTURE)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)