### PR TITLE
feat(core): Add `active_workflow_info` and make `workflow_info` leader-only

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -100,6 +100,15 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		});
 	}
 
+	async getWorkflowInfo({
+		activeOnly,
+	}: { activeOnly: boolean }): Promise<Array<{ id: string; name: string }>> {
+		return await this.find({
+			select: ['id', 'name'],
+			...(activeOnly ? { where: { activeVersionId: Not(IsNull()) } } : {}),
+		});
+	}
+
 	async getPublishedCount() {
 		return await this.count({
 			where: { activeVersionId: Not(IsNull()), isArchived: false },

--- a/packages/cli/src/metrics/prometheus/__tests__/workflow-info-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/workflow-info-metrics.service.test.ts
@@ -1,8 +1,9 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { PrometheusMetricsConfig } from '@n8n/config';
 import type { WorkflowRepository } from '@n8n/db';
-import { mock } from 'vitest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
 import promClient from 'prom-client';
+import { mock } from 'vitest-mock-extended';
 
 import type { CacheService } from '@/services/cache/cache.service';
 
@@ -18,6 +19,7 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 	});
 	const workflowRepository = mock<WorkflowRepository>();
 	const cacheService = mock<CacheService>();
+	const instanceSettings = mock<InstanceSettings>({ isLeader: true });
 	let service: PrometheusWorkflowInfoMetricsService;
 
 	beforeEach(() => {
@@ -26,7 +28,13 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 			includeWorkflowInfoMetrics: true,
 			workflowInfoMetricInterval: 60,
 		});
-		service = new PrometheusWorkflowInfoMetricsService(config, workflowRepository, cacheService);
+		Object.assign(instanceSettings, { isLeader: true });
+		service = new PrometheusWorkflowInfoMetricsService(
+			config,
+			workflowRepository,
+			cacheService,
+			instanceSettings,
+		);
 	});
 
 	afterEach(() => {
@@ -52,18 +60,32 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 
 			expect(promClient.Gauge).toHaveBeenCalledWith({
 				name: 'n8n_workflow_info',
-				help: 'Map of workflow ID to name.',
+				help: 'Map of workflow ID to name. Reported by the leader main only.',
 				labelNames: ['workflow_id', 'workflow_name'],
 				collect: expect.any(Function) as unknown,
 			});
 		});
 
-		it('should apply custom prefix to metric name', () => {
+		it('should create `active_workflow_info` gauge with correct config', () => {
+			service.init();
+
+			expect(promClient.Gauge).toHaveBeenCalledWith({
+				name: 'n8n_active_workflow_info',
+				help: 'Map of active workflow ID to name. Reported by the leader main only.',
+				labelNames: ['workflow_id', 'workflow_name'],
+				collect: expect.any(Function) as unknown,
+			});
+		});
+
+		it('should apply custom prefix to metric names', () => {
 			config.prefix = 'custom_';
 			service.init();
 
 			expect(promClient.Gauge).toHaveBeenCalledWith(
 				expect.objectContaining({ name: 'custom_workflow_info' }),
+			);
+			expect(promClient.Gauge).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'custom_active_workflow_info' }),
 			);
 		});
 	});
@@ -88,7 +110,7 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
 			expect(cacheService.get.mock.calls[0]).toEqual(['metrics:workflow-info:v2']);
-			expect(workflowRepository.find.mock.calls).toHaveLength(0);
+			expect(workflowRepository.getWorkflowInfo.mock.calls).toHaveLength(0);
 			expect(mockGauge.reset).toHaveBeenCalled();
 			expect(mockLabels).toHaveBeenCalledWith({
 				workflow_id: 'wf_1',
@@ -102,14 +124,14 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 
 		it('should query DB, cache result, and set labels on cache miss', async () => {
 			cacheService.get.mockResolvedValue(undefined);
-			workflowRepository.find.mockResolvedValue(workflows as never);
+			workflowRepository.getWorkflowInfo.mockResolvedValue(workflows as never);
 			const collectFn = extractCollectFn();
 			const mockLabels = vi.fn().mockReturnValue({ set: vi.fn() });
 			const mockGauge = { reset: vi.fn(), labels: mockLabels };
 
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
-			expect(workflowRepository.find).toHaveBeenCalledWith({ select: ['id', 'name'] });
+			expect(workflowRepository.getWorkflowInfo).toHaveBeenCalledWith({ activeOnly: false });
 			expect(cacheService.set).toHaveBeenCalledWith(
 				'metrics:workflow-info:v2',
 				workflows,
@@ -123,6 +145,21 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 				workflow_id: 'wf_2',
 				workflow_name: 'Another Workflow',
 			});
+		});
+
+		it('should reset and report nothing when not the leader', async () => {
+			Object.assign(instanceSettings, { isLeader: false });
+			cacheService.get.mockResolvedValue(workflows);
+			const collectFn = extractCollectFn();
+			const mockLabels = vi.fn().mockReturnValue({ set: vi.fn() });
+			const mockGauge = { reset: vi.fn(), labels: mockLabels };
+
+			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
+
+			expect(mockGauge.reset).toHaveBeenCalledTimes(1);
+			expect(mockLabels).not.toHaveBeenCalled();
+			expect(cacheService.get).not.toHaveBeenCalled();
+			expect(workflowRepository.getWorkflowInfo).not.toHaveBeenCalled();
 		});
 
 		it('should reset the gauge before setting new values', async () => {
@@ -139,7 +176,7 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 		it('should use the configured interval for the cache TTL', async () => {
 			config.workflowInfoMetricInterval = 120;
 			cacheService.get.mockResolvedValue(undefined);
-			workflowRepository.find.mockResolvedValue(workflows as never);
+			workflowRepository.getWorkflowInfo.mockResolvedValue(workflows as never);
 			const collectFn = extractCollectFn();
 			const mockLabels = vi.fn().mockReturnValue({ set: vi.fn() });
 			const mockGauge = { reset: vi.fn(), labels: mockLabels };
@@ -162,6 +199,51 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
 			expect(mockSet).toHaveBeenCalledWith(1);
+		});
+	});
+
+	describe('active_workflow_info collect callback', () => {
+		const extractActiveCollectFn = () => {
+			service.init();
+			return vi.mocked(promClient.Gauge).mock.calls[1][0].collect!;
+		};
+
+		const workflows = [{ id: 'wf_1', name: 'My First Workflow' }];
+
+		it('should query only active workflows and cache under its own key', async () => {
+			cacheService.get.mockResolvedValue(undefined);
+			workflowRepository.getWorkflowInfo.mockResolvedValue(workflows as never);
+			const collectFn = extractActiveCollectFn();
+			const mockLabels = vi.fn().mockReturnValue({ set: vi.fn() });
+			const mockGauge = { reset: vi.fn(), labels: mockLabels };
+
+			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
+
+			expect(cacheService.get.mock.calls[0]).toEqual(['metrics:active-workflow-info:v1']);
+			expect(workflowRepository.getWorkflowInfo).toHaveBeenCalledWith({ activeOnly: true });
+			expect(cacheService.set).toHaveBeenCalledWith(
+				'metrics:active-workflow-info:v1',
+				workflows,
+				60 * 1000,
+			);
+			expect(mockLabels).toHaveBeenCalledWith({
+				workflow_id: 'wf_1',
+				workflow_name: 'My First Workflow',
+			});
+		});
+
+		it('should reset and report nothing when not the leader', async () => {
+			Object.assign(instanceSettings, { isLeader: false });
+			cacheService.get.mockResolvedValue(workflows);
+			const collectFn = extractActiveCollectFn();
+			const mockLabels = vi.fn().mockReturnValue({ set: vi.fn() });
+			const mockGauge = { reset: vi.fn(), labels: mockLabels };
+
+			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
+
+			expect(mockGauge.reset).toHaveBeenCalledTimes(1);
+			expect(mockLabels).not.toHaveBeenCalled();
+			expect(workflowRepository.getWorkflowInfo).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/metrics/prometheus/workflow-info-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-info-metrics.service.ts
@@ -2,6 +2,7 @@ import { PrometheusMetricsConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
 import promClient from 'prom-client';
 
 import { CacheService } from '@/services/cache/cache.service';
@@ -9,9 +10,19 @@ import { CacheService } from '@/services/cache/cache.service';
 import type { PrometheusMetricsCollector } from './base';
 import { CachedMetricQuery } from './cached-metric-query';
 
+type WorkflowInfoGaugeParams = {
+	name: string;
+	help: string;
+	cacheKey: string;
+	activeOnly: boolean;
+};
+
 /**
- * Exposes a gauge (`n8n_workflow_info`) that maps workflow IDs to their human-readable
- * names, enabling dashboards to resolve IDs to names without extra lookups.
+ * Exposes gauges that map workflow IDs to their human-readable names, enabling
+ * dashboards to resolve IDs to names without extra lookups.
+ *
+ * Only the leader reports, as the mapping is instance-wide state.
+ *
  * Results are cached to avoid hitting the database on every metrics scrape;
  * cache TTL is controlled by `endpoints.metrics.workflowInfoMetricInterval`.
  */
@@ -21,6 +32,7 @@ export class PrometheusWorkflowInfoMetricsService implements PrometheusMetricsCo
 		private readonly config: PrometheusMetricsConfig,
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly cacheService: CacheService,
+		private readonly instanceSettings: InstanceSettings,
 	) {}
 
 	get enabled(): boolean {
@@ -28,24 +40,42 @@ export class PrometheusWorkflowInfoMetricsService implements PrometheusMetricsCo
 	}
 
 	init() {
+		this.initGauge({
+			name: 'workflow_info',
+			help: 'Map of workflow ID to name. Reported by the leader main only.',
+			cacheKey: 'metrics:workflow-info:v2',
+			activeOnly: false,
+		});
+		this.initGauge({
+			name: 'active_workflow_info',
+			help: 'Map of active workflow ID to name. Reported by the leader main only.',
+			cacheKey: 'metrics:active-workflow-info:v1',
+			activeOnly: true,
+		});
+	}
+
+	private initGauge({ name, help, cacheKey, activeOnly }: WorkflowInfoGaugeParams) {
+		const { instanceSettings } = this;
 		const cacheTtl = this.config.workflowInfoMetricInterval * Time.seconds.toMilliseconds;
 		const query = new CachedMetricQuery<Array<{ id: string; name: string }>>({
 			cacheService: this.cacheService,
-			cacheKey: 'metrics:workflow-info:v2',
+			cacheKey,
 			ttlMs: cacheTtl,
-			query: async () => await this.workflowRepository.find({ select: ['id', 'name'] }),
+			query: async () => await this.workflowRepository.getWorkflowInfo({ activeOnly }),
 		});
 
 		new promClient.Gauge({
-			name: `${this.config.prefix}workflow_info`,
-			help: 'Map of workflow ID to name.',
+			name: `${this.config.prefix}${name}`,
+			help,
 			labelNames: ['workflow_id', 'workflow_name'],
 			async collect() {
 				this.reset();
 
+				if (!instanceSettings.isLeader) return;
+
 				const workflows = await query.get();
-				for (const { id, name } of workflows) {
-					this.labels({ workflow_id: id, workflow_name: name }).set(1);
+				for (const { id, name: workflowName } of workflows) {
+					this.labels({ workflow_id: id, workflow_name: workflowName }).set(1);
 				}
 			},
 		});


### PR DESCRIPTION
## Summary

We export a Prom info metric `n8n_workflow_info` that maps each workflow's ID to its name.

Today every single pod exports this catalog, which lists every single workflow in the DB. On our internal instance that is ~12k workflows times 10 pods = 120k series, re-scraped every 30s, making it by far the largest metric the instance exports. Dashboard queries that join against it are sometimes timing out at longer time ranges, and Prom is storing ten copies of instance-wide state.

Two changes:

- Only the leader main reports this metric. Cuts series 10x with no data loss, though anyone selecting this metric by `pod` label will need to drop that.
- New `n8n_active_workflow_info` metric listing only workflows with an active version. On internal, that is 2.4k of the 12k. Dashboards usually care about that workflows that execute, so joins can switch to this metric more efficiently. `n8n_workflow_info` keeps listing all workflows as before.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] ~PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`~

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34987">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

