### PR TITLE
fix(core): Block deletion of the SSO role mapping default condition role

### DIFF
--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-deletion-checker.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-deletion-checker.ee.test.ts
@@ -1,19 +1,27 @@
+import type { ProvisioningConfigDto } from '@n8n/api-types';
 import type { RoleMappingRuleRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
 import { ProvisioningRoleDeletionChecker } from '../role-deletion-checker.ee';
+import type { ProvisioningService } from '../provisioning.service.ee';
 
 describe('ProvisioningRoleDeletionChecker', () => {
 	const roleMappingRuleRepository = mock<RoleMappingRuleRepository>();
-	const checker = new ProvisioningRoleDeletionChecker(roleMappingRuleRepository);
+	const provisioningService = mock<ProvisioningService>();
+	const checker = new ProvisioningRoleDeletionChecker(
+		roleMappingRuleRepository,
+		provisioningService,
+	);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		roleMappingRuleRepository.count.mockResolvedValue(0);
+		provisioningService.getConfig.mockResolvedValue(
+			mock<ProvisioningConfigDto>({ defaultInstanceRole: undefined }),
+		);
 	});
 
-	it('reports no blockers when no mapping rule references the role', async () => {
-		roleMappingRuleRepository.count.mockResolvedValue(0);
-
+	it('reports no blockers when the role is unreferenced', async () => {
 		const blockers = await checker.findRoleDeletionBlockers('global:auditor');
 
 		expect(roleMappingRuleRepository.count).toHaveBeenCalledWith({
@@ -36,5 +44,29 @@ describe('ProvisioningRoleDeletionChecker', () => {
 		const blockers = await checker.findRoleDeletionBlockers('global:auditor');
 
 		expect(blockers).toEqual(['referenced by 3 role mapping rules']);
+	});
+
+	it('reports a blocker when the role is the default condition role', async () => {
+		provisioningService.getConfig.mockResolvedValue(
+			mock<ProvisioningConfigDto>({ defaultInstanceRole: 'global:auditor' }),
+		);
+
+		const blockers = await checker.findRoleDeletionBlockers('global:auditor');
+
+		expect(blockers).toEqual(['configured as the role mapping default condition role']);
+	});
+
+	it('reports both blockers when the role is referenced by a mapping rule and is the default condition role', async () => {
+		roleMappingRuleRepository.count.mockResolvedValue(1);
+		provisioningService.getConfig.mockResolvedValue(
+			mock<ProvisioningConfigDto>({ defaultInstanceRole: 'global:auditor' }),
+		);
+
+		const blockers = await checker.findRoleDeletionBlockers('global:auditor');
+
+		expect(blockers).toEqual([
+			'referenced by 1 role mapping rule',
+			'configured as the role mapping default condition role',
+		]);
 	});
 });

--- a/packages/cli/src/modules/provisioning.ee/role-deletion-checker.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-deletion-checker.ee.ts
@@ -3,20 +3,36 @@ import { Service } from '@n8n/di';
 
 import type { RoleDeletionChecker } from '@/services/role-deletion-check-proxy.service';
 
+import { ProvisioningService } from './provisioning.service.ee';
+
 /**
  * Blocks deletion of a custom role while it is still targeted by an SSO role
- * mapping rule. Registered on the core `RoleDeletionCheckProxy` by the
- * provisioning module so `RoleService` stays decoupled from this module.
+ * mapping rule or configured as the role mapping default condition.
+ * Registered on the core `RoleDeletionCheckProxy` by the provisioning module
+ * so `RoleService` stays decoupled from this module.
  */
 @Service()
 export class ProvisioningRoleDeletionChecker implements RoleDeletionChecker {
-	constructor(private readonly roleMappingRuleRepository: RoleMappingRuleRepository) {}
+	constructor(
+		private readonly roleMappingRuleRepository: RoleMappingRuleRepository,
+		private readonly provisioningService: ProvisioningService,
+	) {}
 
 	async findRoleDeletionBlockers(roleSlug: string): Promise<string[]> {
+		const blockers: string[] = [];
+
 		const count = await this.roleMappingRuleRepository.count({
 			where: { role: { slug: roleSlug } },
 		});
-		if (count === 0) return [];
-		return [`referenced by ${count} role mapping rule${count === 1 ? '' : 's'}`];
+		if (count > 0) {
+			blockers.push(`referenced by ${count} role mapping rule${count === 1 ? '' : 's'}`);
+		}
+
+		const { defaultInstanceRole } = await this.provisioningService.getConfig();
+		if (defaultInstanceRole === roleSlug) {
+			blockers.push('configured as the role mapping default condition role');
+		}
+
+		return blockers;
 	}
 }


### PR DESCRIPTION
## Summary

- `ProvisioningRoleDeletionChecker` only checked whether a role was referenced by an SSO role mapping rule before allowing deletion.
- It did not know about `defaultInstanceRole` (the SSO role mapping default condition added in #35023), so a custom role configured as the default condition could be deleted with no warning.
- Deleting it doesn't crash anything (the fallback lookup in `ProvisioningService` no-ops with a warning log), but it silently breaks default role assignment on future SSO logins with no admin-facing signal.
- This adds the missing check so deletion is blocked the same way it already is for mapping-rule references.

## How to test

1. Configure the SSO provisioning default condition role to a custom global role.
2. Attempt to delete that role.
3. Deletion should now be blocked with `configured as the role mapping default condition role` in the error.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up from review feedback on #35023.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35086">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

