### PR TITLE
feat(core): Add REST endpoints for agent evals (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -603,6 +603,7 @@ export type {
 	AgentEvalResultRecord,
 	AgentEvalRatingRecord,
 	AgentEvalRunDetail,
+	AgentEvalRunSummary,
 	AgentEvalDraftCase,
 	GenerateDraftCasesOptions,
 	GenerateDraftCasesResult,

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -76,6 +76,10 @@ export type AgentEvalVote = z.infer<typeof agentEvalVoteSchema>;
 // which `Z.class` (flat shape only) cannot express.
 // ---------------------------------------------------------------------------
 
+// `agentId` is also a path param on the create route, which resolves the agent
+// against the project. The two must agree — the API rejects a mismatch rather
+// than picking a winner, since disagreement means the client is confused about
+// which agent it is configuring.
 export const createAgentEvalDatasetSchema = z
 	.object({
 		name: z.string().min(1).max(128),
@@ -99,6 +103,11 @@ export class UpdateAgentEvalDatasetDto extends Z.class(updateAgentEvalDatasetSha
 
 // Kicks off a run of the path dataset. `agentVersionId` optionally pins a
 // published version of the dataset's own agent; omitted runs the current one.
+//
+// The runner has no snapshot-execution path yet, so the API currently *rejects*
+// a pinned version rather than silently running the live agent and misreporting
+// what was measured. Keep the field: the shape is the target contract, and the
+// rejection lifts once version-pinned execution lands.
 const createAgentEvalRunShape = {
 	agentVersionId: z.string().min(1).optional(),
 };
@@ -182,6 +191,21 @@ export type AgentEvalRatingRecord = {
 // A run with its per-case results — the "open a run" view.
 export type AgentEvalRunDetail = AgentEvalRunRecord & {
 	results: AgentEvalResultRecord[];
+};
+
+/**
+ * Run status plus per-case status tallies — the progress-polling shape, kept
+ * deliberately free of the per-case rows so polling it stays cheap.
+ *
+ * `pending` folds `new` + `running`: a caller watching progress only needs "not
+ * settled yet", and collapsing them here means the UI doesn't have to know the
+ * result lifecycle. `total` is the sum of every per-status count, so it also
+ * reflects cases added by a re-seed rather than a value captured at run start.
+ */
+export type AgentEvalRunSummary = {
+	runId: string;
+	status: AgentEvalRunStatus;
+	counts: { total: number; success: number; error: number; cancelled: number; pending: number };
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-evals.schema.ts
@@ -76,10 +76,8 @@ export type AgentEvalVote = z.infer<typeof agentEvalVoteSchema>;
 // which `Z.class` (flat shape only) cannot express.
 // ---------------------------------------------------------------------------
 
-// `agentId` is also a path param on the create route, which resolves the agent
-// against the project. The two must agree — the API rejects a mismatch rather
-// than picking a winner, since disagreement means the client is confused about
-// which agent it is configuring.
+// `agentId` is also a path param on the create route; the API rejects a mismatch
+// rather than picking a winner.
 export const createAgentEvalDatasetSchema = z
 	.object({
 		name: z.string().min(1).max(128),
@@ -101,13 +99,8 @@ export const updateAgentEvalDatasetSchema = z.object(updateAgentEvalDatasetShape
 export type UpdateAgentEvalDatasetPayload = z.infer<typeof updateAgentEvalDatasetSchema>;
 export class UpdateAgentEvalDatasetDto extends Z.class(updateAgentEvalDatasetShape) {}
 
-// Kicks off a run of the path dataset. `agentVersionId` optionally pins a
-// published version of the dataset's own agent; omitted runs the current one.
-//
-// The runner has no snapshot-execution path yet, so the API currently *rejects*
-// a pinned version rather than silently running the live agent and misreporting
-// what was measured. Keep the field: the shape is the target contract, and the
-// rejection lifts once version-pinned execution lands.
+// Kicks off a run of the path dataset. `agentVersionId` would pin a published
+// version, but the API rejects it until the runner can execute a snapshot.
 const createAgentEvalRunShape = {
 	agentVersionId: z.string().min(1).optional(),
 };
@@ -193,15 +186,8 @@ export type AgentEvalRunDetail = AgentEvalRunRecord & {
 	results: AgentEvalResultRecord[];
 };
 
-/**
- * Run status plus per-case status tallies — the progress-polling shape, kept
- * deliberately free of the per-case rows so polling it stays cheap.
- *
- * `pending` folds `new` + `running`: a caller watching progress only needs "not
- * settled yet", and collapsing them here means the UI doesn't have to know the
- * result lifecycle. `total` is the sum of every per-status count, so it also
- * reflects cases added by a re-seed rather than a value captured at run start.
- */
+// The progress-polling shape: status plus tallies, no per-case rows, so polling
+// stays cheap. `pending` folds `new` + `running` — watchers only need "not settled".
 export type AgentEvalRunSummary = {
 	runId: string;
 	status: AgentEvalRunStatus;

--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-dataset.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-dataset.repository.test.ts
@@ -102,47 +102,46 @@ describe('AgentEvalDatasetRepository', () => {
 	});
 
 	describe('updateDataset', () => {
-		const existing = () =>
-			({
-				id: 'ds-1',
-				agentId: 'agent-1',
-				name: 'old',
-				description: 'old desc',
-				columnMapping: { input: 'q' },
-			}) as AgentEvalDataset;
+		const updated = { affected: 1, generatedMaps: [], raw: [] };
 
-		it('applies only the provided fields', async () => {
-			entityManager.findOneBy.mockResolvedValueOnce(existing());
-			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
+		it('writes only the provided fields, scoped to the agent', async () => {
+			entityManager.update.mockResolvedValueOnce(updated);
+			entityManager.findOneBy.mockResolvedValueOnce({ id: 'ds-1' } as AgentEvalDataset);
 
 			await repo.updateDataset('ds-1', 'agent-1', { name: 'new' });
 
-			expect(entityManager.save.mock.calls[0]?.[1]).toMatchObject({
-				name: 'new',
-				// untouched by an absent key
-				description: 'old desc',
-				columnMapping: { input: 'q' },
-			});
+			const [, criteria, patch] = entityManager.update.mock.calls[0] ?? [];
+			expect(criteria).toEqual({ id: 'ds-1', agentId: 'agent-1' });
+			// Absent keys stay out of the patch entirely, so their columns are untouched
+			// and a concurrent patch of a different field can't be clobbered.
+			expect(patch).toEqual({ name: 'new' });
 		});
 
 		it('clears a field when explicitly passed null', async () => {
-			entityManager.findOneBy.mockResolvedValueOnce(existing());
-			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
+			entityManager.update.mockResolvedValueOnce(updated);
+			entityManager.findOneBy.mockResolvedValueOnce({ id: 'ds-1' } as AgentEvalDataset);
 
 			await repo.updateDataset('ds-1', 'agent-1', { description: null, columnMapping: null });
 
-			expect(entityManager.save.mock.calls[0]?.[1]).toMatchObject({
+			expect(entityManager.update.mock.calls[0]?.[2]).toEqual({
 				description: null,
 				columnMapping: null,
 			});
 		});
 
-		it('returns null without writing when the dataset is not this agent’s', async () => {
+		it('skips the write when no known field was given', async () => {
+			entityManager.findOneBy.mockResolvedValueOnce({ id: 'ds-1' } as AgentEvalDataset);
+
+			await repo.updateDataset('ds-1', 'agent-1', {});
+
+			expect(entityManager.update).not.toHaveBeenCalled();
+		});
+
+		it('returns null when the dataset is not this agent’s', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 0, generatedMaps: [], raw: [] });
 			entityManager.findOneBy.mockResolvedValueOnce(null);
 
 			await expect(repo.updateDataset('ds-1', 'other-agent', { name: 'new' })).resolves.toBeNull();
-
-			expect(entityManager.save).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-dataset.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-dataset.repository.test.ts
@@ -87,4 +87,81 @@ describe('AgentEvalDatasetRepository', () => {
 			expect(entityManager.findOneBy.mock.calls[0]?.[1]).toEqual({ id: 'ds-1' });
 		});
 	});
+
+	describe('findByIdAndAgentId', () => {
+		it('filters on the agent as well as the id', async () => {
+			entityManager.findOneBy.mockResolvedValueOnce(null);
+
+			await repo.findByIdAndAgentId('ds-1', 'agent-1');
+
+			expect(entityManager.findOneBy.mock.calls[0]?.[1]).toEqual({
+				id: 'ds-1',
+				agentId: 'agent-1',
+			});
+		});
+	});
+
+	describe('updateDataset', () => {
+		const existing = () =>
+			({
+				id: 'ds-1',
+				agentId: 'agent-1',
+				name: 'old',
+				description: 'old desc',
+				columnMapping: { input: 'q' },
+			}) as AgentEvalDataset;
+
+		it('applies only the provided fields', async () => {
+			entityManager.findOneBy.mockResolvedValueOnce(existing());
+			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
+
+			await repo.updateDataset('ds-1', 'agent-1', { name: 'new' });
+
+			expect(entityManager.save.mock.calls[0]?.[1]).toMatchObject({
+				name: 'new',
+				// untouched by an absent key
+				description: 'old desc',
+				columnMapping: { input: 'q' },
+			});
+		});
+
+		it('clears a field when explicitly passed null', async () => {
+			entityManager.findOneBy.mockResolvedValueOnce(existing());
+			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
+
+			await repo.updateDataset('ds-1', 'agent-1', { description: null, columnMapping: null });
+
+			expect(entityManager.save.mock.calls[0]?.[1]).toMatchObject({
+				description: null,
+				columnMapping: null,
+			});
+		});
+
+		it('returns null without writing when the dataset is not this agent’s', async () => {
+			entityManager.findOneBy.mockResolvedValueOnce(null);
+
+			await expect(repo.updateDataset('ds-1', 'other-agent', { name: 'new' })).resolves.toBeNull();
+
+			expect(entityManager.save).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('deleteDataset', () => {
+		it('scopes the delete to the agent and reports a removal', async () => {
+			entityManager.delete.mockResolvedValueOnce({ affected: 1, raw: [] });
+
+			await expect(repo.deleteDataset('ds-1', 'agent-1')).resolves.toBe(true);
+
+			expect(entityManager.delete.mock.calls[0]?.[1]).toEqual({
+				id: 'ds-1',
+				agentId: 'agent-1',
+			});
+		});
+
+		it('reports no removal when nothing matched', async () => {
+			entityManager.delete.mockResolvedValueOnce({ affected: 0, raw: [] });
+
+			await expect(repo.deleteDataset('ds-1', 'other-agent')).resolves.toBe(false);
+		});
+	});
 });

--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-run.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-run.repository.test.ts
@@ -152,6 +152,33 @@ describe('AgentEvalRunRepository', () => {
 		});
 	});
 
+	// A run has no agent column of its own — the agent under test is its
+	// dataset's — so these scoped reads walk the relation.
+	describe('findByIdAndAgentId', () => {
+		it('constrains the run by its dataset’s agent', async () => {
+			entityManager.findOne.mockResolvedValueOnce(null);
+
+			await repo.findByIdAndAgentId('run-1', 'agent-1');
+
+			expect(entityManager.findOne.mock.calls[0]?.[1]).toEqual({
+				where: { id: 'run-1', dataset: { agentId: 'agent-1' } },
+			});
+		});
+	});
+
+	describe('findByDatasetIdAndAgentId', () => {
+		it('constrains the dataset’s runs by that agent, newest first', async () => {
+			entityManager.find.mockResolvedValueOnce([]);
+
+			await repo.findByDatasetIdAndAgentId('ds-1', 'agent-1');
+
+			expect(entityManager.find.mock.calls[0]?.[1]).toEqual({
+				where: { datasetId: 'ds-1', dataset: { agentId: 'agent-1' } },
+				order: { createdAt: 'DESC' },
+			});
+		});
+	});
+
 	describe('isCancellationRequested', () => {
 		it('reads only the cancel flag and returns it', async () => {
 			entityManager.findOne.mockResolvedValueOnce({ id: 'run-1', cancelRequested: true });

--- a/packages/@n8n/db/src/repositories/agent-eval-dataset.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-dataset.repository.ee.ts
@@ -1,6 +1,7 @@
 import type { DatasetRef } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import { DataSource, Repository } from '@n8n/typeorm';
+import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 
 import { AgentEvalDataset } from '../entities';
 import type { AgentEvalColumnMapping } from '../entities/agent-eval-dataset.ee';
@@ -15,11 +16,8 @@ type CreateAgentEvalDatasetAttrs = {
 	createdById?: string | null;
 };
 
-/**
- * Metadata-only patch. The dataset *source* (`datasetSource` + `datasetRef`) is
- * deliberately absent: repointing a dataset at a different table would silently
- * change what its existing runs were measured against, so that's a new dataset.
- */
+// Metadata only: repointing the source would change what existing runs were
+// measured against, so that's a new dataset.
 type UpdateAgentEvalDatasetAttrs = {
 	name?: string;
 	description?: string | null;
@@ -54,39 +52,34 @@ export class AgentEvalDatasetRepository extends Repository<AgentEvalDataset> {
 		return await this.findOneBy({ id });
 	}
 
-	/**
-	 * Ownership-scoped read: resolves the dataset only if it belongs to `agentId`.
-	 * The REST layer authorizes the *agent*, so every dataset lookup behind it
-	 * must filter on the agent too — a plain `findById` would let a caller
-	 * authorized for one agent address another agent's dataset by id.
-	 */
+	// The REST layer authorizes an agent, so lookups behind it must filter on the
+	// agent — `findById` alone would expose another agent's dataset by id.
 	async findByIdAndAgentId(id: string, agentId: string): Promise<AgentEvalDataset | null> {
 		return await this.findOneBy({ id, agentId });
 	}
 
-	/**
-	 * Patch a dataset's metadata, scoped to its agent. Only the fields present in
-	 * `attrs` are applied, so an absent key leaves the column untouched while an
-	 * explicit `null` clears it. Returns the updated dataset, or `null` when the
-	 * id doesn't resolve for this agent.
-	 *
-	 * Read-modify-save rather than a bare `update`: `columnMapping` is a JSON
-	 * column, which TypeORM's partial-update type can't express, and the read is
-	 * needed anyway to return the current record.
-	 */
+	// An absent key leaves the column alone; an explicit `null` clears it. Writes
+	// only the named columns, so concurrent patches can't clobber each other.
 	async updateDataset(
 		id: string,
 		agentId: string,
 		attrs: UpdateAgentEvalDatasetAttrs,
 	): Promise<AgentEvalDataset | null> {
-		const dataset = await this.findByIdAndAgentId(id, agentId);
-		if (!dataset) return null;
+		const patch: QueryDeepPartialEntity<AgentEvalDataset> = {
+			...(attrs.name !== undefined && { name: attrs.name }),
+			...(attrs.description !== undefined && { description: attrs.description }),
+			...(attrs.columnMapping !== undefined && { columnMapping: attrs.columnMapping }),
+		};
 
-		if (attrs.name !== undefined) dataset.name = attrs.name;
-		if (attrs.description !== undefined) dataset.description = attrs.description;
-		if (attrs.columnMapping !== undefined) dataset.columnMapping = attrs.columnMapping;
+		// Agent-scoped so a foreign agent's patch matches no row. TypeORM rejects an
+		// empty patch, and a body with no known field is a no-op anyway.
+		if (Object.keys(patch).length > 0) {
+			await this.update({ id, agentId }, patch);
+		}
 
-		return await this.save(dataset);
+		// Authoritative for "not found": covers an unknown id and a foreign agent
+		// without depending on driver-specific affected-row counts.
+		return await this.findByIdAndAgentId(id, agentId);
 	}
 
 	/** Delete a dataset, scoped to its agent. Returns whether a row was removed. */

--- a/packages/@n8n/db/src/repositories/agent-eval-dataset.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-dataset.repository.ee.ts
@@ -15,6 +15,17 @@ type CreateAgentEvalDatasetAttrs = {
 	createdById?: string | null;
 };
 
+/**
+ * Metadata-only patch. The dataset *source* (`datasetSource` + `datasetRef`) is
+ * deliberately absent: repointing a dataset at a different table would silently
+ * change what its existing runs were measured against, so that's a new dataset.
+ */
+type UpdateAgentEvalDatasetAttrs = {
+	name?: string;
+	description?: string | null;
+	columnMapping?: AgentEvalColumnMapping | null;
+};
+
 @Service()
 export class AgentEvalDatasetRepository extends Repository<AgentEvalDataset> {
 	constructor(dataSource: DataSource) {
@@ -41,5 +52,46 @@ export class AgentEvalDatasetRepository extends Repository<AgentEvalDataset> {
 
 	async findById(id: string): Promise<AgentEvalDataset | null> {
 		return await this.findOneBy({ id });
+	}
+
+	/**
+	 * Ownership-scoped read: resolves the dataset only if it belongs to `agentId`.
+	 * The REST layer authorizes the *agent*, so every dataset lookup behind it
+	 * must filter on the agent too — a plain `findById` would let a caller
+	 * authorized for one agent address another agent's dataset by id.
+	 */
+	async findByIdAndAgentId(id: string, agentId: string): Promise<AgentEvalDataset | null> {
+		return await this.findOneBy({ id, agentId });
+	}
+
+	/**
+	 * Patch a dataset's metadata, scoped to its agent. Only the fields present in
+	 * `attrs` are applied, so an absent key leaves the column untouched while an
+	 * explicit `null` clears it. Returns the updated dataset, or `null` when the
+	 * id doesn't resolve for this agent.
+	 *
+	 * Read-modify-save rather than a bare `update`: `columnMapping` is a JSON
+	 * column, which TypeORM's partial-update type can't express, and the read is
+	 * needed anyway to return the current record.
+	 */
+	async updateDataset(
+		id: string,
+		agentId: string,
+		attrs: UpdateAgentEvalDatasetAttrs,
+	): Promise<AgentEvalDataset | null> {
+		const dataset = await this.findByIdAndAgentId(id, agentId);
+		if (!dataset) return null;
+
+		if (attrs.name !== undefined) dataset.name = attrs.name;
+		if (attrs.description !== undefined) dataset.description = attrs.description;
+		if (attrs.columnMapping !== undefined) dataset.columnMapping = attrs.columnMapping;
+
+		return await this.save(dataset);
+	}
+
+	/** Delete a dataset, scoped to its agent. Returns whether a row was removed. */
+	async deleteDataset(id: string, agentId: string): Promise<boolean> {
+		const result = await this.delete({ id, agentId });
+		return (result.affected ?? 0) > 0;
 	}
 }

--- a/packages/@n8n/db/src/repositories/agent-eval-run.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-run.repository.ee.ts
@@ -81,6 +81,25 @@ export class AgentEvalRunRepository extends Repository<AgentEvalRun> {
 	}
 
 	/**
+	 * Ownership-scoped read: resolves the run only if its dataset belongs to
+	 * `agentId`. A run carries no agent column of its own — the agent under test
+	 * is the dataset's — so the check has to walk the relation. The REST layer
+	 * authorizes an agent, so every run lookup behind it filters on that agent
+	 * rather than trusting a bare run id.
+	 */
+	async findByIdAndAgentId(id: string, agentId: string): Promise<AgentEvalRun | null> {
+		return await this.findOne({ where: { id, dataset: { agentId } } });
+	}
+
+	/** Runs of a dataset, scoped to the agent that dataset must belong to. */
+	async findByDatasetIdAndAgentId(datasetId: string, agentId: string): Promise<AgentEvalRun[]> {
+		return await this.find({
+			where: { datasetId, dataset: { agentId } },
+			order: { createdAt: 'DESC' },
+		});
+	}
+
+	/**
 	 * Mark every run still in an incomplete state as errored. Called on startup:
 	 * the runner has no resume mechanism, so a run interrupted by a process
 	 * restart can never continue and would otherwise poll as `running` forever.

--- a/packages/@n8n/db/src/repositories/agent-eval-run.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-run.repository.ee.ts
@@ -80,13 +80,8 @@ export class AgentEvalRunRepository extends Repository<AgentEvalRun> {
 		return await this.findOneBy({ id });
 	}
 
-	/**
-	 * Ownership-scoped read: resolves the run only if its dataset belongs to
-	 * `agentId`. A run carries no agent column of its own — the agent under test
-	 * is the dataset's — so the check has to walk the relation. The REST layer
-	 * authorizes an agent, so every run lookup behind it filters on that agent
-	 * rather than trusting a bare run id.
-	 */
+	// A run has no agent column — the agent under test is its dataset's — so the
+	// ownership check walks the relation instead of trusting a bare run id.
 	async findByIdAndAgentId(id: string, agentId: string): Promise<AgentEvalRun | null> {
 		return await this.findOne({ where: { id, dataset: { agentId } } });
 	}

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-case-generation.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-case-generation.service.test.ts
@@ -1,5 +1,4 @@
 import type { AgentJsonConfig } from '@n8n/api-types';
-import { AGENT_EVALS_FLAG } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type { AgentEvalDataset, AgentEvalDatasetRepository, User } from '@n8n/db';
 import type { Mocked } from 'vitest';
@@ -9,13 +8,13 @@ import type { CredentialsService } from '@/credentials/credentials.service';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
-import type { PostHogClient } from '@/posthog';
 
 import type { AgentConfigService } from '../../agents/agent-config.service';
 import type { DataTable } from '../../data-table/data-table.entity';
 import type { DataTableService } from '../../data-table/data-table.service';
 import { DataTableNameConflictError } from '../../data-table/errors/data-table-name-conflict.error';
 import { AgentEvalCaseGenerationService } from '../agent-eval-case-generation.service';
+import type { AgentEvalsFlagGate } from '../agent-evals-flag-gate';
 
 // Stub the @n8n/agents SDK: fluent builder is a no-op; `generate` is a
 // controllable mock so tests drive the model's (in)valid structured output.
@@ -75,7 +74,7 @@ describe('AgentEvalCaseGenerationService', () => {
 	let credentialsService: Mocked<CredentialsService>;
 	let dataTableService: Mocked<DataTableService>;
 	let datasetRepository: Mocked<AgentEvalDatasetRepository>;
-	let postHogClient: Mocked<PostHogClient>;
+	let flagGate: Mocked<AgentEvalsFlagGate>;
 	let sourceControlPreferences: Mocked<SourceControlPreferencesService>;
 
 	beforeEach(() => {
@@ -85,7 +84,7 @@ describe('AgentEvalCaseGenerationService', () => {
 		credentialsService = mock<CredentialsService>();
 		dataTableService = mock<DataTableService>();
 		datasetRepository = mock<AgentEvalDatasetRepository>();
-		postHogClient = mock<PostHogClient>();
+		flagGate = mock<AgentEvalsFlagGate>();
 		sourceControlPreferences = mock<SourceControlPreferencesService>();
 		sourceControlPreferences.getPreferences.mockReturnValue({
 			branchReadOnly: false,
@@ -95,7 +94,7 @@ describe('AgentEvalCaseGenerationService', () => {
 		resolveModelMock.mockReset();
 		resolveModelMock.mockResolvedValue({ id: 'anthropic/claude-sonnet-4-5' });
 
-		postHogClient.getFeatureFlags.mockResolvedValue({ [AGENT_EVALS_FLAG]: true });
+		flagGate.assertEnabled.mockResolvedValue(undefined);
 		agentConfigService.getConfig.mockResolvedValue(makeConfig());
 		dataTableService.createDataTable.mockResolvedValue({ id: 'dt-1' } as DataTable);
 		dataTableService.insertRows.mockResolvedValue(undefined as never);
@@ -107,13 +106,13 @@ describe('AgentEvalCaseGenerationService', () => {
 			credentialsService,
 			dataTableService,
 			datasetRepository,
-			postHogClient,
+			flagGate,
 			sourceControlPreferences,
 		);
 	});
 
 	it('rejects when the agent-evals flag is disabled (as not-found, leaking no flag state)', async () => {
-		postHogClient.getFeatureFlags.mockResolvedValue({});
+		flagGate.assertEnabled.mockRejectedValue(new NotFoundError('Not found'));
 
 		await expect(service.generateDraftCases(user, 'project-1', 'agent-1')).rejects.toThrow(
 			NotFoundError,

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.integration.test.ts
@@ -21,6 +21,7 @@ import type { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent
 import { createUserShell } from '@test-integration/db/users';
 
 import { AgentEvalRunnerService } from '../agent-eval-runner.service';
+import { AgentEvalsFlagGate } from '../agent-evals-flag-gate';
 
 // The agent under test runs through the real reconstruction + live-model path,
 // which needs credentials/network and is covered by the instance-ai eval suite;
@@ -54,6 +55,11 @@ const buildRunner = () =>
 		evalAgentExecutionService,
 		concurrencyControl,
 		Container.get(License),
+		// Real gate, not a mock: it resolves the flag through the real
+		// `PostHogClient`, which (uninitialized here, so no network) falls back to
+		// the env overrides — exercising the operator force-enable path the
+		// `agentEvalsEnabled` assignment in `beforeEach` relies on.
+		Container.get(AgentEvalsFlagGate),
 	);
 
 /** Insert a minimal real agent row so `agent_eval_dataset.agentId`'s FK holds. */
@@ -140,7 +146,7 @@ describe('AgentEvalRunnerService (integration)', () => {
 		const { runId, finished } = await runner.startRun(dataset.id, project.id, owner);
 		await finished;
 
-		const summary = await runner.getRunSummary(runId);
+		const summary = await runner.getRunSummary(runId, agent.id);
 		expect(summary.status).toBe('completed');
 		expect(summary.counts).toMatchObject({ total: 2, success: 2, error: 0, cancelled: 0 });
 
@@ -203,7 +209,7 @@ describe('AgentEvalRunnerService (integration)', () => {
 		const { runId, finished } = await runner.startRun(dataset.id, project.id, owner);
 		await finished;
 
-		const summary = await runner.getRunSummary(runId);
+		const summary = await runner.getRunSummary(runId, agent.id);
 		expect(summary.status).toBe('completed');
 		expect(summary.counts).toMatchObject({ total: 1, success: 0, error: 1 });
 

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -11,6 +11,7 @@ import type { InstanceSettings } from 'n8n-core';
 import { mock, type MockProxy } from 'vitest-mock-extended';
 
 import type { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { resolveEvaluationConcurrencyLimit } from '@/evaluation.ee/evaluation-concurrency.helper';
 import type { License } from '@/license';
 import type { Agent } from '@/modules/agents/entities/agent.entity';
@@ -20,6 +21,7 @@ import type { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent
 import { userHasScopes } from '@/permissions.ee/check-access';
 
 import { AgentEvalRunnerService } from '../agent-eval-runner.service';
+import type { AgentEvalsFlagGate } from '../agent-evals-flag-gate';
 
 // Stub the cross-module specifiers the service statically imports so the unit
 // test doesn't pull in the real agents / data-table / instance-ai module graph.
@@ -100,6 +102,7 @@ describe('AgentEvalRunnerService', () => {
 	let evalAgentExecutionService: MockProxy<EvalAgentExecutionService>;
 	let concurrencyControl: MockProxy<ConcurrencyControlService>;
 	let license: MockProxy<License>;
+	let flagGate: MockProxy<AgentEvalsFlagGate>;
 	let service: AgentEvalRunnerService;
 
 	const dataset = mock<AgentEvalDataset>({
@@ -115,7 +118,6 @@ describe('AgentEvalRunnerService', () => {
 		vi.mocked(resolveEvaluationConcurrencyLimit).mockReturnValue(1); // serial by default
 
 		globalConfig = {
-			evaluation: { agentEvalsEnabled: true },
 			executions: { mode: 'regular' },
 		} as unknown as GlobalConfig;
 		instanceSettings = { hostId: 'main-1' } as unknown as InstanceSettings;
@@ -127,6 +129,7 @@ describe('AgentEvalRunnerService', () => {
 		evalAgentExecutionService = mock<EvalAgentExecutionService>();
 		concurrencyControl = mock<ConcurrencyControlService>();
 		license = mock<License>();
+		flagGate = mock<AgentEvalsFlagGate>();
 
 		datasetRepository.findById.mockResolvedValue(dataset);
 		agentRepository.findByIdAndProjectId.mockResolvedValue(
@@ -155,6 +158,7 @@ describe('AgentEvalRunnerService', () => {
 			evalAgentExecutionService,
 			concurrencyControl,
 			license,
+			flagGate,
 		);
 	});
 
@@ -171,11 +175,14 @@ describe('AgentEvalRunnerService', () => {
 	};
 
 	describe('gating', () => {
-		it('refuses when the flag is off', async () => {
-			globalConfig.evaluation.agentEvalsEnabled = false;
-			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow(
-				'Agent evals are not enabled',
-			);
+		// The flag is resolved per requesting user (PostHog owns cohort rollout),
+		// not per instance — so the gate is asked about `user`, not a config value.
+		it('refuses when the flag is off for the requesting user', async () => {
+			flagGate.assertEnabled.mockRejectedValue(new NotFoundError('Not found'));
+
+			await expect(service.startRun('ds-1', 'proj-1', user)).rejects.toThrow(NotFoundError);
+
+			expect(flagGate.assertEnabled).toHaveBeenCalledWith(user);
 			expect(runRepository.createRun).not.toHaveBeenCalled();
 		});
 
@@ -523,17 +530,30 @@ describe('AgentEvalRunnerService', () => {
 
 	describe('getRunSummary', () => {
 		it('404s when the run is missing', async () => {
-			runRepository.findById.mockResolvedValue(null);
-			await expect(service.getRunSummary('run-x')).rejects.toThrow('not found');
+			runRepository.findByIdAndAgentId.mockResolvedValue(null);
+			await expect(service.getRunSummary('run-x', 'agent-1')).rejects.toThrow('not found');
+		});
+
+		it('404s a run belonging to a different agent, without counting its cases', async () => {
+			// The agent-scoped read is the whole permission check on this path: a
+			// caller authorized for one agent must not be able to poll another
+			// agent's run by id.
+			runRepository.findByIdAndAgentId.mockResolvedValue(null);
+
+			await expect(service.getRunSummary('run-1', 'other-agent')).rejects.toThrow('not found');
+			expect(runRepository.findByIdAndAgentId).toHaveBeenCalledWith('run-1', 'other-agent');
+			expect(resultRepository.countByStatus).not.toHaveBeenCalled();
 		});
 
 		it('reports status + per-status counts from the count query', async () => {
-			runRepository.findById.mockResolvedValue(mock({ id: 'run-1', status: 'completed' }));
+			runRepository.findByIdAndAgentId.mockResolvedValue(
+				mock({ id: 'run-1', status: 'completed' }),
+			);
 			resultRepository.countByStatus.mockResolvedValue(
 				counts({ success: 3, error: 1, running: 1 }),
 			);
 
-			const summary = await service.getRunSummary('run-1');
+			const summary = await service.getRunSummary('run-1', 'agent-1');
 
 			expect(summary).toEqual({
 				runId: 'run-1',

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-scoped-reads.integration.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-scoped-reads.integration.test.ts
@@ -1,0 +1,171 @@
+import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
+import {
+	AgentEvalDatasetRepository,
+	AgentEvalResultRepository,
+	AgentEvalRunRepository,
+} from '@n8n/db';
+import { Container } from '@n8n/di';
+import { DataSource } from '@n8n/typeorm';
+
+import { Agent } from '@/modules/agents/entities/agent.entity';
+
+/**
+ * The agent-eval REST layer authorizes an *agent*, then reaches dataset and run
+ * rows by id. Everything that keeps one agent's caller out of another agent's
+ * evals therefore rests on these repository reads actually filtering by agent in
+ * SQL — including `agent_eval_run`, which has no agent column of its own and has
+ * to constrain through its dataset relation.
+ *
+ * These assertions run against a real database on purpose. Mocking the entity
+ * manager can only check which `where` object was constructed; it cannot tell
+ * whether the relation is joined and the predicate applied. A test that passes
+ * the *matching* agent would keep passing even if the filter were dropped
+ * entirely — so every case below pairs the allowed read with the foreign-agent
+ * read that must come back empty.
+ */
+describe('agent-eval scoped repository reads (integration)', () => {
+	let datasetRepository: AgentEvalDatasetRepository;
+	let runRepository: AgentEvalRunRepository;
+	let resultRepository: AgentEvalResultRepository;
+
+	/** Real agent row so `agent_eval_dataset.agentId`'s FK holds. */
+	async function createAgent(): Promise<Agent> {
+		const project = await createTeamProject();
+		return await Container.get(DataSource)
+			.getRepository(Agent)
+			.save(Object.assign(new Agent(), { name: 'test agent', projectId: project.id }));
+	}
+
+	beforeAll(async () => {
+		await testModules.loadModules(['data-table', 'agents']);
+		await testDb.init();
+		datasetRepository = Container.get(AgentEvalDatasetRepository);
+		runRepository = Container.get(AgentEvalRunRepository);
+		resultRepository = Container.get(AgentEvalResultRepository);
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['AgentEvalResult', 'AgentEvalRun', 'AgentEvalDataset']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	/** Two agents, each owning a dataset; a run + case under the first one's. */
+	async function seedTwoAgents() {
+		const [own, foreign] = await Promise.all([createAgent(), createAgent()]);
+
+		const dataset = await datasetRepository.createDataset({
+			name: 'own dataset',
+			agentId: own.id,
+			datasetSource: 'data_table',
+			datasetRef: { dataTableId: 'dt-own' },
+			columnMapping: { input: 'question' },
+		});
+		const foreignDataset = await datasetRepository.createDataset({
+			name: 'foreign dataset',
+			agentId: foreign.id,
+			datasetSource: 'data_table',
+			datasetRef: { dataTableId: 'dt-foreign' },
+		});
+
+		const run = await runRepository.createRun({ datasetId: dataset.id });
+		const [result] = await resultRepository.seedResults([
+			{ runId: run.id, sourceRowId: 'row-1', runIndex: 0, input: { input: 'q' } },
+		]);
+
+		return { own, foreign, dataset, foreignDataset, run, result };
+	}
+
+	describe('dataset reads', () => {
+		it('resolves a dataset for its own agent and hides it from another', async () => {
+			const { own, foreign, dataset } = await seedTwoAgents();
+
+			await expect(datasetRepository.findByIdAndAgentId(dataset.id, own.id)).resolves.toMatchObject(
+				{ id: dataset.id },
+			);
+			await expect(
+				datasetRepository.findByIdAndAgentId(dataset.id, foreign.id),
+			).resolves.toBeNull();
+		});
+
+		it('lists only the addressed agent’s datasets', async () => {
+			const { own, dataset } = await seedTwoAgents();
+
+			const listed = await datasetRepository.findByAgentId(own.id);
+
+			expect(listed.map((d) => d.id)).toEqual([dataset.id]);
+		});
+	});
+
+	// A run carries no agentId — the agent under test is its dataset's — so these
+	// reads are the ones that have to walk the relation to filter.
+	describe('run reads', () => {
+		it('resolves a run for its dataset’s agent and hides it from another', async () => {
+			const { own, foreign, run } = await seedTwoAgents();
+
+			await expect(runRepository.findByIdAndAgentId(run.id, own.id)).resolves.toMatchObject({
+				id: run.id,
+			});
+			await expect(runRepository.findByIdAndAgentId(run.id, foreign.id)).resolves.toBeNull();
+		});
+
+		it('lists a dataset’s runs only for that dataset’s agent', async () => {
+			const { own, foreign, dataset, run } = await seedTwoAgents();
+
+			await expect(
+				runRepository.findByDatasetIdAndAgentId(dataset.id, own.id),
+			).resolves.toMatchObject([{ id: run.id }]);
+			// Right dataset id, wrong agent — the pairing has to be checked, not just
+			// the dataset id, or a foreign caller reads another agent's run history.
+			await expect(
+				runRepository.findByDatasetIdAndAgentId(dataset.id, foreign.id),
+			).resolves.toEqual([]);
+		});
+	});
+
+	describe('dataset mutations', () => {
+		it('patches a dataset for its own agent', async () => {
+			const { own, dataset } = await seedTwoAgents();
+
+			const updated = await datasetRepository.updateDataset(dataset.id, own.id, {
+				name: 'renamed',
+				description: null,
+			});
+
+			expect(updated).toMatchObject({ id: dataset.id, name: 'renamed', description: null });
+		});
+
+		it('refuses to patch another agent’s dataset and leaves it untouched', async () => {
+			const { foreign, dataset } = await seedTwoAgents();
+
+			await expect(
+				datasetRepository.updateDataset(dataset.id, foreign.id, { name: 'hijacked' }),
+			).resolves.toBeNull();
+
+			const reread = await datasetRepository.findById(dataset.id);
+			expect(reread?.name).toBe('own dataset');
+		});
+
+		it('refuses to delete another agent’s dataset and leaves the row in place', async () => {
+			const { foreign, dataset } = await seedTwoAgents();
+
+			await expect(datasetRepository.deleteDataset(dataset.id, foreign.id)).resolves.toBe(false);
+			await expect(datasetRepository.findById(dataset.id)).resolves.not.toBeNull();
+		});
+
+		// The service reports a delete as success without touching runs or results,
+		// so the cascade is what actually removes them.
+		it('deletes a dataset for its own agent, cascading to its runs and results', async () => {
+			const { own, dataset, run, result } = await seedTwoAgents();
+
+			await expect(datasetRepository.deleteDataset(dataset.id, own.id)).resolves.toBe(true);
+
+			await expect(datasetRepository.findById(dataset.id)).resolves.toBeNull();
+			await expect(runRepository.findById(run.id)).resolves.toBeNull();
+			await expect(resultRepository.findByRunId(run.id)).resolves.toEqual([]);
+			expect(result).toBeDefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-scoped-reads.integration.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-scoped-reads.integration.test.ts
@@ -10,18 +10,10 @@ import { DataSource } from '@n8n/typeorm';
 import { Agent } from '@/modules/agents/entities/agent.entity';
 
 /**
- * The agent-eval REST layer authorizes an *agent*, then reaches dataset and run
- * rows by id. Everything that keeps one agent's caller out of another agent's
- * evals therefore rests on these repository reads actually filtering by agent in
- * SQL — including `agent_eval_run`, which has no agent column of its own and has
- * to constrain through its dataset relation.
- *
- * These assertions run against a real database on purpose. Mocking the entity
- * manager can only check which `where` object was constructed; it cannot tell
- * whether the relation is joined and the predicate applied. A test that passes
- * the *matching* agent would keep passing even if the filter were dropped
- * entirely — so every case below pairs the allowed read with the foreign-agent
- * read that must come back empty.
+ * Real DB on purpose: mocking the entity manager only proves which `where` object
+ * was built, not that the filter applied — and a test using the *matching* agent
+ * would pass even with the filter dropped. So every case here pairs the allowed
+ * read with the foreign-agent read that must come back empty.
  */
 describe('agent-eval scoped repository reads (integration)', () => {
 	let datasetRepository: AgentEvalDatasetRepository;
@@ -99,8 +91,7 @@ describe('agent-eval scoped repository reads (integration)', () => {
 		});
 	});
 
-	// A run carries no agentId — the agent under test is its dataset's — so these
-	// reads are the ones that have to walk the relation to filter.
+	// A run has no agentId of its own, so these reads filter via the dataset relation.
 	describe('run reads', () => {
 		it('resolves a run for its dataset’s agent and hides it from another', async () => {
 			const { own, foreign, run } = await seedTwoAgents();
@@ -117,8 +108,8 @@ describe('agent-eval scoped repository reads (integration)', () => {
 			await expect(
 				runRepository.findByDatasetIdAndAgentId(dataset.id, own.id),
 			).resolves.toMatchObject([{ id: run.id }]);
-			// Right dataset id, wrong agent — the pairing has to be checked, not just
-			// the dataset id, or a foreign caller reads another agent's run history.
+			// Right dataset id, wrong agent: the pairing has to be checked, or a foreign
+			// caller reads another agent's run history.
 			await expect(
 				runRepository.findByDatasetIdAndAgentId(dataset.id, foreign.id),
 			).resolves.toEqual([]);
@@ -155,8 +146,7 @@ describe('agent-eval scoped repository reads (integration)', () => {
 			await expect(datasetRepository.findById(dataset.id)).resolves.not.toBeNull();
 		});
 
-		// The service reports a delete as success without touching runs or results,
-		// so the cascade is what actually removes them.
+		// The service never touches runs or results, so the cascade is what removes them.
 		it('deletes a dataset for its own agent, cascading to its runs and results', async () => {
 			const { own, dataset, run, result } = await seedTwoAgents();
 

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval.service.test.ts
@@ -1,0 +1,392 @@
+import type {
+	AgentEvalDataset,
+	AgentEvalDatasetRepository,
+	AgentEvalResult,
+	AgentEvalResultRepository,
+	AgentEvalRun,
+	AgentEvalRunRepository,
+	User,
+} from '@n8n/db';
+import { mock, type MockProxy } from 'vitest-mock-extended';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { Agent } from '@/modules/agents/entities/agent.entity';
+import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
+
+import type { AgentEvalCaseGenerationService } from '../agent-eval-case-generation.service';
+import type { AgentEvalRunnerService } from '../agent-eval-runner.service';
+import { AgentEvalService } from '../agent-eval.service';
+
+// Stub the cross-module specifiers the service statically imports so this unit
+// test doesn't pull in the real agents / instance-ai module graph.
+vi.mock('@/modules/agents/repositories/agent.repository', () => ({
+	AgentRepository: class AgentRepository {},
+}));
+vi.mock('../agent-eval-runner.service', () => ({
+	AgentEvalRunnerService: class AgentEvalRunnerService {},
+}));
+vi.mock('../agent-eval-case-generation.service', () => ({
+	AgentEvalCaseGenerationService: class AgentEvalCaseGenerationService {},
+}));
+
+const AGENT_ID = 'agent-1';
+const PROJECT_ID = 'proj-1';
+
+describe('AgentEvalService', () => {
+	const user = mock<User>({ id: 'user-1' });
+
+	let agentRepository: MockProxy<AgentRepository>;
+	let datasetRepository: MockProxy<AgentEvalDatasetRepository>;
+	let runRepository: MockProxy<AgentEvalRunRepository>;
+	let resultRepository: MockProxy<AgentEvalResultRepository>;
+	let runner: MockProxy<AgentEvalRunnerService>;
+	let caseGenerationService: MockProxy<AgentEvalCaseGenerationService>;
+	let service: AgentEvalService;
+
+	const makeDataset = (over: Partial<AgentEvalDataset> = {}) =>
+		mock<AgentEvalDataset>({
+			id: 'ds-1',
+			name: 'cases',
+			description: null,
+			agentId: AGENT_ID,
+			datasetSource: 'data_table',
+			datasetRef: { dataTableId: 'dt-1' },
+			columnMapping: { input: 'question' },
+			createdById: 'user-1',
+			createdAt: new Date('2026-01-01T00:00:00.000Z'),
+			updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+			...over,
+		});
+
+	const makeRun = (over: Partial<AgentEvalRun> = {}) =>
+		mock<AgentEvalRun>({
+			id: 'run-1',
+			datasetId: 'ds-1',
+			agentVersionId: null,
+			status: 'running',
+			runAt: new Date('2026-01-03T00:00:00.000Z'),
+			completedAt: null,
+			metrics: null,
+			errorCode: null,
+			errorDetails: null,
+			createdById: 'user-1',
+			createdAt: new Date('2026-01-03T00:00:00.000Z'),
+			updatedAt: new Date('2026-01-03T00:00:00.000Z'),
+			runningInstanceId: 'main-1',
+			cancelRequested: false,
+			...over,
+		});
+
+	beforeEach(() => {
+		agentRepository = mock<AgentRepository>();
+		datasetRepository = mock<AgentEvalDatasetRepository>();
+		runRepository = mock<AgentEvalRunRepository>();
+		resultRepository = mock<AgentEvalResultRepository>();
+		runner = mock<AgentEvalRunnerService>();
+		caseGenerationService = mock<AgentEvalCaseGenerationService>();
+
+		agentRepository.findByIdAndProjectId.mockResolvedValue(mock<Agent>({ id: AGENT_ID }));
+		datasetRepository.findByIdAndAgentId.mockResolvedValue(makeDataset());
+		runRepository.findByIdAndAgentId.mockResolvedValue(makeRun());
+
+		service = new AgentEvalService(
+			agentRepository,
+			datasetRepository,
+			runRepository,
+			resultRepository,
+			runner,
+			caseGenerationService,
+		);
+	});
+
+	// `@ProjectScope` proves the caller may act on the project in the URL. It says
+	// nothing about whether the addressed agent is in that project, so every entry
+	// point has to resolve the agent through the pair.
+	describe('agent scoping', () => {
+		const callsRequiringAnAgent: Array<[string, () => Promise<unknown>]> = [
+			['listDatasets', async () => await service.listDatasets(AGENT_ID, PROJECT_ID)],
+			['getDataset', async () => await service.getDataset(AGENT_ID, PROJECT_ID, 'ds-1')],
+			[
+				'createDataset',
+				async () =>
+					await service.createDataset(user, AGENT_ID, PROJECT_ID, {
+						name: 'cases',
+						agentId: AGENT_ID,
+						datasetSource: 'data_table',
+						datasetRef: { dataTableId: 'dt-1' },
+					}),
+			],
+			[
+				'updateDataset',
+				async () => await service.updateDataset(AGENT_ID, PROJECT_ID, 'ds-1', { name: 'x' }),
+			],
+			['deleteDataset', async () => await service.deleteDataset(AGENT_ID, PROJECT_ID, 'ds-1')],
+			[
+				'generateDraftCases',
+				async () => await service.generateDraftCases(user, AGENT_ID, PROJECT_ID, {}),
+			],
+			['startRun', async () => await service.startRun(user, AGENT_ID, PROJECT_ID, 'ds-1', {})],
+			['listRuns', async () => await service.listRuns(AGENT_ID, PROJECT_ID, 'ds-1')],
+			['getRunDetail', async () => await service.getRunDetail(AGENT_ID, PROJECT_ID, 'run-1')],
+			['getRunSummary', async () => await service.getRunSummary(AGENT_ID, PROJECT_ID, 'run-1')],
+			['cancelRun', async () => await service.cancelRun(AGENT_ID, PROJECT_ID, 'run-1')],
+		];
+
+		it.each(callsRequiringAnAgent)(
+			'%s 404s when the agent is not in the project',
+			async (_name, call) => {
+				agentRepository.findByIdAndProjectId.mockResolvedValue(null);
+
+				await expect(call()).rejects.toThrow(NotFoundError);
+			},
+		);
+
+		it.each(callsRequiringAnAgent)('%s resolves the agent against the project', async (_, call) => {
+			await call().catch(() => {});
+
+			expect(agentRepository.findByIdAndProjectId).toHaveBeenCalledWith(AGENT_ID, PROJECT_ID);
+		});
+	});
+
+	// A dataset/run id from another agent must not resolve just because the caller
+	// legitimately holds the scope on this one.
+	describe('cross-agent id isolation', () => {
+		it('404s a dataset belonging to another agent', async () => {
+			datasetRepository.findByIdAndAgentId.mockResolvedValue(null);
+
+			await expect(service.getDataset(AGENT_ID, PROJECT_ID, 'ds-other')).rejects.toThrow(
+				NotFoundError,
+			);
+			expect(datasetRepository.findByIdAndAgentId).toHaveBeenCalledWith('ds-other', AGENT_ID);
+		});
+
+		it('404s a run belonging to another agent, and reads no results for it', async () => {
+			runRepository.findByIdAndAgentId.mockResolvedValue(null);
+
+			await expect(service.getRunDetail(AGENT_ID, PROJECT_ID, 'run-other')).rejects.toThrow(
+				NotFoundError,
+			);
+			expect(resultRepository.findByRunId).not.toHaveBeenCalled();
+		});
+
+		it('refuses to start a run on another agent’s dataset, without touching the runner', async () => {
+			datasetRepository.findByIdAndAgentId.mockResolvedValue(null);
+
+			await expect(service.startRun(user, AGENT_ID, PROJECT_ID, 'ds-other', {})).rejects.toThrow(
+				NotFoundError,
+			);
+			expect(runner.startRun).not.toHaveBeenCalled();
+		});
+
+		it('passes the agent through to the summary read so it is scoped there too', async () => {
+			runner.getRunSummary.mockResolvedValue({
+				runId: 'run-1',
+				status: 'running',
+				counts: { total: 1, success: 0, error: 0, cancelled: 0, pending: 1 },
+			});
+
+			await service.getRunSummary(AGENT_ID, PROJECT_ID, 'run-1');
+
+			expect(runner.getRunSummary).toHaveBeenCalledWith('run-1', AGENT_ID);
+		});
+	});
+
+	describe('createDataset', () => {
+		it('rejects a body whose agentId contradicts the URL', async () => {
+			await expect(
+				service.createDataset(user, AGENT_ID, PROJECT_ID, {
+					name: 'cases',
+					agentId: 'agent-2',
+					datasetSource: 'data_table',
+					datasetRef: { dataTableId: 'dt-1' },
+				}),
+			).rejects.toThrow(BadRequestError);
+
+			expect(datasetRepository.createDataset).not.toHaveBeenCalled();
+		});
+
+		it('persists with the URL agent and the creating user, defaulting optionals', async () => {
+			datasetRepository.createDataset.mockResolvedValue(makeDataset());
+
+			await service.createDataset(user, AGENT_ID, PROJECT_ID, {
+				name: 'cases',
+				agentId: AGENT_ID,
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+			});
+
+			expect(datasetRepository.createDataset).toHaveBeenCalledWith({
+				name: 'cases',
+				description: null,
+				agentId: AGENT_ID,
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+				columnMapping: null,
+				createdById: 'user-1',
+			});
+		});
+	});
+
+	describe('deleteDataset', () => {
+		it('404s when nothing was removed', async () => {
+			datasetRepository.deleteDataset.mockResolvedValue(false);
+
+			await expect(service.deleteDataset(AGENT_ID, PROJECT_ID, 'ds-1')).rejects.toThrow(
+				NotFoundError,
+			);
+		});
+
+		it('resolves when the dataset was removed', async () => {
+			datasetRepository.deleteDataset.mockResolvedValue(true);
+
+			await expect(service.deleteDataset(AGENT_ID, PROJECT_ID, 'ds-1')).resolves.toBeUndefined();
+		});
+	});
+
+	describe('startRun', () => {
+		beforeEach(() => {
+			runner.startRun.mockResolvedValue({ runId: 'run-1', finished: Promise.resolve() });
+			runRepository.findById.mockResolvedValue(makeRun());
+		});
+
+		it('returns the seeded run without waiting for the cases to finish', async () => {
+			let settled = false;
+			runner.startRun.mockResolvedValue({
+				runId: 'run-1',
+				// A promise that never settles stands in for a long-running batch: if
+				// the service awaited it, this test would time out.
+				finished: new Promise<void>(() => {}).finally(() => {
+					settled = true;
+				}),
+			});
+
+			const run = await service.startRun(user, AGENT_ID, PROJECT_ID, 'ds-1', {});
+
+			expect(run.id).toBe('run-1');
+			expect(settled).toBe(false);
+		});
+
+		it('refuses a pinned agent version while the runner can only run the live agent', async () => {
+			await expect(
+				service.startRun(user, AGENT_ID, PROJECT_ID, 'ds-1', { agentVersionId: 'v-1' }),
+			).rejects.toThrow(BadRequestError);
+
+			expect(runner.startRun).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('cancelRun', () => {
+		it.each(['completed', 'error', 'cancelled'] as const)(
+			'refuses to cancel a run that already finished as %s',
+			async (status) => {
+				runRepository.findByIdAndAgentId.mockResolvedValue(makeRun({ status }));
+
+				await expect(service.cancelRun(AGENT_ID, PROJECT_ID, 'run-1')).rejects.toThrow(
+					BadRequestError,
+				);
+				expect(runRepository.requestCancellation).not.toHaveBeenCalled();
+			},
+		);
+
+		it.each(['new', 'running'] as const)('requests cancellation of a %s run', async (status) => {
+			runRepository.findByIdAndAgentId.mockResolvedValue(makeRun({ status }));
+			runRepository.findById.mockResolvedValue(makeRun({ status }));
+
+			await service.cancelRun(AGENT_ID, PROJECT_ID, 'run-1');
+
+			expect(runRepository.requestCancellation).toHaveBeenCalledWith('run-1');
+		});
+
+		it('falls back to the pre-cancel run when the re-read comes up empty', async () => {
+			runRepository.findById.mockResolvedValue(null);
+
+			const run = await service.cancelRun(AGENT_ID, PROJECT_ID, 'run-1');
+
+			expect(run.id).toBe('run-1');
+		});
+	});
+
+	describe('response mapping', () => {
+		it('serializes dates as ISO strings and keeps run coordination columns off the wire', async () => {
+			resultRepository.findByRunId.mockResolvedValue([]);
+
+			const detail = await service.getRunDetail(AGENT_ID, PROJECT_ID, 'run-1');
+
+			expect(detail.runAt).toBe('2026-01-03T00:00:00.000Z');
+			expect(detail.createdAt).toBe('2026-01-03T00:00:00.000Z');
+			expect(detail).not.toHaveProperty('runningInstanceId');
+			expect(detail).not.toHaveProperty('cancelRequested');
+		});
+
+		it('reassembles the dataset source pointer as a narrowable pair', async () => {
+			const record = await service.getDataset(AGENT_ID, PROJECT_ID, 'ds-1');
+
+			expect(record).toMatchObject({
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-02T00:00:00.000Z',
+			});
+		});
+
+		it('maps a google-sheets dataset onto its own source arm', async () => {
+			datasetRepository.findByIdAndAgentId.mockResolvedValue(
+				makeDataset({
+					datasetSource: 'google_sheets',
+					datasetRef: { credentialId: 'c-1', spreadsheetId: 's-1', sheetName: 'Sheet1' },
+				}),
+			);
+
+			const record = await service.getDataset(AGENT_ID, PROJECT_ID, 'ds-1');
+
+			expect(record).toMatchObject({
+				datasetSource: 'google_sheets',
+				datasetRef: { credentialId: 'c-1', spreadsheetId: 's-1', sheetName: 'Sheet1' },
+			});
+		});
+
+		it('includes every per-case result in a run detail', async () => {
+			resultRepository.findByRunId.mockResolvedValue([
+				mock<AgentEvalResult>({
+					id: 'res-1',
+					runId: 'run-1',
+					status: 'success',
+					runAt: new Date('2026-01-03T00:00:01.000Z'),
+					completedAt: new Date('2026-01-03T00:00:02.000Z'),
+					createdAt: new Date('2026-01-03T00:00:00.000Z'),
+					updatedAt: new Date('2026-01-03T00:00:02.000Z'),
+				}),
+			]);
+
+			const detail = await service.getRunDetail(AGENT_ID, PROJECT_ID, 'run-1');
+
+			expect(detail.results).toHaveLength(1);
+			expect(detail.results[0]).toMatchObject({
+				id: 'res-1',
+				status: 'success',
+				runAt: '2026-01-03T00:00:01.000Z',
+				completedAt: '2026-01-03T00:00:02.000Z',
+			});
+		});
+	});
+
+	describe('generateDraftCases', () => {
+		it('delegates with the project resolved from the URL', async () => {
+			caseGenerationService.generateDraftCases.mockResolvedValue({
+				datasetId: 'ds-1',
+				dataTableId: 'dt-1',
+				cases: [],
+			});
+
+			await service.generateDraftCases(user, AGENT_ID, PROJECT_ID, { count: 3 });
+
+			expect(caseGenerationService.generateDraftCases).toHaveBeenCalledWith(
+				user,
+				PROJECT_ID,
+				AGENT_ID,
+				{ count: 3 },
+			);
+		});
+	});
+});

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval.service.test.ts
@@ -346,6 +346,22 @@ describe('AgentEvalService', () => {
 			});
 		});
 
+		// The source column is authoritative, so a ref that doesn't match it means a
+		// corrupt row. Failing loudly beats reporting a wrong-but-well-typed
+		// `datasetSource` the client would then narrow on.
+		it('refuses to map a dataset whose source and ref disagree', async () => {
+			datasetRepository.findByIdAndAgentId.mockResolvedValue(
+				makeDataset({
+					datasetSource: 'google_sheets',
+					datasetRef: { dataTableId: 'dt-1' },
+				}),
+			);
+
+			await expect(service.getDataset(AGENT_ID, PROJECT_ID, 'ds-1')).rejects.toThrow(
+				/does not match that shape/,
+			);
+		});
+
 		it('includes every per-case result in a run detail', async () => {
 			resultRepository.findByRunId.mockResolvedValue([
 				mock<AgentEvalResult>({

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-evals.controller.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-evals.controller.test.ts
@@ -1,0 +1,216 @@
+import type { AuthenticatedRequest, User } from '@n8n/db';
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import { mock, type MockProxy } from 'vitest-mock-extended';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import type { AgentEvalService } from '../agent-eval.service';
+import type { AgentEvalsFlagGate } from '../agent-evals-flag-gate';
+import { AgentEvalsController } from '../agent-evals.controller';
+
+vi.mock('../agent-eval.service', () => ({ AgentEvalService: class AgentEvalService {} }));
+vi.mock('../agent-evals-flag-gate', () => ({ AgentEvalsFlagGate: class AgentEvalsFlagGate {} }));
+
+const PROJECT_ID = 'proj-1';
+const AGENT_ID = 'agent-1';
+
+describe('AgentEvalsController', () => {
+	const user = mock<User>({ id: 'user-1' });
+
+	let service: MockProxy<AgentEvalService>;
+	let flagGate: MockProxy<AgentEvalsFlagGate>;
+	let controller: AgentEvalsController;
+
+	function makeReq<P extends Record<string, unknown>>(
+		params: P,
+		body: unknown = {},
+	): AuthenticatedRequest<P> {
+		return { user, params, body } as unknown as AuthenticatedRequest<P>;
+	}
+
+	const agentReq = () => makeReq({ projectId: PROJECT_ID, agentId: AGENT_ID });
+	const datasetReq = () => makeReq({ projectId: PROJECT_ID, agentId: AGENT_ID, datasetId: 'ds-1' });
+	const runReq = () => makeReq({ projectId: PROJECT_ID, agentId: AGENT_ID, runId: 'run-1' });
+
+	beforeEach(() => {
+		service = mock<AgentEvalService>();
+		flagGate = mock<AgentEvalsFlagGate>();
+		flagGate.assertEnabled.mockResolvedValue(undefined);
+		controller = new AgentEvalsController(service, flagGate);
+	});
+
+	/**
+	 * Regression guard: a route added without an access scope fails here. Every
+	 * agent-eval route is authenticated and project-scoped — there is no public
+	 * surface, so the assertion is unconditional.
+	 */
+	describe('route access scopes', () => {
+		const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
+			AgentEvalsController as never,
+		);
+		const routeCases = Array.from(metadata.routes.entries()).map(([handlerName, route]) => ({
+			handlerName,
+			route,
+		}));
+
+		it('registers every handler', () => {
+			expect(routeCases).not.toHaveLength(0);
+		});
+
+		it.each(routeCases)('$handlerName is gated by a project-scoped agent:* check', ({ route }) => {
+			expect(route.accessScope).toBeDefined();
+			expect(route.accessScope?.globalOnly).toBe(false);
+			expect(route.accessScope?.scope.startsWith('agent:')).toBe(true);
+		});
+
+		it.each([
+			// Reads stay on agent:read; anything that writes eval config — including
+			// generation, which spends the builder's model credits — needs
+			// agent:update; starting/cancelling a run is agent:execute.
+			['listDatasets', 'agent:read'],
+			['getDataset', 'agent:read'],
+			['listRuns', 'agent:read'],
+			['getRun', 'agent:read'],
+			['getRunSummary', 'agent:read'],
+			['createDataset', 'agent:update'],
+			['updateDataset', 'agent:update'],
+			['deleteDataset', 'agent:update'],
+			['generateDraftCases', 'agent:update'],
+			['startRun', 'agent:execute'],
+			['cancelRun', 'agent:execute'],
+		])('%s uses %s', (handlerName, scope) => {
+			expect(metadata.routes.get(handlerName)?.accessScope?.scope).toBe(scope);
+		});
+	});
+
+	// Flag-off must look like an unknown endpoint on every route, and must not
+	// reach the service.
+	describe('flag gating', () => {
+		const calls: Array<[string, () => Promise<unknown>]> = [
+			['listDatasets', async () => await controller.listDatasets(agentReq())],
+			['getDataset', async () => await controller.getDataset(datasetReq())],
+			[
+				'createDataset',
+				async () =>
+					await controller.createDataset(
+						makeReq(
+							{ projectId: PROJECT_ID, agentId: AGENT_ID },
+							{
+								name: 'cases',
+								agentId: AGENT_ID,
+								datasetSource: 'data_table',
+								datasetRef: { dataTableId: 'dt-1' },
+							},
+						),
+					),
+			],
+			[
+				'updateDataset',
+				async () => await controller.updateDataset(datasetReq(), undefined, { name: 'x' }),
+			],
+			['deleteDataset', async () => await controller.deleteDataset(datasetReq())],
+			[
+				'generateDraftCases',
+				async () => await controller.generateDraftCases(agentReq(), undefined, {}),
+			],
+			['startRun', async () => await controller.startRun(datasetReq(), undefined, {})],
+			['listRuns', async () => await controller.listRuns(datasetReq())],
+			['getRun', async () => await controller.getRun(runReq())],
+			['getRunSummary', async () => await controller.getRunSummary(runReq())],
+			['cancelRun', async () => await controller.cancelRun(runReq())],
+		];
+
+		it.each(calls)('%s 404s when the flag is off for the user', async (_name, call) => {
+			flagGate.assertEnabled.mockRejectedValue(new NotFoundError('Not found'));
+
+			await expect(call()).rejects.toThrow(NotFoundError);
+		});
+
+		it.each(calls)('%s asks the gate about the requesting user', async (_name, call) => {
+			await call().catch(() => {});
+
+			expect(flagGate.assertEnabled).toHaveBeenCalledWith(user);
+		});
+	});
+
+	describe('delegation', () => {
+		it('lists datasets for the path agent', async () => {
+			await controller.listDatasets(agentReq());
+
+			expect(service.listDatasets).toHaveBeenCalledWith(AGENT_ID, PROJECT_ID);
+		});
+
+		it('passes a valid create body through', async () => {
+			const body = {
+				name: 'cases',
+				agentId: AGENT_ID,
+				datasetSource: 'data_table',
+				datasetRef: { dataTableId: 'dt-1' },
+			};
+
+			await controller.createDataset(makeReq({ projectId: PROJECT_ID, agentId: AGENT_ID }, body));
+
+			expect(service.createDataset).toHaveBeenCalledWith(
+				user,
+				AGENT_ID,
+				PROJECT_ID,
+				expect.objectContaining(body),
+			);
+		});
+
+		// This body carries the `DatasetRef` union, so it can't be bound via
+		// `@Body` and is parsed in the handler — which means the handler owns
+		// turning invalid input into a 400 rather than a 500.
+		it('rejects an invalid create body as a bad request', async () => {
+			await expect(
+				controller.createDataset(
+					makeReq({ projectId: PROJECT_ID, agentId: AGENT_ID }, { name: '' }),
+				),
+			).rejects.toThrow(BadRequestError);
+
+			expect(service.createDataset).not.toHaveBeenCalled();
+		});
+
+		it('rejects a create body with an unknown dataset source', async () => {
+			await expect(
+				controller.createDataset(
+					makeReq(
+						{ projectId: PROJECT_ID, agentId: AGENT_ID },
+						{
+							name: 'cases',
+							agentId: AGENT_ID,
+							datasetSource: 'sqlite',
+							datasetRef: { dataTableId: 'dt-1' },
+						},
+					),
+				),
+			).rejects.toThrow(BadRequestError);
+		});
+
+		it('starts a run for the path dataset', async () => {
+			await controller.startRun(datasetReq(), undefined, {});
+
+			expect(service.startRun).toHaveBeenCalledWith(user, AGENT_ID, PROJECT_ID, 'ds-1', {});
+		});
+
+		it('reports a delete as a success envelope', async () => {
+			await expect(controller.deleteDataset(datasetReq())).resolves.toEqual({ success: true });
+
+			expect(service.deleteDataset).toHaveBeenCalledWith(AGENT_ID, PROJECT_ID, 'ds-1');
+		});
+
+		it('reads a run summary scoped to the path agent', async () => {
+			await controller.getRunSummary(runReq());
+
+			expect(service.getRunSummary).toHaveBeenCalledWith(AGENT_ID, PROJECT_ID, 'run-1');
+		});
+
+		it('cancels a run scoped to the path agent', async () => {
+			await controller.cancelRun(runReq());
+
+			expect(service.cancelRun).toHaveBeenCalledWith(AGENT_ID, PROJECT_ID, 'run-1');
+		});
+	});
+});

--- a/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-case-generation.service.ts
@@ -1,7 +1,6 @@
 import type { Agent } from '@n8n/agents';
 import { getProviderPrefix } from '@n8n/ai-utilities/agent-config';
 import {
-	AGENT_EVALS_FLAG,
 	MANAGED_CREDENTIAL_TOKEN,
 	type AgentEvalDraftCase,
 	type AgentJsonConfig,
@@ -16,10 +15,9 @@ import { OperationalError, UserError } from 'n8n-workflow';
 
 import { CredentialsService } from '@/credentials/credentials.service';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
-import { PostHogClient } from '@/posthog';
 
+import { AgentEvalsFlagGate } from './agent-evals-flag-gate';
 import { AgentConfigService } from '../agents/agent-config.service';
 import {
 	buildAgentSummary,
@@ -83,7 +81,7 @@ export class AgentEvalCaseGenerationService {
 		private readonly credentialsService: CredentialsService,
 		private readonly dataTableService: DataTableService,
 		private readonly datasetRepository: AgentEvalDatasetRepository,
-		private readonly postHogClient: PostHogClient,
+		private readonly flagGate: AgentEvalsFlagGate,
 		private readonly sourceControlPreferencesService: SourceControlPreferencesService,
 	) {}
 
@@ -99,7 +97,7 @@ export class AgentEvalCaseGenerationService {
 		agentId: string,
 		options: GenerateDraftCasesOptions = {},
 	): Promise<GenerateDraftCasesResult> {
-		await this.assertFeatureEnabled(user);
+		await this.flagGate.assertEnabled(user);
 		this.assertInstanceWriteAccess();
 
 		const config = await this.agentConfigService.getConfig(agentId, projectId);
@@ -143,18 +141,6 @@ export class AgentEvalCaseGenerationService {
 	}
 
 	// ---- internals ----
-
-	/**
-	 * Gate on the agent-evals rollout flag (honors the env override). Throws
-	 * NotFoundError rather than Forbidden so a flag-off instance looks like an
-	 * unknown feature and leaks no flag state (matching the eval-collections gate).
-	 */
-	private async assertFeatureEnabled(user: User): Promise<void> {
-		const flags = await this.postHogClient.getFeatureFlags(user);
-		if (flags?.[AGENT_EVALS_FLAG] !== true) {
-			throw new NotFoundError('Not found');
-		}
-	}
 
 	/**
 	 * Block writes on a source-control read-only (protected) instance. This

--- a/packages/cli/src/modules/agent-evals/agent-eval-record-mappers.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-record-mappers.ts
@@ -1,0 +1,93 @@
+import type {
+	AgentEvalDatasetRecord,
+	AgentEvalResultRecord,
+	AgentEvalRunRecord,
+	DataTableDatasetRef,
+	DatasetRef,
+} from '@n8n/api-types';
+import type { AgentEvalDataset, AgentEvalResult, AgentEvalRun } from '@n8n/db';
+
+/**
+ * Entity → wire-record mappers for the agent-eval REST responses.
+ *
+ * Explicit field-by-field mapping rather than returning entities directly: it
+ * serializes dates as ISO strings, and it keeps the run's cross-main
+ * coordination columns (`runningInstanceId`, `cancelRequested`) out of the
+ * contract — they're internal scheduling state, and `runningInstanceId` would
+ * expose an instance host id. A new entity column therefore can't leak onto the
+ * API by accident.
+ */
+
+const toIso = (date: Date | null): string | null => date?.toISOString() ?? null;
+
+/**
+ * The two ref shapes are disjoint, so which one a dataset holds is decidable
+ * from the value itself.
+ */
+const isDataTableRef = (ref: DatasetRef['datasetRef']): ref is DataTableDatasetRef =>
+	'dataTableId' in ref;
+
+/**
+ * Rebuild the `datasetSource` + `datasetRef` discriminated union from the
+ * entity, which stores the two halves as independent columns and so has lost
+ * their correlation. Derived from the ref rather than read off the
+ * `datasetSource` column: that keeps the pair narrowable on the client without a
+ * cast, and the two can only ever disagree if a row was written outside
+ * `createDataset`, which always persists them together from a validated union.
+ */
+function toDatasetRefPair(dataset: AgentEvalDataset): DatasetRef {
+	return isDataTableRef(dataset.datasetRef)
+		? { datasetSource: 'data_table', datasetRef: dataset.datasetRef }
+		: { datasetSource: 'google_sheets', datasetRef: dataset.datasetRef };
+}
+
+export function toDatasetRecord(dataset: AgentEvalDataset): AgentEvalDatasetRecord {
+	return {
+		id: dataset.id,
+		name: dataset.name,
+		description: dataset.description,
+		agentId: dataset.agentId,
+		columnMapping: dataset.columnMapping,
+		createdById: dataset.createdById,
+		createdAt: dataset.createdAt.toISOString(),
+		updatedAt: dataset.updatedAt.toISOString(),
+		...toDatasetRefPair(dataset),
+	};
+}
+
+export function toRunRecord(run: AgentEvalRun): AgentEvalRunRecord {
+	return {
+		id: run.id,
+		datasetId: run.datasetId,
+		agentVersionId: run.agentVersionId,
+		status: run.status,
+		runAt: toIso(run.runAt),
+		completedAt: toIso(run.completedAt),
+		metrics: run.metrics,
+		errorCode: run.errorCode,
+		errorDetails: run.errorDetails,
+		createdById: run.createdById,
+		createdAt: run.createdAt.toISOString(),
+		updatedAt: run.updatedAt.toISOString(),
+	};
+}
+
+export function toResultRecord(result: AgentEvalResult): AgentEvalResultRecord {
+	return {
+		id: result.id,
+		runId: result.runId,
+		sourceRowId: result.sourceRowId,
+		runIndex: result.runIndex,
+		status: result.status,
+		input: result.input,
+		output: result.output,
+		toolCalls: result.toolCalls,
+		metrics: result.metrics,
+		runAt: toIso(result.runAt),
+		completedAt: toIso(result.completedAt),
+		errorCode: result.errorCode,
+		errorDetails: result.errorDetails,
+		createdAt: result.createdAt.toISOString(),
+		updatedAt: result.updatedAt.toISOString(),
+	};
+}

--- a/packages/cli/src/modules/agent-evals/agent-eval-record-mappers.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-record-mappers.ts
@@ -4,8 +4,10 @@ import type {
 	AgentEvalRunRecord,
 	DataTableDatasetRef,
 	DatasetRef,
+	GoogleSheetsDatasetRef,
 } from '@n8n/api-types';
 import type { AgentEvalDataset, AgentEvalResult, AgentEvalRun } from '@n8n/db';
+import { UnexpectedError } from 'n8n-workflow';
 
 /**
  * Entity → wire-record mappers for the agent-eval REST responses.
@@ -20,25 +22,41 @@ import type { AgentEvalDataset, AgentEvalResult, AgentEvalRun } from '@n8n/db';
 
 const toIso = (date: Date | null): string | null => date?.toISOString() ?? null;
 
-/**
- * The two ref shapes are disjoint, so which one a dataset holds is decidable
- * from the value itself.
- */
+// The two ref shapes are disjoint, so each is recognizable from the value alone.
+// Used to re-narrow the ref, never to decide which source a dataset is.
 const isDataTableRef = (ref: DatasetRef['datasetRef']): ref is DataTableDatasetRef =>
 	'dataTableId' in ref;
+
+const isGoogleSheetsRef = (ref: DatasetRef['datasetRef']): ref is GoogleSheetsDatasetRef =>
+	'spreadsheetId' in ref;
 
 /**
  * Rebuild the `datasetSource` + `datasetRef` discriminated union from the
  * entity, which stores the two halves as independent columns and so has lost
- * their correlation. Derived from the ref rather than read off the
- * `datasetSource` column: that keeps the pair narrowable on the client without a
- * cast, and the two can only ever disagree if a row was written outside
- * `createDataset`, which always persists them together from a validated union.
+ * their correlation.
+ *
+ * Switches on the persisted `datasetSource` — the authoritative discriminator —
+ * and uses the predicates only to re-narrow the ref. Inferring the source from
+ * the ref's shape instead would silently relabel any future third source as one
+ * of these two, reporting a wrong-but-well-typed `datasetSource` to the client.
+ * A source/ref disagreement is unreachable through `createDataset` (which
+ * persists the pair from an already-validated union) and barred by the column's
+ * CHECK constraint, so it can only mean a corrupt row — hence the loud failure
+ * rather than a guess.
  */
 function toDatasetRefPair(dataset: AgentEvalDataset): DatasetRef {
-	return isDataTableRef(dataset.datasetRef)
-		? { datasetSource: 'data_table', datasetRef: dataset.datasetRef }
-		: { datasetSource: 'google_sheets', datasetRef: dataset.datasetRef };
+	const { datasetSource, datasetRef } = dataset;
+
+	if (datasetSource === 'data_table' && isDataTableRef(datasetRef)) {
+		return { datasetSource, datasetRef };
+	}
+	if (datasetSource === 'google_sheets' && isGoogleSheetsRef(datasetRef)) {
+		return { datasetSource, datasetRef };
+	}
+
+	throw new UnexpectedError(
+		`Agent eval dataset ${dataset.id} has a '${datasetSource}' source whose ref does not match that shape.`,
+	);
 }
 
 export function toDatasetRecord(dataset: AgentEvalDataset): AgentEvalDatasetRecord {

--- a/packages/cli/src/modules/agent-evals/agent-eval-record-mappers.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-record-mappers.ts
@@ -10,20 +10,14 @@ import type { AgentEvalDataset, AgentEvalResult, AgentEvalRun } from '@n8n/db';
 import { UnexpectedError } from 'n8n-workflow';
 
 /**
- * Entity → wire-record mappers for the agent-eval REST responses.
- *
- * Explicit field-by-field mapping rather than returning entities directly: it
- * serializes dates as ISO strings, and it keeps the run's cross-main
- * coordination columns (`runningInstanceId`, `cancelRequested`) out of the
- * contract — they're internal scheduling state, and `runningInstanceId` would
- * expose an instance host id. A new entity column therefore can't leak onto the
- * API by accident.
+ * Entity → wire-record mappers. Mapped field-by-field so dates serialize as ISO
+ * strings and a new entity column can't leak onto the API by accident — notably
+ * the run's `runningInstanceId` (an instance host id) and `cancelRequested`.
  */
 
 const toIso = (date: Date | null): string | null => date?.toISOString() ?? null;
 
-// The two ref shapes are disjoint, so each is recognizable from the value alone.
-// Used to re-narrow the ref, never to decide which source a dataset is.
+// Used only to re-narrow a ref, never to decide which source a dataset is.
 const isDataTableRef = (ref: DatasetRef['datasetRef']): ref is DataTableDatasetRef =>
 	'dataTableId' in ref;
 
@@ -31,18 +25,10 @@ const isGoogleSheetsRef = (ref: DatasetRef['datasetRef']): ref is GoogleSheetsDa
 	'spreadsheetId' in ref;
 
 /**
- * Rebuild the `datasetSource` + `datasetRef` discriminated union from the
- * entity, which stores the two halves as independent columns and so has lost
- * their correlation.
- *
- * Switches on the persisted `datasetSource` — the authoritative discriminator —
- * and uses the predicates only to re-narrow the ref. Inferring the source from
- * the ref's shape instead would silently relabel any future third source as one
- * of these two, reporting a wrong-but-well-typed `datasetSource` to the client.
- * A source/ref disagreement is unreachable through `createDataset` (which
- * persists the pair from an already-validated union) and barred by the column's
- * CHECK constraint, so it can only mean a corrupt row — hence the loud failure
- * rather than a guess.
+ * Rebuild the source/ref union, which the entity stores as two uncorrelated
+ * columns. Switches on `datasetSource` — inferring it from the ref's shape would
+ * silently relabel a future third source as one of today's two. A disagreeing
+ * pair is unreachable via `createDataset`, so it means a corrupt row.
  */
 function toDatasetRefPair(dataset: AgentEvalDataset): DatasetRef {
 	const { datasetSource, datasetRef } = dataset;

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -1,6 +1,7 @@
+import type { AgentEvalRunSummary } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import type { AgentEvalDataset, AgentEvalResult, AgentEvalRunStatus, User } from '@n8n/db';
+import type { AgentEvalDataset, AgentEvalResult, User } from '@n8n/db';
 import {
 	AgentEvalDatasetRepository,
 	AgentEvalResultRepository,
@@ -52,12 +53,6 @@ interface ResolvedCase {
 interface CaseUsage {
 	inputTokens: number;
 	outputTokens: number;
-}
-
-export interface AgentEvalRunSummary {
-	runId: string;
-	status: AgentEvalRunStatus;
-	counts: { total: number; success: number; error: number; cancelled: number; pending: number };
 }
 
 /**

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -96,9 +96,8 @@ export class AgentEvalRunnerService {
 		user: User,
 		options: { timeoutMs?: number } = {},
 	): Promise<{ runId: string; finished: Promise<void> }> {
-		// Resolved per user: PostHog owns cohort rollout, and the operator env
-		// override is layered on top of it, so a rolled-out user needs no env var.
-		// The REST layer gates too — this is the backstop for any other caller.
+		// Per user, since PostHog owns cohort rollout. The REST layer gates too — this
+		// is the backstop for any other caller.
 		await this.flagGate.assertEnabled(user);
 
 		if (this.globalConfig.executions.mode === 'queue') {
@@ -181,15 +180,8 @@ export class AgentEvalRunnerService {
 		return { runId: run.id, finished };
 	}
 
-	/**
-	 * Run + per-case status counts, for polling a run's progress.
-	 *
-	 * Scoped to the agent under test: the REST layer authorizes an agent, so a
-	 * bare run id must not be enough to read a run's progress. Resolving through
-	 * the agent means a run belonging to a different agent — in a project the
-	 * caller has no access to — reads as "not found" here too, rather than relying
-	 * on the caller having checked.
-	 */
+	// Scoped to the agent under test, so a bare run id can't read another agent's
+	// progress even if the caller skipped its own check.
 	async getRunSummary(runId: string, agentId: string): Promise<AgentEvalRunSummary> {
 		const run = await this.runRepository.findByIdAndAgentId(runId, agentId);
 		if (!run) throw new NotFoundError(`Agent eval run ${runId} not found.`);

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -29,6 +29,8 @@ import { DataTableService } from '@/modules/data-table/data-table.service';
 import { EvalAgentExecutionService } from '@/modules/instance-ai/eval/agent-execution.service';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
+import { AgentEvalsFlagGate } from './agent-evals-flag-gate';
+
 const ROW_PAGE_SIZE = 100;
 // Per-run in-flight cap layered on the shared evaluation queue: keeps one run
 // from flooding the queue (and bounds fan-out when the queue is unlimited).
@@ -85,6 +87,7 @@ export class AgentEvalRunnerService {
 		private readonly evalAgentExecutionService: EvalAgentExecutionService,
 		private readonly concurrencyControl: ConcurrencyControlService,
 		private readonly license: License,
+		private readonly flagGate: AgentEvalsFlagGate,
 	) {}
 
 	/**
@@ -98,14 +101,10 @@ export class AgentEvalRunnerService {
 		user: User,
 		options: { timeoutMs?: number } = {},
 	): Promise<{ runId: string; finished: Promise<void> }> {
-		// Behind 101_agent_evals. `agentEvalsEnabled` is a force-enable-only operator
-		// override, so this treats it as the sole gate for now. When the REST layer
-		// lands it must instead resolve the flag per-user via PostHog (which is the
-		// source of truth for cohort rollout) — a rolled-out user shouldn't need the
-		// env var. Until then this stays hard-gated on the override.
-		if (!this.globalConfig.evaluation.agentEvalsEnabled) {
-			throw new BadRequestError('Agent evals are not enabled on this instance.');
-		}
+		// Resolved per user: PostHog owns cohort rollout, and the operator env
+		// override is layered on top of it, so a rolled-out user needs no env var.
+		// The REST layer gates too — this is the backstop for any other caller.
+		await this.flagGate.assertEnabled(user);
 
 		if (this.globalConfig.executions.mode === 'queue') {
 			throw new BadRequestError('Agent eval runs are not supported in queue mode.');
@@ -187,9 +186,17 @@ export class AgentEvalRunnerService {
 		return { runId: run.id, finished };
 	}
 
-	/** Run + per-case status counts, for polling a run's progress. */
-	async getRunSummary(runId: string): Promise<AgentEvalRunSummary> {
-		const run = await this.runRepository.findById(runId);
+	/**
+	 * Run + per-case status counts, for polling a run's progress.
+	 *
+	 * Scoped to the agent under test: the REST layer authorizes an agent, so a
+	 * bare run id must not be enough to read a run's progress. Resolving through
+	 * the agent means a run belonging to a different agent — in a project the
+	 * caller has no access to — reads as "not found" here too, rather than relying
+	 * on the caller having checked.
+	 */
+	async getRunSummary(runId: string, agentId: string): Promise<AgentEvalRunSummary> {
+		const run = await this.runRepository.findByIdAndAgentId(runId, agentId);
 		if (!run) throw new NotFoundError(`Agent eval run ${runId} not found.`);
 		// Count in the DB — this is polled by the UI, so never load the full
 		// per-case rows (input/output/toolCalls JSON) just to tally statuses.

--- a/packages/cli/src/modules/agent-evals/agent-eval.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval.service.ts
@@ -29,18 +29,12 @@ import { AgentEvalRunnerService } from './agent-eval-runner.service';
 const CANCELLABLE_STATUSES = new Set(['new', 'running']);
 
 /**
- * Read/write operations behind the agent-eval REST routes: dataset CRUD, run
- * listing and detail, cancellation, and the delegations to case generation and
- * the runner.
+ * Dataset CRUD, run reads and cancellation behind the agent-eval REST routes.
  *
- * **Every method is agent-scoped.** `@ProjectScope` on the routes proves the
- * caller may act on `:projectId`, but nothing about it proves the addressed
- * agent lives in that project, nor that a dataset/run id belongs to that agent.
- * So each entry point resolves the agent through `(agentId, projectId)` and then
- * loads datasets and runs through agent-filtered repository reads — a caller
- * can't reach another project's agent, or another agent's evals, by id. Missing
- * or foreign ids are all reported as 404 so the routes don't confirm that an id
- * exists somewhere else.
+ * **Every method is agent-scoped.** `@ProjectScope` proves the caller may act on
+ * `:projectId` — not that the agent lives there, nor that a dataset/run id
+ * belongs to it. So each entry point resolves `(agentId, projectId)` and then
+ * reads through agent-filtered queries. Foreign ids 404 like missing ones.
  */
 @Service()
 export class AgentEvalService {
@@ -70,11 +64,8 @@ export class AgentEvalService {
 		return toDatasetRecord(await this.resolveDataset(agentId, datasetId));
 	}
 
-	/**
-	 * The body carries `agentId` as well as the path, so a mismatch is rejected
-	 * rather than silently resolved in favour of one of them — the two disagreeing
-	 * means the client is confused about which agent it's configuring.
-	 */
+	// `agentId` is in both the body and the path; disagreement means the client is
+	// confused about which agent it's configuring, so neither side wins.
 	async createDataset(
 		user: User,
 		agentId: string,
@@ -114,11 +105,8 @@ export class AgentEvalService {
 		return toDatasetRecord(updated);
 	}
 
-	/**
-	 * Deletes the dataset and — by FK cascade — its runs and their results. The
-	 * backing Data Table is left alone: it's an independent resource the user may
-	 * share with other datasets or have authored by hand.
-	 */
+	// FK cascade takes the runs and results. The backing Data Table is left alone —
+	// it's independent, and may be shared or hand-authored.
 	async deleteDataset(agentId: string, projectId: string, datasetId: string): Promise<void> {
 		await this.assertAgentInProject(agentId, projectId);
 		const deleted = await this.datasetRepository.deleteDataset(datasetId, agentId);
@@ -139,13 +127,8 @@ export class AgentEvalService {
 
 	// ---- runs ----
 
-	/**
-	 * Starts a run and returns as soon as it's been created and seeded — the cases
-	 * then execute in the background, so the caller polls
-	 * {@link getRunSummary} for progress. The runner's `finished` promise is
-	 * deliberately dropped rather than awaited: it settles only once every case
-	 * has run, and it never rejects (the runner records failures on the run).
-	 */
+	// Returns once seeded; cases run in the background, so callers poll the summary.
+	// The runner's `finished` promise is dropped on purpose — it never rejects.
 	async startRun(
 		user: User,
 		agentId: string,
@@ -156,8 +139,7 @@ export class AgentEvalService {
 		await this.assertAgentInProject(agentId, projectId);
 		await this.resolveDataset(agentId, datasetId);
 
-		// Accepting this and quietly running the live agent instead would misreport
-		// what was measured, so refuse until the runner can execute a snapshot.
+		// Accepting a pin and running the live agent would misreport what was measured.
 		if (payload.agentVersionId !== undefined) {
 			throw new BadRequestError('Pinning an agent version for an eval run is not supported yet.');
 		}
@@ -192,11 +174,8 @@ export class AgentEvalService {
 		return { ...toRunRecord(run), results: results.map(toResultRecord) };
 	}
 
-	/**
-	 * Per-case status counts for polling a run's progress. Ownership is resolved
-	 * here before the summary is read, so this read path is gated exactly like the
-	 * write paths.
-	 */
+	// Per-case status counts for progress polling, ownership-resolved first so this
+	// read path is gated like the writes.
 	async getRunSummary(
 		agentId: string,
 		projectId: string,
@@ -206,12 +185,8 @@ export class AgentEvalService {
 		return await this.runner.getRunSummary(runId, agentId);
 	}
 
-	/**
-	 * Requests cancellation. This sets the run's flag rather than stopping anything
-	 * synchronously: the executing cases poll it and abort at their next
-	 * checkpoint, so the returned run is still `running` and settles to `cancelled`
-	 * shortly after.
-	 */
+	// Sets the flag rather than stopping anything: running cases abort at their next
+	// checkpoint, so the returned run is still `running` and settles shortly after.
 	async cancelRun(agentId: string, projectId: string, runId: string): Promise<AgentEvalRunRecord> {
 		await this.assertAgentInProject(agentId, projectId);
 		const run = await this.resolveRun(agentId, runId);
@@ -228,11 +203,8 @@ export class AgentEvalService {
 
 	// ---- internals ----
 
-	/**
-	 * The agent must exist *in this project*. Rejecting here is what stops a
-	 * caller with legitimate access to one project from addressing an agent in
-	 * another: `@ProjectScope` only checks the project in the URL.
-	 */
+	// `@ProjectScope` only checks the project in the URL, so this is what stops a
+	// caller with access to one project from addressing an agent in another.
 	private async assertAgentInProject(agentId: string, projectId: string): Promise<void> {
 		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 		if (!agent) throw new NotFoundError(`Agent ${agentId} not found.`);

--- a/packages/cli/src/modules/agent-evals/agent-eval.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval.service.ts
@@ -1,0 +1,252 @@
+import type {
+	AgentEvalDatasetRecord,
+	AgentEvalRunDetail,
+	AgentEvalRunRecord,
+	CreateAgentEvalDatasetDto,
+	CreateAgentEvalRunPayload,
+	GenerateDraftCasesOptions,
+	GenerateDraftCasesResult,
+	UpdateAgentEvalDatasetPayload,
+} from '@n8n/api-types';
+import type { AgentEvalDataset, AgentEvalRun, User } from '@n8n/db';
+import {
+	AgentEvalDatasetRepository,
+	AgentEvalResultRepository,
+	AgentEvalRunRepository,
+} from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { AgentRepository } from '@/modules/agents/repositories/agent.repository';
+
+import { AgentEvalCaseGenerationService } from './agent-eval-case-generation.service';
+import { toDatasetRecord, toResultRecord, toRunRecord } from './agent-eval-record-mappers';
+import type { AgentEvalRunSummary } from './agent-eval-runner.service';
+import { AgentEvalRunnerService } from './agent-eval-runner.service';
+
+/** Statuses a run can still be asked to stop from. */
+const CANCELLABLE_STATUSES = new Set(['new', 'running']);
+
+/**
+ * Read/write operations behind the agent-eval REST routes: dataset CRUD, run
+ * listing and detail, cancellation, and the delegations to case generation and
+ * the runner.
+ *
+ * **Every method is agent-scoped.** `@ProjectScope` on the routes proves the
+ * caller may act on `:projectId`, but nothing about it proves the addressed
+ * agent lives in that project, nor that a dataset/run id belongs to that agent.
+ * So each entry point resolves the agent through `(agentId, projectId)` and then
+ * loads datasets and runs through agent-filtered repository reads — a caller
+ * can't reach another project's agent, or another agent's evals, by id. Missing
+ * or foreign ids are all reported as 404 so the routes don't confirm that an id
+ * exists somewhere else.
+ */
+@Service()
+export class AgentEvalService {
+	constructor(
+		private readonly agentRepository: AgentRepository,
+		private readonly datasetRepository: AgentEvalDatasetRepository,
+		private readonly runRepository: AgentEvalRunRepository,
+		private readonly resultRepository: AgentEvalResultRepository,
+		private readonly runner: AgentEvalRunnerService,
+		private readonly caseGenerationService: AgentEvalCaseGenerationService,
+	) {}
+
+	// ---- datasets ----
+
+	async listDatasets(agentId: string, projectId: string): Promise<AgentEvalDatasetRecord[]> {
+		await this.assertAgentInProject(agentId, projectId);
+		const datasets = await this.datasetRepository.findByAgentId(agentId);
+		return datasets.map(toDatasetRecord);
+	}
+
+	async getDataset(
+		agentId: string,
+		projectId: string,
+		datasetId: string,
+	): Promise<AgentEvalDatasetRecord> {
+		await this.assertAgentInProject(agentId, projectId);
+		return toDatasetRecord(await this.resolveDataset(agentId, datasetId));
+	}
+
+	/**
+	 * The body carries `agentId` as well as the path, so a mismatch is rejected
+	 * rather than silently resolved in favour of one of them — the two disagreeing
+	 * means the client is confused about which agent it's configuring.
+	 */
+	async createDataset(
+		user: User,
+		agentId: string,
+		projectId: string,
+		payload: CreateAgentEvalDatasetDto,
+	): Promise<AgentEvalDatasetRecord> {
+		await this.assertAgentInProject(agentId, projectId);
+
+		if (payload.agentId !== agentId) {
+			throw new BadRequestError(
+				`The dataset's agentId ('${payload.agentId}') does not match the agent in the URL.`,
+			);
+		}
+
+		const dataset = await this.datasetRepository.createDataset({
+			name: payload.name,
+			description: payload.description ?? null,
+			agentId,
+			datasetSource: payload.datasetSource,
+			datasetRef: payload.datasetRef,
+			columnMapping: payload.columnMapping ?? null,
+			createdById: user.id,
+		});
+
+		return toDatasetRecord(dataset);
+	}
+
+	async updateDataset(
+		agentId: string,
+		projectId: string,
+		datasetId: string,
+		payload: UpdateAgentEvalDatasetPayload,
+	): Promise<AgentEvalDatasetRecord> {
+		await this.assertAgentInProject(agentId, projectId);
+		const updated = await this.datasetRepository.updateDataset(datasetId, agentId, payload);
+		if (!updated) throw new NotFoundError(`Agent eval dataset ${datasetId} not found.`);
+		return toDatasetRecord(updated);
+	}
+
+	/**
+	 * Deletes the dataset and — by FK cascade — its runs and their results. The
+	 * backing Data Table is left alone: it's an independent resource the user may
+	 * share with other datasets or have authored by hand.
+	 */
+	async deleteDataset(agentId: string, projectId: string, datasetId: string): Promise<void> {
+		await this.assertAgentInProject(agentId, projectId);
+		const deleted = await this.datasetRepository.deleteDataset(datasetId, agentId);
+		if (!deleted) throw new NotFoundError(`Agent eval dataset ${datasetId} not found.`);
+	}
+
+	// ---- case generation ----
+
+	async generateDraftCases(
+		user: User,
+		agentId: string,
+		projectId: string,
+		options: GenerateDraftCasesOptions,
+	): Promise<GenerateDraftCasesResult> {
+		await this.assertAgentInProject(agentId, projectId);
+		return await this.caseGenerationService.generateDraftCases(user, projectId, agentId, options);
+	}
+
+	// ---- runs ----
+
+	/**
+	 * Starts a run and returns as soon as it's been created and seeded — the cases
+	 * then execute in the background, so the caller polls
+	 * {@link getRunSummary} for progress. The runner's `finished` promise is
+	 * deliberately dropped rather than awaited: it settles only once every case
+	 * has run, and it never rejects (the runner records failures on the run).
+	 */
+	async startRun(
+		user: User,
+		agentId: string,
+		projectId: string,
+		datasetId: string,
+		payload: CreateAgentEvalRunPayload,
+	): Promise<AgentEvalRunRecord> {
+		await this.assertAgentInProject(agentId, projectId);
+		await this.resolveDataset(agentId, datasetId);
+
+		// Accepting this and quietly running the live agent instead would misreport
+		// what was measured, so refuse until the runner can execute a snapshot.
+		if (payload.agentVersionId !== undefined) {
+			throw new BadRequestError('Pinning an agent version for an eval run is not supported yet.');
+		}
+
+		const { runId } = await this.runner.startRun(datasetId, projectId, user);
+
+		const run = await this.runRepository.findById(runId);
+		if (!run) throw new NotFoundError(`Agent eval run ${runId} not found.`);
+		return toRunRecord(run);
+	}
+
+	async listRuns(
+		agentId: string,
+		projectId: string,
+		datasetId: string,
+	): Promise<AgentEvalRunRecord[]> {
+		await this.assertAgentInProject(agentId, projectId);
+		await this.resolveDataset(agentId, datasetId);
+		const runs = await this.runRepository.findByDatasetIdAndAgentId(datasetId, agentId);
+		return runs.map(toRunRecord);
+	}
+
+	/** A run with every per-case result — the "open a run" view. */
+	async getRunDetail(
+		agentId: string,
+		projectId: string,
+		runId: string,
+	): Promise<AgentEvalRunDetail> {
+		await this.assertAgentInProject(agentId, projectId);
+		const run = await this.resolveRun(agentId, runId);
+		const results = await this.resultRepository.findByRunId(runId);
+		return { ...toRunRecord(run), results: results.map(toResultRecord) };
+	}
+
+	/**
+	 * Per-case status counts for polling a run's progress. Ownership is resolved
+	 * here before the summary is read, so this read path is gated exactly like the
+	 * write paths.
+	 */
+	async getRunSummary(
+		agentId: string,
+		projectId: string,
+		runId: string,
+	): Promise<AgentEvalRunSummary> {
+		await this.assertAgentInProject(agentId, projectId);
+		return await this.runner.getRunSummary(runId, agentId);
+	}
+
+	/**
+	 * Requests cancellation. This sets the run's flag rather than stopping anything
+	 * synchronously: the executing cases poll it and abort at their next
+	 * checkpoint, so the returned run is still `running` and settles to `cancelled`
+	 * shortly after.
+	 */
+	async cancelRun(agentId: string, projectId: string, runId: string): Promise<AgentEvalRunRecord> {
+		await this.assertAgentInProject(agentId, projectId);
+		const run = await this.resolveRun(agentId, runId);
+
+		if (!CANCELLABLE_STATUSES.has(run.status)) {
+			throw new BadRequestError(`Agent eval run ${runId} has already finished ('${run.status}').`);
+		}
+
+		await this.runRepository.requestCancellation(runId);
+
+		const updated = await this.runRepository.findById(runId);
+		return toRunRecord(updated ?? run);
+	}
+
+	// ---- internals ----
+
+	/**
+	 * The agent must exist *in this project*. Rejecting here is what stops a
+	 * caller with legitimate access to one project from addressing an agent in
+	 * another: `@ProjectScope` only checks the project in the URL.
+	 */
+	private async assertAgentInProject(agentId: string, projectId: string): Promise<void> {
+		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
+		if (!agent) throw new NotFoundError(`Agent ${agentId} not found.`);
+	}
+
+	private async resolveDataset(agentId: string, datasetId: string): Promise<AgentEvalDataset> {
+		const dataset = await this.datasetRepository.findByIdAndAgentId(datasetId, agentId);
+		if (!dataset) throw new NotFoundError(`Agent eval dataset ${datasetId} not found.`);
+		return dataset;
+	}
+
+	private async resolveRun(agentId: string, runId: string): Promise<AgentEvalRun> {
+		const run = await this.runRepository.findByIdAndAgentId(runId, agentId);
+		if (!run) throw new NotFoundError(`Agent eval run ${runId} not found.`);
+		return run;
+	}
+}

--- a/packages/cli/src/modules/agent-evals/agent-eval.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval.service.ts
@@ -2,6 +2,7 @@ import type {
 	AgentEvalDatasetRecord,
 	AgentEvalRunDetail,
 	AgentEvalRunRecord,
+	AgentEvalRunSummary,
 	CreateAgentEvalDatasetDto,
 	CreateAgentEvalRunPayload,
 	GenerateDraftCasesOptions,
@@ -22,7 +23,6 @@ import { AgentRepository } from '@/modules/agents/repositories/agent.repository'
 
 import { AgentEvalCaseGenerationService } from './agent-eval-case-generation.service';
 import { toDatasetRecord, toResultRecord, toRunRecord } from './agent-eval-record-mappers';
-import type { AgentEvalRunSummary } from './agent-eval-runner.service';
 import { AgentEvalRunnerService } from './agent-eval-runner.service';
 
 /** Statuses a run can still be asked to stop from. */

--- a/packages/cli/src/modules/agent-evals/agent-evals-flag-gate.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals-flag-gate.ts
@@ -1,0 +1,39 @@
+import { AGENT_EVALS_FLAG } from '@n8n/api-types';
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { PostHogClient } from '@/posthog';
+
+/**
+ * Per-user rollout gate for every agent-eval surface.
+ *
+ * PostHog is the source of truth for cohort rollout, so the flag is resolved per
+ * user rather than per instance; `N8N_AGENT_EVALS_ENABLED` still force-enables it
+ * because {@link PostHogClient} layers that override on top of the resolved
+ * flags. A rolled-out user therefore needs no env var, and an operator can still
+ * switch the feature on for a whole instance.
+ *
+ * Shared by the controller and the services behind it so the routes and the
+ * business logic can't drift on what "enabled" means. Resolution is cheap to
+ * repeat: `getFeatureFlags` caches per user, and it degrades to the env
+ * overrides on its own when PostHog is unreachable — so no error handling is
+ * needed here, and an outage reads as flag-off rather than failing the request.
+ */
+@Service()
+export class AgentEvalsFlagGate {
+	constructor(private readonly postHogClient: PostHogClient) {}
+
+	async isEnabled(user: User): Promise<boolean> {
+		const flags = await this.postHogClient.getFeatureFlags(user);
+		return flags?.[AGENT_EVALS_FLAG] === true;
+	}
+
+	/**
+	 * Throws `NotFoundError` rather than `ForbiddenError` when the flag is off, so
+	 * the surface looks like an unknown feature and leaks no flag state.
+	 */
+	async assertEnabled(user: User): Promise<void> {
+		if (!(await this.isEnabled(user))) throw new NotFoundError('Not found');
+	}
+}

--- a/packages/cli/src/modules/agent-evals/agent-evals-flag-gate.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals-flag-gate.ts
@@ -6,19 +6,13 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { PostHogClient } from '@/posthog';
 
 /**
- * Per-user rollout gate for every agent-eval surface.
+ * Per-user rollout gate for every agent-eval surface, shared by the controller
+ * and the services behind it so the two can't disagree on what "enabled" means.
  *
- * PostHog is the source of truth for cohort rollout, so the flag is resolved per
- * user rather than per instance; `N8N_AGENT_EVALS_ENABLED` still force-enables it
+ * PostHog owns cohort rollout; `N8N_AGENT_EVALS_ENABLED` still force-enables
  * because {@link PostHogClient} layers that override on top of the resolved
- * flags. A rolled-out user therefore needs no env var, and an operator can still
- * switch the feature on for a whole instance.
- *
- * Shared by the controller and the services behind it so the routes and the
- * business logic can't drift on what "enabled" means. Resolution is cheap to
- * repeat: `getFeatureFlags` caches per user, and it degrades to the env
- * overrides on its own when PostHog is unreachable — so no error handling is
- * needed here, and an outage reads as flag-off rather than failing the request.
+ * flags. It also caches per user and falls back to those overrides when PostHog
+ * is unreachable, so this needs no caching or error handling of its own.
  */
 @Service()
 export class AgentEvalsFlagGate {
@@ -29,10 +23,7 @@ export class AgentEvalsFlagGate {
 		return flags?.[AGENT_EVALS_FLAG] === true;
 	}
 
-	/**
-	 * Throws `NotFoundError` rather than `ForbiddenError` when the flag is off, so
-	 * the surface looks like an unknown feature and leaks no flag state.
-	 */
+	// 404 rather than 403: a flag-off surface should look unknown, not forbidden.
 	async assertEnabled(user: User): Promise<void> {
 		if (!(await this.isEnabled(user))) throw new NotFoundError('Not found');
 	}

--- a/packages/cli/src/modules/agent-evals/agent-evals.controller.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals.controller.ts
@@ -6,6 +6,7 @@ import {
 	type AgentEvalDatasetRecord,
 	type AgentEvalRunDetail,
 	type AgentEvalRunRecord,
+	type AgentEvalRunSummary,
 	type GenerateDraftCasesResult,
 } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
@@ -13,7 +14,6 @@ import { Body, Delete, Get, Patch, Post, ProjectScope, RestController } from '@n
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 
-import type { AgentEvalRunSummary } from './agent-eval-runner.service';
 import { AgentEvalService } from './agent-eval.service';
 import { AgentEvalsFlagGate } from './agent-evals-flag-gate';
 

--- a/packages/cli/src/modules/agent-evals/agent-evals.controller.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals.controller.ts
@@ -22,20 +22,13 @@ type DatasetParam = AgentParam & { datasetId: string };
 type RunParam = AgentParam & { runId: string };
 
 /**
- * REST surface for agent evals: draft-case generation, datasets, runs, and
- * per-case results.
+ * REST surface for agent evals: generation, datasets, runs and per-case results.
+ * Nested under the agent so `@ProjectScope` rejects before the handler runs.
  *
- * Nested under the agent so `@ProjectScope` can resolve the project straight
- * from `:projectId` and reject before the handler runs. Scope choices mirror the
- * agent's own controllers: `agent:read` for every read, `agent:execute` for
- * starting and cancelling a run (it really does execute the agent, the same
- * capability a project viewer already has), and `agent:update` for anything that
- * writes eval configuration — including case generation, which creates a Data
- * Table and spends the builder's own model credits, so it must not be open to
- * viewers.
- *
- * Ratings live on their own route in a follow-up, together with the service that
- * persists them.
+ * `agent:read` for reads, `agent:execute` for running a run, `agent:update` for
+ * eval-config writes — including generation, which spends the builder's model
+ * credits and so must stay closed to viewers (they hold `agent:execute`).
+ * Ratings ship with the service that persists them.
  */
 @RestController('/projects/:projectId/agents/v2')
 export class AgentEvalsController {
@@ -59,9 +52,8 @@ export class AgentEvalsController {
 	async createDataset(req: AuthenticatedRequest<AgentParam>): Promise<AgentEvalDatasetRecord> {
 		await this.flagGate.assertEnabled(req.user);
 		const { agentId, projectId } = req.params;
-		// Hand-parsed rather than bound via `@Body`: the body carries the
-		// `DatasetRef` discriminated union, which `Z.class` (flat shapes only)
-		// can't express, so this DTO ships as a schema instead of a class.
+		// Hand-parsed, not `@Body`-bound: the `DatasetRef` union can't be expressed as
+		// a `Z.class`, so this DTO ships as a schema and the handler owns the 400.
 		const parsed = createAgentEvalDatasetSchema.safeParse(req.body);
 		if (!parsed.success) {
 			throw new BadRequestError(parsed.error.issues.map((i) => i.message).join(', '));
@@ -100,11 +92,8 @@ export class AgentEvalsController {
 
 	// ---- case generation ----
 
-	/**
-	 * Drafts cases from the agent's own config and persists them as a new dataset.
-	 * Calls the agent's model with the agent's credential, so it is never exposed
-	 * on a read-only scope.
-	 */
+	// Drafts cases from the agent's config into a new dataset, calling the agent's
+	// model with its own credential — hence never on a read-only scope.
 	@Post('/:agentId/evals/generate')
 	@ProjectScope('agent:update')
 	async generateDraftCases(

--- a/packages/cli/src/modules/agent-evals/agent-evals.controller.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals.controller.ts
@@ -1,0 +1,167 @@
+import {
+	CreateAgentEvalRunDto,
+	GenerateDraftCasesOptionsDto,
+	UpdateAgentEvalDatasetDto,
+	createAgentEvalDatasetSchema,
+	type AgentEvalDatasetRecord,
+	type AgentEvalRunDetail,
+	type AgentEvalRunRecord,
+	type GenerateDraftCasesResult,
+} from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { Body, Delete, Get, Patch, Post, ProjectScope, RestController } from '@n8n/decorators';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+
+import type { AgentEvalRunSummary } from './agent-eval-runner.service';
+import { AgentEvalService } from './agent-eval.service';
+import { AgentEvalsFlagGate } from './agent-evals-flag-gate';
+
+type AgentParam = { projectId: string; agentId: string };
+type DatasetParam = AgentParam & { datasetId: string };
+type RunParam = AgentParam & { runId: string };
+
+/**
+ * REST surface for agent evals: draft-case generation, datasets, runs, and
+ * per-case results.
+ *
+ * Nested under the agent so `@ProjectScope` can resolve the project straight
+ * from `:projectId` and reject before the handler runs. Scope choices mirror the
+ * agent's own controllers: `agent:read` for every read, `agent:execute` for
+ * starting and cancelling a run (it really does execute the agent, the same
+ * capability a project viewer already has), and `agent:update` for anything that
+ * writes eval configuration — including case generation, which creates a Data
+ * Table and spends the builder's own model credits, so it must not be open to
+ * viewers.
+ *
+ * Ratings live on their own route in a follow-up, together with the service that
+ * persists them.
+ */
+@RestController('/projects/:projectId/agents/v2')
+export class AgentEvalsController {
+	constructor(
+		private readonly service: AgentEvalService,
+		private readonly flagGate: AgentEvalsFlagGate,
+	) {}
+
+	// ---- datasets ----
+
+	@Get('/:agentId/evals/datasets')
+	@ProjectScope('agent:read')
+	async listDatasets(req: AuthenticatedRequest<AgentParam>): Promise<AgentEvalDatasetRecord[]> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId } = req.params;
+		return await this.service.listDatasets(agentId, projectId);
+	}
+
+	@Post('/:agentId/evals/datasets')
+	@ProjectScope('agent:update')
+	async createDataset(req: AuthenticatedRequest<AgentParam>): Promise<AgentEvalDatasetRecord> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId } = req.params;
+		// Hand-parsed rather than bound via `@Body`: the body carries the
+		// `DatasetRef` discriminated union, which `Z.class` (flat shapes only)
+		// can't express, so this DTO ships as a schema instead of a class.
+		const parsed = createAgentEvalDatasetSchema.safeParse(req.body);
+		if (!parsed.success) {
+			throw new BadRequestError(parsed.error.issues.map((i) => i.message).join(', '));
+		}
+		return await this.service.createDataset(req.user, agentId, projectId, parsed.data);
+	}
+
+	@Get('/:agentId/evals/datasets/:datasetId')
+	@ProjectScope('agent:read')
+	async getDataset(req: AuthenticatedRequest<DatasetParam>): Promise<AgentEvalDatasetRecord> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId, datasetId } = req.params;
+		return await this.service.getDataset(agentId, projectId, datasetId);
+	}
+
+	@Patch('/:agentId/evals/datasets/:datasetId')
+	@ProjectScope('agent:update')
+	async updateDataset(
+		req: AuthenticatedRequest<DatasetParam>,
+		_res: unknown,
+		@Body payload: UpdateAgentEvalDatasetDto,
+	): Promise<AgentEvalDatasetRecord> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId, datasetId } = req.params;
+		return await this.service.updateDataset(agentId, projectId, datasetId, payload);
+	}
+
+	@Delete('/:agentId/evals/datasets/:datasetId')
+	@ProjectScope('agent:update')
+	async deleteDataset(req: AuthenticatedRequest<DatasetParam>): Promise<{ success: true }> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId, datasetId } = req.params;
+		await this.service.deleteDataset(agentId, projectId, datasetId);
+		return { success: true };
+	}
+
+	// ---- case generation ----
+
+	/**
+	 * Drafts cases from the agent's own config and persists them as a new dataset.
+	 * Calls the agent's model with the agent's credential, so it is never exposed
+	 * on a read-only scope.
+	 */
+	@Post('/:agentId/evals/generate')
+	@ProjectScope('agent:update')
+	async generateDraftCases(
+		req: AuthenticatedRequest<AgentParam>,
+		_res: unknown,
+		@Body payload: GenerateDraftCasesOptionsDto,
+	): Promise<GenerateDraftCasesResult> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId } = req.params;
+		return await this.service.generateDraftCases(req.user, agentId, projectId, payload);
+	}
+
+	// ---- runs ----
+
+	/** Returns as soon as the run is seeded; poll the summary route for progress. */
+	@Post('/:agentId/evals/datasets/:datasetId/runs')
+	@ProjectScope('agent:execute')
+	async startRun(
+		req: AuthenticatedRequest<DatasetParam>,
+		_res: unknown,
+		@Body payload: CreateAgentEvalRunDto,
+	): Promise<AgentEvalRunRecord> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId, datasetId } = req.params;
+		return await this.service.startRun(req.user, agentId, projectId, datasetId, payload);
+	}
+
+	@Get('/:agentId/evals/datasets/:datasetId/runs')
+	@ProjectScope('agent:read')
+	async listRuns(req: AuthenticatedRequest<DatasetParam>): Promise<AgentEvalRunRecord[]> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId, datasetId } = req.params;
+		return await this.service.listRuns(agentId, projectId, datasetId);
+	}
+
+	@Get('/:agentId/evals/runs/:runId')
+	@ProjectScope('agent:read')
+	async getRun(req: AuthenticatedRequest<RunParam>): Promise<AgentEvalRunDetail> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId, runId } = req.params;
+		return await this.service.getRunDetail(agentId, projectId, runId);
+	}
+
+	/** Counts only — cheap enough for the UI to poll while a run is in flight. */
+	@Get('/:agentId/evals/runs/:runId/summary')
+	@ProjectScope('agent:read')
+	async getRunSummary(req: AuthenticatedRequest<RunParam>): Promise<AgentEvalRunSummary> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId, runId } = req.params;
+		return await this.service.getRunSummary(agentId, projectId, runId);
+	}
+
+	@Post('/:agentId/evals/runs/:runId/cancel')
+	@ProjectScope('agent:execute')
+	async cancelRun(req: AuthenticatedRequest<RunParam>): Promise<AgentEvalRunRecord> {
+		await this.flagGate.assertEnabled(req.user);
+		const { agentId, projectId, runId } = req.params;
+		return await this.service.cancelRun(agentId, projectId, runId);
+	}
+}

--- a/packages/cli/src/modules/agent-evals/agent-evals.module.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals.module.ts
@@ -3,13 +3,11 @@ import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
 /**
- * Agent-scoped evaluations. Runs eval datasets against a real agent and
- * persists per-case results, and serves the REST surface the editor consumes.
- * Main-process only — the reused tool-mock substrate cannot cross a queue
- * boundary. Opt-in (not a default module) and dark until the `101_agent_evals`
- * flag is on, so the routes register only on an instance that asked for the
- * module and answer only for a user in the rollout; the persistence layer lives
- * in `@n8n/db`.
+ * Agent-scoped evaluations: runs eval datasets against a real agent, persists
+ * per-case results, and serves the REST surface the editor consumes.
+ *
+ * Main-process only — the reused tool-mock substrate can't cross a queue
+ * boundary. Opt-in module, and dark until `101_agent_evals` is on for the user.
  */
 @BackendModule({ name: 'agent-evals', instanceTypes: ['main'] })
 export class AgentEvalsModule implements ModuleInterface {

--- a/packages/cli/src/modules/agent-evals/agent-evals.module.ts
+++ b/packages/cli/src/modules/agent-evals/agent-evals.module.ts
@@ -4,13 +4,18 @@ import { Container } from '@n8n/di';
 
 /**
  * Agent-scoped evaluations. Runs eval datasets against a real agent and
- * persists per-case results. Main-process only — the reused tool-mock substrate
- * cannot cross a queue boundary. Opt-in (not a default module) and dark until
- * the `101_agent_evals` flag is on; the persistence layer lives in `@n8n/db`.
+ * persists per-case results, and serves the REST surface the editor consumes.
+ * Main-process only — the reused tool-mock substrate cannot cross a queue
+ * boundary. Opt-in (not a default module) and dark until the `101_agent_evals`
+ * flag is on, so the routes register only on an instance that asked for the
+ * module and answer only for a user in the rollout; the persistence layer lives
+ * in `@n8n/db`.
  */
 @BackendModule({ name: 'agent-evals', instanceTypes: ['main'] })
 export class AgentEvalsModule implements ModuleInterface {
 	async init() {
+		await import('./agent-evals.controller.js');
+
 		const { AgentEvalRunnerService } = await import('./agent-eval-runner.service.js');
 		const runner = Container.get(AgentEvalRunnerService);
 		// The runner can't resume runs interrupted by a restart — sweep any left


### PR DESCRIPTION
## Summary

REST surface for **Agent Evals** (Phase 1) — the API the editor's Evals tab will consume. Wires the already-merged data model (#34657), DTOs (#34894), runner (#34904), and case-generation service up to HTTP.

New `AgentEvalsController`, nested under the agent so `@ProjectScope` resolves the project straight from the path:

| Route (under `/projects/:projectId/agents/v2/:agentId/evals`) | Scope |
|---|---|
| `GET /datasets` · `GET /datasets/:datasetId` | `agent:read` |
| `POST /datasets` · `PATCH /datasets/:datasetId` · `DELETE /datasets/:datasetId` | `agent:update` |
| `POST /generate` | `agent:update` |
| `POST /datasets/:datasetId/runs` · `POST /runs/:runId/cancel` | `agent:execute` |
| `GET /datasets/:datasetId/runs` · `GET /runs/:runId` · `GET /runs/:runId/summary` | `agent:read` |

Behind it, `AgentEvalService` owns dataset CRUD, run list/detail/cancel, and entity→wire mapping; `AgentEvalsFlagGate` is the single rollout gate; `agent-eval-record-mappers.ts` does the response mapping. All existing `agent:*` scopes sufficed, so no `@n8n/permissions` changes — and no new custom-role migration concerns.

**Authorization.** `@ProjectScope` proves the caller may act on the project in the URL, but nothing about it proves the addressed agent lives in that project, nor that a dataset/run id belongs to that agent. So every service entry point resolves the agent through `(agentId, projectId)` and then loads datasets and runs through **agent-filtered** repository reads (`findByIdAndAgentId`). Unknown and foreign ids both surface as 404, so a route never confirms that an id exists elsewhere.

**Two runner gaps closed, both flagged on the ticket:**

- `getRunSummary` did **no permission check at all**. It now takes the agent and resolves the run through it (a run has no agent column — the agent under test is its dataset's — so the scoped read walks the relation), so a bare run id no longer reads a run's progress.
- `startRun` gated on the `N8N_AGENT_EVALS_ENABLED` env override alone, while case generation and the frontend consulted PostHog — its own comment called that a stopgap until REST landed. Both now share `AgentEvalsFlagGate`, which resolves `101_agent_evals` **per user** via PostHog, with the env override still force-enabling (`PostHogClient` layers it on top). A rolled-out user no longer needs the env var. This also removed the third copy of the same gate.

**Design notes**
- Scope choice for generation is `agent:update`, not `agent:execute` — project viewers hold `agent:execute`, and generation writes a Data Table and spends the builder's own model credits, so it must not be open to viewers.
- Responses map entities field-by-field, keeping the run's `runningInstanceId` / `cancelRequested` coordination columns off the contract (`runningInstanceId` would expose an instance host id). A new entity column can't leak onto the API by accident.
- The dataset source pointer is rebuilt from the persisted `datasetSource` column rather than inferred from the ref's shape, so a future third source can't be silently relabelled as one of today's two; a source that disagrees with its ref can only be a corrupt row and fails loudly.
- The create-dataset body carries the `DatasetRef` discriminated union, so it can't bind via `@Body` (`Z.class` is flat-shape only) and is parsed in the handler — which means the handler owns turning invalid input into a 400 rather than a 500.
- `agentVersionId` on the start-run body is **refused** rather than ignored: the runner deliberately executes the live agent unpinned, so accepting a pin and running something else would misreport what was measured. The create-dataset body's redundant `agentId` must likewise match the path. Both are documented on the schema fields.
- **Ratings endpoints are deliberately absent.** They need the ratings service (TRUST-289), which lands with its own change; the route ships alongside it.

## How to test

Backend-only and dark twice over — the module is opt-in *and* the flag is per-user. To exercise it on an instance:

- Enable the modules: `N8N_ENABLED_MODULES=agent-evals,agents,instance-ai,data-table`
- Enable the flag: `N8N_AGENT_EVALS_ENABLED=true`

Then, against an agent in a project you can access:

```bash
# generate draft cases (creates a Data Table + dataset)
curl -X POST "$N8N/rest/projects/$PROJECT/agents/v2/$AGENT/evals/generate" \
  -H 'content-type: application/json' -d '{"count":3}'

# list datasets, start a run, poll it
curl "$N8N/rest/projects/$PROJECT/agents/v2/$AGENT/evals/datasets"
curl -X POST "$N8N/rest/projects/$PROJECT/agents/v2/$AGENT/evals/datasets/$DATASET/runs" \
  -H 'content-type: application/json' -d '{}'
curl "$N8N/rest/projects/$PROJECT/agents/v2/$AGENT/evals/runs/$RUN/summary"
curl "$N8N/rest/projects/$PROJECT/agents/v2/$AGENT/evals/runs/$RUN"
```

Worth poking at the negative paths, since they're the point of the change: a run id from a *different* agent on `/runs/:runId/summary` should 404, and every route should 404 with the flag off.

Automated tests:

```bash
# packages/cli
pnpm test src/modules/agent-evals                 # 156 unit tests
pnpm test:integration src/modules/agent-evals     # 10 tests, real DB

# packages/@n8n/db
pnpm test src/repositories/__tests__/agent-eval   # 37 repository tests
```

Three things worth knowing about the coverage:

- The controller suite includes a **route-metadata regression test** that fails if a future route is added without an access scope, plus an assertion pinning each handler's exact scope.
- `agent-eval-scoped-reads.integration.test.ts` exercises the agent scoping **against a real database**, pairing every allowed read with the foreign-agent read that must come back empty (plus the cascade the dataset delete relies on). Mocking an entity manager can only assert which `where` object was built — it can't tell whether the relation was joined and the predicate applied, so a mocked test would keep passing if the filter stopped constraining.
- The runner integration test uses the **real** `AgentEvalsFlagGate` rather than a mock, so it exercises the env-override path end to end.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-290

Builds on the merged data model (#34657), DTOs (#34894), and runner (#34904). Ratings endpoints follow with https://linear.app/n8n/issue/TRUST-289.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Feature is dark behind an opt-in module + flag; docs land with the UI. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)