### PR TITLE
feat(ai-builder): Carry an eval case's conversation seed in the case body (no-changelog)

### DIFF
--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -31,7 +31,7 @@ exhaustive field reference; this skill is the opinionated *how*.
 >
 > **Exception — seeded cases.** The case-write API can't hold any seeding mode, so
 > seeded cases are never pushed. A `seedThread` case is a local throwaway (don't
-> commit it either — it dies when its trace is pruned); a `seedFile` or
+> commit it either — it dies when its trace is pruned); a `conversationSeed` or
 > `priorConversation` case isn't transient and has no suite home, so it's the one
 > sanctioned exception — it lives as committed JSON. See [`case-shapes.md`](case-shapes.md).
 
@@ -104,7 +104,7 @@ case can still assert outcome), but the primary shape drives the work.
 | **Build** (default) | Does the workflow the agent builds actually *work*? | `outcomeExpectations` + `executionScenarios` |
 | **Behaviour / process** | Does the agent *converse* correctly (ask the right clarifying question, not re-ask, honour a correction, respect plan approval)? | `processExpectations` + multi-turn director script; often **build-only** |
 | **Credential** | Does the build behave correctly given a specific credential view? | `credentials[]` |
-| **Seeded** | Reproduce a conversation mid-thread and drive the turn under test | `seedThread` / `priorConversation` / `seedFile` |
+| **Seeded** | Reproduce a conversation mid-thread and drive the turn under test | `seedThread` / `priorConversation` / `conversationSeed` |
 
 **Build** is documented in full below. The other three, the director-script
 vocabulary, and the seeding modes are in [`case-shapes.md`](case-shapes.md).
@@ -207,7 +207,7 @@ calibration you hand the driver the thread link + login to review the real build
    case's home, not the repo. Leave the `data/workflows/*.json` file uncommitted
    (or delete it once it's in the suite). Committing new case JSONs into the repo
    is no longer the approach. (Exception: seeded cases can't be pushed — a
-   `seedFile`/`priorConversation` case stays committed JSON, a `seedThread` case is
+   `conversationSeed`/`priorConversation` case stays committed JSON, a `seedThread` case is
    a local throwaway; see [`case-shapes.md`](case-shapes.md).) For a sourced case,
    finish by **linking it to its source thread/finding** over the MCP — see
    [Link the pushed case to its source](#link-the-pushed-case-to-its-source-provenance-step--always-do-this).
@@ -661,10 +661,10 @@ npx dotenvx run -f .env.eval -- pnpm eval:langtracer-push --suite baseline --cha
   deployment predating that change silently ignores the key; if a pushed scenario
   edit doesn't land, update the scenario in the lang-tracer UI.
 - **Seeded cases can't be pushed:** the case-write API rejects every seeding mode
-  (`seedThread` / `seedFile` / `priorConversation`), so the push lists them under
+  (`seedThread` / `conversationSeed` / `priorConversation`), so the push lists them under
   `skipped:` and they never reach the suite. A `seedThread` case shouldn't be
   committed either — it dies when its trace is pruned or deleted — so derive a
-  durable synthetic case as the artifact instead. A `seedFile`/`priorConversation`
+  durable synthetic case as the artifact instead. A `conversationSeed`/`priorConversation`
   case isn't transient and has no suite home, so it's the one exception to
   "don't commit the JSON" — it lives as a committed artifact.
 

--- a/.agents/skills/create-instance-ai-eval/case-shapes.md
+++ b/.agents/skills/create-instance-ai-eval/case-shapes.md
@@ -16,7 +16,7 @@ The schema
 ([`harness/schema.ts`](../../../packages/@n8n/instance-ai/evaluations/harness/schema.ts))
 enforces the rules you must respect:
 
-- `seedFile`, `priorConversation`, `seedThread` are **mutually exclusive** — pick
+- `conversationSeed`, `priorConversation`, `seedThread` are **mutually exclusive** — pick
   one seeding mode.
 - A case needs a `conversation` **or** a `seedThread` (which supplies the live
   turn from the trace).
@@ -149,7 +149,7 @@ Pick the lightest mode that fits:
 |---|---|---|
 | Reproduce a real conversation (common case) | `seedThread` — fetch + reconstruct its LangSmith trace at run time; nothing committed | supplies its own live turn (omit `conversation`) |
 | Prelude is just "what was discussed" (no tool calls, no workflows) | `priorConversation` — prose turns, authored inline | a normal `conversation` for the live turn |
-| A synthetic/sanitised fixture you want durable in git | `seedFile` — a committed seed JSON (never real conversation data) | a normal `conversation` for the live turn |
+| Prior work already exists (a workflow to repair) | `conversationSeed` — prior messages + the workflows they reference, in the case body | a normal `conversation` for the live turn |
 | Shallow 2–3 turn prelude where the agent's live replies matter | none — a plain multi-turn `conversation` re-drives it live | — |
 
 All three modes are implemented and wired (`harness/conversation-seed.ts` +
@@ -175,7 +175,7 @@ after the correction. Asserting on the seeded prelude itself proves nothing.
 ### Which mode — and when to avoid seedThread
 
 Default to a **synthetic** case (an authored prompt + director script, or a
-`priorConversation` / `seedFile` prelude): it's durable, carries no real user
+`priorConversation` / `conversationSeed` prelude): it's durable, carries no real user
 data, never expires, and you control the setup exactly. Reach for **`seedThread`** only when
 the misbehaviour genuinely needs real prior context that's impractical to
 synthesize — a long accumulated thread, specific built workflows/tables — **and**
@@ -236,10 +236,10 @@ which user turn goes live.
   (a synthetic case whose `executionScenarios` precondition builds the stand-in),
   or grade the live turn with `processExpectations` only.
 - **Can't be pushed to a lang-tracer suite either.** The case-write API rejects
-  every seeding mode (`seedThread` / `seedFile` / `priorConversation`), so
+  every seeding mode (`seedThread` / `conversationSeed` / `priorConversation`), so
   `eval:langtracer-push` silently lists them under `skipped:`. Combined with the
   don't-commit rule above, a `seedThread` case has **no durable home by design** —
-  the durable artifact is always the synthetic case you derive from it. (`seedFile`
+  the durable artifact is always the synthetic case you derive from it. (`conversationSeed`
   and `priorConversation` carry no thread dependency and can't be pushed either, so
   — unlike a normal case — they're the one exception to the skill's "push, don't
   commit the JSON" rule: they live as committed artifacts.)
@@ -256,11 +256,20 @@ which user turn goes live.
 Plain text only — no tool calls, no restored workflows. Paired with a normal
 `conversation` for the live turn.
 
-### `seedFile` — durable synthetic fixture
+### `conversationSeed` — durable synthetic fixture
 
-For a **synthetic, sanitised** fixture pinned in git (never a real user's
-conversation): hand-author `data/workflows/seeds/<name>.seed.json` (schema in
+For a **synthetic, sanitised** seed pinned in git (never a real user's
+conversation): author the prior messages, plus the workflows they reference, in
+the case body (schema in
 [`harness/conversation-seed.ts`](../../../packages/@n8n/instance-ai/evaluations/harness/conversation-seed.ts)
-— `messages` + optional `workflows` + `dataTables`) and point `seedFile` at it.
-Real conversations belong in `seedThread`, which keeps their content out of the
-repo.
+— `messages` + optional `workflows` + `dataTables`). Real conversations belong in
+`seedThread`, which keeps their content out of the repo.
+
+Two constraints that bite: a workflow `id` must be ≥8 characters (the id remap
+refuses shorter ones), and a seeded `build-workflow` tool call's
+`output.workflowId` must match the seeded workflow's `id` — otherwise the remap
+separates them and the agent can't find the workflow it should act on.
+
+The seed sits in the case body, not a sibling file, so it travels with the case
+whether it comes off disk, out of a LangTracer suite, or from a dispatched case
+body.

--- a/.agents/skills/create-instance-ai-eval/sourcing-cases.md
+++ b/.agents/skills/create-instance-ai-eval/sourcing-cases.md
@@ -56,7 +56,7 @@ connected.)
 5. **Push it to a curated suite** (don't commit the JSON) with
    `eval:langtracer-push` — see
    [Push to a lang-tracer suite](SKILL.md#push-to-a-lang-tracer-suite). Exception:
-   seeded cases (`seedThread` / `seedFile` / `priorConversation`) can't be pushed —
+   seeded cases (`seedThread` / `conversationSeed` / `priorConversation`) can't be pushed —
    the case-write API rejects every seeding mode, so the push lists them under
    `skipped:`. And a `seedThread` case shouldn't be committed either — it dies when
    its trace is pruned or deleted — so it has no durable home; that's exactly why

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -672,7 +672,7 @@ To record an isolated cohort without touching the shared dataset or baseline —
 
 ## Adding test cases
 
-The corpus lives in **LangTracer** — suite `baseline` is what CI runs. Author a case as a local JSON file in `evaluations/data/workflows/` (disk mode picks it up, no registration step), calibrate it against a real build, then push it to the suite with `pnpm eval:langtracer-push --suite baseline <slug>` and delete the local file rather than committing it. Seeded cases (`priorConversation`/`seedFile`) are the exception — the case-write API can't represent them yet, so they stay as committed JSON. Every case is validated against `harness/schema.ts`.
+The corpus lives in **LangTracer** — suite `baseline` is what CI runs. Author a case as a local JSON file in `evaluations/data/workflows/` (disk mode picks it up, no registration step), calibrate it against a real build, then push it to the suite with `pnpm eval:langtracer-push --suite baseline <slug>` and delete the local file rather than committing it. Seeded cases (`priorConversation`/`conversationSeed`) are the exception — the case-write API can't represent them yet, so they stay as committed JSON. Every case is validated against `harness/schema.ts`.
 
 > The essentials are below. For the full authoring guide — picking a case archetype, sizing assertions so a wrong build fails, multi-turn director scripts, seeding vs synthetic, and calibrating against a real build — follow the [`create-instance-ai-eval` skill](../../../../.agents/skills/create-instance-ai-eval/SKILL.md) (with [`case-shapes.md`](../../../../.agents/skills/create-instance-ai-eval/case-shapes.md) and [`running-evals.md`](../../../../.agents/skills/create-instance-ai-eval/running-evals.md)).
 
@@ -759,7 +759,7 @@ Pick the lightest path that fits:
 |---|---|
 | Reproduce a real conversation (the common case) | `seedThread` — fetch + reconstruct its LangSmith trace at run time; nothing committed |
 | Prelude is just "what was discussed" (no tool calls, no workflows) | `priorConversation` — prose turns, authored inline |
-| A synthetic/sanitized fixture you want durable | `seedFile` — a committed seed JSON (no real conversation data) |
+| Prior work already exists (a workflow to repair) | `conversationSeed` — prior messages + the workflows they reference, in the case body |
 | Shallow 2–3 turn prelude where the agent's live replies matter | Neither — a plain multi-turn `conversation` script re-drives it live |
 
 #### `seedThread` — reproduce a real conversation (no repo content)
@@ -805,9 +805,20 @@ To find the thread id, open the conversation's trace in LangSmith (or read it fr
 
 Paired with a normal `conversation` for the live turn. Plain text only — no tool calls, no restored workflows.
 
-#### `seedFile` — durable synthetic fixture
+#### `conversationSeed` — durable synthetic fixture
 
-For a **synthetic, sanitized** fixture you want pinned in git (never a real user's conversation): hand-author a `data/workflows/seeds/<name>.seed.json` (schema in `harness/conversation-seed.ts` — `messages` + optional `workflows`) and point `seedFile` at it. Real conversations belong in `seedThread`, which keeps their content out of the repo entirely. Paired with a normal `conversation` for the live turn.
+For a **synthetic, sanitized** seed you want pinned in git (never a real user's conversation): author the prior messages, plus the workflows they reference, in the case body. Real conversations belong in `seedThread`, which keeps their content out of the repo entirely. Paired with a normal `conversation` for the live turn.
+
+```json
+"conversationSeed": {
+  "messages": [ … ],
+  "workflows": [ { "id": "wKk3RmT9xQ2bVn7L", "name": "Batch loop", "nodes": [], "connections": {} } ]
+}
+```
+
+Schema in `harness/conversation-seed.ts` — `messages` plus optional `workflows` and `dataTables`. Two constraints worth knowing: a workflow `id` must be ≥8 characters (`remapSeedWorkflowIds` refuses to rewrite shorter ids safely), and a seeded `build-workflow` tool call's `output.workflowId` must match the seeded workflow's `id`, or the remap separates them and the agent can't find the workflow it's meant to act on.
+
+The seed lives **in the case body** rather than in a sibling file, so it travels with the case whatever the source — a JSON on disk, a suite pulled with `--source langtracer`, or a case body handed to a dispatcher. (There used to be a `seedFile` path pointing at a sibling JSON. Only the disk loader could resolve it, so a case delivered any other way lost its seed; the key is gone and a case still carrying it fails at load.)
 
 #### How restore works (all paths)
 
@@ -816,7 +827,7 @@ At build time the seed is restored right after the credential pin: seeded workfl
 Rules of thumb:
 
 - **A seeded case is only worth shipping with `buildExpectations` that detect the misbehaviour recurring** — without them it passes vacuously. Sanity-check by running the case once with the seed removed: it should fail.
-- `seedThread`, `priorConversation` and `seedFile` are mutually exclusive; all order strictly before the live turn. `seedThread` provides its own live turn (omit `conversation`); the other two pair with `conversation`.
+- `seedThread`, `priorConversation` and `conversationSeed` are mutually exclusive; all order strictly before the live turn. `seedThread` provides its own live turn (omit `conversation`); the other two pair with `conversation`.
 
 ## Failure categories
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-workflow-conversation-seed.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-workflow-conversation-seed.test.ts
@@ -1,0 +1,135 @@
+import { vi } from 'vitest';
+
+import type { N8nClient } from '../clients/n8n-client';
+import { buildWorkflow } from '../harness/build-workflow';
+import type { ConversationSeed } from '../harness/conversation-seed';
+import type { EvalLogger } from '../harness/logger';
+
+// Stubbed as in build-workflow-seed-cleanup: only the restore call matters here.
+vi.mock('../harness/chat-loop', () => ({
+	SSE_SETTLE_DELAY_MS: 0,
+	startSseConnection: vi.fn().mockResolvedValue(undefined),
+	waitForAllActivity: vi.fn().mockResolvedValue(undefined),
+	runMultiTurnConversation: vi.fn().mockResolvedValue(undefined),
+	recordUserTurn: vi.fn(),
+}));
+
+vi.mock('../outcome/workflow-discovery', () => ({
+	buildAgentOutcome: vi.fn().mockResolvedValue({
+		workflowsCreated: [{ id: 'built-wf-1', name: 'Built', nodeCount: 3, active: false }],
+		executionsRun: [],
+		dataTablesCreated: [],
+		finalText: 'done',
+		workflowJsons: [{ id: 'built-wf-1', name: 'Built', nodes: [], connections: {} }],
+	}),
+	extractWorkflowIdsFromMessages: vi.fn().mockReturnValue([]),
+}));
+
+const silentLogger: EvalLogger = {
+	info: () => {},
+	verbose: () => {},
+	success: () => {},
+	warn: () => {},
+	error: () => {},
+	isVerbose: false,
+};
+
+const SEED_WF_ID = 'wKk3RmT9xQ2bVn7L';
+
+function inlineSeed(): ConversationSeed {
+	return {
+		messages: [
+			{
+				id: 'seed-1',
+				type: 'llm',
+				role: 'assistant',
+				createdAt: '2026-06-29T09:00:01.000Z',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'tc-1',
+						toolName: 'build-workflow',
+						state: 'resolved',
+						input: {},
+						output: { success: true, workflowId: SEED_WF_ID },
+					},
+				],
+			},
+		],
+		workflows: [{ id: SEED_WF_ID, name: 'Batch loop', nodes: [], connections: {} }],
+		dataTables: [],
+	};
+}
+
+function makeClient(restoreThread: ReturnType<typeof vi.fn>): N8nClient {
+	return {
+		getPersonalProjectId: vi.fn().mockResolvedValue('project-1'),
+		ensureThread: vi.fn().mockResolvedValue(undefined),
+		setThreadCredentialAllowlist: vi.fn().mockResolvedValue(undefined),
+		sendMessage: vi.fn().mockResolvedValue(undefined),
+		getThreadMessages: vi.fn().mockResolvedValue({ messages: [] }),
+		restoreThread,
+	} as unknown as N8nClient;
+}
+
+const baseConfig = {
+	conversation: [{ role: 'user' as const, text: 'the loop never runs twice — fix it' }],
+	outcomeExpectations: ['the processing branch hangs off the loop output'],
+	skipWorkflowChecks: true,
+	preRunWorkflowIds: new Set<string>(),
+	claimedWorkflowIds: new Set<string>(),
+	logger: silentLogger,
+};
+
+describe('buildWorkflow with a conversationSeed', () => {
+	it('restores the inline seed before the live turn', async () => {
+		const restoreThread = vi
+			.fn()
+			.mockResolvedValue({ restored: 1, workflowIds: ['restored-wf-1'], dataTableIds: [] });
+
+		const build = await buildWorkflow({
+			client: makeClient(restoreThread),
+			...baseConfig,
+			conversationSeed: inlineSeed(),
+		});
+
+		expect(build.success).toBe(true);
+		expect(restoreThread).toHaveBeenCalledTimes(1);
+		const [, messages, workflows] = restoreThread.mock.calls[0] as [
+			string,
+			Array<Record<string, unknown>>,
+			Array<{ id: string }>,
+		];
+		expect(messages).toHaveLength(1);
+		expect(workflows).toHaveLength(1);
+		// Remapped to a fresh id so parallel iterations can't share one row.
+		const newId = workflows[0].id;
+		expect(newId).not.toBe(SEED_WF_ID);
+		expect(JSON.stringify(messages)).toContain(newId);
+		expect(JSON.stringify(messages)).not.toContain(SEED_WF_ID);
+	});
+
+	it('fails as a seeding problem when the restore fails — never runs unseeded', async () => {
+		const restoreThread = vi.fn().mockRejectedValue(new Error('restore rejected'));
+
+		const build = await buildWorkflow({
+			client: makeClient(restoreThread),
+			...baseConfig,
+			conversationSeed: inlineSeed(),
+		});
+
+		expect(build.success).toBe(false);
+		expect(build.seedingFailed).toBe(true);
+	});
+
+	it('does not restore anything for a case with no seed', async () => {
+		const restoreThread = vi
+			.fn()
+			.mockResolvedValue({ restored: 0, workflowIds: [], dataTableIds: [] });
+
+		const build = await buildWorkflow({ client: makeClient(restoreThread), ...baseConfig });
+
+		expect(build.success).toBe(true);
+		expect(restoreThread).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/conversation-seed.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/conversation-seed.test.ts
@@ -1,9 +1,4 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 import {
-	loadConversationSeed,
 	remapSeedWorkflowIds,
 	seedFromProse,
 	transcriptPrefixFromSeed,
@@ -45,39 +40,6 @@ function makeSeed(): ConversationSeed {
 		dataTables: [],
 	};
 }
-
-describe('loadConversationSeed', () => {
-	const dir = mkdtempSync(join(tmpdir(), 'conversation-seed-'));
-
-	it('loads and validates a seed file', () => {
-		const path = join(dir, 'valid.seed.json');
-		writeFileSync(path, JSON.stringify(makeSeed()));
-
-		const seed = loadConversationSeed(path);
-		expect(seed.messages).toHaveLength(2);
-		expect(seed.workflows[0].id).toBe(WF_ID);
-	});
-
-	it('defaults workflows to an empty array', () => {
-		const path = join(dir, 'no-workflows.seed.json');
-		writeFileSync(path, JSON.stringify({ messages: [{ id: 'm1' }] }));
-
-		expect(loadConversationSeed(path).workflows).toEqual([]);
-	});
-
-	it('rejects a seed without messages, naming the file', () => {
-		const path = join(dir, 'empty.seed.json');
-		writeFileSync(path, JSON.stringify({ messages: [] }));
-
-		expect(() => loadConversationSeed(path)).toThrow(/Invalid conversation seed .*empty\.seed/);
-	});
-
-	it('rejects a missing file with a readable error', () => {
-		expect(() => loadConversationSeed(join(dir, 'nope.seed.json'))).toThrow(
-			/Failed to read conversation seed/,
-		);
-	});
-});
 
 describe('seedFromProse', () => {
 	it('converts turns to llm text messages with ascending past timestamps', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
@@ -90,11 +90,41 @@ describe('EvalTestCaseSchema', () => {
 		expect(parsed.priorConversation).toHaveLength(1);
 	});
 
-	it('rejects seedFile combined with priorConversation', () => {
+	it('rejects a case still pointing at a seedFile', () => {
+		expect(() =>
+			EvalTestCaseSchema.parse({ ...validFixture(), seedFile: 'seeds/some-thread.seed.json' }),
+		).toThrow(/seedFile/);
+	});
+
+	it('accepts an inline conversationSeed and defaults its optional arrays', () => {
+		const parsed = EvalTestCaseSchema.parse({
+			...validFixture(),
+			conversationSeed: {
+				messages: [
+					{ id: 'm1', type: 'llm', role: 'user', content: [{ type: 'text', text: 'build it' }] },
+				],
+			},
+		});
+		expect(parsed.conversationSeed?.messages).toHaveLength(1);
+		expect(parsed.conversationSeed?.workflows).toEqual([]);
+		expect(parsed.conversationSeed?.dataTables).toEqual([]);
+	});
+
+	it('rejects an inline conversationSeed with no messages', () => {
+		expect(() =>
+			EvalTestCaseSchema.parse({ ...validFixture(), conversationSeed: { messages: [] } }),
+		).toThrow();
+	});
+
+	it('rejects conversationSeed combined with another seeding mode', () => {
 		expect(() =>
 			EvalTestCaseSchema.parse({
 				...validFixture(),
-				seedFile: 'seeds/some-thread.seed.json',
+				conversationSeed: {
+					messages: [
+						{ id: 'm1', type: 'llm', role: 'user', content: [{ type: 'text', text: 'build it' }] },
+					],
+				},
 				priorConversation: [{ role: 'user', text: 'prelude' }],
 			}),
 		).toThrow(/mutually exclusive/);
@@ -164,7 +194,7 @@ describe('EvalTestCaseSchema', () => {
 			EvalTestCaseSchema.parse({
 				...rest,
 				seedThread: { threadId: 't1' },
-				seedFile: 'seeds/x.seed.json',
+				priorConversation: [{ role: 'user', text: 'prelude' }],
 			}),
 		).toThrow(/mutually exclusive/);
 	});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-provider.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-provider.test.ts
@@ -29,6 +29,37 @@ describe('casesFromExportedFiles', () => {
 		expect(cases[0].testCase.outcomeExpectations).toEqual(['has a trigger']);
 	});
 
+	it('keeps an inline conversationSeed on a suite-sourced case', () => {
+		const cases = casesFromExportedFiles(
+			{
+				'repair-it.json': validCase({
+					conversationSeed: {
+						messages: [
+							{
+								id: 'm1',
+								type: 'llm',
+								role: 'user',
+								content: [{ type: 'text', text: 'build it' }],
+							},
+						],
+						workflows: [{ id: 'wKk3RmT9xQ2bVn7L', name: 'Batch loop', nodes: [], connections: {} }],
+					},
+				}),
+			},
+			{ suite: 'demo' },
+		);
+		expect(cases[0].testCase.conversationSeed?.workflows[0].id).toBe('wKk3RmT9xQ2bVn7L');
+	});
+
+	it('refuses a suite-sourced case that points at a seed FILE', () => {
+		expect(() =>
+			casesFromExportedFiles(
+				{ 'repair-it.json': validCase({ seedFile: 'repair-it.seed' }) },
+				{ suite: 'demo' },
+			),
+		).toThrow(/seedFile/);
+	});
+
 	it('aggregates validation errors and names the offending file', () => {
 		expect(() =>
 			casesFromExportedFiles(

--- a/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-to-exported.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-to-exported.test.ts
@@ -110,13 +110,33 @@ describe('unsupportedPushReason', () => {
 		expect(unsupportedPushReason(diskCase())).toBeNull();
 	});
 
-	it('flags seedThread, seedFile and priorConversation as unsupported', () => {
+	it('flags seedThread and priorConversation as unsupported', () => {
 		expect(unsupportedPushReason(diskCase({ seedThread: { threadId: 't' } }))).toMatch(
 			/seedThread/,
 		);
-		expect(unsupportedPushReason(diskCase({ seedFile: '/tmp/seed.json' }))).toMatch(/seedFile/);
 		expect(
 			unsupportedPushReason(diskCase({ priorConversation: [{ role: 'user', text: 'earlier' }] })),
 		).toMatch(/priorConversation/);
+	});
+
+	it('flags an inline conversationSeed as unsupported', () => {
+		expect(
+			unsupportedPushReason(
+				diskCase({
+					conversationSeed: {
+						messages: [
+							{
+								id: 'm1',
+								type: 'llm',
+								role: 'user',
+								content: [{ type: 'text', text: 'build it' }],
+							},
+						],
+						workflows: [],
+						dataTables: [],
+					},
+				}),
+			),
+		).toMatch(/conversationSeed/);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
@@ -135,7 +135,18 @@ describe('unsupportedMcpBuildSetupFields', () => {
 
 	it.each<[string, Partial<WorkflowTestCase>]>([
 		['credentials', { credentials: [{ type: 'slackApi' }] }],
-		['seedFile', { seedFile: 'seeds/some-thread.seed.json' }],
+		[
+			'conversationSeed',
+			{
+				conversationSeed: {
+					messages: [
+						{ id: 'm1', type: 'llm', role: 'user', content: [{ type: 'text', text: 'build it' }] },
+					],
+					workflows: [],
+					dataTables: [],
+				},
+			},
+		],
 		['priorConversation', { priorConversation: [user('We already agreed on #alerts')] }],
 		['seedThread', { seedThread: { threadId: 't1' } }],
 	])('flags %s', (field, overrides) => {

--- a/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
@@ -166,7 +166,7 @@ export const MCP_BUILD_KEY_SUPPORT: Record<
 	// reach this check; classified only to keep the map schema-complete.
 	buildExpectations: 'supported',
 	credentials: 'orchestrator-only',
-	seedFile: 'orchestrator-only',
+	conversationSeed: 'orchestrator-only',
 	priorConversation: 'orchestrator-only',
 	seedThread: 'orchestrator-only',
 	datasets: 'supported',

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -21,7 +21,6 @@ import {
 } from './chat-loop';
 import { runWorkflowChecks, summarizeMissingWorkflowError } from './cleanup';
 import {
-	loadConversationSeed,
 	remapSeedWorkflowIds,
 	seedFromProse,
 	transcriptPrefixFromSeed,
@@ -192,8 +191,8 @@ export interface BuildWorkflowConfig {
 	credentials?: TestCaseCredential[];
 	/** Run-level registry the created credential IDs are added to for cleanup. */
 	createdCredentialIds?: Set<string>;
-	/** Synthetic seed file (path) restored before the live message. */
-	seedFile?: string;
+	/** Prior messages + workflows restored before the live message. */
+	conversationSeed?: ConversationSeed;
 	/** Prose turns seeded as plain-text history. */
 	priorConversation?: ConversationTurn[];
 	/** Reproduce a real conversation from its LangSmith trace (seed = before the
@@ -299,8 +298,8 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 				logger.info(
 					`  Reconstructed seed from thread ${config.seedThread.threadId}: ${String(reconstructed.runCount)} runs → ${String(seed.messages.length)} message(s), ${String(seed.workflows.length)} workflow(s)${contSuffix} [${wsLabel}]${config.laneTag ?? ''}`,
 				);
-			} else if (config.seedFile) {
-				seed = loadConversationSeed(config.seedFile);
+			} else if (config.conversationSeed) {
+				seed = config.conversationSeed;
 			} else if (config.priorConversation && config.priorConversation.length > 0) {
 				seed = seedFromProse(config.priorConversation);
 			}

--- a/packages/@n8n/instance-ai/evaluations/harness/conversation-seed.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/conversation-seed.ts
@@ -1,12 +1,11 @@
-// Conversation seeding for eval builds — backs the `seedFile` (synthetic) and
-// `priorConversation` (prose) paths. Real conversations use `seedThread`
+// Conversation seeding for eval builds — backs the `conversationSeed` (synthetic)
+// and `priorConversation` (prose) paths. Real conversations use `seedThread`
 // (reconstructed from a LangSmith trace; see langsmith-seed.ts).
 
 import { generateNanoId } from '@n8n/utils/generate-nano-id';
 import { isRecord } from '@n8n/utils/is-record';
 import { jsonParse } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
-import { readFileSync } from 'node:fs';
 import { z } from 'zod';
 
 import { DOMAIN_TOOL_IDS, ORCHESTRATION_TOOL_IDS } from '../../src/tools/tool-ids';
@@ -20,7 +19,7 @@ import {
 import type { ConversationTurn, TranscriptStep, TranscriptTurn } from '../types';
 
 // ---------------------------------------------------------------------------
-// Seed file schema
+// Seed schema
 // ---------------------------------------------------------------------------
 
 const SeedWorkflowSchema = z.object({
@@ -56,25 +55,6 @@ export const ConversationSeedSchema = z.object({
 });
 
 export type ConversationSeed = z.infer<typeof ConversationSeedSchema>;
-
-export function loadConversationSeed(filePath: string): ConversationSeed {
-	let raw: unknown;
-	try {
-		raw = JSON.parse(readFileSync(filePath, 'utf-8'));
-	} catch (error) {
-		throw new Error(
-			`Failed to read conversation seed ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
-	const parsed = ConversationSeedSchema.safeParse(raw);
-	if (!parsed.success) {
-		const issues = parsed.error.issues
-			.map((i) => `  - ${i.path.join('.') || '(root)'}: ${i.message}`)
-			.join('\n');
-		throw new Error(`Invalid conversation seed ${filePath}:\n${issues}`);
-	}
-	return parsed.data;
-}
 
 // ---------------------------------------------------------------------------
 // Prose prior turns → seed messages

--- a/packages/@n8n/instance-ai/evaluations/harness/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/schema.ts
@@ -1,6 +1,7 @@
 import { instanceAiEvalSeedDataTableSchema } from '@n8n/api-types';
 import { z } from 'zod';
 
+import { ConversationSeedSchema } from './conversation-seed';
 import { SUPPORTED_CREDENTIAL_TYPES } from '../credentials/seeder';
 
 /** Default `datasets` grouping for a case that omits the field — the single
@@ -86,9 +87,9 @@ const evalTestCaseObjectSchema = z
 				}),
 			)
 			.optional(),
-		/** Synthetic seed file (relative path), resolved + validated at case load.
+		/** Prior messages + the workflows they reference, restored before the live turn.
 		 *  Synthetic fixtures only; real conversations use `seedThread`. */
-		seedFile: z.string().min(1).optional(),
+		conversationSeed: ConversationSeedSchema.optional(),
 		/** Prose turns seeded as plain-text history (no tool calls / workflows). */
 		priorConversation: z.array(ConversationTurnSchema).min(1).optional(),
 		/** Reproduce a real conversation from its LangSmith trace at run time (seed =
@@ -130,10 +131,13 @@ export const WORKFLOW_TEST_CASE_KEYS = Object.keys(evalTestCaseObjectSchema.shap
 
 // At most one seeding mode, and a source for the live turn.
 export const EvalTestCaseSchema = evalTestCaseObjectSchema
-	.refine((c) => [c.seedFile, c.priorConversation, c.seedThread].filter(Boolean).length <= 1, {
-		message:
-			'seedFile, priorConversation and seedThread are mutually exclusive — pick one seeding mode',
-	})
+	.refine(
+		(c) => [c.conversationSeed, c.priorConversation, c.seedThread].filter(Boolean).length <= 1,
+		{
+			message:
+				'conversationSeed, priorConversation and seedThread are mutually exclusive — pick one seeding mode',
+		},
+	)
 	.refine((c) => c.seedThread !== undefined || c.conversation !== undefined, {
 		message:
 			'a case needs a conversation, or a seedThread (which supplies the live turn from the trace)',

--- a/packages/@n8n/instance-ai/evaluations/langtracer/provider.ts
+++ b/packages/@n8n/instance-ai/evaluations/langtracer/provider.ts
@@ -1,6 +1,8 @@
 // lang-tracer test-case provider; `casesFromExportedFiles` is split from the network
 // call so the normalize + validate contract is unit-testable without a server.
 
+import { isRecord } from '@n8n/utils/is-record';
+
 import { LangTracerClient, type ExportedSuite } from './client';
 import { resolveLangTracerConfig } from './config';
 import { normalizeExportedCase } from './normalize';
@@ -30,6 +32,14 @@ export function casesFromExportedFiles(
 
 	for (const [filename, raw] of Object.entries(files)) {
 		const fileSlug = filename.replace(/\.json$/i, '');
+		// Checked on the RAW body: the normalizer whitelists to the schema's keys, so a
+		// leftover `seedFile` would be stripped and the case would run unseeded.
+		if (isRecord(raw) && raw.seedFile !== undefined) {
+			errors.push(
+				`${filename}:\n  - seedFile: no longer supported — carry the seed in the case body as \`conversationSeed\``,
+			);
+			continue;
+		}
 		const parsed = EvalTestCaseSchema.safeParse(normalizeExportedCase(raw));
 		if (!parsed.success) {
 			const issues = parsed.error.issues

--- a/packages/@n8n/instance-ai/evaluations/langtracer/to-exported.ts
+++ b/packages/@n8n/instance-ai/evaluations/langtracer/to-exported.ts
@@ -43,7 +43,9 @@ export interface ToLangTracerOptions {
  *  using any of them can't be pushed. Returns a human-readable reason, else null. */
 export function unsupportedPushReason(testCase: EvalTestCaseInput): string | null {
 	if (testCase.seedThread) return 'uses seedThread (not supported by the case-write API)';
-	if (testCase.seedFile) return 'uses seedFile (not supported by the case-write API)';
+	if (testCase.conversationSeed) {
+		return 'uses conversationSeed (not supported by the case-write API)';
+	}
 	if (testCase.priorConversation) {
 		return 'uses priorConversation (not supported by the case-write API)';
 	}

--- a/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
@@ -4,7 +4,11 @@
 
 import { isRecord } from '@n8n/utils/is-record';
 
-import { DATA_TABLES_TOOL_ID, DOMAIN_TOOL_IDS, EVAL_CONFIG_TOOL_ID } from '../../src/tools/tool-ids';
+import {
+	DATA_TABLES_TOOL_ID,
+	DOMAIN_TOOL_IDS,
+	EVAL_CONFIG_TOOL_ID,
+} from '../../src/tools/tool-ids';
 import type {
 	AgentActivity,
 	ArtifactRef,

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -75,7 +75,7 @@ export type BuildArgs = Pick<
 	| 'conversation'
 	| 'messageBudget'
 	| 'credentials'
-	| 'seedFile'
+	| 'conversationSeed'
 	| 'priorConversation'
 	| 'seedThread'
 	| 'executionScenarios'
@@ -450,7 +450,7 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 						conversation: entry.conversation,
 						messageBudget: entry.messageBudget,
 						credentials: entry.credentials,
-						seedFile: entry.seedFile,
+						conversationSeed: entry.conversationSeed,
 						priorConversation: entry.priorConversation,
 						seedThread: entry.seedThread,
 						executionScenarios: entry.executionScenarios,

--- a/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
@@ -140,7 +140,7 @@ export function createEvalSession(config: EvalSessionConfig): EvalSession {
 						conversation: buildArgs.conversation,
 						messageBudget: buildArgs.messageBudget,
 						credentials: buildArgs.credentials,
-						seedFile: buildArgs.seedFile,
+						conversationSeed: buildArgs.conversationSeed,
 						priorConversation: buildArgs.priorConversation,
 						seedThread: buildArgs.seedThread,
 						executionScenarios: buildArgs.executionScenarios,

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -11,6 +11,7 @@ import type {
 
 import type { CheckOutcome } from './binaryChecks/types';
 import type { WorkflowResponse } from './clients/n8n-client';
+import type { ConversationSeed } from './harness/conversation-seed';
 
 // ---------------------------------------------------------------------------
 // Checklist items and verification
@@ -238,11 +239,11 @@ export interface WorkflowTestCase {
 	 * field build with an empty view (everything mocks).
 	 */
 	credentials?: TestCaseCredential[];
-	/** Synthetic seed file (messages + workflows) restored before the live turn.
-	 *  Synthetic fixtures only; mutually exclusive with the other seeds. */
-	seedFile?: string;
+	/** Prior messages + the workflows they reference, restored before the live turn.
+	 *  Mutually exclusive with the other seeds. */
+	conversationSeed?: ConversationSeed;
 	/** Prose turns seeded as plain-text history (no tool calls/workflows).
-	 *  Mutually exclusive with `seedFile`. */
+	 *  Mutually exclusive with the other seeds. */
 	priorConversation?: ConversationTurn[];
 	/** Reproduce a real conversation from its LangSmith trace at run time: restore
 	 *  up to the live turn (the last user message, or one pinned by `liveTurnRunId`)

--- a/packages/@n8n/instance-ai/evaluations/utils/load-eval-cases.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/load-eval-cases.ts
@@ -1,8 +1,7 @@
 import { readFileSync } from 'fs';
-import { basename, dirname, resolve } from 'path';
+import { basename } from 'path';
 
 import { getJsonFiles } from './get-json-files';
-import { loadConversationSeed } from '../harness/conversation-seed';
 import { EvalTestCaseSchema } from '../harness/schema';
 import type { WorkflowTestCase } from '../types';
 
@@ -32,21 +31,7 @@ function parseTestCaseFile(filePath: string): WorkflowTestCase {
 		throw new Error(`Invalid test case ${filePath}:\n${issues}`);
 	}
 
-	const testCase = parsed.data;
-	if (testCase.seedFile) {
-		// Resolve relative to the case file and validate now, so an authoring
-		// typo fails at load time instead of per-build as an agent failure.
-		const resolved = resolve(dirname(filePath), testCase.seedFile);
-		try {
-			loadConversationSeed(resolved);
-		} catch (error) {
-			throw new Error(
-				`Invalid test case ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
-			);
-		}
-		testCase.seedFile = resolved;
-	}
-	return testCase;
+	return parsed.data;
 }
 
 /** Load test cases with their file slugs (for LangSmith dataset sync derived IDs). */


### PR DESCRIPTION
## Summary

A seeded eval case (one that starts mid-conversation, with workflows that already exist) pointed at its seed with `seedFile` — **a path relative to the case file**. Only the disk loader knows that directory, so only a case read off disk could resolve it.

A case that arrives as a *payload* has no directory: a suite pulled with `--source langtracer`, or a case body handed to a dispatcher. So a seeded case couldn't run that way at all — and it didn't fail cleanly. The relative path resolved against the process cwd, `loadConversationSeed` failed, `buildWorkflow` tagged `seedingFailed`, and every iteration landed as a `framework_issue` on a case that looked otherwise healthy.

This replaces it with `conversationSeed` — the seed itself, in the case body, so it travels with the case whatever the source:

```json
{
  "conversation": [{ "role": "user", "text": "the loop never runs twice — fix it" }],
  "conversationSeed": {
    "messages": [ "…" ],
    "workflows": [{ "id": "wKk3RmT9xQ2bVn7L", "name": "Batch loop", "nodes": [], "connections": {} }]
  }
}
```

`seedFile` is **removed** rather than kept alongside. Nothing in the repo used it — no `.seed.json` exists, and the one seeded case on disk uses `priorConversation` — and a second way to express the same seed is what let the transports diverge in the first place. `loadConversationSeed` goes with it.

Seeding is now three modes, each just a *source* for the one `ConversationSeed` the runner restores:

| mode | where the seed comes from |
|---|---|
| `seedThread` | reconstructed from a LangSmith trace at run time |
| `priorConversation` | prose turns, stamped into messages |
| `conversationSeed` | authored outright, in the case body |

Restore itself is untouched: same `remapSeedWorkflowIds` + `restoreThread` call, so fresh workflow ids, credential stripping, schema-only data tables and seeded-transcript marking all behave as before.

Two guardrails, because a silently missing seed turns a repair test into a build-from-scratch test that can still pass:

- **the provider rejects** a suite-sourced case carrying `seedFile`, naming `conversationSeed`. Checked against the **raw** case body on purpose: `normalizeExportedCase` whitelists to the schema's keys, so without this the seed is stripped and the case quietly runs unseeded.
- **`langtracer-push` refuses** a case carrying a seed, since the case-write API has no field for it yet, so the push would land a case missing its seed.

## How to test

Unit: `pnpm --filter @n8n/instance-ai test` — 3398 green. New/updated coverage:

- `build-workflow-conversation-seed.test.ts` — the seed reaches `restoreThread` with the workflow id remapped in both the workflow and the history; a restore failure still fails as `seedingFailed`; an unseeded case restores nothing.
- `data-workflows-schema.test.ts` — an inline seed parses and defaults its optional arrays; a seed with no messages is rejected; a case still pointing at a `seedFile` is rejected; mutual exclusion holds.
- `langtracer-provider.test.ts` — a suite-sourced seed survives the pull; a suite-sourced `seedFile` is refused.
- `mcp-builder.test.ts` / `langtracer-to-exported.test.ts` — the key is classified `orchestrator-only`, and push refuses it.

End to end, locally:

1. Drop a case JSON in `evaluations/data/workflows/` with `conversationSeed` (shape above).
2. `pnpm --filter @n8n/instance-ai eval:instance-ai --filter <slug> --base-url http://localhost:5678 …`
3. The build log shows `Seeded N prior message(s), 1 workflow(s)` before the live turn, and the workflow opens in the eval instance in its seeded (broken) state.

The same case body delivered from a suite now runs identically — that's the point of the change.

## Related Linear tickets, Github issues, and Community forum posts

<!-- none -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.