### PR TITLE
ci: Bump install-and-build runner to 4-vCPU (no-changelog)

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   install-and-build:
     name: Install & Build
-    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-2vcpu-ubuntu-2204' }}
+    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Install & Build
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     env:
-      NODE_OPTIONS: '--max-old-space-size=6144'
+      NODE_OPTIONS: '--max-old-space-size=7168'
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       QA_METRICS_WEBHOOK_URL: ${{ secrets.QA_METRICS_WEBHOOK_URL }}
       QA_METRICS_WEBHOOK_USER: ${{ secrets.QA_METRICS_WEBHOOK_USER }}


### PR DESCRIPTION
## Summary

The `install-and-build` job in `ci-pull-requests.yml` runs a full `pnpm build` and gates the entire downstream fan-out (typecheck, lint, unit, db-tests, packaging, security, …) on **every PR and every merge-queue entry** — making it the tall pole for both PR feedback and merge-queue latency. It runs on `blacksmith-2vcpu`.

The build is CPU-bound: a local `editor-ui` build (Rolldown-Vite) uses **29.6 core-seconds over 10.6s wall ≈ ~2.8 average cores**. A 2-vCPU runner can't supply that, so the tall pole is throttled. The full monorepo build has additional inter-package Turbo parallelism on top, so **4 vCPU is a conservative floor**.

Applies to both `pull_request` and `merge_group` — the build is the common-case tall pole and faster PR feedback is the larger win. GitHub-provider path (`ubuntu-latest`) unchanged.

**Cost:** Blacksmith bills per-vCPU-minute; for a CPU-bound job ~2× cores roughly halves wall time → ~cost-neutral.

## How to test

CI on this PR runs `install-and-build` on the 4-vCPU runner. Compare its wall-clock against a recent 2-vCPU run on `master`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-668

Same pattern as previously-shipped bumps: DEVP-229, DEVP-315, DEVP-357.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Tests included. <!-- N/A — CI runner config only -->

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

