### PR TITLE
feat(core): Periodically tear down ghost triggers on non-leader instances

### DIFF
--- a/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
+++ b/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
@@ -57,4 +57,10 @@ export type WorkflowPublicationMetricsEventMap = {
 		versionSkewCount: number;
 		durationMs: number;
 	};
+
+	/** Emitted only when a sweep found something, so idle follower passes stay off the bus. */
+	'workflow-publication-ghost-trigger-sweep': {
+		/** Workflows whose ghost triggers were torn down on a non-leader instance. */
+		removedCount: number;
+	};
 };

--- a/packages/cli/src/metrics/prometheus/__tests__/workflow-publication-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/workflow-publication-metrics.service.test.ts
@@ -189,6 +189,12 @@ describe('PrometheusWorkflowPublicationMetricsService', () => {
 			expect(mockCounterInc).toHaveBeenCalledWith(2);
 			expect(mockHistogramObserve).toHaveBeenCalledWith({ result: 'success' }, 0.5);
 		});
+
+		it('records ghost-trigger sweep removals', () => {
+			eventHandler('workflow-publication-ghost-trigger-sweep')!({ removedCount: 3 } as never);
+
+			expect(mockCounterInc).toHaveBeenCalledWith(3);
+		});
 	});
 
 	describe('gauge collection', () => {

--- a/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
@@ -57,6 +57,7 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 		this.initTriggerMetrics();
 		this.initCleanupMetrics();
 		this.initReconciliationMetrics();
+		this.initGhostSweepMetrics();
 	}
 
 	private initOutboxGauges() {
@@ -225,5 +226,18 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 				duration.observe({ result }, durationMs * Time.milliseconds.toSeconds);
 			},
 		);
+	}
+
+	private initGhostSweepMetrics() {
+		const prefix = this.config.prefix;
+
+		const removed = new promClient.Counter({
+			name: `${prefix}workflow_publication_reconciliation_ghost_trigger_workflows_total`,
+			help: 'Total number of workflows whose ghost triggers were torn down because they were registered on a non-leader instance.',
+		});
+
+		this.eventService.on('workflow-publication-ghost-trigger-sweep', ({ removedCount }) => {
+			removed.inc(removedCount);
+		});
 	}
 }

--- a/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
@@ -1,11 +1,13 @@
 import type { Logger } from '@n8n/backend-common';
 import type { WorkflowsConfig } from '@n8n/config';
 import { mock } from 'vitest-mock-extended';
-import type { ActiveWorkflowTriggers, ErrorReporter } from 'n8n-core';
+import type { ActiveWorkflowTriggers, ErrorReporter, InstanceSettings } from 'n8n-core';
 
 import { PublishedWorkflowTriggerDeactivator } from '@/workflows/publication/published-workflow-trigger-deactivator';
 import type { WorkflowPublicationLifecycleLock } from '@/workflows/publication/workflow-publication-lifecycle-lock';
 import type { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workflow-publication-outbox-consumer';
+
+const RECONCILE_INTERVAL_SECONDS = 10;
 
 describe('PublishedWorkflowTriggerDeactivator', () => {
 	const logger = mock<Logger>();
@@ -16,8 +18,14 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 	const activeWorkflowTriggers = mock<ActiveWorkflowTriggers>();
 	const outboxConsumer = mock<WorkflowPublicationOutboxConsumer>();
 
+	// A follower by default; tests flip `isLeader` to simulate (mid-sweep) promotion.
+	let instanceSettings: InstanceSettings;
+
 	function createDeactivator(useWorkflowPublicationService = true) {
-		const workflowsConfig = mock<WorkflowsConfig>({ useWorkflowPublicationService });
+		const workflowsConfig = mock<WorkflowsConfig>({
+			useWorkflowPublicationService,
+			publicationReconcileIntervalSeconds: RECONCILE_INTERVAL_SECONDS,
+		});
 		return new PublishedWorkflowTriggerDeactivator(
 			logger,
 			workflowsConfig,
@@ -25,11 +33,13 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 			lifecycleLock,
 			activeWorkflowTriggers,
 			outboxConsumer,
+			instanceSettings,
 		);
 	}
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		instanceSettings = { isLeader: false } as InstanceSettings;
 		lifecycleLock.isLocked.mockReturnValue(false);
 		lifecycleLock.getLockedWorkflowIds.mockReturnValue([]);
 		// By default the lock runs the teardown immediately without timing out.
@@ -37,6 +47,11 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 			await fn();
 			return { timedOut: false };
 		});
+		lifecycleLock.runExclusive.mockImplementation(
+			async (_workflowId, fn) => await (fn as () => Promise<unknown>)(),
+		);
+		activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([]);
+		activeWorkflowTriggers.remove.mockResolvedValue(true);
 	});
 
 	test('does nothing when the publication service is disabled', async () => {
@@ -116,5 +131,161 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 
 		expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-stuck');
 		expect(errorReporter.error).toHaveBeenCalledWith(expect.any(Error), { shouldBeLogged: true });
+	});
+
+	describe('ghost-trigger janitor (follower)', () => {
+		describe('sweepGhostTriggers', () => {
+			test('removes registered workflows under their lock and returns the count', async () => {
+				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue(['wf-1', 'wf-2']);
+
+				const removed = await createDeactivator().sweepGhostTriggers();
+
+				expect(removed).toBe(2);
+				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-1', expect.any(Function));
+				expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-2', expect.any(Function));
+				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-1');
+				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-2');
+				// A ghost on a follower is evidence of a zombie writer — loud, not debug.
+				expect(logger.warn).toHaveBeenCalled();
+			});
+
+			test('does nothing on the leader', async () => {
+				instanceSettings = { isLeader: true } as InstanceSettings;
+				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue(['wf-1']);
+
+				const removed = await createDeactivator().sweepGhostTriggers();
+
+				expect(removed).toBe(0);
+				expect(activeWorkflowTriggers.remove).not.toHaveBeenCalled();
+			});
+
+			test('skips a workflow whose lifecycle lock is held and sweeps the rest', async () => {
+				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([
+					'wf-busy',
+					'wf-free',
+				]);
+				lifecycleLock.isLocked.mockImplementation((workflowId) => workflowId === 'wf-busy');
+
+				const removed = await createDeactivator().sweepGhostTriggers();
+
+				expect(removed).toBe(1);
+				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-free');
+				expect(activeWorkflowTriggers.remove).not.toHaveBeenCalledWith('wf-busy');
+				expect(lifecycleLock.runExclusive).not.toHaveBeenCalledWith(
+					'wf-busy',
+					expect.any(Function),
+				);
+			});
+
+			test('aborts inside the lock when promoted to leader mid-sweep', async () => {
+				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue(['wf-1']);
+				lifecycleLock.runExclusive.mockImplementation(async (_workflowId, fn) => {
+					// Promotion lands while this sweep is waiting on the lock.
+					instanceSettings = Object.assign(instanceSettings, { isLeader: true });
+					return await (fn as () => Promise<unknown>)();
+				});
+
+				const removed = await createDeactivator().sweepGhostTriggers();
+
+				expect(removed).toBe(0);
+				expect(activeWorkflowTriggers.remove).not.toHaveBeenCalled();
+			});
+
+			test('reports a failing teardown and keeps sweeping the remaining workflows', async () => {
+				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([
+					'wf-stuck',
+					'wf-fine',
+				]);
+				activeWorkflowTriggers.remove.mockImplementation(async (workflowId) => {
+					if (workflowId === 'wf-stuck') throw new Error('closeFunction failed');
+					return true;
+				});
+
+				// Must resolve, not reject: the interval callback has nobody awaiting it,
+				// so a rejection here would crash the process.
+				const removed = await createDeactivator().sweepGhostTriggers();
+
+				expect(removed).toBe(1);
+				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-fine');
+				expect(errorReporter.error).toHaveBeenCalledWith(expect.any(Error), {
+					shouldBeLogged: true,
+				});
+			});
+
+			test('does not count workflows that were no longer active and stays quiet when nothing was removed', async () => {
+				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue(['wf-gone']);
+				activeWorkflowTriggers.remove.mockResolvedValue(false);
+
+				const removed = await createDeactivator().sweepGhostTriggers();
+
+				expect(removed).toBe(0);
+				expect(logger.warn).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('interval lifecycle', () => {
+			beforeEach(() => {
+				vi.useFakeTimers();
+			});
+
+			afterEach(() => {
+				vi.useRealTimers();
+			});
+
+			const advanceOneInterval = async () =>
+				await vi.advanceTimersByTimeAsync(RECONCILE_INTERVAL_SECONDS * 1000);
+
+			test('sweeps every reconcile interval once started', async () => {
+				const deactivator = createDeactivator();
+				deactivator.startGhostTriggerJanitor();
+
+				await advanceOneInterval();
+				await advanceOneInterval();
+
+				expect(activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds).toHaveBeenCalledTimes(2);
+
+				deactivator.stopGhostTriggerJanitor();
+			});
+
+			test('does not start when the publication service is disabled', async () => {
+				createDeactivator(false).startGhostTriggerJanitor();
+
+				await advanceOneInterval();
+
+				expect(activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds).not.toHaveBeenCalled();
+			});
+
+			test('starting twice schedules only one interval', async () => {
+				const deactivator = createDeactivator();
+				deactivator.startGhostTriggerJanitor();
+				deactivator.startGhostTriggerJanitor();
+
+				await advanceOneInterval();
+
+				expect(activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds).toHaveBeenCalledTimes(1);
+
+				deactivator.stopGhostTriggerJanitor();
+			});
+
+			test('stops sweeping once stopped', async () => {
+				const deactivator = createDeactivator();
+				deactivator.startGhostTriggerJanitor();
+				deactivator.stopGhostTriggerJanitor();
+
+				await advanceOneInterval();
+
+				expect(activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds).not.toHaveBeenCalled();
+			});
+
+			test('does not restart after shutdown', async () => {
+				const deactivator = createDeactivator();
+				deactivator.shutdown();
+				deactivator.startGhostTriggerJanitor();
+
+				await advanceOneInterval();
+
+				expect(activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds).not.toHaveBeenCalled();
+			});
+		});
 	});
 });

--- a/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
@@ -3,6 +3,7 @@ import type { WorkflowsConfig } from '@n8n/config';
 import { mock } from 'vitest-mock-extended';
 import type { ActiveWorkflowTriggers, ErrorReporter, InstanceSettings } from 'n8n-core';
 
+import type { EventService } from '@/events/event.service';
 import { PublishedWorkflowTriggerDeactivator } from '@/workflows/publication/published-workflow-trigger-deactivator';
 import type { WorkflowPublicationLifecycleLock } from '@/workflows/publication/workflow-publication-lifecycle-lock';
 import type { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workflow-publication-outbox-consumer';
@@ -17,6 +18,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 	const lifecycleLock = mock<WorkflowPublicationLifecycleLock>();
 	const activeWorkflowTriggers = mock<ActiveWorkflowTriggers>();
 	const outboxConsumer = mock<WorkflowPublicationOutboxConsumer>();
+	const eventService = mock<EventService>();
 
 	// A follower by default; tests flip `isLeader` to simulate (mid-sweep) promotion.
 	let instanceSettings: InstanceSettings;
@@ -34,6 +36,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 			activeWorkflowTriggers,
 			outboxConsumer,
 			instanceSettings,
+			eventService,
 		);
 	}
 
@@ -147,6 +150,9 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 				expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-2');
 				// A ghost on a follower is evidence of a zombie writer — loud, not debug.
 				expect(logger.warn).toHaveBeenCalled();
+				expect(eventService.emit).toHaveBeenCalledWith('workflow-publication-ghost-trigger-sweep', {
+					removedCount: 2,
+				});
 			});
 
 			test('does nothing on the leader', async () => {
@@ -220,6 +226,7 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 
 				expect(removed).toBe(0);
 				expect(logger.warn).not.toHaveBeenCalled();
+				expect(eventService.emit).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/published-workflow-trigger-deactivator.test.ts
@@ -197,6 +197,21 @@ describe('PublishedWorkflowTriggerDeactivator', () => {
 				expect(activeWorkflowTriggers.remove).not.toHaveBeenCalled();
 			});
 
+			test('resolves and reports when a sweep listener throws', async () => {
+				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue(['wf-1', 'wf-2']);
+				eventService.emit.mockImplementation(() => {
+					throw new Error('listener blew up');
+				});
+
+				// Must resolve, not reject: the interval callback has nobody awaiting it.
+				const removed = await createDeactivator().sweepGhostTriggers();
+
+				expect(removed).toBe(2);
+				expect(errorReporter.error).toHaveBeenCalledWith(expect.any(Error), {
+					shouldBeLogged: true,
+				});
+			});
+
 			test('reports a failing teardown and keeps sweeping the remaining workflows', async () => {
 				activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([
 					'wf-stuck',

--- a/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
+++ b/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
@@ -1,9 +1,9 @@
 import { Logger } from '@n8n/backend-common';
 import { WorkflowsConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
-import { OnLeaderStepdown, OnShutdown } from '@n8n/decorators';
+import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { ActiveWorkflowTriggers, ErrorReporter } from 'n8n-core';
+import { ActiveWorkflowTriggers, ErrorReporter, InstanceSettings } from 'n8n-core';
 import { UnexpectedError } from 'n8n-workflow';
 
 import { WorkflowPublicationLifecycleLock } from '@/workflows/publication/workflow-publication-lifecycle-lock';
@@ -22,6 +22,9 @@ const STEPDOWN_TEARDOWN_TIMEOUT_MS = 30 * Time.seconds.toMilliseconds;
  */
 @Service()
 export class PublishedWorkflowTriggerDeactivator {
+	private ghostTriggerJanitorInterval: NodeJS.Timeout | undefined;
+	private isShuttingDown = false;
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly workflowsConfig: WorkflowsConfig,
@@ -29,6 +32,7 @@ export class PublishedWorkflowTriggerDeactivator {
 		private readonly lifecycleLock: WorkflowPublicationLifecycleLock,
 		private readonly activeWorkflowTriggers: ActiveWorkflowTriggers,
 		private readonly outboxConsumer: WorkflowPublicationOutboxConsumer,
+		private readonly instanceSettings: InstanceSettings,
 	) {
 		this.logger = this.logger.scoped('workflow-publication');
 	}
@@ -62,6 +66,63 @@ export class PublishedWorkflowTriggerDeactivator {
 		for (const workflowId of lockedWorkflowIds) {
 			await this.deactivateWorkflow(workflowId);
 		}
+	}
+
+	async sweepGhostTriggers(): Promise<number> {
+		if (this.instanceSettings.isLeader) return 0;
+
+		const candidates = this.activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds();
+		const ghosts: string[] = [];
+
+		for (const candidate of candidates) {
+			if (this.lifecycleLock.isLocked(candidate)) continue;
+
+			await this.lifecycleLock.runExclusive(candidate, async () => {
+				if (this.instanceSettings.isLeader) return;
+
+				const result = await this.activeWorkflowTriggers
+					.remove(candidate)
+					.catch((error) => this.errorReporter.error(error, { shouldBeLogged: true }));
+
+				if (result) {
+					ghosts.push(candidate);
+				}
+			});
+		}
+
+		if (ghosts.length > 0) {
+			this.logger.warn(`Found ${ghosts.length} ghost workflows. Removed them.`, {
+				workflowIds: ghosts,
+			});
+		}
+
+		return ghosts.length;
+	}
+
+	@OnLeaderStepdown()
+	startGhostTriggerJanitor(): void {
+		if (!this.workflowsConfig.useWorkflowPublicationService) return;
+		if (this.isShuttingDown) return;
+		if (this.ghostTriggerJanitorInterval) return;
+
+		this.ghostTriggerJanitorInterval = setInterval(
+			async () => await this.sweepGhostTriggers(),
+			this.workflowsConfig.publicationReconcileIntervalSeconds * Time.seconds.toMilliseconds,
+		);
+	}
+
+	@OnLeaderTakeover()
+	stopGhostTriggerJanitor(): void {
+		if (this.ghostTriggerJanitorInterval) {
+			clearInterval(this.ghostTriggerJanitorInterval);
+			this.ghostTriggerJanitorInterval = undefined;
+		}
+	}
+
+	@OnShutdown()
+	shutdown(): void {
+		this.isShuttingDown = true;
+		this.stopGhostTriggerJanitor();
 	}
 
 	/**

--- a/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
+++ b/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
@@ -6,6 +6,7 @@ import { Service } from '@n8n/di';
 import { ActiveWorkflowTriggers, ErrorReporter, InstanceSettings } from 'n8n-core';
 import { UnexpectedError } from 'n8n-workflow';
 
+import { EventService } from '@/events/event.service';
 import { WorkflowPublicationLifecycleLock } from '@/workflows/publication/workflow-publication-lifecycle-lock';
 import { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workflow-publication-outbox-consumer';
 
@@ -33,6 +34,7 @@ export class PublishedWorkflowTriggerDeactivator {
 		private readonly activeWorkflowTriggers: ActiveWorkflowTriggers,
 		private readonly outboxConsumer: WorkflowPublicationOutboxConsumer,
 		private readonly instanceSettings: InstanceSettings,
+		private readonly eventService: EventService,
 	) {
 		this.logger = this.logger.scoped('workflow-publication');
 	}
@@ -93,6 +95,9 @@ export class PublishedWorkflowTriggerDeactivator {
 		if (ghosts.length > 0) {
 			this.logger.warn(`Found ${ghosts.length} ghost workflows. Removed them.`, {
 				workflowIds: ghosts,
+			});
+			this.eventService.emit('workflow-publication-ghost-trigger-sweep', {
+				removedCount: ghosts.length,
 			});
 		}
 

--- a/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
+++ b/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
@@ -73,32 +73,39 @@ export class PublishedWorkflowTriggerDeactivator {
 	async sweepGhostTriggers(): Promise<number> {
 		if (this.instanceSettings.isLeader) return 0;
 
-		const candidates = this.activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds();
 		const ghosts: string[] = [];
 
-		for (const candidate of candidates) {
-			if (this.lifecycleLock.isLocked(candidate)) continue;
+		// Nothing may escape this method: the interval callback driving it has
+		// nobody awaiting it, so an escaped rejection would crash the process.
+		try {
+			const candidates = this.activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds();
 
-			await this.lifecycleLock.runExclusive(candidate, async () => {
-				if (this.instanceSettings.isLeader) return;
+			for (const candidate of candidates) {
+				if (this.lifecycleLock.isLocked(candidate)) continue;
 
-				const result = await this.activeWorkflowTriggers
-					.remove(candidate)
-					.catch((error) => this.errorReporter.error(error, { shouldBeLogged: true }));
+				await this.lifecycleLock.runExclusive(candidate, async () => {
+					if (this.instanceSettings.isLeader) return;
 
-				if (result) {
-					ghosts.push(candidate);
-				}
-			});
-		}
+					const result = await this.activeWorkflowTriggers
+						.remove(candidate)
+						.catch((error) => this.errorReporter.error(error, { shouldBeLogged: true }));
 
-		if (ghosts.length > 0) {
-			this.logger.warn(`Found ${ghosts.length} ghost workflows. Removed them.`, {
-				workflowIds: ghosts,
-			});
-			this.eventService.emit('workflow-publication-ghost-trigger-sweep', {
-				removedCount: ghosts.length,
-			});
+					if (result) {
+						ghosts.push(candidate);
+					}
+				});
+			}
+
+			if (ghosts.length > 0) {
+				this.logger.warn(`Found ${ghosts.length} ghost workflows. Removed them.`, {
+					workflowIds: ghosts,
+				});
+				this.eventService.emit('workflow-publication-ghost-trigger-sweep', {
+					removedCount: ghosts.length,
+				});
+			}
+		} catch (error) {
+			this.errorReporter.error(error, { shouldBeLogged: true });
 		}
 
 		return ghosts.length;

--- a/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
+++ b/packages/cli/src/workflows/publication/published-workflow-trigger-deactivator.ts
@@ -18,8 +18,11 @@ import { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workf
 const STEPDOWN_TEARDOWN_TIMEOUT_MS = 30 * Time.seconds.toMilliseconds;
 
 /**
- * Tears down in-memory triggers on leader stepdown and shutdown. Teardown is
- * coordinated with in-flight outbox records via {@link WorkflowPublicationLifecycleLock}.
+ * Tears down in-memory triggers on leader stepdown and shutdown, and — as a
+ * safeguard — periodically sweeps the registry while not leader: a trigger
+ * registration on a non-leader should never exist, so anything found is torn
+ * down and reported. Teardown is coordinated with in-flight outbox records
+ * via {@link WorkflowPublicationLifecycleLock}.
  */
 @Service()
 export class PublishedWorkflowTriggerDeactivator {

--- a/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
@@ -783,6 +783,8 @@ describe('ActiveWorkflowTriggers', () => {
 		});
 
 		it('should return false when removing non-existent workflow', async () => {
+			scheduledTaskManager.deregisterGroup.mockReturnValue(false);
+
 			const result = await activeWorkflowTriggers.remove('non-existent');
 
 			expect(result).toBe(false);
@@ -1211,16 +1213,17 @@ describe('ActiveWorkflowTriggers', () => {
 			vi.useRealTimers();
 		});
 
-		it('should stop a stranded cron on remove even when the workflow is not active in memory', async () => {
+		it('should stop a stranded cron on remove and report it as removed even when the workflow is not active in memory', async () => {
 			// A cron registered in the ScheduledTaskManager while the workflow is not
-			// tracked as active in memory must still be stoppable via remove().
+			// tracked as active in memory must still be stoppable via remove(), and
+			// counts as a removal so callers (e.g. the follower ghost sweep) see it.
 			registerStrandedCron(workflowId);
 			expect(realScheduledTaskManager.hasGroup(workflowGroup())).toBe(true);
 			expect(activeWorkflowTriggersReal.isActive(workflowId)).toBe(false);
 
 			const result = await activeWorkflowTriggersReal.remove(workflowId);
 
-			expect(result).toBe(false);
+			expect(result).toBe(true);
 			expect(realScheduledTaskManager.hasGroup(workflowGroup())).toBe(false);
 		});
 

--- a/packages/core/src/execution-engine/active-workflow-triggers.ts
+++ b/packages/core/src/execution-engine/active-workflow-triggers.ts
@@ -446,7 +446,9 @@ export class ActiveWorkflowTriggers {
 	}
 
 	/**
-	 * Makes a workflow inactive in memory.
+	 * Makes a workflow inactive in memory. Returns whether anything was
+	 * removed — tracked trigger registrations or stranded orphan crons alike —
+	 * so callers can tell "found and removed something" from "nothing was there".
 	 */
 	async remove(workflowId: string) {
 		// Ensure crons are deregistered to prevent executions on inactive workflows
@@ -463,7 +465,7 @@ export class ActiveWorkflowTriggers {
 				);
 			}
 
-			return false;
+			return hadRegisteredCrons;
 		}
 
 		const triggers = this.activeTriggersByWorkflowId.get(workflowId);


### PR DESCRIPTION
## Summary

In-memory (poll/schedule) trigger registrations must only exist on the leader — it is the only instance that activates and executes them. A registration on a non-leader should never happen. If it ever does, the consequences are bad: the triggers keep firing duplicate executions until the process restarts, and no DB-side reconciliation can reach another instance's memory.

This PR adds a safeguard for that case: while not leader, periodically sweep the in-memory trigger registry and tear down whatever is found — and report it, loudly, because a hit means there is a bug to root-cause and fix at the source. The sweep corrects the state automatically; the warn log and metric are there so we find out it happened.

- **Detection is the registry itself.** No DB reads — any registration on a non-leader is illegitimate by definition.
- **Never fights an in-flight apply.** Workflows whose lifecycle lock is held are skipped and retried next pass; removal runs under the lock and re-checks leadership, so a promotion mid-sweep aborts instead of tearing down what the takeover enqueuer is building.
- **Never crashes the interval.** A failing trigger `closeFunction` is reported per workflow and the sweep continues. For a trigger that can never be torn down this means retrying and re-reporting every pass — deliberately so: a ghost that is still firing is an ongoing incident, not a one-time event.
- Runs on the reconcile interval (default 10s), starts on stepdown, stops on takeover/shutdown. A hit logs at `warn` with the workflow ids and increments a new `workflow_publication_reconciliation_ghost_trigger_workflows_total` Prometheus counter (second commit; the event is emitted only on non-empty sweeps, so idle follower passes stay off the event bus).

## How to test

Unit tests cover the sweep (removal under lock, leader no-op, skip-if-locked, mid-sweep promotion abort, teardown failure isolation) and the interval lifecycle (start/stop/idempotence/shutdown), plus the metrics wiring.

Manual (multi-main): arrange for a trigger registration to linger on a demoted instance (any interruption of the stepdown teardown will do) — it is removed within one reconcile interval, with a warn log naming the workflow and the counter incremented.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3795
- Related: #34877

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
