### PR TITLE
refactor(editor): Move agent capabilities below channels (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderEditorColumn.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderEditorColumn.spec.ts
@@ -85,7 +85,7 @@ vi.mock('../components/AgentInfoPanel.vue', () => ({
 		name: 'AgentInfoPanel',
 		template:
 			'<div><div v-if="showModel !== false" data-testid="agent-model-panel" /><div v-if="showInstructions !== false" data-testid="agent-instructions-panel" /></div>',
-		props: ['showModel', 'showInstructions', 'showInstructionsToolbar'],
+		props: ['showModel', 'showInstructions', 'showInstructionsToolbar', 'instructionsMaxHeight'],
 	},
 }));
 
@@ -175,7 +175,12 @@ async function mountColumn(
 					name: 'AgentInfoPanel',
 					template:
 						'<div><div v-if="showModel !== false" data-testid="agent-model-panel" /><div v-if="showInstructions !== false" data-testid="agent-instructions-panel" /></div>',
-					props: ['showModel', 'showInstructions', 'showInstructionsToolbar'],
+					props: [
+						'showModel',
+						'showInstructions',
+						'showInstructionsToolbar',
+						'instructionsMaxHeight',
+					],
 				},
 				AgentPanelHeader: true,
 				AgentAdvancedPanel: true,
@@ -325,28 +330,29 @@ describe('AgentBuilderEditorColumn', () => {
 		expect(wrapper.findComponent({ name: 'AgentAdvancedPanel' }).exists()).toBe(false);
 	});
 
-	it('orders the Agent tab as channels, model, instructions, then capabilities', async () => {
+	it('orders the Agent tab as channels, capabilities, model, then instructions', async () => {
 		const wrapper = await mountColumn({ knowledgeBaseEnabled: false });
 		await flushPromises();
 
 		const channels = wrapper.findComponent({ name: 'AgentChannelsSection' });
-		const model = wrapper.find('[data-testid="agent-model-panel"]');
 		const capabilities = wrapper.findComponent({ name: 'AgentCapabilitiesSection' });
+		const model = wrapper.find('[data-testid="agent-model-panel"]');
 		const instructions = wrapper.find('[data-testid="agent-instructions-panel"]');
 
 		expect(channels.exists()).toBe(true);
-		expect(model.exists()).toBe(true);
 		expect(capabilities.exists()).toBe(true);
+		expect(model.exists()).toBe(true);
 		expect(instructions.exists()).toBe(true);
 		expect(
-			channels.element.compareDocumentPosition(model.element) & Node.DOCUMENT_POSITION_FOLLOWING,
-		).toBeTruthy();
-		expect(
-			model.element.compareDocumentPosition(instructions.element) &
+			channels.element.compareDocumentPosition(capabilities.element) &
 				Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
 		expect(
-			instructions.element.compareDocumentPosition(capabilities.element) &
+			capabilities.element.compareDocumentPosition(model.element) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+		expect(
+			model.element.compareDocumentPosition(instructions.element) &
 				Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
 	});
@@ -360,5 +366,6 @@ describe('AgentBuilderEditorColumn', () => {
 			.find((panel) => panel.props('showModel') === false);
 
 		expect(instructionsPanel?.props('showInstructionsToolbar')).toBe(true);
+		expect(instructionsPanel?.props('instructionsMaxHeight')).toBe('none');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
@@ -113,23 +113,6 @@ const i18n = useI18n();
 						@agent-changed="emit('agent-changed')"
 					/>
 
-					<AgentInfoPanel
-						:config="localConfig"
-						:disabled="childrenDisabled"
-						:project-id="projectId"
-						:show-instructions="false"
-						embedded
-						@update:config="emit('update:config', $event)"
-					/>
-					<AgentInfoPanel
-						:config="localConfig"
-						:disabled="childrenDisabled"
-						:project-id="projectId"
-						:show-model="false"
-						:show-instructions-toolbar="true"
-						embedded
-						@update:config="emit('update:config', $event)"
-					/>
 					<AgentCapabilitiesSection
 						:config="localConfig"
 						:tools="localConfig?.tools ?? []"
@@ -151,6 +134,25 @@ const i18n = useI18n();
 						@remove-skill="emit('remove-skill', $event)"
 						@toggle-task="emit('toggle-task', $event)"
 						@tasks-changed="emit('tasks-changed')"
+					/>
+
+					<AgentInfoPanel
+						:config="localConfig"
+						:disabled="childrenDisabled"
+						:project-id="projectId"
+						:show-instructions="false"
+						embedded
+						@update:config="emit('update:config', $event)"
+					/>
+					<AgentInfoPanel
+						:config="localConfig"
+						:disabled="childrenDisabled"
+						:project-id="projectId"
+						:show-model="false"
+						:show-instructions-toolbar="true"
+						instructions-max-height="none"
+						embedded
+						@update:config="emit('update:config', $event)"
 					/>
 				</AgentBuilderTabPanel>
 


### PR DESCRIPTION
## Summary

Reverts the layout change from #33908 in the agent builder (both artefact and agent UX):

- Moves tools, schedules, sub-agents and skills back to just below the Channels section, instead of below the instructions.
- Removes the max-height on the instructions input, since it is now the last element on the page.

The section order on the Agent tab is now: Channels → Capabilities → Model → Instructions.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34921">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

