### PR TITLE
refactor(editor): Resolve TypeScript 7 type errors surfaced in frontend packages

### DIFF
--- a/packages/frontend/@n8n/chat/tsconfig.json
+++ b/packages/frontend/@n8n/chat/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"outDir": "dist",
+		"noEmit": true,
+		"rootDirs": [".", "../design-system/src"],
 		"target": "esnext",
 		"module": "esnext",
 		"moduleResolution": "bundler",

--- a/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/Breadcrumbs.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nBreadcrumbs/Breadcrumbs.vue
@@ -1,7 +1,6 @@
-<script lang="ts" setup generic="UserType extends IUser">
+<script lang="ts" setup>
 import { computed, ref, watch } from 'vue';
 
-import type { IUser } from '../../types';
 import N8nActionToggle from '../N8nActionToggle';
 import type { DropdownMenuItemProps } from '../N8nDropdownMenu/DropdownMenu.types';
 import N8nLink from '../N8nLink';

--- a/packages/frontend/editor-ui/src/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/__tests__/utils.ts
@@ -95,6 +95,8 @@ export const getSelectedDropdownValue = async (items: NodeListOf<Element>) => {
 	return selectedItem?.querySelector('p')?.textContent?.trim();
 };
 
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
 /**
  * Typescript helper for mocking pinia store actions return value
  *
@@ -104,18 +106,20 @@ export const mockedStore = <TStoreDef extends (...args: never[]) => unknown>(
 	useStore: TStoreDef,
 	...args: Parameters<TStoreDef>
 ): TStoreDef extends StoreDefinition<infer Id, infer State, infer Getters, infer Actions>
-	? Store<
-			Id,
-			State,
-			Record<string, never>,
-			{
-				[K in keyof Actions]: Actions[K] extends (...args: infer Args) => infer ReturnT
-					? Mock<(...args: Args) => ReturnT>
-					: Actions[K];
+	? Mutable<
+			Store<
+				Id,
+				State,
+				Record<string, never>,
+				{
+					[K in keyof Actions]: Actions[K] extends (...args: infer Args) => infer ReturnT
+						? Mock<(...args: Args) => ReturnT>
+						: Actions[K];
+				}
+			> & {
+				[K in keyof Getters]: Getters[K] extends ComputedRef<infer T> ? T : never;
 			}
-		> & {
-			[K in keyof Getters]: Getters[K] extends ComputedRef<infer T> ? T : never;
-		}
+		>
 	: ReturnType<TStoreDef> => {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	return useStore(...args) as any;

--- a/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/composables/useExternalSecretsProvider.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/composables/useExternalSecretsProvider.ts
@@ -1,3 +1,5 @@
+import type { DisplayCondition, NodeParameterValue } from 'n8n-workflow';
+
 import type { IUpdateInformation } from '@/Interface';
 import type {
 	ExternalSecretsProvider,
@@ -52,7 +54,9 @@ export function useExternalSecretsProvider(
 			visible =
 				visible &&
 				Object.entries(property.displayOptions.show).every(([key, value]) => {
-					return value?.includes(providerData.value[key] as string);
+					return (value as Array<NodeParameterValue | DisplayCondition>)?.includes(
+						providerData.value[key] as string,
+					);
 				});
 		}
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
@@ -5,7 +5,7 @@ import {
 	type ConnectionProjectSummary,
 } from '@n8n/api-types';
 import type { IUpdateInformation } from '@/Interface';
-import type { INodeProperties } from 'n8n-workflow';
+import type { DisplayCondition, INodeProperties, NodeParameterValue } from 'n8n-workflow';
 import { useSecretsProviderConnection } from './useSecretsProviderConnection.ee';
 import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useToast } from '@/app/composables/useToast';
@@ -64,7 +64,9 @@ export function useConnectionModal(options: UseConnectionModalOptions) {
 			visible =
 				visible &&
 				Object.entries(property.displayOptions.show).every(([key, value]) => {
-					return value?.includes(connectionSettings.value[key] as string);
+					return (value as Array<NodeParameterValue | DisplayCondition>)?.includes(
+						connectionSettings.value[key] as string,
+					);
 				});
 		}
 

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyCreateOrEditModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyCreateOrEditModal.vue
@@ -4,7 +4,6 @@ import RevokeApiKeyConfirmModal from './RevokeApiKeyConfirmModal.vue';
 import Modal from '@/app/components/Modal.vue';
 import { API_KEY_CREATE_OR_EDIT_MODAL_KEY } from '../apiKeys.constants';
 import { computed, onMounted, ref } from 'vue';
-import { storeToRefs } from 'pinia';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { createEventBus } from '@n8n/utils/event-bus';
@@ -48,7 +47,7 @@ const rootStore = useRootStore();
 const clipboard = useClipboard();
 const apiKeysStore = useApiKeysStore();
 const { createApiKey, updateApiKey, deleteApiKey, apiKeysById, availableScopes } = apiKeysStore;
-const { currentUser } = storeToRefs(useUsersStore());
+const usersStore = useUsersStore();
 const documentTitle = useDocumentTitle();
 
 const label = ref('');
@@ -128,8 +127,8 @@ const currentApiKey = computed<ApiKey | null>(() =>
 
 const isReadOnly = computed(() => {
 	const apiKey = currentApiKey.value;
-	if (!apiKey?.owner || !currentUser.value) return false;
-	return apiKey.owner.id !== currentUser.value.id;
+	if (!apiKey?.owner || !usersStore.currentUser) return false;
+	return apiKey.owner.id !== usersStore.currentUser.id;
 });
 
 const isCustomDateInThePast = (date: Date) => Date.now() > date.getTime();


### PR DESCRIPTION
## Summary

Prep work toward type-checking the frontend with TypeScript 7 (tsgo). TS7 checks frontend packages more strictly than the current TS6 and flags genuine type issues the current compiler misses. This PR fixes them; everything type-checks clean on **both** TS6 (current CI) and tsgo.

**With this PR, all frontend packages — including `editor-ui` — type-check with zero errors under tsgo.**

### Fixes

- **`N8nBreadcrumbs`** — remove an unused `UserType` SFC generic (and its now-unused `IUser` import). No consumer instantiates the component with an explicit type argument, so the generic was dead.
- **External-secrets / secrets-provider composables** — `IDisplayOptions['show']` declares special keys (`@version: Array<number | DisplayCondition>`, `@feature`, `@tool: boolean[]`) alongside its index signature, so `Object.entries(...).value` is a union of array types and `.includes()` requires the *intersection* of their element types. TS6 accepted `string` unsoundly. Cast the value to the intended `Array<NodeParameterValue | DisplayCondition>`. Runtime behavior is unchanged.
- **`@n8n/chat`** — align its typecheck `tsconfig` (`noEmit` + `rootDirs`) with the rest of the frontend (design-system, frontend-module-sdk, editor-ui already use this) so imports of sibling package source resolve without `TS6059`.
- **`mockedStore` test helper** — its return type intersected Pinia's `Store<>`, which marks getters read-only, so tests overriding computed getters failed under tsgo (~262 sites). Wrap the mock type in a `Mutable<>` mapped type so overrides stay writable.
- **`ApiKeyCreateOrEditModal`** — `storeToRefs(useUsersStore())` yields a concrete `Store` type that isn't assignable to Pinia's `StoreGeneric` under tsgo; read `currentUser` directly off the store instead, matching the rest of the codebase.

## How to test

- `pnpm --filter n8n-editor-ui typecheck`
- `pnpm --filter @n8n/design-system typecheck`
- `pnpm --filter @n8n/chat typecheck`

All pass with no errors.

## Related Linear tickets, Github issues, and Community forum posts

None yet.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Tests included. <!-- behavior-neutral type/config fixes; no test changes -->