### PR TITLE
ci: Snapshot Chromatic on master to establish TurboSnap baselines

### DIFF
--- a/.github/workflows/release-chromatic.yml
+++ b/.github/workflows/release-chromatic.yml
@@ -1,6 +1,16 @@
 name: 'Release: Chromatic'
 
 on:
+  # Snapshot master so PRs have a fresh baseline to diff against. Without base-branch
+  # builds, TurboSnap diffs each PR against a stale ancestor, sees ~all files changed,
+  # and disables itself — rebuilding every story on every PR.
+  push:
+    branches:
+      - master
+    paths:
+      - 'packages/frontend/@n8n/design-system/**'
+      - 'packages/frontend/@n8n/storybook/**'
+      - '.github/workflows/release-chromatic.yml'
   workflow_dispatch:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary

Follow-up to #35016 — that PR fixed a real but *inactive* TurboSnap vector; it did not fix the actual failure, because TurboSnap was being **disabled entirely** on every PR.

From the Chromatic build log on a recent PR (adding one component, 7 files changed):

```
→ Commit '…' on branch '…'; found 1 parent build and 16066 changed files
Could not retrieve dependency changes from lockfiles; checking package.json
⚠ TurboSnap disabled due to file change
  → Found a dependency change in .github/scripts/package.json or one of its 75 siblings
Running 495 tests
```

**Root cause:** Chromatic only ran on PR approval (`ci-pull-request-review.yml`), never on `master`. With no builds on the base branch, there is no baseline to diff against — so TurboSnap compared each PR to an ancient ancestor build (~16k changed files), found a `package.json` in that diff, and disabled itself, rebuilding all ~495 stories. This fired on *every* PR (the diff-to-stale-baseline always contains a `package.json`), which is why unrelated PRs all reported the full component set as changed.

## Fix

Run the Chromatic build on pushes to `master` (path-filtered to the design-system / storybook paths) so each merge refreshes the baseline. PR diffs then shrink to their actual changes, TurboSnap stays enabled, and snapshots scope to the touched components. `autoAcceptChanges: 'master'` (already set) auto-accepts each master build as the new baseline.

**One-time cost:** the first master build after this merges still sees the stale baseline and snapshots all 495 once; subsequent builds are TurboSnap-scoped.

## Follow-up (not in this PR)

Chromatic also logs `Could not retrieve dependency changes from lockfiles` because the action runs from `packages/frontend/@n8n/storybook` while `pnpm-lock.yaml` is at the repo root, forcing the coarser package.json heuristic. Worth addressing later via `storybookBaseDir` / running from repo root, but fixing the baseline resolves the reported error on its own.

## How to test

After merge, confirm a Chromatic build runs on the master merge commit (establishes the baseline). Then on the next design-system PR touching a single component, the Chromatic build log should show a small changed-file count, TurboSnap enabled, and only the affected stories snapshotted.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-667

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

