### PR TITLE
perf(core): Build $now, $today and $agentInfo lazily in the workflow data proxy

### DIFF
--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -805,6 +805,14 @@ export class WorkflowDataProxy {
 	getDataProxy(opts?: { throwOnMissingExecutionData: boolean }): IWorkflowDataProxyData {
 		const that = this;
 
+		// Memo slots for the lazy `$now` / `$today` / `$agentInfo` getters below
+		let lazyNow: DateTime | undefined;
+		let lazyToday: DateTime | undefined;
+		let lazyAgentInfo: { computed: boolean; value: ReturnType<WorkflowDataProxy['agentInfo']> } = {
+			computed: false,
+			value: undefined,
+		};
+
 		// replacing proxies with the actual data.
 		const jmespathWrapper = (data: IDataObject | IDataObject[], query: string) => {
 			if (typeof data !== 'object' || typeof query !== 'string') {
@@ -1622,8 +1630,17 @@ export class WorkflowDataProxy {
 			$mode: this.mode,
 			$workflow: this.workflowGetter(),
 			$itemIndex: this.itemIndex,
-			$now: DateTime.now(),
-			$today: DateTime.now().set({ hour: 0, minute: 0, second: 0, millisecond: 0 }),
+			// Lazy: Luxon DateTime construction in a named zone is expensive and
+			// most evaluations never touch these. Memoized so repeated accesses
+			// within one proxy observe a single instant, and the zone is bound
+			// explicitly because the global `Settings.defaultZone` may have been
+			// changed by another proxy by the time the getter runs.
+			get $now(): DateTime {
+				return (lazyNow ??= DateTime.now().setZone(that.timezone));
+			},
+			get $today(): DateTime {
+				return (lazyToday ??= this.$now.set({ hour: 0, minute: 0, second: 0, millisecond: 0 }));
+			},
 			$jmesPath: jmespathWrapper,
 
 			DateTime,
@@ -1642,7 +1659,13 @@ export class WorkflowDataProxy {
 			$thisRunIndex: this.runIndex,
 			$nodeVersion: that.workflow.getNode(that.activeNodeName)?.typeVersion,
 			$nodeId: that.workflow.getNode(that.activeNodeName)?.id,
-			$agentInfo: this.agentInfo(),
+			// Lazy: scans the workflow graph when the active node is an agent
+			get $agentInfo() {
+				if (!lazyAgentInfo.computed) {
+					lazyAgentInfo = { computed: true, value: that.agentInfo() };
+				}
+				return lazyAgentInfo.value;
+			},
 			$webhookId: that.workflow.getNode(that.activeNodeName)?.webhookId,
 		};
 		const throwOnMissingExecutionData = opts?.throwOnMissingExecutionData ?? true;
@@ -1652,13 +1675,11 @@ export class WorkflowDataProxy {
 			get(target, name, receiver) {
 				if (name === 'isProxy') return true;
 
-				const JSON_ACCESS_KEYS = ['$data', '$json'];
-
-				if (that.workflow.settings?.binaryMode === BINARY_MODE_COMBINED) {
-					JSON_ACCESS_KEYS.push('$item');
-				}
-
-				if (typeof name === 'string' && JSON_ACCESS_KEYS.includes(name)) {
+				if (
+					name === '$data' ||
+					name === '$json' ||
+					(name === '$item' && that.workflow.settings?.binaryMode === BINARY_MODE_COMBINED)
+				) {
 					return that.nodeDataGetter(that.contextNodeName, true, throwOnMissingExecutionData)?.json;
 				}
 				if (name === '$binary') {

--- a/packages/workflow/test/workflow-data-proxy.test.ts
+++ b/packages/workflow/test/workflow-data-proxy.test.ts
@@ -1,4 +1,4 @@
-import { DateTime, Duration, Interval } from 'luxon';
+import { DateTime, Duration, Interval, Settings } from 'luxon';
 
 import * as Helpers from './helpers';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
@@ -99,6 +99,50 @@ const getProxyFromFixture = (
 };
 
 describe('WorkflowDataProxy', () => {
+	describe('$now / $today', () => {
+		const fixture = loadFixture('multiple_outputs');
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		test('should create $now on first access and reuse it within the proxy', () => {
+			const nowSpy = vi.spyOn(DateTime, 'now');
+			const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Edit Fields');
+			expect(nowSpy).not.toHaveBeenCalled();
+
+			const first = proxy.$now;
+			const second = proxy.$now;
+			const today = proxy.$today;
+
+			expect(first).toBe(second);
+			expect(nowSpy).toHaveBeenCalledTimes(1);
+			expect(today.hour).toBe(0);
+			expect(today.minute).toBe(0);
+			expect(today.second).toBe(0);
+			expect(today.millisecond).toBe(0);
+		});
+
+		test('should bind $now to the workflow timezone even if the default zone changed after proxy creation', () => {
+			const workflowWithTimezone = {
+				...fixture.workflow,
+				settings: { ...fixture.workflow.settings, timezone: 'Europe/Berlin' },
+			};
+			const proxy = getProxyFromFixture(workflowWithTimezone, fixture.run, 'Edit Fields');
+
+			const previousZone = Settings.defaultZone;
+			// another WorkflowDataProxy construction can change the global default
+			// zone between this proxy's creation and the first $now access
+			Settings.defaultZone = 'America/New_York';
+			try {
+				expect(proxy.$now.zoneName).toBe('Europe/Berlin');
+				expect(proxy.$today.zoneName).toBe('Europe/Berlin');
+			} finally {
+				Settings.defaultZone = previousZone;
+			}
+		});
+	});
+
 	describe('$(If))', () => {
 		const fixture = loadFixture('multiple_outputs');
 		const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Edit Fields');

--- a/packages/workflow/test/workflow-data-proxy.test.ts
+++ b/packages/workflow/test/workflow-data-proxy.test.ts
@@ -143,6 +143,29 @@ describe('WorkflowDataProxy', () => {
 		});
 	});
 
+	describe('$agentInfo', () => {
+		const fixture = loadFixture('multiple_outputs');
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		test('should compute $agentInfo on first access and memoize it', () => {
+			const agentInfoSpy = vi.spyOn(
+				WorkflowDataProxy.prototype as unknown as { agentInfo: () => unknown },
+				'agentInfo',
+			);
+			const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Edit Fields');
+			expect(agentInfoSpy).not.toHaveBeenCalled();
+
+			const first = proxy.$agentInfo;
+			const second = proxy.$agentInfo;
+
+			expect(agentInfoSpy).toHaveBeenCalledTimes(1);
+			expect(first).toBe(second);
+		});
+	});
+
 	describe('$(If))', () => {
 		const fixture = loadFixture('multiple_outputs');
 		const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Edit Fields');


### PR DESCRIPTION
## Summary

Every expression evaluation builds a `WorkflowDataProxy`, and building one used to construct `$now`, `$today`, and `$agentInfo` up front, even though most evaluations never read any of them. `$now` and `$today` are Luxon `DateTime`s in a named timezone, and each one costs an Intl offset computation. A proxy is built per expression, per parameter, per item, so that fixed cost was the largest single part of expression resolution on the default engine.

This PR turns `$now`, `$today`, and `$agentInfo` into lazy, memoized getters, so the work only runs when an expression actually reads them:

- `$now` is built on first access and reused for the life of the proxy, so repeated reads within one evaluation still see a single instant, same as before.
- `$today` is derived from the memoized `$now` instead of making a second `DateTime.now()` call microseconds later.
- `$agentInfo`, which scans the workflow graph when the active node is an agent, is computed on demand and memoized.
- The `$now`/`$today` zone is now bound explicitly to the proxy's own workflow timezone. In the normal case this is the same value as before. Under concurrent executions with different workflow timezones it also closes a latent race, where another proxy could change the ambient `Settings.defaultZone` before `$now` was read.

One incidental cleanup: the proxy `get` trap no longer allocates a key-list array on every property access, it compares the names directly.

### Measured impact

Interleaved A/B of the full `getParameterValue` path (parse, proxy build, and eval), taking medians over repeated rounds. Reported as relative speedup, since absolute throughput varies by machine.

Default (`legacy`) engine:

| Expression | speedup |
|---|---|
| `{{ "hello " + "world" }}` | +78% |
| `{{ $json.num + $json.num2 }}` | +75% |
| `{{ $json.items.filter(i => i.active).map(i => i.name).join(", ") }}` | +85% |
| `{{ JSON.stringify($json) }}` | +81% |
| `{{ $now.toISO() }}` (reads the time) | +54% |

Experimental (`vm`) engine: +16% to +36%, shrinking as the expression body gets heavier.

Two things worth calling out:

- The gain barely depends on how heavy the expression body is. The realistic array pipeline gains as much as a trivial string concat, because on the legacy engine the per-evaluation cost is dominated by fixed proxy and parse overhead, and the two named-zone `DateTime`s were roughly half of that overhead.
- An expression that reads `$now` still gains (+54%), because the old path built both `$now` and `$today`. The lazy path still builds `$now` on access but skips the separate `$today` construction.

This is a per-evaluation saving, so it shows up most on workflows that evaluate many expressions over many items with cheap nodes (Set, IF, Edit Fields). On I/O-bound workflows the saving is real but not visible in wall-clock time.

### Behavior notes

`$now`, `$today`, and `$agentInfo` are now accessor properties. Nothing in the repo assigns to them (checked), and enumeration order and `Object.keys` output are unchanged (covered by the task runner's `built-ins-parser` test). Consumers that spread the proxy invoke the getters at spread time and get the same values as before.

## How to test

1. Run the regression tests: `cd packages/workflow && pnpm test test/workflow-data-proxy.test.ts`. They cover that `$now` is built on first access and memoized, that it is bound to the workflow timezone, and that `$agentInfo` is computed once and memoized.
2. Any workflow using `{{ $now }}` or `{{ $today }}` behaves as before, including with a workflow timezone set in workflow settings.
3. For the perf claim: run a Code node that emits ~10k items into a Set node with several expressions, and compare execution time against master.

## Related Linear tickets, Github issues, and Community forum posts

None. Found during a backend performance review of the expression hot path.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created (no docs impact, no behavior change).
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
