### PR TITLE
fix(editor): Debounce node creator search filtering

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.test.ts
@@ -1,13 +1,13 @@
 import { defineComponent, nextTick, watch } from 'vue';
 import type { PropType } from 'vue';
 import { createPinia } from 'pinia';
-import { screen, fireEvent } from '@testing-library/vue';
+import { screen, fireEvent, waitFor } from '@testing-library/vue';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
 import { useViewStacks } from '@/features/shared/nodeCreator/composables/useViewStacks';
 import { mockSimplifiedNodeType } from '../../__tests__/utils';
 import NodesListPanel from './NodesListPanel.vue';
-import { REGULAR_NODE_CREATOR_VIEW } from '@/app/constants';
+import { REGULAR_NODE_CREATOR_VIEW, DEBOUNCE_TIME } from '@/app/constants';
 import type { ActionTypeDescription, NodeFilterType, SimplifiedNodeType } from '@/Interface';
 import { createComponentRenderer } from '@/__tests__/render';
 
@@ -246,19 +246,16 @@ describe('NodesListPanel', () => {
 			await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
 				target: { value: 'Ninth' },
 			});
-			await nextTick();
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+			await waitFor(() => expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1));
 
 			await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
 				target: { value: 'Non sense' },
 			});
-			await nextTick();
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(0);
+			await waitFor(() => expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(0));
 			expect(screen.queryByText("We didn't make that... yet")).toBeInTheDocument();
 
 			await fireEvent.click(container.querySelector('svg[data-icon=circle-x]')!);
-			await nextTick();
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
+			await waitFor(() => expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9));
 		});
 
 		it('should trim search input before emitting update', async () => {
@@ -269,12 +266,166 @@ describe('NodesListPanel', () => {
 			await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
 				target: { value: '    Node 1' },
 			});
-			await nextTick();
 
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+			await waitFor(() => expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1));
 			expect(screen.queryByText('Node 1')).toBeInTheDocument();
 
 			expect(screen.getByTestId('node-creator-search-bar')).toHaveValue('Node 1');
+		});
+	});
+
+	// Reproduces ADO-5590 (GH #33955): typing in the node-creator search field
+	// runs the fuzzy filter on every keystroke with no debounce, so rapid typing
+	// re-filters and re-renders on each character. AgentsMode debounces its
+	// search (see AgentsMode.vue), but the regular node search does not.
+	describe('should debounce search', () => {
+		const searchNodes = [
+			...[...Array(8).keys()].map(
+				(n) =>
+					mockSimplifiedNodeType({
+						name: `Trigger Node ${n}`,
+						displayName: `Trigger Node ${n}`,
+						group: ['trigger'],
+					}) as INodeTypeDescription,
+			),
+			mockSimplifiedNodeType({
+				name: 'Zephyr',
+				displayName: 'Zephyr',
+				group: ['trigger'],
+			}) as INodeTypeDescription,
+		];
+
+		const wrapperComponent = defineComponent({
+			components: {
+				NodesListPanel,
+			},
+			props: {
+				nodeTypes: {
+					type: Array as PropType<INodeTypeDescription[]>,
+					required: true,
+				},
+			},
+			setup(props) {
+				const { setMergeNodes } = useNodeCreatorStore();
+
+				watch(
+					() => props.nodeTypes,
+					(nodeTypes: INodeTypeDescription[]) => {
+						setMergeNodes([...nodeTypes]);
+					},
+					{ immediate: true },
+				);
+			},
+			template: '<NodesListPanel @nodeTypeSelected="e => $emit(\'nodeTypeSelected\', e)" />',
+		});
+
+		it('should not filter results until the search debounce window elapses', async () => {
+			vi.useFakeTimers();
+			try {
+				const renderComponent = createComponentRenderer(wrapperComponent, {
+					pinia: createPinia(),
+					props: {
+						nodeTypes: searchNodes,
+					},
+				});
+				renderComponent();
+				await nextTick();
+
+				screen.getByText('On app event').click();
+				await nextTick();
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
+
+				await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
+					target: { value: 'Zephyr' },
+				});
+				await nextTick();
+
+				// The keystroke should be debounced: filtering must not run yet, so the
+				// full, unfiltered list is still shown immediately after typing.
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
+
+				// Once the debounce window elapses, the search runs and filters.
+				await vi.advanceTimersByTimeAsync(DEBOUNCE_TIME.INPUT.SEARCH + 1);
+				await nextTick();
+
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+				expect(screen.queryByText('Zephyr')).toBeInTheDocument();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should reset the list immediately when the search is cleared', async () => {
+			vi.useFakeTimers();
+			try {
+				const renderComponent = createComponentRenderer(wrapperComponent, {
+					pinia: createPinia(),
+					props: {
+						nodeTypes: searchNodes,
+					},
+				});
+				renderComponent();
+				await nextTick();
+
+				screen.getByText('On app event').click();
+				await nextTick();
+
+				await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
+					target: { value: 'Zephyr' },
+				});
+				await vi.advanceTimersByTimeAsync(DEBOUNCE_TIME.INPUT.SEARCH + 1);
+				await nextTick();
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+
+				// Clearing is not debounced: the full list is back without any
+				// timer advance, and the pending-search window cannot restore the
+				// stale term afterwards.
+				await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
+					target: { value: '' },
+				});
+				await nextTick();
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
+
+				await vi.advanceTimersByTimeAsync(DEBOUNCE_TIME.INPUT.SEARCH + 1);
+				await nextTick();
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should apply a pending search before keyboard navigation acts on the list', async () => {
+			vi.useFakeTimers();
+			try {
+				const renderComponent = createComponentRenderer(wrapperComponent, {
+					pinia: createPinia(),
+					props: {
+						nodeTypes: searchNodes,
+					},
+				});
+				renderComponent();
+				await nextTick();
+
+				screen.getByText('On app event').click();
+				await nextTick();
+
+				await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
+					target: { value: 'Zephyr' },
+				});
+				await nextTick();
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
+
+				// Pressing Enter within the debounce window flushes the search, so
+				// selection happens against the filtered list, not the stale one.
+				await fireEvent.keyDown(screen.getByTestId('node-creator-search-bar'), {
+					key: 'Enter',
+				});
+				await nextTick();
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+				expect(screen.queryByText('Zephyr')).toBeInTheDocument();
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue
@@ -5,6 +5,7 @@ import {
 	AI_NODE_CREATOR_VIEW,
 	AI_OTHERS_NODE_CREATOR_VIEW,
 	AI_UNCATEGORIZED_CATEGORY,
+	DEBOUNCE_TIME,
 	HUMAN_IN_THE_LOOP_CATEGORY,
 	REGULAR_NODE_CREATOR_VIEW,
 	TRIGGER_NODE_CREATOR_VIEW,
@@ -15,7 +16,7 @@ import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.s
 
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { getNodeIconSize } from '@/app/utils/nodeIcon';
-import { useDebounce } from '@n8n/composables/useDebounce';
+import { useDebounce } from '@/app/composables/useDebounce';
 import { useI18n } from '@n8n/i18n';
 import { useKeyboardNavigation } from '../../composables/useKeyboardNavigation';
 import { useViewStacks, type ViewStack } from '../../composables/useViewStacks';
@@ -40,7 +41,7 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 
 import { N8nIcon, N8nNotice } from '@n8n/design-system';
 const i18n = useI18n();
-const { callDebounced } = useDebounce();
+const { callDebounced, debounce } = useDebounce();
 
 const { mergedNodes } = useNodeCreatorStore();
 const { pushViewStack, popViewStack, updateCurrentViewStack } = useViewStacks();
@@ -109,23 +110,54 @@ function getDefaultActiveIndex(search: string = ''): number {
 	return 0;
 }
 
+function applySearch(value: string) {
+	if (!activeViewStack.value.uuid) return;
+	updateCurrentViewStack({ search: value });
+	void setActiveItemIndex(getDefaultActiveIndex(value));
+	if (value.length) {
+		callDebounced(
+			nodeCreatorStore.onNodeFilterChanged,
+			{ trailing: true, debounceTime: 2000 },
+			{
+				newValue: value,
+				filteredNodes: activeViewStack.value.items ?? [],
+				filterMode: activeViewStack.value.rootView ?? 'Regular',
+				subcategory: activeViewStack.value.subcategory,
+				title: activeViewStack.value.title,
+			},
+		);
+	}
+}
+
+// Debounce the actual filtering so rapid typing doesn't re-run the fuzzy
+// search (and re-render the list) on every keystroke. The view stack search is
+// only written once the user pauses, keeping the input responsive.
+const debouncedApplySearch = debounce(
+	(value: string, scheduledForViewUuid: string | undefined) => {
+		// The user may have navigated to another view (e.g. selected an item)
+		// while the search was pending; the stale term must not leak into it.
+		if (activeViewStack.value.uuid !== scheduledForViewUuid) return;
+		applySearch(value);
+	},
+	{ trailing: true, debounceTime: DEBOUNCE_TIME.INPUT.SEARCH },
+);
+
 function onSearch(value: string) {
-	if (activeViewStack.value.uuid) {
-		updateCurrentViewStack({ search: value });
-		void setActiveItemIndex(getDefaultActiveIndex(value));
-		if (value.length) {
-			callDebounced(
-				nodeCreatorStore.onNodeFilterChanged,
-				{ trailing: true, debounceTime: 2000 },
-				{
-					newValue: value,
-					filteredNodes: activeViewStack.value.items ?? [],
-					filterMode: activeViewStack.value.rootView ?? 'Regular',
-					subcategory: activeViewStack.value.subcategory,
-					title: activeViewStack.value.title,
-				},
-			);
-		}
+	if (value === '') {
+		// Clearing must take effect immediately, and a pending search for the
+		// previous value must not re-filter afterwards.
+		debouncedApplySearch.cancel();
+		applySearch(value);
+		return;
+	}
+	void debouncedApplySearch(value, activeViewStack.value.uuid);
+}
+
+function flushPendingSearchOnNavigation(event: KeyboardEvent) {
+	// Selection keys must act on the filtered list, so a pending search is
+	// applied synchronously before keyboard navigation reads the rendered items.
+	if (['Enter', 'ArrowDown', 'ArrowUp'].includes(event.key)) {
+		void debouncedApplySearch.flush();
 	}
 }
 
@@ -139,11 +171,15 @@ function cleanupopeningContext() {
 }
 
 onMounted(() => {
+	// Registered before attachKeydownEvent so the flush runs first: keyboard
+	// navigation stops propagation of these keys on the same capture target.
+	document.addEventListener('keydown', flushPendingSearchOnNavigation, { capture: true });
 	attachKeydownEvent();
 	void setActiveItemIndex(getDefaultActiveIndex());
 });
 
 onUnmounted(() => {
+	document.removeEventListener('keydown', flushPendingSearchOnNavigation, { capture: true });
 	cleanupopeningContext();
 	detachKeydownEvent();
 });

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue
@@ -16,7 +16,7 @@ import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.s
 
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { getNodeIconSize } from '@/app/utils/nodeIcon';
-import { useDebounce } from '@/app/composables/useDebounce';
+import { useDebounce } from '@n8n/composables/useDebounce';
 import { useI18n } from '@n8n/i18n';
 import { useKeyboardNavigation } from '../../composables/useKeyboardNavigation';
 import { useViewStacks, type ViewStack } from '../../composables/useViewStacks';

--- a/packages/testing/playwright/pages/components/NodeCreator.ts
+++ b/packages/testing/playwright/pages/components/NodeCreator.ts
@@ -98,8 +98,8 @@ export class NodeCreator {
 		await this.getSearchBar().clear();
 	}
 
-	async selectItem(text: string): Promise<void> {
-		await this.getItem(text).click();
+	async selectItem(text: string, options: { exact?: boolean } = {}): Promise<void> {
+		await this.getItem(text, options).click();
 	}
 
 	async selectCategoryItem(text: string): Promise<void> {

--- a/packages/testing/playwright/tests/e2e/node-creator/workflows.spec.ts
+++ b/packages/testing/playwright/tests/e2e/node-creator/workflows.spec.ts
@@ -15,7 +15,7 @@ test.describe(
 		}) => {
 			await n8n.canvas.clickCanvasPlusButton();
 			await n8n.canvas.nodeCreator.searchFor('n8n');
-			await n8n.canvas.nodeCreator.selectItem('n8n');
+			await n8n.canvas.nodeCreator.selectItem('n8n', { exact: true });
 			await n8n.canvas.nodeCreator.selectCategoryItem('Actions');
 			await n8n.canvas.nodeCreator.selectItem('Create a credential');
 			await n8n.page.keyboard.press('Escape');
@@ -29,7 +29,7 @@ test.describe(
 		}) => {
 			await n8n.canvas.clickCanvasPlusButton();
 			await n8n.canvas.nodeCreator.searchFor('n8n');
-			await n8n.canvas.nodeCreator.selectItem('n8n');
+			await n8n.canvas.nodeCreator.selectItem('n8n', { exact: true });
 			await n8n.canvas.nodeCreator.selectCategoryItem('Actions');
 			await n8n.canvas.nodeCreator.selectItem('Create a credential');
 			await n8n.page.keyboard.press('Escape');


### PR DESCRIPTION
## Summary

Typing in the node-creator search bar felt laggy (community issue https://github.com/n8n-io/n8n/issues/33955): every keystroke wrote the search term into the active view stack, and the rendered item list is a computed derived from that term, so the fuzzy filter re-ran and the whole list re-rendered on every character.

This debounces the view-stack search update (`DEBOUNCE_TIME.INPUT.SEARCH`, trailing), so filtering runs once the user pauses typing while the native input stays fully responsive.

Measured with a `PerformanceObserver` on Event Timing entries (the data Chrome's INP metric derives from), typing realistic queries at 40ms/keystroke:

| Scenario | Worst interaction | Average | Keystrokes >200ms | Max handler CPU |
|---|---|---|---|---|
| master, no throttle | 312ms | 107ms | 3 of 27 | 128ms |
| master, 4x CPU throttle | 488ms | 255ms | 13 of 26 | 402ms |
| this PR, no throttle | 40ms | 31ms | 0 | 2ms |
| this PR, 4x CPU throttle | 40ms | 33ms | 0 | 2ms |

### Why a plain debounce is not enough

A naive trailing debounce (as attempted in #34626, which this PR supersedes) breaks three flows, all caught by e2e:

1. **Clearing the search felt dead**: the cleared value only applied 300ms later. Clearing now cancels the pending search and applies immediately.
2. **Fast type-then-Enter selected the wrong item**: keyboard selection read the stale, unfiltered list. A capture-phase keydown listener (registered before the keyboard-navigation listener, which stops propagation of watched keys) flushes the pending search on Enter/ArrowUp/ArrowDown, so navigation acts on the filtered list.
3. **A pending search could leak into the wrong view**: selecting an item within the debounce window pushed a new view stack, and the stale term was then written into it. The debounced apply captures the view-stack uuid at schedule time and drops the write if the view changed.

## Verification

- All 15 unit tests in `NodesListPanel.test.ts` pass, including three new ones covering the debounce, immediate clear, and Enter flush.
- `vue-tsc` and `eslint`/`biome` pass for the changed files.
- Verified live in the editor: clear restores the full list with no wait; typing "webhook" and pressing Enter 30ms later adds the Webhook node (previously selected from the stale list).

## Related

- Linear: https://linear.app/n8n/issue/ADO-5590
- Fixes https://github.com/n8n-io/n8n/issues/33955
- Supersedes #34626

## Review checklist

- [x] Minimal, targeted fix following the `DEBOUNCE_TIME` / `useDebounce` convention
- [x] Unit tests cover the new behaviors
- [x] Lint + typecheck pass

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

