### PR TITLE
feat(core): Recommend sleep helper for banned setTimeout/clearTimeout

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-restricted-globals.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/no-restricted-globals.md
@@ -33,12 +33,26 @@ export class MyNode implements INodeType {
 ### ✅ Correct
 
 ```typescript
+import { sleep } from 'n8n-workflow';
+
 export class MyNode implements INodeType {
   async execute(this: IExecuteFunctions) {
     // Use n8n context methods instead
     const timezone = this.getTimezone();
 
+    // Use the sleep helper instead of setTimeout
+    await sleep(1000);
+
     return this.prepareOutputData([]);
   }
 }
 ```
+
+## Alternatives to restricted timer globals
+
+`n8n-workflow` exports helpers that work the same everywhere, including on
+n8n Cloud, instead of reaching for the restricted timer globals directly:
+
+- Instead of `setTimeout(resolve, ms)`, use `await sleep(ms)`.
+- Instead of `setTimeout` + `clearTimeout` for a cancellable delay, use
+  `await sleepWithAbort(ms, abortSignal)`.

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-restricted-globals.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-restricted-globals.test.ts
@@ -70,6 +70,17 @@ var __dirname = '/path';
 const __filename = 'file.js';
 			`,
 		},
+		{
+			name: 'sleep and sleepWithAbort from n8n-workflow should be allowed',
+			code: `
+import { sleep, sleepWithAbort } from 'n8n-workflow';
+
+async function wait(signal) {
+	await sleep(1000);
+	await sleepWithAbort(1000, signal);
+}
+			`,
+		},
 	],
 	invalid: [
 		{
@@ -82,7 +93,12 @@ const __filename = 'file.js';
 		},
 		{
 			code: 'setTimeout(() => {}, 1000);',
-			errors: [{ messageId: 'restrictedGlobal', data: { name: 'setTimeout' } }],
+			errors: [
+				{
+					messageId: 'restrictedGlobalWithHint',
+					data: { name: 'setTimeout', hint: "Use the 'sleep' helper from 'n8n-workflow' instead." },
+				},
+			],
 		},
 		{
 			code: 'clearInterval(timer);',
@@ -90,7 +106,15 @@ const __filename = 'file.js';
 		},
 		{
 			code: 'clearTimeout(timer);',
-			errors: [{ messageId: 'restrictedGlobal', data: { name: 'clearTimeout' } }],
+			errors: [
+				{
+					messageId: 'restrictedGlobalWithHint',
+					data: {
+						name: 'clearTimeout',
+						hint: "Use 'sleepWithAbort' from 'n8n-workflow' with an AbortSignal instead.",
+					},
+				},
+			],
 		},
 		{
 			code: 'setInterval(() => {}, 1000);',

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-restricted-globals.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-restricted-globals.ts
@@ -17,6 +17,12 @@ const restrictedGlobals = [
 	'__filename',
 ];
 
+// Nudge toward the n8n-workflow alternatives that work under n8n Cloud's restrictions
+const restrictedGlobalHints: Record<string, string> = {
+	setTimeout: "Use the 'sleep' helper from 'n8n-workflow' instead.",
+	clearTimeout: "Use 'sleepWithAbort' from 'n8n-workflow' with an AbortSignal instead.",
+};
+
 export const NoRestrictedGlobalsRule = createRule({
 	name: 'no-restricted-globals',
 	meta: {
@@ -26,6 +32,7 @@ export const NoRestrictedGlobalsRule = createRule({
 		},
 		messages: {
 			restrictedGlobal: "Use of restricted global '{{ name }}' is not allowed",
+			restrictedGlobalWithHint: "Use of restricted global '{{ name }}' is not allowed. {{ hint }}",
 		},
 		schema: [],
 	},
@@ -43,11 +50,21 @@ export const NoRestrictedGlobalsRule = createRule({
 				return;
 			}
 
-			context.report({
-				node: ref.identifier,
-				messageId: 'restrictedGlobal',
-				data: { name },
-			});
+			const hint = restrictedGlobalHints[name];
+
+			context.report(
+				hint
+					? {
+							node: ref.identifier,
+							messageId: 'restrictedGlobalWithHint',
+							data: { name, hint },
+						}
+					: {
+							node: ref.identifier,
+							messageId: 'restrictedGlobal',
+							data: { name },
+						},
+			);
 		}
 
 		return {


### PR DESCRIPTION
## Summary

`setTimeout()`/`clearTimeout()` are banned in community nodes via the `no-restricted-globals` ESLint rule, but this wasn't documented anywhere, so node authors hit the lint error with no clear alternative.

- The rule now attaches a hint to the `setTimeout`/`clearTimeout` violations pointing to the `sleep`/`sleepWithAbort` helpers exported from `n8n-workflow`.
- `docs/rules/no-restricted-globals.md` documents these alternatives with a usage example.
- Added a regression test confirming `sleep`/`sleepWithAbort` imported from `n8n-workflow` are never flagged by the rule.

## How to test

```bash
cd packages/@n8n/eslint-plugin-community-nodes
pnpm test no-restricted-globals
pnpm lint
pnpm typecheck
```

Or lint a community node that calls `setTimeout(...)` directly and confirm the error message now includes: "Use the 'sleep' helper from 'n8n-workflow' instead."

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-1072

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35114">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->