### PR TITLE
fix(editor): Update AI Agent preview label

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.test.ts
@@ -14,7 +14,7 @@ describe('PreviewTag', () => {
 	});
 
 	it('renders custom text instead of the default label', () => {
-		const { getByText } = render(PreviewTag, { props: { text: 'Custom preview' } });
-		expect(getByText('Custom preview')).toBeInTheDocument();
+		const { getByText } = render(PreviewTag, { props: { text: 'Early preview' } });
+		expect(getByText('Early preview')).toBeInTheDocument();
 	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.test.ts
@@ -14,7 +14,7 @@ describe('PreviewTag', () => {
 	});
 
 	it('renders custom text instead of the default label', () => {
-		const { getByText } = render(PreviewTag, { props: { text: 'Early preview' } });
-		expect(getByText('Early preview')).toBeInTheDocument();
+		const { getByText } = render(PreviewTag, { props: { text: 'Custom preview' } });
+		expect(getByText('Custom preview')).toBeInTheDocument();
 	});
 });

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2176,7 +2176,7 @@
 	"nodeCreator.nodeItem.triggerIconTitle": "Trigger Node",
 	"nodeCreator.nodeItem.aiIconTitle": "LangChain AI Node",
 	"nodeCreator.nodeItem.deprecated": "Deprecated",
-	"nodeCreator.nodeItem.earlyPreview": "Early preview",
+	"nodeCreator.nodeItem.earlyPreview": "Preview",
 	"nodeCreator.nodeItem.beta": "Beta",
 	"nodeCredentials.createNew": "Create new credential",
 	"nodeCredentials.createNew.permissionDenied": "Your current role does not allow you to create credentials",

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -916,12 +916,12 @@ describe('NodeCreator - utils', () => {
 			},
 		);
 
-		it('should show Early preview badge on the AI Agent V1 node', () => {
+		it('should show Preview badge on the AI Agent V1 node', () => {
 			mockSettingsStore(true);
 			const [result] = finalizeItems([
 				makeAgentNode(MESSAGE_AN_AGENT_NODE_TYPE),
 			]) as NodeCreateElement[];
-			expect(result.properties.tag).toEqual({ preview: true, text: 'Early preview' });
+			expect(result.properties.tag).toEqual({ preview: true, text: 'Preview' });
 		});
 
 		it('should keep a pre-set tag', () => {


### PR DESCRIPTION
## Summary

Change the new AI Agent node badge from "Early preview" to "Preview".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-469

<img width="392" height="104" alt="image" src="https://github.com/user-attachments/assets/c16ff1b1-e745-476f-a6e9-3c9f185179f5" />

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR labeled with a backport label if needed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35102">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

