### PR TITLE
feat(core): Add shared agent-eval interfaces (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -566,7 +566,35 @@ export {
 	type EvalVersionsResponse,
 } from './schemas/eval-collections.schema';
 
-export { AGENT_EVALS_FLAG } from './schemas/agent-evals.schema';
+export {
+	AGENT_EVALS_FLAG,
+	agentEvalColumnMappingSchema,
+	agentEvalRunStatusSchema,
+	agentEvalResultStatusSchema,
+	agentEvalVoteSchema,
+	createAgentEvalDatasetSchema,
+	updateAgentEvalDatasetSchema,
+	UpdateAgentEvalDatasetDto,
+	createAgentEvalRunSchema,
+	CreateAgentEvalRunDto,
+	createAgentEvalRatingSchema,
+	CreateAgentEvalRatingDto,
+} from './schemas/agent-evals.schema';
+export type {
+	AgentEvalColumnMapping,
+	AgentEvalRunStatus,
+	AgentEvalResultStatus,
+	AgentEvalVote,
+	CreateAgentEvalDatasetDto,
+	UpdateAgentEvalDatasetPayload,
+	CreateAgentEvalRunPayload,
+	CreateAgentEvalRatingPayload,
+	AgentEvalDatasetRecord,
+	AgentEvalRunRecord,
+	AgentEvalResultRecord,
+	AgentEvalRatingRecord,
+	AgentEvalRunDetail,
+} from './schemas/agent-evals.schema';
 
 export {
 	aiInsightsStatusSchema,

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -579,6 +579,9 @@ export {
 	CreateAgentEvalRunDto,
 	createAgentEvalRatingSchema,
 	CreateAgentEvalRatingDto,
+	agentEvalDraftCaseSchema,
+	generateDraftCasesOptionsSchema,
+	GenerateDraftCasesOptionsDto,
 } from './schemas/agent-evals.schema';
 export type {
 	AgentEvalColumnMapping,
@@ -594,6 +597,9 @@ export type {
 	AgentEvalResultRecord,
 	AgentEvalRatingRecord,
 	AgentEvalRunDetail,
+	AgentEvalDraftCase,
+	GenerateDraftCasesOptions,
+	GenerateDraftCasesResult,
 } from './schemas/agent-evals.schema';
 
 export {

--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
@@ -1,11 +1,13 @@
 import {
 	agentEvalColumnMappingSchema,
+	agentEvalDraftCaseSchema,
 	agentEvalResultStatusSchema,
 	agentEvalRunStatusSchema,
 	agentEvalVoteSchema,
 	createAgentEvalDatasetSchema,
 	CreateAgentEvalRatingDto,
 	CreateAgentEvalRunDto,
+	GenerateDraftCasesOptionsDto,
 	UpdateAgentEvalDatasetDto,
 } from '../agent-evals.schema';
 
@@ -161,7 +163,57 @@ describe('CreateAgentEvalRatingDto', () => {
 		).toBe(true);
 	});
 
+	it('accepts a nested JSON correction', () => {
+		expect(
+			CreateAgentEvalRatingDto.safeParse({
+				vote: 'down',
+				correction: { output: { text: 'x', items: [1, 'two', true, null] }, score: 3 },
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects a correction with a non-JSON leaf', () => {
+		expect(
+			CreateAgentEvalRatingDto.safeParse({
+				vote: 'down',
+				correction: { output: () => 'not json' },
+			}).success,
+		).toBe(false);
+	});
+
 	it('rejects an invalid vote', () => {
 		expect(CreateAgentEvalRatingDto.safeParse({ vote: 'maybe' }).success).toBe(false);
+	});
+});
+
+describe('agentEvalDraftCaseSchema', () => {
+	it('accepts a valid draft case', () => {
+		expect(
+			agentEvalDraftCaseSchema.safeParse({
+				input: 'Reset my password',
+				whatToCheck: 'Explains steps',
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects a draft case missing whatToCheck', () => {
+		expect(agentEvalDraftCaseSchema.safeParse({ input: 'Reset my password' }).success).toBe(false);
+	});
+});
+
+describe('GenerateDraftCasesOptionsDto', () => {
+	it('accepts an empty options body', () => {
+		expect(GenerateDraftCasesOptionsDto.safeParse({}).success).toBe(true);
+	});
+
+	it('accepts count and datasetName', () => {
+		expect(
+			GenerateDraftCasesOptionsDto.safeParse({ count: 6, datasetName: 'Support' }).success,
+		).toBe(true);
+	});
+
+	it('rejects a non-positive or non-integer count', () => {
+		expect(GenerateDraftCasesOptionsDto.safeParse({ count: 0 }).success).toBe(false);
+		expect(GenerateDraftCasesOptionsDto.safeParse({ count: 2.5 }).success).toBe(false);
 	});
 });

--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
@@ -1,0 +1,154 @@
+import {
+	agentEvalColumnMappingSchema,
+	agentEvalResultStatusSchema,
+	agentEvalRunStatusSchema,
+	agentEvalVoteSchema,
+	createAgentEvalDatasetSchema,
+	CreateAgentEvalRatingDto,
+	CreateAgentEvalRunDto,
+	UpdateAgentEvalDatasetDto,
+} from '../agent-evals.schema';
+
+describe('agentEvalColumnMappingSchema', () => {
+	it('accepts an input-only mapping', () => {
+		expect(agentEvalColumnMappingSchema.safeParse({ input: 'question' }).success).toBe(true);
+	});
+
+	it('accepts a full mapping', () => {
+		expect(
+			agentEvalColumnMappingSchema.safeParse({
+				input: 'question',
+				expectedOutput: 'answer',
+				criteria: 'what to check',
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects a missing input column', () => {
+		expect(agentEvalColumnMappingSchema.safeParse({ expectedOutput: 'answer' }).success).toBe(
+			false,
+		);
+	});
+
+	it('rejects an empty input column', () => {
+		expect(agentEvalColumnMappingSchema.safeParse({ input: '' }).success).toBe(false);
+	});
+});
+
+describe('status / vote enums', () => {
+	it('accepts valid run statuses and rejects unknown ones', () => {
+		expect(agentEvalRunStatusSchema.safeParse('completed').success).toBe(true);
+		expect(agentEvalRunStatusSchema.safeParse('success').success).toBe(false);
+	});
+
+	it('accepts valid result statuses and rejects unknown ones', () => {
+		expect(agentEvalResultStatusSchema.safeParse('success').success).toBe(true);
+		expect(agentEvalResultStatusSchema.safeParse('completed').success).toBe(false);
+	});
+
+	it('accepts up/down votes and rejects anything else', () => {
+		expect(agentEvalVoteSchema.safeParse('up').success).toBe(true);
+		expect(agentEvalVoteSchema.safeParse('down').success).toBe(true);
+		expect(agentEvalVoteSchema.safeParse('meh').success).toBe(false);
+	});
+});
+
+describe('createAgentEvalDatasetSchema', () => {
+	const base = {
+		name: 'Support cases',
+		agentId: 'agent-1',
+		columnMapping: { input: 'question', expectedOutput: 'answer' },
+	};
+
+	it('accepts a data_table source', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				...base,
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+			}).success,
+		).toBe(true);
+	});
+
+	it('accepts a google_sheets source', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				...base,
+				datasetSource: 'google_sheets',
+				datasetRef: {
+					credentialId: 'cred-1',
+					spreadsheetId: 'sheet-1',
+					sheetName: 'Cases',
+				},
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects a missing agentId', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				name: 'Support cases',
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+			}).success,
+		).toBe(false);
+	});
+
+	it('rejects an unknown dataset source', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				...base,
+				datasetSource: 'csv',
+				datasetRef: { dataTableId: 'dt-1' },
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe('UpdateAgentEvalDatasetDto', () => {
+	it('accepts a partial metadata patch', () => {
+		expect(UpdateAgentEvalDatasetDto.safeParse({ name: 'Renamed' }).success).toBe(true);
+	});
+
+	it('accepts an empty patch', () => {
+		expect(UpdateAgentEvalDatasetDto.safeParse({}).success).toBe(true);
+	});
+
+	it('rejects a non-string name', () => {
+		expect(UpdateAgentEvalDatasetDto.safeParse({ name: 42 }).success).toBe(false);
+	});
+});
+
+describe('CreateAgentEvalRunDto', () => {
+	it('accepts an empty body (run current version)', () => {
+		expect(CreateAgentEvalRunDto.safeParse({}).success).toBe(true);
+	});
+
+	it('accepts a pinned agent version', () => {
+		expect(CreateAgentEvalRunDto.safeParse({ agentVersionId: 'v-1' }).success).toBe(true);
+	});
+
+	it('rejects an empty agent version', () => {
+		expect(CreateAgentEvalRunDto.safeParse({ agentVersionId: '' }).success).toBe(false);
+	});
+});
+
+describe('CreateAgentEvalRatingDto', () => {
+	it('accepts a bare vote', () => {
+		expect(CreateAgentEvalRatingDto.safeParse({ vote: 'up' }).success).toBe(true);
+	});
+
+	it('accepts a vote with comment and correction', () => {
+		expect(
+			CreateAgentEvalRatingDto.safeParse({
+				vote: 'down',
+				comment: 'Wrong tool used',
+				correction: { output: 'the expected answer' },
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects an invalid vote', () => {
+		expect(CreateAgentEvalRatingDto.safeParse({ vote: 'maybe' }).success).toBe(false);
+	});
+});

--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
@@ -84,6 +84,19 @@ describe('createAgentEvalDatasetSchema', () => {
 		).toBe(true);
 	});
 
+	it('accepts an explicit null description and columnMapping', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				name: 'Support cases',
+				agentId: 'agent-1',
+				description: null,
+				columnMapping: null,
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+			}).success,
+		).toBe(true);
+	});
+
 	it('rejects a missing agentId', () => {
 		expect(
 			createAgentEvalDatasetSchema.safeParse({

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -1,3 +1,8 @@
+import { z } from 'zod';
+
+import { datasetRefSchema, type DatasetRef } from '../dto/evaluations/evaluation-config.dto';
+import { Z } from '../zod-class';
+
 // PostHog rollout flag id gating the agent-evals feature surface. Every new
 // agent-eval endpoint + frontend entry point consults this; the flag-off
 // cohort sees no agent-eval surface at all. Single source of truth shared
@@ -5,3 +10,159 @@
 // numeric-prefix convention used by every other n8n PostHog flag (next
 // available after `100_n8n_credits_credential_selection`).
 export const AGENT_EVALS_FLAG = '101_agent_evals';
+
+// ---------------------------------------------------------------------------
+// Shared value types — the FE/BE contract mirrored by the `@n8n/db` entities,
+// which import these from here (as they already do for `DatasetRef`) rather
+// than redefining them. This is the canonical home.
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps the roles an agent eval needs onto columns of the referenced dataset (a
+ * Data Table or Google Sheet). Only `input` is required; without an
+ * `expectedOutput`/`criteria` column a run simply has no reference answer or
+ * per-case check to judge against.
+ */
+export const agentEvalColumnMappingSchema = z.object({
+	input: z.string().min(1),
+	expectedOutput: z.string().min(1).optional(),
+	criteria: z.string().min(1).optional(),
+});
+export type AgentEvalColumnMapping = z.infer<typeof agentEvalColumnMappingSchema>;
+
+export const agentEvalRunStatusSchema = z.enum([
+	'new',
+	'running',
+	'completed',
+	'error',
+	'cancelled',
+]);
+export type AgentEvalRunStatus = z.infer<typeof agentEvalRunStatusSchema>;
+
+export const agentEvalResultStatusSchema = z.enum([
+	'new',
+	'running',
+	'success',
+	'error',
+	'cancelled',
+]);
+export type AgentEvalResultStatus = z.infer<typeof agentEvalResultStatusSchema>;
+
+export const agentEvalVoteSchema = z.enum(['up', 'down']);
+export type AgentEvalVote = z.infer<typeof agentEvalVoteSchema>;
+
+// ---------------------------------------------------------------------------
+// Request DTOs. Parent resource ids (datasetId, resultId) are path params, so
+// they are not part of these bodies. Flat bodies use `Z.class` for controller
+// `@Body` binding; the dataset-create body carries the `DatasetRef` union, so
+// it follows the `UpsertEvaluationConfigDto` pattern (schema + inferred type)
+// which `Z.class` (flat shape only) cannot express.
+// ---------------------------------------------------------------------------
+
+export const createAgentEvalDatasetSchema = z
+	.object({
+		name: z.string().min(1).max(128),
+		description: z.string().optional(),
+		agentId: z.string().min(1),
+		columnMapping: agentEvalColumnMappingSchema.optional(),
+	})
+	.and(datasetRefSchema);
+export type CreateAgentEvalDatasetDto = z.infer<typeof createAgentEvalDatasetSchema>;
+
+// Metadata patch only; changing the dataset source is a new dataset, so the
+// `DatasetRef` union is intentionally not part of the update body.
+const updateAgentEvalDatasetShape = {
+	name: z.string().min(1).max(128).optional(),
+	description: z.string().nullable().optional(),
+	columnMapping: agentEvalColumnMappingSchema.nullable().optional(),
+};
+export const updateAgentEvalDatasetSchema = z.object(updateAgentEvalDatasetShape);
+export type UpdateAgentEvalDatasetPayload = z.infer<typeof updateAgentEvalDatasetSchema>;
+export class UpdateAgentEvalDatasetDto extends Z.class(updateAgentEvalDatasetShape) {}
+
+// Kicks off a run of the path dataset. `agentVersionId` optionally pins a
+// published version of the dataset's own agent; omitted runs the current one.
+const createAgentEvalRunShape = {
+	agentVersionId: z.string().min(1).optional(),
+};
+export const createAgentEvalRunSchema = z.object(createAgentEvalRunShape);
+export type CreateAgentEvalRunPayload = z.infer<typeof createAgentEvalRunSchema>;
+export class CreateAgentEvalRunDto extends Z.class(createAgentEvalRunShape) {}
+
+// A human's 👍/👎 on the path result, with an optional free-text comment and an
+// edited "should have been" output.
+const createAgentEvalRatingShape = {
+	vote: agentEvalVoteSchema,
+	comment: z.string().optional(),
+	correction: z.record(z.string(), z.unknown()).optional(),
+};
+export const createAgentEvalRatingSchema = z.object(createAgentEvalRatingShape);
+export type CreateAgentEvalRatingPayload = z.infer<typeof createAgentEvalRatingSchema>;
+export class CreateAgentEvalRatingDto extends Z.class(createAgentEvalRatingShape) {}
+
+// ---------------------------------------------------------------------------
+// Response shapes: plain types (not zod) so the server needn't round-trip its
+// own output through validation. Dates are serialized as ISO strings; internal
+// coordination columns (`runningInstanceId`, `cancelRequested`) are omitted
+// from the contract.
+// ---------------------------------------------------------------------------
+
+export type AgentEvalDatasetRecord = {
+	id: string;
+	name: string;
+	description: string | null;
+	agentId: string;
+	columnMapping: AgentEvalColumnMapping | null;
+	createdById: string | null;
+	createdAt: string;
+	updatedAt: string;
+} & DatasetRef;
+
+export type AgentEvalRunRecord = {
+	id: string;
+	datasetId: string;
+	agentVersionId: string | null;
+	status: AgentEvalRunStatus;
+	runAt: string | null;
+	completedAt: string | null;
+	metrics: Record<string, unknown> | null;
+	errorCode: string | null;
+	errorDetails: Record<string, unknown> | null;
+	createdById: string | null;
+	createdAt: string;
+	updatedAt: string;
+};
+
+export type AgentEvalResultRecord = {
+	id: string;
+	runId: string;
+	sourceRowId: string | null;
+	runIndex: number | null;
+	status: AgentEvalResultStatus;
+	input: Record<string, unknown> | null;
+	output: Record<string, unknown> | null;
+	toolCalls: Record<string, unknown> | null;
+	metrics: Record<string, unknown> | null;
+	runAt: string | null;
+	completedAt: string | null;
+	errorCode: string | null;
+	errorDetails: Record<string, unknown> | null;
+	createdAt: string;
+	updatedAt: string;
+};
+
+export type AgentEvalRatingRecord = {
+	id: string;
+	resultId: string;
+	vote: AgentEvalVote;
+	comment: string | null;
+	correction: Record<string, unknown> | null;
+	ratedById: string | null;
+	createdAt: string;
+	updatedAt: string;
+};
+
+// A run with its per-case results — the "open a run" view.
+export type AgentEvalRunDetail = AgentEvalRunRecord & {
+	results: AgentEvalResultRecord[];
+};

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -62,9 +62,9 @@ export type AgentEvalVote = z.infer<typeof agentEvalVoteSchema>;
 export const createAgentEvalDatasetSchema = z
 	.object({
 		name: z.string().min(1).max(128),
-		description: z.string().optional(),
+		description: z.string().nullable().optional(),
 		agentId: z.string().min(1),
-		columnMapping: agentEvalColumnMappingSchema.optional(),
+		columnMapping: agentEvalColumnMappingSchema.nullable().optional(),
 	})
 	.and(datasetRefSchema);
 export type CreateAgentEvalDatasetDto = z.infer<typeof createAgentEvalDatasetSchema>;

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -1,7 +1,24 @@
+import type { JsonObject, JsonValue } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { datasetRefSchema, type DatasetRef } from '../dto/evaluations/evaluation-config.dto';
 import { Z } from '../zod-class';
+
+// A JSON blob that flows from a request into persistence must infer to the
+// repository's `JsonObject`, not `Record<string, unknown>` — the latter permits
+// non-JSON leaves and isn't assignable to `JsonObject` without a cast. Recursive
+// so nested values are validated too.
+const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+	z.union([
+		z.string(),
+		z.number(),
+		z.boolean(),
+		z.null(),
+		z.record(z.string(), jsonValueSchema),
+		z.array(jsonValueSchema),
+	]),
+);
+const jsonObjectSchema: z.ZodType<JsonObject> = z.record(z.string(), jsonValueSchema);
 
 // PostHog rollout flag id gating the agent-evals feature surface. Every new
 // agent-eval endpoint + frontend entry point consults this; the flag-off
@@ -94,7 +111,7 @@ export class CreateAgentEvalRunDto extends Z.class(createAgentEvalRunShape) {}
 const createAgentEvalRatingShape = {
 	vote: agentEvalVoteSchema,
 	comment: z.string().optional(),
-	correction: z.record(z.string(), z.unknown()).optional(),
+	correction: jsonObjectSchema.optional(),
 };
 export const createAgentEvalRatingSchema = z.object(createAgentEvalRatingShape);
 export type CreateAgentEvalRatingPayload = z.infer<typeof createAgentEvalRatingSchema>;
@@ -165,4 +182,38 @@ export type AgentEvalRatingRecord = {
 // A run with its per-case results — the "open a run" view.
 export type AgentEvalRunDetail = AgentEvalRunRecord & {
 	results: AgentEvalResultRecord[];
+};
+
+// ---------------------------------------------------------------------------
+// Case generation. The AI case-generation service drafts cases from an agent's
+// config; these types are the shared contract for its request/response so the
+// generate endpoint and editor-ui use one definition (the service impl and its
+// synthesis logic live in the backend).
+// ---------------------------------------------------------------------------
+
+/**
+ * A single AI-generated draft eval case: a realistic end-user input plus a
+ * plain-language "what to check". Drafts have no gold answer and are never
+ * auto-graded — the user edits them before saving as a dataset.
+ */
+export const agentEvalDraftCaseSchema = z.object({
+	input: z.string().min(1),
+	whatToCheck: z.string().min(1),
+});
+export type AgentEvalDraftCase = z.infer<typeof agentEvalDraftCaseSchema>;
+
+// Request body for the generate-cases endpoint. `count` is a positive int; the
+// service clamps it to its supported maximum rather than rejecting.
+const generateDraftCasesOptionsShape = {
+	count: z.number().int().min(1).optional(),
+	datasetName: z.string().min(1).optional(),
+};
+export const generateDraftCasesOptionsSchema = z.object(generateDraftCasesOptionsShape);
+export type GenerateDraftCasesOptions = z.infer<typeof generateDraftCasesOptionsSchema>;
+export class GenerateDraftCasesOptionsDto extends Z.class(generateDraftCasesOptionsShape) {}
+
+export type GenerateDraftCasesResult = {
+	datasetId: string;
+	dataTableId: string;
+	cases: AgentEvalDraftCase[];
 };

--- a/packages/@n8n/db/src/entities/agent-eval-dataset.ee.ts
+++ b/packages/@n8n/db/src/entities/agent-eval-dataset.ee.ts
@@ -1,19 +1,11 @@
-import type { DatasetRef } from '@n8n/api-types';
+import type { AgentEvalColumnMapping, DatasetRef } from '@n8n/api-types';
 import { Column, Entity, Index } from '@n8n/typeorm';
 
 import { JsonColumn, WithTimestampsAndStringId } from './abstract-entity';
 
-/**
- * Maps the roles an agent eval needs onto columns of the referenced dataset
- * (a Data Table or Google Sheet). Only `input` is required; a run without a
- * `expectedOutput`/`criteria` column simply has no reference answer or
- * per-case check to judge against.
- */
-export interface AgentEvalColumnMapping {
-	input: string;
-	expectedOutput?: string;
-	criteria?: string;
-}
+// The FE/BE contract for this shape lives in `@n8n/api-types`; re-exported so
+// existing db-internal consumers keep importing it from the entity.
+export type { AgentEvalColumnMapping };
 
 /**
  * A named, reusable eval setup for a single agent: which dataset to run and how

--- a/packages/@n8n/db/src/entities/agent-eval-rating.ee.ts
+++ b/packages/@n8n/db/src/entities/agent-eval-rating.ee.ts
@@ -1,10 +1,13 @@
+import type { AgentEvalVote } from '@n8n/api-types';
 import { Column, Entity, Index, ManyToOne } from '@n8n/typeorm';
 import type { JsonObject } from 'n8n-workflow';
 
 import { JsonColumn, WithTimestampsAndStringId } from './abstract-entity';
 import { AgentEvalResult } from './agent-eval-result.ee';
 
-export type AgentEvalVote = 'up' | 'down';
+// The FE/BE contract for this union lives in `@n8n/api-types`; re-exported so
+// existing db-internal consumers keep importing it from the entity.
+export type { AgentEvalVote };
 
 /**
  * A human's rating of an {@link AgentEvalResult}: a 👍/👎 vote plus an optional

--- a/packages/@n8n/db/src/entities/agent-eval-result.ee.ts
+++ b/packages/@n8n/db/src/entities/agent-eval-result.ee.ts
@@ -1,3 +1,4 @@
+import type { AgentEvalResultStatus } from '@n8n/api-types';
 import { Column, Entity, Index, ManyToOne, OneToMany } from '@n8n/typeorm';
 import type { IDataObject, JsonObject } from 'n8n-workflow';
 
@@ -5,7 +6,9 @@ import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from './abstrac
 import type { AgentEvalRating } from './agent-eval-rating.ee';
 import { AgentEvalRun } from './agent-eval-run.ee';
 
-export type AgentEvalResultStatus = 'new' | 'running' | 'success' | 'error' | 'cancelled';
+// The FE/BE contract for this union lives in `@n8n/api-types`; re-exported so
+// existing db-internal consumers keep importing it from the entity.
+export type { AgentEvalResultStatus };
 
 /**
  * Per-case outcome of an {@link AgentEvalRun}: the agent's output, tool-call

--- a/packages/@n8n/db/src/entities/agent-eval-run.ee.ts
+++ b/packages/@n8n/db/src/entities/agent-eval-run.ee.ts
@@ -1,3 +1,4 @@
+import type { AgentEvalRunStatus } from '@n8n/api-types';
 import { Column, Entity, Index, ManyToOne, OneToMany } from '@n8n/typeorm';
 import type { IDataObject } from 'n8n-workflow';
 
@@ -5,7 +6,9 @@ import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from './abstrac
 import { AgentEvalDataset } from './agent-eval-dataset.ee';
 import type { AgentEvalResult } from './agent-eval-result.ee';
 
-export type AgentEvalRunStatus = 'new' | 'running' | 'completed' | 'error' | 'cancelled';
+// The FE/BE contract for this union lives in `@n8n/api-types`; re-exported so
+// existing db-internal consumers keep importing it from the entity.
+export type { AgentEvalRunStatus };
 
 /**
  * One execution of an {@link AgentEvalDataset} against a specific agent version.


### PR DESCRIPTION
## Summary

Second Phase 0 PR of the Agent Evals epic — the shared FE/BE contract for
agent evals in `@n8n/api-types`, so the API and editor-ui PRs build against a
stable interface. **Dark**: no controller/service/UI reads these yet; the whole
surface is gated behind `101_agent_evals` in later PRs.

Adds to `@n8n/api-types` (`schemas/agent-evals.schema.ts`), mirroring the
agent-eval entities added by the data-model PR (#34657):

- **Shared value types** — `AgentEvalColumnMapping`, `AgentEvalRunStatus`,
  `AgentEvalResultStatus`, `AgentEvalVote` (each with a matching zod schema).
- **Request DTOs** — `createAgentEvalDatasetSchema` (carries the existing
  `DatasetRef` union via `.and(...)`, mirroring `UpsertEvaluationConfigDto`);
  `UpdateAgentEvalDatasetDto`, `CreateAgentEvalRunDto`, `CreateAgentEvalRatingDto`
  as flat `Z.class` bodies (mirroring `AddRunToCollectionDto`). Parent ids
  (`datasetId`, `resultId`) stay path params, so they're not in the bodies.
- **Response records** — `AgentEvalDatasetRecord`, `AgentEvalRunRecord`,
  `AgentEvalResultRecord`, `AgentEvalRatingRecord`, and the `AgentEvalRunDetail`
  composite. Dates serialize as ISO strings; internal coordination columns
  (`runningInstanceId`, `cancelRequested`) are omitted from the contract.

No `any` (JSON blobs are typed as `Record<string, unknown>`).

### Single source of truth

The four shared value types were previously defined locally in the `@n8n/db`
entities (#34657). They now live canonically in `@n8n/api-types`, and the
entities import and re-export them — the same pattern the dataset entity already
uses for `DatasetRef`. `entities/index.ts` and the repositories consume them
unchanged, so there is exactly one definition of each type.

## How to test

Types-only and dark — no env vars, license, or feature flag needed; nothing
reads these types yet.

- `cd packages/@n8n/api-types && pnpm typecheck && pnpm lint && pnpm test agent-evals`
  (21 schema-validation tests).
- `cd packages/@n8n/db && pnpm typecheck && pnpm lint && pnpm test agent-eval`
  — the existing data-model repository tests (19) still pass after the entities
  switch to importing the shared types.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-285

Follows the data-model PR #34657 (https://linear.app/n8n/issue/TRUST-284).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI