### PR TITLE
fix(editor): Keep publish gate closed after submitting a workflow for review

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowPublishChoiceDialog.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowPublishChoiceDialog.vue
@@ -86,7 +86,7 @@ const chooseReview = () => {
 
 .dontShowAgain {
 	:deep(label) {
-		color: var(--color--text--tint-1);
+		color: var(--text-color--subtler);
 	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.test.ts
@@ -44,6 +44,7 @@ const renderDialog = async (flushSave = vi.fn().mockResolvedValue('version-1')) 
 		...result,
 		flushSave,
 		reviewRequiredStore,
+		reviewStatusStore,
 		fetchStatusSpy,
 	};
 };
@@ -85,7 +86,7 @@ describe('WorkflowSubmitForReviewDialog', () => {
 	});
 
 	it('submits the flushed version and resets review required after success', async () => {
-		const { getByTestId, flushSave, reviewRequiredStore, fetchStatusSpy, emitted } =
+		const { getByTestId, flushSave, reviewRequiredStore, reviewStatusStore, emitted } =
 			await renderDialog();
 
 		await userEvent.type(getByTestId('workflow-review-title-input'), '  Review payments  ');
@@ -101,7 +102,8 @@ describe('WorkflowSubmitForReviewDialog', () => {
 		});
 		expect(flushSave).toHaveBeenCalledOnce();
 		expect(reviewRequiredStore.isReviewRequired('workflow-1')).toBe(false);
-		expect(fetchStatusSpy).toHaveBeenCalledWith('workflow-1');
+		expect(reviewStatusStore.hasOpenReview('workflow-1')).toBe(true);
+		expect(reviewStatusStore.openReviewRequest('workflow-1')?.id).toBe('review-1');
 		expect(emitted('submitted')).toHaveLength(1);
 		expect(emitted('update:open')).toContainEqual([false]);
 	});

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
@@ -63,17 +63,22 @@ const reviewerOptions = computed<IUser[]>(() =>
 	})),
 );
 
+let loadReviewersSequence = 0;
+
 const loadEligibleReviewers = async () => {
+	const sequence = ++loadReviewersSequence;
 	isLoadingReviewers.value = true;
 	try {
 		const { data } = await fetchEligibleReviewers(rootStore.restApiContext, {
 			workflowId: props.workflowId,
 		});
+		if (sequence !== loadReviewersSequence) return;
 		eligibleReviewers.value = data;
 	} catch {
+		if (sequence !== loadReviewersSequence) return;
 		eligibleReviewers.value = [];
 	} finally {
-		isLoadingReviewers.value = false;
+		if (sequence === loadReviewersSequence) isLoadingReviewers.value = false;
 	}
 };
 

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowSubmitForReviewDialog.vue
@@ -116,15 +116,17 @@ const submit = async () => {
 		}
 
 		const trimmedDescription = description.value.trim();
-		await createWorkflowReviewRequest(rootStore.restApiContext, {
+		const reviewRequest = await createWorkflowReviewRequest(rootStore.restApiContext, {
 			title: reviewTitle.value.trim(),
 			description: trimmedDescription || undefined,
 			workflows: [{ workflowId: props.workflowId, workflowVersionId }],
 			reviewerUserIds: selectedReviewerId.value ? [selectedReviewerId.value] : undefined,
 		});
 
+		// install the response before clearing the local flag so the
+		// publish gate never opens while a refetch is in flight
+		reviewStatusStore.setOpenReview(props.workflowId, reviewRequest);
 		reviewRequiredStore.setReviewRequired(props.workflowId, false);
-		void reviewStatusStore.fetchStatus(props.workflowId);
 		emit('update:open', false);
 		emit('submitted');
 	} catch (error) {

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/reviewStatus.store.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/reviewStatus.store.ts
@@ -62,13 +62,19 @@ export const useWorkflowReviewStatusStore = defineStore('workflowReviewStatus', 
 		delete openReviewByWorkflowId.value[workflowId];
 	};
 
+	const setOpenReview = (workflowId: string, review: WorkflowReviewRequestSummary): void => {
+		latestSequenceByWorkflowId[workflowId] = (latestSequenceByWorkflowId[workflowId] ?? 0) + 1;
+		openReviewByWorkflowId.value[workflowId] = review;
+	};
+
 	return {
-		// all writes must go through fetchStatus/clearStatus so the
+		// all writes must go through fetchStatus/setOpenReview/clearStatus so the
 		// sequence protocol stays the only write path.
 		openReviewByWorkflowId: readonly(openReviewByWorkflowId),
 		openReviewRequest,
 		hasOpenReview,
 		fetchStatus,
+		setOpenReview,
 		clearStatus,
 	};
 });

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/workflowReviews.api.ts
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/workflowReviews.api.ts
@@ -1,4 +1,6 @@
 import type {
+	CreateWorkflowReviewRequestDto,
+	GetWorkflowReviewEligibleReviewersQueryDto,
 	GetWorkflowReviewInboxSummaryResponse,
 	ListWorkflowReviewInboxResponse,
 	WorkflowReviewEligibleReviewersList,
@@ -7,16 +9,6 @@ import type {
 	WorkflowReviewRequestSummary,
 } from '@n8n/api-types';
 import { makeRestApiRequest, type IRestApiContext } from '@n8n/rest-api-client';
-
-export interface CreateWorkflowReviewRequestPayload {
-	title: string;
-	description?: string;
-	workflows: Array<{
-		workflowId: string;
-		workflowVersionId: string;
-	}>;
-	reviewerUserIds?: string[];
-}
 
 export type FetchWorkflowReviewInboxParams = {
 	state?: WorkflowReviewRequestState;
@@ -39,7 +31,7 @@ export async function fetchWorkflowReviewRequests(
 
 export async function fetchEligibleReviewers(
 	context: IRestApiContext,
-	query: { workflowId: string },
+	query: GetWorkflowReviewEligibleReviewersQueryDto,
 ): Promise<WorkflowReviewEligibleReviewersList> {
 	return await makeRestApiRequest<WorkflowReviewEligibleReviewersList>(
 		context,
@@ -51,7 +43,7 @@ export async function fetchEligibleReviewers(
 
 export async function createWorkflowReviewRequest(
 	context: IRestApiContext,
-	payload: CreateWorkflowReviewRequestPayload,
+	payload: CreateWorkflowReviewRequestDto,
 ): Promise<WorkflowReviewRequestSummary> {
 	return await makeRestApiRequest<WorkflowReviewRequestSummary>(
 		context,


### PR DESCRIPTION
## Summary

After a successful submit-for-review, the dialog cleared the local review-required flag synchronously but only fire-and-forgot `reviewStatusStore.fetchStatus()`. Until that round trip resolved, the publish gate (`hasOpenReview || isReviewRequired`) read false even though an open review now existed, so clicking Publish routed into the publish-choice flow instead of the update-review handoff — and if the refetch failed transiently, the store kept the last known "no open review" and the gate stayed open until a later refetch.

The old code made an extra network request to learn something the create response already told it. The new code just installs the response it already has via a new `reviewStatusStore.setOpenReview()`: one fewer request, no race window, and `setOpenReview` (which bumps the store's fetch sequence so an in-flight refetch can't clobber the fresher state) is the pattern any future flow that receives an authoritative review object can reuse.

Also included as separate commits:

- **Stale reviewer-list guard**: a load sequence in the submit dialog so a slow eligible-reviewers response can't clobber a newer load after the dialog is reopened for another workflow.
- **Shared DTO types**: `workflowReviews.api.ts` now uses `CreateWorkflowReviewRequestDto` and `GetWorkflowReviewEligibleReviewersQueryDto` from `@n8n/api-types` instead of hand-written shapes, so the FE/BE contracts can't drift. The workflow-scoped list query stays hand-written because the shared DTO types its pagination fields as string→number wire transforms.
- **Design token cleanup**: `WorkflowPublishChoiceDialog` used the legacy `--color--text--tint-1`; switched to the semantic `--text-color--subtler` the sibling review-submitted dialog already uses (resolved colors identical).

## How to test

Requires the workflow reviews feature (enterprise license + review policy enabled), which is not user-facing yet.

1. Open a workflow with "Review required" enabled and click **Publish** → the submit-for-review dialog opens.
2. Submit the review, then immediately click **Publish** again (or simulate a slow/failed `GET /workflow-review-requests` in dev tools).
3. Before: the publish-choice dialog or publish modal could open. After: the update-review dialog opens right away — no refetch is needed for the gate to close.

Covered by unit tests: `WorkflowSubmitForReviewDialog.test.ts` now asserts the store reports the open review synchronously after submit.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-890

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35027">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

