### PR TITLE
fix(Execute Workflow Node): Load sub-workflow input fields from draft instead of published version

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/local-load-options-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/local-load-options-context.test.ts
@@ -150,6 +150,55 @@ describe('LocalLoadOptionsContext', () => {
 			});
 		});
 
+		it('should use draft nodes by default even when an activeVersion exists', async () => {
+			const workflowId = 'workflow-123';
+			const nodeParameters = { inputSource: 'workflowInputs' };
+			additionalData.currentNodeParameters = {
+				workflowId: { value: workflowId },
+			};
+
+			const draftNode = mock<INode>({
+				type: targetNodeType,
+				name: 'Draft Trigger',
+				parameters: nodeParameters,
+			});
+			const activeVersionNode = mock<INode>({
+				type: targetNodeType,
+				name: 'Active Version Trigger',
+			});
+			const dbWorkflow = mock<IWorkflowBase>({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [draftNode],
+				activeVersion: {
+					versionId: 'version-1',
+					workflowId,
+					nodes: [activeVersionNode],
+					connections: {},
+					authors: 'test',
+					name: 'Test Workflow',
+					description: null,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+			workflowLoader.get.mockResolvedValue(dbWorkflow);
+
+			const context = new LocalLoadOptionsContext(nodeTypes, additionalData, path, workflowLoader);
+
+			const result = await context.getWorkflowNodeContext(targetNodeType);
+
+			expect(result).toBeInstanceOf(LoadWorkflowNodeContext);
+			expect(Workflow).toHaveBeenCalledWith({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes: [draftNode],
+				connections: {},
+				active: false,
+				nodeTypes,
+			});
+		});
+
 		it('should use activeVersion nodes when useActiveVersion is true', async () => {
 			const workflowId = 'workflow-123';
 			const nodeParameters = { inputSource: 'passthrough' };

--- a/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
@@ -168,10 +168,10 @@ export function getCurrentWorkflowInputData(this: IExecuteFunctions | ISupplyDat
 export async function loadWorkflowInputMappings(
 	this: ILocalLoadOptionsFunctions,
 ): Promise<WorkflowInputsData> {
-	const nodeLoadContext = await this.getWorkflowNodeContext(
-		EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
-		true,
-	);
+	// Read the trigger from the sub-workflow draft so the resource mapper reflects the
+	// latest saved inputs. Manual/chat executions run the draft, and production executions
+	// resolve the published version at runtime, so this only affects the editing surface.
+	const nodeLoadContext = await this.getWorkflowNodeContext(EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE);
 	let fields: ResourceMapperField[] = [];
 	let dataMode: string = PASSTHROUGH;
 	let subworkflowInfo: { workflowId?: string; triggerId?: string } | undefined;

--- a/packages/nodes-base/utils/workflowInputsResourceMapping/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/__tests__/GenericFunctions.test.ts
@@ -1,7 +1,14 @@
 import { mock } from 'vitest-mock-extended';
-import type { ISupplyDataFunctions } from 'n8n-workflow';
+import type {
+	ILocalLoadOptionsFunctions,
+	INode,
+	ISupplyDataFunctions,
+	IWorkflowNodeContext,
+	NodeParameterValueType,
+} from 'n8n-workflow';
+import { EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 
-import { getWorkflowInputValues } from '../GenericFunctions';
+import { getWorkflowInputValues, loadWorkflowInputMappings } from '../GenericFunctions';
 
 describe('getWorkflowInputValues', () => {
 	const supplyDataFunctions = mock<ISupplyDataFunctions>();
@@ -59,5 +66,73 @@ describe('getWorkflowInputValues', () => {
 			1,
 			{},
 		);
+	});
+});
+
+describe('loadWorkflowInputMappings', () => {
+	const localLoadOptions = mock<ILocalLoadOptionsFunctions>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should load fields from the sub-workflow draft, without preferring the active version', async () => {
+		const nodeContext = mock<IWorkflowNodeContext>();
+		nodeContext.getNodeParameter.mockImplementation(
+			(
+				parameterName: string,
+				_itemIndex: number,
+				fallbackValue?: NodeParameterValueType,
+			): NodeParameterValueType => {
+				const parameters: Record<string, NodeParameterValueType> = {
+					inputSource: 'workflowInputs',
+					'workflowInputs.values': [
+						{ name: 'Tipo de reporte', type: 'string' },
+						{ name: 'existingInput', type: 'any' },
+					],
+				};
+				return parameters[parameterName] ?? fallbackValue;
+			},
+		);
+		nodeContext.getWorkflow.mockReturnValue({ id: 'sub-workflow-id', name: 'Sub', active: false });
+		nodeContext.getNode.mockReturnValue(mock<INode>({ id: 'trigger-id' }));
+		localLoadOptions.getWorkflowNodeContext.mockResolvedValue(nodeContext);
+
+		const result = await loadWorkflowInputMappings.call(localLoadOptions);
+
+		expect(localLoadOptions.getWorkflowNodeContext).toHaveBeenCalledWith(
+			EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+		);
+		expect(result).toEqual({
+			dataMode: 'workflowInputs',
+			subworkflowInfo: { workflowId: 'sub-workflow-id', triggerId: 'trigger-id' },
+			fields: [
+				{
+					id: 'Tipo de reporte',
+					displayName: 'Tipo de reporte',
+					required: false,
+					defaultMatch: false,
+					display: true,
+					canBeUsedToMatch: true,
+					type: 'string',
+				},
+				{
+					id: 'existingInput',
+					displayName: 'existingInput',
+					required: false,
+					defaultMatch: false,
+					display: true,
+					canBeUsedToMatch: true,
+				},
+			],
+		});
+	});
+
+	it('should default to passthrough when the sub-workflow has no trigger node', async () => {
+		localLoadOptions.getWorkflowNodeContext.mockResolvedValue(null);
+
+		const result = await loadWorkflowInputMappings.call(localLoadOptions);
+
+		expect(result).toEqual({ fields: [], dataMode: 'passthrough', subworkflowInfo: undefined });
 	});
 });


### PR DESCRIPTION
## Summary

Input fields added to a sub-workflow's "When Executed by Another Workflow" trigger did not show up in the parent workflow's Execute Workflow node (or the Call n8n Workflow Tool) until the sub-workflow was republished.

The resource mapper loader (`loadWorkflowInputMappings`) resolved the sub-workflow trigger with `preferActiveVersion: true`, so whenever a published version existed, fields saved only to the draft were invisible in the parent. This PR removes the flag so the mapper reads the trigger from the draft.

**Why draft is correct now:** #22907 intentionally made the mapper prefer the published version, which matched runtime behavior at the time. Two weeks later, #23166 changed runtime so that manual/chat executions run the sub-workflow draft (to allow iterating without publishing), while production executions still run the published version. That left the mapper inconsistent with the manual execution path, which is exactly the reported bug. This change realigns the design-time surface with #23166's semantics. Production executions are unaffected: they still resolve the published version at runtime.

Known trade-off: a field mapped from the draft is not used by production until the sub-workflow is republished. That divergence is inherent to the draft/publish model from #23166 and applies to any draft edit; surfacing it (e.g. an "unpublished changes" hint) is out of scope here.

Note: community PR #34522 attempts an editor-side fix for the same symptom; if this lands, that PR is likely redundant.

## How to test

1. Create a sub-workflow with a "When Executed by Another Workflow" trigger using "Define using fields below", add a field (e.g. `nombre`), and publish it.
2. Create a parent workflow with an Execute Workflow node pointing at the sub-workflow. The field appears in the input mapper.
3. Go back to the sub-workflow, add a second field (e.g. `Tipo de reporte`), and save without republishing.
4. Reopen the Execute Workflow node in the parent. Before this fix only `nombre` is shown; with the fix both fields appear.

Covered by regression tests in `packages/nodes-base/utils/workflowInputsResourceMapping/__tests__/GenericFunctions.test.ts` and `packages/core/src/execution-engine/node-execution-context/__tests__/local-load-options-context.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-5610
- fixes #34517
- Context: #22907 (mapper preferred published version), #23166 (manual/chat executions run the draft), #34522 (overlapping community PR)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34917">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

