### PR TITLE
refactor: Widen i18nInstance so vue-i18n drops the message schema type

### DIFF
--- a/packages/frontend/@n8n/i18n/src/index.ts
+++ b/packages/frontend/@n8n/i18n/src/index.ts
@@ -2,6 +2,7 @@
 import type { INodeProperties, INodePropertyCollection, INodePropertyOptions } from 'n8n-workflow';
 import { ref } from 'vue';
 import { createI18n } from 'vue-i18n';
+import type { I18n } from 'vue-i18n';
 
 import englishBaseText from './locales/en.json';
 import type { BaseTextKey, LocaleMessages, INodeTranslationHeaders } from './types';
@@ -14,7 +15,11 @@ import {
 
 export type * from './types';
 
-export const i18nInstance = createI18n({
+// Widened from the inferred type: vue-i18n otherwise resolves every t() call against a
+// schema of all ~7.7k en.json keys, costing tens of seconds of typecheck in each consumer.
+// Key safety is enforced at the baseText(key: BaseTextKey) boundary instead.
+type LooseSchema = Record<string, unknown>;
+export const i18nInstance: I18n<LooseSchema, LooseSchema, LooseSchema, string, false> = createI18n({
 	legacy: false,
 	locale: 'en',
 	fallbackLocale: 'en',


### PR DESCRIPTION
## Summary

One of four independent build-perf PRs from the critical-path analysis in https://linear.app/n8n/issue/DEVP-669 (#35089, #35090, #35092 are the siblings — mergeable in any order).

vue-i18n infers a message schema from `messages: { en: englishBaseText }` and then resolves its schema-typed `t()` overloads against a type of all ~7.7k `en.json` keys. A compiler trace pinned 22s of `@n8n/i18n`'s 31s check time on the two `t()` call sites inside `baseText()`. Annotating `i18nInstance` with widened generics cuts the package's check time from 30.7s to 0.25s (`vue-tsc --extendedDiagnostics`), removing the repo's second-slowest typecheck task entirely.

Type-safety is unchanged:
- `BaseTextKey` is derived straight from the JSON in `types.ts` (independent of vue-i18n) — invalid keys still fail with TS2345 at the `baseText(key: BaseTextKey)` boundary (probe-verified).
- Runtime behavior is untouched (type-only change); all 19 package tests pass.

Reviewer note: `Record<string, unknown>` is deliberate — `Record<string, never>` sends vue-i18n's conditional types into TS2589 infinite recursion, and `{}` violates our lint rules.

## How to test

```bash
cd packages/frontend/@n8n/i18n
pnpm typecheck        # fast + green
pnpm test             # 19 tests
# add i18n.baseText('not.a.real.key') anywhere in editor-ui → TS2345
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-669

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)