### PR TITLE
fix(editor): Preserve agent tool name translations

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatToolSteps.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatToolSteps.test.ts
@@ -55,9 +55,24 @@ vi.mock('@n8n/design-system', () => ({
 	N8nTooltip: { template: '<div><slot /></div>', props: ['content', 'placement'] },
 }));
 
-vi.mock('@n8n/i18n', () => ({
-	useI18n: () => ({
-		baseText: (key: string, opts?: { interpolate?: { name?: string; count?: string } }) => {
+vi.mock('@n8n/i18n', () => {
+	const i18n = {
+		translations: {
+			'agents.chat.toolNames.webSearch': 'Web search',
+			'instanceAi.tools.search_nodes': 'Search nodes',
+			'agents.chat.difficulty.low': 'Low',
+			'agents.chat.difficulty.medium': 'Medium',
+			'agents.chat.difficulty.high': 'High',
+			'agents.chat.writeTodos.status.inProgress': 'In progress',
+			'agents.chat.writeTodos.status.pending': 'Pending',
+			'agents.chat.writeTodos.status.completed': 'Completed',
+			'agents.chat.writeTodos.status.blocked': 'Blocked',
+			'agents.chat.writeTodos.status.cancelled': 'Cancelled',
+			'agents.chat.writeTodos.hint.difficulty': 'Difficulty',
+			'agents.chat.writeTodos.hint.subAgent': 'Sub-agent',
+			'agents.chat.writeTodos.hint.expectedOutput': 'Expected output',
+		} as Record<string, string>,
+		baseText(key: string, opts?: { interpolate?: { name?: string; count?: string } }) {
 			if (key === 'agents.chat.delegate.label' && opts?.interpolate?.name) {
 				return `Sub-agent · ${opts.interpolate.name}`;
 			}
@@ -70,23 +85,12 @@ vi.mock('@n8n/i18n', () => ({
 				return `${opts.interpolate.count} tasks`;
 			}
 			if (key === 'agents.chat.writeTodos.summary.done') return 'done';
-			const statusLabels: Record<string, string> = {
-				'agents.chat.difficulty.low': 'Low',
-				'agents.chat.difficulty.medium': 'Medium',
-				'agents.chat.difficulty.high': 'High',
-				'agents.chat.writeTodos.status.inProgress': 'In progress',
-				'agents.chat.writeTodos.status.pending': 'Pending',
-				'agents.chat.writeTodos.status.completed': 'Completed',
-				'agents.chat.writeTodos.status.blocked': 'Blocked',
-				'agents.chat.writeTodos.status.cancelled': 'Cancelled',
-				'agents.chat.writeTodos.hint.difficulty': 'Difficulty',
-				'agents.chat.writeTodos.hint.subAgent': 'Sub-agent',
-				'agents.chat.writeTodos.hint.expectedOutput': 'Expected output',
-			};
-			return statusLabels[key] ?? key;
+			return this.translations[key] ?? key;
 		},
-	}),
-}));
+	};
+
+	return { useI18n: () => i18n };
+});
 
 vi.mock('../composables/useSubAgentNames', () => ({
 	useSubAgentNames: () => ({ subAgentNameById: { value: new Map() } }),
@@ -102,6 +106,25 @@ function mountSteps(
 }
 
 describe('AgentChatToolSteps', () => {
+	it('renders native web search tool calls as expandable', async () => {
+		const wrapper = mountSteps([
+			{
+				tool: 'openai.web_search',
+				toolCallId: 'tc-web-search',
+				state: TOOL_CALL_STATE.DONE,
+				input: { query: 'n8n agents' },
+				output: { results: [{ title: 'Agents documentation' }] },
+			},
+		]);
+
+		expect(wrapper.text()).toContain('Web search');
+		expect(wrapper.find('button').exists()).toBe(true);
+
+		await wrapper.find('button').trigger('click');
+		expect(wrapper.text()).toContain('n8n agents');
+		expect(wrapper.text()).toContain('Agents documentation');
+	});
+
 	it('makes generic tool steps with output data expandable', async () => {
 		const wrapper = mountSteps([
 			{

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/toolDisplayName.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/toolDisplayName.test.ts
@@ -1,3 +1,4 @@
+import type { BaseTextKey } from '@n8n/i18n';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -49,6 +50,21 @@ describe('formatToolNameForDisplay', () => {
 	});
 
 	it('falls back to a humanized tool name when a translation key is missing', () => {
-		expect(resolveToolNameForDisplay('search_nodes', (key) => key)).toBe('Search nodes');
+		expect(resolveToolNameForDisplay('search_nodes', { baseText: (key) => key })).toBe(
+			'Search nodes',
+		);
+	});
+
+	it('preserves the translation context when resolving a tool name', () => {
+		const translator = {
+			translations: {
+				[WEB_SEARCH_TOOL_NAME_KEY]: 'Web search',
+			} as Partial<Record<BaseTextKey, string>>,
+			baseText(key: BaseTextKey) {
+				return this.translations[key] ?? key;
+			},
+		};
+
+		expect(resolveToolNameForDisplay('web_search', translator)).toBe('Web search');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatToolSteps.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatToolSteps.vue
@@ -107,7 +107,7 @@ interface ToolStepDisplay {
 }
 
 function getToolDisplayName(toolName: string): string {
-	return resolveToolNameForDisplay(toolName, i18n.baseText);
+	return resolveToolNameForDisplay(toolName, i18n);
 }
 
 function toolStepLabel(tc: ToolCall): string {

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
@@ -136,7 +136,7 @@ function highlightJson(value: unknown, indent = 0): string {
 const toolDisplayName = computed((): string => {
 	if (!props.item || (props.item.kind !== 'tool' && props.item.kind !== 'suspension')) return '';
 	if (props.item.isUserFeedback) return i18n.baseText('agentSessions.timeline.userFeedback');
-	return resolveToolNameForDisplay(props.item.toolName, i18n.baseText);
+	return resolveToolNameForDisplay(props.item.toolName, i18n);
 });
 
 const isSubAgent = computed((): boolean =>

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
@@ -110,7 +110,7 @@ function popoverName(item: TimelineItem): string {
 		case 'agent':
 			return truncate(item.content ?? '', 80);
 		case 'tool': {
-			return resolveToolNameForDisplay(item.toolName, i18n.baseText);
+			return resolveToolNameForDisplay(item.toolName, i18n);
 		}
 		case 'workflow':
 			return item.workflowName ?? formatToolNameForDisplay(item.toolName);

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineRow.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineRow.vue
@@ -47,7 +47,7 @@ const infoText = computed((): string => {
 		case 'tool': {
 			if (it.isUserFeedback) return i18n.baseText('agentSessions.timeline.userFeedback');
 			if (isSubAgent.value) return delegateLabel(i18n, it.subAgentName ?? '');
-			return resolveToolNameForDisplay(it.toolName, i18n.baseText);
+			return resolveToolNameForDisplay(it.toolName, i18n);
 		}
 		case 'workflow':
 			return it.workflowName ?? formatToolNameForDisplay(it.toolName);

--- a/packages/frontend/editor-ui/src/features/agents/utils/toolDisplayName.ts
+++ b/packages/frontend/editor-ui/src/features/agents/utils/toolDisplayName.ts
@@ -1,4 +1,4 @@
-import type { BaseTextKey } from '@n8n/i18n';
+import type { BaseTextKey, I18nClass } from '@n8n/i18n';
 
 export const WEB_SEARCH_TOOL_NAME_KEY: BaseTextKey = 'agents.chat.toolNames.webSearch';
 export const FIND_FILE_TOOL_NAME_KEY: BaseTextKey = 'agents.chat.toolNames.findFile';
@@ -52,12 +52,12 @@ export function getToolNameTranslationKey(toolName: string | undefined): BaseTex
 
 export function resolveToolNameForDisplay(
 	toolName: string | undefined,
-	baseText: (key: BaseTextKey) => string,
+	i18n: Pick<I18nClass, 'baseText'>,
 ): string {
 	const translationKey = getToolNameTranslationKey(toolName);
 	if (!translationKey) return formatToolNameForDisplay(toolName);
 
-	const translated = baseText(translationKey);
+	const translated = i18n.baseText(translationKey);
 	return translated === translationKey ? formatToolNameForDisplay(toolName) : translated;
 }
 


### PR DESCRIPTION
## Summary

Preserve i18n context while resolving translated agent tool names so native tool calls render and expand consistently in preview chat and session timelines.

<img width="776" height="636" alt="image" src="https://github.com/user-attachments/assets/f0c49eac-2478-4ecb-8c20-fc35a15a7b3f" />

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR labeled for backporting if needed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

