### PR TITLE
fix(core): Close child_process detection gaps in community node lint rule (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-dangerous-functions.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-dangerous-functions.md
@@ -16,7 +16,9 @@ The `child_process` functions are detected only when they originate from the `ch
 
 The module counts as the origin however it is reached: a static `import`, a `require`, or an awaited dynamic `import()`, whether it is bound to a name first or used inline. Keys are resolved whenever they are statically knowable, so `cp['exec']` and `const { 'exec': run }` are treated like `cp.exec` and `const { exec }`. Access that can only be resolved by running the code, such as `cp[name]`, is left alone.
 
-The rule reasons about syntax, not values, and it tracks names in a flat, file-wide set rather than per scope. It therefore does not follow the module through a callback (`import('child_process').then(cp => cp.exec(...))`), through later reassignment (`let cp; cp = require('child_process')`), or through aliasing a namespace to a second name — that last one is deliberate, since minting a name from a name would make every unrelated binding of that name look like `child_process`. Bindings also have to appear before the call that uses them. It is defence in depth for reviewers alongside [`no-restricted-imports`](no-restricted-imports.md), not a sandbox.
+Bindings are matched by the variable they declare, resolved through lexical scope, so a parameter or block-scoped binding that happens to reuse a tracked name is left alone — as is a call to a locally declared `require`, which is not the CommonJS loader.
+
+The rule still reasons about syntax rather than values, so it does not follow the module through a callback (`import('child_process').then(cp => cp.exec(...))`) or through later reassignment (`let cp; cp = require('child_process')`), and a binding has to appear before the call that uses it. It is defence in depth for reviewers alongside [`no-restricted-imports`](no-restricted-imports.md), not a sandbox.
 
 This complements [`no-restricted-imports`](no-restricted-imports.md) (which blocks the `child_process` module entirely on n8n Cloud) and [`no-restricted-globals`](no-restricted-globals.md), providing a clear, specific error and defense-in-depth that also applies when the import restrictions are relaxed.
 

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-dangerous-functions.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-dangerous-functions.md
@@ -12,7 +12,11 @@ Community nodes run inside the n8n runtime, often on shared infrastructure. Func
 - **`Function(...)` / `new Function(...)`** — the `Function` constructor is an `eval` equivalent that builds a callable from a string body.
 - **`child_process` process spawners** — `exec`, `execSync`, `execFile`, `execFileSync`, `spawn`, `spawnSync`, and `fork`.
 
-The `child_process` functions are detected only when they originate from the `child_process` / `node:child_process` module (via `import` or `require`), so unrelated methods such as `RegExp.prototype.exec` are not affected.
+The `child_process` functions are detected only when they originate from the `child_process` / `node:child_process` module, so unrelated methods such as `RegExp.prototype.exec` are not affected.
+
+The module counts as the origin however it is reached: a static `import`, a `require`, or an awaited dynamic `import()`, whether it is bound to a name first or used inline. Keys are resolved whenever they are statically knowable, so `cp['exec']` and `const { 'exec': run }` are treated like `cp.exec` and `const { exec }`. Access that can only be resolved by running the code, such as `cp[name]`, is left alone.
+
+The rule reasons about syntax, not values, and it tracks names in a flat, file-wide set rather than per scope. It therefore does not follow the module through a callback (`import('child_process').then(cp => cp.exec(...))`), through later reassignment (`let cp; cp = require('child_process')`), or through aliasing a namespace to a second name — that last one is deliberate, since minting a name from a name would make every unrelated binding of that name look like `child_process`. Bindings also have to appear before the call that uses them. It is defence in depth for reviewers alongside [`no-restricted-imports`](no-restricted-imports.md), not a sandbox.
 
 This complements [`no-restricted-imports`](no-restricted-imports.md) (which blocks the `child_process` module entirely on n8n Cloud) and [`no-restricted-globals`](no-restricted-globals.md), providing a clear, specific error and defense-in-depth that also applies when the import restrictions are relaxed.
 
@@ -28,6 +32,18 @@ eval(userProvidedCode);
 const compiled = new Function('return ' + expression);
 
 exec(`rm -rf ${userInput}`);
+```
+
+The same calls are still reported when the module is never bound to a name, or
+when it arrives through a dynamic import:
+
+```typescript
+require('child_process').exec(`rm -rf ${userInput}`);
+
+async function run() {
+	const { spawn } = await import('node:child_process');
+	spawn('sh', ['-c', userInput]);
+}
 ```
 
 ### ✅ Correct

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-dangerous-functions.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-dangerous-functions.test.ts
@@ -57,12 +57,28 @@ ruleTester.run('no-dangerous-functions', NoDangerousFunctionsRule, {
 			name: 'unawaited dynamic import',
 			code: "const pending = import('child_process'); pending.then(handle);",
 		},
-		// Names are tracked in a flat, file-wide set, so aliasing a namespace to
-		// another name is deliberately not followed — doing so would make every
-		// unrelated binding of that name look like `child_process`.
+		// Bindings are matched by the variable they declare, so an unrelated
+		// binding that happens to reuse a tracked name is left alone.
 		{
 			name: 'unrelated binding reusing an aliased name',
 			code: "const cp = require('child_process');\nconst alias = cp;\nfunction f(x) { const alias = getLogger(); alias.fork(x); }",
+		},
+		{
+			name: 'shadowed parameter named after the namespace',
+			code: "import * as cp from 'child_process';\nexport function f(cp) { cp.exec('x'); }",
+		},
+		{
+			name: 'member alias off a shadowed parameter',
+			code: "import * as cp from 'child_process';\nexport function f(cp) { const run = cp.exec; run('x'); }",
+		},
+		{
+			name: 'block shadowing with a different module',
+			code: "{ const cp = require('child_process'); }\n{ const cp = require('sqlite3'); cp.exec('x'); }",
+		},
+		// A locally declared `require` is not the CommonJS loader.
+		{
+			name: 'locally shadowed require',
+			code: "function load(require) { return require('child_process').exec('ls'); }",
 		},
 	],
 	invalid: [
@@ -225,6 +241,16 @@ ruleTester.run('no-dangerous-functions', NoDangerousFunctionsRule, {
 		{
 			name: 'SECURITY: member alias off a namespace',
 			code: "const cp = require('child_process'); const run = cp.spawn; run('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'spawn' } }],
+		},
+		{
+			name: 'SECURITY: aliased namespace binding',
+			code: "const cp = require('child_process'); const alias = cp; alias.exec('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: member alias off an aliased namespace',
+			code: "import * as cp from 'child_process'; const alias = cp; const run = alias.spawn; run('ls');",
 			errors: [{ messageId: 'noChildProcess', data: { name: 'spawn' } }],
 		},
 	],

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-dangerous-functions.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-dangerous-functions.test.ts
@@ -27,6 +27,43 @@ ruleTester.run('no-dangerous-functions', NoDangerousFunctionsRule, {
 			name: 'spawn from unrelated module',
 			code: "import { spawn } from 'some-lib'; spawn('x');",
 		},
+		// Computed access and inline module expressions must stay scoped to
+		// `child_process` — unrelated objects and modules are not the target.
+		{ name: 'computed exec on unrelated object', code: "db['exec']('SELECT 1');" },
+		{ name: 'computed exec on unrelated module', code: "require('sqlite')['exec']('SELECT 1');" },
+		{
+			name: 'inline require of unrelated module',
+			code: "require('node:fs').readFileSync('a.txt');",
+		},
+		{
+			name: 'dynamic import of unrelated module',
+			code: "async function run() { const lib = await import('some-lib'); lib.spawn('x'); }",
+		},
+		{
+			name: 'dynamic member access is not statically knowable',
+			code: "const cp = require('child_process'); cp[name]('ls');",
+		},
+		{
+			name: 'non-dangerous computed member on the namespace',
+			code: "import * as cp from 'child_process'; const path = cp['execPath'];",
+		},
+		// `require.resolve` returns a path string, not the module.
+		{
+			name: 'binding from require.resolve',
+			code: "const resolved = require.resolve('child_process'); resolved.exec('x');",
+		},
+		// A dynamic import that is never awaited is a Promise, not the module.
+		{
+			name: 'unawaited dynamic import',
+			code: "const pending = import('child_process'); pending.then(handle);",
+		},
+		// Names are tracked in a flat, file-wide set, so aliasing a namespace to
+		// another name is deliberately not followed — doing so would make every
+		// unrelated binding of that name look like `child_process`.
+		{
+			name: 'unrelated binding reusing an aliased name',
+			code: "const cp = require('child_process');\nconst alias = cp;\nfunction f(x) { const alias = getLogger(); alias.fork(x); }",
+		},
 	],
 	invalid: [
 		{
@@ -78,6 +115,117 @@ ruleTester.run('no-dangerous-functions', NoDangerousFunctionsRule, {
 			name: 'SECURITY: namespace require fork',
 			code: "const cp = require('node:child_process'); cp.fork('./worker.js');",
 			errors: [{ messageId: 'noChildProcess', data: { name: 'fork' } }],
+		},
+		// The module can be reached without ever binding it to a name, and the
+		// member can be selected with a computed key. Both still spawn a process.
+		{
+			name: 'SECURITY: exec on an inline require',
+			code: "require('child_process').exec('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: spawn on an inline require of node:child_process',
+			code: "require('node:child_process').spawn('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'spawn' } }],
+		},
+		{
+			name: 'SECURITY: computed member on a required namespace',
+			code: "const cp = require('child_process'); cp['exec']('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: computed member on an imported namespace',
+			code: "import * as cp from 'child_process'; cp[`execSync`]('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'execSync' } }],
+		},
+		{
+			name: 'SECURITY: computed member on an inline require',
+			code: "require('child_process')['exec']('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: destructured dynamic import',
+			code: "async function run() { const { exec } = await import('child_process'); exec('ls'); }",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: namespace from dynamic import',
+			code: "async function run() { const cp = await import('node:child_process'); cp.spawnSync('ls'); }",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'spawnSync' } }],
+		},
+		{
+			name: 'SECURITY: member on an inline dynamic import',
+			code: "async function run() { (await import('child_process')).execFile('ls'); }",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'execFile' } }],
+		},
+		// Destructuring keys can be written as literals, computed or not.
+		{
+			name: 'SECURITY: destructured with a string-literal key',
+			code: "const { 'exec': run } = require('child_process'); run('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: destructured with a computed key',
+			code: "const { ['exec']: run } = require('child_process'); run('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		// Under ESM/CJS interop the namespace's `default` is the module itself.
+		{
+			name: 'SECURITY: interop default on an inline dynamic import',
+			code: "async function run() { (await import('node:child_process')).default.exec('ls'); }",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: interop default on a dynamic import namespace',
+			code: "async function run() { const cp = await import('child_process'); cp.default.exec('ls'); }",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: interop default destructured from a dynamic import',
+			code: "async function run() { const { default: cp } = await import('child_process'); cp.exec('ls'); }",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		// Expression wrappers that do not change the value being accessed.
+		{
+			name: 'SECURITY: sequence expression wrapper',
+			code: "(0, require('child_process')).exec('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: as-expression wrapper',
+			code: "const cp = require('child_process') as any; cp.exec('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: satisfies-expression wrapper',
+			code: "const cp = require('child_process') satisfies unknown; cp.exec('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: non-null-assertion wrapper',
+			code: "require('child_process')!.exec('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: import-equals require',
+			code: "import cp = require('child_process'); cp.exec('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: rest element copies the module',
+			code: "const { ...cp } = require('child_process'); cp.exec('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		// Pulling a spawner out as a member, the equivalent of destructuring it.
+		{
+			name: 'SECURITY: member alias off an inline require',
+			code: "const run = require('child_process').exec; run('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'exec' } }],
+		},
+		{
+			name: 'SECURITY: member alias off a namespace',
+			code: "const cp = require('child_process'); const run = cp.spawn; run('ls');",
+			errors: [{ messageId: 'noChildProcess', data: { name: 'spawn' } }],
 		},
 	],
 });

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-dangerous-functions.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-dangerous-functions.ts
@@ -1,4 +1,5 @@
 import { TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 import { createRule, getStaticStringValue, isDirectRequireCall } from '../utils/index.js';
 
@@ -65,72 +66,112 @@ export const NoDangerousFunctionsRule = createRule({
 	},
 	defaultOptions: [],
 	create(context) {
-		// Local names bound to dangerous named imports, e.g. `import { exec as run }` -> `run`.
-		const dangerousLocalNames = new Map<string, string>();
-		// Local names bound to the whole module, e.g. `import * as cp` or `const cp = require(...)`.
-		const namespaceNames = new Set<string>();
+		const { sourceCode } = context;
+
+		// Bindings are tracked by the variable they declare, not by name, so a
+		// binding in one scope cannot be confused with an unrelated binding of
+		// the same name in another.
+
+		/** Variables bound to a dangerous function, e.g. `import { exec as run }`. */
+		const dangerousVariables = new Map<TSESLint.Scope.Variable, string>();
+		/** Variables bound to the module itself, e.g. `import * as cp`. */
+		const namespaceVariables = new Set<TSESLint.Scope.Variable>();
+
+		/** The variable an identifier refers to, or null when it is unresolved. */
+		const resolveVariable = (identifier: TSESTree.Identifier): TSESLint.Scope.Variable | null => {
+			for (
+				let scope: TSESLint.Scope.Scope | null = sourceCode.getScope(identifier);
+				scope;
+				scope = scope.upper
+			) {
+				const variable = scope.set.get(identifier.name);
+				if (variable) return variable;
+			}
+
+			return null;
+		};
+
+		/** The variable a declaration introduces for `identifier`. */
+		const resolveDeclaredVariable = (
+			declaration: TSESTree.Node,
+			identifier: TSESTree.Identifier,
+		): TSESLint.Scope.Variable | null =>
+			sourceCode
+				.getDeclaredVariables(declaration)
+				.find((variable) => variable.defs.some((def) => def.name === identifier)) ?? null;
 
 		/**
-		 * Resolves whether an expression is the `child_process` module.
-		 *
-		 * `followBindings` decides whether a bare identifier may be matched
-		 * against the recorded names. Reporting a call site does follow them —
-		 * that is the point of recording. Deciding whether a *declaration*
-		 * introduces a new name does not, because names are tracked in a flat,
-		 * file-wide set: minting `alias` from `const alias = cp` would make
-		 * every unrelated `alias` in the file look like `child_process`.
+		 * True for the `require` of the CommonJS loader. A `require` declared in
+		 * the file — a parameter, a local helper — shadows it and loads nothing.
 		 */
-		const resolveModule = (
-			node: TSESTree.Node | null | undefined,
-			followBindings: boolean,
-		): boolean => {
+		const isModuleLoaderRequire = (node: TSESTree.CallExpression): boolean => {
+			if (!isDirectRequireCall(node) || node.callee.type !== AST_NODE_TYPES.Identifier) {
+				return false;
+			}
+
+			// A global has no definition site; anything with one is a local binding.
+			const variable = resolveVariable(node.callee);
+			return variable === null || variable.defs.length === 0;
+		};
+
+		/** Whether an expression is the `child_process` module. */
+		const resolvesToChildProcessModule = (node: TSESTree.Node | null | undefined): boolean => {
 			if (!node) return false;
 
 			switch (node.type) {
-				case AST_NODE_TYPES.Identifier:
-					return followBindings && namespaceNames.has(node.name);
+				case AST_NODE_TYPES.Identifier: {
+					const variable = resolveVariable(node);
+					return variable !== null && namespaceVariables.has(variable);
+				}
 				// `require('child_process')`. `require.resolve(...)` is deliberately
 				// excluded: it returns a path string, not the module.
 				case AST_NODE_TYPES.CallExpression:
-					return isDirectRequireCall(node) && isChildProcessModule(node.arguments[0] ?? null);
+					return isModuleLoaderRequire(node) && isChildProcessModule(node.arguments[0] ?? null);
 				case AST_NODE_TYPES.AwaitExpression:
-					return (
-						isChildProcessImport(node.argument) || resolveModule(node.argument, followBindings)
-					);
+					return isChildProcessImport(node.argument) || resolvesToChildProcessModule(node.argument);
 				// `mod.default` is the CommonJS module object under interop.
 				case AST_NODE_TYPES.MemberExpression:
 					return (
-						getStaticPropertyName(node) === 'default' && resolveModule(node.object, followBindings)
+						getStaticPropertyName(node) === 'default' && resolvesToChildProcessModule(node.object)
 					);
 				// Wrappers that do not change the value being accessed:
 				// `(0, require('child_process'))`, `require('child_process') as any`,
 				// `... satisfies unknown`, `...!`, `<any>...`.
 				case AST_NODE_TYPES.SequenceExpression:
-					return resolveModule(node.expressions.at(-1), followBindings);
+					return resolvesToChildProcessModule(node.expressions.at(-1));
 				case AST_NODE_TYPES.TSAsExpression:
 				case AST_NODE_TYPES.TSSatisfiesExpression:
 				case AST_NODE_TYPES.TSNonNullExpression:
 				case AST_NODE_TYPES.TSTypeAssertion:
-					return resolveModule(node.expression, followBindings);
+					return resolvesToChildProcessModule(node.expression);
 				default:
 					return false;
 			}
 		};
 
-		/** The module, reached through a recorded binding or written out in place. */
-		const resolvesToChildProcessModule = (node: TSESTree.Node | null | undefined): boolean =>
-			resolveModule(node, true);
+		const recordNamespace = (declaration: TSESTree.Node, identifier: TSESTree.Identifier) => {
+			const variable = resolveDeclaredVariable(declaration, identifier);
+			if (variable) namespaceVariables.add(variable);
+		};
 
-		/** The module written out in place, without consulting recorded names. */
-		const isChildProcessModuleExpression = (node: TSESTree.Node | null | undefined): boolean =>
-			resolveModule(node, false);
+		const recordDangerous = (
+			declaration: TSESTree.Node,
+			identifier: TSESTree.Identifier,
+			functionName: string,
+		) => {
+			const variable = resolveDeclaredVariable(declaration, identifier);
+			if (variable) dangerousVariables.set(variable, functionName);
+		};
 
-		const recordDestructuredModule = (pattern: TSESTree.ObjectPattern) => {
+		const recordDestructuredModule = (
+			declaration: TSESTree.Node,
+			pattern: TSESTree.ObjectPattern,
+		) => {
 			for (const property of pattern.properties) {
 				// `const { ...cp } = require('child_process')` copies the module.
 				if (property.type === AST_NODE_TYPES.RestElement) {
 					if (property.argument.type === AST_NODE_TYPES.Identifier) {
-						namespaceNames.add(property.argument.name);
+						recordNamespace(declaration, property.argument);
 					}
 					continue;
 				}
@@ -141,9 +182,9 @@ export const NoDangerousFunctionsRule = createRule({
 				if (keyName === null) continue;
 
 				if (DANGEROUS_CHILD_PROCESS_FUNCTIONS.has(keyName)) {
-					dangerousLocalNames.set(property.value.name, keyName);
+					recordDangerous(declaration, property.value, keyName);
 				} else if (keyName === 'default') {
-					namespaceNames.add(property.value.name);
+					recordNamespace(declaration, property.value);
 				}
 			}
 		};
@@ -158,12 +199,12 @@ export const NoDangerousFunctionsRule = createRule({
 						specifier.imported.type === AST_NODE_TYPES.Identifier &&
 						DANGEROUS_CHILD_PROCESS_FUNCTIONS.has(specifier.imported.name)
 					) {
-						dangerousLocalNames.set(specifier.local.name, specifier.imported.name);
+						recordDangerous(node, specifier.local, specifier.imported.name);
 					} else if (
 						specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier ||
 						specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier
 					) {
-						namespaceNames.add(specifier.local.name);
+						recordNamespace(node, specifier.local);
 					}
 				}
 			},
@@ -174,16 +215,16 @@ export const NoDangerousFunctionsRule = createRule({
 					node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference &&
 					isChildProcessModule(node.moduleReference.expression)
 				) {
-					namespaceNames.add(node.id.name);
+					recordNamespace(node, node.id);
 				}
 			},
 
 			VariableDeclarator(node) {
-				if (isChildProcessModuleExpression(node.init)) {
+				if (resolvesToChildProcessModule(node.init)) {
 					if (node.id.type === AST_NODE_TYPES.ObjectPattern) {
-						recordDestructuredModule(node.id);
+						recordDestructuredModule(node, node.id);
 					} else if (node.id.type === AST_NODE_TYPES.Identifier) {
-						namespaceNames.add(node.id.name);
+						recordNamespace(node, node.id);
 					}
 					return;
 				}
@@ -203,7 +244,7 @@ export const NoDangerousFunctionsRule = createRule({
 					DANGEROUS_CHILD_PROCESS_FUNCTIONS.has(memberName) &&
 					resolvesToChildProcessModule(node.init.object)
 				) {
-					dangerousLocalNames.set(node.id.name, memberName);
+					recordDangerous(node, node.id, memberName);
 				}
 			},
 
@@ -227,7 +268,8 @@ export const NoDangerousFunctionsRule = createRule({
 						return;
 					}
 
-					const originalName = dangerousLocalNames.get(callee.name);
+					const variable = resolveVariable(callee);
+					const originalName = variable && dangerousVariables.get(variable);
 					if (originalName) {
 						context.report({ node, messageId: 'noChildProcess', data: { name: originalName } });
 					}

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-dangerous-functions.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-dangerous-functions.ts
@@ -1,11 +1,6 @@
 import { TSESTree } from '@typescript-eslint/utils';
 
-import {
-	createRule,
-	getModulePath,
-	isDirectRequireCall,
-	isRequireMemberCall,
-} from '../utils/index.js';
+import { createRule, getStaticStringValue, isDirectRequireCall } from '../utils/index.js';
 
 const { AST_NODE_TYPES } = TSESTree;
 
@@ -26,9 +21,29 @@ const DANGEROUS_CHILD_PROCESS_FUNCTIONS = new Set([
 ]);
 
 const isChildProcessModule = (node: TSESTree.Node | null): boolean => {
-	const modulePath = getModulePath(node);
+	const modulePath = getStaticStringValue(node);
 	return modulePath !== null && CHILD_PROCESS_MODULES.has(modulePath);
 };
+
+/** `import('child_process')`, which yields the module once awaited. */
+const isChildProcessImport = (node: TSESTree.Node): boolean =>
+	node.type === AST_NODE_TYPES.ImportExpression && isChildProcessModule(node.source);
+
+/**
+ * Returns the name a key refers to when it is statically knowable, so that
+ * `exec`, `'exec'`, `['exec']` and `` [`exec`] `` are all treated alike. Keys
+ * that can only be resolved by running the code (`[name]`) return null.
+ */
+const getStaticKeyName = (key: TSESTree.Node, computed: boolean): string | null => {
+	if (!computed && key.type === AST_NODE_TYPES.Identifier) {
+		return key.name;
+	}
+
+	return getStaticStringValue(key);
+};
+
+const getStaticPropertyName = (node: TSESTree.MemberExpression): string | null =>
+	getStaticKeyName(node.property, node.computed);
 
 export const NoDangerousFunctionsRule = createRule({
 	name: 'no-dangerous-functions',
@@ -55,18 +70,80 @@ export const NoDangerousFunctionsRule = createRule({
 		// Local names bound to the whole module, e.g. `import * as cp` or `const cp = require(...)`.
 		const namespaceNames = new Set<string>();
 
+		/**
+		 * Resolves whether an expression is the `child_process` module.
+		 *
+		 * `followBindings` decides whether a bare identifier may be matched
+		 * against the recorded names. Reporting a call site does follow them —
+		 * that is the point of recording. Deciding whether a *declaration*
+		 * introduces a new name does not, because names are tracked in a flat,
+		 * file-wide set: minting `alias` from `const alias = cp` would make
+		 * every unrelated `alias` in the file look like `child_process`.
+		 */
+		const resolveModule = (
+			node: TSESTree.Node | null | undefined,
+			followBindings: boolean,
+		): boolean => {
+			if (!node) return false;
+
+			switch (node.type) {
+				case AST_NODE_TYPES.Identifier:
+					return followBindings && namespaceNames.has(node.name);
+				// `require('child_process')`. `require.resolve(...)` is deliberately
+				// excluded: it returns a path string, not the module.
+				case AST_NODE_TYPES.CallExpression:
+					return isDirectRequireCall(node) && isChildProcessModule(node.arguments[0] ?? null);
+				case AST_NODE_TYPES.AwaitExpression:
+					return (
+						isChildProcessImport(node.argument) || resolveModule(node.argument, followBindings)
+					);
+				// `mod.default` is the CommonJS module object under interop.
+				case AST_NODE_TYPES.MemberExpression:
+					return (
+						getStaticPropertyName(node) === 'default' && resolveModule(node.object, followBindings)
+					);
+				// Wrappers that do not change the value being accessed:
+				// `(0, require('child_process'))`, `require('child_process') as any`,
+				// `... satisfies unknown`, `...!`, `<any>...`.
+				case AST_NODE_TYPES.SequenceExpression:
+					return resolveModule(node.expressions.at(-1), followBindings);
+				case AST_NODE_TYPES.TSAsExpression:
+				case AST_NODE_TYPES.TSSatisfiesExpression:
+				case AST_NODE_TYPES.TSNonNullExpression:
+				case AST_NODE_TYPES.TSTypeAssertion:
+					return resolveModule(node.expression, followBindings);
+				default:
+					return false;
+			}
+		};
+
+		/** The module, reached through a recorded binding or written out in place. */
+		const resolvesToChildProcessModule = (node: TSESTree.Node | null | undefined): boolean =>
+			resolveModule(node, true);
+
+		/** The module written out in place, without consulting recorded names. */
+		const isChildProcessModuleExpression = (node: TSESTree.Node | null | undefined): boolean =>
+			resolveModule(node, false);
+
 		const recordDestructuredModule = (pattern: TSESTree.ObjectPattern) => {
 			for (const property of pattern.properties) {
-				if (
-					property.type !== AST_NODE_TYPES.Property ||
-					property.key.type !== AST_NODE_TYPES.Identifier ||
-					!DANGEROUS_CHILD_PROCESS_FUNCTIONS.has(property.key.name)
-				) {
+				// `const { ...cp } = require('child_process')` copies the module.
+				if (property.type === AST_NODE_TYPES.RestElement) {
+					if (property.argument.type === AST_NODE_TYPES.Identifier) {
+						namespaceNames.add(property.argument.name);
+					}
 					continue;
 				}
 
-				if (property.value.type === AST_NODE_TYPES.Identifier) {
-					dangerousLocalNames.set(property.value.name, property.key.name);
+				if (property.value.type !== AST_NODE_TYPES.Identifier) continue;
+
+				const keyName = getStaticKeyName(property.key, property.computed);
+				if (keyName === null) continue;
+
+				if (DANGEROUS_CHILD_PROCESS_FUNCTIONS.has(keyName)) {
+					dangerousLocalNames.set(property.value.name, keyName);
+				} else if (keyName === 'default') {
+					namespaceNames.add(property.value.name);
 				}
 			}
 		};
@@ -91,19 +168,42 @@ export const NoDangerousFunctionsRule = createRule({
 				}
 			},
 
-			VariableDeclarator(node) {
+			// `import cp = require('child_process')`, the TypeScript spelling.
+			TSImportEqualsDeclaration(node) {
 				if (
-					node.init?.type !== AST_NODE_TYPES.CallExpression ||
-					!(isDirectRequireCall(node.init) || isRequireMemberCall(node.init)) ||
-					!isChildProcessModule(node.init.arguments[0] ?? null)
+					node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference &&
+					isChildProcessModule(node.moduleReference.expression)
+				) {
+					namespaceNames.add(node.id.name);
+				}
+			},
+
+			VariableDeclarator(node) {
+				if (isChildProcessModuleExpression(node.init)) {
+					if (node.id.type === AST_NODE_TYPES.ObjectPattern) {
+						recordDestructuredModule(node.id);
+					} else if (node.id.type === AST_NODE_TYPES.Identifier) {
+						namespaceNames.add(node.id.name);
+					}
+					return;
+				}
+
+				// `const run = cp.exec` — the member equivalent of destructuring a
+				// spawner out of the module, which is already tracked above.
+				if (
+					node.id.type !== AST_NODE_TYPES.Identifier ||
+					node.init?.type !== AST_NODE_TYPES.MemberExpression
 				) {
 					return;
 				}
 
-				if (node.id.type === AST_NODE_TYPES.ObjectPattern) {
-					recordDestructuredModule(node.id);
-				} else if (node.id.type === AST_NODE_TYPES.Identifier) {
-					namespaceNames.add(node.id.name);
+				const memberName = getStaticPropertyName(node.init);
+				if (
+					memberName !== null &&
+					DANGEROUS_CHILD_PROCESS_FUNCTIONS.has(memberName) &&
+					resolvesToChildProcessModule(node.init.object)
+				) {
+					dangerousLocalNames.set(node.id.name, memberName);
 				}
 			},
 
@@ -135,18 +235,18 @@ export const NoDangerousFunctionsRule = createRule({
 					return;
 				}
 
-				if (
-					callee.type === AST_NODE_TYPES.MemberExpression &&
-					!callee.computed &&
-					callee.object.type === AST_NODE_TYPES.Identifier &&
-					namespaceNames.has(callee.object.name) &&
-					callee.property.type === AST_NODE_TYPES.Identifier &&
-					DANGEROUS_CHILD_PROCESS_FUNCTIONS.has(callee.property.name)
-				) {
+				if (callee.type !== AST_NODE_TYPES.MemberExpression) return;
+
+				const propertyName = getStaticPropertyName(callee);
+				if (propertyName === null || !DANGEROUS_CHILD_PROCESS_FUNCTIONS.has(propertyName)) {
+					return;
+				}
+
+				if (resolvesToChildProcessModule(callee.object)) {
 					context.report({
 						node,
 						messageId: 'noChildProcess',
-						data: { name: callee.property.name },
+						data: { name: propertyName },
 					});
 				}
 			},

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-restricted-imports.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-restricted-imports.ts
@@ -1,5 +1,5 @@
 import {
-	getModulePath,
+	getStaticStringValue,
 	isDirectRequireCall,
 	isRequireMemberCall,
 	createRule,
@@ -62,7 +62,7 @@ export const NoRestrictedImportsRule = createRule({
 
 		return {
 			ImportDeclaration(node) {
-				const modulePath = getModulePath(node.source);
+				const modulePath = getStaticStringValue(node.source);
 				if (modulePath && !isModuleAllowed(modulePath, devDependencies)) {
 					context.report({
 						node,
@@ -75,7 +75,7 @@ export const NoRestrictedImportsRule = createRule({
 			},
 
 			ImportExpression(node) {
-				const modulePath = getModulePath(node.source);
+				const modulePath = getStaticStringValue(node.source);
 				if (modulePath && !isModuleAllowed(modulePath, devDependencies)) {
 					context.report({
 						node,
@@ -89,7 +89,7 @@ export const NoRestrictedImportsRule = createRule({
 
 			CallExpression(node) {
 				if (isDirectRequireCall(node) || isRequireMemberCall(node)) {
-					const modulePath = getModulePath(node.arguments[0] ?? null);
+					const modulePath = getStaticStringValue(node.arguments[0] ?? null);
 					if (modulePath && !isModuleAllowed(modulePath, devDependencies)) {
 						context.report({
 							node,

--- a/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
@@ -67,9 +67,14 @@ export function getStringLiteralValue(node: TSESTree.Node | null): string | null
 	return typeof value === 'string' ? value : null;
 }
 
-export function getModulePath(node: TSESTree.Node | null): string | null {
+/**
+ * Returns the statically-known string a node evaluates to — a string literal or
+ * a template literal with no substitutions — or null when it cannot be known
+ * without evaluating the code.
+ */
+export function getStaticStringValue(node: TSESTree.Node | null): string | null {
 	const stringValue = getStringLiteralValue(node);
-	if (stringValue) {
+	if (stringValue !== null) {
 		return stringValue;
 	}
 


### PR DESCRIPTION
## Summary

`no-dangerous-functions` should stop community nodes from using `child_process`. It only found it when the module was assigned to a name and the function was called with a normal property access. Other common ways to reach the module were not detected.

## What changed

The rule now also finds:

- `require('child_process').exec(...)` used directly
- `await import('child_process')`
- computed or destructured access: `cp['exec'](...)`, `const { 'exec': run } = ...`
- CommonJS interop: `cp.default.exec(...)`, `import cp = require('child_process')`
- aliases: `const alias = cp`, `const run = cp.exec`

I also changed how a binding is tracked. Before, the rule kept a set of names for the whole file. Now it resolves the variable through lexical scope. That is what makes it safe to follow aliases, and it also fixes false positives that existed before, for example `function f(cp) { cp.exec(x) }` where `cp` is only a parameter, or a file where `require` itself is a local variable.

Callbacks and reassignment are still not followed. That needs flow analysis, so I kept it out of this PR.

## Why

This rule is a security check for community nodes. The cases it missed are normal ways to import a module, so the rule gave false confidence.

## Testing

Rule tests go from 20 to 56. They cover each new pattern, the scope cases, and the cases I decided not to follow. Rule doc updated.

## Notes

Two things are now treated as not the module: `require.resolve('child_process')` and an `import('child_process')` that is not awaited. Neither of them is the module.

`no-restricted-imports.ts` only changes because `getModulePath` was renamed to `getStaticStringValue` (3 call sites, same behaviour).
