### PR TITLE
fix(core): Require an authenticated session for the MCP registry test seed endpoint (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/mcp-registry-seeder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/mcp-registry-seeder.test.ts
@@ -1,0 +1,39 @@
+import { N8nApiError } from '../clients/n8n-client';
+import type { N8nClient } from '../clients/n8n-client';
+import { seedMcpRegistry } from '../mcp-registry/seeder';
+
+// 404 = endpoint not mounted (no E2E_TESTS) → soft skip; 401/403 after a
+// successful login → abort instead of running with an empty registry.
+
+const makeClient = (seed: () => Promise<{ count: number }>) =>
+	({ seedMcpRegistry: seed }) as unknown as N8nClient;
+
+describe('seedMcpRegistry', () => {
+	it('returns seeded count on success', async () => {
+		const client = makeClient(async () => await Promise.resolve({ count: 2 }));
+
+		await expect(seedMcpRegistry(client)).resolves.toEqual({ seeded: true, count: 2 });
+	});
+
+	it('soft-skips when the endpoint is missing (404)', async () => {
+		const client = makeClient(
+			async () =>
+				await Promise.reject(
+					new N8nApiError('n8n API POST /rest/mcp-registry/test/seed failed (404)', 404),
+				),
+		);
+
+		await expect(seedMcpRegistry(client)).resolves.toEqual({ seeded: false, count: 0 });
+	});
+
+	it.each([401, 403])('rethrows auth errors (%i)', async (status) => {
+		const client = makeClient(
+			async () =>
+				await Promise.reject(
+					new N8nApiError(`n8n API POST /rest/mcp-registry/test/seed failed (${status})`, status),
+				),
+		);
+
+		await expect(seedMcpRegistry(client)).rejects.toThrow(N8nApiError);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -558,7 +558,9 @@ export class N8nClient {
 	/**
 	 * Seed the MCP registry with the test fixture (Notion + Linear mock servers)
 	 * and trigger a synthetic node-type reload. Requires the server to be running
-	 * with `E2E_TESTS=true` so the test controller is mounted.
+	 * with `E2E_TESTS=true` so the test controller is mounted, and an
+	 * authenticated session (`login()` first) — the endpoint rejects
+	 * unauthenticated calls.
 	 * POST /rest/mcp-registry/test/seed  body: none
 	 */
 	async seedMcpRegistry(): Promise<{ count: number }> {

--- a/packages/@n8n/instance-ai/evaluations/mcp-registry/seeder.ts
+++ b/packages/@n8n/instance-ai/evaluations/mcp-registry/seeder.ts
@@ -9,14 +9,15 @@
 // builder agent.
 //
 // This seeder calls the test endpoint to deterministically upsert the Notion +
-// Linear mock entries and trigger a node-type reload. Best-effort and
-// idempotent — multiple calls are no-ops.
+// Linear mock entries and trigger a node-type reload. Best-effort on a missing
+// endpoint and idempotent — multiple calls are no-ops.
 //
 // Requires the n8n server to be running with E2E_TESTS=true so the test
-// controller is mounted. CI containers already set this; local dev does not by
-// default.
+// controller is mounted (CI containers already set this; local dev does not by
+// default), and an authenticated client — call after `client.login()`.
 // ---------------------------------------------------------------------------
 
+import { N8nApiError } from '../clients/n8n-client';
 import type { N8nClient } from '../clients/n8n-client';
 import type { EvalLogger } from '../harness/logger';
 
@@ -28,8 +29,10 @@ export interface McpRegistrySeedResult {
 /**
  * Seed the MCP registry into the n8n instance for evaluation runs.
  *
- * Non-fatal on failure — the most common cause is `E2E_TESTS=true` not being
- * set on the server, which is informative rather than a run-stopper.
+ * Non-fatal when the endpoint is missing — `E2E_TESTS=true` not being set on
+ * the server is informative rather than a run-stopper. Auth errors are fatal:
+ * they arrive only after a successful login, and swallowing one would let the
+ * run proceed with an empty registry and misattribute failures to the builder.
  */
 export async function seedMcpRegistry(
 	client: N8nClient,
@@ -39,6 +42,9 @@ export async function seedMcpRegistry(
 		const { count } = await client.seedMcpRegistry();
 		return { seeded: true, count };
 	} catch (error) {
+		if (error instanceof N8nApiError && (error.status === 401 || error.status === 403)) {
+			throw error;
+		}
 		const message = error instanceof Error ? error.message : String(error);
 		logger?.verbose(`  Skipping MCP registry seed: ${message}`);
 		return { seeded: false, count: 0 };

--- a/packages/cli/src/modules/mcp-registry/mcp-registry-test.controller.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry-test.controller.ts
@@ -10,7 +10,7 @@ import { notionMockServer, linearMockServer } from './registry/mock-servers';
 
 /**
  * Test-only endpoints for seeding MCP registry data in E2E tests.
- * Only registered when E2E_TESTS is set.
+ * Only registered when E2E_TESTS is set; callers must be authenticated.
  */
 @RestController('/mcp-registry')
 export class McpRegistryTestController {
@@ -19,7 +19,7 @@ export class McpRegistryTestController {
 		private readonly service: McpRegistryService,
 	) {}
 
-	@Post('/test/seed', { skipAuth: true })
+	@Post('/test/seed')
 	async seed() {
 		this.assertE2ETestsEnabled();
 


### PR DESCRIPTION
## Summary

Follow-up to #34811. `POST /rest/mcp-registry/test/seed` now requires an authenticated session (drops `skipAuth: true`); the mount gate stays `E2E_TESTS=true`. This keeps the test-only endpoint out of the unauthenticated-mutation class in every deployment type, per the review discussion on #34811.

Both existing consumers already authenticate before calling it, so no caller changes were needed:
- the eval harness seeds immediately after `client.login()` (`evaluations/run/lane-setup.ts`)
- the Playwright `api` fixture signs in as owner before the test body runs (`fixtures/base.ts`)

The eval seeder's error handling is now split by cause: 401/403 are rethrown (they can only occur after a successful login; swallowing one would let a run proceed with an empty registry and misattribute the failures), while 404 stays the soft "endpoint not mounted" skip for local dev without `E2E_TESTS`.

## How to test

Unit: `pnpm test evaluations/__tests__/mcp-registry-seeder.test.ts` (instance-ai) and `pnpm test src/modules/mcp-registry/__tests__/mcp-registry-test.controller.test.ts` (cli).

Live contract (validated on this branch):
1. Boot n8n with `E2E_TESTS=true`
2. Unauthenticated `POST /rest/mcp-registry/test/seed` → `401`
3. After `POST /rest/login` with the owner session cookie → `200 {"data":{"ok":true,"count":2}}`

Also validated locally on this branch:
- Eval harness: three runs against this build each log `Seeded 2 MCP registry server(s)` right after login, and the MCP-catalog expectations (Notion MCP attached from the seeded catalog) pass.
- Playwright: `pnpm test:local:isolated tests/e2e/mcp-registry/mcp-registry.spec.ts` → 1 passed. Note the PR CI e2e suite does not trigger on backend-only paths, hence the local run.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-335

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34880">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

