### PR TITLE
fix(core): Preserve credential field expressions when caching preAuthentication tokens

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -8,6 +8,7 @@ import { Container } from '@n8n/di';
 import { EntityNotFoundError } from '@n8n/typeorm';
 import {
 	type InstanceSettings,
+	type Credentials,
 	Cipher,
 	CipherAes256GCM,
 	CipherAes256CBC,
@@ -1806,6 +1807,7 @@ describe('CredentialsHelper', () => {
 
 		const helpers = mock<IHttpRequestHelper>();
 		let updateSpy: MockInstance;
+		let getSpy: MockInstance;
 		let credentials: ICredentialDataDecryptedObject;
 
 		beforeEach(() => {
@@ -1825,6 +1827,19 @@ describe('CredentialsHelper', () => {
 			// what the request helper merges back into the in-memory credentials for the
 			// next request (see httpRequestWithAuthentication).
 			updateSpy = vi.spyOn(credentialsHelper, 'updateCredentials').mockResolvedValue();
+			// preAuthentication reads the raw stored credential before caching the token.
+			getSpy = vi.spyOn(credentialsHelper, 'getCredentials').mockResolvedValue(
+				mock<Credentials>({
+					getData: vi.fn().mockResolvedValue({
+						accessToken: '',
+						instanceUrl: '',
+						clientId: 'connected-app-client-id',
+						username: 'user@example.com',
+						privateKey,
+						environment: 'production',
+					}),
+				}),
+			);
 
 			credentials = {
 				accessToken: '',
@@ -1836,7 +1851,10 @@ describe('CredentialsHelper', () => {
 			};
 		});
 
-		afterEach(() => updateSpy.mockRestore());
+		afterEach(() => {
+			updateSpy.mockRestore();
+			getSpy.mockRestore();
+		});
 
 		test('logs in once and reuses the cached token across requests', async () => {
 			// Request 1: no cached token → exactly one login.
@@ -1910,6 +1928,105 @@ describe('CredentialsHelper', () => {
 
 			expect(mockTokenRequest).toHaveBeenCalledTimes(2);
 			expect(refreshed).toMatchObject({ accessToken: 'TOKEN_2' });
+		});
+	});
+
+	describe('preAuthentication expression preservation', () => {
+		// A credential field holding an expression must survive a manual/test run.
+		// preAuthentication resolves the expression to a static value for the run and
+		// caches the fetched token; it must persist only the token, leaving the raw
+		// expression in the stored credential so later runs stay dynamic.
+		const expressionText = "={{ $('Webhook').item.json.body.installation.id }}";
+
+		// Mimics a credential whose preAuthentication spreads the resolved credentials
+		// back into its output (the GitHub App shape) — the strictest case, since the
+		// resolved value is present in `output` itself.
+		class SpreadingExpirableApi implements ICredentialType {
+			name = 'spreadingExpirableApi';
+
+			displayName = 'Spreading Expirable API';
+
+			properties: INodeProperties[] = [
+				{ displayName: 'Installation ID', name: 'installationId', type: 'string', default: '' },
+				{
+					displayName: 'Access Token',
+					name: 'accessToken',
+					type: 'hidden',
+					typeOptions: { expirable: true },
+					default: '',
+				},
+			];
+
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async preAuthentication(
+				this: IHttpRequestHelper,
+				credentials: ICredentialDataDecryptedObject,
+			): Promise<ICredentialDataDecryptedObject> {
+				return { ...credentials, accessToken: 'NEW_TOKEN' };
+			}
+
+			authenticate: IAuthenticateGeneric = { type: 'generic', properties: {} };
+		}
+
+		const spreadingCred = new SpreadingExpirableApi();
+
+		const node: INode = {
+			id: 'uuid-spread',
+			name: 'Node',
+			type: 'n8n-nodes-base.noOp',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+			credentials: { spreadingExpirableApi: { id: 'cred-1', name: 'Cred' } },
+		};
+
+		const helpers = mock<IHttpRequestHelper>();
+		let updateSpy: MockInstance;
+		let getSpy: MockInstance;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			mockNodesAndCredentials.getCredential
+				.calledWith('spreadingExpirableApi')
+				.mockReturnValue({ type: spreadingCred, sourcePath: '' });
+
+			updateSpy = vi.spyOn(credentialsHelper, 'updateCredentials').mockResolvedValue();
+			// The raw stored credential keeps the expression; getData() returns it verbatim.
+			getSpy = vi.spyOn(credentialsHelper, 'getCredentials').mockResolvedValue(
+				mock<Credentials>({
+					getData: vi.fn().mockResolvedValue({ installationId: expressionText, accessToken: '' }),
+				}),
+			);
+		});
+
+		afterEach(() => {
+			updateSpy.mockRestore();
+			getSpy.mockRestore();
+		});
+
+		test('persists only the fetched token and keeps the stored expression intact', async () => {
+			// The credentials the helper receives are already expression-resolved for
+			// this run: installationId is the static value the expression evaluated to.
+			const resolved: ICredentialDataDecryptedObject = {
+				installationId: '12345',
+				accessToken: '',
+			};
+
+			const result = await credentialsHelper.preAuthentication(
+				helpers,
+				resolved,
+				'spreadingExpirableApi',
+				node,
+				false,
+			);
+
+			expect(updateSpy).toHaveBeenCalledTimes(1);
+			expect(updateSpy).toHaveBeenCalledWith(
+				node.credentials!.spreadingExpirableApi,
+				'spreadingExpirableApi',
+				{ installationId: expressionText, accessToken: 'NEW_TOKEN' },
+			);
+			expect(result).toMatchObject({ accessToken: 'NEW_TOKEN' });
 		});
 	});
 });

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -199,11 +199,21 @@ export class CredentialsHelper extends ICredentialsHelper {
 					}
 
 					if (node.credentials) {
-						await this.updateCredentials(
-							node.credentials[credentialType.name],
-							credentialType.name,
-							Object.assign(credentials, output),
-						);
+						const nodeCredentials = node.credentials[credentialType.name];
+						// Cache the freshly-fetched token onto the raw stored credentials, but
+						// never overwrite a field the user stored as an expression with the value
+						// it resolved to this run — otherwise later runs reuse a stale static value.
+						const storedData = await (
+							await this.getCredentials(nodeCredentials, credentialType.name)
+						).getData();
+						const dataToPersist: ICredentialDataDecryptedObject = { ...storedData };
+						for (const [key, value] of Object.entries(output as ICredentialDataDecryptedObject)) {
+							if (key === expirableProperty.name || !isExpression(storedData[key])) {
+								dataToPersist[key] = value;
+							}
+						}
+
+						await this.updateCredentials(nodeCredentials, credentialType.name, dataToPersist);
 						return Object.assign(credentials, output);
 					}
 				}


### PR DESCRIPTION
## Summary

Credential types that declare an *expirable* token field (e.g. **GitHub App API**)
run a `preAuthentication` hook that fetches a token and caches it on the
credential. The caching path wrote the **expression-resolved** credential object
back to the database, so any credential field entered as an expression
(e.g. `Installation ID` = `{{ $json.body.installation.id }}`) was permanently
replaced by the static value it happened to resolve to during a manual or test
run. Later runs then reused that stale value.

This PR changes the write-back so it persists the freshly-fetched token onto the
**raw stored** credential data and never overwrites a field the user stored as an
expression with its resolved value. The expression is kept intact; only the token
(and genuinely derived auth fields) are cached.

### Why

Reported in [#34107](https://github.com/n8n-io/n8n/issues/34107): a GitHub App
`Installation ID` set as an expression was silently overwritten by the resolved
number after a manual execution, locking subsequent runs to that one value.

Root cause is in the shared helper, not the node: `CredentialsHelper.preAuthentication`
persisted `Object.assign(credentials, output)`, where `credentials` is the
expression-resolved copy (resolution happens upstream in `applyDefaultsAndOverwrites`),
and `updateCredentials` → `Credentials.setData` overwrites the full stored blob.
This affected **any** expirable credential using expressions; GitHub App is the
reported instance. Fixing it in the helper covers all such credential types, so
no node/credential contract change was needed.

### How to test manually

The GitHub App hook only needs a token back, so a tiny local mock removes the
dependency on real GitHub (it does not validate the signed JWT):

1. Start n8n locally (`pnpm dev`).
2. Run a mock token endpoint on `:8099`:
   ```js
   // node mock-github.mjs
   import http from 'node:http';
   http.createServer((req, res) => {
     console.log(req.method, req.url);            // watch which installationId is hit
     res.setHeader('content-type', 'application/json');
     if (req.method === 'POST') return res.end(JSON.stringify({ token: 'ghs_mock' }));
     res.end(JSON.stringify({ repositories: [] }));
   }).listen(8099);
   ```
   Generate a throwaway key for the credential's Private Key field: `openssl genrsa 2048`.
3. Create a **GitHub App API** credential: GitHub Server `http://localhost:8099`,
   App ID `1`, **Installation ID** → switch to Expression → `={{ $json.installationId }}`,
   Private Key = the generated key.
4. Build a workflow: `Manual Trigger` → `Edit Fields (Set)` with `installationId = 12345`
   → `HTTP Request` (Authentication → Predefined Credential Type → GitHub App API,
   URL `http://localhost:8099/installation/repositories`).
5. Execute manually, then **reopen the credential**.

**Expected (this PR):** the Installation ID field still shows
`={{ $json.installationId }}`.
**Before this PR:** it showed the static `12345`, and the expression was gone.

### Key implementation decisions

- **Guard on the stored value, not the resolved copy.** The write-back loads the
  raw stored credential and only overwrites a key when it is the expirable token
  field or the stored value is not an expression (`isExpression`). This preserves
  all other current behavior — derived non-expression fields (e.g. Salesforce
  `instanceUrl`) and token refresh are unchanged.
- **Top-level expression check only.** It covers every expirable credential today:
  non-spreading credentials never place user fields in the hook output, and the
  only credential that spreads its input back (GitHub App) has flat string fields.
  A nested expression inside a future credential that both spreads its resolved
  input *and* uses object/collection fields is knowingly out of scope.
- **No change to `GithubAppApi`.** Its resolved fields are filtered out at persist
  time, so the node's public `preAuthentication` return shape is untouched.
- **Known follow-up (not in this PR):** the expirable token is still cached on the
  credential, so for a *dynamic* credential the cached token is reused across runs
  and is not re-minted when the expression resolves to a different value. Making
  dynamic credentials re-mint per execution is a separate behavioral change and is
  tracked separately.

## Related

- Linear: https://linear.app/n8n/issue/IAM-1032
- GitHub issue: https://github.com/n8n-io/n8n/issues/34107

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35064">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

