### PR TITLE
ci(ai-builder): Run the MCP eval claude build from an isolated working directory (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-mcp.yml
+++ b/.github/workflows/test-evals-mcp.yml
@@ -283,6 +283,16 @@ jobs:
           CONCURRENCY="${EVAL_CONCURRENCY:-$((LANES * 2))}"
           echo "Lanes: $LANES | eval concurrency: $CONCURRENCY"
 
+          # Spawn the `claude` build subprocess from an empty directory outside
+          # the checkout. Inheriting the repo cwd would load the repo's Claude
+          # config into the builder (CLAUDE.md/AGENTS.md, .claude/settings.json
+          # with the n8n plugin's skills and hooks) and allow permissionless
+          # reads of repo files — including the eval harness and case corpus.
+          # The MCP config is unaffected: it is staged per lane and pinned with
+          # --strict-mcp-config either way.
+          BUILD_CWD="$RUNNER_TEMP/mcp-build-cwd"
+          mkdir -p "$BUILD_CWD"
+
           # --dataset + --baseline-prefix keep the MCP cohort isolated from the
           # Instance AI dataset/baseline in LangSmith (both halves required).
           # --timeout-ms 25min: MCP-tier multi-agent cases with large mocked
@@ -299,6 +309,7 @@ jobs:
             --timeout-ms 1500000
             --dataset mcp-workflow-evals
             --baseline-prefix mcp-baseline-
+            --build-cwd "$BUILD_CWD"
             --verbose
           )
           # LangTracer is the only CI case source (no disk fallback by design).


### PR DESCRIPTION
## Summary

The MCP workflow eval lane (`test-evals-mcp.yml`) builds workflows by driving `claude -p` as a subprocess of the eval CLI (`evaluations/cli/mcp-builder.ts`). CI never set `--build-cwd`, so the subprocess inherited the eval step's working directory — `packages/@n8n/instance-ai` **inside the repo checkout**. Running there, the builder picks up context the cohort under measurement should not have:

- the repo's `CLAUDE.md`/`AGENTS.md` ancestry (including the instance-ai architecture doc),
- the checked-in `.claude/settings.json` — which enables the n8n plugin (all `.agents/skills` skills, a `PostToolUse` hook script, and a Bash permission allowlist),
- permissionless reads of repo files, including the eval harness source and the case corpus under `evaluations/data/workflows/` (grounding-contamination risk for eval results).

This PR points `--build-cwd` (already plumbed through `args.ts` → `build-orchestrator.ts` → the spawn) at an empty directory under `$RUNNER_TEMP`, severing all three. The MCP side is unchanged: the per-lane staged config is already pinned with `--strict-mcp-config`, and MCP trust comes from `$HOME/.claude/settings.json` (`enableAllProjectMcpServers`), which is cwd-independent. Local `--build-via-mcp` runs keep the documented cwd-inheritance behavior (`evaluations/README.md` describes loading your own project's skills as a feature); only the CI lane is pinned.

Note for comparisons: MCP-lane experiments after this change measure a cleaner cohort — a delta vs. older experiments may partly reflect the removed repo context, not a product change.

## How to test

Validated with a smoke dispatch on this branch: [run 30024949135](https://github.com/n8n-io/n8n/actions/runs/30024949135) (`filter=order-threshold-notify`, `iterations=1`, `lanes=2`, experiment `mcp-build-cwd-smoke-20260723`).

- The eval CLI received `--build-cwd /home/runner/_work/_temp/mcp-build-cwd` (outside the checkout at `/home/runner/_work/n8n/n8n`) — visible in the step log's `tsx evaluations/cli/index.ts …` line.
- The build succeeded from the isolated cwd: 1/1 case built, 2/2 execution scenarios passed, all workflow checks green.

Caveat: the per-attempt build log (`--output-format json`) records only the final result message, not the session init, so the loaded-context surface (skills/commands list) can't be asserted from the artifact — the isolation guarantee here is structural (empty temp dir outside any repo: no `CLAUDE.md` ancestry, no `.claude/` settings in scope, repo reads require permission headless mode doesn't grant).

## Related Linear tickets, Github issues, and Community forum posts

—

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)