### PR TITLE
fix: Keep agent preview streams responsive

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -9,8 +10,8 @@ import type { AgentExecutionOrchestratorService } from '../agent-execution-orche
 import type { AgentExecutionService } from '../agent-execution.service';
 import type { FlushableResponse } from '../agent-sse-stream';
 import type { AgentTestChatService } from '../agent-test-chat.service';
-import type { AgentsService } from '../agents.service';
 import type { AgentValidationService } from '../agent-validation.service';
+import type { AgentsService } from '../agents.service';
 import type { AgentsBuilderService } from '../builder/agents-builder.service';
 import {
 	expectProjectScopedAgentRoutes,
@@ -49,6 +50,31 @@ function makeController() {
 				Pick<AgentExecutionOrchestratorService, 'getConversationHistory'>
 		>,
 	};
+}
+
+function makeSseResponse(writes: string[]): FlushableResponse {
+	const emitter = new EventEmitter();
+	const res = Object.assign(emitter, {
+		socket: {
+			setTimeout: vi.fn(),
+			setNoDelay: vi.fn(),
+			setKeepAlive: vi.fn(),
+		},
+		setHeader: vi.fn(),
+		flushHeaders: vi.fn(),
+		write: vi.fn((chunk: string) => {
+			writes.push(String(chunk));
+			return true;
+		}),
+		flush: vi.fn(),
+		end: vi.fn(() => {
+			emitter.emit('finish');
+		}),
+		writableEnded: false,
+		destroyed: false,
+	});
+
+	return res as unknown as FlushableResponse;
 }
 
 describe('AgentChatController route access scopes', () => {
@@ -134,11 +160,7 @@ describe('AgentChatController SSE done payload', () => {
 		});
 
 		const writes: string[] = [];
-		const res = mock<FlushableResponse>();
-		res.write.mockImplementation((chunk: string) => {
-			writes.push(String(chunk));
-			return true;
-		});
+		const res = makeSseResponse(writes);
 
 		await controller.chat(
 			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
@@ -166,11 +188,7 @@ describe('AgentChatController SSE done payload', () => {
 		});
 
 		const writes: string[] = [];
-		const res = mock<FlushableResponse>();
-		res.write.mockImplementation((chunk: string) => {
-			writes.push(String(chunk));
-			return true;
-		});
+		const res = makeSseResponse(writes);
 
 		await controller.chatResume(
 			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,

--- a/packages/cli/src/modules/agents/__tests__/agent-sse-stream.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-sse-stream.test.ts
@@ -1,7 +1,8 @@
 import type { StreamChunk } from '@n8n/agents';
 import type { AgentSseEvent } from '@n8n/api-types';
+import { EventEmitter } from 'node:events';
 
-import { pumpChunks } from '../agent-sse-stream';
+import { initSseStream, pumpChunks, type FlushableResponse } from '../agent-sse-stream';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -18,6 +19,72 @@ async function collectEvents(chunks: StreamChunk[]): Promise<AgentSseEvent[]> {
 	await pumpChunks(toAsyncIterable(chunks), (e) => events.push(e));
 	return events;
 }
+
+function createResponse() {
+	const socket = {
+		setTimeout: vi.fn(),
+		setNoDelay: vi.fn(),
+		setKeepAlive: vi.fn(),
+	};
+	const res = Object.assign(new EventEmitter(), {
+		setHeader: vi.fn(),
+		flushHeaders: vi.fn(),
+		write: vi.fn(),
+		flush: vi.fn(),
+		socket,
+		writableEnded: false,
+		destroyed: false,
+	}) as unknown as FlushableResponse;
+
+	return { res, socket };
+}
+
+describe('agent-sse-stream — connection setup', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('configures the response to remain open through reverse proxies', () => {
+		const { res, socket } = createResponse();
+
+		initSseStream(res);
+
+		expect(socket.setTimeout).toHaveBeenCalledWith(0);
+		expect(socket.setNoDelay).toHaveBeenCalledWith(true);
+		expect(socket.setKeepAlive).toHaveBeenCalledWith(true);
+		expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache, no-transform');
+		expect(res.write).toHaveBeenCalledWith(':ok\n\n');
+		expect(res.flush).toHaveBeenCalled();
+		res.emit('close');
+	});
+
+	it('writes an SSE heartbeat after 30 seconds of inactivity', () => {
+		vi.useFakeTimers();
+		const { res } = createResponse();
+		initSseStream(res);
+		vi.mocked(res.write).mockClear();
+		vi.mocked(res.flush).mockClear();
+
+		vi.advanceTimersByTime(29_999);
+		expect(res.write).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1);
+		expect(res.write).toHaveBeenCalledWith(':ping\n\n');
+		expect(res.flush).toHaveBeenCalled();
+	});
+
+	it.each(['finish', 'close'])('stops the heartbeat after the response emits %s', (event) => {
+		vi.useFakeTimers();
+		const { res } = createResponse();
+		initSseStream(res);
+		vi.mocked(res.write).mockClear();
+
+		res.emit(event);
+		vi.advanceTimersByTime(30_000);
+
+		expect(res.write).not.toHaveBeenCalled();
+	});
+});
 
 // ---------------------------------------------------------------------------
 // stringifyError — tested through pumpChunks / emitChunkEvents
@@ -77,6 +144,51 @@ describe('agent-sse-stream — stream completion', () => {
 		expect(events).toEqual([
 			{ type: 'text-delta', id: 't-1', delta: 'hello' },
 			{ type: 'text-end', id: 't-1' },
+		]);
+	});
+
+	it('drains every suspension chunk before reporting that the run paused', async () => {
+		const chunks: StreamChunk[] = [
+			{
+				type: 'tool-call-suspended',
+				runId: 'run-1',
+				toolCallId: 'tc-1',
+				toolName: 'ask_questions',
+				suspendPayload: { question: 'First question' },
+			},
+			{
+				type: 'tool-call-suspended',
+				runId: 'run-1',
+				toolCallId: 'tc-2',
+				toolName: 'ask_questions',
+				suspendPayload: { question: 'Second question' },
+			},
+			{ type: 'finish', finishReason: 'other' },
+		];
+		const events: AgentSseEvent[] = [];
+
+		const suspended = await pumpChunks(toAsyncIterable(chunks), (event) => events.push(event));
+
+		expect(suspended).toBe(true);
+		expect(events).toEqual([
+			{
+				type: 'tool-call-suspended',
+				payload: {
+					toolCallId: 'tc-1',
+					runId: 'run-1',
+					toolName: 'ask_questions',
+					input: { question: 'First question' },
+				},
+			},
+			{
+				type: 'tool-call-suspended',
+				payload: {
+					toolCallId: 'tc-2',
+					runId: 'run-1',
+					toolName: 'ask_questions',
+					input: { question: 'Second question' },
+				},
+			},
 		]);
 	});
 });

--- a/packages/cli/src/modules/agents/agent-sse-stream.ts
+++ b/packages/cli/src/modules/agents/agent-sse-stream.ts
@@ -10,6 +10,8 @@ import { LoggerProxy } from 'n8n-workflow';
 
 export type FlushableResponse = Response & { flush?: () => void };
 
+const SSE_HEARTBEAT_INTERVAL_MS = 30_000;
+
 interface ChunkHandlerCtx {
 	send: (e: AgentSseEvent) => void;
 }
@@ -19,11 +21,26 @@ interface ChunkHandlerCtx {
  */
 export function initSseStream(res: FlushableResponse) {
 	res.setHeader('Content-Type', 'text/event-stream; charset=UTF-8');
-	res.setHeader('Cache-Control', 'no-cache');
+	res.setHeader('Cache-Control', 'no-cache, no-transform');
 	res.setHeader('Connection', 'keep-alive');
 	res.setHeader('X-Accel-Buffering', 'no');
 	res.flushHeaders();
-	(res.socket as { setNoDelay?: (v: boolean) => void })?.setNoDelay?.(true);
+	res.socket?.setTimeout(0);
+	res.socket?.setNoDelay(true);
+	res.socket?.setKeepAlive(true);
+	res.write(':ok\n\n');
+	res.flush?.();
+
+	const heartbeat = setInterval(() => {
+		if (!res.writableEnded && !res.destroyed) {
+			res.write(':ping\n\n');
+			res.flush?.();
+		}
+	}, SSE_HEARTBEAT_INTERVAL_MS);
+	heartbeat.unref();
+	const stopHeartbeat = () => clearInterval(heartbeat);
+	res.once('finish', stopHeartbeat);
+	res.once('close', stopHeartbeat);
 
 	const send = (event: AgentSseEvent) => {
 		res.write(`data: ${JSON.stringify(event)}\n\n`);
@@ -177,8 +194,7 @@ function emitToolChunk(
  * Translate a single chunk into one or more SSE events.
  *
  * Returns `{ suspended: true }` when the chunk was a `tool-call-suspended`
- * — the run pauses and the caller stops pumping. All other chunks return
- * `{ suspended: false }`.
+ * and `{ suspended: false }` for all other chunks.
  */
 function emitChunkEvents(chunk: StreamChunk, ctx: ChunkHandlerCtx): { suspended: boolean } {
 	switch (chunk.type) {
@@ -255,10 +271,11 @@ export async function pumpChunks(
 	send: (e: AgentSseEvent) => void,
 ): Promise<boolean> {
 	const ctx: ChunkHandlerCtx = { send };
+	let suspended = false;
 
 	for await (const chunk of chunks) {
-		const { suspended } = emitChunkEvents(chunk, ctx);
-		if (suspended) return true;
+		const result = emitChunkEvents(chunk, ctx);
+		suspended ||= result.suspended;
 	}
-	return false;
+	return suspended;
 }

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7100,6 +7100,7 @@
 	"agents.builder.chat.newChat.label": "New chat",
 	"agents.chat.loadHistory.error": "Could not load chat history",
 	"agents.chat.clearHistory.error": "Could not clear chat history",
+	"agents.chat.streamInterrupted": "The connection was interrupted. Refresh the page to see the latest response.",
 	"agents.chat.toolError.generic": "Something went wrong while running this tool",
 	"agents.chat.clearHistory": "Clear chat history",
 	"agents.chat.input.placeholder": "Type a message...",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
@@ -46,6 +46,27 @@ function makeSseResponse(events: AgentSseEvent[]): Response {
 	});
 }
 
+function makeInterruptedSseResponse(events: AgentSseEvent[]): Response {
+	const encoder = new TextEncoder();
+	let eventsSent = false;
+	const stream = new ReadableStream<Uint8Array>({
+		pull(controller) {
+			if (!eventsSent) {
+				eventsSent = true;
+				controller.enqueue(
+					encoder.encode(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join('')),
+				);
+				return;
+			}
+			controller.error(new Error('connection lost'));
+		},
+	});
+	return new Response(stream, {
+		status: 200,
+		headers: { 'Content-Type': 'text/event-stream' },
+	});
+}
+
 function buildHook(continueSessionId?: string) {
 	return useAgentChatStream({
 		projectId: ref('p1'),
@@ -111,6 +132,40 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 			toolName: 'calculator',
 			args: { input: '2 + 2' },
 		});
+	});
+
+	it('treats a suspension as a valid ending when the stream closes without done', async () => {
+		const events: AgentSseEvent[] = [
+			{
+				type: 'tool-call',
+				toolCallId: 'tc-approval',
+				toolName: 'calculator',
+				input: { input: '2 + 2' },
+			},
+			{
+				type: 'tool-call-suspended',
+				payload: {
+					toolCallId: 'tc-approval',
+					runId: 'run-approval',
+					toolName: 'calculator',
+					input: {
+						type: 'approval',
+						toolName: 'calculator',
+						args: { input: '2 + 2' },
+					},
+				},
+			},
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('calculate 2 + 2');
+		await nextTick();
+
+		const assistantMessages = hook.messages.value.filter((message) => message.role === 'assistant');
+		expect(assistantMessages).toHaveLength(1);
+		expect(assistantMessages[0].status).toBe('awaitingUser');
+		expect(assistantMessages[0].toolCalls?.[0].state).toBe('suspended');
 	});
 
 	it('posts approval resumes to the chat resume endpoint in preview chat mode', async () => {
@@ -191,6 +246,92 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		await nextTick();
 
 		expect(hook.isStreaming.value).toBe(false);
+	});
+
+	it('marks active messages and tool calls as failed when the stream closes prematurely', async () => {
+		const events: AgentSseEvent[] = [
+			{ type: 'start-step' },
+			{
+				type: 'tool-call',
+				toolCallId: 'tc-1',
+				toolName: 'lookup',
+				input: { query: 'n8n' },
+			},
+			{ type: 'finish-step' },
+			{
+				type: 'tool-execution-start',
+				toolCallId: 'tc-1',
+				toolName: 'lookup',
+				startTime: 1_000,
+			},
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('look this up');
+		await nextTick();
+
+		const assistantMessages = hook.messages.value.filter((message) => message.role === 'assistant');
+		expect(assistantMessages).toHaveLength(2);
+		expect(assistantMessages[0].status).toBe('error');
+		expect(assistantMessages[0].toolCalls?.[0].state).toBe('error');
+		expect(assistantMessages[1]).toMatchObject({
+			content: 'agents.chat.streamInterrupted',
+			status: 'error',
+		});
+		expect(hook.isStreaming.value).toBe(false);
+	});
+
+	it('marks active messages and tool calls as failed when reading the stream throws', async () => {
+		const events: AgentSseEvent[] = [
+			{
+				type: 'tool-call',
+				toolCallId: 'tc-1',
+				toolName: 'lookup',
+				input: { query: 'n8n' },
+			},
+			{
+				type: 'tool-execution-start',
+				toolCallId: 'tc-1',
+				toolName: 'lookup',
+				startTime: 1_000,
+			},
+		];
+		globalThis.fetch = vi.fn(async () => makeInterruptedSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('look this up');
+		await nextTick();
+
+		const assistantMessages = hook.messages.value.filter((message) => message.role === 'assistant');
+		expect(assistantMessages).toHaveLength(2);
+		expect(assistantMessages[0].status).toBe('error');
+		expect(assistantMessages[0].toolCalls?.[0].state).toBe('error');
+		expect(assistantMessages[1]).toMatchObject({
+			content: 'agents.chat.streamInterrupted',
+			status: 'error',
+		});
+		expect(hook.isStreaming.value).toBe(false);
+	});
+
+	it('preserves partial reasoning when the stream closes prematurely', async () => {
+		const events: AgentSseEvent[] = [
+			{ type: 'reasoning-start', id: 'r-1' },
+			{ type: 'reasoning-delta', id: 'r-1', delta: 'Checking the workflow' },
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('inspect this');
+		await nextTick();
+
+		const assistantMessages = hook.messages.value.filter((message) => message.role === 'assistant');
+		expect(assistantMessages).toHaveLength(2);
+		expect(assistantMessages[0]).toMatchObject({
+			thinking: 'Checking the workflow',
+			status: 'error',
+		});
+		expect(assistantMessages[1].content).toBe('agents.chat.streamInterrupted');
 	});
 
 	it('opens a fresh ChatMessage after finish-step / start-step iteration boundary', async () => {
@@ -446,6 +587,29 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		expect(assistantMsgs).toHaveLength(2);
 		expect(assistantMsgs[0].toolCalls).toHaveLength(1);
 		expect(assistantMsgs[1].status).toBe('error');
+	});
+
+	it('marks in-flight messages and tool calls as failed when an error event arrives', async () => {
+		const events: AgentSseEvent[] = [
+			{ type: 'tool-call', toolCallId: 'tc-1', toolName: 'lookup', input: {} },
+			{
+				type: 'tool-execution-start',
+				toolCallId: 'tc-1',
+				toolName: 'lookup',
+				startTime: 1_000,
+			},
+			{ type: 'error', message: 'Tool failed', errorCode: 'runtime_error' },
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('search');
+		await nextTick();
+
+		const assistantMsgs = hook.messages.value.filter((message) => message.role === 'assistant');
+		expect(assistantMsgs[0].status).toBe('error');
+		expect(assistantMsgs[0].toolCalls?.[0].state).toBe('error');
+		expect(assistantMsgs[1]).toMatchObject({ content: 'Tool failed', status: 'error' });
 	});
 
 	it('flips a ToolCall from pending → running on tool-execution-start, then to done on tool-result', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -152,6 +152,8 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		 * that was applied before the round-trip.
 		 */
 		errorEmitted: boolean;
+		/** Set when the stream reaches a valid terminal event. */
+		terminalEventReceived: boolean;
 		/**
 		 * Cursor pointing at the ChatMessage currently being filled by
 		 * text/reasoning/tool-input events. `start-step` / `finish-step`
@@ -209,11 +211,42 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 
 	function dropOrphanMintedBubbles(session: StreamSession): void {
 		for (const msg of session.minted) {
-			if (!msg.content && (msg.toolCalls?.length ?? 0) === 0) {
+			if (!msg.content && !msg.thinking && (msg.toolCalls?.length ?? 0) === 0) {
 				messages.value = messages.value.filter((m) => m !== msg);
 				session.minted.delete(msg);
 			}
 		}
+	}
+
+	function markInFlightStateFailed(session: StreamSession): void {
+		for (const msg of session.minted) {
+			if (msg.status === CHAT_MESSAGE_STATUS.STREAMING) {
+				msg.status = CHAT_MESSAGE_STATUS.ERROR;
+			}
+			for (const toolCall of msg.toolCalls ?? []) {
+				if (
+					toolCall.state === TOOL_CALL_STATE.PENDING ||
+					toolCall.state === TOOL_CALL_STATE.RUNNING
+				) {
+					toolCall.state = TOOL_CALL_STATE.ERROR;
+				}
+			}
+		}
+	}
+
+	function markStreamInterrupted(session: StreamSession): void {
+		dropOrphanMintedBubbles(session);
+		markInFlightStateFailed(session);
+		messages.value.push(
+			reactive<ChatMessage>({
+				id: crypto.randomUUID(),
+				role: 'assistant',
+				content: locale.baseText('agents.chat.streamInterrupted'),
+				thinking: '',
+				toolCalls: [],
+				status: CHAT_MESSAGE_STATUS.ERROR,
+			}),
+		);
 	}
 
 	function handleEvent(
@@ -390,6 +423,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 					upsertMessageInteractive(msg, interactive);
 					msg.status = CHAT_MESSAGE_STATUS.AWAITING_USER;
 				}
+				session.terminalEventReceived = true;
 				break;
 			}
 			case 'message':
@@ -409,6 +443,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 			case 'error': {
 				session.errorEmitted = true;
 				dropOrphanMintedBubbles(session);
+				markInFlightStateFailed(session);
 				if (event.errorCode === 'agent_misconfigured') {
 					fatalError.value = { message: event.message, missing: event.missing ?? [] };
 				} else {
@@ -423,6 +458,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 						}),
 					);
 				}
+				session.terminalEventReceived = true;
 				break;
 			}
 			case 'done':
@@ -431,6 +467,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 						msg.executionId = event.executionId;
 					}
 				}
+				session.terminalEventReceived = true;
 				return { done: true };
 			default:
 				break;
@@ -484,6 +521,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 	): Promise<{ ok: boolean }> {
 		const session: StreamSession = {
 			errorEmitted: false,
+			terminalEventReceived: false,
 			minted: new Set(),
 		};
 
@@ -515,23 +553,26 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 			}
 
 			await consumeStream(response, session);
+			if (!session.terminalEventReceived) {
+				transportFailed = true;
+				markStreamInterrupted(session);
+				return { ok: false };
+			}
 			finalizeStream(session);
-		} catch (e) {
-			if (e instanceof DOMException && e.name === 'AbortError') {
+		} catch (error) {
+			if (error instanceof DOMException && error.name === 'AbortError') {
 				finalizeStream(session);
 				// User-initiated abort — surface as a failure so optimistic
 				// callers (resume) restore their pre-flight state instead of
 				// leaving the UI half-committed.
 				return { ok: false };
 			}
-			transportFailed = true;
-			const text = `Error: ${e instanceof Error ? e.message : 'Unknown error'}`;
-			messages.value.push({
-				id: crypto.randomUUID(),
-				role: 'assistant',
-				content: text,
-				status: 'error',
-			});
+			if (session.terminalEventReceived) {
+				finalizeStream(session);
+			} else {
+				transportFailed = true;
+				markStreamInterrupted(session);
+			}
 		} finally {
 			abortController.value = null;
 			isStreaming.value = false;


### PR DESCRIPTION
## Summary

- Keep agent preview SSE connections alive during long-running tool calls.
- Deliver all HITL suspension events and surface interrupted streams instead of leaving chat state stuck.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-455

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with Backport to Beta, Backport to Stable, or Backport to v1 if required.