### PR TITLE
fix(editor): Prevent reactive feedback loop when opening workflow diff

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
@@ -4,6 +4,7 @@ import {
 	toValue,
 	computed,
 	ref,
+	watch,
 	watchEffect,
 	shallowRef,
 	onScopeDispose,
@@ -147,31 +148,34 @@ function createDiffRenderData(
 		}
 	}
 
-	watchEffect(() => {
-		const wf = workflowRef.value;
-		if (!wf?.id) return;
+	watch(
+		[workflowRef, workflowNodes],
+		([wf]) => {
+			if (!wf?.id) return;
 
-		disposeStores();
+			disposeStores();
 
-		const versionId = wf.versionId ?? `diff-${side}`;
-		const docId = createWorkflowDocumentId(wf.id, versionId);
+			const versionId = wf.versionId ?? `diff-${side}`;
+			const docId = createWorkflowDocumentId(wf.id, versionId);
 
-		workflowDocumentStore = useWorkflowDocumentStore(docId);
-		// Hydrate from the same normalized nodes that feed the canvas so the
-		// render-data maps are keyed by the same node IDs the canvas looks up.
-		// Shallow-copy the nodes so the document store owns/mutates its own node
-		// objects (e.g. position snapping) without leaking into `workflowNodes`.
-		workflowDocumentStore.hydrate({
-			...wf,
-			nodes: workflowNodes.value.map((node) => ({ ...node })),
-			versionId,
-		} as IWorkflowDb);
-		currentDocumentId = docId;
-		renderDataScope = effectScope(true);
-		renderDataScope.run(() => {
-			renderData.value = useWorkflowDocumentRenderData(docId);
-		});
-	});
+			workflowDocumentStore = useWorkflowDocumentStore(docId);
+			// Hydrate from the same normalized nodes that feed the canvas so the
+			// render-data maps are keyed by the same node IDs the canvas looks up.
+			// Shallow-copy the nodes so the document store owns/mutates its own node
+			// objects (e.g. position snapping) without leaking into `workflowNodes`.
+			workflowDocumentStore.hydrate({
+				...wf,
+				nodes: workflowNodes.value.map((node) => ({ ...node })),
+				versionId,
+			} as IWorkflowDb);
+			currentDocumentId = docId;
+			renderDataScope = effectScope(true);
+			renderDataScope.run(() => {
+				renderData.value = useWorkflowDocumentRenderData(docId);
+			});
+		},
+		{ immediate: true },
+	);
 
 	return { renderData, dispose: disposeStores };
 }


### PR DESCRIPTION
## Summary

Opening Workflow Diff could freeze the browser and eventually crash the tab. The `watchEffect` in `createDiffRenderData` (`useWorkflowDiff.ts`) tracked every reactive read in its body — including internals of `disposeStores()`, `hydrate()`, and `useWorkflowDocumentRenderData()`. With Pinia devtools wrapping `$dispose` with its own reactive bookkeeping, those implicit dependencies retriggered the effect indefinitely.

This replaces the `watchEffect` with an explicit `watch` on `[workflowRef, workflowNodes]` (with `immediate: true`), which are the only intended dependencies. Watch callbacks perform no dependency tracking, so store creation/disposal/hydration inside the callback can no longer retrigger it — fixing the loop at the root rather than only for the devtools case.

Behavior is otherwise unchanged: same pre-flush timing, single dispose/recreate cycle per workflow change, and the initial run still happens synchronously with populated nodes.

## How to test

1. Enable the Vue.js Devtools browser extension (this amplified the loop).
2. Run n8n in development and open the Workflow Diff view (e.g. compare two workflow versions).
3. Before: the page shows a loading state, the tab freezes and eventually crashes. After: the diff renders normally.
4. Existing coverage: all 119 tests in `src/features/workflows/workflowDiff/` pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-887

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34897">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

