### PR TITLE
fix(editor): Center empty state content vertically on short viewports

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
@@ -96,7 +96,6 @@ const handleAppSelectionContinue = () => {
 		:class="[
 			$style.emptyStateLayout,
 			{
-				[$style.noTemplatesContent]: !showAppSelection,
 				[$style.builderLayout]: showAppSelection,
 			},
 		]"
@@ -219,17 +218,13 @@ const handleAppSelectionContinue = () => {
 	justify-content: center;
 	align-content: center;
 	height: 100%;
-	padding: var(--spacing--4xl) var(--spacing--2xl) 0;
+	// Vertical padding must stay symmetric so justify-content centers the content
+	padding: 0 var(--spacing--2xl);
 	max-width: var(--content-container--width);
 	width: 100%;
 
 	@media (max-width: vars.$breakpoint-lg) {
-		padding: var(--spacing--xl) var(--spacing--xs) 0;
-	}
-
-	// Vertical padding must stay symmetric (0/0) so justify-content centers the content
-	&.noTemplatesContent {
-		padding-top: 0;
+		padding: 0 var(--spacing--xs);
 	}
 
 	&.builderLayout {

--- a/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
@@ -227,8 +227,9 @@ const handleAppSelectionContinue = () => {
 		padding: var(--spacing--xl) var(--spacing--xs) 0;
 	}
 
+	// Vertical padding must stay symmetric (0/0) so justify-content centers the content
 	&.noTemplatesContent {
-		padding-top: var(--spacing--3xl);
+		padding-top: 0;
 	}
 
 	&.builderLayout {

--- a/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
+++ b/packages/frontend/editor-ui/src/app/components/layouts/EmptyStateLayout.vue
@@ -229,8 +229,6 @@ const handleAppSelectionContinue = () => {
 
 	&.builderLayout {
 		align-items: center;
-		justify-content: center;
-		width: 100%;
 		max-width: none;
 		padding: var(--spacing--lg);
 	}


### PR DESCRIPTION
## Summary

The workflows empty state ("Let's build your first automation") was pushed below vertical center because the `noTemplatesContent` variant of `EmptyStateLayout` applied `padding-top: var(--spacing--3xl)` (64px) with no matching bottom padding. The container centers its content with `justify-content: center`, but flexbox centers within the content box, so the asymmetric padding offset everything down by 64px. This is most visible on short viewports.

The padding was a leftover from the old "recommended templates" layout: `noTemplatesContent` existed as its counterpart, and the templates variant was removed with feature flag `070_empty_screen_layout` (#34272). Since then every render gets either `noTemplatesContent` or `builderLayout`, making the class and the base rule's top padding dead weight.

Changes:

- Removed the vestigial `noTemplatesContent` class (template binding and style block); it had no other references.
- Folded the effective padding into the base `.emptyStateLayout` rule as symmetric `padding: 0 var(--spacing--2xl)` (and `0 var(--spacing--xs)` under the `lg` breakpoint) so `justify-content: center` actually centers the content.
- Dropped two no-op overrides from the `builderLayout` variant (`justify-content: center`, `width: 100%`) that duplicated the base rule; the app-selection layout is otherwise unchanged.

Verified manually against a fresh instance: at 1280×700 the content box has 243.5px of free space above and below (exactly centered), and at 1280×450 it is 118.5px/118.5px with no top clipping. Before the fix the space above exceeded the space below by 64px.

## How to test

1. Log in as a user with no workflows so the empty state ("Let's build your first automation") is shown.
2. Reduce the browser window height.
3. The heading and action cards should be vertically centered in the viewport instead of sitting below center.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5637

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)