### PR TITLE
perf(core): Fix mock() proxy slowdown in cli unit tests (no-changelog)

### DIFF
--- a/packages/cli/src/auth/__tests__/auth.service.test.ts
+++ b/packages/cli/src/auth/__tests__/auth.service.test.ts
@@ -29,7 +29,13 @@ describe('AuthService', () => {
 		mfaEnabled: false,
 		role: GLOBAL_OWNER_ROLE,
 	};
-	const user = mock<User>(userData);
+	// Assign user data onto an empty mock instead of passing it as overrides:
+	// mock(overrides) deep-wraps nested objects in proxies and mutates shared
+	// constants like GLOBAL_OWNER_ROLE in place, stacking a proxy layer per
+	// call and slowing the whole file down.
+	const mockUser = (overrides: Partial<User> = {}) =>
+		Object.assign(mock<User>(), userData, overrides);
+	const user = mockUser();
 	const globalConfig = mock<GlobalConfig>({
 		auth: { cookie: { secure: true, samesite: 'lax' } },
 		userManagement: { jwtSecret: 'random-secret' },
@@ -435,7 +441,7 @@ describe('AuthService', () => {
 			});
 
 			it('should clear cookie if MFA required and not used', async () => {
-				const userWithMfa = mock<User>({ ...userData, mfaEnabled: true, mfaSecret: 'secret' });
+				const userWithMfa = mockUser({ mfaEnabled: true, mfaSecret: 'secret' });
 
 				const req = mockReq();
 				req.cookies[AUTH_COOKIE_NAME] = validToken; // validToken has usedMfa: false
@@ -712,7 +718,7 @@ describe('AuthService', () => {
 				{ ...userData, mfaEnabled: true, mfaSecret: '123' },
 			],
 		])('should throw if %s', async (_, data) => {
-			userRepository.findOne.mockResolvedValueOnce(data && mock<User>(data));
+			userRepository.findOne.mockResolvedValueOnce(data && Object.assign(mock<User>(), data));
 			await expect(authService.resolveJwt(validToken, req, res)).rejects.toThrow('Unauthorized');
 			expect(res.cookie).not.toHaveBeenCalled();
 		});
@@ -1036,7 +1042,7 @@ describe('AuthService', () => {
 		it('should throw when user is disabled', async () => {
 			const token = authService.issueJWT(user, false, browserId);
 			invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
-			userRepository.findOne.mockResolvedValue(mock<User>({ ...userData, disabled: true }));
+			userRepository.findOne.mockResolvedValue(mockUser({ disabled: true }));
 
 			await expect(authService.validateCookieToken(token)).rejects.toThrow('Unauthorized');
 		});
@@ -1171,7 +1177,7 @@ describe('AuthService', () => {
 			it('should throw when user is disabled', async () => {
 				const token = authService.issueJWT(user, false, browserId);
 				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
-				userRepository.findOne.mockResolvedValue(mock<User>({ ...userData, disabled: true }));
+				userRepository.findOne.mockResolvedValue(mockUser({ disabled: true }));
 
 				await expect(
 					authService.authenticateUserBasedOnToken(token, method, endpoint, browserId),
@@ -1181,9 +1187,7 @@ describe('AuthService', () => {
 			it('should throw when user password has changed', async () => {
 				const token = authService.issueJWT(user, false, browserId);
 				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
-				userRepository.findOne.mockResolvedValue(
-					mock<User>({ ...userData, password: 'newPasswordHash' }),
-				);
+				userRepository.findOne.mockResolvedValue(mockUser({ password: 'newPasswordHash' }));
 
 				await expect(
 					authService.authenticateUserBasedOnToken(token, method, endpoint, browserId),
@@ -1409,7 +1413,7 @@ describe('AuthService', () => {
 			it('should throw when user is disabled', async () => {
 				const token = authService.issueJWT(user, true, browserId);
 				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
-				userRepository.findOne.mockResolvedValue(mock<User>({ ...userData, disabled: true }));
+				userRepository.findOne.mockResolvedValue(mockUser({ disabled: true }));
 
 				await expect(authService.authenticateUserByCookie(token)).rejects.toThrow('Unauthorized');
 			});
@@ -1417,9 +1421,7 @@ describe('AuthService', () => {
 			it('should throw when user password hash changed', async () => {
 				const token = authService.issueJWT(user, true, browserId);
 				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
-				userRepository.findOne.mockResolvedValue(
-					mock<User>({ ...userData, password: 'newPasswordHash' }),
-				);
+				userRepository.findOne.mockResolvedValue(mockUser({ password: 'newPasswordHash' }));
 
 				await expect(authService.authenticateUserByCookie(token)).rejects.toThrow('Unauthorized');
 			});

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub-tool.service.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub-tool.service.test.ts
@@ -34,7 +34,10 @@ function makeTool(overrides: Partial<ChatHubTool> = {}): ChatHubTool {
 	const id = overrides.id ?? uuid();
 	const name = overrides.name ?? mockDefinition.name;
 
-	return mock<ChatHubTool>({
+	// Assign onto an empty mock instead of passing overrides to mock():
+	// mock(overrides) deep-wraps nested objects in proxies and mutates the
+	// shared mockDefinition in place, stacking a proxy layer per call.
+	return Object.assign(mock<ChatHubTool>(), {
 		id,
 		name,
 		type: mockDefinition.type,

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -2515,7 +2515,7 @@ describe('getStatus', () => {
 		describe('git as source of truth', () => {
 			it('should mark local-only data table as deleted during pull', async () => {
 				// ARRANGE
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const localDataTable = {
 					id: 'dt-local-only',
@@ -2551,7 +2551,7 @@ describe('getStatus', () => {
 
 			it('should mark remote-only data table as deleted during push', async () => {
 				// ARRANGE
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const remoteDataTable = {
 					id: 'dt-remote-only',
@@ -2587,7 +2587,7 @@ describe('getStatus', () => {
 
 			it('should not treat same-named tables in different projects as a collision during pull', async () => {
 				// ARRANGE
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const remoteDataTable = {
 					id: 'dt-remote',
@@ -2635,7 +2635,7 @@ describe('getStatus', () => {
 
 			it('should offer a remote-only table as a deletion during push even when a same-named local table exists in another project', async () => {
 				// ARRANGE
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const remoteFromInstanceA = {
 					id: 'dt-instance-a',
@@ -2683,7 +2683,7 @@ describe('getStatus', () => {
 
 			it('should emit a single modified entry for a name collision during pull', async () => {
 				// ARRANGE
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const remoteDataTable = {
 					id: 'dt-remote',
@@ -2733,7 +2733,7 @@ describe('getStatus', () => {
 			it('should emit a single modified entry for a personal-project name collision during pull', async () => {
 				// ARRANGE — the owner email resolves to the same local personal
 				// project the colliding table lives in
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const remoteDataTable = {
 					id: 'dt-remote',
@@ -2780,7 +2780,7 @@ describe('getStatus', () => {
 
 			it('should carry the incoming id on a collision entry regardless of preferLocalVersion', async () => {
 				// ARRANGE
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const remoteDataTable = {
 					id: 'dt-remote',
@@ -2828,7 +2828,7 @@ describe('getStatus', () => {
 			it('should detect a collision even when another project has a same-named remote table', async () => {
 				// ARRANGE — the other-project table is listed last so a name-only
 				// lookup would mask the real same-project collision
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const remoteSameProject = {
 					id: 'dt-remote-a',
@@ -2886,7 +2886,7 @@ describe('getStatus', () => {
 
 			it('should keep the created + conflict entry pair for a name collision during push', async () => {
 				// ARRANGE — the single-entry collision shape applies to pull only
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+				const user = globalAdminUserWithId;
 
 				const remoteDataTable = {
 					id: 'dt-remote',

--- a/packages/cli/src/node-execution/__tests__/ephemeral-node-executor.test.ts
+++ b/packages/cli/src/node-execution/__tests__/ephemeral-node-executor.test.ts
@@ -28,9 +28,11 @@ import {
 	isUsableAsAgentTool,
 } from '../ephemeral-node-executor';
 
-// vitest-mock-extended's recursive DeepPartial narrows nested objects (e.g. `defaults`),
-// so a full INodeTypeDescription isn't assignable to the partial. Cast through this helper.
-const mockNodeType = (overrides: object = {}) => mock<INodeType>(overrides as never);
+// Assign overrides onto an empty mock instead of passing them to mock():
+// mock(overrides) deep-wraps nested objects in proxies and mutates shared
+// fixtures (e.g. `toolDescription`) in place, stacking a proxy layer per call.
+// Assigning also sidesteps DeepPartial narrowing of nested objects like `defaults`.
+const mockNodeType = (overrides: object = {}) => Object.assign(mock<INodeType>(), overrides);
 
 const mockGetBase = vi.fn();
 


### PR DESCRIPTION
## Summary

`vitest-mock-extended`'s `mock(overrides)` deep-wraps nested override objects in Proxies and writes them back into the caller's objects. When the overrides reference a shared module-scope fixture (`GLOBAL_OWNER_ROLE` with 161 scope objects, a shared node description, …), the shared object gains one more proxy layer on every `mock()` call in the file, so per-call and per-access cost grows super-quadratically with test count (same mechanism as #27205; upstream bug: marchaos/jest-mock-extended#128, still unfixed in latest releases).

This converts the four cli test files with consistent cross-run slowness to `Object.assign(mock<T>(), data)` — the mock keeps its typing and auto-mock behavior for missing properties, but overrides are assigned through the proxy's `set` trap, which never wraps, so nothing accumulates. In-suite timings (11-core M-series, medians across runs):

| file | before | after |
|---|---|---|
| `auth.service.test.ts` (92 tests) | 5.5–9.8 s | ~0.1 s |
| `ephemeral-node-executor.test.ts` | 2.9 s | 40 ms |
| `chat-hub-tool.service.test.ts` | ~0.5 s | 33 ms |
| `source-control-status.service.test.ts` | 0.8 s | 80 ms |

Full cli unit suite: 14,692/14,692 pass; tests-phase CPU ~108 s → ~95 s.

## How to test

```
cd packages/cli
pnpm test src/auth/__tests__/auth.service.test.ts \
  src/node-execution/__tests__/ephemeral-node-executor.test.ts \
  src/modules/chat-hub/__tests__/chat-hub-tool.service.test.ts \
  src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
```

All tests pass unchanged; the vitest-reported `tests` phase for each file should be double-digit milliseconds. Behavior-only-in-tests change — no runtime code touched.

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket — follow-up to the test-performance investigation behind https://github.com/n8n-io/n8n/pull/27205.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

