### PR TITLE
test(core): Align MCP server name validation

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-config.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-config.service.test.ts
@@ -170,7 +170,7 @@ describe('AgentConfigService', () => {
 				...baseConfig,
 				mcpServers: [
 					{
-						name: 'has spaces',
+						name: '   ',
 						url: 'https://example.com/mcp',
 						transport: 'streamableHttp',
 						authentication: 'none',
@@ -181,9 +181,7 @@ describe('AgentConfigService', () => {
 			expect(result.valid).toBe(false);
 			if (result.valid) return;
 			expect(result.error).toContain('mcpServers.0.name');
-			expect(result.error).toContain(
-				'MCP server name can only contain letters, numbers, hyphens, and underscores',
-			);
+			expect(result.error).toContain('MCP server name cannot be blank');
 			expect(result.error).not.toContain('"validation": "regex"');
 		});
 	});


### PR DESCRIPTION
## Summary

### Fixes test failing on master

Update the agent config service test to validate the remaining invalid MCP server display-name case: a blank name.

The schema now accepts display names containing spaces, but this test still expected the previous restricted-character validation.

## How to test

Run:

```bash
pnpm test src/modules/agents/__tests__/agent-config.service.test.ts
```

Also checked the changed file with ESLint and Biome.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #34931.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs are not affected.
- [x] Tests included.
- [ ] Backport label is not required.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

