### PR TITLE
refactor(editor): Rename redirection core to match the composable-name convention (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useBasePageRedirectionHelper.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useBasePageRedirectionHelper.test.ts
@@ -1,7 +1,7 @@
 import { ROLE } from '@n8n/api-types';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import merge from 'lodash/merge';
-import { usePageRedirectionHelper } from './usePageRedirectionHelper.core';
+import { useBasePageRedirectionHelper } from './useBasePageRedirectionHelper';
 import { defaultSettings } from '@/__tests__/defaults';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { createPinia, setActivePinia } from 'pinia';
@@ -22,7 +22,7 @@ vi.mock('@/app/composables/useWorkflowId', async () => {
 let settingsStore: ReturnType<typeof useSettingsStore>;
 let usersStore: ReturnType<typeof useUsersStore>;
 let versionStore: ReturnType<typeof useVersionsStore>;
-let pageRedirectionHelper: ReturnType<typeof usePageRedirectionHelper>;
+let pageRedirectionHelper: ReturnType<typeof useBasePageRedirectionHelper>;
 
 vi.mock('@/app/composables/useTelemetry', () => {
 	const track = vi.fn();
@@ -35,7 +35,7 @@ vi.mock('@/app/composables/useTelemetry', () => {
 	};
 });
 
-describe('usePageRedirectionHelper', () => {
+describe('useBasePageRedirectionHelper', () => {
 	afterEach(() => {
 		vi.clearAllMocks();
 	});
@@ -46,7 +46,7 @@ describe('usePageRedirectionHelper', () => {
 		usersStore = useUsersStore();
 		versionStore = useVersionsStore();
 
-		pageRedirectionHelper = usePageRedirectionHelper({ guard: async () => true });
+		pageRedirectionHelper = useBasePageRedirectionHelper({ guard: async () => true });
 
 		vi.spyOn(cloudPlanApi, 'getAdminPanelLoginCode').mockResolvedValue({
 			code: '123',
@@ -259,7 +259,7 @@ describe('usePageRedirectionHelper', () => {
 		test('aborts the redirect and skips telemetry when the guard resolves false', async () => {
 			const telemetry = useTelemetry();
 			const initialHref = location.href;
-			const helper = usePageRedirectionHelper({ guard: async () => false });
+			const helper = useBasePageRedirectionHelper({ guard: async () => false });
 
 			await helper.goToUpgrade('advanced-permissions', 'upgrade-api', 'redirect');
 
@@ -269,7 +269,7 @@ describe('usePageRedirectionHelper', () => {
 
 		test('proceeds with the redirect when the guard resolves true', async () => {
 			const telemetry = useTelemetry();
-			const helper = usePageRedirectionHelper({ guard: async () => true });
+			const helper = useBasePageRedirectionHelper({ guard: async () => true });
 
 			await helper.goToUpgrade('advanced-permissions', 'upgrade-api', 'redirect');
 

--- a/packages/frontend/editor-ui/src/app/composables/useBasePageRedirectionHelper.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useBasePageRedirectionHelper.ts
@@ -13,7 +13,12 @@ import { N8N_PRICING_PAGE_URL } from '@/app/constants';
  */
 export type UpgradeRedirectGuard = () => Promise<boolean>;
 
-export function usePageRedirectionHelper({ guard }: { guard: UpgradeRedirectGuard }) {
+/**
+ * Injectable page-redirection composable. The app-facing `usePageRedirectionHelper`
+ * wraps this and supplies the guard; this base carries no feature dependency and is
+ * the unit that moves to `@n8n/composables` in N8N-71.
+ */
+export function useBasePageRedirectionHelper({ guard }: { guard: UpgradeRedirectGuard }) {
 	const usersStore = useUsersStore();
 	const cloudPlanStore = useCloudPlanStore();
 	const versionsStore = useVersionsStore();

--- a/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.test.ts
@@ -1,9 +1,9 @@
 import { usePageRedirectionHelper } from './usePageRedirectionHelper';
-import { usePageRedirectionHelper as useBasePageRedirectionHelper } from './usePageRedirectionHelper.core';
+import { useBasePageRedirectionHelper } from './useBasePageRedirectionHelper';
 import { confirmIfBuilderStreaming } from '@/features/ai/assistant/composables/useBuilderStreamingGuard';
 
-vi.mock('./usePageRedirectionHelper.core', () => ({
-	usePageRedirectionHelper: vi.fn(() => ({
+vi.mock('./useBasePageRedirectionHelper', () => ({
+	useBasePageRedirectionHelper: vi.fn(() => ({
 		goToDashboard: vi.fn(),
 		goToVersions: vi.fn(),
 		goToUpgrade: vi.fn(),

--- a/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.ts
@@ -1,7 +1,7 @@
 import { confirmIfBuilderStreaming } from '@/features/ai/assistant/composables/useBuilderStreamingGuard';
-import { usePageRedirectionHelper as useBasePageRedirectionHelper } from './usePageRedirectionHelper.core';
+import { useBasePageRedirectionHelper } from './useBasePageRedirectionHelper';
 
-export type { UpgradeRedirectGuard } from './usePageRedirectionHelper.core';
+export type { UpgradeRedirectGuard } from './useBasePageRedirectionHelper';
 
 /**
  * App-facing `usePageRedirectionHelper`, pre-bound with the AI builder streaming


### PR DESCRIPTION
## Summary

Post-merge follow-up to #34890 (merged as `8d1187bbc7`), applying the Operator's file-naming convention: **file name = composable name**. #34890 introduced `usePageRedirectionHelper.core.ts`, whose `.core` suffix does not match its exported composable name.

This renames the base composable so both files follow the convention, with no behavior change:

- `usePageRedirectionHelper.core.ts` → `useBasePageRedirectionHelper.ts`, and its export `usePageRedirectionHelper` → `useBasePageRedirectionHelper`.
- The app-facing wrapper keeps the name `usePageRedirectionHelper` (the path all ~40 upgrade CTAs already import, unchanged) and binds the builder-streaming guard; its import of the base is de-aliased.
- Tests follow the rename.

The rename is self-contained: `useBasePageRedirectionHelper` is imported only by the wrapper and the two test files, and the old `.core` path is grep-clean across `editor-ui`. No call site changes.

## How to test

Behavior is unchanged; this is a rename only.

- `packages/frontend/editor-ui`: `pnpm test PageRedirectionHelper` → wrapper + base composable suites green (34/34 including `init.test` on the equivalent tree).
- `pnpm typecheck` / `pnpm lint` — green.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-68

Naming-convention follow-up to #34890. Also keeps N8N-71 (the `usePageRedirectionHelper` move into `@n8n/composables`) a clean `git mv` of `useBasePageRedirectionHelper`.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35012">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

