### PR TITLE
feat(core): Set medium reasoning effort for Instance AI Anthropic models (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
@@ -36,11 +36,28 @@ describe('thinkingToProviderOptions', () => {
 		});
 	});
 
-	it('anthropic: adaptive mode defaults display to summarized', () => {
+	it('anthropic: adaptive mode defaults display to summarized and effort to medium', () => {
 		expect(
 			getProviderQuirks('anthropic').thinkingToProviderOptions?.({ mode: 'adaptive' }),
 		).toEqual({
-			anthropic: { thinking: { type: 'adaptive', display: 'summarized' } },
+			anthropic: {
+				thinking: { type: 'adaptive', display: 'summarized' },
+				effort: 'medium',
+			},
+		});
+	});
+
+	it('anthropic: adaptive mode forwards explicit effort', () => {
+		expect(
+			getProviderQuirks('anthropic').thinkingToProviderOptions?.({
+				mode: 'adaptive',
+				effort: 'high',
+			}),
+		).toEqual({
+			anthropic: {
+				thinking: { type: 'adaptive', display: 'summarized' },
+				effort: 'high',
+			},
 		});
 	});
 

--- a/packages/@n8n/agents/src/runtime/model/provider-quirks.ts
+++ b/packages/@n8n/agents/src/runtime/model/provider-quirks.ts
@@ -44,6 +44,7 @@ export const PROVIDER_QUIRKS: Partial<Record<ProviderId, ProviderQuirks>> = {
 				return {
 					anthropic: {
 						thinking: { type: 'adaptive', display: cfg.display ?? 'summarized' },
+						effort: cfg.effort ?? 'medium',
 					},
 				};
 			}

--- a/packages/@n8n/agents/src/types/sdk/provider.ts
+++ b/packages/@n8n/agents/src/types/sdk/provider.ts
@@ -35,6 +35,8 @@ export type AnthropicThinkingConfig =
 			 * reasoning streams and replay metadata are available.
 			 */
 			display?: 'omitted' | 'summarized';
+			/** Reasoning effort for adaptive thinking. Defaults to 'medium'. */
+			effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 	  }
 	| {
 			mode?: 'enabled';

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -25,13 +25,19 @@ describe('applyAgentThinking', () => {
 	it('enables adaptive thinking for Anthropic', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'anthropic/claude-opus-4-8');
-		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', { mode: 'adaptive' });
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
+			mode: 'adaptive',
+			effort: 'medium',
+		});
 	});
 
 	it('enables adaptive thinking for dotted Anthropic provider IDs', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'anthropic.messages/claude-opus-4-8');
-		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', { mode: 'adaptive' });
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
+			mode: 'adaptive',
+			effort: 'medium',
+		});
 	});
 
 	it('enables adaptive thinking for AI SDK Anthropic model objects', () => {
@@ -40,7 +46,10 @@ describe('applyAgentThinking', () => {
 			modelId: 'claude-opus-4-8',
 			config: { provider: 'anthropic.messages' },
 		} as unknown as Parameters<typeof applyAgentThinking>[1]);
-		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', { mode: 'adaptive' });
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
+			mode: 'adaptive',
+			effort: 'medium',
+		});
 	});
 
 	it('enables OpenAI reasoning for supported models', () => {

--- a/packages/@n8n/instance-ai/src/agent/__tests__/instance-agent.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/instance-agent.test.ts
@@ -637,6 +637,7 @@ describe('createInstanceAgent', () => {
 
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
 			mode: 'adaptive',
+			effort: 'medium',
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -44,7 +44,7 @@ export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	}
 
 	if (provider === 'anthropic') {
-		agent.thinking('anthropic', { mode: 'adaptive' });
+		agent.thinking('anthropic', { mode: 'adaptive', effort: 'medium' });
 		return;
 	}
 }

--- a/packages/@n8n/instance-ai/src/utils/__tests__/eval-agents.test.ts
+++ b/packages/@n8n/instance-ai/src/utils/__tests__/eval-agents.test.ts
@@ -103,6 +103,7 @@ describe('eval agent model config', () => {
 		expect(mockAgentInstances[0]?.model).toHaveBeenCalledWith(fallbackModelConfig);
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', {
 			mode: 'adaptive',
+			effort: 'medium',
 		});
 	});
 


### PR DESCRIPTION
## Summary

Instance AI now sets `effort: medium` when enabling adaptive thinking for Anthropic models (including Opus), matching the Anthropic Chat Model node default.

Changes:
- `apply-agent-thinking.ts` passes `{ mode: 'adaptive', effort: 'medium' }` for Anthropic providers
- `@n8n/agents` Anthropic thinking config gains an optional `effort` field
- Provider quirks map adaptive effort through the AI SDK (`anthropic.effort` → `output_config.effort`), defaulting to `medium`

## How to test

1. Run unit tests:
   ```bash
   cd packages/@n8n/agents && pnpm test src/runtime/__tests__/provider-quirks.test.ts
   cd packages/@n8n/instance-ai && pnpm test src/agent/__tests__/apply-agent-thinking.test.ts src/agent/__tests__/instance-agent.test.ts src/utils/__tests__/eval-agents.test.ts
   ```
2. Start Instance AI with an Anthropic Opus model and confirm outgoing API requests include `output_config.effort: "medium"` when adaptive thinking is enabled.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2663/set-medium-reasoning-effort-for-instance-ai-anthropic-models

Stacked on https://linear.app/n8n/issue/AI-2662/slim-instance-ai-system-prompt-by-moving-build-guidance-into-skills

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34819">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

