### PR TITLE
feat(editor): Show sub-workflow executions live on the canvas and log view

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -111,6 +111,7 @@ export type {
 } from './push/chat-hub';
 
 export type { Collaborator } from './push/collaboration';
+export type { SubExecutionParent } from './push/execution';
 export type { WorkflowPublicationStatusMessage } from './push/workflow';
 export type { HeartbeatMessage } from './push/heartbeat';
 export { createHeartbeatMessage, heartbeatMessageSchema } from './push/heartbeat';

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -115,6 +115,7 @@ export type {
 } from './push/chat-hub';
 
 export type { Collaborator } from './push/collaboration';
+export type { SubExecutionParent } from './push/execution';
 export type { WorkflowPublicationStatusMessage } from './push/workflow';
 export type { HeartbeatMessage } from './push/heartbeat';
 export { createHeartbeatMessage, heartbeatMessageSchema } from './push/heartbeat';

--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -8,11 +8,8 @@ import type {
 } from 'n8n-workflow';
 
 /**
- * Identifies the node run that started a sub-workflow execution. Present on the
- * sub-execution's `executionStarted` so the editor can bind the sub-execution's
- * live node events to the node that started it. The run index distinguishes
- * iterations, letting the editor surface only the current one when a node
- * executes the sub-workflow repeatedly (in a loop or once per item).
+ * The node run that started a sub-workflow execution, so the editor can bind the
+ * sub-execution's live events to it. `runIndex` distinguishes loop iterations.
  */
 export type SubExecutionParent = {
 	executionId: string;
@@ -35,10 +32,7 @@ export type ExecutionStarted = {
 		workflowName?: string;
 		retryOf?: string;
 		flattedRunData: string;
-		/**
-		 * Set when this execution is a sub-workflow execution of another execution
-		 * the same session is watching. Absent for top-level executions.
-		 */
+		/** Set only when this execution is a sub-workflow of another one. */
 		parent?: SubExecutionParent;
 	};
 };

--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -7,6 +7,19 @@ import type {
 	WorkflowExecutionSource,
 } from 'n8n-workflow';
 
+/**
+ * Identifies the node run that started a sub-workflow execution. Present on the
+ * sub-execution's `executionStarted` so the editor can bind the sub-execution's
+ * live node events to the node that started it. The run index distinguishes
+ * iterations, letting the editor surface only the current one when a node
+ * executes the sub-workflow repeatedly (in a loop or once per item).
+ */
+export type SubExecutionParent = {
+	executionId: string;
+	nodeName: string;
+	runIndex: number;
+};
+
 export type ExecutionStarted = {
 	type: 'executionStarted';
 	data: {
@@ -22,6 +35,11 @@ export type ExecutionStarted = {
 		workflowName?: string;
 		retryOf?: string;
 		flattedRunData: string;
+		/**
+		 * Set when this execution is a sub-workflow execution of another execution
+		 * the same session is watching. Absent for top-level executions.
+		 */
+		parent?: SubExecutionParent;
 	};
 };
 

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -4,6 +4,7 @@ import type { WorkflowEntity, Project, WorkflowHistory } from '@n8n/db';
 import {
 	ExecutionRepository,
 	ExecutionDataRepository,
+	UserRepository,
 	WorkflowPublishHistoryRepository,
 	WorkflowRepository,
 } from '@n8n/db';
@@ -32,11 +33,13 @@ import { CredentialsHelper } from '@/credentials-helper';
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
+import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import {
 	CredentialsPermissionChecker,
 	SubworkflowPolicyChecker,
 } from '@/executions/pre-execution-checks';
 import { ExternalHooks } from '@/external-hooks';
+import { Push } from '@/push';
 import { AgentWorkflowExecutionService } from '@/modules/agents/agent-workflow-execution.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { OwnershipService } from '@/services/ownership.service';
@@ -130,6 +133,12 @@ describe('WorkflowExecuteAdditionalData', () => {
 	mockInstance(WorkflowPublishHistoryRepository);
 	mockInstance(DataTableProxyService);
 	mockInstance(WorkflowHookContextService);
+	// A sub-execution installs push hooks when its parent carries a push ref, and
+	// `mock<IWorkflowExecuteAdditionalData>()` stubs `pushRef` truthy, so these
+	// have to resolve here.
+	mockInstance(Push);
+	mockInstance(UserRepository);
+	mockInstance(ExecutionRedactionServiceProxy);
 	const workflowPublishedDataService = mockInstance(WorkflowPublishedDataService);
 	const workflowsConfig = Container.get(WorkflowsConfig);
 	afterEach(() => {

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -4,6 +4,7 @@ import type { WorkflowEntity, Project, WorkflowHistory } from '@n8n/db';
 import {
 	ExecutionRepository,
 	ExecutionDataRepository,
+	UserRepository,
 	WorkflowPublishHistoryRepository,
 	WorkflowRepository,
 } from '@n8n/db';
@@ -32,6 +33,7 @@ import { CredentialsHelper } from '@/credentials-helper';
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
+import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction-proxy.service';
 import {
 	CredentialsPermissionChecker,
 	SubworkflowPolicyChecker,
@@ -41,6 +43,7 @@ import { ExternalHooks } from '@/external-hooks';
 import { hashAgentSandboxPrincipal } from '@/modules/agents/agent-sandbox-principal';
 import { AgentWorkflowExecutionService } from '@/modules/agents/agent-workflow-execution.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
+import { Push } from '@/push';
 import { OwnershipService } from '@/services/ownership.service';
 import { UrlService } from '@/services/url.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
@@ -133,6 +136,12 @@ describe('WorkflowExecuteAdditionalData', () => {
 	mockInstance(WorkflowPublishHistoryRepository);
 	mockInstance(DataTableProxyService);
 	mockInstance(WorkflowHookContextService);
+	// A sub-execution installs push hooks when its parent carries a push ref, and
+	// `mock<IWorkflowExecuteAdditionalData>()` stubs `pushRef` truthy, so these
+	// have to resolve here.
+	mockInstance(Push);
+	mockInstance(UserRepository);
+	mockInstance(ExecutionRedactionServiceProxy);
 	const workflowPublishedDataService = mockInstance(WorkflowPublishedDataService);
 	const workflowsConfig = Container.get(WorkflowsConfig);
 	afterEach(() => {

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -48,6 +48,7 @@ import { OwnershipService } from '@/services/ownership.service';
 import { UrlService } from '@/services/url.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
 import { Telemetry } from '@/telemetry';
+import { getLifecycleHooksForSubExecutions } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import {
 	executeAgent,
 	executeWorkflow,
@@ -104,6 +105,15 @@ const getCancelablePromise = async (run: IRun) =>
 	});
 
 const processRunExecutionData = vi.fn();
+
+vi.mock('@/execution-lifecycle/execution-lifecycle-hooks', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('@/execution-lifecycle/execution-lifecycle-hooks')>();
+	return {
+		...actual,
+		getLifecycleHooksForSubExecutions: vi.fn(actual.getLifecycleHooksForSubExecutions),
+	};
+});
 
 vi.mock('n8n-core', async () => ({
 	__esModule: true,
@@ -216,6 +226,55 @@ describe('WorkflowExecuteAdditionalData', () => {
 			).rejects.toThrow('blocked');
 
 			expect(activeExecutions.add).not.toHaveBeenCalled();
+		});
+
+		describe('live sub-execution push gate', () => {
+			const CALLING_NODE = 'Execute Sub-workflow';
+
+			async function runSubWorkflow() {
+				await executeWorkflow(
+					mock<IExecuteWorkflowInfo>(),
+					mock<IWorkflowExecuteAdditionalData>({ pushRef: 'push-1', executionId: 'e-parent' }),
+					mock<ExecuteWorkflowOptions>({
+						loadedWorkflowData: undefined,
+						doNotWaitToFinish: false,
+						node: mock<INode>({ name: CALLING_NODE }),
+						nodeRunIndex: 2,
+					}),
+				);
+
+				return vi.mocked(getLifecycleHooksForSubExecutions).mock.calls.at(-1)?.[0];
+			}
+
+			it('passes the push session and calling node run when enabled', async () => {
+				vi.stubEnv('N8N_ENV_FEAT_LIVE_SUB_EXECUTIONS', 'true');
+
+				const options = await runSubWorkflow();
+
+				expect(options?.pushRef).toBe('push-1');
+				expect(options?.subExecutionParent).toEqual({
+					executionId: 'e-parent',
+					nodeName: CALLING_NODE,
+					runIndex: 2,
+				});
+			});
+
+			it('withholds both when disabled, so no push hooks install', async () => {
+				vi.stubEnv('N8N_ENV_FEAT_LIVE_SUB_EXECUTIONS', 'false');
+
+				const options = await runSubWorkflow();
+
+				expect(options?.pushRef).toBeUndefined();
+				expect(options?.subExecutionParent).toBeUndefined();
+			});
+
+			it('is off when the flag is unset', async () => {
+				vi.stubEnv('N8N_ENV_FEAT_LIVE_SUB_EXECUTIONS', undefined);
+
+				const options = await runSubWorkflow();
+
+				expect(options?.pushRef).toBeUndefined();
+			});
 		});
 
 		it('should execute workflow, return data and execution id', async () => {

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1786,6 +1786,9 @@ describe('Execution Lifecycle Hooks', () => {
 					mode: 'manual',
 					executionId,
 					workflowData,
+					// Resolvable, so skipping the payload push is the gate's doing and not
+					// the fail-closed redaction path.
+					userId,
 					pushRef,
 					subExecutionParent,
 				});
@@ -1816,6 +1819,31 @@ describe('Execution Lifecycle Hooks', () => {
 					}),
 					pushRef,
 				);
+			});
+
+			it('pushes node metadata but not item payloads', async () => {
+				await lifecycleHooks.runHook('nodeExecuteAfter', [nodeName, taskData, runExecutionData]);
+
+				// Item counts still ride along, so the editor can build placeholders.
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'nodeExecuteAfter',
+						data: expect.objectContaining({ executionId, nodeName }),
+					}),
+					pushRef,
+				);
+
+				expect(push.send).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'nodeExecuteAfterData' }),
+					pushRef,
+					true,
+				);
+			});
+
+			it('does not resolve the user for redaction, having no payload to redact', async () => {
+				await lifecycleHooks.runHook('nodeExecuteAfter', [nodeName, taskData, runExecutionData]);
+
+				expect(userRepository.findOne).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1764,6 +1764,61 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.sendChunk).toHaveLength(0);
 		});
 
+		it('installs no push handlers without a push ref', async () => {
+			await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
+			await lifecycleHooks.runHook('nodeExecuteBefore', [
+				'test-node',
+				{ startTime: 0, executionIndex: 0, source: [] },
+			]);
+
+			expect(push.send).not.toHaveBeenCalled();
+		});
+
+		describe('when the parent run carries a push ref', () => {
+			const subExecutionParent = {
+				executionId: 'parent-execution-id',
+				nodeName: 'Execute Sub-workflow',
+				runIndex: 2,
+			};
+
+			beforeEach(() => {
+				lifecycleHooks = getLifecycleHooksForSubExecutions({
+					mode: 'manual',
+					executionId,
+					workflowData,
+					pushRef,
+					subExecutionParent,
+				});
+			});
+
+			it('reports the node run that started it, so the editor can bind it', async () => {
+				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
+
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'executionStarted',
+						data: expect.objectContaining({ executionId, parent: subExecutionParent }),
+					}),
+					pushRef,
+				);
+			});
+
+			it('pushes its node events', async () => {
+				await lifecycleHooks.runHook('nodeExecuteBefore', [
+					'test-node',
+					{ startTime: 0, executionIndex: 0, source: [] },
+				]);
+
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'nodeExecuteBefore',
+						data: expect.objectContaining({ executionId, nodeName: 'test-node' }),
+					}),
+					pushRef,
+				);
+			});
+		});
+
 		describe('when parentExecution is provided', () => {
 			const parentWorkflowId = 'parent-workflow-id';
 			const parentExecutionId = 'parent-execution-id';

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1735,12 +1735,11 @@ describe('Execution Lifecycle Hooks', () => {
 
 	describe('getLifecycleHooksForSubExecutions', () => {
 		beforeEach(() => {
-			lifecycleHooks = getLifecycleHooksForSubExecutions(
-				'manual',
+			lifecycleHooks = getLifecycleHooksForSubExecutions({
+				mode: 'manual',
 				executionId,
 				workflowData,
-				undefined,
-			);
+			});
 		});
 
 		workflowEventTests();
@@ -1774,13 +1773,12 @@ describe('Execution Lifecycle Hooks', () => {
 			};
 
 			beforeEach(() => {
-				lifecycleHooks = getLifecycleHooksForSubExecutions(
-					'integrated',
+				lifecycleHooks = getLifecycleHooksForSubExecutions({
+					mode: 'integrated',
 					executionId,
 					workflowData,
-					undefined,
 					parentExecution,
-				);
+				});
 			});
 
 			it('should duplicate binary data to parent execution', async () => {

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1888,6 +1888,9 @@ describe('Execution Lifecycle Hooks', () => {
 					mode: 'manual',
 					executionId,
 					workflowData,
+					// Resolvable, so skipping the payload push is the gate's doing and not
+					// the fail-closed redaction path.
+					userId,
 					pushRef,
 					subExecutionParent,
 				});
@@ -1918,6 +1921,31 @@ describe('Execution Lifecycle Hooks', () => {
 					}),
 					pushRef,
 				);
+			});
+
+			it('pushes node metadata but not item payloads', async () => {
+				await lifecycleHooks.runHook('nodeExecuteAfter', [nodeName, taskData, runExecutionData]);
+
+				// Item counts still ride along, so the editor can build placeholders.
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'nodeExecuteAfter',
+						data: expect.objectContaining({ executionId, nodeName }),
+					}),
+					pushRef,
+				);
+
+				expect(push.send).not.toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'nodeExecuteAfterData' }),
+					pushRef,
+					true,
+				);
+			});
+
+			it('does not resolve the user for redaction, having no payload to redact', async () => {
+				await lifecycleHooks.runHook('nodeExecuteAfter', [nodeName, taskData, runExecutionData]);
+
+				expect(userRepository.findOne).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1866,6 +1866,61 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(handlers.sendChunk).toHaveLength(0);
 		});
 
+		it('installs no push handlers without a push ref', async () => {
+			await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
+			await lifecycleHooks.runHook('nodeExecuteBefore', [
+				'test-node',
+				{ startTime: 0, executionIndex: 0, source: [] },
+			]);
+
+			expect(push.send).not.toHaveBeenCalled();
+		});
+
+		describe('when the parent run carries a push ref', () => {
+			const subExecutionParent = {
+				executionId: 'parent-execution-id',
+				nodeName: 'Execute Sub-workflow',
+				runIndex: 2,
+			};
+
+			beforeEach(() => {
+				lifecycleHooks = getLifecycleHooksForSubExecutions({
+					mode: 'manual',
+					executionId,
+					workflowData,
+					pushRef,
+					subExecutionParent,
+				});
+			});
+
+			it('reports the node run that started it, so the editor can bind it', async () => {
+				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
+
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'executionStarted',
+						data: expect.objectContaining({ executionId, parent: subExecutionParent }),
+					}),
+					pushRef,
+				);
+			});
+
+			it('pushes its node events', async () => {
+				await lifecycleHooks.runHook('nodeExecuteBefore', [
+					'test-node',
+					{ startTime: 0, executionIndex: 0, source: [] },
+				]);
+
+				expect(push.send).toHaveBeenCalledWith(
+					expect.objectContaining({
+						type: 'nodeExecuteBefore',
+						data: expect.objectContaining({ executionId, nodeName: 'test-node' }),
+					}),
+					pushRef,
+				);
+			});
+		});
+
 		describe('when parentExecution is provided', () => {
 			const parentWorkflowId = 'parent-workflow-id';
 			const parentExecutionId = 'parent-execution-id';

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1837,12 +1837,11 @@ describe('Execution Lifecycle Hooks', () => {
 
 	describe('getLifecycleHooksForSubExecutions', () => {
 		beforeEach(() => {
-			lifecycleHooks = getLifecycleHooksForSubExecutions(
-				'manual',
+			lifecycleHooks = getLifecycleHooksForSubExecutions({
+				mode: 'manual',
 				executionId,
 				workflowData,
-				undefined,
-			);
+			});
 		});
 
 		workflowEventTests();
@@ -1876,13 +1875,12 @@ describe('Execution Lifecycle Hooks', () => {
 			};
 
 			beforeEach(() => {
-				lifecycleHooks = getLifecycleHooksForSubExecutions(
-					'integrated',
+				lifecycleHooks = getLifecycleHooksForSubExecutions({
+					mode: 'integrated',
 					executionId,
 					workflowData,
-					undefined,
 					parentExecution,
-				);
+				});
 			});
 
 			it('should duplicate binary data to parent execution', async () => {

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -152,10 +152,7 @@ type HooksSetupParameters = {
 	parentExecution?: RelatedExecution;
 	source?: IWorkflowExecutionDataProcess['source'];
 	suppressErrorWorkflow?: IWorkflowExecutionDataProcess['suppressErrorWorkflow'];
-	/**
-	 * Node run that started this execution as a sub-workflow. Reported to the
-	 * editor so it can attribute this execution's live events to that node run.
-	 */
+	/** Node run that started this execution as a sub-workflow. */
 	subExecutionParent?: SubExecutionParent;
 };
 
@@ -416,9 +413,8 @@ function hookFunctionsPush(
 		// empty runData rather than skipping the push or leaking unredacted data.
 		let runDataToStringify: IRunData = {};
 		const hasRunData = data?.resultData.runData && Object.keys(data.resultData.runData).length > 0;
-		// Resolved only when there is run data to redact. An execution that starts
-		// empty — every sub-execution, and every run that isn't a retry or resume —
-		// would otherwise pay a user lookup it never reads.
+		// Only needed to redact run data, so an execution that starts empty (every
+		// sub-execution) skips the lookup.
 		const user = hasRunData ? await getUser() : null;
 
 		if (hasRunData && user) {
@@ -806,13 +802,9 @@ export type SubExecutionHooksOptions = {
 	parentExecution?: RelatedExecution;
 	projectId?: string;
 	projectName?: string;
-	/**
-	 * Push session watching the root execution, present only when an editor
-	 * started it. Set to also stream this sub-execution's lifecycle events to
-	 * that session.
-	 */
+	/** Set to stream this sub-execution's lifecycle events to the editor too. */
 	pushRef?: string;
-	/** Node run that started this sub-execution — see {@link SubExecutionParent}. */
+	/** Node run that started this sub-execution. */
 	subExecutionParent?: SubExecutionParent;
 };
 
@@ -840,10 +832,9 @@ export function getLifecycleHooksForSubExecutions({
 	hookFunctionsSaveProgress(hooks, { saveSettings });
 	hookFunctionsStatistics(hooks);
 	hookFunctionsExternalHooks(hooks);
-	// A sub-execution is its own execution, so without this the editor watching
-	// the parent run would never hear about it and the sub-workflow's branch
-	// would stay idle on the canvas until the parent node returned. No-ops when
-	// `pushRef` is unset, which is the case for every production run.
+	// Without this the editor never hears about the sub-execution, leaving its
+	// branch idle until the calling node returns. No-ops without a `pushRef`,
+	// i.e. for every production run.
 	hookFunctionsPush(hooks, { saveSettings, pushRef, subExecutionParent }, userId);
 	Container.get(ModulesHooksRegistry).addHooks(hooks);
 	return hooks;

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -347,6 +347,14 @@ function hookFunctionsPush(
 			pushRef,
 		);
 
+		// A sub-execution streams to the parent's session only so the canvas and log
+		// tree can follow it live, and the metadata push above already covers that:
+		// the editor builds placeholder run data from `itemCountByConnectionType`.
+		// Item payloads are ~90% of a sub-execution's wire traffic and a loop keeps
+		// only its last iteration, so they are not streamed; the editor backfills
+		// the sub-executions still on display over REST once the parent run ends.
+		if (subExecutionParent) return;
+
 		// Fail-closed redaction: if user cannot be resolved, skip the data push
 		// entirely rather than sending unredacted data to the client.
 		const user = await getUser();

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import type { SubExecutionParent } from '@n8n/api-types';
 import type { User } from '@n8n/db';
 import { ExecutionRepository, UserRepository } from '@n8n/db';
 import { LifecycleMetadata } from '@n8n/decorators';
@@ -151,6 +152,11 @@ type HooksSetupParameters = {
 	parentExecution?: RelatedExecution;
 	source?: IWorkflowExecutionDataProcess['source'];
 	suppressErrorWorkflow?: IWorkflowExecutionDataProcess['suppressErrorWorkflow'];
+	/**
+	 * Node run that started this execution as a sub-workflow. Reported to the
+	 * editor so it can attribute this execution's live events to that node run.
+	 */
+	subExecutionParent?: SubExecutionParent;
 };
 
 function hookFunctionsWorkflowEvents(
@@ -271,7 +277,7 @@ function buildRedactableExecution(
  */
 function hookFunctionsPush(
 	hooks: ExecutionLifecycleHooks,
-	{ pushRef, retryOf }: HooksSetupParameters,
+	{ pushRef, retryOf, subExecutionParent }: HooksSetupParameters,
 	userId?: string,
 	source?: IWorkflowExecutionDataProcess['source'],
 ) {
@@ -408,9 +414,12 @@ function hookFunctionsPush(
 		// Apply copy-on-write redaction to flattedRunData when retrying/resuming.
 		// Fail-closed: if user cannot be resolved or redaction throws, send
 		// empty runData rather than skipping the push or leaking unredacted data.
-		const user = await getUser();
 		let runDataToStringify: IRunData = {};
 		const hasRunData = data?.resultData.runData && Object.keys(data.resultData.runData).length > 0;
+		// Resolved only when there is run data to redact. An execution that starts
+		// empty — every sub-execution, and every run that isn't a retry or resume —
+		// would otherwise pay a user lookup it never reads.
+		const user = hasRunData ? await getUser() : null;
 
 		if (hasRunData && user) {
 			try {
@@ -451,6 +460,7 @@ function hookFunctionsPush(
 					workflowId,
 					workflowName,
 					flattedRunData: stringify(runDataToStringify),
+					parent: subExecutionParent,
 				},
 			},
 			pushRef,
@@ -788,19 +798,39 @@ function hookFunctionsSaveWorker(
 	});
 }
 
+export type SubExecutionHooksOptions = {
+	mode: WorkflowExecuteMode;
+	executionId: string;
+	workflowData: IWorkflowBase;
+	userId?: string;
+	parentExecution?: RelatedExecution;
+	projectId?: string;
+	projectName?: string;
+	/**
+	 * Push session watching the root execution, present only when an editor
+	 * started it. Set to also stream this sub-execution's lifecycle events to
+	 * that session.
+	 */
+	pushRef?: string;
+	/** Node run that started this sub-execution — see {@link SubExecutionParent}. */
+	subExecutionParent?: SubExecutionParent;
+};
+
 /**
  * Returns ExecutionLifecycleHooks instance for running integrated workflows
  * (Workflows which get started inside of another workflow)
  */
-export function getLifecycleHooksForSubExecutions(
-	mode: WorkflowExecuteMode,
-	executionId: string,
-	workflowData: IWorkflowBase,
-	userId?: string,
-	parentExecution?: RelatedExecution,
-	projectId?: string,
-	projectName?: string,
-): ExecutionLifecycleHooks {
+export function getLifecycleHooksForSubExecutions({
+	mode,
+	executionId,
+	workflowData,
+	userId,
+	parentExecution,
+	projectId,
+	projectName,
+	pushRef,
+	subExecutionParent,
+}: SubExecutionHooksOptions): ExecutionLifecycleHooks {
 	const hooks = new ExecutionLifecycleHooks(mode, executionId, workflowData);
 	const saveSettings = toSaveSettings(workflowData.settings);
 	hookFunctionsWorkflowEvents(hooks, userId, projectId, projectName);
@@ -810,6 +840,11 @@ export function getLifecycleHooksForSubExecutions(
 	hookFunctionsSaveProgress(hooks, { saveSettings });
 	hookFunctionsStatistics(hooks);
 	hookFunctionsExternalHooks(hooks);
+	// A sub-execution is its own execution, so without this the editor watching
+	// the parent run would never hear about it and the sub-workflow's branch
+	// would stay idle on the canvas until the parent node returned. No-ops when
+	// `pushRef` is unset, which is the case for every production run.
+	hookFunctionsPush(hooks, { saveSettings, pushRef, subExecutionParent }, userId);
 	Container.get(ModulesHooksRegistry).addHooks(hooks);
 	return hooks;
 }

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -1,3 +1,4 @@
+import type { SubExecutionParent } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
@@ -150,6 +151,11 @@ type HooksSetupParameters = {
 	parentExecution?: RelatedExecution;
 	source?: IWorkflowExecutionDataProcess['source'];
 	suppressErrorWorkflow?: IWorkflowExecutionDataProcess['suppressErrorWorkflow'];
+	/**
+	 * Node run that started this execution as a sub-workflow. Reported to the
+	 * editor so it can attribute this execution's live events to that node run.
+	 */
+	subExecutionParent?: SubExecutionParent;
 };
 
 function hookFunctionsWorkflowEvents(
@@ -270,7 +276,7 @@ function buildRedactableExecution(
  */
 function hookFunctionsPush(
 	hooks: ExecutionLifecycleHooks,
-	{ pushRef, retryOf }: HooksSetupParameters,
+	{ pushRef, retryOf, subExecutionParent }: HooksSetupParameters,
 	userId?: string,
 	source?: IWorkflowExecutionDataProcess['source'],
 ) {
@@ -407,9 +413,12 @@ function hookFunctionsPush(
 		// Apply copy-on-write redaction to flattedRunData when retrying/resuming.
 		// Fail-closed: if user cannot be resolved or redaction throws, send
 		// empty runData rather than skipping the push or leaking unredacted data.
-		const user = await getUser();
 		let runDataToStringify: IRunData = {};
 		const hasRunData = data?.resultData.runData && Object.keys(data.resultData.runData).length > 0;
+		// Resolved only when there is run data to redact. An execution that starts
+		// empty — every sub-execution, and every run that isn't a retry or resume —
+		// would otherwise pay a user lookup it never reads.
+		const user = hasRunData ? await getUser() : null;
 
 		if (hasRunData && user) {
 			try {
@@ -450,6 +459,7 @@ function hookFunctionsPush(
 					workflowId,
 					workflowName,
 					flattedRunData: stringify(runDataToStringify),
+					parent: subExecutionParent,
 				},
 			},
 			pushRef,
@@ -797,19 +807,39 @@ function hookFunctionsSaveWorker(
 	});
 }
 
+export type SubExecutionHooksOptions = {
+	mode: WorkflowExecuteMode;
+	executionId: string;
+	workflowData: IWorkflowBase;
+	userId?: string;
+	parentExecution?: RelatedExecution;
+	projectId?: string;
+	projectName?: string;
+	/**
+	 * Push session watching the root execution, present only when an editor
+	 * started it. Set to also stream this sub-execution's lifecycle events to
+	 * that session.
+	 */
+	pushRef?: string;
+	/** Node run that started this sub-execution — see {@link SubExecutionParent}. */
+	subExecutionParent?: SubExecutionParent;
+};
+
 /**
  * Returns ExecutionLifecycleHooks instance for running integrated workflows
  * (Workflows which get started inside of another workflow)
  */
-export function getLifecycleHooksForSubExecutions(
-	mode: WorkflowExecuteMode,
-	executionId: string,
-	workflowData: IWorkflowBase,
-	userId?: string,
-	parentExecution?: RelatedExecution,
-	projectId?: string,
-	projectName?: string,
-): ExecutionLifecycleHooks {
+export function getLifecycleHooksForSubExecutions({
+	mode,
+	executionId,
+	workflowData,
+	userId,
+	parentExecution,
+	projectId,
+	projectName,
+	pushRef,
+	subExecutionParent,
+}: SubExecutionHooksOptions): ExecutionLifecycleHooks {
 	const hooks = new ExecutionLifecycleHooks(mode, executionId, workflowData);
 	const saveSettings = toSaveSettings(workflowData.settings);
 	hookFunctionsWorkflowEvents(hooks, userId, projectId, projectName);
@@ -820,6 +850,11 @@ export function getLifecycleHooksForSubExecutions(
 	hookFunctionsStatistics(hooks);
 	hookFunctionsPreExecute(hooks);
 	hookFunctionsPostExecute(hooks);
+	// A sub-execution is its own execution, so without this the editor watching
+	// the parent run would never hear about it and the sub-workflow's branch
+	// would stay idle on the canvas until the parent node returned. No-ops when
+	// `pushRef` is unset, which is the case for every production run.
+	hookFunctionsPush(hooks, { saveSettings, pushRef, subExecutionParent }, userId);
 	Container.get(ModulesHooksRegistry).addHooks(hooks);
 	return hooks;
 }

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -151,10 +151,7 @@ type HooksSetupParameters = {
 	parentExecution?: RelatedExecution;
 	source?: IWorkflowExecutionDataProcess['source'];
 	suppressErrorWorkflow?: IWorkflowExecutionDataProcess['suppressErrorWorkflow'];
-	/**
-	 * Node run that started this execution as a sub-workflow. Reported to the
-	 * editor so it can attribute this execution's live events to that node run.
-	 */
+	/** Node run that started this execution as a sub-workflow. */
 	subExecutionParent?: SubExecutionParent;
 };
 
@@ -415,9 +412,8 @@ function hookFunctionsPush(
 		// empty runData rather than skipping the push or leaking unredacted data.
 		let runDataToStringify: IRunData = {};
 		const hasRunData = data?.resultData.runData && Object.keys(data.resultData.runData).length > 0;
-		// Resolved only when there is run data to redact. An execution that starts
-		// empty — every sub-execution, and every run that isn't a retry or resume —
-		// would otherwise pay a user lookup it never reads.
+		// Only needed to redact run data, so an execution that starts empty (every
+		// sub-execution) skips the lookup.
 		const user = hasRunData ? await getUser() : null;
 
 		if (hasRunData && user) {
@@ -815,13 +811,9 @@ export type SubExecutionHooksOptions = {
 	parentExecution?: RelatedExecution;
 	projectId?: string;
 	projectName?: string;
-	/**
-	 * Push session watching the root execution, present only when an editor
-	 * started it. Set to also stream this sub-execution's lifecycle events to
-	 * that session.
-	 */
+	/** Set to stream this sub-execution's lifecycle events to the editor too. */
 	pushRef?: string;
-	/** Node run that started this sub-execution — see {@link SubExecutionParent}. */
+	/** Node run that started this sub-execution. */
 	subExecutionParent?: SubExecutionParent;
 };
 
@@ -850,10 +842,9 @@ export function getLifecycleHooksForSubExecutions({
 	hookFunctionsStatistics(hooks);
 	hookFunctionsPreExecute(hooks);
 	hookFunctionsPostExecute(hooks);
-	// A sub-execution is its own execution, so without this the editor watching
-	// the parent run would never hear about it and the sub-workflow's branch
-	// would stay idle on the canvas until the parent node returned. No-ops when
-	// `pushRef` is unset, which is the case for every production run.
+	// Without this the editor never hears about the sub-execution, leaving its
+	// branch idle until the calling node returns. No-ops without a `pushRef`,
+	// i.e. for every production run.
 	hookFunctionsPush(hooks, { saveSettings, pushRef, subExecutionParent }, userId);
 	Container.get(ModulesHooksRegistry).addHooks(hooks);
 	return hooks;

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -346,6 +346,14 @@ function hookFunctionsPush(
 			pushRef,
 		);
 
+		// A sub-execution streams to the parent's session only so the canvas and log
+		// tree can follow it live, and the metadata push above already covers that:
+		// the editor builds placeholder run data from `itemCountByConnectionType`.
+		// Item payloads are ~90% of a sub-execution's wire traffic and a loop keeps
+		// only its last iteration, so they are not streamed; the editor backfills
+		// the sub-executions still on display over REST once the parent run ends.
+		if (subExecutionParent) return;
+
 		// Fail-closed redaction: if user cannot be resolved, skip the data push
 		// entirely rather than sending unredacted data to the client.
 		const user = await getUser();

--- a/packages/cli/src/execution-lifecycle/live-sub-executions-flag.ts
+++ b/packages/cli/src/execution-lifecycle/live-sub-executions-flag.ts
@@ -1,0 +1,11 @@
+import { isEnvFeatureEnabled } from '@n8n/backend-common';
+
+/**
+ * Whether a run the editor is watching streams its sub-executions to the same
+ * push session, so the canvas and log tree can follow them live. When off, a
+ * sub-execution installs no push hooks and reports no parent, which is what
+ * every production run does anyway.
+ */
+export function isLiveSubExecutionsEnabled(): boolean {
+	return isEnvFeatureEnabled('N8N_ENV_FEAT_LIVE_SUB_EXECUTIONS');
+}

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -191,8 +191,8 @@ export class JobProcessor {
 		);
 		additionalData.hooks = lifecycleHooks;
 
-		// Mirrors the worker's own push gate above: sub-executions stream their
-		// lifecycle events to the session only when this execution does too.
+		// Mirrors the worker's push gate above: sub-executions push only when this
+		// execution does.
 		if (pushRef && execution.mode === 'manual') {
 			additionalData.pushRef = pushRef;
 		}

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -191,6 +191,12 @@ export class JobProcessor {
 		);
 		additionalData.hooks = lifecycleHooks;
 
+		// Mirrors the worker's own push gate above: sub-executions stream their
+		// lifecycle events to the session only when this execution does too.
+		if (pushRef && execution.mode === 'manual') {
+			additionalData.pushRef = pushRef;
+		}
+
 		if (pushRef) {
 			additionalData.sendDataToUI = WorkflowExecuteAdditionalData.sendDataToUI.bind({
 				pushRef,

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -228,8 +228,8 @@ export class JobProcessor {
 		);
 		additionalData.hooks = lifecycleHooks;
 
-		// Mirrors the worker's own push gate above: sub-executions stream their
-		// lifecycle events to the session only when this execution does too.
+		// Mirrors the worker's push gate above: sub-executions push only when this
+		// execution does.
 		if (pushRef && execution.mode === 'manual') {
 			additionalData.pushRef = pushRef;
 		}

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -228,6 +228,12 @@ export class JobProcessor {
 		);
 		additionalData.hooks = lifecycleHooks;
 
+		// Mirrors the worker's own push gate above: sub-executions stream their
+		// lifecycle events to the session only when this execution does too.
+		if (pushRef && execution.mode === 'manual') {
+			additionalData.pushRef = pushRef;
+		}
+
 		if (pushRef) {
 			additionalData.sendDataToUI = WorkflowExecuteAdditionalData.sendDataToUI.bind({
 				pushRef,

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -558,10 +558,8 @@ async function startExecution(
 			workflowId: workflowData.id,
 			workflowSettings,
 		});
-		// Editor-started runs stream their sub-executions' lifecycle events to the
-		// same push session, so the parent's canvas and log view can follow them
-		// live. `parentExecutionId` is the execution containing the node that
-		// started this one — the editor needs it to tell whether the sub-execution
+		// Editor-started runs stream their sub-executions to the same push session.
+		// The editor needs the calling execution to tell whether a sub-execution
 		// belongs to the run it is watching.
 		const parentExecutionId = additionalData.executionId;
 		additionalDataIntegrated.pushRef = additionalData.pushRef;

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -558,13 +558,29 @@ async function startExecution(
 			workflowId: workflowData.id,
 			workflowSettings,
 		});
-		additionalDataIntegrated.hooks = getLifecycleHooksForSubExecutions(
-			runData.executionMode,
+		// Editor-started runs stream their sub-executions' lifecycle events to the
+		// same push session, so the parent's canvas and log view can follow them
+		// live. `parentExecutionId` is the execution containing the node that
+		// started this one — the editor needs it to tell whether the sub-execution
+		// belongs to the run it is watching.
+		const parentExecutionId = additionalData.executionId;
+		additionalDataIntegrated.pushRef = additionalData.pushRef;
+		additionalDataIntegrated.hooks = getLifecycleHooksForSubExecutions({
+			mode: runData.executionMode,
 			executionId,
 			workflowData,
-			additionalData.userId,
-			options.parentExecution,
-		);
+			userId: additionalData.userId,
+			parentExecution: options.parentExecution,
+			pushRef: additionalData.pushRef,
+			subExecutionParent:
+				parentExecutionId && options.node
+					? {
+							executionId: parentExecutionId,
+							nodeName: options.node.name,
+							runIndex: options.nodeRunIndex ?? 0,
+						}
+					: undefined,
+		});
 		additionalDataIntegrated.executionId = executionId;
 		additionalDataIntegrated.parentCallbackManager = options.parentCallbackManager;
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -604,10 +604,8 @@ async function startExecution(
 			workflowId: workflowData.id,
 			workflowSettings,
 		});
-		// Editor-started runs stream their sub-executions' lifecycle events to the
-		// same push session, so the parent's canvas and log view can follow them
-		// live. `parentExecutionId` is the execution containing the node that
-		// started this one — the editor needs it to tell whether the sub-execution
+		// Editor-started runs stream their sub-executions to the same push session.
+		// The editor needs the calling execution to tell whether a sub-execution
 		// belongs to the run it is watching.
 		const parentExecutionId = additionalData.executionId;
 		additionalDataIntegrated.pushRef = additionalData.pushRef;

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -59,7 +59,9 @@ import { CredentialsHelper } from '@/credentials-helper';
 import { PreExecuteBlockedError } from '@/errors/pre-execute-blocked.error';
 import { EventService } from '@/events/event.service';
 import type { AiEventPayload } from '@/events/maps/ai.event-map';
+import type { SubExecutionHooksOptions } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import { getLifecycleHooksForSubExecutions } from '@/execution-lifecycle/execution-lifecycle-hooks';
+import { isLiveSubExecutionsEnabled } from '@/execution-lifecycle/live-sub-executions-flag';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { isManualOrChatExecution } from '@/executions/execution.utils';
 import { FailedRunFactory } from '@/executions/failed-run-factory';
@@ -539,6 +541,32 @@ export function buildSubWorkflowOutput(
 	return WorkflowHelpers.getLastExecutedNodeData(data)?.data?.main ?? [null];
 }
 
+/**
+ * Streams a sub-execution to the push session watching its parent run. Empty
+ * unless the feature is on and a session is watching, which leaves the
+ * sub-execution with no push hooks.
+ */
+function subExecutionPushOptions(
+	additionalData: IWorkflowExecuteAdditionalData,
+	options: ExecuteWorkflowOptions,
+): Pick<SubExecutionHooksOptions, 'pushRef' | 'subExecutionParent'> {
+	if (!isLiveSubExecutionsEnabled() || !additionalData.pushRef) return {};
+
+	// The editor needs the calling node run to bind the sub-execution to it.
+	const parentExecutionId = additionalData.executionId;
+	return {
+		pushRef: additionalData.pushRef,
+		subExecutionParent:
+			parentExecutionId && options.node
+				? {
+						executionId: parentExecutionId,
+						nodeName: options.node.name,
+						runIndex: options.nodeRunIndex ?? 0,
+					}
+				: undefined,
+	};
+}
+
 async function startExecution(
 	additionalData: IWorkflowExecuteAdditionalData,
 	options: ExecuteWorkflowOptions,
@@ -604,26 +632,15 @@ async function startExecution(
 			workflowId: workflowData.id,
 			workflowSettings,
 		});
-		// Editor-started runs stream their sub-executions to the same push session.
-		// The editor needs the calling execution to tell whether a sub-execution
-		// belongs to the run it is watching.
-		const parentExecutionId = additionalData.executionId;
-		additionalDataIntegrated.pushRef = additionalData.pushRef;
+		const push = subExecutionPushOptions(additionalData, options);
+		additionalDataIntegrated.pushRef = push.pushRef;
 		additionalDataIntegrated.hooks = getLifecycleHooksForSubExecutions({
 			mode: runData.executionMode,
 			executionId,
 			workflowData,
 			userId: additionalData.userId,
 			parentExecution: options.parentExecution,
-			pushRef: additionalData.pushRef,
-			subExecutionParent:
-				parentExecutionId && options.node
-					? {
-							executionId: parentExecutionId,
-							nodeName: options.node.name,
-							runIndex: options.nodeRunIndex ?? 0,
-						}
-					: undefined,
+			...push,
 		});
 		additionalDataIntegrated.executionId = executionId;
 		additionalDataIntegrated.parentCallbackManager = options.parentCallbackManager;

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -604,13 +604,29 @@ async function startExecution(
 			workflowId: workflowData.id,
 			workflowSettings,
 		});
-		additionalDataIntegrated.hooks = getLifecycleHooksForSubExecutions(
-			runData.executionMode,
+		// Editor-started runs stream their sub-executions' lifecycle events to the
+		// same push session, so the parent's canvas and log view can follow them
+		// live. `parentExecutionId` is the execution containing the node that
+		// started this one — the editor needs it to tell whether the sub-execution
+		// belongs to the run it is watching.
+		const parentExecutionId = additionalData.executionId;
+		additionalDataIntegrated.pushRef = additionalData.pushRef;
+		additionalDataIntegrated.hooks = getLifecycleHooksForSubExecutions({
+			mode: runData.executionMode,
 			executionId,
 			workflowData,
-			additionalData.userId,
-			options.parentExecution,
-		);
+			userId: additionalData.userId,
+			parentExecution: options.parentExecution,
+			pushRef: additionalData.pushRef,
+			subExecutionParent:
+				parentExecutionId && options.node
+					? {
+							executionId: parentExecutionId,
+							nodeName: options.node.name,
+							runIndex: options.nodeRunIndex ?? 0,
+						}
+					: undefined,
+		});
 		additionalDataIntegrated.executionId = executionId;
 		additionalDataIntegrated.parentCallbackManager = options.parentCallbackManager;
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -376,6 +376,9 @@ export class WorkflowRunner {
 		additionalData.restartExecutionId = restartExecutionId;
 		additionalData.streamingEnabled = data.streamingEnabled;
 		additionalData.encryptedRunnerIdentity = data.encryptedRunnerIdentity;
+		// Carried so sub-executions can push their lifecycle events to the same
+		// session as this run (see `startExecution` in workflow-execute-additional-data)
+		additionalData.pushRef = data.pushRef;
 
 		additionalData.executionId = executionId;
 		additionalData.evaluationRunId = data.evaluationRunId;

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -376,8 +376,7 @@ export class WorkflowRunner {
 		additionalData.restartExecutionId = restartExecutionId;
 		additionalData.streamingEnabled = data.streamingEnabled;
 		additionalData.encryptedRunnerIdentity = data.encryptedRunnerIdentity;
-		// Carried so sub-executions can push their lifecycle events to the same
-		// session as this run (see `startExecution` in workflow-execute-additional-data)
+		// Carried so sub-executions push to the same session as this run.
 		additionalData.pushRef = data.pushRef;
 
 		additionalData.executionId = executionId;

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -461,8 +461,7 @@ export class WorkflowRunner {
 		additionalData.restartExecutionId = restartExecutionId;
 		additionalData.streamingEnabled = data.streamingEnabled;
 		additionalData.encryptedRunnerIdentity = data.encryptedRunnerIdentity;
-		// Carried so sub-executions can push their lifecycle events to the same
-		// session as this run (see `startExecution` in workflow-execute-additional-data)
+		// Carried so sub-executions push to the same session as this run.
 		additionalData.pushRef = data.pushRef;
 
 		additionalData.executionId = executionId;

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -461,6 +461,9 @@ export class WorkflowRunner {
 		additionalData.restartExecutionId = restartExecutionId;
 		additionalData.streamingEnabled = data.streamingEnabled;
 		additionalData.encryptedRunnerIdentity = data.encryptedRunnerIdentity;
+		// Carried so sub-executions can push their lifecycle events to the same
+		// session as this run (see `startExecution` in workflow-execute-additional-data)
+		additionalData.pushRef = data.pushRef;
 
 		additionalData.executionId = executionId;
 		additionalData.evaluationRunId = data.evaluationRunId;

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -170,6 +170,7 @@ export class BaseExecuteContext extends NodeExecutionContext {
 				inputData,
 				parentWorkflowSettings: this.workflow.settings,
 				node: this.node,
+				nodeRunIndex: this.runIndex,
 				parentCallbackManager,
 			});
 		} catch (error) {

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -164,6 +164,7 @@ export class BaseExecuteContext extends NodeExecutionContext {
 				inputData,
 				parentWorkflowSettings: this.workflow.settings,
 				node: this.node,
+				nodeRunIndex: this.runIndex,
 				parentCallbackManager,
 			});
 		} catch (error) {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -68,10 +68,9 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 
-	// A sub-execution of the tracked run finishing is not the run finishing: it
-	// must not clear the active execution id, re-fetch the run, or toast. Its data
-	// stays on display — the canvas and log view keep showing the sub-workflow's
-	// branch — so only its status and running indicator are settled here.
+	// A sub-execution finishing is not the run finishing: no clearing the active
+	// id, re-fetching, or toasting. Its data stays on display, so only its status
+	// and running indicator settle here.
 	if (workflowExecutionStateStore.isTrackedSubExecution(data.executionId)) {
 		markSubExecutionFinished(data, documentId);
 		return;
@@ -111,7 +110,7 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 	// running state. `clearNodeExecutionQueue` also resets `lastAddedExecutingNode`.
 	if (belongsToThisDocument || activeExecutionId === undefined) {
 		workflowExecutionStateStore.executingNode.clearNodeExecutionQueue();
-		// The run is over, so nothing inside its sub-executions can still be running.
+		// The run is over, so nothing in its sub-executions can still be running.
 		workflowExecutionStateStore.subExecutingNode.clearNodeExecutionQueue();
 	}
 
@@ -252,11 +251,9 @@ export function continueEvaluationLoop(execution: SimplifiedExecution, opts: Pus
 }
 
 /**
- * Settles a finished sub-execution of the tracked run: records its terminal
- * status on its own store and clears the sub-execution running indicator. The run
- * data it accumulated from live pushes is kept — it is what the canvas and the
- * log view show for the sub-workflow's branch, and unlike the tracked run there
- * is no re-fetch to replace it with.
+ * Settles a finished sub-execution: records its terminal status and clears the
+ * running indicator. Its live-pushed run data is kept — it is what the canvas and
+ * log view show, and there is no re-fetch to replace it with.
  */
 function markSubExecutionFinished(data: ExecutionFinished['data'], documentId: WorkflowDocumentId) {
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -68,6 +68,15 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 
+	// A sub-execution of the tracked run finishing is not the run finishing: it
+	// must not clear the active execution id, re-fetch the run, or toast. Its data
+	// stays on display — the canvas and log view keep showing the sub-workflow's
+	// branch — so only its status and running indicator are settled here.
+	if (workflowExecutionStateStore.isTrackedSubExecution(data.executionId)) {
+		markSubExecutionFinished(data, documentId);
+		return;
+	}
+
 	// Only act on the finish of the execution this document is actually tracking.
 	// Normal match is on the execution id; when the active execution is still
 	// pending (null) because this finish raced ahead of `executionStarted`, fall
@@ -102,6 +111,8 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 	// running state. `clearNodeExecutionQueue` also resets `lastAddedExecutingNode`.
 	if (belongsToThisDocument || activeExecutionId === undefined) {
 		workflowExecutionStateStore.executingNode.clearNodeExecutionQueue();
+		// The run is over, so nothing inside its sub-executions can still be running.
+		workflowExecutionStateStore.subExecutingNode.clearNodeExecutionQueue();
 	}
 
 	if (!belongsToThisDocument) {
@@ -238,6 +249,21 @@ export function continueEvaluationLoop(execution: SimplifiedExecution, opts: Pus
 			rerunTriggerNode: true,
 		});
 	}
+}
+
+/**
+ * Settles a finished sub-execution of the tracked run: records its terminal
+ * status on its own store and clears the sub-execution running indicator. The run
+ * data it accumulated from live pushes is kept — it is what the canvas and the
+ * log view show for the sub-workflow's branch, and unlike the tracked run there
+ * is no re-fetch to replace it with.
+ */
+function markSubExecutionFinished(data: ExecutionFinished['data'], documentId: WorkflowDocumentId) {
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
+	const executionDataStore = useExecutionDataStore(createExecutionDataId(data.executionId));
+
+	executionDataStore.setExecutionStatus(data.status, new Date());
+	workflowExecutionStateStore.markSubExecutionFinished(data.executionId);
 }
 
 /**

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -73,6 +73,12 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 	// and running indicator settle here.
 	if (workflowExecutionStateStore.isTrackedSubExecution(data.executionId)) {
 		markSubExecutionFinished(data, documentId);
+		// With "wait for sub-workflow" off the parent run ends first, so no parent
+		// finish is coming to backfill this one's item payloads. Superseded
+		// iterations are already unregistered, so this is the surviving one.
+		if (workflowExecutionStateStore.activeExecutionId === undefined) {
+			await backfillSubExecutionRunData(documentId);
+		}
 		return;
 	}
 
@@ -204,7 +210,43 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 
 	setRunExecutionData(execution, runExecutionData, documentId);
 
+	await backfillSubExecutionRunData(documentId);
+
 	continueEvaluationLoop(execution, options);
+}
+
+/**
+ * Sub-executions stream node metadata but not item payloads, so their run data
+ * holds trimmed placeholders while the run is live. This replaces those with the
+ * real data for the sub-executions still on display.
+ *
+ * Costs one request per calling node rather than one per loop iteration:
+ * superseded iterations are already out of the registry, and iterations that have
+ * not finished are skipped — with "wait for sub-workflow" off the parent can
+ * finish while a child is still going, and its data would be incomplete.
+ */
+async function backfillSubExecutionRunData(documentId: WorkflowDocumentId) {
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
+	const workflowsStore = useWorkflowsStore();
+	const links = [...workflowExecutionStateStore.subExecutionLinks];
+
+	await Promise.all(
+		links.map(async (link) => {
+			const executionDataStore = useExecutionDataStore(createExecutionDataId(link.executionId));
+			const status = executionDataStore.execution?.status;
+			if (status === undefined || status === 'running' || status === 'waiting') return;
+
+			try {
+				const fetched = await workflowsStore.fetchExecutionDataById(link.executionId);
+				if (!fetched?.data) return;
+				// `setExecutionRunData` keeps `workflowData` — for a workflow calling
+				// itself that is the canvas snapshot the overlay reads from.
+				executionDataStore.setExecutionRunData(fetched.data);
+			} catch {
+				// Placeholders stay; the log view still fetches on expand.
+			}
+		}),
+	);
 }
 
 /**
@@ -252,8 +294,9 @@ export function continueEvaluationLoop(execution: SimplifiedExecution, opts: Pus
 
 /**
  * Settles a finished sub-execution: records its terminal status and clears the
- * running indicator. Its live-pushed run data is kept — it is what the canvas and
- * log view show, and there is no re-fetch to replace it with.
+ * running indicator. Its live-pushed run data is kept as-is here — item payloads
+ * are not streamed for sub-executions, so the placeholders stand until
+ * {@link backfillSubExecutionRunData} replaces them when the parent run ends.
  */
 function markSubExecutionFinished(data: ExecutionFinished['data'], documentId: WorkflowDocumentId) {
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -69,6 +69,15 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 
+	// A sub-execution of the tracked run finishing is not the run finishing: it
+	// must not clear the active execution id, re-fetch the run, or toast. Its data
+	// stays on display — the canvas and log view keep showing the sub-workflow's
+	// branch — so only its status and running indicator are settled here.
+	if (workflowExecutionStateStore.isTrackedSubExecution(data.executionId)) {
+		markSubExecutionFinished(data, documentId);
+		return;
+	}
+
 	// Only act on the finish of the execution this document is actually tracking.
 	// Normal match is on the execution id; when the active execution is still
 	// pending (null) because this finish raced ahead of `executionStarted`, fall
@@ -103,6 +112,8 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 	// running state. `clearNodeExecutionQueue` also resets `lastAddedExecutingNode`.
 	if (belongsToThisDocument || activeExecutionId === undefined) {
 		workflowExecutionStateStore.executingNode.clearNodeExecutionQueue();
+		// The run is over, so nothing inside its sub-executions can still be running.
+		workflowExecutionStateStore.subExecutingNode.clearNodeExecutionQueue();
 	}
 
 	if (!belongsToThisDocument) {
@@ -264,6 +275,21 @@ export function continueEvaluationLoop(execution: SimplifiedExecution, opts: Pus
 			rerunTriggerNode: true,
 		});
 	}
+}
+
+/**
+ * Settles a finished sub-execution of the tracked run: records its terminal
+ * status on its own store and clears the sub-execution running indicator. The run
+ * data it accumulated from live pushes is kept — it is what the canvas and the
+ * log view show for the sub-workflow's branch, and unlike the tracked run there
+ * is no re-fetch to replace it with.
+ */
+function markSubExecutionFinished(data: ExecutionFinished['data'], documentId: WorkflowDocumentId) {
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
+	const executionDataStore = useExecutionDataStore(createExecutionDataId(data.executionId));
+
+	executionDataStore.setExecutionStatus(data.status, new Date());
+	workflowExecutionStateStore.markSubExecutionFinished(data.executionId);
 }
 
 /**

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -69,10 +69,9 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 
-	// A sub-execution of the tracked run finishing is not the run finishing: it
-	// must not clear the active execution id, re-fetch the run, or toast. Its data
-	// stays on display — the canvas and log view keep showing the sub-workflow's
-	// branch — so only its status and running indicator are settled here.
+	// A sub-execution finishing is not the run finishing: no clearing the active
+	// id, re-fetching, or toasting. Its data stays on display, so only its status
+	// and running indicator settle here.
 	if (workflowExecutionStateStore.isTrackedSubExecution(data.executionId)) {
 		markSubExecutionFinished(data, documentId);
 		return;
@@ -112,7 +111,7 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 	// running state. `clearNodeExecutionQueue` also resets `lastAddedExecutingNode`.
 	if (belongsToThisDocument || activeExecutionId === undefined) {
 		workflowExecutionStateStore.executingNode.clearNodeExecutionQueue();
-		// The run is over, so nothing inside its sub-executions can still be running.
+		// The run is over, so nothing in its sub-executions can still be running.
 		workflowExecutionStateStore.subExecutingNode.clearNodeExecutionQueue();
 	}
 
@@ -278,11 +277,9 @@ export function continueEvaluationLoop(execution: SimplifiedExecution, opts: Pus
 }
 
 /**
- * Settles a finished sub-execution of the tracked run: records its terminal
- * status on its own store and clears the sub-execution running indicator. The run
- * data it accumulated from live pushes is kept — it is what the canvas and the
- * log view show for the sub-workflow's branch, and unlike the tracked run there
- * is no re-fetch to replace it with.
+ * Settles a finished sub-execution: records its terminal status and clears the
+ * running indicator. Its live-pushed run data is kept — it is what the canvas and
+ * log view show, and there is no re-fetch to replace it with.
  */
 function markSubExecutionFinished(data: ExecutionFinished['data'], documentId: WorkflowDocumentId) {
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -74,6 +74,12 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 	// and running indicator settle here.
 	if (workflowExecutionStateStore.isTrackedSubExecution(data.executionId)) {
 		markSubExecutionFinished(data, documentId);
+		// With "wait for sub-workflow" off the parent run ends first, so no parent
+		// finish is coming to backfill this one's item payloads. Superseded
+		// iterations are already unregistered, so this is the surviving one.
+		if (workflowExecutionStateStore.activeExecutionId === undefined) {
+			await backfillSubExecutionRunData(documentId);
+		}
 		return;
 	}
 
@@ -210,7 +216,43 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 
 	setRunExecutionData(execution, runExecutionData, documentId);
 
+	await backfillSubExecutionRunData(documentId);
+
 	continueEvaluationLoop(execution, options);
+}
+
+/**
+ * Sub-executions stream node metadata but not item payloads, so their run data
+ * holds trimmed placeholders while the run is live. This replaces those with the
+ * real data for the sub-executions still on display.
+ *
+ * Costs one request per calling node rather than one per loop iteration:
+ * superseded iterations are already out of the registry, and iterations that have
+ * not finished are skipped — with "wait for sub-workflow" off the parent can
+ * finish while a child is still going, and its data would be incomplete.
+ */
+async function backfillSubExecutionRunData(documentId: WorkflowDocumentId) {
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
+	const workflowsStore = useWorkflowsStore();
+	const links = [...workflowExecutionStateStore.subExecutionLinks];
+
+	await Promise.all(
+		links.map(async (link) => {
+			const executionDataStore = useExecutionDataStore(createExecutionDataId(link.executionId));
+			const status = executionDataStore.execution?.status;
+			if (status === undefined || status === 'running' || status === 'waiting') return;
+
+			try {
+				const fetched = await workflowsStore.fetchExecutionDataById(link.executionId);
+				if (!fetched?.data) return;
+				// `setExecutionRunData` keeps `workflowData` — for a workflow calling
+				// itself that is the canvas snapshot the overlay reads from.
+				executionDataStore.setExecutionRunData(fetched.data);
+			} catch {
+				// Placeholders stay; the log view still fetches on expand.
+			}
+		}),
+	);
 }
 
 /**
@@ -278,8 +320,9 @@ export function continueEvaluationLoop(execution: SimplifiedExecution, opts: Pus
 
 /**
  * Settles a finished sub-execution: records its terminal status and clears the
- * running indicator. Its live-pushed run data is kept — it is what the canvas and
- * log view show, and there is no re-fetch to replace it with.
+ * running indicator. Its live-pushed run data is kept as-is here — item payloads
+ * are not streamed for sub-executions, so the placeholders stand until
+ * {@link backfillSubExecutionRunData} replaces them when the parent run ends.
  */
 function markSubExecutionFinished(data: ExecutionFinished['data'], documentId: WorkflowDocumentId) {
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
@@ -9,14 +9,10 @@ import type { IWorkflowDb } from '@/Interface';
 import type { PushHandlerOptions } from './types';
 
 /**
- * Registers a starting sub-workflow execution against the run being watched and
- * seeds its execution-data store, so its node events have somewhere to land.
- *
- * The store is seeded with the sub-workflow's own node snapshot when it is the
- * workflow on the canvas — a workflow calling itself — because that is what lets
- * the canvas mirror the sub-execution's progress. For any other sub-workflow the
- * editor has no node snapshot to hand, so the store carries run data only; the
- * log view resolves the graph it needs separately.
+ * Registers a starting sub-workflow execution and seeds its data store so its
+ * node events have somewhere to land. Seeded with the canvas's node snapshot for
+ * a workflow calling itself, which is what lets the canvas mirror it; any other
+ * sub-workflow carries run data only and the log view resolves its graph itself.
  */
 function startSubExecution(
 	data: ExecutionStarted['data'],
@@ -74,10 +70,9 @@ export async function executionStarted(
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 	const isIframe = window !== window.parent;
 
-	// A sub-workflow execution of the run being watched. It is its own execution,
-	// so it gets its own data store rather than the pending/active slots — and it
-	// must not go through the checks below, whose whole point is to keep another
-	// workflow's execution from hijacking those slots.
+	// Its own execution, so it gets its own data store rather than the
+	// pending/active slots — and must skip the checks below, which exist to stop
+	// another workflow's execution from hijacking those slots.
 	if (data.parent) {
 		startSubExecution(data, data.parent, documentId);
 		return;

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
@@ -1,11 +1,67 @@
-import type { ExecutionStarted } from '@n8n/api-types/push/execution';
+import type { ExecutionStarted, SubExecutionParent } from '@n8n/api-types/push/execution';
 import { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
 import { parse } from 'flatted';
 import { createRunExecutionData } from 'n8n-workflow';
 import type { IRunExecutionData } from 'n8n-workflow';
+import type { IWorkflowDb } from '@/Interface';
 import type { PushHandlerOptions } from './types';
+
+/**
+ * Registers a starting sub-workflow execution against the run being watched and
+ * seeds its execution-data store, so its node events have somewhere to land.
+ *
+ * The store is seeded with the sub-workflow's own node snapshot when it is the
+ * workflow on the canvas — a workflow calling itself — because that is what lets
+ * the canvas mirror the sub-execution's progress. For any other sub-workflow the
+ * editor has no node snapshot to hand, so the store carries run data only; the
+ * log view resolves the graph it needs separately.
+ */
+function startSubExecution(
+	data: ExecutionStarted['data'],
+	parent: SubExecutionParent,
+	documentId: PushHandlerOptions['documentId'],
+) {
+	const workflowDocumentStore = useWorkflowDocumentStore(documentId);
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
+
+	const registered = workflowExecutionStateStore.registerSubExecution({
+		executionId: data.executionId,
+		workflowId: data.workflowId,
+		parentExecutionId: parent.executionId,
+		parentNodeName: parent.nodeName,
+		parentNodeRunIndex: parent.runIndex,
+	});
+	if (!registered) return;
+
+	const isSameWorkflow = data.workflowId === workflowDocumentStore.workflowId;
+	const workflowData: IWorkflowDb = isSameWorkflow
+		? workflowDocumentStore.getSnapshot()
+		: {
+				id: data.workflowId,
+				name: data.workflowName ?? '',
+				nodes: [],
+				connections: {},
+				active: false,
+				isArchived: false,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+				versionId: '',
+				activeVersionId: null,
+			};
+
+	useExecutionDataStore(createExecutionDataId(data.executionId)).setExecution({
+		id: data.executionId,
+		finished: false,
+		mode: data.mode,
+		status: 'running',
+		createdAt: new Date(),
+		startedAt: new Date(data.startedAt),
+		workflowData,
+		data: createRunExecutionData(),
+	});
+}
 
 /**
  * Handles the 'executionStarted' event, which happens when a workflow is executed.
@@ -17,6 +73,15 @@ export async function executionStarted(
 	const workflowDocumentStore = useWorkflowDocumentStore(documentId);
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 	const isIframe = window !== window.parent;
+
+	// A sub-workflow execution of the run being watched. It is its own execution,
+	// so it gets its own data store rather than the pending/active slots — and it
+	// must not go through the checks below, whose whole point is to keep another
+	// workflow's execution from hijacking those slots.
+	if (data.parent) {
+		startSubExecution(data, data.parent, documentId);
+		return;
+	}
 
 	// A single push connection serves the active document, so a concurrent
 	// execution of a *different* workflow (e.g. a scheduled run firing while this

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
@@ -98,6 +98,45 @@ describe('nodeExecuteAfter', () => {
 		});
 	});
 
+	it('routes a sub-execution node to the sub queue and leaves parent agent progress alone', async () => {
+		const clearAgentNodeProgress = vi.spyOn(workflowExecutionStateStore, 'clearAgentNodeProgress');
+		vi.spyOn(workflowExecutionStateStore.subExecutingNode, 'removeExecutingNode');
+
+		workflowExecutionStateStore.registerSubExecution({
+			executionId: 'sub-exec-1',
+			workflowId: 'test-wf',
+			parentExecutionId: 'exec-1',
+			parentNodeName: 'Execute Sub-workflow',
+			parentNodeRunIndex: 0,
+		});
+
+		// Reusing the parent's node name is what makes clearing agent progress by
+		// name alone unsafe for a sub-execution.
+		const event: NodeExecuteAfter = {
+			type: 'nodeExecuteAfter',
+			data: {
+				executionId: 'sub-exec-1',
+				nodeName: 'Test Node',
+				sequenceNumber: 1,
+				itemCountByConnectionType: { main: [1] },
+				data: {
+					executionTime: 100,
+					startTime: 1234567890,
+					executionIndex: 0,
+					source: [],
+				},
+			},
+		};
+
+		await nodeExecuteAfter(event, options);
+
+		expect(workflowExecutionStateStore.subExecutingNode.removeExecutingNode).toHaveBeenCalledWith(
+			'Test Node',
+		);
+		expect(workflowExecutionStateStore.executingNode.removeExecutingNode).not.toHaveBeenCalled();
+		expect(clearAgentNodeProgress).not.toHaveBeenCalled();
+	});
+
 	it('tracks a non-waiting node execution exactly once', async () => {
 		const event: NodeExecuteAfter = {
 			type: 'nodeExecuteAfter',

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -21,10 +21,12 @@ export async function nodeExecuteAfter(
 	const assistantStore = useAssistantStore();
 
 	// Ignore node events that don't belong to the execution this document is
-	// tracking — a concurrent execution's node must not write into this
-	// document's data or fire its side effects (form popups, tracking, assistant).
+	// tracking, or to one of its sub-executions — a concurrent execution's node
+	// must not write into this document's data or fire its side effects (form
+	// popups, tracking, assistant).
 	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
-	if (activeExecutionId !== pushData.executionId) {
+	const isSubExecution = workflowExecutionStateStore.isTrackedSubExecution(pushData.executionId);
+	if (activeExecutionId !== pushData.executionId && !isSubExecution) {
 		return;
 	}
 
@@ -65,14 +67,21 @@ export async function nodeExecuteAfter(
 		pushDataWithPlaceholderOutputData,
 	);
 
-	workflowExecutionStateStore.executingNode.removeExecutingNode(pushData.nodeName);
+	const queue = isSubExecution
+		? workflowExecutionStateStore.subExecutingNode
+		: workflowExecutionStateStore.executingNode;
+	queue.removeExecutingNode(pushData.nodeName);
 
-	// Side effects
+	// Side effects. A form waiting inside a sub-workflow still needs its popup —
+	// it is the user this run is waiting on. Telemetry and the assistant are
+	// scoped to the workflow on screen, so they only cover its own nodes.
 	if (pushData.data.executionStatus === 'waiting' && pushData.data.metadata?.resumeFormUrl) {
 		openFormPopupWindow(pushData.data.metadata.resumeFormUrl);
-	} else if (pushData.data.executionStatus !== 'waiting') {
+	} else if (pushData.data.executionStatus !== 'waiting' && !isSubExecution) {
 		void trackNodeExecution(pushData, workflowExecutionStateStore.workflowId);
 	}
 
-	void assistantStore.onNodeExecution(pushData);
+	if (!isSubExecution) {
+		void assistantStore.onNodeExecution(pushData);
+	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -20,10 +20,8 @@ export async function nodeExecuteAfter(
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 	const assistantStore = useAssistantStore();
 
-	// Ignore node events that don't belong to the execution this document is
-	// tracking, or to one of its sub-executions — a concurrent execution's node
-	// must not write into this document's data or fire its side effects (form
-	// popups, tracking, assistant).
+	// Ignore events for anything but the tracked execution or its sub-executions,
+	// so a concurrent run can't write here or fire side effects.
 	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
 	const isSubExecution = workflowExecutionStateStore.isTrackedSubExecution(pushData.executionId);
 	if (activeExecutionId !== pushData.executionId && !isSubExecution) {
@@ -72,9 +70,8 @@ export async function nodeExecuteAfter(
 		: workflowExecutionStateStore.executingNode;
 	queue.removeExecutingNode(pushData.nodeName);
 
-	// Side effects. A form waiting inside a sub-workflow still needs its popup —
-	// it is the user this run is waiting on. Telemetry and the assistant are
-	// scoped to the workflow on screen, so they only cover its own nodes.
+	// A form waiting inside a sub-workflow still needs its popup. Telemetry and
+	// the assistant are scoped to the workflow on screen, so they skip it.
 	if (pushData.data.executionStatus === 'waiting' && pushData.data.metadata?.resumeFormUrl) {
 		openFormPopupWindow(pushData.data.metadata.resumeFormUrl);
 	} else if (pushData.data.executionStatus !== 'waiting' && !isSubExecution) {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -20,10 +20,8 @@ export async function nodeExecuteAfter(
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 	const assistantStore = useAssistantStore();
 
-	// Ignore node events that don't belong to the execution this document is
-	// tracking, or to one of its sub-executions — a concurrent execution's node
-	// must not write into this document's data or fire its side effects (form
-	// popups, tracking, assistant).
+	// Ignore events for anything but the tracked execution or its sub-executions,
+	// so a concurrent run can't write here or fire side effects.
 	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
 	const isSubExecution = workflowExecutionStateStore.isTrackedSubExecution(pushData.executionId);
 	if (activeExecutionId !== pushData.executionId && !isSubExecution) {
@@ -76,9 +74,8 @@ export async function nodeExecuteAfter(
 		workflowExecutionStateStore.clearAgentNodeProgress(pushData.nodeName);
 	}
 
-	// Side effects. A form waiting inside a sub-workflow still needs its popup —
-	// it is the user this run is waiting on. Telemetry and the assistant are
-	// scoped to the workflow on screen, so they only cover its own nodes.
+	// A form waiting inside a sub-workflow still needs its popup. Telemetry and
+	// the assistant are scoped to the workflow on screen, so they skip it.
 	if (pushData.data.executionStatus === 'waiting' && pushData.data.metadata?.resumeFormUrl) {
 		openFormPopupWindow(pushData.data.metadata.resumeFormUrl);
 	} else if (pushData.data.executionStatus !== 'waiting' && !isSubExecution) {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -21,10 +21,12 @@ export async function nodeExecuteAfter(
 	const assistantStore = useAssistantStore();
 
 	// Ignore node events that don't belong to the execution this document is
-	// tracking — a concurrent execution's node must not write into this
-	// document's data or fire its side effects (form popups, tracking, assistant).
+	// tracking, or to one of its sub-executions — a concurrent execution's node
+	// must not write into this document's data or fire its side effects (form
+	// popups, tracking, assistant).
 	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
-	if (activeExecutionId !== pushData.executionId) {
+	const isSubExecution = workflowExecutionStateStore.isTrackedSubExecution(pushData.executionId);
+	if (activeExecutionId !== pushData.executionId && !isSubExecution) {
 		return;
 	}
 
@@ -65,15 +67,25 @@ export async function nodeExecuteAfter(
 		pushDataWithPlaceholderOutputData,
 	);
 
-	workflowExecutionStateStore.executingNode.removeExecutingNode(pushData.nodeName);
-	workflowExecutionStateStore.clearAgentNodeProgress(pushData.nodeName);
+	// Agent progress is only tracked for the execution on screen, and a sub-workflow
+	// may reuse a parent node name, so clearing it stays scoped to the parent.
+	if (isSubExecution) {
+		workflowExecutionStateStore.subExecutingNode.removeExecutingNode(pushData.nodeName);
+	} else {
+		workflowExecutionStateStore.executingNode.removeExecutingNode(pushData.nodeName);
+		workflowExecutionStateStore.clearAgentNodeProgress(pushData.nodeName);
+	}
 
-	// Side effects
+	// Side effects. A form waiting inside a sub-workflow still needs its popup —
+	// it is the user this run is waiting on. Telemetry and the assistant are
+	// scoped to the workflow on screen, so they only cover its own nodes.
 	if (pushData.data.executionStatus === 'waiting' && pushData.data.metadata?.resumeFormUrl) {
 		openFormPopupWindow(pushData.data.metadata.resumeFormUrl);
-	} else if (pushData.data.executionStatus !== 'waiting') {
+	} else if (pushData.data.executionStatus !== 'waiting' && !isSubExecution) {
 		void trackNodeExecution(pushData, workflowExecutionStateStore.workflowId);
 	}
 
-	void assistantStore.onNodeExecution(pushData);
+	if (!isSubExecution) {
+		void assistantStore.onNodeExecution(pushData);
+	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.ts
@@ -16,9 +16,7 @@ export async function nodeExecuteAfterData(
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 	const schemaPreviewStore = useSchemaPreviewStore();
 
-	// Ignore node events that don't belong to the execution this document is
-	// tracking, or to one of its sub-executions — a concurrent execution's data
-	// must not land on this document.
+	// Ignore events for anything but the tracked execution or its sub-executions.
 	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
 	const isSubExecution = workflowExecutionStateStore.isTrackedSubExecution(pushData.executionId);
 	if (activeExecutionId !== pushData.executionId && !isSubExecution) {
@@ -29,8 +27,8 @@ export async function nodeExecuteAfterData(
 		pushData,
 	);
 
-	// Schema previews are recorded per workflow, so a sub-execution's data would
-	// be attributed to the wrong one.
+	// Schema previews are per workflow, so a sub-execution's data would be
+	// attributed to the wrong one.
 	if (isSubExecution) {
 		return;
 	}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.ts
@@ -17,15 +17,23 @@ export async function nodeExecuteAfterData(
 	const schemaPreviewStore = useSchemaPreviewStore();
 
 	// Ignore node events that don't belong to the execution this document is
-	// tracking — a concurrent execution's data must not land on this document.
+	// tracking, or to one of its sub-executions — a concurrent execution's data
+	// must not land on this document.
 	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
-	if (activeExecutionId !== pushData.executionId) {
+	const isSubExecution = workflowExecutionStateStore.isTrackedSubExecution(pushData.executionId);
+	if (activeExecutionId !== pushData.executionId && !isSubExecution) {
 		return;
 	}
 
 	useExecutionDataStore(createExecutionDataId(pushData.executionId)).updateNodeExecutionRunData(
 		pushData,
 	);
+
+	// Schema previews are recorded per workflow, so a sub-execution's data would
+	// be attributed to the wrong one.
+	if (isSubExecution) {
+		return;
+	}
 
 	const node = workflowDocumentStore.getNodeByName(pushData.nodeName);
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
@@ -13,14 +13,22 @@ export async function nodeExecuteBefore(
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 
 	// Ignore node events that don't belong to the execution this document is
-	// tracking — otherwise a concurrent execution's node would pollute this
-	// document's spinner queue and execution data.
+	// tracking, or to one of its sub-executions — otherwise a concurrent
+	// execution's node would pollute this document's spinner queue and execution
+	// data.
 	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
-	if (activeExecutionId !== data.executionId) {
+	const isSubExecution = workflowExecutionStateStore.isTrackedSubExecution(data.executionId);
+	if (activeExecutionId !== data.executionId && !isSubExecution) {
 		return;
 	}
 
-	workflowExecutionStateStore.executingNode.addExecutingNode(data.nodeName, data.sequenceNumber);
+	// A sub-execution advances its own queue: the node that started it stays
+	// running until it returns, and the two executions number their node events
+	// independently.
+	const queue = isSubExecution
+		? workflowExecutionStateStore.subExecutingNode
+		: workflowExecutionStateStore.executingNode;
+	queue.addExecutingNode(data.nodeName, data.sequenceNumber);
 
 	useExecutionDataStore(createExecutionDataId(data.executionId)).addNodeExecutionStartedData(data);
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
@@ -12,19 +12,16 @@ export async function nodeExecuteBefore(
 ) {
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 
-	// Ignore node events that don't belong to the execution this document is
-	// tracking, or to one of its sub-executions — otherwise a concurrent
-	// execution's node would pollute this document's spinner queue and execution
-	// data.
+	// Ignore events for anything but the tracked execution or its sub-executions,
+	// so a concurrent run can't pollute this document's queue and data.
 	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
 	const isSubExecution = workflowExecutionStateStore.isTrackedSubExecution(data.executionId);
 	if (activeExecutionId !== data.executionId && !isSubExecution) {
 		return;
 	}
 
-	// A sub-execution advances its own queue: the node that started it stays
-	// running until it returns, and the two executions number their node events
-	// independently.
+	// A sub-execution advances its own queue: the calling node stays running until
+	// it returns, and the two number their events independently.
 	const queue = isSubExecution
 		? workflowExecutionStateStore.subExecutingNode
 		: workflowExecutionStateStore.executingNode;

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/subExecutions.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/subExecutions.test.ts
@@ -24,7 +24,9 @@ import {
 	useWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
+import { createRunExecutionData, TRIMMED_TASK_DATA_CONNECTIONS_KEY } from 'n8n-workflow';
 import {
 	createTestNode,
 	createTestWorkflow,
@@ -111,6 +113,18 @@ function executionFinishedEvent(executionId: string): ExecutionFinished {
 		type: 'executionFinished',
 		data: { executionId, workflowId: WORKFLOW_ID, status: 'success' },
 	};
+}
+
+/** What the REST API returns for the root run when its finish is processed. */
+function rootExecutionResponse() {
+	return createTestWorkflowExecutionResponse({
+		id: ROOT_EXECUTION_ID,
+		status: 'success',
+		workflowData: createTestWorkflow({
+			id: WORKFLOW_ID,
+			nodes: [CALLER_NODE, SUB_TRIGGER_NODE, SUB_STEP_NODE],
+		}),
+	});
 }
 
 /** Runs the sub-workflow branch to completion under `executionId`. */
@@ -332,6 +346,109 @@ describe('live sub-executions', () => {
 			await executionFinished(executionFinishedEvent(ROOT_EXECUTION_ID), options);
 
 			expect(executionStateStore.subExecutingNode.executingNode).toEqual([]);
+		});
+	});
+
+	describe('backfilling item payloads', () => {
+		/** Real run data as the REST API would return it for a sub-execution. */
+		function fetchedSubExecution(value: string) {
+			return createTestWorkflowExecutionResponse({
+				id: 'exec-sub',
+				status: 'success',
+				data: createRunExecutionData({
+					resultData: {
+						runData: {
+							[SUB_STEP_NODE.name]: [
+								{
+									startTime: 0,
+									executionIndex: 0,
+									executionTime: 1,
+									executionStatus: 'success',
+									source: [],
+									data: { main: [[{ json: { value } }]] },
+								},
+							],
+						},
+					},
+				}),
+			});
+		}
+
+		it('replaces the placeholders once the tracked run finishes', async () => {
+			const fetchSpy = vi
+				.spyOn(useWorkflowsStore(), 'fetchExecutionDataById')
+				.mockImplementation(async (id) =>
+					id === 'exec-sub' ? fetchedSubExecution('real') : rootExecutionResponse(),
+				);
+
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await runSubWorkflowBranch('exec-sub');
+			await executionFinished(executionFinishedEvent('exec-sub'), options);
+
+			// Live pushes carry counts only, so the payload is a trimmed placeholder.
+			const subStore = useExecutionDataStore(createExecutionDataId('exec-sub'));
+			expect(
+				subStore.execution?.data?.resultData.runData[SUB_STEP_NODE.name][0].data?.main[0]?.[0].json,
+			).toHaveProperty(TRIMMED_TASK_DATA_CONNECTIONS_KEY);
+
+			await executionFinished(executionFinishedEvent(ROOT_EXECUTION_ID), options);
+
+			expect(fetchSpy).toHaveBeenCalledWith('exec-sub');
+			expect(
+				subStore.execution?.data?.resultData.runData[SUB_STEP_NODE.name][0].data?.main[0]?.[0].json,
+			).toEqual({ value: 'real' });
+		});
+
+		it('costs one request per calling node, not per loop iteration', async () => {
+			const fetchSpy = vi
+				.spyOn(useWorkflowsStore(), 'fetchExecutionDataById')
+				.mockImplementation(async (id) =>
+					id === ROOT_EXECUTION_ID ? rootExecutionResponse() : fetchedSubExecution('real'),
+				);
+
+			// A loop over the same node: each iteration supersedes the previous one.
+			for (const id of ['exec-sub-1', 'exec-sub-2', 'exec-sub-3']) {
+				await executionStarted(subExecutionStartedEvent(id), options);
+				await runSubWorkflowBranch(id);
+				await executionFinished(executionFinishedEvent(id), options);
+			}
+			await executionFinished(executionFinishedEvent(ROOT_EXECUTION_ID), options);
+
+			const subFetches = fetchSpy.mock.calls.filter(([id]) => id !== ROOT_EXECUTION_ID);
+			expect(subFetches).toEqual([['exec-sub-3']]);
+		});
+
+		it('skips a sub-execution that has not finished yet', async () => {
+			const fetchSpy = vi
+				.spyOn(useWorkflowsStore(), 'fetchExecutionDataById')
+				.mockResolvedValue(rootExecutionResponse());
+
+			// "Wait for sub-workflow" off: the parent ends while the child runs on, so
+			// fetching now would capture incomplete data.
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await executionFinished(executionFinishedEvent(ROOT_EXECUTION_ID), options);
+
+			expect(fetchSpy.mock.calls.filter(([id]) => id === 'exec-sub')).toEqual([]);
+		});
+
+		it('backfills on the child finish when the parent run already ended', async () => {
+			const fetchSpy = vi
+				.spyOn(useWorkflowsStore(), 'fetchExecutionDataById')
+				.mockImplementation(async (id) =>
+					id === 'exec-sub' ? fetchedSubExecution('late') : rootExecutionResponse(),
+				);
+
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await runSubWorkflowBranch('exec-sub');
+			await executionFinished(executionFinishedEvent(ROOT_EXECUTION_ID), options);
+			expect(fetchSpy.mock.calls.filter(([id]) => id === 'exec-sub')).toEqual([]);
+
+			await executionFinished(executionFinishedEvent('exec-sub'), options);
+
+			const subStore = useExecutionDataStore(createExecutionDataId('exec-sub'));
+			expect(
+				subStore.execution?.data?.resultData.runData[SUB_STEP_NODE.name][0].data?.main[0]?.[0].json,
+			).toEqual({ value: 'late' });
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/subExecutions.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/subExecutions.test.ts
@@ -1,7 +1,7 @@
 /**
  * Live sub-execution mirroring, driven through the push handlers the way the
- * backend drives them: a workflow calling itself reports the sub-workflow's
- * progress under a separate execution id, and the canvas has to light up for it.
+ * backend drives them: a workflow calling itself reports the sub-workflow under a
+ * separate execution id, and the canvas has to light up for it.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/subExecutions.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/subExecutions.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Live sub-execution mirroring, driven through the push handlers the way the
+ * backend drives them: a workflow calling itself reports the sub-workflow's
+ * progress under a separate execution id, and the canvas has to light up for it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { mock } from 'vitest-mock-extended';
+import type { Router } from 'vue-router';
+import type {
+	ExecutionFinished,
+	ExecutionStarted,
+	NodeExecuteAfter,
+	NodeExecuteBefore,
+	SubExecutionParent,
+} from '@n8n/api-types/push/execution';
+import { executionStarted } from './executionStarted';
+import { executionFinished } from './executionFinished';
+import { nodeExecuteBefore } from './nodeExecuteBefore';
+import { nodeExecuteAfter } from './nodeExecuteAfter';
+import type { PushHandlerOptions } from './types';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
+import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
+import {
+	createTestNode,
+	createTestWorkflow,
+	createTestWorkflowExecutionResponse,
+} from '@/__tests__/mocks';
+
+const WORKFLOW_ID = 'wf-self';
+const ROOT_EXECUTION_ID = 'exec-root';
+
+// Trigger branch and sub-workflow branch of one self-calling workflow.
+const CALLER_NODE = createTestNode({ id: 'id-caller', name: 'Execute Sub-workflow' });
+const SUB_TRIGGER_NODE = createTestNode({ id: 'id-sub-trigger', name: 'Sub Trigger' });
+const SUB_STEP_NODE = createTestNode({ id: 'id-sub-step', name: 'Sub Step' });
+
+const documentId = createWorkflowDocumentId(WORKFLOW_ID);
+let options: PushHandlerOptions;
+let executionStateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
+
+function subExecutionStartedEvent(
+	executionId: string,
+	parent: Partial<SubExecutionParent> = {},
+	workflowId = WORKFLOW_ID,
+): ExecutionStarted {
+	return {
+		type: 'executionStarted',
+		data: {
+			executionId,
+			mode: 'integrated',
+			startedAt: new Date(),
+			workflowId,
+			workflowName: 'self-calling',
+			flattedRunData: '',
+			parent: {
+				executionId: ROOT_EXECUTION_ID,
+				nodeName: CALLER_NODE.name,
+				runIndex: 0,
+				...parent,
+			},
+		},
+	};
+}
+
+function nodeExecuteBeforeEvent(
+	executionId: string,
+	nodeName: string,
+	sequenceNumber = 0,
+): NodeExecuteBefore {
+	return {
+		type: 'nodeExecuteBefore',
+		data: {
+			executionId,
+			nodeName,
+			sequenceNumber,
+			data: { startTime: 0, executionIndex: 0, source: [] },
+		},
+	};
+}
+
+function nodeExecuteAfterEvent(
+	executionId: string,
+	nodeName: string,
+	sequenceNumber = 1,
+): NodeExecuteAfter {
+	return {
+		type: 'nodeExecuteAfter',
+		data: {
+			executionId,
+			nodeName,
+			sequenceNumber,
+			itemCountByConnectionType: { main: [1] },
+			data: {
+				startTime: 0,
+				executionIndex: 0,
+				executionTime: 1,
+				executionStatus: 'success',
+				source: [],
+			},
+		},
+	};
+}
+
+function executionFinishedEvent(executionId: string): ExecutionFinished {
+	return {
+		type: 'executionFinished',
+		data: { executionId, workflowId: WORKFLOW_ID, status: 'success' },
+	};
+}
+
+/** Runs the sub-workflow branch to completion under `executionId`. */
+async function runSubWorkflowBranch(executionId: string) {
+	await nodeExecuteBefore(nodeExecuteBeforeEvent(executionId, SUB_TRIGGER_NODE.name, 0), options);
+	await nodeExecuteAfter(nodeExecuteAfterEvent(executionId, SUB_TRIGGER_NODE.name, 1), options);
+	await nodeExecuteBefore(nodeExecuteBeforeEvent(executionId, SUB_STEP_NODE.name, 2), options);
+	await nodeExecuteAfter(nodeExecuteAfterEvent(executionId, SUB_STEP_NODE.name, 3), options);
+}
+
+describe('live sub-executions', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		options = { router: mock<Router>(), documentId };
+
+		const documentStore = useWorkflowDocumentStore(documentId);
+		documentStore.setNodes([CALLER_NODE, SUB_TRIGGER_NODE, SUB_STEP_NODE]);
+
+		executionStateStore = useWorkflowExecutionStateStore(documentId);
+		useExecutionDataStore(createExecutionDataId(ROOT_EXECUTION_ID)).setExecution(
+			createTestWorkflowExecutionResponse({
+				id: ROOT_EXECUTION_ID,
+				status: 'running',
+				workflowData: createTestWorkflow({
+					id: WORKFLOW_ID,
+					nodes: [CALLER_NODE, SUB_TRIGGER_NODE, SUB_STEP_NODE],
+				}),
+			}),
+		);
+		executionStateStore.setActiveExecutionId(ROOT_EXECUTION_ID);
+	});
+
+	describe('registration', () => {
+		it('registers a sub-execution of the tracked run', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+
+			expect(executionStateStore.isTrackedSubExecution('exec-sub')).toBe(true);
+			expect(executionStateStore.subExecutionLinks).toEqual([
+				{
+					executionId: 'exec-sub',
+					workflowId: WORKFLOW_ID,
+					parentExecutionId: ROOT_EXECUTION_ID,
+					parentNodeName: CALLER_NODE.name,
+					parentNodeRunIndex: 0,
+				},
+			]);
+		});
+
+		it('ignores a sub-execution whose parent is not the tracked run', async () => {
+			await executionStarted(
+				subExecutionStartedEvent('exec-sub', { executionId: 'someone-elses-run' }),
+				options,
+			);
+
+			expect(executionStateStore.isTrackedSubExecution('exec-sub')).toBe(false);
+		});
+
+		it('registers a sub-execution nested inside another sub-execution', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await executionStarted(
+				subExecutionStartedEvent('exec-grandchild', { executionId: 'exec-sub' }),
+				options,
+			);
+
+			expect(executionStateStore.isTrackedSubExecution('exec-grandchild')).toBe(true);
+		});
+
+		it('does not take over the tracked run slots', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+
+			expect(executionStateStore.activeExecutionId).toBe(ROOT_EXECUTION_ID);
+			expect(executionStateStore.displayedExecutionId).toBe(ROOT_EXECUTION_ID);
+		});
+	});
+
+	describe('canvas mirroring', () => {
+		it('turns the sub-workflow branch green as its nodes finish', async () => {
+			expect(executionStateStore.activeExecutionStatusByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(
+				'new',
+			);
+
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await runSubWorkflowBranch('exec-sub');
+
+			expect(executionStateStore.activeExecutionStatusByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(
+				'success',
+			);
+			expect(
+				executionStateStore.activeExecutionRunDataByNodeId.get(SUB_STEP_NODE.id)?.value,
+			).toHaveLength(1);
+			// The per-output aggregation feeding edge item counts is throttled.
+			await vi.waitFor(() =>
+				expect(
+					executionStateStore.activeExecutionRunDataOutputMapByNodeId.get(SUB_STEP_NODE.id),
+				).toBeDefined(),
+			);
+		});
+
+		it('marks the sub-execution node as running while it is in flight', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await nodeExecuteBefore(nodeExecuteBeforeEvent('exec-sub', SUB_STEP_NODE.name), options);
+
+			expect(executionStateStore.executionRunningByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(true);
+
+			await nodeExecuteAfter(nodeExecuteAfterEvent('exec-sub', SUB_STEP_NODE.name), options);
+
+			expect(executionStateStore.executionRunningByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(false);
+		});
+
+		it('keeps the node executing the sub-workflow running while the sub-execution advances', async () => {
+			await nodeExecuteBefore(
+				nodeExecuteBeforeEvent(ROOT_EXECUTION_ID, CALLER_NODE.name, 0),
+				options,
+			);
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await nodeExecuteBefore(nodeExecuteBeforeEvent('exec-sub', SUB_STEP_NODE.name, 0), options);
+
+			expect(executionStateStore.executionRunningByNodeId.get(CALLER_NODE.id)?.value).toBe(true);
+			expect(executionStateStore.executionRunningByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(true);
+		});
+
+		it("leaves the tracked run's own node state untouched", async () => {
+			await nodeExecuteBefore(
+				nodeExecuteBeforeEvent(ROOT_EXECUTION_ID, CALLER_NODE.name, 0),
+				options,
+			);
+			await nodeExecuteAfter(
+				nodeExecuteAfterEvent(ROOT_EXECUTION_ID, CALLER_NODE.name, 1),
+				options,
+			);
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await runSubWorkflowBranch('exec-sub');
+
+			expect(executionStateStore.activeExecutionStatusByNodeId.get(CALLER_NODE.id)?.value).toBe(
+				'success',
+			);
+			// The sub-execution's data lives in its own store, so it must not leak
+			// into the run data the tracked execution reports.
+			expect(Object.keys(executionStateStore.activeExecutionRunData ?? {}).sort()).toEqual([
+				CALLER_NODE.name,
+			]);
+		});
+
+		it('contributes nothing when the sub-workflow is a different workflow', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub', {}, 'wf-other'), options);
+			await runSubWorkflowBranch('exec-sub');
+
+			expect(executionStateStore.activeExecutionStatusByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(
+				'new',
+			);
+		});
+	});
+
+	describe('loops', () => {
+		it('shows only the current iteration', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub-0', { runIndex: 0 }), options);
+			await runSubWorkflowBranch('exec-sub-0');
+			await executionFinished(executionFinishedEvent('exec-sub-0'), options);
+
+			await executionStarted(subExecutionStartedEvent('exec-sub-1', { runIndex: 1 }), options);
+
+			expect(executionStateStore.isTrackedSubExecution('exec-sub-0')).toBe(false);
+			expect(executionStateStore.subExecutionLinks.map((l) => l.executionId)).toEqual([
+				'exec-sub-1',
+			]);
+			// Superseded iteration's data is gone, so the branch reflects the current
+			// one only — which has not run any node yet.
+			expect(executionStateStore.activeExecutionStatusByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(
+				'new',
+			);
+
+			await runSubWorkflowBranch('exec-sub-1');
+
+			expect(executionStateStore.activeExecutionStatusByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(
+				'success',
+			);
+		});
+
+		it('drops the superseded iteration´s own sub-executions too', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub-0', { runIndex: 0 }), options);
+			await executionStarted(
+				subExecutionStartedEvent('exec-grandchild', { executionId: 'exec-sub-0' }),
+				options,
+			);
+
+			await executionStarted(subExecutionStartedEvent('exec-sub-1', { runIndex: 1 }), options);
+
+			expect(executionStateStore.isTrackedSubExecution('exec-grandchild')).toBe(false);
+		});
+	});
+
+	describe('finishing', () => {
+		it('does not end the tracked run when a sub-execution finishes', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await runSubWorkflowBranch('exec-sub');
+			await executionFinished(executionFinishedEvent('exec-sub'), options);
+
+			expect(executionStateStore.activeExecutionId).toBe(ROOT_EXECUTION_ID);
+			// Its data stays on display, so the branch remains lit.
+			expect(executionStateStore.activeExecutionStatusByNodeId.get(SUB_STEP_NODE.id)?.value).toBe(
+				'success',
+			);
+		});
+
+		it('settles the sub-execution status on its own store', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await executionFinished(executionFinishedEvent('exec-sub'), options);
+
+			const subStore = useExecutionDataStore(createExecutionDataId('exec-sub'));
+			expect(subStore.execution?.status).toBe('success');
+			expect(subStore.execution?.finished).toBe(true);
+		});
+
+		it('clears the sub-execution running indicator when the run ends', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await nodeExecuteBefore(nodeExecuteBeforeEvent('exec-sub', SUB_STEP_NODE.name), options);
+			expect(executionStateStore.subExecutingNode.executingNode).toEqual([SUB_STEP_NODE.name]);
+
+			await executionFinished(executionFinishedEvent(ROOT_EXECUTION_ID), options);
+
+			expect(executionStateStore.subExecutingNode.executingNode).toEqual([]);
+		});
+	});
+
+	describe('cleanup', () => {
+		it('forgets sub-executions when a new run starts', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await runSubWorkflowBranch('exec-sub');
+
+			executionStateStore.setWorkflowExecutionData(null);
+
+			expect(executionStateStore.isTrackedSubExecution('exec-sub')).toBe(false);
+			expect(executionStateStore.subExecutionLinks).toEqual([]);
+		});
+
+		it('forgets sub-executions on reset', async () => {
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+
+			executionStateStore.resetExecutionState();
+
+			expect(executionStateStore.isTrackedSubExecution('exec-sub')).toBe(false);
+		});
+	});
+
+	describe('side effects', () => {
+		it('does not report a sub-execution node to workflow-scoped telemetry', async () => {
+			const telemetry = await import('./trackNodeExecution');
+			const spy = vi.spyOn(telemetry, 'trackNodeExecution');
+
+			await executionStarted(subExecutionStartedEvent('exec-sub'), options);
+			await nodeExecuteAfter(nodeExecuteAfterEvent('exec-sub', SUB_STEP_NODE.name), options);
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/useSubExecutions.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSubExecutions.ts
@@ -5,10 +5,9 @@ import { useExecutingNode } from '@/app/composables/useExecutingNode';
 export type SubExecutionLink = {
 	executionId: string;
 	workflowId: string;
-	/** Execution containing the node that started this one. */
 	parentExecutionId: string;
 	parentNodeName: string;
-	/** Run of that node — one sub-execution per iteration when it runs in a loop. */
+	/** One sub-execution per iteration when the node runs in a loop. */
 	parentNodeRunIndex: number;
 };
 
@@ -17,18 +16,12 @@ function parentNodeKey(parentExecutionId: string, parentNodeName: string) {
 }
 
 /**
- * Tracks the sub-workflow executions belonging to the run a document is watching.
+ * Tracks the sub-workflow executions of the run a document is watching. Their
+ * node events arrive under their own execution id, so registering them here is
+ * what lets the push handlers accept them instead of discarding them as foreign.
  *
- * A sub-workflow runs as its own execution, so its live node events arrive under
- * its own execution id. Registering them here is what lets the push handlers
- * accept those events instead of discarding them as foreign, the canvas mirror
- * them, and the log view nest them under the node that started them — all while
- * the run is still in flight.
- *
- * Only the newest sub-execution per parent node is kept. A node executing a
- * sub-workflow in a loop (or once per input item) produces one sub-execution per
- * iteration, and the canvas has a single node per name to show them on, so
- * superseded iterations are dropped rather than piling up.
+ * Only the newest sub-execution per parent node is kept: the canvas has one node
+ * per name, so superseded loop iterations are dropped rather than piling up.
  */
 export function useSubExecutions() {
 	const byExecutionId = ref(new Map<string, SubExecutionLink>());
@@ -36,11 +29,9 @@ export function useSubExecutions() {
 	const currentByParentNode = ref(new Map<string, string>());
 
 	/**
-	 * Node currently executing inside a sub-execution. Kept apart from the parent
-	 * run's queue: the two executions number their node events independently, so
-	 * sharing one queue would make them fight over which node is current — and the
-	 * node executing the sub-workflow should keep its own indicator while its
-	 * child advances.
+	 * Node currently executing inside a sub-execution. Separate from the parent
+	 * run's queue, which numbers its node events independently and whose calling
+	 * node stays running while the child advances.
 	 */
 	const executingNode = useExecutingNode();
 
@@ -82,9 +73,8 @@ export function useSubExecutions() {
 	}
 
 	/**
-	 * Registers a sub-execution, superseding the previous one started by the same
-	 * parent node. Returns the ids it superseded — that iteration plus everything
-	 * it started in turn — so the caller can dispose their data.
+	 * Registers a sub-execution, superseding the previous one from the same parent
+	 * node. Returns the superseded ids (and their descendants) to dispose.
 	 */
 	function register(link: SubExecutionLink): string[] {
 		const key = parentNodeKey(link.parentExecutionId, link.parentNodeName);

--- a/packages/frontend/editor-ui/src/app/composables/useSubExecutions.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSubExecutions.ts
@@ -1,0 +1,125 @@
+import { ref } from 'vue';
+import { useExecutingNode } from '@/app/composables/useExecutingNode';
+
+/** Where a live sub-workflow execution hangs off the run that started it. */
+export type SubExecutionLink = {
+	executionId: string;
+	workflowId: string;
+	/** Execution containing the node that started this one. */
+	parentExecutionId: string;
+	parentNodeName: string;
+	/** Run of that node — one sub-execution per iteration when it runs in a loop. */
+	parentNodeRunIndex: number;
+};
+
+function parentNodeKey(parentExecutionId: string, parentNodeName: string) {
+	return `${parentExecutionId}:${parentNodeName}`;
+}
+
+/**
+ * Tracks the sub-workflow executions belonging to the run a document is watching.
+ *
+ * A sub-workflow runs as its own execution, so its live node events arrive under
+ * its own execution id. Registering them here is what lets the push handlers
+ * accept those events instead of discarding them as foreign, the canvas mirror
+ * them, and the log view nest them under the node that started them — all while
+ * the run is still in flight.
+ *
+ * Only the newest sub-execution per parent node is kept. A node executing a
+ * sub-workflow in a loop (or once per input item) produces one sub-execution per
+ * iteration, and the canvas has a single node per name to show them on, so
+ * superseded iterations are dropped rather than piling up.
+ */
+export function useSubExecutions() {
+	const byExecutionId = ref(new Map<string, SubExecutionLink>());
+	/** Newest sub-execution id per `parentExecutionId:parentNodeName`. */
+	const currentByParentNode = ref(new Map<string, string>());
+
+	/**
+	 * Node currently executing inside a sub-execution. Kept apart from the parent
+	 * run's queue: the two executions number their node events independently, so
+	 * sharing one queue would make them fight over which node is current — and the
+	 * node executing the sub-workflow should keep its own indicator while its
+	 * child advances.
+	 */
+	const executingNode = useExecutingNode();
+
+	function has(executionId: string): boolean {
+		return byExecutionId.value.has(executionId);
+	}
+
+	function get(executionId: string): SubExecutionLink | undefined {
+		return byExecutionId.value.get(executionId);
+	}
+
+	/** Ids of `executionId`'s own sub-executions, transitively. */
+	function collectDescendants(executionId: string): string[] {
+		const descendants: string[] = [];
+		const queue = [executionId];
+
+		while (queue.length > 0) {
+			const current = queue.shift()!;
+			for (const link of byExecutionId.value.values()) {
+				if (link.parentExecutionId === current) {
+					descendants.push(link.executionId);
+					queue.push(link.executionId);
+				}
+			}
+		}
+
+		return descendants;
+	}
+
+	function forget(executionId: string) {
+		const link = byExecutionId.value.get(executionId);
+		if (!link) return;
+
+		byExecutionId.value.delete(executionId);
+		const key = parentNodeKey(link.parentExecutionId, link.parentNodeName);
+		if (currentByParentNode.value.get(key) === executionId) {
+			currentByParentNode.value.delete(key);
+		}
+	}
+
+	/**
+	 * Registers a sub-execution, superseding the previous one started by the same
+	 * parent node. Returns the ids it superseded — that iteration plus everything
+	 * it started in turn — so the caller can dispose their data.
+	 */
+	function register(link: SubExecutionLink): string[] {
+		const key = parentNodeKey(link.parentExecutionId, link.parentNodeName);
+		const superseded = currentByParentNode.value.get(key);
+		const dropped =
+			superseded !== undefined && superseded !== link.executionId
+				? [superseded, ...collectDescendants(superseded)]
+				: [];
+
+		for (const id of dropped) forget(id);
+
+		byExecutionId.value.set(link.executionId, link);
+		currentByParentNode.value.set(key, link.executionId);
+
+		return dropped;
+	}
+
+	/** Returns every registered id and empties the registry. */
+	function clear(): string[] {
+		const ids = Array.from(byExecutionId.value.keys());
+		byExecutionId.value = new Map();
+		currentByParentNode.value = new Map();
+		executingNode.clearNodeExecutionQueue();
+		return ids;
+	}
+
+	return {
+		/** Registered sub-executions, in the order they started. */
+		byExecutionId,
+		executingNode,
+		has,
+		get,
+		register,
+		forget,
+		collectDescendants,
+		clear,
+	};
+}

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -486,10 +486,8 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 		}
 
 		/**
-		 * Settles this execution's terminal status without touching its run data.
-		 * For an execution whose data arrived purely from live pushes — a
-		 * sub-execution of the run being watched — there is no authoritative copy to
-		 * re-fetch, so the accumulated data must survive the status change.
+		 * Settles the terminal status without touching run data. A sub-execution's
+		 * data comes purely from live pushes, so it must survive the status change.
 		 */
 		function setExecutionStatus(status: ExecutionStatus, stoppedAt: Date) {
 			if (!execution.value) return;

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -485,6 +485,24 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			fireChange(value === null ? CHANGE_ACTION.DELETE : CHANGE_ACTION.UPDATE);
 		}
 
+		/**
+		 * Settles this execution's terminal status without touching its run data.
+		 * For an execution whose data arrived purely from live pushes — a
+		 * sub-execution of the run being watched — there is no authoritative copy to
+		 * re-fetch, so the accumulated data must survive the status change.
+		 */
+		function setExecutionStatus(status: ExecutionStatus, stoppedAt: Date) {
+			if (!execution.value) return;
+			execution.value = {
+				...execution.value,
+				status,
+				stoppedAt,
+				finished: status === 'success',
+			};
+			executionResultDataLastUpdate.value = Date.now();
+			fireChange(CHANGE_ACTION.UPDATE);
+		}
+
 		function setExecutionRunData(runExecutionData: IRunExecutionData) {
 			if (!execution.value) return;
 			execution.value = { ...execution.value, data: runExecutionData };
@@ -729,6 +747,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			getExecutionSnapshot,
 			// Write API
 			setExecution,
+			setExecutionStatus,
 			setExecutionRunData,
 			addNodeExecutionStartedData,
 			clearExecutionStartedData,

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -535,6 +535,24 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			fireChange(value === null ? CHANGE_ACTION.DELETE : CHANGE_ACTION.UPDATE);
 		}
 
+		/**
+		 * Settles this execution's terminal status without touching its run data.
+		 * For an execution whose data arrived purely from live pushes — a
+		 * sub-execution of the run being watched — there is no authoritative copy to
+		 * re-fetch, so the accumulated data must survive the status change.
+		 */
+		function setExecutionStatus(status: ExecutionStatus, stoppedAt: Date) {
+			if (!execution.value) return;
+			execution.value = {
+				...execution.value,
+				status,
+				stoppedAt,
+				finished: status === 'success',
+			};
+			executionResultDataLastUpdate.value = Date.now();
+			fireChange(CHANGE_ACTION.UPDATE);
+		}
+
 		function setExecutionRunData(runExecutionData: IRunExecutionData) {
 			if (!execution.value) return;
 			execution.value = { ...execution.value, data: runExecutionData };
@@ -781,6 +799,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			getExecutionSnapshot,
 			// Write API
 			setExecution,
+			setExecutionStatus,
 			setExecutionRunData,
 			addNodeExecutionStartedData,
 			clearExecutionStartedData,

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -536,10 +536,8 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 		}
 
 		/**
-		 * Settles this execution's terminal status without touching its run data.
-		 * For an execution whose data arrived purely from live pushes — a
-		 * sub-execution of the run being watched — there is no authoritative copy to
-		 * re-fetch, so the accumulated data must survive the status change.
+		 * Settles the terminal status without touching run data. A sub-execution's
+		 * data comes purely from live pushes, so it must survive the status change.
 		 */
 		function setExecutionStatus(status: ExecutionStatus, stoppedAt: Date) {
 			if (!execution.value) return;

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -26,6 +26,7 @@ import type {
 } from '@/features/execution/executions/executions.types';
 import { IN_PROGRESS_EXECUTION_ID } from '@/app/constants/placeholders';
 import { useExecutingNode } from '@/app/composables/useExecutingNode';
+import { useSubExecutions, type SubExecutionLink } from '@/app/composables/useSubExecutions';
 import { useUIStore } from '@/app/stores/ui.store';
 import {
 	createExecutionDataId,
@@ -157,6 +158,13 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		 * intentionally not wired into the change-event mechanism below.
 		 */
 		const executingNode = useExecutingNode();
+
+		/**
+		 * Sub-workflow executions of the run being watched. Each one owns its own
+		 * execution-data store, keyed by its own execution id; this registry is what
+		 * binds them back to the node that started them.
+		 */
+		const subExecutions = useSubExecutions();
 
 		const onWorkflowExecutionStateChange = createEventHook<WorkflowExecutionStateChangeEvent>();
 
@@ -317,23 +325,155 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		// consistent with `activeExecutionRunData`; falls back to an empty Map
 		// sentinel only when no execution is being tracked.
 
-		const activeExecutionStatusByNodeId = computed(() => {
+		// ---------------------------------------------------------------------
+		// Live sub-execution overlay.
+		//
+		// A sub-workflow runs as its own execution with its own execution-data
+		// store, so the nodes it runs would stay blank on this canvas. When the
+		// sub-workflow *is* the workflow on the canvas — a workflow calling itself —
+		// those nodes exist here under the same ids, so filling in the
+		// sub-execution's state wherever this execution has none lights the branch
+		// up as it runs. Node ids only line up in that self-call case, which is
+		// exactly when the overlay is meaningful: a different sub-workflow
+		// contributes nothing and the maps come through untouched.
+		//
+		// The overlay outlives the run. It reads from separate stores, so the
+		// authoritative run data fetched when the parent finishes replaces only the
+		// parent's own state and the sub-workflow's branch stays lit.
+		// ---------------------------------------------------------------------
+
+		/** Registered sub-executions of the tracked run, in the order they started. */
+		const subExecutionLinks = computed(() =>
+			Array.from(subExecutions.byExecutionId.value.values()),
+		);
+
+		/**
+		 * Execution-data stores of the live sub-executions, oldest first. Reading the
+		 * registry here is what makes the overlays re-resolve when a sub-execution
+		 * starts or is superseded.
+		 */
+		function subExecutionStores() {
+			return Array.from(subExecutions.byExecutionId.value.keys(), (executionId) =>
+				useExecutionDataStore(createExecutionDataId(executionId)),
+			);
+		}
+
+		/** Node ids present in any of the given maps. */
+		function unionOfNodeIds(maps: Array<Map<string, unknown>>): Set<string> {
+			const nodeIds = new Set<string>();
+			for (const map of maps) for (const nodeId of map.keys()) nodeIds.add(nodeId);
+			return nodeIds;
+		}
+
+		function ownStatusByNodeId() {
 			const executionId = getResolvedActiveExecutionId();
-			if (!executionId) return EMPTY_EXECUTION_STATUS_BY_NODE_ID;
-			return useExecutionDataStore(createExecutionDataId(executionId)).executionStatusByNodeId;
+			return executionId
+				? useExecutionDataStore(createExecutionDataId(executionId)).executionStatusByNodeId
+				: EMPTY_EXECUTION_STATUS_BY_NODE_ID;
+		}
+
+		function ownRunDataByNodeId() {
+			const executionId = getResolvedActiveExecutionId();
+			return executionId
+				? useExecutionDataStore(createExecutionDataId(executionId)).executionRunDataByNodeId
+				: EMPTY_EXECUTION_RUN_DATA_BY_NODE_ID;
+		}
+
+		function computeOverlaidStatus(nodeId: string): ExecutionStatus {
+			const ownStatus = ownStatusByNodeId().get(nodeId)?.value;
+			if (ownStatus !== undefined && ownStatus !== 'new') return ownStatus;
+			// Newest sub-execution wins, so a node that ran in an earlier iteration
+			// doesn't outrank the one running now.
+			const stores = subExecutionStores();
+			for (let i = stores.length - 1; i >= 0; i--) {
+				const status = stores[i].executionStatusByNodeId.get(nodeId)?.value;
+				if (status !== undefined && status !== 'new') return status;
+			}
+			return ownStatus ?? 'new';
+		}
+
+		function computeOverlaidRunData(nodeId: string): ITaskData[] | null {
+			const ownTasks = ownRunDataByNodeId().get(nodeId)?.value;
+			if (ownTasks) return ownTasks;
+			const stores = subExecutionStores();
+			for (let i = stores.length - 1; i >= 0; i--) {
+				const tasks = stores[i].executionRunDataByNodeId.get(nodeId)?.value;
+				if (tasks) return tasks;
+			}
+			return null;
+		}
+
+		// Overlay entries resolve the active execution *and* the registry on read,
+		// so they stay valid across every sub-execution start and are created once
+		// per node instead of once per node per iteration — a loop calling a
+		// sub-workflow hundreds of times would otherwise churn through one computed
+		// per node per iteration. Owned by a scope stopped on store disposal;
+		// per-node entries are dropped alongside the running maps below.
+		const overlayScope = effectScope();
+		const overlayStatusEntries = new Map<string, ComputedRef<ExecutionStatus>>();
+		const overlayRunDataEntries = new Map<string, ComputedRef<ITaskData[] | null>>();
+
+		function overlayStatusEntry(nodeId: string): ComputedRef<ExecutionStatus> {
+			let entry = overlayStatusEntries.get(nodeId);
+			if (!entry) {
+				entry = overlayScope.run(() => structuralComputed(() => computeOverlaidStatus(nodeId)))!;
+				overlayStatusEntries.set(nodeId, entry);
+			}
+			return entry;
+		}
+
+		function overlayRunDataEntry(nodeId: string): ComputedRef<ITaskData[] | null> {
+			let entry = overlayRunDataEntries.get(nodeId);
+			if (!entry) {
+				// Plain `computed` for the same reason the per-execution store uses one:
+				// task data can be megabytes, so reference identity is the right gate.
+				entry = overlayScope.run(() => computed(() => computeOverlaidRunData(nodeId)))!;
+				overlayRunDataEntries.set(nodeId, entry);
+			}
+			return entry;
+		}
+
+		const activeExecutionStatusByNodeId = computed(() => {
+			const own = ownStatusByNodeId();
+			const overlays = subExecutionStores().map((store) => store.executionStatusByNodeId);
+			if (overlays.length === 0) return own;
+
+			const merged = new Map<string, ComputedRef<ExecutionStatus>>();
+			for (const nodeId of unionOfNodeIds([own, ...overlays])) {
+				merged.set(nodeId, overlayStatusEntry(nodeId));
+			}
+			return merged;
 		});
 
 		const activeExecutionRunDataByNodeId = computed(() => {
-			const executionId = getResolvedActiveExecutionId();
-			if (!executionId) return EMPTY_EXECUTION_RUN_DATA_BY_NODE_ID;
-			return useExecutionDataStore(createExecutionDataId(executionId)).executionRunDataByNodeId;
+			const own = ownRunDataByNodeId();
+			const overlays = subExecutionStores().map((store) => store.executionRunDataByNodeId);
+			if (overlays.length === 0) return own;
+
+			const merged = new Map<string, ComputedRef<ITaskData[] | null>>();
+			for (const nodeId of unionOfNodeIds([own, ...overlays])) {
+				merged.set(nodeId, overlayRunDataEntry(nodeId));
+			}
+			return merged;
 		});
 
 		const activeExecutionRunDataOutputMapByNodeId = computed(() => {
 			const executionId = getResolvedActiveExecutionId();
-			if (!executionId) return EMPTY_EXECUTION_RUN_DATA_OUTPUT_MAP_BY_NODE_ID;
-			return useExecutionDataStore(createExecutionDataId(executionId))
-				.executionRunDataOutputMapByNodeId;
+			const own = executionId
+				? useExecutionDataStore(createExecutionDataId(executionId))
+						.executionRunDataOutputMapByNodeId
+				: EMPTY_EXECUTION_RUN_DATA_OUTPUT_MAP_BY_NODE_ID;
+			const overlays = subExecutionStores().map((store) => store.executionRunDataOutputMapByNodeId);
+			if (overlays.length === 0) return own;
+
+			// Entries exist only for nodes that produced output, so a missing key is
+			// the emptiness signal — no per-node wrapper needed.
+			const merged = new Map<string, ExecutionOutputMap>();
+			for (const overlay of overlays) {
+				for (const [nodeId, outputMap] of overlay.entries()) merged.set(nodeId, outputMap);
+			}
+			for (const [nodeId, outputMap] of own.entries()) merged.set(nodeId, outputMap);
+			return merged;
 		});
 
 		const activeExecutionWaitingByNodeId = computed(() => {
@@ -386,7 +526,13 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			// Pinia unwraps it to a Map at the store boundary.
 			const node = documentStore.nodesById.get(nodeId);
 			if (!node) return false;
-			return executingNode.isNodeExecuting(node.name);
+			// Either this run or a sub-execution of it can have the node mid-flight —
+			// the node executing the sub-workflow stays running while its child
+			// advances, so both queues count.
+			return (
+				executingNode.isNodeExecuting(node.name) ||
+				subExecutions.executingNode.isNodeExecuting(node.name)
+			);
 		}
 
 		function computeExecutionWaitingForNext(nodeId: string): boolean {
@@ -420,6 +566,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			runningScopes.delete(nodeId);
 			executionRunningByNodeId.delete(nodeId);
 			executionWaitingForNextByNodeId.delete(nodeId);
+			overlayStatusEntries.delete(nodeId);
+			overlayRunDataEntries.delete(nodeId);
 		}
 
 		function applyReconcileRunningEntries(nodeIds: string[]) {
@@ -477,6 +625,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			runningScopes.clear();
 			executionRunningByNodeId.clear();
 			executionWaitingForNextByNodeId.clear();
+			overlayScope.stop();
+			overlayStatusEntries.clear();
+			overlayRunDataEntries.clear();
 		});
 
 		/**
@@ -587,11 +738,57 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		}
 
 		/**
+		 * Binds a starting sub-workflow execution to the run this document is
+		 * watching, so its live node events are accepted and mirrored instead of
+		 * discarded as foreign. Ignored unless its parent chain reaches the tracked
+		 * execution — a sub-execution of somebody else's run must not write here.
+		 * Returns whether it was registered.
+		 */
+		function registerSubExecution(link: SubExecutionLink): boolean {
+			const belongsToTrackedRun =
+				link.parentExecutionId === activeExecutionId.value ||
+				subExecutions.has(link.parentExecutionId);
+			if (!belongsToTrackedRun) return false;
+
+			// The iteration this one supersedes is no longer shown anywhere, so drop
+			// its data rather than keeping every iteration of a loop in memory.
+			for (const id of subExecutions.register(link)) {
+				disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(id)));
+				trackedExecutionIds.value.delete(id);
+			}
+			trackExecutionId(link.executionId);
+			return true;
+		}
+
+		/**
+		 * A sub-execution reached a terminal state. Its data stays registered — the
+		 * canvas and log view keep showing it — but nothing in it is running, so the
+		 * sub-execution queue is cleared. Any sibling still running re-fills it on
+		 * its next node event.
+		 */
+		function markSubExecutionFinished(executionId: string) {
+			if (!subExecutions.has(executionId)) return;
+			subExecutions.executingNode.clearNodeExecutionQueue();
+		}
+
+		/** Empties the sub-execution registry and disposes the data it was showing. */
+		function clearSubExecutions() {
+			for (const id of subExecutions.clear()) {
+				disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(id)));
+				trackedExecutionIds.value.delete(id);
+			}
+		}
+
+		/**
 		 * Applies a fetched/started execution result to this document's session state:
 		 * clears it when null, stages it as the pending scaffold while in progress, or
 		 * tracks it as a displayed execution once it has a backend id.
 		 */
 		function setWorkflowExecutionData(workflowResultData: IExecutionResponse | null) {
+			// Any call here starts, clears, or swaps the execution on display, so the
+			// previous run's sub-executions stop being relevant.
+			clearSubExecutions();
+
 			if (workflowResultData === null) {
 				setPendingExecution(null);
 				clearDisplayedExecution();
@@ -832,6 +1029,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			lastSuccessfulExecutionId.value = null;
 			stoppedExecutionId.value = null;
 			executingNode.clearNodeExecutionQueue();
+			// Stores already disposed by the loop above; just drop the registry.
+			subExecutions.clear();
 			fireChange(CHANGE_ACTION.DELETE, 'state');
 		}
 
@@ -847,6 +1046,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 
 			setActiveExecutionId(undefined);
 			executingNode.clearNodeExecutionQueue();
+			// Stopping the run aborts its sub-executions too, but their data stays on
+			// display — only the running indicators go.
+			subExecutions.executingNode.clearNodeExecutionQueue();
 			setExecutionWaitingForWebhook(false);
 
 			useDocumentTitle().setDocumentTitle(useWorkflowDocumentStore(documentId).name, 'IDLE');
@@ -903,6 +1105,10 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			lastSuccessfulExecutionId: readonly(lastSuccessfulExecutionId),
 			stoppedExecutionId: readonly(stoppedExecutionId),
 			executingNode,
+			/** Node currently executing inside a sub-execution of the tracked run. */
+			subExecutingNode: subExecutions.executingNode,
+			subExecutionLinks,
+			isTrackedSubExecution: subExecutions.has,
 			activeExecution,
 			isExecutionDataDisplayed,
 			activeExecutionRunData,
@@ -926,6 +1132,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			resolveExecutionTriggerNodeName,
 			// Write API
 			trackExecutionId,
+			registerSubExecution,
+			markSubExecutionFinished,
+			clearSubExecutions,
 			setActiveExecutionId,
 			setWorkflowExecutionData,
 			setDisplayedExecutionId,

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -159,11 +159,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		 */
 		const executingNode = useExecutingNode();
 
-		/**
-		 * Sub-workflow executions of the run being watched. Each one owns its own
-		 * execution-data store, keyed by its own execution id; this registry is what
-		 * binds them back to the node that started them.
-		 */
+		/** Sub-workflow executions of the run being watched. */
 		const subExecutions = useSubExecutions();
 
 		const onWorkflowExecutionStateChange = createEventHook<WorkflowExecutionStateChangeEvent>();
@@ -325,22 +321,13 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		// consistent with `activeExecutionRunData`; falls back to an empty Map
 		// sentinel only when no execution is being tracked.
 
-		// ---------------------------------------------------------------------
-		// Live sub-execution overlay.
-		//
-		// A sub-workflow runs as its own execution with its own execution-data
-		// store, so the nodes it runs would stay blank on this canvas. When the
-		// sub-workflow *is* the workflow on the canvas — a workflow calling itself —
-		// those nodes exist here under the same ids, so filling in the
-		// sub-execution's state wherever this execution has none lights the branch
-		// up as it runs. Node ids only line up in that self-call case, which is
-		// exactly when the overlay is meaningful: a different sub-workflow
-		// contributes nothing and the maps come through untouched.
-		//
-		// The overlay outlives the run. It reads from separate stores, so the
-		// authoritative run data fetched when the parent finishes replaces only the
-		// parent's own state and the sub-workflow's branch stays lit.
-		// ---------------------------------------------------------------------
+		// Live sub-execution overlay: fills in per-node state from the live
+		// sub-executions wherever this execution has none, lighting up the branch of
+		// a workflow calling itself. Node ids only line up in that self-call case,
+		// so a different sub-workflow contributes nothing and the maps come through
+		// untouched. Reading from separate stores means the authoritative run data
+		// fetched at the end replaces only the parent's own state, so the branch
+		// stays lit.
 
 		/** Registered sub-executions of the tracked run, in the order they started. */
 		const subExecutionLinks = computed(() =>
@@ -348,9 +335,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		);
 
 		/**
-		 * Execution-data stores of the live sub-executions, oldest first. Reading the
-		 * registry here is what makes the overlays re-resolve when a sub-execution
-		 * starts or is superseded.
+		 * Live sub-executions' data stores, oldest first. Reading the registry here
+		 * is what re-resolves the overlays when one starts or is superseded.
 		 */
 		function subExecutionStores() {
 			return Array.from(subExecutions.byExecutionId.value.keys(), (executionId) =>
@@ -382,8 +368,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		function computeOverlaidStatus(nodeId: string): ExecutionStatus {
 			const ownStatus = ownStatusByNodeId().get(nodeId)?.value;
 			if (ownStatus !== undefined && ownStatus !== 'new') return ownStatus;
-			// Newest sub-execution wins, so a node that ran in an earlier iteration
-			// doesn't outrank the one running now.
+			// Newest wins, so an earlier iteration doesn't outrank the current one.
 			const stores = subExecutionStores();
 			for (let i = stores.length - 1; i >= 0; i--) {
 				const status = stores[i].executionStatusByNodeId.get(nodeId)?.value;
@@ -403,12 +388,10 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			return null;
 		}
 
-		// Overlay entries resolve the active execution *and* the registry on read,
-		// so they stay valid across every sub-execution start and are created once
-		// per node instead of once per node per iteration — a loop calling a
-		// sub-workflow hundreds of times would otherwise churn through one computed
-		// per node per iteration. Owned by a scope stopped on store disposal;
-		// per-node entries are dropped alongside the running maps below.
+		// Entries resolve the active execution and the registry on read, so they are
+		// created once per node rather than once per node per iteration — a long loop
+		// would otherwise churn through thousands of computeds. Owned by a scope
+		// stopped on disposal; entries drop alongside the running maps below.
 		const overlayScope = effectScope();
 		const overlayStatusEntries = new Map<string, ComputedRef<ExecutionStatus>>();
 		const overlayRunDataEntries = new Map<string, ComputedRef<ITaskData[] | null>>();
@@ -425,8 +408,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		function overlayRunDataEntry(nodeId: string): ComputedRef<ITaskData[] | null> {
 			let entry = overlayRunDataEntries.get(nodeId);
 			if (!entry) {
-				// Plain `computed` for the same reason the per-execution store uses one:
-				// task data can be megabytes, so reference identity is the right gate.
+				// Plain `computed`: task data can be megabytes, so reference identity is
+				// the right gate (same reason as the per-execution store).
 				entry = overlayScope.run(() => computed(() => computeOverlaidRunData(nodeId)))!;
 				overlayRunDataEntries.set(nodeId, entry);
 			}
@@ -466,8 +449,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			const overlays = subExecutionStores().map((store) => store.executionRunDataOutputMapByNodeId);
 			if (overlays.length === 0) return own;
 
-			// Entries exist only for nodes that produced output, so a missing key is
-			// the emptiness signal — no per-node wrapper needed.
+			// Only nodes that produced output have an entry, so a missing key is the
+			// emptiness signal — no per-node wrapper needed.
 			const merged = new Map<string, ExecutionOutputMap>();
 			for (const overlay of overlays) {
 				for (const [nodeId, outputMap] of overlay.entries()) merged.set(nodeId, outputMap);
@@ -526,9 +509,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			// Pinia unwraps it to a Map at the store boundary.
 			const node = documentStore.nodesById.get(nodeId);
 			if (!node) return false;
-			// Either this run or a sub-execution of it can have the node mid-flight —
-			// the node executing the sub-workflow stays running while its child
-			// advances, so both queues count.
+			// Both queues count: the calling node stays running while its child
+			// advances.
 			return (
 				executingNode.isNodeExecuting(node.name) ||
 				subExecutions.executingNode.isNodeExecuting(node.name)
@@ -738,11 +720,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		}
 
 		/**
-		 * Binds a starting sub-workflow execution to the run this document is
-		 * watching, so its live node events are accepted and mirrored instead of
-		 * discarded as foreign. Ignored unless its parent chain reaches the tracked
-		 * execution — a sub-execution of somebody else's run must not write here.
-		 * Returns whether it was registered.
+		 * Binds a starting sub-execution to the run this document is watching, so its
+		 * node events are accepted. Ignored unless its parent chain reaches the
+		 * tracked execution. Returns whether it was registered.
 		 */
 		function registerSubExecution(link: SubExecutionLink): boolean {
 			const belongsToTrackedRun =
@@ -750,8 +730,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 				subExecutions.has(link.parentExecutionId);
 			if (!belongsToTrackedRun) return false;
 
-			// The iteration this one supersedes is no longer shown anywhere, so drop
-			// its data rather than keeping every iteration of a loop in memory.
+			// The superseded iteration is no longer shown, so drop its data rather
+			// than keeping every loop iteration in memory.
 			for (const id of subExecutions.register(link)) {
 				disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(id)));
 				trackedExecutionIds.value.delete(id);
@@ -761,10 +741,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		}
 
 		/**
-		 * A sub-execution reached a terminal state. Its data stays registered — the
-		 * canvas and log view keep showing it — but nothing in it is running, so the
-		 * sub-execution queue is cleared. Any sibling still running re-fills it on
-		 * its next node event.
+		 * A sub-execution finished. Its data stays registered (the canvas and log
+		 * view keep showing it) but nothing in it runs, so the queue is cleared; a
+		 * sibling still running re-fills it on its next node event.
 		 */
 		function markSubExecutionFinished(executionId: string) {
 			if (!subExecutions.has(executionId)) return;
@@ -785,8 +764,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		 * tracks it as a displayed execution once it has a backend id.
 		 */
 		function setWorkflowExecutionData(workflowResultData: IExecutionResponse | null) {
-			// Any call here starts, clears, or swaps the execution on display, so the
-			// previous run's sub-executions stop being relevant.
+			// Starts, clears, or swaps the displayed execution, so the previous run's
+			// sub-executions stop being relevant.
 			clearSubExecutions();
 
 			if (workflowResultData === null) {
@@ -1046,8 +1025,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 
 			setActiveExecutionId(undefined);
 			executingNode.clearNodeExecutionQueue();
-			// Stopping the run aborts its sub-executions too, but their data stays on
-			// display — only the running indicators go.
+			// Sub-executions abort too, but their data stays on display.
 			subExecutions.executingNode.clearNodeExecutionQueue();
 			setExecutionWaitingForWebhook(false);
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -265,11 +265,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			);
 		}
 
-		/**
-		 * Sub-workflow executions of the run being watched. Each one owns its own
-		 * execution-data store, keyed by its own execution id; this registry is what
-		 * binds them back to the node that started them.
-		 */
+		/** Sub-workflow executions of the run being watched. */
 		const subExecutions = useSubExecutions();
 
 		const onWorkflowExecutionStateChange = createEventHook<WorkflowExecutionStateChangeEvent>();
@@ -462,22 +458,13 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		// consistent with `activeExecutionRunData`; falls back to an empty Map
 		// sentinel only when no execution is being tracked.
 
-		// ---------------------------------------------------------------------
-		// Live sub-execution overlay.
-		//
-		// A sub-workflow runs as its own execution with its own execution-data
-		// store, so the nodes it runs would stay blank on this canvas. When the
-		// sub-workflow *is* the workflow on the canvas — a workflow calling itself —
-		// those nodes exist here under the same ids, so filling in the
-		// sub-execution's state wherever this execution has none lights the branch
-		// up as it runs. Node ids only line up in that self-call case, which is
-		// exactly when the overlay is meaningful: a different sub-workflow
-		// contributes nothing and the maps come through untouched.
-		//
-		// The overlay outlives the run. It reads from separate stores, so the
-		// authoritative run data fetched when the parent finishes replaces only the
-		// parent's own state and the sub-workflow's branch stays lit.
-		// ---------------------------------------------------------------------
+		// Live sub-execution overlay: fills in per-node state from the live
+		// sub-executions wherever this execution has none, lighting up the branch of
+		// a workflow calling itself. Node ids only line up in that self-call case,
+		// so a different sub-workflow contributes nothing and the maps come through
+		// untouched. Reading from separate stores means the authoritative run data
+		// fetched at the end replaces only the parent's own state, so the branch
+		// stays lit.
 
 		/** Registered sub-executions of the tracked run, in the order they started. */
 		const subExecutionLinks = computed(() =>
@@ -485,9 +472,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		);
 
 		/**
-		 * Execution-data stores of the live sub-executions, oldest first. Reading the
-		 * registry here is what makes the overlays re-resolve when a sub-execution
-		 * starts or is superseded.
+		 * Live sub-executions' data stores, oldest first. Reading the registry here
+		 * is what re-resolves the overlays when one starts or is superseded.
 		 */
 		function subExecutionStores() {
 			return Array.from(subExecutions.byExecutionId.value.keys(), (executionId) =>
@@ -519,8 +505,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		function computeOverlaidStatus(nodeId: string): ExecutionStatus {
 			const ownStatus = ownStatusByNodeId().get(nodeId)?.value;
 			if (ownStatus !== undefined && ownStatus !== 'new') return ownStatus;
-			// Newest sub-execution wins, so a node that ran in an earlier iteration
-			// doesn't outrank the one running now.
+			// Newest wins, so an earlier iteration doesn't outrank the current one.
 			const stores = subExecutionStores();
 			for (let i = stores.length - 1; i >= 0; i--) {
 				const status = stores[i].executionStatusByNodeId.get(nodeId)?.value;
@@ -540,12 +525,10 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			return null;
 		}
 
-		// Overlay entries resolve the active execution *and* the registry on read,
-		// so they stay valid across every sub-execution start and are created once
-		// per node instead of once per node per iteration — a loop calling a
-		// sub-workflow hundreds of times would otherwise churn through one computed
-		// per node per iteration. Owned by a scope stopped on store disposal;
-		// per-node entries are dropped alongside the running maps below.
+		// Entries resolve the active execution and the registry on read, so they are
+		// created once per node rather than once per node per iteration — a long loop
+		// would otherwise churn through thousands of computeds. Owned by a scope
+		// stopped on disposal; entries drop alongside the running maps below.
 		const overlayScope = effectScope();
 		const overlayStatusEntries = new Map<string, ComputedRef<ExecutionStatus>>();
 		const overlayRunDataEntries = new Map<string, ComputedRef<ITaskData[] | null>>();
@@ -562,8 +545,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		function overlayRunDataEntry(nodeId: string): ComputedRef<ITaskData[] | null> {
 			let entry = overlayRunDataEntries.get(nodeId);
 			if (!entry) {
-				// Plain `computed` for the same reason the per-execution store uses one:
-				// task data can be megabytes, so reference identity is the right gate.
+				// Plain `computed`: task data can be megabytes, so reference identity is
+				// the right gate (same reason as the per-execution store).
 				entry = overlayScope.run(() => computed(() => computeOverlaidRunData(nodeId)))!;
 				overlayRunDataEntries.set(nodeId, entry);
 			}
@@ -603,8 +586,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			const overlays = subExecutionStores().map((store) => store.executionRunDataOutputMapByNodeId);
 			if (overlays.length === 0) return own;
 
-			// Entries exist only for nodes that produced output, so a missing key is
-			// the emptiness signal — no per-node wrapper needed.
+			// Only nodes that produced output have an entry, so a missing key is the
+			// emptiness signal — no per-node wrapper needed.
 			const merged = new Map<string, ExecutionOutputMap>();
 			for (const overlay of overlays) {
 				for (const [nodeId, outputMap] of overlay.entries()) merged.set(nodeId, outputMap);
@@ -675,9 +658,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			// Pinia unwraps it to a Map at the store boundary.
 			const node = documentStore.nodesById.get(nodeId);
 			if (!node) return false;
-			// Either this run or a sub-execution of it can have the node mid-flight —
-			// the node executing the sub-workflow stays running while its child
-			// advances, so both queues count.
+			// Both queues count: the calling node stays running while its child
+			// advances.
 			return (
 				executingNode.isNodeExecuting(node.name) ||
 				subExecutions.executingNode.isNodeExecuting(node.name)
@@ -889,11 +871,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		}
 
 		/**
-		 * Binds a starting sub-workflow execution to the run this document is
-		 * watching, so its live node events are accepted and mirrored instead of
-		 * discarded as foreign. Ignored unless its parent chain reaches the tracked
-		 * execution — a sub-execution of somebody else's run must not write here.
-		 * Returns whether it was registered.
+		 * Binds a starting sub-execution to the run this document is watching, so its
+		 * node events are accepted. Ignored unless its parent chain reaches the
+		 * tracked execution. Returns whether it was registered.
 		 */
 		function registerSubExecution(link: SubExecutionLink): boolean {
 			const belongsToTrackedRun =
@@ -901,8 +881,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 				subExecutions.has(link.parentExecutionId);
 			if (!belongsToTrackedRun) return false;
 
-			// The iteration this one supersedes is no longer shown anywhere, so drop
-			// its data rather than keeping every iteration of a loop in memory.
+			// The superseded iteration is no longer shown, so drop its data rather
+			// than keeping every loop iteration in memory.
 			for (const id of subExecutions.register(link)) {
 				disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(id)));
 				trackedExecutionIds.value.delete(id);
@@ -912,10 +892,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		}
 
 		/**
-		 * A sub-execution reached a terminal state. Its data stays registered — the
-		 * canvas and log view keep showing it — but nothing in it is running, so the
-		 * sub-execution queue is cleared. Any sibling still running re-fills it on
-		 * its next node event.
+		 * A sub-execution finished. Its data stays registered (the canvas and log
+		 * view keep showing it) but nothing in it runs, so the queue is cleared; a
+		 * sibling still running re-fills it on its next node event.
 		 */
 		function markSubExecutionFinished(executionId: string) {
 			if (!subExecutions.has(executionId)) return;
@@ -936,8 +915,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		 * tracks it as a displayed execution once it has a backend id.
 		 */
 		function setWorkflowExecutionData(workflowResultData: IExecutionResponse | null) {
-			// Any call here starts, clears, or swaps the execution on display, so the
-			// previous run's sub-executions stop being relevant.
+			// Starts, clears, or swaps the displayed execution, so the previous run's
+			// sub-executions stop being relevant.
 			clearSubExecutions();
 
 			if (workflowResultData === null) {
@@ -1198,8 +1177,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 
 			setActiveExecutionId(undefined);
 			executingNode.clearNodeExecutionQueue();
-			// Stopping the run aborts its sub-executions too, but their data stays on
-			// display — only the running indicators go.
+			// Sub-executions abort too, but their data stays on display.
 			subExecutions.executingNode.clearNodeExecutionQueue();
 			setExecutionWaitingForWebhook(false);
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -28,6 +28,7 @@ import type {
 } from '@/features/execution/executions/executions.types';
 import { IN_PROGRESS_EXECUTION_ID } from '@/app/constants/placeholders';
 import { useExecutingNode } from '@/app/composables/useExecutingNode';
+import { useSubExecutions, type SubExecutionLink } from '@/app/composables/useSubExecutions';
 import { useUIStore } from '@/app/stores/ui.store';
 import {
 	createExecutionDataId,
@@ -264,6 +265,13 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			);
 		}
 
+		/**
+		 * Sub-workflow executions of the run being watched. Each one owns its own
+		 * execution-data store, keyed by its own execution id; this registry is what
+		 * binds them back to the node that started them.
+		 */
+		const subExecutions = useSubExecutions();
+
 		const onWorkflowExecutionStateChange = createEventHook<WorkflowExecutionStateChangeEvent>();
 
 		function fireChange(action: ChangeAction, field: WorkflowExecutionStateField) {
@@ -454,23 +462,155 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		// consistent with `activeExecutionRunData`; falls back to an empty Map
 		// sentinel only when no execution is being tracked.
 
-		const activeExecutionStatusByNodeId = computed(() => {
+		// ---------------------------------------------------------------------
+		// Live sub-execution overlay.
+		//
+		// A sub-workflow runs as its own execution with its own execution-data
+		// store, so the nodes it runs would stay blank on this canvas. When the
+		// sub-workflow *is* the workflow on the canvas — a workflow calling itself —
+		// those nodes exist here under the same ids, so filling in the
+		// sub-execution's state wherever this execution has none lights the branch
+		// up as it runs. Node ids only line up in that self-call case, which is
+		// exactly when the overlay is meaningful: a different sub-workflow
+		// contributes nothing and the maps come through untouched.
+		//
+		// The overlay outlives the run. It reads from separate stores, so the
+		// authoritative run data fetched when the parent finishes replaces only the
+		// parent's own state and the sub-workflow's branch stays lit.
+		// ---------------------------------------------------------------------
+
+		/** Registered sub-executions of the tracked run, in the order they started. */
+		const subExecutionLinks = computed(() =>
+			Array.from(subExecutions.byExecutionId.value.values()),
+		);
+
+		/**
+		 * Execution-data stores of the live sub-executions, oldest first. Reading the
+		 * registry here is what makes the overlays re-resolve when a sub-execution
+		 * starts or is superseded.
+		 */
+		function subExecutionStores() {
+			return Array.from(subExecutions.byExecutionId.value.keys(), (executionId) =>
+				useExecutionDataStore(createExecutionDataId(executionId)),
+			);
+		}
+
+		/** Node ids present in any of the given maps. */
+		function unionOfNodeIds(maps: Array<Map<string, unknown>>): Set<string> {
+			const nodeIds = new Set<string>();
+			for (const map of maps) for (const nodeId of map.keys()) nodeIds.add(nodeId);
+			return nodeIds;
+		}
+
+		function ownStatusByNodeId() {
 			const executionId = getResolvedActiveExecutionId();
-			if (!executionId) return EMPTY_EXECUTION_STATUS_BY_NODE_ID;
-			return useExecutionDataStore(createExecutionDataId(executionId)).executionStatusByNodeId;
+			return executionId
+				? useExecutionDataStore(createExecutionDataId(executionId)).executionStatusByNodeId
+				: EMPTY_EXECUTION_STATUS_BY_NODE_ID;
+		}
+
+		function ownRunDataByNodeId() {
+			const executionId = getResolvedActiveExecutionId();
+			return executionId
+				? useExecutionDataStore(createExecutionDataId(executionId)).executionRunDataByNodeId
+				: EMPTY_EXECUTION_RUN_DATA_BY_NODE_ID;
+		}
+
+		function computeOverlaidStatus(nodeId: string): ExecutionStatus {
+			const ownStatus = ownStatusByNodeId().get(nodeId)?.value;
+			if (ownStatus !== undefined && ownStatus !== 'new') return ownStatus;
+			// Newest sub-execution wins, so a node that ran in an earlier iteration
+			// doesn't outrank the one running now.
+			const stores = subExecutionStores();
+			for (let i = stores.length - 1; i >= 0; i--) {
+				const status = stores[i].executionStatusByNodeId.get(nodeId)?.value;
+				if (status !== undefined && status !== 'new') return status;
+			}
+			return ownStatus ?? 'new';
+		}
+
+		function computeOverlaidRunData(nodeId: string): ITaskData[] | null {
+			const ownTasks = ownRunDataByNodeId().get(nodeId)?.value;
+			if (ownTasks) return ownTasks;
+			const stores = subExecutionStores();
+			for (let i = stores.length - 1; i >= 0; i--) {
+				const tasks = stores[i].executionRunDataByNodeId.get(nodeId)?.value;
+				if (tasks) return tasks;
+			}
+			return null;
+		}
+
+		// Overlay entries resolve the active execution *and* the registry on read,
+		// so they stay valid across every sub-execution start and are created once
+		// per node instead of once per node per iteration — a loop calling a
+		// sub-workflow hundreds of times would otherwise churn through one computed
+		// per node per iteration. Owned by a scope stopped on store disposal;
+		// per-node entries are dropped alongside the running maps below.
+		const overlayScope = effectScope();
+		const overlayStatusEntries = new Map<string, ComputedRef<ExecutionStatus>>();
+		const overlayRunDataEntries = new Map<string, ComputedRef<ITaskData[] | null>>();
+
+		function overlayStatusEntry(nodeId: string): ComputedRef<ExecutionStatus> {
+			let entry = overlayStatusEntries.get(nodeId);
+			if (!entry) {
+				entry = overlayScope.run(() => structuralComputed(() => computeOverlaidStatus(nodeId)))!;
+				overlayStatusEntries.set(nodeId, entry);
+			}
+			return entry;
+		}
+
+		function overlayRunDataEntry(nodeId: string): ComputedRef<ITaskData[] | null> {
+			let entry = overlayRunDataEntries.get(nodeId);
+			if (!entry) {
+				// Plain `computed` for the same reason the per-execution store uses one:
+				// task data can be megabytes, so reference identity is the right gate.
+				entry = overlayScope.run(() => computed(() => computeOverlaidRunData(nodeId)))!;
+				overlayRunDataEntries.set(nodeId, entry);
+			}
+			return entry;
+		}
+
+		const activeExecutionStatusByNodeId = computed(() => {
+			const own = ownStatusByNodeId();
+			const overlays = subExecutionStores().map((store) => store.executionStatusByNodeId);
+			if (overlays.length === 0) return own;
+
+			const merged = new Map<string, ComputedRef<ExecutionStatus>>();
+			for (const nodeId of unionOfNodeIds([own, ...overlays])) {
+				merged.set(nodeId, overlayStatusEntry(nodeId));
+			}
+			return merged;
 		});
 
 		const activeExecutionRunDataByNodeId = computed(() => {
-			const executionId = getResolvedActiveExecutionId();
-			if (!executionId) return EMPTY_EXECUTION_RUN_DATA_BY_NODE_ID;
-			return useExecutionDataStore(createExecutionDataId(executionId)).executionRunDataByNodeId;
+			const own = ownRunDataByNodeId();
+			const overlays = subExecutionStores().map((store) => store.executionRunDataByNodeId);
+			if (overlays.length === 0) return own;
+
+			const merged = new Map<string, ComputedRef<ITaskData[] | null>>();
+			for (const nodeId of unionOfNodeIds([own, ...overlays])) {
+				merged.set(nodeId, overlayRunDataEntry(nodeId));
+			}
+			return merged;
 		});
 
 		const activeExecutionRunDataOutputMapByNodeId = computed(() => {
 			const executionId = getResolvedActiveExecutionId();
-			if (!executionId) return EMPTY_EXECUTION_RUN_DATA_OUTPUT_MAP_BY_NODE_ID;
-			return useExecutionDataStore(createExecutionDataId(executionId))
-				.executionRunDataOutputMapByNodeId;
+			const own = executionId
+				? useExecutionDataStore(createExecutionDataId(executionId))
+						.executionRunDataOutputMapByNodeId
+				: EMPTY_EXECUTION_RUN_DATA_OUTPUT_MAP_BY_NODE_ID;
+			const overlays = subExecutionStores().map((store) => store.executionRunDataOutputMapByNodeId);
+			if (overlays.length === 0) return own;
+
+			// Entries exist only for nodes that produced output, so a missing key is
+			// the emptiness signal — no per-node wrapper needed.
+			const merged = new Map<string, ExecutionOutputMap>();
+			for (const overlay of overlays) {
+				for (const [nodeId, outputMap] of overlay.entries()) merged.set(nodeId, outputMap);
+			}
+			for (const [nodeId, outputMap] of own.entries()) merged.set(nodeId, outputMap);
+			return merged;
 		});
 
 		const activeExecutionWaitingByNodeId = computed(() => {
@@ -535,7 +675,13 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			// Pinia unwraps it to a Map at the store boundary.
 			const node = documentStore.nodesById.get(nodeId);
 			if (!node) return false;
-			return executingNode.isNodeExecuting(node.name);
+			// Either this run or a sub-execution of it can have the node mid-flight —
+			// the node executing the sub-workflow stays running while its child
+			// advances, so both queues count.
+			return (
+				executingNode.isNodeExecuting(node.name) ||
+				subExecutions.executingNode.isNodeExecuting(node.name)
+			);
 		}
 
 		function computeExecutionWaitingForNext(nodeId: string): boolean {
@@ -569,6 +715,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			runningScopes.delete(nodeId);
 			executionRunningByNodeId.delete(nodeId);
 			executionWaitingForNextByNodeId.delete(nodeId);
+			overlayStatusEntries.delete(nodeId);
+			overlayRunDataEntries.delete(nodeId);
 		}
 
 		function applyReconcileRunningEntries(nodeIds: string[]) {
@@ -626,6 +774,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			runningScopes.clear();
 			executionRunningByNodeId.clear();
 			executionWaitingForNextByNodeId.clear();
+			overlayScope.stop();
+			overlayStatusEntries.clear();
+			overlayRunDataEntries.clear();
 			clearAgentProgress();
 		});
 
@@ -738,11 +889,57 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		}
 
 		/**
+		 * Binds a starting sub-workflow execution to the run this document is
+		 * watching, so its live node events are accepted and mirrored instead of
+		 * discarded as foreign. Ignored unless its parent chain reaches the tracked
+		 * execution — a sub-execution of somebody else's run must not write here.
+		 * Returns whether it was registered.
+		 */
+		function registerSubExecution(link: SubExecutionLink): boolean {
+			const belongsToTrackedRun =
+				link.parentExecutionId === activeExecutionId.value ||
+				subExecutions.has(link.parentExecutionId);
+			if (!belongsToTrackedRun) return false;
+
+			// The iteration this one supersedes is no longer shown anywhere, so drop
+			// its data rather than keeping every iteration of a loop in memory.
+			for (const id of subExecutions.register(link)) {
+				disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(id)));
+				trackedExecutionIds.value.delete(id);
+			}
+			trackExecutionId(link.executionId);
+			return true;
+		}
+
+		/**
+		 * A sub-execution reached a terminal state. Its data stays registered — the
+		 * canvas and log view keep showing it — but nothing in it is running, so the
+		 * sub-execution queue is cleared. Any sibling still running re-fills it on
+		 * its next node event.
+		 */
+		function markSubExecutionFinished(executionId: string) {
+			if (!subExecutions.has(executionId)) return;
+			subExecutions.executingNode.clearNodeExecutionQueue();
+		}
+
+		/** Empties the sub-execution registry and disposes the data it was showing. */
+		function clearSubExecutions() {
+			for (const id of subExecutions.clear()) {
+				disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(id)));
+				trackedExecutionIds.value.delete(id);
+			}
+		}
+
+		/**
 		 * Applies a fetched/started execution result to this document's session state:
 		 * clears it when null, stages it as the pending scaffold while in progress, or
 		 * tracks it as a displayed execution once it has a backend id.
 		 */
 		function setWorkflowExecutionData(workflowResultData: IExecutionResponse | null) {
+			// Any call here starts, clears, or swaps the execution on display, so the
+			// previous run's sub-executions stop being relevant.
+			clearSubExecutions();
+
 			if (workflowResultData === null) {
 				setPendingExecution(null);
 				clearDisplayedExecution();
@@ -983,6 +1180,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			lastSuccessfulExecutionId.value = null;
 			stoppedExecutionId.value = null;
 			executingNode.clearNodeExecutionQueue();
+			// Stores already disposed by the loop above; just drop the registry.
+			subExecutions.clear();
 			clearAgentProgress();
 			fireChange(CHANGE_ACTION.DELETE, 'state');
 		}
@@ -999,6 +1198,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 
 			setActiveExecutionId(undefined);
 			executingNode.clearNodeExecutionQueue();
+			// Stopping the run aborts its sub-executions too, but their data stays on
+			// display — only the running indicators go.
+			subExecutions.executingNode.clearNodeExecutionQueue();
 			setExecutionWaitingForWebhook(false);
 
 			useDocumentTitle().setDocumentTitle(useWorkflowDocumentStore(documentId).name, 'IDLE');
@@ -1055,6 +1257,10 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			lastSuccessfulExecutionId: readonly(lastSuccessfulExecutionId),
 			stoppedExecutionId: readonly(stoppedExecutionId),
 			executingNode,
+			/** Node currently executing inside a sub-execution of the tracked run. */
+			subExecutingNode: subExecutions.executingNode,
+			subExecutionLinks,
+			isTrackedSubExecution: subExecutions.has,
 			activeExecution,
 			isExecutionDataDisplayed,
 			activeExecutionRunData,
@@ -1081,6 +1287,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			resolveExecutionTriggerNodeName,
 			// Write API
 			trackExecutionId,
+			registerSubExecution,
+			markSubExecutionFinished,
+			clearSubExecutions,
 			setActiveExecutionId,
 			setWorkflowExecutionData,
 			setDisplayedExecutionId,

--- a/packages/frontend/editor-ui/src/features/execution/logs/__test__/data.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/__test__/data.ts
@@ -35,6 +35,7 @@ export function createTestLogTreeCreationContext(
 		isSubExecution: false,
 		nodeGroups,
 		subWorkflowNodeGroups: {},
+		liveSubExecutions: {},
 	};
 }
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/liveSubExecutionCost.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/liveSubExecutionCost.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Work-volume guardrails for live sub-execution mirroring in the log view.
+ *
+ * Each live sub-execution costs one `copyRunData` of its run data per update,
+ * and that copy drives a tree rebuild. Counting the copies catches the ways this
+ * grows without looking any different in review: a copy per pair rather than per
+ * sub-execution, and an update that runs when nothing changed.
+ */
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import { mockedStore, waitAllPromises } from '@/__tests__/utils';
+import {
+	createTestNode,
+	createTestTaskData,
+	createTestWorkflow,
+	createTestWorkflowExecutionResponse,
+} from '@/__tests__/mocks';
+import { createRunExecutionData, type IRunData } from 'n8n-workflow';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
+import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
+import { nodeTypes } from '../__test__/data';
+
+const { copyRunDataSpy } = vi.hoisted(() => ({ copyRunDataSpy: vi.fn() }));
+
+vi.mock('@/features/execution/logs/logs.utils', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/features/execution/logs/logs.utils')>();
+	return {
+		...actual,
+		copyRunData: (...args: Parameters<typeof actual.copyRunData>) => {
+			copyRunDataSpy();
+			return actual.copyRunData(...args);
+		},
+	};
+});
+
+vi.mock('@n8n/composables/useToast');
+
+// Imported after the mock so the composable picks up the wrapped `copyRunData`.
+const { useLogsExecutionData } = await import('./useLogsExecutionData');
+
+const PARENT_EXECUTION_ID = 'e-parent';
+const SUB_WORKFLOW_ID = 'w-sub';
+const SUB_NODE = 'Sub Step';
+
+describe('live sub-execution work volume', () => {
+	let executionStateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
+
+	beforeEach(() => {
+		copyRunDataSpy.mockClear();
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		setActivePinia(createTestingPinia({ stubActions: false }));
+
+		mockedStore(useNodeTypesStore).setNodeTypes(nodeTypes);
+		mockedStore(useWorkflowsListStore).fetchWorkflow.mockResolvedValue(
+			createTestWorkflow({ id: SUB_WORKFLOW_ID, nodes: [createTestNode({ name: SUB_NODE })] }),
+		);
+		mockedStore(useWorkflowsStore);
+		useWorkflowDocumentStore(createWorkflowDocumentId(''));
+		executionStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(''));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	/** Puts the parent run on screen, with one run entry per calling node. */
+	function setParentRun(callerNodes: string[], taskCount = 1) {
+		const runData: IRunData = {};
+		for (const name of callerNodes) {
+			runData[name] = Array.from({ length: taskCount }, () => createTestTaskData());
+		}
+
+		executionStateStore.setWorkflowExecutionData(
+			createTestWorkflowExecutionResponse({
+				id: PARENT_EXECUTION_ID,
+				status: 'running',
+				workflowData: createTestWorkflow({
+					id: 'w-parent',
+					nodes: callerNodes.map((name) => createTestNode({ name })),
+				}),
+				data: createRunExecutionData({ resultData: { runData } }),
+			}),
+		);
+		executionStateStore.setActiveExecutionId(PARENT_EXECUTION_ID);
+	}
+
+	/** The registry keeps one sub-execution per calling node, so each needs its own. */
+	function registerLink(executionId: string, callerNode: string) {
+		executionStateStore.registerSubExecution({
+			executionId,
+			workflowId: SUB_WORKFLOW_ID,
+			parentExecutionId: PARENT_EXECUTION_ID,
+			parentNodeName: callerNode,
+			parentNodeRunIndex: 0,
+		});
+	}
+
+	/** Registers a live sub-execution and gives it run data to mirror. */
+	function addLiveSubExecution(executionId: string, callerNode: string) {
+		registerLink(executionId, callerNode);
+
+		useExecutionDataStore(createExecutionDataId(executionId)).setExecution(
+			createTestWorkflowExecutionResponse({
+				id: executionId,
+				status: 'running',
+				workflowData: createTestWorkflow({
+					id: SUB_WORKFLOW_ID,
+					nodes: [createTestNode({ name: SUB_NODE })],
+				}),
+				data: createRunExecutionData({
+					resultData: { runData: { [SUB_NODE]: [createTestTaskData()] } },
+				}),
+			}),
+		);
+	}
+
+	/**
+	 * Reports one more node result for a sub-execution. Time has to move so the
+	 * store's update stamp changes and the throttled watcher sees a new signature.
+	 */
+	function reportSubExecutionProgress(executionId: string, taskCount: number) {
+		vi.advanceTimersByTime(50);
+		useExecutionDataStore(createExecutionDataId(executionId)).setExecutionRunData(
+			createRunExecutionData({
+				resultData: {
+					runData: { [SUB_NODE]: Array.from({ length: taskCount }, () => createTestTaskData()) },
+				},
+			}),
+		);
+	}
+
+	async function settle() {
+		vi.advanceTimersByTime(2000);
+		await waitAllPromises();
+	}
+
+	it('copies run data once per live sub-execution, not once per pair', async () => {
+		setParentRun(['Caller A', 'Caller B', 'Caller C']);
+		addLiveSubExecution('e-sub-1', 'Caller A');
+		addLiveSubExecution('e-sub-2', 'Caller B');
+		addLiveSubExecution('e-sub-3', 'Caller C');
+
+		const { entries } = useLogsExecutionData();
+		// The first pass only requests the sub-workflow graph, so copying starts on
+		// the pass after it resolves.
+		await settle();
+		copyRunDataSpy.mockClear();
+
+		reportSubExecutionProgress('e-sub-1', 2);
+		await settle();
+
+		// Proves the copies were reached, so the count below is not a false zero.
+		expect(entries.value.flatMap((entry) => entry.children)).not.toHaveLength(0);
+		expect(copyRunDataSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it('does not copy run data again when no sub-execution changed', async () => {
+		setParentRun(['Caller A']);
+		addLiveSubExecution('e-sub-1', 'Caller A');
+
+		useLogsExecutionData();
+		await settle();
+		reportSubExecutionProgress('e-sub-1', 2);
+		await settle();
+		expect(copyRunDataSpy).toHaveBeenCalled();
+
+		copyRunDataSpy.mockClear();
+		await settle();
+		await settle();
+
+		expect(copyRunDataSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not copy run data when a sub-execution re-registers with no new data', async () => {
+		setParentRun(['Caller A']);
+		addLiveSubExecution('e-sub-1', 'Caller A');
+
+		useLogsExecutionData();
+		await settle();
+		reportSubExecutionProgress('e-sub-1', 2);
+		await settle();
+		expect(copyRunDataSpy).toHaveBeenCalled();
+
+		copyRunDataSpy.mockClear();
+		// A repeated executionStarted push re-registers a link we already hold, which
+		// rebuilds the link list without changing what it says.
+		registerLink('e-sub-1', 'Caller A');
+		await settle();
+
+		expect(copyRunDataSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not copy run data for a run with no sub-executions', async () => {
+		setParentRun(['Caller A']);
+
+		useLogsExecutionData();
+		await settle();
+
+		// A parent-only run reporting progress must not start paying for this.
+		for (let taskCount = 2; taskCount < 5; taskCount++) {
+			vi.advanceTimersByTime(50);
+			setParentRun(['Caller A'], taskCount);
+			await settle();
+		}
+
+		expect(copyRunDataSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
@@ -66,11 +66,9 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 	const subWorkflowNodeGroups = ref<Record<string, IWorkflowGroup[]>>({});
 	const workflow = ref<Workflow>();
 
-	// --- live sub-executions ---
-	// A sub-workflow of the run being watched pushes its node events as they
-	// happen, so its subtree can be shown while it is still running instead of
-	// only after the parent node returns. Kept apart from the lazily-fetched data
-	// above, which covers sub-executions that already finished.
+	// Live sub-executions push their node events as they happen, so their subtree
+	// can be shown mid-flight. Kept apart from the lazily-fetched data above,
+	// which covers sub-executions that already finished.
 	const liveSubExecutionData = ref<Record<string, IRunExecutionData>>({});
 	const liveSubWorkflows = ref<Record<string, Workflow>>({});
 	const liveSubExecutionLocators = ref<Record<string, RelatedExecution>>({});
@@ -79,10 +77,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 
 	const subExecutionLinks = computed(() => workflowExecutionStateStore.value.subExecutionLinks);
 
-	/**
-	 * Bumps whenever any live sub-execution's data changes, so the throttled
-	 * snapshot below picks up nodes completing inside a sub-workflow.
-	 */
+	/** Bumps when any live sub-execution's data changes, driving the snapshot. */
 	const subExecutionDataStamps = computed(() =>
 		subExecutionLinks.value.map(
 			(link) =>
@@ -92,8 +87,8 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 	);
 
 	/**
-	 * Resolves the graph of a live sub-workflow. A workflow calling itself already
-	 * has it on screen; anything else is fetched once and cached.
+	 * Graph of a live sub-workflow. A workflow calling itself already has it on
+	 * screen; anything else is fetched once and cached.
 	 */
 	function resolveLiveSubWorkflow(workflowId: string): Workflow | undefined {
 		if (liveSubWorkflows.value[workflowId]) return liveSubWorkflows.value[workflowId];
@@ -114,8 +109,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 					subWorkflowNodeGroups.value[workflowId] ??= fetched.nodeGroups ?? [];
 				})
 				.catch(() => {
-					// The subtree stays collapsed until the sub-execution finishes, at
-					// which point the on-expand fetch covers it.
+					// Falls back to the on-expand fetch once the sub-execution finishes.
 					requestedSubWorkflowIds.delete(workflowId);
 				});
 		}
@@ -124,9 +118,8 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 	}
 
 	function snapshotLiveSubExecutions() {
-		// Resolving a sub-workflow's graph can cost a request, so don't while
-		// nothing is rendering the tree. The snapshot runs again on the next data
-		// change once the view is back.
+		// Resolving a sub-workflow's graph can cost a request, so skip it while
+		// nothing renders the tree.
 		if (isEnabled !== undefined && !isEnabled.value) {
 			return;
 		}
@@ -138,8 +131,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 			const subWorkflow = resolveLiveSubWorkflow(link.workflowId);
 			if (!subWorkflow) continue;
 
-			// Snapshot rather than the readonly store ref: the tree consumes plain,
-			// non-reactive data.
+			// Snapshot, not the store ref: the tree consumes plain, non-reactive data.
 			const execution = useExecutionDataStore(
 				createExecutionDataId(link.executionId),
 			).getExecutionSnapshot();
@@ -265,8 +257,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 			() => workflowExecutionStateStore.value.activeExecutionStartedData,
 			subExecutionLinks,
 			subExecutionDataStamps,
-			// Opening the view has to snapshot the live sub-executions it skipped
-			// while closed.
+			// Opening the view snapshots what it skipped while closed.
 			() => isEnabled?.value,
 		],
 		useThrottleFn(

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
@@ -5,15 +5,20 @@ import {
 	type IRunExecutionData,
 	type ITaskStartedData,
 	type IWorkflowGroup,
+	type RelatedExecution,
 } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { injectWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import {
 	copyExecutionData,
+	copyRunData,
 	createLogTree,
 	findSubExecutionLocator,
+	liveSubExecutionKey,
 	mergeStartData,
 } from '@/features/execution/logs/logs.utils';
 import { useToast } from '@n8n/composables/useToast';
@@ -36,6 +41,7 @@ interface UseLogsExecutionDataOptions {
 export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionDataOptions = {}) {
 	const nodeHelpers = useNodeHelpers();
 	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
@@ -59,6 +65,103 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 	const subWorkflows = ref<Record<string, Workflow>>({});
 	const subWorkflowNodeGroups = ref<Record<string, IWorkflowGroup[]>>({});
 	const workflow = ref<Workflow>();
+
+	// --- live sub-executions ---
+	// A sub-workflow of the run being watched pushes its node events as they
+	// happen, so its subtree can be shown while it is still running instead of
+	// only after the parent node returns. Kept apart from the lazily-fetched data
+	// above, which covers sub-executions that already finished.
+	const liveSubExecutionData = ref<Record<string, IRunExecutionData>>({});
+	const liveSubWorkflows = ref<Record<string, Workflow>>({});
+	const liveSubExecutionLocators = ref<Record<string, RelatedExecution>>({});
+	/** Sub-workflows whose graph is being fetched, so we only ask once. */
+	const requestedSubWorkflowIds = new Set<string>();
+
+	const subExecutionLinks = computed(() => workflowExecutionStateStore.value.subExecutionLinks);
+
+	/**
+	 * Bumps whenever any live sub-execution's data changes, so the throttled
+	 * snapshot below picks up nodes completing inside a sub-workflow.
+	 */
+	const subExecutionDataStamps = computed(() =>
+		subExecutionLinks.value.map(
+			(link) =>
+				useExecutionDataStore(createExecutionDataId(link.executionId))
+					.executionResultDataLastUpdate ?? 0,
+		),
+	);
+
+	/**
+	 * Resolves the graph of a live sub-workflow. A workflow calling itself already
+	 * has it on screen; anything else is fetched once and cached.
+	 */
+	function resolveLiveSubWorkflow(workflowId: string): Workflow | undefined {
+		if (liveSubWorkflows.value[workflowId]) return liveSubWorkflows.value[workflowId];
+
+		if (workflowId === workflowDocumentStore.value.workflowId && workflow.value) {
+			return workflow.value;
+		}
+
+		if (!requestedSubWorkflowIds.has(workflowId)) {
+			requestedSubWorkflowIds.add(workflowId);
+			workflowsListStore
+				.fetchWorkflow(workflowId)
+				.then((fetched) => {
+					liveSubWorkflows.value[workflowId] = new Workflow({
+						...fetched,
+						nodeTypes: nodeTypesStore.getAllNodeTypes(),
+					});
+					subWorkflowNodeGroups.value[workflowId] ??= fetched.nodeGroups ?? [];
+				})
+				.catch(() => {
+					// The subtree stays collapsed until the sub-execution finishes, at
+					// which point the on-expand fetch covers it.
+					requestedSubWorkflowIds.delete(workflowId);
+				});
+		}
+
+		return undefined;
+	}
+
+	function snapshotLiveSubExecutions() {
+		// Resolving a sub-workflow's graph can cost a request, so don't while
+		// nothing is rendering the tree. The snapshot runs again on the next data
+		// change once the view is back.
+		if (isEnabled !== undefined && !isEnabled.value) {
+			return;
+		}
+
+		const data: Record<string, IRunExecutionData> = {};
+		const locators: Record<string, RelatedExecution> = {};
+
+		for (const link of subExecutionLinks.value) {
+			const subWorkflow = resolveLiveSubWorkflow(link.workflowId);
+			if (!subWorkflow) continue;
+
+			// Snapshot rather than the readonly store ref: the tree consumes plain,
+			// non-reactive data.
+			const execution = useExecutionDataStore(
+				createExecutionDataId(link.executionId),
+			).getExecutionSnapshot();
+
+			liveSubWorkflows.value[link.workflowId] = subWorkflow;
+			subWorkflowNodeGroups.value[link.workflowId] ??= execution?.workflowData.nodeGroups ?? [];
+			data[link.executionId] = copyRunData(execution?.data);
+			locators[
+				liveSubExecutionKey(link.parentExecutionId, link.parentNodeName, link.parentNodeRunIndex)
+			] = { workflowId: link.workflowId, executionId: link.executionId };
+		}
+
+		liveSubExecutionData.value = data;
+		liveSubExecutionLocators.value = locators;
+	}
+
+	function resetLiveSubExecutions() {
+		liveSubExecutionData.value = {};
+		liveSubWorkflows.value = {};
+		liveSubExecutionLocators.value = {};
+		requestedSubWorkflowIds.clear();
+	}
 
 	const latestNodeNameById = computed(() =>
 		Object.values(workflow.value?.nodes ?? {}).reduce<Record<string, LatestNodeInfo>>(
@@ -107,11 +210,12 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 		return createLogTree(
 			workflow.value,
 			mergedExecutionData,
-			subWorkflows.value,
-			subWorkflowExecData.value,
+			{ ...subWorkflows.value, ...liveSubWorkflows.value },
+			{ ...subWorkflowExecData.value, ...liveSubExecutionData.value },
 			filter?.value,
 			nodeGroups,
 			subWorkflowNodeGroups.value,
+			liveSubExecutionLocators.value,
 		);
 	});
 
@@ -159,6 +263,11 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 			() => currentExecution.value?.status,
 			() => workflowExecutionStateStore.value.activeExecutionResultDataLastUpdate,
 			() => workflowExecutionStateStore.value.activeExecutionStartedData,
+			subExecutionLinks,
+			subExecutionDataStamps,
+			// Opening the view has to snapshot the live sub-executions it skipped
+			// while closed.
+			() => isEnabled?.value,
 		],
 		useThrottleFn(
 			([executionId], [previousExecutionId]) => {
@@ -175,7 +284,10 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 					subWorkflowExecData.value = {};
 					subWorkflows.value = {};
 					subWorkflowNodeGroups.value = {};
+					resetLiveSubExecutions();
 				}
+
+				snapshotLiveSubExecutions();
 			},
 			updateInterval,
 			true,

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
@@ -77,13 +77,23 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 
 	const subExecutionLinks = computed(() => workflowExecutionStateStore.value.subExecutionLinks);
 
-	/** Bumps when any live sub-execution's data changes, driving the snapshot. */
-	const subExecutionDataStamps = computed(() =>
-		subExecutionLinks.value.map(
-			(link) =>
-				useExecutionDataStore(createExecutionDataId(link.executionId))
-					.executionResultDataLastUpdate ?? 0,
-		),
+	/**
+	 * Which live sub-executions there are and how fresh each one's data is, as a
+	 * single string so it can drive the throttled watcher below. Deliberately not
+	 * an array: the watcher compares sources by reference, and a computed handing
+	 * back a fresh array would report a change every time it re-evaluated, firing
+	 * the throttled update and pushing the real one into the next window.
+	 */
+	const subExecutionSignature = computed(() =>
+		subExecutionLinks.value
+			.map(
+				(link) =>
+					`${link.executionId}@${
+						useExecutionDataStore(createExecutionDataId(link.executionId))
+							.executionResultDataLastUpdate ?? 0
+					}`,
+			)
+			.join(','),
 	);
 
 	/**
@@ -121,6 +131,14 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 		// Resolving a sub-workflow's graph can cost a request, so skip it while
 		// nothing renders the tree.
 		if (isEnabled !== undefined && !isEnabled.value) {
+			return;
+		}
+
+		// Nothing live: leave the refs as they are. Swapping in fresh empty objects
+		// would change their identity on every tick and rebuild the whole tree, so a
+		// run with no sub-workflow at all would pay for this feature.
+		if (subExecutionLinks.value.length === 0) {
+			if (Object.keys(liveSubExecutionData.value).length > 0) resetLiveSubExecutions();
 			return;
 		}
 
@@ -255,8 +273,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 			() => currentExecution.value?.status,
 			() => workflowExecutionStateStore.value.activeExecutionResultDataLastUpdate,
 			() => workflowExecutionStateStore.value.activeExecutionStartedData,
-			subExecutionLinks,
-			subExecutionDataStamps,
+			subExecutionSignature,
 			// Opening the view snapshots what it skipped while closed.
 			() => isEnabled?.value,
 		],

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.types.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.types.ts
@@ -4,7 +4,7 @@ import type {
 	LOGS_PANEL_STATE,
 } from '@/features/execution/logs/logs.constants';
 import type { INodeUi, LlmTokenUsageData } from '@/Interface';
-import type { IRunExecutionData, ITaskData, IWorkflowGroup } from 'n8n-workflow';
+import type { IRunExecutionData, ITaskData, IWorkflowGroup, RelatedExecution } from 'n8n-workflow';
 
 type BaseLogEntry = {
 	parent?: LogEntry;
@@ -70,6 +70,13 @@ export interface LogTreeCreationContext {
 	nodeGroups: IWorkflowGroup[];
 	/** Canvas groups of loaded sub-workflows, keyed by workflow id, applied when recursing into them */
 	subWorkflowNodeGroups: Record<string, IWorkflowGroup[]>;
+	/**
+	 * Sub-executions still in flight, keyed by the node run that started them (see
+	 * `liveSubExecutionKey`). A node whose sub-workflow has not returned yet has no
+	 * `subExecution` metadata to locate it by, so this is what lets the log view
+	 * nest a sub-execution while it is still running.
+	 */
+	liveSubExecutions: Record<string, RelatedExecution>;
 }
 
 export interface LatestNodeInfo {

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.types.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.types.ts
@@ -72,9 +72,8 @@ export interface LogTreeCreationContext {
 	subWorkflowNodeGroups: Record<string, IWorkflowGroup[]>;
 	/**
 	 * Sub-executions still in flight, keyed by the node run that started them (see
-	 * `liveSubExecutionKey`). A node whose sub-workflow has not returned yet has no
-	 * `subExecution` metadata to locate it by, so this is what lets the log view
-	 * nest a sub-execution while it is still running.
+	 * `liveSubExecutionKey`). Such a run has no `subExecution` metadata yet, so
+	 * this is what lets the log view nest it mid-flight.
 	 */
 	liveSubExecutions: Record<string, RelatedExecution>;
 }

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
@@ -15,6 +15,7 @@ import {
 	getSubtreeTotalConsumedTokens,
 	getTreeNodeData,
 	isSubNodeLog,
+	liveSubExecutionKey,
 	mergeStartData,
 	restoreChatHistory,
 	processFiles,
@@ -1124,6 +1125,62 @@ describe(createLogTree, () => {
 		expect(logs[1].children[1].execution).toBe(subExecutionData);
 		expect(logs[1].children[1].executionId).toBe('sub-exec-id');
 		expect(logs[1].children[1].children).toHaveLength(0);
+	});
+
+	it('should nest a sub execution that is still running under the node run that started it', () => {
+		const workflow = createTestWorkflowObject({
+			id: 'root-workflow-id',
+			nodes: [createTestNode({ name: 'A' }), createTestNode({ name: 'B' })],
+			connections: {
+				A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			},
+		});
+		const subWorkflow = createTestWorkflowObject({
+			id: 'sub-workflow-id',
+			nodes: [createTestNode({ name: 'C' })],
+		});
+		// Mid-flight: the calling node has not returned, so its task carries no
+		// `subExecution` metadata yet — the live registry is the only link.
+		const rootExecutionData = createTestWorkflowExecutionResponse({
+			id: 'root-exec-id',
+			data: createRunExecutionData({
+				resultData: { runData: { A: [createTestTaskData()], B: [createTestTaskData()] } },
+			}),
+		});
+		const subExecutionData = createRunExecutionData({
+			resultData: { runData: { C: [createTestTaskData()] } },
+		});
+
+		const logs = createLogTree(
+			workflow,
+			rootExecutionData,
+			{ 'sub-workflow-id': subWorkflow },
+			{ 'live-exec-id': subExecutionData },
+			undefined,
+			[],
+			{},
+			{
+				[liveSubExecutionKey('root-exec-id', 'B', 0)]: {
+					workflowId: 'sub-workflow-id',
+					executionId: 'live-exec-id',
+				},
+			},
+		);
+		assertNodeTree(logs);
+
+		expect(logs).toHaveLength(2);
+		expect(logs[0].node.name).toBe('A');
+		expect(logs[0].children).toHaveLength(0);
+
+		// Nested under B rather than surfacing at the top level.
+		expect(logs[1].node.name).toBe('B');
+		expect(logs[1].children).toHaveLength(1);
+		expect(logs[1].children[0].node.name).toBe('C');
+		expect(logs[1].children[0].workflow).toBe(subWorkflow);
+		expect(logs[1].children[0].executionId).toBe('live-exec-id');
+
+		// And shown expanded, so its nodes populate in place as they run.
+		expect(getDefaultCollapsedEntries(logs)[logs[1].id]).toBeUndefined();
 	});
 
 	it('should include all runs of sub nodes in sub execution under correct parent run', () => {

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
@@ -95,9 +95,8 @@ function getChildNodes(
 	runIndex: number | undefined,
 	context: LogTreeCreationContext,
 ) {
-	// A completed run carries its sub-execution in task metadata; a run whose
-	// sub-workflow is still in flight has none yet, so fall back to the live
-	// registry keyed by this node run.
+	// A completed run carries its sub-execution in task metadata; one still in
+	// flight has none, so fall back to the live registry.
 	const subExecutionLocator =
 		findSubExecutionLocator(treeNode) ??
 		context.liveSubExecutions[liveSubExecutionKey(context.executionId, node.name, runIndex ?? 0)];
@@ -772,9 +771,8 @@ export function hasSubExecution(entry: LogEntry): boolean {
 }
 
 /**
- * Key a still-running sub-execution is registered under: the node run that
- * started it, scoped by the execution that run belongs to so nested
- * sub-workflows stay distinct.
+ * Key for a still-running sub-execution: the node run that started it, scoped by
+ * its execution so nested sub-workflows stay distinct.
  */
 export function liveSubExecutionKey(executionId: string, nodeName: string, runIndex: number) {
 	return `${executionId}:${nodeName}:${runIndex}`;

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
@@ -95,7 +95,12 @@ function getChildNodes(
 	runIndex: number | undefined,
 	context: LogTreeCreationContext,
 ) {
-	const subExecutionLocator = findSubExecutionLocator(treeNode);
+	// A completed run carries its sub-execution in task metadata; a run whose
+	// sub-workflow is still in flight has none yet, so fall back to the live
+	// registry keyed by this node run.
+	const subExecutionLocator =
+		findSubExecutionLocator(treeNode) ??
+		context.liveSubExecutions[liveSubExecutionKey(context.executionId, node.name, runIndex ?? 0)];
 
 	if (subExecutionLocator !== undefined) {
 		const workflow = context.workflows[subExecutionLocator.workflowId];
@@ -579,6 +584,7 @@ export function createLogTree(
 	filter?: LogTreeFilter,
 	nodeGroups: IWorkflowGroup[] = [],
 	subWorkflowNodeGroups: Record<string, IWorkflowGroup[]> = {},
+	liveSubExecutions: Record<string, RelatedExecution> = {},
 ): LogEntry[] {
 	return createLogTreeRec(filter, {
 		parent: undefined,
@@ -591,6 +597,7 @@ export function createLogTree(
 		isSubExecution: false,
 		nodeGroups,
 		subWorkflowNodeGroups,
+		liveSubExecutions,
 	});
 }
 
@@ -762,6 +769,15 @@ export function mergeStartData(
 
 export function hasSubExecution(entry: LogEntry): boolean {
 	return findSubExecutionLocator(entry) !== undefined;
+}
+
+/**
+ * Key a still-running sub-execution is registered under: the node run that
+ * started it, scoped by the execution that run belongs to so nested
+ * sub-workflows stay distinct.
+ */
+export function liveSubExecutionKey(executionId: string, nodeName: string, runIndex: number) {
+	return `${executionId}:${nodeName}:${runIndex}`;
 }
 
 export function findSubExecutionLocator(entry: LogEntry): RelatedExecution | undefined {
@@ -1000,16 +1016,18 @@ export function isPlaceholderLog(treeNode: LogEntry): boolean {
  * TODO: use shallowRef() for execution data in workflows store to make this unnecessary.
  */
 export function copyExecutionData(executionData: IExecutionResponse): IExecutionResponse {
-	return {
-		...executionData,
-		data: createRunExecutionData({
-			...executionData.data,
-			resultData: {
-				...executionData.data?.resultData,
-				runData: Object.fromEntries(
-					Object.entries(executionData.data?.resultData.runData ?? {}).map(([k, v]) => [k, [...v]]),
-				),
-			},
-		}),
-	};
+	return { ...executionData, data: copyRunData(executionData.data) };
+}
+
+/** {@link copyExecutionData} for a bare run-execution-data payload. */
+export function copyRunData(data: IRunExecutionData | undefined): IRunExecutionData {
+	return createRunExecutionData({
+		...data,
+		resultData: {
+			...data?.resultData,
+			runData: Object.fromEntries(
+				Object.entries(data?.resultData.runData ?? {}).map(([k, v]) => [k, [...v]]),
+			),
+		},
+	});
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3530,11 +3530,7 @@ export interface IWorkflowExecutionDataProcess {
 
 export interface ExecuteWorkflowOptions {
 	node?: INode;
-	/**
-	 * Run index of `node`, so a node executing the sub-workflow repeatedly (in a
-	 * loop or once per item) can be told apart run by run. Reported to the editor
-	 * with the sub-execution's lifecycle events.
-	 */
+	/** Run index of `node`, so loop iterations can be told apart. */
 	nodeRunIndex?: number;
 	parentWorkflowId: string;
 	inputData?: INodeExecutionData[];
@@ -3616,10 +3612,8 @@ export interface IWorkflowExecuteAdditionalData {
 	executionId?: string;
 	restartExecutionId?: string;
 	/**
-	 * Push session watching this execution, set only for runs an editor started
-	 * (manual/chat). Propagated into sub-executions so their lifecycle events
-	 * reach the same session and the parent's canvas and log view can follow them
-	 * live.
+	 * Push session watching this execution; set only for editor-started runs.
+	 * Propagated into sub-executions so the editor can follow them live.
 	 */
 	pushRef?: string;
 	getRuntimeCredential(

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3530,6 +3530,12 @@ export interface IWorkflowExecutionDataProcess {
 
 export interface ExecuteWorkflowOptions {
 	node?: INode;
+	/**
+	 * Run index of `node`, so a node executing the sub-workflow repeatedly (in a
+	 * loop or once per item) can be told apart run by run. Reported to the editor
+	 * with the sub-execution's lifecycle events.
+	 */
+	nodeRunIndex?: number;
 	parentWorkflowId: string;
 	inputData?: INodeExecutionData[];
 	loadedWorkflowData?: IWorkflowBase;
@@ -3609,6 +3615,13 @@ export interface IWorkflowExecuteAdditionalData {
 	getRunExecutionData: (executionId: string) => Promise<IRunExecutionData | undefined>;
 	executionId?: string;
 	restartExecutionId?: string;
+	/**
+	 * Push session watching this execution, set only for runs an editor started
+	 * (manual/chat). Propagated into sub-executions so their lifecycle events
+	 * reach the same session and the parent's canvas and log view can follow them
+	 * live.
+	 */
+	pushRef?: string;
 	getRuntimeCredential(
 		runExecutionData: IRunExecutionData,
 		alias: string,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3739,11 +3739,7 @@ export interface IWorkflowExecutionDataProcess {
 
 export interface ExecuteWorkflowOptions {
 	node?: INode;
-	/**
-	 * Run index of `node`, so a node executing the sub-workflow repeatedly (in a
-	 * loop or once per item) can be told apart run by run. Reported to the editor
-	 * with the sub-execution's lifecycle events.
-	 */
+	/** Run index of `node`, so loop iterations can be told apart. */
 	nodeRunIndex?: number;
 	parentWorkflowId: string;
 	inputData?: INodeExecutionData[];
@@ -3826,10 +3822,8 @@ export interface IWorkflowExecuteAdditionalData {
 	executionId?: string;
 	restartExecutionId?: string;
 	/**
-	 * Push session watching this execution, set only for runs an editor started
-	 * (manual/chat). Propagated into sub-executions so their lifecycle events
-	 * reach the same session and the parent's canvas and log view can follow them
-	 * live.
+	 * Push session watching this execution; set only for editor-started runs.
+	 * Propagated into sub-executions so the editor can follow them live.
 	 */
 	pushRef?: string;
 	getRuntimeCredential(

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3739,6 +3739,12 @@ export interface IWorkflowExecutionDataProcess {
 
 export interface ExecuteWorkflowOptions {
 	node?: INode;
+	/**
+	 * Run index of `node`, so a node executing the sub-workflow repeatedly (in a
+	 * loop or once per item) can be told apart run by run. Reported to the editor
+	 * with the sub-execution's lifecycle events.
+	 */
+	nodeRunIndex?: number;
 	parentWorkflowId: string;
 	inputData?: INodeExecutionData[];
 	loadedWorkflowData?: IWorkflowBase;
@@ -3819,6 +3825,13 @@ export interface IWorkflowExecuteAdditionalData {
 	getRunExecutionData: (executionId: string) => Promise<IRunExecutionData | undefined>;
 	executionId?: string;
 	restartExecutionId?: string;
+	/**
+	 * Push session watching this execution, set only for runs an editor started
+	 * (manual/chat). Propagated into sub-executions so their lifecycle events
+	 * reach the same session and the parent's canvas and log view can follow them
+	 * live.
+	 */
+	pushRef?: string;
 	getRuntimeCredential(
 		runExecutionData: IRunExecutionData,
 		alias: string,


### PR DESCRIPTION
## Summary

A sub-workflow runs as its own execution, so the editor watching the parent run never heard about it — a workflow calling itself left the sub-workflow's branch idle on the canvas until the calling node returned, and the log view could only load the sub-execution after the fact. Editor-started runs now stream their sub-executions' lifecycle events to the same push session, with each sub-execution keeping its own execution-data store bound back to the node run that started it, so the sub-workflow's nodes light up as they run (and stay lit once the run settles) and the log view nests the sub-execution under the calling node while it is still in flight. Only the newest sub-execution per calling node is retained, so a node executing a sub-workflow in a loop surfaces the current iteration instead of piling every iteration onto one set of canvas nodes. Production runs are untouched — the push hooks no-op without a push ref, which only exists for manual and chat executions — and when nothing calls a sub-workflow the canvas projections hand back the underlying store maps unchanged, so the common path carries no extra work.

**Sub-executions stream node metadata but not item payloads.** `nodeExecuteAfter` already carries `itemCountByConnectionType`, from which the editor builds placeholder run data, so the live view needs nothing more; `nodeExecuteAfterData` measured at ~90% of a sub-execution's wire traffic for data a loop discards all but the last iteration of. The editor backfills the real payloads over REST for the sub-executions still on display once the run ends — one request per calling node, not per iteration, since superseded iterations are already out of the registry and unfinished ones are skipped. Without this, a fire-and-forget loop over a few hundred sizeable items could saturate the push connection (details below).

**Scope note for reviewers:** live streaming applies to *every* sub-workflow, not only the self-calling case. A foreign sub-workflow contributes nothing to the canvas overlay (node ids only line up when a workflow calls itself) but its subtree does appear live in the log view, with its graph fetched once and cached.

Verified end-to-end against a real instance in Chrome: a self-calling workflow lights its sub-branch node by node with the running border on the in-flight node, and a 3-iteration loop shows `✓3` on the caller while the sub-branch reflects only the current iteration (nodes the earlier iterations already completed correctly return to un-run). After the run, opening a node inside the sub-branch shows the surviving iteration's real data.

### Demo video

[subworkflow-progress-light.webm](https://github.com/user-attachments/assets/aa756f75-52b9-4478-9c27-d9e36591ed63)


## How to test

1. Paste the workflow below onto a new canvas, then open the **Execute Sub-workflow** node and point its *Workflow* parameter at **this same workflow** (self-reference can't be encoded in the export).
2. Open the **Logs** panel and hit **Execute workflow**.
3. On the canvas: the bottom branch (`When Executed by Another Workflow` → `Slow Step` → `After Slow`) should light up live — the sub-trigger green, `Slow Step` with the running border, `After Slow` still un-run — while `Execute Sub-workflow` also shows as running.
4. In the log view: `Execute Sub-workflow` shows "Running for Ns" with the sub-execution's nodes nested underneath, one row per loop iteration.
5. Watch across iterations: when iteration 2 starts, `After Slow` returns to un-run even though iteration 1 completed it — only the current loop item is displayed. At the end, the branch stays lit rather than reverting to grey.
6. Once the run finishes, click a node inside the sub-branch (e.g. `Slow Step`) and confirm it shows the last iteration's real output — not a "data is trimmed" placeholder. That data arrives from the post-run backfill rather than from the live stream.

<details>
<summary>Example workflow</summary>

```json
{
  "name": "loop calls sub-workflow",
  "nodes": [
    { "id": "n-manual", "name": "When clicking Test workflow", "type": "n8n-nodes-base.manualTrigger", "typeVersion": 1, "position": [-200, 0], "parameters": {} },
    { "id": "n-items", "name": "Three Items", "type": "n8n-nodes-base.code", "typeVersion": 2, "position": [40, 0], "parameters": { "jsCode": "return [{json:{i:1}},{json:{i:2}},{json:{i:3}}];" } },
    { "id": "n-loop", "name": "Loop Over Items", "type": "n8n-nodes-base.splitInBatches", "typeVersion": 3, "position": [280, 0], "parameters": { "options": {} } },
    { "id": "n-exec", "name": "Execute Sub-workflow", "type": "n8n-nodes-base.executeWorkflow", "typeVersion": 1.2, "position": [560, 120], "parameters": { "workflowId": { "__rl": true, "value": "", "mode": "id" }, "mode": "once", "options": { "waitForSubWorkflow": true } } },
    { "id": "n-subtrigger", "name": "When Executed by Another Workflow", "type": "n8n-nodes-base.executeWorkflowTrigger", "typeVersion": 1.1, "position": [-200, 420], "parameters": { "inputSource": "passthrough" } },
    { "id": "n-slow", "name": "Slow Step", "type": "n8n-nodes-base.code", "typeVersion": 2, "position": [40, 420], "parameters": { "jsCode": "const i = $input.first().json.i;\nawait new Promise((r) => setTimeout(r, 5000));\nreturn [{ json: { iteration: i } }];" } },
    { "id": "n-after", "name": "After Slow", "type": "n8n-nodes-base.set", "typeVersion": 3.4, "position": [280, 420], "parameters": { "mode": "raw", "jsonOutput": "={{ JSON.stringify({ ranIteration: $json.iteration }) }}", "options": {} } }
  ],
  "connections": {
    "When clicking Test workflow": { "main": [[{ "node": "Three Items", "type": "main", "index": 0 }]] },
    "Three Items": { "main": [[{ "node": "Loop Over Items", "type": "main", "index": 0 }]] },
    "Loop Over Items": { "main": [[], [{ "node": "Execute Sub-workflow", "type": "main", "index": 0 }]] },
    "Execute Sub-workflow": { "main": [[{ "node": "Loop Over Items", "type": "main", "index": 0 }]] },
    "When Executed by Another Workflow": { "main": [[{ "node": "Slow Step", "type": "main", "index": 0 }]] },
    "Slow Step": { "main": [[{ "node": "After Slow", "type": "main", "index": 0 }]] }
  },
  "settings": { "executionOrder": "v1" }
}
```

</details>

<details>
<summary>Performance measurements</summary>

Measured against a real instance (manual runs only; production traffic is unchanged).

**Frontend — bounded regardless of iteration count.** Sampling the Pinia registry every 100 ms:

| Scenario | `executionData` stores (max) | Heap start → peak → settled | Long tasks |
|---|---|---|---|
| 500 iterations × 1 KB | **3** (flat) | 127 → — → 121 MB | 4, 266 ms total, worst 87 ms |
| 25 iterations × 1 MB | **3** | 209 → 292 → 286 MB | 1, 61 ms |
| 100 iterations, 151-node canvas | **3** | 173 → 315 → 189 MB | 3, 186 ms total, worst 75 ms |

Three stores = parent + `__IN_PROGRESS__` sentinel + one live sub-execution. Superseded iterations are disposed, so 500 sub-executions retain one iteration's data. Under 1% of wall clock in long tasks in every case.

**Wire cost — why item payloads are no longer streamed.** Instrumenting WebSocket frames in Chrome and attributing each to the parent or a sub-execution, on a self-calling workflow processing items through `Execute Sub-workflow`:

| Sub-execution traffic (2000 iterations × 20 KB) | Streaming payloads | Metadata only (current) |
|---|---|---|
| Total | 47.73 MB / 15.6k frames | **4.66 MB** / 12k frames |
| `nodeExecuteAfterData` | 43.05 MB (90.2%) | **0** |

The multiplier depends on whether the sub-workflow's output flows back through the parent. With *Wait for sub-workflow* **on** the parent pushes the same data anyway, so total traffic went from 2.09× the parent's own to **1.06×**. With it **off** the parent pushes essentially nothing, so all sub-execution traffic was additive — 0.09 MB → 47.7 MB before, ~4.7 MB now.

That mattered because the push layer has no backpressure and the server terminates a connection after a missed 60 s pong. On a throttled 5 Mbit link (a remote instance on a mediocre connection), the 2000-iteration fire-and-forget run previously dropped the socket and left the editor showing a fully successful run as still executing; it now completes in **18 s** with the connection intact. The post-run backfill costs **2** REST calls for that run (the parent's own finish plus one surviving sub-execution), verified in the browser.

**Pre-existing issues found while measuring** (reproducible on `master` without this feature, so not addressed here — worth their own ticket):

- After a dropped push connection the editor never re-syncs, so a completed run displays as running indefinitely.
- `websocket.push.ts` sends with no `bufferedAmount` check or chunking, so a single large `nodeExecuteAfterData` frame from an ordinary *parent* node (~20 MB in testing) is enough to kill the connection on a slow link.

</details>

<details>
<summary>Deliberately out of scope</summary>

From the review thread, a toggle to disable sub-workflow rendering (workflow settings, or a conditional parameter on the *Execute Workflow* node) was proposed as a performance escape hatch. The measurements above make it a product decision rather than a performance necessity, so it is not in this PR. The other thread items are covered: sub-execution logs nest under the calling node and render expanded, the executions list is untouched, and multiple sub-executions are no longer merged into runs of a single execution.

</details>

## Related Linear tickets, Github issues, and Community forum posts

None yet — this started from a bug report in conversation rather than a ticket. Happy to file one if you'd like it linked.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35042">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


