### PR TITLE
fix(ai-builder): Halt workflow verification at send-and-wait gates on loops

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/__tests__/analyze-result.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/__tests__/analyze-result.test.ts
@@ -1,0 +1,75 @@
+import type { WorkflowBuildOutcome } from '../../../../workflow-loop/workflow-loop-state';
+import { analyzeVerificationResult } from '../analyze-result';
+import type { ExecutionRunResult } from '../types';
+
+function makeBuildOutcome(overrides: Partial<WorkflowBuildOutcome> = {}): WorkflowBuildOutcome {
+	return {
+		workItemId: 'wi_1',
+		taskId: 'task_1',
+		workflowId: 'wf_1',
+		submitted: true,
+		triggerType: 'manual_or_testable',
+		needsUserInput: false,
+		summary: 'Built',
+		...overrides,
+	};
+}
+
+const buildOutcome = makeBuildOutcome({
+	nodeSimulationPlan: [
+		{
+			nodeName: 'Email Approval',
+			verdict: 'simulate',
+			reason: 'Send-and-wait gate on a loop',
+			confidence: 'high',
+			source: 'deterministic',
+			haltBranch: true,
+		},
+		{
+			nodeName: 'Publish',
+			verdict: 'simulate',
+			reason: 'Sends a message',
+			confidence: 'high',
+			source: 'deterministic',
+		},
+	],
+});
+
+const result = {
+	executionId: 'exec-1',
+	status: 'success',
+	executedNodeNames: ['Trigger', 'Format Draft', 'Email Approval'],
+	lastNodeExecuted: 'Email Approval',
+	data: { Trigger: [{}], 'Format Draft': [{}], 'Email Approval': [] },
+} as unknown as ExecutionRunResult;
+
+describe('analyzeVerificationResult — halted wait gates', () => {
+	it('explains the expected stop at the gate instead of the generic zero-output guidance', () => {
+		const analysis = analyzeVerificationResult({
+			result,
+			buildOutcome,
+			simulatedNodes: [{ nodeName: 'Email Approval', reason: 'Send-and-wait gate on a loop' }],
+			haltedGateNames: ['Email Approval'],
+			stateBefore: undefined,
+			runId: 'run-1',
+		});
+
+		expect(analysis.success).toBe(true);
+		expect(analysis.nodesNotReached).toEqual(['Publish']);
+		expect(analysis.coverageNote).toContain('halted at send-and-wait gate');
+		expect(analysis.coverageNote).toContain('manual');
+		expect(analysis.coverageNote).not.toContain('Seed matching test data');
+	});
+
+	it('keeps the generic partial-coverage guidance when no gate halted the run', () => {
+		const analysis = analyzeVerificationResult({
+			result,
+			buildOutcome,
+			simulatedNodes: [],
+			stateBefore: undefined,
+			runId: 'run-1',
+		});
+
+		expect(analysis.coverageNote).toContain('Partial coverage');
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/__tests__/analyze-result.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/__tests__/analyze-result.test.ts
@@ -56,9 +56,13 @@ describe('analyzeVerificationResult — halted wait gates', () => {
 
 		expect(analysis.success).toBe(true);
 		expect(analysis.nodesNotReached).toEqual(['Publish']);
-		expect(analysis.coverageNote).toContain('halted at send-and-wait gate');
-		expect(analysis.coverageNote).toContain('manual');
-		expect(analysis.coverageNote).not.toContain('Seed matching test data');
+		expect(analysis.coverageNote).toContain('pauses at wait gate');
+		expect(analysis.coverageNote).toContain('live end-to-end test');
+		// Gate-agnostic wording: no approval/human-decision claims (the halt also
+		// covers time-based Wait and Form gates), and non-gate dead ends keep the
+		// seed-and-re-run guidance instead of being attributed to the gate.
+		expect(analysis.coverageNote).not.toContain('human decision');
+		expect(analysis.coverageNote).toContain('NOT behind the gate');
 	});
 
 	it('keeps the generic partial-coverage guidance when no gate halted the run', () => {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/__tests__/prepare-run.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/__tests__/prepare-run.test.ts
@@ -1,0 +1,88 @@
+import type { WorkflowBuildOutcome } from '../../../../workflow-loop/workflow-loop-state';
+import { prepareVerificationRun } from '../prepare-run';
+
+function makeBuildOutcome(overrides: Partial<WorkflowBuildOutcome> = {}): WorkflowBuildOutcome {
+	return {
+		workItemId: 'wi_1',
+		taskId: 'task_1',
+		workflowId: 'wf_1',
+		submitted: true,
+		triggerType: 'manual_or_testable',
+		needsUserInput: false,
+		summary: 'Built',
+		...overrides,
+	};
+}
+
+const gateVerdict = {
+	nodeName: 'Email Approval',
+	verdict: 'simulate' as const,
+	reason: 'Send-and-wait gate on a loop',
+	confidence: 'high' as const,
+	source: 'deterministic' as const,
+	haltBranch: true,
+};
+
+const plainVerdict = {
+	nodeName: 'Send Message',
+	verdict: 'simulate' as const,
+	reason: 'Sends a message',
+	confidence: 'high' as const,
+	source: 'deterministic' as const,
+};
+
+describe('prepareVerificationRun — halted wait gates', () => {
+	it('pins a halted gate with zero items, ignoring any stored fixture', () => {
+		const result = prepareVerificationRun(
+			makeBuildOutcome({
+				nodeSimulationPlan: [gateVerdict, plainVerdict],
+				simulationFixtures: {
+					'Email Approval': [{ data: { Decision: 'Approve' } }],
+					'Send Message': [{ ok: true }],
+				},
+			}),
+			undefined,
+		);
+
+		expect(result.kind).toBe('ready');
+		if (result.kind !== 'ready') return;
+		expect(result.prepared.verificationPinData?.['Email Approval']).toEqual([]);
+		expect(result.prepared.verificationPinData?.['Send Message']).toEqual([{ ok: true }]);
+		expect(result.prepared.haltedGateNames).toEqual(['Email Approval']);
+	});
+
+	it('still pins a fixture-less simulated node with one empty item', () => {
+		const result = prepareVerificationRun(
+			makeBuildOutcome({ nodeSimulationPlan: [plainVerdict] }),
+			undefined,
+		);
+
+		expect(result.kind).toBe('ready');
+		if (result.kind !== 'ready') return;
+		expect(result.prepared.verificationPinData?.['Send Message']).toEqual([{}]);
+		expect(result.prepared.haltedGateNames).toEqual([]);
+	});
+
+	it('blocks fixture overrides that target a halted gate', () => {
+		const result = prepareVerificationRun(makeBuildOutcome({ nodeSimulationPlan: [gateVerdict] }), {
+			'Email Approval': [{ data: { Decision: 'Request changes' } }],
+		});
+
+		expect(result.kind).toBe('blocked');
+		if (result.kind !== 'blocked') return;
+		expect(result.result.guidance).toContain('human decision');
+		expect(result.result.remediation?.category).toBe('blocked');
+	});
+
+	it('keeps applying overrides to ordinary simulated nodes', () => {
+		const result = prepareVerificationRun(
+			makeBuildOutcome({ nodeSimulationPlan: [gateVerdict, plainVerdict] }),
+			{ 'Send Message': [{ ok: false }] },
+		);
+
+		expect(result.kind).toBe('ready');
+		if (result.kind !== 'ready') return;
+		expect(result.prepared.verificationPinData?.['Send Message']).toEqual([{ ok: false }]);
+		expect(result.prepared.verificationPinData?.['Email Approval']).toEqual([]);
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
@@ -224,8 +224,18 @@ function buildCoverageNote(
 	nodesNotReached: string[],
 	result: ExecutionRunResult,
 	success: boolean,
+	reachedHaltedGates: string[],
 ): string | undefined {
 	if (nodesNotReached.length === 0) return undefined;
+	if (success && reachedHaltedGates.length > 0) {
+		return (
+			`Verification halted at send-and-wait gate(s) ${reachedHaltedGates.join(', ')}: continuing needs a ` +
+			`human decision, so ${nodesNotReached.length} downstream node(s) were not executed and remain ` +
+			`unverified: ${nodesNotReached.join(', ')}. This is expected for approval loops — do not edit the ` +
+			'workflow or re-run verification to force coverage. Report that the approval path needs a manual ' +
+			'end-to-end test.'
+		);
+	}
 	const ending = result.lastNodeExecuted
 		? `. Execution ended at "${result.lastNodeExecuted}"${success ? ' because it produced no output items (empty item lists stop downstream nodes)' : ''}.`
 		: '.';
@@ -280,10 +290,12 @@ export function analyzeVerificationResult(args: {
 	result: ExecutionRunResult;
 	buildOutcome: WorkflowBuildOutcome;
 	simulatedNodes: Array<{ nodeName: string; reason: string }>;
+	/** Wait-gate nodes pinned with zero items — the run is expected to stop at these. */
+	haltedGateNames?: string[];
 	stateBefore: WorkflowLoopState | undefined;
 	runId: string;
 }): VerificationAnalysis {
-	const { result, buildOutcome, simulatedNodes, stateBefore, runId } = args;
+	const { result, buildOutcome, simulatedNodes, haltedGateNames, stateBefore, runId } = args;
 	const nodeErrors = result.nodeErrors ?? [];
 	const reachedNames = new Set(
 		result.executedNodeNames ?? (result.data ? Object.keys(result.data) : []),
@@ -321,7 +333,12 @@ export function analyzeVerificationResult(args: {
 		remediation,
 		nodesExecuted: namesOrDataKeys(reachedNames, result.data),
 		simulationNote: buildSimulationNote(reachedSimulatedNodes, false),
-		coverageNote: buildCoverageNote(nodesNotReached, result, success),
+		coverageNote: buildCoverageNote(
+			nodesNotReached,
+			result,
+			success,
+			(haltedGateNames ?? []).filter((name) => reachedNames.has(name)),
+		),
 		errorMessage,
 		nodeErrors,
 	};

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
@@ -229,11 +229,14 @@ function buildCoverageNote(
 	if (nodesNotReached.length === 0) return undefined;
 	if (success && reachedHaltedGates.length > 0) {
 		return (
-			`Verification halted at send-and-wait gate(s) ${reachedHaltedGates.join(', ')}: continuing needs a ` +
-			`human decision, so ${nodesNotReached.length} downstream node(s) were not executed and remain ` +
-			`unverified: ${nodesNotReached.join(', ')}. This is expected for approval loops — do not edit the ` +
-			'workflow or re-run verification to force coverage. Report that the approval path needs a manual ' +
-			'end-to-end test.'
+			`Verification pauses at wait gate(s) ${reachedHaltedGates.join(', ')} — in a live run the ` +
+			'workflow stops there (for a human response or a wait condition), so execution past the ' +
+			`gate is not simulated. ${nodesNotReached.length} planned node(s) were not reached: ` +
+			`${nodesNotReached.join(', ')}. Nodes behind the gate are expected to be unreached — do ` +
+			'not edit the workflow or re-run verification to force coverage there; recommend a live ' +
+			'end-to-end test instead. Any unreached node NOT behind the gate did not receive input ' +
+			'items (usually an empty lookup or query) — seed matching test data and re-run before ' +
+			'treating it as verified.'
 		);
 	}
 	const ending = result.lastNodeExecuted

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/prepare-run.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/prepare-run.ts
@@ -45,8 +45,7 @@ function buildVerificationPinData(
 		if (verdict.verdict !== 'simulate') continue;
 		simulatedNodes.push({ nodeName: verdict.nodeName, reason: verdict.reason });
 		if (verdict.haltBranch) {
-			// Zero items stop the branch at the gate — a fixture here would re-run
-			// the loop with the same canned decision forever.
+			// Zero items halt the branch at the gate; a fixture would loop forever.
 			haltedGateNames.push(verdict.nodeName);
 			merged[verdict.nodeName] = [];
 			continue;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/prepare-run.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/prepare-run.ts
@@ -5,6 +5,8 @@ import type { WorkflowBuildOutcome } from '../../../workflow-loop/workflow-loop-
 export interface PreparedVerificationRun {
 	verificationPinData: Record<string, unknown[]> | undefined;
 	simulatedNodes: Array<{ nodeName: string; reason: string }>;
+	/** Wait-gate nodes pinned with zero items — verification halts at these. */
+	haltedGateNames: string[];
 }
 
 function getInvalidFixtureOverrideNodeNames(
@@ -37,16 +39,25 @@ function buildVerificationPinData(
 	const merged: Record<string, unknown[]> = { ...(buildOutcome.verificationPinData ?? {}) };
 	const fixtures = buildOutcome.simulationFixtures ?? {};
 	const simulatedNodes: Array<{ nodeName: string; reason: string }> = [];
+	const haltedGateNames: string[] = [];
 
 	for (const verdict of buildOutcome.nodeSimulationPlan ?? []) {
 		if (verdict.verdict !== 'simulate') continue;
 		simulatedNodes.push({ nodeName: verdict.nodeName, reason: verdict.reason });
+		if (verdict.haltBranch) {
+			// Zero items stop the branch at the gate — a fixture here would re-run
+			// the loop with the same canned decision forever.
+			haltedGateNames.push(verdict.nodeName);
+			merged[verdict.nodeName] = [];
+			continue;
+		}
 		const items = fixtures[verdict.nodeName];
 		merged[verdict.nodeName] = items?.length ? items : [{}];
 	}
 
 	if (fixtureOverrides) {
 		for (const [nodeName, items] of Object.entries(fixtureOverrides)) {
+			if (haltedGateNames.includes(nodeName)) continue;
 			merged[nodeName] = items;
 		}
 	}
@@ -54,6 +65,7 @@ function buildVerificationPinData(
 	return {
 		verificationPinData: Object.keys(merged).length > 0 ? merged : undefined,
 		simulatedNodes,
+		haltedGateNames,
 	};
 }
 
@@ -63,6 +75,35 @@ export function prepareVerificationRun(
 ):
 	| { kind: 'ready'; prepared: PreparedVerificationRun }
 	| { kind: 'blocked'; result: VerifyBuiltWorkflowOutput } {
+	const haltedOverrideNodeNames = Object.keys(fixtureOverrides ?? {}).filter((nodeName) =>
+		(buildOutcome.nodeSimulationPlan ?? []).some(
+			(verdict) =>
+				verdict.nodeName === nodeName && verdict.verdict === 'simulate' && verdict.haltBranch,
+		),
+	);
+	if (haltedOverrideNodeNames.length > 0) {
+		const guidance =
+			`Node(s) ${haltedOverrideNodeNames.join(', ')} pause the workflow for a human decision and sit on a loop — ` +
+			'verification always halts there and their output cannot be overridden: a canned response would ' +
+			're-run the loop with the same answer forever. Treat reaching the gate as verified and tell the ' +
+			'user the approval loop needs a manual end-to-end test.';
+		const remediation = createRemediation({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'halted_wait_gate_override',
+			guidance,
+		});
+		return {
+			kind: 'blocked',
+			result: {
+				success: false,
+				error: guidance,
+				remediation,
+				guidance,
+			},
+		};
+	}
+
 	const invalidFixtureOverrideNodeNames = getInvalidFixtureOverrideNodeNames(
 		buildOutcome,
 		fixtureOverrides,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
@@ -171,6 +171,7 @@ export function createVerifyBuiltWorkflowTool(context: OrchestrationContext) {
 				result,
 				buildOutcome,
 				simulatedNodes: prepared.simulatedNodes,
+				haltedGateNames: prepared.haltedGateNames,
 				stateBefore: target.stateBefore,
 				runId: context.runId,
 			});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/plan-verification-simulation.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/plan-verification-simulation.test.ts
@@ -319,3 +319,112 @@ describe('planVerificationSimulation — simulated trigger verdicts', () => {
 		expect(simulationFixtures).toEqual({ 'On New Email': [{ subject: 'declared' }] });
 	});
 });
+
+describe('planVerificationSimulation — wait-gate halt verdicts', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGenerateFixtures.mockResolvedValue({});
+	});
+
+	const simulateVerdict = (nodeName: string): NodeSimulationVerdict => ({
+		nodeName,
+		verdict: 'simulate',
+		reason: 'Credentials are not configured for this node',
+		confidence: 'high',
+		source: 'deterministic',
+	});
+
+	const gateWorkflow = (connections: Record<string, unknown>): WorkflowJSON =>
+		({
+			name: 'approval loop',
+			nodes: [
+				{
+					id: 'id-0',
+					name: 'Format Draft',
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				{
+					id: 'id-1',
+					name: 'Email Approval',
+					type: 'n8n-nodes-base.gmail',
+					typeVersion: 2,
+					position: [100, 0],
+					parameters: { operation: 'sendAndWait' },
+				},
+				{
+					id: 'id-2',
+					name: 'Revise Post',
+					type: 'n8n-nodes-base.openAi',
+					typeVersion: 1,
+					position: [200, 0],
+					parameters: {},
+				},
+			],
+			connections,
+		}) as unknown as WorkflowJSON;
+
+	const loopConnections = {
+		'Format Draft': { main: [[{ node: 'Email Approval', type: 'main', index: 0 }]] },
+		'Email Approval': { main: [[{ node: 'Revise Post', type: 'main', index: 0 }]] },
+		'Revise Post': { main: [[{ node: 'Format Draft', type: 'main', index: 0 }]] },
+	};
+
+	it('halts a simulated send-and-wait gate that sits on a loop', async () => {
+		mockClassify.mockResolvedValue([
+			simulateVerdict('Email Approval'),
+			simulateVerdict('Revise Post'),
+		]);
+
+		const { nodeSimulationPlan } = await planVerificationSimulation({
+			workflow: gateWorkflow(loopConnections),
+			workflowId: 'wf-1',
+		});
+
+		const gateVerdict = nodeSimulationPlan?.find((v) => v.nodeName === 'Email Approval');
+		expect(gateVerdict).toMatchObject({ verdict: 'simulate', haltBranch: true });
+		expect(gateVerdict?.reason).toContain('human decision');
+		// Non-gate loop members keep their fixture behaviour.
+		expect(
+			nodeSimulationPlan?.find((v) => v.nodeName === 'Revise Post')?.haltBranch,
+		).toBeUndefined();
+		// No fixture is generated for a halted gate.
+		const fixtureInput = mockGenerateFixtures.mock.calls[0][0];
+		expect(fixtureInput.plan.map((verdict) => verdict.nodeName)).not.toContain('Email Approval');
+		expect(fixtureInput.plan.map((verdict) => verdict.nodeName)).toContain('Revise Post');
+	});
+
+	it('leaves a simulated gate off any loop untouched', async () => {
+		mockClassify.mockResolvedValue([simulateVerdict('Email Approval')]);
+
+		const { nodeSimulationPlan } = await planVerificationSimulation({
+			workflow: gateWorkflow({
+				'Format Draft': { main: [[{ node: 'Email Approval', type: 'main', index: 0 }]] },
+				'Email Approval': { main: [[{ node: 'Revise Post', type: 'main', index: 0 }]] },
+			}),
+			workflowId: 'wf-1',
+		});
+
+		expect(
+			nodeSimulationPlan?.find((v) => v.nodeName === 'Email Approval')?.haltBranch,
+		).toBeUndefined();
+	});
+
+	it('leaves an execute-verdict gate alone — a live gate pauses and breaks the loop itself', async () => {
+		mockClassify.mockResolvedValue([executeVerdict('Email Approval')]);
+
+		const { nodeSimulationPlan } = await planVerificationSimulation({
+			workflow: gateWorkflow(loopConnections),
+			workflowId: 'wf-1',
+		});
+
+		expect(nodeSimulationPlan?.find((v) => v.nodeName === 'Email Approval')).toMatchObject({
+			verdict: 'execute',
+		});
+		expect(
+			nodeSimulationPlan?.find((v) => v.nodeName === 'Email Approval')?.haltBranch,
+		).toBeUndefined();
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/reconcile-simulation-plan.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/reconcile-simulation-plan.test.ts
@@ -380,3 +380,81 @@ describe('reconcileSimulationPlan', () => {
 		expect(patch?.setupRequirement).toBeUndefined();
 	});
 });
+
+describe('reconcileSimulationPlan — wait-gate halt re-derivation', () => {
+	it('re-applies haltBranch to a still-simulated gate on a loop after an AI-root refresh', async () => {
+		const workflow = {
+			name: 'approval loop',
+			nodes: [
+				{
+					id: 'id-0',
+					name: 'Generate',
+					type: '@n8n/n8n-nodes-langchain.chainLlm',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+				{
+					id: 'id-1',
+					name: 'Model',
+					type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+					typeVersion: 1,
+					position: [0, 100],
+					parameters: {},
+					credentials: { openAiApi: { id: 'cred-1', name: 'OpenAI' } },
+				},
+				{
+					id: 'id-2',
+					name: 'Gate',
+					type: 'n8n-nodes-base.gmail',
+					typeVersion: 2,
+					position: [100, 0],
+					parameters: { operation: 'sendAndWait' },
+				},
+				{
+					id: 'id-3',
+					name: 'Revise',
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [200, 0],
+					parameters: {},
+				},
+			],
+			connections: {
+				Model: { ai_languageModel: [[{ node: 'Generate', type: 'ai_languageModel', index: 0 }]] },
+				Generate: { main: [[{ node: 'Gate', type: 'main', index: 0 }]] },
+				Gate: { main: [[{ node: 'Revise', type: 'main', index: 0 }]] },
+				Revise: { main: [[{ node: 'Gate', type: 'main', index: 0 }]] },
+			},
+		} as unknown as WorkflowJSON;
+
+		const patch = await reconcileSimulationPlan({
+			buildOutcome: makeBuildOutcome({
+				nodeSimulationPlan: [
+					{
+						nodeName: 'Generate',
+						verdict: 'simulate',
+						reason: CREDENTIALLESS_AI_ROOT_SIMULATION_REASON,
+						confidence: 'high',
+						source: 'deterministic',
+					},
+					mockedVerdict('Gate'),
+				],
+				mockedCredentialsByNode: { Gate: ['gmailOAuth2'] },
+				mockedNodeNames: ['Gate'],
+			}),
+			workflow,
+			availableCredentials: makeCredentialMap([]),
+		});
+
+		// The AI root regained credentials, so the plan was refreshed…
+		expect(patch?.nodeSimulationPlan?.find((v) => v.nodeName === 'Generate')?.verdict).toBe(
+			'execute',
+		);
+		// …and the still-simulated gate on the loop keeps halting.
+		expect(patch?.nodeSimulationPlan?.find((v) => v.nodeName === 'Gate')).toMatchObject({
+			verdict: 'simulate',
+			haltBranch: true,
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-json-utils.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-json-utils.test.ts
@@ -5,6 +5,8 @@ import {
 	ensureWebhookIds,
 	isMockableTriggerNodeType,
 	isTriggerNodeType,
+	isWaitGateNode,
+	nodeCanReachItself,
 	preserveExistingNodeGroupIds,
 	preserveExistingSetupValues,
 } from '../workflow-json-utils';
@@ -737,5 +739,65 @@ describe('preserveExistingSetupValues', () => {
 		await expect(preserveExistingSetupValues(workflow, 'wf-1', context)).rejects.toThrow(
 			'Failed to load existing workflow wf-1 to preserve setup values: Workflow not found',
 		);
+	});
+});
+
+describe('isWaitGateNode', () => {
+	const node = (
+		type: string,
+		parameters: Record<string, unknown> = {},
+	): WorkflowJSON['nodes'][number] =>
+		({
+			id: 'node-1',
+			name: 'Node',
+			type,
+			typeVersion: 1,
+			position: [0, 0],
+			parameters,
+		}) as WorkflowJSON['nodes'][number];
+
+	it('detects send-and-wait operations and pausing node types', () => {
+		expect(isWaitGateNode(node('n8n-nodes-base.gmail', { operation: 'sendAndWait' }))).toBe(true);
+		expect(isWaitGateNode(node('n8n-nodes-base.slack', { operation: 'sendAndWait' }))).toBe(true);
+		expect(isWaitGateNode(node('n8n-nodes-base.wait'))).toBe(true);
+		expect(isWaitGateNode(node('n8n-nodes-base.form'))).toBe(true);
+	});
+
+	it('rejects ordinary operations and node types', () => {
+		expect(isWaitGateNode(node('n8n-nodes-base.gmail', { operation: 'send' }))).toBe(false);
+		expect(isWaitGateNode(node('n8n-nodes-base.set'))).toBe(false);
+	});
+});
+
+describe('nodeCanReachItself', () => {
+	const withConnections = (connections: Record<string, unknown>): WorkflowJSON =>
+		({ name: 'test', nodes: [], connections }) as unknown as WorkflowJSON;
+	const main = (...targets: string[]) => ({
+		main: [targets.map((target) => ({ node: target, type: 'main', index: 0 }))],
+	});
+
+	it('finds nodes on a revision loop and spares the terminal branch', () => {
+		const json = withConnections({
+			Format: main('Email'),
+			Email: main('Approved?'),
+			'Approved?': {
+				main: [
+					[{ node: 'Publish', type: 'main', index: 0 }],
+					[{ node: 'Revise', type: 'main', index: 0 }],
+				],
+			},
+			Revise: main('Format'),
+		});
+
+		expect(nodeCanReachItself(json, 'Email')).toBe(true);
+		expect(nodeCanReachItself(json, 'Revise')).toBe(true);
+		expect(nodeCanReachItself(json, 'Publish')).toBe(false);
+	});
+
+	it('returns false on acyclic graphs and unknown nodes', () => {
+		const json = withConnections({ A: main('B'), B: main('C') });
+
+		expect(nodeCanReachItself(json, 'B')).toBe(false);
+		expect(nodeCanReachItself(json, 'Missing')).toBe(false);
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/workflows/plan-verification-simulation.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/plan-verification-simulation.ts
@@ -20,7 +20,12 @@ import {
 	generateSimulationFixtures,
 	type SimulationFixtures,
 } from './generate-simulation-fixtures.service';
-import { isMockableTriggerNodeType, isTriggerNodeType } from './workflow-json-utils';
+import {
+	isMockableTriggerNodeType,
+	isTriggerNodeType,
+	isWaitGateNode,
+	nodeCanReachItself,
+} from './workflow-json-utils';
 import type { Logger } from '../../logger';
 import type { ModelConfig } from '../../types';
 import type { NodeSimulationVerdict } from '../../workflow-loop/workflow-loop-state';
@@ -209,6 +214,40 @@ function withSimulatedCredentiallessAiRootVerdicts(
 	return verdicts;
 }
 
+export const WAIT_GATE_HALT_REASON =
+	'Send-and-wait gate on a loop — verification pauses here because continuing needs a human decision';
+
+/**
+ * Simulated wait-gate nodes that can loop back into themselves are halted:
+ * `haltBranch` makes verification pin them with zero items so the branch stops
+ * at the gate, mirroring how a live gate pauses the execution. A fixture there
+ * would replay the same canned decision on every pass and the loop would run
+ * unbounded. Gates with an `execute` verdict are left alone — the real node
+ * pauses and breaks the loop by itself. Runs LAST so it overrides fixtures
+ * from every source (classifier, declared outputs, mocked credentials).
+ */
+export function withWaitGateHaltVerdicts(
+	plan: NodeSimulationVerdict[],
+	workflow: WorkflowJSON,
+): NodeSimulationVerdict[] {
+	const nodesByName = new Map(
+		(workflow.nodes ?? [])
+			.filter((node): node is WorkflowJSON['nodes'][number] & { name: string } =>
+				Boolean(node.name),
+			)
+			.map((node) => [node.name, node] as const),
+	);
+
+	return plan.map((verdict) => {
+		if (verdict.verdict !== 'simulate' || verdict.haltBranch) return verdict;
+		const node = nodesByName.get(verdict.nodeName);
+		if (!node || !isWaitGateNode(node) || !nodeCanReachItself(workflow, verdict.nodeName)) {
+			return verdict;
+		}
+		return { ...verdict, haltBranch: true, reason: WAIT_GATE_HALT_REASON };
+	});
+}
+
 function nonEmptyDeclaredFixtures(
 	fixtures: SimulationFixtures | undefined,
 ): SimulationFixtures | undefined {
@@ -277,10 +316,13 @@ export async function planVerificationSimulation({
 			workflow,
 			new Set(mockedNodeNames ?? []),
 		);
+		nodeSimulationPlan = withWaitGateHaltVerdicts(nodeSimulationPlan, workflow);
 		if (nodeSimulationPlan.length > 0) {
 			const planNeedingGeneratedFixtures = nodeSimulationPlan.filter(
 				(verdict) =>
-					verdict.verdict === 'simulate' && !declaredFixtures?.[verdict.nodeName]?.length,
+					verdict.verdict === 'simulate' &&
+					!verdict.haltBranch &&
+					!declaredFixtures?.[verdict.nodeName]?.length,
 			);
 			const generatedFixtures =
 				planNeedingGeneratedFixtures.length > 0
@@ -322,6 +364,7 @@ export async function planVerificationSimulation({
 				workflow,
 				new Set(mockedNodeNames ?? []),
 			);
+			nodeSimulationPlan = withWaitGateHaltVerdicts(nodeSimulationPlan, workflow);
 			simulationFixtures = declaredFixtures;
 		}
 	}

--- a/packages/@n8n/instance-ai/src/tools/workflows/plan-verification-simulation.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/plan-verification-simulation.ts
@@ -218,13 +218,10 @@ export const WAIT_GATE_HALT_REASON =
 	'Send-and-wait gate on a loop — verification pauses here because continuing needs a human decision';
 
 /**
- * Simulated wait-gate nodes that can loop back into themselves are halted:
- * `haltBranch` makes verification pin them with zero items so the branch stops
- * at the gate, mirroring how a live gate pauses the execution. A fixture there
- * would replay the same canned decision on every pass and the loop would run
- * unbounded. Gates with an `execute` verdict are left alone — the real node
- * pauses and breaks the loop by itself. Runs LAST so it overrides fixtures
- * from every source (classifier, declared outputs, mocked credentials).
+ * Halt simulated wait gates that sit on a loop: pin them with zero items
+ * instead of a fixture — a pinned gate cannot pause, so its canned decision
+ * would re-run the loop forever. Live (`execute`) gates pause on their own.
+ * Runs last so it overrides fixtures from every source.
  */
 export function withWaitGateHaltVerdicts(
 	plan: NodeSimulationVerdict[],

--- a/packages/@n8n/instance-ai/src/tools/workflows/reconcile-simulation-plan.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/reconcile-simulation-plan.ts
@@ -18,6 +18,7 @@ import { isAiGatewayManagedCredential } from './credential-utils';
 import {
 	CREDENTIALLESS_AI_ROOT_SIMULATION_REASON,
 	findCredentiallessAiRoots,
+	withWaitGateHaltVerdicts,
 } from './plan-verification-simulation';
 import type { CredentialMap } from './resolve-credentials';
 import type { ModelConfig } from '../../types';
@@ -143,7 +144,7 @@ export async function reconcileSimulationPlan(args: {
 	// flow) keeps its stored verdict — losing coverage is worse than an extra
 	// simulation. Restored AI roots are deterministically safe by type, so
 	// flipping straight to execute matches what a rebuild would classify.
-	const nodeSimulationPlan = buildOutcome.nodeSimulationPlan?.map((verdict) => {
+	const reconciledPlan = buildOutcome.nodeSimulationPlan?.map((verdict) => {
 		if (satisfiedNames.has(verdict.nodeName)) {
 			return freshVerdictByName.get(verdict.nodeName) ?? verdict;
 		}
@@ -158,6 +159,9 @@ export async function reconcileSimulationPlan(args: {
 		}
 		return verdict;
 	});
+	// Fresh verdicts from re-classification drop `haltBranch`; re-derive it so a
+	// wait gate that stays simulated keeps halting instead of looping.
+	const nodeSimulationPlan = reconciledPlan && withWaitGateHaltVerdicts(reconciledPlan, workflow);
 
 	const retainedFixtureEntries = Object.entries(buildOutcome.simulationFixtures ?? {}).filter(
 		([nodeName]) =>

--- a/packages/@n8n/instance-ai/src/tools/workflows/reconcile-simulation-plan.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/reconcile-simulation-plan.ts
@@ -159,8 +159,7 @@ export async function reconcileSimulationPlan(args: {
 		}
 		return verdict;
 	});
-	// Fresh verdicts from re-classification drop `haltBranch`; re-derive it so a
-	// wait gate that stays simulated keeps halting instead of looping.
+	// Re-classification drops `haltBranch` — re-derive so a still-simulated gate keeps halting.
 	const nodeSimulationPlan = reconciledPlan && withWaitGateHaltVerdicts(reconciledPlan, workflow);
 
 	const retainedFixtureEntries = Object.entries(buildOutcome.simulationFixtures ?? {}).filter(

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-json-utils.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-json-utils.ts
@@ -48,6 +48,61 @@ export function isTriggerNodeType(nodeType: string | undefined): boolean {
 	return isCanonicalTriggerNodeType(nodeType);
 }
 
+/** Mid-flow node types that park the execution until an external resume. */
+const WAIT_GATE_NODE_TYPES = new Set(['n8n-nodes-base.wait', 'n8n-nodes-base.form']);
+
+/** Shared operation name of the send-and-wait resource operations (Gmail, Slack, …). */
+const SEND_AND_WAIT_OPERATION = 'sendAndWait';
+
+/**
+ * True for nodes that pause a live execution until a human responds —
+ * send-and-wait operations, the Wait node, and mid-flow Form pages. Pinning
+ * such a node removes the pause and replays the same canned response on every
+ * arrival, so a loop through it can never terminate.
+ */
+export function isWaitGateNode(node: WorkflowJSON['nodes'][number]): boolean {
+	if (WAIT_GATE_NODE_TYPES.has(node.type)) return true;
+	const parameters = isRecord(node.parameters) ? node.parameters : {};
+	return parameters.operation === SEND_AND_WAIT_OPERATION;
+}
+
+/**
+ * True when `nodeName` lies on a directed cycle — it can reach itself again by
+ * following outgoing connections of any type. Disabled nodes still forward
+ * data at runtime, so they stay part of the walk.
+ */
+export function nodeCanReachItself(json: WorkflowJSON, nodeName: string): boolean {
+	const adjacency = new Map<string, string[]>();
+	for (const [sourceName, connectionsByType] of Object.entries(json.connections ?? {})) {
+		if (!isRecord(connectionsByType)) continue;
+		const targets: string[] = [];
+		for (const groups of Object.values(connectionsByType)) {
+			if (!Array.isArray(groups)) continue;
+			for (const group of groups) {
+				if (!Array.isArray(group)) continue;
+				for (const connection of group) {
+					if (isRecord(connection) && typeof connection.node === 'string') {
+						targets.push(connection.node);
+					}
+				}
+			}
+		}
+		adjacency.set(sourceName, targets);
+	}
+
+	const queue = [...(adjacency.get(nodeName) ?? [])];
+	const visited = new Set<string>();
+	while (queue.length > 0) {
+		const current = queue.pop();
+		if (current === undefined) break;
+		if (current === nodeName) return true;
+		if (visited.has(current)) continue;
+		visited.add(current);
+		queue.push(...(adjacency.get(current) ?? []));
+	}
+	return false;
+}
+
 function extractWorkflowIdParameter(value: unknown): string | undefined {
 	const rawValue = isRecord(value) ? value.value : value;
 	if (typeof rawValue !== 'string') return undefined;

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-json-utils.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-json-utils.ts
@@ -54,12 +54,7 @@ const WAIT_GATE_NODE_TYPES = new Set(['n8n-nodes-base.wait', 'n8n-nodes-base.for
 /** Shared operation name of the send-and-wait resource operations (Gmail, Slack, …). */
 const SEND_AND_WAIT_OPERATION = 'sendAndWait';
 
-/**
- * True for nodes that pause a live execution until a human responds —
- * send-and-wait operations, the Wait node, and mid-flow Form pages. Pinning
- * such a node removes the pause and replays the same canned response on every
- * arrival, so a loop through it can never terminate.
- */
+/** True for nodes that pause a live execution until a human responds. */
 export function isWaitGateNode(node: WorkflowJSON['nodes'][number]): boolean {
 	if (WAIT_GATE_NODE_TYPES.has(node.type)) return true;
 	const parameters = isRecord(node.parameters) ? node.parameters : {};
@@ -67,9 +62,8 @@ export function isWaitGateNode(node: WorkflowJSON['nodes'][number]): boolean {
 }
 
 /**
- * True when `nodeName` lies on a directed cycle — it can reach itself again by
- * following outgoing connections of any type. Disabled nodes still forward
- * data at runtime, so they stay part of the walk.
+ * True when `nodeName` can reach itself by following outgoing connections of
+ * any type. Disabled nodes still forward data, so they stay in the walk.
  */
 export function nodeCanReachItself(json: WorkflowJSON, nodeName: string): boolean {
 	const adjacency = new Map<string, string[]>();

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -243,10 +243,9 @@ export const nodeSimulationVerdictSchema = z.object({
 	confidence: z.enum(['high', 'low']),
 	source: z.enum(['deterministic', 'llm', 'fallback']),
 	/**
-	 * Verification pins this node with ZERO items so the branch halts there.
-	 * Set for wait-gate nodes that can loop back into themselves: a pinned gate
-	 * cannot pause, so a fixture would re-run the loop with the same canned
-	 * response forever. Fixtures and overrides never apply to these nodes.
+	 * Verification pins this node with zero items so the branch halts there —
+	 * a pinned wait gate on a loop would replay the same decision forever.
+	 * Fixtures and overrides never apply to these nodes.
 	 */
 	haltBranch: z.boolean().optional(),
 });

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -242,6 +242,13 @@ export const nodeSimulationVerdictSchema = z.object({
 	reason: z.string(),
 	confidence: z.enum(['high', 'low']),
 	source: z.enum(['deterministic', 'llm', 'fallback']),
+	/**
+	 * Verification pins this node with ZERO items so the branch halts there.
+	 * Set for wait-gate nodes that can loop back into themselves: a pinned gate
+	 * cannot pause, so a fixture would re-run the loop with the same canned
+	 * response forever. Fixtures and overrides never apply to these nodes.
+	 */
+	haltBranch: z.boolean().optional(),
 });
 
 export type NodeSimulationVerdict = z.infer<typeof nodeSimulationVerdictSchema>;

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2980,7 +2980,22 @@ describe('createExecutionAdapter run()', () => {
 			saveManualExecutions: true,
 			saveDataSuccessExecution: 'all',
 			saveDataErrorExecution: 'all',
+			executionTimeout: 300,
 		});
+	});
+
+	it('bounds the execution inside the engine with the wait budget, capped at the max', async () => {
+		const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
+			id: 'wf-1',
+			nodes: [],
+		});
+
+		await adapter.run('wf-1', undefined, { timeout: 60_000 });
+		await adapter.run('wf-1', undefined, { timeout: 60 * 60 * 1000 });
+
+		const [firstRun, secondRun] = mockWorkflowRunner.run.mock.calls.map((call) => call[0]);
+		expect(firstRun.workflowData.settings?.executionTimeout).toBe(60);
+		expect(secondRun.workflowData.settings?.executionTimeout).toBe(600);
 	});
 
 	it('attaches Instance AI execution telemetry metadata to workflow runs', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1154,10 +1154,8 @@ export class InstanceAiAdapterService {
 							saveManualExecutions: true,
 							saveDataSuccessExecution: 'all',
 							saveDataErrorExecution: 'all',
-							// Enforce the wait budget inside the engine too: its soft-timeout
-							// check runs synchronously between node executions, so it still
-							// stops a fast all-pinned loop whose microtask churn starves the
-							// timer-based cancellation race below.
+							// Engine-side bound: checked between node executions, so it fires
+							// even when a fast pinned loop starves the timer-based cancel below.
 							executionTimeout: Math.ceil(timeoutMs / 1000),
 						},
 					},

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1136,6 +1136,8 @@ export class InstanceAiAdapterService {
 					? (nodes.find((n) => n.name === options.triggerNodeName) ?? findTriggerNode(nodes))
 					: findTriggerNode(nodes);
 
+				const timeoutMs = Math.min(options?.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+
 				// Force-save AI-initiated executions so that follow-up
 				// `executions(list/get/debug)` calls can read the result, regardless of
 				// instance-wide or per-workflow save settings. Manual mode is gated by
@@ -1152,6 +1154,11 @@ export class InstanceAiAdapterService {
 							saveManualExecutions: true,
 							saveDataSuccessExecution: 'all',
 							saveDataErrorExecution: 'all',
+							// Enforce the wait budget inside the engine too: its soft-timeout
+							// check runs synchronously between node executions, so it still
+							// stops a fast all-pinned loop whose microtask churn starves the
+							// timer-based cancellation race below.
+							executionTimeout: Math.ceil(timeoutMs / 1000),
 						},
 					},
 					userId: user.id,
@@ -1259,7 +1266,6 @@ export class InstanceAiAdapterService {
 					};
 
 					// Wait for completion with timeout / abort protection
-					const timeoutMs = Math.min(options?.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 					const abortSignal = options?.abortSignal;
 
 					if (activeExecutions.has(executionId)) {


### PR DESCRIPTION
## Summary

Build-time verification runs a just-built workflow with pin data covering every simulated node. When the workflow routes back into a **send-and-wait gate** (Gmail/Slack `sendAndWait`, Wait, mid-flow Form) — e.g. an email-approval loop with a revise branch — the pinned gate cannot pause and replays the same canned decision on every arrival. The revision cycle becomes a tight in-process loop: run data grows until the V8 heap limit kills the whole n8n instance (`FATAL ERROR: Ineffective mark-compacts near heap limit`). On the eval CI lanes this shows up as container OOM + restart and the chronic nightly failure of the `pre-publish-email-approval-loop` case since Jul 15 (regression window opened by #33896, which made schedule-triggered workflows execution-verifiable).

Two layers:

1. **Halt simulated wait gates that sit on a loop.** The simulation planner marks them `haltBranch`; verification pins them with **zero items** so the run stops at the gate — mirroring how a live gate pauses the execution. Fixture generation skips them, `fixtureOverrides` targeting them are refused with guidance, credential reconciliation re-derives the flag, and the verify result explains the expected stop instead of the generic "seed test data and re-run" coverage guidance. Gates **off** any loop keep today's fixture behavior, so plain approve→act workflows still get downstream verification.
2. **Enforce the wait budget inside the engine.** `executionService.run` now sets `settings.executionTimeout` on the ephemeral run data. The engine's soft-timeout check runs synchronously between node executions, so it also stops a fast all-pinned loop whose microtask churn starves the adapter's timer-based cancellation race — which is exactly how the runaway execution outlived its 5-minute cancel.

Why halt only gates on a loop: a live gate breaks a cycle by pausing; only a *pinned* gate removes that brake. A pinned gate inside a cycle can never change its answer, so the loop is unconditionally infinite.

## How to test

- Unit tests: `pnpm test plan-verification-simulation prepare-run analyze-result reconcile-simulation-plan workflow-json-utils` in `packages/@n8n/instance-ai`, and `pnpm test src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts` in `packages/cli`.
- Manual repro: with no Gmail/LinkedIn credentials, ask the AI builder for "Every day at 9am, use AI to write a LinkedIn post, email it to me via Gmail send-and-wait for approval; on a change request, revise and re-send for approval; publish only once approved", and let it verify the change-request path.
  - Before: the verification execution loops (execution row stuck `running`), the n8n process climbs to the heap limit within minutes and aborts.
  - After: verification stops at the gate in milliseconds, reports the halted gate + manual-test guidance, and the instance stays healthy.
- Eval: `pre-publish-email-approval-loop` (workflow-eval case), red on every master nightly since Jul 15 with the lane OOM signature. N=2 local run on this branch: **100% pass (14/14 trials — scenario + all 6 build expectations on both iterations)**. Build verification completed in 7–28 ms (previously an unbounded loop), scenario executions paused cleanly at the gate, and the backend stayed at ~0% CPU throughout.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-963

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
