### PR TITLE
feat(core): Add AI case-generation service for agent evals (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -566,7 +566,35 @@ export {
 	type EvalVersionsResponse,
 } from './schemas/eval-collections.schema';
 
-export { AGENT_EVALS_FLAG } from './schemas/agent-evals.schema';
+export {
+	AGENT_EVALS_FLAG,
+	agentEvalColumnMappingSchema,
+	agentEvalRunStatusSchema,
+	agentEvalResultStatusSchema,
+	agentEvalVoteSchema,
+	createAgentEvalDatasetSchema,
+	updateAgentEvalDatasetSchema,
+	UpdateAgentEvalDatasetDto,
+	createAgentEvalRunSchema,
+	CreateAgentEvalRunDto,
+	createAgentEvalRatingSchema,
+	CreateAgentEvalRatingDto,
+} from './schemas/agent-evals.schema';
+export type {
+	AgentEvalColumnMapping,
+	AgentEvalRunStatus,
+	AgentEvalResultStatus,
+	AgentEvalVote,
+	CreateAgentEvalDatasetDto,
+	UpdateAgentEvalDatasetPayload,
+	CreateAgentEvalRunPayload,
+	CreateAgentEvalRatingPayload,
+	AgentEvalDatasetRecord,
+	AgentEvalRunRecord,
+	AgentEvalResultRecord,
+	AgentEvalRatingRecord,
+	AgentEvalRunDetail,
+} from './schemas/agent-evals.schema';
 
 export {
 	aiInsightsStatusSchema,

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -579,6 +579,9 @@ export {
 	CreateAgentEvalRunDto,
 	createAgentEvalRatingSchema,
 	CreateAgentEvalRatingDto,
+	agentEvalDraftCaseSchema,
+	generateDraftCasesOptionsSchema,
+	GenerateDraftCasesOptionsDto,
 } from './schemas/agent-evals.schema';
 export type {
 	AgentEvalColumnMapping,
@@ -594,6 +597,9 @@ export type {
 	AgentEvalResultRecord,
 	AgentEvalRatingRecord,
 	AgentEvalRunDetail,
+	AgentEvalDraftCase,
+	GenerateDraftCasesOptions,
+	GenerateDraftCasesResult,
 } from './schemas/agent-evals.schema';
 
 export {

--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
@@ -1,11 +1,13 @@
 import {
 	agentEvalColumnMappingSchema,
+	agentEvalDraftCaseSchema,
 	agentEvalResultStatusSchema,
 	agentEvalRunStatusSchema,
 	agentEvalVoteSchema,
 	createAgentEvalDatasetSchema,
 	CreateAgentEvalRatingDto,
 	CreateAgentEvalRunDto,
+	GenerateDraftCasesOptionsDto,
 	UpdateAgentEvalDatasetDto,
 } from '../agent-evals.schema';
 
@@ -161,7 +163,57 @@ describe('CreateAgentEvalRatingDto', () => {
 		).toBe(true);
 	});
 
+	it('accepts a nested JSON correction', () => {
+		expect(
+			CreateAgentEvalRatingDto.safeParse({
+				vote: 'down',
+				correction: { output: { text: 'x', items: [1, 'two', true, null] }, score: 3 },
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects a correction with a non-JSON leaf', () => {
+		expect(
+			CreateAgentEvalRatingDto.safeParse({
+				vote: 'down',
+				correction: { output: () => 'not json' },
+			}).success,
+		).toBe(false);
+	});
+
 	it('rejects an invalid vote', () => {
 		expect(CreateAgentEvalRatingDto.safeParse({ vote: 'maybe' }).success).toBe(false);
+	});
+});
+
+describe('agentEvalDraftCaseSchema', () => {
+	it('accepts a valid draft case', () => {
+		expect(
+			agentEvalDraftCaseSchema.safeParse({
+				input: 'Reset my password',
+				whatToCheck: 'Explains steps',
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects a draft case missing whatToCheck', () => {
+		expect(agentEvalDraftCaseSchema.safeParse({ input: 'Reset my password' }).success).toBe(false);
+	});
+});
+
+describe('GenerateDraftCasesOptionsDto', () => {
+	it('accepts an empty options body', () => {
+		expect(GenerateDraftCasesOptionsDto.safeParse({}).success).toBe(true);
+	});
+
+	it('accepts count and datasetName', () => {
+		expect(
+			GenerateDraftCasesOptionsDto.safeParse({ count: 6, datasetName: 'Support' }).success,
+		).toBe(true);
+	});
+
+	it('rejects a non-positive or non-integer count', () => {
+		expect(GenerateDraftCasesOptionsDto.safeParse({ count: 0 }).success).toBe(false);
+		expect(GenerateDraftCasesOptionsDto.safeParse({ count: 2.5 }).success).toBe(false);
 	});
 });

--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
@@ -1,0 +1,154 @@
+import {
+	agentEvalColumnMappingSchema,
+	agentEvalResultStatusSchema,
+	agentEvalRunStatusSchema,
+	agentEvalVoteSchema,
+	createAgentEvalDatasetSchema,
+	CreateAgentEvalRatingDto,
+	CreateAgentEvalRunDto,
+	UpdateAgentEvalDatasetDto,
+} from '../agent-evals.schema';
+
+describe('agentEvalColumnMappingSchema', () => {
+	it('accepts an input-only mapping', () => {
+		expect(agentEvalColumnMappingSchema.safeParse({ input: 'question' }).success).toBe(true);
+	});
+
+	it('accepts a full mapping', () => {
+		expect(
+			agentEvalColumnMappingSchema.safeParse({
+				input: 'question',
+				expectedOutput: 'answer',
+				criteria: 'what to check',
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects a missing input column', () => {
+		expect(agentEvalColumnMappingSchema.safeParse({ expectedOutput: 'answer' }).success).toBe(
+			false,
+		);
+	});
+
+	it('rejects an empty input column', () => {
+		expect(agentEvalColumnMappingSchema.safeParse({ input: '' }).success).toBe(false);
+	});
+});
+
+describe('status / vote enums', () => {
+	it('accepts valid run statuses and rejects unknown ones', () => {
+		expect(agentEvalRunStatusSchema.safeParse('completed').success).toBe(true);
+		expect(agentEvalRunStatusSchema.safeParse('success').success).toBe(false);
+	});
+
+	it('accepts valid result statuses and rejects unknown ones', () => {
+		expect(agentEvalResultStatusSchema.safeParse('success').success).toBe(true);
+		expect(agentEvalResultStatusSchema.safeParse('completed').success).toBe(false);
+	});
+
+	it('accepts up/down votes and rejects anything else', () => {
+		expect(agentEvalVoteSchema.safeParse('up').success).toBe(true);
+		expect(agentEvalVoteSchema.safeParse('down').success).toBe(true);
+		expect(agentEvalVoteSchema.safeParse('meh').success).toBe(false);
+	});
+});
+
+describe('createAgentEvalDatasetSchema', () => {
+	const base = {
+		name: 'Support cases',
+		agentId: 'agent-1',
+		columnMapping: { input: 'question', expectedOutput: 'answer' },
+	};
+
+	it('accepts a data_table source', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				...base,
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+			}).success,
+		).toBe(true);
+	});
+
+	it('accepts a google_sheets source', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				...base,
+				datasetSource: 'google_sheets',
+				datasetRef: {
+					credentialId: 'cred-1',
+					spreadsheetId: 'sheet-1',
+					sheetName: 'Cases',
+				},
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects a missing agentId', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				name: 'Support cases',
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+			}).success,
+		).toBe(false);
+	});
+
+	it('rejects an unknown dataset source', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				...base,
+				datasetSource: 'csv',
+				datasetRef: { dataTableId: 'dt-1' },
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe('UpdateAgentEvalDatasetDto', () => {
+	it('accepts a partial metadata patch', () => {
+		expect(UpdateAgentEvalDatasetDto.safeParse({ name: 'Renamed' }).success).toBe(true);
+	});
+
+	it('accepts an empty patch', () => {
+		expect(UpdateAgentEvalDatasetDto.safeParse({}).success).toBe(true);
+	});
+
+	it('rejects a non-string name', () => {
+		expect(UpdateAgentEvalDatasetDto.safeParse({ name: 42 }).success).toBe(false);
+	});
+});
+
+describe('CreateAgentEvalRunDto', () => {
+	it('accepts an empty body (run current version)', () => {
+		expect(CreateAgentEvalRunDto.safeParse({}).success).toBe(true);
+	});
+
+	it('accepts a pinned agent version', () => {
+		expect(CreateAgentEvalRunDto.safeParse({ agentVersionId: 'v-1' }).success).toBe(true);
+	});
+
+	it('rejects an empty agent version', () => {
+		expect(CreateAgentEvalRunDto.safeParse({ agentVersionId: '' }).success).toBe(false);
+	});
+});
+
+describe('CreateAgentEvalRatingDto', () => {
+	it('accepts a bare vote', () => {
+		expect(CreateAgentEvalRatingDto.safeParse({ vote: 'up' }).success).toBe(true);
+	});
+
+	it('accepts a vote with comment and correction', () => {
+		expect(
+			CreateAgentEvalRatingDto.safeParse({
+				vote: 'down',
+				comment: 'Wrong tool used',
+				correction: { output: 'the expected answer' },
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects an invalid vote', () => {
+		expect(CreateAgentEvalRatingDto.safeParse({ vote: 'maybe' }).success).toBe(false);
+	});
+});

--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-evals.schema.test.ts
@@ -84,6 +84,19 @@ describe('createAgentEvalDatasetSchema', () => {
 		).toBe(true);
 	});
 
+	it('accepts an explicit null description and columnMapping', () => {
+		expect(
+			createAgentEvalDatasetSchema.safeParse({
+				name: 'Support cases',
+				agentId: 'agent-1',
+				description: null,
+				columnMapping: null,
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+			}).success,
+		).toBe(true);
+	});
+
 	it('rejects a missing agentId', () => {
 		expect(
 			createAgentEvalDatasetSchema.safeParse({

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -1,3 +1,8 @@
+import { z } from 'zod';
+
+import { datasetRefSchema, type DatasetRef } from '../dto/evaluations/evaluation-config.dto';
+import { Z } from '../zod-class';
+
 // PostHog rollout flag id gating the agent-evals feature surface. Every new
 // agent-eval endpoint + frontend entry point consults this; the flag-off
 // cohort sees no agent-eval surface at all. Single source of truth shared
@@ -5,3 +10,159 @@
 // numeric-prefix convention used by every other n8n PostHog flag (next
 // available after `100_n8n_credits_credential_selection`).
 export const AGENT_EVALS_FLAG = '101_agent_evals';
+
+// ---------------------------------------------------------------------------
+// Shared value types — the FE/BE contract mirrored by the `@n8n/db` entities,
+// which import these from here (as they already do for `DatasetRef`) rather
+// than redefining them. This is the canonical home.
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps the roles an agent eval needs onto columns of the referenced dataset (a
+ * Data Table or Google Sheet). Only `input` is required; without an
+ * `expectedOutput`/`criteria` column a run simply has no reference answer or
+ * per-case check to judge against.
+ */
+export const agentEvalColumnMappingSchema = z.object({
+	input: z.string().min(1),
+	expectedOutput: z.string().min(1).optional(),
+	criteria: z.string().min(1).optional(),
+});
+export type AgentEvalColumnMapping = z.infer<typeof agentEvalColumnMappingSchema>;
+
+export const agentEvalRunStatusSchema = z.enum([
+	'new',
+	'running',
+	'completed',
+	'error',
+	'cancelled',
+]);
+export type AgentEvalRunStatus = z.infer<typeof agentEvalRunStatusSchema>;
+
+export const agentEvalResultStatusSchema = z.enum([
+	'new',
+	'running',
+	'success',
+	'error',
+	'cancelled',
+]);
+export type AgentEvalResultStatus = z.infer<typeof agentEvalResultStatusSchema>;
+
+export const agentEvalVoteSchema = z.enum(['up', 'down']);
+export type AgentEvalVote = z.infer<typeof agentEvalVoteSchema>;
+
+// ---------------------------------------------------------------------------
+// Request DTOs. Parent resource ids (datasetId, resultId) are path params, so
+// they are not part of these bodies. Flat bodies use `Z.class` for controller
+// `@Body` binding; the dataset-create body carries the `DatasetRef` union, so
+// it follows the `UpsertEvaluationConfigDto` pattern (schema + inferred type)
+// which `Z.class` (flat shape only) cannot express.
+// ---------------------------------------------------------------------------
+
+export const createAgentEvalDatasetSchema = z
+	.object({
+		name: z.string().min(1).max(128),
+		description: z.string().optional(),
+		agentId: z.string().min(1),
+		columnMapping: agentEvalColumnMappingSchema.optional(),
+	})
+	.and(datasetRefSchema);
+export type CreateAgentEvalDatasetDto = z.infer<typeof createAgentEvalDatasetSchema>;
+
+// Metadata patch only; changing the dataset source is a new dataset, so the
+// `DatasetRef` union is intentionally not part of the update body.
+const updateAgentEvalDatasetShape = {
+	name: z.string().min(1).max(128).optional(),
+	description: z.string().nullable().optional(),
+	columnMapping: agentEvalColumnMappingSchema.nullable().optional(),
+};
+export const updateAgentEvalDatasetSchema = z.object(updateAgentEvalDatasetShape);
+export type UpdateAgentEvalDatasetPayload = z.infer<typeof updateAgentEvalDatasetSchema>;
+export class UpdateAgentEvalDatasetDto extends Z.class(updateAgentEvalDatasetShape) {}
+
+// Kicks off a run of the path dataset. `agentVersionId` optionally pins a
+// published version of the dataset's own agent; omitted runs the current one.
+const createAgentEvalRunShape = {
+	agentVersionId: z.string().min(1).optional(),
+};
+export const createAgentEvalRunSchema = z.object(createAgentEvalRunShape);
+export type CreateAgentEvalRunPayload = z.infer<typeof createAgentEvalRunSchema>;
+export class CreateAgentEvalRunDto extends Z.class(createAgentEvalRunShape) {}
+
+// A human's 👍/👎 on the path result, with an optional free-text comment and an
+// edited "should have been" output.
+const createAgentEvalRatingShape = {
+	vote: agentEvalVoteSchema,
+	comment: z.string().optional(),
+	correction: z.record(z.string(), z.unknown()).optional(),
+};
+export const createAgentEvalRatingSchema = z.object(createAgentEvalRatingShape);
+export type CreateAgentEvalRatingPayload = z.infer<typeof createAgentEvalRatingSchema>;
+export class CreateAgentEvalRatingDto extends Z.class(createAgentEvalRatingShape) {}
+
+// ---------------------------------------------------------------------------
+// Response shapes: plain types (not zod) so the server needn't round-trip its
+// own output through validation. Dates are serialized as ISO strings; internal
+// coordination columns (`runningInstanceId`, `cancelRequested`) are omitted
+// from the contract.
+// ---------------------------------------------------------------------------
+
+export type AgentEvalDatasetRecord = {
+	id: string;
+	name: string;
+	description: string | null;
+	agentId: string;
+	columnMapping: AgentEvalColumnMapping | null;
+	createdById: string | null;
+	createdAt: string;
+	updatedAt: string;
+} & DatasetRef;
+
+export type AgentEvalRunRecord = {
+	id: string;
+	datasetId: string;
+	agentVersionId: string | null;
+	status: AgentEvalRunStatus;
+	runAt: string | null;
+	completedAt: string | null;
+	metrics: Record<string, unknown> | null;
+	errorCode: string | null;
+	errorDetails: Record<string, unknown> | null;
+	createdById: string | null;
+	createdAt: string;
+	updatedAt: string;
+};
+
+export type AgentEvalResultRecord = {
+	id: string;
+	runId: string;
+	sourceRowId: string | null;
+	runIndex: number | null;
+	status: AgentEvalResultStatus;
+	input: Record<string, unknown> | null;
+	output: Record<string, unknown> | null;
+	toolCalls: Record<string, unknown> | null;
+	metrics: Record<string, unknown> | null;
+	runAt: string | null;
+	completedAt: string | null;
+	errorCode: string | null;
+	errorDetails: Record<string, unknown> | null;
+	createdAt: string;
+	updatedAt: string;
+};
+
+export type AgentEvalRatingRecord = {
+	id: string;
+	resultId: string;
+	vote: AgentEvalVote;
+	comment: string | null;
+	correction: Record<string, unknown> | null;
+	ratedById: string | null;
+	createdAt: string;
+	updatedAt: string;
+};
+
+// A run with its per-case results — the "open a run" view.
+export type AgentEvalRunDetail = AgentEvalRunRecord & {
+	results: AgentEvalResultRecord[];
+};

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -62,9 +62,9 @@ export type AgentEvalVote = z.infer<typeof agentEvalVoteSchema>;
 export const createAgentEvalDatasetSchema = z
 	.object({
 		name: z.string().min(1).max(128),
-		description: z.string().optional(),
+		description: z.string().nullable().optional(),
 		agentId: z.string().min(1),
-		columnMapping: agentEvalColumnMappingSchema.optional(),
+		columnMapping: agentEvalColumnMappingSchema.nullable().optional(),
 	})
 	.and(datasetRefSchema);
 export type CreateAgentEvalDatasetDto = z.infer<typeof createAgentEvalDatasetSchema>;

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -1,7 +1,24 @@
+import type { JsonObject, JsonValue } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { datasetRefSchema, type DatasetRef } from '../dto/evaluations/evaluation-config.dto';
 import { Z } from '../zod-class';
+
+// A JSON blob that flows from a request into persistence must infer to the
+// repository's `JsonObject`, not `Record<string, unknown>` — the latter permits
+// non-JSON leaves and isn't assignable to `JsonObject` without a cast. Recursive
+// so nested values are validated too.
+const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+	z.union([
+		z.string(),
+		z.number(),
+		z.boolean(),
+		z.null(),
+		z.record(z.string(), jsonValueSchema),
+		z.array(jsonValueSchema),
+	]),
+);
+const jsonObjectSchema: z.ZodType<JsonObject> = z.record(z.string(), jsonValueSchema);
 
 // PostHog rollout flag id gating the agent-evals feature surface. Every new
 // agent-eval endpoint + frontend entry point consults this; the flag-off
@@ -94,7 +111,7 @@ export class CreateAgentEvalRunDto extends Z.class(createAgentEvalRunShape) {}
 const createAgentEvalRatingShape = {
 	vote: agentEvalVoteSchema,
 	comment: z.string().optional(),
-	correction: z.record(z.string(), z.unknown()).optional(),
+	correction: jsonObjectSchema.optional(),
 };
 export const createAgentEvalRatingSchema = z.object(createAgentEvalRatingShape);
 export type CreateAgentEvalRatingPayload = z.infer<typeof createAgentEvalRatingSchema>;
@@ -165,4 +182,38 @@ export type AgentEvalRatingRecord = {
 // A run with its per-case results — the "open a run" view.
 export type AgentEvalRunDetail = AgentEvalRunRecord & {
 	results: AgentEvalResultRecord[];
+};
+
+// ---------------------------------------------------------------------------
+// Case generation. The AI case-generation service drafts cases from an agent's
+// config; these types are the shared contract for its request/response so the
+// generate endpoint and editor-ui use one definition (the service impl and its
+// synthesis logic live in the backend).
+// ---------------------------------------------------------------------------
+
+/**
+ * A single AI-generated draft eval case: a realistic end-user input plus a
+ * plain-language "what to check". Drafts have no gold answer and are never
+ * auto-graded — the user edits them before saving as a dataset.
+ */
+export const agentEvalDraftCaseSchema = z.object({
+	input: z.string().min(1),
+	whatToCheck: z.string().min(1),
+});
+export type AgentEvalDraftCase = z.infer<typeof agentEvalDraftCaseSchema>;
+
+// Request body for the generate-cases endpoint. `count` is a positive int; the
+// service clamps it to its supported maximum rather than rejecting.
+const generateDraftCasesOptionsShape = {
+	count: z.number().int().min(1).optional(),
+	datasetName: z.string().min(1).optional(),
+};
+export const generateDraftCasesOptionsSchema = z.object(generateDraftCasesOptionsShape);
+export type GenerateDraftCasesOptions = z.infer<typeof generateDraftCasesOptionsSchema>;
+export class GenerateDraftCasesOptionsDto extends Z.class(generateDraftCasesOptionsShape) {}
+
+export type GenerateDraftCasesResult = {
+	datasetId: string;
+	dataTableId: string;
+	cases: AgentEvalDraftCase[];
 };

--- a/packages/@n8n/db/src/entities/agent-eval-dataset.ee.ts
+++ b/packages/@n8n/db/src/entities/agent-eval-dataset.ee.ts
@@ -1,19 +1,11 @@
-import type { DatasetRef } from '@n8n/api-types';
+import type { AgentEvalColumnMapping, DatasetRef } from '@n8n/api-types';
 import { Column, Entity, Index } from '@n8n/typeorm';
 
 import { JsonColumn, WithTimestampsAndStringId } from './abstract-entity';
 
-/**
- * Maps the roles an agent eval needs onto columns of the referenced dataset
- * (a Data Table or Google Sheet). Only `input` is required; a run without a
- * `expectedOutput`/`criteria` column simply has no reference answer or
- * per-case check to judge against.
- */
-export interface AgentEvalColumnMapping {
-	input: string;
-	expectedOutput?: string;
-	criteria?: string;
-}
+// The FE/BE contract for this shape lives in `@n8n/api-types`; re-exported so
+// existing db-internal consumers keep importing it from the entity.
+export type { AgentEvalColumnMapping };
 
 /**
  * A named, reusable eval setup for a single agent: which dataset to run and how

--- a/packages/@n8n/db/src/entities/agent-eval-rating.ee.ts
+++ b/packages/@n8n/db/src/entities/agent-eval-rating.ee.ts
@@ -1,10 +1,13 @@
+import type { AgentEvalVote } from '@n8n/api-types';
 import { Column, Entity, Index, ManyToOne } from '@n8n/typeorm';
 import type { JsonObject } from 'n8n-workflow';
 
 import { JsonColumn, WithTimestampsAndStringId } from './abstract-entity';
 import { AgentEvalResult } from './agent-eval-result.ee';
 
-export type AgentEvalVote = 'up' | 'down';
+// The FE/BE contract for this union lives in `@n8n/api-types`; re-exported so
+// existing db-internal consumers keep importing it from the entity.
+export type { AgentEvalVote };
 
 /**
  * A human's rating of an {@link AgentEvalResult}: a 👍/👎 vote plus an optional

--- a/packages/@n8n/db/src/entities/agent-eval-result.ee.ts
+++ b/packages/@n8n/db/src/entities/agent-eval-result.ee.ts
@@ -1,3 +1,4 @@
+import type { AgentEvalResultStatus } from '@n8n/api-types';
 import { Column, Entity, Index, ManyToOne, OneToMany } from '@n8n/typeorm';
 import type { IDataObject, JsonObject } from 'n8n-workflow';
 
@@ -5,7 +6,9 @@ import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from './abstrac
 import type { AgentEvalRating } from './agent-eval-rating.ee';
 import { AgentEvalRun } from './agent-eval-run.ee';
 
-export type AgentEvalResultStatus = 'new' | 'running' | 'success' | 'error' | 'cancelled';
+// The FE/BE contract for this union lives in `@n8n/api-types`; re-exported so
+// existing db-internal consumers keep importing it from the entity.
+export type { AgentEvalResultStatus };
 
 /**
  * Per-case outcome of an {@link AgentEvalRun}: the agent's output, tool-call

--- a/packages/@n8n/db/src/entities/agent-eval-run.ee.ts
+++ b/packages/@n8n/db/src/entities/agent-eval-run.ee.ts
@@ -1,3 +1,4 @@
+import type { AgentEvalRunStatus } from '@n8n/api-types';
 import { Column, Entity, Index, ManyToOne, OneToMany } from '@n8n/typeorm';
 import type { IDataObject } from 'n8n-workflow';
 
@@ -5,7 +6,9 @@ import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from './abstrac
 import { AgentEvalDataset } from './agent-eval-dataset.ee';
 import type { AgentEvalResult } from './agent-eval-result.ee';
 
-export type AgentEvalRunStatus = 'new' | 'running' | 'completed' | 'error' | 'cancelled';
+// The FE/BE contract for this union lives in `@n8n/api-types`; re-exported so
+// existing db-internal consumers keep importing it from the entity.
+export type { AgentEvalRunStatus };
 
 /**
  * One execution of an {@link AgentEvalDataset} against a specific agent version.

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-case-generation.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-case-generation.service.test.ts
@@ -6,7 +6,9 @@ import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import type { PostHogClient } from '@/posthog';
 
 import type { AgentConfigService } from '../../agents/agent-config.service';
@@ -74,6 +76,7 @@ describe('AgentEvalCaseGenerationService', () => {
 	let dataTableService: Mocked<DataTableService>;
 	let datasetRepository: Mocked<AgentEvalDatasetRepository>;
 	let postHogClient: Mocked<PostHogClient>;
+	let sourceControlPreferences: Mocked<SourceControlPreferencesService>;
 
 	beforeEach(() => {
 		logger = mock<Logger>();
@@ -83,6 +86,10 @@ describe('AgentEvalCaseGenerationService', () => {
 		dataTableService = mock<DataTableService>();
 		datasetRepository = mock<AgentEvalDatasetRepository>();
 		postHogClient = mock<PostHogClient>();
+		sourceControlPreferences = mock<SourceControlPreferencesService>();
+		sourceControlPreferences.getPreferences.mockReturnValue({
+			branchReadOnly: false,
+		} as ReturnType<SourceControlPreferencesService['getPreferences']>);
 
 		generateMock.mockReset();
 		resolveModelMock.mockReset();
@@ -101,6 +108,7 @@ describe('AgentEvalCaseGenerationService', () => {
 			dataTableService,
 			datasetRepository,
 			postHogClient,
+			sourceControlPreferences,
 		);
 	});
 
@@ -109,6 +117,17 @@ describe('AgentEvalCaseGenerationService', () => {
 
 		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
 			NotFoundError,
+		);
+		expect(agentConfigService.getConfig).not.toHaveBeenCalled();
+	});
+
+	it('rejects on a source-control read-only instance', async () => {
+		sourceControlPreferences.getPreferences.mockReturnValue({
+			branchReadOnly: true,
+		} as ReturnType<SourceControlPreferencesService['getPreferences']>);
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			ForbiddenError,
 		);
 		expect(agentConfigService.getConfig).not.toHaveBeenCalled();
 	});
@@ -198,13 +217,59 @@ describe('AgentEvalCaseGenerationService', () => {
 		expect(generateMock).toHaveBeenCalledTimes(2);
 	});
 
-	it('fails without persisting when the model returns no valid cases after a retry', async () => {
+	it('fails without persisting when the model returns no cases after a retry', async () => {
 		generateMock.mockResolvedValue({ structuredOutput: { cases: [] } });
 
 		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
-			/no valid cases/,
+			/fewer valid cases than requested/,
 		);
 		expect(dataTableService.createDataTable).not.toHaveBeenCalled();
+	});
+
+	it('fails without persisting when the model returns fewer cases than requested', async () => {
+		// Default count is 6; the model only returns 4 on both attempts.
+		generateMock.mockResolvedValue({ structuredOutput: { cases: makeCases(4) } });
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			/fewer valid cases than requested/,
+		);
+		expect(generateMock).toHaveBeenCalledTimes(2);
+		expect(dataTableService.createDataTable).not.toHaveBeenCalled();
+	});
+
+	it('retries when the first response is underfilled, then succeeds', async () => {
+		generateMock
+			.mockResolvedValueOnce({ structuredOutput: { cases: makeCases(4) } })
+			.mockResolvedValueOnce({ structuredOutput: { cases: makeCases(6) } });
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).resolves.toMatchObject({
+			datasetId: 'ds-1',
+		});
+		expect(generateMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('trims fields and drops blank cases from the model output', async () => {
+		generateMock.mockResolvedValue({
+			structuredOutput: {
+				cases: [
+					{ input: '  needs trimming  ', whatToCheck: '  ok  ' },
+					...makeCases(5),
+					{ input: '   ', whatToCheck: 'blank input dropped' },
+					{ input: 'blank check dropped', whatToCheck: '  ' },
+				],
+			},
+		});
+
+		const result = await service.generateDraftCases(user, 'project-1', 'agent-1');
+
+		// 8 returned, 2 blank dropped → 6 valid, capped at the requested 6.
+		expect(result.cases).toHaveLength(6);
+		expect(result.cases[0]).toEqual({ input: 'needs trimming', whatToCheck: 'ok' });
+		const insertedRows = dataTableService.insertRows.mock.calls[0][2] as Array<{
+			input: string;
+			criteria: string;
+		}>;
+		expect(insertedRows.every((r) => r.input.length > 0 && r.criteria.length > 0)).toBe(true);
 	});
 
 	it('cleans up the Data Table if inserting rows fails', async () => {

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-case-generation.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-case-generation.service.test.ts
@@ -1,0 +1,272 @@
+import type { AgentJsonConfig } from '@n8n/api-types';
+import { AGENT_EVALS_FLAG } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
+import type { AgentEvalDataset, AgentEvalDatasetRepository, User } from '@n8n/db';
+import type { Mocked } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { PostHogClient } from '@/posthog';
+
+import type { AgentConfigService } from '../../agents/agent-config.service';
+import type { DataTable } from '../../data-table/data-table.entity';
+import type { DataTableService } from '../../data-table/data-table.service';
+import { DataTableNameConflictError } from '../../data-table/errors/data-table-name-conflict.error';
+import { AgentEvalCaseGenerationService } from '../agent-eval-case-generation.service';
+
+// Stub the @n8n/agents SDK: fluent builder is a no-op; `generate` is a
+// controllable mock so tests drive the model's (in)valid structured output.
+const { generateMock } = vi.hoisted(() => ({ generateMock: vi.fn() }));
+vi.mock('@n8n/agents', () => ({
+	Agent: class {
+		model() {
+			return this;
+		}
+		instructions() {
+			return this;
+		}
+		structuredOutput() {
+			return this;
+		}
+		async generate(...args: unknown[]) {
+			return await generateMock(...args);
+		}
+	},
+}));
+
+// Model + credential resolution touches credentials/DB — stub it. The provider
+// support check (`isSupportedAgentProvider`) and `getProviderPrefix` stay real
+// so the "unsupported provider" path is exercised for real.
+const { resolveModelMock } = vi.hoisted(() => ({ resolveModelMock: vi.fn() }));
+vi.mock('../../agents/json-config/model-config', () => ({
+	resolveCredentialAwareModelConfig: (...args: unknown[]) => resolveModelMock(...args),
+}));
+vi.mock('../../agents/utils/agent-credential-provider', () => ({
+	createAgentCredentialProvider: vi.fn(() => ({})),
+}));
+
+const user = mock<User>({ id: 'user-1' });
+
+function makeConfig(over: Partial<AgentJsonConfig> = {}): AgentJsonConfig {
+	return {
+		name: 'Support Bot',
+		model: 'anthropic/claude-sonnet-4-5',
+		credential: 'cred-1',
+		instructions: 'Help customers with billing questions.',
+		tools: [{ type: 'node', name: 'lookupOrder', node: {} }],
+		...over,
+	} as AgentJsonConfig;
+}
+
+function makeCases(n: number) {
+	return Array.from({ length: n }, (_, i) => ({
+		input: `input ${i + 1}`,
+		whatToCheck: `check ${i + 1}`,
+	}));
+}
+
+describe('AgentEvalCaseGenerationService', () => {
+	let service: AgentEvalCaseGenerationService;
+	let logger: Mocked<Logger>;
+	let agentConfigService: Mocked<AgentConfigService>;
+	let credentialsService: Mocked<CredentialsService>;
+	let dataTableService: Mocked<DataTableService>;
+	let datasetRepository: Mocked<AgentEvalDatasetRepository>;
+	let postHogClient: Mocked<PostHogClient>;
+
+	beforeEach(() => {
+		logger = mock<Logger>();
+		logger.scoped.mockReturnValue(logger);
+		agentConfigService = mock<AgentConfigService>();
+		credentialsService = mock<CredentialsService>();
+		dataTableService = mock<DataTableService>();
+		datasetRepository = mock<AgentEvalDatasetRepository>();
+		postHogClient = mock<PostHogClient>();
+
+		generateMock.mockReset();
+		resolveModelMock.mockReset();
+		resolveModelMock.mockResolvedValue({ id: 'anthropic/claude-sonnet-4-5' });
+
+		postHogClient.getFeatureFlags.mockResolvedValue({ [AGENT_EVALS_FLAG]: true });
+		agentConfigService.getConfig.mockResolvedValue(makeConfig());
+		dataTableService.createDataTable.mockResolvedValue({ id: 'dt-1' } as DataTable);
+		dataTableService.insertRows.mockResolvedValue(undefined as never);
+		datasetRepository.createDataset.mockResolvedValue({ id: 'ds-1' } as AgentEvalDataset);
+
+		service = new AgentEvalCaseGenerationService(
+			logger,
+			agentConfigService,
+			credentialsService,
+			dataTableService,
+			datasetRepository,
+			postHogClient,
+		);
+	});
+
+	it('rejects when the agent-evals flag is disabled (as not-found, leaking no flag state)', async () => {
+		postHogClient.getFeatureFlags.mockResolvedValue({});
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			NotFoundError,
+		);
+		expect(agentConfigService.getConfig).not.toHaveBeenCalled();
+	});
+
+	it('rejects an agent without a configured model + credential', async () => {
+		agentConfigService.getConfig.mockResolvedValue(makeConfig({ model: '', credential: '' }));
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			/configured model and API-key credential/,
+		);
+		expect(generateMock).not.toHaveBeenCalled();
+	});
+
+	it('rejects a managed-credential agent (no bring-your-own key)', async () => {
+		agentConfigService.getConfig.mockResolvedValue(makeConfig({ credential: 'managed' }));
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			/configured model and API-key credential/,
+		);
+	});
+
+	it('rejects an unsupported model provider', async () => {
+		agentConfigService.getConfig.mockResolvedValue(makeConfig({ model: 'ollama/llama3' }));
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			/not supported for case generation/,
+		);
+		expect(generateMock).not.toHaveBeenCalled();
+	});
+
+	it('generates cases and persists them as a Data Table + dataset pointer', async () => {
+		const cases = makeCases(6);
+		generateMock.mockResolvedValue({ structuredOutput: { cases } });
+
+		const result = await service.generateDraftCases(user, 'project-1', 'agent-1');
+
+		// Prompt asks for the default count.
+		expect(generateMock).toHaveBeenCalledWith(
+			expect.stringContaining('Write exactly 6'),
+			expect.anything(),
+		);
+		// Table has the input + criteria string columns.
+		expect(dataTableService.createDataTable).toHaveBeenCalledWith('project-1', {
+			name: 'Draft cases for Support Bot',
+			columns: [
+				{ name: 'input', type: 'string' },
+				{ name: 'criteria', type: 'string' },
+			],
+		});
+		// Rows map input → input, whatToCheck → criteria.
+		expect(dataTableService.insertRows).toHaveBeenCalledWith(
+			'dt-1',
+			'project-1',
+			cases.map((c) => ({ input: c.input, criteria: c.whatToCheck })),
+		);
+		// Dataset points at the table and never carries an expectedOutput (no gold).
+		expect(datasetRepository.createDataset).toHaveBeenCalledWith({
+			name: 'Draft cases for Support Bot',
+			agentId: 'agent-1',
+			datasetSource: 'data_table',
+			datasetRef: { dataTableId: 'dt-1' },
+			columnMapping: { input: 'input', criteria: 'criteria' },
+			createdById: 'user-1',
+		});
+		expect(result).toEqual({ datasetId: 'ds-1', dataTableId: 'dt-1', cases });
+	});
+
+	it('honors a custom count in the prompt', async () => {
+		generateMock.mockResolvedValue({ structuredOutput: { cases: makeCases(3) } });
+
+		await service.generateDraftCases(user, 'project-1', 'agent-1', { count: 3 });
+
+		expect(generateMock).toHaveBeenCalledWith(
+			expect.stringContaining('Write exactly 3'),
+			expect.anything(),
+		);
+	});
+
+	it('retries once on invalid structured output, then succeeds', async () => {
+		generateMock
+			.mockResolvedValueOnce({ structuredOutput: { not: 'valid' } })
+			.mockResolvedValueOnce({ structuredOutput: { cases: makeCases(6) } });
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).resolves.toMatchObject({
+			datasetId: 'ds-1',
+		});
+		expect(generateMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('fails without persisting when the model returns no valid cases after a retry', async () => {
+		generateMock.mockResolvedValue({ structuredOutput: { cases: [] } });
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			/no valid cases/,
+		);
+		expect(dataTableService.createDataTable).not.toHaveBeenCalled();
+	});
+
+	it('cleans up the Data Table if inserting rows fails', async () => {
+		generateMock.mockResolvedValue({ structuredOutput: { cases: makeCases(6) } });
+		dataTableService.insertRows.mockRejectedValue(new Error('insert failed'));
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			'insert failed',
+		);
+		expect(dataTableService.deleteDataTable).toHaveBeenCalledWith('dt-1', 'project-1');
+		expect(datasetRepository.createDataset).not.toHaveBeenCalled();
+	});
+
+	it('cleans up the Data Table if creating the dataset pointer fails', async () => {
+		generateMock.mockResolvedValue({ structuredOutput: { cases: makeCases(6) } });
+		datasetRepository.createDataset.mockRejectedValue(new Error('dataset insert failed'));
+
+		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
+			'dataset insert failed',
+		);
+		// The rows were inserted, but the pointer failed — so the table must be rolled back.
+		expect(dataTableService.insertRows).toHaveBeenCalled();
+		expect(dataTableService.deleteDataTable).toHaveBeenCalledWith('dt-1', 'project-1');
+	});
+
+	it('caps and truncates untrusted model output before persisting', async () => {
+		// Model returns more cases than requested (default 6), with an oversized field.
+		const overLimit = Array.from({ length: 8 }, (_, i) => ({
+			input: i === 0 ? 'x'.repeat(5000) : `input ${i + 1}`,
+			whatToCheck: `check ${i + 1}`,
+		}));
+		generateMock.mockResolvedValue({ structuredOutput: { cases: overLimit } });
+
+		const result = await service.generateDraftCases(user, 'project-1', 'agent-1');
+
+		expect(result.cases).toHaveLength(6);
+		const insertedRows = dataTableService.insertRows.mock.calls[0][2] as Array<{
+			input: string;
+			criteria: string;
+		}>;
+		expect(insertedRows).toHaveLength(6);
+		expect(insertedRows[0].input).toHaveLength(2000);
+	});
+
+	it('retries with a suffixed name on a per-project name clash', async () => {
+		generateMock.mockResolvedValue({ structuredOutput: { cases: makeCases(6) } });
+		dataTableService.createDataTable
+			.mockRejectedValueOnce(new DataTableNameConflictError('Draft cases for Support Bot'))
+			.mockResolvedValueOnce({ id: 'dt-1' } as DataTable);
+
+		await service.generateDraftCases(user, 'project-1', 'agent-1');
+
+		expect(dataTableService.createDataTable).toHaveBeenCalledTimes(2);
+		expect(dataTableService.createDataTable).toHaveBeenLastCalledWith('project-1', {
+			name: 'Draft cases for Support Bot (2)',
+			columns: [
+				{ name: 'input', type: 'string' },
+				{ name: 'criteria', type: 'string' },
+			],
+		});
+		expect(datasetRepository.createDataset).toHaveBeenCalledWith(
+			expect.objectContaining({ name: 'Draft cases for Support Bot (2)' }),
+		);
+	});
+});

--- a/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
@@ -91,6 +91,12 @@ export class AgentEvalCaseGenerationService {
 		private readonly postHogClient: PostHogClient,
 	) {}
 
+	/**
+	 * Generate and persist draft cases for an agent. The caller is responsible for
+	 * authorizing `user` against `projectId` — the REST layer must apply
+	 * `@ProjectScope`. This resolves and uses the agent's own credential, so it
+	 * must never be exposed on an unscoped route.
+	 */
 	async generateDraftCases(
 		user: User,
 		projectId: string,
@@ -315,5 +321,5 @@ function suffixedName(baseName: string, n: number): string {
 }
 
 function truncateName(name: string, max = 128): string {
-	return name.length > max ? name.slice(0, max) : name;
+	return truncateText(name, max);
 }

--- a/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
@@ -8,7 +8,9 @@ import { Service } from '@n8n/di';
 import { OperationalError, UserError } from 'n8n-workflow';
 
 import { CredentialsService } from '@/credentials/credentials.service';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { PostHogClient } from '@/posthog';
 
 import { AgentConfigService } from '../agents/agent-config.service';
@@ -89,6 +91,7 @@ export class AgentEvalCaseGenerationService {
 		private readonly dataTableService: DataTableService,
 		private readonly datasetRepository: AgentEvalDatasetRepository,
 		private readonly postHogClient: PostHogClient,
+		private readonly sourceControlPreferencesService: SourceControlPreferencesService,
 	) {}
 
 	/**
@@ -104,6 +107,7 @@ export class AgentEvalCaseGenerationService {
 		options: GenerateDraftCasesOptions = {},
 	): Promise<GenerateDraftCasesResult> {
 		await this.assertFeatureEnabled(user);
+		this.assertInstanceWriteAccess();
 
 		const config = await this.agentConfigService.getConfig(agentId, projectId);
 		const modelConfig = await this.resolveAgentModel(config, projectId, user);
@@ -116,6 +120,7 @@ export class AgentEvalCaseGenerationService {
 		const generated = await this.invokeModel(
 			modelConfig,
 			buildCaseGenerationUserPrompt(summary, tuples),
+			tuples.length,
 		);
 		// Cap to the requested count and bound each field: the model output is
 		// untrusted, so a runaway or prompt-injected response can't balloon the
@@ -159,6 +164,19 @@ export class AgentEvalCaseGenerationService {
 	}
 
 	/**
+	 * Block writes on a source-control read-only (protected) instance. This
+	 * service writes a Data Table directly (bypassing the data-table controller),
+	 * so it must mirror the controller's guard.
+	 */
+	private assertInstanceWriteAccess(): void {
+		if (this.sourceControlPreferencesService.getPreferences().branchReadOnly) {
+			throw new ForbiddenError(
+				'Cannot generate eval cases on a protected instance. This instance is in read-only mode.',
+			);
+		}
+	}
+
+	/**
 	 * Resolve the agent's configured model + credential into a ready-to-use model
 	 * config, the same way the agent runtime does. Rejects agents without a usable
 	 * bring-your-own-key model (draft/unset, managed, or unsupported provider),
@@ -186,15 +204,18 @@ export class AgentEvalCaseGenerationService {
 	}
 
 	/**
-	 * Call the model to fill the sampled scenarios with concrete cases. One
-	 * stricter retry on invalid/empty structured output — a real model's JSON can
-	 * drift — then fail rather than persist an empty dataset. Intentionally
-	 * tool-less: the prompt embeds the agent's own (untrusted) instructions, so a
-	 * planted directive can only bias the drafts, never trigger a tool.
+	 * Call the model to fill the sampled scenarios with concrete cases. Trims each
+	 * field and drops blank ones, then requires at least `expectedCount` valid
+	 * cases so a partial (or empty) dataset is never persisted. One stricter retry
+	 * on invalid / underfilled output (a real model's JSON can drift), then fail.
+	 * Intentionally tool-less: the prompt embeds the agent's own (untrusted)
+	 * instructions, so a planted directive can only bias the drafts, never trigger
+	 * a tool.
 	 */
 	private async invokeModel(
 		modelConfig: Awaited<ReturnType<typeof resolveCredentialAwareModelConfig>>,
 		userPrompt: string,
+		expectedCount: number,
 	): Promise<AgentEvalDraftCase[]> {
 		// Lazy-load the agents SDK so it stays out of the boot path for instances
 		// that never generate cases.
@@ -209,19 +230,27 @@ export class AgentEvalCaseGenerationService {
 				abortSignal: AbortSignal.timeout(GENERATE_TIMEOUT_MS),
 			});
 			const parsed = generatedCasesSchema.safeParse(result.structuredOutput);
-			if (!parsed.success || parsed.data.cases.length === 0) return null;
-			return parsed.data.cases;
+			if (!parsed.success) return null;
+			// Trim and drop cases with a blank input or check — a whitespace-only
+			// field would persist an unusable draft row.
+			const cases = parsed.data.cases
+				.map((c) => ({ input: c.input.trim(), whatToCheck: c.whatToCheck.trim() }))
+				.filter((c) => c.input.length > 0 && c.whatToCheck.length > 0);
+			// Require the full requested count so a partial dataset is never persisted.
+			return cases.length >= expectedCount ? cases : null;
 		};
 
 		const first = await attempt(userPrompt);
 		if (first) return first;
 
 		const retry = await attempt(
-			`${userPrompt}\n\nReturn ONLY a JSON object matching the required schema exactly — no extra keys, no prose.`,
+			`${userPrompt}\n\nReturn ONLY a JSON object with exactly ${expectedCount} cases matching the required schema — no extra keys, no prose.`,
 		);
 		if (retry) return retry;
 
-		throw new OperationalError('Case generation returned no valid cases after a retry');
+		throw new OperationalError(
+			'Case generation returned fewer valid cases than requested after a retry',
+		);
 	}
 
 	/**

--- a/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
@@ -1,6 +1,13 @@
 import type { Agent } from '@n8n/agents';
 import { getProviderPrefix } from '@n8n/ai-utilities/agent-config';
-import { AGENT_EVALS_FLAG, MANAGED_CREDENTIAL_TOKEN, type AgentJsonConfig } from '@n8n/api-types';
+import {
+	AGENT_EVALS_FLAG,
+	MANAGED_CREDENTIAL_TOKEN,
+	type AgentEvalDraftCase,
+	type AgentJsonConfig,
+	type GenerateDraftCasesOptions,
+	type GenerateDraftCasesResult,
+} from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { AgentEvalDatasetRepository } from '@n8n/db';
@@ -20,7 +27,6 @@ import {
 	CASE_GENERATION_SYSTEM_PROMPT,
 	deriveCapabilities,
 	generatedCasesSchema,
-	type AgentEvalDraftCase,
 } from './case-generation/case-generation-prompt';
 import { sampleDimensionTuples } from './case-generation/dimensions';
 import { isSupportedAgentProvider } from '../agents/json-config/credential-field-mapping';
@@ -48,19 +54,6 @@ const CRITERIA_COLUMN = 'criteria';
 // How many name variants ("… (2)", "… (3)") to try before giving up on a
 // per-project name clash.
 const MAX_NAME_ATTEMPTS = 20;
-
-export interface GenerateDraftCasesOptions {
-	/** How many cases to generate (clamped to [1, 20]). Defaults to 6. */
-	count?: number;
-	/** Dataset/table name; defaults to one derived from the agent name. */
-	datasetName?: string;
-}
-
-export interface GenerateDraftCasesResult {
-	datasetId: string;
-	dataTableId: string;
-	cases: AgentEvalDraftCase[];
-}
 
 /**
  * Generates a handful of realistic draft eval cases from an agent's config

--- a/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
@@ -1,0 +1,319 @@
+import type { Agent } from '@n8n/agents';
+import { getProviderPrefix } from '@n8n/ai-utilities/agent-config';
+import { AGENT_EVALS_FLAG, MANAGED_CREDENTIAL_TOKEN, type AgentJsonConfig } from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import { AgentEvalDatasetRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { OperationalError, UserError } from 'n8n-workflow';
+
+import { CredentialsService } from '@/credentials/credentials.service';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { PostHogClient } from '@/posthog';
+
+import { AgentConfigService } from '../agents/agent-config.service';
+import {
+	buildAgentSummary,
+	buildCaseGenerationUserPrompt,
+	CASE_GENERATION_SYSTEM_PROMPT,
+	deriveCapabilities,
+	generatedCasesSchema,
+	type AgentEvalDraftCase,
+} from './case-generation/case-generation-prompt';
+import { sampleDimensionTuples } from './case-generation/dimensions';
+import { isSupportedAgentProvider } from '../agents/json-config/credential-field-mapping';
+import { resolveCredentialAwareModelConfig } from '../agents/json-config/model-config';
+import { createAgentCredentialProvider } from '../agents/utils/agent-credential-provider';
+import { DataTableService } from '../data-table/data-table.service';
+import { DataTableNameConflictError } from '../data-table/errors/data-table-name-conflict.error';
+
+const DEFAULT_CASE_COUNT = 6;
+const MAX_CASE_COUNT = 20;
+
+// Upper bound per generated field. The model output is untrusted (the prompt
+// embeds the agent's own instructions), so persisted text can't balloon.
+const MAX_CASE_TEXT_CHARS = 2_000;
+
+// Bound a single generation so a hung provider can't pin the request.
+const GENERATE_TIMEOUT_MS = 60_000;
+
+// Dataset column roles → generated fields. `input` is the user message;
+// `criteria` holds the plain-language "what to check". No `expectedOutput`:
+// drafts have no gold answer and are never auto-graded.
+const INPUT_COLUMN = 'input';
+const CRITERIA_COLUMN = 'criteria';
+
+// How many name variants ("… (2)", "… (3)") to try before giving up on a
+// per-project name clash.
+const MAX_NAME_ATTEMPTS = 20;
+
+export interface GenerateDraftCasesOptions {
+	/** How many cases to generate (clamped to [1, 20]). Defaults to 6. */
+	count?: number;
+	/** Dataset/table name; defaults to one derived from the agent name. */
+	datasetName?: string;
+}
+
+export interface GenerateDraftCasesResult {
+	datasetId: string;
+	dataTableId: string;
+	cases: AgentEvalDraftCase[];
+}
+
+/**
+ * Generates a handful of realistic draft eval cases from an agent's config
+ * (name / instructions / tools) and persists them as an editable dataset.
+ *
+ * Uses dimension-tuple synthesis (see {@link sampleDimensionTuples}) rather than
+ * a one-shot "give me test queries" call, so the cases vary across capability,
+ * difficulty, and input flavor instead of clustering on the happy path. The
+ * tuples are sampled deterministically in code and the model fills each with a
+ * concrete `input` + plain-language `whatToCheck`.
+ *
+ * The generation call reuses the agent's own model + credential (resolved
+ * exactly as the agent runtime does, via {@link resolveCredentialAwareModelConfig}),
+ * so no separate provider config or entitlement is needed — the builder's own
+ * API key does the work.
+ *
+ * Output is persisted as a Data Table (the cases are its rows) with an
+ * {@link AgentEvalDataset} pointing at it — the same dataset mechanism the
+ * agent-eval runner reads. Framed as drafts: the user reviews and edits them;
+ * they are never auto-graded.
+ */
+@Service()
+export class AgentEvalCaseGenerationService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly agentConfigService: AgentConfigService,
+		private readonly credentialsService: CredentialsService,
+		private readonly dataTableService: DataTableService,
+		private readonly datasetRepository: AgentEvalDatasetRepository,
+		private readonly postHogClient: PostHogClient,
+	) {}
+
+	async generateDraftCases(
+		user: User,
+		projectId: string,
+		agentId: string,
+		options: GenerateDraftCasesOptions = {},
+	): Promise<GenerateDraftCasesResult> {
+		await this.assertFeatureEnabled(user);
+
+		const config = await this.agentConfigService.getConfig(agentId, projectId);
+		const modelConfig = await this.resolveAgentModel(config, projectId, user);
+
+		const count = clampCount(options.count);
+		const capabilities = deriveCapabilities(config);
+		const tuples = sampleDimensionTuples(capabilities, count);
+
+		const summary = buildAgentSummary(config);
+		const generated = await this.invokeModel(
+			modelConfig,
+			buildCaseGenerationUserPrompt(summary, tuples),
+		);
+		// Cap to the requested count and bound each field: the model output is
+		// untrusted, so a runaway or prompt-injected response can't balloon the
+		// persisted dataset.
+		const cases = boundCases(generated, tuples.length);
+
+		// Blank/whitespace names fall back to the agent-derived default.
+		const trimmedName = options.datasetName?.trim();
+		const baseName =
+			trimmedName && trimmedName.length > 0 ? trimmedName : defaultDatasetName(config.name);
+
+		const { datasetId, dataTableId } = await this.persistDataset(
+			projectId,
+			agentId,
+			user.id,
+			baseName,
+			cases,
+		);
+
+		this.logger.debug('Generated draft eval cases', {
+			agentId,
+			datasetId,
+			caseCount: cases.length,
+		});
+
+		return { datasetId, dataTableId, cases };
+	}
+
+	// ---- internals ----
+
+	/**
+	 * Gate on the agent-evals rollout flag (honors the env override). Throws
+	 * NotFoundError rather than Forbidden so a flag-off instance looks like an
+	 * unknown feature and leaks no flag state (matching the eval-collections gate).
+	 */
+	private async assertFeatureEnabled(user: User): Promise<void> {
+		const flags = await this.postHogClient.getFeatureFlags(user);
+		if (flags?.[AGENT_EVALS_FLAG] !== true) {
+			throw new NotFoundError('Not found');
+		}
+	}
+
+	/**
+	 * Resolve the agent's configured model + credential into a ready-to-use model
+	 * config, the same way the agent runtime does. Rejects agents without a usable
+	 * bring-your-own-key model (draft/unset, managed, or unsupported provider),
+	 * since generation calls the provider directly with that credential.
+	 */
+	private async resolveAgentModel(config: AgentJsonConfig, projectId: string, user: User) {
+		const { model, credential } = config;
+		if (!model || !credential || credential === MANAGED_CREDENTIAL_TOKEN) {
+			throw new UserError(
+				'This agent needs a configured model and API-key credential before draft cases can be generated.',
+			);
+		}
+		if (!isSupportedAgentProvider(getProviderPrefix(model))) {
+			throw new UserError(
+				`The agent's model provider is not supported for case generation ("${model}").`,
+			);
+		}
+
+		const credentialProvider = createAgentCredentialProvider(
+			this.credentialsService,
+			projectId,
+			user,
+		);
+		return await resolveCredentialAwareModelConfig(model, credential, credentialProvider);
+	}
+
+	/**
+	 * Call the model to fill the sampled scenarios with concrete cases. One
+	 * stricter retry on invalid/empty structured output — a real model's JSON can
+	 * drift — then fail rather than persist an empty dataset. Intentionally
+	 * tool-less: the prompt embeds the agent's own (untrusted) instructions, so a
+	 * planted directive can only bias the drafts, never trigger a tool.
+	 */
+	private async invokeModel(
+		modelConfig: Awaited<ReturnType<typeof resolveCredentialAwareModelConfig>>,
+		userPrompt: string,
+	): Promise<AgentEvalDraftCase[]> {
+		// Lazy-load the agents SDK so it stays out of the boot path for instances
+		// that never generate cases.
+		const { Agent } = await import('@n8n/agents');
+		const agent: Agent = new Agent('agent-eval-case-generation')
+			.model(modelConfig)
+			.instructions(CASE_GENERATION_SYSTEM_PROMPT)
+			.structuredOutput(generatedCasesSchema);
+
+		const attempt = async (prompt: string): Promise<AgentEvalDraftCase[] | null> => {
+			const result = await agent.generate(prompt, {
+				abortSignal: AbortSignal.timeout(GENERATE_TIMEOUT_MS),
+			});
+			const parsed = generatedCasesSchema.safeParse(result.structuredOutput);
+			if (!parsed.success || parsed.data.cases.length === 0) return null;
+			return parsed.data.cases;
+		};
+
+		const first = await attempt(userPrompt);
+		if (first) return first;
+
+		const retry = await attempt(
+			`${userPrompt}\n\nReturn ONLY a JSON object matching the required schema exactly — no extra keys, no prose.`,
+		);
+		if (retry) return retry;
+
+		throw new OperationalError('Case generation returned no valid cases after a retry');
+	}
+
+	/**
+	 * Create the backing Data Table (input + criteria columns), insert the rows,
+	 * and create the dataset pointer. Retries on a per-project name clash with a
+	 * numeric suffix. If anything after table creation fails (row insert or dataset
+	 * creation), the table is deleted so a populated-but-unreferenced dataset is
+	 * never left behind; a cleanup failure is logged without masking the original
+	 * error.
+	 */
+	private async persistDataset(
+		projectId: string,
+		agentId: string,
+		createdById: string,
+		baseName: string,
+		cases: AgentEvalDraftCase[],
+	): Promise<{ datasetId: string; dataTableId: string }> {
+		const columns = [
+			{ name: INPUT_COLUMN, type: 'string' as const },
+			{ name: CRITERIA_COLUMN, type: 'string' as const },
+		];
+
+		let table: Awaited<ReturnType<DataTableService['createDataTable']>> | undefined;
+		let name = baseName;
+		for (let attempt = 0; table === undefined; attempt++) {
+			name = attempt === 0 ? baseName : suffixedName(baseName, attempt + 1);
+			try {
+				table = await this.dataTableService.createDataTable(projectId, { name, columns });
+			} catch (error) {
+				if (error instanceof DataTableNameConflictError && attempt < MAX_NAME_ATTEMPTS - 1) {
+					continue;
+				}
+				throw error;
+			}
+		}
+
+		try {
+			const rows = cases.map((c) => ({
+				[INPUT_COLUMN]: c.input,
+				[CRITERIA_COLUMN]: c.whatToCheck,
+			}));
+			await this.dataTableService.insertRows(table.id, projectId, rows);
+
+			const dataset = await this.datasetRepository.createDataset({
+				name,
+				agentId,
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: table.id },
+				columnMapping: { input: INPUT_COLUMN, criteria: CRITERIA_COLUMN },
+				createdById,
+			});
+			return { datasetId: dataset.id, dataTableId: table.id };
+		} catch (error) {
+			await this.rollBackDataTable(table.id, projectId);
+			throw error;
+		}
+	}
+
+	/** Delete a just-created table after a failed persist; never mask the cause. */
+	private async rollBackDataTable(dataTableId: string, projectId: string): Promise<void> {
+		try {
+			await this.dataTableService.deleteDataTable(dataTableId, projectId);
+		} catch (cleanupError) {
+			this.logger.error('Failed to clean up data table after case-generation failure', {
+				dataTableId,
+				error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+			});
+		}
+	}
+}
+
+/** Cap the model output to the requested count and bound each field's length. */
+function boundCases(cases: AgentEvalDraftCase[], limit: number): AgentEvalDraftCase[] {
+	return cases.slice(0, limit).map((c) => ({
+		input: truncateText(c.input, MAX_CASE_TEXT_CHARS),
+		whatToCheck: truncateText(c.whatToCheck, MAX_CASE_TEXT_CHARS),
+	}));
+}
+
+function truncateText(text: string, max: number): string {
+	return text.length > max ? text.slice(0, max) : text;
+}
+
+function clampCount(count: number | undefined): number {
+	if (count === undefined || !Number.isFinite(count)) return DEFAULT_CASE_COUNT;
+	return Math.min(Math.max(Math.trunc(count), 1), MAX_CASE_COUNT);
+}
+
+function defaultDatasetName(agentName: string): string {
+	return truncateName(`Draft cases for ${agentName}`);
+}
+
+/** Append " (n)" while keeping the whole name within the 128-char limit. */
+function suffixedName(baseName: string, n: number): string {
+	const suffix = ` (${n})`;
+	return `${truncateName(baseName, 128 - suffix.length)}${suffix}`;
+}
+
+function truncateName(name: string, max = 128): string {
+	return name.length > max ? name.slice(0, max) : name;
+}

--- a/packages/cli/src/modules/agent-evals/case-generation/__tests__/case-generation-prompt.test.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/__tests__/case-generation-prompt.test.ts
@@ -50,6 +50,16 @@ describe('buildAgentSummary', () => {
 		expect(summary.tools[0].description).toBeUndefined();
 	});
 
+	it('caps very long tool/capability labels', () => {
+		const longName = 'n'.repeat(500);
+		const cfg = config({
+			tools: [{ type: 'node', name: longName, node: {} }] as AgentJsonConfig['tools'],
+		});
+		// 100-char cap + a single ellipsis character.
+		expect(buildAgentSummary(cfg).tools[0].name.length).toBeLessThanOrEqual(101);
+		expect(deriveCapabilities(cfg)[0].length).toBeLessThanOrEqual(101);
+	});
+
 	it('caps the number of tools in the summary', () => {
 		const many = Array.from({ length: 40 }, (_, i) => ({
 			type: 'node' as const,

--- a/packages/cli/src/modules/agent-evals/case-generation/__tests__/case-generation-prompt.test.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/__tests__/case-generation-prompt.test.ts
@@ -1,0 +1,94 @@
+import type { AgentJsonConfig } from '@n8n/api-types';
+
+import {
+	buildAgentSummary,
+	buildCaseGenerationUserPrompt,
+	deriveCapabilities,
+} from '../case-generation-prompt';
+import type { DimensionTuple } from '../dimensions';
+
+function config(over: Partial<AgentJsonConfig> = {}): AgentJsonConfig {
+	return {
+		name: 'Bot',
+		model: 'anthropic/claude-sonnet-4-5',
+		credential: 'cred-1',
+		instructions: 'Do useful things.',
+		...over,
+	} as AgentJsonConfig;
+}
+
+describe('buildAgentSummary', () => {
+	it('truncates very long instructions', () => {
+		const summary = buildAgentSummary(config({ instructions: 'a'.repeat(5000) }));
+		expect(summary.instructions).toHaveLength(4001); // 4000 chars + ellipsis
+		expect(summary.instructions.endsWith('…')).toBe(true);
+	});
+
+	it('names tools by kind: custom→id, node/workflow→name (falling back to the kind)', () => {
+		const summary = buildAgentSummary(
+			config({
+				tools: [
+					{ type: 'custom', id: 'myTool' },
+					{ type: 'node', name: 'lookupOrder', node: {}, description: 'looks up orders' },
+					{ type: 'workflow', workflow: 'wf1' },
+				] as AgentJsonConfig['tools'],
+			}),
+		);
+		expect(summary.tools.map((t) => t.name)).toEqual(['myTool', 'lookupOrder', 'workflow']);
+		expect(summary.tools[1].description).toBe('looks up orders');
+		expect(summary.tools[0].description).toBeUndefined();
+	});
+
+	it('drops blank tool descriptions', () => {
+		const summary = buildAgentSummary(
+			config({
+				tools: [
+					{ type: 'node', name: 'n', node: {}, description: '   ' },
+				] as AgentJsonConfig['tools'],
+			}),
+		);
+		expect(summary.tools[0].description).toBeUndefined();
+	});
+
+	it('caps the number of tools in the summary', () => {
+		const many = Array.from({ length: 40 }, (_, i) => ({
+			type: 'node' as const,
+			name: `tool${i}`,
+			node: {},
+		}));
+		const summary = buildAgentSummary(config({ tools: many as AgentJsonConfig['tools'] }));
+		expect(summary.tools).toHaveLength(30);
+	});
+});
+
+describe('deriveCapabilities', () => {
+	it('combines tools, skills, MCP servers, and vector stores, deduped', () => {
+		const caps = deriveCapabilities(
+			config({
+				tools: [{ type: 'node', name: 'searchWeb', node: {} }] as AgentJsonConfig['tools'],
+				skills: [{ id: 'writeEmail' }] as AgentJsonConfig['skills'],
+				mcpServers: [{ name: 'github' }] as AgentJsonConfig['mcpServers'],
+				vectorStores: [{ name: 'docs' }] as AgentJsonConfig['vectorStores'],
+			}),
+		);
+		expect(caps).toEqual(expect.arrayContaining(['searchWeb', 'writeEmail', 'github', 'docs']));
+	});
+
+	it('returns empty when the agent declares no capabilities', () => {
+		expect(deriveCapabilities(config())).toEqual([]);
+	});
+});
+
+describe('buildCaseGenerationUserPrompt', () => {
+	it('asks for exactly one case per tuple and names each capability', () => {
+		const tuples: DimensionTuple[] = [
+			{ capability: 'general', difficulty: 'simple', flavor: 'happy_path' },
+			{ capability: 'searchWeb', difficulty: 'multi_step', flavor: 'adversarial' },
+		];
+		const prompt = buildCaseGenerationUserPrompt(buildAgentSummary(config()), tuples);
+		expect(prompt).toContain('Write exactly 2');
+		expect(prompt).toMatch(/^1\. /m);
+		expect(prompt).toMatch(/^2\. /m);
+		expect(prompt).toContain('searchWeb');
+	});
+});

--- a/packages/cli/src/modules/agent-evals/case-generation/__tests__/dimensions.test.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/__tests__/dimensions.test.ts
@@ -1,0 +1,58 @@
+import {
+	CASE_DIFFICULTIES,
+	CASE_INPUT_FLAVORS,
+	GENERAL_CAPABILITY,
+	sampleDimensionTuples,
+} from '../dimensions';
+
+describe('sampleDimensionTuples', () => {
+	const key = (t: { capability: string; difficulty: string; flavor: string }) =>
+		`${t.capability}|${t.difficulty}|${t.flavor}`;
+
+	it('returns exactly `count` tuples', () => {
+		expect(sampleDimensionTuples(['a', 'b'], 6)).toHaveLength(6);
+		expect(sampleDimensionTuples([], 3)).toHaveLength(3);
+	});
+
+	it('returns nothing for a non-positive count', () => {
+		expect(sampleDimensionTuples(['a'], 0)).toEqual([]);
+		expect(sampleDimensionTuples(['a'], -2)).toEqual([]);
+	});
+
+	it('falls back to the general capability when none are supplied', () => {
+		const tuples = sampleDimensionTuples([], 4);
+		expect(tuples.every((t) => t.capability === GENERAL_CAPABILITY)).toBe(true);
+	});
+
+	it('is deterministic for identical inputs', () => {
+		expect(sampleDimensionTuples(['x', 'y'], 5)).toEqual(sampleDimensionTuples(['x', 'y'], 5));
+	});
+
+	it('produces only valid difficulties and flavors', () => {
+		for (const tuple of sampleDimensionTuples(['a', 'b', 'c'], 12)) {
+			expect(CASE_DIFFICULTIES).toContain(tuple.difficulty);
+			expect(CASE_INPUT_FLAVORS).toContain(tuple.flavor);
+		}
+	});
+
+	it('spreads across the grid without duplicates when count < grid size', () => {
+		// grid = 1 cap × 2 difficulties × 4 flavors = 8; ask for 6 distinct.
+		const tuples = sampleDimensionTuples([GENERAL_CAPABILITY], 6);
+		expect(new Set(tuples.map(key)).size).toBe(6);
+		// A small sample should still touch every flavor.
+		expect(new Set(tuples.map((t) => t.flavor)).size).toBe(CASE_INPUT_FLAVORS.length);
+	});
+
+	it('spreads across every capability', () => {
+		const caps = ['tool-a', 'tool-b', 'tool-c'];
+		const tuples = sampleDimensionTuples(caps, caps.length * 2);
+		expect(new Set(tuples.map((t) => t.capability))).toEqual(new Set(caps));
+	});
+
+	it('cycles the grid when count exceeds the grid size', () => {
+		// grid = 8; ask for 10 → still 10, cycling back through the grid.
+		const tuples = sampleDimensionTuples([GENERAL_CAPABILITY], 10);
+		expect(tuples).toHaveLength(10);
+		expect(tuples[8]).toEqual(tuples[0]);
+	});
+});

--- a/packages/cli/src/modules/agent-evals/case-generation/__tests__/dimensions.test.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/__tests__/dimensions.test.ts
@@ -49,6 +49,17 @@ describe('sampleDimensionTuples', () => {
 		expect(new Set(tuples.map((t) => t.capability))).toEqual(new Set(caps));
 	});
 
+	it('varies difficulty within each capability (difficulty decorrelated from capability)', () => {
+		// With 2 capabilities and 2 difficulties, naive `i % n` indexing would lock
+		// each capability to a single difficulty; assert both appear per capability.
+		const caps = ['a', 'b'];
+		const tuples = sampleDimensionTuples(caps, 8);
+		for (const cap of caps) {
+			const diffs = new Set(tuples.filter((t) => t.capability === cap).map((t) => t.difficulty));
+			expect(diffs).toEqual(new Set(CASE_DIFFICULTIES));
+		}
+	});
+
 	it('cycles the grid when count exceeds the grid size', () => {
 		// grid = 8; ask for 10 → still 10, cycling back through the grid.
 		const tuples = sampleDimensionTuples([GENERAL_CAPABILITY], 10);

--- a/packages/cli/src/modules/agent-evals/case-generation/case-generation-prompt.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/case-generation-prompt.ts
@@ -30,8 +30,6 @@ export const generatedCasesSchema = z.object({
 	cases: z.array(draftCaseSchema),
 });
 
-export type GeneratedCases = z.infer<typeof generatedCasesSchema>;
-
 // Bound the prompt so token cost stays predictable regardless of how large the
 // agent's own instructions/toolset are.
 const MAX_INSTRUCTIONS_CHARS = 4000;

--- a/packages/cli/src/modules/agent-evals/case-generation/case-generation-prompt.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/case-generation-prompt.ts
@@ -1,0 +1,149 @@
+import type { AgentJsonConfig, AgentJsonToolConfig } from '@n8n/api-types';
+import { z } from 'zod';
+
+import {
+	GENERAL_CAPABILITY,
+	type CaseDifficulty,
+	type CaseInputFlavor,
+	type DimensionTuple,
+} from './dimensions';
+
+/** A single draft case: what to send the agent + a plain-language check. */
+export interface AgentEvalDraftCase {
+	/** A realistic end-user message to send the agent. */
+	input: string;
+	/** Plain-language description of what a good response should do. */
+	whatToCheck: string;
+}
+
+const draftCaseSchema = z.object({
+	input: z.string().min(1),
+	whatToCheck: z.string().min(1),
+});
+
+/**
+ * Structured-output schema for the generation call. Wrapping the array in an
+ * object (rather than a bare array) is more reliable across providers' JSON
+ * modes.
+ */
+export const generatedCasesSchema = z.object({
+	cases: z.array(draftCaseSchema),
+});
+
+export type GeneratedCases = z.infer<typeof generatedCasesSchema>;
+
+// Bound the prompt so token cost stays predictable regardless of how large the
+// agent's own instructions/toolset are.
+const MAX_INSTRUCTIONS_CHARS = 4000;
+const MAX_TOOLS_IN_PROMPT = 30;
+const MAX_TOOL_DESCRIPTION_CHARS = 200;
+
+/** Bounded, prompt-safe view of the agent's config. */
+export interface AgentConfigSummary {
+	name: string;
+	instructions: string;
+	tools: Array<{ name: string; description?: string }>;
+}
+
+function truncate(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/** Human-readable name for a configured tool, by tool kind. */
+function toolDisplayName(tool: AgentJsonToolConfig): string {
+	if (tool.type === 'custom') return tool.id;
+	return tool.name ?? tool.type;
+}
+
+export function buildAgentSummary(config: AgentJsonConfig): AgentConfigSummary {
+	const tools = (config.tools ?? []).slice(0, MAX_TOOLS_IN_PROMPT).map((tool) => {
+		// Empty/whitespace descriptions collapse to falsy and are dropped below.
+		const description = tool.type === 'custom' ? undefined : tool.description?.trim();
+		return {
+			name: toolDisplayName(tool),
+			...(description ? { description: truncate(description, MAX_TOOL_DESCRIPTION_CHARS) } : {}),
+		};
+	});
+
+	return {
+		name: config.name,
+		instructions: truncate(config.instructions ?? '', MAX_INSTRUCTIONS_CHARS),
+		tools,
+	};
+}
+
+/**
+ * Capability labels the case sampler varies over: the agent's tool/skill names.
+ * Deduped and bounded; empty when the agent has none (the sampler then falls
+ * back to a single `general` capability).
+ */
+export function deriveCapabilities(config: AgentJsonConfig): string[] {
+	const labels = [
+		...(config.tools ?? []).map(toolDisplayName),
+		...(config.skills ?? []).map((skill) => skill.id),
+		...(config.mcpServers ?? []).map((server) => server.name),
+		...(config.vectorStores ?? []).map((store) => store.name),
+	];
+	return [...new Set(labels.filter((label) => label.trim().length > 0))].slice(
+		0,
+		MAX_TOOLS_IN_PROMPT,
+	);
+}
+
+const DIFFICULTY_HINT: Record<CaseDifficulty, string> = {
+	simple: 'a single, direct request the agent can answer in one step',
+	multi_step: 'a request that requires several steps or combining multiple pieces of information',
+};
+
+const FLAVOR_HINT: Record<CaseInputFlavor, string> = {
+	happy_path: 'a clear, well-formed request squarely within what the agent is meant to do',
+	underspecified:
+		'a vague or incomplete request missing details the agent should ask about or reasonably assume',
+	out_of_scope:
+		'a plausible request that falls outside the stated purpose, to check the agent declines gracefully',
+	adversarial:
+		'a request that tries to push the agent off its instructions (e.g. ignore its rules), to check it stays on task',
+};
+
+/** One scenario line for the prompt, derived from a dimension tuple. */
+function describeTuple(tuple: DimensionTuple): string {
+	const capability =
+		tuple.capability === GENERAL_CAPABILITY
+			? 'the general purpose of the agent'
+			: `the "${tuple.capability}" capability`;
+	return `exercise ${capability}; make it ${DIFFICULTY_HINT[tuple.difficulty]}; the input should be ${FLAVOR_HINT[tuple.flavor]}`;
+}
+
+export const CASE_GENERATION_SYSTEM_PROMPT = [
+	'You generate realistic test cases for evaluating a specific AI agent.',
+	'Each test case has two fields:',
+	'- `input`: a realistic message an end user would actually send this agent.',
+	'- `whatToCheck`: a short, plain-language description of what a good response should do — NOT a score, NOT code, NOT a rubric.',
+	'',
+	'Rules:',
+	'- Ground every case in the actual name, instructions, and tools of the agent below. Do not invent capabilities it does not have.',
+	'- These are DRAFTS a human will review and edit. Never assume a single "correct" answer or write grading logic.',
+	'- Write one case per numbered scenario, in order, following the guidance for that scenario.',
+	'- Keep each `input` natural and self-contained (no placeholders like "<name>").',
+].join('\n');
+
+/**
+ * Build the user prompt: the bounded agent summary plus one numbered scenario
+ * per sampled tuple. The model is asked to return exactly one case per scenario,
+ * in order, matching {@link generatedCasesSchema}.
+ */
+export function buildCaseGenerationUserPrompt(
+	summary: AgentConfigSummary,
+	tuples: DimensionTuple[],
+): string {
+	const scenarios = tuples.map((tuple, i) => `${i + 1}. ${describeTuple(tuple)}`).join('\n');
+	return [
+		'Here is the agent to write test cases for:',
+		JSON.stringify(summary),
+		'',
+		`Write exactly ${tuples.length} test cases — one for each numbered scenario below, in the same order:`,
+		scenarios,
+		'',
+		'Return a JSON object of the form { "cases": [ { "input": "…", "whatToCheck": "…" }, … ] }.',
+	].join('\n');
+}

--- a/packages/cli/src/modules/agent-evals/case-generation/case-generation-prompt.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/case-generation-prompt.ts
@@ -1,4 +1,8 @@
-import type { AgentJsonConfig, AgentJsonToolConfig } from '@n8n/api-types';
+import {
+	agentEvalDraftCaseSchema,
+	type AgentJsonConfig,
+	type AgentJsonToolConfig,
+} from '@n8n/api-types';
 import { z } from 'zod';
 
 import {
@@ -8,28 +12,14 @@ import {
 	type DimensionTuple,
 } from './dimensions';
 
-/** A single draft case: what to send the agent + a plain-language check. */
-export interface AgentEvalDraftCase {
-	/** A realistic end-user message to send the agent. */
-	input: string;
-	/** Plain-language description of what a good response should do. */
-	whatToCheck: string;
-}
-
-// Structural only: blank/whitespace fields are trimmed and dropped by the
-// service, so a single bad case doesn't invalidate an otherwise-good batch.
-const draftCaseSchema = z.object({
-	input: z.string(),
-	whatToCheck: z.string(),
-});
-
 /**
- * Structured-output schema for the generation call. Wrapping the array in an
- * object (rather than a bare array) is more reliable across providers' JSON
- * modes.
+ * LLM-output envelope for the generation call. Kept local — it's a parsing
+ * detail, not an FE/BE contract. Wrapping the array in an object (rather than a
+ * bare array) is more reliable across providers' JSON modes; the per-case shape
+ * is the shared `agentEvalDraftCaseSchema`.
  */
 export const generatedCasesSchema = z.object({
-	cases: z.array(draftCaseSchema),
+	cases: z.array(agentEvalDraftCaseSchema),
 });
 
 // Bound the prompt so token cost stays predictable regardless of how large the

--- a/packages/cli/src/modules/agent-evals/case-generation/case-generation-prompt.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/case-generation-prompt.ts
@@ -16,9 +16,11 @@ export interface AgentEvalDraftCase {
 	whatToCheck: string;
 }
 
+// Structural only: blank/whitespace fields are trimmed and dropped by the
+// service, so a single bad case doesn't invalidate an otherwise-good batch.
 const draftCaseSchema = z.object({
-	input: z.string().min(1),
-	whatToCheck: z.string().min(1),
+	input: z.string(),
+	whatToCheck: z.string(),
 });
 
 /**
@@ -35,6 +37,9 @@ export const generatedCasesSchema = z.object({
 const MAX_INSTRUCTIONS_CHARS = 4000;
 const MAX_TOOLS_IN_PROMPT = 30;
 const MAX_TOOL_DESCRIPTION_CHARS = 200;
+// Tool/skill/capability names are unbounded in the agent config schema; cap each
+// label so a pathologically long name can't blow the prompt's token budget.
+const MAX_LABEL_CHARS = 100;
 
 /** Bounded, prompt-safe view of the agent's config. */
 export interface AgentConfigSummary {
@@ -47,10 +52,10 @@ function truncate(text: string, max: number): string {
 	return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
-/** Human-readable name for a configured tool, by tool kind. */
+/** Human-readable, length-capped name for a configured tool, by tool kind. */
 function toolDisplayName(tool: AgentJsonToolConfig): string {
-	if (tool.type === 'custom') return tool.id;
-	return tool.name ?? tool.type;
+	const name = tool.type === 'custom' ? tool.id : (tool.name ?? tool.type);
+	return truncate(name, MAX_LABEL_CHARS);
 }
 
 export function buildAgentSummary(config: AgentJsonConfig): AgentConfigSummary {
@@ -78,9 +83,9 @@ export function buildAgentSummary(config: AgentJsonConfig): AgentConfigSummary {
 export function deriveCapabilities(config: AgentJsonConfig): string[] {
 	const labels = [
 		...(config.tools ?? []).map(toolDisplayName),
-		...(config.skills ?? []).map((skill) => skill.id),
-		...(config.mcpServers ?? []).map((server) => server.name),
-		...(config.vectorStores ?? []).map((store) => store.name),
+		...(config.skills ?? []).map((skill) => truncate(skill.id, MAX_LABEL_CHARS)),
+		...(config.mcpServers ?? []).map((server) => truncate(server.name, MAX_LABEL_CHARS)),
+		...(config.vectorStores ?? []).map((store) => truncate(store.name, MAX_LABEL_CHARS)),
 	];
 	return [...new Set(labels.filter((label) => label.trim().length > 0))].slice(
 		0,

--- a/packages/cli/src/modules/agent-evals/case-generation/dimensions.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/dimensions.ts
@@ -1,0 +1,100 @@
+/**
+ * Dimension-tuple synthesis for draft eval cases.
+ *
+ * Instead of asking the model for "N test queries" in one shot — which tends to
+ * return near-duplicates clustered on the happy path — we vary the cases along
+ * independent axes and generate one case per (capability, difficulty, flavor)
+ * tuple. The tuple set is sampled *in code* (deterministically), so coverage is
+ * predictable and testable; the model only fills each tuple with concrete text.
+ */
+
+/** How much work a case implies for the agent. */
+export type CaseDifficulty = 'simple' | 'multi_step';
+
+/**
+ * The shape of the user input, so the sample spans well-formed requests as well
+ * as the messy ones a real agent has to cope with.
+ */
+export type CaseInputFlavor = 'happy_path' | 'underspecified' | 'out_of_scope' | 'adversarial';
+
+/** One point in the dimension space; becomes exactly one generated case. */
+export interface DimensionTuple {
+	/** A capability of the agent (tool/skill name), or `general` when it has none. */
+	capability: string;
+	difficulty: CaseDifficulty;
+	flavor: CaseInputFlavor;
+}
+
+export const CASE_DIFFICULTIES: readonly CaseDifficulty[] = ['simple', 'multi_step'];
+export const CASE_INPUT_FLAVORS: readonly CaseInputFlavor[] = [
+	'happy_path',
+	'underspecified',
+	'out_of_scope',
+	'adversarial',
+];
+
+/** Fallback capability label when the agent config declares no tools/skills. */
+export const GENERAL_CAPABILITY = 'general';
+
+/**
+ * Sample `count` dimension tuples, spread evenly across the full
+ * capability × difficulty × flavor grid.
+ *
+ * Deterministic: same inputs → same tuples (no randomness), so the generator is
+ * reproducible and unit-testable. Each axis advances independently (round-robin)
+ * so even a short sample spans every capability, difficulty, and flavor; when a
+ * combination repeats it walks to the next unused grid cell, keeping the tuples
+ * distinct until the grid is exhausted, after which the grid is cycled.
+ */
+export function sampleDimensionTuples(capabilities: string[], count: number): DimensionTuple[] {
+	if (count <= 0) return [];
+
+	const caps = capabilities.length > 0 ? capabilities : [GENERAL_CAPABILITY];
+	const nCaps = caps.length;
+	const nDiff = CASE_DIFFICULTIES.length;
+	const nFlavors = CASE_INPUT_FLAVORS.length;
+	const gridSize = nCaps * nDiff * nFlavors;
+
+	const key = (c: number, d: number, f: number) => `${c}:${d}:${f}`;
+	const seen = new Set<string>();
+	const tuples: DimensionTuple[] = [];
+
+	for (let i = 0; i < count; i++) {
+		// Once every combination has been used, cycle the distinct tuples already
+		// produced rather than inventing repeats in an arbitrary order.
+		if (tuples.length >= gridSize) {
+			tuples.push(tuples[i % gridSize]);
+			continue;
+		}
+
+		// Preferred position: advance each axis independently so a short sample
+		// still touches every capability, difficulty, and flavor.
+		let c = i % nCaps;
+		let d = i % nDiff;
+		let f = i % nFlavors;
+
+		// If that combination is taken, walk the grid (flavor-fastest) to the next
+		// unused cell. A free cell is guaranteed while `tuples.length < gridSize`.
+		while (seen.has(key(c, d, f))) {
+			f += 1;
+			if (f === nFlavors) {
+				f = 0;
+				d += 1;
+			}
+			if (d === nDiff) {
+				d = 0;
+				c += 1;
+			}
+			if (c === nCaps) c = 0;
+		}
+
+		seen.add(key(c, d, f));
+		tuples.push({
+			capability: caps[c],
+			difficulty: CASE_DIFFICULTIES[d],
+			flavor: CASE_INPUT_FLAVORS[f],
+		});
+	}
+
+	return tuples;
+}

--- a/packages/cli/src/modules/agent-evals/case-generation/dimensions.ts
+++ b/packages/cli/src/modules/agent-evals/case-generation/dimensions.ts
@@ -67,10 +67,13 @@ export function sampleDimensionTuples(capabilities: string[], count: number): Di
 			continue;
 		}
 
-		// Preferred position: advance each axis independently so a short sample
-		// still touches every capability, difficulty, and flavor.
+		// Preferred position. Capability cycles fastest so a short sample spreads
+		// across capabilities. Difficulty advances once per full capability cycle
+		// (`floor(i / nCaps)`) rather than per step, so it stays decorrelated from
+		// capability — otherwise, e.g., 2 capabilities would each lock to a single
+		// difficulty. Flavor cycles fastest of all.
 		let c = i % nCaps;
-		let d = i % nDiff;
+		let d = Math.floor(i / nCaps) % nDiff;
 		let f = i % nFlavors;
 
 		// If that combination is taken, walk the grid (flavor-fastest) to the next


### PR DESCRIPTION
## Summary

Adds `AgentEvalCaseGenerationService` — the AI case-generation step of the Agent Evals "test-drive" flow. It drafts a handful of realistic test cases from an agent's own config (`name` / `instructions` / `tools`), each a natural end-user `input` plus a plain-language "what to check".

Key design points:

- **Dimension-tuple synthesis, not one-shot.** Rather than asking the model for "N test queries" (which clusters on the happy path), cases are varied along independent axes — **capability × difficulty × input-flavor** (happy-path / underspecified / out-of-scope / adversarial). The tuples are sampled **deterministically in code** (so coverage is predictable and unit-testable); the model only fills each tuple with concrete text in a single batched call.
- **Reuses the agent's own model + credential** — resolved exactly as the agent runtime does (`resolveCredentialAwareModelConfig`), so it's bring-your-own-key with no extra provider config or entitlement. Agents without a usable model/credential (unset, `managed`, or an unsupported provider) are rejected with a clear error.
- **Persisted as editable drafts, never auto-graded.** Output is written to a **Data Table** (the cases are its rows: `input` + `criteria` columns) with an `AgentEvalDataset` pointing at it via the `DatasetRef` mechanism from the data-model PR (#34657). If the row-insert or the dataset-pointer creation fails, the table is rolled back so a populated-but-unreferenced dataset is never orphaned.
- **Bounded + safe.** Single LLM call with a 60s timeout, one stricter retry, and fail-without-persisting on invalid/empty output. Model output is treated as untrusted (the prompt embeds the agent's own instructions): the agent is built **tool-less**, and the response is capped to the requested count with each field length-bounded before persisting. Gated behind the `101_agent_evals` flag.

### Scope / deferred

- **Backend service only** — no REST controller (that's the agent-evals REST ticket) and no `agent-evals` module registration (owned by the agent-target runner ticket, which creates the module). This lands "dark" and independently mergeable, matching #34657.
- No `@n8n/api-types` change: the draft-case shape is a local generation detail; shared interfaces are their own ticket.
- Two notes for reviewers: `AgentJsonConfig` has **no top-level `description`** field, so the goal's "instructions/description/tools" maps to `name` + `instructions` + `tools`; and generation reads the agent's **current** config (not the published `activeVersionId`).

## How to test

This is a dark backend service — it has no route or UI yet, so there is no live endpoint to hit (REST wiring lands in a follow-up ticket). Verify via the unit tests, which exercise the real dimension sampler, prompt building, model-resolution guards, persistence orchestration, and error/rollback paths (the LLM and DB collaborators are mocked):

```bash
cd packages/cli
pnpm test src/modules/agent-evals
```

When the REST/runner tickets wire it up, the feature surface is gated by the `101_agent_evals` PostHog flag; a local instance can force it on with `N8N_AGENT_EVALS_ENABLED=true`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-287

Part of the Agent Evals phase-1 epic; builds on the agent-scoped eval data model in #34657.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34907">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

