### PR TITLE
feat(editor): Add CopyInput component

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.stories.ts
@@ -1,0 +1,51 @@
+import type { StoryFn } from '@storybook/vue3-vite';
+
+import N8nCopyInput from './CopyInput.vue';
+
+export default {
+	title: 'Core/CopyInput',
+	component: N8nCopyInput,
+	argTypes: {
+		size: {
+			control: 'select',
+			options: ['mini', 'small', 'medium', 'large', 'xlarge'],
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A readonly input with an attached copy button, rendered as one continuous bordered field. ' +
+					'Clicking the button writes the full value to the clipboard and morphs the copy icon into a ' +
+					'check mark through the blur-swap motion. Use `displayValue` to show a truncated secret ' +
+					'while still copying the full value.',
+			},
+		},
+	},
+};
+
+const Template: StoryFn = (args, { argTypes }) => ({
+	setup: () => ({ args }),
+	props: Object.keys(argTypes),
+	components: {
+		N8nCopyInput,
+	},
+	template: '<n8n-copy-input v-bind="args" />',
+});
+
+export const Default = Template.bind({});
+Default.args = {
+	value: 'n8n_api_3f9d2c1b8a7e6f5d4c3b2a1908f7e6d5c4b3a291',
+};
+
+export const TruncatedSecret = Template.bind({});
+TruncatedSecret.args = {
+	value: 'n8n_api_3f9d2c1b8a7e6f5d4c3b2a1908f7e6d5c4b3a291',
+	displayValue: 'n8n_api_3f9d2c1b8a7e...6d5c4b3a291',
+};
+
+export const Medium = Template.bind({});
+Medium.args = {
+	value: 'https://example.n8n.cloud/webhook/abcd-1234',
+	size: 'medium',
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.stories.ts
@@ -1,14 +1,17 @@
-import type { StoryFn } from '@storybook/vue3-vite';
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
 
 import N8nCopyInput from './CopyInput.vue';
 
-export default {
+const meta = {
 	title: 'Core/CopyInput',
 	component: N8nCopyInput,
 	argTypes: {
 		size: {
 			control: 'select',
-			options: ['mini', 'small', 'medium', 'large', 'xlarge'],
+			options: ['xlarge', 'large', 'medium', 'small', 'mini'],
+		},
+		disabled: {
+			control: 'boolean',
 		},
 	},
 	parameters: {
@@ -16,36 +19,81 @@ export default {
 			description: {
 				component:
 					'A readonly input with an attached copy button, rendered as one continuous bordered field. ' +
-					'Clicking the button writes the full value to the clipboard and morphs the copy icon into a ' +
-					'check mark through the blur-swap motion. Use `displayValue` to show a truncated secret ' +
-					'while still copying the full value.',
+					'Clicking the field selects the whole value; the copy button and Cmd/Ctrl+C both write the ' +
+					'full `value` to the clipboard and morph the copy icon into a check mark. Use `displayValue` ' +
+					'to show a truncated secret while still copying the full value.',
 			},
 		},
 	},
-};
+} satisfies Meta<typeof N8nCopyInput>;
+export default meta;
 
-const Template: StoryFn = (args, { argTypes }) => ({
-	setup: () => ({ args }),
-	props: Object.keys(argTypes),
-	components: {
-		N8nCopyInput,
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		label: 'API key',
+		value: 'n8n_api_3f9d2c1b8a7e6f5d4c3b2a1908f7e6d5c4b3a291',
 	},
-	template: '<n8n-copy-input v-bind="args" />',
-});
+} satisfies Story;
 
-export const Default = Template.bind({});
-Default.args = {
-	value: 'n8n_api_3f9d2c1b8a7e6f5d4c3b2a1908f7e6d5c4b3a291',
-};
+export const TruncatedSecret = {
+	args: {
+		label: 'API key',
+		value: 'n8n_api_3f9d2c1b8a7e6f5d4c3b2a1908f7e6d5c4b3a291',
+		displayValue: 'n8n_api_3f9d2c1b8a7e...6d5c4b3a291',
+	},
+} satisfies Story;
 
-export const TruncatedSecret = Template.bind({});
-TruncatedSecret.args = {
-	value: 'n8n_api_3f9d2c1b8a7e6f5d4c3b2a1908f7e6d5c4b3a291',
-	displayValue: 'n8n_api_3f9d2c1b8a7e...6d5c4b3a291',
-};
+export const Disabled = {
+	args: {
+		label: 'Webhook URL',
+		value: 'https://example.n8n.cloud/webhook/abcd-1234',
+		disabled: true,
+	},
+} satisfies Story;
 
-export const Medium = Template.bind({});
-Medium.args = {
-	value: 'https://example.n8n.cloud/webhook/abcd-1234',
-	size: 'medium',
-};
+export const Sizes = {
+	render: (args) => ({
+		components: { N8nCopyInput },
+		setup: () => ({ args }),
+		template: `
+		<div style="display: flex; gap: var(--spacing--md); align-items: flex-start;">
+			<div style="display: grid; gap: var(--spacing--3xs);">
+				<N8nCopyInput v-bind="args" size="xlarge" />
+				<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+					xlarge (40px)
+				</span>
+			</div>
+			<div style="display: grid; gap: var(--spacing--3xs);">
+				<N8nCopyInput v-bind="args" size="large" />
+				<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+					large (36px)
+				</span>
+			</div>
+			<div style="display: grid; gap: var(--spacing--3xs);">
+				<N8nCopyInput v-bind="args" size="medium" />
+				<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+					medium (32px)
+				</span>
+			</div>
+			<div style="display: grid; gap: var(--spacing--3xs);">
+				<N8nCopyInput v-bind="args" size="small" />
+				<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+					small (28px)
+				</span>
+			</div>
+			<div style="display: grid; gap: var(--spacing--3xs);">
+				<N8nCopyInput v-bind="args" size="mini" />
+				<span style="font-size: var(--font-size--2xs); color: var(--color--text--tint-1);">
+					mini (24px)
+				</span>
+			</div>
+		</div>
+		`,
+	}),
+	args: {
+		label: 'Webhook URL',
+		value: 'https://example.n8n.cloud/webhook/abcd-1234',
+	},
+} satisfies Story;

--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.test.ts
@@ -1,0 +1,79 @@
+import { fireEvent, render } from '@testing-library/vue';
+import { nextTick } from 'vue';
+
+import N8nCopyInput from './CopyInput.vue';
+
+const clipboardCopy = vi.fn();
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+	const original = await importOriginal<typeof import('@vueuse/core')>();
+	return {
+		...original,
+		useClipboard: () => ({ copy: clipboardCopy }),
+	};
+});
+
+describe('N8nCopyInput', () => {
+	beforeEach(() => {
+		clipboardCopy.mockClear();
+	});
+
+	it('renders the value in a readonly input', () => {
+		const { getByDisplayValue } = render(N8nCopyInput, {
+			props: { value: 'secret-token' },
+		});
+
+		const input = getByDisplayValue('secret-token');
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveAttribute('readonly');
+	});
+
+	it('shows the display value but copies the full value', async () => {
+		const { getByDisplayValue, getByTestId, queryByDisplayValue, emitted } = render(N8nCopyInput, {
+			props: { value: 'secret-token', displayValue: 'secret...oken' },
+		});
+
+		expect(getByDisplayValue('secret...oken')).toBeInTheDocument();
+		expect(queryByDisplayValue('secret-token')).not.toBeInTheDocument();
+
+		await fireEvent.click(getByTestId('copy-input-button'));
+
+		expect(clipboardCopy).toHaveBeenCalledWith('secret-token');
+		expect(emitted('copy')).toEqual([['secret-token']]);
+	});
+
+	it('flips the copy button to a check mark after copying, then back', async () => {
+		vi.useFakeTimers();
+		try {
+			const { getByTestId } = render(N8nCopyInput, {
+				props: { value: 'secret-token', feedbackDurationMs: 1000 },
+			});
+
+			const button = getByTestId('copy-input-button');
+			expect(button).toHaveAccessibleName('Copy');
+
+			await fireEvent.click(button);
+			await nextTick();
+			expect(button).toHaveAccessibleName('Copied to clipboard');
+
+			await vi.advanceTimersByTimeAsync(1000);
+			await nextTick();
+			expect(button).toHaveAccessibleName('Copy');
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('uses custom button labels', async () => {
+		const { getByTestId } = render(N8nCopyInput, {
+			props: { value: 'secret-token', copyLabel: 'Kopieren', copiedLabel: 'Kopiert' },
+		});
+
+		const button = getByTestId('copy-input-button');
+		expect(button).toHaveAccessibleName('Kopieren');
+
+		await fireEvent.click(button);
+		await nextTick();
+		expect(button).toHaveAccessibleName('Kopiert');
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.test.ts
@@ -3,58 +3,63 @@ import { nextTick } from 'vue';
 
 import N8nCopyInput from './CopyInput.vue';
 
-const clipboardCopy = vi.fn();
+const writeText = vi.fn<(text: string) => Promise<void>>();
 
-vi.mock('@vueuse/core', async (importOriginal) => {
-	const original = await importOriginal<typeof import('@vueuse/core')>();
-	return {
-		...original,
-		useClipboard: () => ({ copy: clipboardCopy }),
-	};
-});
+const tooltipStub = {
+	template:
+		'<span data-test-id="tooltip" :data-content="content" :data-disabled="disabled"><slot /></span>',
+	props: ['content', 'disabled'],
+};
+
+const renderComponent = (props: Partial<InstanceType<typeof N8nCopyInput>['$props']> = {}) =>
+	render(N8nCopyInput, {
+		props: { value: 'secret-token', label: 'API key', ...props },
+		global: { stubs: { N8nTooltip: tooltipStub } },
+	});
 
 describe('N8nCopyInput', () => {
 	beforeEach(() => {
-		clipboardCopy.mockClear();
+		writeText.mockReset().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, 'clipboard', {
+			value: { writeText },
+			configurable: true,
+		});
 	});
 
-	it('renders the value in a readonly input', () => {
-		const { getByDisplayValue } = render(N8nCopyInput, {
-			props: { value: 'secret-token' },
-		});
+	it('renders a labelled readonly input', () => {
+		const { getByRole } = renderComponent();
 
-		const input = getByDisplayValue('secret-token');
-		expect(input).toBeInTheDocument();
+		const input = getByRole('textbox', { name: 'API key' });
+		expect(input).toHaveValue('secret-token');
 		expect(input).toHaveAttribute('readonly');
 	});
 
 	it('shows the display value but copies the full value', async () => {
-		const { getByDisplayValue, getByTestId, queryByDisplayValue, emitted } = render(N8nCopyInput, {
-			props: { value: 'secret-token', displayValue: 'secret...oken' },
+		const { getByRole, getByTestId, emitted } = renderComponent({
+			displayValue: 'secret...oken',
 		});
 
-		expect(getByDisplayValue('secret...oken')).toBeInTheDocument();
-		expect(queryByDisplayValue('secret-token')).not.toBeInTheDocument();
+		expect(getByRole('textbox')).toHaveValue('secret...oken');
 
 		await fireEvent.click(getByTestId('copy-input-button'));
 
-		expect(clipboardCopy).toHaveBeenCalledWith('secret-token');
+		expect(writeText).toHaveBeenCalledWith('secret-token');
 		expect(emitted('copy')).toEqual([['secret-token']]);
 	});
 
 	it('flips the copy button to a check mark after copying, then back', async () => {
 		vi.useFakeTimers();
 		try {
-			const { getByTestId } = render(N8nCopyInput, {
-				props: { value: 'secret-token', feedbackDurationMs: 1000 },
-			});
+			const { getByTestId } = renderComponent({ feedbackDurationMs: 1000 });
 
 			const button = getByTestId('copy-input-button');
 			expect(button).toHaveAccessibleName('Copy');
+			expect(getByTestId('tooltip')).toHaveAttribute('data-content', 'Copy');
 
 			await fireEvent.click(button);
 			await nextTick();
 			expect(button).toHaveAccessibleName('Copied to clipboard');
+			expect(getByTestId('tooltip')).toHaveAttribute('data-content', 'Copied to clipboard');
 
 			await vi.advanceTimersByTimeAsync(1000);
 			await nextTick();
@@ -65,9 +70,7 @@ describe('N8nCopyInput', () => {
 	});
 
 	it('uses custom button labels', async () => {
-		const { getByTestId } = render(N8nCopyInput, {
-			props: { value: 'secret-token', copyLabel: 'Kopieren', copiedLabel: 'Kopiert' },
-		});
+		const { getByTestId } = renderComponent({ copyLabel: 'Kopieren', copiedLabel: 'Kopiert' });
 
 		const button = getByTestId('copy-input-button');
 		expect(button).toHaveAccessibleName('Kopieren');
@@ -75,5 +78,80 @@ describe('N8nCopyInput', () => {
 		await fireEvent.click(button);
 		await nextTick();
 		expect(button).toHaveAccessibleName('Kopiert');
+	});
+
+	it('emits an error and keeps the resting state when the clipboard rejects the write', async () => {
+		writeText.mockRejectedValue(new Error('denied'));
+		const { getByTestId, emitted } = renderComponent();
+
+		await fireEvent.click(getByTestId('copy-input-button'));
+		await nextTick();
+
+		expect(emitted('error')).toEqual([[expect.any(Error)]]);
+		expect(emitted('copy')).toBeUndefined();
+		expect(getByTestId('copy-input-button')).toHaveAccessibleName('Copy');
+	});
+
+	it('selects the whole value when the field is focused or clicked', async () => {
+		const select = vi.spyOn(HTMLInputElement.prototype, 'select');
+		try {
+			const { getByRole } = renderComponent({ displayValue: 'secret...oken' });
+			const input = getByRole('textbox');
+
+			await fireEvent.focus(input);
+			expect(select).toHaveBeenCalledTimes(1);
+
+			select.mockClear();
+			await fireEvent.click(input);
+			expect(select).toHaveBeenCalled();
+		} finally {
+			select.mockRestore();
+		}
+	});
+
+	it('does not focus or select the field when the copy button is clicked', async () => {
+		const select = vi.spyOn(HTMLInputElement.prototype, 'select');
+		try {
+			const { getByRole, getByTestId } = renderComponent();
+
+			await fireEvent.click(getByTestId('copy-input-button'));
+
+			expect(select).not.toHaveBeenCalled();
+			expect(getByRole('textbox')).not.toHaveFocus();
+		} finally {
+			select.mockRestore();
+		}
+	});
+
+	it('writes the full value on a native copy instead of the display value', async () => {
+		const { getByRole, getByTestId, emitted } = renderComponent({
+			displayValue: 'secret...oken',
+		});
+		const setData = vi.fn();
+
+		const event = new Event('copy', { bubbles: true, cancelable: true });
+		Object.defineProperty(event, 'clipboardData', { value: { setData } });
+		await fireEvent(getByRole('textbox'), event);
+		await nextTick();
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(setData).toHaveBeenCalledWith('text/plain', 'secret-token');
+		expect(writeText).not.toHaveBeenCalled();
+		expect(emitted('copy')).toEqual([['secret-token']]);
+		expect(getByTestId('copy-input-button')).toHaveAccessibleName('Copied to clipboard');
+	});
+
+	it('disables the field, the button and the tooltip', () => {
+		const { getByRole, getByTestId } = renderComponent({ disabled: true });
+
+		expect(getByRole('textbox')).toBeDisabled();
+		expect(getByTestId('copy-input-button')).toBeDisabled();
+		expect(getByTestId('tooltip')).toHaveAttribute('data-disabled', 'true');
+	});
+
+	it('passes the size through to the copy button', () => {
+		const { getByTestId } = renderComponent({ size: 'small' });
+
+		expect(getByTestId('copy-input-button').className).toContain('small');
 	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
@@ -1,0 +1,157 @@
+<script lang="ts" setup>
+import { useClipboard } from '@vueuse/core';
+import { computed, onBeforeUnmount, ref } from 'vue';
+
+import type { InputSize } from '../../types/input';
+import N8nButton from '../N8nButton';
+import N8nIcon from '../N8nIcon';
+import N8nInput from '../N8nInput';
+
+interface CopyInputProps {
+	/** Full value written to the clipboard. */
+	value: string;
+	/**
+	 * Optional display override, e.g. a middle-truncated secret. The copy button
+	 * always copies the full `value`.
+	 */
+	displayValue?: string;
+	size?: InputSize;
+	/** Accessible label of the copy button in its resting state. */
+	copyLabel?: string;
+	/** Accessible label of the copy button while the copied feedback shows. */
+	copiedLabel?: string;
+	/** How long the check-mark feedback lingers, in milliseconds. */
+	feedbackDurationMs?: number;
+}
+
+defineOptions({ name: 'N8nCopyInput' });
+
+const props = withDefaults(defineProps<CopyInputProps>(), {
+	displayValue: undefined,
+	size: 'large',
+	copyLabel: 'Copy',
+	copiedLabel: 'Copied to clipboard',
+	feedbackDurationMs: 2000,
+});
+
+const emit = defineEmits<{
+	/** Emitted after the value has been written to the clipboard. */
+	copy: [value: string];
+}>();
+
+// legacy: falls back to document.execCommand on insecure origins (plain-http
+// self-hosted instances), where navigator.clipboard is unavailable.
+const clipboard = useClipboard({ legacy: true });
+
+const showCopiedFeedback = ref(false);
+let feedbackTimer: ReturnType<typeof setTimeout> | undefined;
+
+onBeforeUnmount(() => clearTimeout(feedbackTimer));
+
+async function onCopyClick() {
+	await clipboard.copy(props.value);
+	emit('copy', props.value);
+	showCopiedFeedback.value = true;
+	clearTimeout(feedbackTimer);
+	feedbackTimer = setTimeout(() => {
+		showCopiedFeedback.value = false;
+	}, props.feedbackDurationMs);
+}
+
+const buttonSize = computed(() => {
+	switch (props.size) {
+		case 'mini':
+		case 'small':
+			return 'small';
+		case 'large':
+		case 'xlarge':
+			return 'large';
+		default:
+			return 'medium';
+	}
+});
+</script>
+
+<template>
+	<N8nInput :model-value="displayValue ?? value" :size="size" readonly :class="$style.copyInput">
+		<template #append>
+			<N8nButton
+				variant="ghost"
+				:size="buttonSize"
+				icon-only
+				:aria-label="showCopiedFeedback ? copiedLabel : copyLabel"
+				data-test-id="copy-input-button"
+				@click="onCopyClick"
+			>
+				<template #icon>
+					<span :class="$style.iconSwap">
+						<Transition
+							:enter-active-class="$style.swapEnterActive"
+							:leave-active-class="$style.swapLeaveActive"
+						>
+							<N8nIcon v-if="showCopiedFeedback" key="check" icon="check" :size="buttonSize" />
+							<N8nIcon v-else key="copy" icon="copy" :size="buttonSize" />
+						</Transition>
+					</span>
+				</template>
+			</N8nButton>
+		</template>
+	</N8nInput>
+</template>
+
+<style lang="scss" module>
+@use '../../css/mixins/motion';
+
+/*
+ * One continuous bordered field (the instance-settings copy-field pattern):
+ * border, radius and background move onto the input CONTAINER (with overflow
+ * hidden so the append segment is clipped by the outer radius), the wrapper
+ * drops its own border so it doesn't double up, and the append becomes a
+ * transparent, full-height button segment separated from the value by a single
+ * border-left divider. Focus indication is unaffected — the design system
+ * draws it with outline, not box-shadow.
+ */
+.copyInput {
+	gap: 0;
+	border-radius: var(--input--radius);
+	background-color: var(--input--color--background);
+	box-shadow: inset var(--input--border--shadow);
+	overflow: hidden;
+
+	:global(.n8n-input__wrapper) {
+		box-shadow: none;
+		background-color: transparent;
+	}
+
+	:global(.n8n-input__wrapper) + span {
+		background-color: transparent;
+		border-left: var(--border);
+		margin: 0;
+		padding: 0;
+	}
+}
+
+/*
+ * Copy -> check swap: both icons overlap in the same spot (the leaving one is
+ * absolutely positioned) and crossfade through the blur-swap motion. The blur
+ * is tightened for icon-sized glyphs — the surface-level 4px default dissolves
+ * a glyph this small instead of morphing it.
+ */
+.iconSwap {
+	--animation--blur-swap--blur: 2px;
+
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.swapEnterActive {
+	@include motion.blur-swap-in;
+}
+
+.swapLeaveActive {
+	position: absolute;
+	@include motion.blur-swap-out;
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/CopyInput.vue
@@ -1,24 +1,29 @@
 <script lang="ts" setup>
-import { useClipboard } from '@vueuse/core';
-import { computed, onBeforeUnmount, ref } from 'vue';
+import { computed, onBeforeUnmount, ref, useCssModule } from 'vue';
 
+import { useI18n } from '../../composables/useI18n';
+import type { IconSize } from '../../types';
 import type { InputSize } from '../../types/input';
 import N8nButton from '../N8nButton';
 import N8nIcon from '../N8nIcon';
 import N8nInput from '../N8nInput';
+import N8nTooltip from '../N8nTooltip';
 
 interface CopyInputProps {
 	/** Full value written to the clipboard. */
 	value: string;
+	/** Accessible name of the field, e.g. "API key". */
+	label: string;
 	/**
-	 * Optional display override, e.g. a middle-truncated secret. The copy button
-	 * always copies the full `value`.
+	 * Optional display override, e.g. a middle-truncated secret. Copying — via the
+	 * button or Cmd/Ctrl+C — always yields the full `value`.
 	 */
 	displayValue?: string;
 	size?: InputSize;
-	/** Accessible label of the copy button in its resting state. */
+	disabled?: boolean;
+	/** Tooltip and accessible label of the copy button in its resting state. */
 	copyLabel?: string;
-	/** Accessible label of the copy button while the copied feedback shows. */
+	/** Tooltip and accessible label of the copy button while the copied feedback shows. */
 	copiedLabel?: string;
 	/** How long the check-mark feedback lingers, in milliseconds. */
 	feedbackDurationMs?: number;
@@ -29,28 +34,87 @@ defineOptions({ name: 'N8nCopyInput' });
 const props = withDefaults(defineProps<CopyInputProps>(), {
 	displayValue: undefined,
 	size: 'large',
-	copyLabel: 'Copy',
-	copiedLabel: 'Copied to clipboard',
+	disabled: false,
+	copyLabel: undefined,
+	copiedLabel: undefined,
 	feedbackDurationMs: 2000,
 });
 
 const emit = defineEmits<{
 	/** Emitted after the value has been written to the clipboard. */
 	copy: [value: string];
+	/** Emitted when the clipboard rejected the write; no copied feedback is shown. */
+	error: [error: Error];
 }>();
 
-// legacy: falls back to document.execCommand on insecure origins (plain-http
-// self-hosted instances), where navigator.clipboard is unavailable.
-const clipboard = useClipboard({ legacy: true });
+const { t } = useI18n();
+const $style = useCssModule();
 
+const inputRef = ref<InstanceType<typeof N8nInput>>();
+const isInputFocused = ref(false);
 const showCopiedFeedback = ref(false);
 let feedbackTimer: ReturnType<typeof setTimeout> | undefined;
 
 onBeforeUnmount(() => clearTimeout(feedbackTimer));
 
-async function onCopyClick() {
-	await clipboard.copy(props.value);
-	emit('copy', props.value);
+const buttonLabel = computed(() =>
+	showCopiedFeedback.value
+		? (props.copiedLabel ?? t('copyInput.copied'))
+		: (props.copyLabel ?? t('copyInput.copy')),
+);
+
+const iconSizes: Record<InputSize, IconSize> = {
+	mini: 'xsmall',
+	small: 'xsmall',
+	medium: 'small',
+	large: 'medium',
+	xlarge: 'large',
+};
+
+const iconSize = computed(() => iconSizes[props.size]);
+
+const containerClasses = computed(() => [
+	$style.copyInput,
+	{
+		[$style.focused]: isInputFocused.value,
+		[$style.disabled]: props.disabled,
+	},
+]);
+
+function legacyCopy(text: string): boolean {
+	if (typeof document.execCommand !== 'function') return false;
+
+	const textarea = document.createElement('textarea');
+	textarea.value = text;
+	textarea.setAttribute('readonly', '');
+	textarea.style.position = 'fixed';
+	textarea.style.opacity = '0';
+	document.body.appendChild(textarea);
+	textarea.select();
+
+	try {
+		return document.execCommand('copy');
+	} finally {
+		textarea.remove();
+	}
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return;
+		} catch {
+			// Insecure origin or denied permission — try the legacy command below.
+		}
+	}
+
+	if (!legacyCopy(text)) {
+		throw new Error('Copying to the clipboard was blocked');
+	}
+}
+
+function showFeedback() {
 	showCopiedFeedback.value = true;
 	clearTimeout(feedbackTimer);
 	feedbackTimer = setTimeout(() => {
@@ -58,86 +122,149 @@ async function onCopyClick() {
 	}, props.feedbackDurationMs);
 }
 
-const buttonSize = computed(() => {
-	switch (props.size) {
-		case 'mini':
-		case 'small':
-			return 'small';
-		case 'large':
-		case 'xlarge':
-			return 'large';
-		default:
-			return 'medium';
+async function onCopyClick() {
+	try {
+		await copyToClipboard(props.value);
+	} catch (error) {
+		emit('error', error instanceof Error ? error : new Error(String(error)));
+		return;
 	}
-});
+
+	emit('copy', props.value);
+	showFeedback();
+}
+
+function onNativeCopy(event: ClipboardEvent) {
+	if (!event.clipboardData) return;
+
+	// The visible text may be a truncated display value; the clipboard always gets the real one.
+	event.preventDefault();
+	event.clipboardData.setData('text/plain', props.value);
+	emit('copy', props.value);
+	showFeedback();
+}
+
+function selectValue() {
+	inputRef.value?.select();
+}
+
+function onInputFocus() {
+	isInputFocused.value = true;
+	selectValue();
+}
+
+function onInputBlur() {
+	isInputFocused.value = false;
+}
 </script>
 
 <template>
-	<N8nInput :model-value="displayValue ?? value" :size="size" readonly :class="$style.copyInput">
+	<N8nInput
+		ref="inputRef"
+		:model-value="displayValue ?? value"
+		:size="size"
+		:disabled="disabled"
+		:aria-label="label"
+		readonly
+		:class="containerClasses"
+		@focus="onInputFocus"
+		@blur="onInputBlur"
+		@click="selectValue"
+		@copy="onNativeCopy"
+	>
 		<template #append>
-			<N8nButton
-				variant="ghost"
-				:size="buttonSize"
-				icon-only
-				:aria-label="showCopiedFeedback ? copiedLabel : copyLabel"
-				data-test-id="copy-input-button"
-				@click="onCopyClick"
-			>
-				<template #icon>
-					<span :class="$style.iconSwap">
-						<Transition
-							:enter-active-class="$style.swapEnterActive"
-							:leave-active-class="$style.swapLeaveActive"
-						>
-							<N8nIcon v-if="showCopiedFeedback" key="check" icon="check" :size="buttonSize" />
-							<N8nIcon v-else key="copy" icon="copy" :size="buttonSize" />
-						</Transition>
-					</span>
-				</template>
-			</N8nButton>
+			<N8nTooltip :content="buttonLabel" :disabled="disabled" as-child>
+				<N8nButton
+					variant="ghost"
+					:size="size"
+					:disabled="disabled"
+					icon-only
+					:aria-label="buttonLabel"
+					data-test-id="copy-input-button"
+					@click="onCopyClick"
+				>
+					<template #icon>
+						<span :class="$style.iconSwap">
+							<Transition
+								:enter-active-class="$style.swapEnterActive"
+								:leave-active-class="$style.swapLeaveActive"
+							>
+								<N8nIcon v-if="showCopiedFeedback" key="check" icon="check" :size="iconSize" />
+								<N8nIcon v-else key="copy" icon="copy" :size="iconSize" />
+							</Transition>
+						</span>
+					</template>
+				</N8nButton>
+			</N8nTooltip>
 		</template>
 	</N8nInput>
 </template>
 
 <style lang="scss" module>
+@use '../../css/mixins/focus';
 @use '../../css/mixins/motion';
 
-/*
- * One continuous bordered field (the instance-settings copy-field pattern):
- * border, radius and background move onto the input CONTAINER (with overflow
- * hidden so the append segment is clipped by the outer radius), the wrapper
- * drops its own border so it doesn't double up, and the append becomes a
- * transparent, full-height button segment separated from the value by a single
- * border-left divider. Focus indication is unaffected — the design system
- * draws it with outline, not box-shadow.
- */
 .copyInput {
 	gap: 0;
 	border-radius: var(--input--radius);
 	background-color: var(--input--color--background);
 	box-shadow: inset var(--input--border--shadow);
-	overflow: hidden;
 
-	:global(.n8n-input__wrapper) {
-		box-shadow: none;
-		background-color: transparent;
+	&:hover:not(.disabled):not(.focused) {
+		box-shadow: inset var(--input--border--shadow--hover);
 	}
 
-	:global(.n8n-input__wrapper) + span {
-		background-color: transparent;
-		border-left: var(--border);
+	&.focused {
+		@include focus.focus-ring;
+		box-shadow: inset var(--input--border--shadow--focus);
+	}
+
+	&.disabled {
+		cursor: not-allowed;
+		opacity: 0.6;
+	}
+
+	// The input wrapper keeps its layout but hands border, background and focus
+	// ring over to this container, through the variables it already consumes.
+	> div {
+		--input--color--background: transparent;
+		--input--shadow: 0 0 0 0 transparent;
+		--input--shadow--hover: 0 0 0 0 transparent;
+		--input--shadow--focus: 0 0 0 0 transparent;
+		--input--border--shadow: 0 0 0 0 transparent;
+		--input--border--shadow--hover: 0 0 0 0 transparent;
+		--input--border--shadow--focus: 0 0 0 0 transparent;
+
+		&:focus-within {
+			outline: none;
+		}
+	}
+
+	input {
+		text-overflow: ellipsis;
+	}
+
+	> span {
+		align-self: stretch;
 		margin: 0;
 		padding: 0;
+		background-color: transparent;
+		border-left: var(--border);
+
+		button {
+			border-radius: 0 var(--input--radius) var(--input--radius) 0;
+		}
+	}
+
+	// The container fades the whole field once; the inner parts must not fade again.
+	&.disabled > div,
+	&.disabled button {
+		opacity: 1;
 	}
 }
 
-/*
- * Copy -> check swap: both icons overlap in the same spot (the leaving one is
- * absolutely positioned) and crossfade through the blur-swap motion. The blur
- * is tightened for icon-sized glyphs — the surface-level 4px default dissolves
- * a glyph this small instead of morphing it.
- */
 .iconSwap {
+	// The surface-level 4px default dissolves a glyph this small instead of morphing it.
 	--animation--blur-swap--blur: 2px;
 
 	position: relative;

--- a/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nCopyInput/index.ts
@@ -1,0 +1,3 @@
+import CopyInput from './CopyInput.vue';
+
+export default CopyInput;

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -38,6 +38,7 @@ export { default as N8nCard } from './N8nCard';
 export { default as N8nCircleLoader } from './N8nCircleLoader';
 export { default as N8nCollapsiblePanel } from './N8nCollapsiblePanel';
 export { default as N8nColorPicker } from './N8nColorPicker';
+export { default as N8nCopyInput } from './N8nCopyInput';
 export { default as N8nDatatable } from './N8nDatatable';
 export { default as N8nEmptyState } from './N8nEmptyState';
 export type { EmptyStateCardIcon, EmptyStateIconCards } from './N8nEmptyState';

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -34,6 +34,8 @@ export default {
 	'codeDiff.replaceMyCode': 'Replace my code',
 	'codeDiff.replacing': 'Replacing...',
 	'codeDiff.undo': 'Undo',
+	'copyInput.copy': 'Copy',
+	'copyInput.copied': 'Copied to clipboard',
 	'previewTag.preview': 'Preview',
 	'askAssistantButton.askAssistant': 'n8n AI',
 	'assistantChat.builder.name': 'AI Builder',


### PR DESCRIPTION
## Summary

- Adds `N8nCopyInput`, a reusable readonly input with an attached design-system copy button, rendered as one continuous bordered field.
- Supports a separate `displayValue` for truncated secrets while copying the complete `value` — through the copy button and through Cmd/Ctrl+C alike (the native copy event is intercepted so the clipboard never receives the truncated text).
- Clicking or focusing the field selects the whole value; hovering anywhere on the field (button included) uses the input's hover border, and focusing the field draws the standard input focus ring around the whole field.
- Copy button: tooltip + accessible label (`Copy` → `Copied to clipboard`, resolved through the design-system locale, overridable via `copyLabel` / `copiedLabel`), icon sized per input size, and the copy → check swap using the shared blur-swap motion from the base PR.
- Clipboard failures (permission denied, blocked `execCommand` on plain-http instances) are surfaced through an `error` event instead of a false check mark.
- `label` (required) names the field for assistive tech; `disabled` fades the whole field once, disables both the input and the button, and suppresses the tooltip.
- Storybook: Default, Truncated Secret, Disabled, Sizes.

Depends on #34943. This PR is stacked on that shared blur-motion contribution so its diff contains only the component, stories, tests, export, and two locale strings. The component is consumed by the API keys settings refresh in #34925 (which needs to pass the new `label` prop once it picks this version up).

## Review notes

- The field styling no longer uses `:global`. The inner input wrapper is neutralized through the CSS variables `N8nInput` already consumes (`--input--border--shadow*`, `--input--shadow*`, `--input--color--background`) plus element selectors, and the container carries border, hover, and focus itself. `overflow: hidden` is gone, so the button's focus ring is fully visible; the button squares its inner corners against the divider.

## Test plan

- [x] `pnpm typecheck` in `@n8n/design-system`
- [x] `pnpm vitest run src/components/N8nCopyInput/CopyInput.test.ts` (10 tests: labelled readonly input, display vs copied value, feedback swap and tooltip copy, custom labels, clipboard failure → `error`, select-on-focus/click, button click not focusing the field, Cmd/Ctrl+C writing the full value, disabled state, size pass-through)
- [x] Storybook: hover/focus/keyboard focus rings, select-all, Cmd/Ctrl+C, tooltip, disabled, and all five sizes checked in the browser
- [x] Pre-commit formatting and style checks
