### PR TITLE
fix(core): Return 405 for GET requests to the instance MCP endpoint

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts
@@ -328,27 +328,24 @@ describe('McpController', () => {
 			expect(res.json).toHaveBeenCalledWith({ message: 'MCP access is disabled' });
 		});
 
-		test('delegates to transport.handleRequest', async () => {
+		// The listen stream is unsupported in stateless mode: a GET routed into
+		// the transport would hang forever, so the route must answer 405 itself.
+		test('returns 405 without touching the MCP transport', async () => {
 			(mcpSettingsService.getEnabled as Mock).mockResolvedValue(true);
-			(mcpService.resolveFeatureFlags as Mock).mockResolvedValue({
-				mcpApps: { enabled: true, variant: 'variant' },
-				canvasGroupsEnabled: false,
-			});
-			(mcpService.getServer as unknown as Mock).mockReturnValue({
-				connect: vi.fn().mockResolvedValue(undefined),
-				close: vi.fn().mockResolvedValue(undefined),
-			});
-			const req = createReq();
 			const res = createRes();
-			await controller.handleGet(req, res);
-			expect(mcpService.resolveFeatureFlags as Mock).toHaveBeenCalledTimes(1);
-			expect(mcpService.getServer as unknown as Mock).toHaveBeenCalledWith(
-				expect.objectContaining({ id: 'user-1' }),
-				{ mcpApps: { enabled: true, variant: 'variant' }, canvasGroupsEnabled: false },
-				undefined,
-				undefined,
-			);
-			expect(mockHandleRequest).toHaveBeenCalledWith(req, res, undefined);
+			await controller.handleGet(createReq(), res);
+			expect(res.header).toHaveBeenCalledWith('Allow', 'POST');
+			expect(res.status).toHaveBeenCalledWith(405);
+			expect(res.json).toHaveBeenCalledWith({
+				jsonrpc: '2.0',
+				error: {
+					code: -32000,
+					message: 'Method not allowed.',
+				},
+				id: null,
+			});
+			expect(mcpService.getServer as unknown as Mock).not.toHaveBeenCalled();
+			expect(mockHandleRequest).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/mcp.controller.ts
+++ b/packages/cli/src/modules/mcp/mcp.controller.ts
@@ -74,8 +74,12 @@ export class McpController {
 	}
 
 	/**
-	 * GET endpoint for SSE stream (MCP Streamable HTTP spec)
-	 * Allows clients like Gemini CLI to establish an SSE stream for server-to-client notifications.
+	 * GET endpoint (MCP Streamable HTTP spec). The server runs in stateless mode
+	 * (a fresh transport per request), so it can never deliver server-initiated
+	 * messages on a GET listen stream: routing the request into the transport
+	 * leaves the SSE stream open and silent forever, stalling clients during
+	 * connection setup. The spec requires servers that don't offer the stream
+	 * to respond with 405.
 	 */
 	@Get('/http', {
 		ipRateLimit: createIpRateLimit(mcpConfig.rateLimitServer),
@@ -83,7 +87,7 @@ export class McpController {
 		skipAuth: true,
 		usesTemplates: true,
 	})
-	async handleGet(req: AuthenticatedRequest, res: FlushableResponse) {
+	async handleGet(_req: AuthenticatedRequest, res: Response) {
 		this.setCorsHeaders(res);
 
 		const enabled = await this.mcpSettingsService.getEnabled();
@@ -92,22 +96,15 @@ export class McpController {
 			return;
 		}
 
-		try {
-			const featureFlags = await this.mcpService.resolveFeatureFlags(req.user);
-			await this.handleTransportRequest(req, res, featureFlags);
-		} catch (error) {
-			this.errorReporter.error(error);
-			if (!res.headersSent) {
-				res.status(500).json({
-					jsonrpc: '2.0',
-					error: {
-						code: -32603,
-						message: INTERNAL_SERVER_ERROR_MESSAGE,
-					},
-					id: null,
-				});
-			}
-		}
+		res.header('Allow', 'POST');
+		res.status(405).json({
+			jsonrpc: '2.0',
+			error: {
+				code: -32000,
+				message: 'Method not allowed.',
+			},
+			id: null,
+		});
 	}
 
 	@Post('/http', {
@@ -199,7 +196,7 @@ export class McpController {
 		req: AuthenticatedRequest,
 		res: FlushableResponse,
 		featureFlags: McpFeatureFlags,
-		body?: unknown,
+		body: unknown,
 	) {
 		const { StreamableHTTPServerTransport } = await import(
 			'@modelcontextprotocol/sdk/server/streamableHttp.js'


### PR DESCRIPTION
## Summary

`GET /mcp-server/http` currently routes into a per-request, stateless `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`). In that mode the SDK answers a GET by opening an SSE listen stream that is never written to and never closed, because the server instance created for that request can never produce server-initiated messages. The request therefore hangs until the client gives up. Behind buffering proxies (e.g. cloudflared) not even the response headers arrive.

MCP clients such as Claude open this GET listen stream right after the OAuth handshake. The hang makes the connector setup time out, which Claude surfaces as `McpAuthorizationError` ("the integration rejected the credentials it just issued") even though token minting and verification work correctly.

The Streamable HTTP spec says a server that does not offer the SSE listen stream at this endpoint MUST return 405 Method Not Allowed, and clients MUST tolerate it (the SDK client silently ignores a 405 here). This PR makes the GET route answer 405 with an `Allow: POST` header and the same JSON-RPC error body the SDK uses for unsupported methods, instead of entering the transport. Auth behavior is unchanged: unauthenticated GETs still get the 401 + `WWW-Authenticate` discovery response, and the 403 for disabled MCP access is kept for parity with POST.

### Why only some clients are affected

The listen stream is optional in the spec, so the bug shows a different face depending on client behavior and network path:

- Clients that never issue the GET (curl and other POST-only request/response clients) never hit the broken path and work fine.
- Clients that open the GET as a fire-and-forget background task (e.g. the official TypeScript SDK client, used by Claude Code) receive the 200 + `text/event-stream` headers on a direct connection and treat the silent stream as a healthy idle listen stream. Nothing fails visibly; the server just holds a dead socket and an `McpServer` instance per GET until the client disconnects.
- Clients that validate stream setup as part of connector setup (Claude web/desktop), especially behind a buffering proxy (cloudflared in the report), see zero bytes: the proxy withholds even the headers because no body byte is ever written. The request times out and the failure is attributed to the last meaningful step, surfacing as `McpAuthorizationError`.

The 405 resolves all three cases at once: it is a complete response, so it flushes through buffering proxies, tolerant clients ignore it per spec, and strict clients get a definitive answer instead of a timeout.

## How to test

1. Enable Instance MCP (Settings → MCP) and add the Claude callback URLs to the allowed OAuth redirect URLs.
2. `POST /mcp-server/http` with a valid token and an `initialize` body: still returns the initialize result.
3. `GET /mcp-server/http` with a valid token and `Accept: text/event-stream`: previously hung forever with zero bytes (curl exit 28); now returns 405 immediately with `Allow: POST` and a JSON-RPC error body.
4. Connect Claude (web or desktop) as a custom connector to `https://<host>/mcp-server/http`: the connector completes setup after consent instead of failing with `McpAuthorizationError`.

Unit tests: `packages/cli/src/modules/mcp/__tests__/mcp.controller.test.ts` (GET now asserts the 405 and that the MCP transport is never constructed).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-5635
- fixes https://github.com/n8n-io/n8n/issues/34713

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


