### PR TITLE
fix(core): Keep MCP server display names free-form in agent config

### DIFF
--- a/packages/@n8n/api-types/src/agents/__tests__/agent-json-config.schema.test.ts
+++ b/packages/@n8n/api-types/src/agents/__tests__/agent-json-config.schema.test.ts
@@ -550,7 +550,7 @@ describe('formatAgentConfigZodError', () => {
 			...minimalConfig,
 			mcpServers: [
 				{
-					name: 'has spaces',
+					name: '   ',
 					url: 'https://example.com/mcp',
 					transport: 'streamableHttp',
 					authentication: 'none',
@@ -563,12 +563,8 @@ describe('formatAgentConfigZodError', () => {
 
 		const formatted = formatAgentConfigZodError(result.error);
 		expect(formatted).toContain('mcpServers.0.name');
-		expect(formatted).toContain(
-			'MCP server name can only contain letters, numbers, hyphens, and underscores',
-		);
+		expect(formatted).toContain('MCP server name cannot be blank');
 		expect(formatted).not.toContain('"validation": "regex"');
-		expect(result.error.issues[0]?.message).toBe(
-			'MCP server name can only contain letters, numbers, hyphens, and underscores',
-		);
+		expect(result.error.issues[0]?.message).toBe('MCP server name cannot be blank');
 	});
 });

--- a/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
+++ b/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
@@ -236,10 +236,6 @@ export const McpServerConfigSchema = z
 			.string()
 			.min(1)
 			.max(64)
-			.regex(
-				/^[a-zA-Z0-9_-]+$/,
-				'MCP server name can only contain letters, numbers, hyphens, and underscores',
-			)
 			.refine((name) => name.trim().length > 0, 'MCP server name cannot be blank')
 			.describe('Unique display name. The SDK normalizes it when building model-facing tool names'),
 		description: z.string().max(512).optional().describe('Human-readable server description'),


### PR DESCRIPTION
## Summary

Master CI is red since #34867: the `Backend Unit Tests` job fails on `preserves human-readable MCP server names` (`packages/cli/src/modules/agents/__tests__/from-json-config.test.ts`).

#34867 was about formatting zod errors, but alongside adding messages to existing regexes it also introduced a **new** `^[a-zA-Z0-9_-]+$` regex on `McpServerConfigSchema.name`. That conflicts with #34827, which deliberately made MCP server names free-form display names (the schema's own description: *"Unique display name. The SDK normalizes it when building model-facing tool names"*) and added the test that now fails. Both PRs were green individually; combined on master they can't both pass.

This PR removes the newly-introduced regex so display names stay free-form, and repoints the `formatAgentConfigZodError` test from #34867 at the existing blank-name validation, preserving its actual purpose (asserting `path: message` formatting without a Zod JSON dump).

## How to test

- `pnpm vitest run src/agents/__tests__/agent-json-config.schema.test.ts` in `packages/@n8n/api-types` (42 passed)
- `pnpm test src/modules/agents/__tests__/from-json-config.test.ts` in `packages/cli` — the test that is red on master

## Related Linear tickets, Github issues, and Community forum posts

Fixes master CI breakage introduced by #34867; restores behavior from #34827.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34931">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

