### PR TITLE
chore: Ignore `.pi-subagents` agent artifacts (no-changelog)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ build.log
 tcr-dry.log
 .agent-setup/
 .agent-recordings/
+.pi-subagents/
 sbom-source.cdx.json
 *.junit.xml
 junit.xml


### PR DESCRIPTION
## Summary

Adds `.pi-subagents/` to `.gitignore`, next to the existing `.agent-setup/` and `.agent-recordings/` entries.

Local AI agent tooling writes per-run artifacts to `.pi-subagents/artifacts/` — the task input, the model's output, a metadata file and the full conversation transcript. Four of those files were committed to a feature branch and are currently live in an open PR on this public repository (#33622, 337 lines, ~430 KB), added as collateral in a commit whose stated purpose was removing a test.

Nothing credential-shaped is in them — no API keys, AWS key IDs or bearer tokens — but they do publish internal tooling details, a model identifier, per-run token cost and a contributor's local filesystem path. None of that is meant to ship.

This is the preventative half. `.pi-subagents/` is generated output, so it belongs in the same block as the other agent scratch directories; ignoring it repo-wide means the next run can't stage these by accident. Removing the already-committed copies is handled separately against the branch that carries them (#33622).

## How to test

```bash
mkdir -p .pi-subagents/artifacts && touch .pi-subagents/artifacts/probe.md
git check-ignore -v .pi-subagents/artifacts/probe.md
# → .gitignore:40:.pi-subagents/  .pi-subagents/artifacts/probe.md
git status --porcelain   # clean — the path is no longer offered for staging
rm -rf .pi-subagents
```

## Related Linear tickets, Github issues, and Community forum posts

Follows from PR hygiene review of #33622.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — n/a, `.gitignore` only
- [x] Tests included. — n/a; verified with `git check-ignore` above
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35103">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

