### PR TITLE
feat(ai-builder): Emit transcriptPerRun and buildErrorPerRun in eval-results.json (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -7,7 +7,12 @@ import { join } from 'path';
 import type { CheckOutcome } from '../binaryChecks/types';
 import { aggregateResults } from '../run/aggregator';
 import { writeEvalResults } from '../run/persist';
-import type { ExecutionScenario, WorkflowTestCase, WorkflowTestCaseResult } from '../types';
+import type {
+	ExecutionScenario,
+	TranscriptTurn,
+	WorkflowTestCase,
+	WorkflowTestCaseResult,
+} from '../types';
 
 // Pins the `eval-results.json` fields the lang-tracer dispatcher ingests
 // (lang-tracer-dispatcher `src/lib/runner.ts`): it spawns this CLI per case in
@@ -39,10 +44,26 @@ const passingCheck: CheckOutcome = {
 	status: 'pass',
 };
 
+const transcript: TranscriptTurn[] = [
+	{
+		userMessage: 'send me a daily digest',
+		steps: [
+			{ kind: 'agent-text', text: 'Building the digest workflow.' },
+			{
+				kind: 'tool-call',
+				toolName: 'add-nodes',
+				args: { nodeType: 'n8n-nodes-base.scheduleTrigger' },
+				result: { added: true },
+			},
+		],
+	},
+];
+
 function iteration1(): WorkflowTestCaseResult {
 	return {
 		testCase,
 		workflowBuildSuccess: true,
+		transcript,
 		workflowChecks: [passingCheck],
 		workflowJson: {
 			id: 'wf-1',
@@ -63,6 +84,7 @@ function iteration2(): WorkflowTestCaseResult {
 	return {
 		testCase,
 		workflowBuildSuccess: true,
+		buildError: 'agent stopped before producing a workflow',
 		buildExpectationResults: [
 			{ expectation: 'sends a digest', pass: false, reason: 'digest node missing' },
 		],
@@ -99,6 +121,8 @@ interface DispatcherView {
 		}> | null>;
 		buildCostUsdPerRun?: Array<number | null>;
 		buildTurnsPerRun?: Array<number | null>;
+		transcriptPerRun: Array<TranscriptTurn[] | null>;
+		buildErrorPerRun: Array<string | null>;
 		scenarios: Array<{
 			name: string;
 			passCount: number;
@@ -163,6 +187,24 @@ describe('eval-results.json — dispatcher contract', () => {
 		// recorded `claude` spend, so non-MCP dispatcher output is unchanged.
 		expect(tc).not.toHaveProperty('buildCostUsdPerRun');
 		expect(tc).not.toHaveProperty('buildTurnsPerRun');
+
+		// Per-iteration conversation transcript — one entry per run, null when
+		// the iteration captured none. A present transcript keeps the full
+		// step detail (tool calls with args + results) the dispatcher renders.
+		expect(tc.transcriptPerRun).toHaveLength(2);
+		expect(tc.transcriptPerRun[1]).toBeNull();
+		const turn = tc.transcriptPerRun[0]?.[0];
+		expect(turn?.userMessage).toBe('send me a daily digest');
+		expect(turn?.steps[0]).toEqual({ kind: 'agent-text', text: 'Building the digest workflow.' });
+		expect(turn?.steps[1]).toEqual({
+			kind: 'tool-call',
+			toolName: 'add-nodes',
+			args: { nodeType: 'n8n-nodes-base.scheduleTrigger' },
+			result: { added: true },
+		});
+
+		// Per-iteration build-failure reason — one `string | null` per run.
+		expect(tc.buildErrorPerRun).toEqual([null, 'agent stopped before producing a workflow']);
 
 		// Scenario blocks serialize under the flat `scenarios` key with a flat
 		// `name` — the shape the dispatcher's fallback reader consumes today.

--- a/packages/@n8n/instance-ai/evaluations/__tests__/fixtures/eval-results.partial-abort.json
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/fixtures/eval-results.partial-abort.json
@@ -38,7 +38,9 @@
 						}
 					]
 				}
-			]
+			],
+			"transcriptPerRun": [null],
+			"buildErrorPerRun": [null]
 		},
 		{
 			"name": "build me something",
@@ -69,7 +71,9 @@
 						}
 					]
 				}
-			]
+			],
+			"transcriptPerRun": [null],
+			"buildErrorPerRun": ["TimeoutError: The operation was aborted due to timeout"]
 		}
 	]
 }

--- a/packages/@n8n/instance-ai/evaluations/__tests__/redact.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/redact.test.ts
@@ -110,6 +110,34 @@ describe('redactSecretsInText', () => {
 		expect(redactSecretsInText('password: hunter2')).toBe('password: [REDACTED]');
 	});
 
+	it('masks bare well-known credential formats with no surrounding key', () => {
+		// OpenAI/Anthropic-style
+		expect(redactSecretsInText('the run used sk-abc123DEF456ghi789jkl012 for calls')).toBe(
+			'the run used [REDACTED] for calls',
+		);
+		expect(redactSecretsInText('key sk-ant-api03-Zm9vYmFyYmF6cXV4 set')).toBe('key [REDACTED] set');
+		// Slack bot/user/app tokens
+		expect(redactSecretsInText('posted with xoxb-1234567890-abcdefghijkl')).toBe(
+			'posted with [REDACTED]',
+		);
+		// GitHub tokens (classic + fine-grained prefixes)
+		expect(redactSecretsInText('cloned using ghp_ABCdef123456789012345678901234567890')).toBe(
+			'cloned using [REDACTED]',
+		);
+		// AWS access key id
+		expect(redactSecretsInText('signed as AKIAIOSFODNN7EXAMPLE today')).toBe(
+			'signed as [REDACTED] today',
+		);
+	});
+
+	it('leaves lookalike prose untouched (short or non-token shapes)', () => {
+		expect(redactSecretsInText('we use sk-learn for clustering')).toBe(
+			'we use sk-learn for clustering',
+		);
+		expect(redactSecretsInText('the xoxo sign-off stays')).toBe('the xoxo sign-off stays');
+		expect(redactSecretsInText('AKIA is an AWS prefix')).toBe('AKIA is an AWS prefix');
+	});
+
 	it('leaves secret words used as prose untouched (no separator → no match)', () => {
 		expect(redactSecretsInText('Invalid token format in the request')).toBe(
 			'Invalid token format in the request',

--- a/packages/@n8n/instance-ai/evaluations/__tests__/redact.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/redact.test.ts
@@ -120,6 +120,10 @@ describe('redactSecretsInText', () => {
 		expect(redactSecretsInText('posted with xoxb-1234567890-abcdefghijkl')).toBe(
 			'posted with [REDACTED]',
 		);
+		// Slack app-level tokens use the xapp- prefix, not xox?-
+		expect(redactSecretsInText('socket mode via xapp-1-A012-3456-abcdef')).toBe(
+			'socket mode via [REDACTED]',
+		);
 		// GitHub tokens (classic + fine-grained prefixes)
 		expect(redactSecretsInText('cloned using ghp_ABCdef123456789012345678901234567890')).toBe(
 			'cloned using [REDACTED]',

--- a/packages/@n8n/instance-ai/evaluations/__tests__/redact.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/redact.test.ts
@@ -1,4 +1,10 @@
-import { redactSecrets, redactSecretsInText, stringifyError, truncate } from '../harness/redact';
+import {
+	redactSecrets,
+	redactSecretsInText,
+	redactSecretsInTextDeep,
+	stringifyError,
+	truncate,
+} from '../harness/redact';
 
 describe('redactSecrets', () => {
 	it('redacts values under secret-shaped keys', () => {
@@ -111,6 +117,57 @@ describe('redactSecretsInText', () => {
 		expect(redactSecretsInText('the secret sauce was missing')).toBe(
 			'the secret sauce was missing',
 		);
+	});
+});
+
+describe('redactSecretsInTextDeep', () => {
+	it('scrubs inline tokens in string leaves of nested objects and arrays', () => {
+		const input = {
+			log: 'Request failed: Authorization: Bearer sk-abc.def (401)',
+			nested: { note: 'retry with api_key=sk-inline-1' },
+			list: ['header was Bearer eyJ0eXAi.payload', 'plain entry'],
+		};
+
+		expect(redactSecretsInTextDeep(input)).toEqual({
+			log: 'Request failed: Authorization: Bearer [REDACTED] (401)',
+			nested: { note: 'retry with api_key=[REDACTED]' },
+			list: ['header was Bearer [REDACTED]', 'plain entry'],
+		});
+	});
+
+	it('passes non-string primitives, null, and undefined through unchanged', () => {
+		expect(redactSecretsInTextDeep(42)).toBe(42);
+		expect(redactSecretsInTextDeep(true)).toBe(true);
+		expect(redactSecretsInTextDeep(null)).toBeNull();
+		expect(redactSecretsInTextDeep(undefined)).toBeUndefined();
+	});
+
+	it('leaves benign strings untouched', () => {
+		expect(redactSecretsInTextDeep({ msg: 'Invalid token format in the request' })).toEqual({
+			msg: 'Invalid token format in the request',
+		});
+	});
+
+	it('does not mutate the original object', () => {
+		const original = { note: 'api_key=sk-real' };
+		redactSecretsInTextDeep(original);
+		expect(original.note).toBe('api_key=sk-real');
+	});
+
+	it('caps recursion depth so deeply nested input cannot blow the stack', () => {
+		let nested: unknown = { note: 'api_key=sk-leaf' };
+		for (let i = 0; i < 12; i += 1) {
+			nested = { wrap: nested };
+		}
+		expect(() => redactSecretsInTextDeep(nested)).not.toThrow();
+	});
+
+	it('leaves class instances untouched (only walks plain objects)', () => {
+		class WithText {
+			constructor(public note: string) {}
+		}
+		const instance = new WithText('api_key=sk-keep');
+		expect(redactSecretsInTextDeep(instance)).toBe(instance);
 	});
 });
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/transcript-from-events.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/transcript-from-events.test.ts
@@ -120,6 +120,24 @@ describe('buildTranscriptFromEvents', () => {
 			expect(turns[0].userMessage).toContain('for the request');
 		});
 
+		it('scrubs an inline token in fallback (no-marker) opening and follow-up messages', () => {
+			const turns = buildTranscriptFromEvents({
+				events: [
+					RUN_START,
+					evt('text-delta', { text: 'first' }),
+					RUN_START,
+					evt('text-delta', { text: 'second' }),
+				],
+				openingMessage: 'use token=abc-open-111 to authenticate',
+				followUpMessages: ['and api_key=abc-follow-222 for the sync'],
+			});
+			expect(turns).toHaveLength(2);
+			expect(turns[0].userMessage).not.toContain('abc-open-111');
+			expect(turns[0].userMessage).toContain('token=[REDACTED]');
+			expect(turns[1].userMessage).not.toContain('abc-follow-222');
+			expect(turns[1].userMessage).toContain('api_key=[REDACTED]');
+		});
+
 		it('scrubs an inline token inside a string value of tool-call args', () => {
 			const turns = buildTranscriptFromEvents({
 				events: [

--- a/packages/@n8n/instance-ai/evaluations/__tests__/transcript-from-events.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/transcript-from-events.test.ts
@@ -1,5 +1,6 @@
 import { buildTranscriptFromEvents } from '../outcome/transcript-from-events';
 import type { CapturedEvent } from '../types';
+import { USER_TURN_EVENT } from '../types';
 
 function evt(type: string, data: Record<string, unknown> = {}): CapturedEvent {
 	return { timestamp: 0, type, data };
@@ -89,6 +90,77 @@ describe('buildTranscriptFromEvents', () => {
 				kind: 'tool-call',
 				result: { id: 'c1', token: '[REDACTED]' },
 			});
+		});
+
+		it('scrubs an inline token in agent narration', () => {
+			const turns = buildTranscriptFromEvents({
+				events: [
+					RUN_START,
+					evt('text-delta', { text: 'Calling the API with api_key=sk-narrated-123 now.' }),
+				],
+			});
+			const step = turns[0].steps[0];
+			expect(step.kind).toBe('agent-text');
+			const text = step.kind === 'agent-text' ? step.text : '';
+			expect(text).not.toContain('sk-narrated-123');
+			expect(text).toContain('api_key=[REDACTED]');
+			expect(text).toContain('Calling the API');
+		});
+
+		it('scrubs an inline token in the user turn message', () => {
+			const turns = buildTranscriptFromEvents({
+				events: [
+					evt(USER_TURN_EVENT, { payload: { text: 'use token=abc-user-999 for the request' } }),
+					RUN_START,
+					evt('text-delta', { text: 'ok' }),
+				],
+			});
+			expect(turns[0].userMessage).not.toContain('abc-user-999');
+			expect(turns[0].userMessage).toContain('token=[REDACTED]');
+			expect(turns[0].userMessage).toContain('for the request');
+		});
+
+		it('scrubs an inline token inside a string value of tool-call args', () => {
+			const turns = buildTranscriptFromEvents({
+				events: [
+					RUN_START,
+					evt('tool-call', {
+						payload: {
+							toolName: 'httpRequest',
+							toolCallId: 'tc-args',
+							args: { note: 'send with Authorization: Bearer sk-args-leak' },
+						},
+					}),
+				],
+			});
+			const step = turns[0].steps[0];
+			expect(step.kind).toBe('tool-call');
+			const args = step.kind === 'tool-call' ? (step.args ?? {}) : {};
+			expect(JSON.stringify(args)).not.toContain('sk-args-leak');
+			expect(args.note).toContain('Bearer [REDACTED]');
+		});
+
+		it('scrubs an inline token inside a string value of a paired tool-result', () => {
+			const turns = buildTranscriptFromEvents({
+				events: [
+					RUN_START,
+					evt('tool-call', {
+						payload: { toolName: 'httpRequest', toolCallId: 'tc-res', args: { url: 'x' } },
+					}),
+					evt('tool-result', {
+						payload: {
+							toolName: 'httpRequest',
+							toolCallId: 'tc-res',
+							result: { log: 'upstream said api_key=sk-result-leak was invalid' },
+						},
+					}),
+				],
+			});
+			const step = turns[0].steps[0];
+			expect(step.kind).toBe('tool-call');
+			const result = step.kind === 'tool-call' ? step.result : undefined;
+			expect(JSON.stringify(result)).not.toContain('sk-result-leak');
+			expect(JSON.stringify(result)).toContain('api_key=[REDACTED]');
 		});
 
 		it('scrubs a secret embedded in a paired tool-error string', () => {

--- a/packages/@n8n/instance-ai/evaluations/harness/redact.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/redact.ts
@@ -74,6 +74,28 @@ export function redactSecretsInText(text: string): string {
 }
 
 /**
+ * Content-based pass over a value tree: applies `redactSecretsInText` to every
+ * string leaf. Complements the key-based `redactSecrets` for payloads where a
+ * token sits inline in a value under a non-secret-shaped key. Same walk rules
+ * as `redactSecrets`: plain objects and arrays only, depth-capped.
+ */
+export function redactSecretsInTextDeep(value: unknown, depth = 0): unknown {
+	if (depth > 10 || value === null || value === undefined) return value;
+	if (typeof value === 'string') return redactSecretsInText(value);
+	if (Array.isArray(value)) {
+		return value.map((entry) => redactSecretsInTextDeep(entry, depth + 1));
+	}
+	if (typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+		const out: Record<string, unknown> = {};
+		for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+			out[k] = redactSecretsInTextDeep(v, depth + 1);
+		}
+		return out;
+	}
+	return value;
+}
+
+/**
  * Truncates serializable values to a max stringified length, redacting
  * secrets first. Returns the redacted value when it fits, the truncated
  * string otherwise, or `'<unserializable>'` if `JSON.stringify` returns

--- a/packages/@n8n/instance-ai/evaluations/harness/redact.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/redact.ts
@@ -63,6 +63,17 @@ const SECRET_TEXT_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
 		/\b(api[-_]?key|access[-_]?key|x-api-key|access[-_]?token|refresh[-_]?token|client[-_]?secret|private[-_]?key|secret|token|password|passwd|cookie|set-cookie|session[-_]?id)("?\s*[:=]\s*"?)[^\s"',&}]+/gi,
 		'$1$2[REDACTED]',
 	],
+	// Bare well-known credential formats — recognizable with no key or scheme
+	// around them. Length floors keep prose lookalikes (sk-learn, xoxo, the
+	// AKIA prefix mentioned in text) unmatched.
+	// OpenAI/Anthropic-style: sk-…, sk-ant-…, sk-proj-….
+	[/\bsk-(?:[a-z0-9]+-)*[A-Za-z0-9_-]{16,}\b/g, '[REDACTED]'],
+	// Slack tokens: xoxb-/xoxp-/xoxa-/xoxs-….
+	[/\bxox[a-z]-[A-Za-z0-9-]{8,}\b/gi, '[REDACTED]'],
+	// GitHub tokens: ghp_/gho_/ghu_/ghs_/ghr_ + fine-grained github_pat_.
+	[/\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{20,}\b/g, '[REDACTED]'],
+	// AWS access key ids.
+	[/\bAKIA[0-9A-Z]{16}\b/g, '[REDACTED]'],
 ];
 
 /** Mask secrets embedded inline in free text (e.g. a token in a tool-error string). */

--- a/packages/@n8n/instance-ai/evaluations/harness/redact.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/redact.ts
@@ -68,8 +68,8 @@ const SECRET_TEXT_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
 	// AKIA prefix mentioned in text) unmatched.
 	// OpenAI/Anthropic-style: sk-…, sk-ant-…, sk-proj-….
 	[/\bsk-(?:[a-z0-9]+-)*[A-Za-z0-9_-]{16,}\b/g, '[REDACTED]'],
-	// Slack tokens: xoxb-/xoxp-/xoxa-/xoxs-….
-	[/\bxox[a-z]-[A-Za-z0-9-]{8,}\b/gi, '[REDACTED]'],
+	// Slack tokens: xoxb-/xoxp-/xoxa-/xoxs-… plus app-level xapp-….
+	[/\b(?:xox[a-z]|xapp)-[A-Za-z0-9-]{8,}\b/gi, '[REDACTED]'],
 	// GitHub tokens: ghp_/gho_/ghu_/ghs_/ghr_ + fine-grained github_pat_.
 	[/\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{20,}\b/g, '[REDACTED]'],
 	// AWS access key ids.

--- a/packages/@n8n/instance-ai/evaluations/outcome/transcript-from-events.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/transcript-from-events.ts
@@ -9,7 +9,7 @@
 import type { InstanceAiConfirmRequest } from '@n8n/api-types';
 import { isRecord } from '@n8n/utils/is-record';
 
-import { redactSecrets, redactSecretsInText } from '../harness/redact';
+import { redactSecrets, redactSecretsInText, redactSecretsInTextDeep } from '../harness/redact';
 import type {
 	AskUserAnswer,
 	AskUserQuestion,
@@ -87,7 +87,10 @@ function splitEventsByUserTurn(
 
 function extractUserTurnText(event: CapturedEvent): string | undefined {
 	const payload = getRecord(event.data, 'payload');
-	return payload ? getString(payload, 'text') : undefined;
+	const text = payload ? getString(payload, 'text') : undefined;
+	// The transcript leaves the machine via eval-results.json — content-scrub
+	// user messages the same as every other free-text step.
+	return text === undefined ? undefined : redactSecretsInText(text);
 }
 
 // ---------------------------------------------------------------------------
@@ -111,7 +114,9 @@ function buildTurn(
 
 	const flushText = () => {
 		if (textBuffer.length > 0) {
-			steps.push({ kind: 'agent-text', text: textBuffer });
+			// Agent narration can echo a token verbatim (e.g. from a tool result) —
+			// content-scrub before the text lands in the persisted transcript.
+			steps.push({ kind: 'agent-text', text: redactSecretsInText(textBuffer) });
 			textBuffer = '';
 		}
 	};
@@ -164,8 +169,9 @@ function collectToolOutcomes(events: CapturedEvent[]): Map<string, ToolOutcome> 
 			// Flat string, so content-scrub (key-based redaction can't reach an inline token).
 			map.set(callId, { error: redactSecretsInText(getString(payload, 'error') ?? 'tool error') });
 		} else {
-			// Redact secret-shaped keys before the result reaches the report/judge.
-			map.set(callId, { result: redactSecrets(payload.result) });
+			// Redact secret-shaped keys, then content-scrub string leaves — a token
+			// inlined in a value under a benign key survives the key-based pass.
+			map.set(callId, { result: redactSecretsInTextDeep(redactSecrets(payload.result)) });
 		}
 	}
 	return map;
@@ -200,7 +206,10 @@ function interpretToolCall(
 		toolName,
 		toolCallId: callId,
 		args:
-			Object.keys(args).length > 0 ? (redactSecrets(args) as Record<string, unknown>) : undefined,
+			Object.keys(args).length > 0
+				? // Key-based pass, then a content pass over string leaves (see collectToolOutcomes).
+					(redactSecretsInTextDeep(redactSecrets(args)) as Record<string, unknown>)
+				: undefined,
 		result,
 		error: outcome?.error,
 	};

--- a/packages/@n8n/instance-ai/evaluations/outcome/transcript-from-events.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/transcript-from-events.ts
@@ -87,10 +87,9 @@ function splitEventsByUserTurn(
 
 function extractUserTurnText(event: CapturedEvent): string | undefined {
 	const payload = getRecord(event.data, 'payload');
-	const text = payload ? getString(payload, 'text') : undefined;
-	// The transcript leaves the machine via eval-results.json — content-scrub
-	// user messages the same as every other free-text step.
-	return text === undefined ? undefined : redactSecretsInText(text);
+	// Raw here — buildTurn content-scrubs every user message at the shared
+	// boundary, covering this path and the legacy fallback alike.
+	return payload ? getString(payload, 'text') : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -149,7 +148,14 @@ function buildTurn(
 	}
 
 	flushText();
-	return { userMessage, steps };
+	// The transcript leaves the machine via eval-results.json — content-scrub
+	// the user message HERE, the boundary both capture paths share (the
+	// marker path's extracted turn text AND the legacy fallback's raw
+	// opening/follow-up messages).
+	return {
+		userMessage: userMessage === undefined ? undefined : redactSecretsInText(userMessage),
+		steps,
+	};
 }
 
 interface ToolOutcome {

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -429,6 +429,11 @@ export function writeEvalResults(
 				passHatK: terminalRate(ea.passHatK),
 			})),
 			threadIds: tc.runs.map((run) => run.threadId ?? null),
+			// Per-iteration conversation transcript + build-failure reason — the
+			// LangTracer dispatcher ingests both (null when an iteration has none).
+			// Transcript content is redacted at capture (transcript-from-events).
+			transcriptPerRun: tc.runs.map((run) => run.transcript ?? null),
+			buildErrorPerRun: tc.runs.map((run) => run.buildError ?? null),
 			// `claude` build spend per iteration (--build-via-mcp only) — the
 			// dedupe-safe source for per-case cost (LangSmith feedback repeats the
 			// value on every row of a case's build).


### PR DESCRIPTION
## Summary

The eval harness builds a full per-iteration conversation transcript (`TranscriptTurn[]` — agent text, tool calls, ask-user Q&A, confirmations) and a per-iteration build-failure reason (`WorkflowTestCaseResult.buildError`) in memory, but both are dropped at the `eval-results.json` boundary today. The LangTracer eval pipeline (n8n-io/lang-tracer#102) now ingests both fields to show reviewers the full conversation of a run and why a build failed.

- **`evaluations/run/persist.ts`** — the per-test-case block now emits `transcriptPerRun` and `buildErrorPerRun` (one entry per run, `null` when absent), next to the existing `threadIds`. No plumbing needed: both fields were already populated on `WorkflowTestCaseResult` by `run/reshape.ts`.
- **`evaluations/__tests__/eval-results-dispatcher-contract.test.ts`** — the pinned downstream contract now covers both arrays (length = runs, `TranscriptTurn[] | null` / `string | null` entries, tool-call step shape).
- **Redaction hardening** (the transcript now leaves the machine via eval-results.json): new `redactSecretsInTextDeep` in `harness/redact.ts` (content-based scrub over string leaves, same depth-10 cap as `redactSecrets`), applied in `outcome/transcript-from-events.ts` to agent narration, user-turn messages, and tool-call `args`/`result` string leaves. Previously only tool errors and setup-card params got the content scrub — an inline `Bearer …` or `api_key=…` under a benign key passed through raw.

## How to test

- `pnpm --filter @n8n/instance-ai test evaluations/__tests__/eval-results-dispatcher-contract.test.ts evaluations/__tests__/redact.test.ts evaluations/__tests__/transcript-from-events.test.ts evaluations/__tests__/write-eval-results.test.ts` — 4 files, 51 tests (11 new, written red-first).
- End to end: run any eval case with `--output-dir`, open `eval-results.json` → each test case carries `transcriptPerRun` (turn/step structure per build iteration) and `buildErrorPerRun`; grep the transcript for a seeded credential token to confirm it arrives masked.

## Related Linear tickets, Github issues, and Community forum posts

- Downstream consumer: https://github.com/n8n-io/lang-tracer/pull/102 (dispatcher ingest + persistence + Transcript tab in the run drawer)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35078">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

