### PR TITLE
feat(editor): Refine action dropdown item styling

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/ActionDropdown.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/ActionDropdown.test.ts
@@ -106,6 +106,27 @@ describe('components', () => {
 			// This ensures badge-click only emits for disabled items
 		});
 
+		it('should mark destructive items with the destructive class', async () => {
+			const wrapper = render(N8nActionDropdown, {
+				props: {
+					items: [
+						{ id: 'edit', label: 'Edit' },
+						{ id: 'delete', label: 'Delete', variant: 'destructive' as const },
+					],
+				},
+			});
+
+			await userEvent.click(wrapper.container.querySelector('button')!);
+
+			await waitFor(() => {
+				const deleteItem = document.querySelector('[data-test-id="action-delete"]');
+				expect(deleteItem?.className).toContain('destructive');
+
+				const editItem = document.querySelector('[data-test-id="action-edit"]');
+				expect(editItem?.className).not.toContain('destructive');
+			});
+		});
+
 		it('should render footer content', async () => {
 			const wrapper = render(N8nActionDropdown, {
 				props: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/ActionDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nActionDropdown/ActionDropdown.vue
@@ -99,6 +99,7 @@ const getItemClasses = (item: ActionDropdownItem<T>): Record<string, boolean> =>
 	return {
 		[$style.itemContainer]: true,
 		[$style.disabled]: !!item.disabled,
+		[$style.destructive]: item.variant === 'destructive',
 		[$style.hasCustomStyling]: item.customClass !== undefined,
 		...(item.customClass !== undefined ? { [item.customClass]: true } : {}),
 	};
@@ -200,7 +201,9 @@ const getItemClasses = (item: ActionDropdownItem<T>): Record<string, boolean> =>
 .itemContainer {
 	display: flex;
 	align-items: center;
-	gap: var(--spacing--sm);
+	/* Matches the base N8nDropdownMenu item gap so icon-to-label spacing is
+	 * consistent across every menu in the app. */
+	gap: var(--spacing--2xs);
 	justify-content: space-between;
 	font-size: var(--font-size--2xs);
 	line-height: 18px;
@@ -214,6 +217,19 @@ const getItemClasses = (item: ActionDropdownItem<T>): Record<string, boolean> =>
 
 	:global([data-disabled]) & {
 		color: inherit;
+	}
+}
+
+/* Destructive items (delete, revoke, ...) turn danger-red on hover or keyboard
+ * highlight: the icon and label both inherit the item color, so one rule
+ * covers them, and the token adapts to light/dark themes on its own. */
+.destructive {
+	&:not([data-disabled]) {
+		&:hover,
+		&[data-highlighted],
+		&[aria-selected='true'] {
+			color: var(--color--danger);
+		}
 	}
 }
 

--- a/packages/frontend/@n8n/design-system/src/types/action-dropdown.ts
+++ b/packages/frontend/@n8n/design-system/src/types/action-dropdown.ts
@@ -15,4 +15,6 @@ export interface ActionDropdownItem<T extends string> {
 	shortcut?: KeyboardShortcut;
 	customClass?: string;
 	checked?: boolean;
+	/** Destructive items (delete, revoke, ...) turn danger-red on hover. */
+	variant?: 'default' | 'destructive';
 }


### PR DESCRIPTION
## Summary

- Aligns `N8nActionDropdown` icon-to-label spacing with the 8px gap used by the base `N8nDropdownMenu` instead of overriding it to 16px.
- Adds a first-class `destructive` item variant that turns both icon and label danger-red on pointer hover and keyboard highlight.
- Uses the existing theme-aware `--color--danger` token so the state remains legible in light and dark modes.

The API key Revoke action in #34925 consumes this variant.

## Test plan

- [x] `pnpm typecheck` in `@n8n/design-system`
- [x] `pnpm vitest run src/components/N8nActionDropdown/ActionDropdown.test.ts` (7 tests)
- [x] Verified the destructive color and shared icon/label inheritance in light and dark themes
- [x] Pre-commit formatting and style checks

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34941">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->