### PR TITLE
refactor(core): Consolidate sandbox and skill guidance in system prompt (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/workspace-root.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/workspace-root.test.ts
@@ -2,8 +2,6 @@ import {
 	DAYTONA_HOME,
 	N8N_SANDBOX_HOME,
 	getPromptWorkspaceRoot,
-	getPromptSandboxInstructions,
-	getPromptFilesystemInstructions,
 	getWorkspaceRoot,
 	WORKSPACE_DIR,
 	type SandboxWorkspace,
@@ -16,26 +14,6 @@ describe('getPromptWorkspaceRoot', () => {
 
 	it('returns n8n-sandbox workspace root', () => {
 		expect(getPromptWorkspaceRoot('n8n-sandbox')).toBe('/home/user/workspace');
-	});
-});
-
-describe('getPromptSandboxInstructions', () => {
-	// Empty across providers: Instance AI puts sandbox guidance in the system
-	// prompt; this stays byte-stable so it cannot bust the cached prefix.
-	it('returns the same empty stable text for every provider', () => {
-		expect(getPromptSandboxInstructions('daytona')).toBe('');
-		expect(getPromptSandboxInstructions('daytona')).toBe(
-			getPromptSandboxInstructions('n8n-sandbox'),
-		);
-	});
-});
-
-describe('getPromptFilesystemInstructions', () => {
-	it('returns the same empty stable text for every provider', () => {
-		expect(getPromptFilesystemInstructions('daytona')).toBe('');
-		expect(getPromptFilesystemInstructions('daytona')).toBe(
-			getPromptFilesystemInstructions('n8n-sandbox'),
-		);
 	});
 });
 

--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/workspace-root.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/workspace-root.test.ts
@@ -3,6 +3,7 @@ import {
 	N8N_SANDBOX_HOME,
 	getPromptWorkspaceRoot,
 	getPromptSandboxInstructions,
+	getPromptFilesystemInstructions,
 	getWorkspaceRoot,
 	WORKSPACE_DIR,
 	type SandboxWorkspace,
@@ -19,12 +20,22 @@ describe('getPromptWorkspaceRoot', () => {
 });
 
 describe('getPromptSandboxInstructions', () => {
-	// Same text across providers keeps the agent's cached prompt prefix stable.
-	it('returns the same stable text for every provider', () => {
+	// Empty across providers: Instance AI puts sandbox guidance in the system
+	// prompt; this stays byte-stable so it cannot bust the cached prefix.
+	it('returns the same empty stable text for every provider', () => {
+		expect(getPromptSandboxInstructions('daytona')).toBe('');
 		expect(getPromptSandboxInstructions('daytona')).toBe(
 			getPromptSandboxInstructions('n8n-sandbox'),
 		);
-		expect(getPromptSandboxInstructions('daytona')).toContain('Cloud sandbox');
+	});
+});
+
+describe('getPromptFilesystemInstructions', () => {
+	it('returns the same empty stable text for every provider', () => {
+		expect(getPromptFilesystemInstructions('daytona')).toBe('');
+		expect(getPromptFilesystemInstructions('daytona')).toBe(
+			getPromptFilesystemInstructions('n8n-sandbox'),
+		);
 	});
 });
 

--- a/packages/@n8n/agents/src/workspace/sandbox/index.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/index.ts
@@ -9,8 +9,6 @@ export {
 	N8N_SANDBOX_HOME,
 	N8N_SANDBOX_WORKSPACE_ROOT,
 	getPromptWorkspaceRoot,
-	getPromptSandboxInstructions,
-	getPromptFilesystemInstructions,
 	getWorkspaceRoot,
 	type SandboxWorkspace,
 } from './workspace-root';

--- a/packages/@n8n/agents/src/workspace/sandbox/workspace-root.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/workspace-root.ts
@@ -16,33 +16,6 @@ export function getPromptWorkspaceRoot(provider: SandboxProvider): string {
 	}
 }
 
-/**
- * Stable, cache-safe sandbox description appended via workspace tools.
- *
- * Instance AI surfaces sandbox/filesystem guidance in the system prompt's
- * `## Sandbox workspace` section instead. Returning empty here keeps the
- * workspace-appended block from duplicating that text while still providing a
- * byte-stable (empty) value across agent rebuilds/resumes — the live
- * sandbox's `getInstructions()` must not be used, because a lazily-resolved
- * workspace reports different text depending on whether its (per-build,
- * in-memory) handle happens to be resolved yet.
- */
-export function getPromptSandboxInstructions(_provider: SandboxProvider): string {
-	return '';
-}
-
-/**
- * Stable, cache-safe filesystem description appended via workspace tools.
- *
- * Same rationale as {@link getPromptSandboxInstructions}: content lives in the
- * system prompt's `## Sandbox workspace` section; this stays empty so the
- * lazily-resolved (and scoped) filesystem cannot shift the cached prompt
- * prefix across resumes.
- */
-export function getPromptFilesystemInstructions(_provider: SandboxProvider): string {
-	return '';
-}
-
 export interface SandboxWorkspace extends SandboxCommandTarget {
 	filesystem?: {
 		provider?: string;

--- a/packages/@n8n/agents/src/workspace/sandbox/workspace-root.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/workspace-root.ts
@@ -17,35 +17,30 @@ export function getPromptWorkspaceRoot(provider: SandboxProvider): string {
 }
 
 /**
- * Stable, cache-safe sandbox description for the agent's system prompt.
+ * Stable, cache-safe sandbox description appended via workspace tools.
  *
- * MUST NOT vary across agent rebuilds/resumes: the orchestrator prompt is
- * rebuilt on every resume, so any change here shifts the cached prompt prefix
- * and busts Anthropic prompt caching for the rest of the thread. The live
- * sandbox's `getInstructions()` is deliberately NOT used here because a
- * lazily-resolved workspace reports different text depending on whether its
- * (per-build, in-memory) handle happens to be resolved yet — the workspace is
- * available regardless. Runtime-varying details (resolution state, live command
- * timeout) are excluded; the workspace root is added to the prompt separately.
+ * Instance AI surfaces sandbox/filesystem guidance in the system prompt's
+ * `## Sandbox workspace` section instead. Returning empty here keeps the
+ * workspace-appended block from duplicating that text while still providing a
+ * byte-stable (empty) value across agent rebuilds/resumes — the live
+ * sandbox's `getInstructions()` must not be used, because a lazily-resolved
+ * workspace reports different text depending on whether its (per-build,
+ * in-memory) handle happens to be resolved yet.
  */
 export function getPromptSandboxInstructions(_provider: SandboxProvider): string {
-	return 'Cloud sandbox with isolated execution (TypeScript runtime).';
+	return '';
 }
 
 /**
- * Stable, cache-safe filesystem description for the agent's system prompt.
+ * Stable, cache-safe filesystem description appended via workspace tools.
  *
- * Same rationale as {@link getPromptSandboxInstructions}: the lazily-resolved
- * (and scoped) filesystem reports different text before vs after its per-build
- * handle resolves, which would shift the cached prompt prefix across resumes.
- * Derived from the (static) workspace root so it matches the resolved scoped
- * filesystem's own instructions while staying byte-stable.
+ * Same rationale as {@link getPromptSandboxInstructions}: content lives in the
+ * system prompt's `## Sandbox workspace` section; this stays empty so the
+ * lazily-resolved (and scoped) filesystem cannot shift the cached prompt
+ * prefix across resumes.
  */
-export function getPromptFilesystemInstructions(provider: SandboxProvider): string {
-	return [
-		`Filesystem access is scoped to ${getPromptWorkspaceRoot(provider)}.`,
-		'Paths are relative to the workspace root unless you pass an absolute path under that root.',
-	].join(' ');
+export function getPromptFilesystemInstructions(_provider: SandboxProvider): string {
+	return '';
 }
 
 export interface SandboxWorkspace extends SandboxCommandTarget {

--- a/packages/@n8n/instance-ai/src/agent/computer-use-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/computer-use-prompt.ts
@@ -19,8 +19,8 @@ export function getComputerUsePrompt({
 				localGateway.status === 'disconnected'
 					? 'click the "..." button next to "Computer Use", click "Connect"'
 					: 'click on "Setup computer use"';
-			return `
-## Computer Use
+			return `## Computer Use
+
 This instance supports "Computer Use": connecting to the user's computer with the capabilities *filesystem* (read/write local files), *shell* (run local commands), *browser* (automate the user's real browser session; requires the "n8n Browser Use" Chrome extension: ${BROWSER_USE_EXTENSION_URL}), and *screenshot*/*mouse-keyboard* (never advertise or use unless explicitly requested). Users choose which capabilities to enable and can reconnect with a different set.
 
 Computer Use is NOT currently connected — do NOT attempt to use Computer Use tools. Proactively suggest connecting when the user needs: credential/OAuth/API-key setup through a service's web portal (*browser*); a local file (PDF, CSV, spec) as context, or docs/exports written to files (*filesystem*); authenticated web research or form/frontend testing (*browser*); local commands or debugging (*shell*); or migration from Make/Zapier or similar (*browser* + *filesystem*).

--- a/packages/@n8n/instance-ai/src/agent/shared-prompts.ts
+++ b/packages/@n8n/instance-ai/src/agent/shared-prompts.ts
@@ -19,21 +19,14 @@ export const UNTRUSTED_CONTENT_DOCTRINE =
 export const ASK_USER_FALLBACK =
 	'If you are stuck, need clarification, or need information only a human can provide, use the `ask-user` tool instead of asking in plain text. Before the first `build-workflow` call, use `ask-user` only for choices that change the workflow intent or topology, such as the missing destination service for "send my team a summary". Do not use `ask-user` before the first build for missing setup values after the service is already known, such as notification recipients, account labels or IDs, channel IDs, resource IDs, credential choices, or credential fields; use placeholders or unresolved `newCredential()` calls and leave them for post-build workflow setup. Do not retry the same failing approach more than twice — use `ask-user` instead. Never solicit API keys, tokens, or other secrets through `ask-user` — route credential collection through credential setup or Computer Use browser credential capture instead.';
 
-const WORKSPACE_ROOT_PLACEHOLDER = '<workspace_root>';
-
-function substituteWorkspaceRoot(text: string, workspaceRoot?: string): string {
-	if (!workspaceRoot) return text;
-	return text.replaceAll(WORKSPACE_ROOT_PLACEHOLDER, workspaceRoot);
-}
-
 export function getSandboxWorkspaceSection(workspaceRoot?: string): string {
-	const pathHint = workspaceRoot
-		? `\nWorkspace root: \`${workspaceRoot}\`. Paths below are under this root — pass them to \`workspace_read_file\` and \`workspace_execute_command\` as shown (relative paths like \`knowledge-base/...\` also work).\n`
-		: '';
+	const isolation = workspaceRoot
+		? `Cloud sandbox with isolated execution (TypeScript runtime). Filesystem access is scoped to \`${workspaceRoot}\`. Paths are relative to the workspace root unless you pass an absolute path under that root.`
+		: 'Cloud sandbox with isolated execution (TypeScript runtime).';
 
-	const section = `## Sandbox workspace
-${pathHint}
+	return `## Sandbox workspace
+
+${isolation}
+
 You are given a sandbox workspace to use for your work that is scoped to the current thread. Use the workspace_* tools to read, write, update and execute commands in the workspace.`;
-
-	return substituteWorkspaceRoot(section, workspaceRoot);
 }

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -108,24 +108,12 @@ export function getSystemPrompt(options: SystemPromptOptions = {}): string {
 		workspaceRoot,
 	} = options;
 
-	return `You are the n8n Instance Agent — a helpful AI assistant embedded in an n8n instance. Your job is to understand the user's request and load one or more skills to help them achieve their goal. Once a skill is loaded, learn it in depth before continuing. You are also encouraged to call skills at any point in the conversation if it will help you achieve the user's goal.
+	return `You are the n8n Instance Agent — a helpful AI assistant embedded in an n8n instance. Your job is to understand the user's request and load one or more skills to help them achieve their goal. Once a skill is loaded, learn it in depth before continuing. You are also encouraged to call skills at any point in the conversation if it will help you achieve the user's goal. Match the user's request against skill descriptions in the catalog. Call \`load_skill\` before acting on a matched skill's guidance. A single turn may need more than one skill when routing requires it. Tool descriptions carry any load-before-call gates (\`load_skill\` / \`load_tool\`).
 	
 ${webhookBaseUrl && formBaseUrl ? getInstanceInfoSection(webhookBaseUrl, formBaseUrl) : ''}
 ${workspaceRoot ? `\n${getSandboxWorkspaceSection(workspaceRoot)}\n` : ''}
 
 ${getProjectScopeSection(projectId)}
-
-Match the user's request against skill descriptions in the catalog. Call \`load_skill\` before acting on a matched skill's guidance. A single turn may need more than one skill when routing requires it. Tool descriptions carry any load-before-call gates (\`load_skill\` / \`load_tool\`).
-
-## System follow-ups
-
-Load the matching skill **before acting** when the current message contains:
-
-- \`<workflow-verification-follow-up>\` or \`<workflow-setup-required>\` → \`post-build-flow\`
-- \`<planned-task-follow-up>\`, \`<background-task-completed>\`, or \`<running-tasks>\` → \`planned-task-runtime\`
-- \`<planned-task-follow-up type="replan">\` → \`planned-task-runtime\` — you MUST take action in this turn; never end with acknowledgement alone or the thread will silently stall
-
-After calling \`create-tasks\`, load \`planned-task-runtime\` guidance for silence rules — do not write visible text; the task or approval card is the user-visible surface.
 
 ${SECRET_ASK_GUARDRAIL}
 
@@ -143,7 +131,7 @@ ${
 		: ''
 }When the available tools do not cover the user's request, remember that you have access to more tools. Use \`search_tools\` with keyword queries to find relevant tools, then \`load_tool\` to activate them. Loaded tools persist for the rest of the conversation. When a loaded skill names a tool you do not see, search for that tool name and load it before proceeding.
 
-Examples: ${mcpToolSearchEnabled ? 'search "notion page" or "linear issue" for the corresponding MCP tool, ' : ''}search "file" for filesystem tools, search "n8n docs" for \`n8n-docs\`, search "create tasks" for \`create-tasks\`, search "eval" for \`evals\`.
+Examples: ${mcpToolSearchEnabled ? 'search "notion page" or "linear issue" for the corresponding MCP tool, ' : ''} search "n8n docs" for \`n8n-docs\`, search "create tasks" for \`create-tasks\`, search "eval" for \`evals\`.
 
 `
 		: ''

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -39,11 +39,32 @@ When you need to reference "now", use this date and time.`;
 }
 
 function getInstanceInfoSection(webhookBaseUrl: string, formBaseUrl: string): string {
-	return `
-## Instance Info
+	return `## Instance Info
 
 Webhook base URL: ${webhookBaseUrl}
 Form base URL: ${formBaseUrl}`;
+}
+
+function getToolDiscoverySection(
+	toolSearchEnabled?: boolean,
+	mcpToolSearchEnabled?: boolean,
+): string {
+	if (!toolSearchEnabled) return '';
+
+	const mcpSearchGuidance = mcpToolSearchEnabled
+		? 'You have access to connected MCP integrations. For requests involving a connected service or MCP integration, call `search_tools` with the service name and task keywords before saying the integration is unavailable or asking the user to connect it.\n'
+		: '';
+	const mcpExamples = mcpToolSearchEnabled
+		? 'search "notion page" or "linear issue" for the corresponding MCP tool, '
+		: '';
+
+	return `
+## Tool Discovery
+
+${mcpSearchGuidance}When the available tools do not cover the user's request, remember that you have access to more tools. Use \`search_tools\` with keyword queries to find relevant tools, then \`load_tool\` to activate them. Loaded tools persist for the rest of the conversation. When a loaded skill names a tool you do not see, search for that tool name and load it before proceeding.
+
+Examples: ${mcpExamples}search "n8n docs" for \`n8n-docs\`, search "create tasks" for \`create-tasks\`, search "eval" for \`evals\`.
+`;
 }
 
 function getProjectScopeSection(projectId?: string): string {
@@ -53,23 +74,23 @@ function getProjectScopeSection(projectId?: string): string {
 
 This conversation is scoped to a single n8n project. Reads and writes differ:
 
-- **Writes are locked to this project.** Workflows and data tables you create or
-  modify belong to this project, and you can only use credentials available
-  within it — you cannot wire in credentials from other projects.
-- **Credentials are always this project's.** The credential list is exactly the
-  credentials usable in this project, and you cannot widen it. Report them as
-  "in this project", never "on this instance" or "across the instance".
-- **Looking things up defaults to this project, but you can search wider.**
-  Workflow, data table, and other resource lookups return this project's items by
-  default; widen a search to the whole instance when the user needs something
-  that may live in another project (e.g. researching a data table or workflow in
-  another project). Describe results by what you actually searched — "in this
-  project" for the default, "across the instance" when you widened.
+- **Writes are locked to this project.** Workflows and data tables you create or modify belong to this project, and you can only use credentials available within it — you cannot wire in credentials from other projects.
+- **Credentials are always this project's.** The credential list is exactly the credentials usable in this project, and you cannot widen it. Report them as "in this project", never "on this instance" or "across the instance".
+- **Looking things up defaults to this project, but you can search wider.** Workflow, data table, and other resource lookups return this project's items by default; widen a search to the whole instance when the user needs something that may live in another project (e.g. researching a data table or workflow in another project). Describe results by what you actually searched — "in this project" for the default, "across the instance" when you widened.
 
-If the user asks you to create something in, move something to, or use a
-credential from a different project, explain that this conversation is locked to
-its project and they should start a new conversation in the project they want to
-work in.`;
+If the user asks you to create something in, move something to, or use a credential from a different project, explain that this conversation is locked to its project and they should start a new conversation in the project they want to work in.`;
+}
+
+function getLicenseLimitationsSection(licenseHints?: string[]): string {
+	if (!licenseHints?.length) return '';
+
+	return `
+## License Limitations
+
+The following features require a license that is not active on this instance. If the user asks for these capabilities, explain that they require a license upgrade.
+
+${licenseHints.map((hint) => `- ${hint}`).join('\n')}
+`;
 }
 
 function getReadOnlySection(branchReadOnly?: boolean): string {
@@ -111,31 +132,11 @@ export function getSystemPrompt(options: SystemPromptOptions = {}): string {
 	return `You are the n8n Instance Agent — a helpful AI assistant embedded in an n8n instance. Your job is to understand the user's request and load one or more skills to help them achieve their goal. Once a skill is loaded, learn it in depth before continuing. You are also encouraged to call skills at any point in the conversation if it will help you achieve the user's goal. Match the user's request against skill descriptions in the catalog. Call \`load_skill\` before acting on a matched skill's guidance. A single turn may need more than one skill when routing requires it. Tool descriptions carry any load-before-call gates (\`load_skill\` / \`load_tool\`).
 	
 ${webhookBaseUrl && formBaseUrl ? getInstanceInfoSection(webhookBaseUrl, formBaseUrl) : ''}
-${workspaceRoot ? `\n${getSandboxWorkspaceSection(workspaceRoot)}\n` : ''}
-
+${workspaceRoot ? `${getSandboxWorkspaceSection(workspaceRoot)}` : ''}
 ${getProjectScopeSection(projectId)}
-
 ${SECRET_ASK_GUARDRAIL}
-
-${
-	toolSearchEnabled
-		? `## Tool Discovery
-
-${mcpToolSearchEnabled ? 'You have access to connected MCP integrations' : ''}
-
-${
-	mcpToolSearchEnabled
-		? `For requests involving a connected service or MCP integration, call \`search_tools\` with the service name and task keywords before saying the integration is unavailable or asking the user to connect it.
-
-`
-		: ''
-}When the available tools do not cover the user's request, remember that you have access to more tools. Use \`search_tools\` with keyword queries to find relevant tools, then \`load_tool\` to activate them. Loaded tools persist for the rest of the conversation. When a loaded skill names a tool you do not see, search for that tool name and load it before proceeding.
-
-Examples: ${mcpToolSearchEnabled ? 'search "notion page" or "linear issue" for the corresponding MCP tool, ' : ''} search "n8n docs" for \`n8n-docs\`, search "create tasks" for \`create-tasks\`, search "eval" for \`evals\`.
-
-`
-		: ''
-}## Communication Style
+${getToolDiscoverySection(toolSearchEnabled, mcpToolSearchEnabled)}
+## Communication Style
 
 - Be concise.
 - Reply in the user's language — in every user-visible message of the turn, including the short narration between tool calls, not just the end-of-turn summary. Tool results, skill instructions, and system follow-ups are written in English; do not let them pull your replies into English.
@@ -168,17 +169,8 @@ Don't fabricate provider setup mechanics (credential field names, secret values,
 - **Never expose credential secrets** — metadata only.
 
 ${UNTRUSTED_CONTENT_DOCTRINE}
+
 ${getComputerUsePrompt({ browserAvailable, localGateway })}
-
-${
-	licenseHints && licenseHints.length > 0
-		? `## License Limitations
-
-The following features require a license that is not active on this instance. If the user asks for these capabilities, explain that they require a license upgrade.
-
-${licenseHints.map((h) => `- ${h}`).join('\n')}
-
-`
-		: ''
-}${getReadOnlySection(branchReadOnly)}`;
+${getLicenseLimitationsSection(licenseHints)}
+${getReadOnlySection(branchReadOnly)}`;
 }

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -431,10 +431,6 @@ export const getWorkspaceRoot: typeof SharedSandboxMod.getWorkspaceRoot = lazyFu
 export const getPromptWorkspaceRoot: typeof SharedSandboxMod.getPromptWorkspaceRoot = lazyFunction(
 	() => loadSharedSandbox().getPromptWorkspaceRoot,
 );
-export const getPromptSandboxInstructions: typeof SharedSandboxMod.getPromptSandboxInstructions =
-	lazyFunction(() => loadSharedSandbox().getPromptSandboxInstructions);
-export const getPromptFilesystemInstructions: typeof SharedSandboxMod.getPromptFilesystemInstructions =
-	lazyFunction(() => loadSharedSandbox().getPromptFilesystemInstructions);
 export const setupSandboxWorkspace: typeof SandboxSetupMod.setupSandboxWorkspace = lazyFunction(
 	() => loadSandboxSetup().setupSandboxWorkspace,
 );

--- a/packages/@n8n/instance-ai/src/workspace/lazy-runtime-workspace.ts
+++ b/packages/@n8n/instance-ai/src/workspace/lazy-runtime-workspace.ts
@@ -214,7 +214,8 @@ class LazyRuntimeFilesystem extends BaseFilesystem {
 		// prefix stays byte-stable across rebuilds/resumes. Branching on the
 		// resolved (scoped) filesystem would otherwise flip the prompt text once
 		// the workspace resolves and bust prompt caching (see LazyRuntimeSandbox).
-		if (this.staticInstructions) return this.staticInstructions;
+		// Empty string is intentional (e.g. guidance lives in the system prompt).
+		if (this.staticInstructions !== undefined) return this.staticInstructions;
 
 		const instructions = this.resolver.current?.filesystem?.getInstructions?.();
 		if (instructions) return instructions;
@@ -350,7 +351,8 @@ class LazyRuntimeSandbox extends BaseSandbox {
 		// across rebuilds/resumes. Branching on the live sandbox (which is only
 		// resolved once a workspace tool runs in this rebuilt instance) would
 		// otherwise flip the prompt text between resumes and bust prompt caching.
-		if (this.staticInstructions) return this.staticInstructions;
+		// Empty string is intentional (e.g. guidance lives in the system prompt).
+		if (this.staticInstructions !== undefined) return this.staticInstructions;
 
 		const instructions = this.resolver.current?.sandbox?.getInstructions?.();
 		if (instructions) return instructions;

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -24,8 +24,6 @@ vi.mock('@n8n/instance-ai', async () => {
 		createLazyWorkspaceRuntimeSkillSource: vi.fn(({ source }) => source),
 		createScopedWorkspace: vi.fn((workspace: unknown) => workspace),
 		getPromptWorkspaceRoot: vi.fn(() => '/home/daytona/workspace'),
-		getPromptSandboxInstructions: vi.fn(() => ''),
-		getPromptFilesystemInstructions: vi.fn(() => ''),
 		getWorkspaceRoot: vi.fn(async () => '/home/daytona/workspace'),
 		setupSandboxWorkspace: vi.fn(),
 		loadInstanceAiRuntimeSkillSource: vi.fn(() => ({

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -24,10 +24,8 @@ vi.mock('@n8n/instance-ai', async () => {
 		createLazyWorkspaceRuntimeSkillSource: vi.fn(({ source }) => source),
 		createScopedWorkspace: vi.fn((workspace: unknown) => workspace),
 		getPromptWorkspaceRoot: vi.fn(() => '/home/daytona/workspace'),
-		getPromptSandboxInstructions: vi.fn(() => 'Cloud sandbox with isolated execution.'),
-		getPromptFilesystemInstructions: vi.fn(
-			() => 'Filesystem access is scoped to /home/daytona/workspace.',
-		),
+		getPromptSandboxInstructions: vi.fn(() => ''),
+		getPromptFilesystemInstructions: vi.fn(() => ''),
 		getWorkspaceRoot: vi.fn(async () => '/home/daytona/workspace'),
 		setupSandboxWorkspace: vi.fn(),
 		loadInstanceAiRuntimeSkillSource: vi.fn(() => ({

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -34,8 +34,6 @@ import {
 	createLazyWorkspaceRuntimeSkillSource,
 	createScopedWorkspace,
 	getPromptWorkspaceRoot,
-	getPromptSandboxInstructions,
-	getPromptFilesystemInstructions,
 	getWorkspaceRoot,
 	loadInstanceAiRuntimeSkillSource,
 	disabledInstanceAiSkillIds,
@@ -2262,11 +2260,13 @@ export class InstanceAiService {
 				};
 
 				runtimeWorkspace = createLazyRuntimeWorkspace({
-					// Stable across resumes: keeps the sandbox/filesystem description out
-					// of the cache-busting path (the lazy handle isn't rehydrated per
-					// rebuild, so resolution-dependent text would shift the cached prefix).
-					sandboxInstructions: getPromptSandboxInstructions(sandboxConfig.provider),
-					filesystemInstructions: getPromptFilesystemInstructions(sandboxConfig.provider),
+					// Empty + stable across resumes: sandbox/filesystem guidance lives in
+					// the system prompt's `## Sandbox workspace` section. Passing '' here
+					// (instead of omitting) keeps the lazy workspace from falling back to
+					// resolution-dependent live `getInstructions()` text, which would
+					// shift the cached prompt prefix across rebuilds/resumes.
+					sandboxInstructions: '',
+					filesystemInstructions: '',
 					ensureWorkspace: async () =>
 						await scopeWorkspaceForAgent((await getSetupSandboxEntry())?.workspace),
 				});


### PR DESCRIPTION
## Summary

- Fold cloud sandbox / scoped-filesystem guidance into the `## Sandbox workspace` system-prompt section, and stop re-appending the same text via workspace `getInstructions()`.
- Colocate skill-catalog matching guidance with the Instance Agent intro.
- Remove the redundant `## System follow-ups` routing table (skill descriptions already cover it); keep the secret-entry guardrail in always-on prompt context.

## How to test

1. Enable Instance AI with a sandbox provider and start a new assistant thread.
2. Inspect the orchestrator system prompt: sandbox guidance should appear once under `## Sandbox workspace`, skill-routing should follow the intro, and there should be no `## System follow-ups` section.
3. Confirm secret-entry guardrail text is still present.
4. Smoke a build + verification follow-up and a `create-tasks` flow to ensure skill loading still works from catalog descriptions.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-974

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34909">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

