### PR TITLE
fix: Test Google Service Account credentials with their configured scopes

### DIFF
--- a/packages/nodes-base/credentials/GoogleApi.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleApi.credentials.ts
@@ -7,6 +7,7 @@ import type {
 	INodeProperties,
 	Icon,
 } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 
 import { formatGoogleScopesForJwt, parseGoogleScopes } from './common/google-scopes';
 import { getTokenRequestClient, TOKEN_REQUEST_TIMEOUT } from './common/token-request';
@@ -316,6 +317,7 @@ export class GoogleApi implements ICredentialType {
 			default: '',
 			description:
 				'You can find the scopes for services <a href="https://developers.google.com/identity/protocols/oauth2/scopes" target="_blank">here</a>',
+			required: true,
 			displayOptions: {
 				show: {
 					httpNode: [true],
@@ -333,9 +335,16 @@ export class GoogleApi implements ICredentialType {
 		const privateKey = (credentials.privateKey as string).replace(/\\n/g, '\n').trim();
 		credentials.email = (credentials.email as string).trim();
 
-		const scopes = formatGoogleScopesForJwt(
-			parseGoogleScopes(typeof credentials.scopes === 'string' ? credentials.scopes : ''),
+		const parsedScopes = parseGoogleScopes(
+			typeof credentials.scopes === 'string' ? credentials.scopes : '',
 		);
+		if (parsedScopes.length === 0) {
+			throw new UserError(
+				'Add at least one scope in the "Scope(s)" field to use this credential with the HTTP Request node.',
+			);
+		}
+
+		const scopes = formatGoogleScopesForJwt(parsedScopes);
 
 		const now = moment().unix();
 

--- a/packages/nodes-base/credentials/GoogleApi.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleApi.credentials.ts
@@ -8,6 +8,7 @@ import type {
 	Icon,
 } from 'n8n-workflow';
 
+import { formatGoogleScopesForJwt, parseGoogleScopes } from './common/google-scopes';
 import { getTokenRequestClient, TOKEN_REQUEST_TIMEOUT } from './common/token-request';
 
 const regions = [
@@ -330,14 +331,11 @@ export class GoogleApi implements ICredentialType {
 		if (!credentials.httpNode) return requestOptions;
 
 		const privateKey = (credentials.privateKey as string).replace(/\\n/g, '\n').trim();
-		const credentialsScopes = (credentials.scopes as string).replace(/\\n/g, '\n').trim();
 		credentials.email = (credentials.email as string).trim();
 
-		const regex = /[,\s\n]+/;
-		const scopes = credentialsScopes
-			.split(regex)
-			.filter((scope) => scope)
-			.join(' ');
+		const scopes = formatGoogleScopesForJwt(
+			parseGoogleScopes(typeof credentials.scopes === 'string' ? credentials.scopes : ''),
+		);
 
 		const now = moment().unix();
 

--- a/packages/nodes-base/credentials/common/google-scopes.test.ts
+++ b/packages/nodes-base/credentials/common/google-scopes.test.ts
@@ -1,0 +1,43 @@
+import { formatGoogleScopesForJwt, parseGoogleScopes } from './google-scopes';
+
+describe('parseGoogleScopes', () => {
+	it('should split scopes on commas, whitespace, and newlines', () => {
+		expect(
+			parseGoogleScopes(
+				'https://www.googleapis.com/auth/calendar.readonly,\nhttps://www.googleapis.com/auth/gmail.readonly ',
+			),
+		).toEqual([
+			'https://www.googleapis.com/auth/calendar.readonly',
+			'https://www.googleapis.com/auth/gmail.readonly',
+		]);
+	});
+
+	it('should unescape literal \\n sequences before splitting', () => {
+		expect(
+			parseGoogleScopes(
+				'https://www.googleapis.com/auth/calendar.readonly\\nhttps://www.googleapis.com/auth/gmail.readonly',
+			),
+		).toEqual([
+			'https://www.googleapis.com/auth/calendar.readonly',
+			'https://www.googleapis.com/auth/gmail.readonly',
+		]);
+	});
+
+	it('should return an empty array for blank input', () => {
+		expect(parseGoogleScopes('')).toEqual([]);
+		expect(parseGoogleScopes('   ')).toEqual([]);
+	});
+});
+
+describe('formatGoogleScopesForJwt', () => {
+	it('should join scopes with spaces for JWT claims', () => {
+		expect(
+			formatGoogleScopesForJwt([
+				'https://www.googleapis.com/auth/calendar.readonly',
+				'https://www.googleapis.com/auth/gmail.readonly',
+			]),
+		).toBe(
+			'https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/gmail.readonly',
+		);
+	});
+});

--- a/packages/nodes-base/credentials/common/google-scopes.ts
+++ b/packages/nodes-base/credentials/common/google-scopes.ts
@@ -1,0 +1,9 @@
+const SCOPE_SEPARATOR = /[,\s\n]+/;
+
+export function parseGoogleScopes(rawScopes: string): string[] {
+	return rawScopes.replace(/\\n/g, '\n').trim().split(SCOPE_SEPARATOR).filter(Boolean);
+}
+
+export function formatGoogleScopesForJwt(scopes: string[]): string {
+	return scopes.join(' ');
+}

--- a/packages/nodes-base/credentials/test/GoogleApi.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/GoogleApi.credentials.test.ts
@@ -111,5 +111,15 @@ describe('GoogleApi Credential', () => {
 			expect(signOptions.header).toEqual({ typ: 'JWT', alg: 'RS256' });
 			expect(signOptions.header).not.toHaveProperty('kid');
 		});
+
+		it('throws a UserError when httpNode is enabled but no scopes are configured', async () => {
+			await expect(
+				credential.authenticate({ ...baseCredentials, scopes: '' }, requestOptions),
+			).rejects.toThrow(
+				'Add at least one scope in the "Scope(s)" field to use this credential with the HTTP Request node.',
+			);
+
+			expect(requestMock).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Google/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GenericFunctions.ts
@@ -81,10 +81,12 @@ export async function getGoogleAccessToken(
 		| IPollFunctions,
 	credentials: IDataObject,
 	service: GoogleServiceAccount,
+	/** Overrides the scopes looked up for `service`, e.g. to test user-configured HTTP Request node scopes. */
+	scopeOverride?: string[],
 ): Promise<IDataObject> {
 	//https://developers.google.com/identity/protocols/oauth2/service-account#httprest
 
-	const scopes = googleServiceAccountScopes[service];
+	const scopes = scopeOverride ?? googleServiceAccountScopes[service];
 
 	const privateKey = formatPemBlock(credentials.privateKey as string);
 	credentials.email = ((credentials.email as string) || '').trim();

--- a/packages/nodes-base/nodes/Google/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GenericFunctions.ts
@@ -80,13 +80,13 @@ export async function getGoogleAccessToken(
 		| ICredentialTestFunctions
 		| IPollFunctions,
 	credentials: IDataObject,
-	service: GoogleServiceAccount,
-	/** Overrides the scopes looked up for `service`, e.g. to test user-configured HTTP Request node scopes. */
+	/** Omit when passing `scopeOverride` instead, e.g. to test user-configured HTTP Request node scopes. */
+	service: GoogleServiceAccount | undefined,
 	scopeOverride?: string[],
 ): Promise<IDataObject> {
 	//https://developers.google.com/identity/protocols/oauth2/service-account#httprest
 
-	const scopes = scopeOverride ?? googleServiceAccountScopes[service];
+	const scopes = scopeOverride ?? (service ? googleServiceAccountScopes[service] : []);
 
 	const privateKey = formatPemBlock(credentials.privateKey as string);
 	credentials.email = ((credentials.email as string) || '').trim();

--- a/packages/nodes-base/nodes/Google/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GenericFunctions.ts
@@ -88,6 +88,10 @@ export async function getGoogleAccessToken(
 
 	const scopes = scopeOverride ?? (service ? googleServiceAccountScopes[service] : []);
 
+	if (scopes.length === 0) {
+		throw new Error('At least one scope is required to generate a Google access token.');
+	}
+
 	const privateKey = formatPemBlock(credentials.privateKey as string);
 	credentials.email = ((credentials.email as string) || '').trim();
 

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
@@ -4,7 +4,8 @@ import type { ICredentialsDecrypted, ICredentialTestFunctions } from 'n8n-workfl
 import { getGoogleAccessToken } from '../../../../GenericFunctions';
 import { googleApiCredentialTest } from '../../../v2/methods/credentialTest';
 
-vi.mock('../../../../GenericFunctions', () => ({
+vi.mock('../../../../GenericFunctions', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../../../../GenericFunctions')>()),
 	getGoogleAccessToken: vi.fn(),
 }));
 
@@ -37,23 +38,97 @@ describe('googleApiCredentialTest', () => {
 		});
 	});
 
-	it('should return Error when token generation throws', async () => {
+	it('should return Error including the attempted scopes when token generation throws', async () => {
 		vi.mocked(getGoogleAccessToken).mockRejectedValue(new Error('invalid key'));
 
 		const result = await googleApiCredentialTest.call(testFunctions, credential);
 
 		expect(result).toEqual({
 			status: 'Error',
-			message: expect.stringContaining('Private key validation failed'),
+			message:
+				'Private key validation failed: invalid key (requested scopes: https://www.googleapis.com/auth/drive.file, https://www.googleapis.com/auth/spreadsheets, https://www.googleapis.com/auth/drive.metadata)',
 		});
 	});
 
-	it('should request the narrower sheetV2 service scope, not sheetV2Trigger', async () => {
+	it('should request the narrower sheetV2 service scope, not sheetV2Trigger, when not an HTTP Request node credential', async () => {
 		vi.mocked(getGoogleAccessToken).mockResolvedValue({ access_token: 'a-token' });
 
 		await googleApiCredentialTest.call(testFunctions, credential);
 
-		expect(getGoogleAccessToken).toHaveBeenCalledWith(credential.data, 'sheetV2');
-		expect(getGoogleAccessToken).not.toHaveBeenCalledWith(expect.anything(), 'sheetV2Trigger');
+		expect(getGoogleAccessToken).toHaveBeenCalledWith(credential.data, 'sheetV2', undefined);
+		expect(getGoogleAccessToken).not.toHaveBeenCalledWith(
+			expect.anything(),
+			'sheetV2Trigger',
+			expect.anything(),
+		);
+	});
+
+	describe('when set up for use in the HTTP Request node', () => {
+		const httpNodeCredential = {
+			data: {
+				email: 'test@test.com',
+				privateKey: 'private-key',
+				httpNode: true,
+				scopes: 'https://www.googleapis.com/auth/calendar.readonly',
+			},
+		} as unknown as ICredentialsDecrypted;
+
+		it("should request the user's configured scopes instead of the sheetV2 default", async () => {
+			vi.mocked(getGoogleAccessToken).mockResolvedValue({ access_token: 'a-token' });
+
+			await googleApiCredentialTest.call(testFunctions, httpNodeCredential);
+
+			expect(getGoogleAccessToken).toHaveBeenCalledWith(httpNodeCredential.data, 'sheetV2', [
+				'https://www.googleapis.com/auth/calendar.readonly',
+			]);
+		});
+
+		it('should split multiple scopes on commas, whitespace, and newlines', async () => {
+			vi.mocked(getGoogleAccessToken).mockResolvedValue({ access_token: 'a-token' });
+			const credentialWithMultipleScopes = {
+				data: {
+					...httpNodeCredential.data,
+					scopes:
+						'https://www.googleapis.com/auth/calendar.readonly,\nhttps://www.googleapis.com/auth/gmail.readonly ',
+				},
+			} as unknown as ICredentialsDecrypted;
+
+			await googleApiCredentialTest.call(testFunctions, credentialWithMultipleScopes);
+
+			expect(getGoogleAccessToken).toHaveBeenCalledWith(
+				credentialWithMultipleScopes.data,
+				'sheetV2',
+				[
+					'https://www.googleapis.com/auth/calendar.readonly',
+					'https://www.googleapis.com/auth/gmail.readonly',
+				],
+			);
+		});
+
+		it('should return an Error without calling getGoogleAccessToken when no scopes are configured', async () => {
+			const credentialWithNoScopes = {
+				data: { ...httpNodeCredential.data, scopes: '' },
+			} as unknown as ICredentialsDecrypted;
+
+			const result = await googleApiCredentialTest.call(testFunctions, credentialWithNoScopes);
+
+			expect(result).toEqual({
+				status: 'Error',
+				message: 'Add at least one scope in the "Scope(s)" field to test this credential.',
+			});
+			expect(getGoogleAccessToken).not.toHaveBeenCalled();
+		});
+
+		it('should return Error including the configured scopes when token generation throws', async () => {
+			vi.mocked(getGoogleAccessToken).mockRejectedValue(new Error('unauthorized_client'));
+
+			const result = await googleApiCredentialTest.call(testFunctions, httpNodeCredential);
+
+			expect(result).toEqual({
+				status: 'Error',
+				message:
+					'Private key validation failed: unauthorized_client (requested scopes: https://www.googleapis.com/auth/calendar.readonly)',
+			});
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
@@ -78,9 +78,14 @@ describe('googleApiCredentialTest', () => {
 
 			await googleApiCredentialTest.call(testFunctions, httpNodeCredential);
 
-			expect(getGoogleAccessToken).toHaveBeenCalledWith(httpNodeCredential.data, 'sheetV2', [
+			expect(getGoogleAccessToken).toHaveBeenCalledWith(httpNodeCredential.data, undefined, [
 				'https://www.googleapis.com/auth/calendar.readonly',
 			]);
+			expect(getGoogleAccessToken).not.toHaveBeenCalledWith(
+				expect.anything(),
+				'sheetV2',
+				expect.anything(),
+			);
 		});
 
 		it('should split multiple scopes on commas, whitespace, and newlines', async () => {
@@ -97,7 +102,7 @@ describe('googleApiCredentialTest', () => {
 
 			expect(getGoogleAccessToken).toHaveBeenCalledWith(
 				credentialWithMultipleScopes.data,
-				'sheetV2',
+				undefined,
 				[
 					'https://www.googleapis.com/auth/calendar.readonly',
 					'https://www.googleapis.com/auth/gmail.readonly',

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
@@ -110,18 +110,20 @@ describe('googleApiCredentialTest', () => {
 			);
 		});
 
-		it('should return an Error without calling getGoogleAccessToken when httpNode is enabled but no scopes are configured', async () => {
+		it('should fall back to the sheetV2 default when httpNode is enabled but no scopes are configured', async () => {
+			vi.mocked(getGoogleAccessToken).mockResolvedValue({ access_token: 'a-token' });
 			const credentialWithNoScopes = {
 				data: { ...httpNodeCredential.data, scopes: '' },
 			} as unknown as ICredentialsDecrypted;
 
 			const result = await googleApiCredentialTest.call(testFunctions, credentialWithNoScopes);
 
-			expect(result).toEqual({
-				status: 'Error',
-				message: 'Add at least one scope in the "Scope(s)" field to test this credential.',
-			});
-			expect(getGoogleAccessToken).not.toHaveBeenCalled();
+			expect(result).toEqual({ status: 'OK', message: 'Connection successful!' });
+			expect(getGoogleAccessToken).toHaveBeenCalledWith(
+				credentialWithNoScopes.data,
+				'sheetV2',
+				undefined,
+			);
 		});
 
 		it('should return Error including the configured scopes when token generation throws', async () => {

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
@@ -88,13 +88,13 @@ describe('googleApiCredentialTest', () => {
 			);
 		});
 
-		it('should split multiple scopes on commas, whitespace, and newlines', async () => {
+		it('should split multiple scopes on commas, whitespace, newlines, and escaped newlines', async () => {
 			vi.mocked(getGoogleAccessToken).mockResolvedValue({ access_token: 'a-token' });
 			const credentialWithMultipleScopes = {
 				data: {
 					...httpNodeCredential.data,
 					scopes:
-						'https://www.googleapis.com/auth/calendar.readonly,\nhttps://www.googleapis.com/auth/gmail.readonly ',
+						'https://www.googleapis.com/auth/calendar.readonly\\nhttps://www.googleapis.com/auth/gmail.readonly',
 				},
 			} as unknown as ICredentialsDecrypted;
 
@@ -110,18 +110,20 @@ describe('googleApiCredentialTest', () => {
 			);
 		});
 
-		it('should return an Error without calling getGoogleAccessToken when no scopes are configured', async () => {
+		it('should fall back to the sheetV2 default when httpNode is enabled but no scopes are configured', async () => {
+			vi.mocked(getGoogleAccessToken).mockResolvedValue({ access_token: 'a-token' });
 			const credentialWithNoScopes = {
 				data: { ...httpNodeCredential.data, scopes: '' },
 			} as unknown as ICredentialsDecrypted;
 
 			const result = await googleApiCredentialTest.call(testFunctions, credentialWithNoScopes);
 
-			expect(result).toEqual({
-				status: 'Error',
-				message: 'Add at least one scope in the "Scope(s)" field to test this credential.',
-			});
-			expect(getGoogleAccessToken).not.toHaveBeenCalled();
+			expect(result).toEqual({ status: 'OK', message: 'Connection successful!' });
+			expect(getGoogleAccessToken).toHaveBeenCalledWith(
+				credentialWithNoScopes.data,
+				'sheetV2',
+				undefined,
+			);
 		});
 
 		it('should return Error including the configured scopes when token generation throws', async () => {

--- a/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/v2/methods/credentialTest.test.ts
@@ -110,20 +110,18 @@ describe('googleApiCredentialTest', () => {
 			);
 		});
 
-		it('should fall back to the sheetV2 default when httpNode is enabled but no scopes are configured', async () => {
-			vi.mocked(getGoogleAccessToken).mockResolvedValue({ access_token: 'a-token' });
+		it('should return an Error without calling getGoogleAccessToken when httpNode is enabled but no scopes are configured', async () => {
 			const credentialWithNoScopes = {
 				data: { ...httpNodeCredential.data, scopes: '' },
 			} as unknown as ICredentialsDecrypted;
 
 			const result = await googleApiCredentialTest.call(testFunctions, credentialWithNoScopes);
 
-			expect(result).toEqual({ status: 'OK', message: 'Connection successful!' });
-			expect(getGoogleAccessToken).toHaveBeenCalledWith(
-				credentialWithNoScopes.data,
-				'sheetV2',
-				undefined,
-			);
+			expect(result).toEqual({
+				status: 'Error',
+				message: 'Add at least one scope in the "Scope(s)" field to test this credential.',
+			});
+			expect(getGoogleAccessToken).not.toHaveBeenCalled();
 		});
 
 		it('should return Error including the configured scopes when token generation throws', async () => {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
@@ -4,14 +4,37 @@ import type {
 	INodeCredentialTestResult,
 } from 'n8n-workflow';
 
-import { getGoogleAccessToken } from '../../../GenericFunctions';
+import { getGoogleAccessToken, googleServiceAccountScopes } from '../../../GenericFunctions';
+
+// Matches the scope-string parsing in GoogleApi.credentials.ts's `authenticate`.
+const SCOPE_SEPARATOR = /[,\s]+/;
 
 export async function googleApiCredentialTest(
 	this: ICredentialTestFunctions,
 	credential: ICredentialsDecrypted,
 ): Promise<INodeCredentialTestResult> {
+	const data = credential.data ?? {};
+
+	// This credential is shared across many Google nodes, but only the HTTP Request
+	// node lets users pick arbitrary scopes. For that case the test must request the
+	// scopes the user actually configured instead of the Sheets-specific default
+	// below - otherwise domain-wide delegation impersonation fails the test for
+	// every non-Sheets scope, even though the credential works fine at request time.
+	const isHttpNodeCredential = data.httpNode === true;
+	const rawScopes = typeof data.scopes === 'string' ? data.scopes : '';
+	const scopeOverride = isHttpNodeCredential
+		? rawScopes.split(SCOPE_SEPARATOR).filter(Boolean)
+		: undefined;
+
+	if (scopeOverride?.length === 0) {
+		return {
+			status: 'Error',
+			message: 'Add at least one scope in the "Scope(s)" field to test this credential.',
+		};
+	}
+
 	try {
-		const tokenRequest = await getGoogleAccessToken.call(this, credential.data!, 'sheetV2');
+		const tokenRequest = await getGoogleAccessToken.call(this, data, 'sheetV2', scopeOverride);
 		if (!tokenRequest.access_token) {
 			return {
 				status: 'Error',
@@ -19,9 +42,10 @@ export async function googleApiCredentialTest(
 			};
 		}
 	} catch (err) {
+		const attemptedScopes = (scopeOverride ?? googleServiceAccountScopes.sheetV2).join(', ');
 		return {
 			status: 'Error',
-			message: `Private key validation failed: ${err.message}`,
+			message: `Private key validation failed: ${err.message} (requested scopes: ${attemptedScopes})`,
 		};
 	}
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
@@ -33,8 +33,13 @@ export async function googleApiCredentialTest(
 		};
 	}
 
+	// When testing user-configured scopes, don't also pass the sheetV2 default:
+	// getGoogleAccessToken would ignore it, but keeping it out makes it obvious
+	// at the call site that the Sheets-specific scopes play no part here.
+	const service = scopeOverride ? undefined : 'sheetV2';
+
 	try {
-		const tokenRequest = await getGoogleAccessToken.call(this, data, 'sheetV2', scopeOverride);
+		const tokenRequest = await getGoogleAccessToken.call(this, data, service, scopeOverride);
 		if (!tokenRequest.access_token) {
 			return {
 				status: 'Error',

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
@@ -21,6 +21,14 @@ export async function googleApiCredentialTest(
 	const isHttpNodeCredential = data.httpNode === true;
 	const rawScopes = typeof data.scopes === 'string' ? data.scopes : '';
 	const parsedScopes = isHttpNodeCredential ? parseGoogleScopes(rawScopes) : [];
+
+	if (isHttpNodeCredential && parsedScopes.length === 0) {
+		return {
+			status: 'Error',
+			message: 'Add at least one scope in the "Scope(s)" field to test this credential.',
+		};
+	}
+
 	const scopeOverride = parsedScopes.length > 0 ? parsedScopes : undefined;
 
 	// When testing user-configured scopes, don't also pass the sheetV2 default:

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
@@ -21,14 +21,6 @@ export async function googleApiCredentialTest(
 	const isHttpNodeCredential = data.httpNode === true;
 	const rawScopes = typeof data.scopes === 'string' ? data.scopes : '';
 	const parsedScopes = isHttpNodeCredential ? parseGoogleScopes(rawScopes) : [];
-
-	if (isHttpNodeCredential && parsedScopes.length === 0) {
-		return {
-			status: 'Error',
-			message: 'Add at least one scope in the "Scope(s)" field to test this credential.',
-		};
-	}
-
 	const scopeOverride = parsedScopes.length > 0 ? parsedScopes : undefined;
 
 	// When testing user-configured scopes, don't also pass the sheetV2 default:

--- a/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/methods/credentialTest.ts
@@ -4,10 +4,8 @@ import type {
 	INodeCredentialTestResult,
 } from 'n8n-workflow';
 
+import { parseGoogleScopes } from '../../../../../credentials/common/google-scopes';
 import { getGoogleAccessToken, googleServiceAccountScopes } from '../../../GenericFunctions';
-
-// Matches the scope-string parsing in GoogleApi.credentials.ts's `authenticate`.
-const SCOPE_SEPARATOR = /[,\s]+/;
 
 export async function googleApiCredentialTest(
 	this: ICredentialTestFunctions,
@@ -22,16 +20,8 @@ export async function googleApiCredentialTest(
 	// every non-Sheets scope, even though the credential works fine at request time.
 	const isHttpNodeCredential = data.httpNode === true;
 	const rawScopes = typeof data.scopes === 'string' ? data.scopes : '';
-	const scopeOverride = isHttpNodeCredential
-		? rawScopes.split(SCOPE_SEPARATOR).filter(Boolean)
-		: undefined;
-
-	if (scopeOverride?.length === 0) {
-		return {
-			status: 'Error',
-			message: 'Add at least one scope in the "Scope(s)" field to test this credential.',
-		};
-	}
+	const parsedScopes = isHttpNodeCredential ? parseGoogleScopes(rawScopes) : [];
+	const scopeOverride = parsedScopes.length > 0 ? parsedScopes : undefined;
 
 	// When testing user-configured scopes, don't also pass the sheetV2 default:
 	// getGoogleAccessToken would ignore it, but keeping it out makes it obvious

--- a/packages/nodes-base/nodes/Google/test/GenericFunctions.accessToken.test.ts
+++ b/packages/nodes-base/nodes/Google/test/GenericFunctions.accessToken.test.ts
@@ -32,4 +32,16 @@ describe('getGoogleAccessToken', () => {
 		expect(signOptions.header).toEqual({ typ: 'JWT', alg: 'RS256' });
 		expect(signOptions.header).not.toHaveProperty('kid');
 	});
+
+	it('throws when neither service nor scopeOverride is provided', async () => {
+		const ctx = mock<IExecuteFunctions>();
+		const credentials: IDataObject = {
+			email: 'svc@project.iam.gserviceaccount.com',
+			privateKey: '-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----',
+		};
+
+		await expect(getGoogleAccessToken.call(ctx, credentials, undefined)).rejects.toThrow(
+			'At least one scope is required to generate a Google access token.',
+		);
+	});
 });


### PR DESCRIPTION
## Summary

The `Google Service Account API` (`googleApi`) credential's **Test** button always requested the hardcoded Google Sheets scope set (`sheetV2`), ignoring the credential's own `Scope(s)` field.

This was invisible with "Impersonate a User" off, since a two-legged JWT flow has no domain-wide-delegation (DWD) check. With impersonation **on**, Google enforces DWD against whatever scopes are requested - so the test always checked Sheets/Drive scopes regardless of what the credential is actually used for. Anyone using this shared credential for a non-Sheets service via the HTTP Request node (Calendar, BigQuery, Gmail, etc.) would see the test fail with `unauthorized_client`, even though the credential's runtime `authenticate()` already reads the user's configured scopes correctly and the credential works fine for real requests.

This PR:

* Makes the credential test request the user-configured `Scope(s)` field when the credential is set up for the HTTP Request node, instead of always defaulting to Sheets scopes.
* Rejects the test early with a clear message if no scopes are configured.
* Includes the attempted scopes in the failure message, since "Private key validation failed" was misleading (the key is usually fine - it's the scope/DWD grant that's mismatched).

## How to test

1. Create a GCP service account, download the JSON key, enable an API other than Sheets (e.g. Google Calendar).
2. In Google Workspace Admin console → Security → API controls → Domain-wide delegation, authorize the service account's client ID for only that API's scope (e.g. `https://www.googleapis.com/auth/calendar.readonly`).
3. In n8n, create a `Google Service Account API` credential:
   * Fill in Service Account Email + Private Key
   * Enable **Set up for use in HTTP Request node**
   * Set **Scope(s)** to the scope granted above
   * Enable **Impersonate a User** with a real Workspace user's email
4. Click **Test**.
   * Before this fix: fails with `Private key validation failed: ... unauthorized_client` (it requested Sheets scopes).
   * After this fix: passes (it requests the configured Calendar scope), and a failure (e.g. wrong DWD grant) now reports which scopes were attempted.

Unit tests cover the scope-selection/parsing/error-message logic without needing live GCP credentials: `cd packages/nodes-base && pnpm test credentialTest.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

[NODE-5563](https://linear.app/n8n/issue/NODE-5563)

closes [#34970](<https://github.com/n8n-io/n8n/issues/34970>)

---

![Open in Stage](https://camo.githubusercontent.com/e3b46e319aace348a9c2eabc45f307a073a3bf5a08d5220b2027eac6649007b5/68747470733a2f2f73746167657265766965772e6170702f6173736574732f67682d6f70656e2d696e2d73746167652d6c696768742e737667)

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)