### PR TITLE
feat(core): Add step-executor seam to @n8n/engine (no-changelog)

### DIFF
--- a/packages/@n8n/engine/src/dependencies/external-dependencies.ts
+++ b/packages/@n8n/engine/src/dependencies/external-dependencies.ts
@@ -1,0 +1,62 @@
+import type { JsonValue } from '../common';
+import type { ExecutionMode } from '../execution';
+import type { GraphNode } from '../graph';
+
+/**
+ * Host integration seam — how the engine reaches capabilities it does not own.
+ *
+ * The engine runs steps but has no knowledge of what a `v1-node` step actually
+ * is: executing one requires the v1 node runtime (node types, expressions,
+ * credentials), which lives outside this package. In integrated mode the host
+ * supplies an `IStepExecutor` for those step types; the engine only ever sees
+ * the interfaces below.
+ *
+ * `inputs` and `outputs` are `JsonValue`, not `unknown`: the engine persists
+ * step outputs to a `jsonb` column and reloads them as downstream inputs, so
+ * anything crossing this seam must survive a JSON round-trip. The concrete
+ * shape is step-type-specific (for `v1-node` it is the v1
+ * `INodeExecutionData[][]`); constraining to `JsonValue` enforces
+ * serializability without teaching the engine that shape — which is what keeps
+ * this package free of `n8n-workflow` / `n8n-core`.
+ */
+
+/** Ambient facts about the execution a step belongs to. */
+export interface StepExecutionContext {
+	executionId: string;
+	workflowId: string;
+	mode: ExecutionMode;
+}
+
+/** A single step handed to an executor. */
+export interface StepExecutionRequest {
+	/** The graph node to run; `node.config` is the step-type-specific payload. */
+	node: GraphNode;
+	/** Inputs gathered from predecessor steps; opaque to the engine but serializable. */
+	inputs: JsonValue;
+	context: StepExecutionContext;
+}
+
+export interface StepExecutionResult {
+	/** Step outputs; persisted by the engine without inspection. */
+	outputs: JsonValue;
+}
+
+/**
+ * Executes a step whose behaviour the engine does not implement itself.
+ * Implemented by the host (for `v1-node`, by the node-engine-compatibility
+ * layer, which adapts v1 nodes to this interface).
+ */
+export interface IStepExecutor {
+	execute(request: StepExecutionRequest): Promise<StepExecutionResult>;
+}
+
+/**
+ * Capabilities the host injects at engine construction time. Standalone mode
+ * omits them and falls back to default behaviour; concrete shapes for other
+ * hooks (pre-fetch, status callbacks) are introduced with the tickets that
+ * first need them.
+ */
+export interface ExternalDependencies {
+	/** Executes `v1-node` steps — supplied by the host in integrated mode. */
+	v1StepExecutor?: IStepExecutor;
+}

--- a/packages/@n8n/engine/src/dependencies/external-dependencies.ts
+++ b/packages/@n8n/engine/src/dependencies/external-dependencies.ts
@@ -18,11 +18,16 @@ import type { GraphNode } from '../graph';
  * `INodeExecutionData[][]`); constraining to `JsonValue` enforces
  * serializability without teaching the engine that shape — which is what keeps
  * this package free of `n8n-workflow` / `n8n-core`.
+ *
+ * The legacy engine passes live objects between nodes in memory, whereas all
+ * non-JSON values inside step data (e.g. `Date`) are coerced by the round-trip
+ * on every hop. This coercion is an accepted behavioural divergence from legacy.
  */
 
 /** Ambient facts about the execution a step belongs to. */
 export interface StepExecutionContext {
 	executionId: string;
+	stepId: string;
 	workflowId: string;
 	mode: ExecutionMode;
 }
@@ -45,6 +50,10 @@ export interface StepExecutionResult {
  * Executes a step whose behaviour the engine does not implement itself.
  * Implemented by the host (for `v1-node`, by the node-engine-compatibility
  * layer, which adapts v1 nodes to this interface).
+ *
+ * A failed step signals by throwing. The engine catches, records the error
+ * on the step row, and classifies it as retryable or not. If `continueOnFail`
+ * is enabled, errors travel as data inside `outputs`.
  */
 export interface IStepExecutor {
 	execute(request: StepExecutionRequest): Promise<StepExecutionResult>;
@@ -55,6 +64,9 @@ export interface IStepExecutor {
  * omits them and falls back to default behaviour; concrete shapes for other
  * hooks (pre-fetch, status callbacks) are introduced with the tickets that
  * first need them.
+ *
+ * Step types that are native to the engine (`wait`, `subworkflow`, `batch`)
+ * do not go through this interface.
  */
 export interface ExternalDependencies {
 	/** Executes `v1-node` steps — supplied by the host in integrated mode. */

--- a/packages/@n8n/engine/src/dependencies/index.ts
+++ b/packages/@n8n/engine/src/dependencies/index.ts
@@ -1,0 +1,7 @@
+export type {
+	ExternalDependencies,
+	IStepExecutor,
+	StepExecutionContext,
+	StepExecutionRequest,
+	StepExecutionResult,
+} from './external-dependencies';

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -11,6 +11,14 @@ export type {
 	WorkflowGraph,
 } from './graph';
 
+export type {
+	ExternalDependencies,
+	IStepExecutor,
+	StepExecutionContext,
+	StepExecutionRequest,
+	StepExecutionResult,
+} from './dependencies';
+
 export { AllowAllAdmittance, AdmittanceRejectedError } from './admittance';
 export type {
 	AdmittanceDecision,


### PR DESCRIPTION
## Summary

Introduces the host-integration seam the Engine 2.0 execution engine uses to run steps whose behaviour it does not implement itself (notably `v1-node` steps). The engine dispatches a step through `IStepExecutor`; the concrete implementation is supplied by the host via `ExternalDependencies`.

New interfaces in `@n8n/engine` (`src/dependencies/`):
- `IStepExecutor.execute(request) => Promise<StepExecutionResult>`
- `ExternalDependencies` (`v1StepExecutor?`) — capabilities injected at engine construction
- `StepExecutionRequest` (`node`, `inputs`, `context`), `StepExecutionResult` (`outputs`), `StepExecutionContext`

Design notes:
- **`inputs`/`outputs` are typed `JsonValue`, not `unknown`.** The engine persists step outputs to a `jsonb` column and reloads them as downstream inputs, so anything crossing the seam must survive a JSON round-trip. Constraining to `JsonValue` enforces serializability while keeping the shape opaque to the engine.
- This is what lets the engine stay free of `n8n-workflow` / `n8n-core`: it never learns the concrete (v1) step shape. The v1 adapter that produces `INodeExecutionData[][]` lives in a separate compatibility layer (follow-up PR).

This is an interface-only, additive change with no runtime behaviour and no consumer yet — it unblocks the v1 executor and step-planner work to proceed in parallel against a stable contract.

## How to test

Interfaces only — no runtime behaviour. Verified in `packages/@n8n/engine`:
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (existing 4 tests unaffected; engine remains import-free of `n8n-workflow` / `n8n-core`)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2911

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- Interface-only change; no runtime behaviour to test. Coverage lands with the executor in the follow-up PR. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34784">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

