### PR TITLE
fix(core): Update-workflow-post-save-fallback

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { ProjectRepository, User, WorkflowEntity } from '@n8n/db';
 import { NodeConnectionTypes, type INode } from 'n8n-workflow';
@@ -14,6 +15,7 @@ import { Telemetry } from '@/telemetry';
 import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
+import { McpPostSaveMetricsService } from '../mcp-post-save-metrics.service';
 import {
 	createCreateWorkflowFromCodeTool,
 	type CreateWorkflowFromCodeToolOptions,
@@ -170,6 +172,11 @@ describe('create-workflow-from-code MCP tool', () => {
 	const aiGatewayService = mock<AiGatewayService>();
 	aiGatewayService.isAvailable.mockResolvedValue({ available: false });
 
+	const logger = mockInstance(Logger, { error: vi.fn(), warn: vi.fn() });
+	const postSaveMetrics = mockInstance(McpPostSaveMetricsService, {
+		incrementPostSaveFailure: vi.fn(),
+	});
+
 	const createTool = (options?: CreateWorkflowFromCodeToolOptions) =>
 		createCreateWorkflowFromCodeTool(
 			user,
@@ -183,6 +190,8 @@ describe('create-workflow-from-code MCP tool', () => {
 			dataTableOps as never,
 			aiGatewayService,
 			options,
+			logger,
+			postSaveMetrics,
 		);
 
 	// Helper to call handler with proper typing (optional fields default to undefined)
@@ -444,6 +453,85 @@ describe('create-workflow-from-code MCP tool', () => {
 				type: 'team',
 			});
 			expect(response.note).toContain('post-save operation failed');
+		});
+
+		test('logs a warning when post-create verification lookup throws and still reports the original error', async () => {
+			createWorkflowMock.mockImplementation(async (_user, workflow: WorkflowEntity) => {
+				workflow.id = 'wf-lookup-fail-1';
+				throw new Error('Outer failure');
+			});
+			(workflowFinderService.findWorkflowForUser as Mock).mockRejectedValueOnce(
+				new Error('Lookup DB outage'),
+			);
+
+			const result = await callHandler({ code: 'const wf = ...' });
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toBe('Outer failure');
+			expect(response.errorCode).toBe('UNKNOWN_ERROR');
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Post-create verification lookup failed',
+				expect.objectContaining({ workflowId: 'wf-lookup-fail-1' }),
+			);
+		});
+
+		test('does not report a successful save when the post-create lookup cannot find the workflow', async () => {
+			createWorkflowMock.mockImplementation(async (_user, workflow: WorkflowEntity) => {
+				workflow.id = 'wf-missing-1';
+				throw new Error('Post-save hook failed');
+			});
+			(workflowFinderService.findWorkflowForUser as Mock).mockResolvedValueOnce(null);
+
+			const result = await callHandler({ code: 'const wf = ...' });
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toBe('Post-save hook failed');
+			// Genuine failure path: errorCode is exposed.
+			expect(response.errorCode).toBe('UNKNOWN_ERROR');
+		});
+
+		test('returns success when telemetry fails after a successful persist and records the post-save metric', async () => {
+			(telemetry.track as Mock).mockImplementationOnce(() => {
+				throw new Error('Telemetry pipeline exploded');
+			});
+
+			const result = await callHandler({ code: 'const wf = ...' });
+
+			const response = parseResult(result);
+			// The response still describes the persisted workflow, not the telemetry
+			// failure — the workflow was successfully saved.
+			expect(response.workflowId).toBe('wf-saved-1');
+			expect(result.isError).toBeUndefined();
+			expect(postSaveMetrics.incrementPostSaveFailure).toHaveBeenCalledWith(
+				'create',
+				expect.any(Error),
+			);
+			expect(logger.error).toHaveBeenCalledWith(
+				'Post-save side effect failed for create_workflow_from_code',
+				expect.objectContaining({ workflowId: 'wf-saved-1' }),
+			);
+		});
+
+		test('includes errorCode on genuine failure responses', async () => {
+			mockParseAndValidate.mockRejectedValue(new Error('Invalid syntax at line 5'));
+
+			const result = await callHandler({ code: 'bad code' });
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toBe('Invalid syntax at line 5');
+			expect(response.errorCode).toBe('UNKNOWN_ERROR');
+		});
+
+		test('includes errorCode on the folderId-without-projectId early-return error', async () => {
+			const result = await callHandler({ code: 'const wf = ...', folderId: 'folder-1' });
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toBe('projectId is required when folderId is provided');
+			expect(response.errorCode).toBe('MISSING_PROJECT_ID');
 		});
 
 		test('returns error when service throws permission error', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/mcp-post-save-metrics.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-post-save-metrics.service.test.ts
@@ -1,0 +1,122 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { PrometheusMetricsConfig } from '@n8n/config';
+import { Counter } from 'prom-client';
+import type { Mock } from 'vitest';
+
+import { McpPostSaveMetricsService } from '../mcp-post-save-metrics.service';
+
+vi.mock('prom-client');
+
+describe('McpPostSaveMetricsService', () => {
+	let config: PrometheusMetricsConfig;
+	let service: McpPostSaveMetricsService;
+	let mockCounterInc: Mock;
+
+	beforeEach(() => {
+		config = mockInstance(PrometheusMetricsConfig, {
+			prefix: 'n8n_',
+		});
+		service = new McpPostSaveMetricsService(config);
+		mockCounterInc = vi.fn();
+		Counter.prototype.inc = mockCounterInc;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should not construct Counter on service instantiation', () => {
+		expect(Counter).not.toHaveBeenCalled();
+	});
+
+	it('should lazily initialize Counter on first incrementPostSaveFailure call', () => {
+		const error = new Error('Test error');
+		service.incrementPostSaveFailure('create', error);
+
+		expect(Counter).toHaveBeenCalledTimes(1);
+		expect(Counter).toHaveBeenCalledWith({
+			name: 'n8n_mcp_post_save_failures_total',
+			help: 'MCP workflow-builder tool failures that occurred after a successful database write (hooks, telemetry, auto-assign). The client still receives success — these are observability-only.',
+			labelNames: ['tool', 'error_type'],
+		});
+	});
+
+	it('should reuse Counter instance on subsequent calls', () => {
+		service.incrementPostSaveFailure('create', new Error('First error'));
+		service.incrementPostSaveFailure('update', new Error('Second error'));
+
+		expect(Counter).toHaveBeenCalledTimes(1);
+		expect(mockCounterInc).toHaveBeenCalledTimes(2);
+	});
+
+	it('should support custom metric prefix from config', () => {
+		config.prefix = 'custom_prefix_';
+		service.incrementPostSaveFailure('create', new Error('Error'));
+
+		expect(Counter).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'custom_prefix_mcp_post_save_failures_total',
+			}),
+		);
+	});
+
+	describe('tool label parameter', () => {
+		it('should pass tool=create to metric increment', () => {
+			service.incrementPostSaveFailure('create', new Error('Fail'));
+
+			expect(mockCounterInc).toHaveBeenCalledWith({ tool: 'create', error_type: 'Error' }, 1);
+		});
+
+		it('should pass tool=update to metric increment', () => {
+			service.incrementPostSaveFailure('update', new Error('Fail'));
+
+			expect(mockCounterInc).toHaveBeenCalledWith({ tool: 'update', error_type: 'Error' }, 1);
+		});
+	});
+
+	describe('error type resolution', () => {
+		it('should extract constructor name for Error instance', () => {
+			service.incrementPostSaveFailure('create', new Error('Something went wrong'));
+
+			expect(mockCounterInc).toHaveBeenCalledWith({ tool: 'create', error_type: 'Error' }, 1);
+		});
+
+		it('should extract constructor name for TypeError instance', () => {
+			service.incrementPostSaveFailure('create', new TypeError('Type mismatch'));
+
+			expect(mockCounterInc).toHaveBeenCalledWith({ tool: 'create', error_type: 'TypeError' }, 1);
+		});
+
+		it('should extract constructor name for custom Error subclass', () => {
+			class CustomPostSaveError extends Error {}
+			service.incrementPostSaveFailure('create', new CustomPostSaveError('Custom error'));
+
+			expect(mockCounterInc).toHaveBeenCalledWith(
+				{ tool: 'create', error_type: 'CustomPostSaveError' },
+				1,
+			);
+		});
+
+		it('should use raw string when error is a string', () => {
+			service.incrementPostSaveFailure('update', 'Hook execution timed out');
+
+			expect(mockCounterInc).toHaveBeenCalledWith(
+				{ tool: 'update', error_type: 'Hook execution timed out' },
+				1,
+			);
+		});
+
+		it.each([
+			['null', null],
+			['undefined', undefined],
+			['number', 500],
+			['boolean', false],
+			['plain object', { message: 'Failed' }],
+			['array', ['an', 'error']],
+		])('should fallback to "Unknown" when error is %s', (_, errorValue) => {
+			service.incrementPostSaveFailure('create', errorValue);
+
+			expect(mockCounterInc).toHaveBeenCalledWith({ tool: 'create', error_type: 'Unknown' }, 1);
+		});
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/mcp-scopes.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-scopes.test.ts
@@ -44,6 +44,7 @@ import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-hi
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 
+import { McpPostSaveMetricsService } from '../mcp-post-save-metrics.service';
 import { BUILDER_TOOLS, getAllowedToolNames, TOOLS_BY_SCOPE } from '../mcp-scopes';
 import { McpService, type McpFeatureFlags } from '../mcp.service';
 
@@ -125,6 +126,7 @@ describe('McpService scope enforcement', () => {
 			mockInstance(AiGatewayService, {
 				isAvailable: vi.fn().mockResolvedValue({ available: false }),
 			}),
+			mockInstance(McpPostSaveMetricsService),
 		);
 
 	beforeEach(() => {

--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -34,11 +34,11 @@ import {
 	MCP_CANVAS_GROUPS_FLAG,
 } from '@n8n/api-types';
 
-import { MCP_PREVIEW_RENDER_REQUESTED_EVENT } from '../mcp.constants';
 import { ActiveExecutions } from '@/active-executions';
 import { CollaborationService } from '@/collaboration/collaboration.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { ExecutionService } from '@/executions/execution.service';
+import { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks/subworkflow-policy-checker';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { NodeCatalogService } from '@/node-catalog';
 import { NodeTypes } from '@/node-types';
@@ -55,9 +55,10 @@ import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
-import { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks/subworkflow-policy-checker';
 import { WorkflowService } from '@/workflows/workflow.service';
 
+import { McpPostSaveMetricsService } from '../mcp-post-save-metrics.service';
+import { MCP_PREVIEW_RENDER_REQUESTED_EVENT } from '../mcp.constants';
 import { McpService, type McpFeatureFlags } from '../mcp.service';
 
 const mockAiGatewayService = () =>
@@ -124,6 +125,7 @@ describe('McpService', () => {
 			mockInstance(WorkflowPublishedDataService),
 			mockInstance(SubworkflowPolicyChecker),
 			mockAiGatewayService(),
+			mockInstance(McpPostSaveMetricsService),
 		);
 	});
 
@@ -173,6 +175,7 @@ describe('McpService', () => {
 				mockInstance(WorkflowPublishedDataService),
 				mockInstance(SubworkflowPolicyChecker),
 				mockAiGatewayService(),
+				mockInstance(McpPostSaveMetricsService),
 			);
 
 			expect(queueMcpService.isQueueMode).toBe(true);
@@ -377,6 +380,7 @@ describe('McpService', () => {
 				mockInstance(WorkflowPublishedDataService),
 				mockInstance(SubworkflowPolicyChecker),
 				mockAiGatewayService(),
+				mockInstance(McpPostSaveMetricsService),
 			);
 
 		const user = Object.assign(new User(), { id: 'user-1' });
@@ -571,6 +575,7 @@ describe('McpService', () => {
 				mockInstance(WorkflowPublishedDataService),
 				mockInstance(SubworkflowPolicyChecker),
 				mockAiGatewayService(),
+				mockInstance(McpPostSaveMetricsService),
 			);
 
 			const server = await service.getServer(user, mcpFeatureFlags());
@@ -622,6 +627,7 @@ describe('McpService', () => {
 				mockInstance(WorkflowPublishedDataService),
 				mockInstance(SubworkflowPolicyChecker),
 				mockAiGatewayService(),
+				mockInstance(McpPostSaveMetricsService),
 			);
 
 			const server = await service.getServer(user, mcpFeatureFlags());
@@ -698,6 +704,7 @@ describe('McpService', () => {
 					mockInstance(WorkflowPublishedDataService),
 					mockInstance(SubworkflowPolicyChecker),
 					mockAiGatewayService(),
+					mockInstance(McpPostSaveMetricsService),
 				);
 			};
 

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import { SharedWorkflowRepository, User, WorkflowEntity, type Project } from '@n8n/db';
@@ -15,9 +16,9 @@ import { CollaborationService } from '@/collaboration/collaboration.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { SubworkflowPolicyDenialError } from '@/errors/subworkflow-policy-denial.error';
-import type { AiGatewayService } from '@/services/ai-gateway.service';
 import { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks/subworkflow-policy-checker';
 import { NodeTypes } from '@/node-types';
+import type { AiGatewayService } from '@/services/ai-gateway.service';
 import { TagService } from '@/services/tag.service';
 import { UrlService } from '@/services/url.service';
 import { Telemetry } from '@/telemetry';
@@ -25,6 +26,7 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 
+import { McpPostSaveMetricsService } from '../mcp-post-save-metrics.service';
 import { createUpdateWorkflowTool } from '../tools/workflow-builder/update-workflow.tool';
 
 const mockAutoPopulateNodeCredentials = vi.fn();
@@ -185,6 +187,11 @@ describe('update-workflow MCP tool', () => {
 	const aiGatewayService = mock<AiGatewayService>();
 	aiGatewayService.isAvailable.mockResolvedValue({ available: false });
 
+	const logger = mockInstance(Logger, { error: vi.fn(), warn: vi.fn() });
+	const postSaveMetrics = mockInstance(McpPostSaveMetricsService, {
+		incrementPostSaveFailure: vi.fn(),
+	});
+
 	const createTool = (options?: { canvasGroupsEnabled?: boolean }) =>
 		createUpdateWorkflowTool(
 			user,
@@ -203,6 +210,8 @@ describe('update-workflow MCP tool', () => {
 			workflowPublishedDataService,
 			aiGatewayService,
 			options,
+			logger,
+			postSaveMetrics,
 		);
 
 	const callHandler = async (
@@ -521,6 +530,185 @@ describe('update-workflow MCP tool', () => {
 			expect(b.alwaysOutputData).toBe(true);
 			expect(b.executeOnce).toBe(true);
 			expect(b.parameters).toEqual({ url: 'https://old', method: 'GET' });
+		});
+
+		test('returns success when post-save side effect fails but DB write committed', async () => {
+			// workflowService.update succeeds, but telemetry throws afterwards —
+			// mimics an `workflow.afterUpdate` hook or reactivate step that explodes
+			// after the row is already on disk.
+			(telemetry.track as Mock).mockImplementationOnce(() => {
+				throw new Error('Telemetry pipeline exploded');
+			});
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [
+					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+				],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBeUndefined();
+			expect(response.workflowId).toBe('wf-1');
+			expect(postSaveMetrics.incrementPostSaveFailure).toHaveBeenCalledWith(
+				'update',
+				expect.any(Error),
+			);
+			expect(logger.error).toHaveBeenCalledWith(
+				'Post-save side effect failed for update_workflow',
+				expect.objectContaining({ workflowId: 'wf-1' }),
+			);
+		});
+
+		test('recovers from a thrown post-save error when persisted nodes and connections match expected', async () => {
+			const expectedWf = buildExistingWorkflow();
+			expectedWf.nodes.find((n) => n.name === 'B')!.parameters = {
+				url: 'https://new',
+				method: 'GET',
+			};
+
+			updateMock.mockImplementation(async (_user, _workflow: WorkflowEntity, _id: string) => {
+				throw new Error('workflow.afterUpdate hook failed');
+			});
+			// The first findWorkflowForUser call is the pre-update read; the second
+			// is the post-save recovery check.
+			findWorkflowMock
+				.mockResolvedValueOnce(buildExistingWorkflow())
+				.mockResolvedValueOnce(expectedWf);
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [
+					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+				],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBeUndefined();
+			expect(response.workflowId).toBe('wf-1');
+			expect(response.name).toBe('Existing');
+			expect(response.url).toBe('https://n8n.example.com/workflow/wf-1');
+			expect(response.note).toContain('post-save operation failed');
+			// Verify recovery output payload is trimmed (nodes, active, updatedAt, versionId removed)
+			expect(response.nodes).toBeUndefined();
+			expect(response.active).toBeUndefined();
+			expect(response.updatedAt).toBeUndefined();
+			expect(response.versionId).toBeUndefined();
+		});
+
+		test('recovers settings-only update when updatedAt changed', async () => {
+			const recent = new Date();
+			updateMock.mockRejectedValue(new Error('Post-save hook failed'));
+
+			const preUpdate = buildExistingWorkflow();
+			const recovered = buildExistingWorkflow();
+			recovered.updatedAt = recent;
+			// No node/connection changes
+
+			findWorkflowMock.mockResolvedValueOnce(preUpdate).mockResolvedValueOnce(recovered);
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [{ type: 'setWorkflowSettings', settings: { executionTimeout: 120 } }],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBeUndefined();
+			expect(response.workflowId).toBe('wf-1');
+			expect(response.note).toContain('post-save operation failed');
+		});
+
+		test('reports a genuine failure when persisted nodes differ from expected (concurrent edit or uncommitted update)', async () => {
+			updateMock.mockRejectedValue(new Error('Connection lost mid-save'));
+			// Recovery fetch returns a workflow with different nodes (e.g. edited concurrently by another process)
+			const concurrentWf = buildExistingWorkflow();
+			concurrentWf.nodes.push(makeNode({ id: 'c', name: 'C' }));
+
+			findWorkflowMock
+				.mockResolvedValueOnce(buildExistingWorkflow())
+				.mockResolvedValueOnce(concurrentWf);
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [
+					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+				],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toBe('Connection lost mid-save');
+			expect(response.errorCode).toBe('UNKNOWN_ERROR');
+		});
+
+		test('maps NotFoundError to errorCode HTTP_404', async () => {
+			findWorkflowMock.mockRejectedValue(new NotFoundError('Workflow not found'));
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [
+					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+				],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.errorCode).toBe('HTTP_404');
+		});
+
+		test('reports a genuine failure when the recovery lookup returns null', async () => {
+			updateMock.mockRejectedValue(new Error('DB write exploded'));
+			// Pre-update read: empty (workflow not yet seen), then recovery read:
+			// still empty (the row really does not exist).
+			findWorkflowMock.mockResolvedValueOnce(buildExistingWorkflow());
+			findWorkflowMock.mockResolvedValueOnce(null);
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [
+					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+				],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toBe('DB write exploded');
+			expect(response.errorCode).toBe('UNKNOWN_ERROR');
+		});
+
+		test('logs and falls through to genuine failure when the recovery lookup throws', async () => {
+			updateMock.mockRejectedValue(new Error('Outer failure'));
+			// Pre-update read OK; the post-save recovery lookup itself throws.
+			findWorkflowMock.mockResolvedValueOnce(buildExistingWorkflow());
+			findWorkflowMock.mockRejectedValueOnce(new Error('Lookup DB outage'));
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [
+					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+				],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toBe('Outer failure');
+			expect(response.errorCode).toBe('UNKNOWN_ERROR');
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Post-update verification lookup failed',
+				expect.objectContaining({ workflowId: 'wf-1' }),
+			);
+		});
+
+		test('includes errorCode on validation error responses', async () => {
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [{ type: 'invalidOp' as never, nodeName: 'B' }],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(typeof response.errorCode).toBe('string');
+			expect(response.error).toContain('Invalid operations');
 		});
 
 		describe('setWorkflowSettings', () => {
@@ -987,6 +1175,9 @@ describe('update-workflow MCP tool', () => {
 					subworkflowPolicyChecker,
 					workflowPublishedDataService,
 					aiGatewayService,
+					{},
+					logger,
+					postSaveMetrics,
 				);
 				findWorkflowMock.mockImplementation(async (id: string) =>
 					id === 'wf-1'
@@ -2259,6 +2450,9 @@ describe('update-workflow MCP tool', () => {
 					subworkflowPolicyChecker,
 					workflowPublishedDataService,
 					aiGatewayService,
+					{},
+					logger,
+					postSaveMetrics,
 				);
 
 				await callHandler(
@@ -2296,6 +2490,9 @@ describe('update-workflow MCP tool', () => {
 					subworkflowPolicyChecker,
 					workflowPublishedDataService,
 					aiGatewayService,
+					{},
+					logger,
+					postSaveMetrics,
 				);
 
 				const result = await callHandler(

--- a/packages/cli/src/modules/mcp/mcp-post-save-metrics.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-post-save-metrics.service.ts
@@ -1,0 +1,44 @@
+import { PrometheusMetricsConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import { Counter } from 'prom-client';
+
+/**
+ * Counters for failures that happen *after* a workflow create/update has been
+ * persisted to the database. The MCP workflow-builder tools recover from these
+ * (the row is already on disk), so the failure is observability-only — the
+ * client still sees success. This service exists so operators can spot
+ * regressions in hooks, telemetry, or auto-assignment without parsing logs.
+ *
+ * Registered lazily on first use so unit tests that don't touch the counter
+ * (and disabled-metric configurations) never construct a `Counter` instance.
+ */
+@Service()
+export class McpPostSaveMetricsService {
+	private readonly config: PrometheusMetricsConfig;
+	private postSaveFailuresTotal?: Counter<'tool' | 'error_type'>;
+
+	constructor(config: PrometheusMetricsConfig) {
+		this.config = config;
+	}
+
+	/**
+	 * Increment `mcp_post_save_failures_total{tool, error_type}`. `error_type`
+	 * is the class name of the thrown error, falling back to a stable string
+	 * for non-Error throws so the label cardinality stays bounded.
+	 */
+	incrementPostSaveFailure(tool: 'create' | 'update', error: unknown): void {
+		this.postSaveFailuresTotal ??= new Counter({
+			name: `${this.config.prefix}mcp_post_save_failures_total`,
+			help: 'MCP workflow-builder tool failures that occurred after a successful database write (hooks, telemetry, auto-assign). The client still receives success — these are observability-only.',
+			labelNames: ['tool', 'error_type'],
+		});
+
+		const errorType =
+			error instanceof Error
+				? error.constructor.name
+				: typeof error === 'string'
+					? error
+					: 'Unknown';
+		this.postSaveFailuresTotal.inc({ tool, error_type: errorType }, 1);
+	}
+}

--- a/packages/cli/src/modules/mcp/mcp.module.ts
+++ b/packages/cli/src/modules/mcp/mcp.module.ts
@@ -14,6 +14,8 @@ export class McpModule implements ModuleInterface {
 	async init() {
 		await import('./mcp.controller.js');
 		await import('./mcp.settings.controller.js');
+		const { McpPostSaveMetricsService } = await import('./mcp-post-save-metrics.service.js');
+		Container.get(McpPostSaveMetricsService);
 
 		// Register the instance MCP server as a protected resource of the shared
 		// OAuth server, so its tokens are minted and verified with the right

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -50,6 +50,7 @@ import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-hi
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 
+import { McpPostSaveMetricsService } from './mcp-post-save-metrics.service';
 import { getAllowedToolNames } from './mcp-scopes';
 import { MCP_PREVIEW_RENDER_REQUESTED_EVENT } from './mcp.constants';
 import type { McpAppsTelemetryVariant, McpClientInfo, RegisterToolFn } from './mcp.types';
@@ -160,6 +161,7 @@ export class McpService {
 		private readonly workflowPublishedDataService: WorkflowPublishedDataService,
 		private readonly subworkflowPolicyChecker: SubworkflowPolicyChecker,
 		private readonly aiGatewayService: AiGatewayService,
+		private readonly postSaveMetrics: McpPostSaveMetricsService,
 	) {}
 
 	/**
@@ -520,6 +522,8 @@ export class McpService {
 			dataTableOps,
 			this.aiGatewayService,
 			{ canvasGroupsEnabled: featureFlags.canvasGroupsEnabled },
+			this.logger,
+			this.postSaveMetrics,
 		);
 
 		// The preview app only accompanies the create tool, so both are gated
@@ -597,6 +601,8 @@ export class McpService {
 			this.workflowPublishedDataService,
 			this.aiGatewayService,
 			{ canvasGroupsEnabled: featureFlags.canvasGroupsEnabled },
+			this.logger,
+			this.postSaveMetrics,
 		);
 		registerIfAllowed(updateTool);
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/__tests__/error-code.utils.test.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/__tests__/error-code.utils.test.ts
@@ -1,0 +1,38 @@
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { getErrorCode } from '../error-code.utils';
+
+describe('getErrorCode utility', () => {
+	test('returns HTTP_404 for NotFoundError', () => {
+		const error = new NotFoundError('Resource not found');
+		expect(getErrorCode(error)).toBe('HTTP_404');
+	});
+
+	test('returns HTTP_<statusCode> for objects with httpStatusCode', () => {
+		expect(getErrorCode({ httpStatusCode: 403, message: 'Forbidden' })).toBe('HTTP_403');
+		expect(getErrorCode({ httpStatusCode: 400, message: 'Bad request' })).toBe('HTTP_400');
+		expect(getErrorCode({ httpStatusCode: 500, message: 'Internal error' })).toBe('HTTP_500');
+	});
+
+	test('returns string errorCode if present and httpStatusCode is absent', () => {
+		const error = { errorCode: 'MISSING_PROJECT_ID' };
+		expect(getErrorCode(error)).toBe('MISSING_PROJECT_ID');
+	});
+
+	test('returns numeric errorCode converted to string if httpStatusCode is absent', () => {
+		const error = { errorCode: 1001 };
+		expect(getErrorCode(error)).toBe('1001');
+	});
+
+	test('returns UNKNOWN_ERROR for standard Error without errorCode or httpStatusCode', () => {
+		const error = new Error('Generic error');
+		expect(getErrorCode(error)).toBe('UNKNOWN_ERROR');
+	});
+
+	test('returns UNKNOWN_ERROR for primitives and null/undefined', () => {
+		expect(getErrorCode(null)).toBe('UNKNOWN_ERROR');
+		expect(getErrorCode(undefined)).toBe('UNKNOWN_ERROR');
+		expect(getErrorCode('string error')).toBe('UNKNOWN_ERROR');
+		expect(getErrorCode(123)).toBe('UNKNOWN_ERROR');
+	});
+});

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -1,5 +1,16 @@
+import type { Logger } from '@n8n/backend-common';
 import { type Project, type ProjectRepository, type User, WorkflowEntity } from '@n8n/db';
 import z from 'zod';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+import type { DataTableUserOperations } from '@/modules/data-table/data-table-proxy.service';
+import type { NodeTypes } from '@/node-types';
+import type { AiGatewayService } from '@/services/ai-gateway.service';
+import type { UrlService } from '@/services/url.service';
+import type { Telemetry } from '@/telemetry';
+import { resolveNodeWebhookIds } from '@/workflow-helpers';
+import type { WorkflowCreationService } from '@/workflows/workflow-creation.service';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { buildInvalidAiToolSourceErrorResponse } from './connection-structure-check';
 import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL, CODE_BUILDER_VALIDATE_TOOL } from './constants';
@@ -10,6 +21,7 @@ import {
 	trackAutoassignOutcomes,
 } from './credentials-auto-assign';
 import { validateDataTableReferencesForWorkflow } from './data-table-validation';
+import { getErrorCode } from './error-code.utils';
 import { sanitizeSkillsUsed, SKILLS_USED_PARAM_DESCRIPTION } from './skills-used';
 import {
 	buildCreateVersionMetadata,
@@ -17,20 +29,12 @@ import {
 	versionDescriptionInputSchema,
 	versionNameInputSchema,
 } from './version-metadata';
+import type { McpPostSaveMetricsService } from '../../mcp-post-save-metrics.service';
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 import { getSdkReferenceHint } from '../workflow-validation.utils';
 
-import type { CredentialsService } from '@/credentials/credentials.service';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import type { DataTableUserOperations } from '@/modules/data-table/data-table-proxy.service';
-import type { NodeTypes } from '@/node-types';
-import type { AiGatewayService } from '@/services/ai-gateway.service';
-import type { UrlService } from '@/services/url.service';
-import type { Telemetry } from '@/telemetry';
-import { resolveNodeWebhookIds } from '@/workflow-helpers';
-import type { WorkflowCreationService } from '@/workflows/workflow-creation.service';
-import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 const MAX_WORKFLOW_DESCRIPTION_LENGTH = 255;
 
@@ -165,6 +169,10 @@ const outputSchema = {
 		.string()
 		.optional()
 		.describe('Error message explaining why the creation failed. Present only on failure.'),
+	errorCode: z
+		.string()
+		.optional()
+		.describe('Machine-readable error code. Present only on failure.'),
 } satisfies z.ZodRawShape;
 
 /**
@@ -183,6 +191,8 @@ export const createCreateWorkflowFromCodeTool = (
 	dataTableOps: DataTableUserOperations,
 	aiGatewayService: AiGatewayService,
 	options: CreateWorkflowFromCodeToolOptions = {},
+	logger: Logger,
+	postSaveMetrics: McpPostSaveMetricsService,
 ): ToolDefinition<typeof inputSchema> => ({
 	name: MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName,
 	config: {
@@ -197,6 +207,8 @@ export const createCreateWorkflowFromCodeTool = (
 			openWorldHint: false,
 		},
 	},
+
+	// eslint-disable-next-line complexity
 	handler: async ({
 		code,
 		skillsUsed,
@@ -235,9 +247,10 @@ export const createCreateWorkflowFromCodeTool = (
 			const errorMessage = 'projectId is required when folderId is provided';
 			telemetryPayload.results = { success: false, error: errorMessage };
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+			const output = { error: errorMessage, errorCode: 'MISSING_PROJECT_ID' };
 			return {
-				content: [{ type: 'text', text: JSON.stringify({ error: errorMessage }, null, 2) }],
-				structuredContent: { error: errorMessage },
+				content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+				structuredContent: output,
 				isError: true,
 			};
 		}
@@ -347,32 +360,8 @@ export const createCreateWorkflowFromCodeTool = (
 				versionDescription: versionMetadata.description,
 			});
 
-			const nodeTypesByName = new Map(savedWorkflow.nodes.map((n) => [n.name, n.type]));
-			trackAutoassignOutcomes(
-				telemetry,
-				user.id,
-				'create_workflow_from_code',
-				autoAssignOutcomes,
-				nodeTypesByName,
-				savedWorkflow.id,
-			);
-
 			const baseUrl = urlService.getInstanceBaseUrl();
 			const workflowUrl = `${baseUrl}/workflow/${savedWorkflow.id}`;
-
-			telemetryPayload.results = {
-				success: true,
-				data: {
-					workflowId: savedWorkflow.id,
-					nodeCount: savedWorkflow.nodes.length,
-					// Rollout monitoring for `102_mcp_canvas_groups`; absent when the
-					// flag is off so the payload stays identical across cohorts.
-					...(options.canvasGroupsEnabled
-						? { groupCount: workflowJson.nodeGroups?.length ?? 0 }
-						: {}),
-				},
-			};
-			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
 
 			const notes = [
 				descriptionTruncated
@@ -399,12 +388,48 @@ export const createCreateWorkflowFromCodeTool = (
 			const output =
 				result.warnings.length > 0 ? { ...baseOutput, warnings: result.warnings } : baseOutput;
 
+			// The response is fully built above. Side effects below (telemetry,
+			// credential auto-assign tracking) must not turn a successful persist
+			// into a client-visible error — they are observability-only.
+			try {
+				const nodeTypesByName = new Map(savedWorkflow.nodes.map((n) => [n.name, n.type]));
+				trackAutoassignOutcomes(
+					telemetry,
+					user.id,
+					'create_workflow_from_code',
+					autoAssignOutcomes,
+					nodeTypesByName,
+					savedWorkflow.id,
+				);
+
+				telemetryPayload.results = {
+					success: true,
+					data: {
+						workflowId: savedWorkflow.id,
+						nodeCount: savedWorkflow.nodes.length,
+						// Rollout monitoring for `102_mcp_canvas_groups`; absent when the
+						// flag is off so the payload stays identical across cohorts.
+						...(options.canvasGroupsEnabled
+							? { groupCount: workflowJson.nodeGroups?.length ?? 0 }
+							: {}),
+					},
+				};
+				telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+			} catch (sideEffectError) {
+				logger.error('Post-save side effect failed for create_workflow_from_code', {
+					workflowId: savedWorkflow.id,
+					error: sideEffectError,
+				});
+				postSaveMetrics.incrementPostSaveFailure('create', sideEffectError);
+			}
+
 			return {
 				content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
 				structuredContent: output,
 			};
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
+			const errorCode = getErrorCode(error);
 
 			// Check whether the workflow was actually persisted despite the error.
 			// TypeORM sets the entity id during save(), even inside a transaction that
@@ -417,23 +442,38 @@ export const createCreateWorkflowFromCodeTool = (
 					persisted = await workflowFinderService.findWorkflowForUser(newWorkflow.id, user, [
 						'workflow:read',
 					]);
-				} catch {
-					// Verification lookup failed — fall through and report the original error.
+				} catch (lookupError) {
+					logger.warn('Post-create verification lookup failed', {
+						workflowId: newWorkflow.id,
+						error: lookupError,
+					});
+					// fall through — let the existing logic decide (error path)
 				}
 
 				if (persisted && landingProject) {
 					const baseUrl = urlService.getInstanceBaseUrl();
 					const workflowUrl = `${baseUrl}/workflow/${persisted.id}`;
 
-					telemetryPayload.results = {
-						success: true,
-						data: {
-							workflowId: persisted.id,
-							nodeCount: persisted.nodes.length,
-							postSaveError: errorMessage,
-						},
-					};
-					telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+					try {
+						telemetryPayload.results = {
+							success: true,
+							data: {
+								workflowId: persisted.id,
+								nodeCount: persisted.nodes.length,
+								postSaveError: errorMessage,
+							},
+						};
+						telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+					} catch (telemetryError) {
+						logger.error(
+							'Post-save telemetry failed for create_workflow_from_code (recovery path)',
+							{
+								workflowId: persisted.id,
+								error: telemetryError,
+							},
+						);
+						postSaveMetrics.incrementPostSaveFailure('create', telemetryError);
+					}
 
 					const output = {
 						workflowId: persisted.id,
@@ -456,16 +496,27 @@ export const createCreateWorkflowFromCodeTool = (
 				}
 			}
 
-			telemetryPayload.results = {
-				success: false,
-				error: errorMessage,
-			};
-			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+			try {
+				telemetryPayload.results = {
+					success: false,
+					error: errorMessage,
+				};
+				telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+			} catch (telemetryError) {
+				logger.error('Post-save telemetry failed for create_workflow_from_code (error path)', {
+					error: telemetryError,
+				});
+				postSaveMetrics.incrementPostSaveFailure('create', telemetryError);
+			}
 
 			const hint = getSdkReferenceHint(error, {
 				afterReference: `Rewrite the code, call ${CODE_BUILDER_VALIDATE_TOOL.toolName} until it returns valid=true, then call ${MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName} again.`,
 			});
-			const output = { error: errorMessage, ...(hint ? { hint } : {}) };
+			const output = {
+				error: errorMessage,
+				errorCode,
+				...(hint ? { hint } : {}),
+			};
 
 			return {
 				content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/error-code.utils.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/error-code.utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Pick a stable machine-readable error code for the response. `ResponseError`
+ * subclasses expose `httpStatusCode` (an HTTP status number); other thrown values
+ * or custom error objects may expose `errorCode`. If `httpStatusCode` is present,
+ * it is mapped to `'HTTP_' + value`. Otherwise, `errorCode` is used if present.
+ * If neither is present, falls back to `'UNKNOWN_ERROR'`.
+ */
+export function getErrorCode(error: unknown): string {
+	if (typeof error === 'object' && error !== null) {
+		if ('httpStatusCode' in error) {
+			const value = (error as { httpStatusCode: unknown }).httpStatusCode;
+			if (typeof value === 'number' || typeof value === 'string') {
+				return `HTTP_${value}`;
+			}
+		}
+		if ('errorCode' in error) {
+			const value = (error as { errorCode: unknown }).errorCode;
+			if (typeof value === 'number') return String(value);
+			if (typeof value === 'string') return value;
+		}
+	}
+	return 'UNKNOWN_ERROR';
+}

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -1,12 +1,28 @@
+import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
 import { type User, type SharedWorkflowRepository, WorkflowEntity } from '@n8n/db';
 import { hasGlobalScope } from '@n8n/permissions';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import isEqual from 'lodash/isEqual';
 import { Workflow, type INode, type IWorkflowSettings } from 'n8n-workflow';
 import z from 'zod';
 
-import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
-import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
+import type { CollaborationService } from '@/collaboration/collaboration.service';
+import type { CredentialsService } from '@/credentials/credentials.service';
+import { SubworkflowPolicyDenialError } from '@/errors/subworkflow-policy-denial.error';
+import type { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks/subworkflow-policy-checker';
+import type { DataTableUserOperations } from '@/modules/data-table/data-table-proxy.service';
+import type { McpPostSaveMetricsService } from '@/modules/mcp/mcp-post-save-metrics.service';
+import type { NodeTypes } from '@/node-types';
+import type { AiGatewayService } from '@/services/ai-gateway.service';
+import type { TagService } from '@/services/tag.service';
+import type { UrlService } from '@/services/url.service';
+import type { Telemetry } from '@/telemetry';
+import { resolveNodeWebhookIds } from '@/workflow-helpers';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import type { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
+import type { WorkflowService } from '@/workflows/workflow.service';
+
 import { buildInvalidAiToolSourceErrorResponse } from './connection-structure-check';
 import { MCP_UPDATE_WORKFLOW_TOOL } from './constants';
 import { validateCredentialReferences } from './credential-validation';
@@ -30,22 +46,8 @@ import {
 	workflowSettingsObjectSchema,
 	type PartialUpdateOperation,
 } from './workflow-operations';
-
-import type { CollaborationService } from '@/collaboration/collaboration.service';
-import type { CredentialsService } from '@/credentials/credentials.service';
-import { SubworkflowPolicyDenialError } from '@/errors/subworkflow-policy-denial.error';
-import type { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks/subworkflow-policy-checker';
-import type { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
-import type { DataTableUserOperations } from '@/modules/data-table/data-table-proxy.service';
-import type { NodeTypes } from '@/node-types';
-import type { TagService } from '@/services/tag.service';
-import type { AiGatewayService } from '@/services/ai-gateway.service';
-import type { UrlService } from '@/services/url.service';
-import type { Telemetry } from '@/telemetry';
-import { resolveNodeWebhookIds } from '@/workflow-helpers';
-import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
-import type { WorkflowService } from '@/workflows/workflow.service';
-
+import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
+import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 import { getMcpWorkflow } from '../workflow-validation.utils';
 
 const MAX_OPERATIONS_PER_CALL = 100;
@@ -285,17 +287,17 @@ const buildInputSchema = (canvasGroupsEnabled: boolean) =>
 		),
 	}) satisfies z.ZodRawShape;
 
-// The MCP SDK publishes this schema with `additionalProperties: false` and
-// validates `structuredContent` against it on every response. Success returns
-// the full payload below; the error path returns only `{ error }`. To keep
-// both shapes valid under strict clients, the success fields are optional and
-// `error` is a declared, optional property — otherwise a thrown handler error
-// surfaces as an opaque `-32602` schema mismatch instead of the real message.
+import { getErrorCode } from './error-code.utils';
+
 const outputSchema = {
 	workflowId: z.string().optional(),
 	name: z.string().optional(),
 	nodeCount: z.number().optional(),
 	url: z.string().optional(),
+	nodes: z.array(z.unknown()).optional(),
+	active: z.boolean().optional(),
+	updatedAt: z.union([z.string(), z.date()]).optional(),
+	versionId: z.string().optional(),
 	appliedOperations: z.number().optional().describe('Number of operations applied.'),
 	autoAssignedCredentials: z
 		.array(
@@ -331,6 +333,7 @@ const outputSchema = {
 		.string()
 		.optional()
 		.describe('Error message explaining why the update failed. Present only on failure.'),
+	errorCode: z.string().optional().describe('Machine-readable error code.'),
 } satisfies z.ZodRawShape;
 
 /**
@@ -517,6 +520,8 @@ export const createUpdateWorkflowTool = (
 		 */
 		canvasGroupsEnabled?: boolean;
 	} = {},
+	logger: Logger,
+	postSaveMetrics: McpPostSaveMetricsService,
 ): ToolDefinition<ReturnType<typeof buildInputSchema>> => ({
 	name: MCP_UPDATE_WORKFLOW_TOOL.toolName,
 	config: {
@@ -532,6 +537,8 @@ export const createUpdateWorkflowTool = (
 			openWorldHint: false,
 		},
 	},
+
+	// eslint-disable-next-line complexity
 	handler: async ({
 		workflowId,
 		skillsUsed,
@@ -559,6 +566,11 @@ export const createUpdateWorkflowTool = (
 			},
 		};
 
+		let updateAttempted = false;
+		let expectedWorkflow: { nodes: unknown; connections: unknown } | null = null;
+		let existingWorkflow: Awaited<ReturnType<WorkflowFinderService['findWorkflowForUser']>> | null =
+			null;
+
 		try {
 			const strictOperations = parseStrictOperations(operations);
 
@@ -584,7 +596,7 @@ export const createUpdateWorkflowTool = (
 				);
 			}
 
-			const existingWorkflow = await getMcpWorkflow(
+			existingWorkflow = await getMcpWorkflow(
 				workflowId,
 				user,
 				['workflow:update'],
@@ -618,7 +630,7 @@ export const createUpdateWorkflowTool = (
 			const invalidToolSourceResponse = buildInvalidAiToolSourceErrorResponse(
 				{ nodes: result.workflow.nodes, connections: result.workflow.connections },
 				nodeTypes,
-				(errorMessage) => ({ error: errorMessage }),
+				(errorMessage) => ({ error: errorMessage, errorCode: 'INVALID_AI_TOOL_SOURCE' }),
 				telemetryPayload,
 				telemetry,
 			);
@@ -806,6 +818,11 @@ export const createUpdateWorkflowTool = (
 				),
 			);
 
+			expectedWorkflow = {
+				nodes: workflowUpdateData.nodes,
+				connections: workflowUpdateData.connections,
+			};
+			updateAttempted = true;
 			const updatedWorkflow = await workflowService.update(user, workflowUpdateData, workflowId, {
 				aiBuilderAssisted: hasNonTagOperations,
 				source: 'n8n-mcp',
@@ -814,31 +831,8 @@ export const createUpdateWorkflowTool = (
 				...(tagIds !== undefined ? { tagIds } : {}),
 			});
 
-			if (autoAssignOutcomes.length > 0) {
-				const nodeTypesByName = new Map(updatedWorkflow.nodes.map((n) => [n.name, n.type]));
-				trackAutoassignOutcomes(
-					telemetry,
-					user.id,
-					'update_workflow',
-					autoAssignOutcomes,
-					nodeTypesByName,
-					workflowId,
-				);
-			}
-
-			void collaborationService.broadcastWorkflowUpdate(workflowId, user.id).catch(() => {});
-
 			const baseUrl = urlService.getInstanceBaseUrl();
 			const workflowUrl = `${baseUrl}/workflow/${updatedWorkflow.id}`;
-
-			telemetryPayload.results = {
-				success: true,
-				data: {
-					workflowId: updatedWorkflow.id,
-					nodeCount: updatedWorkflow.nodes.length,
-				},
-			};
-			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
 
 			const output = {
 				workflowId: updatedWorkflow.id,
@@ -854,20 +848,134 @@ export const createUpdateWorkflowTool = (
 				settings: hasSettingsOperations ? (updatedWorkflow.settings ?? {}) : undefined,
 			};
 
+			try {
+				if (autoAssignOutcomes.length > 0) {
+					const nodeTypesByName = new Map(updatedWorkflow.nodes.map((n) => [n.name, n.type]));
+					trackAutoassignOutcomes(
+						telemetry,
+						user.id,
+						'update_workflow',
+						autoAssignOutcomes,
+						nodeTypesByName,
+						workflowId,
+					);
+				}
+
+				void collaborationService.broadcastWorkflowUpdate(workflowId, user.id).catch(() => {});
+
+				telemetryPayload.results = {
+					success: true,
+					data: {
+						workflowId: updatedWorkflow.id,
+						nodeCount: updatedWorkflow.nodes.length,
+					},
+				};
+				telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+			} catch (sideEffectError) {
+				logger.error('Post-save side effect failed for update_workflow', {
+					workflowId: updatedWorkflow.id,
+					error: sideEffectError,
+				});
+				postSaveMetrics.incrementPostSaveFailure('update', sideEffectError);
+			}
+
 			return {
 				content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
 				structuredContent: output,
 			};
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
+			const errorCode = getErrorCode(error);
 
-			telemetryPayload.results = {
-				success: false,
+			if (updateAttempted && existingWorkflow) {
+				let persisted: Awaited<ReturnType<WorkflowFinderService['findWorkflowForUser']>> | null =
+					null;
+				try {
+					persisted = await workflowFinderService.findWorkflowForUser(workflowId, user, [
+						'workflow:read',
+					]);
+				} catch (lookupError) {
+					logger.warn('Post-update verification lookup failed', {
+						workflowId,
+						error: lookupError,
+					});
+				}
+
+				const matchesExpected =
+					persisted &&
+					expectedWorkflow &&
+					isEqual(persisted.nodes, expectedWorkflow.nodes) &&
+					isEqual(persisted.connections, expectedWorkflow.connections);
+
+				const wasTouched = Boolean(
+					existingWorkflow?.updatedAt &&
+						persisted?.updatedAt &&
+						new Date(persisted.updatedAt).getTime() >
+							new Date(existingWorkflow.updatedAt).getTime(),
+				);
+
+				// Recovery succeeds if the persisted workflow matches our expected state
+				// (nodes+connections) OR if the updatedAt timestamp indicates a write occurred.
+				// The latter catches settings-only updates and concurrent edits where
+				// the content still matches, while the content check prevents false positives
+				// from purely concurrent edits that changed nodes.
+				// Trade-off: Settings-only updates where updatedAt changes due to another
+				// process's write could still cause a false positive recovery, but this is
+				// acceptable because the workflow was indeed updated (just not by our call).
+				// The client can verify via get_workflow if needed.
+				if (persisted && (matchesExpected || wasTouched)) {
+					const baseUrl = urlService.getInstanceBaseUrl();
+					const workflowUrl = `${baseUrl}/workflow/${persisted.id}`;
+
+					try {
+						telemetryPayload.results = {
+							success: true,
+							data: {
+								workflowId: persisted.id,
+								nodeCount: persisted.nodes.length,
+								postSaveError: errorMessage,
+							},
+						};
+						telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+					} catch (telemetryError) {
+						logger.error('Post-save telemetry failed for update_workflow (recovery path)', {
+							workflowId: persisted.id,
+							error: telemetryError,
+						});
+						postSaveMetrics.incrementPostSaveFailure('update', telemetryError);
+					}
+
+					const output = {
+						workflowId: persisted.id,
+						name: persisted.name,
+						url: workflowUrl,
+						note: `Workflow was updated successfully, but a post-save operation failed: ${errorMessage}`,
+					};
+
+					return {
+						content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+						structuredContent: output,
+					};
+				}
+			}
+
+			try {
+				telemetryPayload.results = {
+					success: false,
+					error: errorMessage,
+				};
+				telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+			} catch (telemetryError) {
+				logger.error('Post-save telemetry failed for update_workflow (error path)', {
+					error: telemetryError,
+				});
+				postSaveMetrics.incrementPostSaveFailure('update', telemetryError);
+			}
+
+			const output = {
 				error: errorMessage,
+				errorCode,
 			};
-			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
-
-			const output = { error: errorMessage };
 
 			return {
 				content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34974">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

