### PR TITLE
feat(core): Re-deliver terminal execution events on WebSocket reconnect (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -113,6 +113,9 @@ export type { Collaborator } from './push/collaboration';
 export type { WorkflowPublicationStatusMessage } from './push/workflow';
 export type { HeartbeatMessage } from './push/heartbeat';
 export { createHeartbeatMessage, heartbeatMessageSchema } from './push/heartbeat';
+export type { PushMessageMeta } from './push/meta';
+export type { ResumeMessage } from './push/resume';
+export { resumeMessageSchema, RESUME_AWAITING_MAX } from './push/resume';
 export type { SendWorkerStatusMessage } from './push/worker';
 
 export type { FavoriteResourceType } from './schemas/favorites.schema';

--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -34,8 +34,8 @@ export type ExecutionWaiting = {
 		source?: WorkflowExecutionSource;
 	};
 	/**
-	 * Terminal-class event (spinner → idle). Carries delivery metadata so it can
-	 * be deduped and replayed on reconnect. See {@link PushMessageMeta}.
+	 * Terminal-class execution event (spinner → idle). Carries delivery metadata
+	 * so it can be deduped and replayed on reconnect. See {@link PushMessageMeta}.
 	 */
 	meta?: PushMessageMeta;
 };
@@ -53,8 +53,8 @@ export type ExecutionFinished = {
 		source?: WorkflowExecutionSource;
 	};
 	/**
-	 * Delivery metadata so this terminal event can be deduped and replayed on
-	 * reconnect. See {@link PushMessageMeta}.
+	 * Delivery metadata so this terminal execution event can be deduped and
+	 * replayed on reconnect. See {@link PushMessageMeta}.
 	 */
 	meta?: PushMessageMeta;
 };
@@ -68,14 +68,15 @@ export type ExecutionRecovered = {
 
 /**
  * Server → client message closing the reconnect handshake: sent after the
- * server has re-delivered any terminal events the client missed (in response to
- * a `resume` message), so the client knows catch-up is done.
+ * server has re-delivered any terminal execution events the client missed (in
+ * response to a `resume` message), so the client knows catch-up is done.
  */
 export type ResumeComplete = {
 	type: 'resumeComplete';
 	data: {
 		/**
-		 * Execution ids whose terminal event was re-delivered during this resume.
+		 * Execution ids whose terminal execution event was re-delivered during
+		 * this resume.
 		 * Informational — the client dedups by executionId regardless; empty when
 		 * nothing needed replaying.
 		 */

--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -7,6 +7,8 @@ import type {
 	WorkflowExecutionSource,
 } from 'n8n-workflow';
 
+import type { PushMessageMeta } from './meta';
+
 export type ExecutionStarted = {
 	type: 'executionStarted';
 	data: {
@@ -31,6 +33,11 @@ export type ExecutionWaiting = {
 		executionId: string;
 		source?: WorkflowExecutionSource;
 	};
+	/**
+	 * Terminal-class event (spinner → idle). Carries delivery metadata so it can
+	 * be deduped and replayed on reconnect. See {@link PushMessageMeta}.
+	 */
+	meta?: PushMessageMeta;
 };
 
 export type ExecutionFinished = {
@@ -45,12 +52,34 @@ export type ExecutionFinished = {
 		 */
 		source?: WorkflowExecutionSource;
 	};
+	/**
+	 * Delivery metadata so this terminal event can be deduped and replayed on
+	 * reconnect. See {@link PushMessageMeta}.
+	 */
+	meta?: PushMessageMeta;
 };
 
 export type ExecutionRecovered = {
 	type: 'executionRecovered';
 	data: {
 		executionId: string;
+	};
+};
+
+/**
+ * Server → client message closing the reconnect handshake: sent after the
+ * server has re-delivered any terminal events the client missed (in response to
+ * a `resume` message), so the client knows catch-up is done.
+ */
+export type ResumeComplete = {
+	type: 'resumeComplete';
+	data: {
+		/**
+		 * Execution ids whose terminal event was re-delivered during this resume.
+		 * Informational — the client dedups by executionId regardless; empty when
+		 * nothing needed replaying.
+		 */
+		replayed: string[];
 	};
 };
 
@@ -124,6 +153,7 @@ export type ExecutionPushMessage =
 	| ExecutionWaiting
 	| ExecutionFinished
 	| ExecutionRecovered
+	| ResumeComplete
 	| NodeExecuteBefore
 	| NodeExecuteAfter
 	| NodeExecuteAfterData;

--- a/packages/@n8n/api-types/src/push/meta.ts
+++ b/packages/@n8n/api-types/src/push/meta.ts
@@ -1,0 +1,16 @@
+/**
+ * Optional, additive envelope metadata carried alongside a push message's
+ * `type`/`data`. Present on terminal execution events so the client can dedup
+ * and distinguish a live delivery from a replay on reconnect.
+ *
+ * Backward-compatible in both directions: old clients ignore it, and a new
+ * client tolerates its absence from an old server.
+ */
+export type PushMessageMeta = {
+	/** Stable id for a single emission, for dedup and delivery telemetry. */
+	eventId: string;
+	/** Server emit time, ISO-8601. Server clock only — never the client's. */
+	ts: string;
+	/** `true` when this event was re-delivered on reconnect rather than pushed live. */
+	replayed?: boolean;
+};

--- a/packages/@n8n/api-types/src/push/resume.ts
+++ b/packages/@n8n/api-types/src/push/resume.ts
@@ -12,7 +12,8 @@ export const RESUME_AWAITING_MAX = 50;
  * Client → server message sent over the (bidirectional) WebSocket push channel
  * right after reconnecting, before consuming live events. It names the
  * executions the client still shows as running so the server can re-deliver any
- * terminal events the client missed while disconnected, sourced from the DB.
+ * terminal execution events the client missed while disconnected, sourced from
+ * the DB.
  *
  * Not used on the SSE transport (unidirectional): there, recovery degrades to
  * the REST reconcile path.

--- a/packages/@n8n/api-types/src/push/resume.ts
+++ b/packages/@n8n/api-types/src/push/resume.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+/**
+ * Defensive upper bound on the number of execution ids accepted in a single
+ * `resume` handshake. The editor canvas tracks a single in-flight execution,
+ * so `awaiting` is 0-or-1 in practice; this cap only guards against a
+ * misbehaving or malicious client.
+ */
+export const RESUME_AWAITING_MAX = 50;
+
+/**
+ * Client → server message sent over the (bidirectional) WebSocket push channel
+ * right after reconnecting, before consuming live events. It names the
+ * executions the client still shows as running so the server can re-deliver any
+ * terminal events the client missed while disconnected, sourced from the DB.
+ *
+ * Not used on the SSE transport (unidirectional): there, recovery degrades to
+ * the REST reconcile path.
+ */
+export const resumeMessageSchema = z.object({
+	type: z.literal('resume'),
+	data: z.object({
+		/**
+		 * Execution ids the client still shows as running. Derived from the
+		 * single tracked execution on the canvas (0-or-1 in practice).
+		 */
+		awaiting: z.array(z.string().min(1)).max(RESUME_AWAITING_MAX),
+	}),
+});
+
+export type ResumeMessage = z.infer<typeof resumeMessageSchema>;

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -608,6 +608,22 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		return await this.delete({ id: In(executionIds) });
 	}
 
+	/**
+	 * Minimal lookup of `{ id, workflowId, status }` for the given execution ids,
+	 * used to re-deliver terminal push events on client reconnect. Ids not found
+	 * (e.g. pruned) are simply absent from the result.
+	 */
+	async findStatusByIds(
+		executionIds: string[],
+	): Promise<Array<{ id: string; workflowId: string; status: ExecutionStatus }>> {
+		if (executionIds.length === 0) return [];
+
+		return await this.find({
+			select: ['id', 'workflowId', 'status'],
+			where: { id: In(executionIds) },
+		});
+	}
+
 	async getWaitingExecutions() {
 		// Find all the executions which should be triggered in the next 70 seconds
 		const waitTill = new Date(Date.now() + 70000);

--- a/packages/cli/src/collaboration/__tests__/collaboration.message.test.ts
+++ b/packages/cli/src/collaboration/__tests__/collaboration.message.test.ts
@@ -1,0 +1,26 @@
+import { isCollaborationMessage } from '@/collaboration/collaboration.message';
+
+describe('isCollaborationMessage', () => {
+	it.each([
+		'workflowOpened',
+		'workflowClosed',
+		'writeAccessRequested',
+		'writeAccessReleaseRequested',
+		'writeAccessHeartbeat',
+	])('accepts the collaboration message type "%s"', (type) => {
+		expect(isCollaborationMessage({ type, workflowId: 'wf-1' })).toBe(true);
+	});
+
+	it.each([
+		{ type: 'resume', data: { awaiting: ['e1'] } }, // another consumer's message
+		{ type: 'heartbeat' },
+		{ type: 'somethingElse' },
+		{ workflowId: 'wf-1' }, // no type
+		{},
+		null,
+		undefined,
+		'a string',
+	])('ignores non-collaboration message %j', (msg) => {
+		expect(isCollaborationMessage(msg)).toBe(false);
+	});
+});

--- a/packages/cli/src/collaboration/collaboration.message.ts
+++ b/packages/cli/src/collaboration/collaboration.message.ts
@@ -65,6 +65,26 @@ export type WriteAccessHeartbeatMessage = z.infer<typeof writeAccessHeartbeatMes
 
 export type WorkflowMessage = z.infer<typeof workflowMessageSchema>;
 
+const COLLABORATION_MESSAGE_TYPES = new Set<WorkflowMessage['type']>([
+	'workflowOpened',
+	'workflowClosed',
+	'writeAccessRequested',
+	'writeAccessReleaseRequested',
+	'writeAccessHeartbeat',
+]);
+
+/**
+ * Whether the message's `type` is a collaboration message type. The push
+ * `message` channel is multiplexed across features, so this lets the
+ * collaboration consumer skip messages meant for other consumers before
+ * attempting (and reporting) a strict parse.
+ */
+export const isCollaborationMessage = (msg: unknown): boolean =>
+	typeof msg === 'object' &&
+	msg !== null &&
+	'type' in msg &&
+	COLLABORATION_MESSAGE_TYPES.has((msg as { type: WorkflowMessage['type'] }).type);
+
 /**
  * Parses the given message and ensure it's of type WorkflowMessage
  */

--- a/packages/cli/src/collaboration/collaboration.service.ts
+++ b/packages/cli/src/collaboration/collaboration.service.ts
@@ -7,7 +7,7 @@ import { ErrorReporter } from 'n8n-core';
 import type { IWorkflowSettings, Workflow } from 'n8n-workflow';
 import { UnexpectedError } from 'n8n-workflow';
 
-import { parseWorkflowMessage } from './collaboration.message';
+import { isCollaborationMessage, parseWorkflowMessage } from './collaboration.message';
 import type {
 	WorkflowClosedMessage,
 	WorkflowOpenedMessage,
@@ -76,6 +76,10 @@ export class CollaborationService {
 	}
 
 	async handleUserMessage(userId: User['id'], clientId: string, msg: unknown) {
+		// The push `message` channel is multiplexed across features; ignore
+		// messages that aren't collaboration messages (e.g. execution `resume`).
+		if (!isCollaborationMessage(msg)) return;
+
 		const workflowMessage = await parseWorkflowMessage(msg);
 
 		if (workflowMessage.type === 'workflowOpened') {

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -953,6 +953,10 @@ describe('Execution Lifecycle Hooks', () => {
 							status: 'success',
 							workflowId: 'test-workflow-id',
 						},
+						meta: expect.objectContaining({
+							eventId: expect.any(String),
+							ts: expect.any(String),
+						}),
 					},
 					pushRef,
 				);
@@ -965,6 +969,10 @@ describe('Execution Lifecycle Hooks', () => {
 					{
 						type: 'executionWaiting',
 						data: { executionId },
+						meta: expect.objectContaining({
+							eventId: expect.any(String),
+							ts: expect.any(String),
+						}),
 					},
 					pushRef,
 				);

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -29,7 +29,7 @@ import type { RedactableExecution } from '@/executions/execution-redaction';
 import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import { ExternalHooks } from '@/external-hooks';
 import { Push } from '@/push';
-import { createTerminalEventMeta } from '@/push/terminal-event-meta';
+import { createTerminalExecutionEventMeta } from '@/push/terminal-execution-event-meta';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
 import { isWorkflowIdValid } from '@/utils';
 import { getItemCountByConnectionType } from '@/utils/get-item-count-by-connection-type';
@@ -461,7 +461,7 @@ function hookFunctionsPush(
 				{
 					type: 'executionWaiting',
 					data: { executionId, source },
-					meta: createTerminalEventMeta(),
+					meta: createTerminalExecutionEventMeta(),
 				},
 				pushRef,
 			);
@@ -470,7 +470,7 @@ function hookFunctionsPush(
 				{
 					type: 'executionFinished',
 					data: { executionId, workflowId, status, source },
-					meta: createTerminalEventMeta(),
+					meta: createTerminalExecutionEventMeta(),
 				},
 				pushRef,
 			);

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -29,6 +29,7 @@ import type { RedactableExecution } from '@/executions/execution-redaction';
 import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import { ExternalHooks } from '@/external-hooks';
 import { Push } from '@/push';
+import { createTerminalEventMeta } from '@/push/terminal-event-meta';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
 import { isWorkflowIdValid } from '@/utils';
 import { getItemCountByConnectionType } from '@/utils/get-item-count-by-connection-type';
@@ -456,10 +457,21 @@ function hookFunctionsPush(
 
 		const { status } = fullRunData;
 		if (status === 'waiting') {
-			pushInstance.send({ type: 'executionWaiting', data: { executionId, source } }, pushRef);
+			pushInstance.send(
+				{
+					type: 'executionWaiting',
+					data: { executionId, source },
+					meta: createTerminalEventMeta(),
+				},
+				pushRef,
+			);
 		} else {
 			pushInstance.send(
-				{ type: 'executionFinished', data: { executionId, workflowId, status, source } },
+				{
+					type: 'executionFinished',
+					data: { executionId, workflowId, status, source },
+					meta: createTerminalEventMeta(),
+				},
 				pushRef,
 			);
 		}

--- a/packages/cli/src/executions/__tests__/execution-push-resume.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-push-resume.service.test.ts
@@ -1,0 +1,228 @@
+import type { Logger } from '@n8n/backend-common';
+import type { ExecutionRepository } from '@n8n/db';
+import type { ErrorReporter } from 'n8n-core';
+import type { ExecutionStatus } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { ExecutionPushResumeService } from '@/executions/execution-push-resume.service';
+import type { Push } from '@/push';
+import type { OnPushMessage } from '@/push/types';
+import type { AccessService } from '@/services/access.service';
+
+describe('ExecutionPushResumeService', () => {
+	const logger = mock<Logger>();
+	const errorReporter = mock<ErrorReporter>();
+	const push = mock<Push>();
+	const executionRepository = mock<ExecutionRepository>();
+	const accessService = mock<AccessService>();
+
+	const pushRef = 'push-ref-1';
+	const userId = 'user-1';
+
+	let handleMessage: (event: OnPushMessage) => Promise<void>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger.scoped.mockReturnValue(logger);
+		accessService.hasReadAccess.mockResolvedValue(true);
+
+		const service = new ExecutionPushResumeService(
+			logger,
+			errorReporter,
+			push,
+			executionRepository,
+			accessService,
+		);
+		service.init();
+
+		// Capture the listener the service registered on the push `message` channel.
+		const call = push.on.mock.calls.find(([event]) => event === 'message');
+		handleMessage = call![1] as unknown as (event: OnPushMessage) => Promise<void>;
+	});
+
+	const resumeEvent = (awaiting: string[]): OnPushMessage => ({
+		pushRef,
+		userId,
+		msg: { type: 'resume', data: { awaiting } },
+	});
+
+	const stubExecution = (id: string, status: ExecutionStatus, workflowId = 'wf-1') => ({
+		id,
+		workflowId,
+		status,
+	});
+
+	describe('terminal executions are re-delivered', () => {
+		it('replays executionFinished with meta.replayed for a completed execution', async () => {
+			executionRepository.findStatusByIds.mockResolvedValue([stubExecution('e1', 'success')]);
+
+			await handleMessage(resumeEvent(['e1']));
+
+			expect(push.send).toHaveBeenCalledWith(
+				{
+					type: 'executionFinished',
+					data: { executionId: 'e1', workflowId: 'wf-1', status: 'success' },
+					meta: expect.objectContaining({
+						replayed: true,
+						eventId: expect.any(String),
+						ts: expect.any(String),
+					}),
+				},
+				pushRef,
+			);
+			expect(push.send).toHaveBeenCalledWith(
+				{ type: 'resumeComplete', data: { replayed: ['e1'] } },
+				pushRef,
+			);
+		});
+
+		it.each<ExecutionStatus>(['success', 'error', 'crashed', 'canceled'])(
+			'treats status "%s" as terminal and replays executionFinished',
+			async (status) => {
+				executionRepository.findStatusByIds.mockResolvedValue([stubExecution('e1', status)]);
+
+				await handleMessage(resumeEvent(['e1']));
+
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'executionFinished',
+						data: expect.objectContaining({ status }),
+					}),
+					pushRef,
+				);
+			},
+		);
+
+		it('replays executionWaiting for a waiting execution (terminal-class for the spinner)', async () => {
+			executionRepository.findStatusByIds.mockResolvedValue([stubExecution('e1', 'waiting')]);
+
+			await handleMessage(resumeEvent(['e1']));
+
+			expect(push.send).toHaveBeenCalledWith(
+				{
+					type: 'executionWaiting',
+					data: { executionId: 'e1' },
+					meta: expect.objectContaining({ replayed: true }),
+				},
+				pushRef,
+			);
+			expect(push.send).toHaveBeenCalledWith(
+				{ type: 'resumeComplete', data: { replayed: ['e1'] } },
+				pushRef,
+			);
+		});
+	});
+
+	describe('non-terminal executions stay silent', () => {
+		it.each<ExecutionStatus>(['running', 'new', 'unknown'])(
+			'sends no replay for an in-progress execution (status "%s")',
+			async (status) => {
+				executionRepository.findStatusByIds.mockResolvedValue([stubExecution('e1', status)]);
+
+				await handleMessage(resumeEvent(['e1']));
+
+				expect(push.send).toHaveBeenCalledTimes(1);
+				expect(push.send).toHaveBeenCalledWith(
+					{ type: 'resumeComplete', data: { replayed: [] } },
+					pushRef,
+				);
+			},
+		);
+	});
+
+	describe('unknown / pruned ids', () => {
+		it('does not crash and replays nothing when the id is absent from the DB', async () => {
+			executionRepository.findStatusByIds.mockResolvedValue([]);
+
+			await handleMessage(resumeEvent(['gone']));
+
+			expect(accessService.hasReadAccess).not.toHaveBeenCalled();
+			expect(push.send).toHaveBeenCalledTimes(1);
+			expect(push.send).toHaveBeenCalledWith(
+				{ type: 'resumeComplete', data: { replayed: [] } },
+				pushRef,
+			);
+		});
+	});
+
+	describe('authorization', () => {
+		it('does not replay executions the user cannot read', async () => {
+			executionRepository.findStatusByIds.mockResolvedValue([stubExecution('e1', 'success')]);
+			accessService.hasReadAccess.mockResolvedValue(false);
+
+			await handleMessage(resumeEvent(['e1']));
+
+			expect(push.send).toHaveBeenCalledTimes(1);
+			expect(push.send).toHaveBeenCalledWith(
+				{ type: 'resumeComplete', data: { replayed: [] } },
+				pushRef,
+			);
+		});
+	});
+
+	describe('mixed batch', () => {
+		it('replays only the terminal, authorized ids and reports them in resumeComplete', async () => {
+			executionRepository.findStatusByIds.mockResolvedValue([
+				stubExecution('done', 'success'),
+				stubExecution('busy', 'running'),
+			]);
+
+			await handleMessage(resumeEvent(['done', 'busy', 'pruned']));
+
+			expect(push.send).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'executionFinished',
+					data: expect.objectContaining({ executionId: 'done' }),
+				}),
+				pushRef,
+			);
+			expect(push.send).toHaveBeenCalledWith(
+				{ type: 'resumeComplete', data: { replayed: ['done'] } },
+				pushRef,
+			);
+			expect(push.send).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('handshake is always closed', () => {
+		it('sends resumeComplete without a DB read when awaiting is empty', async () => {
+			await handleMessage(resumeEvent([]));
+
+			expect(executionRepository.findStatusByIds).not.toHaveBeenCalled();
+			expect(push.send).toHaveBeenCalledTimes(1);
+			expect(push.send).toHaveBeenCalledWith(
+				{ type: 'resumeComplete', data: { replayed: [] } },
+				pushRef,
+			);
+		});
+	});
+
+	describe('messages that are not a valid resume', () => {
+		it('ignores a message of another type', async () => {
+			await handleMessage({ pushRef, userId, msg: { type: 'workflowOpened', workflowId: 'wf-1' } });
+
+			expect(push.send).not.toHaveBeenCalled();
+			expect(executionRepository.findStatusByIds).not.toHaveBeenCalled();
+		});
+
+		it('ignores a resume message exceeding the awaiting cap', async () => {
+			const tooMany = Array.from({ length: 51 }, (_, i) => `e${i}`);
+
+			await handleMessage(resumeEvent(tooMany));
+
+			expect(push.send).not.toHaveBeenCalled();
+			expect(executionRepository.findStatusByIds).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('error handling', () => {
+		it('reports to the error reporter and does not throw when a DB read fails', async () => {
+			executionRepository.findStatusByIds.mockRejectedValue(new Error('db down'));
+
+			await expect(handleMessage(resumeEvent(['e1']))).resolves.toBeUndefined();
+
+			expect(errorReporter.error).toHaveBeenCalled();
+			expect(push.send).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/executions/execution-push-resume.service.ts
+++ b/packages/cli/src/executions/execution-push-resume.service.ts
@@ -1,0 +1,118 @@
+import type { ResumeMessage } from '@n8n/api-types';
+import { resumeMessageSchema } from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import { ExecutionRepository } from '@n8n/db';
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { ErrorReporter } from 'n8n-core';
+import { isTerminalExecutionStatus, UnexpectedError } from 'n8n-workflow';
+
+import { Push } from '@/push';
+import { createTerminalEventMeta } from '@/push/terminal-event-meta';
+import type { OnPushMessage } from '@/push/types';
+import { AccessService } from '@/services/access.service';
+
+/**
+ * Re-delivers terminal execution events a client missed while disconnected.
+ *
+ * On reconnect the client sends a `resume` message naming the executions it
+ * still shows as running (see `resumeMessageSchema`). For each, the server
+ * reads the durable truth — the execution row — and, if the execution has
+ * already reached a terminal state, re-pushes the terminal event marked
+ * `meta.replayed = true`. Executions still running (or unknown/pruned) get
+ * nothing. A `resumeComplete` message always closes the handshake.
+ *
+ * This is the WebSocket producer of the "at-least-once terminal delivery"
+ * guarantee; on SSE (unidirectional) recovery degrades to the REST reconcile
+ * path instead. No server-side buffer, acks, or sequence counters — the DB is
+ * the durability and the client dedups by executionId.
+ */
+@Service()
+export class ExecutionPushResumeService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly errorReporter: ErrorReporter,
+		private readonly push: Push,
+		private readonly executionRepository: ExecutionRepository,
+		private readonly accessService: AccessService,
+	) {
+		this.logger = this.logger.scoped('push');
+	}
+
+	init() {
+		this.push.on('message', async (event: OnPushMessage) => {
+			// The push `message` channel is multiplexed across features, so ignore
+			// anything that isn't a well-formed `resume` message.
+			const parsed = resumeMessageSchema.safeParse(event.msg);
+			if (!parsed.success) return;
+
+			try {
+				await this.handleResume(event.pushRef, event.userId, parsed.data);
+			} catch (error) {
+				this.errorReporter.error(
+					new UnexpectedError('Error handling push resume message', {
+						extra: { pushRef: event.pushRef, userId: event.userId },
+						cause: error,
+					}),
+				);
+			}
+		});
+	}
+
+	private async handleResume(pushRef: string, userId: User['id'], msg: ResumeMessage) {
+		const { awaiting } = msg.data;
+		const replayed: string[] = [];
+
+		if (awaiting.length > 0) {
+			const executions = await this.executionRepository.findStatusByIds(awaiting);
+			const executionById = new Map(executions.map((execution) => [execution.id, execution]));
+
+			for (const executionId of awaiting) {
+				const execution = executionById.get(executionId);
+
+				// Unknown or pruned id: nothing to replay. The client falls back to a
+				// full REST reconcile for anything it still shows as running.
+				if (!execution) continue;
+
+				const { workflowId, status } = execution;
+
+				// Only replay executions the requesting user is allowed to read.
+				if (!(await this.accessService.hasReadAccess(userId, workflowId))) continue;
+
+				if (status === 'waiting') {
+					// Terminal-class for the spinner (waiting → idle).
+					this.push.send(
+						{
+							type: 'executionWaiting',
+							data: { executionId },
+							meta: createTerminalEventMeta({ replayed: true }),
+						},
+						pushRef,
+					);
+					replayed.push(executionId);
+				} else if (isTerminalExecutionStatus(status)) {
+					this.push.send(
+						{
+							type: 'executionFinished',
+							data: { executionId, workflowId, status },
+							meta: createTerminalEventMeta({ replayed: true }),
+						},
+						pushRef,
+					);
+					replayed.push(executionId);
+				}
+				// Otherwise still running (new/running/unknown): send nothing, live
+				// events resume on their own.
+			}
+		}
+
+		// Always close the handshake so the client knows catch-up is done.
+		this.push.send({ type: 'resumeComplete', data: { replayed } }, pushRef);
+
+		this.logger.debug('Handled push resume', {
+			pushRef,
+			awaiting: awaiting.length,
+			replayed: replayed.length,
+		});
+	}
+}

--- a/packages/cli/src/executions/execution-push-resume.service.ts
+++ b/packages/cli/src/executions/execution-push-resume.service.ts
@@ -8,7 +8,7 @@ import { ErrorReporter } from 'n8n-core';
 import { isTerminalExecutionStatus, UnexpectedError } from 'n8n-workflow';
 
 import { Push } from '@/push';
-import { createTerminalEventMeta } from '@/push/terminal-event-meta';
+import { createTerminalExecutionEventMeta } from '@/push/terminal-execution-event-meta';
 import type { OnPushMessage } from '@/push/types';
 import { AccessService } from '@/services/access.service';
 
@@ -18,7 +18,7 @@ import { AccessService } from '@/services/access.service';
  * On reconnect the client sends a `resume` message naming the executions it
  * still shows as running (see `resumeMessageSchema`). For each, the server
  * reads the durable truth — the execution row — and, if the execution has
- * already reached a terminal state, re-pushes the terminal event marked
+ * already reached a terminal state, re-pushes the terminal execution event marked
  * `meta.replayed = true`. Executions still running (or unknown/pruned) get
  * nothing. A `resumeComplete` message always closes the handshake.
  *
@@ -85,7 +85,7 @@ export class ExecutionPushResumeService {
 						{
 							type: 'executionWaiting',
 							data: { executionId },
-							meta: createTerminalEventMeta({ replayed: true }),
+							meta: createTerminalExecutionEventMeta({ replayed: true }),
 						},
 						pushRef,
 					);
@@ -95,7 +95,7 @@ export class ExecutionPushResumeService {
 						{
 							type: 'executionFinished',
 							data: { executionId, workflowId, status },
-							meta: createTerminalEventMeta({ replayed: true }),
+							meta: createTerminalExecutionEventMeta({ replayed: true }),
 						},
 						pushRef,
 					);

--- a/packages/cli/src/push/abstract.push.ts
+++ b/packages/cli/src/push/abstract.push.ts
@@ -76,15 +76,17 @@ export abstract class AbstractPush<Connection> extends TypedEmitter<AbstractPush
 		delete this.userIdByPushRef[pushRef];
 	}
 
-	private sendTo({ type, data }: PushMessage, pushRefs: string[], asBinary: boolean = false) {
+	private sendTo(pushMsg: PushMessage, pushRefs: string[], asBinary: boolean = false) {
 		if (pushRefs.length === 0) return;
 
-		this.logger.debug(`Pushed to frontend: ${type}`, {
-			dataType: type,
+		this.logger.debug(`Pushed to frontend: ${pushMsg.type}`, {
+			dataType: pushMsg.type,
 			pushRefs: pushRefs.join(', '),
 		});
 
-		const stringifiedPayload = jsonStringify({ type, data }, { replaceCircularRefs: true });
+		// Serialize the whole message so the optional, additive `meta` envelope
+		// (present on terminal events) is preserved on the wire.
+		const stringifiedPayload = jsonStringify(pushMsg, { replaceCircularRefs: true });
 
 		for (const pushRef of pushRefs) {
 			const connection = this.connections[pushRef];

--- a/packages/cli/src/push/abstract.push.ts
+++ b/packages/cli/src/push/abstract.push.ts
@@ -85,7 +85,7 @@ export abstract class AbstractPush<Connection> extends TypedEmitter<AbstractPush
 		});
 
 		// Serialize the whole message so the optional, additive `meta` envelope
-		// (present on terminal events) is preserved on the wire.
+		// (present on terminal execution events) is preserved on the wire.
 		const stringifiedPayload = jsonStringify(pushMsg, { replaceCircularRefs: true });
 
 		for (const pushRef of pushRefs) {

--- a/packages/cli/src/push/terminal-delivery.md
+++ b/packages/cli/src/push/terminal-delivery.md
@@ -1,0 +1,132 @@
+# Terminal push event delivery guarantee
+
+## Guarantee
+
+**At-least-once delivery of terminal execution events across a client
+disconnect that spans the finish.** If a manual execution finishes while the
+editor is disconnected (laptop sleep, deploy, network blip), the terminal event
+is re-delivered on reconnect without a manual refresh.
+
+Terminal events:
+
+- `executionFinished` — the run reached a completed/terminal status
+  (`success`, `error`, `crashed`, `canceled`).
+- `executionWaiting` — the run is waiting (Wait/Form node). Terminal *for the
+  spinner*: canvas goes from "executing" to idle.
+
+Non-terminal, high-volume streaming events (`nodeExecuteBefore`,
+`nodeExecuteAfter`, `nodeExecuteAfterData`) remain **best-effort**. Their final
+state is backfilled by the terminal replay plus the frontend reconcile. We do
+not make the whole event stream durable.
+
+## Why this is cheap: the durable log already exists
+
+The durable log is the **execution row**. Terminal state is persisted around the
+finish regardless of push; the push is a best-effort nudge on top. So this is
+not a new message queue — it is "on reconnect, re-deliver terminal truth from
+the DB the client missed."
+
+Consequently Lane 1 (REST reconcile on reconnect) and Lane 3 (this push replay)
+are the **same idempotent consumer with two producers**.
+
+## Mechanism
+
+### 1. Additive envelope metadata
+
+Terminal events carry an optional `meta` alongside `type`/`data`:
+
+```jsonc
+{
+  "type": "executionFinished",
+  "data": { "executionId": "...", "workflowId": "...", "status": "success" },
+  "meta": {
+    "eventId": "…",      // per-emission id, for dedup/telemetry
+    "ts": "…",           // server emit time, ISO-8601 (server clock only)
+    "replayed": true     // present only on a reconnect re-delivery
+  }
+}
+```
+
+Backward-compatible **both directions**: old clients ignore `meta`; a new client
+tolerates its absence from an old server. Built by `createTerminalEventMeta()`
+so the live-push and replay paths emit an identically shaped envelope.
+
+### 2. WebSocket reconnect handshake (bidirectional transport)
+
+On reconnect, before consuming live events, the client sends:
+
+```jsonc
+{ "type": "resume", "data": { "awaiting": ["<executionId>"] } }
+```
+
+`awaiting` is the set of executions the client still shows as running — derived
+from the single tracked execution on the canvas, so **0-or-1 in practice**
+(capped at 50 defensively). For each id the server reads the execution row and:
+
+- **already terminal** → re-delivers the terminal event with `meta.replayed = true`;
+- **still running** (`new` / `running` / `unknown`) → sends nothing (live events resume);
+- **unknown / pruned** → sends nothing (client falls back to a full REST reconcile);
+- **not readable by the requesting user** → sends nothing.
+
+The server then closes the handshake with `{ "type": "resumeComplete", "data": {
+"replayed": [...] } }` so the client knows catch-up is done. `replayed` lists the
+ids that were re-delivered (informational; the client dedups by `executionId`
+regardless).
+
+Implemented in `executions/execution-push-resume.service.ts`, wired for
+WebSocket only (`server.ts`, inside the `push.isBidirectional` block).
+
+### 3. SSE (unidirectional transport)
+
+SSE has no client→server channel and emits no `id:` line, so there is no
+server-side resume. Recovery **degrades to the frontend REST reconcile**
+(`getActiveExecutions` diff), which carries the delivery guarantee on SSE.
+
+## What this deliberately does NOT add
+
+- **No server-side buffer or replay journal** — nothing to size, trim, or leak.
+  `awaiting` is 0-or-1 and the durability is the DB.
+- **No required acks** — a client MAY ack for telemetry, but a missing ack never
+  loses a terminal event; the DB is the durability.
+- **No sequence counters, no cross-main shared state.** The client carries the
+  id, `pushRef` is stable across reconnects, and the execution row is shared, so
+  a reconnect that lands on a **different main** still resolves correctly.
+
+## Client idempotency contract (normative)
+
+- **Idempotency key = `executionId`.** A terminal event/reconcile for an
+  execution the client is not tracking is a no-op.
+- **Convergent:** the same `(executionId, status)` yields the same final state
+  regardless of source (live push / replay / `executionRecovered` / REST
+  reconcile) or arrival count. Duplicate toasts are suppressed via `meta.replayed`.
+- **Terminal is absorbing per `executionId`:** a late live event must not
+  resurrect a cleared spinner.
+
+## Scope boundaries
+
+- **Manual (editor) executions only.** Terminal push is gated on `pushRef`;
+  production/trigger runs have no editor session, so they are out by construction.
+- **Pending window is out of scope.** When the run has started but no
+  `executionId` is assigned yet, there is no id to place in `awaiting[]` and none
+  for reconcile to match. That time-bound backstop belongs to the stale-state
+  lane, not here.
+- `source` (AI-assistant attribution) is omitted on replay — it is not persisted
+  for this path and the client keys on `executionId`.
+
+## Failure modes → detection → recovery
+
+| Failure | Detected by | Recovery |
+| --- | --- | --- |
+| Finish push dropped while client offline | client still shows running on reconnect | `resume` → DB read → terminal event replayed |
+| `resume` id already pruned from DB | absent from DB lookup | client falls back to full REST reconcile |
+| Disconnect longer than the client's guard window | client-side timer | client does a full reconcile instead of/alongside replay |
+| Client on SSE (no upstream channel) | transport is unidirectional | REST reconcile carries the guarantee |
+| DB read fails during resume | error reporter | handshake aborts for that batch; client's reconcile backstop still heals |
+| Reconnect lands on a different main | — (no per-main state needed) | shared DB + stable `pushRef` + client-carried id resolve it |
+
+## Observability
+
+`ExecutionPushResumeService` logs each resume under the `push` scope with the
+`awaiting` and `replayed` counts; DB-read failures are sent to the error
+reporter. `eventId` on the envelope is the correlation handle for delivery
+telemetry (delivered / replayed).

--- a/packages/cli/src/push/terminal-delivery.md
+++ b/packages/cli/src/push/terminal-delivery.md
@@ -1,13 +1,13 @@
-# Terminal push event delivery guarantee
+# Terminal execution event delivery guarantee
 
 ## Guarantee
 
 **At-least-once delivery of terminal execution events across a client
 disconnect that spans the finish.** If a manual execution finishes while the
-editor is disconnected (laptop sleep, deploy, network blip), the terminal event
-is re-delivered on reconnect without a manual refresh.
+editor is disconnected (laptop sleep, deploy, network blip), the terminal
+execution event is re-delivered on reconnect without a manual refresh.
 
-Terminal events:
+Terminal execution events:
 
 - `executionFinished` — the run reached a completed/terminal status
   (`success`, `error`, `crashed`, `canceled`).
@@ -33,7 +33,7 @@ are the **same idempotent consumer with two producers**.
 
 ### 1. Additive envelope metadata
 
-Terminal events carry an optional `meta` alongside `type`/`data`:
+Terminal execution events carry an optional `meta` alongside `type`/`data`:
 
 ```jsonc
 {
@@ -48,8 +48,9 @@ Terminal events carry an optional `meta` alongside `type`/`data`:
 ```
 
 Backward-compatible **both directions**: old clients ignore `meta`; a new client
-tolerates its absence from an old server. Built by `createTerminalEventMeta()`
-so the live-push and replay paths emit an identically shaped envelope.
+tolerates its absence from an old server. Built by
+`createTerminalExecutionEventMeta()` so the live-push and replay paths emit an
+identically shaped envelope.
 
 ### 2. WebSocket reconnect handshake (bidirectional transport)
 
@@ -63,7 +64,7 @@ On reconnect, before consuming live events, the client sends:
 from the single tracked execution on the canvas, so **0-or-1 in practice**
 (capped at 50 defensively). For each id the server reads the execution row and:
 
-- **already terminal** → re-delivers the terminal event with `meta.replayed = true`;
+- **already terminal** → re-delivers the terminal execution event with `meta.replayed = true`;
 - **still running** (`new` / `running` / `unknown`) → sends nothing (live events resume);
 - **unknown / pruned** → sends nothing (client falls back to a full REST reconcile);
 - **not readable by the requesting user** → sends nothing.
@@ -87,15 +88,15 @@ server-side resume. Recovery **degrades to the frontend REST reconcile**
 - **No server-side buffer or replay journal** — nothing to size, trim, or leak.
   `awaiting` is 0-or-1 and the durability is the DB.
 - **No required acks** — a client MAY ack for telemetry, but a missing ack never
-  loses a terminal event; the DB is the durability.
+  loses a terminal execution event; the DB is the durability.
 - **No sequence counters, no cross-main shared state.** The client carries the
   id, `pushRef` is stable across reconnects, and the execution row is shared, so
   a reconnect that lands on a **different main** still resolves correctly.
 
 ## Client idempotency contract (normative)
 
-- **Idempotency key = `executionId`.** A terminal event/reconcile for an
-  execution the client is not tracking is a no-op.
+- **Idempotency key = `executionId`.** A terminal execution event/reconcile for
+  an execution the client is not tracking is a no-op.
 - **Convergent:** the same `(executionId, status)` yields the same final state
   regardless of source (live push / replay / `executionRecovered` / REST
   reconcile) or arrival count. Duplicate toasts are suppressed via `meta.replayed`.
@@ -117,7 +118,7 @@ server-side resume. Recovery **degrades to the frontend REST reconcile**
 
 | Failure | Detected by | Recovery |
 | --- | --- | --- |
-| Finish push dropped while client offline | client still shows running on reconnect | `resume` → DB read → terminal event replayed |
+| Finish push dropped while client offline | client still shows running on reconnect | `resume` → DB read → terminal execution event replayed |
 | `resume` id already pruned from DB | absent from DB lookup | client falls back to full REST reconcile |
 | Disconnect longer than the client's guard window | client-side timer | client does a full reconcile instead of/alongside replay |
 | Client on SSE (no upstream channel) | transport is unidirectional | REST reconcile carries the guarantee |

--- a/packages/cli/src/push/terminal-event-meta.ts
+++ b/packages/cli/src/push/terminal-event-meta.ts
@@ -1,0 +1,21 @@
+import type { PushMessageMeta } from '@n8n/api-types';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * Builds the additive `meta` envelope carried on terminal execution events
+ * (`executionFinished`, `executionWaiting`). Single source of truth so the
+ * live-push and reconnect-replay paths emit an identically shaped envelope.
+ *
+ * `eventId` is per-emission (a replay gets a fresh id); dedup on the client is
+ * keyed on `executionId`, not `eventId`. `ts` is the server emit time.
+ */
+export function createTerminalEventMeta(options?: { replayed?: boolean }): PushMessageMeta {
+	const meta: PushMessageMeta = {
+		eventId: uuid(),
+		ts: new Date().toISOString(),
+	};
+
+	if (options?.replayed) meta.replayed = true;
+
+	return meta;
+}

--- a/packages/cli/src/push/terminal-execution-event-meta.ts
+++ b/packages/cli/src/push/terminal-execution-event-meta.ts
@@ -9,7 +9,9 @@ import { v4 as uuid } from 'uuid';
  * `eventId` is per-emission (a replay gets a fresh id); dedup on the client is
  * keyed on `executionId`, not `eventId`. `ts` is the server emit time.
  */
-export function createTerminalEventMeta(options?: { replayed?: boolean }): PushMessageMeta {
+export function createTerminalExecutionEventMeta(options?: {
+	replayed?: boolean;
+}): PushMessageMeta {
 	const meta: PushMessageMeta = {
 		eventId: uuid(),
 		ts: new Date().toISOString(),

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -219,6 +219,13 @@ export class Server extends AbstractServer {
 
 			const collaborationService = Container.get(CollaborationService);
 			collaborationService.init();
+
+			// Re-delivers terminal execution events a client missed while
+			// disconnected. Requires a client->server channel, so WebSocket only.
+			const { ExecutionPushResumeService } = await import(
+				'@/executions/execution-push-resume.service.js'
+			);
+			Container.get(ExecutionPushResumeService).init();
 		} else {
 			this.logger.warn(
 				'Collaboration features are disabled because push is configured unidirectional. Use N8N_PUSH_BACKEND=websocket environment variable to enable them.',


### PR DESCRIPTION
## Summary

Backend / push-layer slice of the push-durability work: provides **at-least-once
delivery of terminal execution events** (`executionFinished`, `executionWaiting`)
across a client disconnect that spans the finish — the root-cause fix for the
stranded editor spinner, where a dropped finish push leaves the canvas spinning
until a manual refresh.

The durable log already exists — it is the execution row — so this is
replay-from-DB on reconnect, **not** a new queue or buffer.

What this PR adds (backend only):

- **Additive envelope metadata.** Terminal execution events now carry an
  optional `meta { eventId, ts, replayed? }` alongside `type`/`data`.
  Backward-compatible both directions — old clients ignore it; a new client
  tolerates its absence. Built by a single `createTerminalExecutionEventMeta()`
  helper so the live and replay paths emit an identical shape.
- **WebSocket `resume` handshake.** On reconnect the client sends
  `{ type: 'resume', data: { awaiting: string[] } }`. For each id the server
  reads the execution row: already terminal → re-delivers the terminal event
  with `meta.replayed = true`; still running / unknown / pruned → nothing.
  The server always closes with `{ type: 'resumeComplete', data: { replayed } }`.
  Replay reads are scoped to executions the requesting user can read.
- **Multiplexing hygiene.** The push `message` channel now carries more than
  collaboration messages, so the collaboration consumer skips messages that are
  not its own instead of error-reporting them.

Deliberately **not** added: no server-side buffer/journal, no required acks, no
sequence counters, no cross-main shared state. The DB is the durability and the
client dedups by `executionId`; a reconnect that lands on a different main still
resolves. SSE (unidirectional) has no resume path and degrades to the frontend
REST reconcile.

Delivery guarantee, scope fences, and failure-mode/recovery table are documented
in `packages/cli/src/push/terminal-delivery.md`.

## How to test

Automated (backend):

```bash
cd packages/cli
pnpm test src/executions/__tests__/execution-push-resume.service.test.ts
pnpm test src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
pnpm test src/push src/collaboration
pnpm test:integration test/integration/collaboration/collaboration.service.test.ts
```

Resume-handler unit coverage: terminal → replay (all terminal statuses),
`waiting` → replay, still-running → silent, unknown/pruned id → silent + no
crash, access-denied → silent, empty `awaiting` → `resumeComplete` only, cap
boundary, and DB-error handling.

End-to-end disconnect-across-finish behavior lands with the frontend `resume`
emission and the QA integration test (separate children) — see below.

## Related Linear tickets, Github issues, and Community forum posts

Backend slice of the approved push-durability feature (Lane 3). The frontend
`resume` emission / `resumeComplete` handling / toast suppression and the
disconnect-across-finish integration test are tracked as separate children.

**Draft — do not merge on its own.** The user-visible fix requires the frontend
child; integrated behavior must be verified by QA first.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. Title carries `(no-changelog)` — this backend slice has no user-visible effect until the frontend child lands.
- [ ] Docs updated or follow-up ticket created. (Delivery guarantee documented in-repo; user-facing docs, if any, follow with the frontend child.)
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


