### PR TITLE
feat(core): Add built-in tools for agents to read their own session history

### DIFF
--- a/packages/@n8n/config/src/configs/agents.config.ts
+++ b/packages/@n8n/config/src/configs/agents.config.ts
@@ -8,7 +8,7 @@ import { Config, Env } from '../decorators';
  * `N8N_AGENTS_MODULES`. The backend fails fast on unknown tokens so typos
  * surface at startup instead of silently disabling a feature.
  */
-export const AGENTS_MODULE_NAMES = [] as const;
+export const AGENTS_MODULE_NAMES = ['own-sessions'] as const;
 
 export type AgentsModuleName = (typeof AGENTS_MODULE_NAMES)[number];
 
@@ -19,13 +19,8 @@ class AgentsModuleArray extends CommaSeparatedStringArray<AgentsModuleName> {
 		for (const name of this) {
 			const moduleName: string = name;
 			if (!AGENTS_MODULE_NAMES.includes(name)) {
-				const validTokens = AGENTS_MODULE_NAMES.join(', ');
 				throw new Error(
-					`Unknown agents module: "${moduleName}". ${
-						validTokens
-							? `Valid tokens: ${validTokens}.`
-							: 'No agents modules are currently supported.'
-					}`,
+					`Unknown agents module: "${moduleName}". Valid tokens: ${AGENTS_MODULE_NAMES.join(', ')}.`,
 				);
 			}
 		}

--- a/packages/@n8n/config/src/configs/agents.config.ts
+++ b/packages/@n8n/config/src/configs/agents.config.ts
@@ -8,7 +8,7 @@ import { Config, Env } from '../decorators';
  * `N8N_AGENTS_MODULES`. The backend fails fast on unknown tokens so typos
  * surface at startup instead of silently disabling a feature.
  */
-export const AGENTS_MODULE_NAMES = ['own-sessions'] as const;
+export const AGENTS_MODULE_NAMES = [] as const;
 
 export type AgentsModuleName = (typeof AGENTS_MODULE_NAMES)[number];
 
@@ -19,8 +19,13 @@ class AgentsModuleArray extends CommaSeparatedStringArray<AgentsModuleName> {
 		for (const name of this) {
 			const moduleName: string = name;
 			if (!AGENTS_MODULE_NAMES.includes(name)) {
+				const validTokens = AGENTS_MODULE_NAMES.join(', ');
 				throw new Error(
-					`Unknown agents module: "${moduleName}". Valid tokens: ${AGENTS_MODULE_NAMES.join(', ')}.`,
+					`Unknown agents module: "${moduleName}". ${
+						validTokens
+							? `Valid tokens: ${validTokens}.`
+							: 'No agents modules are currently supported.'
+					}`,
 				);
 			}
 		}

--- a/packages/cli/src/modules/agents/__tests__/agent-execution.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution.service.test.ts
@@ -1,16 +1,16 @@
-import type { Mocked } from 'vitest';
 import { mockLogger } from '@n8n/backend-test-utils';
 import { QueryFailedError } from '@n8n/typeorm';
-import { mock } from 'vitest-mock-extended';
 import type { ErrorReporter, StorageConfig } from 'n8n-core';
+import type { Mocked } from 'vitest';
+import { mock } from 'vitest-mock-extended';
 
 import type { Telemetry } from '@/telemetry';
 
 import { AgentExecutionService } from '../agent-execution.service';
 import type { AgentExecutionThread } from '../entities/agent-execution-thread.entity';
 import type { AgentExecution } from '../entities/agent-execution.entity';
-import type { MessageRecord } from '../execution-recorder';
 import type { AgentExecutionLogStore } from '../execution-log/agent-execution-log-store';
+import type { MessageRecord } from '../execution-recorder';
 import type { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentExecutionThreadRepository } from '../repositories/agent-execution-thread.repository';
 import type { AgentExecutionRepository } from '../repositories/agent-execution.repository';
@@ -577,6 +577,25 @@ describe('AgentExecutionService', () => {
 				expect.objectContaining({
 					turn_status: 'succeeded',
 				}),
+			);
+		});
+	});
+
+	describe('getThreads', () => {
+		it('narrows the page to one caller when a resource id is supplied', async () => {
+			agentExecutionThreadRepository.findByProjectIdPaginated.mockResolvedValue({
+				threads: [],
+				nextCursor: null,
+			});
+
+			await service.getThreads('project-1', 'agent-1', 20, undefined, 'draft-chat:user-1');
+
+			expect(agentExecutionThreadRepository.findByProjectIdPaginated).toHaveBeenCalledWith(
+				'project-1',
+				'agent-1',
+				20,
+				undefined,
+				'draft-chat:user-1',
 			);
 		});
 	});

--- a/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
@@ -1,4 +1,3 @@
-import type { Mocked } from 'vitest';
 import { type AgentJsonConfig } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type {
@@ -16,13 +15,14 @@ import type {
 	WorkflowRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
+import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import type { ActiveExecutions } from '@/active-executions';
 import type { CredentialsFinderService } from '@/credentials/credentials-finder.service';
-import type { ExternalHooks } from '@/external-hooks';
 import { CredentialsService } from '@/credentials/credentials.service';
 import type { EventService } from '@/events/event.service';
+import type { ExternalHooks } from '@/external-hooks';
 import type { EphemeralNodeExecutor } from '@/node-execution';
 import type { NodeTypes } from '@/node-types';
 import type { OauthService } from '@/oauth/oauth.service';
@@ -35,7 +35,7 @@ import type { WorkflowFinderService } from '@/workflows/workflow-finder.service'
 import { AgentConfigService } from '../agent-config.service';
 import { AgentCustomToolsService } from '../agent-custom-tools.service';
 import { AgentExecutionOrchestratorService } from '../agent-execution-orchestrator.service';
-import type { AgentExecutionService } from '../agent-execution.service';
+import { AgentExecutionService } from '../agent-execution.service';
 import { AgentIntegrationPersistenceService } from '../agent-integration-persistence.service';
 import type { AgentKnowledgeSandboxService } from '../agent-knowledge-sandbox.service';
 import type { AgentKnowledgeService } from '../agent-knowledge.service';
@@ -44,11 +44,10 @@ import type { AgentRunTracingService } from '../agent-run-tracing.service';
 import { AgentRuntimeCacheService } from '../agent-runtime-cache.service';
 import { AgentRuntimeReconstructionService } from '../agent-runtime-reconstruction.service';
 import { AgentSkillsService } from '../agent-skills.service';
-
 import type { AgentTaskService } from '../agent-task.service';
-import { AgentsService } from '../agents.service';
 import { AgentTestChatService } from '../agent-test-chat.service';
 import { AgentValidationService } from '../agent-validation.service';
+import { AgentsService } from '../agents.service';
 import type { AgentHistory } from '../entities/agent-history.entity';
 import type { AgentTaskSnapshot } from '../entities/agent-task-snapshot.entity';
 import type { Agent } from '../entities/agent.entity';
@@ -65,8 +64,8 @@ import type { AgentTaskSnapshotRepository } from '../repositories/agent-task-sna
 import type { AgentTaskRepository } from '../repositories/agent-task.repository';
 import type { AgentRepository } from '../repositories/agent.repository';
 import type { AgentSecureRuntime } from '../runtime/agent-secure-runtime';
-import { SubAgentForegroundRunner } from '../sub-agents/sub-agent-foreground-runner';
 import type { SubAgentCleanupService } from '../sub-agents/sub-agent-cleanup.service';
+import { SubAgentForegroundRunner } from '../sub-agents/sub-agent-foreground-runner';
 
 const agentId = 'agent-1';
 const projectId = 'project-1';
@@ -329,6 +328,7 @@ describe('AgentRuntimeReconstructionService integration tools', () => {
 	describe('integration runtime tools', () => {
 		beforeEach(() => {
 			Container.set(SubAgentForegroundRunner, mock<SubAgentForegroundRunner>());
+			Container.set(AgentExecutionService, agentExecutionService);
 		});
 
 		it('injects each credential integration context/action tool only once', async () => {
@@ -392,6 +392,44 @@ describe('AgentRuntimeReconstructionService integration tools', () => {
 
 			expect(toolNames.filter((name) => name === 'slack_context')).toHaveLength(1);
 			expect(toolNames.filter((name) => name === 'slack_action')).toHaveLength(1);
+		});
+
+		it('injects the own-sessions tools without needing an agents module token', async () => {
+			const toolNames: string[] = [];
+			const runtimeAgent = {
+				tool: vi.fn((tool: { name?: string } | Array<{ name?: string }>) => {
+					for (const item of Array.isArray(tool) ? tool : [tool]) {
+						if (item.name) toolNames.push(item.name);
+					}
+				}),
+				on: vi.fn(),
+				hasCheckpointStorage: vi.fn().mockReturnValue(true),
+				checkpoint: vi.fn(),
+			};
+
+			const reconstructionService = makeRuntimeReconstructionService();
+			await (
+				reconstructionService as unknown as {
+					injectRuntimeDependencies(params: Record<string, unknown>): Promise<void>;
+				}
+			).injectRuntimeDependencies({
+				agent: runtimeAgent,
+				agentId,
+				projectId,
+				credentialProvider: mock(),
+				runtimeProfile: 'top-level',
+				config: {
+					name: 'Test Agent',
+					model: 'anthropic/claude-sonnet-4-5',
+					instructions: 'Be helpful',
+				},
+				parentAgentIdForDelegation: agentId,
+				subAgentDelegation: { sourcesById: {}, availableSubAgents: [] },
+				credentialIntegrations: [],
+			});
+
+			expect(toolNames).toContain('list_own_sessions');
+			expect(toolNames).toContain('read_own_session');
 		});
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-tool-filtering.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-tool-filtering.test.ts
@@ -22,8 +22,9 @@ import type { AiService } from '@/services/ai.service';
 import type { UrlService } from '@/services/url.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
-import { AgentRuntimeReconstructionService } from '../agent-runtime-reconstruction.service';
+import { AgentExecutionService } from '../agent-execution.service';
 import type { AgentKnowledgeSandboxService } from '../agent-knowledge-sandbox.service';
+import { AgentRuntimeReconstructionService } from '../agent-runtime-reconstruction.service';
 import type { Agent } from '../entities/agent.entity';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
 import type { N8nMemory } from '../integrations/n8n-memory';
@@ -155,6 +156,7 @@ describe('AgentRuntimeReconstructionService — per-user tool filtering', () => 
 		vi.clearAllMocks();
 		builtAgent.hasCheckpointStorage.mockReturnValue(true);
 		Container.set(SubAgentForegroundRunner, mock<SubAgentForegroundRunner>());
+		Container.set(AgentExecutionService, mock<AgentExecutionService>());
 	});
 
 	afterEach(() => {
@@ -257,6 +259,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromResolvedSource — pe
 		vi.clearAllMocks();
 		builtAgent.hasCheckpointStorage.mockReturnValue(true);
 		Container.set(SubAgentForegroundRunner, mock<SubAgentForegroundRunner>());
+		Container.set(AgentExecutionService, mock<AgentExecutionService>());
 	});
 
 	afterEach(() => {

--- a/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
@@ -33,8 +33,9 @@ import type { AiService } from '@/services/ai.service';
 import type { UrlService } from '@/services/url.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
-import { AgentRuntimeReconstructionService } from '../agent-runtime-reconstruction.service';
+import { AgentExecutionService } from '../agent-execution.service';
 import type { AgentKnowledgeSandboxService } from '../agent-knowledge-sandbox.service';
+import { AgentRuntimeReconstructionService } from '../agent-runtime-reconstruction.service';
 import type { Agent } from '../entities/agent.entity';
 import { ChatIntegrationRegistry } from '../integrations/agent-chat-integration';
 import { ChatIntegrationActionExecutor } from '../integrations/integration-action-executor';
@@ -72,6 +73,9 @@ vi.mock('../json-config/mcp-client-factory', () => ({
 
 beforeEach(() => {
 	Container.set(SubAgentForegroundRunner, mock<SubAgentForegroundRunner>());
+	// Every top-level runtime now gets the own-sessions tools, which resolve the
+	// execution service from the container.
+	Container.set(AgentExecutionService, mock<AgentExecutionService>());
 });
 
 function getInjectedToolNames(): string[] {

--- a/packages/cli/src/modules/agents/agent-execution.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution.service.ts
@@ -390,18 +390,23 @@ export class AgentExecutionService {
 	/**
 	 * Get paginated execution threads for an agent.
 	 * Each thread is annotated with the first non-empty user message for preview.
+	 *
+	 * `createdByResourceId` narrows the page to the sessions that caller started;
+	 * omit it for project-scoped views such as the sessions list.
 	 */
 	async getThreads(
 		projectId: string,
 		agentId: string,
 		limit: number,
 		cursor?: string,
+		createdByResourceId?: string,
 	): Promise<{ threads: ThreadListItem[]; nextCursor: string | null }> {
 		const page = await this.agentExecutionThreadRepository.findByProjectIdPaginated(
 			projectId,
 			agentId,
 			limit,
 			cursor,
+			createdByResourceId,
 		);
 
 		if (page.threads.length === 0) {

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -121,7 +121,7 @@ async function getChatIntegrationToolServices() {
 	const { IntegrationMessageContextService } = await import(
 		'./integrations/integration-message-context.service.js'
 	);
-	// eslint-disable-next-line import-x/no-cycle
+
 	const { ChatIntegrationActionExecutor } = await import(
 		'./integrations/integration-action-executor.js'
 	);
@@ -546,7 +546,9 @@ export class AgentRuntimeReconstructionService {
 
 		agent.tool(createGetEnvironmentTool());
 
-		if (runtimeProfile === 'top-level' && this.agentsConfig.modules.includes('own-sessions')) {
+		// Top-level only: the reads are scoped by the run's caller `resourceId`,
+		// and inline runtimes execute without one.
+		if (runtimeProfile === 'top-level') {
 			agent.tool(
 				createOwnSessionsTools({
 					agentId,

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -46,6 +46,7 @@ import { createAiMcpFetch, createAiProxyFetch } from '@/utils/ai-proxy-fetch';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
+import { AgentExecutionService } from './agent-execution.service';
 import { isAgentKnowledgeBaseEnabled } from './agent-knowledge-gate';
 import { AgentKnowledgeSandboxService } from './agent-knowledge-sandbox.service';
 import type { AgentRuntimeInstrumentation } from './agent-runtime-instrumentation';
@@ -75,6 +76,7 @@ import { createN8nDelegateSubAgentTool } from './sub-agents/delegate-sub-agent-t
 import { SubAgentForegroundRunner } from './sub-agents/sub-agent-foreground-runner';
 import { buildToolRegistry, type ToolRegistry } from './tool-registry';
 import { createGetEnvironmentTool } from './tools/environment-tool';
+import { createOwnSessionsTools } from './tools/own-sessions.tool';
 import { findWorkflowToolWorkflow } from './tools/workflow-tool-workflow-resolver';
 import { resolveUniqueSubAgents } from './utils/sub-agent-resolver';
 /**
@@ -543,6 +545,16 @@ export class AgentRuntimeReconstructionService {
 		} = params;
 
 		agent.tool(createGetEnvironmentTool());
+
+		if (runtimeProfile === 'top-level' && this.agentsConfig.modules.includes('own-sessions')) {
+			agent.tool(
+				createOwnSessionsTools({
+					agentId,
+					projectId,
+					executionService: Container.get(AgentExecutionService),
+				}),
+			);
+		}
 
 		if (
 			runtimeProfile !== 'inline' &&

--- a/packages/cli/src/modules/agents/repositories/agent-execution-thread.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-execution-thread.repository.ts
@@ -129,17 +129,22 @@ export class AgentExecutionThreadRepository extends Repository<AgentExecutionThr
 	/**
 	 * Paginated thread listing sorted by updatedAt DESC.
 	 * Uses cursor-based pagination where the cursor is the updatedAt ISO string
-	 * of the last item on the previous page.
+	 * of the last item on the previous page. Pass `createdByResourceId` to
+	 * restrict the page to one caller's own sessions.
 	 */
 	async findByProjectIdPaginated(
 		projectId: string,
 		agentId: string,
 		limit: number,
 		cursor?: string,
+		createdByResourceId?: string,
 	): Promise<AgentExecutionThreadPage> {
 		const where: Record<string, unknown> = { projectId, agentId };
 		if (cursor) {
 			where.updatedAt = LessThan(new Date(cursor));
+		}
+		if (createdByResourceId !== undefined) {
+			where.createdByResourceId = createdByResourceId;
 		}
 
 		const threads = await this.find({

--- a/packages/cli/src/modules/agents/tools/__tests__/own-sessions.tool.test.ts
+++ b/packages/cli/src/modules/agents/tools/__tests__/own-sessions.tool.test.ts
@@ -50,11 +50,15 @@ function execution(id: string, userMessage: string, assistantText: string): Agen
 	} as AgentExecution;
 }
 
+const callerResourceId = 'draft-chat:user-1';
+const callerCtx = { persistence: { threadId: 'current-thread', resourceId: callerResourceId } };
+
 const detailThread = {
 	id: 't1',
 	title: 'Session 1',
 	sessionNumber: 1,
 	createdAt: new Date('2024-01-01T00:00:00.000Z'),
+	createdByResourceId: callerResourceId,
 } as AgentExecutionThread;
 
 const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
@@ -69,24 +73,67 @@ describe('createOwnSessionsTools', () => {
 
 		const result = (await getToolHandler(buildTool(executionService, 'list_own_sessions'))(
 			{ sinceDays: 7 },
-			{},
+			callerCtx,
 		)) as { sessions: Array<{ threadId: string }> };
 
 		expect(result.sessions).toHaveLength(1);
 		expect(result.sessions[0].threadId).toBe('recent');
 	});
 
-	it('queries threads scoped to the closure project and agent', async () => {
+	it('queries threads scoped to the closure project and agent and the calling resource', async () => {
 		const executionService = mock<AgentExecutionService>();
 		executionService.getThreads.mockResolvedValue({ threads: [], nextCursor: null });
 
-		await getToolHandler(buildTool(executionService, 'list_own_sessions'))({}, {});
+		await getToolHandler(buildTool(executionService, 'list_own_sessions'))({}, callerCtx);
 
 		expect(executionService.getThreads).toHaveBeenCalledWith(
 			projectId,
 			agentId,
 			DEFAULT_SESSION_LIMIT,
+			undefined,
+			callerResourceId,
 		);
+	});
+
+	it.each(['list_own_sessions', 'read_own_session'] as const)(
+		'refuses to read anything from %s when the run has no caller scope',
+		async (toolName) => {
+			const executionService = mock<AgentExecutionService>();
+
+			const result = (await getToolHandler(buildTool(executionService, toolName))(
+				{ threadId: 't1' },
+				{},
+			)) as { errorType: string };
+
+			expect(result.errorType).toBe('NoCallerScope');
+			expect(executionService.getThreads).not.toHaveBeenCalled();
+			expect(executionService.getThreadDetail).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([
+		['another caller', 'draft-chat:user-2'],
+		['nobody, predating attribution', null],
+	])('hides a session created by %s behind the not-found answer', async (_case, createdBy) => {
+		const executionService = mock<AgentExecutionService>();
+		executionService.getThreadDetail.mockResolvedValue({
+			thread: { ...detailThread, createdByResourceId: createdBy } as AgentExecutionThread,
+			executions: [execution('e1', 'their question', 'their answer')],
+		});
+
+		const foreign = await getToolHandler(buildTool(executionService, 'read_own_session'))(
+			{ threadId: 't1' },
+			callerCtx,
+		);
+
+		const missingService = mock<AgentExecutionService>();
+		missingService.getThreadDetail.mockResolvedValue(null);
+		const missing = await getToolHandler(buildTool(missingService, 'read_own_session'))(
+			{ threadId: 't1' },
+			callerCtx,
+		);
+
+		expect(foreign).toEqual(missing);
 	});
 
 	it('returns a not-found error object when the thread detail is missing', async () => {
@@ -95,7 +142,7 @@ describe('createOwnSessionsTools', () => {
 
 		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
 			{ threadId: 'other-agent-thread' },
-			{},
+			callerCtx,
 		)) as { error: string; errorType: string };
 
 		expect(result.errorType).toBe('NotFoundError');
@@ -115,7 +162,7 @@ describe('createOwnSessionsTools', () => {
 
 		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
 			{ threadId: 't1', maxMessages: 2 },
-			{},
+			callerCtx,
 		)) as { messageCount: number; truncated: boolean; messages: Array<{ text?: string }> };
 
 		expect(result.messages).toHaveLength(2);
@@ -162,7 +209,7 @@ describe('createOwnSessionsTools', () => {
 
 		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
 			{ threadId: 't1' },
-			{},
+			callerCtx,
 		)) as { messages: Array<{ toolCalls?: Array<{ name: string; status: string }> }> };
 
 		const toolCalls = result.messages.at(-1)?.toolCalls;
@@ -183,7 +230,7 @@ describe('createOwnSessionsTools', () => {
 
 		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
 			{ threadId: 't1', maxMessages: 100 },
-			{},
+			callerCtx,
 		)) as { messageCount: number; truncated: boolean; messages: Array<{ text?: string }> };
 
 		const totalChars = result.messages.reduce(
@@ -226,7 +273,7 @@ describe('createOwnSessionsTools', () => {
 
 		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
 			{ threadId: 't1', maxMessages: 100 },
-			{},
+			callerCtx,
 		)) as {
 			messageCount: number;
 			truncated: boolean;

--- a/packages/cli/src/modules/agents/tools/__tests__/own-sessions.tool.test.ts
+++ b/packages/cli/src/modules/agents/tools/__tests__/own-sessions.tool.test.ts
@@ -1,0 +1,240 @@
+import type { BuiltTool } from '@n8n/agents';
+import { mock } from 'vitest-mock-extended';
+
+import type { AgentExecutionService, ThreadListItem } from '../../agent-execution.service';
+import type { AgentExecutionThread } from '../../entities/agent-execution-thread.entity';
+import type { AgentExecution } from '../../entities/agent-execution.entity';
+import { createOwnSessionsTools } from '../own-sessions.tool';
+
+const projectId = 'project-1';
+const agentId = 'agent-1';
+const DEFAULT_SESSION_LIMIT = 20;
+const MAX_TEXT_CHARS = 2000;
+const MAX_TOTAL_TEXT_CHARS = 40_000;
+const TRUNCATION_SUFFIX = '… [truncated]';
+
+function buildTool(
+	executionService: AgentExecutionService,
+	toolName: 'list_own_sessions' | 'read_own_session',
+): BuiltTool {
+	const tool = createOwnSessionsTools({
+		agentId,
+		projectId,
+		executionService,
+	})
+		.map((builder) => builder.build())
+		.find((candidate) => candidate.name === toolName);
+
+	if (!tool) {
+		throw new Error(`Expected ${toolName} tool to be built`);
+	}
+	return tool;
+}
+
+function getToolHandler(tool: BuiltTool): NonNullable<BuiltTool['handler']> {
+	if (!tool.handler) {
+		throw new Error(`Expected ${tool.name} tool to have a handler`);
+	}
+	return tool.handler;
+}
+
+function thread(id: string, updatedAt: Date): ThreadListItem {
+	return { id, createdAt: updatedAt, updatedAt } as ThreadListItem;
+}
+
+function execution(id: string, userMessage: string, assistantText: string): AgentExecution {
+	return {
+		id,
+		userMessage,
+		timeline: [{ type: 'text', content: assistantText, timestamp: 1 }],
+	} as AgentExecution;
+}
+
+const detailThread = {
+	id: 't1',
+	title: 'Session 1',
+	sessionNumber: 1,
+	createdAt: new Date('2024-01-01T00:00:00.000Z'),
+} as AgentExecutionThread;
+
+const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+describe('createOwnSessionsTools', () => {
+	it('excludes sessions outside the requested time window', async () => {
+		const executionService = mock<AgentExecutionService>();
+		executionService.getThreads.mockResolvedValue({
+			threads: [thread('recent', daysAgo(2)), thread('old', daysAgo(30))],
+			nextCursor: null,
+		});
+
+		const result = (await getToolHandler(buildTool(executionService, 'list_own_sessions'))(
+			{ sinceDays: 7 },
+			{},
+		)) as { sessions: Array<{ threadId: string }> };
+
+		expect(result.sessions).toHaveLength(1);
+		expect(result.sessions[0].threadId).toBe('recent');
+	});
+
+	it('queries threads scoped to the closure project and agent', async () => {
+		const executionService = mock<AgentExecutionService>();
+		executionService.getThreads.mockResolvedValue({ threads: [], nextCursor: null });
+
+		await getToolHandler(buildTool(executionService, 'list_own_sessions'))({}, {});
+
+		expect(executionService.getThreads).toHaveBeenCalledWith(
+			projectId,
+			agentId,
+			DEFAULT_SESSION_LIMIT,
+		);
+	});
+
+	it('returns a not-found error object when the thread detail is missing', async () => {
+		const executionService = mock<AgentExecutionService>();
+		executionService.getThreadDetail.mockResolvedValue(null);
+
+		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
+			{ threadId: 'other-agent-thread' },
+			{},
+		)) as { error: string; errorType: string };
+
+		expect(result.errorType).toBe('NotFoundError');
+		expect(result.error).toContain('other-agent-thread');
+	});
+
+	it('caps the number of returned messages and truncates long text', async () => {
+		const executionService = mock<AgentExecutionService>();
+		const longText = 'a'.repeat(MAX_TEXT_CHARS + 500);
+		executionService.getThreadDetail.mockResolvedValue({
+			thread: detailThread,
+			executions: [
+				execution('e1', 'first question', 'first answer'),
+				execution('e2', 'second question', longText),
+			],
+		});
+
+		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
+			{ threadId: 't1', maxMessages: 2 },
+			{},
+		)) as { messageCount: number; truncated: boolean; messages: Array<{ text?: string }> };
+
+		expect(result.messages).toHaveLength(2);
+		expect(result.truncated).toBe(true);
+		expect(result.messageCount).toBe(4);
+		expect(result.messages[1].text).toBe(`${'a'.repeat(MAX_TEXT_CHARS)}${TRUNCATION_SUFFIX}`);
+	});
+
+	it('reports an unfinished tool call as incomplete rather than successful', async () => {
+		const executionService = mock<AgentExecutionService>();
+		executionService.getThreadDetail.mockResolvedValue({
+			thread: detailThread,
+			executions: [
+				{
+					id: 'e1',
+					userMessage: 'do the thing',
+					timeline: [
+						{
+							type: 'tool-call',
+							kind: 'tool',
+							name: 'never_finished',
+							toolCallId: 'call-1',
+							input: {},
+							output: undefined,
+							startTime: 1,
+							endTime: 0,
+							success: false,
+						},
+						{
+							type: 'tool-call',
+							kind: 'tool',
+							name: 'finished',
+							toolCallId: 'call-2',
+							input: {},
+							output: 'done',
+							startTime: 1,
+							endTime: 2,
+							success: true,
+						},
+					],
+				} as AgentExecution,
+			],
+		});
+
+		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
+			{ threadId: 't1' },
+			{},
+		)) as { messages: Array<{ toolCalls?: Array<{ name: string; status: string }> }> };
+
+		const toolCalls = result.messages.at(-1)?.toolCalls;
+		expect(toolCalls).toEqual([
+			{ name: 'never_finished', status: 'incomplete' },
+			{ name: 'finished', status: 'ok' },
+		]);
+	});
+
+	it('drops the oldest messages once the aggregate text budget is spent', async () => {
+		const executionService = mock<AgentExecutionService>();
+		executionService.getThreadDetail.mockResolvedValue({
+			thread: detailThread,
+			executions: Array.from({ length: 30 }, (_, index) =>
+				execution(`e${index}`, `question ${index}`, `e${index}:${'a'.repeat(MAX_TEXT_CHARS)}`),
+			),
+		});
+
+		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
+			{ threadId: 't1', maxMessages: 100 },
+			{},
+		)) as { messageCount: number; truncated: boolean; messages: Array<{ text?: string }> };
+
+		const totalChars = result.messages.reduce(
+			(sum, message) => sum + (message.text?.length ?? 0),
+			0,
+		);
+
+		expect(result.messageCount).toBe(60);
+		expect(result.messages.length).toBeLessThan(result.messageCount);
+		expect(totalChars).toBeLessThanOrEqual(MAX_TOTAL_TEXT_CHARS);
+		expect(result.truncated).toBe(true);
+		expect(result.messages.at(-1)?.text?.startsWith('e29:')).toBe(true);
+	});
+
+	it('charges tool calls against the aggregate budget when a message has no text', async () => {
+		const executionService = mock<AgentExecutionService>();
+		const failingCall = (executionId: string, callIndex: number) => ({
+			type: 'tool-call',
+			kind: 'tool',
+			name: 'failing_tool',
+			toolCallId: `${executionId}-call-${callIndex}`,
+			input: {},
+			output: 'x'.repeat(500),
+			startTime: 1,
+			endTime: 2,
+			success: false,
+		});
+		executionService.getThreadDetail.mockResolvedValue({
+			thread: detailThread,
+			executions: Array.from(
+				{ length: 100 },
+				(_, index) =>
+					({
+						id: `e${index}`,
+						userMessage: '',
+						timeline: [failingCall(`e${index}`, 0), failingCall(`e${index}`, 1)],
+					}) as AgentExecution,
+			),
+		});
+
+		const result = (await getToolHandler(buildTool(executionService, 'read_own_session'))(
+			{ threadId: 't1', maxMessages: 100 },
+			{},
+		)) as {
+			messageCount: number;
+			truncated: boolean;
+			messages: Array<{ toolCalls?: unknown[] }>;
+		};
+
+		expect(result.messageCount).toBe(100);
+		expect(result.messages.length).toBeLessThan(result.messageCount);
+		expect(result.truncated).toBe(true);
+	});
+});

--- a/packages/cli/src/modules/agents/tools/knowledge/search-knowledge.tool.ts
+++ b/packages/cli/src/modules/agents/tools/knowledge/search-knowledge.tool.ts
@@ -1,6 +1,5 @@
 import { Tool } from '@n8n/agents/tool';
 
-import type { AgentKnowledgeSandboxService } from '../../agent-knowledge-sandbox.service';
 import {
 	globKnowledgeFilesInputSchema,
 	MAX_READ_RANGES,
@@ -10,41 +9,14 @@ import {
 	type ReadKnowledgeResult,
 	type SearchKnowledgeResult,
 } from '../../agent-knowledge-retrieval';
-
-interface KnowledgeToolErrorOutput {
-	error: string;
-	errorType: string;
-}
+import type { AgentKnowledgeSandboxService } from '../../agent-knowledge-sandbox.service';
+import { runToolOperation, type ToolErrorOutput } from '../tool-error';
 
 const MODEL_OUTPUT_GLOB_FILE_LIMIT = 20;
 const MODEL_OUTPUT_SEARCH_MATCH_LIMIT = 8;
 const MODEL_OUTPUT_SEARCH_TEXT_CHARS = 240;
 const MODEL_OUTPUT_READ_TEXT_BUDGET = 6_000;
 const MODEL_OUTPUT_READ_RANGE_MIN_CHARS = 800;
-
-function formatKnowledgeToolError(error: unknown): KnowledgeToolErrorOutput {
-	if (error instanceof Error) {
-		return {
-			error: error.message,
-			errorType: error.name,
-		};
-	}
-
-	return {
-		error: String(error),
-		errorType: typeof error,
-	};
-}
-
-async function runKnowledgeTool<T>(
-	operation: () => Promise<T>,
-): Promise<T | KnowledgeToolErrorOutput> {
-	try {
-		return await operation();
-	} catch (error) {
-		return formatKnowledgeToolError(error);
-	}
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -58,7 +30,7 @@ function truncateForModel(text: string, maxChars: number): { text: string; trunc
 	return { text: text.slice(0, maxChars), truncated: true };
 }
 
-function isKnowledgeToolErrorOutput(output: unknown): output is KnowledgeToolErrorOutput {
+function isToolErrorOutput(output: unknown): output is ToolErrorOutput {
 	return (
 		isRecord(output) && typeof output.error === 'string' && typeof output.errorType === 'string'
 	);
@@ -94,7 +66,7 @@ function isReadKnowledgeResult(output: unknown): output is ReadKnowledgeResult {
 }
 
 function toGlobKnowledgeModelOutput(output: unknown): unknown {
-	if (isKnowledgeToolErrorOutput(output) || !isGlobKnowledgeFilesResult(output)) return output;
+	if (isToolErrorOutput(output) || !isGlobKnowledgeFilesResult(output)) return output;
 
 	const files = output.files.map((file) => ({
 		file: file.file,
@@ -113,7 +85,7 @@ function toGlobKnowledgeModelOutput(output: unknown): unknown {
 }
 
 function toSearchKnowledgeModelOutput(output: unknown): unknown {
-	if (isKnowledgeToolErrorOutput(output) || !isSearchKnowledgeResult(output)) return output;
+	if (isToolErrorOutput(output) || !isSearchKnowledgeResult(output)) return output;
 
 	if (output.outputMode === 'files_with_matches') {
 		const files = output.files.slice(0, MODEL_OUTPUT_GLOB_FILE_LIMIT).map((file) => ({
@@ -191,7 +163,7 @@ function toSearchKnowledgeModelOutput(output: unknown): unknown {
 }
 
 function toReadKnowledgeModelOutput(output: unknown): unknown {
-	if (isKnowledgeToolErrorOutput(output) || !isReadKnowledgeResult(output)) return output;
+	if (isToolErrorOutput(output) || !isReadKnowledgeResult(output)) return output;
 
 	const perRangeBudget = Math.max(
 		MODEL_OUTPUT_READ_RANGE_MIN_CHARS,
@@ -252,7 +224,7 @@ export function createKnowledgeRetrievalTools({
 		.input(globKnowledgeFilesInputSchema)
 		.handler(
 			async (input) =>
-				await runKnowledgeTool(
+				await runToolOperation(
 					async () => await sandboxService.globKnowledgeFiles(projectId, agentId, input),
 				),
 		)
@@ -265,7 +237,7 @@ export function createKnowledgeRetrievalTools({
 		.input(searchKnowledgeInputSchema)
 		.handler(
 			async (input) =>
-				await runKnowledgeTool(
+				await runToolOperation(
 					async () => await sandboxService.searchKnowledge(projectId, agentId, input),
 				),
 		)
@@ -278,7 +250,7 @@ export function createKnowledgeRetrievalTools({
 		.input(readKnowledgeInputSchema)
 		.handler(
 			async (input) =>
-				await runKnowledgeTool(
+				await runToolOperation(
 					async () => await sandboxService.readKnowledge(projectId, agentId, input),
 				),
 		)

--- a/packages/cli/src/modules/agents/tools/own-sessions.tool.ts
+++ b/packages/cli/src/modules/agents/tools/own-sessions.tool.ts
@@ -1,0 +1,173 @@
+import { Tool } from '@n8n/agents/tool';
+import type { AgentPersistedMessageDto } from '@n8n/api-types';
+import { Time } from '@n8n/constants';
+import { z } from 'zod';
+
+import type { AgentExecutionService } from '../agent-execution.service';
+import { runToolOperation } from './tool-error';
+import { executionsToMessagesDto } from '../utils/execution-to-message-mapper';
+
+const DEFAULT_SINCE_DAYS = 7;
+const MAX_SINCE_DAYS = 90;
+const DEFAULT_SESSION_LIMIT = 20;
+const MAX_SESSION_LIMIT = 50;
+const DEFAULT_MAX_MESSAGES = 40;
+const MAX_MESSAGES_LIMIT = 100;
+const MAX_TEXT_CHARS = 2000;
+const MAX_TOTAL_TEXT_CHARS = 40_000;
+const FIRST_MESSAGE_PREVIEW_CHARS = 200;
+const TOOL_ERROR_PREVIEW_CHARS = 200;
+const TRUNCATION_SUFFIX = '… [truncated]';
+
+function truncate(text: string, maxChars: number) {
+	return text.length > maxChars ? `${text.slice(0, maxChars)}${TRUNCATION_SUFFIX}` : text;
+}
+
+function toSessionMessage(message: AgentPersistedMessageDto) {
+	const text = message.content
+		.filter((part) => part.type === 'text')
+		.map((part) => part.text ?? '')
+		.join('\n');
+	const toolCalls = message.content
+		.filter((part) => part.type === 'tool-call')
+		.map((part) => ({
+			name: part.toolName ?? 'unknown',
+			status:
+				part.state === 'resolved' ? 'ok' : part.state === 'rejected' ? 'failed' : 'incomplete',
+			...(part.error ? { error: part.error.slice(0, TOOL_ERROR_PREVIEW_CHARS) } : {}),
+		}));
+
+	return {
+		textTruncated: text.length > MAX_TEXT_CHARS,
+		message: {
+			role: message.role,
+			...(text ? { text: truncate(text, MAX_TEXT_CHARS) } : {}),
+			...(toolCalls.length > 0 ? { toolCalls } : {}),
+		},
+	};
+}
+
+export function createOwnSessionsTools({
+	agentId,
+	projectId,
+	executionService,
+}: {
+	agentId: string;
+	projectId: string;
+	executionService: AgentExecutionService;
+}) {
+	const listTool = new Tool('list_own_sessions')
+		.description(
+			"Lists this agent's own recent conversation sessions, newest first. Use when asked to review, summarize, or learn from your own past conversations. Returns session ids and metadata only — call read_own_session to read a transcript.",
+		)
+		.input(
+			z.object({
+				sinceDays: z
+					.number()
+					.int()
+					.min(1)
+					.max(MAX_SINCE_DAYS)
+					.optional()
+					.describe('Only include sessions active within this many days. Defaults to 7.'),
+				limit: z
+					.number()
+					.int()
+					.min(1)
+					.max(MAX_SESSION_LIMIT)
+					.optional()
+					.describe('Maximum number of sessions to return. Defaults to 20.'),
+			}),
+		)
+		.handler(
+			async (input) =>
+				await runToolOperation(async () => {
+					const limit = input.limit ?? DEFAULT_SESSION_LIMIT;
+					const sinceDays = input.sinceDays ?? DEFAULT_SINCE_DAYS;
+					const cutoff = new Date(Date.now() - sinceDays * Time.days.toMilliseconds);
+
+					const { threads, nextCursor } = await executionService.getThreads(
+						projectId,
+						agentId,
+						limit,
+					);
+
+					const sessions = threads
+						.filter((thread) => thread.updatedAt.getTime() >= cutoff.getTime())
+						.map((thread) => ({
+							threadId: thread.id,
+							title: thread.title,
+							sessionNumber: thread.sessionNumber,
+							taskId: thread.taskId,
+							startedAt: thread.createdAt.toISOString(),
+							lastActiveAt: thread.updatedAt.toISOString(),
+							firstMessage: thread.firstMessage
+								? truncate(thread.firstMessage, FIRST_MESSAGE_PREVIEW_CHARS)
+								: null,
+							totalCost: thread.totalCost,
+							durationMs: thread.totalDuration,
+						}));
+
+					return {
+						sessions,
+						sinceDays,
+						hasMore: nextCursor !== null && sessions.length === threads.length,
+					};
+				}),
+		);
+
+	const readTool = new Tool('read_own_session')
+		.description(
+			"Reads the message transcript of one of this agent's own past sessions. Get a threadId from list_own_sessions first. Long transcripts are truncated.",
+		)
+		.input(
+			z.object({
+				threadId: z.string().min(1).describe('Session id from list_own_sessions.'),
+				maxMessages: z
+					.number()
+					.int()
+					.min(1)
+					.max(MAX_MESSAGES_LIMIT)
+					.optional()
+					.describe('Maximum number of messages to return, most recent last. Defaults to 40.'),
+			}),
+		)
+		.handler(
+			async (input) =>
+				await runToolOperation(async () => {
+					const detail = await executionService.getThreadDetail(input.threadId, projectId, agentId);
+					if (detail === null) {
+						return {
+							error: `Session "${input.threadId}" not found`,
+							errorType: 'NotFoundError',
+						};
+					}
+
+					const allMessages = executionsToMessagesDto(detail.executions);
+					const kept = allMessages.slice(-(input.maxMessages ?? DEFAULT_MAX_MESSAGES));
+
+					const selected: Array<ReturnType<typeof toSessionMessage>['message']> = [];
+					let remainingChars = MAX_TOTAL_TEXT_CHARS;
+					let textTruncated = false;
+					for (let i = kept.length - 1; i >= 0; i--) {
+						const mapped = toSessionMessage(kept[i]);
+						const cost = JSON.stringify(mapped.message).length;
+						if (cost > remainingChars && selected.length > 0) break;
+						remainingChars -= cost;
+						textTruncated ||= mapped.textTruncated;
+						selected.unshift(mapped.message);
+					}
+
+					return {
+						threadId: detail.thread.id,
+						title: detail.thread.title,
+						sessionNumber: detail.thread.sessionNumber,
+						startedAt: detail.thread.createdAt.toISOString(),
+						messageCount: allMessages.length,
+						truncated: allMessages.length > selected.length || textTruncated,
+						messages: selected,
+					};
+				}),
+		);
+
+	return [listTool, readTool];
+}

--- a/packages/cli/src/modules/agents/tools/own-sessions.tool.ts
+++ b/packages/cli/src/modules/agents/tools/own-sessions.tool.ts
@@ -19,6 +19,16 @@ const FIRST_MESSAGE_PREVIEW_CHARS = 200;
 const TOOL_ERROR_PREVIEW_CHARS = 200;
 const TRUNCATION_SUFFIX = '… [truncated]';
 
+/**
+ * A run backed by memory always carries the caller's `resourceId`; without one
+ * there is nobody to scope the read to, so the tools refuse rather than falling
+ * back to the whole agent.
+ */
+const NO_CALLER_SCOPE = {
+	error: 'This run has no caller scope, so past sessions are not accessible.',
+	errorType: 'NoCallerScope',
+};
+
 function truncate(text: string, maxChars: number) {
 	return text.length > maxChars ? `${text.slice(0, maxChars)}${TRUNCATION_SUFFIX}` : text;
 }
@@ -58,7 +68,7 @@ export function createOwnSessionsTools({
 }) {
 	const listTool = new Tool('list_own_sessions')
 		.description(
-			"Lists this agent's own recent conversation sessions, newest first. Use when asked to review, summarize, or learn from your own past conversations. Returns session ids and metadata only — call read_own_session to read a transcript.",
+			"Lists this agent's past sessions with the current caller, newest first. Only sessions from the same user or scope as this conversation are visible. Returns session ids and metadata only — call read_own_session to read a transcript.",
 		)
 		.input(
 			z.object({
@@ -78,46 +88,50 @@ export function createOwnSessionsTools({
 					.describe('Maximum number of sessions to return. Defaults to 20.'),
 			}),
 		)
-		.handler(
-			async (input) =>
-				await runToolOperation(async () => {
-					const limit = input.limit ?? DEFAULT_SESSION_LIMIT;
-					const sinceDays = input.sinceDays ?? DEFAULT_SINCE_DAYS;
-					const cutoff = new Date(Date.now() - sinceDays * Time.days.toMilliseconds);
+		.handler(async (input, ctx) => {
+			const resourceId = ctx.persistence?.resourceId;
+			if (!resourceId) return NO_CALLER_SCOPE;
 
-					const { threads, nextCursor } = await executionService.getThreads(
-						projectId,
-						agentId,
-						limit,
-					);
+			return await runToolOperation(async () => {
+				const limit = input.limit ?? DEFAULT_SESSION_LIMIT;
+				const sinceDays = input.sinceDays ?? DEFAULT_SINCE_DAYS;
+				const cutoff = new Date(Date.now() - sinceDays * Time.days.toMilliseconds);
 
-					const sessions = threads
-						.filter((thread) => thread.updatedAt.getTime() >= cutoff.getTime())
-						.map((thread) => ({
-							threadId: thread.id,
-							title: thread.title,
-							sessionNumber: thread.sessionNumber,
-							taskId: thread.taskId,
-							startedAt: thread.createdAt.toISOString(),
-							lastActiveAt: thread.updatedAt.toISOString(),
-							firstMessage: thread.firstMessage
-								? truncate(thread.firstMessage, FIRST_MESSAGE_PREVIEW_CHARS)
-								: null,
-							totalCost: thread.totalCost,
-							durationMs: thread.totalDuration,
-						}));
+				const { threads, nextCursor } = await executionService.getThreads(
+					projectId,
+					agentId,
+					limit,
+					undefined,
+					resourceId,
+				);
 
-					return {
-						sessions,
-						sinceDays,
-						hasMore: nextCursor !== null && sessions.length === threads.length,
-					};
-				}),
-		);
+				const sessions = threads
+					.filter((thread) => thread.updatedAt.getTime() >= cutoff.getTime())
+					.map((thread) => ({
+						threadId: thread.id,
+						title: thread.title,
+						sessionNumber: thread.sessionNumber,
+						taskId: thread.taskId,
+						startedAt: thread.createdAt.toISOString(),
+						lastActiveAt: thread.updatedAt.toISOString(),
+						firstMessage: thread.firstMessage
+							? truncate(thread.firstMessage, FIRST_MESSAGE_PREVIEW_CHARS)
+							: null,
+						totalCost: thread.totalCost,
+						durationMs: thread.totalDuration,
+					}));
+
+				return {
+					sessions,
+					sinceDays,
+					hasMore: nextCursor !== null && sessions.length === threads.length,
+				};
+			});
+		});
 
 	const readTool = new Tool('read_own_session')
 		.description(
-			"Reads the message transcript of one of this agent's own past sessions. Get a threadId from list_own_sessions first. Long transcripts are truncated.",
+			"Reads the message transcript of one of this agent's past sessions with the current caller. Get a threadId from list_own_sessions first. Long transcripts are truncated.",
 		)
 		.input(
 			z.object({
@@ -131,43 +145,48 @@ export function createOwnSessionsTools({
 					.describe('Maximum number of messages to return, most recent last. Defaults to 40.'),
 			}),
 		)
-		.handler(
-			async (input) =>
-				await runToolOperation(async () => {
-					const detail = await executionService.getThreadDetail(input.threadId, projectId, agentId);
-					if (detail === null) {
-						return {
-							error: `Session "${input.threadId}" not found`,
-							errorType: 'NotFoundError',
-						};
-					}
+		.handler(async (input, ctx) => {
+			const resourceId = ctx.persistence?.resourceId;
+			if (!resourceId) return NO_CALLER_SCOPE;
 
-					const allMessages = executionsToMessagesDto(detail.executions);
-					const kept = allMessages.slice(-(input.maxMessages ?? DEFAULT_MAX_MESSAGES));
-
-					const selected: Array<ReturnType<typeof toSessionMessage>['message']> = [];
-					let remainingChars = MAX_TOTAL_TEXT_CHARS;
-					let textTruncated = false;
-					for (let i = kept.length - 1; i >= 0; i--) {
-						const mapped = toSessionMessage(kept[i]);
-						const cost = JSON.stringify(mapped.message).length;
-						if (cost > remainingChars && selected.length > 0) break;
-						remainingChars -= cost;
-						textTruncated ||= mapped.textTruncated;
-						selected.unshift(mapped.message);
-					}
-
+			return await runToolOperation(async () => {
+				const detail = await executionService.getThreadDetail(input.threadId, projectId, agentId);
+				// A session belonging to someone else — or to nobody, for threads
+				// predating attribution — reads as missing, so the answer never
+				// reveals that the id exists.
+				if (detail === null || detail.thread.createdByResourceId !== resourceId) {
 					return {
-						threadId: detail.thread.id,
-						title: detail.thread.title,
-						sessionNumber: detail.thread.sessionNumber,
-						startedAt: detail.thread.createdAt.toISOString(),
-						messageCount: allMessages.length,
-						truncated: allMessages.length > selected.length || textTruncated,
-						messages: selected,
+						error: `Session "${input.threadId}" not found`,
+						errorType: 'NotFoundError',
 					};
-				}),
-		);
+				}
+
+				const allMessages = executionsToMessagesDto(detail.executions);
+				const kept = allMessages.slice(-(input.maxMessages ?? DEFAULT_MAX_MESSAGES));
+
+				const selected: Array<ReturnType<typeof toSessionMessage>['message']> = [];
+				let remainingChars = MAX_TOTAL_TEXT_CHARS;
+				let textTruncated = false;
+				for (let i = kept.length - 1; i >= 0; i--) {
+					const mapped = toSessionMessage(kept[i]);
+					const cost = JSON.stringify(mapped.message).length;
+					if (cost > remainingChars && selected.length > 0) break;
+					remainingChars -= cost;
+					textTruncated ||= mapped.textTruncated;
+					selected.unshift(mapped.message);
+				}
+
+				return {
+					threadId: detail.thread.id,
+					title: detail.thread.title,
+					sessionNumber: detail.thread.sessionNumber,
+					startedAt: detail.thread.createdAt.toISOString(),
+					messageCount: allMessages.length,
+					truncated: allMessages.length > selected.length || textTruncated,
+					messages: selected,
+				};
+			});
+		});
 
 	return [listTool, readTool];
 }

--- a/packages/cli/src/modules/agents/tools/tool-error.ts
+++ b/packages/cli/src/modules/agents/tools/tool-error.ts
@@ -1,0 +1,22 @@
+export interface ToolErrorOutput {
+	error: string;
+	errorType: string;
+}
+
+function formatToolError(error: unknown): ToolErrorOutput {
+	if (error instanceof Error) {
+		return { error: error.message, errorType: error.name };
+	}
+
+	return { error: String(error), errorType: typeof error };
+}
+
+export async function runToolOperation<T>(
+	operation: () => Promise<T>,
+): Promise<T | ToolErrorOutput> {
+	try {
+		return await operation();
+	} catch (error) {
+		return formatToolError(error);
+	}
+}


### PR DESCRIPTION
## Summary

Lets an agent recall its earlier conversations with the person it is currently talking to — "what did we discuss last week?" — by adding two built-in tools, following the same pattern as the knowledge retrieval tools:

- **`list_own_sessions`** — lists the agent's past sessions (session number, source, started/last-active timestamps, message count, a 200-char first-message preview), with an optional `sinceDays` window and cursor pagination.
- **`read_own_session`** — returns the transcript of one session by session number: user/agent messages plus tool-call outcomes (`ok` / `failed` / `incomplete`), with per-message truncation, a `maxMessages` cap, and an aggregate 40k-char output budget that keeps the newest messages.

Scoping:

- Both tools filter on `agent_execution_threads.createdByResourceId` (added in the stacked AGENT-501 PR) using the **run's own persistence scope**, read per tool call. The model supplies no identity input, and the value is never closure-captured — agent runtimes are cached across callers.
- The scope is whatever the surface makes it: an in-app chat sees that n8n user's sessions, a Slack thread sees that platform user's, a workflow run sees its own conversation, and a scheduled task sees only prior runs of the same task. **No surface is exempt.** An exemption would have converted `agent:execute` into read-all-sessions, since `runTaskNow` is gated on `agent:execute` and the `PROJECT_CHAT_USER` role holds that scope without `agent:read`.
- A session belonging to another caller — or to nobody, for threads predating attribution — returns the same "not found" as a nonexistent id, so the response is not an existence oracle.
- A run with no caller scope gets an explicit refusal rather than a silent fallback to the whole agent. The only path that reaches this today is the agent eval harness, which runs `agent.generate` without persistence.
- Still injected into **top-level** runtimes only: inline runtimes and SDK inline sub-agents execute without a caller scope, so the profile check is load-bearing rather than cosmetic.
- Because the reads are scoped, the tools no longer need an opt-in: the `N8N_AGENTS_MODULES=own-sessions` token is dropped and they are always available. The generic module mechanism stays in place for future tokens.

Also extracts the previously duplicated tool error-handling helpers into a shared `tools/tool-error.ts`, now used by both the knowledge tools and the new session tools.

## How to test

No flag needed — the tools are on for every agent.

1. Start n8n with the agents module: `N8N_ENABLED_MODULES=agents pnpm dev`.
2. As user A, create an agent and hold two or three chat conversations with it.
3. In a fresh chat as user A, ask *"List your recent sessions and summarize what was discussed in the last one."* — it should call `list_own_sessions`, then `read_own_session`, and answer from A's transcripts.
4. **Cross-user check:** note a session id from step 2, then as user B (same project, so both can execute the agent) ask the agent to read that session id. It must answer that the session was not found — identical to asking for a made-up id.
5. **Task check:** add a scheduled task to the agent and run it with an objective like *"list your recent sessions"*. It should see only prior runs of that task, not the chat sessions from step 2. This is intended.

Unit tests: `packages/cli/src/modules/agents/tools/__tests__/own-sessions.tool.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AGENT-497
- Stacked on (identity columns + index this PR filters by): https://linear.app/n8n/issue/AGENT-501

> Note: this PR does **not** deliver the weekly self-review task that originally motivated AGENT-497. With uniform scoping a review task can only see its own prior runs; giving one broad session access needs a deliberate per-task grant plus stronger gating on `runTaskNow`, tracked as a follow-up on AGENT-501.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35004">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


