### PR TITLE
feat(editor): Handle WebSocket resume handshake and terminal-event replay (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -113,6 +113,8 @@ export type { Collaborator } from './push/collaboration';
 export type { WorkflowPublicationStatusMessage } from './push/workflow';
 export type { HeartbeatMessage } from './push/heartbeat';
 export { createHeartbeatMessage, heartbeatMessageSchema } from './push/heartbeat';
+export type { ResumeMessage, ResumeComplete } from './push/resume';
+export { createResumeMessage, resumeMessageSchema } from './push/resume';
 export type { SendWorkerStatusMessage } from './push/worker';
 
 export type { FavoriteResourceType } from './schemas/favorites.schema';

--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -7,6 +7,24 @@ import type {
 	WorkflowExecutionSource,
 } from 'n8n-workflow';
 
+/**
+ * Optional, additive envelope metadata carried by terminal execution events
+ * (`executionFinished`, `executionWaiting`). Backward-compatible: old clients
+ * ignore it, and a new client tolerates its absence from an old server.
+ */
+export type PushMessageMeta = {
+	/** Stable id for deduplication / telemetry. */
+	eventId: string;
+	/** Server emit time, ISO-8601. Server clock only. */
+	ts: string;
+	/**
+	 * `true` when the event is re-delivered on reconnect (in response to a
+	 * `resume` handshake) rather than pushed live. Consumers apply it
+	 * idempotently and suppress the duplicate completion toast.
+	 */
+	replayed?: boolean;
+};
+
 export type ExecutionStarted = {
 	type: 'executionStarted';
 	data: {
@@ -31,6 +49,8 @@ export type ExecutionWaiting = {
 		executionId: string;
 		source?: WorkflowExecutionSource;
 	};
+	/** See {@link PushMessageMeta}. Terminal-class event for spinner purposes. */
+	meta?: PushMessageMeta;
 };
 
 export type ExecutionFinished = {
@@ -45,6 +65,8 @@ export type ExecutionFinished = {
 		 */
 		source?: WorkflowExecutionSource;
 	};
+	/** See {@link PushMessageMeta}. */
+	meta?: PushMessageMeta;
 };
 
 export type ExecutionRecovered = {

--- a/packages/@n8n/api-types/src/push/index.ts
+++ b/packages/@n8n/api-types/src/push/index.ts
@@ -5,6 +5,7 @@ import type { DebugPushMessage } from './debug';
 import type { ExecutionPushMessage } from './execution';
 import type { HotReloadPushMessage } from './hot-reload';
 import type { InstanceAiPushMessage } from './instance-ai';
+import type { ResumeComplete } from './resume';
 import type { WebhookPushMessage } from './webhook';
 import type { WorkerPushMessage } from './worker';
 import type { WorkflowPushMessage } from './workflow';
@@ -21,7 +22,8 @@ export type PushMessage =
 	| BuilderCreditsPushMessage
 	| ChatHubPushMessage
 	| InstanceAiPushMessage
-	| WorkflowReviewPushMessage;
+	| WorkflowReviewPushMessage
+	| ResumeComplete;
 
 export type PushType = PushMessage['type'];
 

--- a/packages/@n8n/api-types/src/push/resume.ts
+++ b/packages/@n8n/api-types/src/push/resume.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+/**
+ * Client → server message sent on WebSocket reconnect to request replay of
+ * terminal execution events (e.g. `executionFinished`) that may have been
+ * dropped while the client was disconnected.
+ *
+ * `awaiting` lists the execution ids the client still shows as running. The
+ * canvas tracks a single execution, so this is 0 or 1 id in practice. The
+ * server reads execution truth from the database for each id, re-delivers the
+ * terminal event (with `meta.replayed = true`) for any that already finished,
+ * then replies with a `resumeComplete` message.
+ */
+export const resumeMessageSchema = z.object({
+	type: z.literal('resume'),
+	data: z.object({
+		awaiting: z.array(z.string()),
+	}),
+});
+
+export type ResumeMessage = z.infer<typeof resumeMessageSchema>;
+
+export const createResumeMessage = (awaiting: string[]): ResumeMessage => ({
+	type: 'resume',
+	data: { awaiting },
+});
+
+/**
+ * Server → client message sent once the server has replayed any missed
+ * terminal events for a `resume` request. Signals that reconnect catch-up is
+ * complete. Carries no payload; `data` is an empty object to keep every push
+ * message envelope shaped as `{ type, data }`.
+ */
+export type ResumeComplete = {
+	type: 'resumeComplete';
+	data: {};
+};

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -771,6 +771,78 @@ describe('executionFinished', () => {
 		expect(workflowExecutionStateStore.clearStoppedExecutionId).not.toHaveBeenCalled();
 		expect(workflowExecutionStateStore.setActiveExecutionId).not.toHaveBeenCalled();
 	});
+
+	describe('replayed terminal events', () => {
+		it('clears the stranded spinner but suppresses the toast for a replayed finish', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			mockShowMessage.mockClear();
+
+			const executionId = 'replayed-exec';
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
+			workflowExecutionStateStore.setActiveExecutionId(executionId);
+			vi.spyOn(useWorkflowsStore(), 'fetchExecutionDataById').mockResolvedValue(null);
+
+			await executionFinished(
+				{
+					type: 'executionFinished',
+					data: { executionId, workflowId: '1', status: 'success' },
+					meta: { eventId: 'evt-1', ts: '2026-07-24T00:00:00.000Z', replayed: true },
+				},
+				opts,
+			);
+
+			// State converges: the stranded spinner clears without a manual refresh.
+			expect(workflowExecutionStateStore.activeExecutionId).toBeUndefined();
+			// ...but the belated finish does not fire a toast.
+			expect(mockShowMessage).not.toHaveBeenCalled();
+		});
+
+		it('shows the toast for the same finish delivered live (non-replayed)', async () => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			mockShowMessage.mockClear();
+
+			const executionId = 'live-exec';
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
+			workflowExecutionStateStore.setActiveExecutionId(executionId);
+			vi.spyOn(useWorkflowsStore(), 'fetchExecutionDataById').mockResolvedValue(null);
+
+			await executionFinished(
+				{
+					type: 'executionFinished',
+					data: { executionId, workflowId: '1', status: 'success' },
+				},
+				opts,
+			);
+
+			// Same setup, delivered live: it DOES toast — proving the suppression above
+			// is driven by `meta.replayed`, not the fixture.
+			expect(workflowExecutionStateStore.activeExecutionId).toBeUndefined();
+			expect(mockShowMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+		});
+
+		it('is a no-op for a replayed finish of an execution this document is not tracking', async () => {
+			setActivePinia(createTestingPinia());
+			mockShowMessage.mockClear();
+
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
+			vi.spyOn(workflowExecutionStateStore, 'activeExecutionId', 'get').mockReturnValue(
+				'current-exec',
+			);
+			const fetchSpy = vi.spyOn(useWorkflowsStore(), 'fetchExecutionDataById');
+
+			await executionFinished(
+				{
+					type: 'executionFinished',
+					data: { executionId: 'other-exec', workflowId: '1', status: 'success' },
+					meta: { eventId: 'evt-2', ts: '2026-07-24T00:00:00.000Z', replayed: true },
+				},
+				opts,
+			);
+
+			expect(fetchSpy).not.toHaveBeenCalled();
+			expect(mockShowMessage).not.toHaveBeenCalled();
+		});
+	});
 });
 
 describe('manual execution stats tracking', () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -59,8 +59,20 @@ export type SimplifiedExecution = Pick<
 /**
  * Handles the 'executionFinished' event, which happens when a workflow execution is finished.
  */
-export async function executionFinished({ data }: ExecutionFinished, options: PushHandlerOptions) {
+export async function executionFinished(
+	{ data, meta }: ExecutionFinished,
+	options: PushHandlerOptions,
+) {
 	const { documentId, suppressExecutionSuccessToasts, suppressExecutionErrorToasts } = options;
+	// A replayed terminal event is re-delivered on reconnect to converge state
+	// the client missed while disconnected. Apply it idempotently (the matching
+	// logic below already no-ops once the id is cleared), but suppress its
+	// completion toast: the finish happened earlier, and at-least-once delivery
+	// means it can arrive alongside the live event — a second toast would be a
+	// duplicate. Clearing the stranded spinner is the visible recovery.
+	const replayed = meta?.replayed === true;
+	const suppressSuccessToasts = suppressExecutionSuccessToasts || replayed;
+	const suppressErrorToasts = suppressExecutionErrorToasts || replayed;
 	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 	const aiTemplatesStarterCollectionStore = useAITemplatesStarterCollectionStore();
@@ -153,7 +165,7 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 			documentId,
 			data.status,
 			successToastAlreadyShown,
-			suppressExecutionSuccessToasts,
+			suppressSuccessToasts,
 		);
 		successToastAlreadyShown = true;
 	}
@@ -181,14 +193,14 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 			execution,
 			runExecutionData,
 			documentId,
-			suppressExecutionErrorToasts,
+			suppressErrorToasts,
 		);
 	} else {
 		handleExecutionFinishedWithSuccessOrOther(
 			documentId,
 			execution.status,
 			successToastAlreadyShown,
-			suppressExecutionSuccessToasts,
+			suppressSuccessToasts,
 		);
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/index.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/index.ts
@@ -8,6 +8,7 @@ export * from './nodeExecuteAfterData';
 export * from './nodeExecuteBefore';
 export * from './reloadNodeType';
 export * from './removeNodeType';
+export * from './resumeComplete';
 export * from './sendConsoleMessage';
 export * from './sendWorkerStatusMessage';
 export * from './testWebhookDeleted';

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/resumeComplete.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/resumeComplete.ts
@@ -1,0 +1,15 @@
+import type { ResumeComplete } from '@n8n/api-types';
+
+/**
+ * Handles the 'resumeComplete' message, which the server sends after replaying
+ * any terminal events missed during a disconnect (in response to the reconnect
+ * `resume` handshake).
+ *
+ * No state change is required here: replayed terminal events (e.g.
+ * `executionFinished` carrying `meta.replayed`) are applied idempotently by
+ * `executionId` as they arrive, so the stranded spinner is already cleared by
+ * the time this arrives. The message only marks the end of the catch-up window;
+ * handling it explicitly keeps the completion signal a known type rather than a
+ * silently dropped one, and leaves a seam for future reconnect diagnostics.
+ */
+export function resumeComplete(_event: ResumeComplete) {}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
@@ -2,9 +2,11 @@ import { usePushConnection } from '@/app/composables/usePushConnection';
 import {
 	testWebhookReceived,
 	builderCreditsUpdated,
+	resumeComplete,
 } from '@/app/composables/usePushConnection/handlers';
 import type { TestWebhookReceived } from '@n8n/api-types/push/webhook';
 import type { BuilderCreditsPushMessage } from '@n8n/api-types/push/builder-credits';
+import type { ResumeComplete } from '@n8n/api-types';
 import { useRouter } from 'vue-router';
 import type { OnPushMessageHandler } from '@/app/stores/pushConnection.store';
 import { createPinia, setActivePinia } from 'pinia';
@@ -12,11 +14,28 @@ import { createPinia, setActivePinia } from 'pinia';
 const removeEventListener = vi.fn();
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const addEventListener = vi.fn((_handler: OnPushMessageHandler) => removeEventListener);
+const removeConnectedHandler = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const addConnectedHandler = vi.fn((_handler: () => void) => removeConnectedHandler);
+const send = vi.fn();
 
 vi.mock('@/app/stores/pushConnection.store', () => ({
 	usePushConnectionStore: () => ({
 		addEventListener,
+		addConnectedHandler,
+		send,
 	}),
+}));
+
+// The resume handshake reads the single tracked execution id. Controlled per
+// test via `mockActiveExecutionId`.
+let mockActiveExecutionId: string | null | undefined;
+vi.mock('@/app/stores/workflowExecutionState.store', () => ({
+	useWorkflowExecutionStateStore: vi.fn(() => ({
+		get activeExecutionId() {
+			return mockActiveExecutionId;
+		},
+	})),
 }));
 
 vi.mock('@/app/composables/usePushConnection/handlers', () => ({
@@ -36,6 +55,7 @@ vi.mock('@/app/composables/usePushConnection/handlers', () => ({
 	workflowPartiallyActivated: vi.fn(),
 	executionFinished: vi.fn(),
 	executionRecovered: vi.fn(),
+	resumeComplete: vi.fn(),
 	workflowActivated: vi.fn(),
 	workflowDeactivated: vi.fn(),
 	collaboratorsChanged: vi.fn(),
@@ -57,6 +77,7 @@ describe('usePushConnection composable', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockActiveExecutionId = undefined;
 
 		setActivePinia(createPinia());
 
@@ -67,6 +88,66 @@ describe('usePushConnection composable', () => {
 	it('should register an event listener on initialize', () => {
 		pushConnection.initialize();
 		expect(addEventListener).toHaveBeenCalledTimes(1);
+	});
+
+	it('should register a connected handler on initialize', () => {
+		pushConnection.initialize();
+		expect(addConnectedHandler).toHaveBeenCalledTimes(1);
+	});
+
+	describe('resume handshake on (re)connect', () => {
+		const triggerConnected = () => {
+			pushConnection.initialize();
+			const connectedHandler = addConnectedHandler.mock.calls[0][0];
+			connectedHandler();
+		};
+
+		it('sends a resume message with no id when no execution is tracked', () => {
+			mockActiveExecutionId = undefined;
+
+			triggerConnected();
+
+			expect(send).toHaveBeenCalledWith({ type: 'resume', data: { awaiting: [] } });
+		});
+
+		it('sends a resume message with the single tracked execution id', () => {
+			mockActiveExecutionId = 'exec-1';
+
+			triggerConnected();
+
+			expect(send).toHaveBeenCalledWith({ type: 'resume', data: { awaiting: ['exec-1'] } });
+		});
+
+		it('omits a pending (null) execution id from the resume message', () => {
+			// `activeExecutionId === null` means a run started but the backend id is
+			// not yet known — there is nothing to await by id.
+			mockActiveExecutionId = null;
+
+			triggerConnected();
+
+			expect(send).toHaveBeenCalledWith({ type: 'resume', data: { awaiting: [] } });
+		});
+	});
+
+	it('should dispatch resumeComplete events to the resumeComplete handler', async () => {
+		pushConnection.initialize();
+
+		const handler = addEventListener.mock.calls[0][0];
+
+		const testEvent: ResumeComplete = { type: 'resumeComplete', data: {} };
+		handler(testEvent);
+
+		await Promise.resolve();
+
+		expect(resumeComplete).toHaveBeenCalledTimes(1);
+		expect(resumeComplete).toHaveBeenCalledWith(testEvent);
+	});
+
+	it('should unregister the connected handler when terminate is called', () => {
+		pushConnection.initialize();
+		pushConnection.terminate();
+
+		expect(removeConnectedHandler).toHaveBeenCalledTimes(1);
 	});
 
 	it('should call the correct handler when an event is received', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import type { PushMessage } from '@n8n/api-types';
+import { createResumeMessage } from '@n8n/api-types';
 
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import {
@@ -19,6 +20,7 @@ import {
 	workflowPartiallyActivated,
 	executionFinished,
 	executionRecovered,
+	resumeComplete,
 	workflowActivated,
 	workflowDeactivated,
 	workflowAutoDeactivated,
@@ -26,6 +28,7 @@ import {
 } from '@/app/composables/usePushConnection/handlers';
 import type { PushHandlerOptions } from '@/app/composables/usePushConnection/handlers/types';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { useEditorContext } from '@/app/composables/useEditorContext';
 import { createEventQueue } from '@n8n/utils/create-event-queue';
 import type { useRouter } from 'vue-router';
@@ -41,17 +44,36 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);
 
 	const removeEventListener = ref<(() => void) | null>(null);
+	const removeConnectedHandler = ref<(() => void) | null>(null);
 
 	function initialize() {
 		removeEventListener.value = pushStore.addEventListener((message) => {
 			enqueue(message);
 		});
+		removeConnectedHandler.value = pushStore.addConnectedHandler(sendResumeHandshake);
 	}
 
 	function terminate() {
 		if (typeof removeEventListener.value === 'function') {
 			removeEventListener.value();
 		}
+		if (typeof removeConnectedHandler.value === 'function') {
+			removeConnectedHandler.value();
+		}
+	}
+
+	/**
+	 * On WebSocket (re)connect, tell the server which execution the canvas still
+	 * shows as running so it can replay a terminal event we may have missed
+	 * while disconnected. Derived from the single tracked execution (0 or 1 id)
+	 * — never from the store's disposal ledger of finished ids, which would
+	 * over-report and trigger false replays.
+	 */
+	function sendResumeHandshake() {
+		const documentId = workflowDocumentStore.value.documentId;
+		const { activeExecutionId } = useWorkflowExecutionStateStore(documentId);
+		const awaiting = typeof activeExecutionId === 'string' ? [activeExecutionId] : [];
+		pushStore.send(createResumeMessage(awaiting));
 	}
 
 	/**
@@ -98,6 +120,8 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 				return await executionFinished(event, options);
 			case 'executionRecovered':
 				return await executionRecovered(event, options);
+			case 'resumeComplete':
+				return resumeComplete(event);
 			case 'workflowActivated':
 				return await workflowActivated(event, options);
 			case 'workflowDeactivated':

--- a/packages/frontend/editor-ui/src/app/push-connection/__tests__/useWebSocketClient.test.ts
+++ b/packages/frontend/editor-ui/src/app/push-connection/__tests__/useWebSocketClient.test.ts
@@ -119,6 +119,25 @@ describe('useWebSocketClient', () => {
 		expect(MockWebSocket.init).toHaveBeenCalledTimes(3);
 	});
 
+	test('should call onConnected callback after connection opens', () => {
+		const onConnected = vi.fn();
+		const { connect, isConnected } = useWebSocketClient({
+			url: 'ws://test.com',
+			onMessage: vi.fn(),
+			onConnected,
+		});
+		connect();
+
+		expect(onConnected).not.toHaveBeenCalled();
+
+		MockWebSocket.getInstance().simulateConnectionOpen();
+
+		// Fired once per (re)connect, only after the connection is live so the
+		// callback can send the resume handshake immediately.
+		expect(onConnected).toHaveBeenCalledTimes(1);
+		expect(isConnected.value).toBe(true);
+	});
+
 	test('should send message when connected', () => {
 		const { connect, sendMessage } = useWebSocketClient({
 			url: 'ws://test.com',

--- a/packages/frontend/editor-ui/src/app/push-connection/useWebSocketClient.ts
+++ b/packages/frontend/editor-ui/src/app/push-connection/useWebSocketClient.ts
@@ -5,6 +5,12 @@ import { createHeartbeatMessage } from '@n8n/api-types';
 export type UseWebSocketClientOptions<T> = {
 	url: string;
 	onMessage: (data: T) => void;
+	/**
+	 * Called whenever the socket (re)connects, after the connection is live so
+	 * messages can be sent immediately. Used to send the reconnect `resume`
+	 * handshake before consuming live events.
+	 */
+	onConnected?: () => void;
 };
 
 /** Defined here as not available in tests */
@@ -42,6 +48,8 @@ export const useWebSocketClient = <T>(options: UseWebSocketClientOptions<T>) => 
 		isConnected.value = true;
 		startHeartbeat();
 		reconnectTimer.resetConnectionAttempts();
+		// Fired after `isConnected` is set so the callback can send immediately.
+		options.onConnected?.();
 	};
 
 	const onConnectionLost = (event: CloseEvent) => {

--- a/packages/frontend/editor-ui/src/app/stores/pushConnection.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/pushConnection.store.test.ts
@@ -49,6 +49,7 @@ describe('usePushConnectionStore', () => {
 	} = {}) => {
 		// Mock connected state
 		let onMessage: (data: unknown) => void = vi.fn();
+		let onConnected: (() => void) | undefined;
 		const mockWebSocketClient: WebSocketClient = {
 			isConnected: ref(isConnected),
 			connect: vi.fn(),
@@ -58,15 +59,23 @@ describe('usePushConnectionStore', () => {
 
 		vi.mocked(useWebSocketClient).mockImplementation((opts) => {
 			onMessage = opts.onMessage;
+			onConnected = opts.onConnected;
 			return mockWebSocketClient;
 		});
 
 		setActivePinia(createPinia());
 
+		// Reading the store forces the `client` computed to evaluate (via the
+		// isConnected watcher), which captures the mocked client options above.
+		const store = usePushConnectionStore();
+
 		return {
-			store: usePushConnectionStore(),
+			store,
 			mockWebSocketClient,
 			onMessage,
+			// The WebSocket client's onConnected hook, captured once the client
+			// computed has run.
+			getOnConnected: () => onConnected,
 		};
 	};
 
@@ -87,6 +96,24 @@ describe('usePushConnectionStore', () => {
 
 		removeListener();
 		expect(store.onMessageReceivedHandlers).toHaveLength(0);
+	});
+
+	test('should register, fire, and unregister connected handlers on (re)connect', () => {
+		const { store, getOnConnected } = createTestInitialState();
+		const handler = vi.fn();
+
+		const removeHandler = store.addConnectedHandler(handler);
+
+		// The WebSocket client invokes onConnected on every (re)connect.
+		getOnConnected()?.();
+		expect(handler).toHaveBeenCalledTimes(1);
+
+		getOnConnected()?.();
+		expect(handler).toHaveBeenCalledTimes(2);
+
+		removeHandler();
+		getOnConnected()?.();
+		expect(handler).toHaveBeenCalledTimes(2);
 	});
 
 	describe('connection handling', () => {

--- a/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/pushConnection.store.ts
@@ -44,6 +44,30 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 		};
 	};
 
+	/**
+	 * Handlers invoked whenever the WebSocket transport (re)connects, after the
+	 * connection is live. Only the WebSocket client fires these — the SSE
+	 * transport has no client→server channel and recovers via REST reconcile.
+	 */
+	const onConnectedHandlers = ref<Array<() => void>>([]);
+
+	const addConnectedHandler = (handler: () => void) => {
+		onConnectedHandlers.value.push(handler);
+
+		return () => {
+			const index = onConnectedHandlers.value.indexOf(handler);
+			if (index !== -1) {
+				onConnectedHandlers.value.splice(index, 1);
+			}
+		};
+	};
+
+	const handleConnected = () => {
+		for (const handler of onConnectedHandlers.value) {
+			handler();
+		}
+	};
+
 	const useWebSockets = computed(() => settingsStore.pushBackend === 'websocket');
 
 	const getConnectionUrl = () => {
@@ -87,7 +111,7 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 
 	const client = computed(() =>
 		useWebSockets.value
-			? useWebSocketClient({ url: url.value, onMessage })
+			? useWebSocketClient({ url: url.value, onMessage, onConnected: handleConnected })
 			: useEventSourceClient({ url: url.value, onMessage }),
 	);
 
@@ -205,6 +229,7 @@ export const usePushConnectionStore = defineStore(STORES.PUSH, () => {
 		isConnectionRequested,
 		onMessageReceivedHandlers,
 		addEventListener,
+		addConnectedHandler,
 		pushConnect,
 		pushDisconnect,
 		send: serializeAndSend,


### PR DESCRIPTION
## Summary

Frontend/consumer slice of the Lane 3 push-durability feature: at-least-once delivery of terminal execution events across a WebSocket disconnect that spans the finish.

Today a dropped `executionFinished` push — the client disconnects across the moment a manual run finishes — strands the canvas spinner until a manual refresh. This adds the client half of a reconnect replay handshake:

- **Resume handshake** — on WebSocket (re)connect, before consuming live events, the client sends `{ type: "resume", data: { awaiting } }` where `awaiting = activeExecutionId ? [activeExecutionId] : []` — the single tracked execution (0 or 1 id). It is derived from `activeExecutionId`, never from the store's `trackedExecutionIds` disposal ledger (which holds finished ids and would trigger false replays).
- **Replayed terminal events** — a terminal event re-delivered by the server carries `meta.replayed === true`. It is applied idempotently by `executionId` (the finished handler already no-ops once the id is cleared), clearing the stranded spinner, and its completion toast is suppressed so an at-least-once duplicate never double-notifies.
- **`resumeComplete`** — the server's end-of-catch-up acknowledgement is handled as a known message type.

Shared, additive contract types are added to `@n8n/api-types` per the agreed v2 contract: optional `meta: { eventId, ts, replayed? }` on `executionFinished` / `executionWaiting`, the client→server `resume` message (schema + creator), and the server→client `resumeComplete` message. All changes are backward-compatible in both directions — an old client ignores `meta` and never sends `resume`; a new client tolerates a missing `meta` and a `resume` that goes unanswered.

SSE has no client→server channel and is out of scope here; it recovers via the Lane 1 REST reconcile. This is the same idempotent consumer for both lanes, with `executionId` as the shared key.

## How to test

Unit tests (from `packages/frontend/editor-ui`):

- `usePushConnection.test.ts` — resume emission with 0 and 1 id; `resumeComplete` dispatch; handler registration/teardown.
- `handlers/executionFinished.test.ts` — a replayed finish clears execution state but suppresses the toast; the same finish delivered live still toasts (proving the suppression is driven by `meta.replayed`); a replayed finish for an untracked execution is a no-op.
- `stores/pushConnection.store.test.ts` and `push-connection/__tests__/useWebSocketClient.test.ts` — the `onConnected` / connected-handler wiring.

End-to-end (needs the backend replay child): run a manual workflow, drop the connection across the finish (offline toggle or server restart), then reconnect — the spinner clears without a refresh and no toast fires for the belated finish.

## Related Linear tickets, Github issues, and Community forum posts

Part of the Lane 3 push-durability feature. Coordinates with the backend push-layer child (produces the `meta` envelope, handles `resume`, replays terminal events from the DB) and the Lane 1 reconcile-on-reconnect work. No Linear ticket or GitHub issue.

## Notes for reviewers

- The `meta` envelope type and the `resume` schema in `@n8n/api-types` are shared with the backend child; both add them per the same v2 contract, so expect a trivial reconcile if the backend PR lands first.
- `ResumeComplete` carries `data: {}` to keep every push envelope shaped as `{ type, data }`, matching the existing `nodeDescriptionUpdated` precedent (so `PushPayload` and the pubsub relay stay unchanged).
- Verified locally: `@n8n/api-types` build, `editor-ui` and `cli` typecheck, targeted eslint, and the four affected test suites (63 tests) all pass.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. Title is suffixed `(no-changelog)` — this slice is inert without the backend replay child, which will own the changelog entry for the complete feature.
- [ ] Docs updated or follow-up ticket created. (No doc surface.)
- [x] Tests included.
- [ ] PR Labeled with a backport label (not an urgent fix).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

