### PR TITLE
feat(Microsoft SharePoint Node): Add v2 Item Create or Update (upsert) operation (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/lookup.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/lookup.test.ts
@@ -1,0 +1,89 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { DeepMockProxy } from 'vitest-mock-extended';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import { lookupItemIdByColumns } from '../../../v2/item';
+
+// No transport mock here: microsoftApiRequestAllItems calls microsoftApiRequest
+// as a same-module reference, so mocking the module wouldn't intercept it.
+// Stubbing the network helper one layer down keeps both request helpers real,
+// which is the whole point — this exercises the actual @odata.nextLink paging.
+const SITE_ID = 'site1';
+const LIST_ID = 'list1';
+const GRAPH_BASE_URL = 'https://graph.microsoft.com';
+const ITEMS_URI = `${GRAPH_BASE_URL}/v1.0/sites/${SITE_ID}/lists/${LIST_ID}/items`;
+const NEXT_LINK = `${ITEMS_URI}?$skiptoken=UGFnZWQ9VFJVRQ`;
+const NEXT_LINK_2 = `${ITEMS_URI}?$skiptoken=UGFnZWQ9VFJVRTI`;
+const PREFER_NON_INDEXED = { Prefer: 'HonorNonIndexedQueriesWarningMayFailRandomly' };
+
+describe('Microsoft SharePoint v2 — lookupItemIdByColumns paging', () => {
+	let ctx: DeepMockProxy<IExecuteFunctions>;
+
+	const lookup = async () =>
+		await lookupItemIdByColumns.call(ctx, SITE_ID, LIST_ID, ['Email'], {
+			Email: 'bob@acme.com',
+		});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ctx = mockDeep<IExecuteFunctions>();
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		// getSharePointCredentialType reads this; anything but the service-principal
+		// type routes through requestOAuth2.
+		ctx.getNodeParameter.mockReturnValue('microsoftOAuth2Api' as never);
+		ctx.getCredentials.mockResolvedValue({ graphApiBaseUrl: GRAPH_BASE_URL });
+	});
+
+	it('reports many when two matches are split across pages (one first-page row, one behind nextLink)', async () => {
+		ctx.helpers.requestOAuth2
+			.mockResolvedValueOnce({ value: [{ id: '17' }], '@odata.nextLink': NEXT_LINK })
+			.mockResolvedValueOnce({ value: [{ id: '42' }] });
+
+		expect(await lookup()).toEqual(['17', '42']);
+		expect(ctx.helpers.requestOAuth2).toHaveBeenCalledTimes(2);
+		// The second page is fetched from the nextLink verbatim, still opting into
+		// non-indexed queries.
+		expect(ctx.helpers.requestOAuth2.mock.calls[1][1]).toEqual(
+			expect.objectContaining({
+				uri: NEXT_LINK,
+				headers: expect.objectContaining(PREFER_NON_INDEXED),
+			}),
+		);
+	});
+
+	it('finds a match that only appears on a later page after an empty first page', async () => {
+		ctx.helpers.requestOAuth2
+			.mockResolvedValueOnce({ value: [], '@odata.nextLink': NEXT_LINK })
+			.mockResolvedValueOnce({ value: [{ id: '42' }] });
+
+		expect(await lookup()).toEqual(['42']);
+		expect(ctx.helpers.requestOAuth2).toHaveBeenCalledTimes(2);
+	});
+
+	it('stops at the second match without fetching further pages', async () => {
+		ctx.helpers.requestOAuth2
+			.mockResolvedValueOnce({ value: [{ id: '17' }], '@odata.nextLink': NEXT_LINK })
+			.mockResolvedValueOnce({ value: [{ id: '42' }], '@odata.nextLink': NEXT_LINK_2 })
+			.mockResolvedValueOnce({ value: [{ id: '99' }] });
+
+		expect(await lookup()).toEqual(['17', '42']);
+		// Two matches already prove "many" — the third page is never requested.
+		expect(ctx.helpers.requestOAuth2).toHaveBeenCalledTimes(2);
+	});
+
+	it('makes a single request when the only match is on the first page', async () => {
+		ctx.helpers.requestOAuth2.mockResolvedValueOnce({ value: [{ id: '17' }] });
+
+		expect(await lookup()).toEqual(['17']);
+		expect(ctx.helpers.requestOAuth2).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports no match only after exhausting every page', async () => {
+		ctx.helpers.requestOAuth2
+			.mockResolvedValueOnce({ value: [], '@odata.nextLink': NEXT_LINK })
+			.mockResolvedValueOnce({ value: [] });
+
+		expect(await lookup()).toEqual([]);
+		expect(ctx.helpers.requestOAuth2).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/update.test.ts
@@ -10,13 +10,16 @@ import { MicrosoftSharePointV2 } from '../../../v2/MicrosoftSharePointV2.node';
 import type * as _importType0 from '../../../v2/transport';
 import * as transport from '../../../v2/transport';
 
-// Real transport module except the network helper, so getSharePointCredentialType
-// keeps its real behavior; only microsoftApiRequest is stubbed.
+// Real transport module except the network helpers, so getSharePointCredentialType
+// keeps its real behavior. microsoftApiRequestAllItems is stubbed too: the item
+// lookup routes through it, and stubbing it lets a test hand back the matched
+// rows directly (its real paging is covered in lookup.test.ts).
 vi.mock('../../../v2/transport', async () => {
 	const originalModule = await vi.importActual<typeof _importType0>('../../../v2/transport');
 	return {
 		...originalModule,
 		microsoftApiRequest: vi.fn(),
+		microsoftApiRequestAllItems: vi.fn(),
 	};
 });
 
@@ -83,6 +86,7 @@ describe('Microsoft SharePoint v2 — Item: Update', () => {
 	let node: MicrosoftSharePointV2;
 	let ctx: DeepMockProxy<IExecuteFunctions>;
 	const apiRequest = transport.microsoftApiRequest as Mock;
+	const apiRequestAllItems = transport.microsoftApiRequestAllItems as Mock;
 
 	const setParams = (params: Record<string, unknown>) => {
 		ctx.getNodeParameter.mockImplementation(
@@ -157,26 +161,27 @@ describe('Microsoft SharePoint v2 — Item: Update', () => {
 				matchingColumns: ['Title'],
 			}),
 		);
+		apiRequestAllItems.mockResolvedValueOnce([{ id: ITEM_ID }]);
 		apiRequest
-			.mockResolvedValueOnce({ value: [{ id: ITEM_ID }] })
 			.mockResolvedValueOnce({ Title: 'Title 2' })
 			.mockResolvedValueOnce({ ...GRAPH_ITEM_REPLY });
 
 		const result = await node.execute.call(ctx);
 
-		expect(apiRequest).toHaveBeenCalledTimes(3);
-		expect(apiRequest).toHaveBeenNthCalledWith(
-			1,
+		// Lookup capped at 2 matches so paged results can't be miscounted.
+		expect(apiRequestAllItems).toHaveBeenCalledWith(
+			'value',
 			'GET',
 			ITEMS_PATH,
 			{},
 			{ $filter: "fields/Title eq 'Title 2'" },
-			undefined,
+			2,
 			{ Prefer: 'HonorNonIndexedQueriesWarningMayFailRandomly' },
 		);
+		expect(apiRequest).toHaveBeenCalledTimes(2);
 		// The matched column stays in the write body, exactly like v1
 		expect(apiRequest).toHaveBeenNthCalledWith(
-			2,
+			1,
 			'PATCH',
 			`${ITEMS_PATH}/${ITEM_ID}/fields`,
 			{ Title: 'Title 2' },
@@ -194,27 +199,28 @@ describe('Microsoft SharePoint v2 — Item: Update', () => {
 				matchingColumns: ['Title'],
 			}),
 		);
-		apiRequest.mockResolvedValueOnce({ value: [] });
+		apiRequestAllItems.mockResolvedValueOnce([]);
 
 		await expect(node.execute.call(ctx)).rejects.toThrow(
 			"The column(s) don't match any existing item",
 		);
-		expect(apiRequest).toHaveBeenCalledTimes(1);
+		expect(apiRequest).not.toHaveBeenCalled();
 	});
 
-	it("throws v1's error when several items match the columns", async () => {
+	it('throws a distinct error and does not update when several items match', async () => {
 		setParams(
 			baseParams({
 				value: { Title: 'Duplicate' },
 				matchingColumns: ['Title'],
 			}),
 		);
-		apiRequest.mockResolvedValueOnce({ value: [{ id: 'item1' }, { id: 'item2' }] });
+		apiRequestAllItems.mockResolvedValueOnce([{ id: 'item1' }, { id: 'item2' }]);
 
 		await expect(node.execute.call(ctx)).rejects.toThrow(
-			"The column(s) don't match any existing item",
+			'Multiple items match the selected column(s)',
 		);
-		expect(apiRequest).toHaveBeenCalledTimes(1);
+		// No write proves the ambiguous match never updated an arbitrary item.
+		expect(apiRequest).not.toHaveBeenCalled();
 	});
 
 	it("throws v1's error when matching by ID but the ID value is empty", async () => {
@@ -238,20 +244,18 @@ describe('Microsoft SharePoint v2 — Item: Update', () => {
 				matchingColumns: ['Title'],
 			}),
 		);
-		apiRequest
-			.mockResolvedValueOnce({ value: [{ id: ITEM_ID }] })
-			.mockResolvedValueOnce({})
-			.mockResolvedValueOnce({ ...GRAPH_ITEM_REPLY });
+		apiRequestAllItems.mockResolvedValueOnce([{ id: ITEM_ID }]);
+		apiRequest.mockResolvedValueOnce({}).mockResolvedValueOnce({ ...GRAPH_ITEM_REPLY });
 
 		await node.execute.call(ctx);
 
-		expect(apiRequest).toHaveBeenNthCalledWith(
-			1,
+		expect(apiRequestAllItems).toHaveBeenCalledWith(
+			'value',
 			'GET',
 			ITEMS_PATH,
 			{},
 			{ $filter: "fields/Title eq 'O''Brien'" },
-			undefined,
+			2,
 			{ Prefer: 'HonorNonIndexedQueriesWarningMayFailRandomly' },
 		);
 	});

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/upsert.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/upsert.test.ts
@@ -1,0 +1,238 @@
+import type { IDataObject, IExecuteFunctions, INode, ResourceMapperValue } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { DeepMockProxy } from 'vitest-mock-extended';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import * as itemActions from '../../../v2/actions/item';
+import { versionDescription } from '../../../v2/actions/versionDescription';
+import { MicrosoftSharePointV2 } from '../../../v2/MicrosoftSharePointV2.node';
+import type * as _importType0 from '../../../v2/transport';
+import * as transport from '../../../v2/transport';
+
+// Real transport module except the network helper, so getSharePointCredentialType
+// keeps its real behavior; only microsoftApiRequest is stubbed.
+vi.mock('../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+const SITE_ID = 'site1';
+const LIST_ID = 'list1';
+const ITEM_ID = 'item1';
+const ITEMS_PATH = `/v1.0/sites/${SITE_ID}/lists/${LIST_ID}/items`;
+
+const GRAPH_ITEM_REPLY: IDataObject = {
+	id: ITEM_ID,
+	fields: { Title: 'Title 2', ID: ITEM_ID },
+};
+
+const SCHEMA: ResourceMapperValue['schema'] = [
+	{
+		id: 'Title',
+		displayName: 'Title',
+		canBeUsedToMatch: true,
+		defaultMatch: false,
+		display: true,
+		readOnly: false,
+		required: false,
+		type: 'string',
+	},
+];
+
+describe('Microsoft SharePoint v2 — Item: Create or Update', () => {
+	let node: MicrosoftSharePointV2;
+	let ctx: DeepMockProxy<IExecuteFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown) =>
+				(name in params ? params[name] : fallback) as never,
+		);
+	};
+
+	const baseParams = (columns: Partial<ResourceMapperValue>) => ({
+		resource: 'item',
+		operation: 'upsert',
+		site: { mode: 'id', value: SITE_ID },
+		list: LIST_ID,
+		'columns.mappingMode': columns.mappingMode ?? 'defineBelow',
+		'columns.schema': columns.schema ?? SCHEMA,
+		'columns.value': columns.value ?? null,
+		'columns.matchingColumns': columns.matchingColumns ?? [],
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		node = new MicrosoftSharePointV2(versionDescription);
+		ctx = mockDeep<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.helpers.returnJsonArray.mockImplementation((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		);
+		ctx.helpers.constructExecutionMetaData.mockImplementation((inputData, options) =>
+			inputData.map((data) => ({ ...data, pairedItem: options?.itemData })),
+		);
+	});
+
+	it('updates the single matched item and returns the item envelope', async () => {
+		setParams(baseParams({ value: { Title: 'Title 2' }, matchingColumns: ['Title'] }));
+		apiRequest
+			.mockResolvedValueOnce({ value: [{ id: ITEM_ID }] })
+			.mockResolvedValueOnce({ Title: 'Title 2' })
+			.mockResolvedValueOnce({ ...GRAPH_ITEM_REPLY });
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledTimes(3);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			1,
+			'GET',
+			ITEMS_PATH,
+			{},
+			{ $filter: "fields/Title eq 'Title 2'" },
+			undefined,
+			{ Prefer: 'HonorNonIndexedQueriesWarningMayFailRandomly' },
+		);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			2,
+			'PATCH',
+			`${ITEMS_PATH}/${ITEM_ID}/fields`,
+			{ Title: 'Title 2' },
+			{},
+			undefined,
+			{},
+		);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			3,
+			'GET',
+			`${ITEMS_PATH}/${ITEM_ID}`,
+			{},
+			{ $expand: 'fields' },
+		);
+		expect(result).toEqual([[{ json: GRAPH_ITEM_REPLY, pairedItem: { item: 0 } }]]);
+	});
+
+	it('creates a new item when nothing matches, mapping the real column values', async () => {
+		setParams(baseParams({ value: { Title: 'Title 2' }, matchingColumns: ['Title'] }));
+		const created = { id: '2', fields: { Title: 'Title 2' } };
+		apiRequest.mockResolvedValueOnce({ value: [] }).mockResolvedValueOnce(created);
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledTimes(2);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			2,
+			'POST',
+			ITEMS_PATH,
+			{ fields: { Title: 'Title 2' } },
+			{},
+			undefined,
+			{},
+		);
+		expect(result).toEqual([[{ json: created, pairedItem: { item: 0 } }]]);
+	});
+
+	it('throws and does neither when several items match (AC#2)', async () => {
+		setParams(baseParams({ value: { Title: 'Duplicate' }, matchingColumns: ['Title'] }));
+		apiRequest.mockResolvedValueOnce({ value: [{ id: 'a' }, { id: 'b' }] });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'Multiple items match the selected column(s)',
+		);
+		// Only the lookup ran — nothing after it proves neither update nor create.
+		expect(apiRequest).toHaveBeenCalledTimes(1);
+	});
+
+	it('propagates a lookup failure instead of silently creating (AC#3)', async () => {
+		setParams(baseParams({ value: { Title: 'Title 2' }, matchingColumns: ['Title'] }));
+		apiRequest.mockRejectedValueOnce(new Error('non-indexed column query failed'));
+
+		await expect(node.execute.call(ctx)).rejects.toThrow('non-indexed column query failed');
+		// One call (the failed lookup) and nothing after it proves no create was attempted.
+		expect(apiRequest).toHaveBeenCalledTimes(1);
+	});
+
+	it('creates without a lookup when no matching columns are selected', async () => {
+		setParams(baseParams({ value: { Title: 'Title 2' }, matchingColumns: [] }));
+		const created = { id: '2', fields: { Title: 'Title 2' } };
+		apiRequest.mockResolvedValueOnce(created);
+
+		const result = await node.execute.call(ctx);
+
+		// No matching columns → skip the lookup GET entirely, straight to the create POST.
+		expect(apiRequest).toHaveBeenCalledTimes(1);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			1,
+			'POST',
+			ITEMS_PATH,
+			{ fields: { Title: 'Title 2' } },
+			{},
+			undefined,
+			{},
+		);
+		expect(result).toEqual([[{ json: created, pairedItem: { item: 0 } }]]);
+	});
+
+	it('folds split hyperlink fields into the two-part shape when updating', async () => {
+		setParams(
+			baseParams({
+				value: { 'Link.Url': 'https://example.com', 'Link.Description': 'Example' },
+				matchingColumns: ['Title'],
+				schema: [
+					...SCHEMA,
+					{
+						id: 'Link.Url',
+						displayName: 'Link (URL)',
+						canBeUsedToMatch: false,
+						defaultMatch: false,
+						display: true,
+						readOnly: false,
+						required: false,
+						type: 'url',
+					},
+					{
+						id: 'Link.Description',
+						displayName: 'Link (Description)',
+						canBeUsedToMatch: false,
+						defaultMatch: false,
+						display: true,
+						readOnly: false,
+						required: false,
+						type: 'string',
+					},
+				],
+			}),
+		);
+		apiRequest
+			.mockResolvedValueOnce({ value: [{ id: ITEM_ID }] })
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ ...GRAPH_ITEM_REPLY });
+
+		await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			2,
+			'PATCH',
+			`${ITEMS_PATH}/${ITEM_ID}/fields`,
+			{ Link: { Url: 'https://example.com', Description: 'Example' } },
+			{},
+			undefined,
+			{ Prefer: 'apiversion=2.1' },
+		);
+	});
+
+	it('registers the Create or Update operation and dispatches to it', () => {
+		const operationProp = itemActions.description[0];
+		expect(operationProp.options).toContainEqual(
+			expect.objectContaining({ name: 'Create or Update', value: 'upsert' }),
+		);
+		expect('upsert' in itemActions).toBe(true);
+		expect(typeof itemActions.upsert.execute).toBe('function');
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/upsert.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/item/upsert.test.ts
@@ -9,13 +9,16 @@ import { MicrosoftSharePointV2 } from '../../../v2/MicrosoftSharePointV2.node';
 import type * as _importType0 from '../../../v2/transport';
 import * as transport from '../../../v2/transport';
 
-// Real transport module except the network helper, so getSharePointCredentialType
-// keeps its real behavior; only microsoftApiRequest is stubbed.
+// Real transport module except the network helpers, so getSharePointCredentialType
+// keeps its real behavior. microsoftApiRequestAllItems is stubbed too: the item
+// lookup routes through it, and stubbing it lets a test hand back the matched
+// rows directly (its real paging is covered in lookup.test.ts).
 vi.mock('../../../v2/transport', async () => {
 	const originalModule = await vi.importActual<typeof _importType0>('../../../v2/transport');
 	return {
 		...originalModule,
 		microsoftApiRequest: vi.fn(),
+		microsoftApiRequestAllItems: vi.fn(),
 	};
 });
 
@@ -46,6 +49,7 @@ describe('Microsoft SharePoint v2 — Item: Create or Update', () => {
 	let node: MicrosoftSharePointV2;
 	let ctx: DeepMockProxy<IExecuteFunctions>;
 	const apiRequest = transport.microsoftApiRequest as Mock;
+	const apiRequestAllItems = transport.microsoftApiRequestAllItems as Mock;
 
 	const setParams = (params: Record<string, unknown>) => {
 		ctx.getNodeParameter.mockImplementation(
@@ -82,25 +86,26 @@ describe('Microsoft SharePoint v2 — Item: Create or Update', () => {
 
 	it('updates the single matched item and returns the item envelope', async () => {
 		setParams(baseParams({ value: { Title: 'Title 2' }, matchingColumns: ['Title'] }));
+		apiRequestAllItems.mockResolvedValueOnce([{ id: ITEM_ID }]);
 		apiRequest
-			.mockResolvedValueOnce({ value: [{ id: ITEM_ID }] })
 			.mockResolvedValueOnce({ Title: 'Title 2' })
 			.mockResolvedValueOnce({ ...GRAPH_ITEM_REPLY });
 
 		const result = await node.execute.call(ctx);
 
-		expect(apiRequest).toHaveBeenCalledTimes(3);
-		expect(apiRequest).toHaveBeenNthCalledWith(
-			1,
+		// Lookup capped at 2 matches so paged results can't be miscounted.
+		expect(apiRequestAllItems).toHaveBeenCalledWith(
+			'value',
 			'GET',
 			ITEMS_PATH,
 			{},
 			{ $filter: "fields/Title eq 'Title 2'" },
-			undefined,
+			2,
 			{ Prefer: 'HonorNonIndexedQueriesWarningMayFailRandomly' },
 		);
+		expect(apiRequest).toHaveBeenCalledTimes(2);
 		expect(apiRequest).toHaveBeenNthCalledWith(
-			2,
+			1,
 			'PATCH',
 			`${ITEMS_PATH}/${ITEM_ID}/fields`,
 			{ Title: 'Title 2' },
@@ -109,7 +114,7 @@ describe('Microsoft SharePoint v2 — Item: Create or Update', () => {
 			{},
 		);
 		expect(apiRequest).toHaveBeenNthCalledWith(
-			3,
+			2,
 			'GET',
 			`${ITEMS_PATH}/${ITEM_ID}`,
 			{},
@@ -121,13 +126,14 @@ describe('Microsoft SharePoint v2 — Item: Create or Update', () => {
 	it('creates a new item when nothing matches, mapping the real column values', async () => {
 		setParams(baseParams({ value: { Title: 'Title 2' }, matchingColumns: ['Title'] }));
 		const created = { id: '2', fields: { Title: 'Title 2' } };
-		apiRequest.mockResolvedValueOnce({ value: [] }).mockResolvedValueOnce(created);
+		apiRequestAllItems.mockResolvedValueOnce([]);
+		apiRequest.mockResolvedValueOnce(created);
 
 		const result = await node.execute.call(ctx);
 
-		expect(apiRequest).toHaveBeenCalledTimes(2);
+		expect(apiRequest).toHaveBeenCalledTimes(1);
 		expect(apiRequest).toHaveBeenNthCalledWith(
-			2,
+			1,
 			'POST',
 			ITEMS_PATH,
 			{ fields: { Title: 'Title 2' } },
@@ -140,22 +146,22 @@ describe('Microsoft SharePoint v2 — Item: Create or Update', () => {
 
 	it('throws and does neither when several items match (AC#2)', async () => {
 		setParams(baseParams({ value: { Title: 'Duplicate' }, matchingColumns: ['Title'] }));
-		apiRequest.mockResolvedValueOnce({ value: [{ id: 'a' }, { id: 'b' }] });
+		apiRequestAllItems.mockResolvedValueOnce([{ id: 'a' }, { id: 'b' }]);
 
 		await expect(node.execute.call(ctx)).rejects.toThrow(
 			'Multiple items match the selected column(s)',
 		);
-		// Only the lookup ran — nothing after it proves neither update nor create.
-		expect(apiRequest).toHaveBeenCalledTimes(1);
+		// Only the lookup ran — no write proves neither update nor create.
+		expect(apiRequest).not.toHaveBeenCalled();
 	});
 
 	it('propagates a lookup failure instead of silently creating (AC#3)', async () => {
 		setParams(baseParams({ value: { Title: 'Title 2' }, matchingColumns: ['Title'] }));
-		apiRequest.mockRejectedValueOnce(new Error('non-indexed column query failed'));
+		apiRequestAllItems.mockRejectedValueOnce(new Error('non-indexed column query failed'));
 
 		await expect(node.execute.call(ctx)).rejects.toThrow('non-indexed column query failed');
-		// One call (the failed lookup) and nothing after it proves no create was attempted.
-		expect(apiRequest).toHaveBeenCalledTimes(1);
+		// The failed lookup and no write proves no create was attempted.
+		expect(apiRequest).not.toHaveBeenCalled();
 	});
 
 	it('creates without a lookup when no matching columns are selected', async () => {
@@ -209,15 +215,13 @@ describe('Microsoft SharePoint v2 — Item: Create or Update', () => {
 				],
 			}),
 		);
-		apiRequest
-			.mockResolvedValueOnce({ value: [{ id: ITEM_ID }] })
-			.mockResolvedValueOnce({})
-			.mockResolvedValueOnce({ ...GRAPH_ITEM_REPLY });
+		apiRequestAllItems.mockResolvedValueOnce([{ id: ITEM_ID }]);
+		apiRequest.mockResolvedValueOnce({}).mockResolvedValueOnce({ ...GRAPH_ITEM_REPLY });
 
 		await node.execute.call(ctx);
 
 		expect(apiRequest).toHaveBeenNthCalledWith(
-			2,
+			1,
 			'PATCH',
 			`${ITEMS_PATH}/${ITEM_ID}/fields`,
 			{ Link: { Url: 'https://example.com', Description: 'Example' } },

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/item/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/item/index.ts
@@ -5,8 +5,9 @@ import * as del from './delete.operation';
 import * as get from './get.operation';
 import * as getAll from './getAll.operation';
 import * as update from './update.operation';
+import * as upsert from './upsert.operation';
 
-export { create, get, getAll, del as delete, update };
+export { create, get, getAll, del as delete, update, upsert };
 
 export const description: INodeProperties[] = [
 	{
@@ -25,6 +26,12 @@ export const description: INodeProperties[] = [
 				value: 'create',
 				description: 'Create an item in an existing list',
 				action: 'Create item',
+			},
+			{
+				name: 'Create or Update',
+				value: 'upsert',
+				description: 'Create a new item, or update the current one if it already exists (upsert)',
+				action: 'Create or update item',
 			},
 			{
 				name: 'Delete',
@@ -59,4 +66,5 @@ export const description: INodeProperties[] = [
 	...getAll.description,
 	...del.description,
 	...update.description,
+	...upsert.description,
 ];

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/item/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/item/update.operation.ts
@@ -7,16 +7,11 @@ import type {
 import { NodeOperationError } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '../../../../../../utils/utilities';
-import {
-	addUniqueConstraintHint,
-	assertPathSegment,
-	HYPERLINK_WRITE_HEADERS,
-} from '../../helpers/utils';
-import { buildItemFieldsPayload, lookupItemIdByColumns, resolveItemMapperValues } from '../../item';
+import { assertPathSegment } from '../../helpers/utils';
+import { resolveItemMapperValues, resolveMatchedItemIds, updateItemFields } from '../../item';
 import { listRLC, untilSiteSelected } from '../../list';
 import { itemColumns } from '../../list/columns';
 import { resolveSiteId, siteRLC } from '../../site';
-import { microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
 	{
@@ -60,63 +55,19 @@ export async function execute(
 	const schema = this.getNodeParameter('columns.schema', i, []) as ResourceMapperField[];
 	const values = resolveItemMapperValues.call(this, i);
 
-	let itemId: string | undefined;
-	if (matchingColumns.includes('id')) {
-		const idValue = values.id;
-		itemId =
-			idValue === undefined || idValue === null || idValue === '' ? undefined : String(idValue);
-	} else if (matchingColumns.length > 0) {
-		itemId = await lookupItemIdByColumns.call(this, siteId, listIdOrTitle, matchingColumns, values);
-	}
-
-	if (itemId === undefined) {
-		// v1's exact wording for "no single item matched"
+	const ids = await resolveMatchedItemIds.call(
+		this,
+		siteId,
+		listIdOrTitle,
+		matchingColumns,
+		values,
+	);
+	if (ids.length !== 1) {
+		// v1's exact wording for "no single item matched" (covers zero and several)
 		throw new NodeOperationError(this.getNode(), "The column(s) don't match any existing item", {
 			description: 'Double-check the value(s) for the columns to match and try again',
 		});
 	}
 
-	itemId = assertPathSegment(this.getNode(), itemId, 'Item');
-
-	const { fields, hasHyperlink } = buildItemFieldsPayload(values, schema);
-
-	try {
-		// The documented route updates the item's fields directly (v1 PATCHed the
-		// item itself with a { fields } wrapper — a route Graph doesn't document).
-		await microsoftApiRequest.call(
-			this,
-			'PATCH',
-			`/v1.0/sites/${encodeURIComponent(siteId)}/lists/${encodeURIComponent(listIdOrTitle)}/items/${encodeURIComponent(itemId)}/fields`,
-			fields,
-			{},
-			undefined,
-			hasHyperlink ? HYPERLINK_WRITE_HEADERS : {},
-		);
-	} catch (error) {
-		addUniqueConstraintHint(error);
-		throw error;
-	}
-
-	// The /fields route replies with only the fieldValueSet, but v1 returned the
-	// full listItem envelope — re-read the item so the output stays identical.
-	try {
-		return await microsoftApiRequest.call(
-			this,
-			'GET',
-			`/v1.0/sites/${encodeURIComponent(siteId)}/lists/${encodeURIComponent(listIdOrTitle)}/items/${encodeURIComponent(itemId)}`,
-			{},
-			{ $expand: 'fields' },
-		);
-	} catch (error) {
-		// The write above already succeeded — a failed read-back must not look
-		// like a failed update, or the user retries a change that went through.
-		const reason = error instanceof Error ? error.message : String(error);
-		throw new NodeOperationError(
-			this.getNode(),
-			'The item was updated, but reading back the updated item failed',
-			{
-				description: `The update itself succeeded — check the item in SharePoint before retrying. Read-back error: ${reason}`,
-			},
-		);
-	}
+	return await updateItemFields.call(this, siteId, listIdOrTitle, ids[0], values, schema);
 }

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/item/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/item/update.operation.ts
@@ -62,10 +62,18 @@ export async function execute(
 		matchingColumns,
 		values,
 	);
-	if (ids.length !== 1) {
-		// v1's exact wording for "no single item matched" (covers zero and several)
+	if (ids.length === 0) {
+		// v1's exact wording for "no item matched"
 		throw new NodeOperationError(this.getNode(), "The column(s) don't match any existing item", {
 			description: 'Double-check the value(s) for the columns to match and try again',
+		});
+	}
+	if (ids.length > 1) {
+		// Several matched: don't silently update an arbitrary one. Same wording as
+		// Create or Update so the ambiguous-match message is consistent.
+		throw new NodeOperationError(this.getNode(), 'Multiple items match the selected column(s)', {
+			description:
+				'Narrow the matching column(s) so they identify a single item, or remove the duplicates, then try again.',
 		});
 	}
 

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/item/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/item/upsert.operation.ts
@@ -1,0 +1,81 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeProperties,
+	ResourceMapperField,
+} from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import { updateDisplayOptions } from '../../../../../../utils/utilities';
+import { assertPathSegment } from '../../helpers/utils';
+import { resolveItemMapperValues, resolveMatchedItemIds, updateItemFields } from '../../item';
+import { listRLC, untilSiteSelected } from '../../list';
+import { itemColumns } from '../../list/columns';
+import { resolveSiteId, siteRLC } from '../../site';
+
+const properties: INodeProperties[] = [
+	{
+		...siteRLC,
+		description: 'Select the site the list belongs to',
+	},
+	{
+		...listRLC,
+		description: 'Select the list you want to create or update an item in',
+		displayOptions: {
+			hide: {
+				...untilSiteSelected,
+			},
+		},
+	},
+	itemColumns('upsert'),
+];
+
+const displayOptions = {
+	show: {
+		resource: ['item'],
+		operation: ['upsert'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	i: number,
+	siteIdCache?: Map<string, string>,
+): Promise<IDataObject | IDataObject[]> {
+	const siteId = await resolveSiteId.call(this, i, siteIdCache);
+	const listIdOrTitle = assertPathSegment(
+		this.getNode(),
+		String(this.getNodeParameter('list', i, '', { extractValue: true })),
+		'List',
+	);
+
+	const matchingColumns = this.getNodeParameter('columns.matchingColumns', i, []) as string[];
+	const schema = this.getNodeParameter('columns.schema', i, []) as ResourceMapperField[];
+	const values = resolveItemMapperValues.call(this, i);
+
+	const ids = await resolveMatchedItemIds.call(
+		this,
+		siteId,
+		listIdOrTitle,
+		matchingColumns,
+		values,
+	);
+	if (ids.length >= 2) {
+		// v1 created on multiple matches; we stop instead so an ambiguous match
+		// never silently updates or duplicates the wrong item.
+		throw new NodeOperationError(this.getNode(), 'Multiple items match the selected column(s)', {
+			description:
+				'Narrow the matching column(s) so they identify a single item, or remove the duplicates, then try again.',
+		});
+	}
+	if (ids.length === 1) {
+		return await updateItemFields.call(this, siteId, listIdOrTitle, ids[0], values, schema);
+	}
+
+	// No match → create. create.execute re-reads the same params (no extra API
+	// call) and POSTs; its field builder also drops `id`, so upsert never leaks one.
+	return await create.execute.call(this, i, siteIdCache);
+}

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/node.type.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/actions/node.type.ts
@@ -3,7 +3,7 @@ import type { AllEntities } from 'n8n-workflow';
 type NodeMap = {
 	file: 'download' | 'update' | 'upload';
 	list: 'get' | 'getAll';
-	item: 'create' | 'get' | 'getAll' | 'delete' | 'update';
+	item: 'create' | 'get' | 'getAll' | 'delete' | 'update' | 'upsert';
 };
 
 export type MicrosoftSharePointType = AllEntities<NodeMap>;

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/item/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/item/index.ts
@@ -6,10 +6,13 @@ import type {
 	INodeProperties,
 	ResourceMapperField,
 } from 'n8n-workflow';
-import { setSafeObjectProperty } from 'n8n-workflow';
+import { NodeOperationError, setSafeObjectProperty } from 'n8n-workflow';
 
 import { type CollectionSearchOptions, searchGraphCollection } from '../helpers/graphSearch';
 import {
+	addUniqueConstraintHint,
+	assertPathSegment,
+	HYPERLINK_WRITE_HEADERS,
 	NON_INDEXED_QUERY_HEADERS,
 	nonIndexedFilterThresholdError,
 	odataFieldEqualsClause,
@@ -90,10 +93,11 @@ export async function getItems(
 type ItemsLookupReply = { value?: Array<{ id?: string | number }> };
 
 /**
- * Finds the one item whose columns match the given values, or `undefined`
- * when zero or several items match — the caller decides what that means
- * (Update fails, Create or Update falls back to creating; both mirror v1).
- * Values are always compared as quoted strings, exactly like v1's filter.
+ * Returns the id of every item whose columns match the given values. Each
+ * caller decides what the count means: Update requires exactly one, Create or
+ * Update maps one→update / none→create / many→error (a deliberate divergence
+ * from v1, which created on many). Values are always compared as quoted
+ * strings, exactly like v1's filter.
  */
 export async function lookupItemIdByColumns(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
@@ -101,7 +105,7 @@ export async function lookupItemIdByColumns(
 	listIdOrTitle: string,
 	matchingColumns: string[],
 	values: IDataObject,
-): Promise<string | undefined> {
+): Promise<string[]> {
 	const filter = matchingColumns
 		.map((column) => odataFieldEqualsClause(column, values[column]))
 		.join(' and ');
@@ -121,10 +125,34 @@ export async function lookupItemIdByColumns(
 		throw nonIndexedFilterThresholdError(this.getNode(), error, filter) ?? error;
 	}
 
-	if (response.value?.length === 1 && response.value[0].id !== undefined) {
-		return String(response.value[0].id);
+	// One page is enough to tell the callers apart: a >page-size match still
+	// yields length ≥ 2, so the multi-match guard fires (Graph rows carry `id`).
+	return (response.value ?? [])
+		.filter((row): row is { id: string | number } => row.id !== undefined)
+		.map((row) => String(row.id));
+}
+
+/**
+ * Resolves the item id(s) an item operation should act on: the `id` matching
+ * column when chosen (update only), otherwise the columns lookup. No try/catch —
+ * a failed lookup propagates so it can never become a silent create.
+ */
+export async function resolveMatchedItemIds(
+	this: IExecuteFunctions,
+	siteId: string,
+	listIdOrTitle: string,
+	matchingColumns: string[],
+	values: IDataObject,
+): Promise<string[]> {
+	if (matchingColumns.includes('id')) {
+		// The `id` matching column is update-only; upsert never offers it.
+		const idValue = values.id;
+		return idValue === undefined || idValue === null || idValue === '' ? [] : [String(idValue)];
 	}
-	return undefined;
+	if (matchingColumns.length > 0) {
+		return await lookupItemIdByColumns.call(this, siteId, listIdOrTitle, matchingColumns, values);
+	}
+	return [];
 }
 
 /**
@@ -189,4 +217,54 @@ export function buildItemFieldsPayload(
 		setSafeObjectProperty(fields, key, fieldValue);
 	}
 	return { fields, hasHyperlink };
+}
+
+/**
+ * Writes the mapped fields to an existing item, then re-reads it. The write goes
+ * to the documented /fields route (v1's `{ fields }`-wrapper PATCH on the item
+ * itself isn't a documented Graph route); that route replies with only the
+ * fieldValueSet, but v1 returned the full listItem envelope, so the GET re-read
+ * keeps the output identical.
+ */
+export async function updateItemFields(
+	this: IExecuteFunctions,
+	siteId: string,
+	listIdOrTitle: string,
+	itemId: string,
+	value: IDataObject,
+	schema: ResourceMapperField[],
+): Promise<IDataObject> {
+	itemId = assertPathSegment(this.getNode(), itemId, 'Item');
+	const { fields, hasHyperlink } = buildItemFieldsPayload(value, schema);
+
+	const itemPath = `/v1.0/sites/${encodeURIComponent(siteId)}/lists/${encodeURIComponent(listIdOrTitle)}/items/${encodeURIComponent(itemId)}`;
+	try {
+		await microsoftApiRequest.call(
+			this,
+			'PATCH',
+			`${itemPath}/fields`,
+			fields,
+			{},
+			undefined,
+			hasHyperlink ? HYPERLINK_WRITE_HEADERS : {},
+		);
+	} catch (error) {
+		addUniqueConstraintHint(error);
+		throw error;
+	}
+
+	try {
+		return await microsoftApiRequest.call(this, 'GET', itemPath, {}, { $expand: 'fields' });
+	} catch (error) {
+		// The write above already succeeded — a failed read-back must not look
+		// like a failed update, or the user retries a change that went through.
+		const reason = error instanceof Error ? error.message : String(error);
+		throw new NodeOperationError(
+			this.getNode(),
+			'The item was updated, but reading back the updated item failed',
+			{
+				description: `The update itself succeeded — check the item in SharePoint before retrying. Read-back error: ${reason}`,
+			},
+		);
+	}
 }

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/item/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/item/index.ts
@@ -18,7 +18,7 @@ import {
 	odataFieldEqualsClause,
 } from '../helpers/utils';
 import { resolveSiteId } from '../site';
-import { microsoftApiRequest } from '../transport';
+import { microsoftApiRequest, microsoftApiRequestAllItems } from '../transport';
 
 /** Keeps the item field hidden until a list is chosen. */
 export const untilListSelected = { list: [''] };
@@ -90,7 +90,7 @@ export async function getItems(
 	});
 }
 
-type ItemsLookupReply = { value?: Array<{ id?: string | number }> };
+type ItemsLookupRow = { id?: string | number };
 
 /**
  * Returns the id of every item whose columns match the given values. Each
@@ -110,24 +110,28 @@ export async function lookupItemIdByColumns(
 		.map((column) => odataFieldEqualsClause(column, values[column]))
 		.join(' and ');
 
-	let response: ItemsLookupReply;
+	// Graph pages filtered results behind @odata.nextLink, and a non-indexed
+	// filter can even return an empty first page while a match waits on a later
+	// one — so a single page can't tell none/one/many apart. Follow the link
+	// until we've collected 2 matches (enough to prove "many") or run out of
+	// pages; the common single-page case still costs exactly one request.
+	let rows: ItemsLookupRow[];
 	try {
-		response = (await microsoftApiRequest.call(
+		rows = (await microsoftApiRequestAllItems.call(
 			this,
+			'value',
 			'GET',
 			`/v1.0/sites/${encodeURIComponent(siteId)}/lists/${encodeURIComponent(listIdOrTitle)}/items`,
 			{},
 			{ $filter: filter },
-			undefined,
+			2,
 			NON_INDEXED_QUERY_HEADERS,
-		)) as ItemsLookupReply;
+		)) as ItemsLookupRow[];
 	} catch (error) {
 		throw nonIndexedFilterThresholdError(this.getNode(), error, filter) ?? error;
 	}
 
-	// One page is enough to tell the callers apart: a >page-size match still
-	// yields length ≥ 2, so the multi-match guard fires (Graph rows carry `id`).
-	return (response.value ?? [])
+	return rows
 		.filter((row): row is { id: string | number } => row.id !== undefined)
 		.map((row) => String(row.id));
 }

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/transport/index.ts
@@ -40,6 +40,10 @@ export const REQUIRED_PERMISSIONS: Readonly<
 		delegated: 'Sites.ReadWrite.All',
 		application: 'Sites.ReadWrite.All (or Sites.Selected granted with write access for this site)',
 	},
+	'item:upsert': {
+		delegated: 'Sites.ReadWrite.All',
+		application: 'Sites.ReadWrite.All (or Sites.Selected granted with write access for this site)',
+	},
 	'list:get': {
 		delegated: 'Sites.Read.All',
 		application: 'Sites.Read.All (or Sites.Selected granted for this site)',


### PR DESCRIPTION
## Summary

Adds **Item → Create or Update** (upsert) to the SharePoint v2 rebuild (v2 stays unregistered).

Looks the item up by the builder's chosen matching columns, then:
- **exactly one match** → update it via the documented `PATCH .../items/{id}/fields` route, re-reading for v1's full listItem envelope;
- **no match** → create (reuses `create.execute`, no extra API call);
- **two or more matches** → stop with a clear error (a deliberate divergence from v1, which created on many, per AC#2);
- **lookup that can't run** (e.g. non-indexed column on a large list) → propagates as a clear error, never a silent create (AC#3).

No new API calls — it adds decision logic on top of the shared lookup + create/update routes.

### Shared-helper refactor
Reuses (and extends) the helpers from Item → Update:
- `lookupItemIdByColumns` now returns **all** matched ids (`string[]`) so callers can tell none/one/many apart.
- New `resolveMatchedItemIds` (id-column vs columns lookup) and `updateItemFields` (PATCH + re-read), both consumed by Update and Create-or-Update.

## How to test

Register v2, then **Item → Create or Update**:
1. Match on a unique column, value matching one item → item updates (output is the full listItem, v1 shape).
2. Same match, value matching no item → a new item is created.
3. Value matching two+ items → `Multiple items match the selected column(s)`; neither update nor create runs.
4. Match on a non-indexed column of a large list that fails → a clear "could not finish filtering" error, no create.

`cd packages/nodes-base && pnpm test SharePoint`

## Related Linear tickets

https://linear.app/n8n/issue/ENT-186

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34854">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->