### PR TITLE
fix(core): Settle interrupted agent preview runs (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/agents/types.ts
+++ b/packages/@n8n/api-types/src/agents/types.ts
@@ -212,6 +212,8 @@ export interface AgentPersistedMessageDto {
 	content: AgentPersistedMessageContentPart[];
 	/** Agent-execution turn id when this message was produced from an execution transcript. */
 	executionId?: string;
+	/** Outcome of the execution that produced this message. */
+	executionStatus?: 'success' | 'error';
 }
 
 export const AGENT_BUILDER_DEFAULT_MODEL = 'claude-sonnet-4-6' as const;

--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -85,6 +85,7 @@ describe('AgentChatController route access scopes', () => {
 	it.each([
 		['chat', 'agent:execute'],
 		['chatResume', 'agent:execute'],
+		['cancelChatRun', 'agent:execute'],
 		['getChatMessages', 'agent:read'],
 		['getTestChatMessages', 'agent:read'],
 		['clearTestChatMessages', 'agent:update'],
@@ -204,6 +205,85 @@ describe('AgentChatController SSE done payload', () => {
 		expect(events).toContainEqual({
 			type: 'done',
 			executionId: 'exec-resume-1',
+		});
+	});
+
+	it.each([
+		{
+			name: 'new chat',
+			start: async (controller: AgentChatController, res: FlushableResponse) =>
+				await controller.chat(
+					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+					res,
+					'agent-1',
+					{ message: 'hi' } as never,
+				),
+			method: 'executeForChat' as const,
+		},
+		{
+			name: 'resumed chat',
+			start: async (controller: AgentChatController, res: FlushableResponse) =>
+				await controller.chatResume(
+					{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+					res,
+					'agent-1',
+					{ runId: 'run-1', toolCallId: 'tc-1', resumeData: { approved: true } } as never,
+				),
+			method: 'resumeForChat' as const,
+		},
+	])('aborts the $name when its SSE response closes early', async ({ start, method }) => {
+		const { controller, agentExecutionOrchestratorService, agentExecutionService } =
+			makeController();
+		agentExecutionService.findThreadById.mockResolvedValue(null);
+
+		let receivedSignal: AbortSignal | undefined;
+		let releaseRun = () => {};
+		let markStarted = () => {};
+		const runStarted = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const runBlocked = new Promise<void>((resolve) => {
+			releaseRun = resolve;
+		});
+		agentExecutionOrchestratorService[method].mockImplementation(async function* (config) {
+			receivedSignal = (config as { abortSignal?: AbortSignal }).abortSignal;
+			markStarted();
+			await runBlocked;
+			yield* [];
+		});
+
+		const res = makeSseResponse([]);
+		const request = start(controller, res);
+		await runStarted;
+		(res as unknown as EventEmitter).emit('close');
+		releaseRun();
+		await request;
+
+		expect(receivedSignal?.aborted).toBe(true);
+	});
+});
+
+describe('AgentChatController HITL cancellation', () => {
+	it('cancels a suspended run for the current preview user', async () => {
+		const { controller, agentExecutionOrchestratorService, agentsService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+		agentExecutionOrchestratorService.cancelChatRun.mockResolvedValue(true);
+
+		await expect(
+			controller.cancelChatRun(
+				{
+					params: { projectId: 'project-1' },
+					user: { id: 'user-1' },
+				} as never,
+				'agent-1',
+				'run-1',
+			),
+		).resolves.toEqual({ cancelled: true });
+
+		expect(agentExecutionOrchestratorService.cancelChatRun).toHaveBeenCalledWith({
+			agentId: 'agent-1',
+			runId: 'run-1',
+			resourceId: 'draft-chat:user-1',
 		});
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -275,6 +275,7 @@ describe('AgentChatController HITL cancellation', () => {
 					params: { projectId: 'project-1' },
 					user: { id: 'user-1' },
 				} as never,
+				{} as never,
 				'agent-1',
 				'run-1',
 			),

--- a/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-chat.controller.test.ts
@@ -151,6 +151,71 @@ describe('AgentChatController chat message history', () => {
 });
 
 describe('AgentChatController SSE done payload', () => {
+	it('does not start a chat after the response closes during session lookup', async () => {
+		const {
+			controller,
+			agentExecutionOrchestratorService,
+			agentExecutionService,
+			agentValidationService,
+		} = makeController();
+		let resolveLookup = (_value: null) => {};
+		agentExecutionService.findThreadById.mockReturnValue(
+			new Promise((resolve) => {
+				resolveLookup = resolve;
+			}),
+		);
+		agentExecutionOrchestratorService.executeForChat.mockImplementation(async function* () {
+			yield* [];
+		});
+
+		const res = makeSseResponse([]);
+		const request = controller.chat(
+			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+			res,
+			'agent-1',
+			{ message: 'hi', sessionId: 'thread-1' } as never,
+		);
+		await vi.waitFor(() => expect(agentExecutionService.findThreadById).toHaveBeenCalled());
+
+		(res as unknown as EventEmitter).emit('close');
+		resolveLookup(null);
+		await request;
+
+		expect(agentValidationService.validateAgentIsRunnable).not.toHaveBeenCalled();
+		expect(agentExecutionOrchestratorService.executeForChat).not.toHaveBeenCalled();
+	});
+
+	it('does not start a chat after the response closes during validation', async () => {
+		const { controller, agentExecutionOrchestratorService, agentValidationService } =
+			makeController();
+		let resolveValidation = (_value: { missing: string[] }) => {};
+		agentValidationService.validateAgentIsRunnable.mockReturnValue(
+			new Promise((resolve) => {
+				resolveValidation = resolve;
+			}),
+		);
+		agentExecutionOrchestratorService.executeForChat.mockImplementation(async function* () {
+			yield* [];
+		});
+
+		const res = makeSseResponse([]);
+		const request = controller.chat(
+			{ params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never,
+			res,
+			'agent-1',
+			{ message: 'hi' } as never,
+		);
+		await vi.waitFor(() =>
+			expect(agentValidationService.validateAgentIsRunnable).toHaveBeenCalled(),
+		);
+
+		(res as unknown as EventEmitter).emit('close');
+		resolveValidation({ missing: [] });
+		await request;
+
+		expect(agentExecutionOrchestratorService.executeForChat).not.toHaveBeenCalled();
+	});
+
 	it('includes executionId on done when recorded', async () => {
 		const { controller, agentExecutionOrchestratorService, agentExecutionService } =
 			makeController();

--- a/packages/cli/src/modules/agents/__tests__/agent-checkpoint.repository.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-checkpoint.repository.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method -- mock-based tests intentionally reference unbound methods */
+import { Equal, IsNull, Or } from '@n8n/typeorm';
 import { mockEntityManager } from '@test/mocking';
 
 import { AgentCheckpoint } from '../entities/agent-checkpoint.entity';
@@ -35,6 +36,26 @@ describe('AgentCheckpointRepository', () => {
 			await expect(
 				repository.claimForResume('run-1', '{"status":"suspended"}', '{"status":"running"}'),
 			).resolves.toBe(false);
+		});
+	});
+
+	describe('cancelSuspended', () => {
+		it('matches checkpoints scoped to the current agent or unscoped', async () => {
+			vi.spyOn(repository, 'update').mockResolvedValue({ affected: 1 } as never);
+
+			await expect(
+				repository.cancelSuspended('run-1', 'agent-1', '{"status":"suspended"}'),
+			).resolves.toBe(true);
+
+			expect(repository.update).toHaveBeenCalledWith(
+				{
+					runId: 'run-1',
+					agentId: Or(Equal('agent-1'), IsNull()),
+					expired: false,
+					state: '{"status":"suspended"}',
+				},
+				{ expired: true, state: null },
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
@@ -1,4 +1,4 @@
-import type { Agent as RuntimeAgent, StreamChunk } from '@n8n/agents';
+import type { Agent as RuntimeAgent, SerializableAgentState, StreamChunk } from '@n8n/agents';
 import { N8N_CHAT_INTEGRATION_TYPE, type AgentJsonConfig } from '@n8n/api-types';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
@@ -133,6 +133,7 @@ describe('AgentExecutionOrchestratorService', () => {
 
 	it('streams chat responses and records suspended executions', async () => {
 		const { service, executionService } = makeService();
+		const abortController = new AbortController();
 		const runtime = makeRuntime([
 			{ type: 'text-start', id: 'text-1' },
 			{ type: 'text-delta', id: 'text-1', delta: 'Choose one' },
@@ -153,6 +154,7 @@ describe('AgentExecutionOrchestratorService', () => {
 				message: 'hello',
 				memory: { threadId: 'thread-1', resourceId: 'resource-1' },
 				projectId,
+				abortSignal: abortController.signal,
 			}),
 		);
 
@@ -162,6 +164,7 @@ describe('AgentExecutionOrchestratorService', () => {
 			expect.objectContaining({
 				persistence: { threadId: 'thread-1', resourceId: 'resource-1' },
 				executionCounter: expect.any(Object),
+				abortSignal: abortController.signal,
 			}),
 		);
 		expect(executionService.recordMessage).toHaveBeenCalledWith(
@@ -540,6 +543,7 @@ describe('AgentExecutionOrchestratorService', () => {
 		} as never);
 		runtimeCacheService.getRuntime.mockResolvedValue(runtime);
 
+		const abortController = new AbortController();
 		await collect(
 			service.resumeForChat({
 				agentId,
@@ -548,13 +552,18 @@ describe('AgentExecutionOrchestratorService', () => {
 				toolCallId: 'tc-1',
 				resumeData: { value: 'yes' },
 				integrationType: 'slack',
+				abortSignal: abortController.signal,
 			}),
 		);
 
 		expect(runtime.agent.resume).toHaveBeenCalledWith(
 			'stream',
 			{ value: 'yes' },
-			expect.objectContaining({ runId: 'run-1', toolCallId: 'tc-1' }),
+			expect.objectContaining({
+				runId: 'run-1',
+				toolCallId: 'tc-1',
+				abortSignal: abortController.signal,
+			}),
 		);
 		expect(externalHooks.run).not.toHaveBeenCalled();
 		expect(JSON.stringify(runtime.agent.resume.mock.calls[0])).not.toContain('platform-user-1');
@@ -569,6 +578,37 @@ describe('AgentExecutionOrchestratorService', () => {
 				},
 			}),
 		);
+	});
+
+	it('atomically cancels only suspended checkpoints owned by the preview user', async () => {
+		const { service, checkpointStorage } = makeService();
+		const checkpoint: SerializableAgentState = {
+			status: 'suspended',
+			persistence: { threadId: 'thread-1', resourceId: 'draft-chat:user-1' },
+			messageList: { messages: [], historyIds: [], inputIds: [], responseIds: [] },
+			pendingToolCalls: {},
+		};
+		checkpointStorage.getStatus.mockResolvedValue({ status: 'active', checkpoint });
+		checkpointStorage.cancelSuspended.mockResolvedValue(true);
+
+		await expect(
+			service.cancelChatRun({
+				agentId,
+				runId: 'run-1',
+				resourceId: 'draft-chat:user-1',
+			}),
+		).resolves.toBe(true);
+		expect(checkpointStorage.cancelSuspended).toHaveBeenCalledWith('run-1', checkpoint, agentId);
+
+		checkpointStorage.cancelSuspended.mockClear();
+		await expect(
+			service.cancelChatRun({
+				agentId,
+				runId: 'run-1',
+				resourceId: 'draft-chat:another-user',
+			}),
+		).resolves.toBe(false);
+		expect(checkpointStorage.cancelSuspended).not.toHaveBeenCalled();
 	});
 
 	it('passes tracing telemetry returned by AgentRunTracingService into stream() and resume()', async () => {

--- a/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
@@ -488,6 +488,44 @@ describe('AgentExecutionOrchestratorService', () => {
 		);
 	});
 
+	it('persists an aborted chat stream as cancelled without discarding partial output', async () => {
+		const { service, executionService } = makeService();
+		const abortController = new AbortController();
+		const runtime = makeRuntime([
+			{ type: 'text-start', id: 'text-1' },
+			{ type: 'text-delta', id: 'text-1', delta: 'partial answer' },
+			{ type: 'error', error: new Error('This operation was aborted') },
+			{ type: 'finish', finishReason: 'error' },
+		]);
+		const stream = service.streamChatResponse({
+			agentInstance: runtime.agent,
+			toolRegistry: runtime.toolRegistry,
+			agentId,
+			message: 'hello',
+			memory: { threadId: 'thread-1', resourceId: 'resource-1' },
+			projectId,
+			abortSignal: abortController.signal,
+			onExecutionRecorded: vi.fn(),
+		});
+
+		await stream.next();
+		await stream.next();
+		abortController.abort();
+		await collect(stream);
+
+		expect(executionService.recordMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				userMessage: 'hello',
+				record: expect.objectContaining({
+					assistantResponse: 'partial answer',
+					finishReason: 'cancelled',
+					error: null,
+					timeline: [expect.objectContaining({ type: 'text', content: 'partial answer' })],
+				}),
+			}),
+		);
+	});
+
 	it('maps persisted execution history to chat DTOs', async () => {
 		const { service, executionService } = makeService();
 		executionService.getThreadDetail.mockResolvedValue({
@@ -576,6 +614,49 @@ describe('AgentExecutionOrchestratorService', () => {
 					runType: 'production',
 					configuration: runtime.telemetryConfiguration,
 				},
+			}),
+		);
+	});
+
+	it('persists an aborted resumed stream as cancelled without discarding partial output', async () => {
+		const { service, checkpointStorage, runtimeCacheService, executionService } = makeService();
+		const abortController = new AbortController();
+		const runtime = makeRuntime([
+			{ type: 'text-start', id: 'text-1' },
+			{ type: 'text-delta', id: 'text-1', delta: 'partial resumed answer' },
+			{ type: 'error', error: new Error('This operation was aborted') },
+			{ type: 'finish', finishReason: 'error' },
+		]);
+		checkpointStorage.getStatus.mockResolvedValue({
+			status: 'active',
+			checkpoint: { persistence: { threadId: 'thread-1', resourceId: 'resource-1' } },
+		} as never);
+		runtimeCacheService.getRuntime.mockResolvedValue(runtime);
+		const stream = service.resumeForChat({
+			agentId,
+			projectId,
+			runId: 'run-1',
+			toolCallId: 'tc-1',
+			resumeData: { value: 'yes' },
+			abortSignal: abortController.signal,
+			onExecutionRecorded: vi.fn(),
+		});
+
+		await stream.next();
+		await stream.next();
+		abortController.abort();
+		await collect(stream);
+
+		expect(executionService.recordMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				userMessage: null,
+				hitlStatus: 'resumed',
+				record: expect.objectContaining({
+					assistantResponse: 'partial resumed answer',
+					finishReason: 'cancelled',
+					error: null,
+					timeline: [expect.objectContaining({ type: 'text', content: 'partial resumed answer' })],
+				}),
 			}),
 		);
 	});

--- a/packages/cli/src/modules/agents/__tests__/execution-to-message-mapper.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/execution-to-message-mapper.test.ts
@@ -112,6 +112,32 @@ describe('execution-to-message-mapper', () => {
 		]);
 	});
 
+	it('includes the execution outcome on assistant messages', () => {
+		const result = executionToMessagesDto(
+			execution({
+				status: 'error',
+				timeline: [
+					{
+						type: 'tool-call',
+						kind: 'tool',
+						name: 'slow_tool',
+						toolCallId: 'call-1',
+						input: {},
+						output: undefined,
+						startTime: 100,
+						endTime: 0,
+						success: false,
+					},
+				],
+			}),
+		);
+
+		expect(result[1]).toMatchObject({
+			role: 'assistant',
+			executionStatus: 'error',
+		});
+	});
+
 	it('flattens multiple executions into a single message list', () => {
 		const result = executionsToMessagesDto([
 			execution({

--- a/packages/cli/src/modules/agents/agent-chat.controller.ts
+++ b/packages/cli/src/modules/agents/agent-chat.controller.ts
@@ -85,6 +85,9 @@ export class AgentChatController {
 			return;
 		}
 
+		const abortController = new AbortController();
+		const abortOnClose = () => abortController.abort();
+		res.once('close', abortOnClose);
 		try {
 			let executionId: string | undefined;
 			const suspended = await pumpChunks(
@@ -100,6 +103,7 @@ export class AgentChatController {
 					onExecutionRecorded: (id) => {
 						executionId = id;
 					},
+					abortSignal: abortController.signal,
 				}),
 				send,
 			);
@@ -107,11 +111,14 @@ export class AgentChatController {
 				send({ type: 'done', sessionId: threadId, ...(executionId ? { executionId } : {}) });
 			}
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : 'Chat failed';
-			send({ type: 'error', message: errorMessage });
+			if (!abortController.signal.aborted) {
+				const errorMessage = error instanceof Error ? error.message : 'Chat failed';
+				send({ type: 'error', message: errorMessage });
+			}
+		} finally {
+			res.off('close', abortOnClose);
+			res.end();
 		}
-
-		res.end();
 	}
 
 	@Post('/:agentId/chat/resume', { usesTemplates: true })
@@ -126,6 +133,9 @@ export class AgentChatController {
 		const { runId, toolCallId, resumeData } = payload;
 		const { send } = initSseStream(res);
 
+		const abortController = new AbortController();
+		const abortOnClose = () => abortController.abort();
+		res.once('close', abortOnClose);
 		try {
 			let executionId: string | undefined;
 			const suspended = await pumpChunks(
@@ -141,6 +151,7 @@ export class AgentChatController {
 					onExecutionRecorded: (id) => {
 						executionId = id;
 					},
+					abortSignal: abortController.signal,
 				}),
 				send,
 			);
@@ -148,11 +159,33 @@ export class AgentChatController {
 				send({ type: 'done', ...(executionId ? { executionId } : {}) });
 			}
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : 'Resume failed';
-			send({ type: 'error', message: errorMessage });
+			if (!abortController.signal.aborted) {
+				const errorMessage = error instanceof Error ? error.message : 'Resume failed';
+				send({ type: 'error', message: errorMessage });
+			}
+		} finally {
+			res.off('close', abortOnClose);
+			res.end();
 		}
+	}
 
-		res.end();
+	@Delete('/:agentId/chat/runs/:runId')
+	@ProjectScope('agent:execute')
+	async cancelChatRun(
+		req: AuthenticatedRequest<{ projectId: string }>,
+		@Param('agentId') agentId: string,
+		@Param('runId') runId: string,
+	) {
+		const { projectId } = req.params;
+		const agent = await this.agentsService.findById(agentId, projectId);
+		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
+
+		const cancelled = await this.agentExecutionOrchestratorService.cancelChatRun({
+			agentId,
+			runId,
+			resourceId: draftChatMemoryResourceId(req.user.id),
+		});
+		return { cancelled };
 	}
 
 	@Get('/:agentId/chat/:threadId/messages')

--- a/packages/cli/src/modules/agents/agent-chat.controller.ts
+++ b/packages/cli/src/modules/agents/agent-chat.controller.ts
@@ -54,42 +54,40 @@ export class AgentChatController {
 		);
 
 		const { send } = initSseStream(res);
-
-		// If the client supplied a sessionId and a thread already exists under that id,
-		// the thread must belong to this (project, agent). Otherwise a caller could
-		// append messages to another user's thread. A non-existent id is fine -
-		// executeForChat will create the thread on first persisted message.
-		if (sessionId) {
-			const existing = await this.agentExecutionService.findThreadById(sessionId);
-			if (existing && !threadBelongsTo(existing, projectId, agentId)) {
-				send({ type: 'error', message: 'Session not found' });
-				res.end();
-				return;
-			}
-		}
-
-		const threadId = sessionId ?? randomUUID();
-
-		const { missing } = await this.agentValidationService.validateAgentIsRunnable(
-			agentId,
-			projectId,
-			credentialProvider,
-		);
-		if (missing.length > 0) {
-			send({
-				type: 'error',
-				message: 'This agent is not ready to run yet.',
-				errorCode: 'agent_misconfigured',
-				missing,
-			});
-			res.end();
-			return;
-		}
-
 		const abortController = new AbortController();
 		const abortOnClose = () => abortController.abort();
 		res.once('close', abortOnClose);
 		try {
+			// If the client supplied a sessionId and a thread already exists under that id,
+			// the thread must belong to this (project, agent). Otherwise a caller could
+			// append messages to another user's thread. A non-existent id is fine -
+			// executeForChat will create the thread on first persisted message.
+			if (sessionId) {
+				const existing = await this.agentExecutionService.findThreadById(sessionId);
+				if (abortController.signal.aborted) return;
+				if (existing && !threadBelongsTo(existing, projectId, agentId)) {
+					send({ type: 'error', message: 'Session not found' });
+					return;
+				}
+			}
+
+			const threadId = sessionId ?? randomUUID();
+			const { missing } = await this.agentValidationService.validateAgentIsRunnable(
+				agentId,
+				projectId,
+				credentialProvider,
+			);
+			if (abortController.signal.aborted) return;
+			if (missing.length > 0) {
+				send({
+					type: 'error',
+					message: 'This agent is not ready to run yet.',
+					errorCode: 'agent_misconfigured',
+					missing,
+				});
+				return;
+			}
+
 			let executionId: string | undefined;
 			const suspended = await pumpChunks(
 				this.agentExecutionOrchestratorService.executeForChat({

--- a/packages/cli/src/modules/agents/agent-chat.controller.ts
+++ b/packages/cli/src/modules/agents/agent-chat.controller.ts
@@ -7,6 +7,7 @@ import {
 import type { AuthenticatedRequest } from '@n8n/db';
 import { Body, Delete, Get, Param, Post, ProjectScope, RestController } from '@n8n/decorators';
 import { randomUUID } from 'crypto';
+import type { Response } from 'express';
 
 import { CredentialsService } from '@/credentials/credentials.service';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -173,6 +174,7 @@ export class AgentChatController {
 	@ProjectScope('agent:execute')
 	async cancelChatRun(
 		req: AuthenticatedRequest<{ projectId: string }>,
+		_res: Response,
 		@Param('agentId') agentId: string,
 		@Param('runId') runId: string,
 	) {

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -13,7 +13,7 @@ import { Telemetry } from '@/telemetry';
 import { AgentExecutionService, type RecordMessageParams } from './agent-execution.service';
 import { AgentRunTracingService, modelIdFromSnapshot } from './agent-run-tracing.service';
 import { AgentRuntimeCacheService } from './agent-runtime-cache.service';
-import { ExecutionRecorder } from './execution-recorder';
+import { ExecutionRecorder, type MessageRecord } from './execution-recorder';
 import { IntegrationMessageContextService } from './integrations/integration-message-context.service';
 import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
 import type { ToolRegistry } from './tool-registry';
@@ -151,6 +151,14 @@ function getMaxIterationsChunks(): StreamChunk[] {
 		},
 		{ type: 'text-end', id },
 	];
+}
+
+function normalizeAbortedMessageRecord(
+	record: MessageRecord,
+	abortSignal?: AbortSignal,
+): MessageRecord {
+	if (!abortSignal?.aborted) return record;
+	return { ...record, finishReason: 'cancelled', error: null };
 }
 
 /**
@@ -309,7 +317,7 @@ export class AgentExecutionOrchestratorService {
 			// Always record resumed executions — even if they suspend again (chained HITL)
 			// or fail while streaming. Don't repeat the original user message — the
 			// pre-suspension execution already has it.
-			const messageRecord = recorder.getMessageRecord();
+			const messageRecord = normalizeAbortedMessageRecord(recorder.getMessageRecord(), abortSignal);
 			await this.persistRecordedExecution({
 				onExecutionRecorded,
 				failureMessage: 'Failed to record resumed agent execution',
@@ -540,7 +548,7 @@ export class AgentExecutionOrchestratorService {
 		} finally {
 			// Always record — even if suspended or failed, the pre-suspension/error
 			// response text and tool calls are valuable.
-			const messageRecord = recorder.getMessageRecord();
+			const messageRecord = normalizeAbortedMessageRecord(recorder.getMessageRecord(), abortSignal);
 			await this.persistRecordedExecution({
 				onExecutionRecorded,
 				failureMessage: 'Failed to record agent execution',

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -9,6 +9,7 @@ import { UserError } from 'n8n-workflow';
 import { ExternalHooks } from '@/external-hooks';
 import type { AgentRunTelemetryType, IAgentConfigurationTelemetryProperties } from '@/interfaces';
 import { Telemetry } from '@/telemetry';
+
 import { AgentExecutionService, type RecordMessageParams } from './agent-execution.service';
 import { AgentRunTracingService, modelIdFromSnapshot } from './agent-run-tracing.service';
 import { AgentRuntimeCacheService } from './agent-runtime-cache.service';
@@ -40,6 +41,7 @@ export interface ExecuteForChatConfig {
 	memory: AgentMemoryScope;
 	/** Fired after the turn is persisted; used to attach `executionId` to SSE `done`. */
 	onExecutionRecorded?: (executionId: string) => void;
+	abortSignal?: AbortSignal;
 }
 
 export interface ExecuteForChatPublishedConfig {
@@ -81,6 +83,7 @@ export interface ResumeForChatConfig {
 	integrationType?: string;
 	/** Fired after the resumed turn is persisted; used to attach `executionId` to SSE `done`. */
 	onExecutionRecorded?: (executionId: string) => void;
+	abortSignal?: AbortSignal;
 }
 
 export interface ExecuteForTaskPublishedConfig {
@@ -134,6 +137,7 @@ export interface StreamChatResponseConfig {
 	};
 	/** Fired after the turn is persisted; used to attach `executionId` to SSE `done`. */
 	onExecutionRecorded?: (executionId: string) => void;
+	abortSignal?: AbortSignal;
 }
 
 function getMaxIterationsChunks(): StreamChunk[] {
@@ -187,6 +191,29 @@ export class AgentExecutionOrchestratorService {
 		return executionsToMessagesDto(detail.executions);
 	}
 
+	async cancelChatRun(params: {
+		agentId: string;
+		runId: string;
+		resourceId: string;
+	}): Promise<boolean> {
+		const checkpointStatus = await this.n8nCheckpointStorage.getStatus(params.runId);
+		if (checkpointStatus.status !== 'active') return false;
+
+		const { checkpoint } = checkpointStatus;
+		if (
+			checkpoint.status !== 'suspended' ||
+			checkpoint.persistence?.resourceId !== params.resourceId
+		) {
+			return false;
+		}
+
+		return await this.n8nCheckpointStorage.cancelSuspended(
+			params.runId,
+			checkpoint,
+			params.agentId,
+		);
+	}
+
 	/**
 	 * Resume a suspended tool call and yield the resulting stream chunks.
 	 * Used by chat integration handlers to continue an agent run after
@@ -203,6 +230,7 @@ export class AgentExecutionOrchestratorService {
 			user,
 			usePublishedVersion = true,
 			onExecutionRecorded,
+			abortSignal,
 		} = config;
 
 		const checkpointStatus = await this.n8nCheckpointStorage.getStatus(runId);
@@ -266,6 +294,7 @@ export class AgentExecutionOrchestratorService {
 					userId: user?.id,
 				}),
 				...(tracing ? { telemetry: tracing } : {}),
+				...(abortSignal ? { abortSignal } : {}),
 			});
 
 			for await (const value of streamAgentChunks(resultStream.stream)) {
@@ -305,7 +334,7 @@ export class AgentExecutionOrchestratorService {
 	 * Execute an agent for the in-app test chat and yield stream chunks.
 	 */
 	async *executeForChat(config: ExecuteForChatConfig): AsyncGenerator<StreamChunk> {
-		const { agentId, projectId, message, user, memory, onExecutionRecorded } = config;
+		const { agentId, projectId, message, user, memory, onExecutionRecorded, abortSignal } = config;
 
 		// `user` is always set (see ExecuteForChatConfig) — this builds/reuses a
 		// runtime scoped to this specific user's tool access.
@@ -337,6 +366,7 @@ export class AgentExecutionOrchestratorService {
 				configuration: runtime.telemetryConfiguration,
 			},
 			onExecutionRecorded,
+			abortSignal,
 		});
 	}
 
@@ -463,6 +493,7 @@ export class AgentExecutionOrchestratorService {
 			taskVersionId,
 			telemetry,
 			onExecutionRecorded,
+			abortSignal,
 		} = config;
 		const { threadId, resourceId } = memory;
 
@@ -482,6 +513,7 @@ export class AgentExecutionOrchestratorService {
 				persistence: { threadId, resourceId },
 				executionCounter: createAgentExecutionCounter(this.telemetry, { agentId, userId }),
 				...(tracing ? { telemetry: tracing } : {}),
+				...(abortSignal ? { abortSignal } : {}),
 			});
 
 			for await (const value of streamAgentChunks(resultStream.stream)) {

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-checkpoint-storage.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-checkpoint-storage.test.ts
@@ -1,7 +1,7 @@
 import type { SerializableAgentState } from '@n8n/agents';
+import type { ModuleRegistry } from '@n8n/backend-common';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { AgentsConfig } from '@n8n/config';
-import type { ModuleRegistry } from '@n8n/backend-common';
 import type { InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
@@ -62,6 +62,19 @@ describe('N8NCheckpointStorage', () => {
 			JSON.stringify({ ...suspendedState, status: 'running' }),
 		);
 		await expect(service.claimForResume('run-1', suspendedState)).resolves.toBe(false);
+	});
+
+	it('atomically expires a suspended checkpoint for an agent', async () => {
+		const { service, repository } = makeService();
+		repository.cancelSuspended.mockResolvedValue(true);
+
+		await expect(service.cancelSuspended('run-1', suspendedState, 'agent-1')).resolves.toBe(true);
+
+		expect(repository.cancelSuspended).toHaveBeenCalledWith(
+			'run-1',
+			'agent-1',
+			JSON.stringify(suspendedState),
+		);
 	});
 
 	it('expires a checkpoint by runId when no agentId is given', async () => {

--- a/packages/cli/src/modules/agents/integrations/n8n-checkpoint-storage.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-checkpoint-storage.ts
@@ -102,6 +102,19 @@ export class N8NCheckpointStorage {
 		);
 	}
 
+	async cancelSuspended(
+		key: string,
+		state: SerializableAgentState,
+		agentId: string,
+	): Promise<boolean> {
+		if (state.status !== 'suspended') return false;
+		return await this.agentCheckpointRepository.cancelSuspended(
+			key,
+			agentId,
+			JSON.stringify(state),
+		);
+	}
+
 	async getStatus(key: string): Promise<CheckpointStatus> {
 		const checkpoint = await this.agentCheckpointRepository.findOneBy({ runId: key });
 		if (!checkpoint) return { status: 'not-found' };

--- a/packages/cli/src/modules/agents/repositories/agent-checkpoint.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-checkpoint.repository.ts
@@ -22,6 +22,15 @@ export class AgentCheckpointRepository extends Repository<AgentCheckpoint> {
 		return (result.affected ?? 0) > 0;
 	}
 
+	async cancelSuspended(runId: string, agentId: string, suspendedState: string): Promise<boolean> {
+		const result = await this.update(
+			{ runId, agentId, expired: false, state: suspendedState },
+			{ expired: true, state: null },
+		);
+
+		return (result.affected ?? 0) > 0;
+	}
+
 	async markExpired(olderThan: Date): Promise<number> {
 		const result = await this.createQueryBuilder()
 			.update()

--- a/packages/cli/src/modules/agents/repositories/agent-checkpoint.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-checkpoint.repository.ts
@@ -1,5 +1,5 @@
 import { Service } from '@n8n/di';
-import { DataSource, Repository } from '@n8n/typeorm';
+import { DataSource, Equal, IsNull, Or, Repository } from '@n8n/typeorm';
 
 import { AgentCheckpoint } from '../entities/agent-checkpoint.entity';
 
@@ -24,7 +24,12 @@ export class AgentCheckpointRepository extends Repository<AgentCheckpoint> {
 
 	async cancelSuspended(runId: string, agentId: string, suspendedState: string): Promise<boolean> {
 		const result = await this.update(
-			{ runId, agentId, expired: false, state: suspendedState },
+			{
+				runId,
+				agentId: Or(Equal(agentId), IsNull()),
+				expired: false,
+				state: suspendedState,
+			},
 			{ expired: true, state: null },
 		);
 

--- a/packages/cli/src/modules/agents/utils/execution-to-message-mapper.ts
+++ b/packages/cli/src/modules/agents/utils/execution-to-message-mapper.ts
@@ -4,7 +4,7 @@ import { isRecord } from '@n8n/utils/is-record';
 import type { AgentExecution } from '../entities/agent-execution.entity';
 import type { TimelineEvent } from '../execution-recorder';
 
-type ExecutionTranscript = Pick<AgentExecution, 'id' | 'userMessage' | 'timeline'>;
+type ExecutionTranscript = Pick<AgentExecution, 'id' | 'userMessage' | 'timeline' | 'status'>;
 
 type ToolCallTimelineEvent = Extract<TimelineEvent, { type: 'tool-call' }>;
 type ToolCallContentPart = AgentPersistedMessageContentPart & {
@@ -155,6 +155,7 @@ export function executionToMessagesDto(execution: ExecutionTranscript): AgentPer
 			role: 'assistant',
 			content: assistantContent,
 			executionId: execution.id,
+			...(execution.status ? { executionStatus: execution.status } : {}),
 		});
 	}
 

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7107,6 +7107,7 @@
 	"agents.builder.chat.newChat.label": "New session",
 	"agents.chat.loadHistory.error": "Could not load chat history",
 	"agents.chat.clearHistory.error": "Could not clear chat history",
+	"agents.chat.stop.error": "Couldn't stop the agent. Try again.",
 	"agents.chat.streamInterrupted": "The connection was interrupted. Refresh the page to see the latest response.",
 	"agents.chat.toolError.generic": "Something went wrong while running this tool",
 	"agents.chat.clearHistory": "Clear chat history",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
@@ -11,6 +11,7 @@ const loadHistoryMock = vi.fn();
 const cancelAndSteerMock = vi.fn();
 const messagesMock = ref<ChatMessage[]>([]);
 const isStreamingMock = ref(false);
+const isCancellingMock = ref(false);
 
 const fatalErrorMock = ref<{ missing: string[] } | null>(null);
 
@@ -56,6 +57,7 @@ vi.mock('../composables/useAgentChatStream', () => ({
 	useAgentChatStream: () => ({
 		messages: messagesMock,
 		isStreaming: isStreamingMock,
+		isCancelling: isCancellingMock,
 		messagingState: computed(() => (isStreamingMock.value ? 'receiving' : 'idle')),
 		fatalError: fatalErrorMock,
 		loadHistory: loadHistoryMock,
@@ -88,6 +90,7 @@ describe('AgentChatPanel', () => {
 		vi.clearAllMocks();
 		messagesMock.value = [];
 		isStreamingMock.value = false;
+		isCancellingMock.value = false;
 		fatalErrorMock.value = null;
 	});
 
@@ -173,6 +176,21 @@ describe('AgentChatPanel', () => {
 
 		expect(sendMessageMock).toHaveBeenCalledWith('update config');
 		expect(events).toEqual(['beforeSend', 'sendMessage']);
+	});
+
+	it('keeps the draft while suspended-run cancellation is pending', async () => {
+		isCancellingMock.value = true;
+		const wrapper = mountPanel();
+
+		(
+			wrapper.vm as unknown as { sendMessageFromOutside: (message: string) => void }
+		).sendMessageFromOutside('keep this draft');
+		await flushPromises();
+
+		const chatInput = wrapper.findComponent({ name: 'ChatInputBase' });
+		expect(chatInput.props('modelValue')).toBe('keep this draft');
+		expect(chatInput.props('disabled')).toBe(true);
+		expect(sendMessageMock).not.toHaveBeenCalled();
 	});
 
 	it('enables chat input and shows answer-question placeholder while an interactive question is unresolved', () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
@@ -33,6 +33,12 @@ vi.mock('@n8n/design-system', () => ({
 	N8nButton: { template: '<button><slot /></button>' },
 	N8nCallout: { template: '<div><slot /><slot name="trailingContent" /></div>' },
 	N8nIconButton: { template: '<button />' },
+	N8nSendStopButton: {
+		name: 'N8nSendStopButton',
+		props: ['streaming', 'stopButtonTestId'],
+		emits: ['stop'],
+		template: '<button :data-test-id="stopButtonTestId" @click="$emit(\'stop\')" />',
+	},
 }));
 
 vi.mock('@/features/ai/shared/components/ChatInputBase.vue', () => ({
@@ -250,14 +256,16 @@ describe('AgentChatPanel', () => {
 		expect(chatInput.props('disabled')).toBe(false);
 	});
 
-	it('keeps the stop control available while an interactive card is unresolved', async () => {
+	it('shows send and stop controls while an interactive question is unresolved', async () => {
 		messagesMock.value = [openInteractiveMessage()];
 
 		const wrapper = mountPanel();
 		const chatInput = wrapper.findComponent({ name: 'ChatInputBase' });
 
-		expect(chatInput.props('isStreaming')).toBe(true);
-		chatInput.vm.$emit('stop');
+		expect(chatInput.props('isStreaming')).toBe(false);
+		const stopButton = wrapper.find('[data-test-id="agent-chat-suspended-stop-button"]');
+		expect(stopButton.exists()).toBe(true);
+		await stopButton.trigger('click');
 		await flushPromises();
 		expect(stopGeneratingMock).toHaveBeenCalledTimes(1);
 	});

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
@@ -232,6 +232,41 @@ describe('AgentChatPanel', () => {
 		expect(chatInput.props('disabled')).toBe(false);
 	});
 
+	it('keeps the stop control available while an interactive card is unresolved', async () => {
+		messagesMock.value = [openInteractiveMessage()];
+
+		const wrapper = mountPanel();
+		const chatInput = wrapper.findComponent({ name: 'ChatInputBase' });
+
+		expect(chatInput.props('isStreaming')).toBe(true);
+		chatInput.vm.$emit('stop');
+		await flushPromises();
+		expect(stopGeneratingMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps the stop control available for a non-card suspension', () => {
+		messagesMock.value = [
+			{
+				id: 'assistant-1',
+				role: 'assistant',
+				content: '',
+				toolCalls: [
+					{
+						tool: 'external_action',
+						toolCallId: 'tc-1',
+						runId: 'run-1',
+						state: 'suspended',
+					},
+				],
+			},
+		];
+
+		const wrapper = mountPanel();
+		const chatInput = wrapper.findComponent({ name: 'ChatInputBase' });
+
+		expect(chatInput.props('isStreaming')).toBe(true);
+	});
+
 	it('does not apply a build-specific character limit', () => {
 		const wrapper = mountPanel();
 		const chatInput = wrapper.findComponent({ name: 'ChatInputBase' });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatToolSteps.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatToolSteps.test.ts
@@ -32,7 +32,8 @@ vi.mock('@n8n/design-system', () => ({
 	},
 	N8nAiActivityStepGroup: {
 		props: ['label', 'size', 'loading'],
-		template: '<div data-test-id="n8n-ai-activity-step-group"><slot /></div>',
+		template:
+			'<div data-test-id="n8n-ai-activity-step-group" :data-loading="String(loading)"><slot /></div>',
 	},
 	N8nButton: {
 		props: ['size', 'variant'],
@@ -106,6 +107,30 @@ function mountSteps(
 }
 
 describe('AgentChatToolSteps', () => {
+	it.each([
+		[TOOL_CALL_STATE.PENDING, 'true'],
+		[TOOL_CALL_STATE.RUNNING, 'true'],
+		[TOOL_CALL_STATE.SUSPENDED, 'false'],
+		[TOOL_CALL_STATE.DONE, 'false'],
+	])('sets grouped tool-call loading for a %s child to %s', (state, expectedLoading) => {
+		const wrapper = mountSteps([
+			{
+				tool: 'search_nodes',
+				toolCallId: 'tc-active',
+				state,
+			},
+			{
+				tool: 'search_nodes',
+				toolCallId: 'tc-done',
+				state: TOOL_CALL_STATE.DONE,
+			},
+		]);
+
+		expect(
+			wrapper.find('[data-test-id="n8n-ai-activity-step-group"]').attributes('data-loading'),
+		).toBe(expectedLoading);
+	});
+
 	it('renders native web search tool calls as expandable', async () => {
 		const wrapper = mountSteps([
 			{

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/agentChatMessages.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/agentChatMessages.test.ts
@@ -217,6 +217,35 @@ describe('convertDbMessages — interactive turn synthesis', () => {
 		expect(tc?.output).toBe('Error: permission denied');
 	});
 
+	it('marks unfinished tool calls from failed executions as errors', () => {
+		const [assistant] = applyOpenSuspensions(
+			convertDbMessages([
+				{
+					id: 'm-error',
+					role: 'assistant',
+					executionStatus: 'error',
+					content: [
+						{
+							type: 'tool-call',
+							toolName: 'calculator',
+							toolCallId: 'tc-error',
+							input: {
+								type: 'approval',
+								toolName: 'calculator',
+								args: { input: '2 + 2' },
+							},
+						},
+					],
+				},
+			]),
+			[],
+		);
+
+		expect(assistant.toolCalls?.[0].state).toBe('error');
+		expect(assistant.status).toBe('error');
+		expect(assistant.interactive).toBeUndefined();
+	});
+
 	it('treats state:resolved non-interactive tool call as done with output', () => {
 		const dbMessages: AgentPersistedMessageDto[] = [
 			{
@@ -562,22 +591,56 @@ describe('applyOpenSuspensions', () => {
 		expect(result[1].interactive?.runId).toBeUndefined();
 	});
 
-	it('returns chat unchanged when the suspension list is empty', () => {
+	it('retires unmatched unresolved interactive cards when no suspension is open', () => {
 		const chat: ChatMessage[] = [
 			{
 				id: 'm1',
 				role: 'assistant',
 				content: '',
+				toolCalls: [{ tool: 'tool_a', toolCallId: 'c1', state: 'suspended' }],
 				interactive: {
 					toolName: APPROVAL_TOOL_NAME,
 					toolCallId: 'c1',
 					input: { type: 'approval', toolName: 'tool_a', args: {} },
 				},
+				status: 'awaitingUser',
 			},
 		];
 		const result = applyOpenSuspensions(chat, []);
 		expect(result).toBe(chat);
-		expect(result[0].interactive?.runId).toBeUndefined();
+		expect(result[0].interactive).toBeUndefined();
+		expect(result[0].toolCalls?.[0]).toMatchObject({ state: 'cancelled', canceled: true });
+		expect(result[0].status).toBe('success');
+	});
+
+	it('retires unfinished non-interactive tools when no suspension is open', () => {
+		const chat: ChatMessage[] = [
+			{
+				id: 'm1',
+				role: 'assistant',
+				content: '',
+				toolCalls: [{ tool: 'external_action', toolCallId: 'c1', state: 'running' }],
+			},
+		];
+
+		applyOpenSuspensions(chat, []);
+
+		expect(chat[0].toolCalls?.[0]).toMatchObject({ state: 'cancelled', canceled: true });
+	});
+
+	it('attaches the run id to an open non-interactive suspension', () => {
+		const chat: ChatMessage[] = [
+			{
+				id: 'm1',
+				role: 'assistant',
+				content: '',
+				toolCalls: [{ tool: 'external_action', toolCallId: 'c1', state: 'running' }],
+			},
+		];
+
+		applyOpenSuspensions(chat, [{ toolCallId: 'c1', runId: 'run-1' }]);
+
+		expect(chat[0].toolCalls?.[0]).toMatchObject({ state: 'suspended', runId: 'run-1' });
 	});
 
 	it('ignores suspensions that do not match any interactive card', () => {
@@ -594,6 +657,6 @@ describe('applyOpenSuspensions', () => {
 			},
 		];
 		applyOpenSuspensions(chat, [{ toolCallId: 'unknown', runId: 'run-x' }]);
-		expect(chat[0].interactive?.runId).toBeUndefined();
+		expect(chat[0].interactive).toBeUndefined();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/app/composables/useToast', () => ({
 
 const getChatMessagesMock = vi.fn();
 const getTestChatMessagesMock = vi.fn();
+const cancelAgentChatRunMock = vi.fn();
 
 vi.mock('../composables/useAgentApi', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('../composables/useAgentApi')>();
@@ -24,6 +25,7 @@ vi.mock('../composables/useAgentApi', async (importOriginal) => {
 		...actual,
 		getChatMessages: (...args: unknown[]) => getChatMessagesMock(...args),
 		getTestChatMessages: (...args: unknown[]) => getTestChatMessagesMock(...args),
+		cancelAgentChatRun: (...args: unknown[]) => cancelAgentChatRunMock(...args),
 	};
 });
 
@@ -67,6 +69,26 @@ function makeInterruptedSseResponse(events: AgentSseEvent[]): Response {
 	});
 }
 
+function makeAbortableSseResponse(events: AgentSseEvent[], signal: AbortSignal | null): Response {
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const event of events) {
+				controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+			}
+			signal?.addEventListener(
+				'abort',
+				() => controller.error(new DOMException('Aborted', 'AbortError')),
+				{ once: true },
+			);
+		},
+	});
+	return new Response(stream, {
+		status: 200,
+		headers: { 'Content-Type': 'text/event-stream' },
+	});
+}
+
 function buildHook(continueSessionId?: string) {
 	return useAgentChatStream({
 		projectId: ref('p1'),
@@ -85,6 +107,9 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		vi.stubGlobal('localStorage', {
 			getItem: vi.fn(() => ''),
 		});
+		cancelAgentChatRunMock.mockReset();
+		cancelAgentChatRunMock.mockResolvedValue({ cancelled: true });
+		getTestChatMessagesMock.mockReset();
 	});
 
 	afterEach(() => {
@@ -232,6 +257,342 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		const assistant = hook.messages.value[1];
 		expect(assistant.interactive?.resolvedValue).toEqual({ approved: true });
 		expect(assistant.status).toBe('success');
+	});
+
+	it('cancels an open chat interaction before steering with a new message', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				makeSseResponse([
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-question',
+						toolName: N8N_CHAT_ACTION_TOOL_NAME,
+						input: {
+							action: 'respond',
+							input: {
+								message: {
+									card: {
+										components: [{ type: 'button', label: 'Continue', value: 'continue' }],
+									},
+								},
+							},
+						},
+					},
+					{
+						type: 'tool-call-suspended',
+						payload: {
+							toolCallId: 'tc-question',
+							runId: 'run-question',
+							toolName: N8N_CHAT_ACTION_TOOL_NAME,
+							input: { type: 'integration_action' },
+						},
+					},
+				]),
+			)
+			.mockResolvedValueOnce(makeSseResponse([{ type: 'done' }]));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('ask me a question');
+		await hook.cancelAndSteer('take another approach');
+
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			'http://localhost:5678/projects/p1/agents/v2/a1/chat/resume',
+			expect.objectContaining({
+				body: JSON.stringify({
+					runId: 'run-question',
+					toolCallId: 'tc-question',
+					resumeData: {
+						_type: 'agent.cancellation',
+						message: 'take another approach',
+					},
+				}),
+			}),
+		);
+	});
+
+	it('cancels an idle suspended interaction and settles its UI state', async () => {
+		globalThis.fetch = vi.fn(async () =>
+			makeSseResponse([
+				{
+					type: 'tool-call',
+					toolCallId: 'tc-approval',
+					toolName: 'calculator',
+					input: { input: '2 + 2' },
+				},
+				{
+					type: 'tool-call-suspended',
+					payload: {
+						toolCallId: 'tc-approval',
+						runId: 'run-approval',
+						toolName: 'calculator',
+						input: {
+							type: 'approval',
+							toolName: 'calculator',
+							args: { input: '2 + 2' },
+						},
+					},
+				},
+			]),
+		) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('calculate 2 + 2');
+		await hook.stopGenerating();
+
+		expect(cancelAgentChatRunMock).toHaveBeenCalledWith(
+			{ baseUrl: 'http://localhost:5678' },
+			'p1',
+			'a1',
+			'run-approval',
+		);
+		const assistant = hook.messages.value[1];
+		expect(assistant.toolCalls?.[0]).toMatchObject({ state: 'cancelled', canceled: true });
+		expect(assistant.interactive?.resolvedAt).toBeDefined();
+		expect(assistant.status).toBe('success');
+	});
+
+	it('cancels a suspended checkpoint when stopping before its stream closes', async () => {
+		const fetchMock = vi.fn(async (_url: string, init: RequestInit) =>
+			makeAbortableSseResponse(
+				[
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-approval',
+						toolName: 'calculator',
+						input: { input: '2 + 2' },
+					},
+					{
+						type: 'tool-call-suspended',
+						payload: {
+							toolCallId: 'tc-approval',
+							runId: 'run-approval',
+							toolName: 'calculator',
+							input: {
+								type: 'approval',
+								toolName: 'calculator',
+								args: { input: '2 + 2' },
+							},
+						},
+					},
+				],
+				init.signal ?? null,
+			),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const hook = buildHook();
+		const send = hook.sendMessage('calculate 2 + 2');
+		await vi.waitFor(() => expect(hook.messages.value[1]?.toolCalls?.[0].state).toBe('suspended'));
+		await hook.stopGenerating();
+		await send;
+
+		expect(cancelAgentChatRunMock).toHaveBeenCalledWith(
+			{ baseUrl: 'http://localhost:5678' },
+			'p1',
+			'a1',
+			'run-approval',
+		);
+		expect(hook.messages.value[1].toolCalls?.[0].state).toBe('cancelled');
+	});
+
+	it('cancels an idle suspension that does not render an interactive card', async () => {
+		globalThis.fetch = vi.fn(async () =>
+			makeSseResponse([
+				{
+					type: 'tool-call',
+					toolCallId: 'tc-external',
+					toolName: 'external_action',
+					input: { channel: 'external' },
+				},
+				{
+					type: 'tool-call-suspended',
+					payload: {
+						toolCallId: 'tc-external',
+						runId: 'run-external',
+						toolName: 'external_action',
+						input: { type: 'integration_action' },
+					},
+				},
+			]),
+		) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('wait for external approval');
+		await hook.stopGenerating();
+
+		expect(cancelAgentChatRunMock).toHaveBeenCalledWith(
+			{ baseUrl: 'http://localhost:5678' },
+			'p1',
+			'a1',
+			'run-external',
+		);
+		expect(hook.messages.value[1].toolCalls?.[0].state).toBe('cancelled');
+	});
+
+	it('settles every suspended tool call belonging to a cancelled run', async () => {
+		globalThis.fetch = vi.fn(async () =>
+			makeSseResponse([
+				{
+					type: 'tool-call',
+					toolCallId: 'tc-first',
+					toolName: 'external_action',
+					input: { value: 'first' },
+				},
+				{
+					type: 'tool-call',
+					toolCallId: 'tc-second',
+					toolName: 'external_action',
+					input: { value: 'second' },
+				},
+				{
+					type: 'tool-call-suspended',
+					payload: {
+						toolCallId: 'tc-first',
+						runId: 'run-parallel',
+						toolName: 'external_action',
+						input: { type: 'integration_action' },
+					},
+				},
+				{
+					type: 'tool-call-suspended',
+					payload: {
+						toolCallId: 'tc-second',
+						runId: 'run-parallel',
+						toolName: 'external_action',
+						input: { type: 'integration_action' },
+					},
+				},
+			]),
+		) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('wait for both actions');
+		await hook.stopGenerating();
+
+		expect(hook.messages.value[1].toolCalls).toEqual([
+			expect.objectContaining({ toolCallId: 'tc-first', state: 'cancelled', canceled: true }),
+			expect.objectContaining({ toolCallId: 'tc-second', state: 'cancelled', canceled: true }),
+		]);
+	});
+
+	it('does not reopen a submitted HITL card when its resumed stream is stopped', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				makeSseResponse([
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-approval',
+						toolName: 'calculator',
+						input: { input: '2 + 2' },
+					},
+					{
+						type: 'tool-call-suspended',
+						payload: {
+							toolCallId: 'tc-approval',
+							runId: 'run-approval',
+							toolName: 'calculator',
+							input: {
+								type: 'approval',
+								toolName: 'calculator',
+								args: { input: '2 + 2' },
+							},
+						},
+					},
+				]),
+			)
+			.mockImplementationOnce(
+				async (_url: string, init: RequestInit) =>
+					await new Promise<Response>((_resolve, reject) => {
+						init.signal?.addEventListener(
+							'abort',
+							() => reject(new DOMException('Aborted', 'AbortError')),
+							{ once: true },
+						);
+					}),
+			);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('calculate 2 + 2');
+		const resume = hook.resume({
+			runId: 'run-approval',
+			toolCallId: 'tc-approval',
+			resumeData: { approved: false },
+		});
+		await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		hook.stopGenerating();
+		await resume;
+
+		const assistant = hook.messages.value[1];
+		expect(assistant.toolCalls?.[0].state).toBe('done');
+		expect(assistant.interactive?.resolvedAt).toBeDefined();
+		expect(assistant.status).toBe('success');
+	});
+
+	it('reconciles a failed resume against the backend suspension state', async () => {
+		const approvalInput = {
+			type: 'approval' as const,
+			toolName: 'calculator',
+			args: { input: '2 + 2' },
+		};
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(
+				makeSseResponse([
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-approval',
+						toolName: 'calculator',
+						input: { input: '2 + 2' },
+					},
+					{
+						type: 'tool-call-suspended',
+						payload: {
+							toolCallId: 'tc-approval',
+							runId: 'run-approval',
+							toolName: 'calculator',
+							input: approvalInput,
+						},
+					},
+				]),
+			)
+			.mockResolvedValueOnce(
+				makeSseResponse([{ type: 'error', message: 'This action has already been handled' }]),
+			) as unknown as typeof fetch;
+		getTestChatMessagesMock.mockResolvedValue({
+			messages: [
+				{
+					id: 'm1',
+					role: 'assistant',
+					content: [
+						{
+							type: 'tool-call',
+							toolName: 'calculator',
+							toolCallId: 'tc-approval',
+							input: approvalInput,
+						},
+					],
+				},
+			],
+			openSuspensions: [],
+		});
+
+		const hook = buildHook();
+		await hook.sendMessage('calculate 2 + 2');
+		await hook.resume({
+			runId: 'run-approval',
+			toolCallId: 'tc-approval',
+			resumeData: { approved: false },
+		});
+
+		expect(getTestChatMessagesMock).toHaveBeenCalled();
+		const assistant = hook.messages.value[0];
+		expect(assistant.interactive).toBeUndefined();
+		expect(assistant.toolCalls?.[0].state).toBe('cancelled');
 	});
 
 	it('breaks out of the consume loop on `done` so isStreaming flips back to false', async () => {
@@ -610,6 +971,40 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		expect(assistantMsgs[0].status).toBe('error');
 		expect(assistantMsgs[0].toolCalls?.[0].state).toBe('error');
 		expect(assistantMsgs[1]).toMatchObject({ content: 'Tool failed', status: 'error' });
+	});
+
+	it('retires a suspended interaction when its run emits an error', async () => {
+		const events: AgentSseEvent[] = [
+			{
+				type: 'tool-call',
+				toolCallId: 'tc-approval',
+				toolName: 'calculator',
+				input: { input: '2 + 2' },
+			},
+			{
+				type: 'tool-call-suspended',
+				payload: {
+					toolCallId: 'tc-approval',
+					runId: 'run-approval',
+					toolName: 'calculator',
+					input: {
+						type: 'approval',
+						toolName: 'calculator',
+						args: { input: '2 + 2' },
+					},
+				},
+			},
+			{ type: 'error', message: 'Run failed', errorCode: 'runtime_error' },
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('calculate 2 + 2');
+
+		const assistant = hook.messages.value[1];
+		expect(assistant.status).toBe('error');
+		expect(assistant.toolCalls?.[0].state).toBe('error');
+		expect(assistant.interactive).toBeUndefined();
 	});
 
 	it('flips a ToolCall from pending → running on tool-execution-start, then to done on tool-result', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
@@ -89,6 +89,44 @@ function makeAbortableSseResponse(events: AgentSseEvent[], signal: AbortSignal |
 	});
 }
 
+function makeControllableSseResponse(
+	events: AgentSseEvent[],
+	signal: AbortSignal | null,
+): { response: Response; close: () => void } {
+	const encoder = new TextEncoder();
+	let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+	let settled = false;
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			streamController = controller;
+			for (const event of events) {
+				controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+			}
+			signal?.addEventListener(
+				'abort',
+				() => {
+					if (settled) return;
+					settled = true;
+					controller.error(new DOMException('Aborted', 'AbortError'));
+				},
+				{ once: true },
+			);
+		},
+	});
+
+	return {
+		response: new Response(stream, {
+			status: 200,
+			headers: { 'Content-Type': 'text/event-stream' },
+		}),
+		close: () => {
+			if (settled) return;
+			settled = true;
+			streamController?.close();
+		},
+	};
+}
+
 function buildHook(continueSessionId?: string) {
 	return useAgentChatStream({
 		projectId: ref('p1'),
@@ -354,6 +392,179 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		expect(assistant.status).toBe('success');
 	});
 
+	it('blocks new messages while suspended-run cancellation is pending', async () => {
+		const fetchMock = vi.fn(async () =>
+			makeSseResponse([
+				{
+					type: 'tool-call',
+					toolCallId: 'tc-external',
+					toolName: 'external_action',
+					input: { channel: 'external' },
+				},
+				{
+					type: 'tool-call-suspended',
+					payload: {
+						toolCallId: 'tc-external',
+						runId: 'run-external',
+						toolName: 'external_action',
+						input: { type: 'integration_action' },
+					},
+				},
+			]),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+		let resolveCancellation = (_value: { cancelled: boolean }) => {};
+		cancelAgentChatRunMock.mockReturnValue(
+			new Promise((resolve) => {
+				resolveCancellation = resolve;
+			}),
+		);
+
+		const hook = buildHook();
+		await hook.sendMessage('wait for external approval');
+		const stop = hook.stopGenerating();
+		await vi.waitFor(() => expect(cancelAgentChatRunMock).toHaveBeenCalled());
+		expect(hook.isCancelling.value).toBe(true);
+
+		await hook.sendMessage('start another run');
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(hook.messages.value.some((message) => message.content === 'start another run')).toBe(
+			false,
+		);
+
+		resolveCancellation({ cancelled: true });
+		await stop;
+		expect(hook.isCancelling.value).toBe(false);
+	});
+
+	it('reconciles history when suspended-run cancellation fails', async () => {
+		const approvalInput = {
+			type: 'approval' as const,
+			toolName: 'calculator',
+			args: { input: '2 + 2' },
+		};
+		let closeStream = () => {};
+		globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+			const controlled = makeControllableSseResponse(
+				[
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-approval',
+						toolName: 'calculator',
+						input: { input: '2 + 2' },
+					},
+					{
+						type: 'tool-call-suspended',
+						payload: {
+							toolCallId: 'tc-approval',
+							runId: 'run-approval',
+							toolName: 'calculator',
+							input: approvalInput,
+						},
+					},
+				],
+				init.signal ?? null,
+			);
+			closeStream = controlled.close;
+			return controlled.response;
+		}) as typeof fetch;
+		cancelAgentChatRunMock.mockRejectedValue(new Error('request failed'));
+		getTestChatMessagesMock.mockResolvedValue({
+			messages: [
+				{
+					id: 'm1',
+					role: 'assistant',
+					content: [
+						{
+							type: 'tool-call',
+							toolName: 'calculator',
+							toolCallId: 'tc-approval',
+							input: approvalInput,
+						},
+					],
+				},
+			],
+			openSuspensions: [{ toolCallId: 'tc-approval', runId: 'run-approval' }],
+		});
+
+		const hook = buildHook();
+		const send = hook.sendMessage('calculate 2 + 2');
+		let sendSettled = false;
+		void send.then(() => {
+			sendSettled = true;
+		});
+		await vi.waitFor(() => expect(hook.messages.value[1]?.status).toBe('awaitingUser'));
+		try {
+			await hook.stopGenerating();
+			await vi.waitFor(() => expect(sendSettled).toBe(true), { timeout: 250 });
+
+			expect(getTestChatMessagesMock).toHaveBeenCalled();
+			const assistant = hook.messages.value.at(-1)!;
+			expect(assistant.status).toBe('awaitingUser');
+			expect(assistant.toolCalls?.[0].state).toBe('suspended');
+			expect(assistant.interactive?.runId).toBe('run-approval');
+		} finally {
+			closeStream();
+			await send;
+		}
+	});
+
+	it('keeps the open suspension when cancellation and history reconciliation fail', async () => {
+		const approvalInput = {
+			type: 'approval' as const,
+			toolName: 'calculator',
+			args: { input: '2 + 2' },
+		};
+		let closeStream = () => {};
+		globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+			const controlled = makeControllableSseResponse(
+				[
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-approval',
+						toolName: 'calculator',
+						input: { input: '2 + 2' },
+					},
+					{
+						type: 'tool-call-suspended',
+						payload: {
+							toolCallId: 'tc-approval',
+							runId: 'run-approval',
+							toolName: 'calculator',
+							input: approvalInput,
+						},
+					},
+				],
+				init.signal ?? null,
+			);
+			closeStream = controlled.close;
+			return controlled.response;
+		}) as typeof fetch;
+		cancelAgentChatRunMock.mockRejectedValue(new Error('request failed'));
+		getTestChatMessagesMock.mockRejectedValue(new Error('history unavailable'));
+
+		const hook = buildHook();
+		const send = hook.sendMessage('calculate 2 + 2');
+		let sendSettled = false;
+		void send.then(() => {
+			sendSettled = true;
+		});
+		await vi.waitFor(() => expect(hook.messages.value[1]?.status).toBe('awaitingUser'));
+		try {
+			await hook.stopGenerating();
+			await vi.waitFor(() => expect(sendSettled).toBe(true), { timeout: 250 });
+
+			const assistant = hook.messages.value[1];
+			expect(assistant.status).toBe('awaitingUser');
+			expect(assistant.toolCalls?.[0].state).toBe('suspended');
+			expect(assistant.interactive?.runId).toBe('run-approval');
+		} finally {
+			closeStream();
+			await send;
+		}
+	});
+
 	it('cancels a suspended checkpoint when stopping before its stream closes', async () => {
 		const fetchMock = vi.fn(async (_url: string, init: RequestInit) =>
 			makeAbortableSseResponse(
@@ -398,30 +609,47 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		expect(hook.messages.value[1].toolCalls?.[0].state).toBe('cancelled');
 	});
 
-	it('cancels an idle suspension that does not render an interactive card', async () => {
-		globalThis.fetch = vi.fn(async () =>
-			makeSseResponse([
-				{
-					type: 'tool-call',
-					toolCallId: 'tc-external',
-					toolName: 'external_action',
-					input: { channel: 'external' },
-				},
-				{
-					type: 'tool-call-suspended',
-					payload: {
+	it('settles an active non-card suspension and its parallel tool calls', async () => {
+		globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) =>
+			makeAbortableSseResponse(
+				[
+					{
+						type: 'tool-call',
 						toolCallId: 'tc-external',
-						runId: 'run-external',
 						toolName: 'external_action',
-						input: { type: 'integration_action' },
+						input: { channel: 'external' },
 					},
-				},
-			]),
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-parallel',
+						toolName: 'slow_action',
+						input: {},
+					},
+					{
+						type: 'tool-execution-start',
+						toolCallId: 'tc-parallel',
+						toolName: 'slow_action',
+						startTime: 1_000,
+					},
+					{
+						type: 'tool-call-suspended',
+						payload: {
+							toolCallId: 'tc-external',
+							runId: 'run-external',
+							toolName: 'external_action',
+							input: { type: 'integration_action' },
+						},
+					},
+				],
+				init.signal ?? null,
+			),
 		) as typeof fetch;
 
 		const hook = buildHook();
-		await hook.sendMessage('wait for external approval');
+		const send = hook.sendMessage('wait for external approval');
+		await vi.waitFor(() => expect(hook.messages.value[1]?.toolCalls?.[0].state).toBe('suspended'));
 		await hook.stopGenerating();
+		await send;
 
 		expect(cancelAgentChatRunMock).toHaveBeenCalledWith(
 			{ baseUrl: 'http://localhost:5678' },
@@ -429,7 +657,19 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 			'a1',
 			'run-external',
 		);
-		expect(hook.messages.value[1].toolCalls?.[0].state).toBe('cancelled');
+		expect(hook.messages.value[1].status).toBe('success');
+		expect(hook.messages.value[1].toolCalls).toEqual([
+			expect.objectContaining({
+				toolCallId: 'tc-external',
+				state: 'cancelled',
+				canceled: true,
+			}),
+			expect.objectContaining({
+				toolCallId: 'tc-parallel',
+				state: 'cancelled',
+				canceled: true,
+			}),
+		]);
 	});
 
 	it('settles every suspended tool call belonging to a cancelled run', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
@@ -835,6 +835,56 @@ describe('useAgentChatStream — SDK-aligned event handling', () => {
 		expect(assistant.toolCalls?.[0].state).toBe('cancelled');
 	});
 
+	it('keeps the suspended card open when failed resume reconciliation returns 404', async () => {
+		const approvalInput = {
+			type: 'approval' as const,
+			toolName: 'calculator',
+			args: { input: '2 + 2' },
+		};
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(
+				makeSseResponse([
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-approval',
+						toolName: 'calculator',
+						input: { input: '2 + 2' },
+					},
+					{
+						type: 'tool-call-suspended',
+						payload: {
+							toolCallId: 'tc-approval',
+							runId: 'run-approval',
+							toolName: 'calculator',
+							input: approvalInput,
+						},
+					},
+				]),
+			)
+			.mockResolvedValueOnce(
+				makeSseResponse([{ type: 'error', message: 'Resume failed' }]),
+			) as unknown as typeof fetch;
+		getTestChatMessagesMock.mockRejectedValue(
+			Object.assign(new Error('thread not found'), { httpStatusCode: 404 }),
+		);
+
+		const hook = buildHook();
+		await hook.sendMessage('calculate 2 + 2');
+		await hook.resume({
+			runId: 'run-approval',
+			toolCallId: 'tc-approval',
+			resumeData: { approved: false },
+		});
+
+		expect(getTestChatMessagesMock).toHaveBeenCalled();
+		expect(hook.messages.value[0].content).toBe('calculate 2 + 2');
+		const assistant = hook.messages.value[1];
+		expect(assistant.status).toBe('awaitingUser');
+		expect(assistant.toolCalls?.[0].state).toBe('suspended');
+		expect(assistant.interactive?.resolvedAt).toBeUndefined();
+	});
+
 	it('breaks out of the consume loop on `done` so isStreaming flips back to false', async () => {
 		const events: AgentSseEvent[] = [
 			{ type: 'text-delta', id: 't-1', delta: 'hello' },

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
@@ -68,6 +68,7 @@ const isPreparingToSend = ref(false);
 const {
 	messages,
 	isStreaming,
+	isCancelling,
 	messagingState,
 	fatalError,
 	warnings,
@@ -143,7 +144,15 @@ watch(isStreaming, (v) => emit('update:streaming', v));
 
 async function onSubmit() {
 	const text = inputText.value.trim();
-	if (!text || isStreaming.value || isPreparingToSend.value || hasOpenApproval.value) return;
+	if (
+		!text ||
+		isStreaming.value ||
+		isCancelling.value ||
+		isPreparingToSend.value ||
+		hasOpenApproval.value
+	) {
+		return;
+	}
 
 	if (hasOpenInteractiveQuestion.value) {
 		inputText.value = '';
@@ -266,12 +275,19 @@ onBeforeUnmount(() => {
 			<ChatInputBase
 				v-model="inputText"
 				:placeholder="chatPlaceholder"
-				:is-streaming="isStreaming || hasOpenInteraction || hasOpenSuspension"
+				:is-streaming="isStreaming || isCancelling || hasOpenInteraction || hasOpenSuspension"
 				:can-submit="
-					!hasOpenApproval && !isStreaming && !isPreparingToSend && inputText.trim().length > 0
+					!hasOpenApproval &&
+					!isStreaming &&
+					!isCancelling &&
+					!isPreparingToSend &&
+					inputText.trim().length > 0
 				"
 				:disabled="
-					hasOpenApproval || isPreparingToSend || (isStreaming && messagingState !== 'receiving')
+					hasOpenApproval ||
+					isCancelling ||
+					isPreparingToSend ||
+					(isStreaming && messagingState !== 'receiving')
 				"
 				data-testid="chat-input"
 				@submit="onSubmit"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
@@ -11,6 +11,7 @@ import AgentChatMessageList from './AgentChatMessageList.vue';
 import type { AgentJsonConfig } from '../types';
 import { useAgentTelemetry } from '../composables/useAgentTelemetry';
 import { buildAgentConfigFingerprint } from '../composables/agentTelemetry.utils';
+import { TOOL_CALL_STATE } from '../constants';
 
 const props = withDefaults(
 	defineProps<{
@@ -122,6 +123,13 @@ const hasOpenApproval = computed(() => openInteractive.value?.toolName === APPRO
 const hasOpenInteractiveQuestion = computed(
 	() => hasOpenInteraction.value && !hasOpenApproval.value,
 );
+const hasOpenSuspension = computed(() =>
+	messages.value.some((message) =>
+		message.toolCalls?.some(
+			(toolCall) => toolCall.state === TOOL_CALL_STATE.SUSPENDED && toolCall.runId,
+		),
+	),
+);
 
 const chatPlaceholder = computed(() =>
 	hasOpenApproval.value
@@ -183,7 +191,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-	stopGenerating();
+	if (isStreaming.value) void stopGenerating();
 });
 </script>
 
@@ -258,7 +266,7 @@ onBeforeUnmount(() => {
 			<ChatInputBase
 				v-model="inputText"
 				:placeholder="chatPlaceholder"
-				:is-streaming="messagingState === 'receiving'"
+				:is-streaming="isStreaming || hasOpenInteraction || hasOpenSuspension"
 				:can-submit="
 					!hasOpenApproval && !isStreaming && !isPreparingToSend && inputText.trim().length > 0
 				"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, toRef, watch, onMounted, onBeforeUnmount } from 'vue';
-import { N8nCallout, N8nIconButton } from '@n8n/design-system';
+import { N8nCallout, N8nIconButton, N8nSendStopButton } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { APPROVAL_TOOL_NAME } from '@n8n/api-types';
 import ChatInputBase from '@/features/ai/shared/components/ChatInputBase.vue';
@@ -130,6 +130,16 @@ const hasOpenSuspension = computed(() =>
 			(toolCall) => toolCall.state === TOOL_CALL_STATE.SUSPENDED && toolCall.runId,
 		),
 	),
+);
+const showSuspensionStopAlongsideSend = computed(
+	() => hasOpenInteractiveQuestion.value && !isStreaming.value && !isCancelling.value,
+);
+const showStopAsPrimaryAction = computed(
+	() =>
+		isStreaming.value ||
+		isCancelling.value ||
+		hasOpenApproval.value ||
+		(hasOpenSuspension.value && !hasOpenInteractiveQuestion.value),
 );
 
 const chatPlaceholder = computed(() =>
@@ -275,7 +285,7 @@ onBeforeUnmount(() => {
 			<ChatInputBase
 				v-model="inputText"
 				:placeholder="chatPlaceholder"
-				:is-streaming="isStreaming || isCancelling || hasOpenInteraction || hasOpenSuspension"
+				:is-streaming="showStopAsPrimaryAction"
 				:can-submit="
 					!hasOpenApproval &&
 					!isStreaming &&
@@ -295,6 +305,12 @@ onBeforeUnmount(() => {
 			>
 				<template #footer-start>
 					<slot name="footer-start" />
+					<N8nSendStopButton
+						v-if="showSuspensionStopAlongsideSend"
+						streaming
+						stop-button-test-id="agent-chat-suspended-stop-button"
+						@stop="stopGenerating"
+					/>
 				</template>
 			</ChatInputBase>
 		</div>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatToolSteps.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatToolSteps.vue
@@ -185,15 +185,17 @@ function groupLabel(): string {
 	});
 }
 
-function hasLoadingToolCall(): boolean {
-	return props.toolCalls.some((tc) => tc.state === 'running' || tc.state === 'suspended');
+function hasActiveToolCall(): boolean {
+	return props.toolCalls.some(
+		(tc) => tc.state === TOOL_CALL_STATE.PENDING || tc.state === TOOL_CALL_STATE.RUNNING,
+	);
 }
 </script>
 
 <template>
 	<div :class="$style.toolSteps">
 		<template v-if="toolCalls.length > 1">
-			<N8nAiActivityStepGroup :label="groupLabel()" size="small" :loading="hasLoadingToolCall()">
+			<N8nAiActivityStepGroup :label="groupLabel()" size="small" :loading="hasActiveToolCall()">
 				<template v-for="tc in toolCalls" :key="tc.toolCallId">
 					<N8nAiActivityStep
 						v-for="view in [toolStepView(tc)]"

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
@@ -552,6 +552,19 @@ export const clearTestChatMessages = async (
 	);
 };
 
+export const cancelAgentChatRun = async (
+	context: IRestApiContext,
+	projectId: string,
+	agentId: string,
+	runId: string,
+): Promise<{ cancelled: boolean }> => {
+	return await makeRestApiRequest<{ cancelled: boolean }>(
+		context,
+		'DELETE',
+		`/projects/${projectId}/agents/v2/${agentId}/chat/runs/${runId}`,
+	);
+};
+
 export const deleteCustomTool = async (
 	context: IRestApiContext,
 	projectId: string,

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -8,7 +8,12 @@ import type {
 	CancellationResumeData,
 } from '@n8n/api-types';
 import { useToast } from '@/app/composables/useToast';
-import { getChatMessages, getTestChatMessages, clearTestChatMessages } from './useAgentApi';
+import {
+	cancelAgentChatRun,
+	clearTestChatMessages,
+	getChatMessages,
+	getTestChatMessages,
+} from './useAgentApi';
 
 import {
 	applyOpenSuspensions,
@@ -85,8 +90,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		return 'receiving';
 	});
 
-	async function loadHistory(): Promise<void> {
-		if (historyLoaded.value) return;
+	async function refreshHistory(): Promise<boolean> {
 		const continueId = params.continueSessionId?.value;
 		try {
 			let dbMessages: AgentPersistedMessageDto[];
@@ -109,23 +113,28 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 				dbMessages = envelope.messages;
 				openSuspensions = envelope.openSuspensions;
 			}
-			if (dbMessages.length > 0) {
-				messages.value = applyOpenSuspensions(convertDbMessages(dbMessages), openSuspensions);
-			}
-			params.onHistoryLoaded?.(messages.value.length);
+			messages.value = applyOpenSuspensions(convertDbMessages(dbMessages), openSuspensions);
+			return true;
 		} catch (error) {
 			// Treat 404 as "no thread yet" rather than surfacing an error —
 			// covers stale continue URLs and any lingering race where the
 			// thread hasn't been persisted on the backend.
 			const status = (error as { httpStatusCode?: number } | null)?.httpStatusCode;
 			if (status === 404) {
-				params.onHistoryLoaded?.(0);
+				messages.value = [];
+				return true;
 			} else {
 				showError(error, locale.baseText('agents.chat.loadHistory.error'));
 			}
-		} finally {
-			historyLoaded.value = true;
+			return false;
 		}
+	}
+
+	async function loadHistory(): Promise<void> {
+		if (historyLoaded.value) return;
+		await refreshHistory();
+		historyLoaded.value = true;
+		params.onHistoryLoaded?.(messages.value.length);
 	}
 
 	async function clearHistory(): Promise<void> {
@@ -201,12 +210,49 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		return null;
 	}
 
+	function findOpenSuspension(): { runId: string; toolCallId: string } | undefined {
+		const interactive = findOpenInteractive(messages.value);
+		if (interactive?.runId) {
+			return { runId: interactive.runId, toolCallId: interactive.toolCallId };
+		}
+
+		for (const message of messages.value) {
+			const toolCall = message.toolCalls?.find(
+				(tc) => tc.state === TOOL_CALL_STATE.SUSPENDED && tc.runId,
+			);
+			if (toolCall?.runId) return { runId: toolCall.runId, toolCallId: toolCall.toolCallId };
+		}
+		return undefined;
+	}
+
 	function markMessageSuccessIfSettled(msg: ChatMessage): void {
 		if (msg.status !== CHAT_MESSAGE_STATUS.AWAITING_USER) return;
 		const hasOpenInteractive = getMessageInteractives(msg).some(
 			(payload) => payload.resolvedAt === undefined,
 		);
 		if (!hasOpenInteractive) msg.status = CHAT_MESSAGE_STATUS.SUCCESS;
+	}
+
+	function markRunCancelled(runId: string): void {
+		for (const message of messages.value) {
+			let changed = false;
+			for (const toolCall of message.toolCalls ?? []) {
+				if (toolCall.runId !== runId) continue;
+				toolCall.state = TOOL_CALL_STATE.CANCELLED;
+				toolCall.canceled = true;
+				changed = true;
+
+				const interactive = getMessageInteractive(message, toolCall.toolCallId);
+				if (interactive) {
+					upsertMessageInteractive(message, {
+						...interactive,
+						resolvedAt: Date.now(),
+						cancelled: true,
+					});
+				}
+			}
+			if (changed) markMessageSuccessIfSettled(message);
+		}
 	}
 
 	function dropOrphanMintedBubbles(session: StreamSession): void {
@@ -220,17 +266,25 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 
 	function markInFlightStateFailed(session: StreamSession): void {
 		for (const msg of session.minted) {
-			if (msg.status === CHAT_MESSAGE_STATUS.STREAMING) {
+			if (
+				msg.status === CHAT_MESSAGE_STATUS.STREAMING ||
+				msg.status === CHAT_MESSAGE_STATUS.AWAITING_USER
+			) {
 				msg.status = CHAT_MESSAGE_STATUS.ERROR;
 			}
 			for (const toolCall of msg.toolCalls ?? []) {
 				if (
 					toolCall.state === TOOL_CALL_STATE.PENDING ||
-					toolCall.state === TOOL_CALL_STATE.RUNNING
+					toolCall.state === TOOL_CALL_STATE.RUNNING ||
+					toolCall.state === TOOL_CALL_STATE.SUSPENDED
 				) {
 					toolCall.state = TOOL_CALL_STATE.ERROR;
 				}
 			}
+			setMessageInteractives(
+				msg,
+				getMessageInteractives(msg).filter((interactive) => interactive.resolvedAt !== undefined),
+			);
 		}
 	}
 
@@ -397,6 +451,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 					msg = found.msg;
 					tc = found.tc;
 					tc.state = TOOL_CALL_STATE.SUSPENDED;
+					tc.runId = payload.runId;
 					if (suspendIsRenderableInput) {
 						tc.input = payload.input;
 					} else {
@@ -408,6 +463,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 						tool: payload.toolName,
 						toolCallId: payload.toolCallId,
 						state: TOOL_CALL_STATE.SUSPENDED,
+						runId: payload.runId,
 						...(suspendIsRenderableInput
 							? { input: payload.input }
 							: { suspendPayload: payload.input }),
@@ -518,7 +574,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 	async function postAndConsume(
 		url: string,
 		body: Record<string, unknown>,
-	): Promise<{ ok: boolean }> {
+	): Promise<{ outcome: 'completed' | 'failed' | 'aborted' }> {
 		const session: StreamSession = {
 			errorEmitted: false,
 			terminalEventReceived: false,
@@ -549,23 +605,21 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 					status: 'error',
 				};
 				messages.value.push(errorMsg);
-				return { ok: false };
+				return { outcome: 'failed' };
 			}
 
 			await consumeStream(response, session);
 			if (!session.terminalEventReceived) {
 				transportFailed = true;
 				markStreamInterrupted(session);
-				return { ok: false };
+				return { outcome: 'failed' };
 			}
 			finalizeStream(session);
 		} catch (error) {
 			if (error instanceof DOMException && error.name === 'AbortError') {
-				finalizeStream(session);
-				// User-initiated abort — surface as a failure so optimistic
-				// callers (resume) restore their pre-flight state instead of
-				// leaving the UI half-committed.
-				return { ok: false };
+				dropOrphanMintedBubbles(session);
+				markInFlightStateFailed(session);
+				return { outcome: 'aborted' };
 			}
 			if (session.terminalEventReceived) {
 				finalizeStream(session);
@@ -578,7 +632,9 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 			isStreaming.value = false;
 		}
 
-		return { ok: !transportFailed && !session.errorEmitted };
+		return {
+			outcome: !transportFailed && !session.errorEmitted ? 'completed' : 'failed',
+		};
 	}
 
 	async function streamChat(message: string): Promise<void> {
@@ -597,8 +653,8 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 	 * `tool-call-suspended` chunk (live) or from the `openSuspensions` sidecar
 	 * applied during history reload.
 	 *
-	 * The UI updates optimistically, then restores the previous card state if
-	 * the resume POST or SSE stream fails.
+	 * The UI updates optimistically, then reconciles with persisted history if
+	 * the resume fails, falling back to the previous card state if history is unavailable.
 	 */
 	async function resume(payload: ResumePayload): Promise<void> {
 		const isCancellation = 'cancelled' in payload;
@@ -668,12 +724,16 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 
 		const { baseUrl } = rootStore.restApiContext;
 		const url = `${baseUrl}/projects/${params.projectId.value}/agents/v2/${params.agentId.value}/chat/resume`;
-		const { ok } = await postAndConsume(url, {
+		const { outcome } = await postAndConsume(url, {
 			runId: payload.runId,
 			toolCallId: payload.toolCallId,
 			resumeData,
 		});
-		if (!ok && snapshot) {
+		let reconciled = false;
+		if (outcome === 'failed') {
+			reconciled = await refreshHistory();
+		}
+		if (outcome === 'failed' && !reconciled && snapshot) {
 			snapshot.tc.state = snapshot.prevState;
 			snapshot.tc.output = snapshot.prevOutput;
 			snapshot.tc.canceled = snapshot.prevCanceled;
@@ -687,7 +747,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 				setMessageInteractives(snapshot.msg, []);
 			}
 		}
-		if (!ok && optimisticUserMessageId) {
+		if (outcome === 'failed' && !reconciled && optimisticUserMessageId) {
 			messages.value = messages.value.filter((m) => m.id !== optimisticUserMessageId);
 		}
 	}
@@ -727,8 +787,31 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		warnings.value = warnings.value.filter((_, i) => i !== index);
 	}
 
-	function stopGenerating(): void {
-		abortController.value?.abort();
+	async function stopGenerating(): Promise<void> {
+		const openSuspension = findOpenSuspension();
+		if (abortController.value) {
+			abortController.value.abort();
+			if (!openSuspension) return;
+		}
+
+		if (!openSuspension) return;
+
+		try {
+			const { cancelled } = await cancelAgentChatRun(
+				rootStore.restApiContext,
+				params.projectId.value,
+				params.agentId.value,
+				openSuspension.runId,
+			);
+			if (!cancelled) {
+				await refreshHistory();
+				return;
+			}
+
+			markRunCancelled(openSuspension.runId);
+		} catch (error) {
+			showError(error, locale.baseText('agents.chat.stop.error'));
+		}
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -93,7 +93,9 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		return 'receiving';
 	});
 
-	async function refreshHistory(): Promise<boolean> {
+	async function refreshHistory({
+		clearOnNotFound = false,
+	}: { clearOnNotFound?: boolean } = {}): Promise<boolean> {
 		const continueId = params.continueSessionId?.value;
 		try {
 			let dbMessages: AgentPersistedMessageDto[];
@@ -119,13 +121,10 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 			messages.value = applyOpenSuspensions(convertDbMessages(dbMessages), openSuspensions);
 			return true;
 		} catch (error) {
-			// Treat 404 as "no thread yet" rather than surfacing an error —
-			// covers stale continue URLs and any lingering race where the
-			// thread hasn't been persisted on the backend.
 			const status = (error as { httpStatusCode?: number } | null)?.httpStatusCode;
 			if (status === 404) {
-				messages.value = [];
-				return true;
+				if (clearOnNotFound) messages.value = [];
+				return clearOnNotFound;
 			} else {
 				showError(error, locale.baseText('agents.chat.loadHistory.error'));
 			}
@@ -135,7 +134,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 
 	async function loadHistory(): Promise<void> {
 		if (historyLoaded.value) return;
-		await refreshHistory();
+		await refreshHistory({ clearOnNotFound: true });
 		historyLoaded.value = true;
 		params.onHistoryLoaded?.(messages.value.length);
 	}

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -68,7 +68,10 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 
 	const messages = ref<ChatMessage[]>([]);
 	const isStreaming = ref(false);
+	const isCancelling = ref(false);
 	const abortController = ref<AbortController | null>(null);
+	const streamSettlements = new WeakMap<AbortController, Promise<void>>();
+	const preserveTerminalStateOnAbort = new WeakSet<AbortController>();
 	const historyLoaded = ref(false);
 	/**
 	 * Set when the backend rejects the stream because the agent itself is
@@ -233,11 +236,22 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		if (!hasOpenInteractive) msg.status = CHAT_MESSAGE_STATUS.SUCCESS;
 	}
 
+	function isToolCallInFlight(toolCall: ToolCall): boolean {
+		return (
+			toolCall.state === TOOL_CALL_STATE.PENDING ||
+			toolCall.state === TOOL_CALL_STATE.RUNNING ||
+			toolCall.state === TOOL_CALL_STATE.SUSPENDED
+		);
+	}
+
 	function markRunCancelled(runId: string): void {
 		for (const message of messages.value) {
+			const belongsToRun = message.toolCalls?.some((toolCall) => toolCall.runId === runId);
+			if (!belongsToRun) continue;
+
 			let changed = false;
 			for (const toolCall of message.toolCalls ?? []) {
-				if (toolCall.runId !== runId) continue;
+				if (toolCall.runId !== runId && !isToolCallInFlight(toolCall)) continue;
 				toolCall.state = TOOL_CALL_STATE.CANCELLED;
 				toolCall.canceled = true;
 				changed = true;
@@ -273,11 +287,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 				msg.status = CHAT_MESSAGE_STATUS.ERROR;
 			}
 			for (const toolCall of msg.toolCalls ?? []) {
-				if (
-					toolCall.state === TOOL_CALL_STATE.PENDING ||
-					toolCall.state === TOOL_CALL_STATE.RUNNING ||
-					toolCall.state === TOOL_CALL_STATE.SUSPENDED
-				) {
+				if (isToolCallInFlight(toolCall)) {
 					toolCall.state = TOOL_CALL_STATE.ERROR;
 				}
 			}
@@ -584,6 +594,11 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		isStreaming.value = true;
 		const controller = new AbortController();
 		abortController.value = controller;
+		let settleStream: (() => void) | undefined;
+		const streamSettlement = new Promise<void>((resolve) => {
+			settleStream = resolve;
+		});
+		streamSettlements.set(controller, streamSettlement);
 		let transportFailed = false;
 
 		try {
@@ -618,7 +633,11 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		} catch (error) {
 			if (error instanceof DOMException && error.name === 'AbortError') {
 				dropOrphanMintedBubbles(session);
-				markInFlightStateFailed(session);
+				if (preserveTerminalStateOnAbort.has(controller) && session.terminalEventReceived) {
+					finalizeStream(session);
+				} else {
+					markInFlightStateFailed(session);
+				}
 				return { outcome: 'aborted' };
 			}
 			if (session.terminalEventReceived) {
@@ -628,8 +647,13 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 				markStreamInterrupted(session);
 			}
 		} finally {
-			abortController.value = null;
-			isStreaming.value = false;
+			if (abortController.value === controller) {
+				abortController.value = null;
+				isStreaming.value = false;
+			}
+			preserveTerminalStateOnAbort.delete(controller);
+			streamSettlements.delete(controller);
+			settleStream?.();
 		}
 
 		return {
@@ -657,6 +681,8 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 	 * the resume fails, falling back to the previous card state if history is unavailable.
 	 */
 	async function resume(payload: ResumePayload): Promise<void> {
+		if (isCancelling.value) return;
+
 		const isCancellation = 'cancelled' in payload;
 		const text = isCancellation ? payload.text.trim() : '';
 		if (isCancellation && !text) return;
@@ -766,7 +792,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 
 	async function sendMessage(text: string): Promise<void> {
 		const trimmed = text.trim();
-		if (!trimmed || isStreaming.value) return;
+		if (!trimmed || isStreaming.value || isCancelling.value) return;
 		// Any new send invalidates a prior misconfig banner — the user is retrying.
 		fatalError.value = null;
 		warnings.value = [];
@@ -788,14 +814,21 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 	}
 
 	async function stopGenerating(): Promise<void> {
+		if (isCancelling.value) return;
+
 		const openSuspension = findOpenSuspension();
-		if (abortController.value) {
-			abortController.value.abort();
-			if (!openSuspension) return;
+		const activeController = abortController.value;
+		const activeStreamSettlement = activeController
+			? streamSettlements.get(activeController)
+			: undefined;
+		if (!openSuspension) {
+			activeController?.abort();
+			await activeStreamSettlement;
+			return;
 		}
 
-		if (!openSuspension) return;
-
+		isCancelling.value = true;
+		let preserveTerminalState = false;
 		try {
 			const { cancelled } = await cancelAgentChatRun(
 				rootStore.restApiContext,
@@ -803,20 +836,32 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 				params.agentId.value,
 				openSuspension.runId,
 			);
-			if (!cancelled) {
-				await refreshHistory();
+			if (cancelled) {
+				markRunCancelled(openSuspension.runId);
+				preserveTerminalState = true;
 				return;
 			}
 
-			markRunCancelled(openSuspension.runId);
+			const reconciled = await refreshHistory();
+			preserveTerminalState = !reconciled;
 		} catch (error) {
+			const reconciled = await refreshHistory();
+			preserveTerminalState = !reconciled;
 			showError(error, locale.baseText('agents.chat.stop.error'));
+		} finally {
+			if (activeController && preserveTerminalState) {
+				preserveTerminalStateOnAbort.add(activeController);
+			}
+			activeController?.abort();
+			await activeStreamSettlement;
+			isCancelling.value = false;
 		}
 	}
 
 	return {
 		messages,
 		isStreaming,
+		isCancelling,
 		messagingState,
 		fatalError,
 		warnings,

--- a/packages/frontend/editor-ui/src/features/ai/shared/agentsChat/messageMappers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/shared/agentsChat/messageMappers.ts
@@ -176,7 +176,8 @@ export function convertDbMessages(dbMessages: AgentPersistedMessageDto[]): ChatM
 		const toolCalls: ToolCall[] = [];
 		const renderParts: ChatMessageRenderPart[] = [];
 		const interactives: InteractivePayload[] = [];
-		let status: ChatMessage['status'];
+		let status: ChatMessage['status'] =
+			msg.executionStatus === 'error' ? CHAT_MESSAGE_STATUS.ERROR : undefined;
 
 		for (const part of msg.content) {
 			if (part.type === 'text' && part.text) {
@@ -200,6 +201,9 @@ export function convertDbMessages(dbMessages: AgentPersistedMessageDto[]): ChatM
 				} else if (part.state === 'rejected') {
 					state = TOOL_CALL_STATE.ERROR;
 					output = part.error;
+				} else if (msg.executionStatus === 'error') {
+					state = TOOL_CALL_STATE.ERROR;
+					output = part.error;
 				} else {
 					state = TOOL_CALL_STATE.RUNNING;
 					output = undefined;
@@ -220,7 +224,7 @@ export function convertDbMessages(dbMessages: AgentPersistedMessageDto[]): ChatM
 
 				const rebuilt = rebuildInteractiveFromHistory(toolCall);
 				if (!rebuilt) continue;
-				if (rebuilt.resolvedAt === undefined) {
+				if (rebuilt.resolvedAt === undefined && msg.executionStatus !== 'error') {
 					toolCall.state = TOOL_CALL_STATE.SUSPENDED;
 					status = CHAT_MESSAGE_STATUS.AWAITING_USER;
 				}
@@ -246,10 +250,10 @@ export function convertDbMessages(dbMessages: AgentPersistedMessageDto[]): ChatM
 }
 
 /**
- * Re-attach a `runId` to each interactive card whose underlying tool call is
- * still suspended on the backend. The sidecar comes from chat history
- * (`openSuspensions`) — `convertDbMessages` can't surface it on its own
- * because raw persisted messages don't carry runIds.
+ * Reconcile unfinished tool calls and interactive cards with the suspensions
+ * still open on the backend. The sidecar comes from chat history
+ * (`openSuspensions`) — raw persisted messages don't carry runIds or enough
+ * information to distinguish a live suspension from an interrupted run.
  *
  * Mutates `chat` in place (history-load happens before reactivity wraps the
  * messages, so this is safe and avoids an extra deep clone) and returns it
@@ -259,15 +263,53 @@ export function applyOpenSuspensions(
 	chat: ChatMessage[],
 	suspensions: AgentBuilderOpenSuspension[],
 ): ChatMessage[] {
-	if (suspensions.length === 0) return chat;
 	const byToolCallId = new Map(suspensions.map((s) => [s.toolCallId, s.runId]));
 	for (const msg of chat) {
-		const interactives = getMessageInteractives(msg);
-		for (const interactive of interactives) {
-			const runId = byToolCallId.get(interactive.toolCallId);
-			if (runId) interactive.runId = runId;
+		let hasOpenToolCall = false;
+		for (const toolCall of msg.toolCalls ?? []) {
+			if (
+				toolCall.state === TOOL_CALL_STATE.DONE ||
+				toolCall.state === TOOL_CALL_STATE.ERROR ||
+				toolCall.state === TOOL_CALL_STATE.CANCELLED
+			) {
+				continue;
+			}
+
+			const runId = byToolCallId.get(toolCall.toolCallId);
+			if (runId) {
+				toolCall.state = TOOL_CALL_STATE.SUSPENDED;
+				toolCall.runId = runId;
+				hasOpenToolCall = true;
+			} else if (msg.status === CHAT_MESSAGE_STATUS.ERROR) {
+				toolCall.state = TOOL_CALL_STATE.ERROR;
+			} else {
+				toolCall.state = TOOL_CALL_STATE.CANCELLED;
+				toolCall.canceled = true;
+			}
 		}
-		setMessageInteractives(msg, interactives);
+
+		const interactives = getMessageInteractives(msg);
+		const retained: InteractivePayload[] = [];
+		for (const interactive of interactives) {
+			if (interactive.resolvedAt !== undefined) {
+				retained.push(interactive);
+				continue;
+			}
+
+			const runId = byToolCallId.get(interactive.toolCallId);
+			if (runId) {
+				interactive.runId = runId;
+				retained.push(interactive);
+			}
+		}
+		setMessageInteractives(msg, retained);
+		if (hasOpenToolCall) {
+			msg.status = CHAT_MESSAGE_STATUS.AWAITING_USER;
+		} else if (msg.status === CHAT_MESSAGE_STATUS.AWAITING_USER) {
+			msg.status = msg.toolCalls?.some((tc) => tc.state === TOOL_CALL_STATE.ERROR)
+				? CHAT_MESSAGE_STATUS.ERROR
+				: CHAT_MESSAGE_STATUS.SUCCESS;
+		}
 	}
 	return chat;
 }

--- a/packages/frontend/editor-ui/src/features/ai/shared/agentsChat/types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/shared/agentsChat/types.ts
@@ -13,6 +13,8 @@ export interface ToolCall {
 	output?: unknown;
 	canceled?: boolean;
 	state: ToolCallState;
+	/** Run id for a currently suspended call, used to cancel non-card HITL waits. */
+	runId?: string;
 	/** Epoch ms when the tool started executing (live: client clock; reload: recorded). */
 	startTime?: number;
 	/** Epoch ms when the tool settled. Absent while still running. */


### PR DESCRIPTION
## Summary

- Stop agent preview runs when their connection closes.
- Cancel suspended HITL runs and retire stale interactions after errors or refreshes.

## Related Linear ticket

Follow-up to https://linear.app/n8n/issue/AGENT-455

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35043">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

