### PR TITLE
build: Emit @n8n/chat declarations only in the lib build pass

### DIFF
--- a/packages/frontend/@n8n/chat/vite.config.mts
+++ b/packages/frontend/@n8n/chat/vite.config.mts
@@ -22,7 +22,8 @@ export default mergeConfig(
 				compiler: 'vue3',
 				autoInstall: true,
 			}),
-			dts(),
+			// The bundle pass emits the same declarations as the lib pass — skip the ~12s duplicate run.
+			...(includeVue ? [] : [dts()]),
 			{
 				name: 'rename-css-file',
 				closeBundle() {


### PR DESCRIPTION
## Summary

One of four independent build-perf PRs from the critical-path analysis in https://linear.app/n8n/issue/DEVP-669 (#35089, #35091, #35092 are the siblings — mergeable in any order).

`@n8n/chat` builds twice (lib pass, then `INCLUDE_VUE` bundle pass into the same `dist/`), and both passes ran `vite-plugin-dts` — the second regenerating byte-identical declarations, ~12s of every build. This runs dts only on the lib pass.

Measured: solo package build 38s → 18s. `@n8n/chat#build` sits on the repo's build critical path (feeds `n8n-editor-ui#build` → `n8n#build`), so cold `pnpm build` drops ~30s. Verified `dist/` file list is unchanged and `style.css` keeps its version banner (the CSS rename/banner plugins still run in both passes).

## How to test

```bash
cd packages/frontend/@n8n/chat
pnpm build && ls dist
# index.d.ts + per-module d.ts, chat.es.js, chat.umd.js, chat.bundle.es.js, chat.bundle.umd.js, style.css
head -1 dist/style.css   # version banner present
pnpm test                # 135 tests
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-669

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)