### PR TITLE
fix(core): Accept 5-field cron expressions in schedule trigger

### DIFF
--- a/packages/@n8n/scheduler/src/core/recurrence/__tests__/next-run.property.test.ts
+++ b/packages/@n8n/scheduler/src/core/recurrence/__tests__/next-run.property.test.ts
@@ -45,6 +45,7 @@ describe('computeNextRunAt (fast-check)', () => {
 		'0 0 0 * * *',
 		'0 30 9 * * 1-5',
 		'0 0 0 1 * *',
+		'30 9 * * 1-5', // 5-field (no seconds): the strictly-after guarantee must hold here too.
 	);
 	const arbTimezone = fc.constantFrom(
 		'UTC',

--- a/packages/@n8n/scheduler/src/core/recurrence/__tests__/next-run.test.ts
+++ b/packages/@n8n/scheduler/src/core/recurrence/__tests__/next-run.test.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import type { CronExpression } from 'n8n-workflow';
 
 import { InvalidScheduleError } from '../../errors';
 import type { CronSchedule, RecurringCronSchedule, Schedule } from '../../types';
@@ -40,6 +41,37 @@ describe('computeNextRunAt', () => {
 			expect(nextOf(schedule, new Date('2026-01-10T00:00:00Z')).toISOString()).toBe(
 				'2026-01-10T00:00:30.000Z',
 			);
+		});
+
+		it('fires a 5-field weekday cron at the right times, skipping the weekend', () => {
+			const schedule: CronSchedule = {
+				kind: 'cron',
+				cronExpression: '0 9 * * 1-5' as unknown as CronExpression,
+				timezone: 'UTC',
+			};
+			// From Friday noon, the next fire is Monday 09:00 (Sat/Sun skipped)...
+			const monday = nextOf(schedule, new Date('2026-07-31T12:00:00Z'));
+			expect(monday.toISOString()).toBe('2026-08-03T09:00:00.000Z');
+			// ...then Tuesday, then Wednesday.
+			const tuesday = nextOf(schedule, monday);
+			expect(tuesday.toISOString()).toBe('2026-08-04T09:00:00.000Z');
+			expect(nextOf(schedule, tuesday).toISOString()).toBe('2026-08-05T09:00:00.000Z');
+		});
+
+		it('treats a 5-field expression as its 6-field seconds-zero equivalent', () => {
+			const after = new Date('2026-01-10T12:00:00Z');
+			const fiveField: CronSchedule = {
+				kind: 'cron',
+				cronExpression: '30 9 * * 1-5' as unknown as CronExpression,
+				timezone: 'UTC',
+			};
+			const sixField: CronSchedule = {
+				kind: 'cron',
+				// Day ranges are valid cron but outside the branded template type.
+				cronExpression: '0 30 9 * * 1-5' as unknown as CronExpression,
+				timezone: 'UTC',
+			};
+			expect(nextOf(fiveField, after)).toEqual(nextOf(sixField, after));
 		});
 
 		it('throws when the timezone is unresolved (null)', () => {

--- a/packages/@n8n/scheduler/src/core/recurrence/__tests__/validate.test.ts
+++ b/packages/@n8n/scheduler/src/core/recurrence/__tests__/validate.test.ts
@@ -21,11 +21,21 @@ describe('validateSchedule', () => {
 			).not.toThrow();
 		});
 
-		it('rejects a 5-field expression (seconds field required)', () => {
+		it('accepts a 5-field expression (seconds default to 0)', () => {
 			expect(() =>
 				validateSchedule({
 					kind: 'cron',
-					cronExpression: '0 12 * * *' as unknown as CronExpression,
+					cronExpression: '0 12 * * 1-5' as unknown as CronExpression,
+					timezone: 'UTC',
+				}),
+			).not.toThrow();
+		});
+
+		it('rejects a 4-field expression (too few fields)', () => {
+			expect(() =>
+				validateSchedule({
+					kind: 'cron',
+					cronExpression: '12 * * *' as unknown as CronExpression,
 					timezone: 'UTC',
 				}),
 			).toThrow(InvalidScheduleError);
@@ -103,7 +113,7 @@ describe('validateSchedule', () => {
 			expect(() =>
 				validateSchedule({
 					...valid,
-					cronExpression: '0 9 * * 1' as unknown as CronExpression,
+					cronExpression: '9 * * 1' as unknown as CronExpression,
 				}),
 			).toThrow(InvalidScheduleError);
 			expect(() => validateSchedule({ ...valid, timezone: 'Mars/Phobos' })).toThrow(/timezone/);

--- a/packages/@n8n/scheduler/src/core/recurrence/kinds/cron.ts
+++ b/packages/@n8n/scheduler/src/core/recurrence/kinds/cron.ts
@@ -6,13 +6,18 @@ import { InvalidScheduleError } from '../../errors';
 import type { CronSchedule, RecurringCronSchedule, ScheduledJob } from '../../types';
 import { required } from '../field';
 
-/** A cron expression must have 6 fields (the first is seconds). */
-const CRON_FIELD_COUNT = 6;
+/**
+ * A cron expression may have:
+ * - 5 fields (standard cron, seconds = 0)
+ * - 6 fields (the first is seconds)
+ */
+const MIN_CRON_FIELD_COUNT = 5;
+const MAX_CRON_FIELD_COUNT = 6;
 
 export type CronCursor = ReturnType<typeof CronExpressionParser.parse>;
 
 /**
- * Checks that a cron schedule is usable: a 6-field expression in a real
+ * Checks that a cron schedule is usable: a 5- or 6-field expression in a real
  * timezone. Also used for `recurring_cron`, which reuses the cron expression.
  * @param schedule The cron (or recurring_cron) schedule to check.
  * @throws {InvalidScheduleError} When the expression or timezone is invalid.
@@ -27,9 +32,9 @@ export function validateCron(schedule: CronSchedule | RecurringCronSchedule): vo
 	}
 
 	const fieldCount = expression.trim().split(/\s+/).length;
-	if (fieldCount !== CRON_FIELD_COUNT) {
+	if (fieldCount < MIN_CRON_FIELD_COUNT || fieldCount > MAX_CRON_FIELD_COUNT) {
 		throw new InvalidScheduleError(
-			`Cron expression must have ${CRON_FIELD_COUNT} fields (seconds included), got ${fieldCount}: ${JSON.stringify(expression)}`,
+			`Cron expression must have ${MIN_CRON_FIELD_COUNT} or ${MAX_CRON_FIELD_COUNT} fields (seconds optional), got ${fieldCount}: ${JSON.stringify(expression)}`,
 		);
 	}
 

--- a/packages/@n8n/scheduler/src/core/types/schedule.ts
+++ b/packages/@n8n/scheduler/src/core/types/schedule.ts
@@ -12,7 +12,8 @@ import type { CronExpression } from 'n8n-workflow';
  */
 
 /**
- * A 6-field cron expression (seconds included) evaluated in an IANA timezone.
+ * A 5- or 6-field cron expression (seconds optional) evaluated in an IANA timezone.
+ * A 5-field expression is treated as seconds = 0.
  * Wall-clock: fires at the given local time, so DST shifts the absolute instant.
  * `timezone === null` means the instance default, resolved by the caller before
  * the math runs.

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-job-registrar.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-job-registrar.ts
@@ -157,8 +157,9 @@ function stableInt(seed: string, label: string, min: number, max: number): numbe
 /**
  * Build a 6-field cron for a poll time. Generated cadences get a node-seeded
  * (not random) seconds field so the job identity is stable; a custom cron is
- * used as-is, widened from 5 to 6 fields when it omits seconds (the legacy cron
- * lib accepted 5-field, but the durable scheduler's validator requires 6).
+ * used as-is, widened from 5 to 6 fields when it omits seconds. The scheduler
+ * accepts 5-field crons directly, but normalizing to 6 keeps every stored
+ * expression one shape, so the job's fingerprint identity stays stable.
  */
 function seededCron(item: TriggerTime, seed: string): CronExpression {
 	if (item.mode === 'custom') {

--- a/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-job-registrar.test.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-job-registrar.test.ts
@@ -156,6 +156,27 @@ describe('ScheduleTriggerJobRegistrar', () => {
 			);
 		});
 
+		it('provisions a 5-field custom cron (no seconds) and plans its first fire', async () => {
+			const session = makeRegistrar().createSession();
+			const collector = session.createCollector(workflow, scheduleNode);
+			collector.registerCron(
+				{ expression: '0 9 * * 1-5' as CronExpression, recurrence: { activated: false } },
+				vi.fn(),
+			);
+
+			await session.commit(WORKFLOW_ID, NODE_ID);
+
+			const desired = jobProvisioner.provision.mock.calls.at(-1)![4];
+			expect(desired).toHaveLength(1);
+			expect(desired[0].schedule).toEqual({
+				kind: 'cron',
+				cronExpression: '0 9 * * 1-5',
+				timezone: null,
+			});
+			// NOW is Monday 00:00 UTC; a weekday 09:00 cron fires the same day.
+			expect(desired[0].firstRunAt).toEqual(NEXT_NINE);
+		});
+
 		it('a rule keeps its name when rules are inserted before it or reordered', async () => {
 			// A positional name would shift here and needlessly redefine the job,
 			// restarting its clock; the definition-derived name must not move.

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -420,7 +420,7 @@ export class ScheduleTrigger implements INodeType {
 										field: ['cronExpression'],
 									},
 								},
-								hint: 'Format: [Second] [Minute] [Hour] [Day of Month] [Month] [Day of Week]',
+								hint: 'Format: ([Second]) [Minute] [Hour] [Day of Month] [Month] [Day of Week]',
 							},
 						],
 					},


### PR DESCRIPTION
## Summary

A standard 5-field cron expression failed the durable scheduler's validation. (but it supports it)

`validateCron` now accepts 5- or 6-field expressions, treating a 5-field one as its seconds-zero equivalent. 

The Schedule Trigger node hint is updated to mark the seconds field as optional.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3853

Ref CAT-3853

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35006">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


