### PR TITLE
test(editor): Restore the dropped TagsDropdown innerSelect coverage (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/tags/components/TagsDropdown.innerSelect.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/tags/components/TagsDropdown.innerSelect.test.ts
@@ -1,0 +1,74 @@
+import { createTestingPinia } from '@pinia/testing';
+
+import { renderComponent } from '@/__tests__/render';
+import TagsDropdown from './TagsDropdown.vue';
+import { MAX_TAG_NAME_LENGTH } from '../tags.constants';
+
+/**
+ * Covers TagsDropdown reaching through N8nSelect's exposed template ref into the
+ * wrapped element-plus instance.
+ *
+ * `onMounted` does:
+ *
+ *     const select = selectRef.value?.innerSelect;
+ *     if (select) {
+ *       const input = select.$refs.input as Element | undefined;
+ *       if (input) { input.setAttribute('maxlength', `${MAX_TAG_NAME_LENGTH}`); ... }
+ *     }
+ *
+ * Both reads sit behind guards, so if `innerSelect` ever stops resolving this
+ * fails *silently* - nothing throws and every existing test still passes. The
+ * tag-name cap and the Escape/Enter handling just quietly disappear.
+ *
+ * These assertions therefore target the observable side effects of that block
+ * rather than the ref itself, and they are the only coverage of this integration:
+ * WorkflowTagsDropdown.test.ts and ExecutionsFilter.test.ts both mock TagsDropdown
+ * away, so neither exercises it.
+ *
+ * `$refs.input` only exists on ElSelect when both `filterable` and `multiple` are
+ * set, which TagsDropdown's template does.
+ */
+const ALL_TAGS = [
+	{ id: '1', name: 'alpha', createdAt: '', updatedAt: '' },
+	{ id: '2', name: 'beta', createdAt: '', updatedAt: '' },
+];
+
+const renderDropdown = () =>
+	renderComponent(TagsDropdown, {
+		pinia: createTestingPinia(),
+		props: {
+			placeholder: 'pick tags',
+			modelValue: [],
+			eventBus: null,
+			allTags: ALL_TAGS,
+			isLoading: false,
+			tagsById: { '1': ALL_TAGS[0], '2': ALL_TAGS[1] },
+		},
+	});
+
+const flush = async () => await new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('TagsDropdown - N8nSelect innerSelect integration', () => {
+	it('caps the tag name length on the inner element-plus input', async () => {
+		const { container } = renderDropdown();
+		await flush();
+
+		const input = container.querySelector('input');
+
+		expect(input).not.toBeNull();
+		// Only passes if `innerSelect` resolved to the element-plus instance and
+		// `innerSelect.$refs.input` was present.
+		expect(input?.getAttribute('maxlength')).toBe(String(MAX_TAG_NAME_LENGTH));
+	});
+
+	it('emits esc from the keydown listener bound to that same input', async () => {
+		const { container, emitted } = renderDropdown();
+		await flush();
+
+		const input = container.querySelector('input');
+		input?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		await flush();
+
+		expect(emitted().esc).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Summary

Restores `TagsDropdown.innerSelect.test.ts`, which was dropped during the N8nSelect test consolidation. **One file, +74/−0, no production code.**

The design-system half of this PR (`Select.exposed.test.ts`) already landed on the base branch — in palette's improved form, which adds tracked teardown and asserts `focus`/`blur` delegation with spies rather than just "does not throw". This branch takes their side on every shared file, so the editor-ui test is the only delta.

## Why this file matters

It is the only test in the repo that executes N8nSelect's `innerSelect` path. `WorkflowTagsDropdown.test.ts` and `ExecutionsFilter.test.ts` both `vi.mock` TagsDropdown away, so neither renders the real component or reaches the ref.

That gap is load-bearing, because both reads in `TagsDropdown.onMounted` sit behind guards:

```
const select = selectRef.value?.innerSelect;
if (select) {
  const input = select.$refs.input as Element | undefined;
  if (input) { input.setAttribute('maxlength', `${MAX_TAG_NAME_LENGTH}`); … }
}
```

Two guards, no else. If `innerSelect` ever stops resolving, nothing throws and every existing test still passes — users just silently lose the 24-char tag-name cap and Escape/Enter handling.

## What it asserts

The observable side effects of that guarded block, not the ref itself:

- `maxlength=24` on the inner element-plus input
- `esc` emitted from the keydown listener bound to that same element

Neither can pass unless `innerSelect` resolved to the real element-plus instance and `$refs.input` was present. (`$refs.input` only exists on ElSelect when both `filterable` and `multiple` are set, which TagsDropdown's template does.)

## Verification at head `5f0e309205`

```
restored test                        2 passed
negative control (ref assignment stubbed to never fire)   2 FAILED
```

The negative control is the point — without it, a green here proves nothing. Sabotaging the ref assignment yields `maxlength: null` and no `esc`, turning both assertions red, so the test is demonstrably sensitive to the exact failure it exists to catch.

Palette's consolidation did not touch `TagsDropdown.vue` or the editor-ui render helper, so the restore applies unchanged at this head.
