### PR TITLE
feat(core): Include workflow tags in exported packages

### DIFF
--- a/packages/@n8n/api-types/src/dto/packages/__tests__/export-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/export-package-request.dto.test.ts
@@ -115,6 +115,35 @@ describe('ExportPackageRequestDto', () => {
 		});
 	});
 
+	describe('includeTags', () => {
+		it('defaults to true when omitted', () => {
+			const result = ExportPackageRequestDto.safeParse({ workflowIds: ['wf-1'] });
+			expect(result.success).toBe(true);
+			if (result.success) expect(result.data.includeTags).toBe(true);
+		});
+
+		it.each([true, false])('accepts explicit %s', (includeTags) => {
+			const result = ExportPackageRequestDto.safeParse({
+				workflowIds: ['wf-1'],
+				includeTags,
+			});
+			expect(result.success).toBe(true);
+			if (result.success) expect(result.data.includeTags).toBe(includeTags);
+		});
+
+		it.each([
+			{ name: 'string value', includeTags: 'false' },
+			{ name: 'numeric value', includeTags: 0 },
+			{ name: 'null value', includeTags: null },
+		])('rejects $name', ({ includeTags }) => {
+			const result = ExportPackageRequestDto.safeParse({
+				workflowIds: ['wf-1'],
+				includeTags,
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
 	describe('missingWorkflowDependencyPolicy', () => {
 		it.each(['fail', 'reference-only', 'include-in-package'])(
 			'accepts %s',

--- a/packages/@n8n/api-types/src/dto/packages/export-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/export-package-request.dto.ts
@@ -7,6 +7,7 @@ export class ExportPackageRequestDto extends Z.class({
 	folderIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
 	projectIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
 	includeVariableValues: z.boolean().default(true),
+	includeTags: z.boolean().default(true),
 	missingWorkflowDependencyPolicy: z
 		.enum(['fail', 'reference-only', 'include-in-package'])
 		.optional()

--- a/packages/@n8n/cli/docs/commands/package.md
+++ b/packages/@n8n/cli/docs/commands/package.md
@@ -27,7 +27,7 @@ n8n-cli package export -w abc --include-tags=false -o export.n8np
 | `-p, --project-id` | Project ID to include. Repeat the flag to export several. |
 | `-o, --output` | File to write the package to. Defaults to `export.n8np`. |
 | `--include-variable-values` | `true` (default) or `false`. Whether values of variables referenced by the exported workflows are bundled into the package. When `false`, variables still travel as name/type files (and in the package requirements), just without their values. |
-| `--include-tags` | `true` (default) or `false`. Whether tags assigned to the exported workflows are bundled into the package. When `false`, no tag files, tag references, or tag requirements travel with the package. |
+| `--include-tags` | `true` (default) or `false`. Whether tags assigned to the exported workflows are bundled into the package. When `false`, no tag data is included in the package. |
 | `--missing-workflow-dependency-policy` | Policy for missing static sub-workflow dependencies: `fail` aborts when any dependency is missing, `include-in-package` automatically adds missing static sub-workflows, and `reference-only` is reserved for a future export mode. |
 
 Provide at least one `--workflow-id`, `--folder-id`, or `--project-id`. Requires

--- a/packages/@n8n/cli/docs/commands/package.md
+++ b/packages/@n8n/cli/docs/commands/package.md
@@ -17,6 +17,7 @@ n8n-cli package export --folder-id=xyz -o folders.n8np
 n8n-cli package export --project-id=abc -o project.n8np
 n8n-cli package export -p abc -p def -o projects.n8np
 n8n-cli package export -w abc --include-variable-values=false -o export.n8np
+n8n-cli package export -w abc --include-tags=false -o export.n8np
 ```
 
 | Flag | Description |
@@ -26,6 +27,7 @@ n8n-cli package export -w abc --include-variable-values=false -o export.n8np
 | `-p, --project-id` | Project ID to include. Repeat the flag to export several. |
 | `-o, --output` | File to write the package to. Defaults to `export.n8np`. |
 | `--include-variable-values` | `true` (default) or `false`. Whether values of variables referenced by the exported workflows are bundled into the package. When `false`, variables still travel as name/type files (and in the package requirements), just without their values. |
+| `--include-tags` | `true` (default) or `false`. Whether tags assigned to the exported workflows are bundled into the package. When `false`, no tag files, tag references, or tag requirements travel with the package. |
 | `--missing-workflow-dependency-policy` | Policy for missing static sub-workflow dependencies: `fail` aborts when any dependency is missing, `include-in-package` automatically adds missing static sub-workflows, and `reference-only` is reserved for a future export mode. |
 
 Provide at least one `--workflow-id`, `--folder-id`, or `--project-id`. Requires

--- a/packages/@n8n/cli/src/__tests__/client.test.ts
+++ b/packages/@n8n/cli/src/__tests__/client.test.ts
@@ -144,6 +144,25 @@ describe('N8nClient packages', () => {
 			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 			expect(init.body).toBe(JSON.stringify({ workflowIds: ['a'] }));
 		});
+
+		it('includes includeTags=false in the body when provided', async () => {
+			fetchMock.mockResolvedValue(binaryResponse(200, new Uint8Array([1])));
+
+			await client.exportPackage({ workflowIds: ['a'], includeTags: false });
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(init.body).toBe(JSON.stringify({ workflowIds: ['a'], includeTags: false }));
+		});
+
+		// Wire-compat pin: servers that predate includeTags reject unknown body properties.
+		it('omits includeTags from the body when not provided', async () => {
+			fetchMock.mockResolvedValue(binaryResponse(200, new Uint8Array([1])));
+
+			await client.exportPackage({ workflowIds: ['a'] });
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(init.body).toBe(JSON.stringify({ workflowIds: ['a'] }));
+		});
 	});
 
 	describe('importPackage', () => {

--- a/packages/@n8n/cli/src/__tests__/client.test.ts
+++ b/packages/@n8n/cli/src/__tests__/client.test.ts
@@ -153,16 +153,6 @@ describe('N8nClient packages', () => {
 			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 			expect(init.body).toBe(JSON.stringify({ workflowIds: ['a'], includeTags: false }));
 		});
-
-		// Wire-compat pin: servers that predate includeTags reject unknown body properties.
-		it('omits includeTags from the body when not provided', async () => {
-			fetchMock.mockResolvedValue(binaryResponse(200, new Uint8Array([1])));
-
-			await client.exportPackage({ workflowIds: ['a'] });
-
-			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-			expect(init.body).toBe(JSON.stringify({ workflowIds: ['a'] }));
-		});
 	});
 
 	describe('importPackage', () => {

--- a/packages/@n8n/cli/src/__tests__/package-export.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-export.test.ts
@@ -72,6 +72,7 @@ describe('package export command', () => {
 			workflowIds: ['wf-1', 'wf-2'],
 			folderIds: [],
 			includeVariableValues: true,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'fail',
 		});
 		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/team.n8np', Buffer.from([1, 2, 3]));
@@ -89,6 +90,7 @@ describe('package export command', () => {
 			workflowIds: [],
 			folderIds: ['fld-1'],
 			includeVariableValues: true,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'fail',
 		});
 		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/folders.n8np', Buffer.from([1, 2, 3]));
@@ -107,6 +109,7 @@ describe('package export command', () => {
 			workflowIds: ['wf-1'],
 			folderIds: ['fld-1'],
 			includeVariableValues: true,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'fail',
 		});
 	});
@@ -125,6 +128,7 @@ describe('package export command', () => {
 			workflowIds: ['wf-1'],
 			folderIds: ['fld-1'],
 			includeVariableValues: true,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'reference-only',
 		});
 	});
@@ -140,6 +144,7 @@ describe('package export command', () => {
 		expect(exportPackage).toHaveBeenCalledWith({
 			projectIds: ['proj-1', 'proj-2'],
 			includeVariableValues: true,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'fail',
 		});
 		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/projects.n8np', Buffer.from([1, 2, 3]));
@@ -157,6 +162,7 @@ describe('package export command', () => {
 		expect(exportPackage).toHaveBeenCalledWith({
 			projectIds: ['proj-1'],
 			includeVariableValues: true,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'include-in-package',
 		});
 	});
@@ -174,6 +180,7 @@ describe('package export command', () => {
 			workflowIds: ['wf-1'],
 			folderIds: [],
 			includeVariableValues: false,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'fail',
 		});
 	});
@@ -190,6 +197,7 @@ describe('package export command', () => {
 		expect(exportPackage).toHaveBeenCalledWith({
 			projectIds: ['proj-1'],
 			includeVariableValues: false,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'fail',
 		});
 	});
@@ -229,7 +237,7 @@ describe('package export command', () => {
 		});
 	});
 
-	it('maps an explicit --include-tags=true to an omitted request field', async () => {
+	it('treats an explicit --include-tags=true like the default', async () => {
 		const { command, exportPackage } = stubCommand({
 			workflowId: ['wf-1'],
 			output: '/tmp/export.n8np',
@@ -238,8 +246,13 @@ describe('package export command', () => {
 
 		await command.run();
 
-		const fields = exportPackage.mock.calls[0][0] as { includeTags?: boolean };
-		expect(fields.includeTags).toBeUndefined();
+		expect(exportPackage).toHaveBeenCalledWith({
+			workflowIds: ['wf-1'],
+			folderIds: [],
+			includeVariableValues: true,
+			includeTags: true,
+			missingWorkflowDependencyPolicy: 'fail',
+		});
 	});
 
 	it('declares the includeTags flag with its alias, options, and default', () => {
@@ -262,6 +275,7 @@ describe('package export command', () => {
 			workflowIds: ['wf-1'],
 			folderIds: [],
 			includeVariableValues: true,
+			includeTags: true,
 			missingWorkflowDependencyPolicy: 'fail',
 		});
 	});

--- a/packages/@n8n/cli/src/__tests__/package-export.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-export.test.ts
@@ -15,6 +15,7 @@ interface ExportFlags {
 	projectId?: string[];
 	output: string;
 	includeVariableValues?: string;
+	includeTags?: string;
 	missingWorkflowDependencyPolicy?: string;
 }
 
@@ -191,6 +192,62 @@ describe('package export command', () => {
 			includeVariableValues: false,
 			missingWorkflowDependencyPolicy: 'fail',
 		});
+	});
+
+	it('forwards includeTags=false when the flag is set', async () => {
+		const { command, exportPackage } = stubCommand({
+			workflowId: ['wf-1'],
+			output: '/tmp/export.n8np',
+			includeTags: 'false',
+		});
+
+		await command.run();
+
+		expect(exportPackage).toHaveBeenCalledWith({
+			workflowIds: ['wf-1'],
+			folderIds: [],
+			includeVariableValues: true,
+			includeTags: false,
+			missingWorkflowDependencyPolicy: 'fail',
+		});
+	});
+
+	it('forwards includeTags=false for a project export', async () => {
+		const { command, exportPackage } = stubCommand({
+			projectId: ['proj-1'],
+			output: '/tmp/project.n8np',
+			includeTags: 'false',
+		});
+
+		await command.run();
+
+		expect(exportPackage).toHaveBeenCalledWith({
+			projectIds: ['proj-1'],
+			includeVariableValues: true,
+			includeTags: false,
+			missingWorkflowDependencyPolicy: 'fail',
+		});
+	});
+
+	// Only `false` may go on the wire — servers that predate the flag reject unknown body properties.
+	it('maps an explicit --include-tags=true to an omitted request field', async () => {
+		const { command, exportPackage } = stubCommand({
+			workflowId: ['wf-1'],
+			output: '/tmp/export.n8np',
+			includeTags: 'true',
+		});
+
+		await command.run();
+
+		const fields = exportPackage.mock.calls[0][0] as { includeTags?: boolean };
+		expect(fields.includeTags).toBeUndefined();
+	});
+
+	it('declares the includeTags flag with its alias, options, and default', () => {
+		const flag = PackageExport.flags.includeTags;
+		expect(flag.aliases).toEqual(['include-tags']);
+		expect(flag.options).toEqual(['true', 'false']);
+		expect(flag.default).toBe('true');
 	});
 
 	it('treats an explicit --include-variable-values=true like the default', async () => {

--- a/packages/@n8n/cli/src/__tests__/package-export.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-export.test.ts
@@ -229,7 +229,6 @@ describe('package export command', () => {
 		});
 	});
 
-	// Only `false` may go on the wire — servers that predate the flag reject unknown body properties.
 	it('maps an explicit --include-tags=true to an omitted request field', async () => {
 		const { command, exportPackage } = stubCommand({
 			workflowId: ['wf-1'],

--- a/packages/@n8n/cli/src/__tests__/package-export.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-export.test.ts
@@ -345,4 +345,20 @@ describe('package export command', () => {
 		const message = vi.mocked(internals.succeed).mock.calls[0][0];
 		expect(message).toBe('Exported 3 workflow(s), 1 folder(s) to /tmp/folders.n8np');
 	});
+
+	it('includes a non-zero tag count in the export message', async () => {
+		const exportPackage = vi.fn().mockResolvedValue({
+			archive: Buffer.from([1, 2, 3]),
+			counts: { workflows: 2, folders: 0, credentials: 0, dataTables: 0, variables: 0, tags: 2 },
+		});
+		const { command, internals } = stubCommand(
+			{ workflowId: ['wf-1', 'wf-2'], output: '/tmp/team.n8np' },
+			exportPackage,
+		);
+
+		await command.run();
+
+		const message = vi.mocked(internals.succeed).mock.calls[0][0];
+		expect(message).toBe('Exported 2 workflow(s), 2 tag(s) to /tmp/team.n8np');
+	});
 });

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -32,6 +32,7 @@ export interface ExportPackageFields {
 	folderIds?: string[];
 	projectIds?: string[];
 	includeVariableValues?: boolean;
+	includeTags?: boolean;
 	missingWorkflowDependencyPolicy?: string;
 }
 
@@ -463,6 +464,7 @@ export class N8nClient {
 			folderIds?: string[];
 			projectIds?: string[];
 			includeVariableValues?: boolean;
+			includeTags?: boolean;
 			missingWorkflowDependencyPolicy?: string;
 		} = {};
 		if (fields.workflowIds?.length) body.workflowIds = fields.workflowIds;
@@ -470,6 +472,7 @@ export class N8nClient {
 		if (fields.projectIds?.length) body.projectIds = fields.projectIds;
 		// `undefined` is dropped by JSON serialization, so the API's default applies.
 		body.includeVariableValues = fields.includeVariableValues;
+		body.includeTags = fields.includeTags;
 		if (fields.missingWorkflowDependencyPolicy)
 			body.missingWorkflowDependencyPolicy = fields.missingWorkflowDependencyPolicy;
 

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -43,6 +43,8 @@ export interface ExportPackageCounts {
 	credentials: number;
 	dataTables: number;
 	variables: number;
+	/** Absent when the server predates tag export. */
+	tags?: number;
 }
 
 export interface ExportPackageResult {

--- a/packages/@n8n/cli/src/commands/package/export.ts
+++ b/packages/@n8n/cli/src/commands/package/export.ts
@@ -19,6 +19,7 @@ function describeExport(counts: ExportPackageCounts & { projects?: number }): st
 	if (counts.credentials) parts.push(`${counts.credentials} credential(s)`);
 	if (counts.dataTables) parts.push(`${counts.dataTables} data table(s)`);
 	if (counts.variables) parts.push(`${counts.variables} variable(s)`);
+	if (counts.tags) parts.push(`${counts.tags} tag(s)`);
 	return parts.length > 0 ? parts.join(', ') : 'nothing';
 }
 

--- a/packages/@n8n/cli/src/commands/package/export.ts
+++ b/packages/@n8n/cli/src/commands/package/export.ts
@@ -66,6 +66,12 @@ export default class PackageExport extends BaseCommand {
 			default: 'true',
 			aliases: ['include-variable-values'],
 		}),
+		includeTags: Flags.string({
+			description: 'Whether tags assigned to the exported workflows are bundled into the package',
+			options: ['true', 'false'],
+			default: 'true',
+			aliases: ['include-tags'],
+		}),
 		missingWorkflowDependencyPolicy: Flags.string({
 			options: ['fail', 'reference-only', 'include-in-package'],
 			default: 'fail',
@@ -81,6 +87,9 @@ export default class PackageExport extends BaseCommand {
 		const folderIds = flags.folderId ?? [];
 		const projectIds = flags.projectId ?? [];
 		const includeVariableValues = flags.includeVariableValues !== 'false';
+		// Only `false` goes on the wire: servers that predate the flag reject unknown
+		// body properties, and the server default already supplies `true`.
+		const includeTags = flags.includeTags === 'false' ? false : undefined;
 		const missingWorkflowDependencyPolicy = flags.missingWorkflowDependencyPolicy;
 
 		// A package is either loose workflows/folders or whole projects, not both.
@@ -97,8 +106,14 @@ export default class PackageExport extends BaseCommand {
 			try {
 				result = await client.exportPackage(
 					projectIds.length > 0
-						? { projectIds, includeVariableValues, missingWorkflowDependencyPolicy }
-						: { workflowIds, folderIds, includeVariableValues, missingWorkflowDependencyPolicy },
+						? { projectIds, includeVariableValues, includeTags, missingWorkflowDependencyPolicy }
+						: {
+								workflowIds,
+								folderIds,
+								includeVariableValues,
+								includeTags,
+								missingWorkflowDependencyPolicy,
+							},
 				);
 			} catch (error) {
 				throw toPackagesError(error);

--- a/packages/@n8n/cli/src/commands/package/export.ts
+++ b/packages/@n8n/cli/src/commands/package/export.ts
@@ -88,9 +88,7 @@ export default class PackageExport extends BaseCommand {
 		const folderIds = flags.folderId ?? [];
 		const projectIds = flags.projectId ?? [];
 		const includeVariableValues = flags.includeVariableValues !== 'false';
-		// Only `false` goes on the wire: servers that predate the flag reject unknown
-		// body properties, and the server default already supplies `true`.
-		const includeTags = flags.includeTags === 'false' ? false : undefined;
+		const includeTags = flags.includeTags !== 'false';
 		const missingWorkflowDependencyPolicy = flags.missingWorkflowDependencyPolicy;
 
 		// A package is either loose workflows/folders or whole projects, not both.

--- a/packages/@n8n/cli/src/commands/package/export.ts
+++ b/packages/@n8n/cli/src/commands/package/export.ts
@@ -32,6 +32,7 @@ export default class PackageExport extends BaseCommand {
 		'<%= config.bin %> package export --project-id=abc -o project.n8np',
 		'<%= config.bin %> package export -p abc -p def -o projects.n8np',
 		'<%= config.bin %> package export -w abc --include-variable-values=false -o export.n8np',
+		'<%= config.bin %> package export -w abc --include-tags=false -o export.n8np',
 	];
 
 	static override flags = {

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -168,6 +168,7 @@ describe('LogStreamingEventRelay', () => {
 					credentials: 1,
 					dataTables: 1,
 					variables: 1,
+					tags: 1,
 				},
 			};
 

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2313,6 +2313,7 @@ describe('TelemetryEventRelay', () => {
 					credentials: 2,
 					dataTables: 1,
 					variables: 4,
+					tags: 2,
 				},
 			};
 
@@ -2325,6 +2326,7 @@ describe('TelemetryEventRelay', () => {
 				credential_count: 2,
 				data_table_count: 1,
 				variable_count: 4,
+				tag_count: 2,
 			});
 		});
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1087,6 +1087,7 @@ export class TelemetryEventRelay extends EventRelay {
 			credential_count: counts.credentials,
 			data_table_count: counts.dataTables,
 			variable_count: counts.variables,
+			tag_count: counts.tags,
 		});
 	}
 

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-tags.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-tags.integration.test.ts
@@ -1,10 +1,12 @@
 import { LicenseState } from '@n8n/backend-common';
 import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import { WorkflowTagMappingRepository } from '@n8n/db';
+import { TagRepository, WorkflowTagMappingRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { jsonParse } from 'n8n-workflow';
 
+import { EventService } from '@/events/event.service';
+import type { RelayEventMap } from '@/events/maps/relay.event-map';
 import { createFolder } from '@test-integration/db/folders';
 import { assignTagToWorkflow, createTag } from '@test-integration/db/tags';
 import { createOwner } from '@test-integration/db/users';
@@ -62,31 +64,40 @@ describe('workflow package export — with tags', () => {
 		const owner = await createOwner();
 		const project = await createTeamProject('Project A', owner);
 		const workflow = await createWorkflow({ name: 'Tagged workflow' }, project);
-		const alpha = await createTag({ name: 'alpha' }, workflow);
+		// Created in reverse of sorted order so the exact-order assertions pin the sort.
 		const beta = await createTag({ name: 'beta' }, workflow);
+		const alpha = await createTag({ name: 'alpha' }, workflow);
 
-		const stream = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
-		const { manifest, entries } = await readExport(stream);
+		const emitSpy = vi.spyOn(Container.get(EventService), 'emit');
+		try {
+			const stream = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+			const { manifest, entries } = await readExport(stream);
 
-		expect(manifest.tags).toEqual([
-			{ id: alpha.id, name: 'alpha', target: 'tags/alpha' },
-			{ id: beta.id, name: 'beta', target: 'tags/beta' },
-		]);
-		expect(manifest.requirements!.tags).toEqual([
-			{ id: alpha.id, name: 'alpha', usedByWorkflows: [workflow.id] },
-			{ id: beta.id, name: 'beta', usedByWorkflows: [workflow.id] },
-		]);
+			expect(manifest.tags).toEqual([
+				{ id: alpha.id, name: 'alpha', target: 'tags/alpha' },
+				{ id: beta.id, name: 'beta', target: 'tags/beta' },
+			]);
+			expect(manifest.requirements!.tags).toEqual([
+				{ id: alpha.id, name: 'alpha', usedByWorkflows: [workflow.id] },
+				{ id: beta.id, name: 'beta', usedByWorkflows: [workflow.id] },
+			]);
 
-		const serialized = workflowJson(entries, manifest.workflows![0].target);
-		expect(serialized.tagIds).toEqual([alpha.id, beta.id]);
+			const serialized = workflowJson(entries, manifest.workflows![0].target);
+			expect(serialized.tagIds).toEqual([alpha.id, beta.id]);
 
-		for (const entry of manifest.tags!) {
-			const file = entries.find((e) => e.name === `${entry.target}/tag.json`);
-			expect(file).toBeDefined();
-			const parsed = jsonParse<Record<string, unknown>>(file!.content.toString());
-			expect(parsed).toEqual({ id: entry.id, name: entry.name });
-			expect(Object.keys(parsed).sort()).toEqual(['id', 'name']);
-			expect(serialized.tagIds).toContain(entry.id);
+			for (const entry of manifest.tags!) {
+				const file = entries.find((e) => e.name === `${entry.target}/tag.json`);
+				expect(file).toBeDefined();
+				const parsed = jsonParse<Record<string, unknown>>(file!.content.toString());
+				expect(parsed).toEqual({ id: entry.id, name: entry.name });
+			}
+
+			const exportedEvents = emitSpy.mock.calls.filter(([name]) => name === 'n8n-package-exported');
+			expect(exportedEvents).toHaveLength(1);
+			const payload = exportedEvents[0][1] as RelayEventMap['n8n-package-exported'];
+			expect(payload.counts.tags).toBe(2);
+		} finally {
+			emitSpy.mockRestore();
 		}
 	});
 
@@ -243,9 +254,10 @@ describe('workflow package export — with tags', () => {
 		expect(result.workflows).toHaveLength(1);
 		expect(result.workflows[0].status).toBe('created');
 
-		// Only the source workflow's mapping remains — the import assigned no tags.
+		// Only the source tag and the source workflow's mapping remain — the import created neither.
 		const mappings = await Container.get(WorkflowTagMappingRepository).find();
 		expect(mappings).toHaveLength(1);
 		expect(mappings[0].workflowId).toBe(workflow.id);
+		expect(await Container.get(TagRepository).count()).toBe(1);
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-tags.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-tags.integration.test.ts
@@ -1,0 +1,251 @@
+import { LicenseState } from '@n8n/backend-common';
+import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import { WorkflowTagMappingRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { jsonParse } from 'n8n-workflow';
+
+import { createFolder } from '@test-integration/db/folders';
+import { assignTagToWorkflow, createTag } from '@test-integration/db/tags';
+import { createOwner } from '@test-integration/db/users';
+import { LicenseMocker } from '@test-integration/license';
+import { initNodeTypes } from '@test-integration/utils';
+
+import { N8nPackagesService } from '../n8n-packages.service';
+import { readExport, streamToBuffer } from './utils/tar-support';
+import type { UnpackedEntry } from './utils/tar-support';
+import { buildWorkflowCallingSubWorkflow } from './utils/test-builders';
+
+const licenseMocker = new LicenseMocker();
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+	await initNodeTypes();
+	licenseMocker.mockLicenseState(Container.get(LicenseState));
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'WorkflowTagMapping',
+		'TagEntity',
+		'Folder',
+		'WorkflowEntity',
+		'SharedWorkflow',
+		'ProjectRelation',
+		'Project',
+	]);
+});
+
+function tagFiles(entries: UnpackedEntry[]) {
+	return entries.filter((entry) => entry.name.endsWith('/tag.json'));
+}
+
+function workflowJson(entries: UnpackedEntry[], target: string) {
+	const file = entries.find((entry) => entry.name === `${target}/workflow.json`);
+	if (!file) throw new Error(`missing ${target}/workflow.json`);
+	return jsonParse<Record<string, unknown>>(file.content.toString());
+}
+
+describe('workflow package export — with tags', () => {
+	let service: N8nPackagesService;
+
+	beforeAll(() => {
+		service = Container.get(N8nPackagesService);
+	});
+
+	it('bundles referenced tags, writes tagIds and catalogs them in manifest and requirements', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const workflow = await createWorkflow({ name: 'Tagged workflow' }, project);
+		const alpha = await createTag({ name: 'alpha' }, workflow);
+		const beta = await createTag({ name: 'beta' }, workflow);
+
+		const stream = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+		const { manifest, entries } = await readExport(stream);
+
+		expect(manifest.tags).toEqual([
+			{ id: alpha.id, name: 'alpha', target: 'tags/alpha' },
+			{ id: beta.id, name: 'beta', target: 'tags/beta' },
+		]);
+		expect(manifest.requirements!.tags).toEqual([
+			{ id: alpha.id, name: 'alpha', usedByWorkflows: [workflow.id] },
+			{ id: beta.id, name: 'beta', usedByWorkflows: [workflow.id] },
+		]);
+
+		const serialized = workflowJson(entries, manifest.workflows![0].target);
+		expect(serialized.tagIds).toEqual([alpha.id, beta.id]);
+
+		for (const entry of manifest.tags!) {
+			const file = entries.find((e) => e.name === `${entry.target}/tag.json`);
+			expect(file).toBeDefined();
+			const parsed = jsonParse<Record<string, unknown>>(file!.content.toString());
+			expect(parsed).toEqual({ id: entry.id, name: entry.name });
+			expect(Object.keys(parsed).sort()).toEqual(['id', 'name']);
+			expect(serialized.tagIds).toContain(entry.id);
+		}
+	});
+
+	it('writes a tag shared by two workflows once', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const wfA = await createWorkflow({ name: 'Workflow A' }, project);
+		const wfB = await createWorkflow({ name: 'Workflow B' }, project);
+		const tag = await createTag({ name: 'shared' });
+		await assignTagToWorkflow(tag, wfA);
+		await assignTagToWorkflow(tag, wfB);
+
+		const stream = await service.exportPackage({ user: owner, workflowIds: [wfA.id, wfB.id] });
+		const { manifest, entries } = await readExport(stream);
+
+		expect(manifest.tags).toEqual([{ id: tag.id, name: 'shared', target: 'tags/shared' }]);
+		expect(tagFiles(entries)).toHaveLength(1);
+		expect(manifest.requirements!.tags).toEqual([
+			{ id: tag.id, name: 'shared', usedByWorkflows: [wfA.id, wfB.id] },
+		]);
+
+		for (const entry of manifest.workflows!) {
+			expect(workflowJson(entries, entry.target).tagIds).toEqual([tag.id]);
+		}
+	});
+
+	it('exports an untagged workflow without any tag artifacts', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const workflow = await createWorkflow({ name: 'Untagged workflow' }, project);
+
+		const stream = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+		const { manifest, entries } = await readExport(stream);
+
+		expect(workflowJson(entries, manifest.workflows![0].target)).not.toHaveProperty('tagIds');
+		expect(tagFiles(entries)).toEqual([]);
+		expect(manifest).not.toHaveProperty('tags');
+		expect(manifest.requirements).toEqual({ nodeTypes: expect.any(Array) });
+	});
+
+	it('with includeTags=false exports a tagged folder workflow without any tag artifacts', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'ops' });
+		const workflow = await createWorkflow({ name: 'In folder', parentFolder: folder }, project);
+		await createTag({ name: 'prod' }, workflow);
+
+		const stream = await service.exportPackage({
+			user: owner,
+			folderIds: [folder.id],
+			includeTags: false,
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		expect(workflowJson(entries, manifest.workflows![0].target)).not.toHaveProperty('tagIds');
+		expect(tagFiles(entries)).toEqual([]);
+		expect(manifest).not.toHaveProperty('tags');
+		expect(manifest.requirements).toEqual({ nodeTypes: expect.any(Array) });
+	});
+
+	it('writes tags at the package root for a project export', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('team-ligo', owner);
+		const folder = await createFolder(project, { name: 'ops' });
+		const workflow = await createWorkflow({ name: 'Deep workflow', parentFolder: folder }, project);
+		const tag = await createTag({ name: 'prod' }, workflow);
+
+		const stream = await service.exportPackage({ user: owner, projectIds: [project.id] });
+		const { manifest, entries } = await readExport(stream);
+
+		expect(manifest.tags).toEqual([{ id: tag.id, name: 'prod', target: 'tags/prod' }]);
+		expect(entries.find((e) => e.name === 'tags/prod/tag.json')).toBeDefined();
+
+		const workflowEntry = manifest.workflows!.find((entry) => entry.id === workflow.id)!;
+		expect(workflowEntry.target).toMatch(/^projects\//);
+		expect(workflowJson(entries, workflowEntry.target).tagIds).toEqual([tag.id]);
+	});
+
+	it('bundles the tags of auto-included sub-workflows', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const sub = await createWorkflow({ name: 'Sub workflow' }, project);
+		const tag = await createTag({ name: 'prod' }, sub);
+		const parent = await buildWorkflowCallingSubWorkflow({
+			name: 'Parent workflow',
+			project,
+			subWorkflowId: sub.id,
+		});
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [parent.id],
+			missingWorkflowDependencyPolicy: 'include-in-package',
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		expect(manifest.tags).toEqual([{ id: tag.id, name: 'prod', target: 'tags/prod' }]);
+		expect(manifest.requirements!.tags).toEqual([
+			{ id: tag.id, name: 'prod', usedByWorkflows: [sub.id] },
+		]);
+
+		const subEntry = manifest.workflows!.find((entry) => entry.id === sub.id)!;
+		expect(workflowJson(entries, subEntry.target).tagIds).toEqual([tag.id]);
+	});
+
+	it('skips tags silently when workflow tags are disabled on the instance', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const workflow = await createWorkflow({ name: 'Tagged workflow' }, project);
+		await createTag({ name: 'prod' }, workflow);
+
+		const globalConfig = Container.get(GlobalConfig);
+		globalConfig.tags.disabled = true;
+		try {
+			const stream = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+			const { manifest, entries } = await readExport(stream);
+
+			expect(workflowJson(entries, manifest.workflows![0].target)).not.toHaveProperty('tagIds');
+			expect(tagFiles(entries)).toEqual([]);
+			expect(manifest).not.toHaveProperty('tags');
+			expect(manifest.requirements).toEqual({ nodeTypes: expect.any(Array) });
+		} finally {
+			globalConfig.tags.disabled = false;
+		}
+	});
+
+	it('imports a tag-bearing package as a no-op for tags', async () => {
+		const owner = await createOwner();
+		const source = await createTeamProject('Source project', owner);
+		const workflow = await createWorkflow({ name: 'Tagged workflow' }, source);
+		await createTag({ name: 'prod' }, workflow);
+		const packageBuffer = await streamToBuffer(
+			await service.exportPackage({ user: owner, workflowIds: [workflow.id] }),
+		);
+
+		const target = await createTeamProject('Target project', owner);
+		const result = await service.importPackage({
+			user: owner,
+			projectId: target.id,
+			packageBuffer,
+			credentialMatchingMode: 'id-only',
+			credentialMissingMode: 'must-preexist',
+			workflowConflictPolicy: 'fail',
+			workflowPublishingPolicy: 'preserve-published-state',
+			workflowIdPolicy: 'new',
+			folderConflictPolicy: 'merge',
+			dataTableMatchingMode: 'by-id',
+			dataTableMissingMode: 'create',
+			dataTableSchemaConflictPolicy: 'keep-existing',
+			variableMissingMode: 'do-nothing',
+			missingNodeTypeMode: 'fail',
+		});
+
+		expect(result.workflows).toHaveLength(1);
+		expect(result.workflows[0].status).toBe('created');
+
+		// Only the source workflow's mapping remains — the import assigned no tags.
+		const mappings = await Container.get(WorkflowTagMappingRepository).find();
+		expect(mappings).toHaveLength(1);
+		expect(mappings[0].workflowId).toBe(workflow.id);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-tags.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-tags.integration.test.ts
@@ -70,7 +70,7 @@ describe('workflow package export — with tags', () => {
 
 		const emitSpy = vi.spyOn(Container.get(EventService), 'emit');
 		try {
-			const stream = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+			const { stream } = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
 			const { manifest, entries } = await readExport(stream);
 
 			expect(manifest.tags).toEqual([
@@ -110,7 +110,7 @@ describe('workflow package export — with tags', () => {
 		await assignTagToWorkflow(tag, wfA);
 		await assignTagToWorkflow(tag, wfB);
 
-		const stream = await service.exportPackage({ user: owner, workflowIds: [wfA.id, wfB.id] });
+		const { stream } = await service.exportPackage({ user: owner, workflowIds: [wfA.id, wfB.id] });
 		const { manifest, entries } = await readExport(stream);
 
 		expect(manifest.tags).toEqual([{ id: tag.id, name: 'shared', target: 'tags/shared' }]);
@@ -129,7 +129,7 @@ describe('workflow package export — with tags', () => {
 		const project = await createTeamProject('Project A', owner);
 		const workflow = await createWorkflow({ name: 'Untagged workflow' }, project);
 
-		const stream = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+		const { stream } = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
 		const { manifest, entries } = await readExport(stream);
 
 		expect(workflowJson(entries, manifest.workflows![0].target)).not.toHaveProperty('tagIds');
@@ -145,7 +145,7 @@ describe('workflow package export — with tags', () => {
 		const workflow = await createWorkflow({ name: 'In folder', parentFolder: folder }, project);
 		await createTag({ name: 'prod' }, workflow);
 
-		const stream = await service.exportPackage({
+		const { stream } = await service.exportPackage({
 			user: owner,
 			folderIds: [folder.id],
 			includeTags: false,
@@ -165,7 +165,7 @@ describe('workflow package export — with tags', () => {
 		const workflow = await createWorkflow({ name: 'Deep workflow', parentFolder: folder }, project);
 		const tag = await createTag({ name: 'prod' }, workflow);
 
-		const stream = await service.exportPackage({ user: owner, projectIds: [project.id] });
+		const { stream } = await service.exportPackage({ user: owner, projectIds: [project.id] });
 		const { manifest, entries } = await readExport(stream);
 
 		expect(manifest.tags).toEqual([{ id: tag.id, name: 'prod', target: 'tags/prod' }]);
@@ -187,7 +187,7 @@ describe('workflow package export — with tags', () => {
 			subWorkflowId: sub.id,
 		});
 
-		const stream = await service.exportPackage({
+		const { stream } = await service.exportPackage({
 			user: owner,
 			workflowIds: [parent.id],
 			missingWorkflowDependencyPolicy: 'include-in-package',
@@ -212,7 +212,7 @@ describe('workflow package export — with tags', () => {
 		const globalConfig = Container.get(GlobalConfig);
 		globalConfig.tags.disabled = true;
 		try {
-			const stream = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+			const { stream } = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
 			const { manifest, entries } = await readExport(stream);
 
 			expect(workflowJson(entries, manifest.workflows![0].target)).not.toHaveProperty('tagIds');
@@ -230,7 +230,7 @@ describe('workflow package export — with tags', () => {
 		const workflow = await createWorkflow({ name: 'Tagged workflow' }, source);
 		await createTag({ name: 'prod' }, workflow);
 		const packageBuffer = await streamToBuffer(
-			await service.exportPackage({ user: owner, workflowIds: [workflow.id] }),
+			(await service.exportPackage({ user: owner, workflowIds: [workflow.id] })).stream,
 		);
 
 		const target = await createTeamProject('Target project', owner);

--- a/packages/cli/src/modules/n8n-packages/entities/__tests__/requirements.types.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/__tests__/requirements.types.test.ts
@@ -1,6 +1,7 @@
 import type { WorkflowCredentialRequirement } from '../credential/credential.types';
 import type { WorkflowDataTableRequirement } from '../data-table/data-table.types';
 import { mergeRequirements } from '../requirements.types';
+import type { WorkflowTagUsage } from '../requirements.types';
 import type { WorkflowVariableRequirement } from '../variable/variable.types';
 import type { WorkflowNodeTypeSource } from '../workflow/node-type-usage';
 
@@ -21,6 +22,10 @@ function dataTable(dataTableId: string, workflowId: string): WorkflowDataTableRe
 	return { workflowId, dataTableId };
 }
 
+function tagUsage(tagId: string, workflowId: string): WorkflowTagUsage {
+	return { workflowId, tag: { id: tagId, name: `Tag ${tagId}` } };
+}
+
 function nodeTypeSource(workflowId: string): WorkflowNodeTypeSource {
 	return { workflowId, nodes: [] };
 }
@@ -32,12 +37,14 @@ describe('mergeRequirements', () => {
 				credentials: [cred('c1', 'w1')],
 				dataTables: [dataTable('dt1', 'w1')],
 				variables: [variable('V1', 'w1')],
+				tags: [tagUsage('t1', 'w1')],
 				nodeTypes: [nodeTypeSource('w1')],
 			},
 			{
 				credentials: [cred('c2', 'w2'), cred('c3', 'w3')],
 				dataTables: [dataTable('dt2', 'w2')],
 				variables: [variable('V2', 'w2')],
+				tags: [tagUsage('t2', 'w2')],
 				nodeTypes: [nodeTypeSource('w2')],
 			},
 		);
@@ -45,6 +52,7 @@ describe('mergeRequirements', () => {
 		expect(merged.credentials).toEqual([cred('c1', 'w1'), cred('c2', 'w2'), cred('c3', 'w3')]);
 		expect(merged.dataTables).toEqual([dataTable('dt1', 'w1'), dataTable('dt2', 'w2')]);
 		expect(merged.variables).toEqual([variable('V1', 'w1'), variable('V2', 'w2')]);
+		expect(merged.tags).toEqual([tagUsage('t1', 'w1'), tagUsage('t2', 'w2')]);
 		expect(merged.nodeTypes).toEqual([nodeTypeSource('w1'), nodeTypeSource('w2')]);
 	});
 
@@ -55,6 +63,7 @@ describe('mergeRequirements', () => {
 				credentials: [cred('c1', 'w1')],
 				dataTables: [dataTable('dt1', 'w1')],
 				variables: [variable('V1', 'w1')],
+				tags: [tagUsage('t1', 'w1')],
 				nodeTypes: [nodeTypeSource('w1')],
 			},
 			undefined,
@@ -63,6 +72,7 @@ describe('mergeRequirements', () => {
 		expect(merged.credentials).toEqual([cred('c1', 'w1')]);
 		expect(merged.dataTables).toEqual([dataTable('dt1', 'w1')]);
 		expect(merged.variables).toEqual([variable('V1', 'w1')]);
+		expect(merged.tags).toEqual([tagUsage('t1', 'w1')]);
 		expect(merged.nodeTypes).toEqual([nodeTypeSource('w1')]);
 	});
 
@@ -71,6 +81,7 @@ describe('mergeRequirements', () => {
 			credentials: [],
 			dataTables: [],
 			variables: [],
+			tags: [],
 			nodeTypes: [],
 		});
 	});

--- a/packages/cli/src/modules/n8n-packages/entities/__tests__/requirements.types.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/__tests__/requirements.types.test.ts
@@ -1,7 +1,7 @@
 import type { WorkflowCredentialRequirement } from '../credential/credential.types';
 import type { WorkflowDataTableRequirement } from '../data-table/data-table.types';
 import { mergeRequirements } from '../requirements.types';
-import type { WorkflowTagUsage } from '../requirements.types';
+import type { WorkflowTagUsage } from '../tag/tag.types';
 import type { WorkflowVariableRequirement } from '../variable/variable.types';
 import type { WorkflowNodeTypeSource } from '../workflow/node-type-usage';
 

--- a/packages/cli/src/modules/n8n-packages/entities/folder/__tests__/folder.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/__tests__/folder.exporter.test.ts
@@ -49,6 +49,7 @@ describe('FolderExporter', () => {
 			user,
 			folderIds: ['fld-1'],
 			writer: new CapturingWriter(),
+			includeTags: true,
 			basePrefix: 'projects/team-ligo',
 		});
 
@@ -71,6 +72,7 @@ describe('FolderExporter', () => {
 				],
 				dataTables: [],
 				variables: [],
+				tags: [],
 				nodeTypes: [],
 			},
 		});
@@ -79,6 +81,7 @@ describe('FolderExporter', () => {
 			user,
 			folderIds: ['fld-1'],
 			writer: new CapturingWriter(),
+			includeTags: true,
 		});
 
 		// The folder's own target is passed as basePrefix, so workflows nest under it.
@@ -106,7 +109,12 @@ describe('FolderExporter', () => {
 		);
 
 		await expect(
-			exporter.export({ user, folderIds: ['fld-1'], writer: new CapturingWriter() }),
+			exporter.export({
+				user,
+				folderIds: ['fld-1'],
+				writer: new CapturingWriter(),
+				includeTags: true,
+			}),
 		).rejects.toThrow(/not found or not accessible/);
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder.exporter.ts
@@ -18,6 +18,7 @@ export interface FolderExportRequest {
 	user: User;
 	folderIds: string[];
 	writer: PackageWriter;
+	includeTags: boolean;
 	/**
 	 * Directory the folder tree is written under. Empty for a top-level folder
 	 * export (`folders/...`); a project exporter passes `projects/<slug>` so the
@@ -181,6 +182,7 @@ export class FolderExporter {
 			user: request.user,
 			writer: request.writer,
 			workflowIds,
+			includeTags: request.includeTags,
 			basePrefix,
 		});
 	}

--- a/packages/cli/src/modules/n8n-packages/entities/project/__tests__/project.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/__tests__/project.exporter.test.ts
@@ -97,7 +97,7 @@ describe('ProjectExporter', () => {
 		const { exporter, projectService } = makeExporter({ projects: [project] });
 		const writer = new CapturingWriter();
 
-		await exporter.export({ user, projectIds: [project.id], writer });
+		await exporter.export({ user, projectIds: [project.id], writer, includeTags: true });
 
 		expect(projectService.findProjectsByIdsForUser).toHaveBeenCalledWith(
 			user,
@@ -111,9 +111,9 @@ describe('ProjectExporter', () => {
 		const { exporter } = makeExporter({ projects: [] });
 		const writer = new CapturingWriter();
 
-		await expect(exporter.export({ user, projectIds: [project.id], writer })).rejects.toThrow(
-			'1 project(s) not found or not accessible. Export aborted.',
-		);
+		await expect(
+			exporter.export({ user, projectIds: [project.id], writer, includeTags: true }),
+		).rejects.toThrow('1 project(s) not found or not accessible. Export aborted.');
 	});
 
 	it('throws PackageEntityNotFoundError when the missing project does not exist at all', async () => {
@@ -121,9 +121,9 @@ describe('ProjectExporter', () => {
 		projectService.findExistingProjectIds.mockResolvedValue(new Set());
 		const writer = new CapturingWriter();
 
-		await expect(exporter.export({ user, projectIds: ['missing'], writer })).rejects.toBeInstanceOf(
-			PackageEntityNotFoundError,
-		);
+		await expect(
+			exporter.export({ user, projectIds: ['missing'], writer, includeTags: true }),
+		).rejects.toBeInstanceOf(PackageEntityNotFoundError);
 	});
 
 	it('throws PackageEntityAccessDeniedError when the missing project exists but is inaccessible', async () => {
@@ -132,7 +132,7 @@ describe('ProjectExporter', () => {
 		const writer = new CapturingWriter();
 
 		await expect(
-			exporter.export({ user, projectIds: ['denied-1'], writer }),
+			exporter.export({ user, projectIds: ['denied-1'], writer, includeTags: true }),
 		).rejects.toBeInstanceOf(PackageEntityAccessDeniedError);
 	});
 
@@ -141,7 +141,12 @@ describe('ProjectExporter', () => {
 		const { exporter } = makeExporter({ projects: [project] });
 		const writer = new CapturingWriter();
 
-		const { entries } = await exporter.export({ user, projectIds: [project.id], writer });
+		const { entries } = await exporter.export({
+			user,
+			projectIds: [project.id],
+			writer,
+			includeTags: true,
+		});
 
 		expect(entries).toEqual([
 			{
@@ -179,6 +184,7 @@ describe('ProjectExporter', () => {
 			user,
 			projectIds: [newerProject.id, olderProject.id],
 			writer,
+			includeTags: true,
 		});
 
 		expect(entries).toEqual([
@@ -200,7 +206,12 @@ describe('ProjectExporter', () => {
 		const { exporter } = makeExporter({ projects: [project] });
 		const writer = new CapturingWriter();
 
-		const { entries } = await exporter.export({ user, projectIds: [project.id], writer });
+		const { entries } = await exporter.export({
+			user,
+			projectIds: [project.id],
+			writer,
+			includeTags: true,
+		});
 
 		expect(entries).toEqual([
 			{

--- a/packages/cli/src/modules/n8n-packages/entities/project/project.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project.exporter.ts
@@ -21,6 +21,7 @@ export interface ProjectExportRequest {
 	user: User;
 	projectIds: string[];
 	writer: PackageWriter;
+	includeTags: boolean;
 }
 
 interface ProjectExportResult {
@@ -109,6 +110,7 @@ export class ProjectExporter {
 			user: request.user,
 			folderIds,
 			writer: request.writer,
+			includeTags: request.includeTags,
 			basePrefix: target,
 		});
 	}
@@ -127,6 +129,7 @@ export class ProjectExporter {
 			user: request.user,
 			workflowIds: rootWorkflowIds,
 			writer: request.writer,
+			includeTags: request.includeTags,
 			basePrefix: target,
 		});
 	}

--- a/packages/cli/src/modules/n8n-packages/entities/requirements.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/requirements.types.ts
@@ -1,12 +1,8 @@
 import type { WorkflowCredentialRequirement } from './credential/credential.types';
 import type { WorkflowDataTableRequirement } from './data-table/data-table.types';
+import type { WorkflowTagUsage } from './tag/tag.types';
 import type { WorkflowVariableRequirement } from './variable/variable.types';
 import type { WorkflowNodeTypeSource } from './workflow/node-type-usage';
-
-export interface WorkflowTagUsage {
-	workflowId: string;
-	tag: { id: string; name: string };
-}
 
 export interface WorkflowExportRequirements {
 	credentials: WorkflowCredentialRequirement[];

--- a/packages/cli/src/modules/n8n-packages/entities/requirements.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/requirements.types.ts
@@ -3,10 +3,16 @@ import type { WorkflowDataTableRequirement } from './data-table/data-table.types
 import type { WorkflowVariableRequirement } from './variable/variable.types';
 import type { WorkflowNodeTypeSource } from './workflow/node-type-usage';
 
+export interface WorkflowTagUsage {
+	workflowId: string;
+	tag: { id: string; name: string };
+}
+
 export interface WorkflowExportRequirements {
 	credentials: WorkflowCredentialRequirement[];
 	dataTables: WorkflowDataTableRequirement[];
 	variables: WorkflowVariableRequirement[];
+	tags: WorkflowTagUsage[];
 	/** Per-workflow node lists; folded into unique pairs at manifest-assembly time. */
 	nodeTypes: WorkflowNodeTypeSource[];
 }
@@ -17,5 +23,6 @@ export const mergeRequirements = (
 	credentials: parts.flatMap((part) => part?.credentials ?? []),
 	dataTables: parts.flatMap((part) => part?.dataTables ?? []),
 	variables: parts.flatMap((part) => part?.variables ?? []),
+	tags: parts.flatMap((part) => part?.tags ?? []),
 	nodeTypes: parts.flatMap((part) => part?.nodeTypes ?? []),
 });

--- a/packages/cli/src/modules/n8n-packages/entities/tag/tag-requirements.extractor.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/tag/tag-requirements.extractor.ts
@@ -1,0 +1,15 @@
+import type { WorkflowEntity } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import type { WorkflowTagUsage } from './tag.types';
+import type { RequirementsExtractor } from '../requirements-extractor';
+
+@Service()
+export class TagRequirementsExtractor implements RequirementsExtractor<WorkflowTagUsage> {
+	extract(workflow: WorkflowEntity): WorkflowTagUsage[] {
+		return (workflow.tags ?? []).map((tag) => ({
+			workflowId: workflow.id,
+			tag: { id: tag.id, name: tag.name },
+		}));
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
@@ -5,7 +5,7 @@ import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
 import type { ManifestEntry } from '../../spec/manifest.schema';
 import type { PackageTagRequirement } from '../../spec/requirements.schema';
 import { serializedTagSchema } from '../../spec/serialized/tag.schema';
-import type { WorkflowTagUsage } from '../requirements.types';
+import { compareTagsByName, type WorkflowTagUsage } from './tag.types';
 
 export interface TagExportRequest {
 	usages: WorkflowTagUsage[];
@@ -30,9 +30,7 @@ export class TagExporter {
 			tagsById.set(tag.id, grouped);
 		}
 
-		const requirements = [...tagsById.values()].sort(
-			(a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id),
-		);
+		const requirements = [...tagsById.values()].sort(compareTagsByName);
 
 		const allocator = new UniqueFilenameAllocator('tags', 'tag');
 		const entries: ManifestEntry[] = [];

--- a/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
@@ -20,27 +20,34 @@ export interface TagExportResult {
 @Service()
 export class TagExporter {
 	export(request: TagExportRequest): TagExportResult {
-		const tagsById = new Map<string, PackageTagRequirement>();
+		const requirementsByTagId = new Map<string, PackageTagRequirement>();
 
 		for (const { workflowId, tag } of request.usages) {
-			const grouped = tagsById.get(tag.id) ?? { id: tag.id, name: tag.name, usedByWorkflows: [] };
-			if (!grouped.usedByWorkflows.includes(workflowId)) {
-				grouped.usedByWorkflows.push(workflowId);
+			const requirement = requirementsByTagId.get(tag.id) ?? {
+				id: tag.id,
+				name: tag.name,
+				usedByWorkflows: [],
+			};
+			if (!requirement.usedByWorkflows.includes(workflowId)) {
+				requirement.usedByWorkflows.push(workflowId);
 			}
-			tagsById.set(tag.id, grouped);
+			requirementsByTagId.set(tag.id, requirement);
 		}
 
-		const requirements = [...tagsById.values()].sort(compareTagsByName);
+		const requirements = [...requirementsByTagId.values()].sort(compareTagsByName);
 
 		const allocator = new UniqueFilenameAllocator('tags', 'tag');
 		const entries: ManifestEntry[] = [];
 
-		for (const tag of requirements) {
-			const target = allocator.allocate(tag.name);
-			const serialized = serializedTagSchema.parse({ id: tag.id, name: tag.name });
-			request.writer.writeDirectory(target);
-			request.writer.writeFile(`${target}/tag.json`, JSON.stringify(serialized, null, '\t'));
-			entries.push({ id: tag.id, name: tag.name, target });
+		for (const { id, name } of requirements) {
+			const tagDirectory = allocator.allocate(name);
+			const serializedTag = serializedTagSchema.parse({ id, name });
+			request.writer.writeDirectory(tagDirectory);
+			request.writer.writeFile(
+				`${tagDirectory}/tag.json`,
+				JSON.stringify(serializedTag, null, '\t'),
+			);
+			entries.push({ id, name, target: tagDirectory });
 		}
 
 		return { entries, requirements };

--- a/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
@@ -1,0 +1,50 @@
+import { Service } from '@n8n/di';
+
+import type { PackageWriter } from '../../io/package-writer';
+import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
+import type { ManifestEntry } from '../../spec/manifest.schema';
+import type { PackageTagRequirement } from '../../spec/requirements.schema';
+import { serializedTagSchema } from '../../spec/serialized/tag.schema';
+import type { WorkflowTagUsage } from '../requirements.types';
+
+export interface TagExportRequest {
+	usages: WorkflowTagUsage[];
+	writer: PackageWriter;
+}
+
+export interface TagExportResult {
+	entries: ManifestEntry[];
+	requirements: PackageTagRequirement[];
+}
+
+@Service()
+export class TagExporter {
+	export(request: TagExportRequest): TagExportResult {
+		const tagsById = new Map<string, PackageTagRequirement>();
+
+		for (const { workflowId, tag } of request.usages) {
+			const grouped = tagsById.get(tag.id) ?? { id: tag.id, name: tag.name, usedByWorkflows: [] };
+			if (!grouped.usedByWorkflows.includes(workflowId)) {
+				grouped.usedByWorkflows.push(workflowId);
+			}
+			tagsById.set(tag.id, grouped);
+		}
+
+		const requirements = [...tagsById.values()].sort(
+			(a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id),
+		);
+
+		const allocator = new UniqueFilenameAllocator('tags', 'tag');
+		const entries: ManifestEntry[] = [];
+
+		for (const tag of requirements) {
+			const target = allocator.allocate(tag.name);
+			const serialized = serializedTagSchema.parse({ id: tag.id, name: tag.name });
+			request.writer.writeDirectory(target);
+			request.writer.writeFile(`${target}/tag.json`, JSON.stringify(serialized, null, '\t'));
+			entries.push({ id: tag.id, name: tag.name, target });
+		}
+
+		return { entries, requirements };
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/tag/tag.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/tag/tag.types.ts
@@ -1,0 +1,10 @@
+export interface WorkflowTagUsage {
+	workflowId: string;
+	tag: { id: string; name: string };
+}
+
+/** Locale pinned so package output is byte-stable across environments. */
+export const compareTagsByName = (
+	a: { id: string; name: string },
+	b: { id: string; name: string },
+) => a.name.localeCompare(b.name, 'en') || a.id.localeCompare(b.id, 'en');

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/auto-included-workflow-resolver.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/auto-included-workflow-resolver.test.ts
@@ -104,6 +104,7 @@ function resolveInput(options: {
 		folderWorkflowIds: options.folderWorkflowIds ?? [],
 		projectWorkflowIds: options.projectWorkflowIds ?? [],
 		requirements: options.requirements,
+		includeTags: true,
 	};
 }
 
@@ -333,7 +334,7 @@ describe('AutoIncludedWorkflowResolver', () => {
 			['b'],
 			user,
 			['workflow:export'],
-			{ includeParentFolder: true },
+			{ includeParentFolder: true, includeTags: true },
 		);
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/auto-included-workflow.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/auto-included-workflow.exporter.test.ts
@@ -9,6 +9,7 @@ import { CredentialRequirementsExtractor } from '../../credential/credential-req
 import { DataTableRequirementsExtractor } from '../../data-table/data-table-requirements.extractor';
 import { FolderSerializer } from '../../folder/folder.serializer';
 import { ProjectSerializer } from '../../project/project.serializer';
+import { TagRequirementsExtractor } from '../../tag/tag-requirements.extractor';
 import { VariableRequirementsExtractor } from '../../variable/variable-requirements.extractor';
 import type { AutoIncludedWorkflow } from '../auto-included-workflow-resolver';
 import { AutoIncludedWorkflowExporter } from '../auto-included-workflow.exporter';
@@ -59,6 +60,7 @@ function makeExporter(
 		credentialExtractor ?? new CredentialRequirementsExtractor(),
 		dataTableExtractor ?? new DataTableRequirementsExtractor(),
 		variableExtractor ?? new VariableRequirementsExtractor(),
+		new TagRequirementsExtractor(),
 	);
 }
 
@@ -69,6 +71,7 @@ function emptyRequest(writer: CapturingWriter, workflows: AutoIncludedWorkflow[]
 		existingWorkflowEntries: [] as ManifestEntry[],
 		existingFolderEntries: [] as ManifestEntry[],
 		existingProjectEntries: [] as ManifestEntry[],
+		includeTags: true,
 	};
 }
 

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
@@ -61,13 +61,13 @@ describe('WorkflowExporter', () => {
 		const { exporter, finder } = makeExporter([workflow]);
 		const writer = new CapturingWriter();
 
-		await exporter.export({ user, workflowIds: [workflow.id], writer });
+		await exporter.export({ user, workflowIds: [workflow.id], writer, includeTags: true });
 
 		expect(finder.findWorkflowsByIdsForUser).toHaveBeenCalledWith(
 			[workflow.id],
 			user,
 			['workflow:export'],
-			{ includeParentFolder: true },
+			{ includeParentFolder: true, includeTags: true },
 		);
 	});
 
@@ -81,6 +81,7 @@ describe('WorkflowExporter', () => {
 				user,
 				workflowIds: ['present-1', 'missing-or-denied'],
 				writer,
+				includeTags: true,
 			}),
 		).rejects.toThrow('1 workflow(s) not found or not accessible. Export aborted.');
 	});
@@ -92,7 +93,7 @@ describe('WorkflowExporter', () => {
 		const writer = new CapturingWriter();
 
 		await expect(
-			exporter.export({ user, workflowIds: ['present-1', 'missing'], writer }),
+			exporter.export({ user, workflowIds: ['present-1', 'missing'], writer, includeTags: true }),
 		).rejects.toBeInstanceOf(PackageEntityNotFoundError);
 	});
 
@@ -103,7 +104,7 @@ describe('WorkflowExporter', () => {
 		const writer = new CapturingWriter();
 
 		await expect(
-			exporter.export({ user, workflowIds: ['present-1', 'denied-1'], writer }),
+			exporter.export({ user, workflowIds: ['present-1', 'denied-1'], writer, includeTags: true }),
 		).rejects.toBeInstanceOf(PackageEntityAccessDeniedError);
 	});
 
@@ -113,7 +114,7 @@ describe('WorkflowExporter', () => {
 		const writer = new CapturingWriter();
 
 		await expect(
-			exporter.export({ user, workflowIds: ['present-1', 'missing'], writer }),
+			exporter.export({ user, workflowIds: ['present-1', 'missing'], writer, includeTags: true }),
 		).rejects.toThrow();
 
 		expect(finder.findExistingWorkflowIds).toHaveBeenCalledWith(['missing']);
@@ -128,6 +129,7 @@ describe('WorkflowExporter', () => {
 			user,
 			workflowIds: [workflow.id, workflow.id],
 			writer,
+			includeTags: true,
 		});
 
 		expect(entries).toEqual([
@@ -148,6 +150,7 @@ describe('WorkflowExporter', () => {
 			user,
 			workflowIds: [a.id, b.id],
 			writer,
+			includeTags: true,
 		});
 
 		expect(entries.map(({ id }) => id)).toEqual([a.id, b.id]);
@@ -176,7 +179,7 @@ describe('WorkflowExporter', () => {
 		const { exporter } = makeExporter([workflow]);
 		const writer = new CapturingWriter();
 
-		await exporter.export({ user, workflowIds: [workflow.id], writer });
+		await exporter.export({ user, workflowIds: [workflow.id], writer, includeTags: true });
 
 		const workflowFile = writer.files.find((f) => f.path === 'workflows/my-workflow/workflow.json');
 		expect(workflowFile).toBeDefined();
@@ -202,6 +205,7 @@ describe('WorkflowExporter', () => {
 			user,
 			workflowIds: [workflow.id],
 			writer,
+			includeTags: true,
 			basePrefix: 'folders/in_progress',
 		});
 
@@ -217,7 +221,12 @@ describe('WorkflowExporter', () => {
 		const { exporter } = makeExporter([a, b]);
 		const writer = new CapturingWriter();
 
-		const { entries } = await exporter.export({ user, workflowIds: [a.id, b.id], writer });
+		const { entries } = await exporter.export({
+			user,
+			workflowIds: [a.id, b.id],
+			writer,
+			includeTags: true,
+		});
 
 		const targets = entries.map((e) => e.target);
 		expect(targets).toEqual(['workflows/same-name', 'workflows/same-name-2']);
@@ -248,6 +257,7 @@ describe('WorkflowExporter', () => {
 			user,
 			workflowIds: [a.id, b.id],
 			writer,
+			includeTags: true,
 		});
 
 		expect(extractor.extract).toHaveBeenCalledTimes(2);
@@ -281,6 +291,7 @@ describe('WorkflowExporter', () => {
 			user,
 			workflowIds: [a.id, b.id],
 			writer,
+			includeTags: true,
 		});
 
 		expect(extractor.extract).toHaveBeenCalledTimes(2);
@@ -304,6 +315,7 @@ describe('WorkflowExporter', () => {
 			user,
 			workflowIds: [a.id, b.id],
 			writer,
+			includeTags: true,
 		});
 
 		expect(extractor.extract).toHaveBeenCalledTimes(2);
@@ -331,6 +343,7 @@ describe('WorkflowExporter', () => {
 			user,
 			workflowIds: [a.id, b.id],
 			writer,
+			includeTags: true,
 		});
 
 		expect(requirements.nodeTypes).toEqual([

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
@@ -14,6 +14,7 @@ import {
 	PackageEntityAccessDeniedError,
 	PackageEntityNotFoundError,
 } from '../../package-export.errors';
+import { TagRequirementsExtractor } from '../../tag/tag-requirements.extractor';
 import { VariableRequirementsExtractor } from '../../variable/variable-requirements.extractor';
 import type { WorkflowVariableRequirement } from '../../variable/variable.types';
 import { WorkflowExporter } from '../workflow.exporter';
@@ -51,6 +52,7 @@ function makeExporter(
 		credentialExtractor ?? new CredentialRequirementsExtractor(),
 		dataTableExtractor ?? new DataTableRequirementsExtractor(),
 		variableExtractor ?? new VariableRequirementsExtractor(),
+		new TagRequirementsExtractor(),
 	);
 	return { exporter, finder };
 }

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/auto-included-workflow-resolver.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/auto-included-workflow-resolver.ts
@@ -40,6 +40,7 @@ export class AutoIncludedWorkflowResolver {
 		topLevelWorkflowIds: string[];
 		folderWorkflowIds: string[];
 		projectWorkflowIds: string[];
+		includeTags: boolean;
 	}): Promise<AutoIncludedWorkflowResolution> {
 		const originsByWorkflowId = this.seedExportedOrigins({
 			topLevelWorkflowIds: options.topLevelWorkflowIds,
@@ -58,6 +59,7 @@ export class AutoIncludedWorkflowResolver {
 			user: options.user,
 			workflowIds: autoIncludedWorkflowIds,
 			originsByWorkflowId,
+			includeTags: options.includeTags,
 		});
 
 		return { autoIncludedWorkflows };
@@ -145,10 +147,15 @@ export class AutoIncludedWorkflowResolver {
 		user: User;
 		workflowIds: string[];
 		originsByWorkflowId: Map<string, Set<WorkflowExportOrigin>>;
+		includeTags: boolean;
 	}): Promise<AutoIncludedWorkflow[]> {
 		if (options.workflowIds.length === 0) return [];
 
-		const workflows = await this.findExportableWorkflows(options.user, options.workflowIds);
+		const workflows = await this.findExportableWorkflows(
+			options.user,
+			options.workflowIds,
+			options.includeTags,
+		);
 		const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 		const ownersByWorkflowId = await this.sharedWorkflowRepository.findOwnerProjectsByWorkflowIds(
 			options.workflowIds,
@@ -221,12 +228,13 @@ export class AutoIncludedWorkflowResolver {
 	private async findExportableWorkflows(
 		user: User,
 		workflowIds: string[],
+		includeTags: boolean,
 	): Promise<WorkflowEntity[]> {
 		const workflows = await this.workflowFinder.findWorkflowsByIdsForUser(
 			workflowIds,
 			user,
 			['workflow:export'],
-			{ includeParentFolder: true },
+			{ includeParentFolder: true, includeTags },
 		);
 
 		await assertEveryRequestedEntityAccessible(

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/auto-included-workflow.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/auto-included-workflow.exporter.ts
@@ -14,7 +14,9 @@ import { DataTableRequirementsExtractor } from '../data-table/data-table-require
 import type { WorkflowDataTableRequirement } from '../data-table/data-table.types';
 import { FolderSerializer } from '../folder/folder.serializer';
 import { ProjectSerializer } from '../project/project.serializer';
-import type { WorkflowExportRequirements, WorkflowTagUsage } from '../requirements.types';
+import type { WorkflowExportRequirements } from '../requirements.types';
+import { TagRequirementsExtractor } from '../tag/tag-requirements.extractor';
+import type { WorkflowTagUsage } from '../tag/tag.types';
 import { VariableRequirementsExtractor } from '../variable/variable-requirements.extractor';
 import type { WorkflowVariableRequirement } from '../variable/variable.types';
 
@@ -24,6 +26,7 @@ export interface AutoIncludedWorkflowExportRequest {
 	existingWorkflowEntries: ManifestEntry[];
 	existingFolderEntries: ManifestEntry[];
 	existingProjectEntries: ManifestEntry[];
+	includeTags: boolean;
 	projectTargetsById?: Map<string, string>;
 }
 
@@ -54,6 +57,7 @@ export class AutoIncludedWorkflowExporter {
 		private readonly credentialRequirementsExtractor: CredentialRequirementsExtractor,
 		private readonly dataTableRequirementsExtractor: DataTableRequirementsExtractor,
 		private readonly variableRequirementsExtractor: VariableRequirementsExtractor,
+		private readonly tagRequirementsExtractor: TagRequirementsExtractor,
 	) {}
 
 	export(request: AutoIncludedWorkflowExportRequest): AutoIncludedWorkflowExportResult {
@@ -114,18 +118,14 @@ export class AutoIncludedWorkflowExporter {
 				baseDir,
 				request.writer,
 				allocators.workflows,
+				request.includeTags,
 			);
 			workflowEntries.push(entry);
 			workflowEntriesById.set(entry.id, entry);
 			credentials.push(...this.credentialRequirementsExtractor.extract(included.workflow));
 			dataTables.push(...this.dataTableRequirementsExtractor.extract(included.workflow));
 			variables.push(...this.variableRequirementsExtractor.extract(included.workflow));
-			tags.push(
-				...(included.workflow.tags ?? []).map((tag) => ({
-					workflowId: included.workflow.id,
-					tag: { id: tag.id, name: tag.name },
-				})),
-			);
+			tags.push(...this.tagRequirementsExtractor.extract(included.workflow));
 			nodeTypes.push({
 				workflowId: included.workflow.id,
 				nodes: included.workflow.nodes ?? [],
@@ -268,9 +268,10 @@ export class AutoIncludedWorkflowExporter {
 		baseDir: string,
 		writer: PackageWriter,
 		allocators: Map<string, UniqueFilenameAllocator>,
+		includeTags: boolean,
 	): ManifestEntry {
 		const target = allocatorFor(allocators, baseDir, 'workflow').allocate(workflow.name);
-		const serialized = this.workflowSerializer.serialize(workflow);
+		const serialized = this.workflowSerializer.serialize(workflow, { includeTags });
 		writer.writeDirectory(target);
 		writer.writeFile(`${target}/workflow.json`, JSON.stringify(serialized, null, '\t'));
 		return { id: workflow.id, name: workflow.name, target };

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/auto-included-workflow.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/auto-included-workflow.exporter.ts
@@ -14,7 +14,7 @@ import { DataTableRequirementsExtractor } from '../data-table/data-table-require
 import type { WorkflowDataTableRequirement } from '../data-table/data-table.types';
 import { FolderSerializer } from '../folder/folder.serializer';
 import { ProjectSerializer } from '../project/project.serializer';
-import type { WorkflowExportRequirements } from '../requirements.types';
+import type { WorkflowExportRequirements, WorkflowTagUsage } from '../requirements.types';
 import { VariableRequirementsExtractor } from '../variable/variable-requirements.extractor';
 import type { WorkflowVariableRequirement } from '../variable/variable.types';
 
@@ -93,6 +93,7 @@ export class AutoIncludedWorkflowExporter {
 		const credentials: WorkflowCredentialRequirement[] = [];
 		const dataTables: WorkflowDataTableRequirement[] = [];
 		const variables: WorkflowVariableRequirement[] = [];
+		const tags: WorkflowTagUsage[] = [];
 		const nodeTypes: WorkflowNodeTypeSource[] = [];
 
 		for (const included of request.workflows) {
@@ -119,6 +120,12 @@ export class AutoIncludedWorkflowExporter {
 			credentials.push(...this.credentialRequirementsExtractor.extract(included.workflow));
 			dataTables.push(...this.dataTableRequirementsExtractor.extract(included.workflow));
 			variables.push(...this.variableRequirementsExtractor.extract(included.workflow));
+			tags.push(
+				...(included.workflow.tags ?? []).map((tag) => ({
+					workflowId: included.workflow.id,
+					tag: { id: tag.id, name: tag.name },
+				})),
+			);
 			nodeTypes.push({
 				workflowId: included.workflow.id,
 				nodes: included.workflow.nodes ?? [],
@@ -129,7 +136,7 @@ export class AutoIncludedWorkflowExporter {
 			workflowEntries,
 			folderEntries,
 			projectEntries,
-			requirements: { credentials, dataTables, variables, nodeTypes },
+			requirements: { credentials, dataTables, variables, tags, nodeTypes },
 			projectTargetsById,
 		};
 	}

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
@@ -13,7 +13,7 @@ import { DataTableRequirementsExtractor } from '../data-table/data-table-require
 import type { WorkflowDataTableRequirement } from '../data-table/data-table.types';
 import type { WorkflowNodeTypeSource } from './node-type-usage';
 import { assertEveryRequestedEntityAccessible } from '../package-export.errors';
-import type { WorkflowExportRequirements } from '../requirements.types';
+import type { WorkflowExportRequirements, WorkflowTagUsage } from '../requirements.types';
 import { VariableRequirementsExtractor } from '../variable/variable-requirements.extractor';
 import type { WorkflowVariableRequirement } from '../variable/variable.types';
 
@@ -21,6 +21,7 @@ export interface WorkflowExportRequest {
 	user: User;
 	workflowIds: string[];
 	writer: PackageWriter;
+	includeTags: boolean;
 
 	// Directory the workflow is written under. e.g. folders/{folderId}/
 	basePrefix?: string;
@@ -46,7 +47,7 @@ export class WorkflowExporter {
 			request.workflowIds,
 			request.user,
 			['workflow:export'],
-			{ includeParentFolder: true },
+			{ includeParentFolder: true, includeTags: request.includeTags },
 		);
 
 		await assertEveryRequestedEntityAccessible(
@@ -61,6 +62,7 @@ export class WorkflowExporter {
 		const credentials: WorkflowCredentialRequirement[] = [];
 		const dataTables: WorkflowDataTableRequirement[] = [];
 		const variables: WorkflowVariableRequirement[] = [];
+		const tags: WorkflowTagUsage[] = [];
 		const nodeTypes: WorkflowNodeTypeSource[] = [];
 		const fileNames = new UniqueFilenameAllocator(
 			request.basePrefix ? `${request.basePrefix}/workflows` : 'workflows',
@@ -83,10 +85,16 @@ export class WorkflowExporter {
 			credentials.push(...this.credentialRequirementsExtractor.extract(workflow));
 			dataTables.push(...this.dataTableRequirementsExtractor.extract(workflow));
 			variables.push(...this.variableRequirementsExtractor.extract(workflow));
+			tags.push(
+				...(workflow.tags ?? []).map((tag) => ({
+					workflowId: workflow.id,
+					tag: { id: tag.id, name: tag.name },
+				})),
+			);
 			nodeTypes.push({ workflowId: workflow.id, nodes: workflow.nodes ?? [] });
 		}
 
-		return { entries, requirements: { credentials, dataTables, variables, nodeTypes } };
+		return { entries, requirements: { credentials, dataTables, variables, tags, nodeTypes } };
 	}
 
 	private orderWorkflowsByRequest(

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
@@ -13,7 +13,9 @@ import { DataTableRequirementsExtractor } from '../data-table/data-table-require
 import type { WorkflowDataTableRequirement } from '../data-table/data-table.types';
 import type { WorkflowNodeTypeSource } from './node-type-usage';
 import { assertEveryRequestedEntityAccessible } from '../package-export.errors';
-import type { WorkflowExportRequirements, WorkflowTagUsage } from '../requirements.types';
+import type { WorkflowExportRequirements } from '../requirements.types';
+import { TagRequirementsExtractor } from '../tag/tag-requirements.extractor';
+import type { WorkflowTagUsage } from '../tag/tag.types';
 import { VariableRequirementsExtractor } from '../variable/variable-requirements.extractor';
 import type { WorkflowVariableRequirement } from '../variable/variable.types';
 
@@ -40,6 +42,7 @@ export class WorkflowExporter {
 		private readonly credentialRequirementsExtractor: CredentialRequirementsExtractor,
 		private readonly dataTableRequirementsExtractor: DataTableRequirementsExtractor,
 		private readonly variableRequirementsExtractor: VariableRequirementsExtractor,
+		private readonly tagRequirementsExtractor: TagRequirementsExtractor,
 	) {}
 
 	async export(request: WorkflowExportRequest): Promise<WorkflowExportResult> {
@@ -71,7 +74,9 @@ export class WorkflowExporter {
 
 		for (const workflow of workflowsForExport) {
 			const target = fileNames.allocate(workflow.name);
-			const serialized = this.workflowSerializer.serialize(workflow);
+			const serialized = this.workflowSerializer.serialize(workflow, {
+				includeTags: request.includeTags,
+			});
 
 			request.writer.writeDirectory(target);
 			request.writer.writeFile(`${target}/workflow.json`, JSON.stringify(serialized, null, '\t'));
@@ -85,12 +90,7 @@ export class WorkflowExporter {
 			credentials.push(...this.credentialRequirementsExtractor.extract(workflow));
 			dataTables.push(...this.dataTableRequirementsExtractor.extract(workflow));
 			variables.push(...this.variableRequirementsExtractor.extract(workflow));
-			tags.push(
-				...(workflow.tags ?? []).map((tag) => ({
-					workflowId: workflow.id,
-					tag: { id: tag.id, name: tag.name },
-				})),
-			);
+			tags.push(...this.tagRequirementsExtractor.extract(workflow));
 			nodeTypes.push({ workflowId: workflow.id, nodes: workflow.nodes ?? [] });
 		}
 

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -6,6 +6,7 @@ import {
 	serializedWorkflowSchema,
 	type SerializedWorkflow,
 } from '../../spec/serialized/workflow.schema';
+import { compareTagsByName } from '../tag/tag.types';
 
 /** Fields restored from package workflow.json; the target instance assigns the rest. */
 type WorkflowPackageContent = Pick<
@@ -15,13 +16,11 @@ type WorkflowPackageContent = Pick<
 
 @Service()
 export class WorkflowSerializer {
-	serialize(workflow: WorkflowEntity): SerializedWorkflow {
-		// The tags relation is loaded only when the export requested includeTags —
-		// its absence IS the gate. A caller loading tags for any other reason
-		// would leak them into the package.
-		const tags = workflow.tags?.length
-			? [...workflow.tags].sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))
-			: undefined;
+	serialize(workflow: WorkflowEntity, options: { includeTags: boolean }): SerializedWorkflow {
+		const tags =
+			options.includeTags && workflow.tags?.length
+				? [...workflow.tags].sort(compareTagsByName)
+				: undefined;
 
 		return serializedWorkflowSchema.parse({
 			id: workflow.id,

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -16,6 +16,13 @@ type WorkflowPackageContent = Pick<
 @Service()
 export class WorkflowSerializer {
 	serialize(workflow: WorkflowEntity): SerializedWorkflow {
+		// The tags relation is loaded only when the export requested includeTags —
+		// its absence IS the gate. A caller loading tags for any other reason
+		// would leak them into the package.
+		const tags = workflow.tags?.length
+			? [...workflow.tags].sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))
+			: undefined;
+
 		return serializedWorkflowSchema.parse({
 			id: workflow.id,
 			name: workflow.name,
@@ -26,6 +33,7 @@ export class WorkflowSerializer {
 			parentFolderId: workflow.parentFolder?.id ?? null,
 			isPublished: workflow.activeVersionId === workflow.versionId,
 			isArchived: workflow.isArchived,
+			...(tags ? { tagIds: tags.map((tag) => tag.id) } : {}),
 		});
 	}
 

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 
@@ -15,6 +16,7 @@ import { FolderExporter } from './entities/folder/folder.exporter';
 import { PackageExportBlockedError } from './entities/package-export.errors';
 import { ProjectExporter } from './entities/project/project.exporter';
 import { mergeRequirements } from './entities/requirements.types';
+import { TagExporter } from './entities/tag/tag.exporter';
 import { VariableExporter } from './entities/variable/variable.exporter';
 import { collectNodeTypeUsage } from './entities/workflow/node-type-usage';
 import { assertStaticSubWorkflowsIncluded } from './entities/workflow/static-sub-workflow-requirements';
@@ -54,6 +56,8 @@ export class N8nPackagesService {
 		private readonly credentialExporter: CredentialExporter,
 		private readonly dataTableExporter: DataTableExporter,
 		private readonly variableExporter: VariableExporter,
+		private readonly tagExporter: TagExporter,
+		private readonly globalConfig: GlobalConfig,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly packageParser: N8nPackageParser,
 		private readonly packageImportConfig: PackageImportConfig,
@@ -79,6 +83,7 @@ export class N8nPackagesService {
 		const workflowIds = request.workflowIds ?? [];
 		const folderIds = request.folderIds ?? [];
 		const projectIds = request.projectIds ?? [];
+		const includeTags = (request.includeTags ?? true) && !this.globalConfig.tags.disabled;
 
 		const folderExportResult =
 			folderIds.length > 0
@@ -86,6 +91,7 @@ export class N8nPackagesService {
 						user: request.user,
 						folderIds,
 						writer,
+						includeTags,
 					})
 				: undefined;
 
@@ -100,6 +106,7 @@ export class N8nPackagesService {
 						user: request.user,
 						workflowIds: workflowsForExport,
 						writer,
+						includeTags,
 					})
 				: undefined;
 
@@ -109,6 +116,7 @@ export class N8nPackagesService {
 						user: request.user,
 						projectIds,
 						writer,
+						includeTags,
 					})
 				: undefined;
 
@@ -137,6 +145,7 @@ export class N8nPackagesService {
 				topLevelWorkflowIds: workflowExportResult?.entries.map(({ id }) => id) ?? [],
 				folderWorkflowIds: folderExportResult?.workflowEntries.map(({ id }) => id) ?? [],
 				projectWorkflowIds: projectExportResult?.workflowEntries.map(({ id }) => id) ?? [],
+				includeTags,
 			});
 
 			autoIncludedExportResult = this.autoIncludedWorkflowExporter.export({
@@ -219,11 +228,17 @@ export class N8nPackagesService {
 			projectTargetsById,
 		});
 
+		const tagExportResult = this.tagExporter.export({
+			usages: requirements.tags,
+			writer,
+		});
+
 		const manifestRequirements = this.buildManifestRequirements({
 			credentials: credentialExportResult.requirements,
 			dataTables: dataTableExportResult.requirements,
 			workflows: workflowRequirementExportResult.requirements,
 			variables: variableExportResult.requirements,
+			tags: tagExportResult.requirements,
 			nodeTypes: collectNodeTypeUsage(requirements.nodeTypes),
 		});
 
@@ -241,6 +256,7 @@ export class N8nPackagesService {
 			...(variableExportResult.entries.length > 0
 				? { variables: variableExportResult.entries }
 				: {}),
+			...(tagExportResult.entries.length > 0 ? { tags: tagExportResult.entries } : {}),
 			...(manifestRequirements ? { requirements: manifestRequirements } : {}),
 			...(allWorkflowsInPackage.length > 0 ? { workflows: allWorkflowsInPackage } : {}),
 			...(allFolders.length > 0 ? { folders: allFolders } : {}),
@@ -257,6 +273,7 @@ export class N8nPackagesService {
 			credentials: credentialExportResult.entries.length,
 			dataTables: dataTableExportResult.entries.length,
 			variables: variableExportResult.entries.length,
+			tags: tagExportResult.entries.length,
 		};
 
 		this.eventService.emit('n8n-package-exported', {
@@ -306,15 +323,17 @@ export class N8nPackagesService {
 		dataTables: PackageRequirements['dataTables'];
 		workflows: PackageRequirements['workflows'];
 		variables: PackageRequirements['variables'];
+		tags: PackageRequirements['tags'];
 		nodeTypes: PackageRequirements['nodeTypes'];
 	}): PackageRequirements | undefined {
-		const { credentials, dataTables, workflows, variables, nodeTypes } = input;
+		const { credentials, dataTables, workflows, variables, tags, nodeTypes } = input;
 
 		const requirements: PackageRequirements = {
 			...(credentials?.length ? { credentials } : {}),
 			...(dataTables?.length ? { dataTables } : {}),
 			...(workflows?.length ? { workflows } : {}),
 			...(variables?.length ? { variables } : {}),
+			...(tags?.length ? { tags } : {}),
 			...(nodeTypes?.length ? { nodeTypes } : {}),
 		};
 		return Object.keys(requirements).length > 0 ? requirements : undefined;

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -154,6 +154,7 @@ export class N8nPackagesService {
 				existingWorkflowEntries: allWorkflowsBeforeAutoInclude,
 				existingFolderEntries: allFoldersBeforeAutoInclude,
 				existingProjectEntries: allProjectsBeforeAutoInclude,
+				includeTags,
 				projectTargetsById: projectExportResult?.projectTargetsById,
 			});
 		}

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -132,6 +132,7 @@ export interface ExportPackageRequest {
 	projectIds?: string[];
 	includeVariableValues?: boolean;
 	canExportVariableValues?: boolean;
+	includeTags?: boolean;
 	missingWorkflowDependencyPolicy?: MissingWorkflowDependencyPolicy;
 }
 
@@ -235,6 +236,7 @@ export type ExportPackageEventCounts = {
 	credentials: number;
 	dataTables: number;
 	variables: number;
+	tags: number;
 };
 
 /**

--- a/packages/cli/src/modules/n8n-packages/spec/__tests__/manifest.schema.test.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/__tests__/manifest.schema.test.ts
@@ -142,6 +142,18 @@ describe('packageManifestSchema', () => {
 		expect(packageManifestSchema.parse(manifest).variables).toEqual(manifest.variables);
 	});
 
+	it('rejects a manifest containing duplicate tag ids', () => {
+		const manifest = {
+			...validManifest,
+			tags: [
+				{ id: 'tag-1', name: 'production', target: 'tags/production' },
+				{ id: 'tag-1', name: 'production', target: 'tags/production-2' },
+			],
+		};
+
+		expect(() => packageManifestSchema.parse(manifest)).toThrow(/duplicate tag id/i);
+	});
+
 	it('accepts manifests with unknown sections for forward compatibility', () => {
 		const manifest = {
 			...validManifest,

--- a/packages/cli/src/modules/n8n-packages/spec/__tests__/requirements.schema.test.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/__tests__/requirements.schema.test.ts
@@ -32,6 +32,13 @@ describe('packageRequirementsSchema', () => {
 		);
 	});
 
+	it('rejects duplicate tag ids', () => {
+		const tag = (id: string) => ({ id, name: 'production', usedByWorkflows: ['wf-1'] });
+		const requirements = { tags: [tag('tag-1'), tag('tag-1')] };
+
+		expect(() => packageRequirementsSchema.parse(requirements)).toThrow(/Duplicate tag id: tag-1/);
+	});
+
 	it('rejects duplicate variable names', () => {
 		const requirements = { variables: [variable('API_URL'), variable('API_URL')] };
 

--- a/packages/cli/src/modules/n8n-packages/spec/manifest.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/manifest.schema.ts
@@ -41,6 +41,7 @@ export const packageManifestSchema = z
 		credentials: z.array(manifestEntrySchema).optional(),
 		dataTables: z.array(manifestEntrySchema).optional(),
 		variables: z.array(manifestEntrySchema).optional(),
+		tags: z.array(manifestEntrySchema).optional(),
 		requirements: packageRequirementsSchema.optional(),
 	})
 	.superRefine((manifest, ctx) => {
@@ -50,6 +51,7 @@ export const packageManifestSchema = z
 		assertNoDuplicateIds(manifest.credentials, 'credential', ctx);
 		assertNoDuplicateIds(manifest.dataTables, 'data table', ctx);
 		assertNoDuplicateIds(manifest.variables, 'variable', ctx);
+		assertNoDuplicateIds(manifest.tags, 'tag', ctx);
 	});
 
 export type ManifestEntry = z.infer<typeof manifestEntrySchema>;

--- a/packages/cli/src/modules/n8n-packages/spec/requirements.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/requirements.schema.ts
@@ -19,6 +19,12 @@ export const packageWorkflowRequirementSchema = z.object({
 	usedByWorkflows: z.array(z.string().min(1)).min(1),
 });
 
+export const packageTagRequirementSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().min(1),
+	usedByWorkflows: z.array(z.string().min(1)).min(1),
+});
+
 // Node types used by the packaged workflows, folded into unique
 // `(type, typeVersion)` pairs. Informational/derived only: import re-derives
 // node type usage from workflow content and never trusts this section.
@@ -84,6 +90,10 @@ export const packageRequirementsSchema = z.object({
 		.superRefine((variables, ctx) =>
 			assertNoDuplicateKey(variables, ({ name }) => name, 'variable name', ctx),
 		),
+	tags: z
+		.array(packageTagRequirementSchema)
+		.optional()
+		.superRefine((tags, ctx) => assertNoDuplicateKey(tags, ({ id }) => id, 'tag id', ctx)),
 	nodeTypes: z
 		.array(packageNodeTypeRequirementSchema)
 		.optional()
@@ -100,6 +110,7 @@ export const packageRequirementsSchema = z.object({
 export type PackageCredentialRequirement = z.infer<typeof packageCredentialRequirementSchema>;
 export type PackageDataTableRequirement = z.infer<typeof packageDataTableRequirementSchema>;
 export type PackageWorkflowRequirement = z.infer<typeof packageWorkflowRequirementSchema>;
+export type PackageTagRequirement = z.infer<typeof packageTagRequirementSchema>;
 export type PackageVariableRequirement = z.infer<typeof packageVariableRequirementSchema>;
 export type PackageNodeTypeRequirement = z.infer<typeof packageNodeTypeRequirementSchema>;
 export type PackageRequirements = z.infer<typeof packageRequirementsSchema>;

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/__tests__/tag.schema.test.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/__tests__/tag.schema.test.ts
@@ -1,0 +1,27 @@
+import { serializedTagSchema } from '../tag.schema';
+
+describe('serializedTagSchema', () => {
+	it('accepts an id/name pair', () => {
+		const tag = { id: 'tag-1', name: 'production' };
+
+		expect(() => serializedTagSchema.parse(tag)).not.toThrow();
+	});
+
+	it('rejects unknown keys such as timestamps', () => {
+		const tag = { id: 'tag-1', name: 'production', createdAt: '2026-01-01T00:00:00.000Z' };
+
+		expect(() => serializedTagSchema.parse(tag)).toThrow();
+	});
+
+	it('rejects an empty name', () => {
+		const tag = { id: 'tag-1', name: '' };
+
+		expect(() => serializedTagSchema.parse(tag)).toThrow();
+	});
+
+	it('rejects a name longer than 24 characters', () => {
+		const tag = { id: 'tag-1', name: 'a'.repeat(25) };
+
+		expect(() => serializedTagSchema.parse(tag)).toThrow();
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/__tests__/tag.schema.test.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/__tests__/tag.schema.test.ts
@@ -19,9 +19,9 @@ describe('serializedTagSchema', () => {
 		expect(() => serializedTagSchema.parse(tag)).toThrow();
 	});
 
-	it('rejects a name longer than 24 characters', () => {
-		const tag = { id: 'tag-1', name: 'a'.repeat(25) };
+	it('accepts a supplementary-plane name', () => {
+		const tag = { id: 'tag-1', name: '😀'.repeat(13) };
 
-		expect(() => serializedTagSchema.parse(tag)).toThrow();
+		expect(() => serializedTagSchema.parse(tag)).not.toThrow();
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/__tests__/workflow.schema.test.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/__tests__/workflow.schema.test.ts
@@ -28,4 +28,18 @@ describe('serializedWorkflowSchema', () => {
 	it('rejects a non-finite node typeVersion (JSON `1e999` parses to Infinity)', () => {
 		expect(() => serializedWorkflowSchema.parse(workflow(Infinity))).toThrow();
 	});
+
+	it('accepts a non-empty tagIds array', () => {
+		expect(() =>
+			serializedWorkflowSchema.parse({ ...workflow(1), tagIds: ['tag-1', 'tag-2'] }),
+		).not.toThrow();
+	});
+
+	it('rejects an empty tagIds array', () => {
+		expect(() => serializedWorkflowSchema.parse({ ...workflow(1), tagIds: [] })).toThrow();
+	});
+
+	it('rejects an empty-string tag id', () => {
+		expect(() => serializedWorkflowSchema.parse({ ...workflow(1), tagIds: [''] })).toThrow();
+	});
 });

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/tag.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/tag.schema.ts
@@ -1,11 +1,9 @@
 import { z } from 'zod';
 
-// Strict: once the importer parses through this schema, adding fields to
-// tag.json is a format-breaking change for older importers.
 export const serializedTagSchema = z
 	.object({
 		id: z.string().min(1),
-		name: z.string().min(1).max(24),
+		name: z.string().min(1),
 	})
 	.strict();
 

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/tag.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/tag.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+// Strict: once the importer parses through this schema, adding fields to
+// tag.json is a format-breaking change for older importers.
+export const serializedTagSchema = z
+	.object({
+		id: z.string().min(1),
+		name: z.string().min(1).max(24),
+	})
+	.strict();
+
+export type SerializedTag = z.infer<typeof serializedTagSchema>;

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/workflow.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/workflow.schema.ts
@@ -51,6 +51,7 @@ export const serializedWorkflowSchema = z.object({
 	parentFolderId: z.string().nullable(),
 	isPublished: z.boolean(),
 	isArchived: z.boolean(),
+	tagIds: z.array(z.string().min(1)).min(1).optional(),
 });
 
 export type SerializedWorkflow = z.infer<typeof serializedWorkflowSchema>;

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -45,6 +45,7 @@ const EXPORT_COUNTS = {
 	credentials: 0,
 	dataTables: 0,
 	variables: 0,
+	tags: 0,
 };
 
 describe('n8n-packages handler', () => {
@@ -500,7 +501,7 @@ describe('n8n-packages handler', () => {
 
 		it('forwards includeTags=false to the service', async () => {
 			const stream = new PassThrough();
-			mockService.exportPackage.mockResolvedValue(stream);
+			mockService.exportPackage.mockResolvedValue({ stream, counts: EXPORT_COUNTS });
 			const res = makeResponse();
 
 			const resultPromise = run(

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -57,6 +57,7 @@ describe('n8n-packages handler', () => {
 			folderIds?: string[];
 			projectIds?: string[];
 			includeVariableValues?: boolean;
+			includeTags?: boolean;
 			missingWorkflowDependencyPolicy?: string;
 		},
 		apiKeyScopes?: string[],
@@ -248,6 +249,7 @@ describe('n8n-packages handler', () => {
 				projectIds: [],
 				includeVariableValues: true,
 				canExportVariableValues: false,
+				includeTags: true,
 				missingWorkflowDependencyPolicy: 'fail',
 			});
 		});
@@ -272,6 +274,7 @@ describe('n8n-packages handler', () => {
 				projectIds: [],
 				includeVariableValues: false,
 				canExportVariableValues: false,
+				includeTags: true,
 				missingWorkflowDependencyPolicy: 'fail',
 			});
 		});
@@ -370,6 +373,7 @@ describe('n8n-packages handler', () => {
 				projectIds: [],
 				includeVariableValues: true,
 				canExportVariableValues: true,
+				includeTags: true,
 				missingWorkflowDependencyPolicy: 'fail',
 			});
 			expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/gzip');
@@ -414,6 +418,7 @@ describe('n8n-packages handler', () => {
 				projectIds: [],
 				includeVariableValues: true,
 				canExportVariableValues: false,
+				includeTags: true,
 				missingWorkflowDependencyPolicy: 'reference-only',
 			});
 		});
@@ -438,6 +443,7 @@ describe('n8n-packages handler', () => {
 				projectIds: ['project-1'],
 				includeVariableValues: true,
 				canExportVariableValues: true,
+				includeTags: true,
 				missingWorkflowDependencyPolicy: 'fail',
 			});
 		});
@@ -462,6 +468,7 @@ describe('n8n-packages handler', () => {
 				projectIds: [],
 				includeVariableValues: true,
 				canExportVariableValues: true,
+				includeTags: true,
 				missingWorkflowDependencyPolicy: 'fail',
 			});
 		});
@@ -486,6 +493,32 @@ describe('n8n-packages handler', () => {
 				projectIds: [],
 				includeVariableValues: false,
 				canExportVariableValues: false,
+				includeTags: true,
+				missingWorkflowDependencyPolicy: 'fail',
+			});
+		});
+
+		it('forwards includeTags=false to the service', async () => {
+			const stream = new PassThrough();
+			mockService.exportPackage.mockResolvedValue(stream);
+			const res = makeResponse();
+
+			const resultPromise = run(
+				makeRequest({ workflowIds: ['wf-1'], includeTags: false }, ['workflow:export']),
+				res,
+			);
+			stream.end(Buffer.from('package-bytes'));
+			const caught = await resultPromise;
+
+			expect(caught).toBeUndefined();
+			expect(mockService.exportPackage).toHaveBeenCalledWith({
+				user: { id: 'user-1' },
+				workflowIds: ['wf-1'],
+				folderIds: [],
+				projectIds: [],
+				includeVariableValues: true,
+				canExportVariableValues: false,
+				includeTags: false,
 				missingWorkflowDependencyPolicy: 'fail',
 			});
 		});

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -34,6 +34,7 @@ type ExportPackageRequest = AuthenticatedRequest<
 		folderIds?: string[];
 		projectIds?: string[];
 		includeVariableValues?: boolean;
+		includeTags?: boolean;
 		missingWorkflowDependencyPolicy?: 'fail' | 'reference-only' | 'include-in-package';
 	}
 >;
@@ -147,6 +148,7 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 					projectIds,
 					includeVariableValues,
 					canExportVariableValues: apiKeyScopes.includes('variable:list'),
+					includeTags: payload.data.includeTags,
 					missingWorkflowDependencyPolicy: payload.data.missingWorkflowDependencyPolicy,
 				});
 

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
@@ -41,6 +41,13 @@ properties:
       bundled into the package. When `false`, variables still travel as
       name/type files and are listed in the package requirements, but no
       values travel with the package.
+  includeTags:
+    type: boolean
+    default: true
+    description: >-
+      Whether tags assigned to the exported workflows are bundled into the
+      package. When `false`, no tag files, tag references, or tag
+      requirements travel with the package.
   missingWorkflowDependencyPolicy:
     type: string
     enum:

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -165,14 +165,16 @@ export class WorkflowFinderService {
 		workflowIds: string[],
 		user: User,
 		scopes: Scope[],
-		options: { includeParentFolder?: boolean } = {},
+		options: { includeParentFolder?: boolean; includeTags?: boolean } = {},
 	): Promise<WorkflowEntity[]> {
 		if (workflowIds.length === 0) return [];
 
 		const where = await this.findAllWhere(user, scopes);
 		const sharedWorkflows = await this.sharedWorkflowRepository.find({
 			where: { ...where, workflowId: In(workflowIds) },
-			relations: { workflow: { parentFolder: options.includeParentFolder } },
+			relations: {
+				workflow: { parentFolder: options.includeParentFolder, tags: options.includeTags },
+			},
 		});
 
 		// A workflow may appear via several share paths (project membership +

--- a/packages/cli/test/integration/public-api/n8n-packages-export.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-export.test.ts
@@ -183,4 +183,17 @@ describe('POST /n8n-packages/export', () => {
 		expect(response.headers['content-type']).toContain('application/gzip');
 		expect(response.headers['content-disposition']).toContain('export.n8np');
 	});
+
+	// The OpenAPI request schema has `additionalProperties: false`, so acceptance
+	// proves `includeTags` is declared in exportPackageRequest.yml.
+	test('accepts includeTags=false through the OpenAPI request validator', async () => {
+		const project = await createTeamProject('Export project', owner);
+		const folder = await createFolder(project, { name: 'to_production' });
+
+		const response = await authOwnerAgent
+			.post('/n8n-packages/export')
+			.send({ folderIds: [folder.id], includeTags: false });
+
+		expect(response.statusCode).toBe(200);
+	});
 });


### PR DESCRIPTION
## Summary

[Quick Walkthrough Video](https://www.loom.com/share/cc3549c231e84ce383ec0b6e107c3fed)

Adds an `includeTags` option (default `true`) to package export, per the "With tags" RFC.

- Each exported workflow's `workflow.json` now carries a `tagIds` array (sorted, omitted when the workflow has no tags).
- Every referenced tag is written once at the package root as `tags/<slug>/tag.json` containing `{ id, name }`, and listed in `manifest.tags[]`.
- `requirements.tags[]` lists each tag as `{ id, name, usedByWorkflows }`, derived from the workflows' tags, so the manifest stays a rebuildable index.
- The flag propagates through all four layers: module, `ExportPackageRequestDto`, public API (`exportPackageRequest.yml`), and the CLI (`--include-tags`).
- Auto-included sub-workflows (dependency resolution) bundle their tags as well.
- Instances with tags disabled (`N8N_WORKFLOW_TAGS_DISABLED`) skip tags silently, regardless of the flag.

The CLI forwards the flag as a boolean on every request, mirroring `--include-variable-values`. The DTO defaults to `true` for API callers that omit the field.

Import is untouched: importers ignore `tagIds`, `manifest.tags`, and tag files (pinned by a round-trip test). Import-side handling lands with LIGO-873/LIGO-874. Folder tags are deferred: `folder.json` is parsed with a strict schema, so adding `tagIds` there would break existing importers, and folder tagging is not user-reachable yet.

## How to test

The `n8n-packages` module is enabled by default.

CLI:

```bash
n8n-cli package export --workflow-id <id> -o export.n8np        # tags included by default
n8n-cli package export --workflow-id <id> --include-tags=false -o export.n8np
```

Untar the `.n8np` and inspect `manifest.json`, `workflows/*/workflow.json` (`tagIds`), and `tags/*/tag.json`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-872/export-include-tags-in-packages

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34892">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
