### PR TITLE
refactor(core): Store agent thread identity in columns instead of the thread id (no-changelog)

### DIFF
--- a/docs/generated/postgres-schema/README.md
+++ b/docs/generated/postgres-schema/README.md
@@ -15,7 +15,7 @@ Auto-generated from the PostgreSQL migrations in @n8n/db. Do not edit by hand.
 | [public.agent_eval_result](public.agent_eval_result.md) | 15 |  | BASE TABLE |
 | [public.agent_eval_run](public.agent_eval_run.md) | 14 |  | BASE TABLE |
 | [public.agent_execution](public.agent_execution.md) | 19 |  | BASE TABLE |
-| [public.agent_execution_threads](public.agent_execution_threads.md) | 17 |  | BASE TABLE |
+| [public.agent_execution_threads](public.agent_execution_threads.md) | 21 |  | BASE TABLE |
 | [public.agent_files](public.agent_files.md) | 8 |  | BASE TABLE |
 | [public.agent_history](public.agent_history.md) | 9 |  | BASE TABLE |
 | [public.agent_task_definition](public.agent_task_definition.md) | 7 |  | BASE TABLE |
@@ -424,8 +424,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   timestamp_3__with_time_zone createdAt
+  varchar_255_ createdByResourceId
   varchar_8_ emoji
+  varchar_255_ externalKey
   varchar_128_ id
+  varchar_32_ origin
+  varchar_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/postgres-schema/public.agent_execution.md
+++ b/docs/generated/postgres-schema/public.agent_execution.md
@@ -80,8 +80,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   timestamp_3__with_time_zone createdAt
+  varchar_255_ createdByResourceId
   varchar_8_ emoji
+  varchar_255_ externalKey
   varchar_128_ id
+  varchar_32_ origin
+  varchar_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/postgres-schema/public.agent_execution_threads.md
+++ b/docs/generated/postgres-schema/public.agent_execution_threads.md
@@ -7,8 +7,12 @@
 | agentId | varchar(36) |  | false |  | [public.agents](public.agents.md) |  |
 | agentName | varchar(255) |  | false |  |  |  |
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
+| createdByResourceId | varchar(255) |  | true |  |  | Memory resourceId of the first writer, e.g. draft-chat:\<userId\> |
 | emoji | varchar(8) |  | true |  |  |  |
+| externalKey | varchar(255) |  | true |  |  | Thread key owned by the origin, e.g. a platform thread id or caller session id |
 | id | varchar(128) |  | false | [public.agent_execution](public.agent_execution.md) |  |  |
+| origin | varchar(32) |  | true |  |  | Surface that started the session: chat/integration/workflow/task/subagent/test |
+| originRef | varchar(255) | ''::character varying | false |  |  | Namespace of externalKey (workflowId for workflow threads); empty when unscoped |
 | parentAgentId | varchar(36) |  | true |  |  | Saved agent id of the parent that delegated this subagent run. |
 | parentThreadId | varchar(128) |  | true |  |  | Parent session thread id that delegated this subagent run. |
 | projectId | varchar(255) |  | false |  | [public.project](public.project.md) |  |
@@ -34,6 +38,7 @@
 | agent_execution_threads_agentName_not_null | n | NOT NULL "agentName" |
 | agent_execution_threads_createdAt_not_null | n | NOT NULL "createdAt" |
 | agent_execution_threads_id_not_null | n | NOT NULL id |
+| agent_execution_threads_originRef_not_null | n | NOT NULL "originRef" |
 | agent_execution_threads_projectId_not_null | n | NOT NULL "projectId" |
 | agent_execution_threads_sessionNumber_not_null | n | NOT NULL "sessionNumber" |
 | agent_execution_threads_totalCompletionTokens_not_null | n | NOT NULL "totalCompletionTokens" |
@@ -48,6 +53,7 @@
 | ---- | ---------- |
 | IDX_0468a9dc35597314e641d4722a | CREATE INDEX "IDX_0468a9dc35597314e641d4722a" ON public.agent_execution_threads USING btree ("agentId") |
 | IDX_0e2f8bf92a7a9c88b89670f701 | CREATE INDEX "IDX_0e2f8bf92a7a9c88b89670f701" ON public.agent_execution_threads USING btree ("projectId") |
+| IDX_agent_execution_threads_agentId_origin_originRef_externalKe | CREATE UNIQUE INDEX "IDX_agent_execution_threads_agentId_origin_originRef_externalKe" ON public.agent_execution_threads USING btree ("agentId", origin, "originRef", "externalKey") WHERE ("externalKey" IS NOT NULL) |
 | IDX_agent_execution_threads_taskVersionId | CREATE INDEX "IDX_agent_execution_threads_taskVersionId" ON public.agent_execution_threads USING btree ("taskVersionId") |
 | PK_22373dbf6ba6929d8ac50093309 | CREATE UNIQUE INDEX "PK_22373dbf6ba6929d8ac50093309" ON public.agent_execution_threads USING btree (id) |
 
@@ -65,8 +71,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   timestamp_3__with_time_zone createdAt
+  varchar_255_ createdByResourceId
   varchar_8_ emoji
+  varchar_255_ externalKey
   varchar_128_ id
+  varchar_32_ origin
+  varchar_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/postgres-schema/public.agent_execution_threads.md
+++ b/docs/generated/postgres-schema/public.agent_execution_threads.md
@@ -53,6 +53,7 @@
 | ---- | ---------- |
 | IDX_0468a9dc35597314e641d4722a | CREATE INDEX "IDX_0468a9dc35597314e641d4722a" ON public.agent_execution_threads USING btree ("agentId") |
 | IDX_0e2f8bf92a7a9c88b89670f701 | CREATE INDEX "IDX_0e2f8bf92a7a9c88b89670f701" ON public.agent_execution_threads USING btree ("projectId") |
+| IDX_agent_execution_threads_agentId_createdByResourceId | CREATE INDEX "IDX_agent_execution_threads_agentId_createdByResourceId" ON public.agent_execution_threads USING btree ("agentId", "createdByResourceId") |
 | IDX_agent_execution_threads_agentId_origin_originRef_externalKe | CREATE UNIQUE INDEX "IDX_agent_execution_threads_agentId_origin_originRef_externalKe" ON public.agent_execution_threads USING btree ("agentId", origin, "originRef", "externalKey") WHERE ("externalKey" IS NOT NULL) |
 | IDX_agent_execution_threads_taskVersionId | CREATE INDEX "IDX_agent_execution_threads_taskVersionId" ON public.agent_execution_threads USING btree ("taskVersionId") |
 | PK_22373dbf6ba6929d8ac50093309 | CREATE UNIQUE INDEX "PK_22373dbf6ba6929d8ac50093309" ON public.agent_execution_threads USING btree (id) |

--- a/docs/generated/postgres-schema/public.agent_history.md
+++ b/docs/generated/postgres-schema/public.agent_history.md
@@ -91,8 +91,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   timestamp_3__with_time_zone createdAt
+  varchar_255_ createdByResourceId
   varchar_8_ emoji
+  varchar_255_ externalKey
   varchar_128_ id
+  varchar_32_ origin
+  varchar_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/postgres-schema/public.agents.md
+++ b/docs/generated/postgres-schema/public.agents.md
@@ -122,8 +122,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   timestamp_3__with_time_zone createdAt
+  varchar_255_ createdByResourceId
   varchar_8_ emoji
+  varchar_255_ externalKey
   varchar_128_ id
+  varchar_32_ origin
+  varchar_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/postgres-schema/public.project.md
+++ b/docs/generated/postgres-schema/public.project.md
@@ -85,8 +85,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   timestamp_3__with_time_zone createdAt
+  varchar_255_ createdByResourceId
   varchar_8_ emoji
+  varchar_255_ externalKey
   varchar_128_ id
+  varchar_32_ origin
+  varchar_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/sqlite-schema/README.md
+++ b/docs/generated/sqlite-schema/README.md
@@ -15,7 +15,7 @@ Auto-generated from the SQLite migrations in @n8n/db. Do not edit by hand.
 | [agent_eval_result](agent_eval_result.md) | 15 |  | table |
 | [agent_eval_run](agent_eval_run.md) | 14 |  | table |
 | [agent_execution](agent_execution.md) | 19 |  | table |
-| [agent_execution_threads](agent_execution_threads.md) | 17 |  | table |
+| [agent_execution_threads](agent_execution_threads.md) | 21 |  | table |
 | [agent_files](agent_files.md) | 8 |  | table |
 | [agent_history](agent_history.md) | 9 |  | table |
 | [agent_task_definition](agent_task_definition.md) | 7 |  | table |
@@ -411,8 +411,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   datetime_3_ createdAt
+  VARCHAR_255_ createdByResourceId
   varchar_8_ emoji
+  VARCHAR_255_ externalKey
   varchar_128_ id PK
+  VARCHAR_32_ origin
+  VARCHAR_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/sqlite-schema/agent_execution.md
+++ b/docs/generated/sqlite-schema/agent_execution.md
@@ -85,8 +85,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   datetime_3_ createdAt
+  VARCHAR_255_ createdByResourceId
   varchar_8_ emoji
+  VARCHAR_255_ externalKey
   varchar_128_ id PK
+  VARCHAR_32_ origin
+  VARCHAR_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/sqlite-schema/agent_execution_threads.md
+++ b/docs/generated/sqlite-schema/agent_execution_threads.md
@@ -53,6 +53,7 @@ CREATE TABLE "agent_execution_threads" ("id" varchar(128) PRIMARY KEY NOT NULL, 
 | ---- | ---------- |
 | IDX_0468a9dc35597314e641d4722a | CREATE INDEX "IDX_0468a9dc35597314e641d4722a" ON "agent_execution_threads" ("agentId")  |
 | IDX_0e2f8bf92a7a9c88b89670f701 | CREATE INDEX "IDX_0e2f8bf92a7a9c88b89670f701" ON "agent_execution_threads" ("projectId")  |
+| IDX_agent_execution_threads_agentId_createdByResourceId | CREATE INDEX "IDX_agent_execution_threads_agentId_createdByResourceId" ON "agent_execution_threads" ("agentId", "createdByResourceId")  |
 | IDX_agent_execution_threads_agentId_origin_originRef_externalKey | CREATE UNIQUE INDEX "IDX_agent_execution_threads_agentId_origin_originRef_externalKey" ON "agent_execution_threads" ("agentId", "origin", "originRef", "externalKey") WHERE "externalKey" IS NOT NULL |
 | IDX_agent_execution_threads_taskVersionId | CREATE INDEX "IDX_agent_execution_threads_taskVersionId" ON "agent_execution_threads" ("taskVersionId")  |
 | sqlite_autoindex_agent_execution_threads_1 | PRIMARY KEY (id) |

--- a/docs/generated/sqlite-schema/agent_execution_threads.md
+++ b/docs/generated/sqlite-schema/agent_execution_threads.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "agent_execution_threads" ("id" varchar(128) PRIMARY KEY NOT NULL, "agentId" varchar(36) NOT NULL, "agentName" varchar(255) NOT NULL, "projectId" varchar(255) NOT NULL, "sessionNumber" integer NOT NULL DEFAULT (0), "totalPromptTokens" integer NOT NULL DEFAULT (0), "totalCompletionTokens" integer NOT NULL DEFAULT (0), "totalCost" real NOT NULL DEFAULT (0), "totalDuration" integer NOT NULL DEFAULT (0), "title" varchar(255), "emoji" varchar(8), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "taskId" varchar(32), "taskVersionId" varchar(36), "parentThreadId" varchar(128), "parentAgentId" varchar(36), CONSTRAINT "FK_0e2f8bf92a7a9c88b89670f701c" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_0468a9dc35597314e641d4722aa" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_f00b52d74fe11838e1fe086deea" FOREIGN KEY ("taskVersionId") REFERENCES "agent_history" ("versionId") ON DELETE SET NULL)
+CREATE TABLE "agent_execution_threads" ("id" varchar(128) PRIMARY KEY NOT NULL, "agentId" varchar(36) NOT NULL, "agentName" varchar(255) NOT NULL, "projectId" varchar(255) NOT NULL, "sessionNumber" integer NOT NULL DEFAULT (0), "totalPromptTokens" integer NOT NULL DEFAULT (0), "totalCompletionTokens" integer NOT NULL DEFAULT (0), "totalCost" real NOT NULL DEFAULT (0), "totalDuration" integer NOT NULL DEFAULT (0), "title" varchar(255), "emoji" varchar(8), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "taskId" varchar(32), "taskVersionId" varchar(36), "parentThreadId" varchar(128), "parentAgentId" varchar(36), "origin" VARCHAR(32), "originRef" VARCHAR(255) NOT NULL DEFAULT '', "externalKey" VARCHAR(255), "createdByResourceId" VARCHAR(255), CONSTRAINT "FK_0e2f8bf92a7a9c88b89670f701c" FOREIGN KEY ("projectId") REFERENCES "project" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_0468a9dc35597314e641d4722aa" FOREIGN KEY ("agentId") REFERENCES "agents" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_f00b52d74fe11838e1fe086deea" FOREIGN KEY ("taskVersionId") REFERENCES "agent_history" ("versionId") ON DELETE SET NULL)
 ```
 
 </details>
@@ -18,8 +18,12 @@ CREATE TABLE "agent_execution_threads" ("id" varchar(128) PRIMARY KEY NOT NULL, 
 | agentId | varchar(36) |  | false |  | [agents](agents.md) |  |
 | agentName | varchar(255) |  | false |  |  |  |
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
+| createdByResourceId | VARCHAR(255) |  | true |  |  |  |
 | emoji | varchar(8) |  | true |  |  |  |
+| externalKey | VARCHAR(255) |  | true |  |  |  |
 | id | varchar(128) |  | false | [agent_execution](agent_execution.md) |  |  |
+| origin | VARCHAR(32) |  | true |  |  |  |
+| originRef | VARCHAR(255) | '' | false |  |  |  |
 | parentAgentId | varchar(36) |  | true |  |  |  |
 | parentThreadId | varchar(128) |  | true |  |  |  |
 | projectId | varchar(255) |  | false |  | [project](project.md) |  |
@@ -49,6 +53,7 @@ CREATE TABLE "agent_execution_threads" ("id" varchar(128) PRIMARY KEY NOT NULL, 
 | ---- | ---------- |
 | IDX_0468a9dc35597314e641d4722a | CREATE INDEX "IDX_0468a9dc35597314e641d4722a" ON "agent_execution_threads" ("agentId")  |
 | IDX_0e2f8bf92a7a9c88b89670f701 | CREATE INDEX "IDX_0e2f8bf92a7a9c88b89670f701" ON "agent_execution_threads" ("projectId")  |
+| IDX_agent_execution_threads_agentId_origin_originRef_externalKey | CREATE UNIQUE INDEX "IDX_agent_execution_threads_agentId_origin_originRef_externalKey" ON "agent_execution_threads" ("agentId", "origin", "originRef", "externalKey") WHERE "externalKey" IS NOT NULL |
 | IDX_agent_execution_threads_taskVersionId | CREATE INDEX "IDX_agent_execution_threads_taskVersionId" ON "agent_execution_threads" ("taskVersionId")  |
 | sqlite_autoindex_agent_execution_threads_1 | PRIMARY KEY (id) |
 
@@ -66,8 +71,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   datetime_3_ createdAt
+  VARCHAR_255_ createdByResourceId
   varchar_8_ emoji
+  VARCHAR_255_ externalKey
   varchar_128_ id PK
+  VARCHAR_32_ origin
+  VARCHAR_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/sqlite-schema/agent_history.md
+++ b/docs/generated/sqlite-schema/agent_history.md
@@ -98,8 +98,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   datetime_3_ createdAt
+  VARCHAR_255_ createdByResourceId
   varchar_8_ emoji
+  VARCHAR_255_ externalKey
   varchar_128_ id PK
+  VARCHAR_32_ origin
+  VARCHAR_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/sqlite-schema/agents.md
+++ b/docs/generated/sqlite-schema/agents.md
@@ -125,8 +125,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   datetime_3_ createdAt
+  VARCHAR_255_ createdByResourceId
   varchar_8_ emoji
+  VARCHAR_255_ externalKey
   varchar_128_ id PK
+  VARCHAR_32_ origin
+  VARCHAR_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/docs/generated/sqlite-schema/project.md
+++ b/docs/generated/sqlite-schema/project.md
@@ -91,8 +91,12 @@ erDiagram
   varchar_36_ agentId FK
   varchar_255_ agentName
   datetime_3_ createdAt
+  VARCHAR_255_ createdByResourceId
   varchar_8_ emoji
+  VARCHAR_255_ externalKey
   varchar_128_ id PK
+  VARCHAR_32_ origin
+  VARCHAR_255_ originRef
   varchar_36_ parentAgentId
   varchar_128_ parentThreadId
   varchar_255_ projectId FK

--- a/packages/@n8n/db/src/migrations/common/1785151856791-AddThreadIdentityToAgentExecutionThreads.ts
+++ b/packages/@n8n/db/src/migrations/common/1785151856791-AddThreadIdentityToAgentExecutionThreads.ts
@@ -6,6 +6,9 @@ const NEW_COLUMNS = ['origin', 'originRef', 'externalKey', 'createdByResourceId'
 
 const NATURAL_KEY = ['agentId', 'origin', 'originRef', 'externalKey'];
 
+/** Serves "the sessions this caller had with this agent". */
+const CALLER_SCOPE = ['agentId', 'createdByResourceId'];
+
 const COLUMN_COMMENTS: Array<[column: string, comment: string]> = [
 	['origin', 'Surface that started the session: chat/integration/workflow/task/subagent/test'],
 	['originRef', 'Namespace of externalKey (workflowId for workflow threads); empty when unscoped'],
@@ -70,9 +73,12 @@ export class AddThreadIdentityToAgentExecutionThreads1785151856791 implements Re
 			undefined,
 			`${escape.columnName('externalKey')} IS NOT NULL`,
 		);
+
+		await createIndex(TABLE, CALLER_SCOPE);
 	}
 
 	async down({ escape, runQuery, schemaBuilder: { dropIndex } }: MigrationContext) {
+		await dropIndex(TABLE, CALLER_SCOPE, { skipIfMissing: true });
 		await dropIndex(TABLE, NATURAL_KEY, { skipIfMissing: true });
 
 		const table = escape.tableName(TABLE);

--- a/packages/@n8n/db/src/migrations/common/1785151856791-AddThreadIdentityToAgentExecutionThreads.ts
+++ b/packages/@n8n/db/src/migrations/common/1785151856791-AddThreadIdentityToAgentExecutionThreads.ts
@@ -1,0 +1,157 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const TABLE = 'agent_execution_threads';
+
+const NEW_COLUMNS = ['origin', 'originRef', 'externalKey', 'createdByResourceId'] as const;
+
+const NATURAL_KEY = ['agentId', 'origin', 'originRef', 'externalKey'];
+
+const COLUMN_COMMENTS: Array<[column: string, comment: string]> = [
+	['origin', 'Surface that started the session: chat/integration/workflow/task/subagent/test'],
+	['originRef', 'Namespace of externalKey (workflowId for workflow threads); empty when unscoped'],
+	['externalKey', 'Thread key owned by the origin, e.g. a platform thread id or caller session id'],
+	['createdByResourceId', 'Memory resourceId of the first writer, e.g. draft-chat:<userId>'],
+];
+
+type ThreadIdRow = { id: string };
+
+/**
+ * Moves thread identity out of the composed `id` string into columns.
+ *
+ * Thread ids used to encode their surface (`wf:<workflowId>:<sessionId>`,
+ * `<agentId>:slack:<channel>:<ts>`, ...) so a continuation could re-derive the
+ * id and look it up by primary key. Storing the parts instead lets new threads
+ * use opaque uuids and turns continuation into a natural-key lookup. Existing
+ * ids are left untouched — they are referenced by foreign keys and by the
+ * execution-log blob keys — and are only parsed here, once, to populate the
+ * new columns.
+ */
+export class AddThreadIdentityToAgentExecutionThreads1785151856791 implements ReversibleMigration {
+	async up(context: MigrationContext) {
+		const {
+			escape,
+			runQuery,
+			isPostgres,
+			schemaBuilder: { createIndex },
+		} = context;
+		const table = escape.tableName(TABLE);
+
+		// Raw ALTER TABLE rather than `addColumns`: on SQLite the DSL recreates the
+		// table, and `agent_execution.threadId` references it ON DELETE CASCADE.
+		await runQuery(`ALTER TABLE ${table} ADD COLUMN ${escape.columnName('origin')} VARCHAR(32)`);
+		await runQuery(
+			`ALTER TABLE ${table} ADD COLUMN ${escape.columnName('originRef')} VARCHAR(255) NOT NULL DEFAULT ''`,
+		);
+		await runQuery(
+			`ALTER TABLE ${table} ADD COLUMN ${escape.columnName('externalKey')} VARCHAR(255)`,
+		);
+		await runQuery(
+			`ALTER TABLE ${table} ADD COLUMN ${escape.columnName('createdByResourceId')} VARCHAR(255)`,
+		);
+
+		if (isPostgres) {
+			for (const [columnName, comment] of COLUMN_COMMENTS) {
+				await runQuery(
+					`COMMENT ON COLUMN ${table}.${escape.columnName(columnName)} IS '${comment}'`,
+				);
+			}
+		}
+
+		await this.backfillWorkflowThreads(context);
+		await this.backfillRemainingOrigins(context);
+		await this.backfillCreatedByResourceId(context);
+
+		// Partial: only rows carrying an external key are continued by lookup, and
+		// every other origin mints a fresh uuid per session.
+		await createIndex(
+			TABLE,
+			NATURAL_KEY,
+			true,
+			undefined,
+			`${escape.columnName('externalKey')} IS NOT NULL`,
+		);
+	}
+
+	async down({ escape, runQuery, schemaBuilder: { dropIndex } }: MigrationContext) {
+		await dropIndex(TABLE, NATURAL_KEY, { skipIfMissing: true });
+
+		const table = escape.tableName(TABLE);
+		for (const columnName of NEW_COLUMNS) {
+			await runQuery(`ALTER TABLE ${table} DROP COLUMN ${escape.columnName(columnName)}`);
+		}
+	}
+
+	/**
+	 * `wf:<workflowId>:<sessionId>` — the session id is caller-supplied and may
+	 * itself contain colons, so the split happens here rather than in SQL (the
+	 * substring-search builtins differ between Postgres and SQLite).
+	 */
+	private async backfillWorkflowThreads({
+		escape,
+		runQuery,
+		runInBatches,
+	}: MigrationContext): Promise<void> {
+		const table = escape.tableName(TABLE);
+
+		await runInBatches<ThreadIdRow>(
+			`SELECT id FROM ${table} WHERE id LIKE 'wf:%' ORDER BY id`,
+			async (rows) => {
+				for (const { id } of rows) {
+					const rest = id.slice('wf:'.length);
+					const separator = rest.indexOf(':');
+					const originRef = separator === -1 ? '' : rest.slice(0, separator);
+					const externalKey = separator === -1 ? '' : rest.slice(separator + 1);
+
+					await runQuery(
+						`UPDATE ${table} SET ${escape.columnName('origin')} = 'workflow', ${escape.columnName('originRef')} = :originRef, ${escape.columnName('externalKey')} = :externalKey WHERE id = :id`,
+						// A malformed id has no key to continue on; leave externalKey null
+						// so it stays out of the unique index.
+						{ originRef, externalKey: externalKey === '' ? null : externalKey, id },
+					);
+				}
+			},
+		);
+	}
+
+	private async backfillRemainingOrigins({ escape, runQuery }: MigrationContext): Promise<void> {
+		const table = escape.tableName(TABLE);
+		const origin = escape.columnName('origin');
+		const agentId = escape.columnName('agentId');
+		const unclassified = `${origin} IS NULL`;
+
+		await runQuery(
+			`UPDATE ${table} SET ${origin} = 'task' WHERE ${unclassified} AND id LIKE 'task-%'`,
+		);
+		await runQuery(
+			`UPDATE ${table} SET ${origin} = 'test' WHERE ${unclassified} AND id LIKE 'test-%'`,
+		);
+
+		// Integration ids are `<agentId>:<platformThreadId>`; the agent id is a
+		// uuid, so it carries no LIKE metacharacters.
+		await runQuery(
+			`UPDATE ${table} SET ${origin} = 'integration', ${escape.columnName('externalKey')} = SUBSTR(id, LENGTH(${agentId}) + 2) WHERE ${unclassified} AND id LIKE ${agentId} || ':%'`,
+		);
+
+		await runQuery(
+			`UPDATE ${table} SET ${origin} = 'subagent' WHERE ${unclassified} AND ${escape.columnName('parentThreadId')} IS NOT NULL`,
+		);
+		await runQuery(`UPDATE ${table} SET ${origin} = 'chat' WHERE ${unclassified}`);
+	}
+
+	/** Earliest memory message wins; threads without memory rows stay null. */
+	private async backfillCreatedByResourceId({ escape, runQuery }: MigrationContext): Promise<void> {
+		const table = escape.tableName(TABLE);
+		const messages = escape.tableName('agents_messages');
+		const resourceId = escape.columnName('resourceId');
+		const createdAt = escape.columnName('createdAt');
+
+		await runQuery(
+			`UPDATE ${table} SET ${escape.columnName('createdByResourceId')} = (
+				SELECT m.${resourceId} FROM ${messages} m
+				WHERE m.${escape.columnName('threadId')} = ${table}.id
+				ORDER BY m.${createdAt} ASC, m.id ASC
+				LIMIT 1
+			)`,
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -230,6 +230,7 @@ import { AddStoredAtToAgentExecution1784815940110 } from '../common/178481594011
 import { AddInstanceCredentials1784815940111 } from '../common/1784815940111-AddInstanceCredentials';
 import { CreateAgentEvalTables1784815940112 } from '../common/1784815940112-CreateAgentEvalTables';
 import { AddAvailableInMcpToAgents1784897791636 } from '../common/1784897791636-AddAvailableInMcpToAgents';
+import { AddThreadIdentityToAgentExecutionThreads1785151856791 } from '../common/1785151856791-AddThreadIdentityToAgentExecutionThreads';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -465,4 +466,5 @@ export const postgresMigrations: Migration[] = [
 	AddInstanceCredentials1784815940111,
 	CreateAgentEvalTables1784815940112,
 	AddAvailableInMcpToAgents1784897791636,
+	AddThreadIdentityToAgentExecutionThreads1785151856791,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -222,6 +222,7 @@ import { CreateWorkflowReviewRequestTables1784000000052 } from '../common/178400
 import { AddStoredAtToAgentExecution1784815940110 } from '../common/1784815940110-AddStoredAtToAgentExecution';
 import { AddInstanceCredentials1784815940111 } from '../common/1784815940111-AddInstanceCredentials';
 import { CreateAgentEvalTables1784815940112 } from '../common/1784815940112-CreateAgentEvalTables';
+import { AddThreadIdentityToAgentExecutionThreads1785151856791 } from '../common/1785151856791-AddThreadIdentityToAgentExecutionThreads';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -447,6 +448,7 @@ const sqliteMigrations: Migration[] = [
 	AddInstanceCredentials1784815940111,
 	CreateAgentEvalTables1784815940112,
 	AddAvailableInMcpToAgents1784897791636,
+	AddThreadIdentityToAgentExecutionThreads1785151856791,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -37,6 +37,7 @@ import {
 	SubworkflowPolicyChecker,
 } from '@/executions/pre-execution-checks';
 import { ExternalHooks } from '@/external-hooks';
+import { AgentExecutionService } from '@/modules/agents/agent-execution.service';
 import { AgentWorkflowExecutionService } from '@/modules/agents/agent-workflow-execution.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { OwnershipService } from '@/services/ownership.service';
@@ -1334,11 +1335,13 @@ describe('WorkflowExecuteAdditionalData', () => {
 	describe('executeAgent', () => {
 		const ownershipService = mockInstance(OwnershipService);
 		const agentWorkflowExecutionService = mockInstance(AgentWorkflowExecutionService);
+		const agentExecutionService = mockInstance(AgentExecutionService);
 
 		const AGENT_ID = 'agent-id';
 		const MESSAGE = 'hello';
 		const EXEC_ID = 'exec-id';
 		const THREAD_ID = 'thread-id';
+		const RESOLVED_THREAD_ID = 'resolved-thread-id';
 
 		beforeEach(() => {
 			vi.clearAllMocks();
@@ -1348,6 +1351,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 			agentWorkflowExecutionService.executeForWorkflow.mockResolvedValue(
 				mock<Awaited<ReturnType<typeof agentWorkflowExecutionService.executeForWorkflow>>>(),
 			);
+			agentExecutionService.resolveThreadIdForKey.mockResolvedValue(RESOLVED_THREAD_ID);
 		});
 
 		it('routes inline sources to executeInlineForWorkflow with a mode-derived run type', async () => {
@@ -1422,13 +1426,38 @@ describe('WorkflowExecuteAdditionalData', () => {
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
-				`wf:workflow-1:${THREAD_ID}`,
+				RESOLVED_THREAD_ID,
 				'project-1',
 				'user-1',
 				true,
 				undefined,
 				undefined,
 			);
+		});
+
+		it('scopes the caller session id to the calling workflow when resolving the thread', async () => {
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				userId: 'user-1',
+				projectId: 'project-1',
+				workflowId: 'workflow-1',
+			});
+
+			await executeAgent(
+				{ agentId: AGENT_ID },
+				MESSAGE,
+				EXEC_ID,
+				THREAD_ID,
+				additionalData,
+				'manual',
+			);
+
+			expect(agentExecutionService.resolveThreadIdForKey).toHaveBeenCalledWith({
+				agentId: AGENT_ID,
+				projectId: 'project-1',
+				origin: 'workflow',
+				originRef: 'workflow-1',
+				externalKey: THREAD_ID,
+			});
 		});
 
 		it('forwards the outputSchema to executeForWorkflow', async () => {
@@ -1457,7 +1486,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
-				`wf:workflow-1:${THREAD_ID}`,
+				RESOLVED_THREAD_ID,
 				'project-1',
 				'user-1',
 				true,
@@ -1495,7 +1524,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
-				`wf:workflow-1:${THREAD_ID}`,
+				RESOLVED_THREAD_ID,
 				'project-1',
 				'user-1',
 				true,
@@ -1528,7 +1557,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
-				`wf:workflow-1:${THREAD_ID}`,
+				RESOLVED_THREAD_ID,
 				'project-1',
 				'user-1',
 				true,
@@ -1590,7 +1619,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
-				`wf:workflow-1:${THREAD_ID}`,
+				RESOLVED_THREAD_ID,
 				'project-1',
 				undefined,
 				false,
@@ -1622,7 +1651,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 					AGENT_ID,
 					MESSAGE,
 					EXEC_ID,
-					`wf:workflow-1:${THREAD_ID}`,
+					RESOLVED_THREAD_ID,
 					'project-1',
 					'user-1',
 					true,
@@ -1656,7 +1685,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
-				`wf:workflow-1:${THREAD_ID}`,
+				RESOLVED_THREAD_ID,
 				'project-1',
 				'user-1',
 				false,

--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -9,6 +9,7 @@ import type { AgentExecutionOrchestratorService } from '../agent-execution-orche
 import type { AgentExecutionService } from '../agent-execution.service';
 import type { FlushableResponse } from '../agent-sse-stream';
 import type { AgentTestChatService } from '../agent-test-chat.service';
+import type { AgentExecutionThread } from '../entities/agent-execution-thread.entity';
 import type { AgentsService } from '../agents.service';
 import type { AgentValidationService } from '../agent-validation.service';
 import type { AgentsBuilderService } from '../builder/agents-builder.service';
@@ -120,6 +121,75 @@ describe('AgentChatController chat message history', () => {
 				params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
 			} as never),
 		).rejects.toThrow(NotFoundError);
+	});
+});
+
+describe('AgentChatController session ownership', () => {
+	async function chatWithSession(thread: Partial<AgentExecutionThread> | null, userId = 'user-1') {
+		const { controller, agentExecutionOrchestratorService, agentExecutionService } =
+			makeController();
+		agentExecutionService.findThreadById.mockResolvedValue(thread as AgentExecutionThread | null);
+		agentExecutionOrchestratorService.executeForChat.mockImplementation(async function* () {
+			yield* [];
+		});
+
+		const writes: string[] = [];
+		const res = mock<FlushableResponse>();
+		res.write.mockImplementation((chunk: string) => {
+			writes.push(String(chunk));
+			return true;
+		});
+
+		await controller.chat(
+			{ params: { projectId: 'project-1' }, user: { id: userId } } as never,
+			res,
+			'agent-1',
+			{ message: 'hi', sessionId: 'thread-1' } as never,
+		);
+
+		return {
+			executed: agentExecutionOrchestratorService.executeForChat.mock.calls.length > 0,
+			events: writes
+				.filter((line) => line.startsWith('data: '))
+				.map((line) => JSON.parse(line.slice(6).trim()) as { type: string; message?: string }),
+		};
+	}
+
+	const otherUsersThread = {
+		projectId: 'project-1',
+		agentId: 'agent-1',
+		createdByResourceId: 'draft-chat:user-2',
+	};
+
+	it('refuses to append to a session started by another user in the same project', async () => {
+		const { executed, events } = await chatWithSession(otherUsersThread);
+
+		expect(executed).toBe(false);
+		expect(events).toContainEqual({ type: 'error', message: 'Session not found' });
+	});
+
+	it('gives the same answer for another user’s session as for one that does not exist', async () => {
+		const denied = await chatWithSession(otherUsersThread);
+		const missing = await chatWithSession({
+			projectId: 'project-2',
+			agentId: 'agent-1',
+			createdByResourceId: null,
+		});
+
+		expect(denied.events).toEqual(missing.events);
+	});
+
+	it.each([
+		['its own creator', 'draft-chat:user-1'],
+		['a session predating attribution', null],
+	])('lets %s continue the conversation', async (_case, createdByResourceId) => {
+		const { executed } = await chatWithSession({
+			projectId: 'project-1',
+			agentId: 'agent-1',
+			createdByResourceId,
+		});
+
+		expect(executed).toBe(true);
 	});
 });
 

--- a/packages/cli/src/modules/agents/__tests__/agent-execution-thread.repository.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-thread.repository.test.ts
@@ -18,6 +18,13 @@ describe('AgentExecutionThreadRepository', () => {
 	});
 
 	describe('findOrCreate', () => {
+		const baseOptions = {
+			threadId: 'thread-1',
+			agentId: 'agent-1',
+			agentName: 'Support agent',
+			projectId: 'project-1',
+		};
+
 		const makeScopedRepository = (saved: AgentExecutionThread, max = 7) => ({
 			findOneBy: vi.fn().mockResolvedValue(null),
 			createQueryBuilder: vi.fn().mockReturnValue({
@@ -37,12 +44,7 @@ describe('AgentExecutionThreadRepository', () => {
 				return await callback(trx as never);
 			});
 
-			const result = await repository.findOrCreate(
-				'thread-1',
-				'agent-1',
-				'Support agent',
-				'project-1',
-			);
+			const result = await repository.findOrCreate(baseOptions);
 
 			expect(entityManager.transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.any(Function));
 			expect(trx.getRepository).toHaveBeenCalledWith(AgentExecutionThread);
@@ -56,11 +58,15 @@ describe('AgentExecutionThreadRepository', () => {
 				sessionNumber: 8,
 				parentThreadId: null,
 				parentAgentId: null,
+				origin: null,
+				originRef: '',
+				externalKey: null,
+				createdByResourceId: null,
 			});
 			expect(result).toEqual({ thread: saved, created: true });
 		});
 
-		it('stores subagent origin metadata when creating a thread', async () => {
+		it('stores thread identity and parent linkage when creating a thread', async () => {
 			const saved = mock<AgentExecutionThread>({ id: 'thread-1', sessionNumber: 8 });
 			const scopedRepository = makeScopedRepository(saved);
 			const trx = { getRepository: vi.fn().mockReturnValue(scopedRepository) };
@@ -68,22 +74,24 @@ describe('AgentExecutionThreadRepository', () => {
 				return await callback(trx as never);
 			});
 
-			await repository.findOrCreate('thread-1', 'agent-1', 'Support agent', 'project-1', {
-				parentThreadId: 'parent-thread-1',
-				parentAgentId: 'parent-agent-1',
+			await repository.findOrCreate({
+				...baseOptions,
+				metadata: { parentThreadId: 'parent-thread-1', parentAgentId: 'parent-agent-1' },
+				origin: 'integration',
+				externalKey: 'slack:C123:1727000000.001',
+				createdByResourceId: 'integration:slack:U1',
 			});
 
-			expect(scopedRepository.create).toHaveBeenCalledWith({
-				id: 'thread-1',
-				agentId: 'agent-1',
-				agentName: 'Support agent',
-				projectId: 'project-1',
-				taskId: null,
-				taskVersionId: null,
-				sessionNumber: 8,
-				parentThreadId: 'parent-thread-1',
-				parentAgentId: 'parent-agent-1',
-			});
+			expect(scopedRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					parentThreadId: 'parent-thread-1',
+					parentAgentId: 'parent-agent-1',
+					origin: 'integration',
+					originRef: '',
+					externalKey: 'slack:C123:1727000000.001',
+					createdByResourceId: 'integration:slack:U1',
+				}),
+			);
 		});
 
 		it('stores the published task snapshot version when supplied', async () => {
@@ -94,15 +102,11 @@ describe('AgentExecutionThreadRepository', () => {
 				return await callback(trx as never);
 			});
 
-			await repository.findOrCreate(
-				'thread-1',
-				'agent-1',
-				'Support agent',
-				'project-1',
-				undefined,
-				'task-1',
-				'version-1',
-			);
+			await repository.findOrCreate({
+				...baseOptions,
+				taskId: 'task-1',
+				taskVersionId: 'version-1',
+			});
 
 			expect(scopedRepository.create).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -125,12 +129,7 @@ describe('AgentExecutionThreadRepository', () => {
 					return await callback(trx as never);
 				});
 
-			const result = await repository.findOrCreate(
-				'thread-1',
-				'agent-1',
-				'Support agent',
-				'project-1',
-			);
+			const result = await repository.findOrCreate(baseOptions);
 
 			expect(entityManager.transaction).toHaveBeenCalledTimes(2);
 			expect(result).toEqual({ thread: saved, created: true });

--- a/packages/cli/src/modules/agents/__tests__/agent-execution.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution.service.test.ts
@@ -1,5 +1,6 @@
 import type { Mocked } from 'vitest';
 import { mockLogger } from '@n8n/backend-test-utils';
+import { QueryFailedError } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 import type { ErrorReporter, StorageConfig } from 'n8n-core';
 
@@ -13,6 +14,7 @@ import type { AgentExecutionLogStore } from '../execution-log/agent-execution-lo
 import type { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentExecutionThreadRepository } from '../repositories/agent-execution-thread.repository';
 import type { AgentExecutionRepository } from '../repositories/agent-execution.repository';
+import type { AgentRepository } from '../repositories/agent.repository';
 
 type N8nMemoryImplementation = ReturnType<N8nMemory['getImplementation']>;
 
@@ -57,6 +59,7 @@ describe('AgentExecutionService', () => {
 	let agentExecutionRepository: Mocked<AgentExecutionRepository>;
 	let agentExecutionThreadRepository: Mocked<AgentExecutionThreadRepository>;
 	let n8nMemory: Mocked<N8nMemory>;
+	let agentRepository: Mocked<AgentRepository>;
 	let memoryBackend: Mocked<N8nMemoryImplementation>;
 	let telemetry: Mocked<Telemetry>;
 	let agentExecutionLogStore: Mocked<AgentExecutionLogStore>;
@@ -68,6 +71,7 @@ describe('AgentExecutionService', () => {
 
 		agentExecutionRepository = mock<AgentExecutionRepository>();
 		agentExecutionThreadRepository = mock<AgentExecutionThreadRepository>();
+		agentRepository = mock<AgentRepository>();
 		n8nMemory = mock<N8nMemory>();
 		memoryBackend = mock<N8nMemoryImplementation>();
 		n8nMemory.getImplementation.mockReturnValue(memoryBackend);
@@ -80,12 +84,82 @@ describe('AgentExecutionService', () => {
 			mockLogger(),
 			agentExecutionRepository,
 			agentExecutionThreadRepository,
+			agentRepository,
 			n8nMemory,
 			telemetry,
 			agentExecutionLogStore,
 			storageConfig,
 			errorReporter,
 		);
+	});
+
+	describe('resolveThreadIdForKey', () => {
+		const key = {
+			agentId: 'agent-1',
+			projectId: 'project-1',
+			origin: 'integration' as const,
+			externalKey: 'slack:C123:1727000000.001',
+			resourceId: 'integration:slack:U1',
+		};
+
+		it('continues the session already started for this conversation', async () => {
+			// Threads created before opaque ids are found the same way: the migration
+			// backfilled their key columns from the composed id.
+			agentExecutionThreadRepository.findIdByNaturalKey.mockResolvedValue(
+				'agent-1:slack:C123:1727000000.001',
+			);
+
+			await expect(service.resolveThreadIdForKey(key)).resolves.toBe(
+				'agent-1:slack:C123:1727000000.001',
+			);
+			expect(agentExecutionThreadRepository.findOrCreate).not.toHaveBeenCalled();
+		});
+
+		it('starts a session under an opaque id keyed by the conversation', async () => {
+			agentExecutionThreadRepository.findIdByNaturalKey.mockResolvedValue(null);
+			agentRepository.findNameByIdAndProjectId.mockResolvedValue('Support agent');
+			agentExecutionThreadRepository.findOrCreate.mockImplementation(
+				async ({ threadId }) =>
+					({ thread: { id: threadId } as AgentExecutionThread, created: true }) as never,
+			);
+
+			const threadId = await service.resolveThreadIdForKey(key);
+
+			expect(threadId).not.toContain('slack');
+			expect(agentExecutionThreadRepository.findOrCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					threadId,
+					agentId: 'agent-1',
+					agentName: 'Support agent',
+					projectId: 'project-1',
+					origin: 'integration',
+					externalKey: 'slack:C123:1727000000.001',
+					createdByResourceId: 'integration:slack:U1',
+				}),
+			);
+		});
+
+		it('adopts the winner of a concurrent first message instead of forking', async () => {
+			agentExecutionThreadRepository.findIdByNaturalKey
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce('winning-thread');
+			agentRepository.findNameByIdAndProjectId.mockResolvedValue('Support agent');
+			agentExecutionThreadRepository.findOrCreate.mockRejectedValue(
+				new QueryFailedError('insert', undefined, { code: '23505' } as unknown as Error),
+			);
+
+			await expect(service.resolveThreadIdForKey(key)).resolves.toBe('winning-thread');
+		});
+
+		it('rejects when the agent is gone rather than orphaning a session', async () => {
+			agentExecutionThreadRepository.findIdByNaturalKey.mockResolvedValue(null);
+			agentRepository.findNameByIdAndProjectId.mockResolvedValue(null);
+
+			await expect(service.resolveThreadIdForKey(key)).rejects.toThrow(
+				'Agent not found or not accessible.',
+			);
+			expect(agentExecutionThreadRepository.findOrCreate).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('recordMessage', () => {
@@ -95,6 +169,7 @@ describe('AgentExecutionService', () => {
 				mockLogger(),
 				agentExecutionRepository,
 				agentExecutionThreadRepository,
+				agentRepository,
 				n8nMemory,
 				telemetry,
 				agentExecutionLogStore,
@@ -149,6 +224,7 @@ describe('AgentExecutionService', () => {
 				mockLogger(),
 				agentExecutionRepository,
 				agentExecutionThreadRepository,
+				agentRepository,
 				n8nMemory,
 				telemetry,
 				agentExecutionLogStore,
@@ -218,6 +294,8 @@ describe('AgentExecutionService', () => {
 				userMessage: 'Goal:\nResearch API behavior.',
 				record,
 				source: 'subagent',
+				origin: 'subagent',
+				resourceId: 'draft-chat:user-1',
 				threadMetadata: {
 					parentThreadId: 'parent-thread-1',
 					parentAgentId: 'parent-agent-1',
@@ -225,16 +303,18 @@ describe('AgentExecutionService', () => {
 			});
 
 			expect(agentExecutionThreadRepository.findOrCreate).toHaveBeenCalledWith(
-				'thread-1',
-				'agent-1',
-				'Agent',
-				'project-1',
-				{
-					parentThreadId: 'parent-thread-1',
-					parentAgentId: 'parent-agent-1',
-				},
-				undefined,
-				undefined,
+				expect.objectContaining({
+					threadId: 'thread-1',
+					agentId: 'agent-1',
+					agentName: 'Agent',
+					projectId: 'project-1',
+					origin: 'subagent',
+					createdByResourceId: 'draft-chat:user-1',
+					metadata: {
+						parentThreadId: 'parent-thread-1',
+						parentAgentId: 'parent-agent-1',
+					},
+				}),
 			);
 		});
 
@@ -259,13 +339,7 @@ describe('AgentExecutionService', () => {
 			});
 
 			expect(agentExecutionThreadRepository.findOrCreate).toHaveBeenCalledWith(
-				'thread-1',
-				'agent-1',
-				'Agent',
-				'project-1',
-				undefined,
-				'task-1',
-				'version-1',
+				expect.objectContaining({ taskId: 'task-1', taskVersionId: 'version-1' }),
 			);
 		});
 

--- a/packages/cli/src/modules/agents/agent-chat.controller.ts
+++ b/packages/cli/src/modules/agents/agent-chat.controller.ts
@@ -13,7 +13,11 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentsCredentialProvider } from './adapters/agents-credential-provider';
 import { AgentExecutionOrchestratorService } from './agent-execution-orchestrator.service';
-import { AgentExecutionService, threadBelongsTo } from './agent-execution.service';
+import {
+	AgentExecutionService,
+	threadAcceptsWritesFrom,
+	threadBelongsTo,
+} from './agent-execution.service';
 import { messagesToDto } from './agent-message-mapper';
 import { type FlushableResponse, initSseStream, pumpChunks } from './agent-sse-stream';
 import { AgentTestChatService, chatThreadId } from './agent-test-chat.service';
@@ -54,13 +58,21 @@ export class AgentChatController {
 
 		const { send } = initSseStream(res);
 
-		// If the client supplied a sessionId and a thread already exists under that id,
-		// the thread must belong to this (project, agent). Otherwise a caller could
-		// append messages to another user's thread. A non-existent id is fine -
-		// executeForChat will create the thread on first persisted message.
+		const resourceId = draftChatMemoryResourceId(req.user.id);
+
+		// If the client supplied a sessionId and a thread already exists under that
+		// id, it must belong to this (project, agent) and to this user — otherwise a
+		// caller could append messages to someone else's session. Both rejections
+		// look like a missing session so the response never confirms that an id
+		// exists. A non-existent id is fine: executeForChat creates the thread on
+		// the first persisted message.
 		if (sessionId) {
 			const existing = await this.agentExecutionService.findThreadById(sessionId);
-			if (existing && !threadBelongsTo(existing, projectId, agentId)) {
+			if (
+				existing &&
+				(!threadBelongsTo(existing, projectId, agentId) ||
+					!threadAcceptsWritesFrom(existing, resourceId))
+			) {
 				send({ type: 'error', message: 'Session not found' });
 				res.end();
 				return;
@@ -93,10 +105,7 @@ export class AgentChatController {
 					projectId,
 					message,
 					user: req.user,
-					memory: {
-						threadId,
-						resourceId: draftChatMemoryResourceId(req.user.id),
-					},
+					memory: { threadId, resourceId },
 					onExecutionRecorded: (id) => {
 						executionId = id;
 					},

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -9,12 +9,18 @@ import { UserError } from 'n8n-workflow';
 import { ExternalHooks } from '@/external-hooks';
 import type { AgentRunTelemetryType, IAgentConfigurationTelemetryProperties } from '@/interfaces';
 import { Telemetry } from '@/telemetry';
-import { AgentExecutionService, type RecordMessageParams } from './agent-execution.service';
+import {
+	AgentExecutionService,
+	type RecordMessageParams,
+	type ResolveThreadParams,
+} from './agent-execution.service';
 import { AgentRunTracingService, modelIdFromSnapshot } from './agent-run-tracing.service';
 import { AgentRuntimeCacheService } from './agent-runtime-cache.service';
+import type { AgentThreadOrigin } from './entities/agent-execution-thread.entity';
 import { ExecutionRecorder } from './execution-recorder';
 import { IntegrationMessageContextService } from './integrations/integration-message-context.service';
 import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
+import type { AgentThreadNaturalKey } from './repositories/agent-execution-thread.repository';
 import type { ToolRegistry } from './tool-registry';
 import { createAgentExecutionCounter } from './utils/agent-execution-counter';
 import { streamAgentChunks } from './utils/agent-stream';
@@ -126,6 +132,8 @@ export interface StreamChatResponseConfig {
 	memory: AgentMemoryScope;
 	projectId: string;
 	source?: string;
+	/** Surface that started the session, stamped when the thread is first created. */
+	origin?: AgentThreadOrigin;
 	taskId?: string;
 	taskVersionId?: string;
 	telemetry?: {
@@ -301,6 +309,16 @@ export class AgentExecutionOrchestratorService {
 		}
 	}
 
+	/** See {@link AgentExecutionService.resolveThreadIdForKey}. */
+	async resolveThreadId(params: ResolveThreadParams): Promise<string> {
+		return await this.agentExecutionService.resolveThreadIdForKey(params);
+	}
+
+	/** See {@link AgentExecutionService.findThreadIdByKey}. */
+	async findThreadIdByKey(key: AgentThreadNaturalKey): Promise<string | null> {
+		return await this.agentExecutionService.findThreadIdByKey(key);
+	}
+
 	/**
 	 * Execute an agent for the in-app test chat and yield stream chunks.
 	 */
@@ -332,6 +350,7 @@ export class AgentExecutionOrchestratorService {
 			message,
 			memory,
 			projectId: runtime.projectId,
+			origin: 'chat',
 			telemetry: {
 				runType: 'test',
 				configuration: runtime.telemetryConfiguration,
@@ -370,6 +389,7 @@ export class AgentExecutionOrchestratorService {
 			memory,
 			projectId: runtime.projectId,
 			source: integrationType,
+			origin: 'integration',
 			telemetry: {
 				runType: 'production',
 				configuration: runtime.telemetryConfiguration,
@@ -404,6 +424,7 @@ export class AgentExecutionOrchestratorService {
 			memory,
 			projectId: runtime.projectId,
 			source: 'task',
+			origin: 'task',
 			taskId,
 			taskVersionId,
 			telemetry: {
@@ -438,6 +459,7 @@ export class AgentExecutionOrchestratorService {
 			memory,
 			projectId: runtime.projectId,
 			source: 'task',
+			origin: 'task',
 			taskId,
 			telemetry: {
 				runType: 'test',
@@ -459,6 +481,7 @@ export class AgentExecutionOrchestratorService {
 			memory,
 			projectId,
 			source,
+			origin,
 			taskId,
 			taskVersionId,
 			telemetry,
@@ -521,6 +544,8 @@ export class AgentExecutionOrchestratorService {
 					record: messageRecord,
 					hitlStatus: recorder.suspended ? 'suspended' : undefined,
 					source,
+					origin,
+					resourceId,
 					taskId,
 					taskVersionId,
 					telemetry,

--- a/packages/cli/src/modules/agents/agent-execution.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution.service.ts
@@ -3,19 +3,28 @@ import type { StorageLocation } from '@n8n/blob-storage';
 import { Service } from '@n8n/di';
 import chunk from 'lodash/chunk';
 import { ErrorReporter, StorageConfig } from 'n8n-core';
-import { UnexpectedError } from 'n8n-workflow';
+import { OperationalError, UnexpectedError } from 'n8n-workflow';
+import { randomUUID } from 'node:crypto';
 
 import type { AgentRunTelemetryType, IAgentConfigurationTelemetryProperties } from '@/interfaces';
+import { isUniqueConstraintError } from '@/response-helper';
 import { Telemetry } from '@/telemetry';
 
-import { AgentExecutionThread } from './entities/agent-execution-thread.entity';
+import {
+	AgentExecutionThread,
+	type AgentThreadOrigin,
+} from './entities/agent-execution-thread.entity';
 import { AgentExecution } from './entities/agent-execution.entity';
-import type { MessageRecord } from './execution-recorder';
 import { AgentExecutionLogStore } from './execution-log/agent-execution-log-store';
+import type { MessageRecord } from './execution-recorder';
 import { N8nMemory } from './integrations/n8n-memory';
 import { AgentExecutionThreadRepository } from './repositories/agent-execution-thread.repository';
-import type { AgentExecutionThreadMetadata } from './repositories/agent-execution-thread.repository';
+import type {
+	AgentExecutionThreadMetadata,
+	AgentThreadNaturalKey,
+} from './repositories/agent-execution-thread.repository';
 import { AgentExecutionRepository } from './repositories/agent-execution.repository';
+import { AgentRepository } from './repositories/agent.repository';
 
 export interface RecordMessageParams {
 	threadId: string;
@@ -30,6 +39,10 @@ export interface RecordMessageParams {
 	source?: string;
 	/** Optional metadata persisted on the thread when it is first created. */
 	threadMetadata?: AgentExecutionThreadMetadata;
+	/** Surface that started the session, stamped when the thread is first created. */
+	origin?: AgentThreadOrigin;
+	/** Memory resourceId of the caller, recorded as the session's first writer. */
+	resourceId?: string;
 	/** When the run was triggered by a scheduled task, the task's id (stamped on the session). */
 	taskId?: string;
 	/** Published agent_history version that supplied the scheduled task snapshot. */
@@ -39,6 +52,18 @@ export interface RecordMessageParams {
 		runType: AgentRunTelemetryType;
 		configuration: IAgentConfigurationTelemetryProperties;
 	};
+}
+
+export interface ResolveThreadParams {
+	agentId: string;
+	projectId: string;
+	origin: AgentThreadOrigin;
+	/** Namespaces `externalKey` where it is only unique within something else. */
+	originRef?: string;
+	/** Thread key owned by the origin, e.g. a platform thread id. */
+	externalKey: string;
+	/** Recorded as the session's first writer. Defaults to the thread id itself. */
+	resourceId?: string;
 }
 
 export interface ThreadDetail {
@@ -59,12 +84,65 @@ export class AgentExecutionService {
 		private readonly logger: Logger,
 		private readonly agentExecutionRepository: AgentExecutionRepository,
 		private readonly agentExecutionThreadRepository: AgentExecutionThreadRepository,
+		private readonly agentRepository: AgentRepository,
 		private readonly n8nMemory: N8nMemory,
 		private readonly telemetry: Telemetry,
 		private readonly agentExecutionLogStore: AgentExecutionLogStore,
 		private readonly storageConfig: StorageConfig,
 		private readonly errorReporter: ErrorReporter,
 	) {}
+
+	/**
+	 * Thread id to run a conversation under, creating the session record if this
+	 * is the conversation's first run.
+	 *
+	 * Surfaces whose conversations are identified by something outside n8n (a
+	 * Slack thread, a caller-supplied workflow session id) used to derive the
+	 * thread id from those parts and look it up by primary key. They now resolve
+	 * it here instead, so the id itself can be an opaque uuid — threads created
+	 * before that switch are still found, because the migration backfilled their
+	 * key columns from the old composed ids.
+	 *
+	 * Resolution happens before the run so the same id backs both the SDK memory
+	 * thread and the session record. Two messages arriving together therefore
+	 * race to insert; the loser reads back the winner's id rather than forking
+	 * the conversation.
+	 */
+	async resolveThreadIdForKey(params: ResolveThreadParams): Promise<string> {
+		const { agentId, projectId, origin, originRef, externalKey, resourceId } = params;
+		const key = { agentId, origin, originRef, externalKey };
+
+		const existing = await this.agentExecutionThreadRepository.findIdByNaturalKey(key);
+		if (existing) return existing;
+
+		const agentName = await this.agentRepository.findNameByIdAndProjectId(agentId, projectId);
+		if (agentName === null) throw new OperationalError('Agent not found or not accessible.');
+
+		const threadId = randomUUID();
+		try {
+			const { thread } = await this.agentExecutionThreadRepository.findOrCreate({
+				threadId,
+				agentId,
+				agentName,
+				projectId,
+				origin,
+				originRef,
+				externalKey,
+				createdByResourceId: resourceId ?? threadId,
+			});
+			return thread.id;
+		} catch (error) {
+			if (!isUniqueConstraintError(error)) throw error;
+			const raced = await this.agentExecutionThreadRepository.findIdByNaturalKey(key);
+			if (!raced) throw error;
+			return raced;
+		}
+	}
+
+	/** Id of an already-started conversation, without creating one. */
+	async findThreadIdByKey(key: AgentThreadNaturalKey): Promise<string | null> {
+		return await this.agentExecutionThreadRepository.findIdByNaturalKey(key);
+	}
 
 	/**
 	 * Record a single agent run within a thread.
@@ -82,18 +160,22 @@ export class AgentExecutionService {
 			threadMetadata,
 			taskId,
 			taskVersionId,
+			origin,
+			resourceId,
 		} = params;
 
 		// Ensure the thread exists and bump its updatedAt
-		const { thread, created } = await this.agentExecutionThreadRepository.findOrCreate(
+		const { thread, created } = await this.agentExecutionThreadRepository.findOrCreate({
 			threadId,
 			agentId,
 			agentName,
 			projectId,
-			threadMetadata,
+			metadata: threadMetadata,
 			taskId,
 			taskVersionId,
-		);
+			origin,
+			createdByResourceId: resourceId,
+		});
 		if (!created) {
 			await this.agentExecutionThreadRepository.bumpUpdatedAt(threadId);
 			// Sync title from the SDK memory thread if we don't have one yet
@@ -427,4 +509,12 @@ export function threadBelongsTo(
 	if (thread.projectId !== projectId) return false;
 	if (thread.agentId !== agentId) return false;
 	return true;
+}
+
+/**
+ * True if `resourceId` may write to `thread`. Threads predating
+ * `createdByResourceId` have no recorded writer and stay open to their project.
+ */
+export function threadAcceptsWritesFrom(thread: AgentExecutionThread, resourceId: string): boolean {
+	return thread.createdByResourceId === null || thread.createdByResourceId === resourceId;
 }

--- a/packages/cli/src/modules/agents/agent-task.service.ts
+++ b/packages/cli/src/modules/agents/agent-task.service.ts
@@ -482,7 +482,7 @@ export class AgentTaskService {
 				return;
 			}
 
-			const { message, threadId } = this.buildTaskRunMessage(taskId, snapshot.objective);
+			const { message, threadId } = this.buildTaskRunMessage(snapshot.objective);
 
 			this.logger.info('[AgentTaskService] Task fired', {
 				taskId,
@@ -518,15 +518,13 @@ export class AgentTaskService {
 	 * a fresh thread id. Shared by the scheduled path (published snapshot body)
 	 * and the manual path (live draft body), so the wake-up format stays in sync.
 	 */
-	private buildTaskRunMessage(
-		taskId: string,
-		objective: string,
-	): { message: string; threadId: string } {
+	private buildTaskRunMessage(objective: string): { message: string; threadId: string } {
 		const timezone = this.globalConfig.generic.timezone;
 		const timestamp = DateTime.now().setZone(timezone).toISO() ?? new Date().toISOString();
 		const message = `${objective}\n\nCurrent date and time: ${timestamp} (timezone: ${timezone})`;
-		const threadId = `task-${taskId}-${randomUUID()}`;
-		return { message, threadId };
+		// Every run is a fresh conversation, and the task is already a column on
+		// the session record, so the id carries nothing.
+		return { message, threadId: randomUUID() };
 	}
 
 	/**
@@ -575,7 +573,7 @@ export class AgentTaskService {
 	}
 
 	private async executeNow(task: AgentTask, projectId: string, user: User): Promise<void> {
-		const { message, threadId } = this.buildTaskRunMessage(task.id, task.objective);
+		const { message, threadId } = this.buildTaskRunMessage(task.objective);
 
 		this.logger.info('[AgentTaskService] Manual task run started', {
 			taskId: task.id,

--- a/packages/cli/src/modules/agents/entities/agent-execution-thread.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-execution-thread.entity.ts
@@ -5,6 +5,9 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from '@n8n/typeorm';
 import { AgentHistory } from './agent-history.entity';
 import { Agent } from './agent.entity';
 
+/** Surface that started a session. */
+export type AgentThreadOrigin = 'chat' | 'integration' | 'workflow' | 'task' | 'subagent' | 'test';
+
 /**
  * One conversation between a user and an agent. Aggregates per-session
  * counters (token usage, cost, duration) so the sessions list can render
@@ -18,6 +21,10 @@ import { Agent } from './agent.entity';
  * which stores chat-history state owned by the n8n-memory integration.
  * Both use the same `threadId` value but serve different layers.
  */
+@Index(['agentId', 'origin', 'originRef', 'externalKey'], {
+	unique: true,
+	where: '"externalKey" IS NOT NULL',
+})
 @Entity({ name: 'agent_execution_threads' })
 export class AgentExecutionThread extends WithTimestampsAndStringId {
 	@ManyToOne(() => Agent, { onDelete: 'CASCADE' })
@@ -31,6 +38,32 @@ export class AgentExecutionThread extends WithTimestampsAndStringId {
 	/** Denormalized for display — avoids joining agents table when listing threads. */
 	@Column({ type: 'varchar', length: 255 })
 	agentName: string;
+
+	/**
+	 * Identity of the conversation this session belongs to. `externalKey` is the
+	 * thread key owned by the origin (a platform thread id, a caller-supplied
+	 * session id); `originRef` namespaces it where the key is only unique within
+	 * something else (the workflow, for workflow threads). Together with
+	 * `agentId` they form the natural key a continuation is looked up by, so
+	 * `id` itself can stay an opaque uuid. Null/empty for origins that mint a
+	 * fresh session per run.
+	 */
+	@Column({ type: 'varchar', length: 32, nullable: true })
+	origin: AgentThreadOrigin | null;
+
+	@Column({ type: 'varchar', length: 255, default: '' })
+	originRef: string;
+
+	@Column({ type: 'varchar', length: 255, nullable: true })
+	externalKey: string | null;
+
+	/**
+	 * Memory `resourceId` of whoever started the session. Immutable once set: a
+	 * shared integration thread has several writers and ownership should not
+	 * depend on who spoke last. Null for threads that predate this column.
+	 */
+	@Column({ type: 'varchar', length: 255, nullable: true })
+	createdByResourceId: string | null;
 
 	/** LLM-generated summary of the first user message. */
 	@Column({ type: 'varchar', length: 255, nullable: true })

--- a/packages/cli/src/modules/agents/entities/agent-execution-thread.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-execution-thread.entity.ts
@@ -25,6 +25,7 @@ export type AgentThreadOrigin = 'chat' | 'integration' | 'workflow' | 'task' | '
 	unique: true,
 	where: '"externalKey" IS NOT NULL',
 })
+@Index(['agentId', 'createdByResourceId'])
 @Entity({ name: 'agent_execution_threads' })
 export class AgentExecutionThread extends WithTimestampsAndStringId {
 	@ManyToOne(() => Agent, { onDelete: 'CASCADE' })

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -94,6 +94,20 @@ async function* toStream(chunks: StreamChunk[]): AsyncGenerator<StreamChunk> {
 	for (const c of chunks) yield c;
 }
 
+// The bridge resolves the session backing a platform thread through the
+// executor. Echoing the legacy composed id keeps the thread-identity
+// assertions below readable.
+const threadResolution = {
+	resolveThreadId: vi.fn(
+		async ({ agentId, externalKey }: { agentId: string; externalKey: string }) =>
+			`${agentId}:${externalKey}`,
+	),
+	findThreadIdByKey: vi.fn(
+		async ({ agentId, externalKey }: { agentId: string; externalKey: string }) =>
+			`${agentId}:${externalKey}`,
+	),
+};
+
 function makeAgentExecutor(chunks: StreamChunk[]) {
 	const captured: { message: string }[] = [];
 	const executeForChatPublished = vi.fn((config: { message: string }) => {
@@ -101,6 +115,7 @@ function makeAgentExecutor(chunks: StreamChunk[]) {
 		return toStream(chunks);
 	});
 	return {
+		...threadResolution,
 		executeForChatPublished,
 		resumeForChat: vi.fn(() => toStream(chunks)),
 		captured,
@@ -768,6 +783,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			const { bot, handlers } = makeBot();
 			const thread = makeThread();
 			const agentExecutor = {
+				...threadResolution,
 				executeForChatPublished: vi.fn(() => toStream([{ type: 'finish', finishReason: 'stop' }])),
 				resumeForChat: vi.fn(() => toStream([{ type: 'finish', finishReason: 'stop' }])),
 			};
@@ -803,6 +819,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			bot.getAdapter.mockReturnValue({ setAssistantStatus });
 			const thread = makeThread();
 			const agentExecutor = {
+				...threadResolution,
 				executeForChatPublished: vi.fn(() =>
 					toStream([
 						{ type: 'text-delta', id: 't1', delta: 'Hello' },
@@ -854,6 +871,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			bot.getAdapter.mockReturnValue({ setAssistantStatus });
 			const thread = makeThread();
 			const agentExecutor = {
+				...threadResolution,
 				executeForChatPublished: vi.fn(() =>
 					toStream([
 						{ type: 'text-delta', id: 't1', delta: 'Hello' },
@@ -911,6 +929,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			bot.getAdapter.mockReturnValue({ setAssistantStatus });
 			const thread = makeThread();
 			const agentExecutor = {
+				...threadResolution,
 				executeForChatPublished: vi.fn(async function* () {
 					await new Promise((resolve) => setTimeout(resolve, 1000));
 					yield { type: 'finish' as const, finishReason: 'stop' as const };
@@ -963,6 +982,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			bot.getAdapter.mockReturnValue({ setAssistantStatus });
 			const thread = makeThread();
 			const agentExecutor = {
+				...threadResolution,
 				// Respond (which clears the status) while the initial "Thinking..."
 				// set is still waiting out its retry delay, then keep the stream open
 				// past that delay so the retry would otherwise fire after the clear.
@@ -1025,6 +1045,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			bot.getAdapter.mockReturnValue({ setAssistantStatus });
 			const thread = makeThread();
 			const agentExecutor = {
+				...threadResolution,
 				executeForChatPublished: vi.fn(() =>
 					toStream([
 						{ type: 'text-delta', id: 't1', delta: 'Hello' },
@@ -1079,6 +1100,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			const { bot, handlers } = makeBot();
 			const thread = makeThread();
 			const agentExecutor = {
+				...threadResolution,
 				executeForChatPublished: vi.fn(() => toStream([{ type: 'finish', finishReason: 'stop' }])),
 				resumeForChat: vi.fn(() =>
 					toStream([
@@ -1306,6 +1328,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			registry.register(new StatusHandleTestIntegration());
 
 			const agentExecutor = {
+				...threadResolution,
 				executeForChatPublished: vi.fn(() => {
 					throw new Error('setup failed');
 				}),

--- a/packages/cli/src/modules/agents/integrations/__tests__/helpers/replay-test-helpers.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/helpers/replay-test-helpers.ts
@@ -2,6 +2,7 @@ import type { StreamChunk } from '@n8n/agents';
 import type { AgentIntegrationConfig } from '@n8n/api-types';
 import { Container } from '@n8n/di';
 import type { Logger } from 'n8n-workflow';
+import { randomUUID } from 'node:crypto';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -188,9 +189,22 @@ export function createReplayContextSetup<TChat extends ChatInstance>(params: {
 		{ type: 'text-delta', id: 'text-1', delta: 'Got it' },
 		{ type: 'finish', finishReason: 'stop' },
 	];
+	// One session per platform thread, keyed the same way production keys it.
+	const threadIdsByExternalKey = new Map<string, string>();
 	const agentExecutor = {
 		executeForChatPublished: vi.fn(() => toStream(stream)),
 		resumeForChat: vi.fn(() => toStream(stream)),
+		resolveThreadId: vi.fn(async ({ externalKey }: { externalKey: string }) => {
+			const existing = threadIdsByExternalKey.get(externalKey);
+			if (existing) return existing;
+			const threadId = randomUUID();
+			threadIdsByExternalKey.set(externalKey, threadId);
+			return threadId;
+		}),
+		findThreadIdByKey: vi.fn(
+			async ({ externalKey }: { externalKey: string }) =>
+				threadIdsByExternalKey.get(externalKey) ?? null,
+		),
 	};
 	const messageContextStore = new MemoryMessageContextStore();
 

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -34,6 +34,21 @@ interface AgentExecutor {
 		integrationType?: string;
 	}): AsyncGenerator<StreamChunk>;
 
+	/** Session backing this platform thread, started on the first inbound message. */
+	resolveThreadId(params: {
+		agentId: string;
+		projectId: string;
+		origin: 'integration';
+		externalKey: string;
+		resourceId: string;
+	}): Promise<string>;
+
+	findThreadIdByKey(key: {
+		agentId: string;
+		origin: 'integration';
+		externalKey: string;
+	}): Promise<string | null>;
+
 	resumeForChat(config: {
 		agentId: string;
 		projectId: string;
@@ -113,7 +128,7 @@ export class AgentChatBridge {
 			logger,
 			callbackStore: this.callbackStore,
 			resolvePlatformThreadId: this.resolvePlatformThreadId.bind(this),
-			toAgentThreadId: this.toAgentThreadId.bind(this),
+			findAgentThreadId: this.findAgentThreadId.bind(this),
 			getPlatformAgentContext: this.getPlatformAgentContext.bind(this),
 			messageContextBridge: this.messageContextBridge,
 			streamConsumer: this.streamConsumer,
@@ -165,6 +180,8 @@ export class AgentChatBridge {
 			async *resumeForChat(config) {
 				yield* agentService.resumeForChat(config);
 			},
+			resolveThreadId: async (params) => await agentService.resolveThreadId(params),
+			findThreadIdByKey: async (key) => await agentService.findThreadIdByKey(key),
 		};
 		return new AgentChatBridge(
 			chat,
@@ -229,8 +246,26 @@ export class AgentChatBridge {
 		return this.integrationImpl?.formatThreadId?.fromSdk(thread) ?? thread.id;
 	}
 
-	private toAgentThreadId(platformThreadId: string) {
-		return toInternalThreadId(`${this.agentId}:${platformThreadId}`);
+	/** Starts the session when this platform thread has not been seen before. */
+	private async toAgentThreadId(platformThreadId: string, resourceId: string) {
+		return toInternalThreadId(
+			await this.agentService.resolveThreadId({
+				agentId: this.agentId,
+				projectId: this.n8nProjectId,
+				origin: 'integration',
+				externalKey: platformThreadId,
+				resourceId,
+			}),
+		);
+	}
+
+	private async findAgentThreadId(platformThreadId: string) {
+		const threadId = await this.agentService.findThreadIdByKey({
+			agentId: this.agentId,
+			origin: 'integration',
+			externalKey: platformThreadId,
+		});
+		return threadId === null ? null : toInternalThreadId(threadId);
 	}
 
 	/**
@@ -261,7 +296,8 @@ export class AgentChatBridge {
 		if (!text) return;
 
 		const platformThreadId = this.resolvePlatformThreadId(thread);
-		const threadId = this.toAgentThreadId(platformThreadId);
+		const resourceId = integrationMemoryResourceId(this.integration.type, message.author.userId);
+		const threadId = await this.toAgentThreadId(platformThreadId, resourceId);
 		const statusRetry = new AbortController();
 		// Platform status hooks, the lazy `message.subject` fetch, and any
 		// thread-history fetch are all remote round-trips on independent
@@ -295,10 +331,7 @@ export class AgentChatBridge {
 				agentId: this.agentId,
 				projectId: this.n8nProjectId,
 				message: agentInput,
-				memory: {
-					threadId,
-					resourceId: integrationMemoryResourceId(this.integration.type, message.author.userId),
-				},
+				memory: { threadId, resourceId },
 				integrationType: this.integration.type,
 			});
 

--- a/packages/cli/src/modules/agents/integrations/agent-chat-hitl-resume-handler.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-hitl-resume-handler.ts
@@ -29,7 +29,7 @@ interface AgentChatHitlResumeHandlerOptions {
 	logger: Logger;
 	callbackStore?: CallbackStore;
 	resolvePlatformThreadId: (thread: Thread<unknown, unknown>) => string;
-	toAgentThreadId: (platformThreadId: string) => InternalThread;
+	findAgentThreadId: (platformThreadId: string) => Promise<InternalThread | null>;
 	getPlatformAgentContext: () => PlatformAgentContext;
 	messageContextBridge: AgentChatMessageContextBridge;
 	streamConsumer: AgentChatStreamConsumer;
@@ -68,13 +68,18 @@ export class AgentChatHitlResumeHandler {
 		// Persist the interacting user / messageId into the thread's message
 		// context so tools running on resume can read it via the message
 		// context store — no need to bolt a duplicate copy onto resumeData.
+		// Resume only ever follows a suspended run, so the session already exists.
+		// Without it there is no thread to attach the context to — the resume
+		// itself runs off the checkpoint's own persistence scope regardless.
 		const platformThreadId = this.options.resolvePlatformThreadId(thread);
-		const threadId = this.options.toAgentThreadId(platformThreadId);
-		await this.options.messageContextBridge.updateLatest(threadId.id, event.user.userId, thread, {
-			messageId: event.messageId,
-			interactingUserId: event.user.userId,
-			...this.options.getPlatformAgentContext(),
-		});
+		const threadId = await this.options.findAgentThreadId(platformThreadId);
+		if (threadId) {
+			await this.options.messageContextBridge.updateLatest(threadId.id, event.user.userId, thread, {
+				messageId: event.messageId,
+				interactingUserId: event.user.userId,
+				...this.options.getPlatformAgentContext(),
+			});
+		}
 
 		await this.cleanUpBeforeResume(event);
 		await this.executeResume(thread, parsed.runId, parsed.toolCallId, parsed.resumeData);

--- a/packages/cli/src/modules/agents/repositories/agent-execution-thread.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-execution-thread.repository.ts
@@ -1,13 +1,38 @@
 import { Service } from '@n8n/di';
 import { DataSource, LessThan, Repository } from '@n8n/typeorm';
 
-import { AgentExecutionThread } from '../entities/agent-execution-thread.entity';
+import {
+	AgentExecutionThread,
+	type AgentThreadOrigin,
+} from '../entities/agent-execution-thread.entity';
 
 const SESSION_NUMBER_RETRY_ATTEMPTS = 3;
 
 export interface AgentExecutionThreadMetadata {
 	parentThreadId?: string;
 	parentAgentId?: string;
+}
+
+/** Identifies the conversation a session continues. See {@link AgentExecutionThread.origin}. */
+export interface AgentThreadNaturalKey {
+	agentId: string;
+	origin: AgentThreadOrigin;
+	originRef?: string;
+	externalKey: string;
+}
+
+export interface FindOrCreateThreadOptions {
+	threadId: string;
+	agentId: string;
+	agentName: string;
+	projectId: string;
+	metadata?: AgentExecutionThreadMetadata;
+	taskId?: string | null;
+	taskVersionId?: string | null;
+	origin?: AgentThreadOrigin;
+	originRef?: string;
+	externalKey?: string | null;
+	createdByResourceId?: string | null;
 }
 
 export interface AgentExecutionThreadPage {
@@ -26,25 +51,11 @@ export class AgentExecutionThreadRepository extends Repository<AgentExecutionThr
 	 * On creation, assigns a stable sessionNumber scoped to the project.
 	 */
 	async findOrCreate(
-		threadId: string,
-		agentId: string,
-		agentName: string,
-		projectId: string,
-		metadata?: AgentExecutionThreadMetadata,
-		taskId?: string | null,
-		taskVersionId?: string | null,
+		options: FindOrCreateThreadOptions,
 	): Promise<{ thread: AgentExecutionThread; created: boolean }> {
 		for (let attempt = 0; ; attempt++) {
 			try {
-				return await this.findOrCreateInSerializableTransaction(
-					threadId,
-					agentId,
-					agentName,
-					projectId,
-					metadata,
-					taskId,
-					taskVersionId,
-				);
+				return await this.findOrCreateInSerializableTransaction(options);
 			} catch (error) {
 				if (attempt >= SESSION_NUMBER_RETRY_ATTEMPTS - 1 || !isRetriableWriteError(error)) {
 					throw error;
@@ -53,15 +64,33 @@ export class AgentExecutionThreadRepository extends Repository<AgentExecutionThr
 		}
 	}
 
-	private async findOrCreateInSerializableTransaction(
-		threadId: string,
-		agentId: string,
-		agentName: string,
-		projectId: string,
-		metadata?: AgentExecutionThreadMetadata,
-		taskId?: string | null,
-		taskVersionId?: string | null,
-	): Promise<{ thread: AgentExecutionThread; created: boolean }> {
+	/** Id of the session continuing this conversation, if one was already started. */
+	async findIdByNaturalKey({
+		agentId,
+		origin,
+		originRef,
+		externalKey,
+	}: AgentThreadNaturalKey): Promise<string | null> {
+		const thread = await this.findOne({
+			select: { id: true },
+			where: { agentId, origin, originRef: originRef ?? '', externalKey },
+		});
+		return thread?.id ?? null;
+	}
+
+	private async findOrCreateInSerializableTransaction({
+		threadId,
+		agentId,
+		agentName,
+		projectId,
+		metadata,
+		taskId,
+		taskVersionId,
+		origin,
+		originRef,
+		externalKey,
+		createdByResourceId,
+	}: FindOrCreateThreadOptions): Promise<{ thread: AgentExecutionThread; created: boolean }> {
 		return await this.manager.transaction('SERIALIZABLE', async (entityManager) => {
 			const repository = entityManager.getRepository(AgentExecutionThread);
 			const existing = await repository.findOneBy({ id: threadId });
@@ -87,6 +116,10 @@ export class AgentExecutionThreadRepository extends Repository<AgentExecutionThr
 				sessionNumber,
 				parentThreadId: metadata?.parentThreadId ?? null,
 				parentAgentId: metadata?.parentAgentId ?? null,
+				origin: origin ?? null,
+				originRef: originRef ?? '',
+				externalKey: externalKey ?? null,
+				createdByResourceId: createdByResourceId ?? null,
 			});
 			const saved = await repository.save(thread);
 			return { thread: saved, created: true };

--- a/packages/cli/src/modules/agents/repositories/agent.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent.repository.ts
@@ -71,6 +71,12 @@ export class AgentRepository extends Repository<Agent> {
 	 * published snapshot (or `null`) in a single query, which is what the publish button uses
 	 * to compute its state (published vs. unpublished, has changes vs. up to date).
 	 */
+	/** Name only — for denormalizing onto a session record without loading the agent. */
+	async findNameByIdAndProjectId(id: string, projectId: string): Promise<string | null> {
+		const agent = await this.findOne({ select: { name: true }, where: { id, projectId } });
+		return agent?.name ?? null;
+	}
+
 	async findByIdAndProjectId(id: string, projectId: string): Promise<Agent | null> {
 		return await this.findOne({
 			where: { id, projectId },

--- a/packages/cli/src/modules/agents/sub-agents/sub-agent-foreground-runner.ts
+++ b/packages/cli/src/modules/agents/sub-agents/sub-agent-foreground-runner.ts
@@ -155,6 +155,7 @@ export class SubAgentForegroundRunner {
 				runtimeSource: runtimeSource.source,
 				projectId: context.projectId,
 				threadId,
+				resourceId,
 				parentThreadId: request.parentThreadId,
 				parentAgentId: context.parentAgentId,
 				taskPath,
@@ -209,6 +210,7 @@ export class SubAgentForegroundRunner {
 		projectId: string;
 		/** Unified thread id, shared with the SDK memory thread. */
 		threadId: string;
+		resourceId: string;
 		parentThreadId?: string;
 		parentAgentId?: string;
 		taskPath: SubAgentTaskPath;
@@ -219,6 +221,7 @@ export class SubAgentForegroundRunner {
 			runtimeSource,
 			projectId,
 			threadId,
+			resourceId,
 			parentThreadId,
 			parentAgentId,
 			taskPath,
@@ -235,6 +238,8 @@ export class SubAgentForegroundRunner {
 				userMessage: prompt,
 				record,
 				source: 'subagent',
+				origin: 'subagent',
+				resourceId,
 				threadMetadata: {
 					...(parentThreadId !== undefined ? { parentThreadId } : {}),
 					...(parentAgentId !== undefined ? { parentAgentId } : {}),

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -399,15 +399,14 @@ export async function executeAgent(
 		throw new UnexpectedError('Cannot execute agent without a workflowId in additional data');
 	}
 
-	// Scope session threads by workflow
-	const scopedThreadId = `wf:${additionalData.workflowId}:${threadId}`;
-
 	if (source.inlineAgent) {
+		// Inline runs record no session, so there is no row to look the thread up
+		// on: the composed key stays the only thing that continues them.
 		return await agentWorkflowExecutionService.executeInlineForWorkflow(
 			source.inlineAgent,
 			message,
 			executionId,
-			scopedThreadId,
+			`wf:${additionalData.workflowId}:${threadId}`,
 			projectId,
 			telemetryUserId,
 			isManualOrChatExecution(executionMode) ? 'test' : 'production',
@@ -417,6 +416,17 @@ export async function executeAgent(
 	}
 
 	const useDraftVersion = isManualOrChatExecution(executionMode);
+
+	// The caller's session id is only unique within its workflow, so the workflow
+	// namespaces it on the session record rather than in the thread id.
+	const { AgentExecutionService } = await import('@/modules/agents/agent-execution.service.js');
+	const scopedThreadId = await Container.get(AgentExecutionService).resolveThreadIdForKey({
+		agentId: source.agentId,
+		projectId,
+		origin: 'workflow',
+		originRef: additionalData.workflowId,
+		externalKey: threadId,
+	});
 
 	const result = await agentWorkflowExecutionService.executeForWorkflow(
 		source.agentId,

--- a/packages/cli/test/migration/1785151856791-add-thread-identity-to-agent-execution-threads.test.ts
+++ b/packages/cli/test/migration/1785151856791-add-thread-identity-to-agent-execution-threads.test.ts
@@ -1,0 +1,294 @@
+import {
+	createTestMigrationContext,
+	initDbUpToMigration,
+	runSingleMigration,
+	undoLastSingleMigration,
+	type TestMigrationContext,
+} from '@n8n/backend-test-utils';
+import { DbConnection } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { DataSource } from '@n8n/typeorm';
+import { randomUUID } from 'node:crypto';
+
+const MIGRATION_NAME = 'AddThreadIdentityToAgentExecutionThreads1785151856791';
+
+type IdentityRow = {
+	origin: string | null;
+	originRef: string;
+	externalKey: string | null;
+	createdByResourceId: string | null;
+};
+
+describe('AddThreadIdentityToAgentExecutionThreads Migration', () => {
+	let dataSource: DataSource;
+	const agentId = randomUUID();
+	const projectId = randomUUID();
+
+	async function withContext<T>(fn: (context: TestMigrationContext) => Promise<T>): Promise<T> {
+		const context = createTestMigrationContext(dataSource);
+		try {
+			return await fn(context);
+		} finally {
+			await context.queryRunner.release();
+		}
+	}
+
+	beforeAll(async () => {
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.init();
+		dataSource = Container.get(DataSource);
+	});
+
+	beforeEach(async () => {
+		await withContext(async (context) => {
+			await context.queryRunner.clearDatabase();
+		});
+		await initDbUpToMigration(MIGRATION_NAME);
+		await withContext(async (context) => {
+			await insertProject(context);
+			await insertAgent(context);
+		});
+	});
+
+	afterAll(async () => {
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.close();
+	});
+
+	async function insertProject(context: TestMigrationContext): Promise<void> {
+		await context.runQuery(
+			`INSERT INTO ${context.escape.tableName('project')} ("id", "name", "type", "createdAt", "updatedAt")
+			 VALUES (:id, :name, :type, :now, :now)`,
+			{ id: projectId, name: 'test-project', type: 'personal', now: new Date() },
+		);
+	}
+
+	async function insertAgent(context: TestMigrationContext): Promise<void> {
+		await context.runQuery(
+			`INSERT INTO ${context.escape.tableName('agents')}
+			   ("id", "name", "projectId", "integrations", "tools", "skills", "createdAt", "updatedAt")
+			 VALUES (:id, :name, :projectId, '[]', '{}', '{}', :now, :now)`,
+			{ id: agentId, name: 'Test Agent', projectId, now: new Date() },
+		);
+	}
+
+	async function insertThread(
+		context: TestMigrationContext,
+		id: string,
+		options: { parentThreadId?: string } = {},
+	): Promise<void> {
+		await context.runQuery(
+			`INSERT INTO ${context.escape.tableName('agent_execution_threads')}
+			   ("id", "agentId", "agentName", "projectId", "parentThreadId", "sessionNumber", "createdAt", "updatedAt")
+			 VALUES (:id, :agentId, :agentName, :projectId, :parentThreadId, 1, :now, :now)`,
+			{
+				id,
+				agentId,
+				agentName: 'Test Agent',
+				projectId,
+				parentThreadId: options.parentThreadId ?? null,
+				now: new Date(),
+			},
+		);
+	}
+
+	async function insertMessage(
+		context: TestMigrationContext,
+		threadId: string,
+		resourceId: string,
+		createdAt: Date,
+	): Promise<void> {
+		await context.runQuery(
+			`INSERT INTO ${context.escape.tableName('agents_threads')} ("id", "resourceId", "createdAt", "updatedAt")
+			 VALUES (:threadId, :resourceId, :createdAt, :createdAt)
+			 ON CONFLICT ("id") DO NOTHING`,
+			{ threadId, resourceId, createdAt },
+		);
+		await context.runQuery(
+			`INSERT INTO ${context.escape.tableName('agents_messages')}
+			   ("id", "threadId", "resourceId", "role", "content", "createdAt", "updatedAt")
+			 VALUES (:id, :threadId, :resourceId, 'user', :content, :createdAt, :createdAt)`,
+			{ id: randomUUID(), threadId, resourceId, content: '{}', createdAt },
+		);
+	}
+
+	async function getIdentity(
+		context: TestMigrationContext,
+		threadId: string,
+	): Promise<IdentityRow> {
+		const rows = await context.runQuery<IdentityRow[]>(
+			`SELECT "origin", "originRef", "externalKey", "createdByResourceId"
+			 FROM ${context.escape.tableName('agent_execution_threads')} WHERE "id" = :id`,
+			{ id: threadId },
+		);
+		return rows[0];
+	}
+
+	describe('up', () => {
+		it('derives origin and external key from each legacy thread id shape', async () => {
+			const chatId = randomUUID();
+			const subAgentId = randomUUID();
+			const parentId = randomUUID();
+			const taskId = `task-${randomUUID()}-${randomUUID()}`;
+			const testId = `test-${agentId}:${randomUUID()}`;
+			const slackId = `${agentId}:slack:C123:1727000000.001`;
+			const workflowId = 'wf:wkfl-1:session:with:colons';
+
+			await withContext(async (context) => {
+				await insertThread(context, parentId);
+				await insertThread(context, chatId);
+				await insertThread(context, subAgentId, { parentThreadId: parentId });
+				await insertThread(context, taskId);
+				await insertThread(context, testId);
+				await insertThread(context, slackId);
+				await insertThread(context, workflowId);
+			});
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			await withContext(async (context) => {
+				expect(await getIdentity(context, chatId)).toMatchObject({
+					origin: 'chat',
+					originRef: '',
+					externalKey: null,
+				});
+				expect(await getIdentity(context, subAgentId)).toMatchObject({ origin: 'subagent' });
+				expect(await getIdentity(context, taskId)).toMatchObject({
+					origin: 'task',
+					externalKey: null,
+				});
+				expect(await getIdentity(context, testId)).toMatchObject({ origin: 'test' });
+				expect(await getIdentity(context, slackId)).toMatchObject({
+					origin: 'integration',
+					originRef: '',
+					externalKey: 'slack:C123:1727000000.001',
+				});
+				expect(await getIdentity(context, workflowId)).toMatchObject({
+					origin: 'workflow',
+					originRef: 'wkfl-1',
+					externalKey: 'session:with:colons',
+				});
+			});
+		});
+
+		it('leaves a workflow thread without a session segment out of the lookup index', async () => {
+			const malformedId = 'wf:wkfl-1';
+
+			await withContext(async (context) => await insertThread(context, malformedId));
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			await withContext(async (context) => {
+				expect(await getIdentity(context, malformedId)).toMatchObject({
+					origin: 'workflow',
+					externalKey: null,
+				});
+			});
+		});
+
+		it('attributes a thread to the resourceId of its earliest message', async () => {
+			const sharedId = randomUUID();
+			const unusedId = randomUUID();
+
+			await withContext(async (context) => {
+				await insertThread(context, sharedId);
+				await insertThread(context, unusedId);
+				await insertMessage(
+					context,
+					sharedId,
+					'integration:slack:U-second',
+					new Date('2026-02-01'),
+				);
+				await insertMessage(context, sharedId, 'integration:slack:U-first', new Date('2026-01-01'));
+			});
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			await withContext(async (context) => {
+				expect((await getIdentity(context, sharedId)).createdByResourceId).toBe(
+					'integration:slack:U-first',
+				);
+				expect((await getIdentity(context, unusedId)).createdByResourceId).toBeNull();
+			});
+		});
+
+		it('enforces uniqueness per external key while allowing many keyless sessions', async () => {
+			await withContext(async (context) => await insertThread(context, randomUUID()));
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			await withContext(async (context) => {
+				const insertResolved = async (id: string, externalKey: string | null) =>
+					await context.runQuery(
+						`INSERT INTO ${context.escape.tableName('agent_execution_threads')}
+						   ("id", "agentId", "agentName", "projectId", "origin", "originRef", "externalKey", "sessionNumber", "createdAt", "updatedAt")
+						 VALUES (:id, :agentId, 'Test Agent', :projectId, 'integration', '', :externalKey, 1, :now, :now)`,
+						{ id, agentId, projectId, externalKey, now: new Date() },
+					);
+
+				await insertResolved(randomUUID(), 'slack:C1:1');
+				await expect(insertResolved(randomUUID(), 'slack:C1:1')).rejects.toThrow();
+
+				await insertResolved(randomUUID(), null);
+				await expect(insertResolved(randomUUID(), null)).resolves.not.toThrow();
+			});
+		});
+
+		it('keeps execution rows belonging to the migrated threads', async () => {
+			const threadId = randomUUID();
+			const executionId = randomUUID();
+
+			await withContext(async (context) => {
+				await insertThread(context, threadId);
+				await context.runQuery(
+					`INSERT INTO ${context.escape.tableName('agent_execution')}
+					   ("id", "threadId", "status", "createdAt", "updatedAt")
+					 VALUES (:id, :threadId, 'success', :now, :now)`,
+					{ id: executionId, threadId, now: new Date() },
+				);
+			});
+
+			await runSingleMigration(MIGRATION_NAME);
+			dataSource = Container.get(DataSource);
+
+			await withContext(async (context) => {
+				const rows = await context.runQuery<Array<{ id: string }>>(
+					`SELECT "id" FROM ${context.escape.tableName('agent_execution')} WHERE "id" = :id`,
+					{ id: executionId },
+				);
+				expect(rows).toHaveLength(1);
+			});
+		});
+	});
+
+	describe('down', () => {
+		it('removes the identity columns while keeping the thread row', async () => {
+			const threadId = randomUUID();
+
+			await withContext(async (context) => await insertThread(context, threadId));
+
+			await runSingleMigration(MIGRATION_NAME);
+			await undoLastSingleMigration();
+			dataSource = Container.get(DataSource);
+
+			await withContext(async (context) => {
+				const table = await context.queryRunner.getTable(
+					`${context.tablePrefix}agent_execution_threads`,
+				);
+				const columnNames = (table?.columns ?? []).map((column) => column.name);
+				expect(columnNames).not.toContain('origin');
+				expect(columnNames).not.toContain('createdByResourceId');
+
+				const rows = await context.runQuery<Array<{ id: string }>>(
+					`SELECT "id" FROM ${context.escape.tableName('agent_execution_threads')} WHERE "id" = :id`,
+					{ id: threadId },
+				);
+				expect(rows).toHaveLength(1);
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Agent thread ids encoded their surface and external conversation key so a continuation could re-derive the id and fetch it by primary key — `wf:<workflowId>:<sessionId>`, `<agentId>:slack:<channel>:<ts>`, `task-<taskId>-<uuid>`, and four more shapes across three separator conventions, two of them with caller-controlled segments. This stores those parts as columns on `agent_execution_threads` and looks the thread up by that natural key instead, so new threads can use opaque uuids.

**Schema** (migration `AddThreadIdentityToAgentExecutionThreads1785151856791`):

| Column | Purpose |
|---|---|
| `origin` | `chat \| integration \| workflow \| task \| subagent \| test` |
| `originRef` | Namespaces `externalKey` where it is only unique within something else (the workflow, for workflow threads) |
| `externalKey` | Thread key owned by the origin — platform thread id, caller session id |
| `createdByResourceId` | Memory resourceId of the first writer, immutable |

Two indexes come with it. A partial unique index on `(agentId, origin, originRef, externalKey) WHERE externalKey IS NOT NULL` is the continuation lookup — `originRef` is `NOT NULL DEFAULT ''` on purpose, because both Postgres and SQLite treat NULLs as distinct in unique indexes, so a nullable column there would silently disable the constraint for exactly the integration rows that depend on it. A plain index on `(agentId, createdByResourceId)` serves "the sessions this caller had with this agent", which is the lookup the AGENT-497 session-reading tool will scope by; it ships here so that follow-up needs no second migration.

Columns are added with raw `ALTER TABLE ADD COLUMN` rather than the DSL's `addColumns`, which recreates the table on SQLite — `agent_execution.threadId` references this table `ON DELETE CASCADE`.

**Continuation.** `AgentExecutionService.resolveThreadIdForKey()` looks up the natural key and, on a miss, mints a uuid and creates the session — reading back the winner's id on a unique violation so two messages arriving together cannot fork one conversation. Resolution runs before the agent starts, so the same id backs both the SDK memory thread and the session record. Wired into the integration bridge, the HITL resume handler (read-only; it never creates), and the workflow path. Scheduled task runs now use a bare `randomUUID()` since `taskId` is already a column.

**Existing threads are never rewritten** — foreign keys and the execution-log blob keys reference the ids. The migration parses them once to backfill the new columns, so an existing Slack thread still resolves to its original id with its history and memory intact. That one-time parse is the only place a thread id is ever parsed.

**Ownership.** The chat endpoint already checked that a client-supplied `sessionId` belonged to the right project and agent, but not the right user, so within one project user A could append to user B's session. It now also checks `createdByResourceId`, returning the same "Session not found" response as a missing session so it is not an existence oracle. Threads predating the column have no recorded writer and stay open to their project.

### Behaviour changes worth review attention

- **Workflow threads are now per-agent.** Previously `wf:<workflowId>:<sessionId>` omitted the agent, so two "Message an Agent" nodes using the same session id against *different* agents collided on one thread, attributed to whichever ran first. They now get separate threads with separate memory. I consider the old behaviour a bug, but it is a change.
- **Session rows for integration and workflow runs are created at run start** rather than on first persist, so sessions appear immediately and a crash before completion can leave a zero-execution row (list endpoints already default those counters to 0).
- **Rolling deploys:** during a mixed-version window an old pod can still create a composed-id thread after the backfill ran; a new pod would miss it by key and fork that conversation once. Accepted rather than carrying a permanent legacy-derive fallback in resolution.

### Deliberately out of scope

- **No participants table.** Five of the six surfaces are single-participant by construction; only a shared integration thread (a Slack channel thread with several humans) has more than one writer, and there only the starter is attributed — a fail-closed under-report. Addable later and backfillable from `agents_messages`, which keeps a resourceId per message.
- **resourceId values are unchanged**, prefixes included. The prefix is the namespace keeping a platform-asserted id from ever equalling an internal one, which matters because episodic memory is keyed by `(agentId, resourceId)` with no thread involved. Normalizing it crosses the `@n8n/agents` SDK boundary and needs its own ticket.
- **Inline workflow agents, ia-builder and legacy test-chat ids** keep their composed ids. Inline runs have no `agents` row so they cannot have a session record to look up; the other two are built entirely from server-controlled uuids and their cleanup paths query `agents_threads`, which has no session rows for them.

## How to test

No feature flag or licence needed; the migration runs on startup.

1. Check out `master`, run n8n, and create conversations that produce legacy ids — a workflow "Message an Agent" node with a Session ID set, and an agent chat session.
2. Check out this branch and start n8n so the migration applies. Verify the backfill:
   ```sql
   SELECT id, origin, "originRef", "externalKey", "createdByResourceId" FROM agent_execution_threads;
   ```
   Every row should have an `origin`; `wf:` rows should be split into `originRef` (workflow id) and `externalKey` (session id); integration rows should carry the platform thread id.
3. **Legacy continuity:** re-run the workflow with the same Session ID. It must continue the *existing* thread (same row, same id, history intact) rather than starting a new one.
4. **New threads:** run a workflow with a fresh Session ID, and trigger a scheduled task. Both should produce sessions whose `id` is a plain uuid with the identifying parts in columns.
5. **Ownership:** as user A, start a chat session and note the `sessionId` from the SSE `done` event. As user B in the same project, POST to `/rest/projects/:projectId/agents/v2/:agentId/chat` with that `sessionId`. Expect `Session not found` — identical to passing a nonexistent id.
6. Slack (if you have an integration configured): reply in an existing bot thread and confirm it continues the same session; start a new thread and confirm it gets a uuid session.

Automated: `pnpm test:sqlite:migrations 1785151856791` and `pnpm test:postgres:migrations:tc 1785151856791` from `packages/cli` (both run green locally), plus the agents module suite.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-501

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35015">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


