### PR TITLE
ci: Fix E2E impact-map source paths and unblock the nightly refresh (no-changelog)

### DIFF
--- a/.github/workflows/test-e2e-coverage-nightly.yml
+++ b/.github/workflows/test-e2e-coverage-nightly.yml
@@ -272,10 +272,18 @@ jobs:
   # couplings get declared uncovered and their E2E specs skipped. Gated on ALL
   # shards passing (complete map) + aggregate having built it — a partial shard
   # set yields a degraded map, worse than a stale one.
+  #
+  # `!cancelled()` is load-bearing: without it a failure in the unit-coverage legs
+  # (which feed the combined lcov, not the impact map) transitively skips this job
+  # even when e2e + aggregate both passed, freezing selection input indefinitely.
+  # The result checks below stay the real gate.
+  #
+  # Default-branch-only: on a workflow_dispatch from a feature branch this would
+  # cut the refresh branch from that branch's HEAD and automerge it into master.
   commit-impact-map:
     name: Commit refreshed impact map
     needs: [e2e, aggregate]
-    if: needs.e2e.result == 'success' && needs.aggregate.result == 'success'
+    if: ${{ !cancelled() && github.ref_name == github.event.repository.default_branch && needs.e2e.result == 'success' && needs.aggregate.result == 'success' }}
     runs-on: ubuntu-latest
     # Least-privilege GITHUB_TOKEN: checkout + download-artifact only need read;
     # the branch push + PR are done with the scoped app token below, not this token.
@@ -362,7 +370,9 @@ jobs:
 
   approve-and-automerge:
     needs: [commit-impact-map]
-    if: needs.commit-impact-map.outputs.pull-request-number != ''
+    # Same `!cancelled()` reasoning as commit-impact-map: a red unit-coverage leg
+    # upstream would otherwise skip this and leave the refresh PR open forever.
+    if: ${{ !cancelled() && needs.commit-impact-map.outputs.pull-request-number != '' }}
     uses: ./.github/workflows/util-approve-and-set-automerge.yml
     secrets: inherit
     with:

--- a/.github/workflows/test-e2e-coverage-nightly.yml
+++ b/.github/workflows/test-e2e-coverage-nightly.yml
@@ -273,13 +273,11 @@ jobs:
   # shards passing (complete map) + aggregate having built it — a partial shard
   # set yields a degraded map, worse than a stale one.
   #
-  # `!cancelled()` is load-bearing: without it a failure in the unit-coverage legs
-  # (which feed the combined lcov, not the impact map) transitively skips this job
-  # even when e2e + aggregate both passed, freezing selection input indefinitely.
-  # The result checks below stay the real gate.
-  #
-  # Default-branch-only: on a workflow_dispatch from a feature branch this would
-  # cut the refresh branch from that branch's HEAD and automerge it into master.
+  # `!cancelled()` is load-bearing: a failing unit-coverage leg (which feeds the
+  # combined lcov, not the impact map) would otherwise transitively skip this job
+  # even with e2e + aggregate green. The result checks stay the real gate.
+  # Default-branch-only: a dispatch from a feature branch would cut the refresh
+  # branch from that branch's HEAD and automerge it.
   commit-impact-map:
     name: Commit refreshed impact map
     needs: [e2e, aggregate]
@@ -370,8 +368,8 @@ jobs:
 
   approve-and-automerge:
     needs: [commit-impact-map]
-    # Same `!cancelled()` reasoning as commit-impact-map: a red unit-coverage leg
-    # upstream would otherwise skip this and leave the refresh PR open forever.
+    # `!cancelled()` for the same reason as commit-impact-map, or the refresh PR
+    # opens and never merges.
     if: ${{ !cancelled() && needs.commit-impact-map.outputs.pull-request-number != '' }}
     uses: ./.github/workflows/util-approve-and-set-automerge.yml
     secrets: inherit

--- a/.github/workflows/test-e2e-coverage-nightly.yml
+++ b/.github/workflows/test-e2e-coverage-nightly.yml
@@ -269,19 +269,23 @@ jobs:
 
   # Refresh the committed impact map PRs read for E2E selection. Without this the
   # map only updates on manual commits and drifts, so newly-covered source→spec
-  # couplings get declared uncovered and their E2E specs skipped. Gated on ALL
-  # shards passing (complete map) + aggregate having built it — a partial shard
-  # set yields a degraded map, worse than a stale one.
+  # couplings get declared uncovered and their E2E specs skipped.
   #
-  # `!cancelled()` is load-bearing: a failing unit-coverage leg (which feeds the
-  # combined lcov, not the impact map) would otherwise transitively skip this job
-  # even with e2e + aggregate green. The result checks stay the real gate.
+  # A partial shard set yields a degraded map, worse than a stale one — but that's
+  # about specs that never RAN, not tests that failed. A failing test still emits
+  # coverage for its spec, so `failure` is allowed through and completeness is
+  # enforced on the map itself (see the spec-count guard below). `cancelled` is not:
+  # a timed-out shard means its specs never reported.
+  #
+  # `!cancelled()` is load-bearing for the job-level skip: a failing unit-coverage
+  # leg (which feeds the combined lcov, not the impact map) would otherwise
+  # transitively skip this job even with e2e + aggregate green.
   # Default-branch-only: a dispatch from a feature branch would cut the refresh
   # branch from that branch's HEAD and automerge it.
   commit-impact-map:
     name: Commit refreshed impact map
     needs: [e2e, aggregate]
-    if: ${{ !cancelled() && github.ref_name == github.event.repository.default_branch && needs.e2e.result == 'success' && needs.aggregate.result == 'success' }}
+    if: ${{ !cancelled() && github.ref_name == github.event.repository.default_branch && needs.e2e.result != 'cancelled' && needs.e2e.result != 'skipped' && needs.aggregate.result == 'success' }}
     runs-on: ubuntu-latest
     # Least-privilege GITHUB_TOKEN: checkout + download-artifact only need read;
     # the branch push + PR are done with the scoped app token below, not this token.
@@ -318,15 +322,23 @@ jobs:
       - name: Copy impact map into place
         run: |
           MAP=/tmp/coverage-report/impact-map.json
-          # Guard: a missing/empty map is a build hiccup — keep the committed map
-          # rather than clobber it with a degraded one.
+          # Completeness guard. This, not the job's e2e result, is what keeps a
+          # degraded map out: a lost shard shows up as a drop in spec count against
+          # the map we already trust. 5% absorbs legitimately deleted specs while
+          # still catching a missing shard (16 shards, so ~6% of specs each).
           node -e '
             const fs = require("fs");
             const m = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
             const n = Array.isArray(m.specs) ? m.specs.length : 0;
             if (!n) { console.error("impact map has no specs — refusing to commit"); process.exit(1); }
+            const current = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+            const floor = Math.floor((Array.isArray(current.specs) ? current.specs.length : 0) * 0.95);
+            if (n < floor) {
+              console.error("impact map has " + n + " specs, expected at least " + floor + " — refusing to commit a degraded map");
+              process.exit(1);
+            }
             console.log("impact map ok: " + n + " specs");
-          ' "$MAP"
+          ' "$MAP" .github/test-metrics/e2e-impact-map.json
           # Raw copy: the map is intentionally minified and biome-ignored
           # (.github/test-metrics/**). Do NOT format it.
           cp "$MAP" .github/test-metrics/e2e-impact-map.json

--- a/packages/testing/playwright/coverage-options.test.ts
+++ b/packages/testing/playwright/coverage-options.test.ts
@@ -74,9 +74,8 @@ describe('mergeV8CoverageByUrl', () => {
 });
 
 describe('resolveSourcePath', () => {
-	// Mirrors the real layout: some packages sit directly under `packages/`, the
-	// frontend ones a level deeper. `@n8n/nodes-langchain` is the case where the dir
-	// name and the package name disagree.
+	// Mirrors the real layout: frontend packages sit a level deeper, and
+	// `@n8n/nodes-langchain` is dir-only (its package name differs).
 	const index = {
 		names: new Map([
 			['@n8n/design-system', 'packages/frontend/@n8n/design-system'],
@@ -123,8 +122,7 @@ describe('resolveSourcePath', () => {
 		);
 	});
 
-	// The regression this guards: `packages/` + name mislabels packages that live
-	// under packages/frontend/, so their changes match nothing in the impact map.
+	// The regression this guards.
 	test('resolves a scoped specifier whose dir is nested', () => {
 		expect(
 			resolveSourcePath(

--- a/packages/testing/playwright/coverage-options.test.ts
+++ b/packages/testing/playwright/coverage-options.test.ts
@@ -144,6 +144,12 @@ describe('resolveSourcePath', () => {
 		expect(resolveSourcePath('unknown-pkg/src/x.ts', index)).toBe('packages/unknown-pkg/src/x.ts');
 	});
 
+	test('leaves an unmapped bundle chunk alone', () => {
+		const out = resolveSourcePath('localhost-45061/assets/chunk-CC9Q.js', index);
+		expect(out).toBe('localhost-45061/assets/chunk-CC9Q.js');
+		expect(out.startsWith('packages/')).toBe(false);
+	});
+
 	test('normalises windows separators', () => {
 		expect(resolveSourcePath('packages\\cli\\src\\server.ts', index)).toBe(
 			'packages/cli/src/server.ts',

--- a/packages/testing/playwright/coverage-options.test.ts
+++ b/packages/testing/playwright/coverage-options.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest';
 
-import { mergeV8CoverageByUrl, type V8CoverageEntry } from './coverage-options';
+import { mergeV8CoverageByUrl, resolveSourcePath, type V8CoverageEntry } from './coverage-options';
 
 const fn = (functionName: string, ranges: Array<[number, number, number]>) => ({
 	functionName,
@@ -70,5 +70,60 @@ describe('mergeV8CoverageByUrl', () => {
 		expect(
 			fns.find((f) => f.functionName === 'f')?.ranges.find((r) => r.startOffset === 20)?.count,
 		).toBe(5);
+	});
+});
+
+describe('resolveSourcePath', () => {
+	// Mirrors the real layout: some packages sit directly under `packages/`, the
+	// frontend ones a level deeper.
+	const packageDirs = new Map([
+		['@n8n/design-system', 'packages/frontend/@n8n/design-system'],
+		['@n8n/chat', 'packages/frontend/@n8n/chat'],
+		['n8n-workflow', 'packages/workflow'],
+	]);
+
+	test('leaves an already repo-relative path untouched', () => {
+		expect(resolveSourcePath('packages/cli/src/server.ts', packageDirs)).toBe(
+			'packages/cli/src/server.ts',
+		);
+	});
+
+	test('strips an absolute prefix down to the packages/ root', () => {
+		expect(
+			resolveSourcePath('/home/runner/_work/n8n/n8n/packages/cli/src/server.ts', packageDirs),
+		).toBe('packages/cli/src/server.ts');
+	});
+
+	test('attributes a bare src/ path to editor-ui', () => {
+		expect(resolveSourcePath('src/views/WorkflowView.vue', packageDirs)).toBe(
+			'packages/frontend/editor-ui/src/views/WorkflowView.vue',
+		);
+	});
+
+	test('resolves a scoped workspace specifier to the package real directory', () => {
+		expect(
+			resolveSourcePath(
+				'@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue',
+				packageDirs,
+			),
+		).toBe('packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue');
+	});
+
+	test('resolves an unscoped workspace specifier', () => {
+		expect(resolveSourcePath('n8n-workflow/src/Expression.ts', packageDirs)).toBe(
+			'packages/workflow/src/Expression.ts',
+		);
+	});
+
+	test('never invents a packages/ path for an unresolvable specifier', () => {
+		const resolved = resolveSourcePath('localhost-45789/assets/chunk-CC9Q.js', packageDirs);
+		expect(resolved).toBe('localhost-45789/assets/chunk-CC9Q.js');
+		expect(resolved).not.toContain('packages/');
+	});
+
+	test('normalises windows separators', () => {
+		expect(resolveSourcePath('packages\\cli\\src\\server.ts', packageDirs)).toBe(
+			'packages/cli/src/server.ts',
+		);
 	});
 });

--- a/packages/testing/playwright/coverage-options.test.ts
+++ b/packages/testing/playwright/coverage-options.test.ts
@@ -75,54 +75,77 @@ describe('mergeV8CoverageByUrl', () => {
 
 describe('resolveSourcePath', () => {
 	// Mirrors the real layout: some packages sit directly under `packages/`, the
-	// frontend ones a level deeper.
-	const packageDirs = new Map([
-		['@n8n/design-system', 'packages/frontend/@n8n/design-system'],
-		['@n8n/chat', 'packages/frontend/@n8n/chat'],
-		['n8n-workflow', 'packages/workflow'],
-	]);
+	// frontend ones a level deeper. `@n8n/nodes-langchain` is the case where the dir
+	// name and the package name disagree.
+	const index = {
+		names: new Map([
+			['@n8n/design-system', 'packages/frontend/@n8n/design-system'],
+			['n8n-workflow', 'packages/workflow'],
+		]),
+		dirs: new Set([
+			'packages',
+			'packages/cli',
+			'packages/cli/src',
+			'packages/cli/src/auth',
+			'packages/@n8n/nodes-langchain',
+			'packages/@n8n/nodes-langchain/nodes',
+		]),
+	};
 
 	test('leaves an already repo-relative path untouched', () => {
-		expect(resolveSourcePath('packages/cli/src/server.ts', packageDirs)).toBe(
+		expect(resolveSourcePath('packages/cli/src/server.ts', index)).toBe(
 			'packages/cli/src/server.ts',
 		);
 	});
 
 	test('strips an absolute prefix down to the packages/ root', () => {
-		expect(
-			resolveSourcePath('/home/runner/_work/n8n/n8n/packages/cli/src/server.ts', packageDirs),
-		).toBe('packages/cli/src/server.ts');
+		expect(resolveSourcePath('/home/runner/_work/n8n/n8n/packages/cli/src/server.ts', index)).toBe(
+			'packages/cli/src/server.ts',
+		);
 	});
 
 	test('attributes a bare src/ path to editor-ui', () => {
-		expect(resolveSourcePath('src/views/WorkflowView.vue', packageDirs)).toBe(
+		expect(resolveSourcePath('src/views/WorkflowView.vue', index)).toBe(
 			'packages/frontend/editor-ui/src/views/WorkflowView.vue',
 		);
 	});
 
-	test('resolves a scoped workspace specifier to the package real directory', () => {
+	// Backend sources arrive relative to packages/, not as package specifiers.
+	test('qualifies a dir-relative backend path', () => {
+		expect(resolveSourcePath('cli/src/auth/auth.service.ts', index)).toBe(
+			'packages/cli/src/auth/auth.service.ts',
+		);
+	});
+
+	test('prefers the dir form when dir and package name disagree', () => {
+		expect(resolveSourcePath('@n8n/nodes-langchain/nodes/Agent.ts', index)).toBe(
+			'packages/@n8n/nodes-langchain/nodes/Agent.ts',
+		);
+	});
+
+	// The regression this guards: `packages/` + name mislabels packages that live
+	// under packages/frontend/, so their changes match nothing in the impact map.
+	test('resolves a scoped specifier whose dir is nested', () => {
 		expect(
 			resolveSourcePath(
 				'@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue',
-				packageDirs,
+				index,
 			),
 		).toBe('packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue');
 	});
 
-	test('resolves an unscoped workspace specifier', () => {
-		expect(resolveSourcePath('n8n-workflow/src/Expression.ts', packageDirs)).toBe(
+	test('resolves an unscoped specifier whose dir differs from its name', () => {
+		expect(resolveSourcePath('n8n-workflow/src/Expression.ts', index)).toBe(
 			'packages/workflow/src/Expression.ts',
 		);
 	});
 
-	test('never invents a packages/ path for an unresolvable specifier', () => {
-		const resolved = resolveSourcePath('localhost-45789/assets/chunk-CC9Q.js', packageDirs);
-		expect(resolved).toBe('localhost-45789/assets/chunk-CC9Q.js');
-		expect(resolved).not.toContain('packages/');
+	test('falls back to a packages/ prefix when nothing resolves', () => {
+		expect(resolveSourcePath('unknown-pkg/src/x.ts', index)).toBe('packages/unknown-pkg/src/x.ts');
 	});
 
 	test('normalises windows separators', () => {
-		expect(resolveSourcePath('packages\\cli\\src\\server.ts', packageDirs)).toBe(
+		expect(resolveSourcePath('packages\\cli\\src\\server.ts', index)).toBe(
 			'packages/cli/src/server.ts',
 		);
 	});

--- a/packages/testing/playwright/coverage-options.ts
+++ b/packages/testing/playwright/coverage-options.ts
@@ -29,12 +29,18 @@ function findRepoRoot(): string {
 	return dir;
 }
 
-/** Package name → repo-relative dir, e.g. `@n8n/design-system` →
- * `packages/frontend/@n8n/design-system`. Read off the filesystem so a package
- * that moves can't drift out of the map. */
-export function buildPackageDirIndex(repoRoot: string): Map<string, string> {
-	const index = new Map<string, string>();
+export interface WorkspaceIndex {
+	/** Package name → repo-relative dir, e.g. `@n8n/design-system` → `packages/frontend/@n8n/design-system`. */
+	names: ReadonlyMap<string, string>;
+	/** Every repo-relative dir under `packages/`, used to tell a dir-relative path from a package specifier. */
+	dirs: ReadonlySet<string>;
+}
+
+export function buildWorkspaceIndex(repoRoot: string): WorkspaceIndex {
+	const names = new Map<string, string>();
+	const dirs = new Set<string>();
 	const walk = (absDir: string, relDir: string) => {
+		dirs.add(relDir);
 		for (const entry of readdirSync(absDir, { withFileTypes: true })) {
 			if (!entry.isDirectory() || entry.name === 'node_modules') continue;
 			const abs = join(absDir, entry.name);
@@ -42,48 +48,47 @@ export function buildPackageDirIndex(repoRoot: string): Map<string, string> {
 			const manifest = join(abs, 'package.json');
 			if (existsSync(manifest)) {
 				const { name } = JSON.parse(readFileSync(manifest, 'utf8')) as { name?: string };
-				if (name) index.set(name, rel);
+				if (name) names.set(name, rel);
 			}
 			walk(abs, rel); // packages nest (packages/frontend/@n8n/*)
 		}
 	};
 	walk(join(repoRoot, 'packages'), 'packages');
-	return index;
+	return { names, dirs };
 }
 
-let packageDirsCache: ReadonlyMap<string, string> | undefined;
+const EMPTY_INDEX: WorkspaceIndex = { names: new Map(), dirs: new Set() };
+let workspaceIndexCache: WorkspaceIndex | undefined;
 
-function packageDirs(): ReadonlyMap<string, string> {
-	if (!packageDirsCache) {
+function workspaceIndex(): WorkspaceIndex {
+	if (!workspaceIndexCache) {
 		try {
-			packageDirsCache = buildPackageDirIndex(findRepoRoot());
+			workspaceIndexCache = buildWorkspaceIndex(findRepoRoot());
 		} catch (error) {
-			console.warn(`⚠ coverage: workspace package index unavailable (${(error as Error).message})`);
-			packageDirsCache = new Map();
+			console.warn(`⚠ coverage: workspace index unavailable (${(error as Error).message})`);
+			workspaceIndexCache = EMPTY_INDEX;
 		}
 	}
-	return packageDirsCache;
+	return workspaceIndexCache;
 }
 
 /** Normalise a post-source-map path to the repo-relative form Codecov and the
  * impact map key on. Takes the index as an argument to stay pure/testable. */
-export function resolveSourcePath(
-	filePath: string,
-	packageDirsIndex: ReadonlyMap<string, string>,
-): string {
+export function resolveSourcePath(filePath: string, index: WorkspaceIndex): string {
 	const norm = filePath.replace(/\\/g, '/');
 	if (norm.startsWith('packages/')) return norm;
 	const i = norm.lastIndexOf('packages/');
 	if (i >= 0) return norm.slice(i);
 	if (norm.startsWith('src/')) return `packages/frontend/editor-ui/${norm}`;
-	// Bare workspace specifier (`@n8n/design-system/src/x.vue`). Resolve the name
-	// to its real dir — prefixing `packages/` assumes every package sits directly
-	// under it, which mislabels those under `packages/frontend/` so their changes
-	// match nothing in the impact map and get declared uncovered.
+	// Backend sources arrive dir-relative (`cli/src/x.ts`); the frontend bundle
+	// arrives as a package specifier (`@n8n/design-system/src/x.vue`) whose dir may
+	// sit under packages/frontend/, so `packages/` + name would mislabel it and its
+	// changes would match nothing in the impact map.
+	const asDir = `packages/${norm}`;
+	if (index.dirs.has(asDir.slice(0, asDir.lastIndexOf('/')))) return asDir;
 	const name = packageNameOf(norm);
-	const dir = packageDirsIndex.get(name);
-	if (dir) return `${dir}${norm.slice(name.length)}`;
-	return norm;
+	const dir = index.names.get(name);
+	return dir ? `${dir}${norm.slice(name.length)}` : asDir;
 }
 
 /**
@@ -106,15 +111,16 @@ export const coverageOptions: CoverageReportOptions = {
 	sourceFilter: (sourcePath) =>
 		!sourcePath.includes('node_modules') &&
 		!sourcePath.includes('/dist/') &&
-		// Chunks that never resolved through a source map arrive URL-derived
-		// (`localhost-45789/assets/chunk-*.js`) with no source behind them.
-		!/^localhost[-:]\d+\//.test(sourcePath) &&
+		// Chunks that never resolved through a source map, with no source behind them.
+		// Unanchored: this runs before sourcePath, so the value may still be the URL
+		// (`http://localhost:41401/assets/…`) rather than monocart's `localhost-41401/…`.
+		!/localhost[-:]\d+\//.test(sourcePath) &&
 		!sourcePath.endsWith('.d.ts') &&
 		!sourcePath.endsWith('.spec.ts') &&
 		!sourcePath.endsWith('.test.ts') &&
 		!sourcePath.includes('/__tests__/') &&
 		!sourcePath.includes('/__mocks__/'),
-	sourcePath: (filePath) => resolveSourcePath(filePath, packageDirs()),
+	sourcePath: (filePath) => resolveSourcePath(filePath, workspaceIndex()),
 };
 
 /**

--- a/packages/testing/playwright/coverage-options.ts
+++ b/packages/testing/playwright/coverage-options.ts
@@ -84,6 +84,10 @@ export function resolveSourcePath(filePath: string, index: WorkspaceIndex): stri
 	// arrives as a package specifier (`@n8n/design-system/src/x.vue`) whose dir may
 	// sit under packages/frontend/, so `packages/` + name would mislabel it and its
 	// changes would match nothing in the impact map.
+	// Bundle chunks with no source map reach here URL-derived (`localhost-41401/
+	// assets/…`). sourceFilter never sees them — there are no sources to filter — so
+	// leave them as-is rather than prefixing them into a package that doesn't exist.
+	if (/^localhost[-:]\d+\//.test(norm)) return norm;
 	const asDir = `packages/${norm}`;
 	if (index.dirs.has(asDir.slice(0, asDir.lastIndexOf('/')))) return asDir;
 	const name = packageNameOf(norm);
@@ -111,10 +115,6 @@ export const coverageOptions: CoverageReportOptions = {
 	sourceFilter: (sourcePath) =>
 		!sourcePath.includes('node_modules') &&
 		!sourcePath.includes('/dist/') &&
-		// Chunks that never resolved through a source map, with no source behind them.
-		// Unanchored: this runs before sourcePath, so the value may still be the URL
-		// (`http://localhost:41401/assets/…`) rather than monocart's `localhost-41401/…`.
-		!/localhost[-:]\d+\//.test(sourcePath) &&
 		!sourcePath.endsWith('.d.ts') &&
 		!sourcePath.endsWith('.spec.ts') &&
 		!sourcePath.endsWith('.test.ts') &&

--- a/packages/testing/playwright/coverage-options.ts
+++ b/packages/testing/playwright/coverage-options.ts
@@ -13,7 +13,6 @@ import { dirname, join, relative } from 'node:path';
  */
 export const COVERAGE_ENABLED = process.env.COVERAGE_ENABLED === 'true';
 
-/** `@scope/name/rest` → `@scope/name`; `name/rest` → `name`. */
 function packageNameOf(specifier: string): string {
 	const segs = specifier.split('/');
 	return specifier.startsWith('@') ? segs.slice(0, 2).join('/') : segs[0];
@@ -30,9 +29,9 @@ function findRepoRoot(): string {
 }
 
 export interface WorkspaceIndex {
-	/** Package name → repo-relative dir, e.g. `@n8n/design-system` → `packages/frontend/@n8n/design-system`. */
+	/** e.g. `@n8n/design-system` → `packages/frontend/@n8n/design-system`. */
 	names: ReadonlyMap<string, string>;
-	/** Every repo-relative dir under `packages/`, used to tell a dir-relative path from a package specifier. */
+	/** Every dir under `packages/` — tells a dir-relative path from a package specifier. */
 	dirs: ReadonlySet<string>;
 }
 
@@ -73,21 +72,19 @@ function workspaceIndex(): WorkspaceIndex {
 }
 
 /** Normalise a post-source-map path to the repo-relative form Codecov and the
- * impact map key on. Takes the index as an argument to stay pure/testable. */
+ * impact map key on. Index passed in to keep this pure. */
 export function resolveSourcePath(filePath: string, index: WorkspaceIndex): string {
 	const norm = filePath.replace(/\\/g, '/');
 	if (norm.startsWith('packages/')) return norm;
 	const i = norm.lastIndexOf('packages/');
 	if (i >= 0) return norm.slice(i);
 	if (norm.startsWith('src/')) return `packages/frontend/editor-ui/${norm}`;
-	// Backend sources arrive dir-relative (`cli/src/x.ts`); the frontend bundle
-	// arrives as a package specifier (`@n8n/design-system/src/x.vue`) whose dir may
-	// sit under packages/frontend/, so `packages/` + name would mislabel it and its
-	// changes would match nothing in the impact map.
-	// Bundle chunks with no source map reach here URL-derived (`localhost-41401/
-	// assets/…`). sourceFilter never sees them — there are no sources to filter — so
-	// leave them as-is rather than prefixing them into a package that doesn't exist.
+	// Chunks with no source map arrive URL-derived; sourceFilter never sees them
+	// (no sources to filter), so keep them out of the packages/ namespace here.
 	if (/^localhost[-:]\d+\//.test(norm)) return norm;
+	// Backend sources are dir-relative (`cli/src/x.ts`); the frontend bundle is a
+	// package specifier whose dir sits under packages/frontend/, so `packages/` +
+	// name would mislabel it and its changes would match nothing in the map.
 	const asDir = `packages/${norm}`;
 	if (index.dirs.has(asDir.slice(0, asDir.lastIndexOf('/')))) return asDir;
 	const name = packageNameOf(norm);

--- a/packages/testing/playwright/coverage-options.ts
+++ b/packages/testing/playwright/coverage-options.ts
@@ -1,6 +1,7 @@
 import type { TestInfo } from '@playwright/test';
 import type { CoverageReport, CoverageReportOptions } from 'monocart-coverage-reports';
-import { relative } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
 
 /**
  * Frontend E2E coverage via browser-native V8 (Playwright `page.coverage`),
@@ -11,6 +12,79 @@ import { relative } from 'node:path';
  * Gated on COVERAGE_ENABLED so normal test runs pay no collection cost.
  */
 export const COVERAGE_ENABLED = process.env.COVERAGE_ENABLED === 'true';
+
+/** `@scope/name/rest` → `@scope/name`; `name/rest` → `name`. */
+function packageNameOf(specifier: string): string {
+	const segs = specifier.split('/');
+	return specifier.startsWith('@') ? segs.slice(0, 2).join('/') : segs[0];
+}
+
+function findRepoRoot(): string {
+	let dir = process.cwd();
+	while (!existsSync(join(dir, 'pnpm-workspace.yaml'))) {
+		const parent = dirname(dir);
+		if (parent === dir) throw new Error(`no pnpm-workspace.yaml above ${process.cwd()}`);
+		dir = parent;
+	}
+	return dir;
+}
+
+/** Package name → repo-relative dir, e.g. `@n8n/design-system` →
+ * `packages/frontend/@n8n/design-system`. Read off the filesystem so a package
+ * that moves can't drift out of the map. */
+export function buildPackageDirIndex(repoRoot: string): Map<string, string> {
+	const index = new Map<string, string>();
+	const walk = (absDir: string, relDir: string) => {
+		for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+			if (!entry.isDirectory() || entry.name === 'node_modules') continue;
+			const abs = join(absDir, entry.name);
+			const rel = `${relDir}/${entry.name}`;
+			const manifest = join(abs, 'package.json');
+			if (existsSync(manifest)) {
+				const { name } = JSON.parse(readFileSync(manifest, 'utf8')) as { name?: string };
+				if (name) index.set(name, rel);
+			}
+			walk(abs, rel); // packages nest (packages/frontend/@n8n/*)
+		}
+	};
+	walk(join(repoRoot, 'packages'), 'packages');
+	return index;
+}
+
+let packageDirsCache: ReadonlyMap<string, string> | undefined;
+
+function packageDirs(): ReadonlyMap<string, string> {
+	if (!packageDirsCache) {
+		try {
+			packageDirsCache = buildPackageDirIndex(findRepoRoot());
+		} catch (error) {
+			console.warn(`⚠ coverage: workspace package index unavailable (${(error as Error).message})`);
+			packageDirsCache = new Map();
+		}
+	}
+	return packageDirsCache;
+}
+
+/** Normalise a post-source-map path to the repo-relative form Codecov and the
+ * impact map key on. Takes the index as an argument to stay pure/testable. */
+export function resolveSourcePath(
+	filePath: string,
+	packageDirsIndex: ReadonlyMap<string, string>,
+): string {
+	const norm = filePath.replace(/\\/g, '/');
+	if (norm.startsWith('packages/')) return norm;
+	const i = norm.lastIndexOf('packages/');
+	if (i >= 0) return norm.slice(i);
+	if (norm.startsWith('src/')) return `packages/frontend/editor-ui/${norm}`;
+	// Bare workspace specifier (`@n8n/design-system/src/x.vue`). Resolve the name
+	// to its real dir — prefixing `packages/` assumes every package sits directly
+	// under it, which mislabels those under `packages/frontend/` so their changes
+	// match nothing in the impact map and get declared uncovered.
+	const name = packageNameOf(norm);
+	const dir = packageDirsIndex.get(name);
+	if (dir) return `${dir}${norm.slice(name.length)}`;
+	return norm;
+}
 
 /**
  * Shared by the per-test collector (`add`) and the report generator
@@ -32,22 +106,15 @@ export const coverageOptions: CoverageReportOptions = {
 	sourceFilter: (sourcePath) =>
 		!sourcePath.includes('node_modules') &&
 		!sourcePath.includes('/dist/') &&
+		// Chunks that never resolved through a source map arrive URL-derived
+		// (`localhost-45789/assets/chunk-*.js`) with no source behind them.
+		!/^localhost[-:]\d+\//.test(sourcePath) &&
 		!sourcePath.endsWith('.d.ts') &&
 		!sourcePath.endsWith('.spec.ts') &&
 		!sourcePath.endsWith('.test.ts') &&
 		!sourcePath.includes('/__tests__/') &&
 		!sourcePath.includes('/__mocks__/'),
-	// Key Codecov + the impact map on repo-relative `packages/.../src/...`.
-	// Backend map-sources resolve to absolute repo paths (package-qualified);
-	// the frontend bundle resolves relative, so its `src/...` sources have no
-	// package and are attributed to editor-ui.
-	sourcePath: (filePath) => {
-		const norm = filePath.replace(/\\/g, '/');
-		if (norm.startsWith('packages/')) return norm;
-		const i = norm.lastIndexOf('packages/');
-		if (i >= 0) return norm.slice(i);
-		return norm.startsWith('src/') ? `packages/frontend/editor-ui/${norm}` : `packages/${norm}`;
-	},
+	sourcePath: (filePath) => resolveSourcePath(filePath, packageDirs()),
 };
 
 /**

--- a/packages/testing/playwright/playwright-projects.ts
+++ b/packages/testing/playwright/playwright-projects.ts
@@ -258,6 +258,9 @@ export function getProjects(): Project[] {
 			fullyParallel: true,
 			use: {
 				containerConfig: {},
+				// workers:1 + V8 collection makes cold boot slow enough to blow the 10s
+				// global; a retry gets a fresh container, so one slow boot burns all 3.
+				navigationTimeout: 30_000,
 				// Capture only on failure (global default is `on`). The shard artifact
 				// is downloaded and aggregated each run, so keep it to coverage data
 				// plus failure diagnostics, not full traces/videos for every test.


### PR DESCRIPTION
## Summary

Three fixes to the E2E coverage nightly, which produces the impact map that scopes which E2E specs run on a PR.

**1. Frontend source paths never matched the map.** `sourcePath` fell back to `packages/${path}`, which assumes every package sits directly under `packages/`. The five that live under `packages/frontend/` were therefore keyed at a path that matches no file, so a change to any of them was declared uncovered (`onUncovered: 'declare'`) and selected **zero** specs — reported as a confident `mode: "scoped"`, not a fail-open `broad`. 575 source files were affected: `@n8n/design-system` (484), `@n8n/chat` (65), `@n8n/composables` (11), `@n8n/stores` (10), `@n8n/i18n` (5).

Post-source-map paths arrive in two shapes, and the fix has to tell them apart: backend sources come dir-relative (`cli/src/x.ts`), the frontend bundle comes as a package specifier (`@n8n/design-system/src/x.vue`). Directory and package name can also disagree — `@n8n/nodes-langchain` is a directory only; its package name is `@n8n/n8n-nodes-langchain`. So we try the directory form first, then a filesystem-derived name→dir index, then keep the old `packages/` prefix as fallback. Deriving from the filesystem means a package that moves can't drift out of the map again.

**2. The map refresh had not opened a PR since 2026-06-19.** Two independent causes. `commit-impact-map` was gated without `!cancelled()`, so a failure in either unit-coverage leg transitively skipped it even when the E2E shards and `aggregate` both succeeded — those legs feed the combined lcov, not the impact map. It also required `e2e == success`, which conflated a spec that never ran with a test that ran and failed; only the first degrades the map, since a failing test still emits V8 coverage for its spec. Runs 30279383874 (0 failures) and 30339886665 (1 failure) both produced 186 mapped specs, while the run with two cancelled shards completed only 175 of 188.

So `failure` is now allowed, `cancelled` still blocks, and completeness is enforced on the artefact instead: a map whose spec count falls more than 5% below the one it would replace is refused. With 16 shards a lost one costs ~6% of specs, so that catches a missing shard while absorbing a few legitimately deleted specs — and it also covers what job status cannot, a shard failing hard enough that its specs never report. Also restricted to the default branch: a `workflow_dispatch` from a feature branch would otherwise cut the refresh branch from that branch's HEAD and automerge it.

**3. Coverage shards were timing out.** The `coverage` project runs `workers: 1` with V8 collection, so a cold container's first `page.goto` could exceed the 10s global `navigationTimeout`. A retry gets a *fresh* container, which re-pays cold start and fails identically, so one slow boot burned all 3 attempts at 60s each. Raised to 30s for that project only, matching the existing `dev-server-smoke` precedent. The global stays at 10s.

`sourcePath` had no test coverage, which is how this shipped. `resolveSourcePath` is now pure and has 13 tests covering both input shapes.

## How to test

Verified against maps generated by three real nightly runs on this branch.

Shard health (fix 3):

| | run 30269539638 (before) | run 30339886665 (after) |
| --- | --- | --- |
| shards | 14 success + 2 cancelled | 16 run, 188/188 specs |
| wall clock | 53 min, 13 specs never ran | 21 min |
| `page.goto` timeouts | every failing test, all 3 attempts | none |

Generated map (fixes 1 and 2):

| | committed | generated (30339886665) |
| --- | --- | --- |
| `packages/@n8n/design-system` (wrong) | 230 | 0 |
| `packages/frontend/@n8n/design-system` (right) | 0 | 232 |
| chat / composables / stores / i18n | 31 wrong | 37 right |
| mapped specs | 162 | 186 |
| paths matching no file | 411 | 11 |

Selector behaviour, using the file list of #34249 ("Fix change in width of all dropdowns in UI", which merged with zero E2E):

```
committed map -> mode=scoped specs=0   uncovered=3
fixed map     -> mode=scoped specs=122 uncovered=1
```

The residual `uncovered` is `DropdownMenu.types.ts` — types don't execute, so no spec covers it.

Completeness guard, exercised against the real maps:

| scenario | map specs | outcome |
| --- | --- | --- |
| generated map vs committed (162) | 186 | commits |
| one lost shard vs healthy map (186) | 173 | refused, floor 176 |
| empty map | 0 | refused |
| 3 specs legitimately deleted | 183 | commits |

Unit tests: `pnpm --filter=n8n-playwright vitest run coverage-options.test.ts` (13 pass), plus typecheck, eslint, biome, actionlint.

## Notes for the reviewer

- **The committed map is not corrected by this PR.** It fixes the generator and unblocks the refresh; the map is replaced on the next nightly that gets far enough to commit it.
- **~122 unmapped bundle chunks remain in the map** as `localhost-<port>/assets/chunk-*.js`. They're inert — they never match a changed file, so selection is unaffected — and this PR only stops them being written as `packages/localhost-*` and polluting the `packages/` namespace in Codecov. Dropping them entirely needs an `entryFilter` change, which isn't obviously safe: the real app bundle also arrives via `/assets/`. Left for follow-up.
- **11 map entries still match no file.** They arrive as bare filenames (`community-packages.handler.ts`, no directory) and can't be located without a search. Pre-existing, unchanged by this PR.
- **One known issue still blocks the refresh on master**, out of scope here: `Unit Coverage (CLI integration + Postgres)` fails on `credentials.repository.test.ts > should return identical results with filters and pagination`. That no longer blocks the map refresh, but it does keep the nightly red. The nightly also has no failure alerting, which is why this went unnoticed for ~38 days.

## Related Linear tickets, Github issues, and Community forum posts

None — found while auditing whether high CI job-success rates were masking test over-filtering.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
