### PR TITLE
fix: Parse structured output from content-block model responses in chain nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -8,6 +8,7 @@ import type { Runnable } from '@langchain/core/runnables';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
 import { isChatInstance } from '@n8n/ai-utilities';
+import { toParserInputText } from '@utils/output_parsers/parserInput';
 import { getTracingConfig } from '@utils/tracing';
 
 import { createPromptTemplate, getAgentStepsParser } from './promptUtils';
@@ -188,6 +189,7 @@ export async function executeChain({
 	} else {
 		chain = promptWithInstructions
 			.pipe(model)
+			.pipe(toParserInputText)
 			.pipe(outputParser)
 			.withConfig(getTracingConfig(context));
 	}

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/chainExecutor.test.ts
@@ -284,8 +284,11 @@ describe('chainExecutor', () => {
 			const pipeOutputParserMock = vi.fn().mockReturnValue({
 				withConfig: withConfigMock,
 			});
-			const pipeMock = vi.fn().mockReturnValue({
+			const pipeCoercionMock = vi.fn().mockReturnValue({
 				pipe: pipeOutputParserMock,
+			});
+			const pipeMock = vi.fn().mockReturnValue({
+				pipe: pipeCoercionMock,
 			});
 
 			mockPromptTemplate.pipe = pipeMock;
@@ -333,8 +336,11 @@ describe('chainExecutor', () => {
 			const pipeOutputParserMock = vi.fn().mockReturnValue({
 				withConfig: withConfigMock,
 			});
-			const pipeMock = vi.fn().mockReturnValue({
+			const pipeCoercionMock = vi.fn().mockReturnValue({
 				pipe: pipeOutputParserMock,
+			});
+			const pipeMock = vi.fn().mockReturnValue({
+				pipe: pipeCoercionMock,
 			});
 
 			mockPromptTemplate.pipe = pipeMock;
@@ -568,8 +574,11 @@ describe('chainExecutor', () => {
 			const pipeOutputParserMock = vi.fn().mockReturnValue({
 				withConfig: withConfigMock,
 			});
-			const pipeMock = vi.fn().mockReturnValue({
+			const pipeCoercionMock = vi.fn().mockReturnValue({
 				pipe: pipeOutputParserMock,
+			});
+			const pipeMock = vi.fn().mockReturnValue({
+				pipe: pipeCoercionMock,
 			});
 
 			mockPromptTemplate.pipe = pipeMock;

--- a/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/processItem.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/InformationExtractor/processItem.ts
@@ -5,6 +5,7 @@ import type { OutputFixingParser } from '@langchain/classic/output_parsers';
 import { NodeOperationError, type IExecuteFunctions } from 'n8n-workflow';
 
 import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
+import { toParserInputText } from '@utils/output_parsers/parserInput';
 import { getTracingConfig } from '@utils/tracing';
 
 import { SYSTEM_PROMPT_TEMPLATE } from './constants';
@@ -44,7 +45,11 @@ export async function processItem(
 		inputPrompt,
 	];
 	const prompt = ChatPromptTemplate.fromMessages(messages);
-	const chain = prompt.pipe(llm).pipe(parser).withConfig(getTracingConfig(ctx));
+	const chain = prompt
+		.pipe(llm)
+		.pipe(toParserInputText)
+		.pipe(parser)
+		.withConfig(getTracingConfig(ctx));
 
 	try {
 		return await chain.invoke(messages);

--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -14,6 +14,7 @@ import type {
 import { z } from 'zod';
 
 import { getBatchingOptionFields } from '@n8n/ai-utilities';
+import { toParserInputText } from '@utils/output_parsers/parserInput';
 import { getTracingConfig } from '@utils/tracing';
 
 const DEFAULT_SYSTEM_PROMPT_TEMPLATE =
@@ -237,7 +238,11 @@ export class SentimentAnalysis implements INodeType {
 					];
 
 					const prompt = ChatPromptTemplate.fromMessages(messages);
-					const chain = prompt.pipe(llm).pipe(parser).withConfig(getTracingConfig(this));
+					const chain = prompt
+						.pipe(llm)
+						.pipe(toParserInputText)
+						.pipe(parser)
+						.withConfig(getTracingConfig(this));
 
 					try {
 						const output = await chain.invoke(messages);
@@ -381,7 +386,11 @@ export class SentimentAnalysis implements INodeType {
 					];
 
 					const prompt = ChatPromptTemplate.fromMessages(messages);
-					const chain = prompt.pipe(llm).pipe(parser).withConfig(getTracingConfig(this));
+					const chain = prompt
+						.pipe(llm)
+						.pipe(toParserInputText)
+						.pipe(parser)
+						.withConfig(getTracingConfig(this));
 
 					try {
 						const output = await chain.invoke(messages);

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/processItem.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/processItem.ts
@@ -5,6 +5,7 @@ import type { OutputFixingParser, StructuredOutputParser } from '@langchain/clas
 import { NodeOperationError, type IExecuteFunctions, type INodeExecutionData } from 'n8n-workflow';
 
 import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
+import { toParserInputText } from '@utils/output_parsers/parserInput';
 import { getTracingConfig } from '@utils/tracing';
 
 import { SYSTEM_PROMPT_TEMPLATE } from './constants';
@@ -56,7 +57,11 @@ export async function processItem(
 		inputPrompt,
 	];
 	const prompt = ChatPromptTemplate.fromMessages(messages);
-	const chain = prompt.pipe(llm).pipe(parser).withConfig(getTracingConfig(ctx));
+	const chain = prompt
+		.pipe(llm)
+		.pipe(toParserInputText)
+		.pipe(parser)
+		.withConfig(getTracingConfig(ctx));
 
 	try {
 		return await chain.invoke(messages);

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/processItem.contentBlocks.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/processItem.contentBlocks.test.ts
@@ -1,0 +1,68 @@
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { AIMessage } from '@langchain/core/messages';
+import type { ChatResult } from '@langchain/core/outputs';
+import { StructuredOutputParser } from '@langchain/classic/output_parsers';
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+import { z } from 'zod';
+
+import { processItem } from '../processItem';
+
+vi.mock('@utils/tracing', () => ({
+	getTracingConfig: vi.fn(() => ({})),
+}));
+
+/** Replies with content-block arrays, the message shape the OpenAI Responses
+ *  API and reasoning models produce (instead of plain string content). */
+class ContentBlocksChatModel extends BaseChatModel {
+	constructor(private readonly reply: string) {
+		super({});
+	}
+
+	_llmType() {
+		return 'content-blocks-fake';
+	}
+
+	async _generate(): Promise<ChatResult> {
+		return {
+			generations: [
+				{
+					message: new AIMessage({ content: [{ type: 'text', text: this.reply }] }),
+					text: '',
+				},
+			],
+		};
+	}
+}
+
+describe('processItem with content-block model output', () => {
+	it('parses the classification from array message content', async () => {
+		const ctx = mock<IExecuteFunctions>();
+		ctx.getNodeParameter.mockImplementation((param, _itemIndex, defaultValue) => {
+			if (param === 'inputText') return 'My invoice was charged twice, please refund';
+			return defaultValue;
+		});
+
+		const categories = [
+			{ category: 'Billing', description: 'Payments and refunds' },
+			{ category: 'Technical', description: 'Bugs and errors' },
+		];
+		const parser = StructuredOutputParser.fromZodSchema(
+			z.object({ Billing: z.boolean(), Technical: z.boolean() }),
+		);
+		const llm = new ContentBlocksChatModel('```json\n{"Billing":true,"Technical":false}\n```');
+
+		const output = await processItem(
+			ctx,
+			0,
+			{ json: {} },
+			llm,
+			parser,
+			categories,
+			'Categories are mutually exclusive, and only one can be true',
+			undefined,
+		);
+
+		expect(output).toEqual({ Billing: true, Technical: false });
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/processItem.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/processItem.test.ts
@@ -72,7 +72,9 @@ describe('processItem', () => {
 
 		const mockPipe = vi.fn().mockReturnValue({
 			pipe: vi.fn().mockReturnValue({
-				withConfig: vi.fn().mockReturnValue(mockChain),
+				pipe: vi.fn().mockReturnValue({
+					withConfig: vi.fn().mockReturnValue(mockChain),
+				}),
 			}),
 		});
 
@@ -122,7 +124,9 @@ describe('processItem', () => {
 
 		const mockPipe = vi.fn().mockReturnValue({
 			pipe: vi.fn().mockReturnValue({
-				withConfig: vi.fn().mockReturnValue(mockChain),
+				pipe: vi.fn().mockReturnValue({
+					withConfig: vi.fn().mockReturnValue(mockChain),
+				}),
 			}),
 		});
 
@@ -158,7 +162,9 @@ describe('processItem', () => {
 
 		const mockPipe = vi.fn().mockReturnValue({
 			pipe: vi.fn().mockReturnValue({
-				withConfig: vi.fn().mockReturnValue(mockChain),
+				pipe: vi.fn().mockReturnValue({
+					withConfig: vi.fn().mockReturnValue(mockChain),
+				}),
 			}),
 		});
 

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/parserInput.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/parserInput.test.ts
@@ -1,0 +1,31 @@
+import { AIMessage } from '@langchain/core/messages';
+
+import { toParserInputText } from './parserInput';
+
+describe('toParserInputText', () => {
+	it('passes string LLM output through unchanged', () => {
+		expect(toParserInputText('plain completion')).toBe('plain completion');
+	});
+
+	it('returns string message content as-is', () => {
+		expect(toParserInputText(new AIMessage('{"ok":true}'))).toBe('{"ok":true}');
+	});
+
+	it('extracts text from content-block arrays (OpenAI Responses API shape)', () => {
+		const message = new AIMessage({
+			content: [{ type: 'text', text: '```json\n{"Billing":true}\n```' }],
+		});
+		expect(toParserInputText(message)).toBe('```json\n{"Billing":true}\n```');
+	});
+
+	it('joins multiple text blocks and skips non-text blocks', () => {
+		const message = new AIMessage({
+			content: [
+				{ type: 'reasoning', reasoning: 'thinking...' } as never,
+				{ type: 'text', text: '{"a":' },
+				{ type: 'text', text: '1}' },
+			],
+		});
+		expect(toParserInputText(message)).toBe('{"a":1}');
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/parserInput.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/parserInput.ts
@@ -1,0 +1,12 @@
+import type { BaseMessage } from '@langchain/core/messages';
+
+/**
+ * LangChain's string-based output parsers stringify array message content (the
+ * content-block shape returned by the OpenAI Responses API and by reasoning
+ * models) instead of extracting its text, so strict parsers reject otherwise
+ * valid replies. Pipe this between a model and a string-based output parser to
+ * hand the parser the message text; string outputs pass through unchanged.
+ */
+export function toParserInputText(output: string | BaseMessage): string {
+	return typeof output === 'string' ? output : output.text;
+}


### PR DESCRIPTION
## Summary

Text Classifier, Information Extractor, Sentiment Analysis, and Basic LLM Chain (typeVersion < 1.9) pipe the chat model's output **directly into a string-based LangChain output parser** (`prompt.pipe(llm).pipe(parser)`).

When the model returns its message content as an **array of content blocks** — the shape `@langchain/openai` produces on the **Responses API** path (which "Use Responses API" on the OpenAI Chat Model node ≥ 1.3 enables **by default**), and the shape reasoning/thinking models produce generally — LangChain's `BaseOutputParser` coerces the message to text with a bare `JSON.stringify(content)`. The parser then sees

```
[{"type":"text","text":"```json\n{\"Billing\":true,...}\n```","annotations":[]}]
```

instead of the model's text, `JSON.parse` yields an **array**, zod expects an **object**, and the node fails every item with **"Model output doesn't fit required format"** — even when the model's reply was exactly what the format instructions asked for.

Upstream context: LangChain's own Guardrails workaround references the same defect — https://github.com/langchain-ai/langchainjs/issues/9012 (`BaseOutputParser` stringifies block-array content). n8n's Guardrails node (`helpers/model.ts`) carries a narrower manual workaround (reads only `content[0]`, throws on a reasoning-first block) and can adopt `toParserInputText` + re-pipe its parser once this lands.

Wire-verified: a fresh Text Classifier + OpenAI Chat Model (defaults, `gpt-5-mini`) workflow fails 100% of executions on current master. This was surfaced by the Instance AI eval suite, where the top mock_issue-attributed case (0/30 pass) turned out to be this product bug — the mock's replies were schema-perfect on the wire.

**Fix:** coerce the model output to its text (`message.text`, which joins text blocks and skips reasoning blocks; plain-string outputs from completion LLMs pass through) between the model and the parser, via a shared `toParserInputText` helper. String-content messages are unaffected (`.text` returns `content` as-is), so chat-completions behavior is unchanged. This also repairs the same crash for Anthropic extended-thinking content and any other block-array-producing model.

- `ChainLLM` ≥ 1.9 already handles this via `getAgentStepsParser` (`steps.text`); only the < 1.9 branch is patched.
- `StringOutputParser` / `JsonOutputParser` (simple-chain path) already coerce correctly and are untouched.

## How to test

1. New workflow: Manual Trigger → Text Classifier (any 2–3 categories) with OpenAI Chat Model (defaults — `gpt-5-mini`, Use Responses API on).
2. Classify any text. On master: "Model output doesn't fit required format" on every item. With this PR: items route to the right category.
3. Unit tests: `packages/@n8n/nodes-langchain` — `utils/output_parsers/parserInput.test.ts` + `nodes/chains/TextClassifier/test/processItem.contentBlocks.test.ts` (regression test fails without the fix).

Live eval validation run (16-case suite, N=5, this fix + eval-harness fixture fixes): https://github.com/n8n-io/n8n/actions/runs/30109482096

## Related Linear tickets, Github issues, and Community forum posts

Surfaced while working on https://linear.app/n8n/issue/TRUST-344

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



---

## Validation result (run [30109482096](https://github.com/n8n-io/n8n/actions/runs/30109482096), N=5, 16-case suite)

All pre-stated criteria met. The classifier-failure signature is **fully eliminated**:
- `build-from-complete-spec` (Text Classifier + OpenAI Chat Model defaults): **0/30 → 15/15 pass**
- `gmail-classify-client-project`: 1/20 → **10/10 pass**
- InformationExtractor-based flows now execute past the parser (previously 100% "Model output doesn't fit required format" on the Responses-API path)

