### PR TITLE
feat(Execute Workflow Node): Deprecate Local File and URL sources

### DIFF
--- a/packages/cli/src/modules/breaking-changes/rules/index.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/index.ts
@@ -25,6 +25,7 @@ import './v3/chat-trigger-embedded-json.rule';
 import './v3/compression-node-limits.rule';
 import './v3/docker-only-deployment.rule';
 import './v3/execute-workflow-each-mode.rule';
+import './v3/execute-workflow-source-modes.rule';
 import './v3/get-paired-item.rule';
 import './v3/gmail-trigger-version.rule';
 import './v3/in-memory-binary-data.rule';

--- a/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/execute-workflow-source-modes.rule.test.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/__tests__/execute-workflow-source-modes.rule.test.ts
@@ -1,0 +1,108 @@
+import { createNode, createWorkflow } from '../../../__tests__/test-helpers';
+import { ExecuteWorkflowSourceModesRule } from '../execute-workflow-source-modes.rule';
+
+describe('ExecuteWorkflowSourceModesRule', () => {
+	let rule: ExecuteWorkflowSourceModesRule;
+
+	beforeEach(() => {
+		rule = new ExecuteWorkflowSourceModesRule();
+	});
+
+	describe('detectWorkflow()', () => {
+		it('should not be affected when there is no Execute Workflow node', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('HTTP', 'n8n-nodes-base.httpRequest'),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should not be affected when Execute Workflow node uses the "database" source', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('SubWF', 'n8n-nodes-base.executeWorkflow', { source: 'database' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should not be affected when Execute Workflow node uses the "parameter" source', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('SubWF', 'n8n-nodes-base.executeWorkflow', { source: 'parameter' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should not be affected when source is unset (defaults to "database")', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('SubWF', 'n8n-nodes-base.executeWorkflow'),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(false);
+			expect(result.issues).toHaveLength(0);
+		});
+
+		it('should detect Execute Workflow node using the "localFile" source', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('SubWF', 'n8n-nodes-base.executeWorkflow', { source: 'localFile' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].title).toContain('SubWF');
+			expect(result.issues[0].title).toContain('Local File');
+			expect(result.issues[0].level).toBe('error');
+			expect(result.issues[0].nodeName).toBe('SubWF');
+		});
+
+		it('should detect Execute Workflow node using the "url" source', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('SubWF', 'n8n-nodes-base.executeWorkflow', { source: 'url' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(1);
+			expect(result.issues[0].title).toContain('URL');
+			expect(result.issues[0].level).toBe('error');
+		});
+
+		it('should flag only the removed-source nodes when multiple Execute Workflow nodes exist', async () => {
+			const { workflow, nodesGroupedByType } = createWorkflow('wf-1', 'Test Workflow', [
+				createNode('LocalOne', 'n8n-nodes-base.executeWorkflow', { source: 'localFile' }),
+				createNode('UrlOne', 'n8n-nodes-base.executeWorkflow', { source: 'url' }),
+				createNode('DbOne', 'n8n-nodes-base.executeWorkflow', { source: 'database' }),
+			]);
+
+			const result = await rule.detectWorkflow(workflow, nodesGroupedByType);
+
+			expect(result.isAffected).toBe(true);
+			expect(result.issues).toHaveLength(2);
+			expect(result.issues.map((issue) => issue.nodeName)).toEqual(['LocalOne', 'UrlOne']);
+		});
+	});
+
+	describe('getRecommendations()', () => {
+		it('should recommend the database source and node-defined JSON', async () => {
+			const recommendations = await rule.getRecommendations([]);
+
+			expect(recommendations).toHaveLength(2);
+			expect(recommendations[0].action).toContain('Database');
+			expect(recommendations[1].action).toContain('workflow JSON');
+		});
+	});
+});

--- a/packages/cli/src/modules/breaking-changes/rules/v3/execute-workflow-source-modes.rule.ts
+++ b/packages/cli/src/modules/breaking-changes/rules/v3/execute-workflow-source-modes.rule.ts
@@ -1,0 +1,77 @@
+import type { BreakingChangeAffectedWorkflow, BreakingChangeRecommendation } from '@n8n/api-types';
+import type { WorkflowEntity } from '@n8n/db';
+import { BreakingChangeRule } from '@n8n/decorators';
+import type { INode } from 'n8n-workflow';
+
+import type {
+	BreakingChangeRuleMetadata,
+	IBreakingChangeWorkflowRule,
+	WorkflowDetectionReport,
+} from '../../types';
+import { BreakingChangeCategory } from '../../types';
+
+const EXECUTE_WORKFLOW_NODE_TYPE = 'n8n-nodes-base.executeWorkflow';
+const REMOVED_SOURCES = ['localFile', 'url'];
+
+const SOURCE_LABELS: Record<string, string> = {
+	localFile: 'Local File',
+	url: 'URL',
+};
+
+@BreakingChangeRule({ version: 'v3' })
+export class ExecuteWorkflowSourceModesRule implements IBreakingChangeWorkflowRule {
+	id = 'execute-workflow-source-modes-v3';
+
+	getMetadata(): BreakingChangeRuleMetadata {
+		return {
+			version: 'v3',
+			title: 'Execute Sub-workflow "Local File" and "URL" sources removed',
+			description:
+				'The "Local File" and "URL" sources of the Execute Sub-workflow node are being removed. Sub-workflows must be loaded from the database or defined in the node parameters.',
+			category: BreakingChangeCategory.workflow,
+			severity: 'medium',
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async getRecommendations(
+		_workflowResults: BreakingChangeAffectedWorkflow[],
+	): Promise<BreakingChangeRecommendation[]> {
+		return [
+			{
+				action: 'Switch to the "Database" source',
+				description:
+					'Import the referenced workflow into this n8n instance and select it via the "Database" source on the flagged Execute Sub-workflow node.',
+			},
+			{
+				action: 'Or define the workflow JSON in the node',
+				description:
+					'Paste the referenced workflow\'s JSON into the "Parameter" source to keep the sub-workflow definition inside the node.',
+			},
+		];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async detectWorkflow(
+		_workflow: WorkflowEntity,
+		nodesGroupedByType: Map<string, INode[]>,
+	): Promise<WorkflowDetectionReport> {
+		const affectedNodes = (nodesGroupedByType.get(EXECUTE_WORKFLOW_NODE_TYPE) ?? []).filter(
+			(node) => REMOVED_SOURCES.includes(node.parameters.source as string),
+		);
+
+		if (affectedNodes.length === 0) return { isAffected: false, issues: [] };
+
+		return {
+			isAffected: true,
+			issues: affectedNodes.map((node) => ({
+				title: `Node '${node.name}' uses the removed "${SOURCE_LABELS[node.parameters.source as string]}" source`,
+				description:
+					'This source is being removed. Import the referenced workflow into this n8n instance and use the "Database" source, or paste its JSON into the "Parameter" source.',
+				level: 'error',
+				nodeId: node.id,
+				nodeName: node.name,
+			})),
+		};
+	}
+}

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -80,6 +80,19 @@ export class ExecuteWorkflow implements INodeType {
 				displayOptions: { show: { '@version': [{ _cnd: { lte: 1.1 } }] } },
 			},
 			{
+				displayName:
+					'The "Local File" and "URL" sources are deprecated and will be removed in a future version. Import the workflow into this n8n instance and use the "Database" source, or paste its JSON into the "Parameter" source instead.',
+				name: 'sourceDeprecationNotice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						source: ['localFile', 'url'],
+						'@version': [{ _cnd: { lte: 1.1 } }],
+					},
+				},
+			},
+			{
 				displayName: 'Source',
 				name: 'source',
 				type: 'options',


### PR DESCRIPTION
## Summary

Prepares the removal of the "Local File" and "URL" sources of the Execute Sub-workflow node planned for n8n v3, without changing any runtime behavior:

- **In-node deprecation notice**: node versions <= 1.1 (the only versions offering these sources) now show a notice when `source` is `localFile` or `url`, pointing users to the "Database" source or to pasting the workflow JSON into the "Parameter" source.
- **v3 breaking-change detection rule**: adds `execute-workflow-source-modes-v3` to `packages/cli/src/modules/breaking-changes/rules/v3/`, flagging every Execute Sub-workflow node using one of the removed sources, with per-node issues and migration recommendations. Like all v3 rules, it stays dormant until `MIGRATION_REPORT_TARGET_VERSION` is set to `'v3'`.

The removal itself will land on the `3.x` branch separately.

## How to test

1. Import a workflow containing an Execute Sub-workflow node with `typeVersion` 1 or 1.1 and set Source to "Local File" or "URL" — the deprecation notice appears at the top of the parameters. Switch Source to "Database"/"Parameter" — the notice disappears.
2. Add a new Execute Sub-workflow node (version 1.3) — no notice, no new parameters.
3. Rule unit tests: `cd packages/cli && pnpm test src/modules/breaking-changes/rules/v3/__tests__/execute-workflow-source-modes.rule.test.ts`
4. To see the rule in the migration report UI, temporarily set `MIGRATION_REPORT_TARGET_VERSION = 'v3'` in `packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts`, then check Settings → Migration report as an instance owner.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3804

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34959">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

