### PR TITLE
refactor: Replace @ts-ignore with @ts-expect-error outside nodes-base

### DIFF
--- a/packages/@n8n/client-oauth2/src/code-flow.ts
+++ b/packages/@n8n/client-oauth2/src/code-flow.ts
@@ -81,8 +81,7 @@ export class CodeFlow {
 		const data =
 			typeof url.search === 'string' ? qs.parse(url.search.substring(1)) : url.search || {};
 
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
+		// @ts-expect-error parsed query is loosely typed
 		const error = getAuthError(data);
 		if (error) throw error;
 

--- a/packages/@n8n/db/src/migrations/common/1630330987096-UpdateWorkflowCredentials.ts
+++ b/packages/@n8n/db/src/migrations/common/1630330987096-UpdateWorkflowCredentials.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { IWorkflowBase } from 'n8n-workflow';
 
 import type { CredentialsEntity, WorkflowEntity } from '../../entities';
@@ -146,10 +145,10 @@ export class UpdateWorkflowCredentials1630330987096 implements ReversibleMigrati
 									(credentials) => credentials.id == creds.id && credentials.type === type,
 								);
 								if (matchingCredentials) {
-									// @ts-ignore
+									// @ts-expect-error migration writes legacy string format
 									node.credentials[type] = matchingCredentials.name;
 								} else {
-									// @ts-ignore
+									// @ts-expect-error migration writes legacy string format
 									node.credentials[type] = creds.name;
 								}
 								credentialsUpdated = true;
@@ -188,10 +187,10 @@ export class UpdateWorkflowCredentials1630330987096 implements ReversibleMigrati
 									(credentials) => credentials.id == creds.id && credentials.type === type,
 								);
 								if (matchingCredentials) {
-									// @ts-ignore
+									// @ts-expect-error migration writes legacy string format
 									node.credentials[type] = matchingCredentials.name;
 								} else {
-									// @ts-ignore
+									// @ts-expect-error migration writes legacy string format
 									node.credentials[type] = creds.name;
 								}
 								credentialsUpdated = true;
@@ -230,10 +229,10 @@ export class UpdateWorkflowCredentials1630330987096 implements ReversibleMigrati
 								(credentials) => credentials.id == creds.id && credentials.type === type,
 							);
 							if (matchingCredentials) {
-								// @ts-ignore
+								// @ts-expect-error migration writes legacy string format
 								node.credentials[type] = matchingCredentials.name;
 							} else {
-								// @ts-ignore
+								// @ts-expect-error migration writes legacy string format
 								node.credentials[type] = creds.name;
 							}
 							credentialsUpdated = true;

--- a/packages/@n8n/tournament/src/VariablePolyfill.ts
+++ b/packages/@n8n/tournament/src/VariablePolyfill.ts
@@ -14,8 +14,7 @@ function assertNever(_value: never): _value is never {
 }
 
 export const globalIdentifier = b.identifier(
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
+	// @ts-expect-error window not in lib target
 	typeof window !== 'object' ? 'global' : 'window',
 );
 

--- a/packages/@n8n/typeorm/test/github-issues/3857/issue-3857.ts
+++ b/packages/@n8n/typeorm/test/github-issues/3857/issue-3857.ts
@@ -29,11 +29,11 @@ describe('github issues > #3857 Schema inheritance when STI pattern is used', ()
 				const personMetadata = connection.getMetadata(Person);
 				const menMetadata = connection.getMetadata(Men);
 				const womenMetadata = connection.getMetadata(Women);
-				// @ts-ignore
+				// @ts-expect-error schema is set for these entities
 				personMetadata.schema.should.be.eq('custom');
-				// @ts-ignore
+				// @ts-expect-error schema is set for these entities
 				menMetadata.schema.should.be.eq(personMetadata.schema);
-				// @ts-ignore
+				// @ts-expect-error schema is set for these entities
 				womenMetadata.schema.should.be.eq(personMetadata.schema);
 			}),
 		));

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -38,7 +38,7 @@ if (!inE2ETests && !inTest) {
 	Object.entries(process.env).forEach(([envName, fileName]) => {
 		if (envName.endsWith('_FILE') && fileName) {
 			const configEnvName = envName.replace(/_FILE$/, '');
-			// @ts-ignore
+			// @ts-expect-error convict internal, not typed
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			const key = config._env[configEnvName]?.[0] as string;
 			if (key) {

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -141,12 +141,12 @@ export class CredentialsHelper extends ICredentialsHelper {
 								node,
 							);
 
-							// @ts-ignore
+							// @ts-expect-error dynamic key on request options
 							if (!requestOptions[outerKey]) {
-								// @ts-ignore
+								// @ts-expect-error dynamic key on request options
 								requestOptions[outerKey] = {};
 							}
-							// @ts-ignore
+							// @ts-expect-error dynamic key on request options
 							requestOptions[outerKey][keyResolved] = valueResolved;
 						});
 					});

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -166,8 +166,8 @@ export class CredentialsOverwrites {
 		const returnData = deepCopy(data);
 		// Overwrite only if there is currently no data set
 		for (const key of Object.keys(overwrites)) {
-			// @ts-ignore
-			if ([null, undefined, ''].includes(returnData[key])) {
+			const current = returnData[key];
+			if (current === null || current === undefined || current === '') {
 				returnData[key] = overwrites[key];
 			}
 		}

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -797,7 +797,7 @@ export class CredentialsService {
 		// every time anybody changes anything on the credentials even if it is just the name.
 		// Exception: when toggling to private (Static→Private), the shared token must be cleared.
 		if (decryptedData.oauthTokenData && !options?.clearOauthTokenData) {
-			// @ts-ignore
+			// @ts-expect-error data is typed as encrypted string
 			updateData.data.oauthTokenData = decryptedData.oauthTokenData;
 		}
 

--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -80,7 +80,7 @@ export class LoadNodesAndCredentials {
 			.filter(Boolean)
 			.join(delimiter);
 
-		// @ts-ignore
+		// @ts-expect-error Node internal _initPaths
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		module.constructor._initPaths();
 

--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.test.ts
@@ -150,7 +150,7 @@ describe('calculateTimeSaved', () => {
 			stoppedAt: DateTime.utc().plus({ minutes: 10 }).toJSDate(),
 		});
 
-		// @ts-ignore-next-line
+		// @ts-expect-error private method under test
 		const timeSaved = insightsCollectionService.calculateTimeSaved(ctx);
 		expect(timeSaved).toBe(10);
 	});
@@ -206,7 +206,7 @@ describe('calculateTimeSaved', () => {
 			},
 		});
 
-		// @ts-ignore-next-line
+		// @ts-expect-error private method under test
 		const timeSaved = insightsCollectionService.calculateTimeSaved(ctx);
 		expect(timeSaved).toBe(20);
 	});

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -273,7 +273,7 @@ export async function encryptCredential(credential: CredentialsEntity): Promise<
 	// Encrypt the data
 	const coreCredential = new Credentials({ id: null, name: credential.name }, credential.type);
 
-	// @ts-ignore
+	// @ts-expect-error entity data typed as string
 	await coreCredential.setData(credential.data);
 
 	return coreCredential.getDataToSave() as ICredentialsDb;

--- a/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-finder.service.test.ts
@@ -40,7 +40,7 @@ describe('CredentialsFinderService', () => {
 
 		// Setup manager mock for global credentials fetching
 
-		// @ts-ignore
+		// @ts-expect-error override readonly manager for test
 		credentialsRepository.manager = {
 			find: vi.fn().mockResolvedValue([]),
 		} as any;

--- a/packages/cli/test/integration/shared/db/credentials.ts
+++ b/packages/cli/test/integration/shared/db/credentials.ts
@@ -15,7 +15,7 @@ export async function encryptCredentialData(
 	const { createCredentialsFromCredentialsEntity } = await import('@/credentials-helper.js');
 	const coreCredential = createCredentialsFromCredentialsEntity(credential, true);
 
-	// @ts-ignore
+	// @ts-expect-error entity data typed as string
 	await coreCredential.setData(credential.data);
 
 	return Object.assign(credential, coreCredential.getDataToSave());

--- a/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useImportCurlCommand.ts
@@ -400,12 +400,12 @@ export const toHttpNodeParameters = (curlCommand: string): HttpNodeParameters =>
 	}
 
 	if (!Object.keys(httpNodeParameters.options?.redirect.redirect).length) {
-		// @ts-ignore
+		// @ts-expect-error key is not optional in type
 		delete httpNodeParameters.options.redirect;
 	}
 
 	if (!Object.keys(httpNodeParameters.options.response.response).length) {
-		// @ts-ignore
+		// @ts-expect-error key is not optional in type
 		delete httpNodeParameters.options.response;
 	}
 

--- a/packages/frontend/editor-ui/src/app/plugins/cache.test.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/cache.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { indexedDbCache } from './cache';
-// @ts-ignore
+// @ts-expect-error no types for subpath import
 import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
-// @ts-ignore
+// @ts-expect-error no types for subpath import
 import FDBKeyRange from 'fake-indexeddb/lib/FDBKeyRange';
 
 const globalTeardown = () => {

--- a/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
@@ -531,7 +531,7 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 					description: nodeTypeDescription,
 					// As we do not have the trigger/poll functions available in the frontend
 					// we use the information available to figure out what are trigger nodes
-					// @ts-ignore
+					// @ts-expect-error frontend flags triggers with a boolean
 					trigger:
 						(![ERROR_TRIGGER_NODE_TYPE].includes(nodeType) &&
 							nodeTypeDescription.inputs.length === 0 &&

--- a/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodes/nodeTransforms.ts
@@ -187,14 +187,14 @@ export function serializeNode(nodeTypeProvider: NodeTypeProvider, node: INodeUi)
 		'status',
 	];
 
-	// @ts-ignore
+	// @ts-expect-error populated field-by-field below
 	const nodeData: INodeUi = {
 		parameters: {},
 	};
 
 	for (const key in node) {
 		if (key.charAt(0) !== '_' && skipKeys.indexOf(key) === -1) {
-			// @ts-ignore
+			// @ts-expect-error dynamic key copy
 			nodeData[key] = node[key];
 		}
 	}

--- a/packages/frontend/editor-ui/src/features/core/auth/components/MfaSetupModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/components/MfaSetupModal.vue
@@ -10,7 +10,6 @@ import { ref, onMounted } from 'vue';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { mfaEventBus } from '../auth.eventBus';
 import { useToast } from '@/app/composables/useToast';
-//@ts-ignore
 import QrcodeVue from 'qrcode.vue';
 import { useClipboard } from '@n8n/composables/useClipboard';
 import { useI18n } from '@n8n/i18n';

--- a/packages/workflow/test/augment-object.test.ts
+++ b/packages/workflow/test/augment-object.test.ts
@@ -266,17 +266,17 @@ describe('AugmentObject', () => {
 			expect(originalObject.a.b.cc).toEqual('3');
 			expect(augmentedObject.a.b.cc).toEqual('93');
 
-			// @ts-ignore
+			// @ts-expect-error ccc is not on the source type
 			augmentedObject.a.b.ccc = {
 				d: '4',
 			};
 
-			// @ts-ignore
+			// @ts-expect-error ccc is not on the source type
 			expect(augmentedObject.a.b.ccc).toEqual({ d: '4' });
 
-			// @ts-ignore
+			// @ts-expect-error ccc is not on the source type
 			augmentedObject.a.b.ccc.d = '94';
-			// @ts-ignore
+			// @ts-expect-error ccc is not on the source type
 			expect(augmentedObject.a.b.ccc.d).toEqual('94');
 
 			expect(originalObject).toEqual(copyOriginal);


### PR DESCRIPTION
## Summary

Replaces every `@ts-ignore` outside `packages/nodes-base` with a reasoned `@ts-expect-error` or a trivial in-place fix. `@ts-ignore` silently suppresses *all* errors on the next line and never warns when the underlying issue is fixed; `@ts-expect-error` is self-invalidating (TS flags it unused once resolved) and — per our lint config — must carry a description.

- **2 removed via trivial fix** — explicit null/empty comparison in `credentials-overwrites.ts`; stale `qrcode.vue` import ignore deleted (it ships types now).
- **33 converted to `@ts-expect-error <short reason>`**.
- **3 now-redundant `eslint-disable @typescript-eslint/ban-ts-comment` lines removed**.

Behavior-neutral: both directives are erased at compile. `nodes-base` (~340 occurrences) is deliberately excluded from this pass. 35 sites across 19 files.

## How to test

Type-only change with no runtime impact. All affected packages (`cli`, `editor-ui`, `workflow`, `@n8n/db`, `@n8n/typeorm`, `@n8n/tournament`, `@n8n/client-oauth2`) `pnpm typecheck` cleanly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-665

Follow-up (properly type the 33 suppressed sites): https://linear.app/n8n/issue/DEVP-666

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. (DEVP-666)
- [ ] Tests included. <!-- behavior-neutral refactor; no new behavior to test -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35009">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

