### PR TITLE
fix(core): Resolve synthetic tool nodes to the requested version

### DIFF
--- a/packages/cli/src/__tests__/node-types.test.ts
+++ b/packages/cli/src/__tests__/node-types.test.ts
@@ -186,6 +186,45 @@ describe('NodeTypes', () => {
 			supplyData: undefined,
 		},
 	};
+	// Versioned node usable as a tool at both versions, where each version exposes
+	// a different parameter (mirrors Notion v2 `databaseId` vs v3 `dataSourceId`).
+	const versionedToolCapableNode: LoadedClass<IVersionedNodeType> = {
+		sourcePath: '',
+		type: {
+			description: {
+				name: 'n8n-nodes-base.versionedToolCapable',
+				displayName: 'Versioned Tool Capable',
+			} as unknown as INodeTypeDescription,
+			currentVersion: 2,
+			nodeVersions: {
+				1: {
+					description: {
+						name: 'n8n-nodes-base.versionedToolCapable',
+						version: 1,
+						usableAsTool: true,
+						properties: [
+							{ displayName: 'Database ID', name: 'databaseId', type: 'string', default: '' },
+						],
+					},
+					supplyData: undefined,
+				} as unknown as INodeType,
+				2: {
+					description: {
+						name: 'n8n-nodes-base.versionedToolCapable',
+						version: 2,
+						usableAsTool: true,
+						properties: [
+							{ displayName: 'Data Source ID', name: 'dataSourceId', type: 'string', default: '' },
+						],
+					},
+					supplyData: undefined,
+				} as unknown as INodeType,
+			},
+			getNodeType(version) {
+				return this.nodeVersions[version === 1 ? 1 : 2];
+			},
+		},
+	};
 	const communityNode: LoadedClass<INodeType> = {
 		sourcePath: '',
 		type: {
@@ -213,6 +252,7 @@ describe('NodeTypes', () => {
 			if (nodeType === 'hitlNode') return hitlSupportingNode;
 			if (nodeType === 'realTool') return realToolNode;
 			if (nodeType === 'replacementToolNode') return replacementToolNode;
+			if (nodeType === 'versionedToolCapable') return versionedToolCapableNode;
 		} else if (fullNodeType === 'n8n-nodes-community.testNode') return communityNode;
 		throw new UnrecognizedNodeTypeError(packageName, nodeType);
 	});
@@ -296,6 +336,24 @@ describe('NodeTypes', () => {
 			const runNodeSpy = vi.spyOn(RoutingNode.prototype, 'runNode').mockResolvedValue([]);
 			await result.execute!.call(mock());
 			expect(runNodeSpy).toHaveBeenCalled();
+		});
+
+		it('should resolve each version of a synthetic tool independently, not the first-cached one', () => {
+			const v1 = nodeTypes.getByNameAndVersion('n8n-nodes-base.versionedToolCapableTool', 1);
+			expect(v1.description.version).toBe(1);
+			expect(v1.description.properties.some((p) => p.name === 'databaseId')).toBe(true);
+
+			const v2 = nodeTypes.getByNameAndVersion('n8n-nodes-base.versionedToolCapableTool', 2);
+			expect(v2.description.version).toBe(2);
+			expect(v2.description.properties.some((p) => p.name === 'dataSourceId')).toBe(true);
+
+			// Re-fetch v1: caching v2 must not clobber the v1 entry.
+			const v1Again = nodeTypes.getByNameAndVersion('n8n-nodes-base.versionedToolCapableTool', 1);
+			expect(v1Again.description.version).toBe(1);
+
+			// No version resolves to the current version and caches independently.
+			const vDefault = nodeTypes.getByNameAndVersion('n8n-nodes-base.versionedToolCapableTool');
+			expect(vDefault.description.version).toBe(2);
 		});
 
 		it('should return a declarative node-type as a tool with an `.execute` method', async () => {

--- a/packages/cli/src/node-types.ts
+++ b/packages/cli/src/node-types.ts
@@ -113,9 +113,12 @@ export class NodeTypes implements INodeTypes {
 
 		if (!isSyntheticTool) return versionedNodeType;
 
+		// Cache key must include the version: a base node can be usable as a tool
+		// at several versions (e.g. Notion v2 vs v3), and they must not collide.
+		const cacheKey = `${origType}?version=${version ?? 'default'}`;
 		const { loadedNodes } = this.loadNodesAndCredentials;
-		if (origType in loadedNodes) {
-			return loadedNodes[origType].type as INodeType;
+		if (cacheKey in loadedNodes) {
+			return loadedNodes[cacheKey].type as INodeType;
 		}
 
 		const isHitlTool = isHitlToolType(origType);
@@ -138,7 +141,7 @@ export class NodeTypes implements INodeTypes {
 		// For HITL tools, use convertNodeToHitlTool; for regular AI tools, use convertNodeToAiTool
 		const tool = isHitlTool ? convertNodeToHitlTool(clonedNode) : convertNodeToAiTool(clonedNode);
 
-		loadedNodes[origType] = { sourcePath: '', type: tool };
+		loadedNodes[cacheKey] = { sourcePath: '', type: tool };
 		return tool;
 	}
 


### PR DESCRIPTION
## Summary

Synthetic AI-tool node types (e.g. `notionTool`, fabricated on demand from the base `notion` node) were cached in the node registry keyed on the **bare node name**, ignoring the requested `typeVersion`. Once any version was fabricated first, that instance stuck for every later request of the same name.

In a shared process this meant a v3 tool request resolved to the cached **v2** tool — running v2 runtime code and exposing v2 methods. For `notionTool` v3 this dropped `dataSourceId`, read an empty `databaseId`, and every `databasePage:getAll` call failed with Notion `400 invalid_request_url`. It also broke the node editor: opening the v3 tool's **Data Source** picker errored with `no listSearch method named "getDataSources"` (a v2 method set on a v3 node).

The fix includes the version in the synthetic-tool cache key, so each `typeVersion` fabricates and caches its own tool and resolves independently. The base-node registry is untouched — this only affects the on-demand tool cache.

## How to test

Requires a process where a v2 `notionTool` is resolved before a v3 one (the collision is process-global). Use workflow below

**Editor (quickest, no external calls):**
1. In an AI Agent, add a **Notion Tool** node at typeVersion 2, then another at typeVersion 3.
2. Open the v3 node → **Resource** `Database Page` → **Operation** `Get Many` → click the **Data Source** list.
   - Before: `Could not load list — Node type "notionTool" has no listSearch method named "getDataSources"`.
   - After: the Data Source list loads.

**Runtime:**
1. AI Agent with a `notionTool` v3 (OAuth2, `databasePage` / `getAll`, `dataSourceId` set, `returnAll`).
2. Have the agent call the tool.
   - Before: every call errors `400 invalid_request_url`; the error node shows the v2 shape (`databaseId: { __rl: true, mode: "list", value: "" }`, no `dataSourceId`).
   - After: the tool runs v3 code, honors `dataSourceId`, and returns pages.

[NODE-5530 repro — notionTool v3 runs as v2.json](https://github.com/user-attachments/files/30336247/NODE-5530.repro.notionTool.v3.runs.as.v2.json)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5530

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34850">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

