### PR TITLE
fix(editor): Remove brackets from docs link in credential setup assistant help

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -462,7 +462,7 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 							>
 								{{ i18n.baseText('credentialEdit.credentialConfig.assistantHelp.orReadThe') }}
 								<N8nLink :to="documentationUrl" size="small" @click="onDocumentationUrlClick">
-									[{{ i18n.baseText('credentialEdit.credentialConfig.assistantHelp.docs') }}]
+									{{ i18n.baseText('credentialEdit.credentialConfig.assistantHelp.docs') }}
 								</N8nLink>
 							</template>
 						</span>


### PR DESCRIPTION
## Summary

The AI Assistant help row in the credential edit modal rendered its documentation link as "or read the [docs]", with literal square brackets hardcoded in the template around the i18n text. This removes the brackets so the link reads "or read the docs".

## How to test

1. Enable the AI Assistant (Instance AI credential help).
2. Open a credential that has a documentation URL (e.g. Notion API).
3. Check the help text next to the Ask Assistant button: the docs link should render without square brackets.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35028">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

