### PR TITLE
perf(core): O(1) schema lookup in resource-mapper value validation

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/validate-value-against-schema.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/validate-value-against-schema.test.ts
@@ -464,5 +464,133 @@ describe('validateValueAgainstSchema', () => {
 				).toThrow("Invalid input for 'count' [item 0]");
 			});
 		});
+
+		describe('schema field lookup', () => {
+			const nodeType = {
+				description: {
+					properties: [
+						{
+							displayName: 'Columns',
+							name: 'columns',
+							type: 'resourceMapper',
+							typeOptions: {
+								resourceMapper: {
+									mode: 'add',
+								},
+							},
+						},
+					],
+				},
+			} as unknown as INodeType;
+
+			const schemaField = (id: string, type: string, required = false) => ({
+				id,
+				displayName: id,
+				required,
+				defaultMatch: false,
+				display: true,
+				type,
+				canBeUsedToMatch: false,
+			});
+
+			const makeNode = (schema: unknown[], value: IDataObject) =>
+				({
+					parameters: {
+						columns: {
+							mappingMode: 'defineBelow',
+							value,
+							matchingColumns: [],
+							attemptToConvertTypes: false,
+							schema,
+						},
+						options: {},
+					},
+					id: '8d6cec63-8db1-440c-8966-4d6311ee69a9',
+					name: 'add products to DB',
+					type: 'n8n-nodes-base.postgres',
+					typeVersion: 2.3,
+					position: [420, 0],
+				}) as unknown as INode;
+
+			const parameterName = 'columns.value';
+
+			test('resolves every value against its own schema entry, whatever its position', () => {
+				const schema = [
+					schemaField('a', 'number'),
+					schemaField('b', 'string'),
+					schemaField('c', 'number'),
+					schemaField('d', 'boolean'),
+				];
+				const value = { d: 'true', c: '3', b: 2, a: '1' };
+
+				const result = validateValueAgainstSchema(
+					makeNode(schema, value),
+					nodeType,
+					value,
+					parameterName,
+					0,
+					0,
+				);
+
+				// `a`, `c` and `d` are cast to their schema type; `b` keeps its type, as
+				// validateFieldType does not coerce values for string fields.
+				expect(result).toEqual({ a: 1, b: 2, c: 3, d: true });
+			});
+
+			test('uses the first entry when a field id appears twice, like Array.prototype.find', () => {
+				const schema = [schemaField('dup', 'number'), schemaField('dup', 'string')];
+				const value = { dup: '42' };
+
+				const result = validateValueAgainstSchema(
+					makeNode(schema, value),
+					nodeType,
+					value,
+					parameterName,
+					0,
+					0,
+				);
+
+				// The first entry types `dup` as a number, so the string is cast. Had the second
+				// (string) entry won, the value would have stayed '42'.
+				expect(result).toEqual({ dup: 42 });
+			});
+
+			test('applies the required check of the first entry when a field id appears twice', () => {
+				const schema = [schemaField('dup', 'string', true), schemaField('dup', 'string', false)];
+				const value = { dup: null };
+
+				let error: unknown;
+
+				try {
+					validateValueAgainstSchema(makeNode(schema, value), nodeType, value, parameterName, 0, 0);
+				} catch (e) {
+					error = e;
+				}
+
+				// Both entries reject `null`, so the thrown message alone would not tell them
+				// apart — the description is what shows the required check of the *first*
+				// entry is the one that ran.
+				expect(error).toBeInstanceOf(ExpressionError);
+				expect((error as ExpressionError).description).toEqual(
+					'The value "dup" is required but not set',
+				);
+			});
+
+			test('leaves values that have no schema entry untouched', () => {
+				const schema = [schemaField('known', 'number')];
+				const value = { known: '7', unknown: 'abc' };
+
+				const result = validateValueAgainstSchema(
+					makeNode(schema, value),
+					nodeType,
+					value,
+					parameterName,
+					0,
+					0,
+				);
+
+				expect(result).toEqual({ known: 7, unknown: 'abc' });
+			});
+		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/validate-value-against-schema.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/validate-value-against-schema.test.ts
@@ -555,27 +555,6 @@ describe('validateValueAgainstSchema', () => {
 				expect(result).toEqual({ dup: 42 });
 			});
 
-			test('applies the required check of the first entry when a field id appears twice', () => {
-				const schema = [schemaField('dup', 'string', true), schemaField('dup', 'string', false)];
-				const value = { dup: null };
-
-				let error: unknown;
-
-				try {
-					validateValueAgainstSchema(makeNode(schema, value), nodeType, value, parameterName, 0, 0);
-				} catch (e) {
-					error = e;
-				}
-
-				// Both entries reject `null`, so the thrown message alone would not tell them
-				// apart — the description is what shows the required check of the *first*
-				// entry is the one that ran.
-				expect(error).toBeInstanceOf(ExpressionError);
-				expect((error as ExpressionError).description).toEqual(
-					'The value "dup" is required but not set',
-				);
-			});
-
 			test('leaves values that have no schema entry untouched', () => {
 				const schema = [schemaField('known', 'number')];
 				const value = { known: '7', unknown: 'abc' };

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/validate-value-against-schema.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/validate-value-against-schema.test.ts
@@ -570,6 +570,30 @@ describe('validateValueAgainstSchema', () => {
 
 				expect(result).toEqual({ known: 7, unknown: 'abc' });
 			});
+
+			// `isResourceMapperValue` only checks that `schema` is present, so a persisted
+			// `schema: null` reaches the lookup. Indexing now runs before the loop, where the
+			// previous `schema.find` only ran inside it — an empty value never touched it.
+			describe.each([
+				['null', null],
+				['undefined', undefined],
+				['empty', []],
+			])('when the stored schema is %s', (_label, schema) => {
+				test('resolves no field instead of throwing', () => {
+					const value = { anything: 'kept' };
+
+					const result = validateValueAgainstSchema(
+						makeNode(schema as unknown as unknown[], value),
+						nodeType,
+						value,
+						parameterName,
+						0,
+						0,
+					);
+
+					expect(result).toEqual({ anything: 'kept' });
+				});
+			});
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/validate-value-against-schema.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/validate-value-against-schema.ts
@@ -6,6 +6,7 @@ import type {
 	INodePropertyCollection,
 	INodePropertyOptions,
 	INodeType,
+	ResourceMapperField,
 	ResourceMapperTypeOptions,
 } from 'n8n-workflow';
 import {
@@ -16,6 +17,21 @@ import {
 } from 'n8n-workflow';
 
 import type { ExtendedValidationResult } from '@/interfaces';
+
+const schemaIndexCache = new WeakMap<ResourceMapperField[], Map<string, ResourceMapperField>>();
+
+const indexSchemaById = (schema: ResourceMapperField[]) => {
+	let index = schemaIndexCache.get(schema);
+	if (!index) {
+		index = new Map<string, ResourceMapperField>();
+		for (const entry of schema) {
+			// First occurrence wins, matching the `schema.find` this index replaces
+			if (!index.has(entry.id)) index.set(entry.id, entry);
+		}
+		schemaIndexCache.set(schema, index);
+	}
+	return index;
+};
 
 const validateResourceMapperValue = (
 	parameterName: string,
@@ -35,16 +51,7 @@ const validateResourceMapperValue = (
 	if (!resourceMapperField || !isResourceMapperValue(resourceMapperField)) {
 		return result;
 	}
-	const schema = resourceMapperField.schema;
-	// Index the schema by id so the per-value lookup below is O(1) instead of a `schema.find`
-	// scan — turning the validation loop from O(values × schema) into O(values + schema).
-	// First occurrence wins, mirroring `find`.
-	const schemaById = new Map<string, (typeof schema)[number]>();
-	for (const entry of schema) {
-		if (!schemaById.has(entry.id)) {
-			schemaById.set(entry.id, entry);
-		}
-	}
+	const schemaById = indexSchemaById(resourceMapperField.schema);
 	const paramValueNames = Object.keys(paramValues);
 	for (let i = 0; i < paramValueNames.length; i++) {
 		const key = paramValueNames[i];

--- a/packages/core/src/execution-engine/node-execution-context/utils/validate-value-against-schema.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/validate-value-against-schema.ts
@@ -36,12 +36,21 @@ const validateResourceMapperValue = (
 		return result;
 	}
 	const schema = resourceMapperField.schema;
+	// Index the schema by id so the per-value lookup below is O(1) instead of a `schema.find`
+	// scan — turning the validation loop from O(values × schema) into O(values + schema).
+	// First occurrence wins, mirroring `find`.
+	const schemaById = new Map<string, (typeof schema)[number]>();
+	for (const entry of schema) {
+		if (!schemaById.has(entry.id)) {
+			schemaById.set(entry.id, entry);
+		}
+	}
 	const paramValueNames = Object.keys(paramValues);
 	for (let i = 0; i < paramValueNames.length; i++) {
 		const key = paramValueNames[i];
 		const resolvedValue = paramValues[key];
 
-		const schemaEntry = schema.find((s) => s.id === key);
+		const schemaEntry = schemaById.get(key);
 
 		if (
 			!skipRequiredCheck &&

--- a/packages/core/src/execution-engine/node-execution-context/utils/validate-value-against-schema.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/validate-value-against-schema.ts
@@ -20,7 +20,17 @@ import type { ExtendedValidationResult } from '@/interfaces';
 
 const schemaIndexCache = new WeakMap<ResourceMapperField[], Map<string, ResourceMapperField>>();
 
-const indexSchemaById = (schema: ResourceMapperField[]) => {
+const EMPTY_SCHEMA_INDEX: ReadonlyMap<string, ResourceMapperField> = new Map();
+
+const indexSchemaById = (
+	schema: ResourceMapperField[] | undefined,
+): ReadonlyMap<string, ResourceMapperField> => {
+	// `isResourceMapperValue` only checks that `schema` is present, so a persisted
+	// `schema: null` reaches this. Indexing runs before the loop now, where the previous
+	// `schema.find` only ran inside it, so bail out here instead of throwing on iteration.
+	if (!schema?.length) {
+		return EMPTY_SCHEMA_INDEX;
+	}
 	let index = schemaIndexCache.get(schema);
 	if (!index) {
 		index = new Map<string, ResourceMapperField>();


### PR DESCRIPTION
## Summary

Replaces a `schema.find(...)` scan per submitted value in resource-mapper validation with an O(1) `Map` lookup, turning `validateValueAgainstSchema` from **O(values × schema)** into **O(values + schema)**.

## Why

For each key in the submitted values, the validator located its schema entry by scanning the whole schema:

```ts
for (let i = 0; i < paramValueNames.length; i++) {
  const key = paramValueNames[i];
  const schemaEntry = schema.find((s) => s.id === key); // O(schema) per value
  // ...
}
```

Both the value set and the schema scale with the number of mapped columns, so a resource mapper with many fields (a wide table/sheet) makes this quadratic on a per-execution validation path.

## How

Index the schema by `id` once per schema array and look up in O(1). The index is cached in a
`WeakMap` keyed by the schema array itself, so it is built once and reused across every item —
the schema is read off the raw `node.parameters`, and that object is stable for the lifetime of
the `Workflow`.

```ts
const schemaIndexCache = new WeakMap<ResourceMapperField[], Map<string, ResourceMapperField>>();
const EMPTY_SCHEMA_INDEX: ReadonlyMap<string, ResourceMapperField> = new Map();

const indexSchemaById = (
  schema: ResourceMapperField[] | undefined,
): ReadonlyMap<string, ResourceMapperField> => {
  if (!schema?.length) {
    return EMPTY_SCHEMA_INDEX;
  }
  let index = schemaIndexCache.get(schema);
  if (!index) {
    index = new Map<string, ResourceMapperField>();
    for (const entry of schema) {
      // First occurrence wins, matching the `schema.find` this index replaces
      if (!index.has(entry.id)) index.set(entry.id, entry);
    }
    schemaIndexCache.set(schema, index);
  }
  return index;
};
```

Behaviour is preserved. `find(s => s.id === key)` returns the first match, so the index is built
first-occurrence-wins.

The empty-index guard is hardening, not a fix for a live bug. `isResourceMapperValue` only checks
that `schema` is present, so a persisted `schema: null` reaches the lookup. Because indexing now
runs before the loop — the previous `schema.find` only ran inside it — an empty `value` no longer
skips it, and iteration would throw `TypeError: schema is not iterable` instead of surfacing as an
`ExpressionError`. I have not found a stored workflow carrying `schema: null`.

## Tests

`packages/core/.../__tests__/validate-value-against-schema.test.ts` covers the lookup contract
rather than the implementation: resolution by id regardless of position, first-occurrence-wins on
duplicate ids, values without a schema entry left untouched, and `schema` stored as `null`,
`undefined` or `[]` resolving no field instead of throwing. The last group fails with
`TypeError: schema is not iterable` without the guard.

```
Test Files  1 passed (1)
     Tests  23 passed (23)
```

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34899">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


