### PR TITLE
feat(editor): Standardize reusable blur motion

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nAnimatedCollapsibleContent/AnimatedCollapsibleContent.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAnimatedCollapsibleContent/AnimatedCollapsibleContent.vue
@@ -1,9 +1,15 @@
 <script lang="ts" setup>
 import { CollapsibleContent } from 'reka-ui';
+
+/**
+ * When set, the height slide is paired with an opacity fade and a subtle blur
+ * that mimics motion blur — the same motion as N8nSettingsRow's expand region.
+ */
+withDefaults(defineProps<{ blur?: boolean }>(), { blur: false });
 </script>
 
 <template>
-	<CollapsibleContent :class="$style.content">
+	<CollapsibleContent :class="[$style.content, blur && $style.blurred]">
 		<slot />
 	</CollapsibleContent>
 </template>
@@ -22,6 +28,19 @@ import { CollapsibleContent } from 'reka-ui';
 	&[data-state='closed'] {
 		--animation--collapsible-slide--duration: 0.2s;
 		@include motion.collapsible-slide-up;
+	}
+}
+
+/* The blurred mixins carry their own reduced-motion overrides, and because
+ * they're included here — after .content's rules in the cascade — they win at
+ * equal specificity in both directions (motion on, motion off). */
+.blurred {
+	&[data-state='open'] {
+		@include motion.collapsible-slide-down-blurred;
+	}
+
+	&[data-state='closed'] {
+		@include motion.collapsible-slide-up-blurred;
 	}
 }
 </style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsRow/SettingsRow.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsRow/SettingsRow.vue
@@ -306,11 +306,12 @@ function onKeydown(event: KeyboardEvent) {
 
 <style lang="scss" module>
 @use '../../css/mixins/utils';
+@use '../../css/mixins/motion';
 
-// The expand/collapse motion. No DS duration token equals 350ms (snappy=200, base=400) and the
-// curve has no token either, so both live here as local constants per the motion spec.
-$expand-duration: 350ms;
-$expand-easing: cubic-bezier(0.32, 0.72, 0, 1);
+// The expand/collapse motion: the shared settings-surface blur motion, whose
+// canonical duration/easing live in the motion mixins.
+$expand-duration: motion.$blur-motion-duration;
+$expand-easing: motion.$blur-motion-easing;
 
 .row {
 	position: relative;

--- a/packages/frontend/@n8n/design-system/src/css/_primitives.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_primitives.scss
@@ -294,9 +294,17 @@
 	--duration--slow: 1000ms;
 	--duration--slowest: 1500ms;
 
+	/* The three easings below are the "cubic" curves from Benjamin De Cock's
+	 * easing set (https://gist.github.com/bendc/ac03faac0bf2aee25b49e5fd260a1fba). */
 	--easing--ease-out: cubic-bezier(0.215, 0.61, 0.355, 1);
 	--easing--ease-in: cubic-bezier(0.55, 0.055, 0.675, 0.19);
 	--easing--ease-in-out: cubic-bezier(0.645, 0.045, 0.355, 1);
+
+	/* Stronger "out" siblings from the same set, for motion that should land
+	 * fast and settle softly (icon swaps, small reveals). */
+	--easing--ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
+	--easing--ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
+	--easing--ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
 
 	--shadow-color: var(--color--black-alpha-100);
 

--- a/packages/frontend/@n8n/design-system/src/css/mixins/motion.scss
+++ b/packages/frontend/@n8n/design-system/src/css/mixins/motion.scss
@@ -74,6 +74,63 @@
 	}
 }
 
+// The settings-surface blur motion (originating in N8nSettingsRow's expand
+// region): a height/visibility change paired with an opacity fade and a subtle
+// blur that reads as motion blur. No global duration token equals 350ms
+// (snappy=200, base=400) and the curve has no token either, so the canonical
+// values live here for every blurred mixin (and N8nSettingsRow) to share.
+$blur-motion-duration: 350ms;
+$blur-motion-easing: cubic-bezier(0.32, 0.72, 0, 1);
+
+// Blurred variants of the collapsible slide: height + opacity + blur together.
+@mixin collapsible-slide-down-blurred {
+	animation: collapsibleSlideDownBlurred
+		var(--animation--collapsible-slide-blurred--duration, #{$blur-motion-duration})
+		var(--animation--collapsible-slide-blurred--easing, #{$blur-motion-easing});
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+}
+
+@mixin collapsible-slide-up-blurred {
+	animation: collapsibleSlideUpBlurred
+		var(--animation--collapsible-slide-blurred--duration, #{$blur-motion-duration})
+		var(--animation--collapsible-slide-blurred--easing, #{$blur-motion-easing});
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+}
+
+// Blur swap - paired enter/leave for swapping an element in place (e.g. a copy
+// button's icon becoming a check mark): the outgoing element blurs and fades
+// away while the incoming one sharpens into position, reading as one
+// continuous morph. Pair with an absolutely-positioned leave element so both
+// occupy the same spot during the swap. Override --animation--blur-swap--blur
+// for small glyphs (icons dissolve at the surface-level 4px default).
+//
+// Unlike the collapsible motion above, the swap has no height change to carry
+// it, so it leans on a stronger deceleration (ease-out-quint) rather than a
+// longer run: the new state lands fast, then settles softly, without dragging.
+@mixin blur-swap-in {
+	animation: blurSwapIn var(--animation--blur-swap--duration, 250ms)
+		var(--animation--blur-swap--easing, var(--easing--ease-out-quint));
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+}
+
+@mixin blur-swap-out {
+	animation: blurSwapOut var(--animation--blur-swap--duration, 250ms)
+		var(--animation--blur-swap--easing, var(--easing--ease-out-quint));
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+}
+
 // Fade in - simple opacity fade for entrance animations
 @mixin fade-in {
 	animation: fadeIn var(--animation--fade-in--duration, var(--duration--snappy))
@@ -167,6 +224,57 @@
 	}
 	to {
 		height: 0;
+	}
+}
+
+/* The filter only exists inside the keyframes: once the animation finishes the
+ * element returns to its unfiltered base styles, so no stacking context (or
+ * compositing surface) stays active on settled content. */
+@keyframes collapsibleSlideDownBlurred {
+	from {
+		height: 0;
+		opacity: 0;
+		filter: blur(var(--animation--collapsible-slide-blurred--blur, 4px));
+	}
+	to {
+		height: var(--reka-collapsible-content-height);
+		opacity: 1;
+		filter: blur(0);
+	}
+}
+
+@keyframes collapsibleSlideUpBlurred {
+	from {
+		height: var(--reka-collapsible-content-height);
+		opacity: 1;
+		filter: blur(0);
+	}
+	to {
+		height: 0;
+		opacity: 0;
+		filter: blur(var(--animation--collapsible-slide-blurred--blur, 4px));
+	}
+}
+
+@keyframes blurSwapIn {
+	from {
+		opacity: 0;
+		filter: blur(var(--animation--blur-swap--blur, 4px));
+	}
+	to {
+		opacity: 1;
+		filter: blur(0);
+	}
+}
+
+@keyframes blurSwapOut {
+	from {
+		opacity: 1;
+		filter: blur(0);
+	}
+	to {
+		opacity: 0;
+		filter: blur(var(--animation--blur-swap--blur, 4px));
 	}
 }
 


### PR DESCRIPTION
## Summary

- Promotes the blur treatment used by `N8nSettingsRow` into shared design-system motion mixins.
- Adds reusable blurred collapsible and in-place blur-swap transitions with reduced-motion fallbacks and CSS-variable tuning hooks.
- Adds stronger ease-out easing tokens and a `blur` option to `N8nAnimatedCollapsibleContent`.
- Keeps `N8nSettingsRow` on the same visual timing while moving its duration and easing to the shared source of truth.

This is the motion foundation used by the API keys settings refresh in #34925 and by the stacked `N8nCopyInput` contribution in #34942.

## Test plan

- [x] `pnpm typecheck` in `@n8n/design-system`
- [x] `pnpm vitest run src/components/N8nSettingsRow/SettingsRow.test.ts` (50 tests)
- [x] Pre-commit formatting and style checks