### PR TITLE
ci: Fix Chromatic marking all components as changed and upgrade action

### DIFF
--- a/.github/workflows/release-chromatic.yml
+++ b/.github/workflows/release-chromatic.yml
@@ -25,7 +25,7 @@ jobs:
           build-command: pnpm run build --filter=@n8n/utils --filter=@n8n/vitest-config --filter=@n8n/chat --filter=@n8n/design-system
 
       - name: Publish to Chromatic
-        uses: chromaui/action@1cfa065cbdab28f6ca3afaeb3d761383076a35aa # v11
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         id: chromatic_tests
         with:
           workingDir: packages/frontend/@n8n/storybook

--- a/packages/frontend/@n8n/storybook/.storybook/preview.ts
+++ b/packages/frontend/@n8n/storybook/.storybook/preview.ts
@@ -1,9 +1,9 @@
 // Import from deep paths, not the '@n8n/design-system' barrel: preview.ts is a
 // TurboSnap global, and the barrel's `export * from './components'` would make
 // every component a global dep, forcing a full snapshot on any component change.
-import { N8nPlugin } from '@n8n/design-system/plugin';
 import { IconBodyLoaderKey } from '@n8n/design-system/composables/useIconBodyLoader';
 import { loadLucideIconBody } from '@n8n/design-system/icons/lucide';
+import { N8nPlugin } from '@n8n/design-system/plugin';
 import { i18nInstance } from '@n8n/i18n';
 import { setup } from '@storybook/vue3';
 import ElementPlus from 'element-plus';

--- a/packages/frontend/@n8n/storybook/.storybook/preview.ts
+++ b/packages/frontend/@n8n/storybook/.storybook/preview.ts
@@ -1,4 +1,8 @@
-import { IconBodyLoaderKey, N8nPlugin } from '@n8n/design-system';
+// Import from deep paths, not the '@n8n/design-system' barrel: preview.ts is a
+// TurboSnap global, and the barrel's `export * from './components'` would make
+// every component a global dep, forcing a full snapshot on any component change.
+import { N8nPlugin } from '@n8n/design-system/plugin';
+import { IconBodyLoaderKey } from '@n8n/design-system/composables/useIconBodyLoader';
 import { loadLucideIconBody } from '@n8n/design-system/icons/lucide';
 import { i18nInstance } from '@n8n/i18n';
 import { setup } from '@storybook/vue3';


### PR DESCRIPTION
## Summary

Two fixes to the Chromatic (visual regression) setup:

1. **Stop full-snapshotting the whole library on every design-system PR.** TurboSnap (`onlyChanged: true`) treats Storybook's `.storybook/preview.ts` — and everything it imports — as *global* dependencies, re-snapshotting every story whenever a global-graph file changes. `preview.ts` imported `N8nPlugin`/`IconBodyLoaderKey` from the `@n8n/design-system` barrel (`export * from './components'`), pulling every component into that global graph. So touching one component marked **all** components as changed. Now imported from deep paths (`@n8n/design-system/plugin`, `@n8n/design-system/composables/useIconBodyLoader`) so the barrel is no longer in the global graph.

2. **Clear the outdated-CLI warning.** CI runs `chromaui/action@v11`, which bundles Chromatic CLI 11.29.0 ("significantly outdated"). Bumped to `v18.1.0` (pinned by SHA). All inputs we use remain valid and non-deprecated. (The `chromatic` npm dep is already current at 13.3.4 — the warning was purely the action's bundled CLI.)

## How to test

Both effects only confirm on a real Chromatic run (approval-gated in CI). On the next approved PR touching a single design-system component, TurboSnap should scope to that component + dependents rather than all stories, and the outdated-CLI warning should be gone.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-667

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35016">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

