### PR TITLE
perf(core): Skip allowed-methods lookup on successful production webhook requests

### DIFF
--- a/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
@@ -181,6 +181,8 @@ describe('LiveWebhooks', () => {
 			await liveWebhooks.executeWebhook(request, mock<Response>());
 
 			expect(capturedNodes[0].id).toBe('webhook-node-active');
+			// The allowed-methods lookup is reserved for 404 responses
+			expect(webhookService.getWebhookMethods).not.toHaveBeenCalled();
 		});
 
 		it('should pass workflowData with activeVersion nodes/connections to executeWebhook', async () => {

--- a/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/live-webhooks.test.ts
@@ -185,6 +185,27 @@ describe('LiveWebhooks', () => {
 			expect(webhookService.getWebhookMethods).not.toHaveBeenCalled();
 		});
 
+		it('should look up allowed methods and include them in the 404 when no webhook is registered', async () => {
+			webhookService.findWebhook.mockResolvedValue(null);
+			webhookService.getWebhookMethods.mockResolvedValue(['POST', 'PUT']);
+
+			const request = mock<WebhookRequest>({
+				method: 'GET',
+				params: { path: WEBHOOK_PATH },
+			});
+
+			const error: unknown = await liveWebhooks
+				.executeWebhook(request, mock<Response>())
+				.then(() => null)
+				.catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(WebhookNotFoundError);
+			expect((error as WebhookNotFoundError).message).toBe(
+				'This webhook is not registered for GET requests. Did you mean to make a POST or PUT request?',
+			);
+			expect(webhookService.getWebhookMethods).toHaveBeenCalledWith(WEBHOOK_PATH);
+		});
+
 		it('should pass workflowData with activeVersion nodes/connections to executeWebhook', async () => {
 			const httpMethod: IHttpRequestMethods = 'POST';
 

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -236,8 +236,10 @@ export class LiveWebhooks implements IWebhookManager {
 		}
 
 		const webhook = await this.webhookService.findWebhook(httpMethod, path);
-		const webhookMethods = await this.getWebhookMethods(path);
 		if (webhook === null) {
+			// Only fetch the allowed methods when building the 404, to keep the
+			// happy path free of this uncached query
+			const webhookMethods = await this.getWebhookMethods(path);
 			throw new WebhookNotFoundError({ path, httpMethod, webhookMethods }, { hint: 'production' });
 		}
 


### PR DESCRIPTION
## Summary

`LiveWebhooks.findWebhook` calls `webhookService.getWebhookMethods(path)` on every production webhook request, but the result is only used to build the `WebhookNotFoundError` (404) message that lists the allowed HTTP methods. Unlike `findWebhook`, this lookup is not cached, so every successful webhook request pays for 1-2 extra database queries whose result is discarded.

This PR moves the lookup inside the `webhook === null` branch, so it only runs when the 404 error is actually being built. The 404 response is unchanged. The eager placement dates back to #11093, which added the allowed-methods hint to the error message; the value was never used outside the error path.

**Benchmarks** (single active GET webhook, `responseMode: onReceived`, interleaved baseline/fixed A/B runs with `autocannon`):

| Setup | Baseline | Fixed |
|---|---|---|
| Postgres 16, sequential (c=1) | ~110 req/s, p99 13-14ms | ~121 req/s, p99 10ms (**+11%**) |
| Postgres 16, concurrent (c=10) | ~181 req/s | ~190 req/s (+4.6%) |
| SQLite (local) | within noise | within noise |

DB query trace per successful webhook request: 24 → 23 queries on Postgres (22 → 21 on SQLite); `webhook_entity` queries on the happy path drop from 1 to 0. The gain scales with database round-trip time, so networked databases benefit the most.

## How to test

1. Create a workflow with a Webhook trigger (e.g. GET, path `perf-test`, respond "Immediately") and activate it.
2. `curl http://localhost:5678/webhook/perf-test` → still responds 200 and executes the workflow.
3. `curl -X POST http://localhost:5678/webhook/perf-test` → still responds 404 with the message listing the allowed method (GET), same as before.
4. With `DB_LOGGING_ENABLED=true DB_LOGGING_OPTIONS=query`, observe that a successful webhook request no longer issues a `webhook_entity` SELECT (the `findWebhook` lookup itself is served from the webhook cache).

Unit test added: the happy-path `executeWebhook` test now asserts `getWebhookMethods` is not called.

## Related Linear tickets, Github issues, and Community forum posts

- Original error-message change that introduced the eager lookup: #11093

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

