### PR TITLE
fix(core): Reject workflow deletion while unpublish is still in progress

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -8,6 +8,7 @@ import type {
 	WorkflowRepository,
 	WorkflowPublishHistoryRepository,
 	WorkflowPublicationOutboxRepository,
+	WorkflowPublishedVersionRepository,
 } from '@n8n/db';
 import { WorkflowEntity, WorkflowHistory } from '@n8n/db';
 import type { Scope } from '@n8n/permissions';
@@ -96,6 +97,7 @@ describe('WorkflowService', () => {
 				mock(), // redactionEnforcementService
 				mock(), // workflowPublicationNotifier
 				mock(), // scheduleTriggerJobRegistrar
+				mock(), // workflowPublishedVersionRepository
 			);
 		});
 
@@ -357,6 +359,7 @@ describe('WorkflowService', () => {
 				redactionEnforcementServiceMock, // redactionEnforcementService
 				mock(), // workflowPublicationNotifier
 				mock(), // scheduleTriggerJobRegistrar
+				mock(), // workflowPublishedVersionRepository
 			);
 
 			vi.clearAllMocks();
@@ -1057,6 +1060,7 @@ describe('WorkflowService', () => {
 				mock(), // redactionEnforcementService
 				mock(), // workflowPublicationNotifier
 				scheduleTriggerJobRegistrarMock, // scheduleTriggerJobRegistrar
+				mock(), // workflowPublishedVersionRepository
 			);
 
 			// Bypass validation internals
@@ -1341,6 +1345,7 @@ describe('WorkflowService', () => {
 		let globalConfigMock: MockProxy<GlobalConfig>;
 		let activeWorkflowManagerMock: MockProxy<ActiveWorkflowManager>;
 		let externalHooksMock: MockProxy<ExternalHooks>;
+		let workflowPublishedVersionRepositoryMock: MockProxy<WorkflowPublishedVersionRepository>;
 
 		const WORKFLOW_ID = 'workflow-1';
 
@@ -1361,6 +1366,8 @@ describe('WorkflowService', () => {
 			executionPersistenceMock = mock();
 			activeWorkflowManagerMock = mock();
 			externalHooksMock = mock<ExternalHooks>();
+			workflowPublishedVersionRepositoryMock = mock<WorkflowPublishedVersionRepository>();
+			workflowPublishedVersionRepositoryMock.getPublishedVersionId.mockResolvedValue(null);
 			globalConfigMock = mock<GlobalConfig>({
 				workflows: mock<WorkflowsConfig>({ useWorkflowPublicationService: true }),
 			});
@@ -1392,6 +1399,7 @@ describe('WorkflowService', () => {
 				mock(), // redactionEnforcementService
 				mock(), // workflowPublicationNotifier
 				mock(), // scheduleTriggerJobRegistrar
+				workflowPublishedVersionRepositoryMock, // workflowPublishedVersionRepository
 			);
 		});
 
@@ -1401,6 +1409,19 @@ describe('WorkflowService', () => {
 
 			await expect(workflowService.delete(mock<User>(), WORKFLOW_ID, true)).rejects.toBeInstanceOf(
 				ConflictError,
+			);
+
+			expect(workflowRepositoryMock.delete).not.toHaveBeenCalled();
+		});
+
+		test('throws ConflictError while the published-version mapping still exists', async () => {
+			const workflow = makeWorkflowEntity({ isArchived: true, activeVersionId: null });
+			workflowFinderServiceMock.findWorkflowForUser.mockResolvedValue(workflow);
+			// The unpublish outbox record has not been consumed yet.
+			workflowPublishedVersionRepositoryMock.getPublishedVersionId.mockResolvedValue('v1');
+
+			await expect(workflowService.delete(mock<User>(), WORKFLOW_ID)).rejects.toThrowError(
+				'Workflow is still being unpublished. Please try again in a few moments.',
 			);
 
 			expect(workflowRepositoryMock.delete).not.toHaveBeenCalled();
@@ -1520,6 +1541,7 @@ describe('WorkflowService', () => {
 				mock(), // redactionEnforcementService
 				mock(), // workflowPublicationNotifier
 				mock(), // scheduleTriggerJobRegistrar
+				mock(), // workflowPublishedVersionRepository
 			);
 		});
 
@@ -1636,6 +1658,7 @@ describe('WorkflowService', () => {
 				mock(), // redactionEnforcementService
 				mock(), // workflowPublicationNotifier
 				mock(), // scheduleTriggerJobRegistrar
+				mock(), // workflowPublishedVersionRepository
 			);
 		});
 

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -11,6 +11,7 @@ import {
 	WorkflowRepository,
 	WorkflowPublishHistoryRepository,
 	WorkflowPublicationOutboxRepository,
+	WorkflowPublishedVersionRepository,
 	ProjectRepository,
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
@@ -90,6 +91,7 @@ export class WorkflowService {
 		private readonly redactionEnforcementService: RedactionEnforcementService,
 		private readonly workflowPublicationNotifier: WorkflowPublicationNotifier,
 		private readonly scheduleTriggerJobRegistrar: ScheduleTriggerJobRegistrar,
+		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
 	) {}
 
 	async getMany(
@@ -1062,11 +1064,24 @@ export class WorkflowService {
 			return;
 		}
 
-		if (
-			this.globalConfig.workflows.useWorkflowPublicationService &&
-			workflow.activeVersionId !== null
-		) {
-			throw new ConflictError('Cannot delete a published workflow. Unpublish it before deleting.');
+		if (this.globalConfig.workflows.useWorkflowPublicationService) {
+			if (workflow.activeVersionId !== null) {
+				throw new ConflictError(
+					'Cannot delete a published workflow. Unpublish it before deleting.',
+				);
+			}
+
+			// Unpublishing clears `activeVersionId` synchronously but defers trigger
+			// teardown to the outbox consumer, which removes the published-version
+			// mapping only once teardown succeeds. That mapping's FK to the workflow
+			// is RESTRICT, so deleting before it is gone would fail at the DB level.
+			const pendingPublishedVersionId =
+				await this.workflowPublishedVersionRepository.getPublishedVersionId(workflowId);
+			if (pendingPublishedVersionId !== null) {
+				throw new ConflictError(
+					'Workflow is still being unpublished. Please try again in a few moments.',
+				);
+			}
 		}
 
 		if (!workflow.isArchived && !force) {

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -91,6 +91,7 @@ beforeAll(async () => {
 		mock(), // redactionEnforcementService
 		mock(), // workflowPublicationNotifier
 		mock(), // scheduleTriggerJobRegistrar
+		workflowPublishedVersionRepository,
 	);
 });
 
@@ -631,6 +632,56 @@ describe('workflow publication outbox', () => {
 				where: { workflowId: workflow.id },
 			});
 			expect(publishedVersionAfter).not.toBeNull();
+		});
+
+		test('should reject deletion while the published-version mapping still exists', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+			// Simulate the outbox consumer having advanced the published version.
+			await workflowPublishedVersionRepository.setPublishedVersion(workflow.id, workflow.versionId);
+
+			await workflowService.deactivateWorkflow(owner, workflow.id);
+			await workflowService.archive(owner, workflow.id);
+
+			// Mapping removal is deferred to the consumer, so deleting now must be
+			// rejected gracefully instead of failing on the mapping's RESTRICT FK.
+			await expect(workflowService.delete(owner, workflow.id)).rejects.toThrowError(
+				'Workflow is still being unpublished. Please try again in a few moments.',
+			);
+
+			const notDeleted = await workflowRepository.findOne({ where: { id: workflow.id } });
+			expect(notDeleted).not.toBeNull();
+		});
+
+		test('should delete a previously published workflow once the unpublish has drained', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+			await workflowPublishedVersionRepository.setPublishedVersion(workflow.id, workflow.versionId);
+
+			await workflowService.deactivateWorkflow(owner, workflow.id);
+			await workflowService.archive(owner, workflow.id);
+			// Simulate the outbox consumer having completed the unpublish.
+			await workflowPublishedVersionRepository.removePublishedVersion(workflow.id);
+
+			await workflowService.delete(owner, workflow.id);
+
+			const deleted = await workflowRepository.findOne({ where: { id: workflow.id } });
+			expect(deleted).toBeNull();
+		});
+
+		test('should reject deletion of a published workflow', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			await expect(workflowService.delete(owner, workflow.id, true)).rejects.toThrowError(
+				'Cannot delete a published workflow. Unpublish it before deleting.',
+			);
 		});
 	});
 


### PR DESCRIPTION
## Summary

When the workflow publication service is enabled (`N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`), unpublishing a workflow clears `activeVersionId` synchronously but defers trigger teardown to the outbox consumer, which removes the `workflow_published_version` mapping only after teardown succeeds. That mapping's FK to the workflow is `onDelete: RESTRICT` (intentional, so triggers can't be orphaned), so deleting a previously published workflow before the consumer drains failed at the database level with an unhandled `QueryFailedError` / 500, shown to the user as a generic error toast.

This PR makes `WorkflowService.delete()` check the published-version mapping and reject with a clear 409 `ConflictError` ("Workflow is still being unpublished. Please try again in a few moments.") instead. Retrying after the consumer has drained succeeds. No frontend change needed, the toast already surfaces the API error message.

## How to test

Requires `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

1. Publish a workflow.
2. Unpublish it from the workflow list.
3. Archive it from the workflow list.
4. Quickly click the "delete permanently" CTA in the notification toast.

Before this change, losing the race against the outbox consumer produced a 500 with a foreign-key constraint error (deterministically reproduced by the new integration test, since the consumer doesn't run there). Now the API returns a 409 with a clear message, and deleting again after the unpublish has drained succeeds.

Covered by tests:
- Integration: delete is rejected while the mapping still exists; delete succeeds once the consumer has removed it; delete of a still-published workflow is rejected.
- Unit: new guard in `delete()`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5605

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

