### PR TITLE
fix(core): Mount the MCP registry test seed endpoint whenever E2E tests are enabled (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-test.controller.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-test.controller.test.ts
@@ -68,10 +68,13 @@ describe('McpRegistryTestController', () => {
 			await expect(controller.seed()).rejects.toThrow(ForbiddenError);
 		});
 
-		it('should throw ForbiddenError in production even when E2E_TESTS is set', async () => {
+		it('should seed when NODE_ENV is production and E2E_TESTS is set', async () => {
 			process.env.NODE_ENV = 'production';
+			service.handleReloadMcpRegistry.mockResolvedValue();
 
-			await expect(controller.seed()).rejects.toThrow(ForbiddenError);
+			const result = await controller.seed();
+
+			expect(result).toEqual({ ok: true, count: 2 });
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp-registry/mcp-registry-test.controller.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry-test.controller.ts
@@ -36,7 +36,7 @@ export class McpRegistryTestController {
 	}
 
 	private assertE2ETestsEnabled(): void {
-		if (process.env.E2E_TESTS !== 'true' || process.env.NODE_ENV === 'production') {
+		if (process.env.E2E_TESTS !== 'true') {
 			throw new ForbiddenError('MCP registry test endpoints are not enabled');
 		}
 	}

--- a/packages/cli/src/modules/mcp-registry/mcp-registry.module.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry.module.ts
@@ -13,7 +13,7 @@ export class McpRegistryModule implements ModuleInterface {
 
 		await import('./mcp-registry.controller.js');
 
-		if (process.env.E2E_TESTS === 'true' && process.env.NODE_ENV !== 'production') {
+		if (process.env.E2E_TESTS === 'true') {
 			await import('./mcp-registry-test.controller.js');
 		}
 	}


### PR DESCRIPTION
## Summary

`POST /rest/mcp-registry/test/seed` was gated on `E2E_TESTS === 'true' && NODE_ENV !== 'production'`. The official Docker image bakes `NODE_ENV=production` (`docker/images/n8n/Dockerfile`), so in any containerized E2E environment the endpoint never mounts and seeding 404s. Since #32899 the registry service also skips its remote catalog refresh when `E2E_TESTS=true` (by design, so tests never reach api.n8n.io) — leaving containerized E2E with **no way to populate the MCP registry at all**: no registry nodes are generated, and anything depending on them silently degrades.

Concretely, this has been breaking the workflow-builder eval CI since June 24: every eval lane logs `Skipping MCP registry seed: … 404` (non-fatal by design) and cases requiring `@n8n/mcp-registry` nodes (e.g. `agent-with-notion-mcp`) fail as `builder_issue` — the builder falls back to native nodes because the registry ones don't exist on the instance.

The fix drops the `NODE_ENV` condition from both the module mount gate and the controller's runtime assert, gating on `E2E_TESTS` alone:

- This matches the existing precedent: `/rest/e2e/reset` — a far more powerful unauthenticated test endpoint (it resets the instance and creates an owner with a known password) — has always been gated on `E2E_TESTS` only (`server.ts`).  Given that, the extra `NODE_ENV` lock here added no real protection; any instance running with `E2E_TESTS=true` is already fully controllable via the e2e controller.
- The `NODE_ENV` clause was introduced without recorded rationale (copied from the instance-ai test controller in #28326 into #30298; no review discussion in either). Playwright E2E never hit it because the test container stack sets `NODE_ENV: 'development'` explicitly (`packages/testing/containers/services/n8n.ts`); the eval workflows' plain `docker run` lanes were the only consumer relying on the image default.

Note: `instance-ai.module.ts` / `instance-ai-test.controller.ts` carry the same double-gate. Left untouched here — nothing in the eval harness calls those endpoints, and Playwright covers them via the env override — but flagging it in case we want to align it too.

## How to test

- Unit: `pnpm test src/modules/mcp-registry/__tests__/mcp-registry-test.controller.test.ts` in `packages/cli` (the production-mode test now asserts seeding succeeds).
- E2E/eval: dispatch `Test: MCP Workflow Evals` on this branch with `filter=agent-with-notion-mcp`, `iterations=1`, `lanes=2`. Lane setup should log `Seeded 2 MCP registry server(s)` instead of `Skipped MCP registry seed (test endpoint unavailable)`, and the builder should now produce the Notion MCP registry node. (Validation run link to follow in a comment thread on this PR once it completes.)

## Related Linear tickets, Github issues, and Community forum posts

—

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34811">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

