### PR TITLE
fix(ai-builder): Route eval report artifacts through --output-dir (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-artifact-output-dir.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-artifact-output-dir.test.ts
@@ -1,0 +1,114 @@
+import { existsSync, mkdtempSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+import { writeRunDebugReport } from '../report/run-debug-report';
+import { writeWorkflowReport } from '../report/workflow-report';
+import type { WorkflowTestCase, WorkflowTestCaseResult } from '../types';
+
+// Pins artifact PLACEMENT for the lang-tracer dispatcher (lang-tracer
+// `packages/dispatcher/src/lib/runner.ts`): it runs several concurrent eval
+// children against ONE n8n checkout in one container — each child gets its own
+// `--output-dir`, and relies on that flag covering EVERY artifact the run
+// writes, not just `eval-results.json`. The HTML reports use stable filenames
+// (`workflow-eval-report.html`, `workflow-eval-llm-debug.html`), so a writer
+// that ignores `--output-dir` and falls back to the package-level `.data`
+// directory silently lets concurrent runs clobber each other's reports.
+// The no-arg default must stay `.data` for local dev.
+
+const DEFAULT_REPORT_DIR = path.join(__dirname, '..', '..', '.data');
+
+const TEST_CASE: WorkflowTestCase = {
+	conversation: [{ role: 'user', text: 'Build a Slack notifier' }],
+	complexity: 'simple',
+	tags: [],
+	executionScenarios: [{ name: 's', description: 'd', dataSetup: '', successCriteria: 'ok' }],
+	datasets: ['full'],
+};
+
+const RESULTS: WorkflowTestCaseResult[] = [
+	{
+		testCase: TEST_CASE,
+		workflowBuildSuccess: true,
+		executionScenarioResults: [],
+		fileSlug: 'slack-notifier',
+	},
+];
+
+function freshOutputDir(): string {
+	return mkdtempSync(path.join(tmpdir(), 'eval-artifact-output-dir-'));
+}
+
+describe('eval report artifacts — --output-dir contract', () => {
+	describe('writeWorkflowReport', () => {
+		it('writes the timestamped and stable reports into the given outputDir', () => {
+			const outputDir = freshOutputDir();
+
+			const reportPath = writeWorkflowReport(RESULTS, outputDir);
+
+			expect(path.dirname(reportPath)).toBe(outputDir);
+			expect(existsSync(reportPath)).toBe(true);
+			expect(existsSync(path.join(outputDir, 'workflow-eval-report.html'))).toBe(true);
+		});
+
+		it('creates the outputDir when it does not exist yet', () => {
+			const outputDir = path.join(freshOutputDir(), 'nested', 'run-1');
+
+			const reportPath = writeWorkflowReport(RESULTS, outputDir);
+
+			expect(path.dirname(reportPath)).toBe(outputDir);
+			expect(readdirSync(outputDir)).toContain('workflow-eval-report.html');
+		});
+
+		it('falls back to the package .data directory when no outputDir is given', () => {
+			const reportPath = writeWorkflowReport(RESULTS);
+
+			expect(path.dirname(reportPath)).toBe(DEFAULT_REPORT_DIR);
+			expect(existsSync(path.join(DEFAULT_REPORT_DIR, 'workflow-eval-report.html'))).toBe(true);
+		});
+	});
+
+	describe('writeRunDebugReport', () => {
+		it('writes the timestamped and stable reports into the given outputDir', () => {
+			const outputDir = freshOutputDir();
+
+			const reportPath = writeRunDebugReport(RESULTS, outputDir);
+
+			expect(path.dirname(reportPath)).toBe(outputDir);
+			expect(existsSync(reportPath)).toBe(true);
+			expect(existsSync(path.join(outputDir, 'workflow-eval-llm-debug.html'))).toBe(true);
+		});
+
+		it('creates the outputDir when it does not exist yet', () => {
+			const outputDir = path.join(freshOutputDir(), 'nested', 'run-2');
+
+			const reportPath = writeRunDebugReport(RESULTS, outputDir);
+
+			expect(path.dirname(reportPath)).toBe(outputDir);
+			expect(readdirSync(outputDir)).toContain('workflow-eval-llm-debug.html');
+		});
+
+		it('falls back to the package .data directory when no outputDir is given', () => {
+			const reportPath = writeRunDebugReport(RESULTS);
+
+			expect(path.dirname(reportPath)).toBe(DEFAULT_REPORT_DIR);
+			expect(existsSync(path.join(DEFAULT_REPORT_DIR, 'workflow-eval-llm-debug.html'))).toBe(true);
+		});
+	});
+
+	it('gives concurrent runs their own copy of the stable-named reports', () => {
+		const dirA = freshOutputDir();
+		const dirB = freshOutputDir();
+
+		writeWorkflowReport(RESULTS, dirA);
+		writeRunDebugReport(RESULTS, dirA);
+		writeWorkflowReport(RESULTS, dirB);
+		writeRunDebugReport(RESULTS, dirB);
+
+		for (const dir of [dirA, dirB]) {
+			const names = readdirSync(dir);
+			expect(names).toContain('workflow-eval-report.html');
+			expect(names).toContain('workflow-eval-llm-debug.html');
+		}
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-artifact-output-dir.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-artifact-output-dir.test.ts
@@ -2,19 +2,23 @@ import { existsSync, mkdtempSync, readdirSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 
+import type { EvalLogger } from '../harness/logger';
+import { writeScenarioVerificationSnapshot } from '../harness/scenario-execution';
 import { writeRunDebugReport } from '../report/run-debug-report';
 import { writeWorkflowReport } from '../report/workflow-report';
-import type { WorkflowTestCase, WorkflowTestCaseResult } from '../types';
+import type { ChecklistResult, WorkflowTestCase, WorkflowTestCaseResult } from '../types';
 
 // Pins artifact PLACEMENT for the lang-tracer dispatcher (lang-tracer
 // `packages/dispatcher/src/lib/runner.ts`): it runs several concurrent eval
 // children against ONE n8n checkout in one container — each child gets its own
 // `--output-dir`, and relies on that flag covering EVERY artifact the run
-// writes, not just `eval-results.json`. The HTML reports use stable filenames
-// (`workflow-eval-report.html`, `workflow-eval-llm-debug.html`), so a writer
-// that ignores `--output-dir` and falls back to the package-level `.data`
-// directory silently lets concurrent runs clobber each other's reports.
-// The no-arg default must stay `.data` for local dev.
+// writes, not just `eval-results.json`. All three writers that used to hardcode
+// the package-level `.data` directory are covered here. The HTML reports are
+// the sharpest case: their filenames are stable
+// (`workflow-eval-report.html`, `workflow-eval-llm-debug.html`), so ignoring
+// `--output-dir` silently lets concurrent runs clobber each other's reports.
+// The no-arg default must stay `.data` for local dev and for n8n's own eval CI,
+// which uploads that path as a build artifact without passing `--output-dir`.
 
 const DEFAULT_REPORT_DIR = path.join(__dirname, '..', '..', '.data');
 
@@ -93,6 +97,74 @@ describe('eval report artifacts — --output-dir contract', () => {
 
 			expect(path.dirname(reportPath)).toBe(DEFAULT_REPORT_DIR);
 			expect(existsSync(path.join(DEFAULT_REPORT_DIR, 'workflow-eval-llm-debug.html'))).toBe(true);
+		});
+	});
+
+	describe('writeScenarioVerificationSnapshot', () => {
+		const CHECKLIST_RESULT: ChecklistResult = {
+			id: 1,
+			pass: true,
+			reasoning: 'digest arrived',
+			strategy: 'llm',
+		};
+
+		/** Collects warnings so a swallowed write error reads differently from a
+		 *  snapshot correctly written somewhere else. */
+		function collectingLogger(): { logger: EvalLogger; warnings: string[] } {
+			const warnings: string[] = [];
+			const logger: EvalLogger = {
+				info: () => {},
+				verbose: () => {},
+				success: () => {},
+				warn: (msg: string) => warnings.push(msg),
+				error: (msg: string) => warnings.push(msg),
+				isVerbose: false,
+			};
+			return { logger, warnings };
+		}
+
+		async function writeSnapshot(testCaseName: string, outputDir?: string): Promise<string[]> {
+			const { logger, warnings } = collectingLogger();
+			await writeScenarioVerificationSnapshot({
+				testCaseName,
+				scenarioName: 'happy path',
+				workflowId: 'wf-1',
+				passed: true,
+				result: CHECKLIST_RESULT,
+				verificationResults: [CHECKLIST_RESULT],
+				verifierAttempts: [],
+				logger,
+				outputDir,
+			});
+			expect(warnings).toEqual([]);
+			return warnings;
+		}
+
+		it('writes the snapshot into the given outputDir', async () => {
+			const outputDir = freshOutputDir();
+
+			await writeSnapshot('daily digest', outputDir);
+
+			const names = readdirSync(outputDir);
+			expect(names).toHaveLength(1);
+			expect(names[0]).toMatch(/^daily-digest_happy-path_.*\.json$/);
+		});
+
+		it('creates the outputDir when it does not exist yet', async () => {
+			const outputDir = path.join(freshOutputDir(), 'nested', 'run-3');
+
+			await writeSnapshot('daily digest', outputDir);
+
+			expect(readdirSync(outputDir)).toHaveLength(1);
+		});
+
+		it('falls back to the package .data directory when no outputDir is given', async () => {
+			const caseName = `fallback case ${String(Date.now())}`;
+
+			await writeSnapshot(caseName);
+
+			const slug = caseName.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+			expect(readdirSync(DEFAULT_REPORT_DIR).some((n) => n.startsWith(`${slug}_`))).toBe(true);
 		});
 	});
 

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -124,6 +124,7 @@ async function main(): Promise<void> {
 			gate,
 			slugByTestCase,
 			commitSha,
+			outputDir: args.outputDir,
 			jsonPath,
 			prCommentPath,
 			experimentName: args.experimentName,

--- a/packages/@n8n/instance-ai/evaluations/harness/agent-execution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/agent-execution.ts
@@ -68,6 +68,7 @@ export async function executeAgentScenario(
 	timeoutMs?: number,
 	testCaseName?: string,
 	buildTrace?: BuildTrace,
+	outputDir?: string,
 ): Promise<ExecutionScenarioResult> {
 	const execStart = Date.now();
 	const projectId = await client.getPersonalProjectId();
@@ -130,6 +131,7 @@ export async function executeAgentScenario(
 		verifierAttempts: verification.attempts,
 		buildTrace,
 		logger,
+		outputDir,
 	});
 	const incomplete = verificationResults.length === 0;
 	const attemptErrors = verification.attempts

--- a/packages/@n8n/instance-ai/evaluations/harness/scenario-execution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/scenario-execution.ts
@@ -54,13 +54,17 @@ export async function writeScenarioVerificationSnapshot(input: {
 	verifierAttempts: VerifierAttemptDebug[];
 	buildTrace?: BuildTrace;
 	logger: EvalLogger;
+	/** --output-dir; falls back to EVAL_DATA_DIR. Concurrent eval children share
+	 *  one checkout, so each needs its snapshots under its own directory. */
+	outputDir?: string;
 }): Promise<void> {
+	const snapshotDir = input.outputDir ?? EVAL_DATA_DIR;
 	const timestamp = makeArtifactTimestamp();
 	const fileName = `${slugifyArtifactSegment(input.testCaseName, 'workflow')}_${slugifyArtifactSegment(input.scenarioName, 'scenario')}_${timestamp}.json`;
-	const filePath = path.join(EVAL_DATA_DIR, fileName);
+	const filePath = path.join(snapshotDir, fileName);
 
 	try {
-		await mkdir(EVAL_DATA_DIR, { recursive: true });
+		await mkdir(snapshotDir, { recursive: true });
 		await writeFile(
 			filePath,
 			JSON.stringify(
@@ -90,6 +94,9 @@ export async function writeScenarioVerificationSnapshot(input: {
 
 /**
  * Execute a single scenario against a pre-built workflow and verify the result.
+ *
+ * `outputDir` (--output-dir) is where the verification snapshot lands; omitting
+ * it keeps the historical EVAL_DATA_DIR location.
  */
 export async function executeScenario(
 	client: N8nClient,
@@ -102,6 +109,7 @@ export async function executeScenario(
 	buildTrace?: BuildTrace,
 	pinAiRoots?: string[],
 	seedContext?: ScenarioSeedContext,
+	outputDir?: string,
 ): Promise<ExecutionScenarioResult> {
 	return await runScenario(
 		client,
@@ -114,6 +122,7 @@ export async function executeScenario(
 		buildTrace,
 		pinAiRoots,
 		seedContext,
+		outputDir,
 	);
 }
 
@@ -248,6 +257,7 @@ async function runScenario(
 	buildTrace?: BuildTrace,
 	pinAiRoots?: string[],
 	seedContext?: ScenarioSeedContext,
+	outputDir?: string,
 ): Promise<ExecutionScenarioResult> {
 	const pinNodes = pinAiRoots && pinAiRoots.length > 0 ? pinAiRoots : undefined;
 	const targetWorkflowId = selectScenarioWorkflowId(scenario, workflowId, workflowJsons, logger);
@@ -336,6 +346,7 @@ async function runScenario(
 		verifierAttempts: verification.attempts,
 		buildTrace,
 		logger,
+		outputDir,
 	});
 	// Empty verification = the verifier itself failed after all attempts. The run
 	// is excluded from scoring (mirrors incomplete build expectations) but stays

--- a/packages/@n8n/instance-ai/evaluations/report/run-debug-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/report/run-debug-report.ts
@@ -415,8 +415,12 @@ export function generateRunDebugReport(results: WorkflowTestCaseResult[]): strin
 </html>`;
 }
 
-export function writeRunDebugReport(results: WorkflowTestCaseResult[]): string {
-	const reportDir = path.join(__dirname, '..', '..', '.data');
+/**
+ * Write the LLM debug report into `outputDir` (--output-dir), falling back to
+ * the package-level `.data` directory — same contract as writeWorkflowReport.
+ */
+export function writeRunDebugReport(results: WorkflowTestCaseResult[], outputDir?: string): string {
+	const reportDir = outputDir ?? path.join(__dirname, '..', '..', '.data');
 	if (!fs.existsSync(reportDir)) {
 		fs.mkdirSync(reportDir, { recursive: true });
 	}

--- a/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
@@ -1806,8 +1806,14 @@ ${results.map((r, i) => renderTestCase(r, i)).join('')}
 // Write report to disk
 // ---------------------------------------------------------------------------
 
-export function writeWorkflowReport(results: WorkflowTestCaseResult[]): string {
-	const reportDir = path.join(__dirname, '..', '..', '.data');
+/**
+ * Write the HTML report into `outputDir` (--output-dir), falling back to the
+ * package-level `.data` directory. The stable filename makes the fallback
+ * unsafe for concurrent runs against one checkout, so callers that have a
+ * per-run directory must pass it (see run/reporters.ts).
+ */
+export function writeWorkflowReport(results: WorkflowTestCaseResult[], outputDir?: string): string {
+	const reportDir = outputDir ?? path.join(__dirname, '..', '..', '.data');
 	if (!fs.existsSync(reportDir)) {
 		fs.mkdirSync(reportDir, { recursive: true });
 	}

--- a/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
@@ -175,6 +175,7 @@ export function createEvalSession(config: EvalSessionConfig): EvalSession {
 						execArgs.buildTrace,
 						args.pinAiRoots,
 						execArgs.seedContext,
+						args.outputDir,
 					),
 			),
 			tracedExecuteAgent: wrap(
@@ -197,6 +198,7 @@ export function createEvalSession(config: EvalSessionConfig): EvalSession {
 						execArgs.timeoutMs,
 						execArgs.testCaseName,
 						execArgs.buildTrace,
+						args.outputDir,
 					),
 			),
 		};

--- a/packages/@n8n/instance-ai/evaluations/run/reporters.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reporters.ts
@@ -84,18 +84,30 @@ export function emitRunReports(config: {
 	gate: GateResult | undefined;
 	slugByTestCase: Map<WorkflowTestCase, string> | undefined;
 	commitSha: string | undefined;
+	/** --output-dir; the HTML reports land here alongside the data artifacts.
+	 *  Undefined leaves each writer on its `.data` default. */
+	outputDir: string | undefined;
 	jsonPath: string;
 	prCommentPath: string;
 	/** --experiment-name; baseline-prefixed names trigger the noise advisory. */
 	experimentName?: string;
 }): void {
-	const { evaluation, outcome, gate, slugByTestCase, commitSha, jsonPath, prCommentPath } = config;
+	const {
+		evaluation,
+		outcome,
+		gate,
+		slugByTestCase,
+		commitSha,
+		outputDir,
+		jsonPath,
+		prCommentPath,
+	} = config;
 	console.log(`Results:    ${jsonPath}`);
 	console.log(`PR comment: ${prCommentPath}`);
 	const reportResults = flattenRunsForReport(evaluation);
-	const htmlPath = writeWorkflowReport(reportResults);
+	const htmlPath = writeWorkflowReport(reportResults, outputDir);
 	console.log(`Report:     ${htmlPath}`);
-	const debugHtmlPath = writeRunDebugReport(reportResults);
+	const debugHtmlPath = writeRunDebugReport(reportResults, outputDir);
 	console.log(`LLM debug:  ${debugHtmlPath}`);
 	console.log(
 		'\n' + formatComparisonTerminal(evaluation, outcome, { commitSha, slugByTestCase, gate }),


### PR DESCRIPTION
## The gap

`--output-dir` is already a first-class eval CLI arg (`evaluations/cli/args.ts` → `CliArgs.outputDir`), and the data artifacts honour it: `writeEvalResults` writes `eval-results.json` + `eval-pr-comment.md` there, and `createRowSink` writes `eval-rows.jsonl` there.

Three artifact writers did not. All three hardcoded

```ts
path.join(__dirname, '..', '..', '.data')
```

and wrote into it regardless of what the caller asked for:

| Writer | Artifact |
|---|---|
| `report/workflow-report.ts` → `writeWorkflowReport` | `workflow-eval-report.html` (**stable name**) |
| `report/run-debug-report.ts` → `writeRunDebugReport` | `workflow-eval-llm-debug.html` (**stable name**) |
| `harness/scenario-execution.ts` → `writeScenarioVerificationSnapshot` | `<testCase>_<scenario>_<timestamp>.json` |

## Why it matters

For a single local run this is invisible. But the LangTracer dispatcher runs **several concurrent eval children against one n8n checkout, in one container**, giving each child its own `--output-dir`. Those children were all writing into the same package-level `.data` directory — and for the two stable-named HTML files that means silently clobbering each other, so a failed case's report could belong to a different case entirely.

Because of that gap, lang-tracer has been **patching this source at Docker-build time** (a sed-like redirect of these three sites to an env var). That patch broke the whole eval fleet when #34834 moved one of the files. Honouring the flag that already exists here lets the downstream patch be deleted.

## What changed

All three writers now take an optional `outputDir` and fall back to the **exact current** `.data` expression when it is absent — no `process.cwd()` fallback, so local dev and every existing caller behave identically to before.

- `writeWorkflowReport(results, outputDir?)` and `writeRunDebugReport(results, outputDir?)`.
- `emitRunReports` gains an explicit `outputDir: string | undefined` config field (the directory was already in hand — `jsonPath`/`prCommentPath` are derived from it) and passes it to both report writers. `evaluations/cli/index.ts` supplies `args.outputDir`.
- `writeScenarioVerificationSnapshot`'s input object gains `outputDir?: string`. `executeScenario`, `runScenario` and `executeAgentScenario` take it as a **trailing optional** parameter, and `createEvalSession` passes `args.outputDir` at both call sites.

Signatures follow the existing convention in `evaluations/run/persist.ts` (`writeEvalResults(..., outputDir)`, `createRowSink(outputDir)`).

Two things deliberately *not* changed, because they turned out not to need it:

- **`EvalSessionConfig` gets no new field.** It already carries `args: CliArgs`, and `args.pinAiRoots` — read straight off it two lines above the `executeScenario` call — is the existing precedent. A parallel `outputDir` field would duplicate state that could disagree with `args.outputDir`, so `direct-driver.ts` and `langsmith-driver.ts` are untouched.
- **`run/build-orchestrator.ts` is untouched.** It references both scenario functions only through `Awaited<ReturnType<typeof …>>`, which is parameter-agnostic.

`executeScenario` is a public package export (`evaluations/index.ts:31`); a trailing optional parameter keeps every existing caller source-compatible.

## Backward compatibility — n8n's own eval CI is unaffected

Two in-repo workflows upload the HTML report as a build artifact by its `.data` path:

- `.github/workflows/test-evals-instance-ai.yml:500` — `packages/@n8n/instance-ai/.data/workflow-eval-report.html`
- `.github/workflows/test-evals-mcp.yml:387` — same path

Neither upload changes location, because **neither workflow passes `--output-dir`**. `grep -rniE 'output.dir|outputDir' .github/` returns only an unrelated `n8n export:entities --outputDir` in `util-data-tooling.yml`; nothing in either eval workflow's `ARGS[@]` sets it. So `args.outputDir` is `undefined` there, every writer takes the `.data` fallback, and the artifact paths resolve exactly as before. (Corroborating signal: those same uploads expect `eval-results.json` at the *package root*, i.e. `process.cwd()` — which is only where `writeEvalResults` puts it when `outputDir` is undefined.)

Each fallback expression is byte-identical to the one it replaced and unmoved within its file, so **any** caller that does not pass the new argument is unchanged — including the timestamped-filename copies written alongside the stable ones. `workflow-eval-llm-debug.html` is not uploaded by any workflow.

Three tests in this PR pin the fallbacks directly, so a future refactor cannot quietly repoint them and break these uploads.

## Tests

New file `evaluations/__tests__/eval-artifact-output-dir.test.ts`, modelled on `eval-results-dispatcher-contract.test.ts` — it pins artifact **placement** for the same downstream consumer that file pins artifact **shape** for, with a header comment explaining why. For each of the three writers it asserts both directions: given an `outputDir` the artifact lands there (including creating a nested directory that does not exist yet), and given none it lands in the existing `.data` location.

Written test-first in two passes, each watched failing before implementing. The report writers failed 5/7 with `Received: ".../packages/@n8n/instance-ai/.data"` where a temp dir was expected; the snapshot cases then failed 2/10 the same way — and because `writeScenarioVerificationSnapshot` swallows write errors, its tests assert the logger recorded no warnings, so "written elsewhere" is distinguishable from "write failed".

```
$ npx vitest run evaluations/__tests__/eval-artifact-output-dir.test.ts --reporter=verbose

 RUN  v4.1.9 /Users/.../packages/@n8n/instance-ai

 ✓ ... > writeWorkflowReport > writes the timestamped and stable reports into the given outputDir 10ms
 ✓ ... > writeWorkflowReport > creates the outputDir when it does not exist yet 1ms
 ✓ ... > writeWorkflowReport > falls back to the package .data directory when no outputDir is given 0ms
 ✓ ... > writeRunDebugReport > writes the timestamped and stable reports into the given outputDir 0ms
 ✓ ... > writeRunDebugReport > creates the outputDir when it does not exist yet 0ms
 ✓ ... > writeRunDebugReport > falls back to the package .data directory when no outputDir is given 0ms
 ✓ ... > writeScenarioVerificationSnapshot > writes the snapshot into the given outputDir 1ms
 ✓ ... > writeScenarioVerificationSnapshot > creates the outputDir when it does not exist yet 0ms
 ✓ ... > writeScenarioVerificationSnapshot > falls back to the package .data directory when no outputDir is given 0ms
 ✓ ... > gives concurrent runs their own copy of the stable-named reports 1ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Adjacent suites still green — `workflow-report` (8), `run-debug-report` (4), `eval-results-dispatcher-contract` (2), `agent-scenario-artifact` (2), `verification-artifact` (14), `partial-results-abort` (4): 44 passed across 7 files.

Typecheck clean:

```
$ pnpm --filter @n8n/instance-ai typecheck
> tsc --noEmit && tsc -p evaluations/tsconfig.json
(exit 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
