### PR TITLE
feat(core): Make MCP clients aware of node groups (no-changelog)

### DIFF
--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/index.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/index.ts
@@ -3,4 +3,4 @@ export { ADDITIONAL_FUNCTIONS } from './additional-functions';
 export { WORKFLOW_RULES } from './workflow-rules';
 export { WORKFLOW_SDK_PATTERNS } from './workflow-patterns';
 export { WORKFLOW_PATTERNS_DETAILED } from './workflow-patterns-detailed';
-export { SDK_LANGUAGE_REFERENCE } from './sdk-language';
+export { NODE_GROUPS_REFERENCE, SDK_LANGUAGE_REFERENCE } from './sdk-language';

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -1,4 +1,4 @@
-import { SDK_LANGUAGE_REFERENCE } from './sdk-language';
+import { NODE_GROUPS_REFERENCE, SDK_LANGUAGE_REFERENCE } from './sdk-language';
 import {
 	SDK_METHODS,
 	FORBIDDEN_NODE_TYPES,
@@ -68,5 +68,67 @@ describe('SDK_LANGUAGE_REFERENCE rendering', () => {
 	it('steers runtime logic to a Code node or expression', () => {
 		expect(SDK_LANGUAGE_REFERENCE).toContain('Code node');
 		expect(SDK_LANGUAGE_REFERENCE).toContain("expr('{{ ... }}')");
+	});
+});
+
+describe('NODE_GROUPS_REFERENCE', () => {
+	it('explains what a group is (visual-only) and how to declare one', () => {
+		expect(NODE_GROUPS_REFERENCE).toContain('## Node groups');
+		expect(NODE_GROUPS_REFERENCE).toMatch(/visual/i);
+	});
+
+	it('explains how to declare a group', () => {
+		// The worked example: .group(name, [members]) declared on the workflow.
+		expect(NODE_GROUPS_REFERENCE).toMatch(/\.group\('[^']+', \[/);
+	});
+
+	it('does not claim a single-entry/single-exit rule the server does not enforce', () => {
+		// That check lives in validateNodeSelectionForExtraction, not group validation.
+		expect(NODE_GROUPS_REFERENCE).not.toMatch(/single (entry|exit)/i);
+		expect(NODE_GROUPS_REFERENCE).not.toMatch(
+			/(one|exactly one) (entry|exit|input|output) (node|point)/i,
+		);
+	});
+
+	it('is embedded verbatim in the IAI-facing full reference', () => {
+		// Guarantees Instance AI ships exactly the shared constant, no drift.
+		expect(SDK_LANGUAGE_REFERENCE).toContain(NODE_GROUPS_REFERENCE);
+	});
+
+	describe('rules for valid groups', () => {
+		it('states the no-trigger rule', () => {
+			// reason: 'trigger-selected'
+			expect(NODE_GROUPS_REFERENCE).toMatch(/trigger nodes? (cannot|can't|may not|must not)/i);
+		});
+
+		it('states the single-connected-subgraph rule', () => {
+			// reason: 'invalid-subgraph' — one connected chunk, not two islands.
+			expect(NODE_GROUPS_REFERENCE).toMatch(/single connected|one connected/i);
+		});
+
+		it('states the AI-Agent-and-sub-nodes-together rule in plain terms', () => {
+			// reason: 'non-main-boundary' — an ai_languageModel/ai_tool/ai_memory wire
+			// must not cross the group boundary, so an Agent and its sub-nodes are
+			// either all in or all out.
+			expect(NODE_GROUPS_REFERENCE).toMatch(/agent/i);
+			expect(NODE_GROUPS_REFERENCE).toMatch(/all (inside|in).*all (outside|out)/is);
+		});
+
+		it('states the one-group-per-node rule', () => {
+			// A node belongs to at most one group.
+			expect(NODE_GROUPS_REFERENCE).toMatch(
+				/only one group|at most one group|one group at a time/i,
+			);
+		});
+
+		it('states the unique-name-and-id rule', () => {
+			expect(NODE_GROUPS_REFERENCE).toMatch(
+				/names? and ids?[^.]*unique|unique[^.]*names? and ids?/i,
+			);
+		});
+
+		it('states the at-least-one-member rule', () => {
+			expect(NODE_GROUPS_REFERENCE).toMatch(/at least one (node|member)/i);
+		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -82,12 +82,16 @@ describe('NODE_GROUPS_REFERENCE', () => {
 		expect(NODE_GROUPS_REFERENCE).toMatch(/\.group\('[^']+', \[/);
 	});
 
-	it('does not claim a single-entry/single-exit rule the server does not enforce', () => {
-		// That check lives in validateNodeSelectionForExtraction, not group validation.
-		expect(NODE_GROUPS_REFERENCE).not.toMatch(/single (entry|exit)/i);
-		expect(NODE_GROUPS_REFERENCE).not.toMatch(
-			/(one|exactly one) (entry|exit|input|output) (node|point)/i,
-		);
+	it('states the single entry/exit boundary rule that grouping enforces', () => {
+		// reason: 'invalid-subgraph' — grouping rejects a group with more than one
+		// incoming or outgoing main connection (single entry/exit *boundary*).
+		expect(NODE_GROUPS_REFERENCE).toMatch(/single entry and exit/i);
+		expect(NODE_GROUPS_REFERENCE).toMatch(/incoming and one outgoing main connection/i);
+	});
+
+	it('does not claim the extraction-only per-node single-main-port rule', () => {
+		// `multiple-input/-output-branches` is extraction-only, never fired by grouping.
+		expect(NODE_GROUPS_REFERENCE).not.toMatch(/input branch|output branch/i);
 	});
 
 	it('is embedded verbatim in the IAI-facing full reference', () => {

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -52,6 +52,54 @@ const SAFE_METHODS_SENTENCE =
 	`and the string methods ${SAFE_STRING_METHOD_NAMES.map((n) => `\`.${n}()\``).join(', ')}. ` +
 	'Native array/string methods such as `.join()`, `.map()`, `.filter()`, `.reduce()`, and `.split()` are NOT available.';
 
+/**
+ * Node-groups documentation, extracted so consumers can import just this section
+ * without the whole builder-language reference. Shared by Instance AI (embedded
+ * in `SDK_LANGUAGE_REFERENCE` below) and the MCP `get_sdk_reference` tool.
+ *
+ * The rules stated here must match what the server enforces on save:
+ * - basic rules: `validateWorkflowNodeGroups`
+ * - structural rules: `validateNodeSelectionForGrouping`
+ * Save-time validation does NOT require a single entry/exit node (that lives in
+ * `validateNodeSelectionForExtraction`), so this doc must not claim it does.
+ */
+export const NODE_GROUPS_REFERENCE = `## Node groups
+
+A node group is a named, visual grouping of nodes (a frame on the canvas). It is
+purely organisational — nothing about execution depends on it. Declare one with
+\`.group(name, members)\` on the workflow. Members are the node handles (the
+\`const\` from \`node(...)\`) — the same way connections reference nodes:
+
+\`\`\`typescript
+const fetch = node({ /* ... name: 'Fetch data' */ });
+const transform = node({ /* ... name: 'Transform' */ });
+export default workflow('id', 'My workflow')
+  .add(fetch)
+  .to(transform)
+  .group('Ingestion', [fetch, transform]);
+\`\`\`
+
+When editing an existing workflow, **keep the \`.group(...)\` calls intact** unless
+the change is specifically about grouping.
+
+an invalid group is rejected on save, so these following rules MUST be followed when
+creating or editing groups.
+
+Rules:
+- **No trigger nodes.** Trigger nodes cannot be part of a group.
+- **One connected section.** Members must form a single connected chain of the
+  graph, not two unrelated islands with a gap between them.
+- **Keep AI sub-nodes with their Agent.** If an AI Agent is in a group, its
+  language-model, tool, and memory sub-nodes belong in the same group — put them
+  either all inside the group or all outside it, never split. A model/tool/memory
+  connection must not cross the group boundary.
+- **One group per node.** A node can belong to only one group at a time.
+- **Unique identity.** Group names and ids must be unique within the workflow.
+- **Non-empty.** A group needs at least one node.
+
+Prefer grouping a linear range of nodes — they read most clearly — but that is a
+readability guideline, not a rule the server enforces.`;
+
 /** Full reference, materialized into the knowledge base for on-demand reading. */
 export const SDK_LANGUAGE_REFERENCE = `# Workflow SDK language reference
 
@@ -66,25 +114,7 @@ ${renderMethodLines()}
 
 ${SAFE_METHODS_SENTENCE}
 
-## Node groups
-
-A node group is a named, visual grouping of nodes (a frame on the canvas).
-Declare one with \`.group(name, members)\` on the workflow. Members are the node
-handles (the \`const\` from \`node(...)\`) — the same way connections reference nodes:
-
-\`\`\`typescript
-const fetch = node({ /* ... name: 'Fetch data' */ });
-const transform = node({ /* ... name: 'Transform' */ });
-export default workflow('id', 'My workflow')
-  .add(fetch)
-  .to(transform)
-  .group('Ingestion', [fetch, transform]);
-\`\`\`
-
-When editing an existing workflow, **keep the \`.group(...)\` calls intact** unless
-the change is specifically about grouping. Group members must form a single
-connected section of the graph and cannot be trigger nodes; an invalid group is
-rejected on save.
+${NODE_GROUPS_REFERENCE}
 
 ## Forbidden constructs
 

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -87,8 +87,9 @@ creating or editing groups.
 
 Rules:
 - **No trigger nodes.** Trigger nodes cannot be part of a group.
-- **One connected section.** Members must form a single connected chain of the
-  graph, not two unrelated islands with a gap between them.
+- **One connected section.** Connectable members must form a single connected section of the
+  graph, not two unrelated islands with a gap between them; sticky notes may accompany
+  the selection without participating in connectivity, and a sticky-only group is valid.
 - **Keep AI sub-nodes with their Agent.** If an AI Agent is in a group, its
   language-model, tool, and memory sub-nodes belong in the same group — put them
   either all inside the group or all outside it, never split. A model/tool/memory

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -2,6 +2,8 @@
  * Builder-facing SDK language reference, rendered from the interpreter's own
  * tables so guidance cannot drift from what the parser accepts.
  */
+import { NODE_GROUPING_RULES } from 'n8n-workflow';
+
 import {
 	SDK_METHODS,
 	FORBIDDEN_NODE_TYPES,
@@ -58,10 +60,16 @@ const SAFE_METHODS_SENTENCE =
  * in `SDK_LANGUAGE_REFERENCE` below) and the MCP `get_sdk_reference` tool.
  *
  * The rules stated here must match what the server enforces on save:
- * - basic rules: `validateWorkflowNodeGroups`
+ * - basic rules (unique id/name, non-empty): `validateWorkflowGroups`
  * - structural rules: `validateNodeSelectionForGrouping`
- * Save-time validation does NOT require a single entry/exit node (that lives in
- * `validateNodeSelectionForExtraction`), so this doc must not claim it does.
+ * The four structural rules (and their save-path rejection messages) are sourced
+ * from the shared `NODE_GROUPING_RULES` constant in `n8n-workflow`, so this doc,
+ * the canvas, and the save path share one definition.
+ *
+ * Grouping DOES enforce a single entry/exit *boundary* (at most one incoming and
+ * one outgoing main connection) via the `invalid-subgraph` rule. The stricter
+ * per-node single-main-port check (`multiple-input/-output-branches`) is
+ * extraction-only (`validateNodeSelectionForExtraction`) and is not stated here.
  */
 export const NODE_GROUPS_REFERENCE = `## Node groups
 
@@ -86,15 +94,10 @@ an invalid group is rejected on save, so these following rules MUST be followed 
 creating or editing groups.
 
 Rules:
-- **No trigger nodes.** Trigger nodes cannot be part of a group.
-- **One connected section.** Connectable members must form a single connected section of the
-  graph, not two unrelated islands with a gap between them; sticky notes may accompany
-  the selection without participating in connectivity, and a sticky-only group is valid.
-- **Keep AI sub-nodes with their Agent.** If an AI Agent is in a group, its
-  language-model, tool, and memory sub-nodes belong in the same group — put them
-  either all inside the group or all outside it, never split. A model/tool/memory
-  connection must not cross the group boundary.
-- **One group per node.** A node can belong to only one group at a time.
+- ${NODE_GROUPING_RULES.triggerSelected.sdkReference}
+- ${NODE_GROUPING_RULES.invalidSubgraph.sdkReference}
+- ${NODE_GROUPING_RULES.nonMainBoundary.sdkReference}
+- ${NODE_GROUPING_RULES.nodeAlreadyGrouped.sdkReference}
 - **Unique identity.** Group names and ids must be unique within the workflow.
 - **Non-empty.** A group needs at least one node.
 

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -23,6 +23,17 @@ const GROUP_LABELS: Record<Exclude<SdkMethodGroup, 'internal'>, string> = {
 
 const PUBLIC_METHODS = SDK_METHODS.filter((m) => m.public);
 
+function renderRulesLines(): string {
+	return [
+		...Object.values(NODE_GROUPING_RULES).map((r) => `- ${r.sdkReference}`),
+		'- **Unique identity.** Group names and ids must be unique within the workflow.',
+		'- **Non-empty.** A group needs at least one node.',
+		'',
+		'Prefer grouping a linear range of nodes — they read most clearly — but that is a',
+		'readability guideline, not a rule the server enforces.',
+	].join('\n');
+}
+
 function renderMethodLines(): string {
 	return (Object.keys(GROUP_LABELS) as Array<keyof typeof GROUP_LABELS>)
 		.map((group) => {
@@ -94,15 +105,8 @@ an invalid group is rejected on save, so these following rules MUST be followed 
 creating or editing groups.
 
 Rules:
-- ${NODE_GROUPING_RULES.triggerSelected.sdkReference}
-- ${NODE_GROUPING_RULES.invalidSubgraph.sdkReference}
-- ${NODE_GROUPING_RULES.nonMainBoundary.sdkReference}
-- ${NODE_GROUPING_RULES.nodeAlreadyGrouped.sdkReference}
-- **Unique identity.** Group names and ids must be unique within the workflow.
-- **Non-empty.** A group needs at least one node.
-
-Prefer grouping a linear range of nodes — they read most clearly — but that is a
-readability guideline, not a rule the server enforces.`;
+${renderRulesLines()}
+`;
 
 /** Full reference, materialized into the knowledge base for on-demand reading. */
 export const SDK_LANGUAGE_REFERENCE = `# Workflow SDK language reference

--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts
@@ -28,7 +28,11 @@ describe('get-workflow-best-practices MCP tool', () => {
 		telemetry = mock<Telemetry>();
 	});
 
-	const createTool = () => createGetWorkflowBestPracticesTool(user, telemetry);
+	const createTool = (canvasGroupsEnabled = false) =>
+		createGetWorkflowBestPracticesTool(user, telemetry, { canvasGroupsEnabled });
+
+	const textOf = (result: { content: Array<{ type: string; text?: string }> }) =>
+		result.content.map((c) => c.text ?? '').join('\n');
 
 	test('exposes the expected tool name and read-only annotations', () => {
 		const tool = createTool();
@@ -98,5 +102,33 @@ describe('get-workflow-best-practices MCP tool', () => {
 		expect(result.structuredContent?.technique).toBe(WorkflowTechnique.MONITORING);
 		expect(result.structuredContent?.documentation).toBeUndefined();
 		expect(result.structuredContent?.message).toContain('does not have detailed best-practices');
+	});
+
+	describe('node grouping guidance', () => {
+		const listText = async (canvasGroupsEnabled: boolean) => {
+			const result = await createTool(canvasGroupsEnabled).handler(
+				{ technique: 'list' },
+				{} as never,
+			);
+			return textOf(result);
+		};
+
+		describe('when canvasGroupsEnabled is true', () => {
+			test('appends a grouping guidance section to the technique list', async () => {
+				const text = await listText(true);
+
+				expect(text).toContain('## Grouping');
+				expect(text).toMatch(/sub-workflow/i); // groups vs sub-workflows
+				expect(text).toMatch(/collapsed/i); // created collapsed by default
+			});
+		});
+
+		describe('when canvasGroupsEnabled is false', () => {
+			test('does not mention grouping in the technique list', async () => {
+				const text = await listText(false);
+
+				expect(text).not.toContain('## Grouping');
+			});
+		});
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-sdk-reference.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-sdk-reference.tool.test.ts
@@ -1,6 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { User } from '@n8n/db';
 import {
+	NODE_GROUPS_REFERENCE,
 	WORKFLOW_PATTERNS_DETAILED,
 	WORKFLOW_SDK_PATTERNS,
 } from '@n8n/workflow-sdk/prompts/sdk-reference';
@@ -52,7 +53,7 @@ describe('get-workflow-sdk-reference MCP tool', () => {
 	});
 
 	test('accepts patterns_detailed as a tool section', async () => {
-		const tool = createGetWorkflowSdkReferenceTool(user, telemetry);
+		const tool = createGetWorkflowSdkReferenceTool(user, telemetry, { canvasGroupsEnabled: false });
 		const sectionSchema = tool.config.inputSchema?.section;
 
 		expect(tool.config.description).toContain('Required reference');
@@ -66,6 +67,79 @@ describe('get-workflow-sdk-reference MCP tool', () => {
 
 		expect(result.structuredContent).toEqual({
 			reference: getSdkReferenceContent('patterns_detailed'),
+		});
+	});
+
+	describe('node groups (canvasGroupsEnabled)', () => {
+		describe('getSdkReferenceContent', () => {
+			test('embeds verbatim the exact shared contents with the IAI in the full reference when enabled', () => {
+				expect(getSdkReferenceContent(undefined, { includeGroups: true })).toContain(
+					NODE_GROUPS_REFERENCE,
+				);
+			});
+
+			test('returns only the group section for section="groups" when enabled', () => {
+				const content = getSdkReferenceContent('groups', { includeGroups: true });
+
+				expect(content).toContain(NODE_GROUPS_REFERENCE);
+				// Just the group section — not the rest of the reference.
+				expect(content).not.toContain('## Workflow Patterns');
+				expect(content).not.toContain('<zero_item_safety>');
+			});
+
+			test('omits the groups description when disabled, leaving today’s output unchanged', () => {
+				const withFlagOff = getSdkReferenceContent(undefined, { includeGroups: false });
+
+				expect(withFlagOff).not.toContain(NODE_GROUPS_REFERENCE);
+
+				expect(withFlagOff).toBe(getSdkReferenceContent());
+			});
+
+			test('section="groups" yields no group content when disabled', () => {
+				expect(getSdkReferenceContent('groups', { includeGroups: false })).not.toContain(
+					NODE_GROUPS_REFERENCE,
+				);
+			});
+		});
+
+		describe('createGetWorkflowSdkReferenceTool', () => {
+			describe('When canvasGroupsEnabled is true', () => {
+				test('the tool accepts section="groups"', () => {
+					const enabled = createGetWorkflowSdkReferenceTool(user, telemetry, {
+						canvasGroupsEnabled: true,
+					});
+
+					expect(enabled.config.inputSchema?.section.safeParse('groups').success).toBe(true);
+				});
+
+				test('the tool handler serves the groups reference', async () => {
+					const enabled = createGetWorkflowSdkReferenceTool(user, telemetry, {
+						canvasGroupsEnabled: true,
+					});
+
+					const enabledResult = await enabled.handler({ section: 'groups' }, {} as never);
+					expect(enabledResult.structuredContent?.reference).toContain(NODE_GROUPS_REFERENCE);
+				});
+			});
+
+			describe('When canvasGroupsEnabled is false', () => {
+				test('the tool does not accept section="groups"', () => {
+					const disabled = createGetWorkflowSdkReferenceTool(user, telemetry, {
+						canvasGroupsEnabled: false,
+					});
+
+					expect(disabled.config.inputSchema?.section.safeParse('groups').success).toBe(false);
+				});
+
+				test('the tool handler does not serve the groups reference', async () => {
+					const disabled = createGetWorkflowSdkReferenceTool(user, telemetry, {
+						canvasGroupsEnabled: false,
+					});
+
+					const disabledResult = await disabled.handler({ section: undefined }, {} as never);
+					expect(disabledResult.structuredContent?.reference).not.toContain(NODE_GROUPS_REFERENCE);
+				});
+			});
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/mcp-instructions.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-instructions.test.ts
@@ -2,13 +2,16 @@ import { getMcpInstructions } from '../tools/workflow-builder/mcp-instructions';
 
 describe('getMcpInstructions', () => {
 	test('returns intro-only string when builder is disabled', () => {
-		const instructions = getMcpInstructions(false);
+		const instructions = getMcpInstructions({ isBuilderEnabled: false });
 		expect(instructions).toContain('official MCP server for n8n');
 		expect(instructions).not.toContain('n8nConnect');
 	});
 
 	test('includes n8n credits hint when builder is enabled and n8n Connect is available', () => {
-		const instructions = getMcpInstructions(true, true);
+		const instructions = getMcpInstructions({
+			isBuilderEnabled: true,
+			isN8nConnectAvailable: true,
+		});
 		expect(instructions).toContain('nodes covered by n8n credits');
 		expect(instructions).toContain('n8nConnect.nodes');
 		expect(instructions).toContain('n8n credits');
@@ -16,7 +19,10 @@ describe('getMcpInstructions', () => {
 	});
 
 	test('omits n8n credits hint when n8n Connect is not available', () => {
-		const instructions = getMcpInstructions(true, false);
+		const instructions = getMcpInstructions({
+			isBuilderEnabled: true,
+			isN8nConnectAvailable: false,
+		});
 		expect(instructions).toContain('official MCP server for n8n');
 		expect(instructions).not.toContain('n8n credits');
 		expect(instructions).not.toContain('n8nConnect');
@@ -24,7 +30,55 @@ describe('getMcpInstructions', () => {
 	});
 
 	test('omits n8n credits hint by default', () => {
-		const instructions = getMcpInstructions(true);
+		const instructions = getMcpInstructions({ isBuilderEnabled: true });
 		expect(instructions).not.toContain('n8n credits');
+	});
+
+	describe('node groups pointer', () => {
+		describe('when canvasGroupsEnabled is true', () => {
+			test('points the client to the groups reference', () => {
+				const instructions = getMcpInstructions({
+					isBuilderEnabled: true,
+					isN8nConnectAvailable: true,
+					canvasGroupsEnabled: true,
+				});
+
+				expect(instructions).toMatch(/group/i);
+				// Points at the on-demand groups section of the SDK reference.
+				expect(instructions).toContain('"groups"');
+			});
+
+			test('stays intro-only when the builder is disabled', () => {
+				const instructions = getMcpInstructions({
+					isBuilderEnabled: false,
+					isN8nConnectAvailable: false,
+					canvasGroupsEnabled: true,
+				});
+
+				expect(instructions).toContain('official MCP server for n8n');
+				expect(instructions).not.toContain('"groups"');
+			});
+		});
+
+		describe('when canvasGroupsEnabled is false', () => {
+			test('does not mention the groups reference', () => {
+				const instructions = getMcpInstructions({
+					isBuilderEnabled: true,
+					isN8nConnectAvailable: true,
+					canvasGroupsEnabled: false,
+				});
+
+				expect(instructions).not.toContain('"groups"');
+			});
+
+			test('omits the groups pointer by default', () => {
+				const instructions = getMcpInstructions({
+					isBuilderEnabled: true,
+					isN8nConnectAvailable: true,
+				});
+
+				expect(instructions).not.toContain('"groups"');
+			});
+		});
 	});
 });

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -274,7 +274,10 @@ export class McpService {
 				version: builderEnabled ? '1.1.0' : '1.0.0',
 			},
 			{
-				instructions: getMcpInstructions(builderInstructionsEnabled, n8nConnectAvailable),
+				instructions: getMcpInstructions({
+					isBuilderEnabled: builderInstructionsEnabled,
+					isN8nConnectAvailable: n8nConnectAvailable,
+				}),
 			},
 		);
 

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -277,6 +277,7 @@ export class McpService {
 				instructions: getMcpInstructions({
 					isBuilderEnabled: builderInstructionsEnabled,
 					isN8nConnectAvailable: n8nConnectAvailable,
+					canvasGroupsEnabled: featureFlags.canvasGroupsEnabled,
 				}),
 			},
 		);

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -606,19 +606,21 @@ export class McpService {
 		registerIfAllowed(restoreVersionTool);
 
 		// SDK reference as MCP resource — for clients that support resources.
-		server.resource(
+		server.registerResource(
 			'workflow-sdk-reference',
 			'n8n://workflow-sdk/reference',
 			{
 				description:
 					'Required n8n Workflow SDK reference for building workflows from code. Read this before writing workflow code.',
 			},
-			async () => ({
+			() => ({
 				contents: [
 					{
 						uri: 'n8n://workflow-sdk/reference',
 						mimeType: 'text/plain',
-						text: getSdkReferenceContent(),
+						text: getSdkReferenceContent(undefined, {
+							includeGroups: featureFlags.canvasGroupsEnabled,
+						}),
 					},
 				],
 			}),
@@ -626,7 +628,9 @@ export class McpService {
 
 		// SDK reference tool — always registered alongside the MCP resource above,
 		// so all clients can access the SDK reference regardless of resource support.
-		const sdkRefTool = createGetWorkflowSdkReferenceTool(user, this.telemetry);
+		const sdkRefTool = createGetWorkflowSdkReferenceTool(user, this.telemetry, {
+			canvasGroupsEnabled: featureFlags.canvasGroupsEnabled,
+		});
 		registerIfAllowed(sdkRefTool);
 	}
 

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -34,36 +34,6 @@ import { ExecutionService } from '@/executions/execution.service';
 import { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks/subworkflow-policy-checker';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { NodeCatalogService } from '@/node-catalog';
-
-import { createExecuteWorkflowTool } from './tools/execute-workflow.tool';
-import { createGetExecutionTool } from './tools/get-execution.tool';
-import { createSearchExecutionsTool } from './tools/search-executions.tool';
-import { createWorkflowDetailsTool } from './tools/get-workflow-details.tool';
-import { createGetWorkflowHistoryTool } from './tools/get-workflow-history.tool';
-import { createGetWorkflowVersionTool } from './tools/get-workflow-version.tool';
-import { createListN8nConnectServicesTool } from './tools/list-n8n-connect-services.tool';
-import { createListCredentialsTool } from './tools/list-credentials.tool';
-import { createListTagsTool } from './tools/list-tags.tool';
-import { createPublishWorkflowTool } from './tools/publish-workflow.tool';
-import { createSearchFoldersTool } from './tools/search-folders.tool';
-import { createSearchProjectsTool } from './tools/search-projects.tool';
-import { createSearchWorkflowsTool } from './tools/search-workflows.tool';
-import { createUnpublishWorkflowTool } from './tools/unpublish-workflow.tool';
-import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL } from './tools/workflow-builder/constants';
-import { createCreateWorkflowFromCodeTool } from './tools/workflow-builder/create-workflow-from-code.tool';
-import { createArchiveWorkflowTool } from './tools/workflow-builder/delete-workflow.tool';
-import { createExploreNodeResourcesTool } from './tools/workflow-builder/explore-node-resources.tool';
-import { createUpdateWorkflowTool } from './tools/workflow-builder/update-workflow.tool';
-import { createRestoreWorkflowVersionTool } from './tools/workflow-builder/restore-workflow-version.tool';
-import { createGetWorkflowBestPracticesTool } from './tools/workflow-builder/get-workflow-best-practices.tool';
-import { createGetWorkflowNodeTypesTool } from './tools/workflow-builder/get-workflow-node-types.tool';
-import { createGetWorkflowSdkReferenceTool } from './tools/workflow-builder/get-workflow-sdk-reference.tool';
-import { getMcpInstructions } from './tools/workflow-builder/mcp-instructions';
-import { createSearchWorkflowNodesTool } from './tools/workflow-builder/search-workflow-nodes.tool';
-import { getSdkReferenceContent } from './tools/workflow-builder/sdk-reference-content';
-import { createValidateNodeTool } from './tools/workflow-builder/validate-node.tool';
-import { createValidateWorkflowCodeTool } from './tools/workflow-builder/validate-workflow-code.tool';
-
 import { NodeTypes } from '@/node-types';
 import { PostHogClient } from '@/posthog';
 import { AiGatewayService } from '@/services/ai-gateway.service';
@@ -80,8 +50,8 @@ import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-hi
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 
-import { MCP_PREVIEW_RENDER_REQUESTED_EVENT } from './mcp.constants';
 import { getAllowedToolNames } from './mcp-scopes';
+import { MCP_PREVIEW_RENDER_REQUESTED_EVENT } from './mcp.constants';
 import type { McpAppsTelemetryVariant, McpClientInfo, RegisterToolFn } from './mcp.types';
 import {
 	createAddDataTableColumnTool,
@@ -92,8 +62,36 @@ import {
 	createRenameDataTableTool,
 	createSearchDataTablesTool,
 } from './tools/data-table';
+import { createExecuteWorkflowTool } from './tools/execute-workflow.tool';
+import { createGetExecutionTool } from './tools/get-execution.tool';
+import { createWorkflowDetailsTool } from './tools/get-workflow-details.tool';
+import { createGetWorkflowHistoryTool } from './tools/get-workflow-history.tool';
+import { createGetWorkflowVersionTool } from './tools/get-workflow-version.tool';
+import { createListCredentialsTool } from './tools/list-credentials.tool';
+import { createListN8nConnectServicesTool } from './tools/list-n8n-connect-services.tool';
+import { createListTagsTool } from './tools/list-tags.tool';
 import { createPrepareTestPinDataTool } from './tools/prepare-workflow-pin-data.tool';
+import { createPublishWorkflowTool } from './tools/publish-workflow.tool';
+import { createSearchExecutionsTool } from './tools/search-executions.tool';
+import { createSearchFoldersTool } from './tools/search-folders.tool';
+import { createSearchProjectsTool } from './tools/search-projects.tool';
+import { createSearchWorkflowsTool } from './tools/search-workflows.tool';
 import { createTestWorkflowTool } from './tools/test-workflow.tool';
+import { createUnpublishWorkflowTool } from './tools/unpublish-workflow.tool';
+import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL } from './tools/workflow-builder/constants';
+import { createCreateWorkflowFromCodeTool } from './tools/workflow-builder/create-workflow-from-code.tool';
+import { createArchiveWorkflowTool } from './tools/workflow-builder/delete-workflow.tool';
+import { createExploreNodeResourcesTool } from './tools/workflow-builder/explore-node-resources.tool';
+import { createGetWorkflowBestPracticesTool } from './tools/workflow-builder/get-workflow-best-practices.tool';
+import { createGetWorkflowNodeTypesTool } from './tools/workflow-builder/get-workflow-node-types.tool';
+import { createGetWorkflowSdkReferenceTool } from './tools/workflow-builder/get-workflow-sdk-reference.tool';
+import { getMcpInstructions } from './tools/workflow-builder/mcp-instructions';
+import { createRestoreWorkflowVersionTool } from './tools/workflow-builder/restore-workflow-version.tool';
+import { getSdkReferenceContent } from './tools/workflow-builder/sdk-reference-content';
+import { createSearchWorkflowNodesTool } from './tools/workflow-builder/search-workflow-nodes.tool';
+import { createUpdateWorkflowTool } from './tools/workflow-builder/update-workflow.tool';
+import { createValidateNodeTool } from './tools/workflow-builder/validate-node.tool';
+import { createValidateWorkflowCodeTool } from './tools/workflow-builder/validate-workflow-code.tool';
 
 /**
  * Pending MCP execution response, used for queue mode support.
@@ -486,7 +484,9 @@ export class McpService {
 		);
 		registerIfAllowed(getNodeTypesTool);
 
-		const bestPracticesTool = createGetWorkflowBestPracticesTool(user, this.telemetry);
+		const bestPracticesTool = createGetWorkflowBestPracticesTool(user, this.telemetry, {
+			canvasGroupsEnabled: featureFlags.canvasGroupsEnabled,
+		});
 		registerIfAllowed(bestPracticesTool);
 
 		const exploreNodeResourcesTool = createExploreNodeResourcesTool(

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
@@ -15,6 +15,23 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.ty
 
 const LIST_SENTINEL = 'list';
 
+/**
+ * Grouping judgement guidance, appended to the technique list when the canvas
+ * groups feature flag is on. Covers *when* to group; the exact rules live in the
+ * SDK reference's "groups" section (see `NODE_GROUPS_REFERENCE`).
+ */
+const GROUPING_GUIDANCE = `## Grouping
+
+Organise larger workflows into named node groups — visual frames drawn on the canvas — so the result is readable the first time the user sees it.
+
+- **When to group:** workflows of roughly 6+ nodes that split into clear stages (e.g. ingest → transform → deliver). Give each stage its own group.
+- **When not to group:** small workflows (2-3 nodes); a group there is just noise.
+- **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is a separately-executed, reusable unit. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
+- **Naming:** short, outcome-first titles ("Fetch new recordings", not "HTTP + Drive").
+- Groups are created collapsed by default, so the name is what the user sees first — make it descriptive.
+
+Fetch the "groups" section of the SDK reference for the exact rules before creating groups.`;
+
 const inputSchema = {
 	technique: z
 		.union([z.nativeEnum(WorkflowTechnique), z.literal(LIST_SENTINEL)])
@@ -46,7 +63,7 @@ const outputSchema = {
 		.describe('All available techniques, returned when "list" was requested.'),
 } satisfies z.ZodRawShape;
 
-function buildListResponse() {
+function buildListResponse(canvasGroupsEnabled: boolean) {
 	const availableTechniques = Object.entries(TechniqueDescription).map(([key, description]) => ({
 		technique: key,
 		description,
@@ -63,6 +80,9 @@ function buildListResponse() {
 			(t) =>
 				`- ${t.technique}${t.hasDocumentation ? '' : ' (no detailed documentation yet)'} — ${t.description}`,
 		),
+		// Grouping guidance is flag-gated and appended last, so flag-off output is
+		// unchanged.
+		...(canvasGroupsEnabled ? ['', GROUPING_GUIDANCE] : []),
 	].join('\n');
 
 	return {
@@ -104,6 +124,7 @@ function buildTechniqueResponse(technique: WorkflowTechniqueType) {
 export const createGetWorkflowBestPracticesTool = (
 	user: User,
 	telemetry: Telemetry,
+	{ canvasGroupsEnabled }: { canvasGroupsEnabled: boolean },
 ): ToolDefinition<typeof inputSchema> => ({
 	name: MCP_GET_WORKFLOW_BEST_PRACTICES_TOOL.toolName,
 	config: {
@@ -128,7 +149,9 @@ export const createGetWorkflowBestPracticesTool = (
 
 		try {
 			const response =
-				technique === LIST_SENTINEL ? buildListResponse() : buildTechniqueResponse(technique);
+				technique === LIST_SENTINEL
+					? buildListResponse(canvasGroupsEnabled)
+					: buildTechniqueResponse(technique);
 
 			telemetryPayload.results = {
 				success: true,

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
@@ -24,8 +24,7 @@ const GROUPING_GUIDANCE = `## Grouping
 
 Organise larger workflows into named node groups — visual frames drawn on the canvas — so the result is readable the first time the user sees it.
 
-- **When to group:** workflows of roughly 6+ nodes that split into clear stages (e.g. ingest → transform → deliver). Give each stage its own group.
-- **When not to group:** small workflows (2-3 nodes); a group there is just noise.
+- **When to group:** larger workflows that split into clear stages (e.g. ingest → transform → deliver). Give each stage its own group. Small workflows don't need groups — a group there is just noise.
 - **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is a separately-executed, reusable unit. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
 - **Naming:** short, outcome-first titles ("Fetch new recordings", not "HTTP + Drive").
 - Groups are created collapsed by default, so the name is what the user sees first — make it descriptive.

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-sdk-reference.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-sdk-reference.tool.ts
@@ -8,7 +8,7 @@ import { getSdkReferenceContent, type SdkReferenceSection } from './sdk-referenc
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 
-const VALID_SECTIONS: SdkReferenceSection[] = [
+const BASE_SECTIONS: SdkReferenceSection[] = [
 	'patterns',
 	'patterns_detailed',
 	'expressions',
@@ -20,14 +20,25 @@ const VALID_SECTIONS: SdkReferenceSection[] = [
 	'all',
 ];
 
-const inputSchema = {
-	section: z
-		.enum(VALID_SECTIONS as [string, ...string[]])
-		.optional()
-		.describe(
-			'Optional section to retrieve. Omit this for the full reference, or use a section for targeted lookup.',
-		),
-} satisfies z.ZodRawShape;
+// `'groups'` is only advertised (and accepted) when the canvas-groups flag is on,
+// so with the flag off the accepted `section` values are exactly what they were
+// before groups existed.
+const buildInputSchema = (canvasGroupsEnabled: boolean) => {
+	const validSections: SdkReferenceSection[] = canvasGroupsEnabled
+		? [...BASE_SECTIONS, 'groups']
+		: BASE_SECTIONS;
+
+	return {
+		section: z
+			.enum(validSections as [string, ...string[]])
+			.optional()
+			.describe(
+				'Optional section to retrieve. Omit this for the full reference, or use a section for targeted lookup.',
+			),
+	} satisfies z.ZodRawShape;
+};
+
+type SdkReferenceInputSchema = ReturnType<typeof buildInputSchema>;
 
 const outputSchema = {
 	reference: z.string().describe('SDK reference documentation content for the requested section'),
@@ -40,12 +51,13 @@ const outputSchema = {
 export const createGetWorkflowSdkReferenceTool = (
 	user: User,
 	telemetry: Telemetry,
-): ToolDefinition<typeof inputSchema> => ({
+	{ canvasGroupsEnabled }: { canvasGroupsEnabled: boolean },
+): ToolDefinition<SdkReferenceInputSchema> => ({
 	name: MCP_GET_SDK_REFERENCE_TOOL.toolName,
 	config: {
 		description:
 			'Required reference for building n8n Workflow SDK code. Call this BEFORE writing workflow code to learn workflow(), trigger()/node(), .add()/.to(), expr(), and credential patterns.',
-		inputSchema,
+		inputSchema: buildInputSchema(canvasGroupsEnabled),
 		outputSchema,
 		annotations: {
 			title: MCP_GET_SDK_REFERENCE_TOOL.displayTitle,
@@ -55,14 +67,16 @@ export const createGetWorkflowSdkReferenceTool = (
 			openWorldHint: false,
 		},
 	},
-	handler: async ({ section }: { section?: string }) => {
+	handler: ({ section }: { section?: string }) => {
 		const telemetryPayload: UserCalledMCPToolEventPayload = {
 			user_id: user.id,
 			tool_name: MCP_GET_SDK_REFERENCE_TOOL.toolName,
 			parameters: { section },
 		};
 
-		const content = getSdkReferenceContent(section as SdkReferenceSection | undefined);
+		const content = getSdkReferenceContent(section as SdkReferenceSection | undefined, {
+			includeGroups: canvasGroupsEnabled,
+		});
 
 		telemetryPayload.results = { success: true };
 		telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
@@ -32,10 +32,23 @@ export type McpInstructionsOptions = {
 	 * If true, the instructions will include a hint about n8n Connect coverage.
 	 */
 	isN8nConnectAvailable?: boolean;
+
+	/**
+	 * Whether canvas node groups are enabled for this user.
+	 * If true, the builder instructions point the client at the groups docs.
+	 */
+	canvasGroupsEnabled?: boolean;
 };
 export function getMcpInstructions(options: McpInstructionsOptions): string {
-	const { isBuilderEnabled, isN8nConnectAvailable = false } = options;
+	const { isBuilderEnabled, isN8nConnectAvailable = false, canvasGroupsEnabled = false } = options;
 	const INTRO = 'This is the official MCP server for n8n, a workflow automation platform.';
+
+	// Only appended when the flag is on; keeps the paid-per-session string short.
+	const GROUPS_HINT = canvasGroupsEnabled
+		? `
+
+Node groups: when a workflow has several distinct stages, organise it into named groups so it is readable on the canvas. Before creating groups, call ${MCP_GET_SDK_REFERENCE_TOOL.toolName} with section "groups" for the rules, and ${MCP_GET_WORKFLOW_BEST_PRACTICES_TOOL.toolName} (technique "list") for when to group.`
+		: '';
 
 	const N8N_CONNECT_HINT = isN8nConnectAvailable
 		? `

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
@@ -20,10 +20,21 @@ import {
 } from './constants';
 import { LIST_N8N_CONNECT_SERVICES_TOOL_NAME } from '../../mcp.constants';
 
-export function getMcpInstructions(
-	isBuilderEnabled: boolean,
-	isN8nConnectAvailable = false,
-): string {
+export type McpInstructionsOptions = {
+	/**
+	 * Whether the workflow builder tools are enabled on this MCP server.
+	 * If false, the instructions will be limited to a brief intro.
+	 */
+	isBuilderEnabled: boolean;
+
+	/**
+	 * Whether n8n Connect is available on this instance.
+	 * If true, the instructions will include a hint about n8n Connect coverage.
+	 */
+	isN8nConnectAvailable?: boolean;
+};
+export function getMcpInstructions(options: McpInstructionsOptions): string {
+	const { isBuilderEnabled, isN8nConnectAvailable = false } = options;
 	const INTRO = 'This is the official MCP server for n8n, a workflow automation platform.';
 
 	const N8N_CONNECT_HINT = isN8nConnectAvailable
@@ -58,7 +69,7 @@ To build n8n workflows, follow these steps in order:
 
 11. Archive: Call ${MCP_ARCHIVE_WORKFLOW_TOOL.toolName} with the workflow ID.
 
-Error handling has two complementary layers. (1) Per-node: set onError ("continueRegularOutput" / "continueErrorOutput"), retryOnFail, and maxTries via setNodeSettings on ${MCP_UPDATE_WORKFLOW_TOOL.toolName}. (2) Failure notifications via an Error Trigger node, which can be wired two ways: (a) Dedicated/shared error workflow — point settings.errorWorkflow (via the setWorkflowSettings operation) at a SEPARATE workflow whose first node is an Error Trigger; this is the common best practice and lets one handler cover many workflows. (b) Same-workflow — add an Error Trigger node (→ a notification node such as Send Email or Slack) INTO this workflow; n8n runs it automatically when the workflow fails, with no settings change needed. Caveats: both fire only for production executions (not manual/test runs), and a configured settings.errorWorkflow takes precedence over a same-workflow Error Trigger for the failing run. When a user asks to "add error handling", "get notified on failure", or "make this reliable", briefly explain both patterns — most users do not know Error Triggers exist — and ask which they prefer before setting one up; do not enable error handling silently. For the shared pattern, reuse an existing handler (find its ID with search_workflows) or create a new one — but a dedicated error workflow must be PUBLISHED before it can be linked, in this order: (1) create it (${MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName}, first node = Error Trigger → a notification node), (2) publish it (publish_workflow), (3) set settings.errorWorkflow via ${MCP_UPDATE_WORKFLOW_TOOL.toolName}. Setting settings.errorWorkflow is rejected if the target has no published version, or no Error Trigger in that published version.`;
+Error handling has two complementary layers. (1) Per-node: set onError ("continueRegularOutput" / "continueErrorOutput"), retryOnFail, and maxTries via setNodeSettings on ${MCP_UPDATE_WORKFLOW_TOOL.toolName}. (2) Failure notifications via an Error Trigger node, which can be wired two ways: (a) Dedicated/shared error workflow — point settings.errorWorkflow (via the setWorkflowSettings operation) at a SEPARATE workflow whose first node is an Error Trigger; this is the common best practice and lets one handler cover many workflows. (b) Same-workflow — add an Error Trigger node (→ a notification node such as Send Email or Slack) INTO this workflow; n8n runs it automatically when the workflow fails, with no settings change needed. Caveats: both fire only for production executions (not manual/test runs), and a configured settings.errorWorkflow takes precedence over a same-workflow Error Trigger for the failing run. When a user asks to "add error handling", "get notified on failure", or "make this reliable", briefly explain both patterns — most users do not know Error Triggers exist — and ask which they prefer before setting one up; do not enable error handling silently. For the shared pattern, reuse an existing handler (find its ID with search_workflows) or create a new one — but a dedicated error workflow must be PUBLISHED before it can be linked, in this order: (1) create it (${MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName}, first node = Error Trigger → a notification node), (2) publish it (publish_workflow), (3) set settings.errorWorkflow via ${MCP_UPDATE_WORKFLOW_TOOL.toolName}. Setting settings.errorWorkflow is rejected if the target has no published version, or no Error Trigger in that published version.${GROUPS_HINT}`;
 
 	return isBuilderEnabled ? `${INTRO}\n\n${BUILDER_INSTRUCTIONS}` : INTRO;
 }

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/sdk-reference-content.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/sdk-reference-content.ts
@@ -13,6 +13,7 @@ import {
 	WORKFLOW_PATTERNS_DETAILED,
 	ADDITIONAL_FUNCTIONS,
 	WORKFLOW_RULES,
+	NODE_GROUPS_REFERENCE,
 } from '@n8n/workflow-sdk/prompts/sdk-reference';
 
 // NOTE: CODING_GUIDELINES and DESIGN_GUIDANCE are MCP-only constants defined
@@ -57,6 +58,7 @@ export type SdkReferenceSection =
 	| 'import'
 	| 'guidelines'
 	| 'design'
+	| 'groups'
 	| 'all';
 
 const SDK_IMPORT_SECTION = `## SDK Import Statement\n\n\`\`\`javascript\n${SDK_IMPORT_STATEMENT}\n\`\`\``;
@@ -69,6 +71,10 @@ const CODING_GUIDELINES_SECTION = `## Coding Guidelines\n\n${CODING_GUIDELINES}`
 
 const DESIGN_GUIDANCE_SECTION = `## Design Guidance\n\n${DESIGN_GUIDANCE}`;
 
+// NODE_GROUPS_REFERENCE already carries its own `## Node groups` heading and is
+// shared verbatim with Instance AI, so it is served as-is (no extra wrapper).
+const GROUPS_SECTION = NODE_GROUPS_REFERENCE;
+
 const SECTIONS: Record<Exclude<SdkReferenceSection, 'all'>, string> = {
 	import: SDK_IMPORT_SECTION,
 	patterns: WORKFLOW_PATTERNS_SECTION,
@@ -78,12 +84,28 @@ const SECTIONS: Record<Exclude<SdkReferenceSection, 'all'>, string> = {
 	rules: WORKFLOW_RULES,
 	guidelines: CODING_GUIDELINES_SECTION,
 	design: DESIGN_GUIDANCE_SECTION,
+	groups: GROUPS_SECTION,
 };
 
 /**
  * Get the full SDK reference content or a filtered section.
+ *
+ * Node-group docs are gated behind `includeGroups` (fed from the
+ * `canvasGroupsEnabled` feature flag): when false, the groups section is omitted
+ * everywhere so the output is byte-identical to before the flag existed.
  */
-export function getSdkReferenceContent(section?: SdkReferenceSection): string {
+export function getSdkReferenceContent(
+	section?: SdkReferenceSection,
+	options: { includeGroups?: boolean } = {},
+): string {
+	const { includeGroups = false } = options;
+
+	// The groups section only exists when the flag is on; otherwise even an
+	// explicit request yields nothing.
+	if (section === 'groups') {
+		return includeGroups ? SECTIONS.groups : '';
+	}
+
 	if (section && section !== 'all' && section in SECTIONS) {
 		return SECTIONS[section];
 	}
@@ -106,5 +128,6 @@ export function getSdkReferenceContent(section?: SdkReferenceSection): string {
 		SECTIONS.guidelines,
 		'',
 		SECTIONS.design,
+		...(includeGroups ? ['', SECTIONS.groups] : []),
 	].join('\n');
 }

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -64,6 +64,45 @@ export type NodeGroupValidationResult<TNode extends INode = INode> =
 			connection: { source: string; target: string; type: string };
 	  };
 
+/**
+ * Single source of truth for the structural grouping rules, shared by three
+ * surfaces so they cannot drift:
+ * - `sdkReference`: the rule as stated in the SDK/MCP docs an agent reads.
+ * - `violation`: the fragment used in the save-path rejection message below.
+ *
+ * Only the four reasons `validateNodeSelectionForGrouping` can actually return
+ * live here. The per-node `multiple-input-branches` / `multiple-output-branches`
+ * checks are extraction-only (`validateNodeSelectionForExtraction`) and are
+ * deliberately absent — a group is never rejected for them.
+ */
+export const NODE_GROUPING_RULES = {
+	triggerSelected: {
+		sdkReference: '**No trigger nodes.** Trigger nodes cannot be part of a group.',
+		violation: 'cannot contain trigger nodes',
+	},
+	invalidSubgraph: {
+		sdkReference:
+			'**One connected section with a single entry and exit.** The connectable members must ' +
+			'form a single connected section of the graph — reachable from one another, not two ' +
+			'unrelated islands — with at most one incoming and one outgoing main connection crossing ' +
+			'the group boundary. Sticky notes may accompany the selection without participating in ' +
+			'connectivity, and a sticky-only group is valid.',
+		violation: 'must form a single connected subgraph with a single entry and exit',
+	},
+	nonMainBoundary: {
+		sdkReference:
+			'**Keep AI sub-nodes with their Agent.** If an AI Agent is in a group, its language-model, ' +
+			'tool, and memory sub-nodes belong in the same group — put them either all inside the group ' +
+			'or all outside it, never split. A model/tool/memory connection must not cross the group boundary.',
+		// Fragment: reads as `<label> cannot cross the "<type>" connection between "<a>" and "<b>".`
+		violation: 'cannot cross the',
+	},
+	nodeAlreadyGrouped: {
+		sdkReference: '**One group per node.** A node can belong to at most one group at a time.',
+		violation: 'contains nodes that already belong to another group',
+	},
+} as const;
+
 export function validateNodeSelectionForExtraction<TNode extends INode>(
 	input: NodeGroupingValidationInput<TNode>,
 ): NodeSelectionValidationResult<TNode> {
@@ -302,17 +341,18 @@ function groupRuleViolationMessage(
 	const label = `Node group "${group.name}" (${group.id})`;
 	switch (result.reason) {
 		case 'trigger-selected':
-			return `${label} cannot contain trigger nodes: ${result.triggers.join(', ')}.`;
+			return `${label} ${NODE_GROUPING_RULES.triggerSelected.violation}: ${result.triggers.join(', ')}.`;
 		case 'invalid-subgraph':
-			return `${label} must form a single connected subgraph with a single entry and exit.`;
+			return `${label} ${NODE_GROUPING_RULES.invalidSubgraph.violation}.`;
+		case 'node-already-grouped':
+			return `${label} ${NODE_GROUPING_RULES.nodeAlreadyGrouped.violation}: ${result.nodeIds.map(nodeLabel).join(', ')}.`;
+		case 'non-main-boundary':
+			return `${label} ${NODE_GROUPING_RULES.nonMainBoundary.violation} "${result.connection.type}" connection between "${result.connection.source}" and "${result.connection.target}".`;
+		// Extraction-only reasons; unreachable from grouping but required for exhaustiveness.
 		case 'multiple-input-branches':
 			return `${label} has multiple input branches at node "${result.node}".`;
 		case 'multiple-output-branches':
 			return `${label} has multiple output branches at node "${result.node}".`;
-		case 'node-already-grouped':
-			return `${label} contains nodes that already belong to another group: ${result.nodeIds.map(nodeLabel).join(', ')}.`;
-		case 'non-main-boundary':
-			return `${label} cannot cross the "${result.connection.type}" connection between "${result.connection.source}" and "${result.connection.target}".`;
 	}
 }
 


### PR DESCRIPTION
## Summary

Teaches MCP clients (Claude, Cursor, …) about **canvas node groups** so AI-built workflows come out organised and readable the first time. Today the MCP server can already create groups (via `update_workflow`), but none of the docs a client reads up-front mention them — so clients never group during the initial build and, when they try, don't know the rules and produce invalid groups that get rejected on save (wasted retries/tokens).

This is the documentation-and-enablement half of the Canvas Groups epic (Notion "Step 1"), covering **two sibling tickets in one PR**:

- **ADO-5620** — extract + expand the shared `NODE_GROUPS_REFERENCE` doc and serve it from `get_sdk_reference` (full reference + a new `section: "groups"`).
- **ADO-5628** — add grouping guidance to `get_workflow_best_practices` and a pointer in the MCP server `instructions`.

Two independent axes, kept separate:

1. **Shared doc constant** (`@n8n/workflow-sdk`) — extracted `NODE_GROUPS_REFERENCE` out of `SDK_LANGUAGE_REFERENCE` and expanded it to state every rule the server actually enforces on save (no triggers; single connected section; keep an AI Agent with its model/tool/memory sub-nodes; one group per node; unique names/ids; non-empty). Deliberately **not** flag-gated — Instance AI consumes this constant and its shipped `workflow-sdk-language.md` gains the same expanded rules. `SDK_LANGUAGE_REFERENCE` now interpolates the constant, so IAI's doc structure is unchanged apart from the intended rule expansion. The docs intentionally do **not** claim a single entry/exit rule, because save-time group validation does not enforce one.
2. **Whether MCP serves the group docs** — gated behind the **`canvasGroupsEnabled`** feature flag across all three surfaces. With the flag **off, every MCP surface is byte-identical to today** (`section: "groups"` isn't even an accepted value).

Also closes the loop so the docs aren't hollow: `create_workflow_from_code` now **persists `nodeGroups`** from the parsed SDK workflow onto the saved entity (previously dropped on create).

## How to test

Run n8n on this branch with the flag on (builder tools are on by default):

```bash
N8N_MCP_CANVAS_GROUPS_ENABLED=true pnpm dev
```

Connect an MCP client to the n8n MCP endpoint, then:

- Call `get_sdk_reference` with `section: "groups"` → returns just the Node groups section (the `.group(...)` example + the six rules).
- Call `get_sdk_reference` with no section → the full reference now contains a Node groups section.
- Call `get_workflow_best_practices` with `technique: "list"` → output ends with a `## Grouping` section (when to group, groups vs sub-workflows, naming, collapsed-by-default).
- The server `instructions` mention groups and point at the `"groups"` section.
- Ask the client to build a multi-stage workflow (e.g. *"every weekday 8am, fetch top Hacker News stories, summarise each with an AI model, then email + Slack the digest; organise it so it's readable"*). The created workflow should have named groups on the canvas, the trigger left ungrouped, and the AI model kept with its Agent — and it should save without a group-validation error.

**Flag-off regression:** restart with `N8N_MCP_CANVAS_GROUPS_ENABLED=false` (default) and reconnect → `section: "groups"` is rejected, no `## Grouping` in best-practices, instructions don't mention groups, and built workflows have no groups. Output matches `master`.

> Note: MCP clients read the tool list + `instructions` at connect time, so reconnect the client after toggling the flag.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-5620
- https://linear.app/n8n/issue/ADO-5628
- Parent: https://linear.app/n8n/issue/ADO-5577

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34810">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->