### PR TITLE
perf(core): Speed up test DB setup and solo-suite CI workers (no-changelog)

### DIFF
--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -68,9 +68,13 @@ jobs:
       - name: Test Unit (backend, except cli and nodes-base)
         run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
+      # This step runs the cli suite alone, so it may use every core instead
+      # of the in-CI 50% cap meant for concurrent suites (see @n8n/vitest-config/node).
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}
         run: pnpm turbo test:unit:changed --filter=n8n --summarize
+        env:
+          N8N_VITEST_MAX_WORKERS: '100%'
 
       - name: Send Test Stats
         if: ${{ !cancelled() }}
@@ -174,8 +178,12 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      # nodes-base is the only suite on this runner, so it may use every core instead
+      # of the in-CI 50% cap meant for concurrent suites (see @n8n/vitest-config/node).
       - name: Test Nodes
         run: pnpm turbo test:changed --filter=n8n-nodes-base --summarize
+        env:
+          N8N_VITEST_MAX_WORKERS: '100%'
 
       - name: Send Test Stats
         if: ${{ !cancelled() }}

--- a/packages/@n8n/backend-test-utils/src/test-db.ts
+++ b/packages/@n8n/backend-test-utils/src/test-db.ts
@@ -6,6 +6,10 @@ import type { DataSourceOptions } from '@n8n/typeorm';
 import { DataSource as Connection } from '@n8n/typeorm';
 import assert from 'assert';
 import { randomString } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
+import { copyFileSync, existsSync, mkdirSync, renameSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 export const testDbPrefix = 'n8n_test_';
 let isInitialized = false;
@@ -28,12 +32,84 @@ export const getBootstrapDBOptions = (): DataSourceOptions => {
 	};
 };
 
+type SqliteTemplate = { dbPath: string; templatePath: string };
+
+/**
+ * SQLite fast path: the first suite to migrate on this machine snapshots its DB
+ * file into a machine-wide template dir; later suites (any process, any run)
+ * copy the snapshot instead of replaying every migration. The template lives in
+ * `os.tmpdir()` — like the per-suite test dirs — so it is shared across
+ * worktrees and the OS eventually cleans it up. Keyed by table prefix plus each
+ * migration's name and compiled source, so adding, removing, or editing a
+ * migration invalidates the template naturally. Set
+ * `N8N_TEST_SQLITE_TEMPLATE=false` to bypass for debugging.
+ */
+function getSqliteTemplate(options: DataSourceOptions): SqliteTemplate | undefined {
+	if (options.type !== 'sqlite-pooled') return undefined;
+	if (process.env.N8N_TEST_SQLITE_TEMPLATE === 'false') return undefined;
+	if (!Array.isArray(options.migrations) || options.migrations.length === 0) return undefined;
+
+	const hash = createHash('sha256').update(options.entityPrefix ?? '');
+	for (const migration of options.migrations) {
+		hash.update(
+			typeof migration === 'string' ? migration : `${migration.name}\n${String(migration)}`,
+		);
+	}
+
+	return {
+		dbPath: options.database,
+		templatePath: path.join(
+			tmpdir(),
+			'n8n-test-db-templates',
+			`${hash.digest('hex').slice(0, 24)}.sqlite`,
+		),
+	};
+}
+
+/** Seed the per-process DB file from the template. Returns false if there is no usable template. */
+function restoreSqliteTemplate({ dbPath, templatePath }: SqliteTemplate): boolean {
+	if (!existsSync(templatePath)) return false;
+	try {
+		mkdirSync(path.dirname(dbPath), { recursive: true });
+		// A leftover WAL/SHM pair from a previous connection to this path must not
+		// be replayed on top of the freshly copied file.
+		rmSync(`${dbPath}-wal`, { force: true });
+		rmSync(`${dbPath}-shm`, { force: true });
+		copyFileSync(templatePath, dbPath);
+		return true;
+	} catch (error) {
+		console.warn('Failed to restore sqlite test DB from template:', error);
+		rmSync(dbPath, { force: true });
+		return false;
+	}
+}
+
+async function saveSqliteTemplate({ templatePath }: SqliteTemplate): Promise<void> {
+	try {
+		mkdirSync(path.dirname(templatePath), { recursive: true });
+		// Stage in a temp path and rename() into place so racing cold processes
+		// never observe a half-written template; race losers overwrite it with
+		// identical content. VACUUM INTO writes a compact, self-contained snapshot
+		// while the pooled connection stays open — copying the live DB file would
+		// miss whatever still sits in the WAL (the pooled driver keeps the -wal
+		// file around even across close()).
+		const stagingPath = `${templatePath}.${process.pid}-${randomString(8)}.tmp`;
+		await Container.get(Connection).query(`VACUUM INTO '${stagingPath}'`);
+		renameSync(stagingPath, templatePath);
+	} catch (error) {
+		console.warn('Failed to save sqlite test DB template:', error);
+	}
+}
+
 /**
  * Initialize one test DB per suite run, with bootstrap connection if needed.
  *
  * When `N8N_TEST_TEMPLATE_DB` is set (Postgres only), the new test DB is created
  * via `CREATE DATABASE ... TEMPLATE <name>`, which clones the schema as a file
  * copy and skips the multi-second migration replay per file.
+ *
+ * On SQLite, the same idea runs automatically via a machine-wide template file:
+ * see {@link getSqliteTemplate}.
  */
 export async function init() {
 	if (isInitialized) return;
@@ -58,14 +134,25 @@ export async function init() {
 	}
 
 	const dbConnection = Container.get(DbConnection);
+	const sqliteTemplate = dbType === 'sqlite' ? getSqliteTemplate(dbConnection.options) : undefined;
+	const restoredFromTemplate =
+		sqliteTemplate !== undefined && restoreSqliteTemplate(sqliteTemplate);
+
 	await dbConnection.init();
 
 	if (templateDb) {
 		// Template already carries migrations + seeded roles — just mark state.
 		dbConnection.connectionState.migrated = true;
 	} else {
+		// After a sqlite template restore both calls are fast no-ops: the copied
+		// migrations table satisfies the executor's by-name pending check, and the
+		// roles sync finds everything in place (healing any drift in role/scope
+		// definitions, which change without a migration).
 		await dbConnection.migrate();
 		await Container.get(AuthRolesService).init();
+		if (sqliteTemplate && !restoredFromTemplate) {
+			await saveSqliteTemplate(sqliteTemplate);
+		}
 	}
 
 	isInitialized = true;

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -42,8 +42,11 @@ export const cjsPinAliases = (deps: string[], from: string = process.cwd()): Ali
  */
 export const forkPoolOptions = (): InlineConfig => {
 	if (process.env.CI !== 'true') return {};
-	// Vitest accepts a percentage for `maxWorkers` (half of availableParallelism).
-	return { pool: 'forks', maxWorkers: '50%' };
+	// Vitest accepts a worker count ("4") or percentage ("100%") for `maxWorkers`.
+	// Solo-suite CI jobs (one suite owning the whole runner, no concurrent turbo
+	// siblings) lift the cap via N8N_VITEST_MAX_WORKERS. Not named VITEST_MAX_WORKERS:
+	// vitest reads that env itself with parseInt, which would turn "100%" into 100 workers.
+	return { pool: 'forks', maxWorkers: process.env.N8N_VITEST_MAX_WORKERS || '50%' };
 };
 
 /**

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,11 @@
 {
 	"globalEnv": ["CI", "BUILD_WITH_COVERAGE"],
-	"globalPassThroughEnv": ["CODECOV_TOKEN", "COVERAGE_ENABLED", "SENTRY_AUTH_TOKEN"],
+	"globalPassThroughEnv": [
+		"CODECOV_TOKEN",
+		"COVERAGE_ENABLED",
+		"N8N_VITEST_MAX_WORKERS",
+		"SENTRY_AUTH_TOKEN"
+	],
 	"boundaries": {
 		// `~icons/*` is a vite virtual module injected by unplugin-icons (design-system
 		// icon barrel), not a real package — declare it so boundaries doesn't flag it.


### PR DESCRIPTION
## Summary

Two test-infrastructure changes, both validated on the full cli unit suite (14,776/14,776 green ×2):

**1. sqlite template fast path** (`@n8n/backend-test-utils/src/test-db.ts`) — every test file that calls `testDb.init()` under sqlite replays the entire ~224-migration chain in its forked process. Now the first init on a machine snapshots its fully-migrated DB into a tmpdir template and later inits copy the file instead. Mirrors the existing Postgres `N8N_TEST_TEMPLATE_DB` idea, but automatic:

- Snapshot via `VACUUM INTO` on the live connection — the pooled sqlite driver keeps the `-wal` file across `close()`, so copying the DB file directly would silently miss whatever sits in the WAL.
- Template keyed by table prefix + each migration's name **and compiled source**, so adding/editing a migration invalidates it naturally; concurrent cold forks race safely via stage-and-atomic-rename; any fs error falls back to a full migrate. `N8N_TEST_SQLITE_TEMPLATE=false` bypasses for debugging.
- The copied migrations table makes the subsequent `migrate()` + `AuthRolesService.init()` fast no-ops that self-heal role/scope drift.

Warm before/after on the same machine (11-core M-series, two runs each): tests-phase CPU 92.9–99.8s → **84.2s**; per-file: `insights.controller` 2580→194ms, `insights.module` 1924→338ms, `workflow-runner` 2614→615ms, oauth-server/mcp api tests −0.5 to −1.4s each. The first-ever run pays a one-time snapshot (~+15s tests-phase CPU, once per machine/schema). The integration suite uses the same `testDb.init()` path, so its hundreds of DB-backed files should benefit more.

**2. `N8N_VITEST_MAX_WORKERS` override** (`@n8n/vitest-config`, `turbo.json`, `test-unit-reusable.yml`) — the shared vitest config caps fork workers at 50% when `CI=true`, sized for runners where turbo executes several suites concurrently. The nodes-base job and the scoped cli step run exactly one suite on a dedicated runner, wasting half of it. Those two steps now set `N8N_VITEST_MAX_WORKERS: '100%'` (n8n-prefixed on purpose: vitest natively `parseInt`s a `VITEST_MAX_WORKERS` env, which would turn `"100%"` into 100 forks). Requires the turbo `globalPassThroughEnv` entry so strict env mode doesn't strip it. Local simulation (`CI=true`, 11 cores): 189.8s → 174.7s; the real effect on 4-vCPU runners is best read off the two steps' durations after merge. Steps where the cap is load-bearing (concurrent turbo suites, integration jobs) are untouched.

## How to test

```
cd packages/cli
# cold (builds the template), then warm (copies it) — watch the tests-phase drop
pnpm test src/modules/insights/__tests__/insights.module.test.ts
pnpm test src/modules/insights/__tests__/insights.module.test.ts
ls "$(node -e 'console.log(require("os").tmpdir())')/n8n-test-db-templates"

# worker override simulation
CI=true pnpm test                              # capped at 50%
CI=true N8N_VITEST_MAX_WORKERS=100% pnpm test  # full workers
```

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket — follow-up from the test-performance investigation behind #35058.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. <!-- test-infrastructure change, exercised by every DB-backed test -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35065">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

