### PR TITLE
fix(node-cli): Update regex for scoped node name validation to allow dots in organization names

### DIFF
--- a/packages/@n8n/node-cli/src/utils/validation.test.ts
+++ b/packages/@n8n/node-cli/src/utils/validation.test.ts
@@ -1,0 +1,45 @@
+import { validateNodeName } from './validation';
+
+describe('validateNodeName', () => {
+	describe('valid names', () => {
+		test.each([
+			['unscoped name', 'n8n-nodes-my-app'],
+			['unscoped name with single segment', 'n8n-nodes-app'],
+			['unscoped name with numbers', 'n8n-nodes-app2'],
+			['unscoped name with many hyphenated segments', 'n8n-nodes-my-really-long-app-name'],
+			['scoped name', '@mycompany/n8n-nodes-my-app'],
+			['scoped name with hyphenated org', '@my-company/n8n-nodes-my-app'],
+			['scoped name with numbers', '@company2/n8n-nodes-app'],
+			['scoped name with dotted org (domain.tld)', '@example.com/n8n-nodes-my-app'],
+			['scoped name with dotted org (tld.domain)', '@com.example/n8n-nodes-my-app'],
+			['scoped name with multi-level dotted org', '@sub.example.com/n8n-nodes-my-app'],
+		])('accepts %s: %s', (_description, name) => {
+			expect(validateNodeName(name)).toBeUndefined();
+		});
+	});
+
+	describe('invalid names', () => {
+		test.each([
+			['missing prefix entirely', 'my-app'],
+			['unscoped without trailing segment', 'n8n-nodes-'],
+			['unscoped with uppercase letters', 'n8n-nodes-MyApp'],
+			['unscoped with underscore', 'n8n-nodes-my_app'],
+			['unscoped with double hyphen', 'n8n-nodes-my--app'],
+			['unscoped with trailing hyphen', 'n8n-nodes-my-app-'],
+			['scoped missing org', '/n8n-nodes-my-app'],
+			['scoped missing leading @', 'mycompany/n8n-nodes-my-app'],
+			['scoped with uppercase org', '@MyCompany/n8n-nodes-my-app'],
+			['scoped with uppercase name', '@mycompany/n8n-nodes-MyApp'],
+			['scoped org with leading dot', '@.example/n8n-nodes-my-app'],
+			['scoped org with trailing dot', '@example./n8n-nodes-my-app'],
+			['scoped org with consecutive dots', '@example..com/n8n-nodes-my-app'],
+			['scoped without n8n-nodes segment', '@mycompany/my-app'],
+			['plain package name', 'my-app'],
+			['whitespace only', '   '],
+		])('rejects %s: %s', (_description, name) => {
+			expect(validateNodeName(name)).toEqual(
+				"Must start with 'n8n-nodes-' or '@org/n8n-nodes-'. Examples: n8n-nodes-my-app, @mycompany/n8n-nodes-my-app",
+			);
+		});
+	});
+});

--- a/packages/@n8n/node-cli/src/utils/validation.ts
+++ b/packages/@n8n/node-cli/src/utils/validation.ts
@@ -2,7 +2,7 @@ export const validateNodeName = (name: string): string | undefined => {
 	if (!name) return;
 
 	// 1. Matches '@org/n8n-nodes-anything'
-	const regexScoped = /^@([a-z0-9]+(?:-[a-z0-9]+)*)\/n8n-nodes-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
+	const regexScoped = /^@([a-z0-9]+(?:[-\.][a-z0-9]+)*)\/n8n-nodes-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
 	// 2. Matches 'n8n-nodes-anything'
 	const regexUnscoped = /^n8n-nodes-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
 


### PR DESCRIPTION
## Summary

This PR updates the validation for scope validation in node-cli, that validates for user input on Node Naming.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

This PR fixes #34949. 

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34950">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

