### PR TITLE
feat(core): Detect and heal published-version skew in trigger reconciliation

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -224,6 +224,49 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 	}
 
 	/**
+	 * Workflows whose `workflow_published_version` mapping disagrees with the
+	 * workflow's canonical `activeVersionId`, in either direction: published but
+	 * the mapping is stale or missing (a lost or rolled-back publication), or
+	 * unpublished but a mapping row remains (a missed unpublish).
+	 *
+	 * Workflows with an in-flight (pending/in_progress) record are excluded:
+	 * mid-publication skew is expected, and that record is about to converge it.
+	 * The exclusion lives in the same statement as the detection, so there is no
+	 * torn read between "is it skewed" and "is it in flight". This also covers
+	 * the applier's mid-apply window: publish/unpublish commit the
+	 * `activeVersionId` change and the outbox enqueue in one transaction, and the
+	 * applier only mutates the mapping while its record is `in_progress` — so a
+	 * skew visible with no in-flight record is a real divergence (e.g. a stalled
+	 * processor writing the mapping after losing its lease), never a normal
+	 * mid-flight state.
+	 */
+	async findVersionSkewedWorkflowIds(): Promise<string[]> {
+		const outboxTableName = this.getTableName('workflow_publication_outbox');
+		const workflowTableName = this.getTableName('workflow_entity');
+		const publishedVersionTableName = this.getTableName('workflow_published_version');
+
+		// `(x IS NULL) <> (y IS NULL) OR x <> y` is the portable spelling of
+		// `activeVersionId IS DISTINCT FROM publishedVersionId`, which sqlite
+		// lacks; both-null (never published, no mapping) compares as equal.
+		const rows: Array<{ workflowId: string }> = await this.query(
+			`SELECT w."id" AS "workflowId"
+			 FROM ${workflowTableName} w
+			 LEFT JOIN ${publishedVersionTableName} pv ON pv."workflowId" = w."id"
+			 WHERE (
+				 (w."activeVersionId" IS NULL) <> (pv."workflowId" IS NULL)
+				 OR w."activeVersionId" <> pv."publishedVersionId"
+			 )
+			 AND NOT EXISTS (
+				 SELECT 1 FROM ${outboxTableName} o
+				 WHERE o."workflowId" = w."id"
+				 AND o."status" IN ('${Status.Pending}', '${Status.InProgress}')
+			 )`,
+		);
+
+		return rows.map((row) => row.workflowId);
+	}
+
+	/**
 	 * Atomically claim the oldest pending record by transitioning its status to
 	 * `in_progress`. Postgres uses `FOR UPDATE SKIP LOCKED` so concurrent
 	 * consumers never receive the same row; SQLite serializes the find-then-update

--- a/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
+++ b/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
@@ -53,6 +53,8 @@ export type WorkflowPublicationMetricsEventMap = {
 		deficientCount: number;
 		/** Registered workflows torn down because they are no longer published. */
 		surplusCount: number;
+		/** Workflows re-enqueued because their published version diverged from the active version. */
+		versionSkewCount: number;
 		durationMs: number;
 	};
 };

--- a/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
@@ -204,6 +204,11 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 			help: 'Total number of registered workflows torn down by trigger reconciliation because they were no longer published.',
 		});
 
+		const versionSkew = new promClient.Counter({
+			name: `${prefix}workflow_publication_reconciliation_version_skew_workflows_total`,
+			help: 'Total number of workflows re-enqueued by reconciliation because their published version diverged from the active version.',
+		});
+
 		const duration = new promClient.Histogram({
 			name: `${prefix}workflow_publication_reconciliation_duration_seconds`,
 			help: 'Duration in seconds of a trigger reconciliation pass by result.',
@@ -213,9 +218,10 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 
 		this.eventService.on(
 			'workflow-publication-reconciliation',
-			({ result, deficientCount, surplusCount, durationMs }) => {
+			({ result, deficientCount, surplusCount, versionSkewCount, durationMs }) => {
 				deficient.inc(deficientCount);
 				surplus.inc(surplusCount);
+				versionSkew.inc(versionSkewCount);
 				duration.observe({ result }, durationMs * Time.milliseconds.toSeconds);
 			},
 		);

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
@@ -61,6 +61,7 @@ beforeEach(() => {
 	triggerStatusRepository.findActivatedInMemoryTriggers.mockResolvedValue([]);
 	outboxRepository.enqueueByWorkflowIds.mockResolvedValue();
 	outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
+	outboxRepository.findVersionSkewedWorkflowIds.mockResolvedValue([]);
 	outboxConsumer.drainPending.mockResolvedValue(0);
 	setRegistered({});
 	activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([]);
@@ -176,6 +177,19 @@ describe('WorkflowPublicationReconciler', () => {
 			await service.reconcile();
 
 			expect(outboxRepository.enqueueByWorkflowIds).toHaveBeenCalledWith(['wf-2']);
+		});
+
+		it('re-enqueues a workflow whose published version diverged from the active version', async () => {
+			outboxRepository.findVersionSkewedWorkflowIds.mockResolvedValue(['wf-skew']);
+
+			await service.reconcile();
+
+			expect(outboxRepository.enqueueByWorkflowIds).toHaveBeenCalledWith(['wf-skew']);
+			expect(outboxConsumer.drainPending).toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'workflow-publication-reconciliation',
+				expect.objectContaining({ result: 'success', versionSkewCount: 1, deficientCount: 0 }),
+			);
 		});
 
 		it('catches and reports errors without throwing', async () => {

--- a/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
@@ -36,6 +36,12 @@ import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox
  * `webhook_entity` table and are reconciled by the applier when a workflow is
  * re-published. Recovery only enqueues through the outbox and wakes the consumer;
  * the applier does the actual re-registration, so this adds no activation logic.
+ *
+ * A third detection compares versions rather than trigger node ids: a
+ * `workflow_published_version` mapping that disagrees with the workflow's
+ * `activeVersionId` (a rolled-back or lost publication, or a missed unpublish)
+ * is invisible to the node-id diffs when the trigger set is unchanged, so it is
+ * detected in the database directly and healed through the same enqueue path.
  */
 @Service()
 export class WorkflowPublicationReconciler {
@@ -120,18 +126,27 @@ export class WorkflowPublicationReconciler {
 				const startedAt = Date.now();
 				try {
 					const surplus = await this.removeGhostTriggers(await this.findSurplusWorkflowIds());
-					const missing = await this.republishMissingWorkflows(
+					const missing = await this.republishWorkflows(
 						await this.findMissingActiveWorkflows(),
+						'Re-publishing workflows with missing in-memory triggers',
+					);
+					// After the missing-trigger drain, so workflows that pass already
+					// converged are not re-detected (and double-counted) as skewed.
+					const versionSkew = await this.republishWorkflows(
+						await this.outboxRepository.findVersionSkewedWorkflowIds(),
+						'Re-enqueuing workflows whose published version diverged from the active version',
 					);
 
 					span.setAttribute('n8n.publication.deficient_workflows', missing);
 					span.setAttribute('n8n.publication.surplus_workflows', surplus);
+					span.setAttribute('n8n.publication.version_skewed_workflows', versionSkew);
 
 					span.setStatus({ code: SpanStatus.ok });
 					this.eventService.emit('workflow-publication-reconciliation', {
 						result: 'success',
 						deficientCount: missing,
 						surplusCount: surplus,
+						versionSkewCount: versionSkew,
 						durationMs: Date.now() - startedAt,
 					});
 				} catch (error) {
@@ -141,6 +156,7 @@ export class WorkflowPublicationReconciler {
 						result: 'failure',
 						deficientCount: 0,
 						surplusCount: 0,
+						versionSkewCount: 0,
 						durationMs: Date.now() - startedAt,
 					});
 				}
@@ -197,11 +213,9 @@ export class WorkflowPublicationReconciler {
 		return missing;
 	}
 
-	private async republishMissingWorkflows(workflowIds: WorkflowId[]): Promise<number> {
+	private async republishWorkflows(workflowIds: WorkflowId[], logMessage: string): Promise<number> {
 		if (workflowIds.length > 0) {
-			this.logger.debug('Re-publishing workflows with missing in-memory triggers', {
-				workflowIds,
-			});
+			this.logger.debug(logMessage, { workflowIds });
 			await this.outboxRepository.enqueueByWorkflowIds(workflowIds);
 			// Drain directly rather than waiting for the next poll cycle. These are
 			// safe to call here, to recover more quickly.

--- a/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
@@ -1,4 +1,5 @@
 import {
+	createWorkflowHistory,
 	createWorkflowWithHistory,
 	mockInstance,
 	setActiveVersion,
@@ -237,6 +238,106 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		await reconciler.reconcile();
 
 		expect(activeWorkflowTriggers.get(workflow.id)?.has(trigger.id)).toBe(true);
+	});
+
+	test('heals a published-version mapping rolled back to an older version', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('skew');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+
+		// A parameter-only newer version is published: the trigger node set is
+		// identical, so no node-id diff can distinguish the two versions.
+		const newVersionId = 'version-2-param-only';
+		await createWorkflowHistory(workflow, owner, undefined, {
+			versionId: newVersionId,
+			nodes: [{ ...trigger, parameters: { rule: { interval: [{ field: 'hours' }] } } }],
+		});
+		await setActiveVersion(workflow.id, newVersionId);
+		await outboxRepository.enqueue(workflow.id, newVersionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+		expect(await publishedVersionRepository.getPublishedVersionId(workflow.id)).toBe(newVersionId);
+
+		// A stalled processor (zombie writer) rolls the mapping back to the old
+		// version after its record already resolved: no in-flight record remains,
+		// and the running trigger's node id still matches the desired one.
+		await publishedVersionRepository.setPublishedVersion(workflow.id, workflow.versionId);
+
+		await reconciler.reconcile();
+
+		// The skew check enqueued a third record and the drain converged the
+		// mapping back to the active version.
+		expect(await publishedVersionRepository.getPublishedVersionId(workflow.id)).toBe(newVersionId);
+		expect(await outboxRepository.countBy({ workflowId: workflow.id })).toBe(3);
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
+	test('removes a published-version mapping left behind by a missed unpublish', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('missed-unpublish');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+
+		// An unpublish fully applied elsewhere (triggers down, status rows
+		// cleared, record terminal), after which a zombie writer restored the
+		// mapping row: no node-id detection has anything to see — only the
+		// version comparison can find the stale mapping.
+		await Container.get(WorkflowRepository).update(workflow.id, { activeVersionId: null });
+		await activeWorkflowTriggers.remove(workflow.id);
+		await triggerStatusRepository.delete({ workflowId: workflow.id });
+		expect(await publishedVersionRepository.getPublishedVersionId(workflow.id)).toBe(
+			workflow.versionId,
+		);
+
+		await reconciler.reconcile();
+
+		expect(await publishedVersionRepository.getPublishedVersionId(workflow.id)).toBeNull();
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
+	test('leaves a skewed workflow with an in-flight publication for that record to converge', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('skew-in-flight');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+
+		// Mid-flight publish of a parameter-only new version: `activeVersionId`
+		// commits together with the pending record, and the mapping still points
+		// at the old version. Expected skew — that record owns convergence.
+		const newVersionId = 'version-2-in-flight';
+		await createWorkflowHistory(workflow, owner, undefined, {
+			versionId: newVersionId,
+			nodes: [{ ...trigger, parameters: { rule: { interval: [{ field: 'hours' }] } } }],
+		});
+		await setActiveVersion(workflow.id, newVersionId);
+		await outboxRepository.enqueue(workflow.id, newVersionId);
+
+		expect(await outboxRepository.findVersionSkewedWorkflowIds()).not.toContain(workflow.id);
+
+		await reconciler.reconcile();
+
+		// Untouched: the mapping still points at the old version and the pending
+		// record is still pending — reconciliation neither enqueued nor drained.
+		expect(await publishedVersionRepository.getPublishedVersionId(workflow.id)).toBe(
+			workflow.versionId,
+		);
+		expect((await outboxRepository.findInFlightByWorkflowId(workflow.id))?.status).toBe('pending');
+
+		// The exclusion also holds while the record is being processed (in_progress).
+		await outboxRepository.claimNextPendingRecord();
+		expect(await outboxRepository.findVersionSkewedWorkflowIds()).not.toContain(workflow.id);
 	});
 
 	test('a pass with nothing missing enqueues no work', async () => {


### PR DESCRIPTION
## Summary

The goal is to have 2 reconciliation loops:

1. reconclie db state (`workflow_entity` with `workflow_published_version` and `workflow_publication_trigger_status`)
2. reconclie db state with memory (`workflow_published_version` with active workflows, meaning registering them on the leader and unregistering them on the followers)

1 always goes throug the outbox, while 2 skips the outbox, the db state is correct and does not need to be fixed.

This PR finishes 1. 
The next PR will split the 2 loop up which are currently conflated:
* surplus removal skips the outbox already, but is intermingled with the db reconciliation
* registering missing triggers in memory actually goes through the outbox but should not

Additionally once this is done we can replace the current failover mechanics with kicking of a reconciliation loop (2.) on the new leader.

This adds a third, DB-only detection to each reconciler pass:

- **Detection** (`WorkflowPublicationOutboxRepository.findVersionSkewedWorkflowIds`): one SQL statement finds skew in both directions — stale/absent publication (`activeVersionId` set, mapping older or missing) and missed unpublish (`activeVersionId` NULL, mapping row remains). `(x IS NULL) <> (y IS NULL) OR x <> y` is the portable spelling of `IS DISTINCT FROM` (SQLite lacks the operator); both-null (never published) compares equal.
- **No fighting in-flight publications**: the `NOT EXISTS` on `pending`/`in_progress` records lives in the *same statement*, so there is no torn read between "is it skewed" and "is it in flight". Publish/unpublish commit the `activeVersionId` change and the outbox enqueue in one transaction, and the applier only mutates the mapping while its record is `in_progress` — so skew with no in-flight record is a real divergence, never a normal mid-flight state.
- **Healing** goes through the existing `enqueueByWorkflowIds` + drain path (shared `republishWorkflows` helper). Its `ON CONFLICT ... DO NOTHING` and enqueue-time re-read of `activeVersionId` handle the detection→enqueue race with a concurrent fresh publish. The skew query runs after the missing-trigger drain so already-converged workflows are not double-counted.
- **Metrics** mirror the `surplusCount` pattern: `versionSkewCount` on the `workflow-publication-reconciliation` event, a `..._reconciliation_version_skew_workflows_total` Prometheus counter, a span attribute, and a scoped debug log.

Not in scope: in-memory ghost trigger registrations on a demoted instance (DB reconciliation cannot reach another instance's memory) — that will be covered by a per-instance memory-reconciliation loop in a follow-up. Likewise skew visible only in the trigger rows (mapping already equal to `activeVersionId` but rows stale/absent) — follow-up.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3795 (heals the DB half of Gap 2; the in-memory half remains)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI