### PR TITLE
build: Shorten monorepo build and typecheck critical paths

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -22,7 +22,10 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           # The default is build without typechecking, we want both
-          build-command: pnpm build
+          build-command: pnpm build --summarize
+
+      - name: Report build critical path
+        run: node scripts/turbo-critical-path.mjs >> "$GITHUB_STEP_SUMMARY"
 
   unit-test:
     name: Unit tests

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -149,7 +149,11 @@ jobs:
         if: fromJSON(steps.ci-filter.outputs.results).ci || fromJSON(steps.ci-filter.outputs.results).e2e
         uses: ./.github/actions/setup-nodejs
         with:
-          build-command: ${{ fromJSON(steps.ci-filter.outputs.results).ci && 'pnpm build' || 'pnpm turbo run build --filter=@n8n/playwright-janitor' }}
+          build-command: ${{ fromJSON(steps.ci-filter.outputs.results).ci && 'pnpm build --summarize' || 'pnpm turbo run build --filter=@n8n/playwright-janitor' }}
+
+      - name: Report build critical path
+        if: fromJSON(steps.ci-filter.outputs.results).ci
+        run: node scripts/turbo-critical-path.mjs >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run format check
         if: fromJSON(steps.ci-filter.outputs.results).ci

--- a/packages/frontend/@n8n/chat/vite.config.mts
+++ b/packages/frontend/@n8n/chat/vite.config.mts
@@ -22,7 +22,8 @@ export default mergeConfig(
 				compiler: 'vue3',
 				autoInstall: true,
 			}),
-			dts(),
+			// The bundle pass emits the same declarations as the lib pass — skip the ~12s duplicate run.
+			...(includeVue ? [] : [dts()]),
 			{
 				name: 'rename-css-file',
 				closeBundle() {

--- a/packages/frontend/@n8n/i18n/src/index.ts
+++ b/packages/frontend/@n8n/i18n/src/index.ts
@@ -2,6 +2,7 @@
 import type { INodeProperties, INodePropertyCollection, INodePropertyOptions } from 'n8n-workflow';
 import { ref } from 'vue';
 import { createI18n } from 'vue-i18n';
+import type { I18n } from 'vue-i18n';
 
 import englishBaseText from './locales/en.json';
 import type { BaseTextKey, LocaleMessages, INodeTranslationHeaders } from './types';
@@ -14,7 +15,11 @@ import {
 
 export type * from './types';
 
-export const i18nInstance = createI18n({
+// Widened from the inferred type: vue-i18n otherwise resolves every t() call against a
+// schema of all ~7.7k en.json keys, costing tens of seconds of typecheck in each consumer.
+// Key safety is enforced at the baseText(key: BaseTextKey) boundary instead.
+type LooseSchema = Record<string, unknown>;
+export const i18nInstance: I18n<LooseSchema, LooseSchema, LooseSchema, string, false> = createI18n({
 	legacy: false,
 	locale: 'en',
 	fallbackLocale: 'en',

--- a/scripts/turbo-critical-path.mjs
+++ b/scripts/turbo-critical-path.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Reports the build-time-weighted critical path of a Turborepo run, from a
+ * `turbo run <task> --summarize` summary file. The critical path is the
+ * dependency chain with the largest total duration — the lower bound on wall
+ * time no amount of parallelism can beat. Use it to spot tasks worth
+ * shrinking or edges worth removing.
+ *
+ * Usage: node scripts/turbo-critical-path.mjs [path-to-summary.json]
+ * Defaults to the newest file in .turbo/runs/. Prints markdown; never fails.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TOP_N = 10;
+
+function newestRunSummary() {
+	const dir = join(process.cwd(), '.turbo', 'runs');
+	const files = readdirSync(dir)
+		.filter((f) => f.endsWith('.json'))
+		.map((f) => join(dir, f))
+		.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+	if (files.length === 0) throw new Error(`no run summaries in ${dir}`);
+	return files[0];
+}
+
+function fmt(seconds) {
+	return seconds >= 100 ? `${Math.round(seconds)}s` : `${seconds.toFixed(1)}s`;
+}
+
+try {
+	const file = process.argv[2] ?? newestRunSummary();
+	const summary = JSON.parse(readFileSync(file, 'utf8'));
+
+	const tasks = (summary.tasks ?? [])
+		.filter((t) => t.execution?.startTime && t.execution?.endTime)
+		.map((t) => ({
+			id: t.taskId,
+			dur: (t.execution.endTime - t.execution.startTime) / 1000,
+			deps: t.dependencies ?? [],
+			cached: t.cache?.status === 'HIT',
+		}));
+	if (tasks.length === 0) throw new Error(`no executed tasks in ${file}`);
+
+	const byId = new Map(tasks.map((t) => [t.id, t]));
+	const memo = new Map();
+	function heaviestChain(id) {
+		if (memo.has(id)) return memo.get(id);
+		const task = byId.get(id);
+		if (!task) return { total: 0, path: [] };
+		// turbo graphs are acyclic, so plain recursion terminates
+		let best = { total: 0, path: [] };
+		for (const dep of task.deps) {
+			const chain = heaviestChain(dep);
+			if (chain.total > best.total) best = chain;
+		}
+		const result = { total: best.total + task.dur, path: [...best.path, id] };
+		memo.set(id, result);
+		return result;
+	}
+
+	let critical = { total: 0, path: [] };
+	for (const t of tasks) {
+		const chain = heaviestChain(t.id);
+		if (chain.total > critical.total) critical = chain;
+	}
+
+	const cpu = tasks.reduce((sum, t) => sum + t.dur, 0);
+	const wall =
+		(Math.max(...summary.tasks.map((t) => t.execution?.endTime ?? 0)) -
+			Math.min(
+				...summary.tasks.filter((t) => t.execution?.startTime).map((t) => t.execution.startTime),
+			)) /
+		1000;
+	const cachedCount = tasks.filter((t) => t.cached).length;
+
+	const label = (t) => `\`${t.id}\`${t.cached ? ' (cache hit)' : ''}`;
+
+	const lines = [
+		`### Turbo critical path — \`${summary.execution?.command ?? 'run'}\``,
+		'',
+		`Wall ${fmt(wall)} · task CPU ${fmt(cpu)} · parallelism ${(cpu / wall).toFixed(1)}× · ${tasks.length} tasks (${cachedCount} cache hits)`,
+		'',
+		`**Critical path: ${fmt(critical.total)}** (${((critical.total / wall) * 100).toFixed(0)}% of wall time)`,
+		'',
+		...critical.path.map((id) => `- ${fmt(byId.get(id).dur)} ${label(byId.get(id))}`),
+		'',
+		`**Slowest tasks**`,
+		'',
+		...tasks
+			.slice()
+			.sort((a, b) => b.dur - a.dur)
+			.slice(0, TOP_N)
+			.map((t) => `- ${fmt(t.dur)} ${label(t)}`),
+		'',
+	];
+	console.log(lines.join('\n'));
+} catch (error) {
+	// Reporting only — never break the build over it.
+	console.log(`turbo-critical-path: skipped (${error.message})`);
+}

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,9 @@
 			"env": ["RELEASE"]
 		},
 		"typecheck": {
-			"dependsOn": ["^typecheck", "^build"]
+			// Typechecks are all --noEmit and read upstream types from dist (^build) or source
+			// (tsconfig paths) — depending on ^typecheck would only serialize the pipeline.
+			"dependsOn": ["^build"]
 		},
 		"format": {},
 		"format:check": {},


### PR DESCRIPTION
## Summary

A weighted critical-path analysis of the turbo task graph (methodology from [Airtable's TypeScript scaling article](https://medium.com/airtable-eng/a-leap-in-the-evolution-of-airtables-codebase-scaling-typescript-to-thousands-of-projects-734326c3a553)) showed `pnpm build` and `pnpm typecheck` are ~97% critical-path-bound — on an 11-core machine parallelism was only ~2–3× because one serial chain dominates wall time. Three fixes plus a measurement tool:

1. **`turbo.json`: `typecheck` no longer depends on `^typecheck`.** All 70 package typecheck scripts are self-contained `--noEmit` runs (audited); upstream types come from `^build` dist or tsconfig-paths source, so the edge only serialized the pipeline. Parallelism goes ~1.9× → ~4.3×. Note: a type error in a low-level package no longer prevents downstream typechecks from running, so one root cause can surface from two packages in the same run.
2. **`@n8n/chat`: run `vite-plugin-dts` only on the lib pass.** The `INCLUDE_VUE` bundle pass regenerated byte-identical declarations (~12s of each build). Solo build 38s → 18s; `dist/` file list is unchanged and the `style.css` version banner is intact.
3. **`@n8n/i18n`: widen `i18nInstance`'s type.** vue-i18n was resolving its schema-typed `t()` overloads against all ~7.7k `en.json` keys — 22s of the package's 31s check time, at two call sites in `baseText()`. Package check time 30.7s → 0.25s. Key safety is unchanged: invalid keys still fail at the `baseText(key: BaseTextKey)` boundary (probe-tested). Gotcha for reviewers: `Record<string, never>` as the Messages generic sends vue-i18n's types into TS2589 recursion; `Record<string, unknown>` is the correct widening.
4. **`scripts/turbo-critical-path.mjs`** reads a `turbo --summarize` run summary and prints wall/CPU/parallelism, the weighted critical path, and the slowest tasks. `ci-pull-requests` and `ci-master` now build with `--summarize` and append the report to `$GITHUB_STEP_SUMMARY`, so every run shows its critical path and regressions are visible at a glance. The script never exits non-zero.

Measured on a clean cache (11-core M-series, single runs):

| | before | after |
|---|---|---|
| cold `pnpm build` | 2m31s wall / 148s path | **1m47s / 105s** |
| clean `pnpm typecheck` | 3m36s wall / 209s path | **2m46s / 160s** |

Remaining critical path: FE build chain → `@n8n/chat#build` (~35s, two Vite bundle passes) → `n8n-editor-ui#typecheck` (~76s vue-tsc, unblocks with vue-language-tools tsgo support — vuejs/language-tools#5381).

Investigated and rejected: severing the runtime-packaging-only `n8n` → `n8n-editor-ui` build edge — turbo has no `dependsOn` exclusion, and enumerating cli's ~30 dependency builds in `turbo.json` would rot into nondeterministic cold-build failures.

## How to test

```bash
# whole repo stays green
pnpm build && pnpm typecheck

# critical-path report from the summary the build just wrote
pnpm build --summarize && node scripts/turbo-critical-path.mjs

# chat dist unchanged by the dts change
cd packages/frontend/@n8n/chat && pnpm build && ls dist  # index.d.ts, chat.*.js, chat.bundle.*.js, style.css all present

# i18n key safety: add i18n.baseText('not.a.real.key') anywhere in editor-ui → TS2345
```

CI itself demonstrates item 4: the *Install & Build* job summary on this PR shows the critical-path report.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-669

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35087">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

