### PR TITLE
feat(core): Add agent-eval runner executing cases against a real agent (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/modules/modules.config.ts
+++ b/packages/@n8n/backend-common/src/modules/modules.config.ts
@@ -4,6 +4,7 @@ import { UnknownModuleError } from './errors/unknown-module.error';
 
 export const MODULE_NAMES = [
 	'agents',
+	'agent-evals',
 	'insights',
 	'external-secrets',
 	'community-packages',

--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-dataset.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-dataset.repository.test.ts
@@ -77,4 +77,14 @@ describe('AgentEvalDatasetRepository', () => {
 			});
 		});
 	});
+
+	describe('findById', () => {
+		it('looks up a single dataset by id', async () => {
+			entityManager.findOneBy.mockResolvedValueOnce(null);
+
+			await repo.findById('ds-1');
+
+			expect(entityManager.findOneBy.mock.calls[0]?.[1]).toEqual({ id: 'ds-1' });
+		});
+	});
 });

--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-result.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-result.repository.test.ts
@@ -125,4 +125,25 @@ describe('AgentEvalResultRepository', () => {
 			expect(callArgs?.[1]).toEqual({ where: { runId: 'run-1' }, order: { runIndex: 'ASC' } });
 		});
 	});
+
+	describe('countByStatus', () => {
+		it('groups counts by status in the DB and zero-fills missing statuses', async () => {
+			const qb = {
+				select: vi.fn().mockReturnThis(),
+				addSelect: vi.fn().mockReturnThis(),
+				where: vi.fn().mockReturnThis(),
+				groupBy: vi.fn().mockReturnThis(),
+				getRawMany: vi.fn().mockResolvedValue([
+					{ status: 'success', count: '3' },
+					{ status: 'error', count: 1 },
+				]),
+			};
+			(entityManager.createQueryBuilder as Mock).mockReturnValue(qb);
+
+			const result = await repo.countByStatus('run-1');
+
+			expect(qb.where).toHaveBeenCalledWith('result.runId = :runId', { runId: 'run-1' });
+			expect(result).toEqual({ new: 0, running: 0, success: 3, error: 1, cancelled: 0 });
+		});
+	});
 });

--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-result.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-result.repository.test.ts
@@ -89,6 +89,32 @@ describe('AgentEvalResultRepository', () => {
 		});
 	});
 
+	describe('markAsRunning', () => {
+		it('marks the case running and stamps runAt', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 1, generatedMaps: [], raw: [] });
+
+			await repo.markAsRunning('res-1');
+
+			const callArgs = entityManager.update.mock.calls[0];
+			expect(callArgs?.[1]).toBe('res-1');
+			expect(callArgs?.[2]).toMatchObject({ status: 'running' });
+			expect((callArgs?.[2] as { runAt: Date }).runAt).toBeInstanceOf(Date);
+		});
+	});
+
+	describe('markAsCancelled', () => {
+		it('marks the case cancelled and stamps completedAt', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 1, generatedMaps: [], raw: [] });
+
+			await repo.markAsCancelled('res-1');
+
+			const callArgs = entityManager.update.mock.calls[0];
+			expect(callArgs?.[1]).toBe('res-1');
+			expect(callArgs?.[2]).toMatchObject({ status: 'cancelled' });
+			expect((callArgs?.[2] as { completedAt: Date }).completedAt).toBeInstanceOf(Date);
+		});
+	});
+
 	describe('findByRunId', () => {
 		it('scopes to runId ordered by runIndex ascending', async () => {
 			entityManager.find.mockResolvedValueOnce([]);

--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-run.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-run.repository.test.ts
@@ -171,4 +171,20 @@ describe('AgentEvalRunRepository', () => {
 			expect(await repo.isCancellationRequested('run-x')).toBe(false);
 		});
 	});
+
+	describe('markAllIncompleteAsError', () => {
+		it('flips new/running runs to error and clears the running instance', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 3, generatedMaps: [], raw: [] });
+
+			await repo.markAllIncompleteAsError();
+
+			const callArgs = entityManager.update.mock.calls[0];
+			// [1] is the status criteria, [2] the patch applied to matching rows.
+			expect(callArgs?.[2]).toMatchObject({
+				status: 'error',
+				errorCode: 'interrupted',
+				runningInstanceId: null,
+			});
+		});
+	});
 });

--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-run.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-run.repository.test.ts
@@ -114,4 +114,61 @@ describe('AgentEvalRunRepository', () => {
 			expect(callArgs?.[1]).toEqual({ where: { datasetId: 'ds-1' }, order: { createdAt: 'DESC' } });
 		});
 	});
+
+	describe('markAsCancelled', () => {
+		it('marks cancelled, persists partial metrics, and clears the running instance', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 1, generatedMaps: [], raw: [] });
+
+			await repo.markAsCancelled('run-1', { total: 3, usage: { inputTokens: 5 } });
+
+			const callArgs = entityManager.update.mock.calls[0];
+			expect(callArgs?.[1]).toBe('run-1');
+			expect(callArgs?.[2]).toMatchObject({
+				status: 'cancelled',
+				metrics: { total: 3, usage: { inputTokens: 5 } },
+				runningInstanceId: null,
+			});
+		});
+
+		it('defaults metrics to null when none are given', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 1, generatedMaps: [], raw: [] });
+
+			await repo.markAsCancelled('run-1');
+
+			expect(entityManager.update.mock.calls[0]?.[2]).toMatchObject({
+				status: 'cancelled',
+				metrics: null,
+			});
+		});
+	});
+
+	describe('findById', () => {
+		it('looks up a run by id', async () => {
+			entityManager.findOneBy.mockResolvedValueOnce(null);
+
+			await repo.findById('run-1');
+
+			expect(entityManager.findOneBy.mock.calls[0]?.[1]).toEqual({ id: 'run-1' });
+		});
+	});
+
+	describe('isCancellationRequested', () => {
+		it('reads only the cancel flag and returns it', async () => {
+			entityManager.findOne.mockResolvedValueOnce({ id: 'run-1', cancelRequested: true });
+
+			const result = await repo.isCancellationRequested('run-1');
+
+			expect(result).toBe(true);
+			expect(entityManager.findOne.mock.calls[0]?.[1]).toEqual({
+				where: { id: 'run-1' },
+				select: ['id', 'cancelRequested'],
+			});
+		});
+
+		it('returns false when the run no longer exists', async () => {
+			entityManager.findOne.mockResolvedValueOnce(null);
+
+			expect(await repo.isCancellationRequested('run-x')).toBe(false);
+		});
+	});
 });

--- a/packages/@n8n/db/src/repositories/agent-eval-dataset.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-dataset.repository.ee.ts
@@ -38,4 +38,8 @@ export class AgentEvalDatasetRepository extends Repository<AgentEvalDataset> {
 	async findByAgentId(agentId: string): Promise<AgentEvalDataset[]> {
 		return await this.find({ where: { agentId }, order: { createdAt: 'DESC' } });
 	}
+
+	async findById(id: string): Promise<AgentEvalDataset | null> {
+		return await this.findOneBy({ id });
+	}
 }

--- a/packages/@n8n/db/src/repositories/agent-eval-result.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-result.repository.ee.ts
@@ -3,6 +3,7 @@ import { DataSource, Repository } from '@n8n/typeorm';
 import type { IDataObject, JsonObject } from 'n8n-workflow';
 
 import { AgentEvalResult } from '../entities';
+import type { AgentEvalResultStatus } from '../entities/agent-eval-result.ee';
 
 type CreateAgentEvalResultAttrs = {
 	runId: string;
@@ -10,6 +11,12 @@ type CreateAgentEvalResultAttrs = {
 	runIndex?: number | null;
 	input?: JsonObject | null;
 };
+
+export type AgentEvalResultStatusCounts = Record<AgentEvalResultStatus, number>;
+
+// Insert seeded rows in chunks so a large dataset stays under the driver's bound
+// parameter limit (SQLite in particular).
+const SEED_CHUNK_SIZE = 100;
 
 @Service()
 export class AgentEvalResultRepository extends Repository<AgentEvalResult> {
@@ -35,7 +42,31 @@ export class AgentEvalResultRepository extends Repository<AgentEvalResult> {
 			}),
 		);
 
-		return await this.save(results);
+		return await this.save(results, { chunk: SEED_CHUNK_SIZE });
+	}
+
+	/**
+	 * Per-status result counts for a run, computed in the database so callers
+	 * (run aggregation, polled run summaries) never load the full result rows —
+	 * including their `input`/`output`/`toolCalls` JSON — just to count them.
+	 */
+	async countByStatus(runId: string): Promise<AgentEvalResultStatusCounts> {
+		const rows = await this.createQueryBuilder('result')
+			.select('result.status', 'status')
+			.addSelect('COUNT(*)', 'count')
+			.where('result.runId = :runId', { runId })
+			.groupBy('result.status')
+			.getRawMany<{ status: AgentEvalResultStatus; count: string | number }>();
+
+		const counts: AgentEvalResultStatusCounts = {
+			new: 0,
+			running: 0,
+			success: 0,
+			error: 0,
+			cancelled: 0,
+		};
+		for (const row of rows) counts[row.status] = Number(row.count);
+		return counts;
 	}
 
 	async markAsRunning(id: string) {

--- a/packages/@n8n/db/src/repositories/agent-eval-result.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-result.repository.ee.ts
@@ -38,6 +38,14 @@ export class AgentEvalResultRepository extends Repository<AgentEvalResult> {
 		return await this.save(results);
 	}
 
+	async markAsRunning(id: string) {
+		return await this.update(id, { status: 'running', runAt: new Date() });
+	}
+
+	async markAsCancelled(id: string) {
+		return await this.update(id, { status: 'cancelled', completedAt: new Date() });
+	}
+
 	async markAsCompleted(
 		id: string,
 		attrs: {

--- a/packages/@n8n/db/src/repositories/agent-eval-run.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-run.repository.ee.ts
@@ -55,10 +55,11 @@ export class AgentEvalRunRepository extends Repository<AgentEvalRun> {
 		});
 	}
 
-	async markAsCancelled(id: string) {
+	async markAsCancelled(id: string, metrics: IDataObject | null = null) {
 		return await this.update(id, {
 			status: 'cancelled',
 			completedAt: new Date(),
+			metrics,
 			runningInstanceId: null,
 		});
 	}
@@ -73,5 +74,15 @@ export class AgentEvalRunRepository extends Repository<AgentEvalRun> {
 
 	async findByDatasetId(datasetId: string): Promise<AgentEvalRun[]> {
 		return await this.find({ where: { datasetId }, order: { createdAt: 'DESC' } });
+	}
+
+	async findById(id: string): Promise<AgentEvalRun | null> {
+		return await this.findOneBy({ id });
+	}
+
+	/** Lightweight read of just the cross-main cancellation flag for a run. */
+	async isCancellationRequested(id: string): Promise<boolean> {
+		const run = await this.findOne({ where: { id }, select: ['id', 'cancelRequested'] });
+		return run?.cancelRequested ?? false;
 	}
 }

--- a/packages/@n8n/db/src/repositories/agent-eval-run.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-run.repository.ee.ts
@@ -1,5 +1,5 @@
 import { Service } from '@n8n/di';
-import { DataSource, Repository } from '@n8n/typeorm';
+import { DataSource, In, Repository } from '@n8n/typeorm';
 import type { IDataObject } from 'n8n-workflow';
 
 import { AgentEvalRun } from '../entities';
@@ -78,6 +78,24 @@ export class AgentEvalRunRepository extends Repository<AgentEvalRun> {
 
 	async findById(id: string): Promise<AgentEvalRun | null> {
 		return await this.findOneBy({ id });
+	}
+
+	/**
+	 * Mark every run still in an incomplete state as errored. Called on startup:
+	 * the runner has no resume mechanism, so a run interrupted by a process
+	 * restart can never continue and would otherwise poll as `running` forever.
+	 * Blanket sweep, mirroring the workflow eval's `markAllIncompleteAsFailed`.
+	 */
+	async markAllIncompleteAsError() {
+		return await this.update(
+			{ status: In(['new', 'running']) },
+			{
+				status: 'error',
+				errorCode: 'interrupted',
+				completedAt: new Date(),
+				runningInstanceId: null,
+			},
+		);
 	}
 
 	/** Lightweight read of just the cross-main cancellation flag for a run. */

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
@@ -13,6 +13,7 @@ import type { InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
 import type { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
+import { License } from '@/license';
 import { Agent } from '@/modules/agents/entities/agent.entity';
 import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
@@ -52,6 +53,7 @@ const buildRunner = () =>
 		Container.get(DataTableService),
 		evalAgentExecutionService,
 		concurrencyControl,
+		Container.get(License),
 	);
 
 /** Insert a minimal real agent row so `agent_eval_dataset.agentId`'s FK holds. */
@@ -69,6 +71,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
 	vi.clearAllMocks();
+	concurrencyControl.throttle.mockResolvedValue(undefined); // no-op queue: slot always granted
 	// Not truncating `Agent`/`Project`: each test creates its own in a fresh
 	// project and the agent is resolved via a mock, so leftovers are invisible
 	// (and `Agent` is a module entity absent from testDb's EntityName union).

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
@@ -12,6 +12,7 @@ import { DataSource } from '@n8n/typeorm';
 import type { InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
+import type { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
 import { Agent } from '@/modules/agents/entities/agent.entity';
 import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
@@ -34,6 +35,8 @@ vi.mock('@/modules/instance-ai/eval/agent-execution.service', () => ({
 const agentRepository = mock<AgentRepository>();
 const evalAgentExecutionService = mock<EvalAgentExecutionService>();
 const instanceSettings = mock<InstanceSettings>({ hostId: 'main-test' });
+// No-op throttle: this test targets DB persistence, not concurrency policy.
+const concurrencyControl = mock<ConcurrencyControlService>();
 
 let owner: User;
 
@@ -48,6 +51,7 @@ const buildRunner = () =>
 		agentRepository,
 		Container.get(DataTableService),
 		evalAgentExecutionService,
+		concurrencyControl,
 	);
 
 /** Insert a minimal real agent row so `agent_eval_dataset.agentId`'s FK holds. */

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
@@ -1,0 +1,207 @@
+import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import {
+	AgentEvalDatasetRepository,
+	AgentEvalResultRepository,
+	AgentEvalRunRepository,
+	GLOBAL_OWNER_ROLE,
+	type User,
+} from '@n8n/db';
+import { Container } from '@n8n/di';
+import { DataSource } from '@n8n/typeorm';
+import type { InstanceSettings } from 'n8n-core';
+import { mock } from 'vitest-mock-extended';
+
+import { Agent } from '@/modules/agents/entities/agent.entity';
+import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
+import { DataTableService } from '@/modules/data-table/data-table.service';
+import type { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent-execution.service';
+import { createUserShell } from '@test-integration/db/users';
+
+import { AgentEvalRunnerService } from '../agent-eval-runner.service';
+
+// The agent under test runs through the real reconstruction + live-model path,
+// which needs credentials/network and is covered by the instance-ai eval suite;
+// loading that module graph here also drags in @n8n/task-runner. Stub those two
+// specifiers so the runner is exercised for real against the DB (real Data Table
+// row resolution, seeded result rows, per-case persistence, run aggregation)
+// with only the LLM-backed execution replaced.
+vi.mock('@/modules/agents/repositories/agent.repository', () => ({ AgentRepository: class {} }));
+vi.mock('@/modules/instance-ai/eval/agent-execution.service', () => ({
+	EvalAgentExecutionService: class {},
+}));
+
+const agentRepository = mock<AgentRepository>();
+const evalAgentExecutionService = mock<EvalAgentExecutionService>();
+const instanceSettings = mock<InstanceSettings>({ hostId: 'main-test' });
+
+let owner: User;
+
+const buildRunner = () =>
+	new AgentEvalRunnerService(
+		mock(),
+		Container.get(GlobalConfig),
+		instanceSettings,
+		Container.get(AgentEvalDatasetRepository),
+		Container.get(AgentEvalRunRepository),
+		Container.get(AgentEvalResultRepository),
+		agentRepository,
+		Container.get(DataTableService),
+		evalAgentExecutionService,
+	);
+
+/** Insert a minimal real agent row so `agent_eval_dataset.agentId`'s FK holds. */
+async function createAgent(projectId: string): Promise<Agent> {
+	return await Container.get(DataSource)
+		.getRepository(Agent)
+		.save(Object.assign(new Agent(), { name: 'test agent', projectId }));
+}
+
+beforeAll(async () => {
+	await testModules.loadModules(['data-table', 'agents']);
+	await testDb.init();
+	owner = await createUserShell(GLOBAL_OWNER_ROLE);
+});
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	// Not truncating `Agent`/`Project`: each test creates its own in a fresh
+	// project and the agent is resolved via a mock, so leftovers are invisible
+	// (and `Agent` is a module entity absent from testDb's EntityName union).
+	await testDb.truncate([
+		'DataTable',
+		'DataTableColumn',
+		'AgentEvalResult',
+		'AgentEvalRun',
+		'AgentEvalDataset',
+	]);
+	Container.get(GlobalConfig).evaluation.agentEvalsEnabled = true;
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('AgentEvalRunnerService (integration)', () => {
+	it('runs each dataset row against the agent and persists results + run status', async () => {
+		const project = await createTeamProject();
+		const agent = await createAgent(project.id);
+		const dataTableService = Container.get(DataTableService);
+
+		const table = await dataTableService.createDataTable(project.id, {
+			name: 'cases',
+			columns: [
+				{ name: 'question', type: 'string' },
+				{ name: 'answer', type: 'string' },
+			],
+		});
+		await dataTableService.insertRows(table.id, project.id, [
+			{ question: 'What is 2+2?', answer: '4' },
+			{ question: 'Capital of France?', answer: 'Paris' },
+		]);
+
+		const dataset = await Container.get(AgentEvalDatasetRepository).createDataset({
+			name: 'ds',
+			agentId: agent.id,
+			datasetSource: 'data_table',
+			datasetRef: { dataTableId: table.id },
+			columnMapping: { input: 'question', expectedOutput: 'answer' },
+		});
+
+		agentRepository.findByIdAndProjectId.mockResolvedValue(
+			mock<Agent>({ id: agent.id, activeVersionId: null }),
+		);
+		evalAgentExecutionService.executeWithLlmMock.mockImplementation(
+			async (_agentId, _user, _options, caseInput) =>
+				({
+					runId: 'exec',
+					success: true,
+					errors: [],
+					finalText: `answer to: ${caseInput}`,
+					model: 'test-model',
+					finishReason: 'stop',
+					toolCalls: [{ tool: 'lookup', kind: 'node', mocked: true, interceptedRequests: [] }],
+					modelTurns: [],
+					usage: { inputTokens: 5, outputTokens: 9 },
+					seed: { openingMessage: caseInput ?? '', globalContext: '', toolHints: {}, warnings: [] },
+					skippedFeatures: [],
+					mockedCredentials: [],
+				}) as never,
+		);
+
+		const runner = buildRunner();
+		const { runId, finished } = await runner.startRun(dataset.id, project.id, owner);
+		await finished;
+
+		const summary = await runner.getRunSummary(runId);
+		expect(summary.status).toBe('completed');
+		expect(summary.counts).toMatchObject({ total: 2, success: 2, error: 0, cancelled: 0 });
+
+		// Each row's input was sent verbatim as the case input.
+		const inputsSent = evalAgentExecutionService.executeWithLlmMock.mock.calls.map((c) => c[3]);
+		expect(inputsSent).toEqual(expect.arrayContaining(['What is 2+2?', 'Capital of France?']));
+
+		const results = await Container.get(AgentEvalResultRepository).findByRunId(runId);
+		expect(results).toHaveLength(2);
+		for (const result of results) {
+			expect(result.status).toBe('success');
+			expect(result.output).toMatchObject({ finalText: expect.stringContaining('answer to:') });
+			expect(result.toolCalls).toMatchObject({ calls: expect.any(Array) });
+			// case snapshot retained for later judging
+			expect(result.input).toMatchObject({
+				input: expect.any(String),
+				expectedOutput: expect.any(String),
+			});
+		}
+
+		const run = await Container.get(AgentEvalRunRepository).findById(runId);
+		expect(run?.status).toBe('completed');
+		expect(run?.metrics).toMatchObject({ usage: { inputTokens: 10, outputTokens: 18 } });
+	});
+
+	it('persists a per-case error without failing the whole run', async () => {
+		const project = await createTeamProject();
+		const agent = await createAgent(project.id);
+		const dataTableService = Container.get(DataTableService);
+		const table = await dataTableService.createDataTable(project.id, {
+			name: 'cases',
+			columns: [{ name: 'question', type: 'string' }],
+		});
+		await dataTableService.insertRows(table.id, project.id, [{ question: 'boom' }]);
+
+		const dataset = await Container.get(AgentEvalDatasetRepository).createDataset({
+			name: 'ds',
+			agentId: agent.id,
+			datasetSource: 'data_table',
+			datasetRef: { dataTableId: table.id },
+			columnMapping: { input: 'question' },
+		});
+
+		agentRepository.findByIdAndProjectId.mockResolvedValue(
+			mock<Agent>({ id: agent.id, activeVersionId: null }),
+		);
+		evalAgentExecutionService.executeWithLlmMock.mockResolvedValue({
+			runId: '',
+			success: false,
+			errors: ['model exploded'],
+			finalText: '',
+			toolCalls: [],
+			modelTurns: [],
+			seed: { openingMessage: '', globalContext: '', toolHints: {}, warnings: [] },
+			skippedFeatures: [],
+			mockedCredentials: [],
+		} as never);
+
+		const runner = buildRunner();
+		const { runId, finished } = await runner.startRun(dataset.id, project.id, owner);
+		await finished;
+
+		const summary = await runner.getRunSummary(runId);
+		expect(summary.status).toBe('completed');
+		expect(summary.counts).toMatchObject({ total: 1, success: 0, error: 1 });
+
+		const [result] = await Container.get(AgentEvalResultRepository).findByRunId(runId);
+		expect(result.status).toBe('error');
+		expect(result.errorCode).toBe('execution_failed');
+	});
+});

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -11,6 +11,8 @@ import type { InstanceSettings } from 'n8n-core';
 import { mock, type MockProxy } from 'vitest-mock-extended';
 
 import type { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
+import { resolveEvaluationConcurrencyLimit } from '@/evaluation.ee/evaluation-concurrency.helper';
+import type { License } from '@/license';
 import type { Agent } from '@/modules/agents/entities/agent.entity';
 import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
 import type { DataTableService } from '@/modules/data-table/data-table.service';
@@ -23,6 +25,11 @@ import { AgentEvalRunnerService } from '../agent-eval-runner.service';
 // test doesn't pull in the real agents / data-table / instance-ai module graph.
 vi.mock('@/concurrency/concurrency-control.service', () => ({
 	ConcurrencyControlService: class ConcurrencyControlService {},
+}));
+vi.mock('@/license', () => ({ License: class License {} }));
+vi.mock('@/evaluation.ee/evaluation-concurrency.helper', () => ({
+	// Fixed per-run limit keeps the pool deterministic (serial) in unit tests.
+	resolveEvaluationConcurrencyLimit: vi.fn().mockReturnValue(1),
 }));
 vi.mock('@/modules/agents/repositories/agent.repository', () => ({
 	AgentRepository: class AgentRepository {},
@@ -92,6 +99,7 @@ describe('AgentEvalRunnerService', () => {
 	let dataTableService: MockProxy<DataTableService>;
 	let evalAgentExecutionService: MockProxy<EvalAgentExecutionService>;
 	let concurrencyControl: MockProxy<ConcurrencyControlService>;
+	let license: MockProxy<License>;
 	let service: AgentEvalRunnerService;
 
 	const dataset = mock<AgentEvalDataset>({
@@ -104,6 +112,8 @@ describe('AgentEvalRunnerService', () => {
 
 	beforeEach(() => {
 		vi.mocked(userHasScopes).mockResolvedValue(true);
+		vi.mocked(resolveEvaluationConcurrencyLimit).mockReturnValue(1); // serial by default
+
 		globalConfig = {
 			evaluation: { agentEvalsEnabled: true },
 			executions: { mode: 'regular' },
@@ -116,6 +126,7 @@ describe('AgentEvalRunnerService', () => {
 		dataTableService = mock<DataTableService>();
 		evalAgentExecutionService = mock<EvalAgentExecutionService>();
 		concurrencyControl = mock<ConcurrencyControlService>();
+		license = mock<License>();
 
 		datasetRepository.findById.mockResolvedValue(dataset);
 		agentRepository.findByIdAndProjectId.mockResolvedValue(
@@ -123,6 +134,7 @@ describe('AgentEvalRunnerService', () => {
 		);
 		runRepository.createRun.mockResolvedValue(mock({ id: 'run-1' }));
 		runRepository.isCancellationRequested.mockResolvedValue(false);
+		concurrencyControl.throttle.mockResolvedValue(undefined); // slot acquired
 		dataTableService.getProjectIdForDataTable.mockResolvedValue('proj-table');
 		// Columns backing the dataset's mapping (input/expectedOutput/criteria).
 		dataTableService.getColumns.mockResolvedValue([
@@ -142,6 +154,7 @@ describe('AgentEvalRunnerService', () => {
 			dataTableService,
 			evalAgentExecutionService,
 			concurrencyControl,
+			license,
 		);
 	});
 
@@ -395,10 +408,14 @@ describe('AgentEvalRunnerService', () => {
 			expect(runRepository.markAsCompleted).not.toHaveBeenCalled();
 		});
 
-		it('cancels the run when Stop arrives after every case has already started', async () => {
+		it('cancels the run when Stop arrives after every case has already run', async () => {
 			seedFor([{ id: 'row-1', question: 'Q' }], { success: 1 });
-			// false while the case runs, true at the post-pool re-check
-			runRepository.isCancellationRequested.mockResolvedValueOnce(false).mockResolvedValue(true);
+			// The case's pre-throttle and post-acquire checks see no cancel (so it
+			// runs); the cancel only lands by the final post-pool re-check.
+			runRepository.isCancellationRequested
+				.mockResolvedValueOnce(false)
+				.mockResolvedValueOnce(false)
+				.mockResolvedValue(true);
 			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
 
 			const { finished } = await service.startRun('ds-1', 'proj-1', user);
@@ -430,6 +447,40 @@ describe('AgentEvalRunnerService', () => {
 			);
 			expect(concurrencyControl.release).toHaveBeenCalledTimes(2);
 			expect(concurrencyControl.release).toHaveBeenCalledWith({ mode: 'evaluation' });
+		});
+
+		it('evicts a still-queued case from the shared queue when the run is cancelled', async () => {
+			vi.mocked(resolveEvaluationConcurrencyLimit).mockReturnValue(2); // admit both at once
+			seedFor(
+				[
+					{ id: 'row-1', question: 'Q0' },
+					{ id: 'row-2', question: 'Q1' },
+				],
+				{ cancelled: 2 },
+			);
+			// case-0 acquires immediately; case-1 stays parked in the queue.
+			concurrencyControl.throttle.mockImplementation(async ({ executionId }) => {
+				if (executionId.endsWith('-case-1')) return await new Promise<void>(() => {}); // parked
+				return undefined;
+			});
+			// Both pass the pre-throttle check; case-0's post-acquire check then sees
+			// the cancel and aborts, which must evict the parked case-1.
+			runRepository.isCancellationRequested
+				.mockResolvedValueOnce(false)
+				.mockResolvedValueOnce(false)
+				.mockResolvedValue(true);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			expect(concurrencyControl.remove).toHaveBeenCalledWith(
+				expect.objectContaining({
+					mode: 'evaluation',
+					executionId: expect.stringContaining('-case-1'),
+				}),
+			);
+			expect(runRepository.markAsCancelled).toHaveBeenCalledWith('run-1', expect.anything());
+			expect(evalAgentExecutionService.executeWithLlmMock).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -482,6 +482,43 @@ describe('AgentEvalRunnerService', () => {
 			expect(runRepository.markAsCancelled).toHaveBeenCalledWith('run-1', expect.anything());
 			expect(evalAgentExecutionService.executeWithLlmMock).not.toHaveBeenCalled();
 		});
+
+		it('releases a slot granted at the same moment the run is cancelled (no leak)', async () => {
+			vi.mocked(resolveEvaluationConcurrencyLimit).mockReturnValue(2); // admit both at once
+			seedFor(
+				[
+					{ id: 'row-1', question: 'Q0' },
+					{ id: 'row-2', question: 'Q1' },
+				],
+				{ cancelled: 2 },
+			);
+			// case-0 acquires immediately; case-1 stays parked until granted below.
+			let grantParkedCase: (() => void) | undefined;
+			concurrencyControl.throttle.mockImplementation(async ({ executionId }) => {
+				if (executionId.endsWith('-case-1')) {
+					await new Promise<void>((resolve) => {
+						grantParkedCase = resolve;
+					});
+				}
+			});
+			// case-0 runs, then its post-acquire check sees the cancel and aborts.
+			runRepository.isCancellationRequested
+				.mockResolvedValueOnce(false)
+				.mockResolvedValueOnce(false)
+				.mockResolvedValue(true);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			// case-1 was aborted while parked, so only case-0's slot is released so far.
+			expect(concurrencyControl.release).toHaveBeenCalledTimes(1);
+
+			// The queue grants case-1 late (racing the abort) — its slot must be
+			// released, not silently dropped (which would leak a slot forever).
+			grantParkedCase?.();
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(concurrencyControl.release).toHaveBeenCalledTimes(2);
+		});
 	});
 
 	describe('getRunSummary', () => {

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -10,6 +10,7 @@ import type {
 import type { InstanceSettings } from 'n8n-core';
 import { mock, type MockProxy } from 'vitest-mock-extended';
 
+import type { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
 import type { Agent } from '@/modules/agents/entities/agent.entity';
 import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
 import type { DataTableService } from '@/modules/data-table/data-table.service';
@@ -20,6 +21,9 @@ import { AgentEvalRunnerService } from '../agent-eval-runner.service';
 
 // Stub the cross-module specifiers the service statically imports so the unit
 // test doesn't pull in the real agents / data-table / instance-ai module graph.
+vi.mock('@/concurrency/concurrency-control.service', () => ({
+	ConcurrencyControlService: class ConcurrencyControlService {},
+}));
 vi.mock('@/modules/agents/repositories/agent.repository', () => ({
 	AgentRepository: class AgentRepository {},
 }));
@@ -87,6 +91,7 @@ describe('AgentEvalRunnerService', () => {
 	let agentRepository: MockProxy<AgentRepository>;
 	let dataTableService: MockProxy<DataTableService>;
 	let evalAgentExecutionService: MockProxy<EvalAgentExecutionService>;
+	let concurrencyControl: MockProxy<ConcurrencyControlService>;
 	let service: AgentEvalRunnerService;
 
 	const dataset = mock<AgentEvalDataset>({
@@ -110,6 +115,7 @@ describe('AgentEvalRunnerService', () => {
 		agentRepository = mock<AgentRepository>();
 		dataTableService = mock<DataTableService>();
 		evalAgentExecutionService = mock<EvalAgentExecutionService>();
+		concurrencyControl = mock<ConcurrencyControlService>();
 
 		datasetRepository.findById.mockResolvedValue(dataset);
 		agentRepository.findByIdAndProjectId.mockResolvedValue(
@@ -135,6 +141,7 @@ describe('AgentEvalRunnerService', () => {
 			agentRepository,
 			dataTableService,
 			evalAgentExecutionService,
+			concurrencyControl,
 		);
 	});
 
@@ -307,12 +314,14 @@ describe('AgentEvalRunnerService', () => {
 				],
 				{ success: 1, error: 1 },
 			);
-			// Run serially so the thrown call is deterministically the first case.
-			evalAgentExecutionService.executeWithLlmMock
-				.mockRejectedValueOnce(new Error('transient failure'))
-				.mockResolvedValueOnce(successExec() as never);
+			// Fail deterministically by input (cases run concurrently, so call order
+			// isn't guaranteed): the 'Q1' case throws, the other succeeds.
+			evalAgentExecutionService.executeWithLlmMock.mockImplementation(async (_a, _u, _o, input) => {
+				if (input === 'Q1') throw new Error('transient failure');
+				return successExec() as never;
+			});
 
-			const { finished } = await service.startRun('ds-1', 'proj-1', user, { concurrency: 1 });
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
 			await finished;
 
 			expect(resultRepository.markAsError).toHaveBeenCalledWith(
@@ -353,7 +362,7 @@ describe('AgentEvalRunnerService', () => {
 			resultRepository.countByStatus.mockResolvedValue(counts({ success: 120 }));
 			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
 
-			const { finished } = await service.startRun('ds-1', 'proj-1', user, { concurrency: 10 });
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
 			await finished;
 
 			expect(resultRepository.seedResults).toHaveBeenCalledTimes(1);
@@ -392,12 +401,35 @@ describe('AgentEvalRunnerService', () => {
 			runRepository.isCancellationRequested.mockResolvedValueOnce(false).mockResolvedValue(true);
 			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
 
-			const { finished } = await service.startRun('ds-1', 'proj-1', user, { concurrency: 1 });
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
 			await finished;
 
 			expect(evalAgentExecutionService.executeWithLlmMock).toHaveBeenCalledTimes(1);
 			expect(runRepository.markAsCancelled).toHaveBeenCalled();
 			expect(runRepository.markAsCompleted).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('concurrency', () => {
+		it('runs each case through the shared evaluation queue and releases the slot', async () => {
+			seedFor(
+				[
+					{ id: 'row-1', question: 'Q1' },
+					{ id: 'row-2', question: 'Q2' },
+				],
+				{ success: 2 },
+			);
+			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			expect(concurrencyControl.throttle).toHaveBeenCalledTimes(2);
+			expect(concurrencyControl.throttle).toHaveBeenCalledWith(
+				expect.objectContaining({ mode: 'evaluation' }),
+			);
+			expect(concurrencyControl.release).toHaveBeenCalledTimes(2);
+			expect(concurrencyControl.release).toHaveBeenCalledWith({ mode: 'evaluation' });
 		});
 	});
 

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -159,6 +159,22 @@ describe('AgentEvalRunnerService', () => {
 		});
 	});
 
+	describe('run creation', () => {
+		it('marks the run errored (not left `new`) when seeding fails', async () => {
+			seedFor([{ id: 'row-1', question: 'Q' }]);
+			resultRepository.seedResults.mockRejectedValue(new Error('db down'));
+
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow('db down');
+
+			expect(runRepository.markAsError).toHaveBeenCalledWith(
+				'run-1',
+				'seed_failed',
+				expect.objectContaining({ message: 'db down' }),
+			);
+			expect(runRepository.markAsRunning).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('running cases', () => {
 		it('runs each case with its input verbatim, persists results, aggregates the run', async () => {
 			seedFor([
@@ -175,10 +191,11 @@ describe('AgentEvalRunnerService', () => {
 			await finished;
 
 			expect(runId).toBe('run-1');
-			// run pins the agent's active version + records who started it
+			// records who started it; version is left unpinned (execution runs the
+			// live agent config, so no version is claimed).
 			expect(runRepository.createRun).toHaveBeenCalledWith({
 				datasetId: 'ds-1',
-				agentVersionId: 'v-1',
+				agentVersionId: null,
 				createdById: 'user-1',
 			});
 			// each case fed its own input as the 4th arg (caseInput)

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -14,6 +14,7 @@ import type { Agent } from '@/modules/agents/entities/agent.entity';
 import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
 import type { DataTableService } from '@/modules/data-table/data-table.service';
 import type { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent-execution.service';
+import { userHasScopes } from '@/permissions.ee/check-access';
 
 import { AgentEvalRunnerService } from '../agent-eval-runner.service';
 
@@ -31,6 +32,22 @@ vi.mock('@/modules/instance-ai/eval/agent-execution.service', () => ({
 vi.mock('@/permissions.ee/check-access', () => ({
 	userHasScopes: vi.fn().mockResolvedValue(true),
 }));
+
+type StatusCounts = {
+	new: number;
+	running: number;
+	success: number;
+	error: number;
+	cancelled: number;
+};
+const counts = (partial: Partial<StatusCounts>): StatusCounts => ({
+	new: 0,
+	running: 0,
+	success: 0,
+	error: 0,
+	cancelled: 0,
+	...partial,
+});
 
 const successExec = (usage = { inputTokens: 3, outputTokens: 7 }) => ({
 	runId: 'exec',
@@ -81,6 +98,7 @@ describe('AgentEvalRunnerService', () => {
 	});
 
 	beforeEach(() => {
+		vi.mocked(userHasScopes).mockResolvedValue(true);
 		globalConfig = {
 			evaluation: { agentEvalsEnabled: true },
 			executions: { mode: 'regular' },
@@ -100,6 +118,12 @@ describe('AgentEvalRunnerService', () => {
 		runRepository.createRun.mockResolvedValue(mock({ id: 'run-1' }));
 		runRepository.isCancellationRequested.mockResolvedValue(false);
 		dataTableService.getProjectIdForDataTable.mockResolvedValue('proj-table');
+		// Columns backing the dataset's mapping (input/expectedOutput/criteria).
+		dataTableService.getColumns.mockResolvedValue([
+			{ name: 'question' },
+			{ name: 'answer' },
+			{ name: 'check' },
+		] as never);
 
 		service = new AgentEvalRunnerService(
 			mock(),
@@ -114,15 +138,16 @@ describe('AgentEvalRunnerService', () => {
 		);
 	});
 
-	const seedFor = (rows: Array<Record<string, unknown>>) => {
+	/** Set up one page of rows + seeded results + a final status count. */
+	const seedFor = (rows: Array<Record<string, unknown>>, endCounts: Partial<StatusCounts> = {}) => {
 		dataTableService.getManyRowsAndCount.mockResolvedValue({
 			count: rows.length,
 			data: rows as never,
 		});
-		// seedResults returns one persisted row per case, in order.
 		resultRepository.seedResults.mockImplementation(async (cases) =>
 			cases.map((_c, i) => mock<AgentEvalResult>({ id: `res-${i}`, status: 'new' })),
 		);
+		resultRepository.countByStatus.mockResolvedValue(counts(endCounts));
 	};
 
 	describe('gating', () => {
@@ -137,6 +162,14 @@ describe('AgentEvalRunnerService', () => {
 		it('refuses in queue mode', async () => {
 			globalConfig.executions.mode = 'queue';
 			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow('queue mode');
+			expect(runRepository.createRun).not.toHaveBeenCalled();
+		});
+
+		it('rejects when the user cannot run agents in the project', async () => {
+			vi.mocked(userHasScopes).mockResolvedValueOnce(false); // agent:execute check
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow(
+				'permission to run agents',
+			);
 			expect(runRepository.createRun).not.toHaveBeenCalled();
 		});
 
@@ -155,6 +188,23 @@ describe('AgentEvalRunnerService', () => {
 		it('rejects a dataset with no rows', async () => {
 			seedFor([]);
 			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow('no rows');
+			expect(runRepository.createRun).not.toHaveBeenCalled();
+		});
+
+		it('rejects a dataset that exceeds the case limit', async () => {
+			dataTableService.getManyRowsAndCount.mockResolvedValue({ count: 501, data: [] as never });
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow(
+				'exceeding the 500-case limit',
+			);
+			expect(runRepository.createRun).not.toHaveBeenCalled();
+		});
+
+		it('rejects when a mapped column is missing from the table', async () => {
+			dataTableService.getColumns.mockResolvedValue([
+				{ name: 'answer' },
+				{ name: 'check' },
+			] as never);
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow("input → 'question'");
 			expect(runRepository.createRun).not.toHaveBeenCalled();
 		});
 	});
@@ -177,15 +227,14 @@ describe('AgentEvalRunnerService', () => {
 
 	describe('running cases', () => {
 		it('runs each case with its input verbatim, persists results, aggregates the run', async () => {
-			seedFor([
-				{ id: 'row-1', question: 'What is 2+2?', answer: '4', check: 'is 4' },
-				{ id: 'row-2', question: 'Capital of France?', answer: 'Paris', check: 'is Paris' },
-			]);
+			seedFor(
+				[
+					{ id: 'row-1', question: 'What is 2+2?', answer: '4', check: 'is 4' },
+					{ id: 'row-2', question: 'Capital of France?', answer: 'Paris', check: 'is Paris' },
+				],
+				{ success: 2 },
+			);
 			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
-			resultRepository.findByRunId.mockResolvedValue([
-				mock<AgentEvalResult>({ status: 'success' }),
-				mock<AgentEvalResult>({ status: 'success' }),
-			]);
 
 			const { runId, finished } = await service.startRun('ds-1', 'proj-1', user);
 			await finished;
@@ -219,11 +268,8 @@ describe('AgentEvalRunnerService', () => {
 		});
 
 		it('snapshots input/expectedOutput/criteria onto the seeded case', async () => {
-			seedFor([{ id: 'row-1', question: 'Q', answer: 'A', check: 'C' }]);
+			seedFor([{ id: 'row-1', question: 'Q', answer: 'A', check: 'C' }], { success: 1 });
 			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
-			resultRepository.findByRunId.mockResolvedValue([
-				mock<AgentEvalResult>({ status: 'success' }),
-			]);
 
 			const { finished } = await service.startRun('ds-1', 'proj-1', user);
 			await finished;
@@ -239,9 +285,8 @@ describe('AgentEvalRunnerService', () => {
 		});
 
 		it('records a failed execution as an errored result but still completes the run', async () => {
-			seedFor([{ id: 'row-1', question: 'Q' }]);
+			seedFor([{ id: 'row-1', question: 'Q' }], { error: 1 });
 			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(failExec() as never);
-			resultRepository.findByRunId.mockResolvedValue([mock<AgentEvalResult>({ status: 'error' })]);
 
 			const { finished } = await service.startRun('ds-1', 'proj-1', user);
 			await finished;
@@ -255,18 +300,17 @@ describe('AgentEvalRunnerService', () => {
 		});
 
 		it('isolates a thrown execution error as a per-case error and still completes the run', async () => {
-			seedFor([
-				{ id: 'row-1', question: 'Q1' },
-				{ id: 'row-2', question: 'Q2' },
-			]);
+			seedFor(
+				[
+					{ id: 'row-1', question: 'Q1' },
+					{ id: 'row-2', question: 'Q2' },
+				],
+				{ success: 1, error: 1 },
+			);
 			// Run serially so the thrown call is deterministically the first case.
 			evalAgentExecutionService.executeWithLlmMock
 				.mockRejectedValueOnce(new Error('transient failure'))
 				.mockResolvedValueOnce(successExec() as never);
-			resultRepository.findByRunId.mockResolvedValue([
-				mock<AgentEvalResult>({ status: 'error' }),
-				mock<AgentEvalResult>({ status: 'success' }),
-			]);
 
 			const { finished } = await service.startRun('ds-1', 'proj-1', user, { concurrency: 1 });
 			await finished;
@@ -276,15 +320,13 @@ describe('AgentEvalRunnerService', () => {
 				'execution_failed',
 				expect.objectContaining({ message: 'transient failure' }),
 			);
-			// One thrown case must not abort the batch or error the whole run.
 			expect(resultRepository.markAsCompleted).toHaveBeenCalledTimes(1);
 			expect(runRepository.markAsCompleted).toHaveBeenCalled();
 			expect(runRepository.markAsError).not.toHaveBeenCalled();
 		});
 
 		it('errors an empty-input case without invoking the agent', async () => {
-			seedFor([{ id: 'row-1', question: '   ' }]);
-			resultRepository.findByRunId.mockResolvedValue([mock<AgentEvalResult>({ status: 'error' })]);
+			seedFor([{ id: 'row-1', question: '   ' }], { error: 1 });
 
 			const { finished } = await service.startRun('ds-1', 'proj-1', user);
 			await finished;
@@ -296,19 +338,40 @@ describe('AgentEvalRunnerService', () => {
 				expect.anything(),
 			);
 		});
+
+		it('pages through every row when the table exceeds one page', async () => {
+			const page = (start: number, len: number) =>
+				Array.from({ length: len }, (_, i) => ({ id: `r${start + i}`, question: `Q${start + i}` }));
+			dataTableService.getManyRowsAndCount.mockImplementation(async (_id, _p, dto) =>
+				(dto?.skip ?? 0) === 0
+					? { count: 120, data: page(0, 100) as never }
+					: { count: 120, data: page(100, 20) as never },
+			);
+			resultRepository.seedResults.mockImplementation(async (cases) =>
+				cases.map((_c, i) => mock<AgentEvalResult>({ id: `res-${i}`, status: 'new' })),
+			);
+			resultRepository.countByStatus.mockResolvedValue(counts({ success: 120 }));
+			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user, { concurrency: 10 });
+			await finished;
+
+			expect(resultRepository.seedResults).toHaveBeenCalledTimes(1);
+			expect(resultRepository.seedResults.mock.calls[0]?.[0]).toHaveLength(120);
+			expect(evalAgentExecutionService.executeWithLlmMock).toHaveBeenCalledTimes(120);
+		});
 	});
 
 	describe('cancellation', () => {
 		it('marks cases and the run cancelled when cancellation is requested', async () => {
-			seedFor([
-				{ id: 'row-1', question: 'Q' },
-				{ id: 'row-2', question: 'Q2' },
-			]);
+			seedFor(
+				[
+					{ id: 'row-1', question: 'Q' },
+					{ id: 'row-2', question: 'Q2' },
+				],
+				{ cancelled: 2 },
+			);
 			runRepository.isCancellationRequested.mockResolvedValue(true);
-			resultRepository.findByRunId.mockResolvedValue([
-				mock<AgentEvalResult>({ status: 'cancelled' }),
-				mock<AgentEvalResult>({ status: 'cancelled' }),
-			]);
 
 			const { finished } = await service.startRun('ds-1', 'proj-1', user);
 			await finished;
@@ -321,6 +384,59 @@ describe('AgentEvalRunnerService', () => {
 				expect.objectContaining({ cancelled: 2 }),
 			);
 			expect(runRepository.markAsCompleted).not.toHaveBeenCalled();
+		});
+
+		it('cancels the run when Stop arrives after every case has already started', async () => {
+			seedFor([{ id: 'row-1', question: 'Q' }], { success: 1 });
+			// false while the case runs, true at the post-pool re-check
+			runRepository.isCancellationRequested.mockResolvedValueOnce(false).mockResolvedValue(true);
+			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user, { concurrency: 1 });
+			await finished;
+
+			expect(evalAgentExecutionService.executeWithLlmMock).toHaveBeenCalledTimes(1);
+			expect(runRepository.markAsCancelled).toHaveBeenCalled();
+			expect(runRepository.markAsCompleted).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getRunSummary', () => {
+		it('404s when the run is missing', async () => {
+			runRepository.findById.mockResolvedValue(null);
+			await expect(service.getRunSummary('run-x')).rejects.toThrow('not found');
+		});
+
+		it('reports status + per-status counts from the count query', async () => {
+			runRepository.findById.mockResolvedValue(mock({ id: 'run-1', status: 'completed' }));
+			resultRepository.countByStatus.mockResolvedValue(
+				counts({ success: 3, error: 1, running: 1 }),
+			);
+
+			const summary = await service.getRunSummary('run-1');
+
+			expect(summary).toEqual({
+				runId: 'run-1',
+				status: 'completed',
+				counts: { total: 5, success: 3, error: 1, cancelled: 0, pending: 1 },
+			});
+		});
+	});
+
+	describe('cleanupInterruptedRuns', () => {
+		it('sweeps incomplete runs and never throws', async () => {
+			runRepository.markAllIncompleteAsError.mockResolvedValue({
+				affected: 2,
+				raw: [],
+				generatedMaps: [],
+			});
+			await expect(service.cleanupInterruptedRuns()).resolves.toBeUndefined();
+			expect(runRepository.markAllIncompleteAsError).toHaveBeenCalled();
+		});
+
+		it('swallows a sweep failure so it cannot block startup', async () => {
+			runRepository.markAllIncompleteAsError.mockRejectedValue(new Error('db down'));
+			await expect(service.cleanupInterruptedRuns()).resolves.toBeUndefined();
 		});
 	});
 });

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -438,5 +438,11 @@ describe('AgentEvalRunnerService', () => {
 			runRepository.markAllIncompleteAsError.mockRejectedValue(new Error('db down'));
 			await expect(service.cleanupInterruptedRuns()).resolves.toBeUndefined();
 		});
+
+		it('does not sweep in queue mode (never touches another main’s runs)', async () => {
+			globalConfig.executions.mode = 'queue';
+			await service.cleanupInterruptedRuns();
+			expect(runRepository.markAllIncompleteAsError).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -1,0 +1,309 @@
+import type { GlobalConfig } from '@n8n/config';
+import type {
+	AgentEvalDataset,
+	AgentEvalResult,
+	AgentEvalDatasetRepository,
+	AgentEvalResultRepository,
+	AgentEvalRunRepository,
+	User,
+} from '@n8n/db';
+import type { InstanceSettings } from 'n8n-core';
+import { mock, type MockProxy } from 'vitest-mock-extended';
+
+import type { Agent } from '@/modules/agents/entities/agent.entity';
+import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
+import type { DataTableService } from '@/modules/data-table/data-table.service';
+import type { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent-execution.service';
+
+import { AgentEvalRunnerService } from '../agent-eval-runner.service';
+
+// Stub the cross-module specifiers the service statically imports so the unit
+// test doesn't pull in the real agents / data-table / instance-ai module graph.
+vi.mock('@/modules/agents/repositories/agent.repository', () => ({
+	AgentRepository: class AgentRepository {},
+}));
+vi.mock('@/modules/data-table/data-table.service', () => ({
+	DataTableService: class DataTableService {},
+}));
+vi.mock('@/modules/instance-ai/eval/agent-execution.service', () => ({
+	EvalAgentExecutionService: class EvalAgentExecutionService {},
+}));
+vi.mock('@/permissions.ee/check-access', () => ({
+	userHasScopes: vi.fn().mockResolvedValue(true),
+}));
+
+const successExec = (usage = { inputTokens: 3, outputTokens: 7 }) => ({
+	runId: 'exec',
+	success: true,
+	errors: [],
+	finalText: 'the answer',
+	model: 'test-model',
+	finishReason: 'stop',
+	toolCalls: [{ tool: 'lookup', kind: 'node', mocked: true, interceptedRequests: [] }],
+	modelTurns: [],
+	usage,
+	seed: { openingMessage: 'hi', globalContext: '', toolHints: {}, warnings: [] },
+	skippedFeatures: [],
+	mockedCredentials: [],
+});
+
+const failExec = () => ({
+	runId: '',
+	success: false,
+	errors: ['model exploded'],
+	finalText: '',
+	toolCalls: [],
+	modelTurns: [],
+	seed: { openingMessage: '', globalContext: '', toolHints: {}, warnings: [] },
+	skippedFeatures: [],
+	mockedCredentials: [],
+});
+
+describe('AgentEvalRunnerService', () => {
+	const user = mock<User>({ id: 'user-1' });
+
+	let globalConfig: GlobalConfig;
+	let instanceSettings: InstanceSettings;
+	let datasetRepository: MockProxy<AgentEvalDatasetRepository>;
+	let runRepository: MockProxy<AgentEvalRunRepository>;
+	let resultRepository: MockProxy<AgentEvalResultRepository>;
+	let agentRepository: MockProxy<AgentRepository>;
+	let dataTableService: MockProxy<DataTableService>;
+	let evalAgentExecutionService: MockProxy<EvalAgentExecutionService>;
+	let service: AgentEvalRunnerService;
+
+	const dataset = mock<AgentEvalDataset>({
+		id: 'ds-1',
+		agentId: 'agent-1',
+		datasetSource: 'data_table',
+		datasetRef: { dataTableId: 'dt-1' },
+		columnMapping: { input: 'question', expectedOutput: 'answer', criteria: 'check' },
+	});
+
+	beforeEach(() => {
+		globalConfig = {
+			evaluation: { agentEvalsEnabled: true },
+			executions: { mode: 'regular' },
+		} as unknown as GlobalConfig;
+		instanceSettings = { hostId: 'main-1' } as unknown as InstanceSettings;
+		datasetRepository = mock<AgentEvalDatasetRepository>();
+		runRepository = mock<AgentEvalRunRepository>();
+		resultRepository = mock<AgentEvalResultRepository>();
+		agentRepository = mock<AgentRepository>();
+		dataTableService = mock<DataTableService>();
+		evalAgentExecutionService = mock<EvalAgentExecutionService>();
+
+		datasetRepository.findById.mockResolvedValue(dataset);
+		agentRepository.findByIdAndProjectId.mockResolvedValue(
+			mock<Agent>({ id: 'agent-1', activeVersionId: 'v-1' }),
+		);
+		runRepository.createRun.mockResolvedValue(mock({ id: 'run-1' }));
+		runRepository.isCancellationRequested.mockResolvedValue(false);
+		dataTableService.getProjectIdForDataTable.mockResolvedValue('proj-table');
+
+		service = new AgentEvalRunnerService(
+			mock(),
+			globalConfig,
+			instanceSettings,
+			datasetRepository,
+			runRepository,
+			resultRepository,
+			agentRepository,
+			dataTableService,
+			evalAgentExecutionService,
+		);
+	});
+
+	const seedFor = (rows: Array<Record<string, unknown>>) => {
+		dataTableService.getManyRowsAndCount.mockResolvedValue({
+			count: rows.length,
+			data: rows as never,
+		});
+		// seedResults returns one persisted row per case, in order.
+		resultRepository.seedResults.mockImplementation(async (cases) =>
+			cases.map((_c, i) => mock<AgentEvalResult>({ id: `res-${i}`, status: 'new' })),
+		);
+	};
+
+	describe('gating', () => {
+		it('refuses when the flag is off', async () => {
+			globalConfig.evaluation.agentEvalsEnabled = false;
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow(
+				'Agent evals are not enabled',
+			);
+			expect(runRepository.createRun).not.toHaveBeenCalled();
+		});
+
+		it('refuses in queue mode', async () => {
+			globalConfig.executions.mode = 'queue';
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow('queue mode');
+			expect(runRepository.createRun).not.toHaveBeenCalled();
+		});
+
+		it('404s when the dataset is missing', async () => {
+			datasetRepository.findById.mockResolvedValue(null);
+			await expect(service.startRun('ds-x', 'proj-1', user)).rejects.toThrow('not found');
+		});
+
+		it('rejects non-data_table datasets', async () => {
+			datasetRepository.findById.mockResolvedValue(
+				mock<AgentEvalDataset>({ ...dataset, datasetSource: 'google_sheets' }),
+			);
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow('data_table');
+		});
+
+		it('rejects a dataset with no rows', async () => {
+			seedFor([]);
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow('no rows');
+			expect(runRepository.createRun).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('running cases', () => {
+		it('runs each case with its input verbatim, persists results, aggregates the run', async () => {
+			seedFor([
+				{ id: 'row-1', question: 'What is 2+2?', answer: '4', check: 'is 4' },
+				{ id: 'row-2', question: 'Capital of France?', answer: 'Paris', check: 'is Paris' },
+			]);
+			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
+			resultRepository.findByRunId.mockResolvedValue([
+				mock<AgentEvalResult>({ status: 'success' }),
+				mock<AgentEvalResult>({ status: 'success' }),
+			]);
+
+			const { runId, finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			expect(runId).toBe('run-1');
+			// run pins the agent's active version + records who started it
+			expect(runRepository.createRun).toHaveBeenCalledWith({
+				datasetId: 'ds-1',
+				agentVersionId: 'v-1',
+				createdById: 'user-1',
+			});
+			// each case fed its own input as the 4th arg (caseInput)
+			expect(evalAgentExecutionService.executeWithLlmMock).toHaveBeenCalledTimes(2);
+			expect(evalAgentExecutionService.executeWithLlmMock).toHaveBeenCalledWith(
+				'agent-1',
+				user,
+				{ projectId: 'proj-1' },
+				'What is 2+2?',
+			);
+			expect(runRepository.markAsRunning).toHaveBeenCalledWith('run-1', 'main-1');
+			expect(resultRepository.markAsCompleted).toHaveBeenCalledTimes(2);
+			expect(runRepository.markAsCompleted).toHaveBeenCalledWith(
+				'run-1',
+				expect.objectContaining({
+					success: 2,
+					error: 0,
+					usage: { inputTokens: 6, outputTokens: 14 },
+				}),
+			);
+		});
+
+		it('snapshots input/expectedOutput/criteria onto the seeded case', async () => {
+			seedFor([{ id: 'row-1', question: 'Q', answer: 'A', check: 'C' }]);
+			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
+			resultRepository.findByRunId.mockResolvedValue([
+				mock<AgentEvalResult>({ status: 'success' }),
+			]);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			expect(resultRepository.seedResults).toHaveBeenCalledWith([
+				{
+					runId: 'run-1',
+					sourceRowId: 'row-1',
+					runIndex: 0,
+					input: { input: 'Q', expectedOutput: 'A', criteria: 'C' },
+				},
+			]);
+		});
+
+		it('records a failed execution as an errored result but still completes the run', async () => {
+			seedFor([{ id: 'row-1', question: 'Q' }]);
+			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(failExec() as never);
+			resultRepository.findByRunId.mockResolvedValue([mock<AgentEvalResult>({ status: 'error' })]);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			expect(resultRepository.markAsError).toHaveBeenCalledWith(
+				'res-0',
+				'execution_failed',
+				expect.objectContaining({ errors: ['model exploded'] }),
+			);
+			expect(runRepository.markAsCompleted).toHaveBeenCalled();
+		});
+
+		it('isolates a thrown execution error as a per-case error and still completes the run', async () => {
+			seedFor([
+				{ id: 'row-1', question: 'Q1' },
+				{ id: 'row-2', question: 'Q2' },
+			]);
+			// Run serially so the thrown call is deterministically the first case.
+			evalAgentExecutionService.executeWithLlmMock
+				.mockRejectedValueOnce(new Error('transient failure'))
+				.mockResolvedValueOnce(successExec() as never);
+			resultRepository.findByRunId.mockResolvedValue([
+				mock<AgentEvalResult>({ status: 'error' }),
+				mock<AgentEvalResult>({ status: 'success' }),
+			]);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user, { concurrency: 1 });
+			await finished;
+
+			expect(resultRepository.markAsError).toHaveBeenCalledWith(
+				'res-0',
+				'execution_failed',
+				expect.objectContaining({ message: 'transient failure' }),
+			);
+			// One thrown case must not abort the batch or error the whole run.
+			expect(resultRepository.markAsCompleted).toHaveBeenCalledTimes(1);
+			expect(runRepository.markAsCompleted).toHaveBeenCalled();
+			expect(runRepository.markAsError).not.toHaveBeenCalled();
+		});
+
+		it('errors an empty-input case without invoking the agent', async () => {
+			seedFor([{ id: 'row-1', question: '   ' }]);
+			resultRepository.findByRunId.mockResolvedValue([mock<AgentEvalResult>({ status: 'error' })]);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			expect(evalAgentExecutionService.executeWithLlmMock).not.toHaveBeenCalled();
+			expect(resultRepository.markAsError).toHaveBeenCalledWith(
+				'res-0',
+				'empty_input',
+				expect.anything(),
+			);
+		});
+	});
+
+	describe('cancellation', () => {
+		it('marks cases and the run cancelled when cancellation is requested', async () => {
+			seedFor([
+				{ id: 'row-1', question: 'Q' },
+				{ id: 'row-2', question: 'Q2' },
+			]);
+			runRepository.isCancellationRequested.mockResolvedValue(true);
+			resultRepository.findByRunId.mockResolvedValue([
+				mock<AgentEvalResult>({ status: 'cancelled' }),
+				mock<AgentEvalResult>({ status: 'cancelled' }),
+			]);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			expect(evalAgentExecutionService.executeWithLlmMock).not.toHaveBeenCalled();
+			expect(resultRepository.markAsCancelled).toHaveBeenCalled();
+			// cancel still records the partial metrics gathered before stopping
+			expect(runRepository.markAsCancelled).toHaveBeenCalledWith(
+				'run-1',
+				expect.objectContaining({ cancelled: 2 }),
+			);
+			expect(runRepository.markAsCompleted).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -16,17 +16,23 @@ import type {
 	JsonValue,
 } from 'n8n-workflow';
 import { jsonParse, jsonStringify } from 'n8n-workflow';
+import pLimit from 'p-limit';
 
 import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { resolveEvaluationConcurrencyLimit } from '@/evaluation.ee/evaluation-concurrency.helper';
+import { License } from '@/license';
 import { AgentRepository } from '@/modules/agents/repositories/agent.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent-execution.service';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
 const ROW_PAGE_SIZE = 100;
+// Per-run in-flight cap layered on the shared evaluation queue: keeps one run
+// from flooding the queue (and bounds fan-out when the queue is unlimited).
+const MAX_PER_RUN_CONCURRENCY = 10;
 // Each case is a real agent execution, so a run is capped rather than letting a
 // large table launch thousands of model calls. Raise deliberately if needed.
 const MAX_CASES = 500;
@@ -58,11 +64,12 @@ export interface AgentEvalRunSummary {
  *
  * Runs on the main process only: the tool-mock substrate reused from the
  * instance-ai eval path carries a closure that cannot cross a queue boundary
- * (see {@link EvalAgentExecutionService}). Cases are throttled through the
- * shared, license-tiered instance-wide evaluation concurrency queue (the same
- * one the workflow eval uses), so concurrent runs can't collectively exceed the
- * plan's limit; cross-main *cancellation* is honored via the run's
- * `cancelRequested` flag. Behind the `101_agent_evals` flag.
+ * (see {@link EvalAgentExecutionService}). A per-run pool caps in-flight cases
+ * and layers on the shared, license-tiered instance-wide evaluation concurrency
+ * queue (the same one the workflow eval uses), so a single run can't flood the
+ * queue and concurrent runs can't collectively exceed the plan limit;
+ * cross-main *cancellation* is honored via the run's `cancelRequested` flag.
+ * Behind the `101_agent_evals` flag.
  */
 @Service()
 export class AgentEvalRunnerService {
@@ -77,6 +84,7 @@ export class AgentEvalRunnerService {
 		private readonly dataTableService: DataTableService,
 		private readonly evalAgentExecutionService: EvalAgentExecutionService,
 		private readonly concurrencyControl: ConcurrencyControlService,
+		private readonly license: License,
 	) {}
 
 	/**
@@ -211,45 +219,81 @@ export class AgentEvalRunnerService {
 			return;
 		}
 		try {
-			let cancelled = false;
+			// Per-run cap layered on the shared instance-wide evaluation queue: a
+			// single run parks at most this many cases in the queue, so it can't
+			// starve a concurrent eval run, and fan-out stays bounded even when the
+			// queue itself is unlimited. Uses the same license-tiered limit as the
+			// queue, clamped by the per-run backstop.
+			const resolvedLimit = resolveEvaluationConcurrencyLimit(
+				this.globalConfig.executions,
+				this.license,
+			);
+			const limit = pLimit(
+				resolvedLimit > 0
+					? Math.min(resolvedLimit, MAX_PER_RUN_CONCURRENCY)
+					: MAX_PER_RUN_CONCURRENCY,
+			);
+			// Cooperative cancellation: whichever case first observes the flag aborts,
+			// which evicts every case still waiting for a queue slot.
+			const abort = new AbortController();
 			const totalUsage: CaseUsage = { inputTokens: 0, outputTokens: 0 };
 
+			const cancelCase = async (resultRow: AgentEvalResult) => {
+				abort.abort();
+				await this.resultRepository.markAsCancelled(resultRow.id);
+			};
+
 			await Promise.all(
-				cases.map(async (resolvedCase, index) => {
-					const resultRow = seeded[index];
-					// Wait for a slot in the shared, license-tiered evaluation queue —
-					// instance-wide, so concurrent runs (agent or workflow) share one
-					// budget; a no-op when the plan is unlimited. The cancel check runs
-					// after the gate so only slot-holders touch the DB, and the slot is
-					// released on every exit path.
-					await this.concurrencyControl.throttle({
-						mode: 'evaluation',
-						executionId: `${runId}-case-${index}`,
-					});
-					try {
-						// Cooperative cancellation: skip once a cancel is requested (a case
-						// already past the gate finishes). Re-read the flag so a cancel from
-						// another main is seen.
-						if (cancelled || (await this.runRepository.isCancellationRequested(runId))) {
-							cancelled = true;
-							await this.resultRepository.markAsCancelled(resultRow.id);
-							return;
-						}
-						const usage = await this.runCase(resultRow, resolvedCase, ctx);
-						if (usage) {
-							totalUsage.inputTokens += usage.inputTokens;
-							totalUsage.outputTokens += usage.outputTokens;
-						}
-					} finally {
-						this.concurrencyControl.release({ mode: 'evaluation' });
-					}
-				}),
+				cases.map(
+					async (resolvedCase, index) =>
+						await limit(async () => {
+							const resultRow = seeded[index];
+							// Don't enqueue a case once the run is cancelled (the flag short-
+							// circuits after the first observer, so this is one DB read per
+							// case at most).
+							if (
+								abort.signal.aborted ||
+								(await this.runRepository.isCancellationRequested(runId))
+							) {
+								await cancelCase(resultRow);
+								return;
+							}
+
+							// Wait for a queue slot, bailing (and evicting the entry) if the run
+							// is cancelled while queued. The helper owns release/remove for the
+							// bail path; the finally owns release for the acquired path.
+							const executionId = `${runId}-case-${index}`;
+							if (!(await this.acquireEvaluationSlot(executionId, abort.signal))) {
+								await this.resultRepository.markAsCancelled(resultRow.id);
+								return;
+							}
+
+							try {
+								// A cancel may have landed while we waited for the slot.
+								if (
+									abort.signal.aborted ||
+									(await this.runRepository.isCancellationRequested(runId))
+								) {
+									await cancelCase(resultRow);
+									return;
+								}
+								const usage = await this.runCase(resultRow, resolvedCase, ctx);
+								if (usage) {
+									totalUsage.inputTokens += usage.inputTokens;
+									totalUsage.outputTokens += usage.outputTokens;
+								}
+							} finally {
+								this.concurrencyControl.release({ mode: 'evaluation' });
+							}
+						}),
+				),
 			);
 
-			// Re-read the flag once more: a Stop that arrived after every case had
-			// already started is never observed in the loop above, so honor it here
-			// rather than reporting the run as completed with the flag still set.
-			const wasCancelled = cancelled || (await this.runRepository.isCancellationRequested(runId));
+			// Re-read once more: a cancel that arrived after every case had already
+			// settled is never observed above, so honor it rather than reporting the
+			// run completed with the flag still set.
+			const wasCancelled =
+				abort.signal.aborted || (await this.runRepository.isCancellationRequested(runId));
 
 			const counts = await this.resultRepository.countByStatus(runId);
 			const metrics: IDataObject = { ...toSummaryCounts(counts), usage: { ...totalUsage } };
@@ -263,6 +307,44 @@ export class AgentEvalRunnerService {
 			const message = error instanceof Error ? error.message : String(error);
 			await this.failRun(runId, message);
 		}
+	}
+
+	/**
+	 * Acquire a slot in the shared evaluation queue, abort-aware. Resolves `true`
+	 * with the slot held (the caller must `release`); resolves `false` if the run
+	 * was cancelled while this entry was still queued — having evicted it so it
+	 * doesn't hold a place other evaluation work could use.
+	 */
+	private async acquireEvaluationSlot(executionId: string, signal: AbortSignal): Promise<boolean> {
+		if (signal.aborted) {
+			this.concurrencyControl.remove({ mode: 'evaluation', executionId });
+			return false;
+		}
+
+		let acquired = false;
+		let onAbort: (() => void) | undefined;
+		const aborted = new Promise<'aborted'>((resolve) => {
+			onAbort = () => resolve('aborted');
+			signal.addEventListener('abort', onAbort, { once: true });
+		});
+		const acquire = this.concurrencyControl
+			.throttle({ mode: 'evaluation', executionId })
+			.then(() => {
+				acquired = true;
+				return 'acquired' as const;
+			});
+
+		const outcome = await Promise.race([acquire, aborted]);
+		if (onAbort) signal.removeEventListener('abort', onAbort);
+
+		if (outcome === 'aborted') {
+			// If microtask ordering let the slot resolve first, hand it back;
+			// otherwise evict the still-queued entry.
+			if (acquired) this.concurrencyControl.release({ mode: 'evaluation' });
+			else this.concurrencyControl.remove({ mode: 'evaluation', executionId });
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -316,32 +316,30 @@ export class AgentEvalRunnerService {
 	 * doesn't hold a place other evaluation work could use.
 	 */
 	private async acquireEvaluationSlot(executionId: string, signal: AbortSignal): Promise<boolean> {
-		if (signal.aborted) {
-			this.concurrencyControl.remove({ mode: 'evaluation', executionId });
-			return false;
-		}
+		// Not enqueued yet, so nothing to release/remove.
+		if (signal.aborted) return false;
 
-		let acquired = false;
 		let onAbort: (() => void) | undefined;
 		const aborted = new Promise<'aborted'>((resolve) => {
 			onAbort = () => resolve('aborted');
 			signal.addEventListener('abort', onAbort, { once: true });
 		});
-		const acquire = this.concurrencyControl
-			.throttle({ mode: 'evaluation', executionId })
-			.then(() => {
-				acquired = true;
-				return 'acquired' as const;
-			});
-
-		const outcome = await Promise.race([acquire, aborted]);
+		// Keep the raw throttle promise: the aborted branch reacts to it rather
+		// than to a flag, which a grant racing the abort could leave stale.
+		const acquire = this.concurrencyControl.throttle({ mode: 'evaluation', executionId });
+		const outcome = await Promise.race([acquire.then(() => 'acquired' as const), aborted]);
 		if (onAbort) signal.removeEventListener('abort', onAbort);
 
 		if (outcome === 'aborted') {
-			// If microtask ordering let the slot resolve first, hand it back;
-			// otherwise evict the still-queued entry.
-			if (acquired) this.concurrencyControl.release({ mode: 'evaluation' });
-			else this.concurrencyControl.remove({ mode: 'evaluation', executionId });
+			// Every enqueue must be balanced exactly once. The queue array is the
+			// single source of truth: `remove` evicts the entry if it is still
+			// queued (a no-op otherwise); the `.then` releases if the slot was — or
+			// gets — granted, which happens when a concurrent `release` dequeues us
+			// at the same tick the abort fires. The two are mutually exclusive: a
+			// removed entry's throttle promise never resolves, so the `.then` never
+			// runs for it — no double release, and no leaked slot.
+			this.concurrencyControl.remove({ mode: 'evaluation', executionId });
+			void acquire.then(() => this.concurrencyControl.release({ mode: 'evaluation' }));
 			return false;
 		}
 		return true;

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -16,8 +16,8 @@ import type {
 	JsonValue,
 } from 'n8n-workflow';
 import { jsonParse, jsonStringify } from 'n8n-workflow';
-import pLimit from 'p-limit';
 
+import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -26,8 +26,6 @@ import { DataTableService } from '@/modules/data-table/data-table.service';
 import { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent-execution.service';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
-const DEFAULT_CONCURRENCY = 5;
-const MAX_CONCURRENCY = 10;
 const ROW_PAGE_SIZE = 100;
 // Each case is a real agent execution, so a run is capped rather than letting a
 // large table launch thousands of model calls. Raise deliberately if needed.
@@ -60,9 +58,11 @@ export interface AgentEvalRunSummary {
  *
  * Runs on the main process only: the tool-mock substrate reused from the
  * instance-ai eval path carries a closure that cannot cross a queue boundary
- * (see {@link EvalAgentExecutionService}). Cases run in a bounded in-process
- * pool; cross-main *cancellation* is honored via the run's `cancelRequested`
- * flag. Behind the `101_agent_evals` flag.
+ * (see {@link EvalAgentExecutionService}). Cases are throttled through the
+ * shared, license-tiered instance-wide evaluation concurrency queue (the same
+ * one the workflow eval uses), so concurrent runs can't collectively exceed the
+ * plan's limit; cross-main *cancellation* is honored via the run's
+ * `cancelRequested` flag. Behind the `101_agent_evals` flag.
  */
 @Service()
 export class AgentEvalRunnerService {
@@ -76,6 +76,7 @@ export class AgentEvalRunnerService {
 		private readonly agentRepository: AgentRepository,
 		private readonly dataTableService: DataTableService,
 		private readonly evalAgentExecutionService: EvalAgentExecutionService,
+		private readonly concurrencyControl: ConcurrencyControlService,
 	) {}
 
 	/**
@@ -87,7 +88,7 @@ export class AgentEvalRunnerService {
 		datasetId: string,
 		projectId: string,
 		user: User,
-		options: { concurrency?: number; timeoutMs?: number } = {},
+		options: { timeoutMs?: number } = {},
 	): Promise<{ runId: string; finished: Promise<void> }> {
 		// Behind 101_agent_evals. `agentEvalsEnabled` is a force-enable-only operator
 		// override, so this treats it as the sole gate for now. When the REST layer
@@ -165,11 +166,6 @@ export class AgentEvalRunnerService {
 			throw error;
 		}
 
-		const concurrency = Math.max(
-			1,
-			Math.min(MAX_CONCURRENCY, Math.floor(options.concurrency ?? DEFAULT_CONCURRENCY)),
-		);
-
 		const finished = this.executeRun({
 			runId: run.id,
 			agentId: dataset.agentId,
@@ -177,7 +173,6 @@ export class AgentEvalRunnerService {
 			user,
 			cases,
 			seeded,
-			concurrency,
 			timeoutMs: options.timeoutMs,
 		});
 
@@ -206,10 +201,9 @@ export class AgentEvalRunnerService {
 		user: User;
 		cases: ResolvedCase[];
 		seeded: AgentEvalResult[];
-		concurrency: number;
 		timeoutMs?: number;
 	}): Promise<void> {
-		const { runId, cases, seeded, concurrency } = ctx;
+		const { runId, cases, seeded } = ctx;
 		// `seedResults` returns rows in input order, so seeded[index] pairs with
 		// cases[index]. Guard the invariant rather than silently mis-pairing.
 		if (seeded.length !== cases.length) {
@@ -217,17 +211,25 @@ export class AgentEvalRunnerService {
 			return;
 		}
 		try {
-			const limit = pLimit(concurrency);
 			let cancelled = false;
 			const totalUsage: CaseUsage = { inputTokens: 0, outputTokens: 0 };
 
 			await Promise.all(
 				cases.map(async (resolvedCase, index) => {
-					await limit(async () => {
-						const resultRow = seeded[index];
-						// Cooperative cancellation: stop starting new cases once a cancel is
-						// requested (in-flight cases finish). Re-read the flag so a cancel
-						// from another main is seen.
+					const resultRow = seeded[index];
+					// Wait for a slot in the shared, license-tiered evaluation queue —
+					// instance-wide, so concurrent runs (agent or workflow) share one
+					// budget; a no-op when the plan is unlimited. The cancel check runs
+					// after the gate so only slot-holders touch the DB, and the slot is
+					// released on every exit path.
+					await this.concurrencyControl.throttle({
+						mode: 'evaluation',
+						executionId: `${runId}-case-${index}`,
+					});
+					try {
+						// Cooperative cancellation: skip once a cancel is requested (a case
+						// already past the gate finishes). Re-read the flag so a cancel from
+						// another main is seen.
 						if (cancelled || (await this.runRepository.isCancellationRequested(runId))) {
 							cancelled = true;
 							await this.resultRepository.markAsCancelled(resultRow.id);
@@ -238,7 +240,9 @@ export class AgentEvalRunnerService {
 							totalUsage.inputTokens += usage.inputTokens;
 							totalUsage.outputTokens += usage.outputTokens;
 						}
-					});
+					} finally {
+						this.concurrencyControl.release({ mode: 'evaluation' });
+					}
 				}),
 			);
 

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import type { AgentEvalDataset, AgentEvalResult, User } from '@n8n/db';
+import type { AgentEvalDataset, AgentEvalResult, AgentEvalRunStatus, User } from '@n8n/db';
 import {
 	AgentEvalDatasetRepository,
 	AgentEvalResultRepository,
@@ -29,6 +29,9 @@ import { userHasScopes } from '@/permissions.ee/check-access';
 const DEFAULT_CONCURRENCY = 5;
 const MAX_CONCURRENCY = 10;
 const ROW_PAGE_SIZE = 100;
+// Each case is a real agent execution, so a run is capped rather than letting a
+// large table launch thousands of model calls. Raise deliberately if needed.
+const MAX_CASES = 500;
 
 /** A dataset row resolved into a runnable case via the dataset's column mapping. */
 interface ResolvedCase {
@@ -47,7 +50,7 @@ interface CaseUsage {
 
 export interface AgentEvalRunSummary {
 	runId: string;
-	status: string;
+	status: AgentEvalRunStatus;
 	counts: { total: number; success: number; error: number; cancelled: number; pending: number };
 }
 
@@ -86,15 +89,25 @@ export class AgentEvalRunnerService {
 		user: User,
 		options: { concurrency?: number; timeoutMs?: number } = {},
 	): Promise<{ runId: string; finished: Promise<void> }> {
-		// Behind 101_agent_evals. Per-cohort PostHog resolution attaches at the REST
-		// layer (which carries the request user); the gate available server-side
-		// here is the operator override.
+		// Behind 101_agent_evals. `agentEvalsEnabled` is a force-enable-only operator
+		// override, so this treats it as the sole gate for now. When the REST layer
+		// lands it must instead resolve the flag per-user via PostHog (which is the
+		// source of truth for cohort rollout) — a rolled-out user shouldn't need the
+		// env var. Until then this stays hard-gated on the override.
 		if (!this.globalConfig.evaluation.agentEvalsEnabled) {
 			throw new BadRequestError('Agent evals are not enabled on this instance.');
 		}
 
 		if (this.globalConfig.executions.mode === 'queue') {
 			throw new BadRequestError('Agent eval runs are not supported in queue mode.');
+		}
+
+		// Authorize up front. `executeWithLlmMock` also checks `agent:execute`, but
+		// it returns an error result rather than throwing — without this a caller
+		// lacking permission would get a created run with every case marked failed
+		// instead of a clean rejection.
+		if (!(await userHasScopes(user, ['agent:execute'], false, { projectId }))) {
+			throw new ForbiddenError('You do not have permission to run agents in this project.');
 		}
 
 		const dataset = await this.datasetRepository.findById(datasetId);
@@ -175,8 +188,10 @@ export class AgentEvalRunnerService {
 	async getRunSummary(runId: string): Promise<AgentEvalRunSummary> {
 		const run = await this.runRepository.findById(runId);
 		if (!run) throw new NotFoundError(`Agent eval run ${runId} not found.`);
-		const results = await this.resultRepository.findByRunId(runId);
-		return { runId: run.id, status: run.status, counts: countByStatus(results) };
+		// Count in the DB — this is polled by the UI, so never load the full
+		// per-case rows (input/output/toolCalls JSON) just to tally statuses.
+		const counts = await this.resultRepository.countByStatus(runId);
+		return { runId: run.id, status: run.status, counts: toSummaryCounts(counts) };
 	}
 
 	/**
@@ -195,6 +210,12 @@ export class AgentEvalRunnerService {
 		timeoutMs?: number;
 	}): Promise<void> {
 		const { runId, cases, seeded, concurrency } = ctx;
+		// `seedResults` returns rows in input order, so seeded[index] pairs with
+		// cases[index]. Guard the invariant rather than silently mis-pairing.
+		if (seeded.length !== cases.length) {
+			await this.failRun(runId, `Seeded ${seeded.length} results for ${cases.length} cases`);
+			return;
+		}
 		try {
 			const limit = pLimit(concurrency);
 			let cancelled = false;
@@ -221,18 +242,59 @@ export class AgentEvalRunnerService {
 				}),
 			);
 
-			const results = await this.resultRepository.findByRunId(runId);
-			const metrics: IDataObject = { ...countByStatus(results), usage: { ...totalUsage } };
+			// Re-read the flag once more: a Stop that arrived after every case had
+			// already started is never observed in the loop above, so honor it here
+			// rather than reporting the run as completed with the flag still set.
+			const wasCancelled = cancelled || (await this.runRepository.isCancellationRequested(runId));
 
-			if (cancelled) {
+			const counts = await this.resultRepository.countByStatus(runId);
+			const metrics: IDataObject = { ...toSummaryCounts(counts), usage: { ...totalUsage } };
+
+			if (wasCancelled) {
 				await this.runRepository.markAsCancelled(runId, metrics);
 			} else {
 				await this.runRepository.markAsCompleted(runId, metrics);
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			this.logger.error(`[AgentEvalRunner] Run ${runId} failed to complete`, { error: message });
+			await this.failRun(runId, message);
+		}
+	}
+
+	/**
+	 * Mark a run errored, best-effort. `executeRun`'s result is a fire-and-forget
+	 * `finished` promise for REST callers, and `packages/cli` has no
+	 * unhandledRejection handler — so a failure to record the error must never
+	 * reject out of here and crash the process.
+	 */
+	private async failRun(runId: string, message: string): Promise<void> {
+		this.logger.error(`[AgentEvalRunner] Run ${runId} failed to complete`, { error: message });
+		try {
 			await this.runRepository.markAsError(runId, 'run_failed', { message });
+		} catch (markError) {
+			this.logger.error(`[AgentEvalRunner] Could not mark run ${runId} as errored`, {
+				error: markError instanceof Error ? markError.message : String(markError),
+			});
+		}
+	}
+
+	/**
+	 * Mark runs left incomplete by a previous process (the runner has no resume
+	 * mechanism) as errored, so they don't poll as `running` forever. Called on
+	 * module startup; best-effort so it can never block boot.
+	 */
+	async cleanupInterruptedRuns(): Promise<void> {
+		try {
+			const result = await this.runRepository.markAllIncompleteAsError();
+			if (result.affected && result.affected > 0) {
+				this.logger.debug(
+					`[AgentEvalRunner] Marked ${result.affected} interrupted run(s) as errored on startup`,
+				);
+			}
+		} catch (error) {
+			this.logger.error('[AgentEvalRunner] Failed to clean up interrupted runs on startup', {
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 
@@ -320,6 +382,27 @@ export class AgentEvalRunnerService {
 
 		const tableProjectId = await this.dataTableService.getProjectIdForDataTable(dataTableId);
 
+		// Validate the mapping against the live columns so a renamed/deleted column
+		// fails loudly here instead of silently turning every case into an
+		// "empty input" error at execution time.
+		const columnNames = new Set(
+			(await this.dataTableService.getColumns(dataTableId, tableProjectId)).map((c) => c.name),
+		);
+		const missing = (
+			[
+				['input', mapping.input],
+				['expectedOutput', mapping.expectedOutput],
+				['criteria', mapping.criteria],
+			] as const
+		)
+			.filter(([, name]) => name && !columnNames.has(name))
+			.map(([role, name]) => `${role} → '${name}'`);
+		if (missing.length > 0) {
+			throw new BadRequestError(
+				`The dataset's column mapping references columns missing from the data table: ${missing.join(', ')}.`,
+			);
+		}
+
 		const rows: DataTableRow[] = [];
 		let skip = 0;
 		for (;;) {
@@ -328,6 +411,13 @@ export class AgentEvalRunnerService {
 				tableProjectId,
 				{ take: ROW_PAGE_SIZE, skip },
 			);
+			// Reject oversized datasets rather than launching thousands of real
+			// agent executions (`count` is the table total, known from page one).
+			if (count > MAX_CASES) {
+				throw new BadRequestError(
+					`The dataset has ${count} rows, exceeding the ${MAX_CASES}-case limit for a single run.`,
+				);
+			}
 			rows.push(...data);
 			skip += data.length;
 			if (data.length === 0 || skip >= count) break;
@@ -349,13 +439,20 @@ export class AgentEvalRunnerService {
 	}
 }
 
-function countByStatus(results: AgentEvalResult[]): AgentEvalRunSummary['counts'] {
+/** Shape the DB per-status counts into the run summary (pending = new + running). */
+function toSummaryCounts(counts: {
+	new: number;
+	running: number;
+	success: number;
+	error: number;
+	cancelled: number;
+}): AgentEvalRunSummary['counts'] {
 	return {
-		total: results.length,
-		success: results.filter((r) => r.status === 'success').length,
-		error: results.filter((r) => r.status === 'error').length,
-		cancelled: results.filter((r) => r.status === 'cancelled').length,
-		pending: results.filter((r) => r.status === 'new' || r.status === 'running').length,
+		total: counts.new + counts.running + counts.success + counts.error + counts.cancelled,
+		success: counts.success,
+		error: counts.error,
+		cancelled: counts.cancelled,
+		pending: counts.new + counts.running,
 	};
 }
 

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -284,6 +284,12 @@ export class AgentEvalRunnerService {
 	 * module startup; best-effort so it can never block boot.
 	 */
 	async cleanupInterruptedRuns(): Promise<void> {
+		// Runs are only ever created/executed on a single-main (non-queue)
+		// instance — `startRun` refuses queue mode, and n8n multi-main requires it.
+		// So on such an instance every incomplete run at startup is this instance's
+		// own leftover, safe to sweep. Skip entirely in queue mode so bringing up
+		// an additional main never touches runs owned by a different instance.
+		if (this.globalConfig.executions.mode === 'queue') return;
 		try {
 			const result = await this.runRepository.markAllIncompleteAsError();
 			if (result.affected && result.affected > 0) {

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -1,0 +1,367 @@
+import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
+import type { AgentEvalDataset, AgentEvalResult, User } from '@n8n/db';
+import {
+	AgentEvalDatasetRepository,
+	AgentEvalResultRepository,
+	AgentEvalRunRepository,
+} from '@n8n/db';
+import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
+import type {
+	DataTableColumnJsType,
+	DataTableRow,
+	IDataObject,
+	JsonObject,
+	JsonValue,
+} from 'n8n-workflow';
+import { jsonParse, jsonStringify } from 'n8n-workflow';
+import pLimit from 'p-limit';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { AgentRepository } from '@/modules/agents/repositories/agent.repository';
+import { DataTableService } from '@/modules/data-table/data-table.service';
+import { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent-execution.service';
+import { userHasScopes } from '@/permissions.ee/check-access';
+
+const DEFAULT_CONCURRENCY = 5;
+const MAX_CONCURRENCY = 10;
+const ROW_PAGE_SIZE = 100;
+
+/** A dataset row resolved into a runnable case via the dataset's column mapping. */
+interface ResolvedCase {
+	/** Origin Data Table row id, tracked loosely (rows are external/mutable). */
+	sourceRowId: string | null;
+	/** The opening message the agent receives. */
+	input: string;
+	/** The case snapshot persisted on the result row for later judging. */
+	snapshot: JsonObject;
+}
+
+interface CaseUsage {
+	inputTokens: number;
+	outputTokens: number;
+}
+
+export interface AgentEvalRunSummary {
+	runId: string;
+	status: string;
+	counts: { total: number; success: number; error: number; cancelled: number; pending: number };
+}
+
+/**
+ * Executes an agent-eval dataset against a real agent and persists per-case
+ * results, then aggregates run-level status.
+ *
+ * Runs on the main process only: the tool-mock substrate reused from the
+ * instance-ai eval path carries a closure that cannot cross a queue boundary
+ * (see {@link EvalAgentExecutionService}). Cases run in a bounded in-process
+ * pool; cross-main *cancellation* is honored via the run's `cancelRequested`
+ * flag. Behind the `101_agent_evals` flag.
+ */
+@Service()
+export class AgentEvalRunnerService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly globalConfig: GlobalConfig,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly datasetRepository: AgentEvalDatasetRepository,
+		private readonly runRepository: AgentEvalRunRepository,
+		private readonly resultRepository: AgentEvalResultRepository,
+		private readonly agentRepository: AgentRepository,
+		private readonly dataTableService: DataTableService,
+		private readonly evalAgentExecutionService: EvalAgentExecutionService,
+	) {}
+
+	/**
+	 * Validate + create a run, seed one result per case, then execute the cases in
+	 * the background. Returns immediately with the run id and a `finished` promise
+	 * that resolves once the run settles (used by callers that want to await it).
+	 */
+	async startRun(
+		datasetId: string,
+		projectId: string,
+		user: User,
+		options: { concurrency?: number; timeoutMs?: number } = {},
+	): Promise<{ runId: string; finished: Promise<void> }> {
+		// Behind 101_agent_evals. Per-cohort PostHog resolution attaches at the REST
+		// layer (which carries the request user); the gate available server-side
+		// here is the operator override.
+		if (!this.globalConfig.evaluation.agentEvalsEnabled) {
+			throw new BadRequestError('Agent evals are not enabled on this instance.');
+		}
+
+		if (this.globalConfig.executions.mode === 'queue') {
+			throw new BadRequestError('Agent eval runs are not supported in queue mode.');
+		}
+
+		const dataset = await this.datasetRepository.findById(datasetId);
+		if (!dataset) throw new NotFoundError(`Agent eval dataset ${datasetId} not found.`);
+
+		if (dataset.datasetSource !== 'data_table') {
+			throw new BadRequestError(
+				`Agent eval runs currently support only data_table datasets (got '${dataset.datasetSource}').`,
+			);
+		}
+
+		const agent = await this.agentRepository.findByIdAndProjectId(dataset.agentId, projectId);
+		if (!agent) {
+			throw new NotFoundError(`Agent ${dataset.agentId} not found or not accessible.`);
+		}
+
+		const cases = await this.resolveCases(dataset, user);
+		if (cases.length === 0) {
+			throw new BadRequestError('The dataset has no rows to run.');
+		}
+
+		const run = await this.runRepository.createRun({
+			datasetId: dataset.id,
+			agentVersionId: agent.activeVersionId,
+			createdById: user.id,
+		});
+
+		const seeded = await this.resultRepository.seedResults(
+			cases.map((c, index) => ({
+				runId: run.id,
+				sourceRowId: c.sourceRowId,
+				runIndex: index,
+				input: c.snapshot,
+			})),
+		);
+
+		await this.runRepository.markAsRunning(run.id, this.instanceSettings.hostId);
+
+		const concurrency = Math.max(
+			1,
+			Math.min(MAX_CONCURRENCY, Math.floor(options.concurrency ?? DEFAULT_CONCURRENCY)),
+		);
+
+		const finished = this.executeRun({
+			runId: run.id,
+			agentId: dataset.agentId,
+			projectId,
+			user,
+			cases,
+			seeded,
+			concurrency,
+			timeoutMs: options.timeoutMs,
+		});
+
+		return { runId: run.id, finished };
+	}
+
+	/** Run + per-case status counts, for polling a run's progress. */
+	async getRunSummary(runId: string): Promise<AgentEvalRunSummary> {
+		const run = await this.runRepository.findById(runId);
+		if (!run) throw new NotFoundError(`Agent eval run ${runId} not found.`);
+		const results = await this.resultRepository.findByRunId(runId);
+		return { runId: run.id, status: run.status, counts: countByStatus(results) };
+	}
+
+	/**
+	 * Executes every case in a bounded pool and settles the run. Never throws —
+	 * an unexpected failure marks the run as errored so callers awaiting
+	 * `finished` always observe a settled run.
+	 */
+	private async executeRun(ctx: {
+		runId: string;
+		agentId: string;
+		projectId: string;
+		user: User;
+		cases: ResolvedCase[];
+		seeded: AgentEvalResult[];
+		concurrency: number;
+		timeoutMs?: number;
+	}): Promise<void> {
+		const { runId, cases, seeded, concurrency } = ctx;
+		try {
+			const limit = pLimit(concurrency);
+			let cancelled = false;
+			const totalUsage: CaseUsage = { inputTokens: 0, outputTokens: 0 };
+
+			await Promise.all(
+				cases.map(async (resolvedCase, index) => {
+					await limit(async () => {
+						const resultRow = seeded[index];
+						// Cooperative cancellation: stop starting new cases once a cancel is
+						// requested (in-flight cases finish). Re-read the flag so a cancel
+						// from another main is seen.
+						if (cancelled || (await this.runRepository.isCancellationRequested(runId))) {
+							cancelled = true;
+							await this.resultRepository.markAsCancelled(resultRow.id);
+							return;
+						}
+						const usage = await this.runCase(resultRow, resolvedCase, ctx);
+						if (usage) {
+							totalUsage.inputTokens += usage.inputTokens;
+							totalUsage.outputTokens += usage.outputTokens;
+						}
+					});
+				}),
+			);
+
+			const results = await this.resultRepository.findByRunId(runId);
+			const metrics: IDataObject = { ...countByStatus(results), usage: { ...totalUsage } };
+
+			if (cancelled) {
+				await this.runRepository.markAsCancelled(runId, metrics);
+			} else {
+				await this.runRepository.markAsCompleted(runId, metrics);
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.logger.error(`[AgentEvalRunner] Run ${runId} failed to complete`, { error: message });
+			await this.runRepository.markAsError(runId, 'run_failed', { message });
+		}
+	}
+
+	/**
+	 * Execute one case and persist its result. Returns the case's token usage.
+	 * Fully self-contained: a thrown execution or DB error is converted into a
+	 * per-case error so one case can never abort the batch or leave its result
+	 * stuck `running`.
+	 */
+	private async runCase(
+		resultRow: AgentEvalResult,
+		resolvedCase: ResolvedCase,
+		ctx: { agentId: string; projectId: string; user: User; timeoutMs?: number },
+	): Promise<CaseUsage | undefined> {
+		try {
+			if (resolvedCase.input.trim().length === 0) {
+				await this.resultRepository.markAsError(resultRow.id, 'empty_input', {
+					message: 'Case has no value in the mapped input column.',
+				});
+				return undefined;
+			}
+
+			await this.resultRepository.markAsRunning(resultRow.id);
+
+			const execResult = await this.evalAgentExecutionService.executeWithLlmMock(
+				ctx.agentId,
+				ctx.user,
+				{ projectId: ctx.projectId, ...(ctx.timeoutMs ? { timeoutMs: ctx.timeoutMs } : {}) },
+				resolvedCase.input,
+			);
+
+			const usage = normalizeUsage(execResult.usage);
+
+			if (!execResult.success) {
+				await this.resultRepository.markAsError(resultRow.id, 'execution_failed', {
+					errors: execResult.errors,
+					finalText: execResult.finalText,
+				});
+				return usage;
+			}
+
+			await this.resultRepository.markAsCompleted(resultRow.id, {
+				output: toJsonObject({
+					finalText: execResult.finalText,
+					model: execResult.model ?? null,
+					finishReason: execResult.finishReason ?? null,
+					skippedFeatures: execResult.skippedFeatures,
+				}),
+				toolCalls: toJsonObject({ calls: execResult.toolCalls }),
+				metrics: usage ? { usage: { ...usage } } : null,
+			});
+
+			return usage;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.logger.error(`[AgentEvalRunner] Case ${resultRow.id} failed`, { error: message });
+			try {
+				await this.resultRepository.markAsError(resultRow.id, 'execution_failed', { message });
+			} catch (markError) {
+				this.logger.error(`[AgentEvalRunner] Could not record failure for case ${resultRow.id}`, {
+					error: markError instanceof Error ? markError.message : String(markError),
+				});
+			}
+			return undefined;
+		}
+	}
+
+	/**
+	 * Resolve the dataset's Data Table rows into runnable cases via its column
+	 * mapping. Mirrors {@link EvaluationDatasetService}'s data-table access: the
+	 * table may live in a different project than the agent, so access is checked
+	 * on the table directly.
+	 */
+	private async resolveCases(dataset: AgentEvalDataset, user: User): Promise<ResolvedCase[]> {
+		const mapping = dataset.columnMapping;
+		if (!mapping?.input) {
+			throw new BadRequestError('The dataset has no input column mapping.');
+		}
+
+		// Narrowed above (datasetSource === 'data_table'): the ref carries a table id.
+		const dataTableId = (dataset.datasetRef as { dataTableId: string }).dataTableId;
+
+		const allowed = await userHasScopes(user, ['dataTable:readRow'], false, { dataTableId });
+		if (!allowed) throw new ForbiddenError('You do not have access to this dataset.');
+
+		const tableProjectId = await this.dataTableService.getProjectIdForDataTable(dataTableId);
+
+		const rows: DataTableRow[] = [];
+		let skip = 0;
+		for (;;) {
+			const { data, count } = await this.dataTableService.getManyRowsAndCount(
+				dataTableId,
+				tableProjectId,
+				{ take: ROW_PAGE_SIZE, skip },
+			);
+			rows.push(...data);
+			skip += data.length;
+			if (data.length === 0 || skip >= count) break;
+		}
+
+		return rows.map((row) => {
+			const snapshot: JsonObject = { input: cellToJson(row[mapping.input]) };
+			if (mapping.expectedOutput) {
+				snapshot.expectedOutput = cellToJson(row[mapping.expectedOutput]);
+			}
+			if (mapping.criteria) snapshot.criteria = cellToJson(row[mapping.criteria]);
+
+			return {
+				sourceRowId: row.id === undefined || row.id === null ? null : String(row.id),
+				input: cellToString(row[mapping.input]),
+				snapshot,
+			};
+		});
+	}
+}
+
+function countByStatus(results: AgentEvalResult[]): AgentEvalRunSummary['counts'] {
+	return {
+		total: results.length,
+		success: results.filter((r) => r.status === 'success').length,
+		error: results.filter((r) => r.status === 'error').length,
+		cancelled: results.filter((r) => r.status === 'cancelled').length,
+		pending: results.filter((r) => r.status === 'new' || r.status === 'running').length,
+	};
+}
+
+/** The execution result reports token counts optionally; default missing to 0. */
+function normalizeUsage(usage?: { inputTokens?: number; outputTokens?: number }):
+	| CaseUsage
+	| undefined {
+	if (!usage) return undefined;
+	return { inputTokens: usage.inputTokens ?? 0, outputTokens: usage.outputTokens ?? 0 };
+}
+
+/** Coerce a Data Table cell into the agent's opening message. */
+function cellToString(value: DataTableColumnJsType | undefined): string {
+	if (value === null || value === undefined) return '';
+	if (value instanceof Date) return value.toISOString();
+	return String(value);
+}
+
+/** Coerce a Data Table cell into a JSON-safe snapshot value. */
+function cellToJson(value: DataTableColumnJsType | undefined): JsonValue {
+	if (value === null || value === undefined) return null;
+	if (value instanceof Date) return value.toISOString();
+	return value;
+}
+
+function toJsonObject(value: unknown): JsonObject {
+	return jsonParse<JsonObject>(jsonStringify(value), { fallbackValue: {} });
+}

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -118,20 +118,39 @@ export class AgentEvalRunnerService {
 
 		const run = await this.runRepository.createRun({
 			datasetId: dataset.id,
-			agentVersionId: agent.activeVersionId,
+			// Left unpinned: execution reloads the live agent by id (there is no
+			// snapshot-execution path yet), so tagging a specific version would
+			// misrepresent what actually ran — mirrors the workflow eval, which
+			// records a version only when it executes that pinned snapshot.
+			// Version-pinned execution is a follow-up.
+			agentVersionId: null,
 			createdById: user.id,
 		});
 
-		const seeded = await this.resultRepository.seedResults(
-			cases.map((c, index) => ({
-				runId: run.id,
-				sourceRowId: c.sourceRowId,
-				runIndex: index,
-				input: c.snapshot,
-			})),
-		);
-
-		await this.runRepository.markAsRunning(run.id, this.instanceSettings.hostId);
+		// The run row now exists; if seeding or marking it running fails, mark the
+		// run errored so polling never shows a permanently `new` run that will
+		// never execute.
+		let seeded: AgentEvalResult[];
+		try {
+			seeded = await this.resultRepository.seedResults(
+				cases.map((c, index) => ({
+					runId: run.id,
+					sourceRowId: c.sourceRowId,
+					runIndex: index,
+					input: c.snapshot,
+				})),
+			);
+			await this.runRepository.markAsRunning(run.id, this.instanceSettings.hostId);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			// Best-effort: don't let a failure to record the error mask the original.
+			try {
+				await this.runRepository.markAsError(run.id, 'seed_failed', { message });
+			} catch {
+				// ignore
+			}
+			throw error;
+		}
 
 		const concurrency = Math.max(
 			1,

--- a/packages/cli/src/modules/agent-evals/agent-evals.module.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals.module.ts
@@ -1,0 +1,17 @@
+import type { ModuleInterface } from '@n8n/decorators';
+import { BackendModule } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+/**
+ * Agent-scoped evaluations. Runs eval datasets against a real agent and
+ * persists per-case results. Main-process only — the reused tool-mock substrate
+ * cannot cross a queue boundary. Opt-in (not a default module) and dark until
+ * the `101_agent_evals` flag is on; the persistence layer lives in `@n8n/db`.
+ */
+@BackendModule({ name: 'agent-evals', instanceTypes: ['main'] })
+export class AgentEvalsModule implements ModuleInterface {
+	async init() {
+		const { AgentEvalRunnerService } = await import('./agent-eval-runner.service.js');
+		Container.get(AgentEvalRunnerService);
+	}
+}

--- a/packages/cli/src/modules/agent-evals/agent-evals.module.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals.module.ts
@@ -12,6 +12,9 @@ import { Container } from '@n8n/di';
 export class AgentEvalsModule implements ModuleInterface {
 	async init() {
 		const { AgentEvalRunnerService } = await import('./agent-eval-runner.service.js');
-		Container.get(AgentEvalRunnerService);
+		const runner = Container.get(AgentEvalRunnerService);
+		// The runner can't resume runs interrupted by a restart — sweep any left
+		// over from a previous process so they don't poll as `running` forever.
+		await runner.cleanupInterruptedRuns();
 	}
 }

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/agent-execution.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/agent-execution.service.test.ts
@@ -190,6 +190,23 @@ describe('EvalAgentExecutionService.executeWithLlmMock', () => {
 		expect(reconstructFromAgentEntity).not.toHaveBeenCalled();
 	});
 
+	it('scrubs secret values from the case scenario signal but runs the case input verbatim', async () => {
+		const generate = vi.fn().mockResolvedValue(makeGenerateResult());
+		const close = vi.fn().mockResolvedValue(undefined);
+		reconstructFromAgentEntity.mockResolvedValue({ agent: { generate, close }, toolRegistry: {} });
+
+		const secret = 'sk-ABCDEF1234567890ABCDEF1234567890';
+		const caseInput = `Refund order #123 with key ${secret}`;
+		await buildService().executeWithLlmMock('agent-1', user, request, caseInput);
+
+		// The signal fed to the seed/mock LLM calls has the secret scrubbed...
+		const seedArgs = vi.mocked(generateAgentScenarioSeed).mock.calls[0]?.[0];
+		expect(seedArgs?.scenarioHints).not.toContain(secret);
+		expect(seedArgs?.scenarioHints).toContain('Refund order #123');
+		// ...but the agent still receives the verbatim case input.
+		expect(generate).toHaveBeenCalledWith(caseInput, expect.anything());
+	});
+
 	it('runs the happy path: real-model turn, mocked tool HTTP, mapped result', async () => {
 		const innerCredentialsHelper = { getDecrypted: vi.fn() };
 		const close = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/src/modules/instance-ai/eval/agent-execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/agent-execution.service.ts
@@ -45,7 +45,7 @@ import {
 	type McpMockToolCall,
 } from './mcp-mock-fetch';
 import { createLlmMockHandler } from './mock-handler';
-import { truncateForLlm } from './request-sanitizer';
+import { redactSecretValuePatterns, truncateForLlm } from './request-sanitizer';
 import { createWebSearchMock } from './web-search-mock';
 
 // ---------------------------------------------------------------------------
@@ -158,9 +158,14 @@ export class EvalAgentExecutionService {
 		// The scenario signal steers seed + mock generation. A fixed case input
 		// doubles as that signal (bounded) so the generated context, per-tool
 		// hints, and mock responses all stay coherent with the message sent.
+		// Secret-value shapes pasted into a case are scrubbed before reaching these
+		// auxiliary LLM calls (which never need the real value); the opening
+		// message the agent actually runs stays verbatim.
 		const scenarioSignal =
 			options.scenarioHints ??
-			(caseInput !== undefined ? truncateForLlm(caseInput, MAX_SCENARIO_HINT_CHARS) : undefined);
+			(caseInput !== undefined
+				? truncateForLlm(redactSecretValuePatterns(caseInput), MAX_SCENARIO_HINT_CHARS)
+				: undefined);
 
 		let seed: InstanceAiEvalAgentScenarioSeed;
 		try {

--- a/packages/cli/src/modules/instance-ai/eval/agent-execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/agent-execution.service.ts
@@ -65,6 +65,10 @@ import { createWebSearchMock } from './web-search-mock';
 // ---------------------------------------------------------------------------
 
 const DEFAULT_TIMEOUT_MS = 600_000;
+// Case input is used verbatim as the opening message, but as a prompt *signal*
+// for seed + mock generation it is bounded — matching the request schema's cap
+// on `scenarioHints` so a large Data Table cell can't blow up those prompts.
+const MAX_SCENARIO_HINT_CHARS = 2_000;
 const DEFAULT_MAX_ITERATIONS = 25;
 const MAX_ITERATIONS_CAP = 40;
 const MAX_AUTO_APPROVALS = 20;
@@ -151,15 +155,20 @@ export class EvalAgentExecutionService {
 
 		const toolSummaries = summarizeTools(config, agentEntity.tools ?? {}, sanitizeToolName);
 
+		// The scenario signal steers seed + mock generation. A fixed case input
+		// doubles as that signal (bounded) so the generated context, per-tool
+		// hints, and mock responses all stay coherent with the message sent.
+		const scenarioSignal =
+			options.scenarioHints ??
+			(caseInput !== undefined ? truncateForLlm(caseInput, MAX_SCENARIO_HINT_CHARS) : undefined);
+
 		let seed: InstanceAiEvalAgentScenarioSeed;
 		try {
 			seed = await generateAgentScenarioSeed({
 				agentName: config.name,
 				instructions: config.instructions,
 				tools: toolSummaries,
-				// A fixed case input doubles as the scenario signal so the generated
-				// context + tool hints stay coherent with the message actually sent.
-				scenarioHints: options.scenarioHints ?? caseInput,
+				scenarioHints: scenarioSignal,
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -176,7 +185,7 @@ export class EvalAgentExecutionService {
 		}
 
 		const mockHandler = createLlmMockHandler({
-			scenarioHints: options.scenarioHints,
+			scenarioHints: scenarioSignal,
 			globalContext: seed.globalContext,
 			nodeHints: seed.toolHints,
 		});
@@ -202,7 +211,7 @@ export class EvalAgentExecutionService {
 				description: server.description,
 			})),
 			agentInstructions: config.instructions,
-			scenarioHints: options.scenarioHints,
+			scenarioHints: scenarioSignal,
 			globalContext: seed.globalContext,
 			serverHints: seed.toolHints,
 			knownToolsByServer,
@@ -242,7 +251,7 @@ export class EvalAgentExecutionService {
 		// search); with native search the tool is never built and this goes unused.
 		const webSearchMock = createWebSearchMock({
 			agentInstructions: config.instructions,
-			scenarioHints: options.scenarioHints,
+			scenarioHints: scenarioSignal,
 			globalContext: seed.globalContext,
 			searchHint: seed.toolHints?.web_search,
 			logger: this.logger,

--- a/packages/cli/src/modules/instance-ai/eval/agent-execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/agent-execution.service.ts
@@ -101,6 +101,11 @@ export class EvalAgentExecutionService {
 		agentId: string,
 		user: User,
 		options: InstanceAiEvalAgentExecutionRequest,
+		// When set, the run uses this exact text as the opening message instead of
+		// a generated scenario. The seed is still generated (its shared context +
+		// per-tool hints keep the tool mocks coherent), but the message the agent
+		// receives is this input verbatim — how a fixed eval case is executed.
+		caseInput?: string,
 	): Promise<InstanceAiEvalAgentExecutionResult> {
 		// Workflow-tool sub-executions carry a configureAdditionalData closure
 		// that doesn't survive queue serialization — refuse upfront so tool
@@ -152,13 +157,22 @@ export class EvalAgentExecutionService {
 				agentName: config.name,
 				instructions: config.instructions,
 				tools: toolSummaries,
-				scenarioHints: options.scenarioHints,
+				// A fixed case input doubles as the scenario signal so the generated
+				// context + tool hints stay coherent with the message actually sent.
+				scenarioHints: options.scenarioHints ?? caseInput,
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			return this.errorResult(
 				message.startsWith('FRAMEWORK ISSUE:') ? message : `FRAMEWORK ISSUE: ${message}`,
 			);
+		}
+
+		// A fixed eval case overrides the generated opening message: keep the
+		// seed's context/hints (they steer the tool mocks) but send the case's
+		// input verbatim.
+		if (caseInput !== undefined) {
+			seed = { ...seed, openingMessage: caseInput };
 		}
 
 		const mockHandler = createLlmMockHandler({


### PR DESCRIPTION
## Summary

Backend runner for **Agent Evals** (Phase 0). Given an agent-scoped eval dataset, it executes every case against a **real agent** and persists per-case results plus an aggregated run — reusing the existing instance-ai eval execution + capture mechanics (`EvalAgentExecutionService`) per the engine-fork decision, rather than the workflow-scoped `evaluation.ee` runner.

New `agent-evals` backend module (opt-in, `instanceTypes: ['main']`) with `AgentEvalRunnerService`:

- `startRun(datasetId, projectId, user)` → validates the flag + main-process mode → resolves the dataset's Data Table rows into cases via its `columnMapping` → seeds one `agent_eval_result` row per case → runs cases through a **bounded in-process concurrency pool** → maps each execution's output / tool-call timeline / token usage onto its result row → aggregates run-level status + metrics. Returns the run id immediately plus a `finished` promise.
- `getRunSummary(runId)` → run status + per-case status counts.

Also folds in the run-lifecycle/aggregation slice (TRUST-288) so the runner owns the full run. Adds a concrete `caseInput` path to `EvalAgentExecutionService` so a fixed case input is sent verbatim as the opening message (the generated seed still supplies tool-mock context/hints).

**Design notes**
- **Main-process only.** The reused tool-mock substrate carries a closure that can't cross a queue boundary, so queue mode is refused up front; cross-main *cancellation* still works via the run's `runningInstanceId` / `cancelRequested` fields.
- **Per-case isolation.** A thrown execution/DB error is converted to a per-case error — it can never abort the batch, error the whole run, or leave a case stuck `running`.
- **Dark / gated.** Opt-in module + behind `101_agent_evals`. Per-cohort PostHog resolution attaches at the REST layer (a later PR); no HTTP surface here.
- `data_table` datasets in v1 (`google_sheets` is refused with a clear message).

## How to test

This is backend-only and gated. To exercise it on an instance:

- Enable the modules: `N8N_ENABLED_MODULES=agent-evals,agents,instance-ai,data-table`
- Enable the flag: `N8N_AGENT_EVALS_ENABLED=true`

Automated tests (run from `packages/cli`):

```bash
pnpm test src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
pnpm test:integration src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
```

The integration test drives `startRun` against a real DB + real Data Table + real agent-eval repositories, asserting run completion and result-row persistence (output + tool-call timeline). Only the LLM-backed agent execution is stubbed — it needs credentials/network and is covered by the instance-ai eval suite. New repository methods are unit-tested in `packages/@n8n/db`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-286
https://linear.app/n8n/issue/TRUST-288 (run-lifecycle/aggregation, folded into this PR)

Builds on the merged data model (#34657) and the merged execution/capture mechanics (#34384).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34904">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

