### PR TITLE
feat(core): Improve workflow groups validation/support in mcp (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -548,7 +548,7 @@ describe('validateWorkflowNodeGroups', () => {
 				},
 				null,
 			),
-		).toThrow('Node "n1" belongs to multiple groups: "Group A" and "Group B".');
+		).toThrow('Node "Node n1" belongs to multiple groups: "Group A" and "Group B".');
 	});
 
 	it('should throw when group names are not unique', () => {

--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -14,7 +14,10 @@ import { Telemetry } from '@/telemetry';
 import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
-import { createCreateWorkflowFromCodeTool } from '../tools/workflow-builder/create-workflow-from-code.tool';
+import {
+	createCreateWorkflowFromCodeTool,
+	type CreateWorkflowFromCodeToolOptions,
+} from '../tools/workflow-builder/create-workflow-from-code.tool';
 
 // Mocks referenced inside vi.mock factories must come from vi.hoisted, otherwise the
 // factory (hoisted above these declarations) silently loads the real module.
@@ -167,7 +170,7 @@ describe('create-workflow-from-code MCP tool', () => {
 	const aiGatewayService = mock<AiGatewayService>();
 	aiGatewayService.isAvailable.mockResolvedValue({ available: false });
 
-	const createTool = () =>
+	const createTool = (options?: CreateWorkflowFromCodeToolOptions) =>
 		createCreateWorkflowFromCodeTool(
 			user,
 			workflowCreationService,
@@ -179,6 +182,7 @@ describe('create-workflow-from-code MCP tool', () => {
 			projectRepository,
 			dataTableOps as never,
 			aiGatewayService,
+			options,
 		);
 
 	// Helper to call handler with proper typing (optional fields default to undefined)
@@ -943,6 +947,88 @@ describe('create-workflow-from-code MCP tool', () => {
 			// so strict clients no longer reject it with -32602.
 			const strictSchema = z.object(tool.config.outputSchema as z.ZodRawShape).strict();
 			expect(() => strictSchema.parse(result.structuredContent)).not.toThrow();
+		});
+	});
+
+	describe('canvas groups (102_mcp_canvas_groups)', () => {
+		const nodeGroups = [{ id: 'g1', name: 'Ingestion', nodeIds: ['node-1', 'node-2'] }];
+
+		/** results.data of the last tracked telemetry event */
+		const trackedData = () => {
+			const payload = vi.mocked(telemetry.track).mock.calls.at(-1)?.[1] as {
+				results?: { data?: Record<string, unknown> };
+			};
+			return payload.results?.data;
+		};
+
+		test('flag off: groups from the code are dropped and telemetry is unchanged', async () => {
+			mockParseAndValidate.mockResolvedValue({
+				workflow: { ...mockWorkflowJson, nodeGroups },
+				warnings: [],
+			});
+
+			const result = await callHandler({ code: 'const wf = ...' });
+
+			expect(parseResult(result).workflowId).toBe('wf-saved-1');
+			const passedWorkflow = createWorkflowMock.mock.calls[0][1] as WorkflowEntity;
+			expect(passedWorkflow).not.toHaveProperty('nodeGroups');
+			// Telemetry payload is byte-identical to the pre-flag shape.
+			expect(trackedData()).toEqual({ workflowId: 'wf-saved-1', nodeCount: 2 });
+		});
+
+		test('flag on: groups from the code are persisted on the created workflow', async () => {
+			mockParseAndValidate.mockResolvedValue({
+				workflow: { ...mockWorkflowJson, nodeGroups },
+				warnings: [],
+			});
+
+			const result = await callHandler(
+				{ code: 'const wf = ...' },
+				createTool({ canvasGroupsEnabled: true }),
+			);
+
+			expect(parseResult(result).workflowId).toBe('wf-saved-1');
+			const passedWorkflow = createWorkflowMock.mock.calls[0][1] as WorkflowEntity;
+			expect(passedWorkflow.nodeGroups).toEqual(nodeGroups);
+			expect(trackedData()).toEqual({ workflowId: 'wf-saved-1', nodeCount: 2, groupCount: 1 });
+		});
+
+		test('flag on: code without groups persists an empty group list', async () => {
+			mockParseAndValidate.mockResolvedValue({ workflow: mockWorkflowJson, warnings: [] });
+
+			await callHandler({ code: 'const wf = ...' }, createTool({ canvasGroupsEnabled: true }));
+
+			const passedWorkflow = createWorkflowMock.mock.calls[0][1] as WorkflowEntity;
+			expect(passedWorkflow.nodeGroups).toEqual([]);
+			expect(trackedData()).toEqual({ workflowId: 'wf-saved-1', nodeCount: 2, groupCount: 0 });
+		});
+
+		test('flag on: invalid groups fail the creation with the save-path message', async () => {
+			// The save path rejects invalid groups (`validateWorkflowNodeGroups`);
+			// the tool intentionally lets that error fail the call so no workflow
+			// is silently created without the authored groups.
+			const saveError = new Error(
+				'Node group "Ingestion" (g1) cannot contain trigger nodes: Webhook.',
+			);
+			mockParseAndValidate.mockResolvedValue({
+				workflow: { ...mockWorkflowJson, nodeGroups },
+				warnings: [],
+			});
+			createWorkflowMock.mockRejectedValue(saveError);
+
+			const result = await callHandler(
+				{ code: 'const wf = ...' },
+				createTool({ canvasGroupsEnabled: true }),
+			);
+
+			expect(result.isError).toBe(true);
+			expect(parseResult(result).error).toBe(saveError.message);
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User called mcp tool',
+				expect.objectContaining({
+					results: expect.objectContaining({ success: false, error: saveError.message }),
+				}),
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/validate-workflow-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/validate-workflow-code.tool.test.ts
@@ -423,6 +423,40 @@ describe('validate-workflow-code MCP tool', () => {
 			});
 		});
 
+		test('flag on: connections under unsafe object keys are skipped, not assigned', async () => {
+			// Built via JSON.parse: an object literal with a "__proto__" key would
+			// invoke the prototype setter instead of creating an own property.
+			// Both entries would be boundary-crossing ai_languageModel connections
+			// into the group if their keys were honored; skipping them is the
+			// deliberate trade-off for never writing object-internal keys.
+			const hostileConnections = JSON.parse(
+				'{"__proto__": {"ai_languageModel": [[{"node": "A", "type": "ai_languageModel", "index": 0}]]},' +
+					' "constructor": {"ai_languageModel": [[{"node": "B", "type": "ai_languageModel", "index": 0}]]}}',
+			) as Record<string, unknown>;
+			const workflow = makeGroupedWorkflow([{ id: 'g1', name: 'Group', nodeIds: ['a', 'b'] }]);
+			mockParseAndValidate.mockResolvedValue({
+				workflow: {
+					...workflow,
+					connections: { ...workflow.connections, ...hostileConnections },
+				},
+				warnings: [],
+			});
+
+			const tool = createTool({ canvasGroupsEnabled: true });
+			const result = await tool.handler({ code: 'const wf = ...' }, {} as never);
+
+			const response = parseResult(result);
+			expect(result.isError).toBeUndefined();
+			expect(response.valid).toBe(true);
+			expect(response).not.toHaveProperty('warnings');
+			expect(trackedData()).toEqual({
+				nodeCount: 3,
+				warningCount: 0,
+				groupCount: 1,
+				groupViolationCount: 0,
+			});
+		});
+
 		test('flag on: workflows without groups report groupCount 0', async () => {
 			mockParseAndValidate.mockResolvedValue({
 				workflow: makeGroupedWorkflow([]),

--- a/packages/cli/src/modules/mcp/__tests__/validate-workflow-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/validate-workflow-code.tool.test.ts
@@ -7,7 +7,6 @@ import { Telemetry } from '@/telemetry';
 
 import {
 	createValidateWorkflowCodeTool,
-	INVALID_NODE_GROUP_WARNING_CODE,
 	type ValidateWorkflowCodeToolOptions,
 } from '../tools/workflow-builder/validate-workflow-code.tool';
 
@@ -313,13 +312,16 @@ describe('validate-workflow-code MCP tool', () => {
 			nodeGroups,
 		});
 
-		/** results.data of the last tracked telemetry event */
-		const trackedData = () => {
+		/** results of the last tracked telemetry event */
+		const trackedResults = () => {
 			const payload = vi.mocked(telemetry.track).mock.calls.at(-1)?.[1] as {
-				results?: { data?: Record<string, unknown> };
+				results?: { success?: boolean; error?: string; data?: Record<string, unknown> };
 			};
-			return payload.results?.data;
+			return payload.results;
 		};
+
+		/** results.data of the last tracked telemetry event */
+		const trackedData = () => trackedResults()?.data;
 
 		beforeEach(() => {
 			// The group validator resolves trigger-ness via description.group.
@@ -347,7 +349,7 @@ describe('validate-workflow-code MCP tool', () => {
 			expect(trackedData()).toEqual({ nodeCount: 3, warningCount: 0 });
 		});
 
-		test('flag on: a valid group produces no warnings but is counted in telemetry', async () => {
+		test('flag on: a valid group produces no errors and is counted in telemetry', async () => {
 			mockParseAndValidate.mockResolvedValue({
 				workflow: makeGroupedWorkflow([{ id: 'g1', name: 'Group', nodeIds: ['a', 'b'] }]),
 				warnings: [],
@@ -363,11 +365,10 @@ describe('validate-workflow-code MCP tool', () => {
 				nodeCount: 3,
 				warningCount: 0,
 				groupCount: 1,
-				groupViolationCount: 0,
 			});
 		});
 
-		test('flag on: group violations are surfaced as warnings with the save-path message', async () => {
+		test('flag on: group violations fail validation with the save-path message', async () => {
 			mockParseAndValidate.mockResolvedValue({
 				workflow: makeGroupedWorkflow([{ id: 'g1', name: 'Group', nodeIds: ['trigger', 'a'] }]),
 				warnings: [],
@@ -377,27 +378,29 @@ describe('validate-workflow-code MCP tool', () => {
 			const result = await tool.handler({ code: 'const wf = ...' }, {} as never);
 
 			const response = parseResult(result);
-			expect(response.valid).toBe(true);
-			expect(result.isError).toBeUndefined();
-			expect(response.warnings).toEqual([
-				{
-					code: INVALID_NODE_GROUP_WARNING_CODE,
-					message: 'Node group "Group" (g1) cannot contain trigger nodes: Trigger.',
+			expect(result.isError).toBe(true);
+			expect(response).toEqual({
+				valid: false,
+				errors: ['Node group "Group" (g1) cannot contain trigger nodes: Trigger.'],
+			});
+			expect(trackedResults()).toEqual({
+				success: false,
+				error: 'Node group "Group" (g1) cannot contain trigger nodes: Trigger.',
+				data: {
+					groupCount: 1,
+					groupViolationCount: 1,
+					groupViolationCodes: ['trigger-selected'],
 				},
-			]);
-			expect(trackedData()).toEqual({
-				nodeCount: 3,
-				warningCount: 0,
-				groupCount: 1,
-				groupViolationCount: 1,
-				groupViolationCodes: ['trigger-selected'],
 			});
 		});
 
-		test('flag on: group warnings are appended after SDK warnings', async () => {
+		test('flag on: all group violations are reported as errors, one entry each', async () => {
 			const sdkWarning = { code: 'deprecated', message: 'Node X is deprecated' };
 			mockParseAndValidate.mockResolvedValue({
-				workflow: makeGroupedWorkflow([{ id: 'g1', name: 'Group', nodeIds: ['a', 'missing'] }]),
+				workflow: makeGroupedWorkflow([
+					{ id: 'g1', name: 'Group', nodeIds: ['a', 'missing'] },
+					{ id: 'g2', name: 'Group', nodeIds: ['b'] },
+				]),
 				warnings: [sdkWarning],
 			});
 
@@ -405,21 +408,24 @@ describe('validate-workflow-code MCP tool', () => {
 			const result = await tool.handler({ code: 'const wf = ...' }, {} as never);
 
 			const response = parseResult(result);
-			expect(response.warnings).toEqual([
-				sdkWarning,
-				{
-					code: INVALID_NODE_GROUP_WARNING_CODE,
-					message:
-						'Group "Group" references node ID "missing" that does not exist in the workflow.',
-				},
+			expect(result.isError).toBe(true);
+			expect(response.valid).toBe(false);
+			expect(response.errors).toEqual([
+				'Group "Group" references node ID "missing" that does not exist in the workflow.',
+				'Duplicate node group name "Group".',
 			]);
-			// SDK warnings keep their own count; group violations are counted separately.
-			expect(trackedData()).toEqual({
-				nodeCount: 3,
-				warningCount: 1,
-				groupCount: 1,
-				groupViolationCount: 1,
-				groupViolationCodes: ['unknown-node-id'],
+			// Error responses carry only errors, matching the other invalid paths.
+			expect(response).not.toHaveProperty('warnings');
+			expect(trackedResults()).toEqual({
+				success: false,
+				error:
+					'Group "Group" references node ID "missing" that does not exist in the workflow. ' +
+					'Duplicate node group name "Group".',
+				data: {
+					groupCount: 2,
+					groupViolationCount: 2,
+					groupViolationCodes: ['unknown-node-id', 'duplicate-group-name'],
+				},
 			});
 		});
 
@@ -453,7 +459,6 @@ describe('validate-workflow-code MCP tool', () => {
 				nodeCount: 3,
 				warningCount: 0,
 				groupCount: 1,
-				groupViolationCount: 0,
 			});
 		});
 
@@ -473,7 +478,6 @@ describe('validate-workflow-code MCP tool', () => {
 				nodeCount: 3,
 				warningCount: 0,
 				groupCount: 0,
-				groupViolationCount: 0,
 			});
 		});
 	});

--- a/packages/cli/src/modules/mcp/__tests__/validate-workflow-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/validate-workflow-code.tool.test.ts
@@ -5,7 +5,11 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import { NodeTypes } from '@/node-types';
 import { Telemetry } from '@/telemetry';
 
-import { createValidateWorkflowCodeTool } from '../tools/workflow-builder/validate-workflow-code.tool';
+import {
+	createValidateWorkflowCodeTool,
+	INVALID_NODE_GROUP_WARNING_CODE,
+	type ValidateWorkflowCodeToolOptions,
+} from '../tools/workflow-builder/validate-workflow-code.tool';
 
 // Mocks referenced inside vi.mock factories must come from vi.hoisted.
 const { mockParseAndValidate, mockStripImportStatements } = vi.hoisted(() => ({
@@ -61,7 +65,8 @@ describe('validate-workflow-code MCP tool', () => {
 		}) as typeof nodeTypes.getByNameAndVersion);
 	});
 
-	const createTool = () => createValidateWorkflowCodeTool(user, telemetry, nodeTypes);
+	const createTool = (options?: ValidateWorkflowCodeToolOptions) =>
+		createValidateWorkflowCodeTool(user, telemetry, nodeTypes, options);
 
 	describe('smoke tests', () => {
 		test('creates tool with correct name and readOnlyHint=true', () => {
@@ -267,6 +272,175 @@ describe('validate-workflow-code MCP tool', () => {
 					}),
 				}),
 			);
+		});
+	});
+
+	describe('canvas groups (102_mcp_canvas_groups)', () => {
+		const makeGroupedWorkflow = (
+			nodeGroups: Array<{ id: string; name: string; nodeIds: string[] }>,
+		) => ({
+			name: 'wf',
+			nodes: [
+				{
+					id: 'trigger',
+					name: 'Trigger',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				{
+					id: 'a',
+					name: 'A',
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [200, 0],
+					parameters: {},
+				},
+				{
+					id: 'b',
+					name: 'B',
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [400, 0],
+					parameters: {},
+				},
+			],
+			connections: {
+				Trigger: { main: [[{ node: 'A', type: 'main', index: 0 }]] },
+				A: { main: [[{ node: 'B', type: 'main', index: 0 }]] },
+			},
+			nodeGroups,
+		});
+
+		/** results.data of the last tracked telemetry event */
+		const trackedData = () => {
+			const payload = vi.mocked(telemetry.track).mock.calls.at(-1)?.[1] as {
+				results?: { data?: Record<string, unknown> };
+			};
+			return payload.results?.data;
+		};
+
+		beforeEach(() => {
+			// The group validator resolves trigger-ness via description.group.
+			nodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === 'n8n-nodes-base.manualTrigger') {
+					return { description: { group: ['trigger'], outputs: [NodeConnectionTypes.Main] } };
+				}
+				return { description: { group: ['transform'], outputs: [NodeConnectionTypes.Main] } };
+			}) as typeof nodeTypes.getByNameAndVersion);
+		});
+
+		test('flag off: groups are not validated and output/telemetry are unchanged', async () => {
+			mockParseAndValidate.mockResolvedValue({
+				workflow: makeGroupedWorkflow([{ id: 'g1', name: 'Group', nodeIds: ['trigger', 'a'] }]),
+				warnings: [],
+			});
+
+			const tool = createTool();
+			const result = await tool.handler({ code: 'const wf = ...' }, {} as never);
+
+			const response = parseResult(result);
+			expect(response.valid).toBe(true);
+			expect(response).not.toHaveProperty('warnings');
+			// Telemetry payload is byte-identical to the pre-flag shape.
+			expect(trackedData()).toEqual({ nodeCount: 3, warningCount: 0 });
+		});
+
+		test('flag on: a valid group produces no warnings but is counted in telemetry', async () => {
+			mockParseAndValidate.mockResolvedValue({
+				workflow: makeGroupedWorkflow([{ id: 'g1', name: 'Group', nodeIds: ['a', 'b'] }]),
+				warnings: [],
+			});
+
+			const tool = createTool({ canvasGroupsEnabled: true });
+			const result = await tool.handler({ code: 'const wf = ...' }, {} as never);
+
+			const response = parseResult(result);
+			expect(response.valid).toBe(true);
+			expect(response).not.toHaveProperty('warnings');
+			expect(trackedData()).toEqual({
+				nodeCount: 3,
+				warningCount: 0,
+				groupCount: 1,
+				groupViolationCount: 0,
+			});
+		});
+
+		test('flag on: group violations are surfaced as warnings with the save-path message', async () => {
+			mockParseAndValidate.mockResolvedValue({
+				workflow: makeGroupedWorkflow([{ id: 'g1', name: 'Group', nodeIds: ['trigger', 'a'] }]),
+				warnings: [],
+			});
+
+			const tool = createTool({ canvasGroupsEnabled: true });
+			const result = await tool.handler({ code: 'const wf = ...' }, {} as never);
+
+			const response = parseResult(result);
+			expect(response.valid).toBe(true);
+			expect(result.isError).toBeUndefined();
+			expect(response.warnings).toEqual([
+				{
+					code: INVALID_NODE_GROUP_WARNING_CODE,
+					message: 'Node group "Group" (g1) cannot contain trigger nodes: Trigger.',
+				},
+			]);
+			expect(trackedData()).toEqual({
+				nodeCount: 3,
+				warningCount: 0,
+				groupCount: 1,
+				groupViolationCount: 1,
+				groupViolationCodes: ['trigger-selected'],
+			});
+		});
+
+		test('flag on: group warnings are appended after SDK warnings', async () => {
+			const sdkWarning = { code: 'deprecated', message: 'Node X is deprecated' };
+			mockParseAndValidate.mockResolvedValue({
+				workflow: makeGroupedWorkflow([{ id: 'g1', name: 'Group', nodeIds: ['a', 'missing'] }]),
+				warnings: [sdkWarning],
+			});
+
+			const tool = createTool({ canvasGroupsEnabled: true });
+			const result = await tool.handler({ code: 'const wf = ...' }, {} as never);
+
+			const response = parseResult(result);
+			expect(response.warnings).toEqual([
+				sdkWarning,
+				{
+					code: INVALID_NODE_GROUP_WARNING_CODE,
+					message:
+						'Group "Group" references node ID "missing" that does not exist in the workflow.',
+				},
+			]);
+			// SDK warnings keep their own count; group violations are counted separately.
+			expect(trackedData()).toEqual({
+				nodeCount: 3,
+				warningCount: 1,
+				groupCount: 1,
+				groupViolationCount: 1,
+				groupViolationCodes: ['unknown-node-id'],
+			});
+		});
+
+		test('flag on: workflows without groups report groupCount 0', async () => {
+			mockParseAndValidate.mockResolvedValue({
+				workflow: makeGroupedWorkflow([]),
+				warnings: [],
+			});
+
+			const tool = createTool({ canvasGroupsEnabled: true });
+			const result = await tool.handler({ code: 'const wf = ...' }, {} as never);
+
+			const response = parseResult(result);
+			expect(response.valid).toBe(true);
+			expect(response).not.toHaveProperty('warnings');
+			expect(trackedData()).toEqual({
+				nodeCount: 3,
+				warningCount: 0,
+				groupCount: 0,
+				groupViolationCount: 0,
+			});
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -496,7 +496,9 @@ export class McpService {
 		);
 		registerIfAllowed(exploreNodeResourcesTool);
 
-		const validateTool = createValidateWorkflowCodeTool(user, this.telemetry, this.nodeTypes);
+		const validateTool = createValidateWorkflowCodeTool(user, this.telemetry, this.nodeTypes, {
+			canvasGroupsEnabled: featureFlags.canvasGroupsEnabled,
+		});
 		registerIfAllowed(validateTool);
 
 		const validateNodeTool = createValidateNodeTool(user, this.telemetry);

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -515,6 +515,7 @@ export class McpService {
 			this.projectRepository,
 			dataTableOps,
 			this.aiGatewayService,
+			{ canvasGroupsEnabled: featureFlags.canvasGroupsEnabled },
 		);
 
 		// The preview app only accompanies the create tool, so both are gated

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -41,7 +41,7 @@ export type CreateWorkflowFromCodeToolOptions = {
 	 * default — groups are then dropped at the entity assembly, exactly like
 	 * before groups were supported. Note that with the flag on, invalid groups
 	 * fail the creation: `WorkflowCreationService.createWorkflow` rejects them
-	 * with the same message the `validate_workflow` tool reports as a warning,
+	 * with the same messages the `validate_workflow` tool reports as errors,
 	 * so agents can catch group problems before calling this tool.
 	 */
 	canvasGroupsEnabled?: boolean;

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -34,6 +34,19 @@ import type { WorkflowFinderService } from '@/workflows/workflow-finder.service'
 
 const MAX_WORKFLOW_DESCRIPTION_LENGTH = 255;
 
+export type CreateWorkflowFromCodeToolOptions = {
+	/**
+	 * `102_mcp_canvas_groups` rollout flag: when true, node groups authored in the
+	 * SDK code (`.group(...)`) are persisted on the created workflow. Off by
+	 * default — groups are then dropped at the entity assembly, exactly like
+	 * before groups were supported. Note that with the flag on, invalid groups
+	 * fail the creation: `WorkflowCreationService.createWorkflow` rejects them
+	 * with the same message the `validate_workflow` tool reports as a warning,
+	 * so agents can catch group problems before calling this tool.
+	 */
+	canvasGroupsEnabled?: boolean;
+};
+
 function normalizeWorkflowDescription(description?: string) {
 	if (!description) return { description: undefined, truncated: false };
 	if (description.length <= MAX_WORKFLOW_DESCRIPTION_LENGTH) {
@@ -169,6 +182,7 @@ export const createCreateWorkflowFromCodeTool = (
 	projectRepository: ProjectRepository,
 	dataTableOps: DataTableUserOperations,
 	aiGatewayService: AiGatewayService,
+	options: CreateWorkflowFromCodeToolOptions = {},
 ): ToolDefinition<typeof inputSchema> => ({
 	name: MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName,
 	config: {
@@ -262,6 +276,8 @@ export const createCreateWorkflowFromCodeTool = (
 				...(workflowDescription ? { description: workflowDescription } : {}),
 				nodes: workflowJson.nodes,
 				connections: workflowJson.connections,
+				// Flag off: groups keep being dropped here, exactly like before.
+				...(options.canvasGroupsEnabled ? { nodeGroups: workflowJson.nodeGroups ?? [] } : {}),
 				settings: { ...workflowJson.settings, executionOrder: 'v1', availableInMCP: true },
 				pinData: workflowJson.pinData,
 				meta: { ...workflowJson.meta, aiBuilderAssisted: true, builderVariant: 'mcp' },
@@ -349,6 +365,11 @@ export const createCreateWorkflowFromCodeTool = (
 				data: {
 					workflowId: savedWorkflow.id,
 					nodeCount: savedWorkflow.nodes.length,
+					// Rollout monitoring for `102_mcp_canvas_groups`; absent when the
+					// flag is off so the payload stays identical across cohorts.
+					...(options.canvasGroupsEnabled
+						? { groupCount: workflowJson.nodeGroups?.length ?? 0 }
+						: {}),
 				},
 			};
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
@@ -115,6 +115,8 @@ export const createValidateWorkflowCodeTool = (
 		},
 	},
 	handler: async ({ code }: { code: string }) => {
+		console.log('[🤖 VALIDATE TOOL] groups: ', options.canvasGroupsEnabled);
+
 		const telemetryPayload: UserCalledMCPToolEventPayload = {
 			user_id: user.id,
 			tool_name: CODE_BUILDER_VALIDATE_TOOL.toolName,

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
@@ -20,14 +20,12 @@ import { getSdkReferenceHint } from '../workflow-validation.utils';
 import { buildInvalidAiToolSourceErrorResponse } from './connection-structure-check';
 import { CODE_BUILDER_VALIDATE_TOOL } from './constants';
 
-/** Warning code carried by node-group rule violations in the tool response. */
-export const INVALID_NODE_GROUP_WARNING_CODE = 'INVALID_NODE_GROUP';
-
 export type ValidateWorkflowCodeToolOptions = {
 	/**
 	 * `102_mcp_canvas_groups` rollout flag: when true, node-group rule violations
-	 * are surfaced as warnings and traced in telemetry. Off by default — the tool
-	 * then behaves exactly as before groups were validated.
+	 * are reported as validation errors (`valid: false`) — they hard-block the
+	 * save path — and traced in telemetry. Off by default — the tool then
+	 * behaves exactly as before groups were validated.
 	 */
 	canvasGroupsEnabled?: boolean;
 };
@@ -149,11 +147,10 @@ export const createValidateWorkflowCodeTool = (
 			);
 			if (invalidToolSourceResponse) return invalidToolSourceResponse;
 
-			// `102_mcp_canvas_groups` rollout: surface node-group rule violations at
-			// validate time, with the same messages the save path rejects with. Flag
-			// off: output and telemetry are identical to before groups existed.
-			const groupWarnings: Array<{ code: string; message: string }> = [];
-			let groupViolationCodes: string[] = [];
+			// `102_mcp_canvas_groups` rollout: report node-group rule violations as
+			// validation errors, with the same messages the save path rejects with —
+			// like the ai_tool-source check above, they hard-block saving. Flag off:
+			// output and telemetry are identical to before groups existed.
 			if (options.canvasGroupsEnabled && (result.workflow.nodeGroups?.length ?? 0) > 0) {
 				// The group validator only reads id/name/type (+ typeVersion via
 				// getNodeType); map the SDK's NodeJSON (optional name/parameters)
@@ -174,15 +171,27 @@ export const createValidateWorkflowCodeTool = (
 					getNodeType: makeGetNodeTypeForGrouping(nodeTypes),
 				});
 				if (!groupsResult.valid) {
-					groupWarnings.push(
-						...groupsResult.violations.map((violation) => ({
-							code: INVALID_NODE_GROUP_WARNING_CODE,
-							message: violation.message,
-						})),
-					);
-					groupViolationCodes = [
-						...new Set(groupsResult.violations.map((violation) => violation.code)),
-					];
+					const errorMessages = groupsResult.violations.map((violation) => violation.message);
+
+					telemetryPayload.results = {
+						success: false,
+						error: errorMessages.join(' '),
+						data: {
+							groupCount: result.workflow.nodeGroups?.length ?? 0,
+							groupViolationCount: groupsResult.violations.length,
+							groupViolationCodes: [
+								...new Set(groupsResult.violations.map((violation) => violation.code)),
+							],
+						},
+					};
+					telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+					const output = { valid: false, errors: errorMessages };
+					return {
+						content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+						structuredContent: output,
+						isError: true,
+					};
 				}
 			}
 
@@ -190,15 +199,11 @@ export const createValidateWorkflowCodeTool = (
 				success: true,
 				data: {
 					nodeCount: result.workflow.nodes.length,
-					// SDK validation warnings only — group violations are counted
-					// separately so the metric keeps its meaning across flag cohorts.
 					warningCount: result.warnings.length,
+					// Rollout monitoring for `102_mcp_canvas_groups`; absent when the
+					// flag is off so the payload stays identical across cohorts.
 					...(options.canvasGroupsEnabled
-						? {
-								groupCount: result.workflow.nodeGroups?.length ?? 0,
-								groupViolationCount: groupWarnings.length,
-								...(groupViolationCodes.length > 0 ? { groupViolationCodes } : {}),
-							}
+						? { groupCount: result.workflow.nodeGroups?.length ?? 0 }
 						: {}),
 				},
 			};
@@ -209,9 +214,8 @@ export const createValidateWorkflowCodeTool = (
 				nodeCount: result.workflow.nodes.length,
 			};
 
-			const warnings = [...result.warnings, ...groupWarnings];
-			if (warnings.length > 0) {
-				response.warnings = warnings;
+			if (result.warnings.length > 0) {
+				response.warnings = result.warnings;
 			}
 
 			return {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
@@ -2,6 +2,7 @@ import type { User } from '@n8n/db';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
 import {
 	isNodeConnectionType,
+	isSafeObjectProperty,
 	validateWorkflowGroups,
 	type IConnections,
 	type INode,
@@ -72,12 +73,19 @@ const outputSchema = {
  * `isNodeConnectionType` guard. Serializer output only ever carries known
  * connection types; if an unknown one ever slips through, that connection is
  * skipped here and the save path still rejects the workflow.
+ *
+ * Node names and connection types come from submitted code, so keys that
+ * resolve to object internals (`__proto__`, `constructor`, ...) are skipped —
+ * assigning them onto a plain object would mutate its prototype instead of
+ * creating an own property, silently corrupting the re-keyed connections.
  */
 function toWorkflowConnections(connections: WorkflowJSON['connections']): IConnections {
 	const bySourceNode: IConnections = {};
 	for (const [sourceNode, byType] of Object.entries(connections ?? {})) {
+		if (!isSafeObjectProperty(sourceNode)) continue;
 		const nodeConnections: INodeConnections = {};
 		for (const [connectionType, outputs] of Object.entries(byType)) {
+			if (!isSafeObjectProperty(connectionType)) continue;
 			nodeConnections[connectionType] = outputs.map(
 				(outputConnections) =>
 					outputConnections?.flatMap((connection) =>

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
@@ -1,14 +1,35 @@
 import type { User } from '@n8n/db';
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import {
+	isNodeConnectionType,
+	validateWorkflowGroups,
+	type IConnections,
+	type INode,
+	type INodeConnections,
+} from 'n8n-workflow';
 import z from 'zod';
 
 import type { NodeTypes } from '@/node-types';
 import type { Telemetry } from '@/telemetry';
+import { makeGetNodeTypeForGrouping } from '@/workflow-helpers';
 
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 import { getSdkReferenceHint } from '../workflow-validation.utils';
 import { buildInvalidAiToolSourceErrorResponse } from './connection-structure-check';
 import { CODE_BUILDER_VALIDATE_TOOL } from './constants';
+
+/** Warning code carried by node-group rule violations in the tool response. */
+export const INVALID_NODE_GROUP_WARNING_CODE = 'INVALID_NODE_GROUP';
+
+export type ValidateWorkflowCodeToolOptions = {
+	/**
+	 * `102_mcp_canvas_groups` rollout flag: when true, node-group rule violations
+	 * are surfaced as warnings and traced in telemetry. Off by default — the tool
+	 * then behaves exactly as before groups were validated.
+	 */
+	canvasGroupsEnabled?: boolean;
+};
 
 const inputSchema = {
 	code: z
@@ -45,6 +66,31 @@ const outputSchema = {
 } satisfies z.ZodRawShape;
 
 /**
+ * Bridges the SDK's connections to `n8n-workflow`'s `IConnections`. The two
+ * declare duplicate but formally separate connection types (the SDK types
+ * `IConnection.type` as plain `string`), so the values are re-keyed through the
+ * `isNodeConnectionType` guard. Serializer output only ever carries known
+ * connection types; if an unknown one ever slips through, that connection is
+ * skipped here and the save path still rejects the workflow.
+ */
+function toWorkflowConnections(connections: WorkflowJSON['connections']): IConnections {
+	const bySourceNode: IConnections = {};
+	for (const [sourceNode, byType] of Object.entries(connections ?? {})) {
+		const nodeConnections: INodeConnections = {};
+		for (const [connectionType, outputs] of Object.entries(byType)) {
+			nodeConnections[connectionType] = outputs.map(
+				(outputConnections) =>
+					outputConnections?.flatMap((connection) =>
+						isNodeConnectionType(connection.type) ? [{ ...connection, type: connection.type }] : [],
+					) ?? null,
+			);
+		}
+		bySourceNode[sourceNode] = nodeConnections;
+	}
+	return bySourceNode;
+}
+
+/**
  * MCP tool that validates n8n Workflow SDK code.
  * Parses and validates the code, returning the workflow JSON if valid or errors if not.
  */
@@ -52,6 +98,7 @@ export const createValidateWorkflowCodeTool = (
 	user: User,
 	telemetry: Telemetry,
 	nodeTypes: NodeTypes,
+	options: ValidateWorkflowCodeToolOptions = {},
 ): ToolDefinition<typeof inputSchema> => ({
 	name: CODE_BUILDER_VALIDATE_TOOL.toolName,
 	config: {
@@ -94,11 +141,57 @@ export const createValidateWorkflowCodeTool = (
 			);
 			if (invalidToolSourceResponse) return invalidToolSourceResponse;
 
+			// `102_mcp_canvas_groups` rollout: surface node-group rule violations at
+			// validate time, with the same messages the save path rejects with. Flag
+			// off: output and telemetry are identical to before groups existed.
+			const groupWarnings: Array<{ code: string; message: string }> = [];
+			let groupViolationCodes: string[] = [];
+			if (options.canvasGroupsEnabled && (result.workflow.nodeGroups?.length ?? 0) > 0) {
+				// The group validator only reads id/name/type (+ typeVersion via
+				// getNodeType); map the SDK's NodeJSON (optional name/parameters)
+				// to the INode shape it expects. Parameters are never read, so an
+				// empty object is passed instead of bridging the parameter types.
+				const groupValidationNodes: INode[] = result.workflow.nodes.map((node) => ({
+					id: node.id,
+					name: node.name ?? '',
+					type: node.type,
+					typeVersion: node.typeVersion,
+					position: node.position,
+					parameters: {},
+				}));
+				const groupsResult = validateWorkflowGroups({
+					nodes: groupValidationNodes,
+					connectionsBySourceNode: toWorkflowConnections(result.workflow.connections),
+					nodeGroups: result.workflow.nodeGroups,
+					getNodeType: makeGetNodeTypeForGrouping(nodeTypes),
+				});
+				if (!groupsResult.valid) {
+					groupWarnings.push(
+						...groupsResult.violations.map((violation) => ({
+							code: INVALID_NODE_GROUP_WARNING_CODE,
+							message: violation.message,
+						})),
+					);
+					groupViolationCodes = [
+						...new Set(groupsResult.violations.map((violation) => violation.code)),
+					];
+				}
+			}
+
 			telemetryPayload.results = {
 				success: true,
 				data: {
 					nodeCount: result.workflow.nodes.length,
+					// SDK validation warnings only — group violations are counted
+					// separately so the metric keeps its meaning across flag cohorts.
 					warningCount: result.warnings.length,
+					...(options.canvasGroupsEnabled
+						? {
+								groupCount: result.workflow.nodeGroups?.length ?? 0,
+								groupViolationCount: groupWarnings.length,
+								...(groupViolationCodes.length > 0 ? { groupViolationCodes } : {}),
+							}
+						: {}),
 				},
 			};
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
@@ -108,8 +201,9 @@ export const createValidateWorkflowCodeTool = (
 				nodeCount: result.workflow.nodes.length,
 			};
 
-			if (result.warnings.length > 0) {
-				response.warnings = result.warnings;
+			const warnings = [...result.warnings, ...groupWarnings];
+			if (warnings.length > 0) {
+				response.warnings = warnings;
 			}
 
 			return {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/validate-workflow-code.tool.ts
@@ -115,8 +115,6 @@ export const createValidateWorkflowCodeTool = (
 		},
 	},
 	handler: async ({ code }: { code: string }) => {
-		console.log('[🤖 VALIDATE TOOL] groups: ', options.canvasGroupsEnabled);
-
 		const telemetryPayload: UserCalledMCPToolEventPayload = {
 			user_id: user.id,
 			tool_name: CODE_BUILDER_VALIDATE_TOOL.toolName,

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -11,7 +11,7 @@ import {
 	resolveVariables,
 	safeParseWorkflowStructure,
 	summarizeDynamicCredentialsUsage,
-	validateNodeSelectionForGrouping,
+	validateWorkflowGroups,
 	type IDataObject,
 	type INode,
 	type INodeCredentialsDetails,
@@ -20,9 +20,7 @@ import {
 	type IRun,
 	type ITaskData,
 	type IWorkflowBase,
-	type IWorkflowGroup,
 	type IWorkflowSettings,
-	type NodeGroupValidationResult,
 	type RelatedExecution,
 	type WorkflowStructureIssue,
 } from 'n8n-workflow';
@@ -169,51 +167,14 @@ export function makeGetNodeTypeForGrouping(nodeTypes: INodeTypes): GetNodeTypeFo
 }
 
 /**
- * Maps a failed `validateNodeSelectionForGrouping` result to an actionable
- * `BadRequestError` that names the offending group and the rule it broke.
- */
-function nodeGroupValidationError(
-	group: IWorkflowGroup,
-	result: Extract<NodeGroupValidationResult, { valid: false }>,
-): BadRequestError {
-	const label = `Node group "${group.name}" (${group.id})`;
-	switch (result.reason) {
-		case 'trigger-selected':
-			return new BadRequestError(
-				`${label} cannot contain trigger nodes: ${result.triggers.join(', ')}.`,
-			);
-		case 'invalid-subgraph':
-			return new BadRequestError(
-				`${label} must form a single connected subgraph with a single entry and exit.`,
-			);
-		case 'multiple-input-branches':
-			return new BadRequestError(`${label} has multiple input branches at node "${result.node}".`);
-		case 'multiple-output-branches':
-			return new BadRequestError(`${label} has multiple output branches at node "${result.node}".`);
-		case 'node-already-grouped':
-			return new BadRequestError(
-				`${label} contains nodes that already belong to another group: ${result.nodeIds.join(', ')}.`,
-			);
-		case 'non-main-boundary':
-			return new BadRequestError(
-				`${label} cannot cross the "${result.connection.type}" connection between "${result.connection.source}" and "${result.connection.target}".`,
-			);
-	}
-}
-
-/**
- * Validates nodeGroups.
+ * Validates nodeGroups on the save path, rejecting with a `BadRequestError`.
  *
- * Basic checks (always run): unique group IDs, unique group names, at least one
- * member, all referenced node IDs exist, and each node belongs to at most one group.
- *
- * Full checks (run only when `getNodeType` is non-null): each group must satisfy
- * the same grouping rules the canvas enforces — no triggers, a single connected
- * subgraph, and no non-main connection crossing the group boundary — validated
- * against the other groups as existing groups. Pass the `getNodeType` callback to
- * run the full checks (on create, and on an update that changed the graph or the
- * groups); pass `null` to run basic checks only (e.g. a git import, so
- * legacy-invalid groups don't block the import).
+ * The rules and messages live in `validateWorkflowGroups` (n8n-workflow), the
+ * single source of truth shared with validate-time surfaces; this wrapper throws
+ * the first violation, preserving the historical throw-on-first behavior. See
+ * that function for the basic-vs-full checks contract (`getNodeType: null` runs
+ * basic checks only, e.g. a git import, so legacy-invalid groups don't block
+ * the import).
  *
  * Note for frontend: Must be called after `addNodeIds` since nodes created via the API
  * may not have IDs until that step assigns them.
@@ -224,65 +185,14 @@ export function validateWorkflowNodeGroups(
 	},
 	getNodeType: GetNodeTypeForGrouping | null,
 ) {
-	const { nodeGroups, nodes } = workflow;
-	if (!nodeGroups || nodeGroups.length === 0) return;
-
-	const nodeIds = new Set(nodes.map((n) => n.id).filter(Boolean));
-	const seenGroupIds = new Set<string>();
-	const seenGroupNames = new Set<string>();
-	const nodeToGroup = new Map<string, string>();
-
-	for (const group of nodeGroups) {
-		// Unique group IDs
-		if (seenGroupIds.has(group.id)) {
-			throw new BadRequestError(`Duplicate node group ID "${group.id}".`);
-		}
-		seenGroupIds.add(group.id);
-
-		// Unique group names
-		if (seenGroupNames.has(group.name)) {
-			throw new BadRequestError(`Duplicate node group name "${group.name}".`);
-		}
-		seenGroupNames.add(group.name);
-
-		if (group.nodeIds.length === 0) {
-			throw new BadRequestError(`Group "${group.name}" has no members.`);
-		}
-
-		for (const nodeId of group.nodeIds) {
-			// All referenced nodes must exist
-			if (!nodeIds.has(nodeId)) {
-				throw new BadRequestError(
-					`Group "${group.name}" references node ID "${nodeId}" that does not exist in the workflow.`,
-				);
-			}
-			// A node can only belong to one group
-			const existingGroup = nodeToGroup.get(nodeId);
-			if (existingGroup) {
-				throw new BadRequestError(
-					`Node "${nodeId}" belongs to multiple groups: "${existingGroup}" and "${group.name}".`,
-				);
-			}
-			nodeToGroup.set(nodeId, group.name);
-		}
-	}
-
-	if (!getNodeType) return;
-
-	const nodeById = new Map(nodes.map((node) => [node.id, node]));
-	const connectionsBySourceNode = workflow.connections ?? {};
-
-	for (const group of nodeGroups) {
-		const groupNodes = group.nodeIds.flatMap((id) => nodeById.get(id) ?? []);
-		const result = validateNodeSelectionForGrouping({
-			nodes: groupNodes,
-			connectionsBySourceNode,
-			getNodeType,
-			existingNodeGroups: nodeGroups.filter((other) => other.id !== group.id),
-		});
-		if (!result.valid) {
-			throw nodeGroupValidationError(group, result);
-		}
+	const result = validateWorkflowGroups({
+		nodes: workflow.nodes,
+		connectionsBySourceNode: workflow.connections,
+		nodeGroups: workflow.nodeGroups,
+		getNodeType,
+	});
+	if (!result.valid) {
+		throw new BadRequestError(result.violations[0].message);
 	}
 }
 

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -136,6 +136,183 @@ export function validateNodeSelectionForGrouping<TNode extends INode>(
 	return { ...subgraphResult, subGraph: input.nodes };
 }
 
+export type WorkflowGroupViolationCode =
+	| 'duplicate-group-id'
+	| 'duplicate-group-name'
+	| 'empty-group'
+	| 'unknown-node-id'
+	| 'node-in-multiple-groups'
+	| Extract<NodeGroupValidationResult, { valid: false }>['reason'];
+
+export type WorkflowGroupViolation = {
+	groupId: string;
+	groupName: string;
+	code: WorkflowGroupViolationCode;
+	/** Actionable, user-facing description; identical to the save-path rejection message. */
+	message: string;
+};
+
+export type WorkflowGroupsValidationInput<TNode extends INode = INode> = {
+	nodes: TNode[];
+	connectionsBySourceNode?: IConnections;
+	nodeGroups?: IWorkflowGroup[];
+	/**
+	 * Resolves a node to its type description (used to detect trigger nodes), or
+	 * `undefined`/`null` for unknown node types so validation degrades gracefully.
+	 * Pass `null` to run basic checks only.
+	 */
+	getNodeType: ((node: TNode) => INodeTypeDescription | null | undefined) | null;
+};
+
+export type WorkflowGroupsValidationResult =
+	| { valid: true }
+	| { valid: false; violations: [WorkflowGroupViolation, ...WorkflowGroupViolation[]] };
+
+/**
+ * Validates a workflow's `nodeGroups` without throwing, collecting all violations.
+ * Single source of truth for group rules: persistence (CLI save path) rejects with
+ * the first violation's message, and validate-time surfaces (e.g. the MCP
+ * `validate_workflow` tool) report all of them as warnings.
+ *
+ * Basic checks (always run): unique group IDs, unique group names, at least one
+ * member, all referenced node IDs exist, and each node belongs to at most one group.
+ *
+ * Full checks (run only when `getNodeType` is non-null, and skipped for groups that
+ * already have a basic violation): each group must satisfy the same grouping rules
+ * the canvas enforces — no triggers, a single connected subgraph, and no non-main
+ * connection crossing the group boundary — validated against the other groups as
+ * existing groups. Pass the `getNodeType` callback to run the full checks (on
+ * create, and on an update that changed the graph or the groups); pass `null` to
+ * run basic checks only (e.g. a git import, so legacy-invalid groups don't block
+ * the import).
+ *
+ * Violations are collected in the same order the save path checks them, so
+ * `violations[0]` is always the error a save would reject with.
+ *
+ * Note: must be called after node IDs are assigned (see `addNodeIds` in the CLI),
+ * since nodes created via the API may not have IDs until that step assigns them.
+ */
+export function validateWorkflowGroups<TNode extends INode>({
+	nodes,
+	connectionsBySourceNode,
+	nodeGroups,
+	getNodeType,
+}: WorkflowGroupsValidationInput<TNode>): WorkflowGroupsValidationResult {
+	if (!nodeGroups || nodeGroups.length === 0) return { valid: true };
+
+	const violations: WorkflowGroupViolation[] = [];
+	// Tracked by object identity: duplicate IDs/names make `group.id` ambiguous.
+	const groupsWithBasicViolations = new Set<IWorkflowGroup>();
+	const addViolation = (
+		group: IWorkflowGroup,
+		code: WorkflowGroupViolationCode,
+		message: string,
+	) => {
+		violations.push({ groupId: group.id, groupName: group.name, code, message });
+	};
+
+	const nodeIds = new Set(nodes.map((n) => n.id).filter(Boolean));
+	const seenGroupIds = new Set<string>();
+	const seenGroupNames = new Set<string>();
+	const nodeToGroup = new Map<string, string>();
+
+	for (const group of nodeGroups) {
+		const addBasicViolation = (code: WorkflowGroupViolationCode, message: string) => {
+			addViolation(group, code, message);
+			groupsWithBasicViolations.add(group);
+		};
+
+		// Unique group IDs
+		if (seenGroupIds.has(group.id)) {
+			addBasicViolation('duplicate-group-id', `Duplicate node group ID "${group.id}".`);
+		}
+		seenGroupIds.add(group.id);
+
+		// Unique group names
+		if (seenGroupNames.has(group.name)) {
+			addBasicViolation('duplicate-group-name', `Duplicate node group name "${group.name}".`);
+		}
+		seenGroupNames.add(group.name);
+
+		if (group.nodeIds.length === 0) {
+			addBasicViolation('empty-group', `Group "${group.name}" has no members.`);
+		}
+
+		for (const nodeId of group.nodeIds) {
+			// All referenced nodes must exist
+			if (!nodeIds.has(nodeId)) {
+				addBasicViolation(
+					'unknown-node-id',
+					`Group "${group.name}" references node ID "${nodeId}" that does not exist in the workflow.`,
+				);
+				continue;
+			}
+			// A node can only belong to one group
+			const existingGroup = nodeToGroup.get(nodeId);
+			if (existingGroup) {
+				addBasicViolation(
+					'node-in-multiple-groups',
+					`Node "${nodeId}" belongs to multiple groups: "${existingGroup}" and "${group.name}".`,
+				);
+			} else {
+				nodeToGroup.set(nodeId, group.name);
+			}
+		}
+	}
+
+	if (getNodeType) {
+		const nodeById = new Map(nodes.map((node) => [node.id, node]));
+		const connections = connectionsBySourceNode ?? {};
+
+		for (const group of nodeGroups) {
+			// A basic violation makes the group's member set unreliable, so the
+			// graph rules would only produce misleading follow-up violations.
+			if (groupsWithBasicViolations.has(group)) continue;
+
+			const groupNodes = group.nodeIds.flatMap((id) => nodeById.get(id) ?? []);
+			const result = validateNodeSelectionForGrouping({
+				nodes: groupNodes,
+				connectionsBySourceNode: connections,
+				getNodeType,
+				existingNodeGroups: nodeGroups.filter((other) => other.id !== group.id),
+			});
+			if (!result.valid) {
+				addViolation(group, result.reason, groupRuleViolationMessage(group, result));
+			}
+		}
+	}
+
+	const [firstViolation, ...restViolations] = violations;
+	if (!firstViolation) return { valid: true };
+	return { valid: false, violations: [firstViolation, ...restViolations] };
+}
+
+/**
+ * Maps a failed `validateNodeSelectionForGrouping` result to an actionable message
+ * that names the offending group and the rule it broke. These strings are the
+ * public save-rejection messages — change them only deliberately.
+ */
+function groupRuleViolationMessage(
+	group: IWorkflowGroup,
+	result: Extract<NodeGroupValidationResult, { valid: false }>,
+): string {
+	const label = `Node group "${group.name}" (${group.id})`;
+	switch (result.reason) {
+		case 'trigger-selected':
+			return `${label} cannot contain trigger nodes: ${result.triggers.join(', ')}.`;
+		case 'invalid-subgraph':
+			return `${label} must form a single connected subgraph with a single entry and exit.`;
+		case 'multiple-input-branches':
+			return `${label} has multiple input branches at node "${result.node}".`;
+		case 'multiple-output-branches':
+			return `${label} has multiple output branches at node "${result.node}".`;
+		case 'node-already-grouped':
+			return `${label} contains nodes that already belong to another group: ${result.nodeIds.join(', ')}.`;
+		case 'non-main-boundary':
+			return `${label} cannot cross the "${result.connection.type}" connection between "${result.connection.source}" and "${result.connection.target}".`;
+	}
+}
+
 function validateNodeSelectionSubgraph<TNode extends INode>({
 	nodes,
 	connectionsBySourceNode,

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -211,7 +211,10 @@ export function validateWorkflowGroups<TNode extends INode>({
 		violations.push({ groupId: group.id, groupName: group.name, code, message });
 	};
 
-	const nodeIds = new Set(nodes.map((n) => n.id).filter(Boolean));
+	const nodeById = new Map(nodes.filter((node) => Boolean(node.id)).map((node) => [node.id, node]));
+	// Node names are how users and agents identify nodes, so messages use them;
+	// the id is only a fallback for members without a resolvable name.
+	const nodeLabel = (nodeId: string) => nodeById.get(nodeId)?.name || nodeId;
 	const seenGroupIds = new Set<string>();
 	const seenGroupNames = new Set<string>();
 	const nodeToGroup = new Map<string, string>();
@@ -240,7 +243,7 @@ export function validateWorkflowGroups<TNode extends INode>({
 
 		for (const nodeId of group.nodeIds) {
 			// All referenced nodes must exist
-			if (!nodeIds.has(nodeId)) {
+			if (!nodeById.has(nodeId)) {
 				addBasicViolation(
 					'unknown-node-id',
 					`Group "${group.name}" references node ID "${nodeId}" that does not exist in the workflow.`,
@@ -252,7 +255,7 @@ export function validateWorkflowGroups<TNode extends INode>({
 			if (existingGroup) {
 				addBasicViolation(
 					'node-in-multiple-groups',
-					`Node "${nodeId}" belongs to multiple groups: "${existingGroup}" and "${group.name}".`,
+					`Node "${nodeLabel(nodeId)}" belongs to multiple groups: "${existingGroup}" and "${group.name}".`,
 				);
 			} else {
 				nodeToGroup.set(nodeId, group.name);
@@ -261,7 +264,6 @@ export function validateWorkflowGroups<TNode extends INode>({
 	}
 
 	if (getNodeType) {
-		const nodeById = new Map(nodes.map((node) => [node.id, node]));
 		const connections = connectionsBySourceNode ?? {};
 
 		for (const group of nodeGroups) {
@@ -277,7 +279,7 @@ export function validateWorkflowGroups<TNode extends INode>({
 				existingNodeGroups: nodeGroups.filter((other) => other.id !== group.id),
 			});
 			if (!result.valid) {
-				addViolation(group, result.reason, groupRuleViolationMessage(group, result));
+				addViolation(group, result.reason, groupRuleViolationMessage(group, result, nodeLabel));
 			}
 		}
 	}
@@ -295,6 +297,7 @@ export function validateWorkflowGroups<TNode extends INode>({
 function groupRuleViolationMessage(
 	group: IWorkflowGroup,
 	result: Extract<NodeGroupValidationResult, { valid: false }>,
+	nodeLabel: (nodeId: string) => string,
 ): string {
 	const label = `Node group "${group.name}" (${group.id})`;
 	switch (result.reason) {
@@ -307,7 +310,7 @@ function groupRuleViolationMessage(
 		case 'multiple-output-branches':
 			return `${label} has multiple output branches at node "${result.node}".`;
 		case 'node-already-grouped':
-			return `${label} contains nodes that already belong to another group: ${result.nodeIds.join(', ')}.`;
+			return `${label} contains nodes that already belong to another group: ${result.nodeIds.map(nodeLabel).join(', ')}.`;
 		case 'non-main-boundary':
 			return `${label} cannot cross the "${result.connection.type}" connection between "${result.connection.source}" and "${result.connection.target}".`;
 	}

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -172,7 +172,7 @@ export type WorkflowGroupsValidationResult =
  * Validates a workflow's `nodeGroups` without throwing, collecting all violations.
  * Single source of truth for group rules: persistence (CLI save path) rejects with
  * the first violation's message, and validate-time surfaces (e.g. the MCP
- * `validate_workflow` tool) report all of them as warnings.
+ * `validate_workflow` tool) report all of them as errors.
  *
  * Basic checks (always run): unique group IDs, unique group names, at least one
  * member, all referenced node IDs exist, and each node belongs to at most one group.

--- a/packages/workflow/test/node-grouping-validation.test.ts
+++ b/packages/workflow/test/node-grouping-validation.test.ts
@@ -731,13 +731,34 @@ describe('validateWorkflowGroups', () => {
 			{
 				groupId: 'g2',
 				code: 'node-in-multiple-groups',
-				message: 'Node "a" belongs to multiple groups: "First" and "Second".',
+				message: 'Node "A" belongs to multiple groups: "First" and "Second".',
 			},
 			// The clean first group still fails its graph rules against the second.
 			{
 				groupId: 'g1',
 				code: 'node-already-grouped',
-				message: 'Node group "First" (g1) contains nodes that already belong to another group: a.',
+				message: 'Node group "First" (g1) contains nodes that already belong to another group: A.',
+			},
+		]);
+	});
+
+	it('falls back to the node id in messages when the node has no name', () => {
+		const unnamed = makeNode({ id: 'node-id-1', name: '' });
+
+		const result = validateWorkflowGroups({
+			nodes: [unnamed],
+			connectionsBySourceNode: {},
+			nodeGroups: [
+				{ id: 'g1', name: 'First', nodeIds: ['node-id-1'] },
+				{ id: 'g2', name: 'Second', nodeIds: ['node-id-1'] },
+			],
+			getNodeType: null,
+		});
+
+		expectViolations(result, [
+			{
+				code: 'node-in-multiple-groups',
+				message: 'Node "node-id-1" belongs to multiple groups: "First" and "Second".',
 			},
 		]);
 	});

--- a/packages/workflow/test/node-grouping-validation.test.ts
+++ b/packages/workflow/test/node-grouping-validation.test.ts
@@ -3,6 +3,7 @@ import {
 	normalizeGroupDescription,
 	validateNodeSelectionForExtraction,
 	validateNodeSelectionForGrouping,
+	validateWorkflowGroups,
 } from '../src/node-grouping-validation';
 import {
 	NodeConnectionTypes,
@@ -578,5 +579,301 @@ describe('normalizeGroupDescription', () => {
 		['null', null],
 	])('drops a non-string value (%s)', (_label, value) => {
 		expect(normalizeGroupDescription(value)).toBeUndefined();
+	});
+});
+
+describe('validateWorkflowGroups', () => {
+	const nodeTypesByName: Record<string, INodeTypeDescription> = {
+		'n8n-nodes-base.set': makeNodeType(),
+		'n8n-nodes-base.manualTrigger': makeNodeType({
+			name: 'n8n-nodes-base.manualTrigger',
+			group: ['trigger'],
+		}),
+	};
+	const getNodeType = (node: INode) => nodeTypesByName[node.type] ?? null;
+
+	const expectViolations = (
+		result: ReturnType<typeof validateWorkflowGroups>,
+		violations: Array<
+			Partial<{ groupId: string; groupName: string; code: string; message: string }>
+		>,
+	) => {
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.violations).toEqual(violations.map((v) => expect.objectContaining(v)));
+		}
+	};
+
+	it('returns valid when nodeGroups is missing or empty', () => {
+		const graph = makeLinearGraph();
+
+		expect(
+			validateWorkflowGroups({
+				nodes: graph.nodes,
+				connectionsBySourceNode: graph.connections,
+				getNodeType,
+			}),
+		).toEqual({ valid: true });
+
+		expect(
+			validateWorkflowGroups({
+				nodes: graph.nodes,
+				connectionsBySourceNode: graph.connections,
+				nodeGroups: [],
+				getNodeType,
+			}),
+		).toEqual({ valid: true });
+	});
+
+	it('returns valid for a well-formed group', () => {
+		const graph = makeLinearGraph();
+
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['a', 'b'] }],
+			getNodeType,
+		});
+
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('reports a duplicate group ID', () => {
+		const graph = makeLinearGraph();
+
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [
+				{ id: 'g1', name: 'First', nodeIds: ['a'] },
+				{ id: 'g1', name: 'Second', nodeIds: ['b'] },
+			],
+			getNodeType,
+		});
+
+		expectViolations(result, [
+			{
+				groupId: 'g1',
+				groupName: 'Second',
+				code: 'duplicate-group-id',
+				message: 'Duplicate node group ID "g1".',
+			},
+		]);
+	});
+
+	it('reports a duplicate group name', () => {
+		const graph = makeLinearGraph();
+
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [
+				{ id: 'g1', name: 'Group', nodeIds: ['a'] },
+				{ id: 'g2', name: 'Group', nodeIds: ['b'] },
+			],
+			getNodeType,
+		});
+
+		expectViolations(result, [
+			{
+				groupId: 'g2',
+				code: 'duplicate-group-name',
+				message: 'Duplicate node group name "Group".',
+			},
+		]);
+	});
+
+	it('reports a memberless group', () => {
+		const graph = makeLinearGraph();
+
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: [] }],
+			getNodeType,
+		});
+
+		expectViolations(result, [{ code: 'empty-group', message: 'Group "Group" has no members.' }]);
+	});
+
+	it('reports a group member that does not exist in the workflow', () => {
+		const graph = makeLinearGraph();
+
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['a', 'missing'] }],
+			getNodeType,
+		});
+
+		expectViolations(result, [
+			{
+				code: 'unknown-node-id',
+				message: 'Group "Group" references node ID "missing" that does not exist in the workflow.',
+			},
+		]);
+	});
+
+	it('reports a node that belongs to multiple groups', () => {
+		const graph = makeLinearGraph();
+
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [
+				{ id: 'g1', name: 'First', nodeIds: ['a'] },
+				{ id: 'g2', name: 'Second', nodeIds: ['a'] },
+			],
+			getNodeType,
+		});
+
+		expectViolations(result, [
+			{
+				groupId: 'g2',
+				code: 'node-in-multiple-groups',
+				message: 'Node "a" belongs to multiple groups: "First" and "Second".',
+			},
+			// The clean first group still fails its graph rules against the second.
+			{
+				groupId: 'g1',
+				code: 'node-already-grouped',
+				message: 'Node group "First" (g1) contains nodes that already belong to another group: a.',
+			},
+		]);
+	});
+
+	it('reports a group containing a trigger node', () => {
+		const graph = makeLinearGraph();
+		const trigger = makeNode({
+			id: 'trigger',
+			name: 'Trigger',
+			type: 'n8n-nodes-base.manualTrigger',
+		});
+		const connections: IConnections = {
+			Trigger: { main: [[{ node: 'A', type: NodeConnectionTypes.Main, index: 0 }]] },
+			...graph.connections,
+		};
+
+		const result = validateWorkflowGroups({
+			nodes: [...graph.nodes, trigger],
+			connectionsBySourceNode: connections,
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['trigger', 'a'] }],
+			getNodeType,
+		});
+
+		expectViolations(result, [
+			{
+				code: 'trigger-selected',
+				message: 'Node group "Group" (g1) cannot contain trigger nodes: Trigger.',
+			},
+		]);
+	});
+
+	it('reports a group crossing a non-main connection boundary', () => {
+		const graph = makeLinearGraph();
+		const model = makeNode({ id: 'model', name: 'Model' });
+		const connections: IConnections = {
+			...graph.connections,
+			Model: {
+				[NodeConnectionTypes.AiLanguageModel]: [
+					[{ node: 'B', type: NodeConnectionTypes.AiLanguageModel, index: 0 }],
+				],
+			},
+		};
+
+		const result = validateWorkflowGroups({
+			nodes: [...graph.nodes, model],
+			connectionsBySourceNode: connections,
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['a', 'b'] }],
+			getNodeType,
+		});
+
+		expectViolations(result, [
+			{
+				code: 'non-main-boundary',
+				message:
+					'Node group "Group" (g1) cannot cross the "ai_languageModel" connection between "Model" and "B".',
+			},
+		]);
+	});
+
+	it('reports a disconnected selection as an invalid subgraph', () => {
+		const graph = makeLinearGraph();
+
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['a', 'c'] }],
+			getNodeType,
+		});
+
+		expectViolations(result, [
+			{
+				code: 'invalid-subgraph',
+				message:
+					'Node group "Group" (g1) must form a single connected subgraph with a single entry and exit.',
+			},
+		]);
+	});
+
+	it('skips graph rules for a group that already has a basic violation', () => {
+		const graph = makeLinearGraph();
+
+		// Without the skip, {a, c} would additionally report invalid-subgraph.
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['a', 'c', 'missing'] }],
+			getNodeType,
+		});
+
+		expectViolations(result, [{ code: 'unknown-node-id' }]);
+	});
+
+	it('runs basic checks only when getNodeType is null', () => {
+		const graph = makeLinearGraph();
+		const trigger = makeNode({
+			id: 'trigger',
+			name: 'Trigger',
+			type: 'n8n-nodes-base.manualTrigger',
+		});
+
+		// A trigger-containing group passes basic-only validation…
+		expect(
+			validateWorkflowGroups({
+				nodes: [...graph.nodes, trigger],
+				connectionsBySourceNode: graph.connections,
+				nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: ['trigger', 'a'] }],
+				getNodeType: null,
+			}),
+		).toEqual({ valid: true });
+
+		// …but basic violations are still reported.
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [{ id: 'g1', name: 'Group', nodeIds: [] }],
+			getNodeType: null,
+		});
+		expectViolations(result, [{ code: 'empty-group' }]);
+	});
+
+	it('collects all violations, basic checks first', () => {
+		const graph = makeLinearGraph();
+
+		const result = validateWorkflowGroups({
+			nodes: graph.nodes,
+			connectionsBySourceNode: graph.connections,
+			nodeGroups: [
+				{ id: 'g1', name: 'Broken', nodeIds: [] },
+				{ id: 'g2', name: 'Disconnected', nodeIds: ['a', 'c'] },
+			],
+			getNodeType,
+		});
+
+		expectViolations(result, [
+			{ groupId: 'g1', code: 'empty-group' },
+			{ groupId: 'g2', code: 'invalid-subgraph' },
+		]);
 	});
 });


### PR DESCRIPTION
## Summary
1. Improve MCP validation tool so invalid groups are caught at that point, instead of failing only on save step
2. Assign groups in `create_workflow_from_code` tools
3. All changes are hidden behind the `102_mcp_canvas_groups` feature flag

## How to test
Check linked ticket comments ([this](https://linear.app/n8n/issue/ADO-5624/core-improve-validation-step-to-catch-invalid-groups#comment-4543c4b2) and [this](https://linear.app/n8n/issue/ADO-5619/create-workflow-from-code-tool-add-group-support-to-tool#comment-0d55c22b)) on manual testing instructions.

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-5624
Closes ADO-5619

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34778">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

