### PR TITLE
feat(core): Infer structured output from example JSON in AI Agent Node

### DIFF
--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -14,7 +14,7 @@ export const baseDescription: INodeTypeBaseDescription = {
 	icon: 'node:ai-agent',
 	group: ['transform'],
 	description: 'Send a message to a n8n agent',
-	defaultVersion: 2,
+	defaultVersion: 3,
 };
 
 export class MessageAnAgent extends VersionedNodeType {
@@ -22,8 +22,11 @@ export class MessageAnAgent extends VersionedNodeType {
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			// v1 keeps the original resourceLocator picker so existing workflows
 			// (typeVersion 1) are unaffected. v2 uses the agentSelector picker.
+			// v3 adds schema-from-example for structured output (same class as v2,
+			// gated via `@version`).
 			1: new MessageAnAgentV1(baseDescription),
 			2: new MessageAnAgentV2(baseDescription),
+			3: new MessageAnAgentV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
@@ -577,6 +577,133 @@ describe('MessageAnAgent Node', () => {
 		expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
 	});
 
+	describe('v3 schema from example', () => {
+		let v3: MessageAnAgentV2;
+
+		beforeEach(() => {
+			v3 = new MessageAnAgentV2(baseDescription);
+			executeFunctions.getNode.mockReturnValue({
+				id: 'test-node-id',
+				name: 'Message an Agent',
+				type: 'n8n-nodes-base.messageAnAgent',
+				typeVersion: 3,
+				position: [0, 0],
+				parameters: {},
+			});
+		});
+
+		it('infers an all-required JSON Schema from a JSON example, without a $schema keyword', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams({
+				useStructuredOutput: true,
+				schemaType: 'fromJson',
+				jsonSchemaExample: JSON.stringify({
+					result: 'ok',
+					nested: { count: 1 },
+				}),
+			});
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await v3.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					outputSchema: {
+						type: 'object',
+						properties: {
+							result: { type: 'string' },
+							nested: {
+								type: 'object',
+								properties: {
+									count: { type: 'number' },
+								},
+								required: ['count'],
+							},
+						},
+						required: ['result', 'nested'],
+					},
+				}),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('forwards a manual output schema when schemaType is manual', async () => {
+			const schemaString = JSON.stringify({
+				type: 'object',
+				properties: { result: { type: 'string' } },
+				required: ['result'],
+			});
+
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams({
+				useStructuredOutput: true,
+				schemaType: 'manual',
+				outputSchema: schemaString,
+			});
+			executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+			await v3.execute.call(executeFunctions);
+
+			expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					outputSchema: {
+						type: 'object',
+						properties: { result: { type: 'string' } },
+						required: ['result'],
+					},
+				}),
+				'Hello agent',
+				'exec-123',
+				0,
+			);
+		});
+
+		it('throws when the JSON example is empty', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams({
+				useStructuredOutput: true,
+				schemaType: 'fromJson',
+				jsonSchemaExample: '   ',
+			});
+			executeFunctions.continueOnFail.mockReturnValue(false);
+
+			await expect(v3.execute.call(executeFunctions)).rejects.toThrow('JSON example is empty');
+			expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
+		});
+
+		it('throws when the JSON example is not valid JSON', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams({
+				useStructuredOutput: true,
+				schemaType: 'fromJson',
+				jsonSchemaExample: '{ not valid',
+			});
+			executeFunctions.continueOnFail.mockReturnValue(false);
+
+			await expect(v3.execute.call(executeFunctions)).rejects.toThrow(
+				'JSON example is not valid JSON',
+			);
+			expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
+		});
+
+		it('throws when the JSON example is an array instead of an object', async () => {
+			executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockParams({
+				useStructuredOutput: true,
+				schemaType: 'fromJson',
+				jsonSchemaExample: JSON.stringify([{ result: 'ok' }]),
+			});
+			executeFunctions.continueOnFail.mockReturnValue(false);
+
+			await expect(v3.execute.call(executeFunctions)).rejects.toThrow(
+				'JSON example must be a JSON object',
+			);
+			expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
+		});
+	});
+
 	it('invokes the agent once with all-items scope in "Once for All Items" mode', async () => {
 		executeFunctions.getInputData.mockReturnValue([{ json: { i: 0 } }, { json: { i: 1 } }]);
 		executeFunctions.getNodeParameter.mockImplementation(
@@ -689,11 +816,11 @@ describe('MessageAnAgent versioning', () => {
 		expect(new MessageAnAgentV2(baseDescription).description.defaults.name).toBe('AI Agent V1');
 	});
 
-	it('exposes v1 and v2 with v2 as the default', () => {
+	it('exposes v1, v2, and v3 with v3 as the default', () => {
 		const versioned = new MessageAnAgent();
 
-		expect(versioned.description.defaultVersion).toBe(2);
-		expect(Object.keys(versioned.nodeVersions)).toEqual(['1', '2']);
+		expect(versioned.description.defaultVersion).toBe(3);
+		expect(Object.keys(versioned.nodeVersions)).toEqual(['1', '2', '3']);
 	});
 
 	it('keeps the original resourceLocator picker on v1 (non-breaking) with the listAgents method', () => {
@@ -733,12 +860,14 @@ describe('MessageAnAgent versioning', () => {
 		});
 	});
 
-	it('uses the agentSelector picker on v2', () => {
+	it('serves v2 and v3 from the same class with the agentSelector picker', () => {
 		const v2 = new MessageAnAgentV2(baseDescription);
 		const agentId = v2.description.properties.find((p) => p.name === 'agentId');
+		const schemaType = v2.description.properties.find((p) => p.name === 'schemaType');
 
-		expect(v2.description.version).toBe(2);
+		expect(v2.description.version).toEqual([2, 3]);
 		expect(agentId?.type).toBe('agentSelector');
+		expect(schemaType?.default).toBe('fromJson');
 	});
 
 	it('resolves parameters for a newly added v2 node', () => {
@@ -759,6 +888,30 @@ describe('MessageAnAgent versioning', () => {
 				false,
 				{ typeVersion: 2 },
 				v2.description,
+			),
+		).not.toThrow();
+	});
+
+	it('resolves parameters for a newly added v3 node', () => {
+		const v3 = new MessageAnAgentV2(baseDescription);
+
+		expect(() =>
+			getNodeParameters(
+				v3.description.properties,
+				{
+					agentSource: 'referenced',
+					agentId: { __rl: true, mode: 'list', value: '' },
+					inlineAgent: {},
+					message: '',
+					useStructuredOutput: true,
+					schemaType: 'fromJson',
+					jsonSchemaExample: '{ "result": "ok" }',
+					advanced: {},
+				},
+				false,
+				false,
+				{ typeVersion: 3 },
+				v3.description,
 			),
 		).not.toThrow();
 	});

--- a/packages/nodes-base/nodes/MessageAnAgent/generateSchemaFromExample.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/generateSchemaFromExample.ts
@@ -1,0 +1,50 @@
+import { json as generateJsonSchema } from 'generate-schema';
+import type { SchemaObject } from 'generate-schema';
+import type { JSONSchema7 } from 'json-schema';
+import { jsonParse } from 'n8n-workflow';
+
+function makeAllPropertiesRequired(schema: JSONSchema7): JSONSchema7 {
+	function isPropertySchema(property: unknown): property is JSONSchema7 {
+		return typeof property === 'object' && property !== null && 'type' in property;
+	}
+
+	if (schema.type === 'object' && schema.properties) {
+		const properties = Object.keys(schema.properties);
+		if (properties.length > 0) {
+			schema.required = properties;
+		}
+
+		for (const key of properties) {
+			if (isPropertySchema(schema.properties[key])) {
+				makeAllPropertiesRequired(schema.properties[key]);
+			}
+		}
+	}
+
+	if (schema.type === 'array' && schema.items && isPropertySchema(schema.items)) {
+		schema.items = makeAllPropertiesRequired(schema.items);
+	}
+
+	return schema;
+}
+
+/**
+ * Infer a JSON Schema from an example JSON string. When `allFieldsRequired`
+ * is true, every object property (nested included) is marked required —
+ * preferred for structured-output providers that reject optional fields.
+ */
+export function generateSchemaFromExample(
+	exampleJsonString: string,
+	allFieldsRequired = false,
+): JSONSchema7 {
+	const parsedExample = jsonParse<SchemaObject>(exampleJsonString);
+	const schema = generateJsonSchema(parsedExample) as JSONSchema7;
+
+	delete schema.$schema;
+
+	if (allFieldsRequired) {
+		return makeAllPropertiesRequired(schema);
+	}
+
+	return schema;
+}

--- a/packages/nodes-base/nodes/MessageAnAgent/shared.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/shared.ts
@@ -11,6 +11,8 @@ import type {
 import { jsonParse, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import crypto from 'node:crypto';
 
+import { generateSchemaFromExample } from './generateSchemaFromExample';
+
 /** Description fields that are identical across versions. */
 export const sharedVersionDescription: Pick<
 	INodeTypeDescription,
@@ -50,6 +52,21 @@ export const messageProperty: INodeProperties = {
  * Every property after the version-specific `agentId` picker and the shared
  * `message` input is identical across versions.
  */
+const defaultOutputSchema = `{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string",
+      "description": "The result of the task"
+    }
+  },
+  "required": ["result"]
+}`;
+
+const defaultJsonSchemaExample = `{
+  "result": "The result of the task"
+}`;
+
 export const commonProperties: INodeProperties[] = [
 	{
 		displayName: 'Require Specific Output Format',
@@ -60,19 +77,68 @@ export const commonProperties: INodeProperties[] = [
 			'Whether to constrain the agent response to a JSON Schema you provide. The conforming object is returned on the "structuredOutput" field.',
 	},
 	{
+		displayName: 'Schema Type',
+		name: 'schemaType',
+		type: 'options',
+		noDataExpression: true,
+		options: [
+			{
+				name: 'Generate From JSON Example',
+				value: 'fromJson',
+				description: 'Generate a schema from an example JSON object',
+			},
+			{
+				name: 'Define Using JSON Schema',
+				value: 'manual',
+				description: 'Define the JSON schema manually',
+			},
+		],
+		default: 'fromJson',
+		description: 'How to specify the structured output schema',
+		displayOptions: {
+			show: {
+				useStructuredOutput: [true],
+				'@version': [{ _cnd: { gte: 3 } }],
+			},
+		},
+	},
+	{
+		displayName: 'JSON Example',
+		name: 'jsonSchemaExample',
+		type: 'json',
+		default: defaultJsonSchemaExample,
+		description: 'Example JSON object used to generate the output schema',
+		typeOptions: {
+			rows: 10,
+		},
+		displayOptions: {
+			show: {
+				useStructuredOutput: [true],
+				schemaType: ['fromJson'],
+				'@version': [{ _cnd: { gte: 3 } }],
+			},
+		},
+	},
+	{
+		displayName:
+			"All properties will be required. To make them optional, use the 'JSON Schema' schema type instead",
+		name: 'jsonSchemaExampleNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				useStructuredOutput: [true],
+				schemaType: ['fromJson'],
+				'@version': [{ _cnd: { gte: 3 } }],
+			},
+		},
+	},
+	// v1/v2: raw schema is the only option
+	{
 		displayName: 'Output Schema',
 		name: 'outputSchema',
 		type: 'json',
-		default: `{
-  "type": "object",
-  "properties": {
-    "result": {
-      "type": "string",
-      "description": "The result of the task"
-    }
-  },
-  "required": ["result"]
-}`,
+		default: defaultOutputSchema,
 		description: 'The JSON Schema that the agent response must conform to',
 		hint: 'Use <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format',
 		typeOptions: {
@@ -81,6 +147,26 @@ export const commonProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				useStructuredOutput: [true],
+				'@version': [{ _cnd: { lt: 3 } }],
+			},
+		},
+	},
+	// v3+: raw schema is the advanced/manual option
+	{
+		displayName: 'Output Schema',
+		name: 'outputSchema',
+		type: 'json',
+		default: defaultOutputSchema,
+		description: 'The JSON Schema that the agent response must conform to',
+		hint: 'Use <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format',
+		typeOptions: {
+			rows: 10,
+		},
+		displayOptions: {
+			show: {
+				useStructuredOutput: [true],
+				schemaType: ['manual'],
+				'@version': [{ _cnd: { gte: 3 } }],
 			},
 		},
 	},
@@ -153,24 +239,11 @@ export const commonProperties: INodeProperties[] = [
 	},
 ];
 
-/**
- * Read and parse the per-item structured-output JSON Schema. Returns `undefined`
- * when the toggle is off; throws a user-facing error when the toggle is on but
- * the schema is empty or not valid JSON.
- */
-export function getStructuredOutputSchema(
+function parseManualOutputSchema(
 	ctx: IExecuteFunctions,
 	itemIndex: number,
-): JSONSchema7 | undefined {
-	const useStructuredOutput = ctx.getNodeParameter(
-		'useStructuredOutput',
-		itemIndex,
-		false,
-	) as boolean;
-	if (!useStructuredOutput) return undefined;
-
-	const rawSchema = ctx.getNodeParameter('outputSchema', itemIndex, '') as unknown;
-
+	rawSchema: unknown,
+): JSONSchema7 {
 	let parsed: JSONSchema7;
 
 	if (typeof rawSchema === 'object') {
@@ -208,6 +281,69 @@ export function getStructuredOutputSchema(
 	}
 
 	return parsed;
+}
+
+/**
+ * Read and parse the per-item structured-output JSON Schema. Returns `undefined`
+ * when the toggle is off; throws a user-facing error when the toggle is on but
+ * the schema is empty or not valid JSON. On typeVersion >= 3, supports inferring
+ * the schema from a JSON example (`schemaType: fromJson`).
+ */
+export function getStructuredOutputSchema(
+	ctx: IExecuteFunctions,
+	itemIndex: number,
+): JSONSchema7 | undefined {
+	const useStructuredOutput = ctx.getNodeParameter(
+		'useStructuredOutput',
+		itemIndex,
+		false,
+	) as boolean;
+	if (!useStructuredOutput) return undefined;
+
+	const { typeVersion } = ctx.getNode();
+	if (typeVersion >= 3) {
+		const schemaType = ctx.getNodeParameter('schemaType', itemIndex, 'fromJson') as
+			| 'fromJson'
+			| 'manual';
+
+		if (schemaType === 'fromJson') {
+			const rawExample = ctx.getNodeParameter('jsonSchemaExample', itemIndex, '') as unknown;
+			const exampleString =
+				typeof rawExample === 'string' ? rawExample : JSON.stringify(rawExample);
+
+			if (!exampleString.trim()) {
+				throw new NodeOperationError(
+					ctx.getNode(),
+					'JSON example is empty. Provide an example object or turn off "Require Specific Output Format".',
+					{ itemIndex },
+				);
+			}
+
+			let schema: JSONSchema7;
+			try {
+				schema = generateSchemaFromExample(exampleString, true);
+			} catch (error) {
+				throw new NodeOperationError(
+					ctx.getNode(),
+					`JSON example is not valid JSON: ${(error as Error).message}`,
+					{ itemIndex },
+				);
+			}
+
+			if (schema.type !== 'object') {
+				throw new NodeOperationError(
+					ctx.getNode(),
+					'JSON example must be a JSON object (e.g. { "result": "value" }), not an array or single value',
+					{ itemIndex },
+				);
+			}
+
+			return schema;
+		}
+	}
+
+	const rawSchema = ctx.getNodeParameter('outputSchema', itemIndex, '') as unknown;
+	return parseManualOutputSchema(ctx, itemIndex, rawSchema);
 }
 
 /**

--- a/packages/nodes-base/nodes/MessageAnAgent/shared.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/shared.ts
@@ -309,7 +309,7 @@ export function getStructuredOutputSchema(
 		if (schemaType === 'fromJson') {
 			const rawExample = ctx.getNodeParameter('jsonSchemaExample', itemIndex, '') as unknown;
 			const exampleString =
-				typeof rawExample === 'string' ? rawExample : JSON.stringify(rawExample);
+				typeof rawExample === 'string' ? rawExample : (JSON.stringify(rawExample) ?? '');
 
 			if (!exampleString.trim()) {
 				throw new NodeOperationError(

--- a/packages/nodes-base/nodes/MessageAnAgent/v2/MessageAnAgentV2.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/v2/MessageAnAgentV2.node.ts
@@ -15,7 +15,10 @@ export class MessageAnAgentV2 implements INodeType {
 		this.description = {
 			...thisBaseDescription,
 			...sharedVersionDescription,
-			version: 2,
+			// v3 adds schema-from-example for structured output; the differences
+			// are gated via `@version` displayOptions and typeVersion checks in
+			// the shared execute, so one class serves both versions.
+			version: [2, 3],
 			properties: [
 				// Set by the node-creator agent picker ('referenced' | 'inline'), not
 				// editable in the NDV. Kept hidden with no displayOptions so saves


### PR DESCRIPTION
## Summary

Hand-writing a JSON Schema for the AI Agent V1 (`messageAnAgent`) node's structured output is overly complicated for beginners. This PR adds a **Generate From JSON Example** option (the new default): users can paste an example JSON object and the schema is inferred from it, same UX as the Structured Output Parser node. Raw schema editing remains available via **Define Using JSON Schema** option.

- New node version `3` (now the default): adds a `Schema Type` toggle and `JSON Example` field, shown when "Require Specific Output Format" is enabled. Served by the same class as v2 (`version: [2, 3]`), gated via `@version` display options — existing v1/v2 workflows are unaffected and keep the raw-schema-only behavior.
- Non-object examples (arrays, primitives) are rejected with a clear node error instead of failing later with an opaque provider error.

## How to test

1. Add an **AI Agent V1** node to a workflow and select an agent.
2. Enable **Require Specific Output Format** — the **Schema Type** defaults to *Generate From JSON Example*.
3. Paste an example, e.g. `{ "sentiment": "positive", "confidence": 0.9 }`, and execute: the `structuredOutput` output field conforms to the inferred schema (all properties required).
4. Switch **Schema Type** to *Define Using JSON Schema* and provide a raw JSON Schema — behaves as before.

**Snap**:
<img width="423" height="681" alt="image" src="https://github.com/user-attachments/assets/f94c171d-3828-4c5f-8b74-031342b2503b" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-449

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34779">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

