### PR TITLE
fix(Kafka Trigger Node): Stop consumers reliably when a workflow is deactivated or updated

### DIFF
--- a/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
@@ -822,6 +822,31 @@ describe('ActiveWorkflowTriggers', () => {
 			});
 		});
 
+		it('should report success and permanently drop the trigger reference when closeFunction fails with TriggerCloseError', async () => {
+			// Characterizes the current leak (ENT-104): a trigger whose connection
+			// outlives a failed close (e.g. a Kafka consumer) is reported as
+			// deactivated while the connection keeps running, and the dropped
+			// reference makes any later stop attempt a no-op.
+			let connectionRunning = true;
+			(triggerResponse.closeFunction as Mock).mockImplementationOnce(async () => {
+				// a successful close would set connectionRunning = false before this
+				throw new TriggerCloseError(triggerNode, { level: 'warning' });
+			});
+			await addWorkflow({ triggerNodes: [triggerNode] });
+
+			const result = await activeWorkflowTriggers.remove(workflowId);
+
+			expect(result).toBe(true);
+			expect(activeWorkflowTriggers.isActive(workflowId)).toBe(false);
+			expect(activeWorkflowTriggers.get(workflowId)).toBeUndefined();
+			expect(connectionRunning).toBe(true);
+
+			const secondAttempt = await activeWorkflowTriggers.remove(workflowId);
+
+			expect(secondAttempt).toBe(false);
+			expect(triggerResponse.closeFunction).toHaveBeenCalledTimes(1);
+		});
+
 		it('should throw WorkflowDeactivationError when closeFunction throws regular error', async () => {
 			const error = new Error('Close function failed');
 			(triggerResponse.closeFunction as Mock).mockRejectedValueOnce(error);

--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -6,7 +6,6 @@ import type {
 	INodeTypeDescription,
 	ITriggerResponse,
 } from 'n8n-workflow';
-import { ensureError } from '@n8n/utils/errors/ensure-error';
 import {
 	NodeConnectionTypes,
 	NodeOperationError,
@@ -25,13 +24,12 @@ import {
 	configureDataEmitter,
 	getAutoCommitSettings,
 	runWithHeartbeat,
+	stopAndDisconnectConsumer,
 	toUserFacingConsumerError,
-	withTimeout,
 	type ConsumerErrorHandler,
 } from './utils';
 
-// Upper bound for each teardown call so a hung broker request cannot block
-// workflow deactivation indefinitely.
+// Bounds each teardown call so a hung broker request cannot block deactivation.
 const CLOSE_TIMEOUT_MS = 30_000;
 
 export class KafkaTrigger implements INodeType {
@@ -410,19 +408,14 @@ export class KafkaTrigger implements INodeType {
 
 		const consumerConfig = createConsumerConfig(this, options, nodeVersion);
 
-		let closeGotCalled = false;
 		const closeController = new AbortController();
+		const closeSignal = closeController.signal;
 
-		// On retriable crashes kafkajs schedules an unconditional consumer restart,
-		// which can outlive (and even race) closeFunction, leaving an untracked
-		// consumer running with a stale workflow snapshot. restartOnFailure is
-		// consulted on every crash and vetoes the restart once close was requested.
-		// The callback must never throw: kafkajs treats a throwing callback as
-		// consent to restart. Consumer-level retry is merged over the kafkajs
-		// defaults, so pre-close retry behavior is unchanged.
+		// Vetoes kafkajs's automatic crash-restart once close was requested; the
+		// callback must never throw (kafkajs treats a throw as consent to restart).
 		const consumer = kafka.consumer({
 			...consumerConfig,
-			retry: { restartOnFailure: async () => !closeGotCalled },
+			retry: { restartOnFailure: async () => !closeSignal.aborted },
 		});
 
 		const processMessage = configureMessageParser(
@@ -436,7 +429,7 @@ export class KafkaTrigger implements INodeType {
 		const batchSize = options.batchSize ?? 1;
 		const partitionsConsumedConcurrently = options.partitionsConsumedConcurrently || undefined;
 
-		const dataEmitter = configureDataEmitter(this, options, nodeVersion, closeController.signal);
+		const dataEmitter = configureDataEmitter(this, options, nodeVersion, closeSignal);
 
 		const startConsumer = async () => {
 			try {
@@ -455,12 +448,9 @@ export class KafkaTrigger implements INodeType {
 						isRunning,
 						commitOffsetsIfNecessary,
 					}: EachBatchPayload) => {
-						// A batch after close means a consumer survived teardown (a kafkajs
-						// crash-restart raced closeFunction): crash it non-retriably so it can
-						// never execute the workflow with a stale snapshot. Below this guard,
-						// avoid throwing in the callback, as it leads to consumer stop,
-						// disconnect and crash.
-						if (closeGotCalled) {
+						// A batch after close means a consumer survived teardown: crash it
+						// non-retriably. Below this guard, never throw in the callback.
+						if (closeSignal.aborted) {
 							throw Object.assign(
 								new UnexpectedError('Kafka trigger consumer received messages after close'),
 								{ retriable: false },
@@ -472,7 +462,7 @@ export class KafkaTrigger implements INodeType {
 
 						for (let i = 0; i < messages.length; i += batchSize) {
 							// stop if consumer stopped, close requested, or partition revoked
-							if (closeGotCalled || !isRunning() || isStale()) {
+							if (closeSignal.aborted || !isRunning() || isStale()) {
 								this.logger.debug('Batch processing interrupted due to rebalance or consumer stop');
 								break;
 							}
@@ -520,59 +510,22 @@ export class KafkaTrigger implements INodeType {
 
 		const handleConsumerError: ConsumerErrorHandler = (error) => {
 			// Don't surface errors that are a side effect of our own teardown.
-			if (!closeGotCalled) {
+			if (!closeSignal.aborted) {
 				this.emitError(toUserFacingConsumerError(this.getNode(), error));
 			}
 		};
 		const listeners = connectEventListeners(consumer, this.logger, handleConsumerError);
 
 		const closeFunction = async () => {
-			closeGotCalled = true;
-			// Unblock any eachBatch waiting on an in-flight execution, so stop() does
-			// not block deactivation for up to the workflow execution timeout.
+			// Unblock any eachBatch waiting on an in-flight execution.
 			closeController.abort();
 			disconnectEventListeners(listeners);
 
-			let teardownError: Error | undefined;
-			let stopSettled = false;
-			// Promise.resolve keeps the kafkajs promise unchanged while tolerating
-			// non-promise mocks. The settle tracker is subscribed before the race
-			// below, so the flag is set by the time the race outcome is observed.
-			const stopPromise = Promise.resolve(consumer.stop());
-			void stopPromise.then(
-				() => (stopSettled = true),
-				() => (stopSettled = true),
+			const teardownError = await stopAndDisconnectConsumer(
+				consumer,
+				this.logger,
+				CLOSE_TIMEOUT_MS,
 			);
-			try {
-				await withTimeout(stopPromise, CLOSE_TIMEOUT_MS, 'Kafka consumer did not stop in time');
-			} catch (error) {
-				teardownError = ensureError(error);
-			}
-
-			if (stopSettled) {
-				// Always attempt to disconnect: a failed stop() must not leave the
-				// broker connection open.
-				try {
-					await withTimeout(
-						consumer.disconnect(),
-						CLOSE_TIMEOUT_MS,
-						'Kafka consumer did not disconnect in time',
-					);
-				} catch (error) {
-					teardownError ??= ensureError(error);
-				}
-			} else {
-				// stop() timed out and is still pending. kafkajs disconnect() awaits
-				// the same shared stop promise, so a serial attempt here could never
-				// reach the broker; disconnect in the background once stop settles.
-				void stopPromise
-					.catch(() => undefined)
-					.then(async () => await consumer.disconnect())
-					.catch((error: unknown) => {
-						this.logger.warn('Kafka consumer disconnect after delayed stop failed', { error });
-					});
-			}
-
 			if (teardownError) {
 				throw new TriggerCloseError(this.getNode(), {
 					cause: teardownError,

--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -7,7 +7,12 @@ import type {
 	ITriggerResponse,
 } from 'n8n-workflow';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
-import { NodeConnectionTypes, NodeOperationError, TriggerCloseError } from 'n8n-workflow';
+import {
+	NodeConnectionTypes,
+	NodeOperationError,
+	TriggerCloseError,
+	UnexpectedError,
+} from 'n8n-workflow';
 
 import {
 	type KafkaTriggerOptions,
@@ -21,8 +26,13 @@ import {
 	getAutoCommitSettings,
 	runWithHeartbeat,
 	toUserFacingConsumerError,
+	withTimeout,
 	type ConsumerErrorHandler,
 } from './utils';
+
+// Upper bound for each teardown call so a hung broker request cannot block
+// workflow deactivation indefinitely.
+const CLOSE_TIMEOUT_MS = 30_000;
 
 export class KafkaTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -399,7 +409,21 @@ export class KafkaTrigger implements INodeType {
 		}
 
 		const consumerConfig = createConsumerConfig(this, options, nodeVersion);
-		const consumer = kafka.consumer(consumerConfig);
+
+		let closeGotCalled = false;
+		const closeController = new AbortController();
+
+		// On retriable crashes kafkajs schedules an unconditional consumer restart,
+		// which can outlive (and even race) closeFunction, leaving an untracked
+		// consumer running with a stale workflow snapshot. restartOnFailure is
+		// consulted on every crash and vetoes the restart once close was requested.
+		// The callback must never throw: kafkajs treats a throwing callback as
+		// consent to restart. Consumer-level retry is merged over the kafkajs
+		// defaults, so pre-close retry behavior is unchanged.
+		const consumer = kafka.consumer({
+			...consumerConfig,
+			retry: { restartOnFailure: async () => !closeGotCalled },
+		});
 
 		const processMessage = configureMessageParser(
 			options,
@@ -412,7 +436,7 @@ export class KafkaTrigger implements INodeType {
 		const batchSize = options.batchSize ?? 1;
 		const partitionsConsumedConcurrently = options.partitionsConsumedConcurrently || undefined;
 
-		const dataEmitter = configureDataEmitter(this, options, nodeVersion);
+		const dataEmitter = configureDataEmitter(this, options, nodeVersion, closeController.signal);
 
 		const startConsumer = async () => {
 			try {
@@ -431,13 +455,24 @@ export class KafkaTrigger implements INodeType {
 						isRunning,
 						commitOffsetsIfNecessary,
 					}: EachBatchPayload) => {
-						// avoid throwing error in the callback, as it leads to consumer stop, disconnect and crash
+						// A batch after close means a consumer survived teardown (a kafkajs
+						// crash-restart raced closeFunction): crash it non-retriably so it can
+						// never execute the workflow with a stale snapshot. Below this guard,
+						// avoid throwing in the callback, as it leads to consumer stop,
+						// disconnect and crash.
+						if (closeGotCalled) {
+							throw Object.assign(
+								new UnexpectedError('Kafka trigger consumer received messages after close'),
+								{ retriable: false },
+							);
+						}
+
 						const messages = batch.messages;
 						const messageTopic = batch.topic;
 
 						for (let i = 0; i < messages.length; i += batchSize) {
-							// stop if consumer stopped or partition revoked
-							if (!isRunning() || isStale()) {
+							// stop if consumer stopped, close requested, or partition revoked
+							if (closeGotCalled || !isRunning() || isStale()) {
 								this.logger.debug('Batch processing interrupted due to rebalance or consumer stop');
 								break;
 							}
@@ -483,7 +518,6 @@ export class KafkaTrigger implements INodeType {
 			}
 		};
 
-		let closeGotCalled = false;
 		const handleConsumerError: ConsumerErrorHandler = (error) => {
 			// Don't surface errors that are a side effect of our own teardown.
 			if (!closeGotCalled) {
@@ -494,13 +528,54 @@ export class KafkaTrigger implements INodeType {
 
 		const closeFunction = async () => {
 			closeGotCalled = true;
+			// Unblock any eachBatch waiting on an in-flight execution, so stop() does
+			// not block deactivation for up to the workflow execution timeout.
+			closeController.abort();
+			disconnectEventListeners(listeners);
+
+			let teardownError: Error | undefined;
+			let stopSettled = false;
+			// Promise.resolve keeps the kafkajs promise unchanged while tolerating
+			// non-promise mocks. The settle tracker is subscribed before the race
+			// below, so the flag is set by the time the race outcome is observed.
+			const stopPromise = Promise.resolve(consumer.stop());
+			void stopPromise.then(
+				() => (stopSettled = true),
+				() => (stopSettled = true),
+			);
 			try {
-				disconnectEventListeners(listeners);
-				await consumer.stop();
-				await consumer.disconnect();
+				await withTimeout(stopPromise, CLOSE_TIMEOUT_MS, 'Kafka consumer did not stop in time');
 			} catch (error) {
+				teardownError = ensureError(error);
+			}
+
+			if (stopSettled) {
+				// Always attempt to disconnect: a failed stop() must not leave the
+				// broker connection open.
+				try {
+					await withTimeout(
+						consumer.disconnect(),
+						CLOSE_TIMEOUT_MS,
+						'Kafka consumer did not disconnect in time',
+					);
+				} catch (error) {
+					teardownError ??= ensureError(error);
+				}
+			} else {
+				// stop() timed out and is still pending. kafkajs disconnect() awaits
+				// the same shared stop promise, so a serial attempt here could never
+				// reach the broker; disconnect in the background once stop settles.
+				void stopPromise
+					.catch(() => undefined)
+					.then(async () => await consumer.disconnect())
+					.catch((error: unknown) => {
+						this.logger.warn('Kafka consumer disconnect after delayed stop failed', { error });
+					});
+			}
+
+			if (teardownError) {
 				throw new TriggerCloseError(this.getNode(), {
-					cause: ensureError(error),
+					cause: teardownError,
 					level: 'warning',
 				});
 			}

--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -450,6 +450,8 @@ export class KafkaTrigger implements INodeType {
 					}: EachBatchPayload) => {
 						// A batch after close means a consumer survived teardown: crash it
 						// non-retriably. Below this guard, never throw in the callback.
+						// UnexpectedError is reported to Sentry, so tripping this backstop
+						// is visible. Use OperationalError instead if that is too noisy.
 						if (closeSignal.aborted) {
 							throw Object.assign(
 								new UnexpectedError('Kafka trigger consumer received messages after close'),

--- a/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
@@ -11,7 +11,7 @@ import {
 	type KafkaMessage,
 	type RecordBatchEntry,
 } from 'kafkajs';
-import { NodeOperationError, TriggerCloseError, type IRun } from 'n8n-workflow';
+import { NodeOperationError, TriggerCloseError, UnexpectedError, type IRun } from 'n8n-workflow';
 
 import { testTriggerNode } from '@test/nodes/TriggerHelpers';
 
@@ -25,6 +25,10 @@ vi.mock('@n8n/utils/sleep', () => ({
 }));
 
 describe('KafkaTrigger Node', () => {
+	// Every consumer config carries the crash-restart kill switch; typed so the
+	// `any` from expect.any does not trip no-unsafe-assignment at each call site.
+	const expectedRetryConfig = { restartOnFailure: expect.any(Function) as unknown };
+
 	let mockKafka: Mocked<Kafka>;
 	let mockRegistry: Mocked<SchemaRegistry>;
 	let mockConsumerConnect: Mock;
@@ -202,6 +206,7 @@ describe('KafkaTrigger Node', () => {
 			sessionTimeout: 30000,
 			heartbeatInterval: 3000,
 			rebalanceTimeout: 600000,
+			retry: expectedRetryConfig,
 		});
 
 		expect(mockConsumerConnect).toHaveBeenCalled();
@@ -1113,6 +1118,7 @@ describe('KafkaTrigger Node', () => {
 			sessionTimeout: 20000,
 			heartbeatInterval: 2000,
 			rebalanceTimeout: 300000,
+			retry: expectedRetryConfig,
 		});
 	});
 
@@ -1254,7 +1260,7 @@ describe('KafkaTrigger Node', () => {
 		expect(mockConsumerDisconnect).toHaveBeenCalled();
 	});
 
-	it('should reject with TriggerCloseError and skip disconnect when consumer.stop() fails on close', async () => {
+	it('should still disconnect and reject with TriggerCloseError when consumer.stop() fails on close', async () => {
 		const teardownError = new Error('The group is rebalancing, so a rejoin is needed');
 		const mockConsumerStop = vi.fn().mockRejectedValue(teardownError);
 
@@ -1294,8 +1300,8 @@ describe('KafkaTrigger Node', () => {
 		expect(error).toBeInstanceOf(TriggerCloseError);
 		expect((error as TriggerCloseError).cause).toBe(teardownError);
 		expect((error as TriggerCloseError).level).toBe('warning');
-		// A failed stop() aborts the teardown before the broker connection is closed
-		expect(mockConsumerDisconnect).not.toHaveBeenCalled();
+		// A failed stop() must not leave the broker connection open
+		expect(mockConsumerDisconnect).toHaveBeenCalled();
 	});
 
 	it('should reject with TriggerCloseError when consumer.disconnect() fails on close', async () => {
@@ -1329,6 +1335,171 @@ describe('KafkaTrigger Node', () => {
 		expect((error as TriggerCloseError).level).toBe('warning');
 	});
 
+	it('should configure a restartOnFailure callback that vetoes consumer restarts only after close', async () => {
+		const { close } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		// The consumer config keeps its base settings and gains the kill switch
+		expect(mockConsumerCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				groupId: 'test-group',
+				retry: expectedRetryConfig,
+			}),
+		);
+		const { retry } = mockConsumerCreate.mock.calls[0][0] as {
+			retry: { restartOnFailure: (error: Error) => Promise<boolean> };
+		};
+
+		// Before close, retriable crashes may restart the consumer as usual
+		await expect(retry.restartOnFailure(new Error('retriable crash'))).resolves.toBe(true);
+
+		await close();
+
+		// After close, a crash-restart that raced teardown must not resurrect the consumer
+		await expect(retry.restartOnFailure(new Error('retriable crash'))).resolves.toBe(false);
+	});
+
+	it('should crash the consumer non-retriably when a batch arrives after close', async () => {
+		const { close, emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		await close();
+
+		const error = await publishMessage({ value: Buffer.from('late-message') }).then(
+			() => null,
+			(e: unknown) => e,
+		);
+
+		expect(error).toBeInstanceOf(UnexpectedError);
+		expect(error).toMatchObject({
+			message: 'Kafka trigger consumer received messages after close',
+			retriable: false,
+		});
+		expect(emit).not.toHaveBeenCalled();
+	});
+
+	it('should unblock a pending onCompletion execution wait when the trigger is closed', async () => {
+		const { close, emit } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				typeVersion: 1.3,
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+					resolveOffset: 'onCompletion',
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const publishPromise = publishMessage({ value: Buffer.from('in-flight') });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// The batch handler is now waiting on the execution's deferred promise
+		expect(emit).toHaveBeenCalled();
+
+		// Close must resolve the batch without the execution ever completing
+		await close();
+		await publishPromise;
+	});
+
+	it('should not block on disconnect when stop() times out, then disconnect once stop settles', async () => {
+		vi.useFakeTimers();
+		try {
+			let resolveStop!: () => void;
+			const mockConsumerStop = vi.fn(
+				async () =>
+					await new Promise<void>((resolve) => {
+						resolveStop = resolve;
+					}),
+			);
+			mockConsumerCreate.mockReturnValueOnce(
+				mock<Consumer>({
+					connect: mockConsumerConnect,
+					subscribe: mockConsumerSubscribe,
+					run: mockConsumerRun,
+					disconnect: mockConsumerDisconnect,
+					stop: mockConsumerStop,
+					on: vi.fn(() => vi.fn()),
+				}),
+			);
+
+			const { close } = await testTriggerNode(KafkaTrigger, {
+				mode: 'trigger',
+				node: {
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'test-group',
+						useSchemaRegistry: false,
+					},
+				},
+				credential: {
+					brokers: 'localhost:9092',
+					clientId: 'n8n-kafka',
+					ssl: false,
+					authentication: false,
+				},
+			});
+
+			const closeResult = close().then(
+				() => null,
+				(e: unknown) => e,
+			);
+
+			await vi.advanceTimersByTimeAsync(30_000);
+			const error = await closeResult;
+
+			expect(error).toBeInstanceOf(TriggerCloseError);
+			expect((error as TriggerCloseError).cause).toMatchObject({
+				message: 'Kafka consumer did not stop in time',
+			});
+			// A still-pending stop() means kafkajs disconnect() would only join the
+			// same shared promise — it must not be awaited serially
+			expect(mockConsumerDisconnect).not.toHaveBeenCalled();
+
+			// Once stop settles, the connection is closed in the background
+			resolveStop();
+			await vi.advanceTimersByTimeAsync(0);
+			expect(mockConsumerDisconnect).toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it('should use default values for consumer config when options are not provided', async () => {
 		await testTriggerNode(KafkaTrigger, {
 			mode: 'trigger',
@@ -1354,6 +1525,7 @@ describe('KafkaTrigger Node', () => {
 			sessionTimeout: 30000,
 			heartbeatInterval: 3000,
 			rebalanceTimeout: 600000,
+			retry: expectedRetryConfig,
 		});
 	});
 
@@ -1476,6 +1648,7 @@ describe('KafkaTrigger Node', () => {
 			rebalanceTimeout: 600000,
 			maxBytesPerPartition: 2097152,
 			minBytes: 1024,
+			retry: expectedRetryConfig,
 		});
 	});
 
@@ -1713,6 +1886,7 @@ describe('KafkaTrigger Node', () => {
 				sessionTimeout: 30000,
 				heartbeatInterval: 10000,
 				rebalanceTimeout: 600000,
+				retry: expectedRetryConfig,
 			});
 		});
 
@@ -1869,6 +2043,7 @@ describe('KafkaTrigger Node', () => {
 				sessionTimeout: 20000,
 				heartbeatInterval: 2000,
 				rebalanceTimeout: 600000,
+				retry: expectedRetryConfig,
 			});
 		});
 

--- a/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
@@ -10,6 +10,7 @@ import {
 	type IHeaders,
 	type KafkaMessage,
 	type RecordBatchEntry,
+	type RetryOptions,
 } from 'kafkajs';
 import { NodeOperationError, TriggerCloseError, UnexpectedError, type IRun } from 'n8n-workflow';
 
@@ -25,9 +26,9 @@ vi.mock('@n8n/utils/sleep', () => ({
 }));
 
 describe('KafkaTrigger Node', () => {
-	// Every consumer config carries the crash-restart kill switch; typed so the
-	// `any` from expect.any does not trip no-unsafe-assignment at each call site.
-	const expectedRetryConfig = { restartOnFailure: expect.any(Function) as unknown };
+	const expectedRetryConfig = {
+		restartOnFailure: expect.any(Function) as RetryOptions['restartOnFailure'],
+	};
 
 	let mockKafka: Mocked<Kafka>;
 	let mockRegistry: Mocked<SchemaRegistry>;
@@ -35,6 +36,7 @@ describe('KafkaTrigger Node', () => {
 	let mockConsumerSubscribe: Mock;
 	let mockConsumerRun: Mock;
 	let mockConsumerDisconnect: Mock;
+	let mockConsumerStop: Mock;
 	let mockConsumerCreate: Mock;
 	let mockRegistryDecode: Mock;
 	let publishMessage: (message: Partial<KafkaMessage>) => Promise<void>;
@@ -61,12 +63,14 @@ describe('KafkaTrigger Node', () => {
 			}
 		});
 		mockConsumerDisconnect = vi.fn();
+		mockConsumerStop = vi.fn(async () => {});
 		mockConsumerCreate = vi.fn(() =>
 			mock<Consumer>({
 				connect: mockConsumerConnect,
 				subscribe: mockConsumerSubscribe,
 				run: mockConsumerRun,
 				disconnect: mockConsumerDisconnect,
+				stop: mockConsumerStop,
 				on: vi.fn((event: string, handler: (event: unknown) => unknown) => {
 					consumerEventHandlers[event] = handler;
 					return vi.fn();
@@ -1201,8 +1205,6 @@ describe('KafkaTrigger Node', () => {
 			.mockReturnValueOnce(mockRemoveListener8)
 			.mockReturnValueOnce(mockRemoveListener9);
 
-		const mockConsumerStop = vi.fn();
-
 		mockConsumerCreate.mockReturnValueOnce(
 			mock<Consumer>({
 				connect: mockConsumerConnect,
@@ -1262,18 +1264,7 @@ describe('KafkaTrigger Node', () => {
 
 	it('should still disconnect and reject with TriggerCloseError when consumer.stop() fails on close', async () => {
 		const teardownError = new Error('The group is rebalancing, so a rejoin is needed');
-		const mockConsumerStop = vi.fn().mockRejectedValue(teardownError);
-
-		mockConsumerCreate.mockReturnValueOnce(
-			mock<Consumer>({
-				connect: mockConsumerConnect,
-				subscribe: mockConsumerSubscribe,
-				run: mockConsumerRun,
-				disconnect: mockConsumerDisconnect,
-				stop: mockConsumerStop,
-				on: vi.fn(() => vi.fn()),
-			}),
-		);
+		mockConsumerStop.mockRejectedValueOnce(teardownError);
 
 		const { close } = await testTriggerNode(KafkaTrigger, {
 			mode: 'trigger',
@@ -1353,7 +1344,6 @@ describe('KafkaTrigger Node', () => {
 			},
 		});
 
-		// The consumer config keeps its base settings and gains the kill switch
 		expect(mockConsumerCreate).toHaveBeenCalledWith(
 			expect.objectContaining({
 				groupId: 'test-group',
@@ -1361,15 +1351,13 @@ describe('KafkaTrigger Node', () => {
 			}),
 		);
 		const { retry } = mockConsumerCreate.mock.calls[0][0] as {
-			retry: { restartOnFailure: (error: Error) => Promise<boolean> };
+			retry: { restartOnFailure: NonNullable<RetryOptions['restartOnFailure']> };
 		};
 
-		// Before close, retriable crashes may restart the consumer as usual
 		await expect(retry.restartOnFailure(new Error('retriable crash'))).resolves.toBe(true);
 
 		await close();
 
-		// After close, a crash-restart that raced teardown must not resurrect the consumer
 		await expect(retry.restartOnFailure(new Error('retriable crash'))).resolves.toBe(false);
 	});
 
@@ -1429,10 +1417,8 @@ describe('KafkaTrigger Node', () => {
 		const publishPromise = publishMessage({ value: Buffer.from('in-flight') });
 		await new Promise((resolve) => setImmediate(resolve));
 
-		// The batch handler is now waiting on the execution's deferred promise
 		expect(emit).toHaveBeenCalled();
 
-		// Close must resolve the batch without the execution ever completing
 		await close();
 		await publishPromise;
 	});
@@ -1441,21 +1427,11 @@ describe('KafkaTrigger Node', () => {
 		vi.useFakeTimers();
 		try {
 			let resolveStop!: () => void;
-			const mockConsumerStop = vi.fn(
+			mockConsumerStop.mockImplementationOnce(
 				async () =>
 					await new Promise<void>((resolve) => {
 						resolveStop = resolve;
 					}),
-			);
-			mockConsumerCreate.mockReturnValueOnce(
-				mock<Consumer>({
-					connect: mockConsumerConnect,
-					subscribe: mockConsumerSubscribe,
-					run: mockConsumerRun,
-					disconnect: mockConsumerDisconnect,
-					stop: mockConsumerStop,
-					on: vi.fn(() => vi.fn()),
-				}),
 			);
 
 			const { close } = await testTriggerNode(KafkaTrigger, {
@@ -1487,11 +1463,9 @@ describe('KafkaTrigger Node', () => {
 			expect((error as TriggerCloseError).cause).toMatchObject({
 				message: 'Kafka consumer did not stop in time',
 			});
-			// A still-pending stop() means kafkajs disconnect() would only join the
-			// same shared promise — it must not be awaited serially
+			// A still-pending stop() means disconnect() would join the same shared promise
 			expect(mockConsumerDisconnect).not.toHaveBeenCalled();
 
-			// Once stop settles, the connection is closed in the background
 			resolveStop();
 			await vi.advanceTimersByTimeAsync(0);
 			expect(mockConsumerDisconnect).toHaveBeenCalled();

--- a/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/KafkaTrigger.node.test.ts
@@ -11,7 +11,7 @@ import {
 	type KafkaMessage,
 	type RecordBatchEntry,
 } from 'kafkajs';
-import { NodeOperationError, type IRun } from 'n8n-workflow';
+import { NodeOperationError, TriggerCloseError, type IRun } from 'n8n-workflow';
 
 import { testTriggerNode } from '@test/nodes/TriggerHelpers';
 
@@ -1252,6 +1252,81 @@ describe('KafkaTrigger Node', () => {
 		// Verify consumer was stopped and disconnected
 		expect(mockConsumerStop).toHaveBeenCalled();
 		expect(mockConsumerDisconnect).toHaveBeenCalled();
+	});
+
+	it('should reject with TriggerCloseError and skip disconnect when consumer.stop() fails on close', async () => {
+		const teardownError = new Error('The group is rebalancing, so a rejoin is needed');
+		const mockConsumerStop = vi.fn().mockRejectedValue(teardownError);
+
+		mockConsumerCreate.mockReturnValueOnce(
+			mock<Consumer>({
+				connect: mockConsumerConnect,
+				subscribe: mockConsumerSubscribe,
+				run: mockConsumerRun,
+				disconnect: mockConsumerDisconnect,
+				stop: mockConsumerStop,
+				on: vi.fn(() => vi.fn()),
+			}),
+		);
+
+		const { close } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const error = await close().then(
+			() => null,
+			(e: unknown) => e,
+		);
+
+		expect(error).toBeInstanceOf(TriggerCloseError);
+		expect((error as TriggerCloseError).cause).toBe(teardownError);
+		expect((error as TriggerCloseError).level).toBe('warning');
+		// A failed stop() aborts the teardown before the broker connection is closed
+		expect(mockConsumerDisconnect).not.toHaveBeenCalled();
+	});
+
+	it('should reject with TriggerCloseError when consumer.disconnect() fails on close', async () => {
+		const teardownError = new Error('The coordinator is not aware of this member');
+		mockConsumerDisconnect.mockRejectedValueOnce(teardownError);
+
+		const { close } = await testTriggerNode(KafkaTrigger, {
+			mode: 'trigger',
+			node: {
+				parameters: {
+					topic: 'test-topic',
+					groupId: 'test-group',
+					useSchemaRegistry: false,
+				},
+			},
+			credential: {
+				brokers: 'localhost:9092',
+				clientId: 'n8n-kafka',
+				ssl: false,
+				authentication: false,
+			},
+		});
+
+		const error = await close().then(
+			() => null,
+			(e: unknown) => e,
+		);
+
+		expect(error).toBeInstanceOf(TriggerCloseError);
+		expect((error as TriggerCloseError).cause).toBe(teardownError);
+		expect((error as TriggerCloseError).level).toBe('warning');
 	});
 
 	it('should use default values for consumer config when options are not provided', async () => {

--- a/packages/nodes-base/nodes/Kafka/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/utils.test.ts
@@ -10,7 +10,7 @@ import type {
 	NodeEgressFilter,
 } from 'n8n-workflow';
 import { sleep } from '@n8n/utils/sleep';
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeOperationError, OperationalError } from 'n8n-workflow';
 import http from 'node:http';
 import https from 'node:https';
 import type { LookupFunction } from 'node:net';
@@ -26,6 +26,7 @@ import {
 	getSchemaRegistryOptions,
 	resolveKafkaSsl,
 	setSchemaRegistry,
+	withTimeout,
 } from '../utils';
 
 vi.mock('@kafkajs/confluent-schema-registry');
@@ -672,6 +673,121 @@ describe('Kafka Utils', () => {
 
 				expect(ctx.emit).toHaveBeenCalledWith([testData], undefined, deferredPromise);
 			});
+		});
+
+		describe('close signal', () => {
+			it('should unblock a pending execution wait when the close signal aborts', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const closeController = new AbortController();
+
+				const emitter = configureDataEmitter(ctx, {}, 1.3, closeController.signal);
+				const resultPromise = emitter([{ json: { message: 'test' } }]);
+
+				closeController.abort();
+
+				const result = await resultPromise;
+
+				expect(result).toEqual({ success: false });
+				// Teardown must not be delayed by the error retry backoff
+				expect(mockedSleep).not.toHaveBeenCalled();
+			});
+
+			it('should not start an execution when the close signal is already aborted', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const closeController = new AbortController();
+				closeController.abort();
+
+				const emitter = configureDataEmitter(ctx, {}, 1.3, closeController.signal);
+				const result = await emitter([{ json: { message: 'test' } }]);
+
+				expect(result).toEqual({ success: false });
+				expect(ctx.emit).not.toHaveBeenCalled();
+			});
+
+			it('should not emit in immediate mode when the close signal is already aborted', async () => {
+				const ctx = createMockContext({ resolveOffset: 'immediately' }, 'trigger');
+				const closeController = new AbortController();
+				closeController.abort();
+
+				const emitter = configureDataEmitter(ctx, {}, 1.3, closeController.signal);
+				const result = await emitter([{ json: { message: 'test' } }]);
+
+				expect(result).toEqual({ success: false });
+				expect(ctx.emit).not.toHaveBeenCalled();
+			});
+
+			it('should cut the error retry backoff short when the close signal aborts mid-backoff', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
+				const closeController = new AbortController();
+				// A backoff that never ends on its own: without the abort race the
+				// emitter (and with it consumer.stop()) would block indefinitely
+				mockedSleep.mockReturnValueOnce(new Promise<void>(() => {}));
+
+				const emitter = configureDataEmitter(ctx, {}, 1.3, closeController.signal);
+				const resultPromise = emitter([{ json: { message: 'test' } }]);
+
+				// A failed execution status sends the emitter into the retry backoff
+				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
+				await vi.advanceTimersByTimeAsync(0);
+				expect(mockedSleep).toHaveBeenCalled();
+
+				closeController.abort();
+
+				const result = await resultPromise;
+				expect(result).toEqual({ success: false });
+			});
+
+			it('should remove the abort listener once the execution completes', async () => {
+				const deferredPromise = createDeferredPromise<IRun>();
+				const ctx = createMockContext(
+					{ resolveOffset: 'onCompletion' },
+					'trigger',
+					deferredPromise,
+				);
+				const closeController = new AbortController();
+				const removeListenerSpy = vi.spyOn(closeController.signal, 'removeEventListener');
+
+				const emitter = configureDataEmitter(ctx, {}, 1.3, closeController.signal);
+				const resultPromise = emitter([{ json: { message: 'test' } }]);
+
+				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
+				await resultPromise;
+
+				expect(removeListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+			});
+		});
+	});
+
+	describe('withTimeout', () => {
+		it('should resolve with the value when the promise settles in time', async () => {
+			await expect(withTimeout(Promise.resolve('ok'), 1000, 'too slow')).resolves.toBe('ok');
+		});
+
+		it('should reject when the promise rejects in time', async () => {
+			await expect(
+				withTimeout(Promise.reject(new Error('boom')), 1000, 'too slow'),
+			).rejects.toThrow('boom');
+		});
+
+		it('should reject with an OperationalError when the promise does not settle in time', async () => {
+			const error = await withTimeout(new Promise<never>(() => {}), 20, 'too slow').then(
+				() => null,
+				(e: unknown) => e,
+			);
+
+			expect(error).toBeInstanceOf(OperationalError);
+			expect((error as Error).message).toBe('too slow');
 		});
 	});
 

--- a/packages/nodes-base/nodes/Kafka/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/utils.test.ts
@@ -1,6 +1,7 @@
 import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { createResultError, createResultOk } from '@n8n/utils/result';
+import type { Consumer } from 'kafkajs';
 import type {
 	ITriggerFunctions,
 	IRun,
@@ -11,6 +12,7 @@ import type {
 } from 'n8n-workflow';
 import { sleep } from '@n8n/utils/sleep';
 import { NodeOperationError, OperationalError } from 'n8n-workflow';
+import { getEventListeners } from 'node:events';
 import http from 'node:http';
 import https from 'node:https';
 import type { LookupFunction } from 'node:net';
@@ -26,6 +28,7 @@ import {
 	getSchemaRegistryOptions,
 	resolveKafkaSsl,
 	setSchemaRegistry,
+	stopAndDisconnectConsumer,
 	withTimeout,
 } from '../utils';
 
@@ -291,7 +294,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({ resolveOffset: 'onCompletion' }, 'manual');
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const result = await emitter(testData);
@@ -304,7 +307,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({}, 'trigger');
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1);
+				const emitter = configureDataEmitter(ctx, options, 1, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const result = await emitter(testData);
@@ -317,7 +320,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({}, 'trigger');
 				const options: KafkaTriggerOptions = { parallelProcessing: true };
 
-				const emitter = configureDataEmitter(ctx, options, 1.1);
+				const emitter = configureDataEmitter(ctx, options, 1.1, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const result = await emitter(testData);
@@ -330,7 +333,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({ resolveOffset: 'immediately' }, 'trigger');
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const result = await emitter(testData);
@@ -350,7 +353,7 @@ describe('Kafka Utils', () => {
 				);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -373,7 +376,7 @@ describe('Kafka Utils', () => {
 				);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -391,7 +394,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({}, 'trigger', deferredPromise);
 				const options: KafkaTriggerOptions = { parallelProcessing: false };
 
-				const emitter = configureDataEmitter(ctx, options, 1.1);
+				const emitter = configureDataEmitter(ctx, options, 1.1, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -411,7 +414,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -428,7 +431,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -447,7 +450,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
 				const options: KafkaTriggerOptions = { errorRetryDelay: 10000 };
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -468,7 +471,9 @@ describe('Kafka Utils', () => {
 				);
 				const options: KafkaTriggerOptions = {};
 
-				expect(() => configureDataEmitter(ctx, options, 1.3)).toThrow(NodeOperationError);
+				expect(() => configureDataEmitter(ctx, options, 1.3, new AbortController().signal)).toThrow(
+					NodeOperationError,
+				);
 			});
 
 			it('should return success when execution status matches allowed statuses', async () => {
@@ -480,7 +485,7 @@ describe('Kafka Utils', () => {
 				);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -501,7 +506,7 @@ describe('Kafka Utils', () => {
 				);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -526,7 +531,7 @@ describe('Kafka Utils', () => {
 				ctx.getWorkflowSettings.mockReturnValue({ executionTimeout: 1 }); // 1 second timeout
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -551,7 +556,7 @@ describe('Kafka Utils', () => {
 				ctx.getWorkflowSettings.mockReturnValue({}); // No timeout configured
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -574,7 +579,7 @@ describe('Kafka Utils', () => {
 				ctx.getWorkflowSettings.mockReturnValue({ executionTimeout: 10 });
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -602,7 +607,7 @@ describe('Kafka Utils', () => {
 				);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -625,7 +630,7 @@ describe('Kafka Utils', () => {
 				);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -645,7 +650,7 @@ describe('Kafka Utils', () => {
 				const ctx = createMockContext({}, 'manual');
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test1' } }, { json: { message: 'test2' } }];
 
 				await emitter(testData);
@@ -662,7 +667,7 @@ describe('Kafka Utils', () => {
 				);
 				const options: KafkaTriggerOptions = {};
 
-				const emitter = configureDataEmitter(ctx, options, 1.3);
+				const emitter = configureDataEmitter(ctx, options, 1.3, new AbortController().signal);
 				const testData = [{ json: { message: 'test' } }];
 
 				const resultPromise = emitter(testData);
@@ -693,7 +698,6 @@ describe('Kafka Utils', () => {
 				const result = await resultPromise;
 
 				expect(result).toEqual({ success: false });
-				// Teardown must not be delayed by the error retry backoff
 				expect(mockedSleep).not.toHaveBeenCalled();
 			});
 
@@ -730,14 +734,12 @@ describe('Kafka Utils', () => {
 				const deferredPromise = createDeferredPromise<IRun>();
 				const ctx = createMockContext({ resolveOffset: 'onSuccess' }, 'trigger', deferredPromise);
 				const closeController = new AbortController();
-				// A backoff that never ends on its own: without the abort race the
-				// emitter (and with it consumer.stop()) would block indefinitely
+				// Never-ending backoff: the test hangs here unless abort cuts it short
 				mockedSleep.mockReturnValueOnce(new Promise<void>(() => {}));
 
 				const emitter = configureDataEmitter(ctx, {}, 1.3, closeController.signal);
 				const resultPromise = emitter([{ json: { message: 'test' } }]);
 
-				// A failed execution status sends the emitter into the retry backoff
 				deferredPromise.resolveWith({ status: 'error' } as unknown as IRun);
 				await vi.advanceTimersByTimeAsync(0);
 				expect(mockedSleep).toHaveBeenCalled();
@@ -748,7 +750,7 @@ describe('Kafka Utils', () => {
 				expect(result).toEqual({ success: false });
 			});
 
-			it('should remove the abort listener once the execution completes', async () => {
+			it('should not accumulate abort listeners across messages', async () => {
 				const deferredPromise = createDeferredPromise<IRun>();
 				const ctx = createMockContext(
 					{ resolveOffset: 'onCompletion' },
@@ -756,16 +758,77 @@ describe('Kafka Utils', () => {
 					deferredPromise,
 				);
 				const closeController = new AbortController();
-				const removeListenerSpy = vi.spyOn(closeController.signal, 'removeEventListener');
 
 				const emitter = configureDataEmitter(ctx, {}, 1.3, closeController.signal);
-				const resultPromise = emitter([{ json: { message: 'test' } }]);
-
 				deferredPromise.resolveWith({ status: 'success' } as unknown as IRun);
-				await resultPromise;
 
-				expect(removeListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+				await emitter([{ json: { message: 'one' } }]);
+				await emitter([{ json: { message: 'two' } }]);
+				await emitter([{ json: { message: 'three' } }]);
+
+				expect(getEventListeners(closeController.signal, 'abort')).toHaveLength(1);
 			});
+		});
+	});
+
+	describe('stopAndDisconnectConsumer', () => {
+		const logger = mock<Logger>();
+
+		it('should stop then disconnect and return undefined on success', async () => {
+			const consumer = mock<Consumer>({
+				stop: vi.fn(async () => {}),
+				disconnect: vi.fn(async () => {}),
+			});
+
+			await expect(stopAndDisconnectConsumer(consumer, logger, 1000)).resolves.toBeUndefined();
+
+			expect(consumer.stop).toHaveBeenCalled();
+			expect(consumer.disconnect).toHaveBeenCalled();
+		});
+
+		it('should still disconnect and return the stop error when stop() rejects', async () => {
+			const stopError = new Error('The group is rebalancing, so a rejoin is needed');
+			const consumer = mock<Consumer>({
+				stop: vi.fn(async () => {
+					throw stopError;
+				}),
+				disconnect: vi.fn(async () => {}),
+			});
+
+			await expect(stopAndDisconnectConsumer(consumer, logger, 1000)).resolves.toBe(stopError);
+
+			expect(consumer.disconnect).toHaveBeenCalled();
+		});
+
+		it('should not await disconnect while stop() is pending, then disconnect once it settles', async () => {
+			vi.useFakeTimers();
+			try {
+				let resolveStop!: () => void;
+				const consumer = mock<Consumer>({
+					stop: vi.fn(
+						async () =>
+							await new Promise<void>((resolve) => {
+								resolveStop = resolve;
+							}),
+					),
+					disconnect: vi.fn(async () => {}),
+				});
+
+				const resultPromise = stopAndDisconnectConsumer(consumer, logger, 1000);
+				await vi.advanceTimersByTimeAsync(1000);
+				const error = await resultPromise;
+
+				expect(error).toBeInstanceOf(OperationalError);
+				expect((error as Error).message).toBe('Kafka consumer did not stop in time');
+				// A still-pending stop() means disconnect() would join the same shared promise
+				expect(consumer.disconnect).not.toHaveBeenCalled();
+
+				resolveStop();
+				await vi.advanceTimersByTimeAsync(0);
+				expect(consumer.disconnect).toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -591,16 +591,15 @@ export function configureDataEmitter(
 	ctx: ITriggerFunctions,
 	options: KafkaTriggerOptions,
 	nodeVersion: number,
-	closeSignal?: AbortSignal,
+	closeSignal: AbortSignal,
 ) {
 	const resolveOffsetMode = getResolveOffsetMode(ctx, options, nodeVersion);
 
 	// For manual mode, always use immediate emit (no donePromise)
 	if (ctx.getMode() === 'manual' || resolveOffsetMode === 'immediately') {
 		return async (dataArray: INodeExecutionData[]) => {
-			// Never start an execution once the trigger is closing; success: false
-			// also skips the offset commit, so the message is redelivered.
-			if (closeSignal?.aborted) return { success: false };
+			// Never start an execution once the trigger is closing.
+			if (closeSignal.aborted) return { success: false };
 			ctx.emit([dataArray]);
 			return { success: true };
 		};
@@ -625,26 +624,26 @@ export function configureDataEmitter(
 		}
 	}
 
+	// Rejects on close; kept handled so it can never become an unhandled rejection.
+	const abortPromise = new Promise<never>((_, reject) => {
+		closeSignal.addEventListener(
+			'abort',
+			() =>
+				reject(
+					new OperationalError(
+						'Trigger closed before the execution finished, offsets not resolved.',
+					),
+				),
+			{ once: true },
+		);
+	});
+	void abortPromise.catch(() => undefined);
+
 	return async (dataArray: INodeExecutionData[]) => {
 		// Never start an execution once the trigger is closing.
-		if (closeSignal?.aborted) return { success: false };
+		if (closeSignal.aborted) return { success: false };
 
 		let timeoutId: NodeJS.Timeout | undefined;
-		let onAbort: (() => void) | undefined;
-		// Rejects when the trigger closes. Raced against both the execution wait
-		// and the error backoff, and the first race subscribes immediately, so a
-		// late rejection can never become an unhandled rejection.
-		const abortPromise = closeSignal
-			? new Promise<never>((_, reject) => {
-					onAbort = () =>
-						reject(
-							new OperationalError(
-								'Trigger closed before the execution finished, offsets not resolved.',
-							),
-						);
-					closeSignal.addEventListener('abort', onAbort, { once: true });
-				})
-			: undefined;
 		try {
 			const responsePromise = ctx.helpers.createDeferredPromise<IRun>();
 			ctx.emit([dataArray], undefined, responsePromise);
@@ -660,10 +659,7 @@ export function configureDataEmitter(
 				}, executionTimeoutInSeconds * 1000);
 			});
 
-			const racers = [responsePromise.promise, timeoutPromise];
-			if (abortPromise) racers.push(abortPromise);
-
-			const run = await Promise.race(racers);
+			const run = await Promise.race([responsePromise.promise, timeoutPromise, abortPromise]);
 
 			if (resolveOffsetMode !== 'onCompletion' && !allowedStatuses.includes(run.status)) {
 				throw new NodeOperationError(
@@ -674,19 +670,15 @@ export function configureDataEmitter(
 
 			return { success: true };
 		} catch (e) {
-			// Skip the retry backoff during teardown (and cut it short if close
-			// arrives mid-backoff) so deactivation is not delayed.
-			if (!closeSignal?.aborted) {
-				const backoffRacers: Array<Promise<void>> = [sleep(errorRetryDelay)];
-				if (abortPromise) backoffRacers.push(abortPromise.catch(() => undefined));
-				await Promise.race(backoffRacers);
+			// The retry backoff must not delay teardown.
+			if (!closeSignal.aborted) {
+				await Promise.race([sleep(errorRetryDelay), abortPromise.catch(() => undefined)]);
 			}
 			const error = ensureError(e);
 			ctx.logger.error(error.message, { error });
 			return { success: false };
 		} finally {
 			if (timeoutId) clearTimeout(timeoutId);
-			if (onAbort) closeSignal?.removeEventListener('abort', onAbort);
 		}
 	};
 }
@@ -713,8 +705,7 @@ export function getAutoCommitSettings(options: KafkaTriggerOptions) {
 /**
  * Bounds a promise with a timeout, rejecting with an `OperationalError` when it
  * does not settle in time. A late rejection of the abandoned promise stays
- * handled (`Promise.race` subscribes to every racer), so it cannot surface as
- * an unhandled rejection.
+ * handled, so it cannot surface as an unhandled rejection.
  * @param promise - The promise to bound
  * @param ms - Timeout in milliseconds
  * @param message - Error message used when the timeout wins
@@ -731,6 +722,60 @@ export async function withTimeout<T>(promise: Promise<T>, ms: number, message: s
 	} finally {
 		if (timer) clearTimeout(timer);
 	}
+}
+
+/**
+ * Stops and disconnects a Kafka consumer, bounding each call so a hung broker
+ * request cannot block teardown. Assumes close was already signaled by the
+ * caller. When stop() times out while still pending, kafkajs disconnect() would
+ * join the same shared stop promise, so the disconnect is instead chained in
+ * the background for whenever stop settles.
+ * @param consumer - The Kafka consumer instance
+ * @param logger - Logger instance
+ * @param timeoutMs - Upper bound for each teardown call
+ * @returns The first teardown error, or undefined when teardown succeeded
+ */
+export async function stopAndDisconnectConsumer(
+	consumer: Consumer,
+	logger: Logger,
+	timeoutMs: number,
+): Promise<Error | undefined> {
+	let teardownError: Error | undefined;
+	let stopSettled = false;
+	// Tracker is subscribed before the race so stopSettled is accurate when the
+	// race settles.
+	const stopPromise = consumer.stop();
+	void stopPromise.then(
+		() => (stopSettled = true),
+		() => (stopSettled = true),
+	);
+	try {
+		await withTimeout(stopPromise, timeoutMs, 'Kafka consumer did not stop in time');
+	} catch (error) {
+		teardownError = ensureError(error);
+	}
+
+	if (!stopSettled) {
+		void stopPromise
+			.catch(() => undefined)
+			.then(async () => await consumer.disconnect())
+			.catch((error: unknown) => {
+				logger.warn('Kafka consumer disconnect after delayed stop failed', { error });
+			});
+		return teardownError;
+	}
+
+	// A failed stop() must not leave the broker connection open.
+	try {
+		await withTimeout(
+			consumer.disconnect(),
+			timeoutMs,
+			'Kafka consumer did not disconnect in time',
+		);
+	} catch (error) {
+		teardownError ??= ensureError(error);
+	}
+	return teardownError;
 }
 
 /**

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -22,7 +22,7 @@ import type {
 } from 'n8n-workflow';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { sleep } from '@n8n/utils/sleep';
-import { jsonParse, NodeOperationError, UserError } from 'n8n-workflow';
+import { jsonParse, NodeOperationError, OperationalError, UserError } from 'n8n-workflow';
 import http from 'node:http';
 import https from 'node:https';
 import type { ConnectionOptions } from 'node:tls';
@@ -583,18 +583,24 @@ function getResolveOffsetMode(
  * @param ctx - The trigger function context
  * @param options - Kafka trigger options
  * @param nodeVersion - The version of the Kafka trigger node
+ * @param closeSignal - Aborted when the trigger is being closed; unblocks any wait
+ * on an in-flight execution so teardown is not delayed, leaving offsets unresolved
  * @returns Async function that emits data and waits for execution completion based on resolve mode
  */
 export function configureDataEmitter(
 	ctx: ITriggerFunctions,
 	options: KafkaTriggerOptions,
 	nodeVersion: number,
+	closeSignal?: AbortSignal,
 ) {
 	const resolveOffsetMode = getResolveOffsetMode(ctx, options, nodeVersion);
 
 	// For manual mode, always use immediate emit (no donePromise)
 	if (ctx.getMode() === 'manual' || resolveOffsetMode === 'immediately') {
 		return async (dataArray: INodeExecutionData[]) => {
+			// Never start an execution once the trigger is closing; success: false
+			// also skips the offset commit, so the message is redelivered.
+			if (closeSignal?.aborted) return { success: false };
 			ctx.emit([dataArray]);
 			return { success: true };
 		};
@@ -620,7 +626,25 @@ export function configureDataEmitter(
 	}
 
 	return async (dataArray: INodeExecutionData[]) => {
+		// Never start an execution once the trigger is closing.
+		if (closeSignal?.aborted) return { success: false };
+
 		let timeoutId: NodeJS.Timeout | undefined;
+		let onAbort: (() => void) | undefined;
+		// Rejects when the trigger closes. Raced against both the execution wait
+		// and the error backoff, and the first race subscribes immediately, so a
+		// late rejection can never become an unhandled rejection.
+		const abortPromise = closeSignal
+			? new Promise<never>((_, reject) => {
+					onAbort = () =>
+						reject(
+							new OperationalError(
+								'Trigger closed before the execution finished, offsets not resolved.',
+							),
+						);
+					closeSignal.addEventListener('abort', onAbort, { once: true });
+				})
+			: undefined;
 		try {
 			const responsePromise = ctx.helpers.createDeferredPromise<IRun>();
 			ctx.emit([dataArray], undefined, responsePromise);
@@ -636,7 +660,10 @@ export function configureDataEmitter(
 				}, executionTimeoutInSeconds * 1000);
 			});
 
-			const run = await Promise.race([responsePromise.promise, timeoutPromise]);
+			const racers = [responsePromise.promise, timeoutPromise];
+			if (abortPromise) racers.push(abortPromise);
+
+			const run = await Promise.race(racers);
 
 			if (resolveOffsetMode !== 'onCompletion' && !allowedStatuses.includes(run.status)) {
 				throw new NodeOperationError(
@@ -647,12 +674,19 @@ export function configureDataEmitter(
 
 			return { success: true };
 		} catch (e) {
-			await sleep(errorRetryDelay);
+			// Skip the retry backoff during teardown (and cut it short if close
+			// arrives mid-backoff) so deactivation is not delayed.
+			if (!closeSignal?.aborted) {
+				const backoffRacers: Array<Promise<void>> = [sleep(errorRetryDelay)];
+				if (abortPromise) backoffRacers.push(abortPromise.catch(() => undefined));
+				await Promise.race(backoffRacers);
+			}
 			const error = ensureError(e);
 			ctx.logger.error(error.message, { error });
 			return { success: false };
 		} finally {
 			if (timeoutId) clearTimeout(timeoutId);
+			if (onAbort) closeSignal?.removeEventListener('abort', onAbort);
 		}
 	};
 }
@@ -674,6 +708,29 @@ export function getAutoCommitSettings(options: KafkaTriggerOptions) {
 		autoCommitInterval,
 		autoCommitThreshold,
 	};
+}
+
+/**
+ * Bounds a promise with a timeout, rejecting with an `OperationalError` when it
+ * does not settle in time. A late rejection of the abandoned promise stays
+ * handled (`Promise.race` subscribes to every racer), so it cannot surface as
+ * an unhandled rejection.
+ * @param promise - The promise to bound
+ * @param ms - Timeout in milliseconds
+ * @param message - Error message used when the timeout wins
+ */
+export async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new OperationalError(message)), ms);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

When an active Kafka Trigger workflow is edited or deactivated, the old consumer can survive teardown and keep executing the old workflow version until the main process is restarted. Deactivating again has no effect because n8n no longer holds a reference to the consumer.

Root cause: on retriable errors (e.g. "The group is rebalancing", "The coordinator is not aware of this member") kafkajs schedules an unconditional consumer restart via `setTimeout`. If `closeFunction` runs while such a restarted `start()` is in flight, `consumer.stop()` resolves cleanly (there is no running runner to stop), n8n drops its reference, and the restart loop re-arms itself — an orphaned, self-healing consumer that rejoins the group and consumes with the workflow snapshot captured at activation time.

Changes (all in the Kafka Trigger node):

- **Veto post-close restarts**: pass `retry.restartOnFailure` to the consumer, returning `false` once close was requested. kafkajs consults this on every crash — including crashes of an in-flight restarted `start()` that raced `closeFunction` — so the restart loop dies instead of re-arming. Consumer-level `retry` is merged over the kafkajs defaults, so pre-close retry behavior is unchanged.
- **Backstop for the untracked-consumer residual**: if a restarted `start()` *succeeds* after `stop()` already returned, that consumer has no API handle and never crashes on its own. `eachBatch` now throws a non-retriable error when invoked after close, so such a consumer terminates on its first batch and can never execute the workflow.
- **Unblock teardown**: with `resolveOffset: onCompletion/onSuccess/onStatus`, `eachBatch` awaits the execution's done-promise for up to the workflow execution timeout (default 3600s), and `consumer.stop()` blocks behind it — so deactivation could hang for up to an hour. `closeFunction` now aborts that wait first via an `AbortSignal` threaded into the data emitter, and the error-retry backoff is raced against the same signal so a close arriving mid-backoff is not delayed either. The pending offset is left unresolved (never committed), so the message is redelivered to the new consumer — standard at-least-once semantics, same as the existing timeout path.
- **Never start an execution after close**: both emitter branches (the deferred-wait modes and the immediate/manual mode) check the close signal before emitting, so a batch that was already past the loop guard when close arrived cannot launch a stale-snapshot execution or commit its offset.
- **Harden `closeFunction`**: always attempt `disconnect()` when `stop()` settled with an error (previously a failed stop skipped it, leaving the broker connection open), and bound both calls at 30s so a hung broker call cannot block deactivation indefinitely. When `stop()` times out while still pending, kafkajs's `disconnect()` would only join the same shared in-flight promise, so instead the disconnect is chained in the background for whenever stop settles and close returns after the single 30s bound.

Notes:

- If an in-flight execution completes after the abort, its redelivered message runs again under the new version — the same at-least-once exposure as the pre-existing execution-timeout path.
- The characterization tests added in the previous commit are updated where the fix intentionally changes behavior (a failed `stop()` no longer skips `disconnect()`).

## How to test

Unit tests: `pnpm test nodes/Kafka` in `packages/nodes-base` (kill-switch wiring, post-close batch backstop, close unblocking a pending `onCompletion` wait, `withTimeout`, close-signal emitter behavior).

Manual reproduction of the orphaned consumer (single main, local broker):

1. Create a workflow with a Kafka Trigger (topic `test`, a fixed group ID) → NoOp, and activate it. Verify one member in the consumer group: `kafka-consumer-groups --describe --group <groupId> --members`.
2. Stop the Kafka broker container, wait ~30s (the consumer enters its crash-restart loop), then deactivate the workflow. Restart the broker.
3. Before this fix: the group regains a member that n8n no longer tracks, and produced messages keep executing the workflow (with the old version if you re-published instead of deactivating). After this fix: the group stays empty.
4. For the blocked-teardown case: use `resolveOffset: onCompletion` with a Wait node, publish a message, and deactivate while the execution is in flight — deactivation now returns promptly instead of hanging.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-104

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35069">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


