### PR TITLE
perf(core): Remove moment-timezone from the server boot path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -233,7 +233,6 @@
     "lodash": "catalog:",
     "lru-cache": "catalog:",
     "luxon": "catalog:",
-    "moment-timezone": "catalog:",
     "ms": "catalog:",
     "multer": "^2.2.0",
     "n8n-core": "workspace:*",

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -31,6 +31,7 @@ import { findMcpSupportedTrigger } from '../mcp.utils';
 import { getMcpWorkflow, type FoundWorkflow } from './workflow-validation.utils';
 
 import type { McpService } from '@/modules/mcp/mcp.service';
+import { buildScheduleTriggerItem } from '@/scheduling/schedule-trigger-node/schedule-trigger-task';
 import type { Telemetry } from '@/telemetry';
 import type { WorkflowRunner } from '@/workflow-runner';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -421,26 +422,8 @@ const getPinDataForTrigger = async (
 		case SCHEDULE_TRIGGER_NODE_TYPE: {
 			// For schedule triggers, we don't map any inputs but we can add expected datetime info
 			const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-			const moment = (await import('moment-timezone')).default;
-			const momentTz = moment.tz(timezone);
 			return {
-				[node.name]: [
-					{
-						json: {
-							timestamp: momentTz.toISOString(true),
-							'Readable date': momentTz.format('MMMM Do YYYY, h:mm:ss a'),
-							'Readable time': momentTz.format('h:mm:ss a'),
-							'Day of week': momentTz.format('dddd'),
-							Year: momentTz.format('YYYY'),
-							Month: momentTz.format('MMMM'),
-							'Day of month': momentTz.format('DD'),
-							Hour: momentTz.format('HH'),
-							Minute: momentTz.format('mm'),
-							Second: momentTz.format('ss'),
-							Timezone: `${timezone} (UTC${momentTz.format('Z')})`,
-						},
-					},
-				],
+				[node.name]: [buildScheduleTriggerItem(new Date(), timezone)],
 			};
 		}
 		default:

--- a/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task.test.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task.test.ts
@@ -53,4 +53,45 @@ describe('buildScheduleTriggerItem', () => {
 			},
 		});
 	});
+
+	test('renders UTC as an explicit +00:00 offset and midnight as 12 am', () => {
+		expect(buildScheduleTriggerItem(new Date('2026-01-01T00:00:30.000Z'), 'UTC')).toEqual({
+			json: {
+				timestamp: '2026-01-01T00:00:30.000+00:00',
+				'Readable date': 'January 1st 2026, 12:00:30 am',
+				'Readable time': '12:00:30 am',
+				'Day of week': 'Thursday',
+				Year: '2026',
+				Month: 'January',
+				'Day of month': '01',
+				Hour: '00',
+				Minute: '00',
+				Second: '30',
+				Timezone: 'UTC (UTC+00:00)',
+			},
+		});
+	});
+
+	test('renders negative offsets and noon as 12 pm', () => {
+		const item = buildScheduleTriggerItem(new Date('2026-07-06T16:00:00.000Z'), 'America/New_York');
+		expect(item.json.timestamp).toBe('2026-07-06T12:00:00.000-04:00');
+		expect(item.json['Readable time']).toBe('12:00:00 pm');
+		expect(item.json.Timezone).toBe('America/New_York (UTC-04:00)');
+	});
+
+	test.each([
+		['2026-03-02', 'March 2nd 2026'],
+		['2026-03-03', 'March 3rd 2026'],
+		['2026-03-04', 'March 4th 2026'],
+		['2026-03-11', 'March 11th 2026'],
+		['2026-03-12', 'March 12th 2026'],
+		['2026-03-13', 'March 13th 2026'],
+		['2026-03-21', 'March 21st 2026'],
+		['2026-03-22', 'March 22nd 2026'],
+		['2026-03-23', 'March 23rd 2026'],
+		['2026-03-31', 'March 31st 2026'],
+	])('renders the ordinal day for %s', (date, expectedPrefix) => {
+		const item = buildScheduleTriggerItem(new Date(`${date}T09:05:07.000Z`), 'UTC');
+		expect(item.json['Readable date']).toBe(`${expectedPrefix}, 9:05:07 am`);
+	});
 });

--- a/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention -- item keys are pinned to the legacy ScheduleTrigger emit shape */
 import type { ClaimedTask } from '@n8n/scheduler';
-import moment from 'moment-timezone';
+import { DateTime } from 'luxon';
 import type { INodeExecutionData } from 'n8n-workflow';
 
 /**
@@ -37,24 +37,42 @@ export const scheduleTriggerDeduplicationKey = ({
  * identical to the legacy emit in `ScheduleTrigger.node.ts`, so a workflow
  * reads the same shape whichever engine fired it.
  */
+// moment's `Do` token has no luxon equivalent
+const ordinalSuffix = (day: number): string => {
+	if (day >= 11 && day <= 13) return 'th';
+	switch (day % 10) {
+		case 1:
+			return 'st';
+		case 2:
+			return 'nd';
+		case 3:
+			return 'rd';
+		default:
+			return 'th';
+	}
+};
+
 export const buildScheduleTriggerItem = (
 	scheduledFor: Date,
 	timezone: string,
 ): INodeExecutionData => {
-	const momentTz = moment.tz(scheduledFor, timezone);
+	// Locale pinned to 'en' and meridiem lowercased to stay byte-identical with
+	// the moment-based legacy emit regardless of the server's ICU locale.
+	const dt = DateTime.fromJSDate(scheduledFor, { zone: timezone }).setLocale('en');
+	const readableTime = `${dt.toFormat('h:mm:ss')} ${dt.toFormat('a').toLowerCase()}`;
 	return {
 		json: {
-			timestamp: momentTz.toISOString(true),
-			'Readable date': momentTz.format('MMMM Do YYYY, h:mm:ss a'),
-			'Readable time': momentTz.format('h:mm:ss a'),
-			'Day of week': momentTz.format('dddd'),
-			Year: momentTz.format('YYYY'),
-			Month: momentTz.format('MMMM'),
-			'Day of month': momentTz.format('DD'),
-			Hour: momentTz.format('HH'),
-			Minute: momentTz.format('mm'),
-			Second: momentTz.format('ss'),
-			Timezone: `${timezone} (UTC${momentTz.format('Z')})`,
+			timestamp: dt.toFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"),
+			'Readable date': `${dt.toFormat('MMMM')} ${dt.day}${ordinalSuffix(dt.day)} ${dt.toFormat('yyyy')}, ${readableTime}`,
+			'Readable time': readableTime,
+			'Day of week': dt.toFormat('cccc'),
+			Year: dt.toFormat('yyyy'),
+			Month: dt.toFormat('MMMM'),
+			'Day of month': dt.toFormat('dd'),
+			Hour: dt.toFormat('HH'),
+			Minute: dt.toFormat('mm'),
+			Second: dt.toFormat('ss'),
+			Timezone: `${timezone} (UTC${dt.toFormat('ZZ')})`,
 		},
 	};
 };

--- a/packages/nodes-base/credentials/GoogleApi.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleApi.credentials.ts
@@ -1,5 +1,4 @@
 import jwt from 'jsonwebtoken';
-import moment from 'moment-timezone';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentialType,
@@ -339,7 +338,7 @@ export class GoogleApi implements ICredentialType {
 			.filter((scope) => scope)
 			.join(' ');
 
-		const now = moment().unix();
+		const now = Math.floor(Date.now() / 1000);
 
 		const signature = jwt.sign(
 			{

--- a/packages/nodes-base/credentials/SalesforceJwtApi.credentials.ts
+++ b/packages/nodes-base/credentials/SalesforceJwtApi.credentials.ts
@@ -1,6 +1,5 @@
 import { formatPemBlock } from '@n8n/utils/format-pem-block';
 import jwt from 'jsonwebtoken';
-import moment from 'moment-timezone';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentialTestRequest,
@@ -96,7 +95,7 @@ export class SalesforceJwtApi implements ICredentialType {
 	// the instance URL) so chained Salesforce actions reuse the same session instead
 	// of logging in on every request.
 	async preAuthentication(this: IHttpRequestHelper, credentials: ICredentialDataDecryptedObject) {
-		const now = moment().unix();
+		const now = Math.floor(Date.now() / 1000);
 		const authUrl = resolveAuthUrl(credentials);
 		const privateKey = formatPemBlock(credentials.privateKey as string);
 		const signature = jwt.sign(

--- a/packages/nodes-base/credentials/SeaTableApi.credentials.ts
+++ b/packages/nodes-base/credentials/SeaTableApi.credentials.ts
@@ -1,4 +1,4 @@
-import moment from 'moment-timezone';
+import tzData from 'moment-timezone/data/packed/latest.json';
 import type {
 	ICredentialTestRequest,
 	ICredentialType,
@@ -6,15 +6,16 @@ import type {
 	INodePropertyOptions,
 } from 'n8n-workflow';
 
-// Get options for timezones
-const timezones: INodePropertyOptions[] = moment.tz
-	.countries()
-	.reduce((tz: INodePropertyOptions[], country: string) => {
-		const zonesForCountry = moment.tz
-			.zonesForCountry(country)
-			.map((zone) => ({ value: zone, name: zone }));
-		return tz.concat(zonesForCountry);
-	}, []);
+// Credential classes are loaded eagerly at server boot, so build the timezone
+// options from moment-timezone's packed data ("CC|Zone Zone…" entries) instead
+// of loading the whole library. Matches moment.tz.countries()/zonesForCountry().
+const timezones: INodePropertyOptions[] = tzData.countries.flatMap((entry) => {
+	const [, zones] = entry.split('|');
+	return zones
+		.split(' ')
+		.sort()
+		.map((zone) => ({ value: zone, name: zone }));
+});
 
 export class SeaTableApi implements ICredentialType {
 	name = 'seaTableApi';

--- a/packages/nodes-base/credentials/moment-timezone-data.d.ts
+++ b/packages/nodes-base/credentials/moment-timezone-data.d.ts
@@ -1,0 +1,11 @@
+// The build config compiles with resolveJsonModule disabled, so type the
+// packed-data JSON (loaded natively by the CJS require at runtime) by hand.
+declare module 'moment-timezone/data/packed/latest.json' {
+	const data: {
+		version: string;
+		zones: string[];
+		links: string[];
+		countries: string[];
+	};
+	export default data;
+}

--- a/packages/nodes-base/credentials/test/SeaTableApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/SeaTableApi.credentials.test.ts
@@ -1,0 +1,24 @@
+import moment from 'moment-timezone';
+import type { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
+
+import { SeaTableApi } from '../SeaTableApi.credentials';
+
+describe('SeaTableApi credential', () => {
+	test('timezone options match the moment-timezone country zone list', () => {
+		const timezoneProperty = new SeaTableApi().properties.find(
+			(property: INodeProperties) => property.name === 'timezone',
+		);
+
+		const fromMomentApi = moment.tz
+			.countries()
+			.reduce(
+				(tz: INodePropertyOptions[], country: string) =>
+					tz.concat(
+						moment.tz.zonesForCountry(country).map((zone) => ({ value: zone, name: zone })),
+					),
+				[],
+			);
+
+		expect(timezoneProperty?.options).toEqual(fromMomentApi);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4311,9 +4311,6 @@ importers:
       luxon:
         specifier: 'catalog:'
         version: 3.7.2
-      moment-timezone:
-        specifier: 'catalog:'
-        version: 0.5.48
       ms:
         specifier: 'catalog:'
         version: 2.1.3


### PR DESCRIPTION
## Summary

**Removes moment-timezone from the boot path of every n8n process (main, webhooks, each worker). Measured on a booted server: 0.74 MiB less retained JS heap per process (consistent across 6 interleaved A/B boots, spread under 0.1 MiB) plus roughly 4-8 MiB RSS, and one less 3 MB library initialized during boot. No output format change: byte-identical emit verified by golden tests and a 55,000-field fuzz.**

Retained heap during startup, forced full GC before every 250 ms sample, mean of 3 boots per variant. Top line: with moment-timezone loaded at boot (master behavior, reproduced by preloading the module). Bottom line: this branch. The mid-boot wiggle is GC timing jitter; the comparable numbers are the flat plateaus once the server is ready:

```mermaid
xychart-beta
    title "Retained heap during n8n startup (MiB, forced GC)"
    x-axis "seconds since spawn" [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75, 4, 4.25, 4.5, 4.75, 5]
    y-axis "retained heap (MiB)" 0 --> 165
    line [6.0, 6.0, 6.0, 53.1, 79.7, 96.8, 90.1, 46.4, 70.7, 91.9, 84.6, 78.8, 151.6, 151.6, 151.6, 151.6, 151.6, 151.6, 151.6, 151.6]
    line [4.5, 4.5, 4.5, 51.6, 63.8, 72.2, 102.9, 86.1, 69.5, 90.8, 77.8, 77.7, 150.9, 150.9, 150.9, 150.9, 150.9, 150.9, 150.9, 150.9]
```

Zoomed on the settled value (GC floor in the 2 s after "Editor is now accessible"), all 6 interleaved boot pairs. The gap is stable at 0.68-0.77 MiB:

```mermaid
xychart-beta
    title "Retained heap once ready, per boot pair (MiB)"
    x-axis "interleaved boot pair" [1, 2, 3, 4, 5, 6]
    y-axis "retained heap (MiB)" 150 --> 152.5
    line [151.73, 151.67, 151.66, 151.61, 151.66, 151.60]
    line [150.97, 150.89, 150.92, 150.89, 150.88, 150.92]
```

### What loads moment-timezone at boot, and what this PR changes

`moment-timezone` reached the boot path of every process two ways (verified by walking `require.cache` parents in a booted server):

1. `packages/cli` scheduler: `schedule-trigger-task.ts` imported it top-level, and the durable scheduler loads that file in every process. Rewritten with `luxon`, which `packages/cli` already ships for other boot-path code, so this drops a whole library instead of adding one. The MCP `execute-workflow` tool duplicated the same emit shape with its own moment import; it now reuses `buildScheduleTriggerItem`. `moment-timezone` is removed from cli's `dependencies`.
2. `packages/nodes-base` credentials: credential classes are not lazy-loaded, all 440 are instantiated at boot, and three of them (`GoogleApi`, `SalesforceJwtApi`, `SeaTableApi`) imported moment-timezone top-level. The first two only needed a unix timestamp (`Math.floor(Date.now() / 1000)`). SeaTable builds its timezone dropdown from moment-timezone's packed data JSON instead of the library; a new unit test asserts the option list stays identical to the `moment.tz.countries()/zonesForCountry()` output (529 entries, same order).

Why the headline is 0.74 MiB and not the library's full footprint: loading moment-timezone retains 1.52 MiB heap in isolation, but the SeaTable dropdown still needs the packed timezone data (0.73 MiB retained). The delta between those matches the in-server measurement. If we ever want the rest, the follow-up is generating a static zone list for that one dropdown.

`nodes-base` keeps its moment-timezone dependency: many nodes use it inside `execute()`, which stays lazy-loaded per node, exactly where that cost belongs.

### Output parity for the schedule trigger emit

The legacy Schedule Trigger emit shape is pinned; the luxon rewrite is byte-identical:

- The pre-existing golden test (written against moment's literal output: `+05:45` offset, `July 6th 2026, 1:15:00 pm`) passes unchanged.
- New golden cases cover the risky spots: UTC rendered as `+00:00` (luxon's default is `Z`), midnight `12:00 am` / noon `12:00 pm` (luxon uppercases meridiem, moment does not), negative offsets, and all ten ordinal suffix branches (`1st`/`2nd`/`3rd`/`4th`/`11th`-`13th`/`21st`...). Locale is pinned with `setLocale('en')` so server ICU settings cannot change the output.
- Fuzz: 5,000 random instants (2000-2040) x 12 timezones including Pacific/Chatham (+12:45), Australia/Lord_Howe (30-minute DST) and America/St_Johns (-03:30), all 11 emitted fields compared against moment: 55,000 comparisons, 0 mismatches.

## How to test

- Unit tests: `packages/cli` scheduling (35) and MCP tool (25) suites, plus the nodes-base credential suites (GoogleApi, SalesforceJwtApi, new SeaTableApi parity test) all pass.
- Boot check: start n8n from this branch with a small preloaded probe and confirm the module is never loaded:
  ```bash
  # probe.cjs
  # setTimeout(() => console.log(Object.keys(require.cache).filter((p) => /moment/.test(p))), 10000);
  node -r ./probe.cjs packages/cli/bin/n8n start
  # prints [] on this branch; on master it prints moment, moment-timezone, and the tz data file
  ```
- Functional: activate a workflow with a Schedule Trigger and compare the emitted item fields against a master instance in the same timezone; they match field for field.

### Steps to replicate the memory measurement

The two variants are the same build, one booted normally and one with moment-timezone preloaded via `--require` (reproducing master, where the scheduler and credentials load it at boot). This isolates exactly the variable being measured. Method: 6 interleaved boot pairs; each boot runs with `--expose-gc` and a preloaded probe that forces a full GC every 250 ms and records `process.memoryUsage()`; the per-boot value is the heap floor in the window 0.8-2.8 s after "Editor is now accessible" (before shutdown teardown). Isolated module costs measured the same way: `require('moment-timezone')` retains 1.52 MiB heap / 10.8 MiB RSS after GC; requiring only its packed data JSON retains 0.73 MiB / 2.7 MiB.

## Related Linear tickets, Github issues, and Community forum posts

Part of a backend dependency audit to reduce per-process memory and install footprint (same series as #34976).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (N/A, no user-facing behavior change)
- [x] Tests included. (golden emit tests extended; SeaTable timezone list parity test added)
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
