### PR TITLE
docs: Record the @n8n/design-system packaging and declaration decisions as ADRs (no-changelog)

### DIFF
--- a/docs/adrs/0001-design-system-ships-as-a-compiled-package.md
+++ b/docs/adrs/0001-design-system-ships-as-a-compiled-package.md
@@ -1,0 +1,127 @@
+# @n8n/design-system ships as a compiled package
+
+Date: 2026-07-28 · Status: accepted
+Implemented by: [#35108](https://github.com/n8n-io/n8n/pull/35108) (open at filing)
+Supersedes: — · Superseded by: —
+
+## Context
+
+`@n8n/design-system` was already being published to npm on every release
+(`release-publish.yml` publishes all non-private packages recursively). What
+shipped was not consumable. Unpacking `2.31.0` from the registry showed three
+artifacts disagreeing about what the package even was:
+
+- `package.json` declared `main`/`import` → `src/index.ts`, raw TypeScript
+  source, with no `exports`, `types`, `module` or `files`. Top-level `import` is
+  not a valid manifest field.
+- `.npmignore` stripped `/src/**/*.{ts,vue,scss,snap}` and re-included `dist`,
+  written by someone who intended `dist` consumption.
+- `.github/scripts/trim-fe-packageJson.js` deleted **all** `dependencies` from
+  the manifest at publish time.
+
+Net result in the published tarball: the declared entry point did not exist, no
+type declarations, zero declared dependencies (33 were removed), and a `dist/`
+that nothing referenced — plus `.turbo/` cache and lint configs shipped as
+junk. A plain `import '@n8n/design-system'` could not resolve, so no working
+external consumer existed. Every packaging decision was therefore still a
+two-way door: there was nobody to break.
+
+`dist/` also had zero consumers inside the monorepo — editor-ui, chat,
+frontend-module-sdk, mcp-apps and storybook all alias
+`@n8n/design-system(.*) → src$1`. Unexercised output rots silently, and did.
+
+Three targets were live, and they plan differently:
+
+- **(A) A compiled npm package** other n8n repos install.
+- **(B) A source package** that pushes our vite/sass/icon toolchain onto every
+  consumer.
+- **(C) Monorepo-internal consumption only**, done properly.
+
+## Decision
+
+We ship `@n8n/design-system` as a **compiled, self-describing npm package**
+(option A): ESM-only `dist` output with `preserveModules`, runtime dependencies
+externalized, tokens and fonts shipped as CSS, lucide icon buckets pre-built as
+lazy chunks, an `exports` allowlist, and `files` in place of `.npmignore`.
+`@n8n/design-system` is removed from the publish-time dependency trim script.
+
+The supported type-resolution target is `bundler`. `node16` is a documented
+limitation, not a failure — see [ADR-0002](0002-per-file-declarations-for-design-system.md).
+
+### Why not B or C
+
+- **(B) Source package — the strongest case against us:** it is the honest
+  description of how the monorepo already consumes this package (everyone
+  aliases to `src`), it needs no build step, and it never desynchronises source
+  from artifact — the exact failure mode that produced the husk. It was rejected
+  because it exports our whole build stack as public API: every consumer would
+  need our vite plugins, sass setup, `@iconify/json` and icon codegen wired
+  identically. That is a far larger and more permanent coupling than a build
+  step, and it makes any toolchain change a breaking change for consumers.
+- **(C) Internal-only:** cheapest, and defensible if nobody outside the
+  monorepo ever consumes it. Rejected because the package is *already* published
+  publicly on every release; choosing C means either un-publishing (a visible
+  break) or knowingly continuing to ship a broken artifact.
+
+## Consequences
+
+**Good**
+
+- `npm i @n8n/design-system` resolves: 341 packages install where the trim
+  script previously removed all 33 dependencies.
+- Verified from a packed tarball in a Vite app outside the monorepo, with no
+  aliases, no sass config and no icon plugins: build clean, 736 custom
+  properties on `:root`, brand orange as the button's computed background,
+  `InterVariable` loaded, N8nSelect interactive, and lucide icons rendering from
+  pre-built chunks.
+- `publint` clean; `arethetypeswrong` 🟢 on `bundler` and `node10`.
+- `preserveModules` output makes the package tree-shakeable without
+  hand-maintaining ~150 entry points; deps stay `import`s, so consumers that
+  already use element-plus/tiptap/vue do not get a second copy.
+- The `exports` allowlist (root, `./theme.css`, `./style.css`, `./scss/*`,
+  `./package.json`) is much tighter than the `"./*": "./*"` catch-all that
+  `@n8n/chat` uses — the public surface is now enumerable.
+
+**Bad**
+
+- `dist` becomes load-bearing, and it is exactly what rotted before. Internal
+  consumers still alias to `src`, so the published artifact remains largely
+  unexercised by our own CI. Nothing yet asserts the tarball works — that gap
+  is tracked as the anti-rot job (N8N-117) and is the single highest-value
+  follow-up in this record.
+- UMD output is dropped. With ~40 externals a UMD bundle needs a `globals` entry
+  per dependency; any consumer still on a non-bundler script-tag flow is broken
+  by this. Accepted: every consumer of a Vue SFC library uses a bundler.
+- An `exports` allowlist can break consumers in ways the alias argument does not
+  predict. It did: `editor-ui/src/app/constants/parameters.ts` imported
+  `@n8n/design-system/src/components/...`, which resolved through `node_modules`
+  before and is blocked by `exports`. The alias reasoning covered the bundler's
+  resolution, not TypeScript's. **An allowlist change requires a consumer
+  typecheck pass, not reasoning.**
+- ~200 internal deep imports remain, unmigrated by choice. They work through the
+  `src` alias, so the allowlist does not break them, but they are not a
+  contract any external consumer can rely on and the codemod is still owed.
+- Publishing a *working* package converts several deferred questions into real
+  obligations the moment anyone adopts: changelog and versioning policy, a
+  consumption doc, and the licence call for consumers outside n8n. None exist
+  yet.
+
+**Neutral**
+
+- `vue` and `vue-router` become peer dependencies (`vue-router` optional);
+  `@types/markdown-it` and `@types/markdown-it-link-attributes` move to
+  `dependencies` because they are part of the public type surface.
+- Styles build through a second vite config (`vite.config.styles.mts`), so
+  `build` is now two passes.
+
+## Revisit triggers
+
+- CI does not yet consume the packed tarball. Until N8N-117 lands, treat every
+  claim in this record as true *as of 2026-07-28* and re-verify by packing.
+- Any consumer requiring `node16`/`nodenext` type resolution → see
+  [ADR-0002](0002-per-file-declarations-for-design-system.md).
+- A named external consumer appears → the deferred obligations above stop being
+  deferrable, starting with versioning policy and the licence call.
+- A second frontend package is found shipping the same husk shape
+  (`@n8n/frontend-module-sdk`, N8N-118) → fix the publish pipeline as a class
+  rather than per package.

--- a/docs/adrs/0001-design-system-ships-as-a-compiled-package.md
+++ b/docs/adrs/0001-design-system-ships-as-a-compiled-package.md
@@ -104,7 +104,20 @@ limitation, not a failure — see [ADR-0002](0002-per-file-declarations-for-desi
 - Publishing a *working* package converts several deferred questions into real
   obligations the moment anyone adopts: changelog and versioning policy, a
   consumption doc, and the licence call for consumers outside n8n. None exist
-  yet.
+  yet. Note that `package.json` already declares
+  `LicenseRef-n8n-sustainable-use`, so shipping a resolvable artifact makes that
+  the de facto answer for external adopters whether or not anyone decides it.
+- **The single-entry collapse has a cost inside the monorepo.** Dropping the
+  `./icons/lucide` subpath moved `loadLucideIconBody` onto the root barrel
+  (`src/index.ts:40`), and that barrel is what internal packages resolve through
+  their `→ src` alias. Any internal build that aliases to `src` *without*
+  registering `lucideIconsPlugin` can no longer import anything from the barrel,
+  because the re-export drags in the unresolvable `virtual:lucide-icons`
+  specifier. Observed as a red `Install & Build` on #35108 via `@n8n/mcp-apps`,
+  with `mcp-browser-extension` carrying the same latent shape. **Unresolved at
+  filing** — a fix that restores the subpath would change the decision recorded
+  here, so a later reader finding a `./icons/lucide` export should expect a
+  superseding record and treat its absence as a gap.
 
 **Neutral**
 
@@ -125,3 +138,11 @@ limitation, not a failure — see [ADR-0002](0002-per-file-declarations-for-desi
 - A second frontend package is found shipping the same husk shape
   (`@n8n/frontend-module-sdk`, N8N-118) → fix the publish pipeline as a class
   rather than per package.
+- **The `./icons/lucide` subpath is restored, or the root barrel stops
+  re-exporting `loadLucideIconBody`** → the single-entry decision above no longer
+  holds; supersede this record rather than editing it. Note that
+  [ADR-0002](0002-per-file-declarations-for-design-system.md) credits the same
+  entry collapse for `attw node10` going green, so the two move together.
+- Any internal package needs to import from the design-system barrel without
+  registering our vite plugins → the barrel's build-time virtual specifiers are a
+  contract nobody wrote down. Write it down.

--- a/docs/adrs/0002-per-file-declarations-for-design-system.md
+++ b/docs/adrs/0002-per-file-declarations-for-design-system.md
@@ -1,0 +1,200 @@
+# Per-file declarations for @n8n/design-system, driven by vite-plugin-dts
+
+Date: 2026-07-28 · Status: accepted
+Implemented by: [#35108](https://github.com/n8n-io/n8n/pull/35108) (open at filing)
+Supersedes: — · Superseded by: —
+Depends on: [ADR-0001](0001-design-system-ships-as-a-compiled-package.md)
+
+## Context
+
+[ADR-0001](0001-design-system-ships-as-a-compiled-package.md) commits us to
+shipping a compiled package, which means shipping `.d.ts` files. The package had
+no declaration pipeline at all (`noEmit: true`, no emit step anywhere), so this
+had to be built from zero.
+
+**Read this part first, it is the expensive lesson.** A bare `vue-tsc` run
+emitted declarations for **104 of 158** components and **exited 0 with no
+diagnostic** for the other 54. Declaration emit fails *silently*: the exit code
+is 0, the log is clean, and the files are simply absent. This cost two full
+passes on this issue before anyone thought to count the output instead of
+trusting the exit code. If you are debugging a `.d.ts` pipeline for a `.vue`
+library: **count emitted declarations against source components. The exit code
+does not tell you anything.**
+
+The skips share one root cause: the inferred template context of a component
+pulls in a type the compiler cannot *name* portably through pnpm's hashed
+`node_modules` paths, and rather than error it drops the file. Two offenders
+accounted for the bulk — `vue-router`'s global `ComponentCustomProperties`
+augmentation (`Router`, `RouteLocationNormalizedLoadedGeneric`) and
+`LooseRequired` from `@vue/shared`, both surfacing as `TS2883`.
+
+This was not cosmetic. editor-ui resolves the component barrel through `dist`
+for types, so missing declarations regressed the monorepo: 5 implicit-`any`
+errors against a baseline of 0 on `master`. The gate for this work was therefore
+not "declarations exist" but **editor-ui typecheck back to 0 errors**.
+
+## Decision
+
+We emit **per-file declarations**, with **`vite-plugin-dts` driving the emit**
+(`rollupTypes: false`, `entryRoot: src`, against a dedicated
+`tsconfig.build.json`), and we fix residual silent skips **at the source** by
+declaring slots explicitly and avoiding template constructs that materialise
+foreign instance types.
+
+Declaration flattening — the option we set out to implement — is **rejected**.
+
+### The finding: who drives the emit matters more than what it emits
+
+Switching from a bare `vue-tsc` invocation to `vite-plugin-dts` — same
+TypeScript, same tsconfig, same components — collapsed the error count from
+**110 → 3**. The entire `vue-router` `TS2883` class, 54 missing components and
+the bulk of the problem, evaporated. No source change caused that; the driver
+did.
+
+This inverts the intuitive diagnosis. The instinct was to make `vue-tsc` name
+the foreign types, and three attempts down that road all failed (below). The
+productive question was not *how do we name these types* but *what is invoking
+the compiler, and with what module resolution*.
+
+### The three residual silent skips, and their mechanisms
+
+These are the durable part of this record. Each is a distinct way a `.vue`
+component can silently lose its declaration.
+
+1. **`TS7056` via `__VLS_TemplateRefs` — `N8nSelect`.** A *string* ref
+   (`ref="innerSelect"`) on `<ElSelect>` registers in vue-tsc's
+   `__VLS_TemplateRefs` map, which materialises element-plus' entire `ElSelect`
+   instance type — larger than the compiler will serialize. Fix: a **function
+   ref**, which never enters that map and is runtime-identical.
+   `src/components/N8nSelect/Select.vue:68,154`
+2. **`TS7056` again, via `defineExpose` — same component, second face.**
+   Exposing the ref itself (`defineExpose({ innerSelect })`) makes vue-tsc unwrap
+   it through `ShallowUnwrapRef`, which loses the `InnerSelectRef` name and
+   re-expands the instance type. Fix: expose a **getter** returning
+   `innerSelect.value`. `src/components/N8nSelect/Select.vue:135`
+3. **`TS2883` via `LooseRequired` — `SelectItem`.** Inferred slot props are
+   wrapped in `LooseRequired` from `@vue/shared`, a transitive dependency the
+   compiler cannot name. Fix: `defineSlots<…>()` instead of inference.
+   `src/v2/components/Select/SelectItem.vue:15`
+4. **`TS7022` via circular `useSlots()` — `SettingsRow`.** `useSlots()` was read
+   by a computed that the template renders, so inference is circular, falls back
+   to `any`, and blocks emit. Fix: `defineSlots<…>()`.
+   `src/components/N8nSettingsRow/SettingsRow.vue:93`
+
+The pattern across all four: **when inference reaches a type the compiler cannot
+name, declare it.** Declaring slots is not a workaround with a cost — those
+slots are now typed for consumers too, which is a net gain.
+
+Fixing `N8nSelect` by mechanism 1 also let us **delete the `ElSelect.props`
+widening entirely**, so element-plus' prop and emit precision survives across
+~940 internal call sites. That cost had previously been refused, correctly.
+
+## Considered options
+
+- **Bare `vue-tsc -p tsconfig.build.json`.** Rejected: 54 silent skips.
+- **`skipTemplateCodegen: true`.** All 158 components emit — genuinely tempting,
+  and the fastest green. Rejected because slot types collapse to `slots: {}` on
+  140 components, and since editor-ui resolves the barrel through `dist` that
+  breaks the monorepo with 33 errors. A green build that lies about slots is
+  worse than a red one.
+- **`"types": ["vue-router"]`.** Rejected *as the fix*: it does not make the
+  augmented types nameable and the skips remain. Note for future readers — this
+  entry is still present in `tsconfig.build.json`; **do not read its presence as
+  evidence that it solved anything.**
+- **Widening `ElSelect.props`.** Gets `N8nSelect` past `TS7056`, at the cost of
+  prop/emit precision across ~940 internal call sites. Rejected, and later
+  deleted outright once the function-ref fix landed.
+- **Flattening / rollup (`rollupTypes: true`, api-extractor)** — this was the
+  directed approach, built first, and rejected on measurement. It worked: a
+  320 KB bundle with 344 exports. Then it showed its ceiling — **api-extractor
+  cannot follow `.vue` module specifiers**, leaving 38 dangling relative imports
+  including `import { default as N8nSelect } from './Select.vue'`. `N8nSelect`
+  degraded to `any`, which turned out to be the actual upstream cause of the 5
+  editor-ui errors all along, not the missing declaration it was blamed on.
+  Flattening was strictly worse here.
+  **Its strongest case, preserved:** flattening is the *only* route that can
+  satisfy `node16`, because it removes the `.vue` and extensionless specifiers
+  Node's ESM resolver rejects. It also collapses the deep-path surface area to
+  one file. If api-extractor learns `.vue`, or a `vue-tsc`-native flattener
+  appears, this option deserves a fresh measurement rather than a citation of
+  this ADR. The diff is one boolean.
+- **Chosen: `vite-plugin-dts`, per-file.** 157 components emit with slot types
+  intact, deep paths keep their types, no api-extractor quirks.
+
+## Consequences
+
+**Good**
+
+- editor-ui typecheck back to **0 errors** — baseline parity with `master`.
+  `@n8n/storybook` also 0. design-system typecheck, lint and format clean;
+  1380 tests across 117 files pass.
+- Deep import paths keep real types instead of resolving to a single flat
+  bundle.
+- The props widening is gone: no prop/emit precision loss across ~940 internal
+  call sites.
+- Three components gained explicitly typed slots, which consumers can now use.
+- `node10` came green for free — a side effect of collapsing to a single entry
+  point, not of anything type-related.
+- From a packed tarball outside the monorepo: 387 declaration files, consumer
+  typecheck and build clean, with a typed `#prepend` slot rendering a lucide icon
+  from a pre-built chunk.
+
+**Bad**
+
+- **`attw` `node16` stays red, by construction.** Per-file declarations keep
+  `./Button.vue` and extensionless specifiers, which Node's ESM resolver
+  rejects. The fix for this is precisely the flattening we removed. `bundler` is
+  the supported target; `@n8n/chat` has the same property.
+- **The emit is silently fragile.** Any new component whose template inference
+  reaches an unnameable type loses its declaration with a clean exit code. There
+  is currently no check that would catch this — the anti-rot job (N8N-117)
+  should assert emitted-declaration count, not merely that the tarball packs.
+- Four components carry hand-declared slots that the compiler will not keep in
+  sync with their templates. Add a slot to the template and forget the
+  `defineSlots` entry, and consumers silently do not see it.
+- `N8nSelect` no longer exposes `innerSelect` as a ref but as a getter. Reads
+  through the exposed proxy are equivalent; anything that treated it as a
+  `Ref` object is not.
+- The declaration pipeline now depends on a plugin's choice of module
+  resolution, which is the thing that fixed it and therefore the thing that can
+  silently break it on upgrade. `vite-plugin-dts` is load-bearing infrastructure
+  here, not a convenience.
+
+**Neutral**
+
+- New `tsconfig.build.json` (`emitDeclarationOnly`, `moduleResolution: bundler`)
+  separate from the typecheck config.
+- `@vue/shared`, `vue` and `vue-router` added as devDependencies for nameability.
+- Props types were extracted from 7 generic SFCs and exported from 6 message
+  components as prerequisite work, clearing the `TS4082` "private name" class of
+  declaration errors.
+
+## Revisit triggers
+
+- **Any consumer needs `node16`/`nodenext` type resolution** → re-measure
+  flattening, and check whether api-extractor can follow `.vue` specifiers yet.
+- **Emitted `.d.ts` count diverges from component count** → a new silent skip has
+  landed. This should be a CI assertion (N8N-117), not a discovery.
+- **A fifth silent-skip mechanism appears** → hand-declared slots are not
+  scaling; consider a lint rule requiring `defineSlots` over `useSlots`
+  inference in this package.
+- **`vite-plugin-dts` major upgrade** → re-count declarations before believing
+  the build.
+
+## Two notes for whoever reads this next
+
+**The comment in `vite.config.mts` contradicts the code.** The block above
+`rollupTypes: false` still describes the *flattened* approach ("One flattened
+.d.ts per entry… Rolling up hoists those types into the bundle instead"). It is
+a leftover from the rejected attempt. Reported on #35108 at filing time; correct
+it there rather than editing this record. It is noted here because a stale
+comment sitting next to a correct flag is exactly how the next reader rebuilds
+the wrong mental model.
+
+**Where the numbers come from.** The emit counts, error counts and gate results
+in this record are the implementer's measurements on
+`agent/palette/bfb92cbd`, with the external-consumer gate evidenced by
+screenshot on N8N-110. The file and line citations were read directly from that
+branch. One discrepancy survives in the source reports: the component
+denominator is given as 158 early on and the final result as "157/157", so treat
+the exact total as ±1 and the mechanisms as the load-bearing content.

--- a/docs/adrs/0002-per-file-declarations-for-design-system.md
+++ b/docs/adrs/0002-per-file-declarations-for-design-system.md
@@ -134,7 +134,9 @@ widening entirely**, so element-plus' prop and emit precision survives across
   call sites.
 - Three components gained explicitly typed slots, which consumers can now use.
 - `node10` came green for free — a side effect of collapsing to a single entry
-  point, not of anything type-related.
+  point, not of anything type-related. That collapse is not free elsewhere; see
+  the entry-collapse cost recorded in
+  [ADR-0001](0001-design-system-ships-as-a-compiled-package.md).
 - From a packed tarball outside the monorepo: 387 declaration files, consumer
   typecheck and build clean, with a typed `#prepend` slot rendering a lucide icon
   from a pre-built chunk.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,40 @@
+# Architecture Decision Records
+
+An ADR records a decision **that was actually made** — the context that made it
+reasonable, the options that were genuinely live, and the costs we accepted. The
+point is that nobody pays for the same lesson twice.
+
+## Index
+
+| #                                                         | Title                                          | Date       | Status   | Tags                            |
+| --------------------------------------------------------- | ---------------------------------------------- | ---------- | -------- | ------------------------------- |
+| [0001](0001-design-system-ships-as-a-compiled-package.md) | @n8n/design-system ships as a compiled package | 2026-07-28 | accepted | frontend, packaging, publishing |
+| [0002](0002-per-file-declarations-for-design-system.md)   | Per-file declarations for @n8n/design-system   | 2026-07-28 | accepted | frontend, typescript, build     |
+
+## Conventions
+
+- **Filename:** `NNNN-kebab-slug.md`, sequential, never reused.
+- **Sections:** Context · Decision · Considered options · Consequences ·
+  Revisit triggers.
+- **The "Bad" consequences are mandatory.** An ADR with only upside is a press
+  release, and it makes the revisit triggers meaningless.
+- **Revisit triggers are written at filing time**, while judgment is cold and
+  nobody is invested in the outcome yet.
+- **ADRs are append-only.** Never edit a record's substance to match new
+  reality — that turns the archive into retroactive fiction. Changed your mind?
+  New ADR with `Supersedes: NNNN`; the old one gets `Superseded by: NNNN` and its
+  status flips. Typo and link fixes are fine.
+- **Statuses:** `proposed` → `accepted` → `superseded` | `deprecated`.
+- **Cross-link both ways.** The PR that implements a decision links to the ADR;
+  the ADR links back.
+
+## Scope
+
+This directory holds decisions that reach past a single package — anything a
+future reader might hit from a different part of the repo. Decisions confined to
+one module may live beside that module instead; those are numbered
+independently and are not indexed here. Existing example:
+`packages/cli/src/modules/promotion-review-prototype/docs/adr/`.
+
+When answering "why is it built this way?", answer with the link first and the
+summary second. An archive nobody searches is a diary.


### PR DESCRIPTION
## Summary

Records the two consequential decisions behind #35108, and establishes `docs/adrs/` as the place repo-wide decisions live.

- **[ADR-0001](https://github.com/n8n-io/n8n/blob/agent/index/01504fc9/docs/adrs/0001-design-system-ships-as-a-compiled-package.md)** — `@n8n/design-system` ships as a compiled package. Context: the package was already publishing to npm on every release as an unusable husk (entry point absent from the tarball, no types, all 33 dependencies stripped at publish). Records why option A beat "source package" and "internal-only", and the costs accepted — notably that `dist` is now load-bearing while our own CI still doesn't consume the tarball.
- **[ADR-0002](https://github.com/n8n-io/n8n/blob/agent/index/01504fc9/docs/adrs/0002-per-file-declarations-for-design-system.md)** — per-file declarations driven by `vite-plugin-dts`, with declaration flattening recorded as a **rejected** alternative and its strongest case preserved for whoever reopens it.

Documentation only. No source or build files touched.

### The part worth reading if you only read one thing

Declaration emit for `.vue` components **fails silently** — `vue-tsc` exits 0, the log is clean, and the `.d.ts` files are simply absent. That cost this work two full passes. ADR-0002 records the four distinct mechanisms that trigger it, each with a file and line citation:

| Mechanism | Error | Fix |
| --- | --- | --- |
| String `ref` registers in `__VLS_TemplateRefs`, materialising element-plus' full instance type | `TS7056` | function ref |
| `defineExpose` on a raw ref unwraps via `ShallowUnwrapRef`, losing the type name | `TS7056` | expose a getter |
| Inferred slot props wrapped in `@vue/shared`'s `LooseRequired`, not nameable | `TS2883` | `defineSlots<…>()` |
| `useSlots()` read by a computed the template renders — circular | `TS7022` | `defineSlots<…>()` |

And the counter-intuitive finding: switching from a bare `vue-tsc` invocation to `vite-plugin-dts` — same TypeScript, same tsconfig, same components — took the error count from 110 to 3. The emit *driver* was the fix, not the emit *shape*. Three attempts at "make `vue-tsc` name the foreign types" all failed first.

## How to test

Documentation only — nothing to execute. Review is a correctness read:

1. Every claim in ADR-0002's mechanism table was read from `agent/palette/bfb92cbd` (`fb29f9bead`) rather than from the report describing it; the file and line citations should resolve on that branch.
2. Counts and gate results are attributed to the implementer's measurements, with the one surviving discrepancy in the source reports (158 vs 157 components) called out rather than smoothed over.
3. `.prettierignore` excludes `**/*.md`, so no formatter applies to these files.

## Related Linear tickets, Github issues, and Community forum posts

Records the decisions implemented by #35108. Internal tracker: N8N-110.

Follow-ups referenced as revisit triggers, both already parked: N8N-117 (CI consumes the packed tarball — the anti-rot job) and N8N-118 (`@n8n/frontend-module-sdk`, same husk defect).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- These *are* the docs. End-user documentation is out of scope: this is an internal decision record. -->
- [ ] Tests included. <!-- N/A — markdown only. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

Two things a reviewer should push back on if they disagree:

1. **Location.** These sit at `docs/adrs/` rather than beside the package. The existing in-repo precedent (`packages/cli/src/modules/promotion-review-prototype/docs/adr/`) is module-local, and I departed from it deliberately: N8N-118 is the same defect class in a *different* package, and nobody debugging `@n8n/frontend-module-sdk` would think to look inside design-system's folder. The README says which scope belongs where.
2. **Two records, not one.** I was asked for the declaration ADR. I filed the packaging decision too, because ADR-0002's context depends on it and leaving the parent decision unrecorded would make the archive's first entry misleading about what was actually decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35110">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

