### PR TITLE
fix(core): Return correct webhook URL in MCP get_workflow_details trigger info

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
@@ -1,6 +1,8 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { User, type WorkflowEntity } from '@n8n/db';
+import type { INodeTypes } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
+import { mock } from 'vitest-mock-extended';
 
 import { CredentialsService } from '@/credentials/credentials.service';
 import { ProjectService } from '@/services/project.service.ee';
@@ -18,6 +20,7 @@ vi.mock('../tools/webhook-utils', () => ({
 describe('get-workflow-details MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
 	const baseWebhookUrl = 'https://example.test';
+	const nodeTypes = mock<INodeTypes>();
 
 	describe('smoke tests', () => {
 		test('it creates tool correctly', () => {
@@ -41,6 +44,7 @@ describe('get-workflow-details MCP tool', () => {
 				baseWebhookUrl,
 				workflowFinderService,
 				credentialsService,
+				nodeTypes,
 				endpoints,
 				telemetry,
 				roleService,
@@ -79,6 +83,7 @@ describe('get-workflow-details MCP tool', () => {
 				baseWebhookUrl,
 				workflowFinderService,
 				credentialsService,
+				nodeTypes,
 				endpoints,
 				roleService,
 				projectService,
@@ -111,6 +116,7 @@ describe('get-workflow-details MCP tool', () => {
 				baseWebhookUrl,
 				workflowFinderService,
 				credentialsService,
+				nodeTypes,
 				endpoints,
 				roleService,
 				projectService,
@@ -141,6 +147,7 @@ describe('get-workflow-details MCP tool', () => {
 				baseWebhookUrl,
 				workflowFinderService,
 				credentialsService,
+				nodeTypes,
 				endpoints,
 				roleService,
 				projectService,
@@ -170,6 +177,7 @@ describe('get-workflow-details MCP tool', () => {
 					baseWebhookUrl,
 					wfFinder,
 					credentialsService,
+					nodeTypes,
 					endpoints,
 					roleService,
 					projectService,
@@ -191,6 +199,7 @@ describe('get-workflow-details MCP tool', () => {
 				baseWebhookUrl,
 				workflowFinderService,
 				credentialsService,
+				nodeTypes,
 				endpoints,
 				roleService,
 				projectService,

--- a/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
@@ -5,9 +5,12 @@ import type {
 	INode,
 	INodeCredentials,
 	INodeParameters,
+	INodeType,
+	INodeTypes,
 	ICredentialDataDecryptedObject,
 } from 'n8n-workflow';
 import { WEBHOOK_NODE_TYPE } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
 
 import { CredentialsService } from '@/credentials/credentials.service';
 
@@ -60,11 +63,49 @@ const createUser = (overrides: Partial<User> = {}): User => {
 	return u;
 };
 
+// Mirrors the Webhook node type, whose webhook description sets a static `isFullPath: true`
+const nodeTypes = mock<INodeTypes>();
+nodeTypes.getByNameAndVersion.mockReturnValue(
+	mock<INodeType>({
+		description: {
+			webhooks: [
+				{
+					name: 'default',
+					httpMethod: '={{$parameter["httpMethod"] || "GET"}}',
+					isFullPath: true,
+					responseMode: '={{$parameter["responseMode"]}}',
+					path: '={{$parameter["path"]}}',
+				},
+			],
+		},
+	}),
+);
+
 describe('getWebhookDetails', () => {
 	const user = createUser();
 	const baseUrl = 'https://example.com';
 	const workflowId = 'wf-1';
 	const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };
+
+	it('returns the URL without the webhookId segment for a standard webhook node', async () => {
+		// Real webhook nodes always carry a webhookId; the URL must not include it (MCP-49)
+		const node = createWebhookNode({
+			webhookId: '3dd18038-ce87-4004-a6e8-5d4a3216066d',
+			parameters: { path: 'codex-basic-webhook-test', httpMethod: 'POST' },
+		});
+		const res = await getWebhookDetails(
+			user,
+			[node],
+			baseUrl,
+			mockCredentialsService(() => ({})),
+			nodeTypes,
+			endpoints,
+			workflowId,
+		);
+		expect(res).toContain('Production URL: https://example.com/webhook/codex-basic-webhook-test');
+		expect(res).toContain('Test URL: https://example.com/webhook-test/codex-basic-webhook-test');
+		expect(res).not.toContain('3dd18038-ce87-4004-a6e8-5d4a3216066d');
+	});
 
 	it('describes a basic webhook without auth', async () => {
 		const node = createWebhookNode({
@@ -76,6 +117,7 @@ describe('getWebhookDetails', () => {
 			[node],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 		);
@@ -94,6 +136,7 @@ describe('getWebhookDetails', () => {
 			[node],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 		);
@@ -108,6 +151,7 @@ describe('getWebhookDetails', () => {
 			[node],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 			'https://editor.example.com',
@@ -123,6 +167,7 @@ describe('getWebhookDetails', () => {
 			[node],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 		);
@@ -138,7 +183,15 @@ describe('getWebhookDetails', () => {
 			expect(id).toBe('cred-1');
 			return { name: 'X-API-Key', value: 'secret' };
 		});
-		const res = await getWebhookDetails(user, [node], baseUrl, credsService, endpoints, workflowId);
+		const res = await getWebhookDetails(
+			user,
+			[node],
+			baseUrl,
+			credsService,
+			nodeTypes,
+			endpoints,
+			workflowId,
+		);
 		expect(res).toContain('requires a header with name "X-API-Key"');
 	});
 
@@ -151,7 +204,15 @@ describe('getWebhookDetails', () => {
 			expect(id).toBe('cred-2');
 			return { secret: 'super-secret', keyType: 'passphrase' };
 		});
-		const res = await getWebhookDetails(user, [node], baseUrl, credsService, endpoints, workflowId);
+		const res = await getWebhookDetails(
+			user,
+			[node],
+			baseUrl,
+			credsService,
+			nodeTypes,
+			endpoints,
+			workflowId,
+		);
 		expect(res).toContain('requires a JWT secret');
 	});
 
@@ -164,7 +225,15 @@ describe('getWebhookDetails', () => {
 			expect(id).toBe('cred-3');
 			return { keyType: 'pemKey', privateKey: 'priv', publicKey: 'pub' };
 		});
-		const res = await getWebhookDetails(user, [node], baseUrl, credsService, endpoints, workflowId);
+		const res = await getWebhookDetails(
+			user,
+			[node],
+			baseUrl,
+			credsService,
+			nodeTypes,
+			endpoints,
+			workflowId,
+		);
 		expect(res).toContain('requires JWT private and public keys');
 	});
 
@@ -175,6 +244,7 @@ describe('getWebhookDetails', () => {
 			[node],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 		);
@@ -190,6 +260,7 @@ describe('getWebhookDetails', () => {
 			[nodeAll],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 		);
@@ -203,6 +274,7 @@ describe('getWebhookDetails', () => {
 			[nodeBin],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 		);
@@ -216,6 +288,7 @@ describe('getWebhookDetails', () => {
 			[nodeNo],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 		);
@@ -227,6 +300,7 @@ describe('getWebhookDetails', () => {
 			[nodeDefault],
 			baseUrl,
 			mockCredentialsService(() => ({})),
+			nodeTypes,
 			endpoints,
 			workflowId,
 		);

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -325,6 +325,7 @@ export class McpService {
 			this.urlService.getWebhookBaseUrl(),
 			this.workflowFinderService,
 			this.credentialsService,
+			this.nodeTypes,
 			{
 				webhook: this.globalConfig.endpoints.webhook,
 				webhookTest: this.globalConfig.endpoints.webhookTest,

--- a/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
@@ -1,4 +1,5 @@
 import type { User } from '@n8n/db';
+import type { INodeTypes } from 'n8n-workflow';
 import z from 'zod';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
@@ -33,6 +34,7 @@ export const createWorkflowDetailsTool = (
 	baseWebhookUrl: string,
 	workflowFinderService: WorkflowFinderService,
 	credentialsService: CredentialsService,
+	nodeTypes: INodeTypes,
 	endpoints: WebhookEndpoints,
 	telemetry: Telemetry,
 	roleService: RoleService,
@@ -67,6 +69,7 @@ export const createWorkflowDetailsTool = (
 					baseWebhookUrl,
 					workflowFinderService,
 					credentialsService,
+					nodeTypes,
 					endpoints,
 					roleService,
 					projectService,
@@ -108,6 +111,7 @@ export async function getWorkflowDetails(
 	baseWebhookUrl: string,
 	workflowFinderService: WorkflowFinderService,
 	credentialsService: CredentialsService,
+	nodeTypes: INodeTypes,
 	endpoints: WebhookEndpoints,
 	roleService: RoleService,
 	projectService: ProjectService,
@@ -154,6 +158,7 @@ export async function getWorkflowDetails(
 		triggers,
 		baseWebhookUrl,
 		credentialsService,
+		nodeTypes,
 		endpoints,
 		workflow.id,
 		testBaseWebhookUrl,

--- a/packages/cli/src/modules/mcp/tools/webhook-utils.ts
+++ b/packages/cli/src/modules/mcp/tools/webhook-utils.ts
@@ -6,6 +6,8 @@ import {
 	CHAT_TRIGGER_NODE_TYPE,
 	NodeHelpers,
 	type INode,
+	type INodeType,
+	type INodeTypes,
 } from 'n8n-workflow';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
@@ -37,6 +39,26 @@ type WebhookNodeDetails = {
 	credentials: WebhookCredentialRequirement;
 };
 
+/**
+ * `isFullPath` lives on the node type's webhook description, not on the node's
+ * parameters. When it resolves to false, getNodeWebhookUrl prefixes the node's
+ * webhookId, producing a URL that does not match the registered webhook.
+ */
+const resolveIsFullPath = (nodeTypes: INodeTypes, node: INode): boolean => {
+	let nodeType: INodeType | undefined;
+	try {
+		nodeType = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+	} catch {
+		return false;
+	}
+	const webhookDescription = nodeType?.description.webhooks?.find(
+		(webhook) => webhook.restartWebhook !== true,
+	);
+	// The value can be an expression, but the Webhook node (the only type routed
+	// here) defines it as a static boolean; treat anything else as false.
+	return webhookDescription?.isFullPath === true;
+};
+
 // Normalizes endpoint segment (strips leading/trailing slashes) and joins with the node path.
 const buildEndpointBaseUrl = (baseUrl: string, endpoint: string) => {
 	const trimmedBase = baseUrl.replace(/\/+$/, '');
@@ -49,6 +71,7 @@ export const getTriggerDetails = async (
 	supportedTriggers: INode[],
 	baseUrl: string,
 	credentialsService: CredentialsService,
+	nodeTypes: INodeTypes,
 	endpoints: WebhookEndpoints,
 	workflowId: string,
 	testBaseUrl: string = baseUrl,
@@ -82,6 +105,7 @@ export const getTriggerDetails = async (
 			triggersByType[WEBHOOK_NODE_TYPE],
 			baseUrl,
 			credentialsService,
+			nodeTypes,
 			endpoints,
 			workflowId,
 			testBaseUrl,
@@ -163,6 +187,7 @@ export const getWebhookDetails = async (
 	webhookNodes: INode[],
 	baseUrl: string,
 	credentialsService: CredentialsService,
+	nodeTypes: INodeTypes,
 	endpoints: WebhookEndpoints,
 	workflowId: string,
 	testBaseUrl: string = baseUrl,
@@ -175,6 +200,7 @@ export const getWebhookDetails = async (
 					node,
 					baseUrl,
 					credentialsService,
+					nodeTypes,
 					endpoints,
 					workflowId,
 					testBaseUrl,
@@ -190,12 +216,13 @@ const collectWebhookNodeDetails = async (
 	node: INode,
 	baseUrl: string,
 	credentialsService: CredentialsService,
+	nodeTypes: INodeTypes,
 	endpoints: WebhookEndpoints,
 	workflowId: string,
 	testBaseUrl: string = baseUrl,
 ): Promise<WebhookNodeDetails> => {
 	const pathParam = typeof node.parameters.path === 'string' ? node.parameters.path : '';
-	const isFullPath = node.parameters.isFullPath === true;
+	const isFullPath = resolveIsFullPath(nodeTypes, node);
 	const httpMethod =
 		typeof node.parameters.httpMethod === 'string' ? node.parameters.httpMethod : 'GET';
 


### PR DESCRIPTION
## Summary

The MCP `get_workflow_details` tool returned webhook URLs in `triggerInfo` with the node's `webhookId` prepended (`/webhook/<uuid>/<path>`) instead of the correct URL shown in the editor UI (`/webhook/<path>`). The UUID-prefixed URL does not match the registered webhook and returns 404, so AI clients handed users a broken URL.

Root cause: `collectWebhookNodeDetails` read `isFullPath` from `node.parameters.isFullPath`, but `isFullPath` is not a node parameter. It is a flag on the node type's webhook description (the Webhook node sets a static `isFullPath: true`). It therefore always resolved to `false`, and `NodeHelpers.getNodeWebhookPath` prefixed the node's `webhookId`.

Fix: resolve `isFullPath` from the node type's webhook description via `INodeTypes.getByNameAndVersion`, matching how the editor UI (`useWorkflowHelpers.getWebhookUrl`) and webhook registration (`webhook.service.ts`) compute it. `NodeTypes` was already injected in `McpService` and is now threaded through to the webhook details helpers.

The existing tests missed this because none of their node fixtures set a `webhookId`, so they only exercised the legacy `webhookId === undefined` branch that real nodes (which always carry a `webhookId`) never hit. Added a regression test with a `webhookId` that reproduces the exact URL from the ticket and asserts the UUID segment is gone.

## How to test

1. Connect an MCP client (e.g. Claude or Codex) to an n8n instance.
2. Ask it to create a basic webhook workflow and return the webhook URL, or call `get_workflow_details` on an existing workflow with a Webhook trigger.
3. The `triggerInfo` Production/Test URLs should be `<instance>/webhook/<path>` with no UUID segment, matching the URL shown in the Webhook node in the editor UI, and a request to it should trigger the workflow.

Unit tests: `pnpm test src/modules/mcp` in `packages/cli` (990 tests pass).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/MCP-49

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

