### PR TITLE
fix(core): Treat referenced webhook lifecycle methods as implemented (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
@@ -23,6 +23,10 @@ reference, so extracting the handlers into named functions is fine. When a group
 spreads another object, a method it does not list itself is assumed to come from
 that spread, but a method it does list must still supply an implementation.
 
+Type annotations (`as`, `satisfies`, `!`, type assertions) are read through, so
+annotating `description`, `webhookMethods`, a lifecycle group, or an individual
+method does not change whether the rule applies.
+
 Polling triggers (trigger nodes without a `webhooks` array and without
 `webhookMethods`) are intentionally out of scope.
 

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
@@ -20,8 +20,9 @@ For every webhook group inside `webhookMethods` (typically `default`), the
 methods `checkExists`, `create`, and `delete` must all be implemented. A method
 counts as implemented whether it is written inline or handed over as a
 reference, so extracting the handlers into named functions is fine. When a group
-spreads another object, a method it does not list itself is assumed to come from
-that spread, but a method it does list must still supply an implementation.
+spreads another object, only the methods written after the last spread settle
+the group: one of those must supply an implementation, while anything the spread
+may still replace or fill in is left alone.
 
 Type annotations (`as`, `satisfies`, `!`, type assertions) are read through, so
 annotating `description`, `webhookMethods`, a lifecycle group, or an individual

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
@@ -17,7 +17,11 @@ This rule applies to node classes that:
 - define a `webhookMethods` class property.
 
 For every webhook group inside `webhookMethods` (typically `default`), the
-methods `checkExists`, `create`, and `delete` must all be implemented.
+methods `checkExists`, `create`, and `delete` must all be implemented. A method
+counts as implemented whether it is written inline or handed over as a
+reference, so extracting the handlers into named functions is fine. A group
+assembled by spreading another object is skipped, since its methods cannot be
+read from the class.
 
 Polling triggers (trigger nodes without a `webhooks` array and without
 `webhookMethods`) are intentionally out of scope.
@@ -83,6 +87,22 @@ export class MyTrigger implements INodeType {
         return true;
       },
     },
+  };
+}
+```
+
+Handing the methods over as references is equally complete:
+
+```typescript
+async function checkExists(this: IHookFunctions): Promise<boolean> { return true; }
+async function create(this: IHookFunctions): Promise<boolean> { return true; }
+async function removeWebhook(this: IHookFunctions): Promise<boolean> { return true; }
+
+export class MyTrigger implements INodeType {
+  description: INodeTypeDescription = { /* ... */ };
+
+  webhookMethods = {
+    default: { checkExists, create, delete: removeWebhook },
   };
 }
 ```

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
@@ -19,9 +19,9 @@ This rule applies to node classes that:
 For every webhook group inside `webhookMethods` (typically `default`), the
 methods `checkExists`, `create`, and `delete` must all be implemented. A method
 counts as implemented whether it is written inline or handed over as a
-reference, so extracting the handlers into named functions is fine. A group
-assembled by spreading another object is skipped, since its methods cannot be
-read from the class.
+reference, so extracting the handlers into named functions is fine. When a group
+spreads another object, a method it does not list itself is assumed to come from
+that spread, but a method it does list must still supply an implementation.
 
 Polling triggers (trigger nodes without a `webhooks` array and without
 `webhookMethods`) are intentionally out of scope.

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -258,6 +258,30 @@ export class RegularClass {
 			],
 		},
 		{
+			name: 'webhookMethods behind an as-expression, delete missing',
+			code: createTriggerNode({
+				webhookMethods: '{ default: { checkExists, create } } as IWebhookMethods',
+			}),
+			errors: [
+				{
+					messageId: 'missingLifecycleMethod',
+					data: { group: 'default', missing: '`delete`' },
+				},
+			],
+		},
+		{
+			name: 'lifecycle group behind an as-expression, delete missing',
+			code: createTriggerNode({
+				webhookMethods: '{ default: { checkExists, create } as IWebhookMethods }',
+			}),
+			errors: [
+				{
+					messageId: 'missingLifecycleMethod',
+					data: { group: 'default', missing: '`delete`' },
+				},
+			],
+		},
+		{
 			name: 'lifecycle method overridden with undefined after a spread',
 			code: createTriggerNode({
 				webhookMethods: '{ default: { ...sharedLifecycle, delete: undefined } }',

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -125,6 +125,12 @@ export class RegularClass {
 				webhookMethods: '{ default: { ...sharedLifecycle, delete: removeWebhook } }',
 			}),
 		},
+		{
+			name: 'lifecycle key superseded by a later spread',
+			code: createTriggerNode({
+				webhookMethods: '{ default: { delete: undefined, ...sharedLifecycle } }',
+			}),
+		},
 	],
 	invalid: [
 		{

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -251,5 +251,23 @@ export class RegularClass {
 				},
 			],
 		},
+		{
+			name: 'lifecycle method set to undefined',
+			code: createTriggerNode({
+				webhookMethods: `{
+					default: {
+						checkExists,
+						create,
+						delete: undefined,
+					},
+				}`,
+			}),
+			errors: [
+				{
+					messageId: 'missingLifecycleMethod',
+					data: { group: 'default', missing: '`delete`' },
+				},
+			],
+		},
 	],
 });

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -100,6 +100,25 @@ export class RegularClass {
 				}`,
 			}),
 		},
+		// A method handed over as a reference is just as implemented as one
+		// written inline.
+		{
+			name: 'lifecycle methods provided as shorthand references',
+			code: createTriggerNode({
+				webhookMethods: '{ default: { checkExists, create, delete: removeWebhook } }',
+			}),
+		},
+		{
+			name: 'lifecycle methods provided as member references',
+			code: createTriggerNode({
+				webhookMethods:
+					'{ default: { checkExists: hooks.checkExists, create: hooks.create, delete: hooks.delete } }',
+			}),
+		},
+		{
+			name: 'lifecycle group composed by spreading another object',
+			code: createTriggerNode({ webhookMethods: '{ default: { ...sharedLifecycle } }' }),
+		},
 	],
 	invalid: [
 		{
@@ -210,6 +229,25 @@ export class RegularClass {
 				{
 					messageId: 'missingLifecycleMethod',
 					data: { group: 'setup', missing: '`checkExists`' },
+				},
+			],
+		},
+		// A key that is present but supplies nothing is still not an implementation.
+		{
+			name: 'lifecycle method set to a nullish placeholder',
+			code: createTriggerNode({
+				webhookMethods: `{
+					default: {
+						checkExists,
+						create,
+						delete: null,
+					},
+				}`,
+			}),
+			errors: [
+				{
+					messageId: 'missingLifecycleMethod',
+					data: { group: 'default', missing: '`delete`' },
 				},
 			],
 		},

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -119,6 +119,12 @@ export class RegularClass {
 			name: 'lifecycle group composed by spreading another object',
 			code: createTriggerNode({ webhookMethods: '{ default: { ...sharedLifecycle } }' }),
 		},
+		{
+			name: 'lifecycle group spreading another object and overriding one method',
+			code: createTriggerNode({
+				webhookMethods: '{ default: { ...sharedLifecycle, delete: removeWebhook } }',
+			}),
+		},
 	],
 	invalid: [
 		{
@@ -243,6 +249,18 @@ export class RegularClass {
 						delete: null,
 					},
 				}`,
+			}),
+			errors: [
+				{
+					messageId: 'missingLifecycleMethod',
+					data: { group: 'default', missing: '`delete`' },
+				},
+			],
+		},
+		{
+			name: 'lifecycle method overridden with undefined after a spread',
+			code: createTriggerNode({
+				webhookMethods: '{ default: { ...sharedLifecycle, delete: undefined } }',
 			}),
 			errors: [
 				{

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
@@ -24,17 +24,19 @@ function hasWebhooksDeclared(descriptionValue: TSESTree.ObjectExpression): boole
 
 /**
  * Returns true when the value supplies an implementation. A method may be
- * written inline or handed over as a reference — `{ checkExists }`,
- * `{ delete: removeWebhook }`, `{ create: hooks.create }` — which is just as
- * implemented as a function expression.
+ * written inline or handed over as a reference (`{ checkExists }`,
+ * `{ delete: removeWebhook }`, `{ create: hooks.create }`), which is just as
+ * implemented as a function expression. `undefined` is an identifier too, but
+ * it supplies nothing.
  */
 function isImplementation(node: TSESTree.Node): boolean {
 	switch (node.type) {
 		case AST_NODE_TYPES.FunctionExpression:
 		case AST_NODE_TYPES.ArrowFunctionExpression:
-		case AST_NODE_TYPES.Identifier:
 		case AST_NODE_TYPES.MemberExpression:
 			return true;
+		case AST_NODE_TYPES.Identifier:
+			return node.name !== 'undefined';
 		case AST_NODE_TYPES.TSAsExpression:
 		case AST_NODE_TYPES.TSSatisfiesExpression:
 		case AST_NODE_TYPES.TSNonNullExpression:

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
@@ -10,6 +10,33 @@ import {
 } from '../utils/index.js';
 
 /**
+ * Strips `as` / `satisfies` / `!` / type assertions to reach the value they
+ * annotate. Annotating a value says nothing about what it holds, so the rule
+ * reads through them everywhere rather than losing sight of the node.
+ */
+function unwrapTypeAnnotations(node: TSESTree.Node): TSESTree.Node {
+	switch (node.type) {
+		case AST_NODE_TYPES.TSAsExpression:
+		case AST_NODE_TYPES.TSSatisfiesExpression:
+		case AST_NODE_TYPES.TSNonNullExpression:
+		case AST_NODE_TYPES.TSTypeAssertion:
+			return unwrapTypeAnnotations(node.expression);
+		default:
+			return node;
+	}
+}
+
+/** Returns the value as an object literal, or undefined when it is not one. */
+function asObjectExpression(
+	node: TSESTree.Node | null | undefined,
+): TSESTree.ObjectExpression | undefined {
+	if (!node) return undefined;
+
+	const value = unwrapTypeAnnotations(node);
+	return value.type === AST_NODE_TYPES.ObjectExpression ? value : undefined;
+}
+
+/**
  * Returns true if the description declares webhook endpoints, indicating the
  * node is a webhook-based trigger that needs a complete lifecycle.
  *
@@ -18,8 +45,11 @@ import {
  */
 function hasWebhooksDeclared(descriptionValue: TSESTree.ObjectExpression): boolean {
 	const webhooksProperty = findObjectProperty(descriptionValue, 'webhooks');
-	if (webhooksProperty?.value.type !== AST_NODE_TYPES.ArrayExpression) return false;
-	return webhooksProperty.value.elements.length > 0;
+	if (!webhooksProperty) return false;
+
+	const webhooks = unwrapTypeAnnotations(webhooksProperty.value);
+	if (webhooks.type !== AST_NODE_TYPES.ArrayExpression) return false;
+	return webhooks.elements.length > 0;
 }
 
 /**
@@ -30,52 +60,42 @@ function hasWebhooksDeclared(descriptionValue: TSESTree.ObjectExpression): boole
  * it supplies nothing.
  */
 function isImplementation(node: TSESTree.Node): boolean {
-	switch (node.type) {
+	const value = unwrapTypeAnnotations(node);
+
+	switch (value.type) {
 		case AST_NODE_TYPES.FunctionExpression:
 		case AST_NODE_TYPES.ArrowFunctionExpression:
 		case AST_NODE_TYPES.MemberExpression:
 			return true;
 		case AST_NODE_TYPES.Identifier:
-			return node.name !== 'undefined';
-		case AST_NODE_TYPES.TSAsExpression:
-		case AST_NODE_TYPES.TSSatisfiesExpression:
-		case AST_NODE_TYPES.TSNonNullExpression:
-		case AST_NODE_TYPES.TSTypeAssertion:
-			return isImplementation(node.expression);
+			return value.name !== 'undefined';
 		default:
 			return false;
 	}
 }
 
-/** Returns true when the property supplies a method named `name`. */
-function isMethodProperty(property: TSESTree.ObjectLiteralElement, name: string): boolean {
+/** Returns true when the property states the key `name`, whatever value it gives it. */
+function declaresKey(
+	property: TSESTree.ObjectLiteralElement,
+	name: string,
+): property is TSESTree.Property {
 	if (property.type !== AST_NODE_TYPES.Property) return false;
 	if (property.computed) return false;
 
-	const keyMatches =
+	return (
 		(property.key.type === AST_NODE_TYPES.Identifier && property.key.name === name) ||
-		(property.key.type === AST_NODE_TYPES.Literal && property.key.value === name);
-	if (!keyMatches) return false;
+		(property.key.type === AST_NODE_TYPES.Literal && property.key.value === name)
+	);
+}
 
-	return isImplementation(property.value);
+/** Returns true when the property supplies a method named `name`. */
+function isMethodProperty(property: TSESTree.ObjectLiteralElement, name: string): boolean {
+	return declaresKey(property, name) && isImplementation(property.value);
 }
 
 /** A group built up by spreading another object does not list all its methods. */
 function isComposedBySpread(group: TSESTree.ObjectExpression): boolean {
 	return group.properties.some((property) => property.type === AST_NODE_TYPES.SpreadElement);
-}
-
-/** Returns true when the group states the key itself, whatever value it gives it. */
-function declaresKey(group: TSESTree.ObjectExpression, name: string): boolean {
-	return group.properties.some((property) => {
-		if (property.type !== AST_NODE_TYPES.Property) return false;
-		if (property.computed) return false;
-
-		return (
-			(property.key.type === AST_NODE_TYPES.Identifier && property.key.name === name) ||
-			(property.key.type === AST_NODE_TYPES.Literal && property.key.value === name)
-		);
-	});
 }
 
 function findMissingMethods(group: TSESTree.ObjectExpression): WebhookLifecycleMethod[] {
@@ -87,7 +107,7 @@ function findMissingMethods(group: TSESTree.ObjectExpression): WebhookLifecycleM
 		// A spread may carry the method in, so a key that is simply absent is not
 		// evidence of anything. A key the group states itself is, since an explicit
 		// `delete: undefined` overrides whatever the spread supplied.
-		return !composedBySpread || declaresKey(group, method);
+		return !composedBySpread || group.properties.some((p) => declaresKey(p, method));
 	});
 }
 
@@ -118,8 +138,8 @@ export const WebhookLifecycleCompleteRule = createRule({
 				const descriptionProperty = findClassProperty(node, 'description');
 				if (!descriptionProperty) return;
 
-				const descriptionValue = descriptionProperty.value;
-				if (descriptionValue?.type !== AST_NODE_TYPES.ObjectExpression) return;
+				const descriptionValue = asObjectExpression(descriptionProperty.value);
+				if (!descriptionValue) return;
 
 				const webhookMethodsProperty = findClassProperty(node, 'webhookMethods');
 
@@ -135,11 +155,10 @@ export const WebhookLifecycleCompleteRule = createRule({
 					return;
 				}
 
-				if (webhookMethodsProperty.value.type !== AST_NODE_TYPES.ObjectExpression) {
-					return;
-				}
+				const webhookMethods = asObjectExpression(webhookMethodsProperty.value);
+				if (!webhookMethods) return;
 
-				if (webhookMethodsProperty.value.properties.length === 0) {
+				if (webhookMethods.properties.length === 0) {
 					context.report({
 						node: webhookMethodsProperty.key,
 						messageId: 'emptyWebhookMethods',
@@ -147,9 +166,11 @@ export const WebhookLifecycleCompleteRule = createRule({
 					return;
 				}
 
-				for (const groupProperty of webhookMethodsProperty.value.properties) {
+				for (const groupProperty of webhookMethods.properties) {
 					if (groupProperty.type !== AST_NODE_TYPES.Property) continue;
-					if (groupProperty.value.type !== AST_NODE_TYPES.ObjectExpression) continue;
+
+					const group = asObjectExpression(groupProperty.value);
+					if (!group) continue;
 
 					const groupName =
 						groupProperty.key.type === AST_NODE_TYPES.Identifier
@@ -158,7 +179,7 @@ export const WebhookLifecycleCompleteRule = createRule({
 								? String(groupProperty.key.value)
 								: 'default';
 
-					const missing = findMissingMethods(groupProperty.value);
+					const missing = findMissingMethods(group);
 					if (missing.length === 0) continue;
 
 					context.report({

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
@@ -93,21 +93,36 @@ function isMethodProperty(property: TSESTree.ObjectLiteralElement, name: string)
 	return declaresKey(property, name) && isImplementation(property.value);
 }
 
-/** A group built up by spreading another object does not list all its methods. */
-function isComposedBySpread(group: TSESTree.ObjectExpression): boolean {
-	return group.properties.some((property) => property.type === AST_NODE_TYPES.SpreadElement);
+/**
+ * Whatever a spread carries in cannot be read from the class, so only the
+ * properties written after the last one settle the group. Everything before it
+ * may be replaced by that spread, and the spread itself may fill in a key the
+ * group never mentions.
+ */
+function conclusiveProperties(
+	group: TSESTree.ObjectExpression,
+): [properties: TSESTree.ObjectLiteralElement[], spreads: boolean] {
+	let lastSpread = -1;
+	group.properties.forEach((property, index) => {
+		if (property.type === AST_NODE_TYPES.SpreadElement) lastSpread = index;
+	});
+
+	return [group.properties.slice(lastSpread + 1), lastSpread !== -1];
 }
 
 function findMissingMethods(group: TSESTree.ObjectExpression): WebhookLifecycleMethod[] {
-	const composedBySpread = isComposedBySpread(group);
+	const [properties, spreads] = conclusiveProperties(group);
 
 	return WEBHOOK_LIFECYCLE_METHODS.filter((method) => {
-		if (group.properties.some((property) => isMethodProperty(property, method))) return false;
+		const declared = properties.find((property): property is TSESTree.Property =>
+			declaresKey(property, method),
+		);
 
-		// A spread may carry the method in, so a key that is simply absent is not
-		// evidence of anything. A key the group states itself is, since an explicit
-		// `delete: undefined` overrides whatever the spread supplied.
-		return !composedBySpread || group.properties.some((p) => declaresKey(p, method));
+		// A key stated last says what the method really is, `delete: undefined`
+		// included. Otherwise a spread leaves it open, and its absence proves
+		// nothing; without one, an absent key is simply missing.
+		if (declared) return !isImplementation(declared.value);
+		return !spreads;
 	});
 }
 

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
@@ -22,7 +22,30 @@ function hasWebhooksDeclared(descriptionValue: TSESTree.ObjectExpression): boole
 	return webhooksProperty.value.elements.length > 0;
 }
 
-/** Returns true when the property defines a (possibly async) method named `name`. */
+/**
+ * Returns true when the value supplies an implementation. A method may be
+ * written inline or handed over as a reference — `{ checkExists }`,
+ * `{ delete: removeWebhook }`, `{ create: hooks.create }` — which is just as
+ * implemented as a function expression.
+ */
+function isImplementation(node: TSESTree.Node): boolean {
+	switch (node.type) {
+		case AST_NODE_TYPES.FunctionExpression:
+		case AST_NODE_TYPES.ArrowFunctionExpression:
+		case AST_NODE_TYPES.Identifier:
+		case AST_NODE_TYPES.MemberExpression:
+			return true;
+		case AST_NODE_TYPES.TSAsExpression:
+		case AST_NODE_TYPES.TSSatisfiesExpression:
+		case AST_NODE_TYPES.TSNonNullExpression:
+		case AST_NODE_TYPES.TSTypeAssertion:
+			return isImplementation(node.expression);
+		default:
+			return false;
+	}
+}
+
+/** Returns true when the property supplies a method named `name`. */
 function isMethodProperty(property: TSESTree.ObjectLiteralElement, name: string): boolean {
 	if (property.type !== AST_NODE_TYPES.Property) return false;
 	if (property.computed) return false;
@@ -32,10 +55,12 @@ function isMethodProperty(property: TSESTree.ObjectLiteralElement, name: string)
 		(property.key.type === AST_NODE_TYPES.Literal && property.key.value === name);
 	if (!keyMatches) return false;
 
-	return (
-		property.value.type === AST_NODE_TYPES.FunctionExpression ||
-		property.value.type === AST_NODE_TYPES.ArrowFunctionExpression
-	);
+	return isImplementation(property.value);
+}
+
+/** A group built up by spreading another object does not list its methods. */
+function isComposedBySpread(group: TSESTree.ObjectExpression): boolean {
+	return group.properties.some((property) => property.type === AST_NODE_TYPES.SpreadElement);
 }
 
 function findMissingMethods(group: TSESTree.ObjectExpression): WebhookLifecycleMethod[] {
@@ -103,6 +128,7 @@ export const WebhookLifecycleCompleteRule = createRule({
 				for (const groupProperty of webhookMethodsProperty.value.properties) {
 					if (groupProperty.type !== AST_NODE_TYPES.Property) continue;
 					if (groupProperty.value.type !== AST_NODE_TYPES.ObjectExpression) continue;
+					if (isComposedBySpread(groupProperty.value)) continue;
 
 					const groupName =
 						groupProperty.key.type === AST_NODE_TYPES.Identifier

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
@@ -60,15 +60,35 @@ function isMethodProperty(property: TSESTree.ObjectLiteralElement, name: string)
 	return isImplementation(property.value);
 }
 
-/** A group built up by spreading another object does not list its methods. */
+/** A group built up by spreading another object does not list all its methods. */
 function isComposedBySpread(group: TSESTree.ObjectExpression): boolean {
 	return group.properties.some((property) => property.type === AST_NODE_TYPES.SpreadElement);
 }
 
+/** Returns true when the group states the key itself, whatever value it gives it. */
+function declaresKey(group: TSESTree.ObjectExpression, name: string): boolean {
+	return group.properties.some((property) => {
+		if (property.type !== AST_NODE_TYPES.Property) return false;
+		if (property.computed) return false;
+
+		return (
+			(property.key.type === AST_NODE_TYPES.Identifier && property.key.name === name) ||
+			(property.key.type === AST_NODE_TYPES.Literal && property.key.value === name)
+		);
+	});
+}
+
 function findMissingMethods(group: TSESTree.ObjectExpression): WebhookLifecycleMethod[] {
-	return WEBHOOK_LIFECYCLE_METHODS.filter(
-		(method) => !group.properties.some((property) => isMethodProperty(property, method)),
-	);
+	const composedBySpread = isComposedBySpread(group);
+
+	return WEBHOOK_LIFECYCLE_METHODS.filter((method) => {
+		if (group.properties.some((property) => isMethodProperty(property, method))) return false;
+
+		// A spread may carry the method in, so a key that is simply absent is not
+		// evidence of anything. A key the group states itself is, since an explicit
+		// `delete: undefined` overrides whatever the spread supplied.
+		return !composedBySpread || declaresKey(group, method);
+	});
 }
 
 export const WebhookLifecycleCompleteRule = createRule({
@@ -130,7 +150,6 @@ export const WebhookLifecycleCompleteRule = createRule({
 				for (const groupProperty of webhookMethodsProperty.value.properties) {
 					if (groupProperty.type !== AST_NODE_TYPES.Property) continue;
 					if (groupProperty.value.type !== AST_NODE_TYPES.ObjectExpression) continue;
-					if (isComposedBySpread(groupProperty.value)) continue;
 
 					const groupName =
 						groupProperty.key.type === AST_NODE_TYPES.Identifier


### PR DESCRIPTION
## Summary

The rule checked how a lifecycle method was written, not what the value actually is. Because of that it got two things wrong.

```typescript
// `delete` is implemented, but the rule reported it as missing.
webhookMethods = {
  default: { checkExists, create, delete: removeWebhook },
};

// `delete` is really missing, but the rule skipped this class and said nothing.
webhookMethods = { default: { checkExists, create } } as IWebhookMethods;
```

## What changed

A method now counts as implemented when the value is a function, a name (`{ checkExists }`, `delete: removeWebhook`), or a member expression (`create: hooks.create`).

`undefined` is also just a name in the AST, so I check for it. `delete: undefined` and `delete: null` are both reported.

`as`, `satisfies`, `!` and type assertions are removed before the rule looks at a value. This is done for `description`, its `webhooks` array, `webhookMethods`, a group, and a single method. Before, any of them could turn the rule off without any message.

For a group with a spread, only the properties after the last spread are checked:

- `{ ...shared }` is fine, the spread may provide everything
- `{ ...shared, delete: removeWebhook }` is fine
- `{ ...shared, delete: undefined }` is reported
- `{ delete: undefined, ...shared }` is fine, because the spread comes later and wins

## Why

This rule runs in the community node submission check with `allowInlineConfig: false`, so a node author cannot turn it off. A false positive blocks a node that is actually complete. A class that is skipped because of a type annotation passes the check with a webhook that is never deleted.

## Testing

Rule tests go from 14 to 24: 5 new valid cases and 5 new invalid cases. Rule doc updated.
