### PR TITLE
fix(editor): Default credential modal to requested auth type and disambiguate managed OAuth2 options

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1039,6 +1039,8 @@
 	"credentialEdit.credentialConfig.missingCredentialType": "This credential's type isn't available. This usually happens when a previously installed community or custom node was uninstalled.",
 	"credentialEdit.credentialConfig.oauthModeManaged": "Managed OAuth2 (recommended)",
 	"credentialEdit.credentialConfig.oauthModeCustom": "Custom OAuth2",
+	"credentialEdit.credentialConfig.oauthModeManagedWithAuthType": "Managed OAuth2 - {authType}",
+	"credentialEdit.credentialConfig.oauthModeCustomWithAuthType": "Custom OAuth2 - {authType}",
 	"credentialEdit.credentialConfig.setupCredential": "Setup credential",
 	"credentialEdit.credentialConfig.quickConnect": "Use quick connect",
 	"credentialEdit.credentialConfig.quickConnectTitle": "Connect to set up a credential",

--- a/packages/frontend/editor-ui/src/app/utils/nodeTypeUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeTypeUtils.test.ts
@@ -339,8 +339,11 @@ describe('getNodeAuthOptions', () => {
 			'microsoftOAuth2Api',
 			'microsoftEntraServicePrincipalApi',
 		]);
-		expect(options[0].name.endsWith('(recommended)')).toBe(true);
-		expect(options[1].name.endsWith('(recommended)')).toBe(true);
+		expect(options.map((o) => o.name)).toEqual([
+			'Outlook OAuth2 (recommended)',
+			'Microsoft OAuth2 (Graph) (recommended)',
+			'Entra Service Principal',
+		]);
 	});
 
 	it('floats a single recommended option above non-recommended ones', () => {

--- a/packages/frontend/editor-ui/src/app/utils/nodeTypeUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeTypeUtils.test.ts
@@ -1,16 +1,21 @@
 import type {
+	ICredentialType,
 	INodeCredentialDescription,
 	INodeProperties,
 	ResourceMapperField,
 } from 'n8n-workflow';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
 import {
 	getMainAuthField,
+	getNodeAuthOptions,
 	getThemedValue,
 	isResourceMapperFieldListStale,
 	isResourceMapperSchemaIncomplete,
 	parseResourceMapperFieldName,
 } from './nodeTypesUtils';
 import { mockNodeTypeDescription } from '@/__tests__/mocks';
+import { useCredentialsStore } from '@/features/credentials/credentials.store';
 
 describe('isResourceMapperFieldListStale', () => {
 	const baseField: ResourceMapperField = {
@@ -235,5 +240,131 @@ describe('getMainAuthField', () => {
 		const node = mockNodeTypeDescription({ credentials, properties: [optionsVersion] });
 
 		expect(getMainAuthField(node)?.name).toBe('jiraVersion');
+	});
+});
+
+describe('getNodeAuthOptions', () => {
+	const managedCredentialType = (name: string): ICredentialType => ({
+		name,
+		displayName: name,
+		properties: [],
+		__overwrittenProperties: ['clientId', 'clientSecret'],
+	});
+
+	const plainCredentialType = (name: string): ICredentialType => ({
+		name,
+		displayName: name,
+		properties: [],
+	});
+
+	// Microsoft Outlook shape: 3 auth options whose values are credential type names.
+	const outlookNodeType = mockNodeTypeDescription({
+		name: 'n8n-nodes-base.microsoftOutlook',
+		credentials: [
+			{
+				name: 'microsoftOutlookOAuth2Api',
+				required: true,
+				displayOptions: { show: { authentication: ['microsoftOutlookOAuth2Api'] } },
+			},
+			{
+				name: 'microsoftOAuth2Api',
+				required: true,
+				displayOptions: { show: { authentication: ['microsoftOAuth2Api'] } },
+			},
+			{
+				name: 'microsoftEntraServicePrincipalApi',
+				required: true,
+				displayOptions: { show: { authentication: ['microsoftEntraServicePrincipalApi'] } },
+			},
+		],
+		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{ name: 'Outlook OAuth2', value: 'microsoftOutlookOAuth2Api' },
+					{ name: 'Microsoft OAuth2 (Graph)', value: 'microsoftOAuth2Api' },
+					{ name: 'Entra Service Principal', value: 'microsoftEntraServicePrincipalApi' },
+				],
+				default: 'microsoftOutlookOAuth2Api',
+			},
+		],
+	});
+
+	// Slack/Google Sheets shape: non-OAuth option listed before the OAuth one.
+	const slackNodeType = mockNodeTypeDescription({
+		name: 'n8n-nodes-base.slack',
+		credentials: [
+			{
+				name: 'slackApi',
+				required: true,
+				displayOptions: { show: { authentication: ['accessToken'] } },
+			},
+			{
+				name: 'slackOAuth2Api',
+				required: true,
+				displayOptions: { show: { authentication: ['oAuth2'] } },
+			},
+		],
+		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{ name: 'Access Token', value: 'accessToken' },
+					{ name: 'OAuth2', value: 'oAuth2' },
+				],
+				default: 'accessToken',
+			},
+		],
+	});
+
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({}));
+	});
+
+	it('keeps descriptor-relative order when multiple options are recommended', () => {
+		useCredentialsStore().state.credentialTypes = {
+			microsoftOutlookOAuth2Api: managedCredentialType('microsoftOutlookOAuth2Api'),
+			microsoftOAuth2Api: managedCredentialType('microsoftOAuth2Api'),
+			microsoftEntraServicePrincipalApi: plainCredentialType('microsoftEntraServicePrincipalApi'),
+		};
+
+		const options = getNodeAuthOptions(outlookNodeType);
+
+		expect(options.map((o) => o.value)).toEqual([
+			'microsoftOutlookOAuth2Api',
+			'microsoftOAuth2Api',
+			'microsoftEntraServicePrincipalApi',
+		]);
+		expect(options[0].name.endsWith('(recommended)')).toBe(true);
+		expect(options[1].name.endsWith('(recommended)')).toBe(true);
+	});
+
+	it('floats a single recommended option above non-recommended ones', () => {
+		useCredentialsStore().state.credentialTypes = {
+			slackApi: plainCredentialType('slackApi'),
+			slackOAuth2Api: managedCredentialType('slackOAuth2Api'),
+		};
+
+		const options = getNodeAuthOptions(slackNodeType);
+
+		expect(options.map((o) => o.value)).toEqual(['oAuth2', 'accessToken']);
+		expect(options[0].name).toBe('OAuth2 (recommended)');
+		expect(options[1].name).toBe('Access Token');
+	});
+
+	it('preserves descriptor order when no option is recommended', () => {
+		useCredentialsStore().state.credentialTypes = {
+			slackApi: plainCredentialType('slackApi'),
+			slackOAuth2Api: plainCredentialType('slackOAuth2Api'),
+		};
+
+		const options = getNodeAuthOptions(slackNodeType);
+
+		expect(options.map((o) => o.value)).toEqual(['accessToken', 'oAuth2']);
+		expect(options.map((o) => o.name)).toEqual(['Access Token', 'OAuth2']);
 	});
 });

--- a/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
@@ -326,14 +326,10 @@ export const getNodeAuthOptions = (
 			);
 		}
 	});
-	// sort so recommended options are first
-	options.forEach((item, i) => {
-		if (item.name.includes(recommendedSuffix)) {
-			options.splice(i, 1);
-			options.unshift(item);
-		}
-	});
-	return options;
+	// recommended options first; stable, so descriptor-relative order is kept within each group
+	const recommended = options.filter((option) => option.name.includes(recommendedSuffix));
+	const notRecommended = options.filter((option) => !option.name.includes(recommendedSuffix));
+	return [...recommended, ...notRecommended];
 };
 
 export const getAllNodeCredentialForAuthType = (

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -955,6 +955,135 @@ describe('CredentialEdit', () => {
 		);
 	});
 
+	test('should use the requested credential type when the node has multiple auth options', async () => {
+		const alphaCredType: ICredentialType = {
+			name: 'alphaApi',
+			displayName: 'Alpha API',
+			properties: [
+				{
+					displayName: 'Alpha Key',
+					name: 'alphaKey',
+					type: 'string',
+					default: '',
+				},
+			],
+		};
+
+		const betaCredType: ICredentialType = {
+			name: 'betaApi',
+			displayName: 'Beta API',
+			properties: [
+				{
+					displayName: 'Beta Token',
+					name: 'betaToken',
+					type: 'string',
+					default: '',
+				},
+			],
+		};
+
+		const pinia = createTestingPinia({
+			initialState: {
+				[STORES.UI]: {
+					modalsById: {
+						[CREDENTIAL_EDIT_MODAL_KEY]: {
+							open: true,
+							showAuthSelector: true,
+						},
+					},
+				},
+				[STORES.SETTINGS]: {
+					settings: {
+						enterprise: {
+							sharing: true,
+							externalSecrets: false,
+						},
+						templates: {
+							host: '',
+						},
+					},
+				},
+				[STORES.PROJECTS]: {
+					personalProject: {
+						id: 'personal-project',
+						type: 'personal',
+						scopes: ['credential:create', 'credential:read'],
+					},
+				},
+			},
+		});
+
+		const credStore = mockedStore(useCredentialsStore);
+		credStore.state.credentialTypes = {
+			alphaApi: alphaCredType,
+			betaApi: betaCredType,
+		};
+		credStore.getNewCredentialName.mockResolvedValue('Beta API');
+
+		const workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsStore.workflowId = 'test-workflow-id';
+		const ndvStore = mockedStore(useNDVStore, createWorkflowDocumentId('test-workflow-id'));
+		ndvStore.activeNode = {
+			name: 'DualAuthTest',
+			type: 'n8n-nodes-base.dualAuthTest',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		} as INode;
+
+		const nodeTypesStore = mockedStore(useNodeTypesStore);
+		const mockNodeType = {
+			displayName: 'Dual Auth Test',
+			name: 'n8n-nodes-base.dualAuthTest',
+			group: ['transform'],
+			version: 1,
+			description: 'Test node',
+			defaults: { name: 'Dual Auth Test' },
+			inputs: ['main'],
+			outputs: ['main'],
+			credentials: [
+				{
+					name: 'alphaApi',
+					required: true,
+					displayOptions: { show: { authentication: ['alpha'] } },
+				},
+				{
+					name: 'betaApi',
+					required: true,
+					displayOptions: { show: { authentication: ['beta'] } },
+				},
+			],
+			properties: [
+				{
+					displayName: 'Authentication',
+					name: 'authentication',
+					type: 'options',
+					options: [
+						{ name: 'Alpha', value: 'alpha' },
+						{ name: 'Beta', value: 'beta' },
+					],
+					default: 'alpha',
+				},
+			],
+		} as unknown as INodeTypeDescription;
+		nodeTypesStore.getNodeType = () => mockNodeType;
+
+		renderComponent({
+			props: {
+				activeId: 'betaApi',
+				modalName: CREDENTIAL_EDIT_MODAL_KEY,
+				mode: 'new',
+			},
+			pinia,
+		});
+
+		await retry(() =>
+			expect(credStore.getNewCredentialName).toHaveBeenCalledWith({
+				credentialTypeName: 'betaApi',
+			}),
+		);
+	});
+
 	describe('saving credentials', () => {
 		const createPiniaForSaveTest = (credentialModalState: Partial<NewCredentialsModal> = {}) =>
 			createTestingPinia({

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -845,33 +845,35 @@ describe('CredentialEdit', () => {
 		});
 	});
 
-	test('should use the requested credential type when node has multiple credential types', async () => {
-		const alphaCredType: ICredentialType = {
-			name: 'alphaApi',
-			displayName: 'Alpha API',
-			properties: [
-				{
-					displayName: 'Alpha Key',
-					name: 'alphaKey',
-					type: 'string',
-					default: '',
-				},
-			],
-		};
+	const alphaCredType: ICredentialType = {
+		name: 'alphaApi',
+		displayName: 'Alpha API',
+		properties: [
+			{
+				displayName: 'Alpha Key',
+				name: 'alphaKey',
+				type: 'string',
+				default: '',
+			},
+		],
+	};
 
-		const betaCredType: ICredentialType = {
-			name: 'betaApi',
-			displayName: 'Beta API',
-			properties: [
-				{
-					displayName: 'Beta Token',
-					name: 'betaToken',
-					type: 'string',
-					default: '',
-				},
-			],
-		};
+	const betaCredType: ICredentialType = {
+		name: 'betaApi',
+		displayName: 'Beta API',
+		properties: [
+			{
+				displayName: 'Beta Token',
+				name: 'betaToken',
+				type: 'string',
+				default: '',
+			},
+		],
+	};
 
+	// Renders the new-credential modal (auth selector on) requesting the beta type
+	// of an alpha/beta node; returns the credentials store for assertions.
+	const renderDualCredModal = (mockNodeType: INodeTypeDescription) => {
 		const pinia = createTestingPinia({
 			initialState: {
 				[STORES.UI]: {
@@ -914,15 +916,30 @@ describe('CredentialEdit', () => {
 		workflowsStore.workflowId = 'test-workflow-id';
 		const ndvStore = mockedStore(useNDVStore, createWorkflowDocumentId('test-workflow-id'));
 		ndvStore.activeNode = {
-			name: 'DualCredTest',
-			type: 'n8n-nodes-base.dualCredTest',
+			name: mockNodeType.displayName,
+			type: mockNodeType.name,
 			typeVersion: 1,
 			position: [0, 0],
 			parameters: {},
 		} as INode;
 
 		const nodeTypesStore = mockedStore(useNodeTypesStore);
-		const mockNodeType = {
+		nodeTypesStore.getNodeType = () => mockNodeType;
+
+		renderComponent({
+			props: {
+				activeId: 'betaApi',
+				modalName: CREDENTIAL_EDIT_MODAL_KEY,
+				mode: 'new',
+			},
+			pinia,
+		});
+
+		return credStore;
+	};
+
+	test('should use the requested credential type when node has multiple credential types', async () => {
+		const credStore = renderDualCredModal({
 			displayName: 'Dual Credential Test',
 			name: 'n8n-nodes-base.dualCredTest',
 			group: ['transform'],
@@ -936,17 +953,7 @@ describe('CredentialEdit', () => {
 				{ name: 'betaApi', required: true },
 			],
 			properties: [],
-		} as unknown as INodeTypeDescription;
-		nodeTypesStore.getNodeType = () => mockNodeType;
-
-		renderComponent({
-			props: {
-				activeId: 'betaApi',
-				modalName: CREDENTIAL_EDIT_MODAL_KEY,
-				mode: 'new',
-			},
-			pinia,
-		});
+		} as unknown as INodeTypeDescription);
 
 		await retry(() =>
 			expect(credStore.getNewCredentialName).toHaveBeenCalledWith({
@@ -956,83 +963,7 @@ describe('CredentialEdit', () => {
 	});
 
 	test('should use the requested credential type when the node has multiple auth options', async () => {
-		const alphaCredType: ICredentialType = {
-			name: 'alphaApi',
-			displayName: 'Alpha API',
-			properties: [
-				{
-					displayName: 'Alpha Key',
-					name: 'alphaKey',
-					type: 'string',
-					default: '',
-				},
-			],
-		};
-
-		const betaCredType: ICredentialType = {
-			name: 'betaApi',
-			displayName: 'Beta API',
-			properties: [
-				{
-					displayName: 'Beta Token',
-					name: 'betaToken',
-					type: 'string',
-					default: '',
-				},
-			],
-		};
-
-		const pinia = createTestingPinia({
-			initialState: {
-				[STORES.UI]: {
-					modalsById: {
-						[CREDENTIAL_EDIT_MODAL_KEY]: {
-							open: true,
-							showAuthSelector: true,
-						},
-					},
-				},
-				[STORES.SETTINGS]: {
-					settings: {
-						enterprise: {
-							sharing: true,
-							externalSecrets: false,
-						},
-						templates: {
-							host: '',
-						},
-					},
-				},
-				[STORES.PROJECTS]: {
-					personalProject: {
-						id: 'personal-project',
-						type: 'personal',
-						scopes: ['credential:create', 'credential:read'],
-					},
-				},
-			},
-		});
-
-		const credStore = mockedStore(useCredentialsStore);
-		credStore.state.credentialTypes = {
-			alphaApi: alphaCredType,
-			betaApi: betaCredType,
-		};
-		credStore.getNewCredentialName.mockResolvedValue('Beta API');
-
-		const workflowsStore = mockedStore(useWorkflowsStore);
-		workflowsStore.workflowId = 'test-workflow-id';
-		const ndvStore = mockedStore(useNDVStore, createWorkflowDocumentId('test-workflow-id'));
-		ndvStore.activeNode = {
-			name: 'DualAuthTest',
-			type: 'n8n-nodes-base.dualAuthTest',
-			typeVersion: 1,
-			position: [0, 0],
-			parameters: {},
-		} as INode;
-
-		const nodeTypesStore = mockedStore(useNodeTypesStore);
-		const mockNodeType = {
+		const credStore = renderDualCredModal({
 			displayName: 'Dual Auth Test',
 			name: 'n8n-nodes-base.dualAuthTest',
 			group: ['transform'],
@@ -1065,17 +996,7 @@ describe('CredentialEdit', () => {
 					default: 'alpha',
 				},
 			],
-		} as unknown as INodeTypeDescription;
-		nodeTypesStore.getNodeType = () => mockNodeType;
-
-		renderComponent({
-			props: {
-				activeId: 'betaApi',
-				modalName: CREDENTIAL_EDIT_MODAL_KEY,
-				mode: 'new',
-			},
-			pinia,
-		});
+		} as unknown as INodeTypeDescription);
 
 		await retry(() =>
 			expect(credStore.getNewCredentialName).toHaveBeenCalledWith({

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.test.ts
@@ -450,6 +450,198 @@ describe('CredentialModeSelector', () => {
 				]);
 			});
 		});
+
+		it('keeps plain managed labels when only one auth option is managed', async () => {
+			const pinia = setupStores({
+				nodeType: twoAuthNodeType,
+				node: makeNode('n8n-nodes-base.dropbox', 'oAuth2'),
+				credentialTypes: {
+					dropboxApi: dropboxApiType,
+					dropboxOAuth2Api: dropboxOAuth2ApiType,
+				},
+			});
+
+			renderComponent({
+				pinia,
+				props: {
+					credentialType: dropboxOAuth2ApiType,
+					showManagedOauthOptions: true,
+					useCustomOauth: false,
+				},
+			});
+
+			await userEvent.click(screen.getByTestId('credential-mode-dropdown-trigger'));
+
+			await waitFor(() => {
+				expect(document.querySelector('[role="menu"]')).toBeInTheDocument();
+			});
+
+			expect(
+				screen.getByRole('menuitem', { name: 'Managed OAuth2 (recommended)' }),
+			).toBeInTheDocument();
+			expect(screen.getByRole('menuitem', { name: 'Custom OAuth2' })).toBeInTheDocument();
+		});
+
+		it('selects the managed option when no node context is available', async () => {
+			const pinia = setupStores({
+				nodeType: twoAuthNodeType,
+				node: makeNode('n8n-nodes-base.dropbox', 'oAuth2'),
+				credentialTypes: {
+					dropboxApi: dropboxApiType,
+					dropboxOAuth2Api: dropboxOAuth2ApiType,
+				},
+			});
+			mockedStore(useNDVStore, createWorkflowDocumentId('test-workflow-id')).activeNode = null;
+
+			renderComponent({
+				pinia,
+				props: {
+					credentialType: dropboxOAuth2ApiType,
+					showManagedOauthOptions: true,
+					useCustomOauth: false,
+				},
+			});
+
+			expect(screen.getByTestId('credential-mode-dropdown-trigger')).toHaveTextContent(
+				'Managed OAuth2 (recommended)',
+			);
+
+			await userEvent.click(screen.getByTestId('credential-mode-dropdown-trigger'));
+
+			await waitFor(() => {
+				expect(document.querySelector('[role="menu"]')).toBeInTheDocument();
+			});
+
+			expect(document.querySelectorAll('[role="menuitem"] [data-icon="check"]')).toHaveLength(1);
+		});
+	});
+
+	describe('multiple managed OAuth pairs', () => {
+		const microsoftOutlookOAuth2ApiType: ICredentialType = {
+			name: 'microsoftOutlookOAuth2Api',
+			extends: ['oAuth2Api'],
+			displayName: 'Microsoft Outlook OAuth2 API',
+			properties: [],
+			__overwrittenProperties: ['clientId', 'clientSecret'],
+		};
+
+		const microsoftOAuth2ApiType: ICredentialType = {
+			name: 'microsoftOAuth2Api',
+			extends: ['oAuth2Api'],
+			displayName: 'Microsoft OAuth2 API',
+			properties: [],
+			__overwrittenProperties: ['clientId', 'clientSecret'],
+		};
+
+		const outlookNodeType = {
+			displayName: 'Microsoft Outlook',
+			name: 'n8n-nodes-base.microsoftOutlook',
+			group: ['input'],
+			version: 1,
+			description: 'Access data on Microsoft Outlook',
+			defaults: { name: 'Microsoft Outlook' },
+			inputs: [NodeConnectionTypes.Main],
+			outputs: [NodeConnectionTypes.Main],
+			credentials: [
+				{
+					name: 'microsoftOutlookOAuth2Api',
+					required: true,
+					displayOptions: { show: { authentication: ['microsoftOutlookOAuth2Api'] } },
+				},
+				{
+					name: 'microsoftOAuth2Api',
+					required: true,
+					displayOptions: { show: { authentication: ['microsoftOAuth2Api'] } },
+				},
+			],
+			properties: [
+				{
+					displayName: 'Authentication',
+					name: 'authentication',
+					type: 'options',
+					options: [
+						{ name: 'Outlook OAuth2', value: 'microsoftOutlookOAuth2Api' },
+						{ name: 'Microsoft OAuth2 (Graph)', value: 'microsoftOAuth2Api' },
+					],
+					default: 'microsoftOutlookOAuth2Api',
+				},
+			],
+		} as unknown as INodeTypeDescription;
+
+		const setupOutlookStores = () =>
+			setupStores({
+				nodeType: outlookNodeType,
+				node: makeNode('n8n-nodes-base.microsoftOutlook', 'microsoftOutlookOAuth2Api'),
+				credentialTypes: {
+					microsoftOutlookOAuth2Api: microsoftOutlookOAuth2ApiType,
+					microsoftOAuth2Api: microsoftOAuth2ApiType,
+				},
+			});
+
+		it('renders disambiguated labels with exactly one checked row', async () => {
+			const pinia = setupOutlookStores();
+
+			renderComponent({
+				pinia,
+				props: {
+					credentialType: microsoftOutlookOAuth2ApiType,
+					showManagedOauthOptions: true,
+					useCustomOauth: false,
+				},
+			});
+
+			await userEvent.click(screen.getByTestId('credential-mode-dropdown-trigger'));
+
+			await waitFor(() => {
+				expect(document.querySelector('[role="menu"]')).toBeInTheDocument();
+			});
+
+			expect(screen.getAllByRole('menuitem').map((el) => el.textContent?.trim())).toEqual([
+				'Managed OAuth2 - Outlook OAuth2',
+				'Custom OAuth2 - Outlook OAuth2',
+				'Managed OAuth2 - Microsoft OAuth2 (Graph)',
+				'Custom OAuth2 - Microsoft OAuth2 (Graph)',
+			]);
+
+			const checkedIcons = document.querySelectorAll('[role="menuitem"] [data-icon="check"]');
+			expect(checkedIcons).toHaveLength(1);
+			expect(checkedIcons[0].closest('[role="menuitem"]')).toHaveTextContent(
+				'Managed OAuth2 - Outlook OAuth2',
+			);
+			expect(screen.getByTestId('credential-mode-dropdown-trigger')).toHaveTextContent(
+				'Managed OAuth2 - Outlook OAuth2',
+			);
+		});
+
+		it('emits update:authType when selecting the managed option of the other auth type', async () => {
+			const pinia = setupOutlookStores();
+
+			const { emitted } = renderComponent({
+				pinia,
+				props: {
+					credentialType: microsoftOutlookOAuth2ApiType,
+					showManagedOauthOptions: true,
+					useCustomOauth: false,
+				},
+			});
+
+			await userEvent.click(screen.getByTestId('credential-mode-dropdown-trigger'));
+
+			await waitFor(() => {
+				expect(document.querySelector('[role="menu"]')).toBeInTheDocument();
+			});
+
+			await userEvent.click(
+				screen.getByRole('menuitem', { name: 'Managed OAuth2 - Microsoft OAuth2 (Graph)' }),
+			);
+
+			await waitFor(() => {
+				expect(emitted('update:authType')).toHaveLength(1);
+				expect(emitted('update:authType')[0]).toEqual([
+					{ type: 'microsoftOAuth2Api', customOauth: false },
+				]);
+			});
+		});
 	});
 
 	describe('quick connect options', () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.test.ts
@@ -493,7 +493,7 @@ describe('CredentialModeSelector', () => {
 			});
 			mockedStore(useNDVStore, createWorkflowDocumentId('test-workflow-id')).activeNode = null;
 
-			renderComponent({
+			const { emitted } = renderComponent({
 				pinia,
 				props: {
 					credentialType: dropboxOAuth2ApiType,
@@ -513,6 +513,12 @@ describe('CredentialModeSelector', () => {
 			});
 
 			expect(document.querySelectorAll('[role="menuitem"] [data-icon="check"]')).toHaveLength(1);
+
+			await userEvent.click(screen.getByRole('menuitem', { name: 'Custom OAuth2' }));
+
+			await waitFor(() => {
+				expect(emitted('update:authType')[0]).toEqual([{ type: 'oAuth2', customOauth: true }]);
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.vue
@@ -57,9 +57,9 @@ const selectedAuthType = computed(() => {
 	return getAuthTypeForNodeCredential(activeNodeType.value, selectedCredentialDescription);
 });
 
-// Auth-type value managed pair options carry when the node has no auth options; isSelected
-// must compare against the same value. Assumes an unlinked managed-OAuth credential has no
-// real node shape (accepted trade-off).
+// The auth-type value that managed pair options carry when the node has no auth options;
+// isSelected must compare against the same fallback. Assumes an unlinked managed-OAuth
+// credential has no real node shape (accepted trade-off).
 const managedFallbackType = computed(() => selectedAuthType.value?.value ?? 'oAuth2');
 
 const isOAuthCredential = computed(() => isOAuthCredentialType(props.credentialType.name));

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.vue
@@ -57,20 +57,33 @@ const selectedAuthType = computed(() => {
 	return getAuthTypeForNodeCredential(activeNodeType.value, selectedCredentialDescription);
 });
 
+// Auth-type value managed pair options carry when the node has no auth options; isSelected
+// must compare against the same value. Assumes an unlinked managed-OAuth credential has no
+// real node shape (accepted trade-off).
+const managedFallbackType = computed(() => selectedAuthType.value?.value ?? 'oAuth2');
+
 const isOAuthCredential = computed(() => isOAuthCredentialType(props.credentialType.name));
 const hasManagedOAuth = computed(() => isOAuthCredential.value && props.showManagedOauthOptions);
 const hasManualCredentialFields = computed(() =>
 	hasManualCredentialInputFields(props.credentialType),
 );
 
-function getManagedOAuthOptions(authType: string): Option[] {
+function getManagedOAuthOptions(authType: string, authTypeLabel?: string): Option[] {
 	return [
 		{
-			name: i18n.baseText('credentialEdit.credentialConfig.oauthModeManaged'),
+			name: authTypeLabel
+				? i18n.baseText('credentialEdit.credentialConfig.oauthModeManagedWithAuthType', {
+						interpolate: { authType: authTypeLabel },
+					})
+				: i18n.baseText('credentialEdit.credentialConfig.oauthModeManaged'),
 			value: { type: authType, customOauth: false },
 		},
 		{
-			name: i18n.baseText('credentialEdit.credentialConfig.oauthModeCustom'),
+			name: authTypeLabel
+				? i18n.baseText('credentialEdit.credentialConfig.oauthModeCustomWithAuthType', {
+						interpolate: { authType: authTypeLabel },
+					})
+				: i18n.baseText('credentialEdit.credentialConfig.oauthModeCustom'),
 			value: { type: authType, customOauth: true },
 		},
 	];
@@ -96,28 +109,36 @@ const manualOptions = computed<Option[]>(() => {
 	const authOptions = getNodeAuthOptions(activeNodeType.value, activeNode.value?.typeVersion);
 
 	if (authOptions.length === 0 && hasManagedOAuth.value) {
-		return getManagedOAuthOptions(selectedAuthType.value?.value ?? 'oAuth2');
+		return getManagedOAuthOptions(managedFallbackType.value);
 	}
 
-	return authOptions.flatMap<Option>((option) => {
-		const authType = option.value;
+	const withExpansion = authOptions.map((option) => {
 		const credential = activeNodeType.value
-			? getNodeCredentialForSelectedAuthType(activeNodeType.value, authType)
+			? getNodeCredentialForSelectedAuthType(activeNodeType.value, option.value)
 			: null;
-
-		if (
+		const splitsIntoManagedPair = !!(
 			credential &&
 			props.showManagedOauthOptions &&
 			isOAuthCredentialType(credential.name) &&
 			canOAuthCredentialQuickConnect(credential.name)
-		) {
-			return getManagedOAuthOptions(authType);
-		}
+		);
+		return { option, splitsIntoManagedPair };
+	});
+	// Disambiguate managed labels only when several auth options expand into managed pairs
+	const managedPairCount = withExpansion.filter((o) => o.splitsIntoManagedPair).length;
+	const recommendedSuffix = i18n.baseText(
+		'credentialEdit.credentialConfig.recommendedAuthTypeSuffix',
+	);
 
-		return {
-			name: option.name,
-			value: { type: authType },
-		};
+	return withExpansion.flatMap<Option>(({ option, splitsIntoManagedPair }) => {
+		if (splitsIntoManagedPair) {
+			// strip the "(recommended)" suffix getNodeAuthOptions appends via the same i18n key
+			const label = option.name.endsWith(recommendedSuffix)
+				? option.name.slice(0, -recommendedSuffix.length).trimEnd()
+				: option.name;
+			return getManagedOAuthOptions(option.value, managedPairCount > 1 ? label : undefined);
+		}
+		return { name: option.name, value: { type: option.value } };
 	});
 });
 
@@ -159,7 +180,12 @@ function isSelected(option: CredentialModeOption): boolean {
 	}
 
 	if (option.customOauth !== undefined) {
-		return isOAuthCredential.value && !!props.useCustomOauth === option.customOauth;
+		// Match the auth type too (a node can expose several managed pairs).
+		return (
+			isOAuthCredential.value &&
+			option.type === managedFallbackType.value &&
+			!!props.useCustomOauth === option.customOauth
+		);
 	}
 
 	return option.type === selectedAuthType.value?.value;

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
-import type { ICredentialType } from 'n8n-workflow';
+import type { ICredentialType, INode, INodeTypeDescription } from 'n8n-workflow';
 
 import { mockedStore } from '@/__tests__/utils';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useCredentialsStore } from '../../credentials.store';
 import type { ICredentialsDecryptedResponse } from '../../credentials.types';
@@ -66,11 +67,26 @@ const skipManagedOAuth: ICredentialType = {
 	],
 };
 
+// Plain per-auth-option types for a node with an auth selector.
+const alphaApi: ICredentialType = {
+	name: 'alphaApi',
+	displayName: 'Alpha API',
+	properties: [],
+};
+
+const betaApi: ICredentialType = {
+	name: 'betaApi',
+	displayName: 'Beta API',
+	properties: [],
+};
+
 const typesByName: Record<string, ICredentialType> = {
 	httpBasicAuth,
 	acmeOAuth2Api: managedOAuth,
 	privateOAuth2Api: privateOAuth,
 	skipOAuth2Api: skipManagedOAuth,
+	alphaApi,
+	betaApi,
 };
 
 describe('useCredentialForm', () => {
@@ -199,6 +215,88 @@ describe('useCredentialForm', () => {
 			const form = await loadPrivateCred();
 
 			expect(form.getChangedSharedFields({ clientId: 'id', clientSecret: 'secret' })).toEqual([]);
+		});
+	});
+
+	describe('selectedCredentialType (auth selector)', () => {
+		const twoAuthNodeType = {
+			displayName: 'Two Auth Service',
+			name: 'n8n-nodes-base.twoAuth',
+			group: ['input'],
+			version: 1,
+			description: 'Service with two auth options',
+			defaults: { name: 'Two Auth Service' },
+			inputs: ['main'],
+			outputs: ['main'],
+			credentials: [
+				{
+					name: 'alphaApi',
+					required: true,
+					displayOptions: { show: { authentication: ['alpha'] } },
+				},
+				{
+					name: 'betaApi',
+					required: true,
+					displayOptions: { show: { authentication: ['beta'] } },
+				},
+			],
+			properties: [
+				{
+					displayName: 'Authentication',
+					name: 'authentication',
+					type: 'options',
+					options: [
+						{ name: 'Alpha', value: 'alpha' },
+						{ name: 'Beta', value: 'beta' },
+					],
+					default: 'alpha',
+				},
+			],
+		} as unknown as INodeTypeDescription;
+
+		const contextNode = {
+			id: 'node-1',
+			name: 'Two Auth Node',
+			type: 'n8n-nodes-base.twoAuth',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		} as INode;
+
+		beforeEach(() => {
+			mockedStore(useNodeTypesStore).getNodeType = () => twoAuthNodeType;
+		});
+
+		it('defaults to the activeId credential type when the node has multiple auth options', () => {
+			const form = useCredentialForm({
+				mode: 'new',
+				activeId: 'betaApi',
+				contextNode,
+				showAuthSelector: true,
+			});
+
+			expect(form.credentialTypeName.value).toBe('betaApi');
+		});
+
+		it('falls back to the first auth option when activeId is not among the node credentials', () => {
+			const form = useCredentialForm({
+				mode: 'new',
+				activeId: 'gammaApi',
+				contextNode,
+				showAuthSelector: true,
+			});
+
+			expect(form.credentialTypeName.value).toBe('alphaApi');
+		});
+
+		it('falls back to the first auth option when no activeId is given', () => {
+			const form = useCredentialForm({
+				mode: 'new',
+				contextNode,
+				showAuthSelector: true,
+			});
+
+			expect(form.credentialTypeName.value).toBe('alphaApi');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
@@ -109,14 +109,16 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 			return credentialsStore.getCredentialTypeByName(selectedCredential.value) ?? null;
 		}
 		if (toValue(options.showAuthSelector)) {
-			const nodeAuthOptions = getNodeAuthOptions(activeNodeType.value);
-			if (nodeAuthOptions.length > 0 && activeNodeType.value?.credentials) {
-				return getNodeCredentialForSelectedAuthType(activeNodeType.value, nodeAuthOptions[0].value);
-			}
+			// The caller-requested type (the auth row clicked in the node's credential
+			// dropdown) wins over the recommended/first auth option.
 			const activeId = toValue(options.activeId);
 			if (activeId) {
 				const nodeCredential = activeNodeType.value?.credentials?.find((c) => c.name === activeId);
 				if (nodeCredential) return nodeCredential;
+			}
+			const nodeAuthOptions = getNodeAuthOptions(activeNodeType.value);
+			if (nodeAuthOptions.length > 0 && activeNodeType.value?.credentials) {
+				return getNodeCredentialForSelectedAuthType(activeNodeType.value, nodeAuthOptions[0].value);
 			}
 			return activeNodeType.value?.credentials?.[0] ?? null;
 		}


### PR DESCRIPTION
## Summary

On nodes with multiple OAuth credential types that are both overwritten on Cloud (Microsoft Outlook and the rest of the Microsoft family since the generic `microsoftOAuth2Api` was added), creating a credential through the modal path picked the wrong credential type, and the auth mode dropdown rendered two checked "Managed OAuth2" rows with identical labels where clicking the other row was a no-op.

Three root causes, all in editor-ui:

1. **`getNodeAuthOptions` reversed descriptor order** when 2+ options are recommended: the old forEach+splice+unshift loop moved each recommended item to the front one by one. Replaced with a stable partition (recommended first, descriptor-relative order preserved within each group).
2. **`useCredentialForm` ignored `activeId`**: `selectedCredentialType` always took `nodeAuthOptions[0]`, so the credential type the user actually clicked (carried as `activeId`) was unreachable for multi-auth nodes. The `activeId` lookup now runs first, falling back to the first auth option, then `credentials[0]`.
3. **`CredentialModeSelector.isSelected` compared only managed/custom mode**, never `option.type`, so with two managed pairs both "Managed OAuth2" rows showed checked and `onOptionChange` early-returned on click. It now also matches the option's auth type (via a shared `managedFallbackType` computed that keeps the no-auth-options fallback path selected). Managed/custom labels are disambiguated with the auth option's display name ("Managed OAuth2 - Outlook OAuth2") via two new interpolated i18n keys, only when a node expands 2+ auth options into managed pairs; single-pair nodes keep today's labels byte-identical.

### Review notes

- **Ordering decision:** the ENT-277 triage comment leaned toward dropping the "recommended first" reordering entirely (pure descriptor order). This PR deliberately keeps recommended-first as a stable partition instead: ~72 node descriptors (Slack, the Google family, Notion, HubSpot, and more) list the Cloud-overwritten OAuth option after a non-OAuth option, so pure descriptor order would demote "Managed OAuth2 (recommended)" below "Access Token" / "Service Account" on exactly the most-used nodes. Only the non-stable implementation of the float was buggy.
- **Blast radius:** order-sensitive consumers of `getNodeAuthOptions` are `useCredentialForm` (default type), `CredentialModeSelector` (row order), and the internal `getAuthTypeForNodeCredential` (find-first; only relevant if one credential were gated on 2+ auth values with 2+ recommended, which no known descriptor does). `useAIAssistantHelpers` matches by value and is order-insensitive.
- Side effect of honoring `activeId`: quick-connect auto-init now targets the clicked credential type instead of the recommended one (e.g. the Entra service principal row opens a plain form instead of auto-quick-connecting the wrong OAuth type).

## How to test

1. Self-hosted: set `CREDENTIALS_OVERWRITE_DATA='{"microsoftOAuth2Api":{"clientId":"x","clientSecret":"y"}}'` (Cloud has this via overwrites keyed at `microsoftOAuth2Api`).
2. Add a **Microsoft Outlook** node, connect the first credential via the NDV Connect button, then open the credential dropdown and click **Create new credential** while a second auth type is available.
3. The modal must open on the credential type matching the node's current `authentication` parameter (previously: the base Microsoft OAuth2 type).
4. Open the auth options dropdown in the modal: four distinct labels ("Managed OAuth2 - Outlook OAuth2", "Custom OAuth2 - Outlook OAuth2", "Managed OAuth2 - Microsoft OAuth2 (Graph)", "Custom OAuth2 - Microsoft OAuth2 (Graph)"), exactly one checked row, and clicking another row switches the form to that type (previously: two identical checked "Managed OAuth2" rows, clicking was a no-op).
5. The Entra Service Principal row must open a plain credential form (no quick-connect).
6. Regression check on a single-pair node (e.g. Dropbox or Google Sheets with overwrites): labels remain exactly "Managed OAuth2 (recommended)" / "Custom OAuth2".

Unit coverage: 11 cases across `nodeTypeUtils.test.ts`, `useCredentialForm.test.ts`, `CredentialEdit.test.ts`, `CredentialModeSelector.test.ts`, including green pins for the previously untested recommended-first float and the no-node-context managed fallback.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-281

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35079">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

