### PR TITLE
feat(Grist Node): Add OAuth2 as an authentication option

### DIFF
--- a/packages/nodes-base/credentials/GristOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GristOAuth2Api.credentials.ts
@@ -1,0 +1,79 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+// Resource scopes from Grist's OAuth-apps authorization server
+// (/.well-known/oauth-authorization-server).
+const scopes = [
+	'offline_access', // issue a refresh token, so the connection outlives the 1 h access token
+	'doc:read', // read records
+	'doc:write', // create, update, and delete records
+	'doc:webhooks', // manage webhooks (for a planned Grist Trigger node; awkward to widen later)
+];
+
+// Mirrors `normalizeBaseUrl` in the node's GenericFunctions. Built with `new RegExp` because a
+// `/.../` literal inside an expression string is awkward to escape.
+const normalizedUrlExpr =
+	'$self["url"].replace(new RegExp("/$"), "").replace(new RegExp("/api$"), "")';
+
+export class GristOAuth2Api implements ICredentialType {
+	name = 'gristOAuth2Api';
+
+	extends = ['oAuth2Api'];
+
+	displayName = 'Grist OAuth2 API';
+
+	documentationUrl = 'grist';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'hidden',
+			default: 'pkce',
+		},
+		{
+			displayName: 'Grist URL',
+			name: 'url',
+			type: 'string',
+			default: 'https://api.getgrist.com',
+			required: true,
+			description:
+				'Defaults to hosted Grist. Use https://YOUR_TEAM.getgrist.com for a single team, or your own URL if self-managed with OAuth apps enabled. Do not include /api.',
+		},
+		{
+			// Grist mounts the OAuth endpoints on every host and canonicalizes the flow to its login
+			// server, so deriving them from the Grist URL works for hosted and self-managed alike.
+			displayName: 'Authorization URL',
+			name: 'authUrl',
+			type: 'hidden',
+			default: `={{${normalizedUrlExpr}}}/oidc/auth`,
+			required: true,
+		},
+		{
+			displayName: 'Access Token URL',
+			name: 'accessTokenUrl',
+			type: 'hidden',
+			default: `={{${normalizedUrlExpr}}}/oidc/token`,
+			required: true,
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'hidden',
+			default: scopes.join(' '),
+		},
+		{
+			// Required: Grist's provider silently drops `offline_access` unless consent is prompted,
+			// leaving no refresh token, so the credential would fail once the access token expires.
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden',
+			default: 'prompt=consent',
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'header',
+		},
+	];
+}

--- a/packages/nodes-base/credentials/test/GristOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/GristOAuth2Api.credentials.test.ts
@@ -1,0 +1,29 @@
+import { GristOAuth2Api } from '../GristOAuth2Api.credentials';
+
+describe('GristOAuth2Api Credential', () => {
+	const credential = new GristOAuth2Api();
+	const property = (name: string) => credential.properties.find((p) => p.name === name);
+
+	it('should extend the generic OAuth2 credential', () => {
+		expect(credential.name).toBe('gristOAuth2Api');
+		expect(credential.extends).toEqual(['oAuth2Api']);
+	});
+
+	it('should use the PKCE grant, which is what Grist supports', () => {
+		expect(property('grantType')?.default).toBe('pkce');
+	});
+
+	it('should default to hosted Grist and require a URL', () => {
+		expect(property('url')?.default).toBe('https://api.getgrist.com');
+		expect(property('url')?.required).toBe(true);
+	});
+
+	it('should prompt for consent, so a refresh token is issued', () => {
+		expect(property('authQueryParameters')?.default).toBe('prompt=consent');
+	});
+
+	// A token keeps the scopes it was granted, so this list cannot be widened after the fact.
+	it('should request read, write, webhook and offline access', () => {
+		expect(property('scope')?.default).toBe('offline_access doc:read doc:write doc:webhooks');
+	});
+});

--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -50,12 +50,11 @@ export async function gristApiRequest(
 	body: IDataObject | number[] = {},
 	qs: IDataObject = {},
 ) {
-	const credentials = await this.getCredentials<GristCredentials>('gristApi');
+	const authentication = this.getNodeParameter('authentication', 0, 'apiKey') as string;
+	const credentialsType = authentication === 'oAuth2' ? 'gristOAuth2Api' : 'gristApi';
+	const credentials = await this.getCredentials<GristCredentials>(credentialsType);
 
 	const options: IRequestOptions = {
-		headers: {
-			Authorization: `Bearer ${credentials.apiKey}`,
-		},
 		method,
 		uri: `${gristBaseUrl(credentials)}/api${endpoint}`,
 		qs,
@@ -71,7 +70,15 @@ export async function gristApiRequest(
 		delete options.qs;
 	}
 
+	// The OAuth helper attaches its own Authorization header; the API key path sets one here.
+	if (authentication !== 'oAuth2') {
+		options.headers = { Authorization: `Bearer ${credentials.apiKey}` };
+	}
+
 	try {
+		if (authentication === 'oAuth2') {
+			return await this.helpers.requestOAuth2.call(this, 'gristOAuth2Api', options);
+		}
 		return await this.helpers.request(options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);

--- a/packages/nodes-base/nodes/Grist/Grist.node.ts
+++ b/packages/nodes-base/nodes/Grist/Grist.node.ts
@@ -52,9 +52,41 @@ export class Grist implements INodeType {
 				name: 'gristApi',
 				required: true,
 				testedBy: 'gristApiTest',
+				displayOptions: {
+					show: {
+						authentication: ['apiKey'],
+					},
+				},
+			},
+			{
+				name: 'gristOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['oAuth2'],
+					},
+				},
 			},
 		],
-		properties: operationFields,
+		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'API Key',
+						value: 'apiKey',
+					},
+					{
+						name: 'OAuth2',
+						value: 'oAuth2',
+					},
+				],
+				default: 'apiKey',
+			},
+			...operationFields,
+		],
 	};
 
 	methods = {

--- a/packages/nodes-base/nodes/Grist/Grist.node.ts
+++ b/packages/nodes-base/nodes/Grist/Grist.node.ts
@@ -55,9 +55,41 @@ export class Grist implements INodeType {
 				name: 'gristApi',
 				required: true,
 				testedBy: 'gristApiTest',
+				displayOptions: {
+					show: {
+						authentication: ['apiKey'],
+					},
+				},
+			},
+			{
+				name: 'gristOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['oAuth2'],
+					},
+				},
 			},
 		],
-		properties: operationFields,
+		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'API Key',
+						value: 'apiKey',
+					},
+					{
+						name: 'OAuth2',
+						value: 'oAuth2',
+					},
+				],
+				default: 'apiKey',
+			},
+			...operationFields,
+		],
 	};
 
 	methods = {

--- a/packages/nodes-base/nodes/Grist/test/Grist.node.test.ts
+++ b/packages/nodes-base/nodes/Grist/test/Grist.node.test.ts
@@ -1,4 +1,5 @@
-import type { ICredentialsDecrypted, ICredentialTestFunctions } from 'n8n-workflow';
+import type { ICredentialsDecrypted, ICredentialTestFunctions, INode } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { Grist } from '../Grist.node';
@@ -60,5 +61,33 @@ describe('Grist credentialTest', () => {
 		});
 
 		expect(request.mock.calls[0][0].uri).toBe('http://localhost:8484/api/orgs');
+	});
+});
+
+describe('Grist authentication parameter', () => {
+	// Workflows saved before the selector existed have no stored `authentication` value. Resolve a
+	// node without one the way execution does, rather than asserting the declared default: adding
+	// `displayOptions` to the parameter would drop it here while a default check still passed.
+	it('resolves to the API key for a workflow saved without one', () => {
+		const description = new Grist().description;
+		const node: INode = {
+			id: 'uuid-1234',
+			name: 'Grist',
+			type: 'n8n-nodes-base.grist',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: { operation: 'getAll', docId: 'doc1', tableId: 'Table1' },
+		};
+
+		const resolved = NodeHelpers.getNodeParameters(
+			description.properties,
+			node.parameters,
+			true,
+			false,
+			node,
+			description,
+		);
+
+		expect(resolved?.authentication).toBe('apiKey');
 	});
 });

--- a/packages/nodes-base/nodes/Grist/test/Grist.node.test.ts
+++ b/packages/nodes-base/nodes/Grist/test/Grist.node.test.ts
@@ -3,8 +3,10 @@ import type {
 	ICredentialsDecrypted,
 	ICredentialTestFunctions,
 	IExecuteFunctions,
+	INode,
 	INodeExecutionData,
 } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
 import { gristApiRequest } from '../GenericFunctions';
@@ -307,5 +309,33 @@ describe('Grist credentialTest', () => {
 		});
 
 		expect(request.mock.calls[0][0].uri).toBe('http://localhost:8484/api/orgs');
+	});
+});
+
+describe('Grist authentication parameter', () => {
+	// Workflows saved before the selector existed have no stored `authentication` value. Resolve a
+	// node without one the way execution does, rather than asserting the declared default: adding
+	// `displayOptions` to the parameter would drop it here while a default check still passed.
+	it('resolves to the API key for a workflow saved without one', () => {
+		const description = new Grist().description;
+		const node: INode = {
+			id: 'uuid-1234',
+			name: 'Grist',
+			type: 'n8n-nodes-base.grist',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: { operation: 'getAll', docId: 'doc1', tableId: 'Table1' },
+		};
+
+		const resolved = NodeHelpers.getNodeParameters(
+			description.properties,
+			node.parameters,
+			true,
+			false,
+			node,
+			description,
+		);
+
+		expect(resolved?.authentication).toBe('apiKey');
 	});
 });

--- a/packages/nodes-base/nodes/Grist/test/gristApiRequest.test.ts
+++ b/packages/nodes-base/nodes/Grist/test/gristApiRequest.test.ts
@@ -1,0 +1,75 @@
+import type { IExecuteFunctions, IRequestOptions } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { gristApiRequest } from '../GenericFunctions';
+
+describe('gristApiRequest', () => {
+	const setup = (authentication: string, credentials: Record<string, unknown>) => {
+		const request = vi.fn().mockResolvedValue({ records: [] });
+		const requestOAuth2 = vi.fn().mockResolvedValue({ records: [] });
+		const ctx = mock<IExecuteFunctions>();
+		// Keyed by name so an unexpected parameter read fails loudly, rather than silently
+		// receiving the auth string.
+		ctx.getNodeParameter.mockImplementation((name) => {
+			if (name === 'authentication') return authentication;
+			throw new Error(`unexpected getNodeParameter(${String(name)})`);
+		});
+		ctx.getCredentials.mockResolvedValue(credentials);
+		ctx.helpers = { ...ctx.helpers, request, requestOAuth2 };
+		return { ctx, request, requestOAuth2 };
+	};
+
+	it('sends the API key as a bearer token when authenticating with an API key', async () => {
+		const { ctx, request, requestOAuth2 } = setup('apiKey', {
+			apiKey: 'k',
+			url: 'https://api.getgrist.com',
+		});
+
+		await gristApiRequest.call(ctx, 'GET', '/docs/abc/tables/People/records');
+
+		expect(ctx.getCredentials).toHaveBeenCalledWith('gristApi');
+		expect(requestOAuth2).not.toHaveBeenCalled();
+		expect(request).toHaveBeenCalledWith(
+			expect.objectContaining({
+				uri: 'https://api.getgrist.com/api/docs/abc/tables/People/records',
+				headers: { Authorization: 'Bearer k' },
+			}),
+		);
+	});
+
+	// The URL here is deliberately sloppy: a clean one would pass even if this path skipped
+	// normalization, since the raw and normalized values would be identical.
+	it('routes through requestOAuth2 when authenticating with OAuth2, normalizing the URL', async () => {
+		const { ctx, request, requestOAuth2 } = setup('oAuth2', {
+			url: 'https://grist.example.com/api/',
+		});
+
+		await gristApiRequest.call(ctx, 'GET', '/orgs');
+
+		expect(ctx.getCredentials).toHaveBeenCalledWith('gristOAuth2Api');
+		expect(request).not.toHaveBeenCalled();
+		expect(requestOAuth2).toHaveBeenCalledWith(
+			'gristOAuth2Api',
+			expect.objectContaining({ uri: 'https://grist.example.com/api/orgs' }),
+		);
+		// The OAuth helper attaches the token itself, so nothing sets an Authorization header here.
+		const [, options] = requestOAuth2.mock.calls[0] as [string, IRequestOptions];
+		expect(options.headers).toBeUndefined();
+	});
+
+	it.each(['apiKey', 'oAuth2'])(
+		'wraps a failing %s request in a NodeApiError',
+		async (authentication) => {
+			const { ctx, request, requestOAuth2 } = setup(authentication, {
+				apiKey: 'k',
+				url: 'https://api.getgrist.com',
+			});
+			const failure = { message: 'Forbidden', statusCode: 403 };
+			request.mockRejectedValue(failure);
+			requestOAuth2.mockRejectedValue(failure);
+
+			await expect(gristApiRequest.call(ctx, 'GET', '/orgs')).rejects.toBeInstanceOf(NodeApiError);
+		},
+	);
+});

--- a/packages/nodes-base/nodes/Grist/test/gristOAuth2Endpoints.test.ts
+++ b/packages/nodes-base/nodes/Grist/test/gristOAuth2Endpoints.test.ts
@@ -1,0 +1,70 @@
+import type { INode, INodeParameters, INodeTypes } from 'n8n-workflow';
+import { Workflow } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { GristOAuth2Api } from '../../../credentials/GristOAuth2Api.credentials';
+import { gristBaseUrl } from '../GenericFunctions';
+
+// The connect flow has to accept the same URLs requests do, otherwise a Grist URL with a trailing
+// slash or `/api` gives working data calls and a broken connect.
+describe('Grist OAuth2 endpoint expressions', () => {
+	// Same setup as the expression tests in packages/workflow/test/expression.test.ts.
+	const node: INode = {
+		id: 'uuid-1234',
+		name: 'node',
+		typeVersion: 1,
+		type: 'test.set',
+		position: [0, 0],
+		parameters: {},
+	};
+	const workflow = new Workflow({
+		nodes: [node],
+		connections: {},
+		active: false,
+		nodeTypes: mock<INodeTypes>(),
+	});
+	const expression = workflow.expression;
+
+	beforeAll(async () => await expression.acquireIsolate());
+	afterAll(async () => await expression.releaseIsolate());
+
+	/** Resolves the credential's endpoint expressions against a given Grist URL. */
+	const endpointsFor = (url: string) => {
+		const { properties } = new GristOAuth2Api();
+		const self: INodeParameters = Object.fromEntries(properties.map((p) => [p.name, p.default]));
+		self.url = url;
+
+		// Passed as both the value and `selfData`, which is what makes `$self` resolve.
+		return expression.getComplexParameterValue(
+			node,
+			self,
+			'manual',
+			{},
+			undefined,
+			undefined,
+			self,
+		) as { authUrl: string; accessTokenUrl: string };
+	};
+
+	it('builds the endpoints from a plain Grist URL', () => {
+		const { authUrl, accessTokenUrl } = endpointsFor('https://api.getgrist.com');
+
+		expect(authUrl).toBe('https://api.getgrist.com/oidc/auth');
+		expect(accessTokenUrl).toBe('https://api.getgrist.com/oidc/token');
+	});
+
+	// The expression duplicates `normalizeBaseUrl`, which cannot be imported into an expression.
+	// Comparing against it directly is what catches the two drifting apart.
+	it.each([
+		'https://grist.example.com',
+		'https://grist.example.com/',
+		'https://grist.example.com/api',
+		'https://grist.example.com/api/',
+	])('normalizes %s the same way requests do', (url) => {
+		const { authUrl, accessTokenUrl } = endpointsFor(url);
+		const base = gristBaseUrl({ url });
+
+		expect(authUrl).toBe(`${base}/oidc/auth`);
+		expect(accessTokenUrl).toBe(`${base}/oidc/token`);
+	});
+});

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -179,6 +179,7 @@
       "dist/credentials/GotifyApi.credentials.js",
       "dist/credentials/GoToWebinarOAuth2Api.credentials.js",
       "dist/credentials/GristApi.credentials.js",
+      "dist/credentials/GristOAuth2Api.credentials.js",
       "dist/credentials/GrafanaApi.credentials.js",
       "dist/credentials/GSuiteAdminOAuth2Api.credentials.js",
       "dist/credentials/GumroadApi.credentials.js",

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -181,6 +181,7 @@
       "dist/credentials/GotifyApi.credentials.js",
       "dist/credentials/GoToWebinarOAuth2Api.credentials.js",
       "dist/credentials/GristApi.credentials.js",
+      "dist/credentials/GristOAuth2Api.credentials.js",
       "dist/credentials/GrafanaApi.credentials.js",
       "dist/credentials/GSuiteAdminOAuth2Api.credentials.js",
       "dist/credentials/GumroadApi.credentials.js",


### PR DESCRIPTION
## Summary

The Grist node could only authenticate with an API key. This adds **OAuth2** as a second authentication method, alongside the API key.

Setup is comparable (a Client ID, Secret, and Grist URL, then **Connect**), but the access is narrower. An API key carries everything its owner can do; the OAuth token is limited to the scopes you grant, and you can revoke it from Grist without rotating a key that may be used elsewhere.

The API key is unchanged and remains the default. Picking a **Grist OAuth2 API** credential on the node switches it to the OAuth path; everything else about the node stays the same, and every existing operation works over either credential.

**Existing workflows are unaffected.** A workflow saved before this change has no stored authentication value, so it resolves the `apiKey` default and keeps using its existing credential with no edits.

The new credential uses the PKCE grant, which is what Grist's authorization server supports. Its authorization and token endpoints are derived from the same **Grist URL** field the API key credential uses, so hosted and self-managed instances are configured the same way. That field is normalized exactly as the node's requests normalize it, so a URL that works for data calls also works for the connect flow.

### The requested scopes

The credential requests three scopes by default: `doc:read` to read records, `doc:write` to create, update and delete them, and `offline_access` for a refresh token so the connection outlives the one-hour access token. To request different scopes, for example for a read-only app, turn on **Custom Scopes** and edit **Enabled Scopes**.

### The credential, connected

<img width="1440" height="900" alt="pr2-01-oauth2-credential-form" src="https://github.com/user-attachments/assets/a0bec6ac-9a2e-42d3-85c6-aede2a016bf4" />

### Grist's consent screen, showing the requested scopes

<img width="560" height="750" alt="pr2-02-oauth2-consent-scopes" src="https://github.com/user-attachments/assets/0aeb8b09-373d-4daa-8c94-d17319c2b01c" />

### Either credential can be selected on the node

<img width="1440" height="900" alt="pr2-03-credential-picker" src="https://github.com/user-attachments/assets/35ddc341-d5f9-461d-afa4-ba5867808a57" />

## How to test

In Grist, register an OAuth app and set its redirect URI to your n8n callback: `.../rest/oauth2-credential/callback` (n8n shows this redirect URL at the top of the credential form, in step 1 below). In Grist, you register apps under account menu > **Account settings** > **Developer**. In n8n:

1. **Credentials** > **Create credential** > **Grist OAuth2 API**. Copy the **OAuth Redirect URL** shown at the top into your Grist OAuth app.
2. Fill in **Client ID**, **Client Secret**, and **Grist URL** (`https://api.getgrist.com` by default), then **Connect**. Authorize on Grist's consent screen. The credential shows **Account connected**.
3. Add a **Grist** node to a workflow and pick that credential. Set a document and table, run **Get Many Rows**, and confirm the rows come back. The request is made with the OAuth token, not an API key.
4. **API key still works:** create a **Grist API** credential as before and point a node at it. Both credential types appear in the node's credential dropdown and both execute.
5. **Backward compatibility:** open a Grist workflow saved before this change. It keeps its API key credential and runs unchanged.
6. **Self-managed / sloppy URLs:** a Grist URL with a trailing slash or a trailing `/api` is normalized for both the connect flow and data requests.
7. Unit tests: `cd packages/nodes-base && pnpm test nodes/Grist`.

## Related Linear tickets, Github issues, and Community forum posts

Part of splitting up #33133 (internal tracker [NODE-5348](https://linear.app/n8n/issue/NODE-5348/community-pr-featgrist-node-add-oauth2-trigger-column-mapping-resource)). Follows #34190, the first slice, which unified the credential's host configuration into the single **Grist URL** field this credential reuses.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. https://github.com/n8n-io/n8n-docs/pull/5122
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (N/A).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34798">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

