### PR TITLE
fix(Google Sheets Node): Prevent hanging on empty sheets

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/utils/utils.test.ts
@@ -124,6 +124,15 @@ describe('Test Google Sheets, removeEmptyRows', () => {
 			[5, 3, 'g', 'h', 'i'],
 		]);
 	});
+
+	it('should return empty array when all rows are empty without throwing', () => {
+		const data = [
+			['', ''],
+			['', ''],
+		];
+		const result = removeEmptyRows(data, true);
+		expect(result).toEqual([]);
+	});
 });
 
 describe('Test Google Sheets, trimLeadingEmptyRows', () => {
@@ -161,6 +170,16 @@ describe('Test Google Sheets, trimLeadingEmptyRows', () => {
 			[3, 1, 'a', 'b', 'c'],
 			[5, 3, 'g', 'h', 'i'],
 		]);
+	});
+	it('should return empty array when all rows are empty', () => {
+		const data = [
+			['', '', '', ''],
+			['', '', '', ''],
+		];
+
+		const result = trimLeadingEmptyRows(data, true);
+
+		expect(result).toEqual([]);
 	});
 });
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/router.ts
@@ -75,7 +75,8 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 		}
 	} catch (error) {
 		if (this.continueOnFail()) {
-			operationResult.push({ json: this.getInputData(0)[0].json, error });
+			const inputData = this.getInputData(0);
+			operationResult.push({ json: inputData[0]?.json ?? {}, error });
 		} else {
 			throw error;
 		}

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -524,7 +524,7 @@ export class GoogleSheet {
 			);
 		}
 
-		const columnNames = sheetDatakeyRow[0];
+		const columnNames = sheetDatakeyRow?.[0] ?? [];
 
 		const keyIndex = columnNames.indexOf(indexKey);
 
@@ -630,7 +630,7 @@ export class GoogleSheet {
 		columnNamesList: string[][],
 	) {
 		const decodedRange = this.getDecodedSheetRange(range);
-		const columnNames = columnNamesList[0];
+		const columnNames = columnNamesList?.[0] ?? [];
 		const updateData: ISheetUpdateData[] = [];
 
 		for (const item of inputData) {
@@ -827,7 +827,7 @@ export class GoogleSheet {
 			);
 		}
 
-		const columnNames = columnNamesRow ? columnNamesRow[0] : [];
+		const columnNames = columnNamesRow?.[0] ?? [];
 		const setData: string[][] = [];
 
 		inputData.forEach((item) => {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheets.utils.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheets.utils.ts
@@ -99,7 +99,9 @@ export function hexToRgb(hex: string) {
 export function addRowNumber(data: SheetRangeData, headerRow: number) {
 	if (data.length === 0) return data;
 	const sheetData = data.map((row, i) => [i + 1, ...row]);
-	sheetData[headerRow][0] = ROW_NUMBER;
+	if (sheetData[headerRow]) {
+		sheetData[headerRow][0] = ROW_NUMBER;
+	}
 	return sheetData;
 }
 
@@ -119,7 +121,7 @@ export function removeEmptyRows(data: SheetRangeData, includesRowNumber = true) 
 			.slice(baseLength)
 			.some((cell) => cell || typeof cell === 'number' || typeof cell === 'boolean'),
 	);
-	if (includesRowNumber) {
+	if (includesRowNumber && notEmptyRows.length > 0) {
 		notEmptyRows[0][0] = ROW_NUMBER;
 	}
 	return notEmptyRows;
@@ -135,8 +137,12 @@ export function trimLeadingEmptyRows(
 		row.slice(baseLength).some((cell) => cell || typeof cell === 'number'),
 	);
 
+	if (firstNotEmptyRowIndex === -1) {
+		return [];
+	}
+
 	const returnData = data.slice(firstNotEmptyRowIndex);
-	if (includesRowNumber) {
+	if (includesRowNumber && returnData.length > 0) {
 		returnData[0][0] = rowNumbersColumnName;
 	}
 
@@ -149,7 +155,7 @@ export function removeEmptyColumns(data: SheetRangeData) {
 	const longestRow = data.reduce((a, b) => (a.length > b.length ? a : b), []).length;
 	for (let col = 0; col < longestRow; col++) {
 		const column = data.map((row) => row[col]);
-		if (column[0] !== '') {
+		if (column[0] !== '' && column[0] !== undefined) {
 			returnData.push(column);
 			continue;
 		}
@@ -158,9 +164,8 @@ export function removeEmptyColumns(data: SheetRangeData) {
 			returnData.push(column);
 		}
 	}
-	return (returnData[0] || []).map((_, i) =>
-		returnData.map((row) => (row[i] === undefined ? '' : row[i])),
-	);
+	if (!returnData.length || !returnData[0]) return [];
+	return returnData[0].map((_, i) => returnData.map((row) => (row[i] === undefined ? '' : row[i])));
 }
 
 export function prepareSheetData(
@@ -262,7 +267,7 @@ export async function autoMapInputData(
 			`${sheetName}!${headerRow}:${headerRow}`,
 			'FORMATTED_VALUE',
 		);
-		columnNames = response ? response[0] : [];
+		columnNames = response?.[0] ?? [];
 	}
 
 	if (handlingExtraData === 'insertInNewColumn') {


### PR DESCRIPTION
## Summary

Fixes an issue where executing Google Sheets node operations (such as `Get Row(s)` or `Append Row`) hung indefinitely with no error on empty or newly created Google Sheets (#34815).

- In `trimLeadingEmptyRows`, when no non-empty row was found (`firstNotEmptyRowIndex === -1`), `data.slice(-1)` sliced the last row and `removeEmptyRows` resulted in an empty array `[]`. Attempting `notEmptyRows[0][0] = ROW_NUMBER` threw an unhandled `TypeError: Cannot set properties of undefined (setting '0')`.
- Safe checks were added to `trimLeadingEmptyRows`, `removeEmptyRows`, `removeEmptyColumns`, and `addRowNumber` to return `[]` cleanly when sheet data is empty.
- Expressions using `response ? response[0] : []` were updated to `response?.[0] ?? []` to prevent `columnNames` from evaluating to `undefined` when `response` is an empty array `[]` (since `[]` is truthy in JavaScript).
- Guarded `router.ts` error reporting on `continueOnFail()` when `getInputData(0)` returns an empty array.

## How to test

1. Create a workflow with a Google Sheets node (operation: `Get Row(s)` or `Append Row`).
2. Select a sheet that is empty or contains only empty rows.
3. Click "Execute step".
4. The node now completes cleanly without hanging indefinitely.

## Related Linear tickets, Github issues, and Community forum posts

fixes #34815

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34817">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

