### PR TITLE
feat(core): Add workflow_step_execution table to @n8n/engine (no-changelog)

### DIFF
--- a/packages/@n8n/engine/package.json
+++ b/packages/@n8n/engine/package.json
@@ -28,9 +28,9 @@
     "@n8n/di": "workspace:*",
     "@n8n/typeorm": "workspace:*",
     "express": "catalog:",
-    "nanoid": "catalog:",
     "pg": "catalog:",
     "reflect-metadata": "catalog:",
+    "uuid": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -1,0 +1,61 @@
+import type { DataSource } from '@n8n/typeorm';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createDataSource } from '../data-source';
+import { WorkflowStepExecution } from '../entities/workflow-step-execution.entity';
+import { TypeOrmStepStore } from '../typeorm-step-store';
+
+describe('workflow_step_execution table (integration)', () => {
+	let container: StartedPostgreSqlContainer;
+	let dataSource: DataSource;
+
+	beforeAll(async () => {
+		container = await new PostgreSqlContainer('postgres:18-alpine').start();
+		dataSource = createDataSource(container.getConnectionUri());
+		await dataSource.initialize();
+		await dataSource.runMigrations();
+	}, 120_000);
+
+	afterAll(async () => {
+		if (dataSource?.isInitialized) await dataSource.destroy();
+		if (container) await container.stop();
+	});
+
+	it('persists and retrieves a workflow_step_execution row', async () => {
+		const repo = dataSource.getRepository(WorkflowStepExecution);
+
+		const created = repo.create({ executionId: 'exec-1', nodeId: 'node-a', status: 'queued' });
+		await repo.save(created);
+
+		const found = await repo.findOneByOrFail({ id: created.id });
+		expect(found.id).toBeTruthy();
+		expect(found.executionId).toBe('exec-1');
+		expect(found.nodeId).toBe('node-a');
+		expect(found.status).toBe('queued');
+		expect(found.createdAt).toBeInstanceOf(Date);
+		expect(found.updatedAt).toBeInstanceOf(Date);
+	});
+
+	it('counts steps by execution and status (readiness-check support)', async () => {
+		const repo = dataSource.getRepository(WorkflowStepExecution);
+
+		await repo.save(repo.create({ executionId: 'exec-2', nodeId: 'a', status: 'queued' }));
+		await repo.save(repo.create({ executionId: 'exec-2', nodeId: 'b', status: 'completed' }));
+
+		const completedForExec2 = await repo.count({
+			where: { executionId: 'exec-2', status: 'completed' },
+		});
+		expect(completedForExec2).toBe(1);
+	});
+
+	it('TypeOrmStepStore.createStep persists a queued step and returns its id', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+
+		const { id } = await store.createStep({ executionId: 'exec-3', nodeId: 'x', status: 'queued' });
+
+		const found = await dataSource.getRepository(WorkflowStepExecution).findOneByOrFail({ id });
+		expect(found.nodeId).toBe('x');
+		expect(found.status).toBe('queued');
+	});
+});

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -2,7 +2,9 @@ import type { DataSource } from '@n8n/typeorm';
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import type { StepStatus } from '../../execution/execution.types';
 import { createDataSource } from '../data-source';
+import { WorkflowExecution } from '../entities/workflow-execution.entity';
 import { WorkflowStepExecution } from '../entities/workflow-step-execution.entity';
 import { TypeOrmStepStore } from '../typeorm-step-store';
 
@@ -22,40 +24,72 @@ describe('workflow_step_execution table (integration)', () => {
 		if (container) await container.stop();
 	});
 
-	it('persists and retrieves a workflow_step_execution row', async () => {
+	/** Steps FK to an execution, so create a parent row first. */
+	async function createExecution(): Promise<string> {
+		const repo = dataSource.getRepository(WorkflowExecution);
+		const execution = repo.create({
+			workflowId: 'wf-1',
+			status: 'running',
+			mode: 'production',
+			graph: { nodes: [], edges: [] },
+			triggerPayload: null,
+			finishedAt: null,
+		});
+		await repo.save(execution);
+		return execution.id;
+	}
+
+	it('persists and retrieves a step row', async () => {
+		const executionId = await createExecution();
 		const repo = dataSource.getRepository(WorkflowStepExecution);
 
-		const created = repo.create({ executionId: 'exec-1', nodeId: 'node-a', status: 'queued' });
+		const created = repo.create({ executionId, nodeId: 'node-a', status: 'queued' });
 		await repo.save(created);
 
 		const found = await repo.findOneByOrFail({ id: created.id });
-		expect(found.id).toBeTruthy();
-		expect(found.executionId).toBe('exec-1');
+		expect(found.executionId).toBe(executionId);
 		expect(found.nodeId).toBe('node-a');
 		expect(found.status).toBe('queued');
 		expect(found.createdAt).toBeInstanceOf(Date);
-		expect(found.updatedAt).toBeInstanceOf(Date);
-	});
-
-	it('counts steps by execution and status (readiness-check support)', async () => {
-		const repo = dataSource.getRepository(WorkflowStepExecution);
-
-		await repo.save(repo.create({ executionId: 'exec-2', nodeId: 'a', status: 'queued' }));
-		await repo.save(repo.create({ executionId: 'exec-2', nodeId: 'b', status: 'completed' }));
-
-		const completedForExec2 = await repo.count({
-			where: { executionId: 'exec-2', status: 'completed' },
-		});
-		expect(completedForExec2).toBe(1);
 	});
 
 	it('TypeOrmStepStore.createStep persists a queued step and returns its id', async () => {
+		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
-		const { id } = await store.createStep({ executionId: 'exec-3', nodeId: 'x', status: 'queued' });
+		const { id } = await store.createStep({ executionId, nodeId: 'x', status: 'queued' });
 
 		const found = await dataSource.getRepository(WorkflowStepExecution).findOneByOrFail({ id });
 		expect(found.nodeId).toBe('x');
 		expect(found.status).toBe('queued');
+	});
+
+	it('cascades step deletion when the parent execution is deleted', async () => {
+		const executionId = await createExecution();
+		const stepRepo = dataSource.getRepository(WorkflowStepExecution);
+		await stepRepo.save(stepRepo.create({ executionId, nodeId: 'a', status: 'queued' }));
+
+		await dataSource.getRepository(WorkflowExecution).delete({ id: executionId });
+
+		expect(await stepRepo.countBy({ executionId })).toBe(0);
+	});
+
+	it('rejects a step referencing a non-existent execution (foreign key)', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		await expect(
+			store.createStep({
+				executionId: '00000000-0000-7000-8000-000000000000',
+				nodeId: 'a',
+				status: 'queued',
+			}),
+		).rejects.toThrow();
+	});
+
+	it('rejects an invalid status (check constraint)', async () => {
+		const executionId = await createExecution();
+		const repo = dataSource.getRepository(WorkflowStepExecution);
+		await expect(
+			repo.save(repo.create({ executionId, nodeId: 'a', status: 'bogus' as StepStatus })),
+		).rejects.toThrow();
 	});
 });

--- a/packages/@n8n/engine/src/database/entities/index.ts
+++ b/packages/@n8n/engine/src/database/entities/index.ts
@@ -1,5 +1,7 @@
 import { WorkflowExecution } from './workflow-execution.entity';
+import { WorkflowStepExecution } from './workflow-step-execution.entity';
 
-export const entities = [WorkflowExecution];
+export const entities = [WorkflowExecution, WorkflowStepExecution];
 
 export { WorkflowExecution };
+export { WorkflowStepExecution };

--- a/packages/@n8n/engine/src/database/entities/workflow-execution.entity.ts
+++ b/packages/@n8n/engine/src/database/entities/workflow-execution.entity.ts
@@ -7,17 +7,17 @@ import {
 	PrimaryColumn,
 	UpdateDateColumn,
 } from '@n8n/typeorm';
-import { nanoid } from 'nanoid';
 
 import type { JsonObject } from '../../common';
 import type { ExecutionMode, ExecutionStatus } from '../../execution/execution.types';
 import type { WorkflowGraph } from '../../graph';
+import { generateId } from '../generate-id';
 
 @Entity('workflow_execution')
 @Index('idx_workflow_execution_workflow_id', ['workflowId'])
 @Index('idx_workflow_execution_status', ['status'])
 export class WorkflowExecution {
-	@PrimaryColumn('varchar')
+	@PrimaryColumn('uuid')
 	id!: string;
 
 	@Column('varchar', { name: 'workflow_id' })
@@ -45,7 +45,7 @@ export class WorkflowExecution {
 	finishedAt!: Date | null;
 
 	@BeforeInsert()
-	generateId(): void {
-		if (!this.id) this.id = nanoid();
+	setId(): void {
+		if (!this.id) this.id = generateId();
 	}
 }

--- a/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
+++ b/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
@@ -1,0 +1,39 @@
+import {
+	BeforeInsert,
+	Column,
+	CreateDateColumn,
+	Entity,
+	Index,
+	PrimaryColumn,
+	UpdateDateColumn,
+} from '@n8n/typeorm';
+import { nanoid } from 'nanoid';
+
+import type { StepStatus } from '../../execution/execution.types';
+
+@Entity('workflow_step_execution')
+@Index('idx_workflow_step_execution_execution_id', ['executionId'])
+export class WorkflowStepExecution {
+	@PrimaryColumn('varchar')
+	id!: string;
+
+	@Column('varchar', { name: 'execution_id' })
+	executionId!: string;
+
+	@Column('varchar', { name: 'node_id' })
+	nodeId!: string;
+
+	@Column('varchar', { length: 32 })
+	status!: StepStatus;
+
+	@CreateDateColumn({ name: 'created_at', type: 'timestamptz', precision: 3 })
+	createdAt!: Date;
+
+	@UpdateDateColumn({ name: 'updated_at', type: 'timestamptz', precision: 3 })
+	updatedAt!: Date;
+
+	@BeforeInsert()
+	generateId(): void {
+		if (!this.id) this.id = nanoid();
+	}
+}

--- a/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
+++ b/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
@@ -7,17 +7,17 @@ import {
 	PrimaryColumn,
 	UpdateDateColumn,
 } from '@n8n/typeorm';
-import { nanoid } from 'nanoid';
 
 import type { StepStatus } from '../../execution/execution.types';
+import { generateId } from '../generate-id';
 
 @Entity('workflow_step_execution')
 @Index('idx_workflow_step_execution_execution_id', ['executionId'])
 export class WorkflowStepExecution {
-	@PrimaryColumn('varchar')
+	@PrimaryColumn('uuid')
 	id!: string;
 
-	@Column('varchar', { name: 'execution_id' })
+	@Column('uuid', { name: 'execution_id' })
 	executionId!: string;
 
 	@Column('varchar', { name: 'node_id' })
@@ -33,7 +33,7 @@ export class WorkflowStepExecution {
 	updatedAt!: Date;
 
 	@BeforeInsert()
-	generateId(): void {
-		if (!this.id) this.id = nanoid();
+	setId(): void {
+		if (!this.id) this.id = generateId();
 	}
 }

--- a/packages/@n8n/engine/src/database/generate-id.ts
+++ b/packages/@n8n/engine/src/database/generate-id.ts
@@ -1,0 +1,10 @@
+import { v7 as uuidv7 } from 'uuid';
+
+/**
+ * Generate a time-ordered (uuidv7) id. The timestamp prefix keeps inserts at
+ * the right edge of the primary-key index rather than scattering them, which
+ * matters for the engine's hot execution/step tables.
+ */
+export function generateId(): string {
+	return uuidv7();
+}

--- a/packages/@n8n/engine/src/database/index.ts
+++ b/packages/@n8n/engine/src/database/index.ts
@@ -1,3 +1,4 @@
 export { createDataSource } from './data-source';
-export { WorkflowExecution } from './entities';
+export { WorkflowExecution, WorkflowStepExecution } from './entities';
 export { TypeOrmExecutionStore } from './typeorm-execution-store';
+export { TypeOrmStepStore } from './typeorm-step-store';

--- a/packages/@n8n/engine/src/database/migrations/1778529600000-CreateWorkflowExecution.ts
+++ b/packages/@n8n/engine/src/database/migrations/1778529600000-CreateWorkflowExecution.ts
@@ -9,7 +9,7 @@ export class CreateWorkflowExecution1778529600000 implements MigrationInterface 
 			new Table({
 				name: TABLE,
 				columns: [
-					{ name: 'id', type: 'varchar', isPrimary: true },
+					{ name: 'id', type: 'uuid', isPrimary: true },
 					{ name: 'workflow_id', type: 'varchar' },
 					{ name: 'status', type: 'varchar', length: '32' },
 					{ name: 'mode', type: 'varchar', length: '32' },
@@ -28,6 +28,12 @@ export class CreateWorkflowExecution1778529600000 implements MigrationInterface 
 						default: 'CURRENT_TIMESTAMP(3)',
 					},
 					{ name: 'finished_at', type: 'timestamptz', precision: 3, isNullable: true },
+				],
+				checks: [
+					{
+						name: 'chk_workflow_execution_status',
+						expression: "status IN ('queued', 'running', 'completed', 'failed', 'cancelled')",
+					},
 				],
 			}),
 		);

--- a/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
+++ b/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
@@ -1,16 +1,16 @@
-import { Table, TableIndex } from '@n8n/typeorm';
+import { Table } from '@n8n/typeorm';
 import type { MigrationInterface, QueryRunner } from '@n8n/typeorm';
 
 const TABLE = 'workflow_step_execution';
 
-export class CreateWorkflowStepExecution1785000000000 implements MigrationInterface {
+export class CreateWorkflowStepExecution1784890100000 implements MigrationInterface {
 	async up(queryRunner: QueryRunner): Promise<void> {
 		await queryRunner.createTable(
 			new Table({
 				name: TABLE,
 				columns: [
-					{ name: 'id', type: 'varchar', isPrimary: true },
-					{ name: 'execution_id', type: 'varchar' },
+					{ name: 'id', type: 'uuid', isPrimary: true },
+					{ name: 'execution_id', type: 'uuid' },
 					{ name: 'node_id', type: 'varchar' },
 					{ name: 'status', type: 'varchar', length: '32' },
 					{
@@ -26,15 +26,25 @@ export class CreateWorkflowStepExecution1785000000000 implements MigrationInterf
 						default: 'CURRENT_TIMESTAMP(3)',
 					},
 				],
+				indices: [
+					{ name: 'idx_workflow_step_execution_execution_id', columnNames: ['execution_id'] },
+				],
+				foreignKeys: [
+					{
+						columnNames: ['execution_id'],
+						referencedTableName: 'workflow_execution',
+						referencedColumnNames: ['id'],
+						onDelete: 'CASCADE',
+					},
+				],
+				checks: [
+					{
+						name: 'chk_workflow_step_execution_status',
+						expression: "status IN ('queued', 'running', 'completed', 'failed', 'cancelled')",
+					},
+				],
 			}),
 		);
-
-		await queryRunner.createIndices(TABLE, [
-			new TableIndex({
-				name: 'idx_workflow_step_execution_execution_id',
-				columnNames: ['execution_id'],
-			}),
-		]);
 	}
 
 	async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/@n8n/engine/src/database/migrations/1785000000000-CreateWorkflowStepExecution.ts
+++ b/packages/@n8n/engine/src/database/migrations/1785000000000-CreateWorkflowStepExecution.ts
@@ -1,0 +1,43 @@
+import { Table, TableIndex } from '@n8n/typeorm';
+import type { MigrationInterface, QueryRunner } from '@n8n/typeorm';
+
+const TABLE = 'workflow_step_execution';
+
+export class CreateWorkflowStepExecution1785000000000 implements MigrationInterface {
+	async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.createTable(
+			new Table({
+				name: TABLE,
+				columns: [
+					{ name: 'id', type: 'varchar', isPrimary: true },
+					{ name: 'execution_id', type: 'varchar' },
+					{ name: 'node_id', type: 'varchar' },
+					{ name: 'status', type: 'varchar', length: '32' },
+					{
+						name: 'created_at',
+						type: 'timestamptz',
+						precision: 3,
+						default: 'CURRENT_TIMESTAMP(3)',
+					},
+					{
+						name: 'updated_at',
+						type: 'timestamptz',
+						precision: 3,
+						default: 'CURRENT_TIMESTAMP(3)',
+					},
+				],
+			}),
+		);
+
+		await queryRunner.createIndices(TABLE, [
+			new TableIndex({
+				name: 'idx_workflow_step_execution_execution_id',
+				columnNames: ['execution_id'],
+			}),
+		]);
+	}
+
+	async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.dropTable(TABLE);
+	}
+}

--- a/packages/@n8n/engine/src/database/migrations/index.ts
+++ b/packages/@n8n/engine/src/database/migrations/index.ts
@@ -1,3 +1,7 @@
 import { CreateWorkflowExecution1778529600000 } from './1778529600000-CreateWorkflowExecution';
+import { CreateWorkflowStepExecution1785000000000 } from './1785000000000-CreateWorkflowStepExecution';
 
-export const migrations = [CreateWorkflowExecution1778529600000];
+export const migrations = [
+	CreateWorkflowExecution1778529600000,
+	CreateWorkflowStepExecution1785000000000,
+];

--- a/packages/@n8n/engine/src/database/migrations/index.ts
+++ b/packages/@n8n/engine/src/database/migrations/index.ts
@@ -1,7 +1,7 @@
 import { CreateWorkflowExecution1778529600000 } from './1778529600000-CreateWorkflowExecution';
-import { CreateWorkflowStepExecution1785000000000 } from './1785000000000-CreateWorkflowStepExecution';
+import { CreateWorkflowStepExecution1784890100000 } from './1784890100000-CreateWorkflowStepExecution';
 
 export const migrations = [
 	CreateWorkflowExecution1778529600000,
-	CreateWorkflowStepExecution1785000000000,
+	CreateWorkflowStepExecution1784890100000,
 ];

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -1,0 +1,15 @@
+import type { Repository } from '@n8n/typeorm';
+
+import type { WorkflowStepExecution } from './entities';
+import type { NewStepRecord, StepStore } from '../execution/step-store';
+
+/** TypeORM-backed `StepStore` adapter. */
+export class TypeOrmStepStore implements StepStore {
+	constructor(private readonly repo: Repository<WorkflowStepExecution>) {}
+
+	async createStep(record: NewStepRecord): Promise<{ id: string }> {
+		const step = this.repo.create(record);
+		await this.repo.save(step);
+		return { id: step.id };
+	}
+}

--- a/packages/@n8n/engine/src/execution/execution.types.ts
+++ b/packages/@n8n/engine/src/execution/execution.types.ts
@@ -3,3 +3,6 @@ export type ExecutionStatus = 'queued' | 'running' | 'completed' | 'failed' | 'c
 
 /** How an execution was initiated. */
 export type ExecutionMode = 'production' | 'manual';
+
+/** Lifecycle status of a single step within an execution. */
+export type StepStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';

--- a/packages/@n8n/engine/src/execution/index.ts
+++ b/packages/@n8n/engine/src/execution/index.ts
@@ -3,5 +3,6 @@ export type {
 	StartExecutionRequest,
 	StartExecutionResult,
 } from './start-execution.service';
-export type { ExecutionMode, ExecutionStatus } from './execution.types';
+export type { ExecutionMode, ExecutionStatus, StepStatus } from './execution.types';
 export type { ExecutionStore, NewExecutionRecord } from './execution-store';
+export type { NewStepRecord, StepRecord, StepStore } from './step-store';

--- a/packages/@n8n/engine/src/execution/index.ts
+++ b/packages/@n8n/engine/src/execution/index.ts
@@ -5,4 +5,4 @@ export type {
 } from './start-execution.service';
 export type { ExecutionMode, ExecutionStatus, StepStatus } from './execution.types';
 export type { ExecutionStore, NewExecutionRecord } from './execution-store';
-export type { NewStepRecord, StepRecord, StepStore } from './step-store';
+export type { NewStepRecord, StepStore } from './step-store';

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -16,8 +16,7 @@ export interface StepRecord {
 }
 
 /**
- * Persistence port for step records. The core depends on this interface, not on
- * TypeORM; the adapter lives in `database/`.
+ * Persistence port for step records.
  */
 export interface StepStore {
 	/** Persist a new step record; returns its generated id. */

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -1,0 +1,25 @@
+import type { StepStatus } from './execution.types';
+
+/** A new step to persist. `id` and timestamps are assigned by the store. */
+export interface NewStepRecord {
+	executionId: string;
+	nodeId: string;
+	status: StepStatus;
+}
+
+/** A persisted step record. */
+export interface StepRecord {
+	id: string;
+	executionId: string;
+	nodeId: string;
+	status: StepStatus;
+}
+
+/**
+ * Persistence port for step records. The core depends on this interface, not on
+ * TypeORM; the adapter lives in `database/`.
+ */
+export interface StepStore {
+	/** Persist a new step record; returns its generated id. */
+	createStep(record: NewStepRecord): Promise<{ id: string }>;
+}

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -7,14 +7,6 @@ export interface NewStepRecord {
 	status: StepStatus;
 }
 
-/** A persisted step record. */
-export interface StepRecord {
-	id: string;
-	executionId: string;
-	nodeId: string;
-	status: StepStatus;
-}
-
 /**
  * Persistence port for step records.
  */

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -30,6 +30,10 @@ export type {
 	ExecutionStatus,
 	ExecutionStore,
 	NewExecutionRecord,
+	NewStepRecord,
+	StepRecord,
+	StepStatus,
+	StepStore,
 } from './execution';
 
-export { createDataSource, TypeOrmExecutionStore } from './database';
+export { createDataSource, TypeOrmExecutionStore, TypeOrmStepStore } from './database';

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -31,7 +31,6 @@ export type {
 	ExecutionStore,
 	NewExecutionRecord,
 	NewStepRecord,
-	StepRecord,
 	StepStatus,
 	StepStore,
 } from './execution';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2226,15 +2226,15 @@ importers:
       express:
         specifier: 'catalog:'
         version: 5.1.0
-      nanoid:
-        specifier: 'catalog:'
-        version: 3.3.8
       pg:
         specifier: 8.21.0
         version: 8.21.0(pg-native@3.8.0)
       reflect-metadata:
         specifier: 'catalog:'
         version: 0.2.2
+      uuid:
+        specifier: 'catalog:'
+        version: 11.1.1
       zod:
         specifier: 3.25.67
         version: 3.25.67


### PR DESCRIPTION
## Summary

Adds the `workflow_step_execution` table to the Engine 2.0 data plane — the durable per-step record the orchestration/step workers build on.

The [next PR](https://github.com/n8n-io/n8n/pull/34795) will use this to implement the `execution:enqueued` event handler and start the execution by planning the first steps.

## Notes for reviewers

- We're intentionally only adding the columns we need to enqueue the steps, not actually execute them. For example, no input/output columns.

## How to test

`pnpm --filter @n8n/engine test:integration` (testcontainer Postgres) round-trips a row and exercises the readiness-check query.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-2912 · consumer: #34795 (CAT-2869)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI