### PR TITLE
fix(cli): forward scopesUseExpressionMapping from config in provisioning loader

### DIFF
--- a/packages/cli/src/instance-settings-loader/__tests__/sso/provisioning.instance-settings-loader.test.ts
+++ b/packages/cli/src/instance-settings-loader/__tests__/sso/provisioning.instance-settings-loader.test.ts
@@ -17,6 +17,7 @@ describe('ProvisioningInstanceSettingsLoader', () => {
 				scopesName: 'n8n',
 				scopesInstanceRoleClaimName: 'n8n_instance_role',
 				scopesProjectsRolesClaimName: 'n8n_projects',
+				scopesUseExpressionMapping: false,
 			},
 		},
 	} as GlobalConfig;
@@ -104,6 +105,36 @@ describe('ProvisioningInstanceSettingsLoader', () => {
 			},
 			{ conflictPaths: ['key'] },
 		);
+	});
+
+	it('should forward scopesUseExpressionMapping from config', async () => {
+		const configWithExpressionMapping = {
+			sso: {
+				provisioning: {
+					scopesName: 'n8n',
+					scopesInstanceRoleClaimName: 'n8n_instance_role',
+					scopesProjectsRolesClaimName: 'n8n_projects',
+					scopesUseExpressionMapping: true,
+				},
+			},
+		} as GlobalConfig;
+
+		const config = {
+			ssoUserRoleProvisioning: 'instance_and_project_roles',
+		} as InstanceSettingsLoaderConfig;
+
+		const loader = new ProvisioningInstanceSettingsLoader(
+			config,
+			configWithExpressionMapping,
+			settingsRepository,
+			logger,
+		);
+
+		await loader.apply();
+
+		const upsertCall = settingsRepository.upsert.mock.calls[0][0] as { value: string };
+		const persisted = jsonParse<Record<string, unknown>>(upsertCall.value);
+		expect(persisted.scopesUseExpressionMapping).toBe(true);
 	});
 
 	describe('persisted value is consumable by ProvisioningConfigDto', () => {

--- a/packages/cli/src/instance-settings-loader/loaders/sso/provisioning.instance-settings-loader.ts
+++ b/packages/cli/src/instance-settings-loader/loaders/sso/provisioning.instance-settings-loader.ts
@@ -49,7 +49,7 @@ export class ProvisioningInstanceSettingsLoader {
 			scopesProvisionInstanceRole:
 				mode === 'instance_role' || mode === 'instance_and_project_roles',
 			scopesProvisionProjectRoles: mode === 'instance_and_project_roles',
-			scopesUseExpressionMapping: false,
+			scopesUseExpressionMapping: provisioning.scopesUseExpressionMapping,
 			scopesName: provisioning.scopesName,
 			scopesInstanceRoleClaimName: provisioning.scopesInstanceRoleClaimName,
 			scopesProjectsRolesClaimName: provisioning.scopesProjectsRolesClaimName,


### PR DESCRIPTION
## Summary

Fixes #35076

`ProvisioningInstanceSettingsLoader` hardcoded `scopesUseExpressionMapping: false`, ignoring the `N8N_SSO_SCOPES_USE_EXPRESSION_MAPPING` env var that is already wired to `ProvisioningConfig.scopesUseExpressionMapping`. On every restart the loader overwrote the DB with `false`, silently disabling expression-based role mapping and falling back to direct-claim provisioning.

## Fix

One-line change: read the value from `provisioning.scopesUseExpressionMapping` instead of hardcoding `false`.

```diff
-scopesUseExpressionMapping: false,
+scopesUseExpressionMapping: provisioning.scopesUseExpressionMapping,
```

## Test

Added `should forward scopesUseExpressionMapping from config` asserting the config value is forwarded to the persisted row. Also added `scopesUseExpressionMapping: false` to the existing mock `globalConfig` so the other tests remain accurate.

Note: I could not run the full test suite locally (sparse checkout without node_modules), but the change is a one-line config read matching the established pattern for the other `scopes*` fields in the same object.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35080">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

