### PR TITLE
fix(core): Follow names to the value they stand for in webhook rules (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-silent-error-swallowing.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-silent-error-swallowing.md
@@ -20,6 +20,11 @@ methods of a node's `webhookMethods` that:
 - have an empty body, or
 - contain only a `return true`, `return false`, or bare `return` statement.
 
+A lifecycle method may be written in place or declared once in the same file
+and handed over by name (`{ default: { delete: removeWebhook } }`). A method
+that comes from an import, or from a binding that can be reassigned, cannot be
+read, and its `catch` blocks are left alone.
+
 Handle the error instead: log it (so it surfaces in execution logs) and/or
 rethrow it. A `catch` that logs before returning, rethrows, or returns a
 computed value is allowed.

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-silent-error-swallowing.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-silent-error-swallowing.md
@@ -21,9 +21,10 @@ methods of a node's `webhookMethods` that:
 - contain only a `return true`, `return false`, or bare `return` statement.
 
 A lifecycle method may be written in place or declared once in the same file
-and handed over by name (`{ default: { delete: removeWebhook } }`). A method
-that comes from an import, or from a binding that can be reassigned, cannot be
-read, and its `catch` blocks are left alone.
+and handed over by name (`{ default: { delete: removeWebhook } }`). The name is
+only followed when nothing in the file can change it afterwards. A method that
+comes from an import, or whose name is reassigned later, has `catch` blocks the
+rule leaves alone, because the body it can read may not be the one that runs.
 
 Handle the error instead: log it (so it surfaces in execution logs) and/or
 rethrow it. A `catch` that logs before returning, rethrows, or returns a

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
@@ -20,9 +20,11 @@ For every webhook group inside `webhookMethods` (typically `default`), the
 methods `checkExists`, `create`, and `delete` must all be implemented.
 
 `description`, `webhookMethods`, and a lifecycle group may be written in place
-or declared once as a `const` in the same file and referred to by name. A value
-that comes from an import, or from a binding that can be reassigned, cannot be
-read, and the class is left alone.
+or declared once as a `const` in the same file and referred to by name. A name
+is only followed when nothing in the file can change it afterwards: an import,
+a `let`, a reassignment, a property written after the fact
+(`METHODS.default.delete = fn`), or handing the object to a call all leave the
+class alone, because the rule cannot tell what it ends up holding.
 
 Polling triggers (trigger nodes without a `webhooks` array and without
 `webhookMethods`) are intentionally out of scope.

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/webhook-lifecycle-complete.md
@@ -19,6 +19,11 @@ This rule applies to node classes that:
 For every webhook group inside `webhookMethods` (typically `default`), the
 methods `checkExists`, `create`, and `delete` must all be implemented.
 
+`description`, `webhookMethods`, and a lifecycle group may be written in place
+or declared once as a `const` in the same file and referred to by name. A value
+that comes from an import, or from a binding that can be reassigned, cannot be
+read, and the class is left alone.
+
 Polling triggers (trigger nodes without a `webhooks` array and without
 `webhookMethods`) are intentionally out of scope.
 

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-silent-error-swallowing.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-silent-error-swallowing.test.ts
@@ -129,8 +129,70 @@ export class RegularClass {
 	};
 }`,
 		},
+		{
+			name: 'method imported from another file is out of reach',
+			code: `
+import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
+import { removeWebhook } from './GenericFunctions';
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = { default: { delete: removeWebhook } };
+}`,
+		},
 	],
 	invalid: [
+		{
+			name: 'silent catch in a method declared above the class and passed by name',
+			code: `
+import type { INodeType, INodeTypeDescription, IHookFunctions } from 'n8n-workflow';
+
+async function removeWebhook(this: IHookFunctions): Promise<boolean> {
+	try {
+		return await this.helpers.httpRequest({ url: 'https://example.com' });
+	} catch (error) {}
+}
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = { default: { delete: removeWebhook } };
+}`,
+			errors: [{ messageId: 'emptyCatch', data: { method: 'delete' } }],
+		},
+		{
+			name: 'silent catch in a const arrow function passed by name',
+			code: `
+import type { INodeType, INodeTypeDescription, IHookFunctions } from 'n8n-workflow';
+
+const checkExists = async function (this: IHookFunctions): Promise<boolean> {
+	try {
+		return await this.helpers.httpRequest({ url: 'https://example.com' });
+	} catch (error) {
+		return false;
+	}
+};
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = { default: { checkExists } };
+}`,
+			errors: [{ messageId: 'silentReturn', data: { method: 'checkExists' } }],
+		},
 		{
 			name: 'empty catch block in checkExists',
 			code: createTriggerNode(`{

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-silent-error-swallowing.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-silent-error-swallowing.test.ts
@@ -130,6 +130,29 @@ export class RegularClass {
 }`,
 		},
 		{
+			name: 'method reassigned after its declaration is not fixed',
+			code: `
+import type { INodeType, INodeTypeDescription, IHookFunctions } from 'n8n-workflow';
+
+async function removeWebhook(this: IHookFunctions): Promise<boolean> {
+	try {
+		return await this.helpers.httpRequest({ url: 'https://example.com' });
+	} catch (error) {}
+}
+
+removeWebhook = safeRemoveWebhook;
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = { default: { delete: removeWebhook } };
+}`,
+		},
+		{
 			name: 'method imported from another file is out of reach',
 			code: `
 import type { INodeType, INodeTypeDescription } from 'n8n-workflow';

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-silent-error-swallowing.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-silent-error-swallowing.ts
@@ -4,6 +4,7 @@ import {
 	createRule,
 	findClassProperty,
 	isNodeTypeClass,
+	resolveIdentifier,
 	WEBHOOK_LIFECYCLE_METHODS,
 } from '../utils/index.js';
 
@@ -61,11 +62,22 @@ export const NoSilentErrorSwallowingRule = createRule({
 	},
 	defaultOptions: [],
 	create(context) {
-		// Maps each lifecycle method's function node to its method name. Populated
-		// when the enclosing class is visited (before its `catch` clauses), so a
-		// `catch` is only flagged when its *nearest* enclosing function is a
-		// lifecycle method — catches inside nested callbacks are left alone.
+		// Maps each lifecycle method's function node to its method name. A `catch`
+		// is only flagged when its *nearest* enclosing function is a lifecycle
+		// method — catches inside nested callbacks are left alone. A method handed
+		// over by name can be declared anywhere in the file, so `catch` clauses are
+		// held until the whole program has been read.
 		const lifecycleMethodByFn = new WeakMap<TSESTree.Node, string>();
+		const catchClauses: TSESTree.CatchClause[] = [];
+
+		/** Reads a method value as a function, following a name to its declaration. */
+		function asFunction(node: TSESTree.Node): TSESTree.Node | null {
+			if (isFunctionNode(node)) return node;
+			if (node.type !== AST_NODE_TYPES.Identifier) return null;
+
+			const declared = resolveIdentifier(context.sourceCode.getScope(node), node);
+			return declared && isFunctionNode(declared) ? declared : null;
+		}
 
 		return {
 			ClassDeclaration(node) {
@@ -84,44 +96,47 @@ export const NoSilentErrorSwallowingRule = createRule({
 						const methodName = getPropertyName(methodProperty);
 						if (methodName === null || !LIFECYCLE_METHODS.includes(methodName)) continue;
 
-						const fn = methodProperty.value;
-						if (
-							fn.type === AST_NODE_TYPES.FunctionExpression ||
-							fn.type === AST_NODE_TYPES.ArrowFunctionExpression
-						) {
-							lifecycleMethodByFn.set(fn, methodName);
-						}
+						const fn = asFunction(methodProperty.value);
+						if (fn !== null) lifecycleMethodByFn.set(fn, methodName);
 					}
 				}
 			},
 
 			CatchClause(node) {
-				const enclosingFn = getEnclosingFunction(node);
-				if (enclosingFn === null) return;
+				catchClauses.push(node);
+			},
 
-				const methodName = lifecycleMethodByFn.get(enclosingFn);
-				if (methodName === undefined) return;
-
-				const statements = node.body.body;
-
-				if (statements.length === 0) {
-					context.report({
-						node: node.body,
-						messageId: 'emptyCatch',
-						data: { method: methodName },
-					});
-					return;
-				}
-
-				const onlyStatement = statements.length === 1 ? statements[0] : undefined;
-				if (onlyStatement && isSilentReturn(onlyStatement)) {
-					context.report({
-						node: onlyStatement,
-						messageId: 'silentReturn',
-						data: { method: methodName },
-					});
-				}
+			'Program:exit'() {
+				for (const node of catchClauses) reportIfSilent(node);
 			},
 		};
+
+		function reportIfSilent(node: TSESTree.CatchClause): void {
+			const enclosingFn = getEnclosingFunction(node);
+			if (enclosingFn === null) return;
+
+			const methodName = lifecycleMethodByFn.get(enclosingFn);
+			if (methodName === undefined) return;
+
+			const statements = node.body.body;
+
+			if (statements.length === 0) {
+				context.report({
+					node: node.body,
+					messageId: 'emptyCatch',
+					data: { method: methodName },
+				});
+				return;
+			}
+
+			const onlyStatement = statements.length === 1 ? statements[0] : undefined;
+			if (onlyStatement && isSilentReturn(onlyStatement)) {
+				context.report({
+					node: onlyStatement,
+					messageId: 'silentReturn',
+					data: { method: methodName },
+				});
+			}
+		}
 	},
 });

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -134,6 +134,44 @@ export class TestTrigger implements INodeType {
 }`,
 		},
 		{
+			name: 'lifecycle group completed by member assignment is not fixed',
+			code: `
+import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
+
+const WEBHOOK_METHODS = { default: {} };
+WEBHOOK_METHODS.default.checkExists = async () => true;
+WEBHOOK_METHODS.default.create = async () => true;
+WEBHOOK_METHODS.default.delete = async () => true;
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = WEBHOOK_METHODS;
+}`,
+		},
+		{
+			name: 'lifecycle group handed to a call is not fixed',
+			code: `
+import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
+
+const WEBHOOK_METHODS = { default: {} };
+Object.assign(WEBHOOK_METHODS.default, sharedLifecycle);
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = WEBHOOK_METHODS;
+}`,
+		},
+		{
 			name: 'webhookMethods held in a let is not fixed',
 			code: `
 import type { INodeType, INodeTypeDescription } from 'n8n-workflow';

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.test.ts
@@ -100,8 +100,113 @@ export class RegularClass {
 				}`,
 			}),
 		},
+		{
+			name: 'webhookMethods referred to by name, complete',
+			code: `
+import type { INodeType, INodeTypeDescription, IHookFunctions } from 'n8n-workflow';
+
+const WEBHOOK_METHODS = ${completeWebhookMethods};
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = WEBHOOK_METHODS;
+}`,
+		},
+		{
+			name: 'webhookMethods imported from another file is out of reach',
+			code: `
+import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
+import { WEBHOOK_METHODS } from './GenericFunctions';
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = WEBHOOK_METHODS;
+}`,
+		},
+		{
+			name: 'webhookMethods held in a let is not fixed',
+			code: `
+import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
+
+let webhookMethodsValue = { default: {} };
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = webhookMethodsValue;
+}`,
+		},
 	],
 	invalid: [
+		{
+			name: 'description referred to by name, delete missing',
+			code: `
+import type { INodeType, INodeTypeDescription, IHookFunctions } from 'n8n-workflow';
+
+const DESCRIPTION = {
+	displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+	description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+	webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+	properties: [],
+};
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = DESCRIPTION;
+
+	webhookMethods = {
+		default: {
+			async checkExists(this: IHookFunctions): Promise<boolean> { return true; },
+			async create(this: IHookFunctions): Promise<boolean> { return true; },
+		},
+	};
+}`,
+			errors: [
+				{
+					messageId: 'missingLifecycleMethod',
+					data: { group: 'default', missing: '`delete`' },
+				},
+			],
+		},
+		{
+			name: 'lifecycle group referred to by name, delete missing',
+			code: `
+import type { INodeType, INodeTypeDescription, IHookFunctions } from 'n8n-workflow';
+
+const defaultGroup = {
+	async checkExists(this: IHookFunctions): Promise<boolean> { return true; },
+	async create(this: IHookFunctions): Promise<boolean> { return true; },
+};
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger', name: 'testTrigger', group: ['trigger'], version: 1,
+		description: 'A test trigger', defaults: { name: 'Test Trigger' }, inputs: [], outputs: ['main'],
+		webhooks: [{ name: 'default', httpMethod: 'POST', responseMode: 'onReceived', path: 'webhook' }],
+		properties: [],
+	};
+	webhookMethods = { default: defaultGroup };
+}`,
+			errors: [
+				{
+					messageId: 'missingLifecycleMethod',
+					data: { group: 'default', missing: '`delete`' },
+				},
+			],
+		},
 		{
 			name: 'trigger node missing webhookMethods entirely',
 			code: createTriggerNode({ webhookMethods: null }),

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/webhook-lifecycle-complete.ts
@@ -5,6 +5,7 @@ import {
 	findClassProperty,
 	findObjectProperty,
 	isNodeTypeClass,
+	resolveIdentifier,
 	WEBHOOK_LIFECYCLE_METHODS,
 	type WebhookLifecycleMethod,
 } from '../utils/index.js';
@@ -64,6 +65,21 @@ export const WebhookLifecycleCompleteRule = createRule({
 	},
 	defaultOptions: [],
 	create(context) {
+		/**
+		 * Reads a value as an object literal, following a name to its declaration
+		 * when the object was written once and referred to by that name.
+		 */
+		function asObjectExpression(
+			node: TSESTree.Node | null | undefined,
+		): TSESTree.ObjectExpression | null {
+			if (!node) return null;
+			if (node.type === AST_NODE_TYPES.ObjectExpression) return node;
+			if (node.type !== AST_NODE_TYPES.Identifier) return null;
+
+			const declared = resolveIdentifier(context.sourceCode.getScope(node), node);
+			return declared?.type === AST_NODE_TYPES.ObjectExpression ? declared : null;
+		}
+
 		return {
 			ClassDeclaration(node) {
 				if (!isNodeTypeClass(node)) return;
@@ -71,8 +87,8 @@ export const WebhookLifecycleCompleteRule = createRule({
 				const descriptionProperty = findClassProperty(node, 'description');
 				if (!descriptionProperty) return;
 
-				const descriptionValue = descriptionProperty.value;
-				if (descriptionValue?.type !== AST_NODE_TYPES.ObjectExpression) return;
+				const descriptionValue = asObjectExpression(descriptionProperty.value);
+				if (!descriptionValue) return;
 
 				const webhookMethodsProperty = findClassProperty(node, 'webhookMethods');
 
@@ -88,11 +104,10 @@ export const WebhookLifecycleCompleteRule = createRule({
 					return;
 				}
 
-				if (webhookMethodsProperty.value.type !== AST_NODE_TYPES.ObjectExpression) {
-					return;
-				}
+				const webhookMethods = asObjectExpression(webhookMethodsProperty.value);
+				if (!webhookMethods) return;
 
-				if (webhookMethodsProperty.value.properties.length === 0) {
+				if (webhookMethods.properties.length === 0) {
 					context.report({
 						node: webhookMethodsProperty.key,
 						messageId: 'emptyWebhookMethods',
@@ -100,9 +115,11 @@ export const WebhookLifecycleCompleteRule = createRule({
 					return;
 				}
 
-				for (const groupProperty of webhookMethodsProperty.value.properties) {
+				for (const groupProperty of webhookMethods.properties) {
 					if (groupProperty.type !== AST_NODE_TYPES.Property) continue;
-					if (groupProperty.value.type !== AST_NODE_TYPES.ObjectExpression) continue;
+
+					const group = asObjectExpression(groupProperty.value);
+					if (!group) continue;
 
 					const groupName =
 						groupProperty.key.type === AST_NODE_TYPES.Identifier
@@ -111,7 +128,7 @@ export const WebhookLifecycleCompleteRule = createRule({
 								? String(groupProperty.key.value)
 								: 'default';
 
-					const missing = findMissingMethods(groupProperty.value);
+					const missing = findMissingMethods(group);
 					if (missing.length === 0) continue;
 
 					context.report({

--- a/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
@@ -1,6 +1,33 @@
 import type { TSESTree } from '@typescript-eslint/utils';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ASTUtils, TSESLint } from '@typescript-eslint/utils';
 import { distance } from 'fastest-levenshtein';
+
+/**
+ * Follows an identifier to the value it stands for, when that value is fixed
+ * and written in this file: a `const` with an initialiser, or a function
+ * declaration. Anything that can hold something else by the time the node runs
+ * (`let`, a parameter, a re-declared name) reads as unresolved, and so does an
+ * import, whose value lives in another file the rule cannot see.
+ */
+export function resolveIdentifier(
+	scope: TSESLint.Scope.Scope,
+	identifier: TSESTree.Identifier,
+): TSESTree.Node | null {
+	const variable = ASTUtils.findVariable(scope, identifier);
+	if (variable === null || variable.defs.length !== 1) return null;
+
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+
+	if (definition.type === TSESLint.Scope.DefinitionType.FunctionName) {
+		return definition.node;
+	}
+
+	if (definition.type !== TSESLint.Scope.DefinitionType.Variable) return null;
+	if (definition.parent.kind !== 'const') return null;
+
+	return definition.node.init;
+}
 
 function implementsInterface(node: TSESTree.ClassDeclaration, interfaceName: string): boolean {
 	return (

--- a/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
@@ -3,11 +3,53 @@ import { AST_NODE_TYPES, ASTUtils, TSESLint } from '@typescript-eslint/utils';
 import { distance } from 'fastest-levenshtein';
 
 /**
+ * True when a reference could change what the name stands for, or change the
+ * value it already holds. `const` fixes the binding and not the object behind
+ * it, and a function declaration fixes neither, so a name is only worth
+ * following when nothing in the file can touch it after it is declared.
+ */
+function canChangeValue(reference: TSESLint.Scope.Reference): boolean {
+	// The declaration writes the value; anything later replaces it.
+	if (reference.isWrite() && !reference.init) return true;
+
+	// Follow `value.a.b` up to the outermost property read, since that is what
+	// the surrounding code actually acts on.
+	let member: TSESTree.Node = reference.identifier;
+	while (
+		member.parent?.type === AST_NODE_TYPES.MemberExpression &&
+		member.parent.object === member
+	) {
+		member = member.parent;
+	}
+
+	const owner = member.parent;
+	if (owner === undefined) return false;
+
+	// `Object.assign(value.default, ...)`: handing the object to a call gives
+	// that call the chance to fill it in.
+	if (
+		(owner.type === AST_NODE_TYPES.CallExpression || owner.type === AST_NODE_TYPES.NewExpression) &&
+		owner.arguments.some((argument) => argument === member)
+	) {
+		return true;
+	}
+
+	// `value.a.b = fn`, `delete value.a`, `value.a++`: the binding is untouched
+	// while what it holds is not.
+	return (
+		(owner.type === AST_NODE_TYPES.AssignmentExpression && owner.left === member) ||
+		owner.type === AST_NODE_TYPES.UpdateExpression ||
+		(owner.type === AST_NODE_TYPES.UnaryExpression && owner.operator === 'delete')
+	);
+}
+
+/**
  * Follows an identifier to the value it stands for, when that value is fixed
  * and written in this file: a `const` with an initialiser, or a function
- * declaration. Anything that can hold something else by the time the node runs
- * (`let`, a parameter, a re-declared name) reads as unresolved, and so does an
- * import, whose value lives in another file the rule cannot see.
+ * declaration that nothing reassigns. Anything that can hold something else by
+ * the time the node runs (`let`, a parameter, a re-declared name) reads as
+ * unresolved, and so does an import, whose value lives in another file the rule
+ * cannot see.
  */
 export function resolveIdentifier(
 	scope: TSESLint.Scope.Scope,
@@ -15,6 +57,7 @@ export function resolveIdentifier(
 ): TSESTree.Node | null {
 	const variable = ASTUtils.findVariable(scope, identifier);
 	if (variable === null || variable.defs.length !== 1) return null;
+	if (variable.references.some(canChangeValue)) return null;
 
 	const [definition] = variable.defs;
 	if (definition === undefined) return null;


### PR DESCRIPTION
## Summary

Both webhook rules read a value only where it was written literally. Declaring it once and referring to it by name is normal TypeScript, but it took the class out of scope without any message.

```typescript
// webhook-lifecycle-complete stopped here and never checked the lifecycle.
const DESCRIPTION = { /* ... webhooks: [...] ... */ };

export class MyTrigger implements INodeType {
  description: INodeTypeDescription = DESCRIPTION;
  webhookMethods = { default: { checkExists, create } };  // `delete` is missing
}

// no-silent-error-swallowing never saw this catch block.
async function removeWebhook(this: IHookFunctions): Promise<boolean> {
  try { return await call(); } catch (error) {}
}

export class MyTrigger implements INodeType {
  webhookMethods = { default: { delete: removeWebhook } };
}
```

## What changed

A name is followed to its declaration when the value is fixed and written in the same file: a `const` with an initialiser, or a function declaration. This is used for `description`, `webhookMethods`, a lifecycle group, and a lifecycle method.

A name is only followed when nothing after the declaration can change it. These all stay out of scope:

- an import, whose value lives in a file the rule does not see
- a `let` or a parameter, which can hold something else by the time the node runs
- a name with more than one declaration
- a name that is reassigned later, including a function declaration, since that binding is mutable too
- an object completed after the fact, by a property write (`METHODS.default.delete = fn`) or by being handed to a call (`Object.assign(METHODS.default, shared)`), because `const` fixes the binding and not what it holds

`no-silent-error-swallowing` also had to change when it decides. A method handed over by name can be declared above the class, so its `catch` clauses were visited before the class that gives them meaning. Catch clauses are now judged at `Program:exit`, once the whole file has been read.

## Why

These rules run in the community node submission check with `allowInlineConfig: false`, so a node author cannot turn them off. Right now a node that keeps its description or its handlers in a `const` passes both checks without being checked at all, which is the opposite of what a submission gate should do.

## Testing

10 new cases. Three pin what is now read (description by name, group by name, method by name including one declared above the class). Seven pin what is deliberately not read, so the boundary cannot drift: an import in each rule, a `let`, a reassigned function, a group completed by property writes, a group handed to `Object.assign`, and a complete `webhookMethods` by name that stays valid.

Package tests: 556 passing. Both rule docs updated.

## Note

This touches the same two rule files as #34968 and #34972. They are separate changes and I kept them apart on purpose, but whichever lands first will make the others need a rebase. Happy to rebase in whatever order suits you.
