### PR TITLE
fix(core): Fix MCP workflow update failing for active workflows on SQLite

### DIFF
--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -61,6 +61,7 @@ export class WorkflowFinderService {
 			relations: { workflow: true },
 			select: {
 				workflowId: true,
+				projectId: true,
 				workflow: { id: true, versionId: true, updatedAt: true },
 			},
 		});

--- a/packages/cli/test/integration/workflows/workflow-finder.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-finder.service.test.ts
@@ -1,0 +1,64 @@
+import { createWorkflow, testDb } from '@n8n/backend-test-utils';
+import { GLOBAL_MEMBER_ROLE, GLOBAL_OWNER_ROLE, type User } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+import { createUser } from '../shared/db/users';
+
+let owner: User;
+let member: User;
+let anotherMember: User;
+let workflowFinderService: WorkflowFinderService;
+
+beforeAll(async () => {
+	await testDb.init();
+	owner = await createUser({ role: GLOBAL_OWNER_ROLE });
+	member = await createUser({ role: GLOBAL_MEMBER_ROLE });
+	anotherMember = await createUser({ role: GLOBAL_MEMBER_ROLE });
+	workflowFinderService = Container.get(WorkflowFinderService);
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow']);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+describe('WorkflowFinderService', () => {
+	describe('findWorkflowHeadForUser', () => {
+		it('should return the workflow head for a user with a project-scoped role', async () => {
+			const workflow = await createWorkflow({}, member);
+
+			const head = await workflowFinderService.findWorkflowHeadForUser(workflow.id, member, [
+				'workflow:publish',
+			]);
+
+			expect(head?.versionId).toBe(workflow.versionId);
+			expect(head?.updatedAt).toBeInstanceOf(Date);
+		});
+
+		it('should return the workflow head for a user with a global scope', async () => {
+			const workflow = await createWorkflow({}, member);
+
+			const head = await workflowFinderService.findWorkflowHeadForUser(workflow.id, owner, [
+				'workflow:publish',
+			]);
+
+			expect(head?.versionId).toBe(workflow.versionId);
+			expect(head?.updatedAt).toBeInstanceOf(Date);
+		});
+
+		it('should return null for a user without access to the workflow', async () => {
+			const workflow = await createWorkflow({}, member);
+
+			const head = await workflowFinderService.findWorkflowHeadForUser(workflow.id, anotherMember, [
+				'workflow:publish',
+			]);
+
+			expect(head).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The MCP server's `update_workflow` tool failed on SQLite with `SQLITE_ERROR: no such column: distinctAlias.SharedWorkflow_projectId` whenever a settings operation targeted a published (active) workflow and the calling user did not have the global `workflow:publish` scope. The same call on an inactive workflow succeeded, and nothing was saved on failure.

Root cause: `WorkflowFinderService.findWorkflowHeadForUser` runs a `findOne` on `SharedWorkflow` with a joined `workflow` relation and a narrowed `select` that omitted `projectId`. `SharedWorkflow` has a composite primary key (`workflowId`, `projectId`), and TypeORM wraps take+join queries in a DISTINCT subquery keyed on the full primary key — so the generated SQL referenced a column that was never selected. The fix selects both PK columns, following the existing precedent in `SharedWorkflowRepository.findSharingRole`.

This also fixes the same failure in the AI Assistant's build-workflow cache-validity check, which shares the helper.

A regression test is included; without the fix it fails with the exact reported error.

## How to test

1. On a SQLite-backed instance, as a user **without** the global `workflow:publish` scope (e.g. a member), create and publish a workflow with `availableInMCP` enabled.
2. Connect to the instance MCP server (`/mcp-server/http`) with that user's MCP API key.
3. Call the `update_workflow` tool with a `setWorkflowSettings` operation (e.g. set `timezone`).
4. Before this fix the call fails with `SQLITE_ERROR: no such column: distinctAlias.SharedWorkflow_projectId`; with the fix it succeeds and the workflow stays active.

Or run the new integration test: `pnpm --filter=n8n test:integration test/integration/workflows/workflow-finder.service.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5644

fixes #34906

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34964">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

