### PR TITLE
fix(editor): Keep Enter selection working when node search ends with a space

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.test.ts
@@ -394,6 +394,47 @@ describe('NodesListPanel', () => {
 			}
 		});
 
+		it('should select the active item with Enter after typing a trailing space', async () => {
+			vi.useFakeTimers();
+			try {
+				const renderComponent = createComponentRenderer(wrapperComponent, {
+					pinia: createPinia(),
+					props: {
+						nodeTypes: searchNodes,
+					},
+				});
+				const { emitted } = renderComponent();
+				await nextTick();
+
+				screen.getByText('On app event').click();
+				await nextTick();
+
+				await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
+					target: { value: 'Zephyr' },
+				});
+				await vi.advanceTimersByTimeAsync(DEBOUNCE_TIME.INPUT.SEARCH + 1);
+				await nextTick();
+				expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+
+				await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
+					target: { value: 'Zephyr ' },
+				});
+				await vi.advanceTimersByTimeAsync(DEBOUNCE_TIME.INPUT.SEARCH + 1);
+				await nextTick();
+
+				await fireEvent.keyDown(screen.getByTestId('node-creator-search-bar'), {
+					key: 'Enter',
+				});
+				// Keyboard navigation refreshes its selectable items via setTimeout
+				await vi.advanceTimersByTimeAsync(1);
+				await nextTick();
+
+				expect(emitted().nodeTypeSelected).toHaveLength(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it('should apply a pending search before keyboard navigation acts on the list', async () => {
 			vi.useFakeTimers();
 			try {

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.vue
@@ -112,6 +112,10 @@ function getDefaultActiveIndex(search: string = ''): number {
 
 function applySearch(value: string) {
 	if (!activeViewStack.value.uuid) return;
+	// Re-applying an identical term (e.g. a trailing space, trimmed on emit) would
+	// regenerate item uuids without the memoized list DOM picking them up,
+	// breaking Enter selection.
+	if (activeViewStack.value.search === value) return;
 	updateCurrentViewStack({ search: value });
 	void setActiveItemIndex(getDefaultActiveIndex(value));
 	if (value.length) {


### PR DESCRIPTION
## Summary

Pressing `Enter` in the nodes panel did nothing when the search term ended with a space (e.g. `ai `), while the same term without the trailing space worked fine.

The `SearchBar` trims input before emitting, so typing a trailing space re-emits the identical search term. Re-applying it still replaced the view stack entry, which invalidates the items computed and regenerates every item's `uuid` — but the rendered list is memoized on the search string (`v-memo`), so the DOM kept the old uuids. When `Enter` fired, the keyboard-selection lookup couldn't find the active DOM uuid among the freshly recomputed items and silently returned.

The fix makes re-applying an identical search term a no-op in `NodesListPanel`, so the uuids stay in sync with the rendered list. This covers all panel modes (nodes, actions, agents), since they share the panel's search handling.

## How to test

1. Open a workflow and press `N` (or `Tab`) to open the nodes panel
2. Type a search term with a trailing space, e.g. `ai `
3. Press `Enter`
4. The highlighted result is selected/added (previously nothing happened)

Also covered by a regression test in `NodesListPanel.test.ts` that fails without the fix.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5654

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35046">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

