### PR TITLE
refactor(core): Split the workflow review request service (no-changelog)

### DIFF
--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-inbox.detail.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-inbox.detail.service.test.ts
@@ -1,31 +1,26 @@
-import type { LicenseState, Logger } from '@n8n/backend-common';
+import type { LicenseState } from '@n8n/backend-common';
 import type {
-	DbLockService,
-	ProjectRelationRepository,
-	SharedWorkflowRepository,
 	User,
 	UserRepository,
 	WorkflowEntity,
 	WorkflowHistory,
 	WorkflowPublishedVersionRepository,
 	WorkflowReviewRequest,
-	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
 	WorkflowReviewRequestReviewerRepository,
 	WorkflowReviewRequestWorkflowRepository,
 } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
-import type { CollaborationService } from '@/collaboration/collaboration.service';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { ProjectService } from '@/services/project.service.ee';
-import type { RoleService } from '@/services/role.service';
 import type { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
-import { WorkflowReviewRequestService } from '../workflow-review-request.service';
+import { WorkflowReviewFeatureGate } from '../workflow-review-feature-gate.service';
+import { WorkflowReviewInboxService } from '../workflow-review-inbox.service';
 
 const requestId = 'req-1';
 const workflowId = 'wf-1';
@@ -68,43 +63,28 @@ function historyVersion(versionId: string) {
 	} as unknown as WorkflowHistory;
 }
 
-describe('WorkflowReviewRequestService.getDetail', () => {
-	const logger = mock<Logger>();
+describe('WorkflowReviewInboxService.getDetail', () => {
 	const workflowReviewPolicyService = mock<WorkflowReviewPolicyService>();
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const workflowHistoryService = mock<WorkflowHistoryService>();
-	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
 	const publishedVersionRepository = mock<WorkflowPublishedVersionRepository>();
 	const requestRepository = mock<WorkflowReviewRequestRepository>();
 	const workflowRepository = mock<WorkflowReviewRequestWorkflowRepository>();
-	const authorRepository = mock<WorkflowReviewRequestAuthorRepository>();
 	const reviewerRepository = mock<WorkflowReviewRequestReviewerRepository>();
 	const userRepository = mock<UserRepository>();
-	const projectRelationRepository = mock<ProjectRelationRepository>();
-	const roleService = mock<RoleService>();
 	const projectService = mock<ProjectService>();
 	const licenseState = mock<LicenseState>();
-	const dbLockService = mock<DbLockService>();
-	const collaborationService = mock<CollaborationService>();
 
-	const service = new WorkflowReviewRequestService(
-		logger,
-		workflowReviewPolicyService,
+	const service = new WorkflowReviewInboxService(
+		new WorkflowReviewFeatureGate(licenseState, workflowReviewPolicyService),
 		workflowFinderService,
 		workflowHistoryService,
-		sharedWorkflowRepository,
 		publishedVersionRepository,
 		requestRepository,
 		workflowRepository,
-		authorRepository,
 		reviewerRepository,
 		userRepository,
-		projectRelationRepository,
-		roleService,
 		projectService,
-		licenseState,
-		dbLockService,
-		collaborationService,
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-inbox.list.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-inbox.list.service.test.ts
@@ -1,53 +1,38 @@
 import { mockInstance } from '@n8n/backend-test-utils';
-import { LicenseState, type Logger } from '@n8n/backend-common';
+import { LicenseState } from '@n8n/backend-common';
 import type {
-	DbLockService,
-	ProjectRelationRepository,
-	SharedWorkflowRepository,
 	User,
 	UserRepository,
 	WorkflowPublishedVersionRepository,
 	WorkflowReviewRequest,
 	WorkflowReviewRequestReviewerRepository,
 } from '@n8n/db';
-import {
-	WorkflowReviewRequestAuthorRepository,
-	WorkflowReviewRequestRepository,
-	WorkflowReviewRequestWorkflowRepository,
-} from '@n8n/db';
+import { WorkflowReviewRequestRepository, WorkflowReviewRequestWorkflowRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
-import type { CollaborationService } from '@/collaboration/collaboration.service';
 import { ProjectService } from '@/services/project.service.ee';
-import type { RoleService } from '@/services/role.service';
 import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
-import { WorkflowReviewRequestService } from '../workflow-review-request.service';
+import { WorkflowReviewFeatureGate } from '../workflow-review-feature-gate.service';
+import { WorkflowReviewInboxService } from '../workflow-review-inbox.service';
 
-describe('WorkflowReviewRequestService list', () => {
-	const logger = mock<Logger>();
+describe('WorkflowReviewInboxService', () => {
 	const workflowReviewPolicyService = mockInstance(WorkflowReviewPolicyService);
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const workflowHistoryService = mock<WorkflowHistoryService>();
-	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
 	const publishedVersionRepository = mock<WorkflowPublishedVersionRepository>();
 	const workflowReviewRequestRepository = mockInstance(WorkflowReviewRequestRepository);
 	const workflowReviewRequestWorkflowRepository = mockInstance(
 		WorkflowReviewRequestWorkflowRepository,
 	);
-	const workflowReviewRequestAuthorRepository = mockInstance(WorkflowReviewRequestAuthorRepository);
 	const reviewerRepository = mock<WorkflowReviewRequestReviewerRepository>();
 	const userRepository = mock<UserRepository>();
-	const projectRelationRepository = mock<ProjectRelationRepository>();
-	const roleService = mock<RoleService>();
 	const projectService = mockInstance(ProjectService);
 	const licenseState = mockInstance(LicenseState);
-	const dbLockService = mock<DbLockService>();
-	const collaborationService = mock<CollaborationService>();
 
-	let service: WorkflowReviewRequestService;
+	let service: WorkflowReviewInboxService;
 
 	const user = mock<User>({ id: 'user-1', role: { slug: 'global:member', scopes: [] } });
 
@@ -59,24 +44,16 @@ describe('WorkflowReviewRequestService list', () => {
 		reviewerRepository.findByRequestIds.mockResolvedValue([]);
 		userRepository.findManyByIds.mockResolvedValue([]);
 
-		service = new WorkflowReviewRequestService(
-			logger,
-			workflowReviewPolicyService,
+		service = new WorkflowReviewInboxService(
+			new WorkflowReviewFeatureGate(licenseState, workflowReviewPolicyService),
 			workflowFinderService,
 			workflowHistoryService,
-			sharedWorkflowRepository,
 			publishedVersionRepository,
 			workflowReviewRequestRepository,
 			workflowReviewRequestWorkflowRepository,
-			workflowReviewRequestAuthorRepository,
 			reviewerRepository,
 			userRepository,
-			projectRelationRepository,
-			roleService,
 			projectService,
-			licenseState,
-			dbLockService,
-			collaborationService,
 		);
 	});
 

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.decide.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.decide.service.test.ts
@@ -7,7 +7,6 @@ import type {
 	User,
 	UserRepository,
 	WorkflowEntity,
-	WorkflowPublishedVersionRepository,
 	WorkflowReviewRequest,
 	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
@@ -23,12 +22,12 @@ import type { CollaborationService } from '@/collaboration/collaboration.service
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import type { ProjectService } from '@/services/project.service.ee';
 import type { RoleService } from '@/services/role.service';
 import type { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
+import { WorkflowReviewFeatureGate } from '../workflow-review-feature-gate.service';
 import { WorkflowReviewRequestService } from '../workflow-review-request.service';
 
 const memberUser = (id = 'user-1') => mock<User>({ id, role: { slug: 'global:member' } });
@@ -43,7 +42,6 @@ describe('WorkflowReviewRequestService.decide', () => {
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const workflowHistoryService = mock<WorkflowHistoryService>();
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
-	const publishedVersionRepository = mock<WorkflowPublishedVersionRepository>();
 	const requestRepository = mock<WorkflowReviewRequestRepository>();
 	const workflowRepository = mock<WorkflowReviewRequestWorkflowRepository>();
 	const authorRepository = mock<WorkflowReviewRequestAuthorRepository>();
@@ -51,7 +49,6 @@ describe('WorkflowReviewRequestService.decide', () => {
 	const userRepository = mock<UserRepository>();
 	const projectRelationRepository = mock<ProjectRelationRepository>();
 	const roleService = mock<RoleService>();
-	const projectService = mock<ProjectService>();
 	const licenseState = mock<LicenseState>();
 	const dbLockService = mock<DbLockService>();
 	const collaborationService = mock<CollaborationService>();
@@ -60,11 +57,10 @@ describe('WorkflowReviewRequestService.decide', () => {
 
 	const service = new WorkflowReviewRequestService(
 		logger,
-		workflowReviewPolicyService,
+		new WorkflowReviewFeatureGate(licenseState, workflowReviewPolicyService),
 		workflowFinderService,
 		workflowHistoryService,
 		sharedWorkflowRepository,
-		publishedVersionRepository,
 		requestRepository,
 		workflowRepository,
 		authorRepository,
@@ -72,8 +68,6 @@ describe('WorkflowReviewRequestService.decide', () => {
 		userRepository,
 		projectRelationRepository,
 		roleService,
-		projectService,
-		licenseState,
 		dbLockService,
 		collaborationService,
 	);

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.service.test.ts
@@ -12,7 +12,6 @@ import type {
 	SharedWorkflowRepository,
 	UserRepository,
 	WorkflowEntity,
-	WorkflowPublishedVersionRepository,
 	WorkflowReviewRequest,
 	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
@@ -28,12 +27,12 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import type { ProjectService } from '@/services/project.service.ee';
 import type { RoleService } from '@/services/role.service';
 import type { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
+import { WorkflowReviewFeatureGate } from '../workflow-review-feature-gate.service';
 import { WorkflowReviewRequestService } from '../workflow-review-request.service';
 
 const user = mock<User>({ id: 'user-1' });
@@ -56,7 +55,6 @@ describe('WorkflowReviewRequestService', () => {
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const workflowHistoryService = mock<WorkflowHistoryService>();
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
-	const publishedVersionRepository = mock<WorkflowPublishedVersionRepository>();
 	const requestRepository = mock<WorkflowReviewRequestRepository>();
 	const workflowRepository = mock<WorkflowReviewRequestWorkflowRepository>();
 	const authorRepository = mock<WorkflowReviewRequestAuthorRepository>();
@@ -64,7 +62,6 @@ describe('WorkflowReviewRequestService', () => {
 	const userRepository = mock<UserRepository>();
 	const projectRelationRepository = mock<ProjectRelationRepository>();
 	const roleService = mock<RoleService>();
-	const projectService = mock<ProjectService>();
 	const licenseState = mock<LicenseState>();
 	const dbLockService = mock<DbLockService>();
 	const collaborationService = mock<CollaborationService>();
@@ -73,11 +70,10 @@ describe('WorkflowReviewRequestService', () => {
 
 	const service = new WorkflowReviewRequestService(
 		logger,
-		workflowReviewPolicyService,
+		new WorkflowReviewFeatureGate(licenseState, workflowReviewPolicyService),
 		workflowFinderService,
 		workflowHistoryService,
 		sharedWorkflowRepository,
-		publishedVersionRepository,
 		requestRepository,
 		workflowRepository,
 		authorRepository,
@@ -85,8 +81,6 @@ describe('WorkflowReviewRequestService', () => {
 		userRepository,
 		projectRelationRepository,
 		roleService,
-		projectService,
-		licenseState,
 		dbLockService,
 		collaborationService,
 	);

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.update.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.update.service.test.ts
@@ -7,7 +7,6 @@ import type {
 	User,
 	UserRepository,
 	WorkflowEntity,
-	WorkflowPublishedVersionRepository,
 	WorkflowReviewRequest,
 	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
@@ -24,12 +23,12 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import type { ProjectService } from '@/services/project.service.ee';
 import type { RoleService } from '@/services/role.service';
 import type { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
+import { WorkflowReviewFeatureGate } from '../workflow-review-feature-gate.service';
 import { WorkflowReviewRequestService } from '../workflow-review-request.service';
 
 const user = mock<User>({ id: 'user-1' });
@@ -45,7 +44,6 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const workflowHistoryService = mock<WorkflowHistoryService>();
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
-	const publishedVersionRepository = mock<WorkflowPublishedVersionRepository>();
 	const requestRepository = mock<WorkflowReviewRequestRepository>();
 	const workflowRepository = mock<WorkflowReviewRequestWorkflowRepository>();
 	const authorRepository = mock<WorkflowReviewRequestAuthorRepository>();
@@ -53,7 +51,6 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 	const userRepository = mock<UserRepository>();
 	const projectRelationRepository = mock<ProjectRelationRepository>();
 	const roleService = mock<RoleService>();
-	const projectService = mock<ProjectService>();
 	const licenseState = mock<LicenseState>();
 	const dbLockService = mock<DbLockService>();
 	const collaborationService = mock<CollaborationService>();
@@ -62,11 +59,10 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 
 	const service = new WorkflowReviewRequestService(
 		logger,
-		workflowReviewPolicyService,
+		new WorkflowReviewFeatureGate(licenseState, workflowReviewPolicyService),
 		workflowFinderService,
 		workflowHistoryService,
 		sharedWorkflowRepository,
-		publishedVersionRepository,
 		requestRepository,
 		workflowRepository,
 		authorRepository,
@@ -74,8 +70,6 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 		userRepository,
 		projectRelationRepository,
 		roleService,
-		projectService,
-		licenseState,
 		dbLockService,
 		collaborationService,
 	);

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-feature-gate.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-feature-gate.service.ts
@@ -1,0 +1,31 @@
+import { LicenseState } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+
+import { isWorkflowReviewsFeatureAvailable } from '@/constants/workflow-reviews';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
+
+/**
+ * Single gate for the workflow reviews feature: license (plus env flag) and the
+ * instance policy. Every entry point of the review services calls it, so a
+ * non-HTTP caller is gated too — the controller's `@Licensed` decorator only
+ * covers the routes.
+ */
+@Service()
+export class WorkflowReviewFeatureGate {
+	constructor(
+		private readonly licenseState: LicenseState,
+		private readonly workflowReviewPolicyService: WorkflowReviewPolicyService,
+	) {}
+
+	async assertAvailable(): Promise<void> {
+		if (!isWorkflowReviewsFeatureAvailable(this.licenseState.isWorkflowReviewsLicensed())) {
+			throw new ForbiddenError('Workflow reviews are not available on this instance');
+		}
+
+		const policy = await this.workflowReviewPolicyService.get();
+		if (!policy.enabled) {
+			throw new ForbiddenError('Workflow reviews are disabled on this instance');
+		}
+	}
+}

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-inbox.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-inbox.service.ts
@@ -1,0 +1,365 @@
+import type {
+	GetWorkflowReviewInboxSummaryResponse,
+	ListWorkflowReviewInboxQueryDto,
+	ListWorkflowReviewInboxResponse,
+	WorkflowReviewEligibleReviewer,
+	WorkflowReviewInboxItem,
+	WorkflowReviewRequestDetail,
+	WorkflowReviewRequestWorkflowDetail,
+	WorkflowReviewVersionSnapshot,
+} from '@n8n/api-types';
+import {
+	UserRepository,
+	WorkflowPublishedVersionRepository,
+	WorkflowReviewRequestRepository,
+	WorkflowReviewRequestReviewerRepository,
+	WorkflowReviewRequestWorkflowRepository,
+	type InboxCursor,
+	type User,
+	type WorkflowHistory,
+	type WorkflowReviewRequest,
+	type WorkflowReviewRequestLinkedWorkflow,
+	type WorkflowReviewRequestReviewer,
+	type WorkflowReviewRequestWorkflowDetailRow,
+} from '@n8n/db';
+import { Service } from '@n8n/di';
+import { hasGlobalScope } from '@n8n/permissions';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { ProjectService } from '@/services/project.service.ee';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
+
+import { WorkflowReviewFeatureGate } from './workflow-review-feature-gate.service';
+
+/**
+ * The reviewer-facing read side of workflow reviews: the cross-project inbox, its
+ * counts, and the detail view a reviewer opens from it. Unlike the workflow-scoped
+ * lifecycle service, visibility here starts from the user's projects rather than
+ * from a known workflow.
+ */
+@Service()
+export class WorkflowReviewInboxService {
+	constructor(
+		private readonly featureGate: WorkflowReviewFeatureGate,
+		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly workflowHistoryService: WorkflowHistoryService,
+		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
+		private readonly workflowReviewRequestRepository: WorkflowReviewRequestRepository,
+		private readonly workflowReviewRequestWorkflowRepository: WorkflowReviewRequestWorkflowRepository,
+		private readonly workflowReviewRequestReviewerRepository: WorkflowReviewRequestReviewerRepository,
+		private readonly userRepository: UserRepository,
+		private readonly projectService: ProjectService,
+	) {}
+
+	async listForInbox(
+		user: User,
+		query: ListWorkflowReviewInboxQueryDto,
+	): Promise<ListWorkflowReviewInboxResponse> {
+		await this.featureGate.assertAvailable();
+
+		const projectIds = await this.resolveAccessibleProjectIds(user);
+		const { limit } = query;
+		const rows = await this.workflowReviewRequestRepository.findManyForInbox({
+			projectIds,
+			requesterId: user.id,
+			state: query.state ?? 'open',
+			limit: limit + 1,
+			cursor: query.cursor ? this.decodeInboxCursor(query.cursor) : undefined,
+		});
+
+		const hasMore = rows.length > limit;
+		const data = rows.slice(0, limit);
+		const lastRow = data.at(-1);
+		const nextCursor = hasMore && lastRow ? this.encodeInboxCursor(lastRow) : null;
+		const requestIds = data.map((row) => row.id);
+		const [linkedWorkflowByRequestId, reviewerRows] = await Promise.all([
+			this.workflowReviewRequestWorkflowRepository.findLinkedWorkflowsByRequestIds(requestIds),
+			this.workflowReviewRequestReviewerRepository.findByRequestIds(requestIds),
+		]);
+
+		const participantsByRequestId = await this.hydrateParticipants(data, reviewerRows);
+
+		return {
+			data: data.map((row) => {
+				const { requester, reviewers } = participantsByRequestId.get(row.id) ?? {
+					requester: null,
+					reviewers: [],
+				};
+				return this.toInboxItem(
+					row,
+					linkedWorkflowByRequestId.get(row.id) ?? null,
+					requester,
+					reviewers,
+				);
+			}),
+			nextCursor,
+			hasMore,
+		};
+	}
+
+	async getInboxSummaryForUser(user: User): Promise<GetWorkflowReviewInboxSummaryResponse> {
+		await this.featureGate.assertAvailable();
+
+		const projectIds = await this.resolveAccessibleProjectIds(user);
+		return await this.workflowReviewRequestRepository.countByStateForInbox({
+			projectIds,
+			requesterId: user.id,
+		});
+	}
+
+	/**
+	 * Visibility starts from the inbox rule (requester OR `workflow:publish` in the
+	 * review's project OR globally), then narrows per workflow to what the caller can
+	 * currently read — see {@link filterReadableWorkflowRows}.
+	 */
+	async getDetail(
+		user: User,
+		workflowReviewRequestId: string,
+	): Promise<WorkflowReviewRequestDetail> {
+		await this.featureGate.assertAvailable();
+
+		const request = await this.workflowReviewRequestRepository.findById(workflowReviewRequestId);
+		if (!request || !(await this.canAccessRequest(user, request))) {
+			throw new NotFoundError('Could not find review request');
+		}
+
+		const [workflowRows, reviewerRows] = await Promise.all([
+			this.workflowReviewRequestWorkflowRepository.findLinkedWorkflowDetailsByRequestId(request.id),
+			this.workflowReviewRequestReviewerRepository.findByRequestIds([request.id]),
+		]);
+
+		const readableRows = await this.filterReadableWorkflowRows(user, workflowRows);
+		// Someone who reaches this review through its project has no reason to learn it
+		// exists once they can read none of the workflows it covers. The requester already
+		// knows, and their inbox still lists it, so they keep the record — narrowed to the
+		// workflows they can currently read.
+		if (request.createdById !== user.id && workflowRows.length > 0 && readableRows.length === 0) {
+			throw new NotFoundError('Could not find review request');
+		}
+
+		const [workflows, participantsByRequestId] = await Promise.all([
+			Promise.all(readableRows.map(async (row) => await this.toWorkflowDetail(row))),
+			this.hydrateParticipants([request], reviewerRows),
+		]);
+
+		const { requester, reviewers } = participantsByRequestId.get(request.id) ?? {
+			requester: null,
+			reviewers: [],
+		};
+		return {
+			// One workflow per review for now, so the summary fields mirror the first row
+			...this.toInboxItem(request, workflows.at(0) ?? null, requester, reviewers),
+			description: request.description,
+			workflows,
+		};
+	}
+
+	/**
+	 * Project IDs for inbox queries. `null` means "all projects, unfiltered" —
+	 * correct for users with `workflow:publish` scoped globally. Requesters always
+	 * see their own reviews regardless (repository OR-matches `requesterId`), so no
+	 * personal-project fallback is needed.
+	 */
+	async resolveAccessibleProjectIds(user: User): Promise<string[] | null> {
+		if (hasGlobalScope(user, 'workflow:publish')) {
+			return null;
+		}
+
+		return await this.projectService.getProjectIdsWithScope(user, ['workflow:publish']);
+	}
+
+	/** Inbox visibility rule: requester, or `workflow:publish` in the review's project. */
+	private async canAccessRequest(user: User, request: WorkflowReviewRequest): Promise<boolean> {
+		if (request.createdById === user.id) {
+			return true;
+		}
+
+		const projectIds = await this.resolveAccessibleProjectIds(user);
+		return projectIds === null || projectIds.includes(request.projectId);
+	}
+
+	/**
+	 * A review's `projectId` is fixed at creation and nothing closes open reviews when a
+	 * workflow is transferred, so the stored project does not prove the caller may still
+	 * read a covered workflow. Re-check every row against the workflow's *current* owner
+	 * before returning its content.
+	 *
+	 * This applies to the requester too. They held publish rights when they opened the
+	 * review, but may have lost them since — and because the baseline is resolved at read
+	 * time, an exemption would leave them reading versions published after they lost
+	 * access.
+	 */
+	private async filterReadableWorkflowRows(
+		user: User,
+		rows: WorkflowReviewRequestWorkflowDetailRow[],
+	): Promise<WorkflowReviewRequestWorkflowDetailRow[]> {
+		const readable = await Promise.all(
+			rows.map(async (row) =>
+				(await this.workflowFinderService.findWorkflowForUser(row.workflowId, user, [
+					'workflow:read',
+				]))
+					? row
+					: null,
+			),
+		);
+
+		return readable.filter((row): row is WorkflowReviewRequestWorkflowDetailRow => row !== null);
+	}
+
+	/**
+	 * Both diff sides for one child row. The baseline is resolved at read time, so
+	 * a publish during an open review moves what reviewers are diffing against.
+	 */
+	private async toWorkflowDetail(
+		row: WorkflowReviewRequestWorkflowDetailRow,
+	): Promise<WorkflowReviewRequestWorkflowDetail> {
+		const publishedVersionId = await this.workflowPublishedVersionRepository.getPublishedVersionId(
+			row.workflowId,
+		);
+
+		const [pinnedVersion, baselineVersion] = await Promise.all([
+			this.findVersionSnapshot(row.workflowId, row.workflowVersionId),
+			this.findVersionSnapshot(row.workflowId, publishedVersionId),
+		]);
+
+		return {
+			workflowId: row.workflowId,
+			workflowName: row.workflowName,
+			workflowVersionId: row.workflowVersionId,
+			pinnedVersion,
+			baselineVersion,
+		};
+	}
+
+	/** `null` version id, or a version whose history row was pruned, both mean "no content". */
+	private async findVersionSnapshot(
+		workflowId: string,
+		versionId: string | null,
+	): Promise<WorkflowReviewVersionSnapshot | null> {
+		if (!versionId) {
+			return null;
+		}
+
+		const version = await this.workflowHistoryService.findVersion(workflowId, versionId);
+		return version ? this.toVersionSnapshot(version) : null;
+	}
+
+	private toVersionSnapshot(version: WorkflowHistory): WorkflowReviewVersionSnapshot {
+		return {
+			versionId: version.versionId,
+			nodes: version.nodes,
+			connections: version.connections,
+			nodeGroups: version.nodeGroups,
+			createdAt: version.createdAt.toISOString(),
+		};
+	}
+
+	/**
+	 * Batch-resolve the requester and requested reviewers for each request row,
+	 * keyed by request id. Deleted users simply drop out of the result.
+	 */
+	private async hydrateParticipants(
+		rows: WorkflowReviewRequest[],
+		reviewerRows: WorkflowReviewRequestReviewer[],
+	): Promise<
+		Map<
+			string,
+			{
+				requester: WorkflowReviewEligibleReviewer | null;
+				reviewers: WorkflowReviewEligibleReviewer[];
+			}
+		>
+	> {
+		const reviewerIdsByRequestId = new Map<string, string[]>();
+		for (const { workflowReviewRequestId, userId } of reviewerRows) {
+			const ids = reviewerIdsByRequestId.get(workflowReviewRequestId) ?? [];
+			ids.push(userId);
+			reviewerIdsByRequestId.set(workflowReviewRequestId, ids);
+		}
+
+		const userIds = new Set([
+			...rows.map((row) => row.createdById).filter((id) => id !== null),
+			...reviewerRows.map((row) => row.userId),
+		]);
+
+		const usersById = new Map<string, WorkflowReviewEligibleReviewer>();
+		if (userIds.size > 0) {
+			for (const user of await this.userRepository.findManyByIds([...userIds])) {
+				usersById.set(user.id, this.toEligibleReviewer(user));
+			}
+		}
+
+		return new Map(
+			rows.map((row) => [
+				row.id,
+				{
+					requester: row.createdById ? (usersById.get(row.createdById) ?? null) : null,
+					reviewers: (reviewerIdsByRequestId.get(row.id) ?? [])
+						.map((userId) => usersById.get(userId))
+						.filter((reviewer) => reviewer !== undefined),
+				},
+			]),
+		);
+	}
+
+	/**
+	 * Project a user onto the boundary shape the review endpoints are allowed to expose.
+	 * Duplicated in `WorkflowReviewRequestService`, consider shared home if we add more callers.
+	 */
+	private toEligibleReviewer(user: User): WorkflowReviewEligibleReviewer {
+		return {
+			id: user.id,
+			email: user.email,
+			firstName: user.firstName ?? null,
+			lastName: user.lastName ?? null,
+		};
+	}
+
+	/**
+	 * Encode the keyset boundary (createdAt + id) into an opaque cursor so the
+	 * next page is resolved without re-reading the anchor row — a review deleted
+	 * between requests no longer truncates the rest of the inbox.
+	 */
+	private encodeInboxCursor(row: WorkflowReviewRequest): string {
+		return Buffer.from(`${row.createdAt.toISOString()}|${row.id}`, 'utf8').toString('base64url');
+	}
+
+	private decodeInboxCursor(cursor: string): InboxCursor {
+		const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+		const separatorIndex = decoded.indexOf('|');
+		if (separatorIndex === -1) {
+			throw new BadRequestError('Invalid pagination cursor');
+		}
+
+		const createdAt = new Date(decoded.slice(0, separatorIndex));
+		const id = decoded.slice(separatorIndex + 1);
+		if (id.length === 0 || Number.isNaN(createdAt.getTime())) {
+			throw new BadRequestError('Invalid pagination cursor');
+		}
+
+		return { createdAt, id };
+	}
+
+	private toInboxItem(
+		entity: WorkflowReviewRequest,
+		linkedWorkflow: WorkflowReviewRequestLinkedWorkflow | null,
+		requester: WorkflowReviewEligibleReviewer | null,
+		reviewers: WorkflowReviewEligibleReviewer[],
+	): WorkflowReviewInboxItem {
+		return {
+			id: entity.id,
+			projectId: entity.projectId,
+			title: entity.title,
+			workflowName: linkedWorkflow?.workflowName ?? null,
+			workflowVersionId: linkedWorkflow?.workflowVersionId ?? null,
+			decision: entity.decision,
+			state: entity.state,
+			createdAt: entity.createdAt.toISOString(),
+			updatedAt: entity.updatedAt.toISOString(),
+			requester,
+			reviewers,
+		};
+	}
+}

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-inbox.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-inbox.service.ts
@@ -32,6 +32,7 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
 import { WorkflowReviewFeatureGate } from './workflow-review-feature-gate.service';
+import { toEligibleReviewer } from './workflow-review.mapper';
 
 /**
  * The reviewer-facing read side of workflow reviews: the cross-project inbox, its
@@ -287,7 +288,7 @@ export class WorkflowReviewInboxService {
 		const usersById = new Map<string, WorkflowReviewEligibleReviewer>();
 		if (userIds.size > 0) {
 			for (const user of await this.userRepository.findManyByIds([...userIds])) {
-				usersById.set(user.id, this.toEligibleReviewer(user));
+				usersById.set(user.id, toEligibleReviewer(user));
 			}
 		}
 
@@ -302,19 +303,6 @@ export class WorkflowReviewInboxService {
 				},
 			]),
 		);
-	}
-
-	/**
-	 * Project a user onto the boundary shape the review endpoints are allowed to expose.
-	 * Duplicated in `WorkflowReviewRequestService`, consider shared home if we add more callers.
-	 */
-	private toEligibleReviewer(user: User): WorkflowReviewEligibleReviewer {
-		return {
-			id: user.id,
-			email: user.email,
-			firstName: user.firstName ?? null,
-			lastName: user.lastName ?? null,
-		};
 	}
 
 	/**

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
@@ -7,64 +7,54 @@ import type {
 	WorkflowReviewEligibleReviewersList,
 	WorkflowReviewRequestList,
 	WorkflowReviewRequestSummary,
-	ListWorkflowReviewInboxQueryDto,
-	ListWorkflowReviewInboxResponse,
-	GetWorkflowReviewInboxSummaryResponse,
-	WorkflowReviewInboxItem,
 	WorkflowReviewEligibleReviewer,
-	WorkflowReviewRequestDetail,
-	WorkflowReviewRequestWorkflowDetail,
-	WorkflowReviewVersionSnapshot,
 } from '@n8n/api-types';
-import { LicenseState, Logger } from '@n8n/backend-common';
+import { Logger } from '@n8n/backend-common';
 import {
 	DbLock,
 	DbLockService,
 	ProjectRelationRepository,
 	SharedWorkflowRepository,
 	UserRepository,
-	WorkflowPublishedVersionRepository,
 	WorkflowReviewRequestAuthorRepository,
 	WorkflowReviewRequestRepository,
 	WorkflowReviewRequestReviewerRepository,
 	WorkflowReviewRequestWorkflowRepository,
-	type InboxCursor,
 	type User,
-	type WorkflowHistory,
 	type WorkflowReviewRequest,
-	type WorkflowReviewRequestLinkedWorkflow,
-	type WorkflowReviewRequestReviewer,
-	type WorkflowReviewRequestWorkflowDetailRow,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 import {
 	GLOBAL_ADMIN_ROLE_SLUG,
 	GLOBAL_OWNER_ROLE_SLUG,
 	PROJECT_ADMIN_ROLE_SLUG,
-	hasGlobalScope,
 } from '@n8n/permissions';
 
 import { CollaborationService } from '@/collaboration/collaboration.service';
-import { isWorkflowReviewsFeatureAvailable } from '@/constants/workflow-reviews';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
-import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
+import { WorkflowReviewFeatureGate } from './workflow-review-feature-gate.service';
+
+/**
+ * The workflow-scoped review request lifecycle: listing a workflow's reviews,
+ * resolving its eligible reviewers, opening a review, re-pinning it to a new
+ * version, and deciding it. The reviewer-facing read side lives in
+ * `WorkflowReviewInboxService`.
+ */
 @Service()
 export class WorkflowReviewRequestService {
 	constructor(
 		private readonly logger: Logger,
-		private readonly workflowReviewPolicyService: WorkflowReviewPolicyService,
+		private readonly featureGate: WorkflowReviewFeatureGate,
 		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly workflowHistoryService: WorkflowHistoryService,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
-		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
 		private readonly workflowReviewRequestRepository: WorkflowReviewRequestRepository,
 		private readonly workflowReviewRequestWorkflowRepository: WorkflowReviewRequestWorkflowRepository,
 		private readonly workflowReviewRequestAuthorRepository: WorkflowReviewRequestAuthorRepository,
@@ -72,8 +62,6 @@ export class WorkflowReviewRequestService {
 		private readonly userRepository: UserRepository,
 		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly roleService: RoleService,
-		private readonly projectService: ProjectService,
-		private readonly licenseState: LicenseState,
 		private readonly dbLockService: DbLockService,
 		private readonly collaborationService: CollaborationService,
 	) {}
@@ -99,10 +87,7 @@ export class WorkflowReviewRequestService {
 		user: User,
 		query: ListWorkflowReviewRequestsQueryDto,
 	): Promise<WorkflowReviewRequestList> {
-		const policy = await this.workflowReviewPolicyService.get();
-		if (!policy.enabled) {
-			throw new ForbiddenError('Workflow reviews are not enabled for this instance');
-		}
+		await this.featureGate.assertAvailable();
 
 		const workflow = await this.workflowFinderService.findWorkflowForUser(query.workflowId, user, [
 			'workflow:read',
@@ -133,10 +118,7 @@ export class WorkflowReviewRequestService {
 		user: User,
 		query: GetWorkflowReviewEligibleReviewersQueryDto,
 	): Promise<WorkflowReviewEligibleReviewersList> {
-		const policy = await this.workflowReviewPolicyService.get();
-		if (!policy.enabled) {
-			throw new ForbiddenError('Workflow reviews are not enabled for this instance');
-		}
+		await this.featureGate.assertAvailable();
 
 		const workflow = await this.workflowFinderService.findWorkflowForUser(query.workflowId, user, [
 			'workflow:publish',
@@ -175,10 +157,7 @@ export class WorkflowReviewRequestService {
 	): Promise<WorkflowReviewRequestSummary> {
 		const { workflowId, workflowVersionId } = dto.workflows[0];
 
-		const policy = await this.workflowReviewPolicyService.get();
-		if (!policy.enabled) {
-			throw new ForbiddenError('Workflow reviews are not enabled for this instance');
-		}
+		await this.featureGate.assertAvailable();
 
 		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, user, [
 			'workflow:publish',
@@ -287,10 +266,7 @@ export class WorkflowReviewRequestService {
 		workflowReviewRequestId: string,
 		dto: UpdateWorkflowReviewRequestVersionDto,
 	): Promise<WorkflowReviewRequestSummary> {
-		const policy = await this.workflowReviewPolicyService.get();
-		if (!policy.enabled) {
-			throw new ForbiddenError('Workflow reviews are not enabled for this instance');
-		}
+		await this.featureGate.assertAvailable();
 
 		const request = await this.workflowReviewRequestRepository.findById(workflowReviewRequestId);
 		if (!request) {
@@ -403,10 +379,7 @@ export class WorkflowReviewRequestService {
 		workflowReviewRequestId: string,
 		dto: DecideWorkflowReviewRequestDto,
 	): Promise<WorkflowReviewRequestSummary> {
-		const policy = await this.workflowReviewPolicyService.get();
-		if (!policy.enabled) {
-			throw new ForbiddenError('Workflow reviews are not enabled for this instance');
-		}
+		await this.featureGate.assertAvailable();
 
 		const request = await this.workflowReviewRequestRepository.findById(workflowReviewRequestId);
 		if (!request) {
@@ -560,320 +533,6 @@ export class WorkflowReviewRequestService {
 			workflowVersionId,
 			createdAt: request.createdAt.toISOString(),
 			updatedAt: request.updatedAt.toISOString(),
-		};
-	}
-
-	/**
-	 * Cross-project inbox.
-	 *
-	 * Defaults to open requests when `state` is omitted. Deferred (LIGO-594):
-	 * `projectId`, `reviewer`, and `author` filters.
-	 */
-	async listForInbox(
-		user: User,
-		query: ListWorkflowReviewInboxQueryDto,
-	): Promise<ListWorkflowReviewInboxResponse> {
-		await this.assertFeatureAvailable();
-
-		const projectIds = await this.resolveAccessibleProjectIds(user);
-		const { limit } = query;
-		const rows = await this.workflowReviewRequestRepository.findManyForInbox({
-			projectIds,
-			requesterId: user.id,
-			state: query.state ?? 'open',
-			limit: limit + 1,
-			cursor: query.cursor ? this.decodeInboxCursor(query.cursor) : undefined,
-		});
-
-		const hasMore = rows.length > limit;
-		const data = rows.slice(0, limit);
-		const lastRow = data.at(-1);
-		const nextCursor = hasMore && lastRow ? this.encodeInboxCursor(lastRow) : null;
-		const requestIds = data.map((row) => row.id);
-		const [linkedWorkflowByRequestId, reviewerRows] = await Promise.all([
-			this.workflowReviewRequestWorkflowRepository.findLinkedWorkflowsByRequestIds(requestIds),
-			this.workflowReviewRequestReviewerRepository.findByRequestIds(requestIds),
-		]);
-
-		const participantsByRequestId = await this.hydrateParticipants(data, reviewerRows);
-
-		return {
-			data: data.map((row) => {
-				const { requester, reviewers } = participantsByRequestId.get(row.id) ?? {
-					requester: null,
-					reviewers: [],
-				};
-				return this.toInboxItem(
-					row,
-					linkedWorkflowByRequestId.get(row.id) ?? null,
-					requester,
-					reviewers,
-				);
-			}),
-			nextCursor,
-			hasMore,
-		};
-	}
-
-	/**
-	 * Batch-resolve the requester and requested reviewers for each request row,
-	 * keyed by request id. Deleted users simply drop out of the result.
-	 */
-	private async hydrateParticipants(
-		rows: WorkflowReviewRequest[],
-		reviewerRows: WorkflowReviewRequestReviewer[],
-	): Promise<
-		Map<
-			string,
-			{
-				requester: WorkflowReviewEligibleReviewer | null;
-				reviewers: WorkflowReviewEligibleReviewer[];
-			}
-		>
-	> {
-		const reviewerIdsByRequestId = new Map<string, string[]>();
-		for (const { workflowReviewRequestId, userId } of reviewerRows) {
-			const ids = reviewerIdsByRequestId.get(workflowReviewRequestId) ?? [];
-			ids.push(userId);
-			reviewerIdsByRequestId.set(workflowReviewRequestId, ids);
-		}
-
-		const userIds = new Set([
-			...rows.map((row) => row.createdById).filter((id) => id !== null),
-			...reviewerRows.map((row) => row.userId),
-		]);
-
-		const usersById = new Map<string, WorkflowReviewEligibleReviewer>();
-		if (userIds.size > 0) {
-			for (const user of await this.userRepository.findManyByIds([...userIds])) {
-				usersById.set(user.id, this.toEligibleReviewer(user));
-			}
-		}
-
-		return new Map(
-			rows.map((row) => [
-				row.id,
-				{
-					requester: row.createdById ? (usersById.get(row.createdById) ?? null) : null,
-					reviewers: (reviewerIdsByRequestId.get(row.id) ?? [])
-						.map((userId) => usersById.get(userId))
-						.filter((reviewer) => reviewer !== undefined),
-				},
-			]),
-		);
-	}
-
-	async getInboxSummaryForUser(user: User): Promise<GetWorkflowReviewInboxSummaryResponse> {
-		await this.assertFeatureAvailable();
-
-		const projectIds = await this.resolveAccessibleProjectIds(user);
-		return await this.workflowReviewRequestRepository.countByStateForInbox({
-			projectIds,
-			requesterId: user.id,
-		});
-	}
-
-	/**
-	 * Visibility starts from the inbox rule (requester OR `workflow:publish` in the
-	 * review's project OR globally), then narrows per workflow to what the caller can
-	 * currently read — see {@link filterReadableWorkflowRows}.
-	 */
-	async getDetail(
-		user: User,
-		workflowReviewRequestId: string,
-	): Promise<WorkflowReviewRequestDetail> {
-		await this.assertFeatureAvailable();
-
-		const request = await this.workflowReviewRequestRepository.findById(workflowReviewRequestId);
-		if (!request || !(await this.canAccessRequest(user, request))) {
-			throw new NotFoundError('Could not find review request');
-		}
-
-		const [workflowRows, reviewerRows] = await Promise.all([
-			this.workflowReviewRequestWorkflowRepository.findLinkedWorkflowDetailsByRequestId(request.id),
-			this.workflowReviewRequestReviewerRepository.findByRequestIds([request.id]),
-		]);
-
-		const readableRows = await this.filterReadableWorkflowRows(user, workflowRows);
-		// Someone who reaches this review through its project has no reason to learn it
-		// exists once they can read none of the workflows it covers. The requester already
-		// knows, and their inbox still lists it, so they keep the record — narrowed to the
-		// workflows they can currently read.
-		if (request.createdById !== user.id && workflowRows.length > 0 && readableRows.length === 0) {
-			throw new NotFoundError('Could not find review request');
-		}
-
-		const [workflows, participantsByRequestId] = await Promise.all([
-			Promise.all(readableRows.map(async (row) => await this.toWorkflowDetail(row))),
-			this.hydrateParticipants([request], reviewerRows),
-		]);
-
-		const { requester, reviewers } = participantsByRequestId.get(request.id) ?? {
-			requester: null,
-			reviewers: [],
-		};
-		return {
-			// One workflow per review for now, so the summary fields mirror the first row
-			...this.toInboxItem(request, workflows.at(0) ?? null, requester, reviewers),
-			description: request.description,
-			workflows,
-		};
-	}
-
-	/** Inbox visibility rule: requester, or `workflow:publish` in the review's project. */
-	private async canAccessRequest(user: User, request: WorkflowReviewRequest): Promise<boolean> {
-		if (request.createdById === user.id) {
-			return true;
-		}
-
-		const projectIds = await this.resolveAccessibleProjectIds(user);
-		return projectIds === null || projectIds.includes(request.projectId);
-	}
-
-	/**
-	 * A review's `projectId` is fixed at creation and nothing closes open reviews when a
-	 * workflow is transferred, so the stored project does not prove the caller may still
-	 * read a covered workflow. Re-check every row against the workflow's *current* owner
-	 * before returning its content.
-	 *
-	 * This applies to the requester too. They held publish rights when they opened the
-	 * review, but may have lost them since — and because the baseline is resolved at read
-	 * time, an exemption would leave them reading versions published after they lost
-	 * access.
-	 */
-	private async filterReadableWorkflowRows(
-		user: User,
-		rows: WorkflowReviewRequestWorkflowDetailRow[],
-	): Promise<WorkflowReviewRequestWorkflowDetailRow[]> {
-		const readable = await Promise.all(
-			rows.map(async (row) =>
-				(await this.workflowFinderService.findWorkflowForUser(row.workflowId, user, [
-					'workflow:read',
-				]))
-					? row
-					: null,
-			),
-		);
-
-		return readable.filter((row): row is WorkflowReviewRequestWorkflowDetailRow => row !== null);
-	}
-
-	/**
-	 * Both diff sides for one child row. The baseline is resolved at read time, so
-	 * a publish during an open review moves what reviewers are diffing against.
-	 */
-	private async toWorkflowDetail(
-		row: WorkflowReviewRequestWorkflowDetailRow,
-	): Promise<WorkflowReviewRequestWorkflowDetail> {
-		const publishedVersionId = await this.workflowPublishedVersionRepository.getPublishedVersionId(
-			row.workflowId,
-		);
-
-		const [pinnedVersion, baselineVersion] = await Promise.all([
-			this.findVersionSnapshot(row.workflowId, row.workflowVersionId),
-			this.findVersionSnapshot(row.workflowId, publishedVersionId),
-		]);
-
-		return {
-			workflowId: row.workflowId,
-			workflowName: row.workflowName,
-			workflowVersionId: row.workflowVersionId,
-			pinnedVersion,
-			baselineVersion,
-		};
-	}
-
-	/** `null` version id, or a version whose history row was pruned, both mean "no content". */
-	private async findVersionSnapshot(
-		workflowId: string,
-		versionId: string | null,
-	): Promise<WorkflowReviewVersionSnapshot | null> {
-		if (!versionId) {
-			return null;
-		}
-
-		const version = await this.workflowHistoryService.findVersion(workflowId, versionId);
-		return version ? this.toVersionSnapshot(version) : null;
-	}
-
-	private toVersionSnapshot(version: WorkflowHistory): WorkflowReviewVersionSnapshot {
-		return {
-			versionId: version.versionId,
-			nodes: version.nodes,
-			connections: version.connections,
-			nodeGroups: version.nodeGroups,
-			createdAt: version.createdAt.toISOString(),
-		};
-	}
-
-	private async assertFeatureAvailable(): Promise<void> {
-		if (!isWorkflowReviewsFeatureAvailable(this.licenseState.isWorkflowReviewsLicensed())) {
-			throw new ForbiddenError('Workflow reviews are not available on this instance');
-		}
-
-		const policy = await this.workflowReviewPolicyService.get();
-		if (!policy.enabled) {
-			throw new ForbiddenError('Workflow reviews are disabled on this instance');
-		}
-	}
-
-	/**
-	 * Project IDs for inbox queries. `null` means "all projects, unfiltered" —
-	 * correct for users with `workflow:publish` scoped globally. Requesters always
-	 * see their own reviews regardless (repository OR-matches `requesterId`), so no
-	 * personal-project fallback is needed.
-	 */
-	async resolveAccessibleProjectIds(user: User): Promise<string[] | null> {
-		if (hasGlobalScope(user, 'workflow:publish')) {
-			return null;
-		}
-
-		return await this.projectService.getProjectIdsWithScope(user, ['workflow:publish']);
-	}
-
-	/**
-	 * Encode the keyset boundary (createdAt + id) into an opaque cursor so the
-	 * next page is resolved without re-reading the anchor row — a review deleted
-	 * between requests no longer truncates the rest of the inbox.
-	 */
-	private encodeInboxCursor(row: WorkflowReviewRequest): string {
-		return Buffer.from(`${row.createdAt.toISOString()}|${row.id}`, 'utf8').toString('base64url');
-	}
-
-	private decodeInboxCursor(cursor: string): InboxCursor {
-		const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
-		const separatorIndex = decoded.indexOf('|');
-		if (separatorIndex === -1) {
-			throw new BadRequestError('Invalid pagination cursor');
-		}
-
-		const createdAt = new Date(decoded.slice(0, separatorIndex));
-		const id = decoded.slice(separatorIndex + 1);
-		if (id.length === 0 || Number.isNaN(createdAt.getTime())) {
-			throw new BadRequestError('Invalid pagination cursor');
-		}
-
-		return { createdAt, id };
-	}
-
-	private toInboxItem(
-		entity: WorkflowReviewRequest,
-		linkedWorkflow: WorkflowReviewRequestLinkedWorkflow | null,
-		requester: WorkflowReviewEligibleReviewer | null,
-		reviewers: WorkflowReviewEligibleReviewer[],
-	): WorkflowReviewInboxItem {
-		return {
-			id: entity.id,
-			projectId: entity.projectId,
-			title: entity.title,
-			workflowName: linkedWorkflow?.workflowName ?? null,
-			workflowVersionId: linkedWorkflow?.workflowVersionId ?? null,
-			decision: entity.decision,
-			state: entity.state,
-			createdAt: entity.createdAt.toISOString(),
-			updatedAt: entity.updatedAt.toISOString(),
-			requester,
-			reviewers,
 		};
 	}
 }

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
@@ -7,7 +7,6 @@ import type {
 	WorkflowReviewEligibleReviewersList,
 	WorkflowReviewRequestList,
 	WorkflowReviewRequestSummary,
-	WorkflowReviewEligibleReviewer,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import {
@@ -40,6 +39,7 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
 import { WorkflowReviewFeatureGate } from './workflow-review-feature-gate.service';
+import { toEligibleReviewer } from './workflow-review.mapper';
 
 /**
  * The workflow-scoped review request lifecycle: listing a workflow's reviews,
@@ -137,17 +137,7 @@ export class WorkflowReviewRequestService {
 		// No pagination: the set is bounded by the project's members plus instance admins
 		return {
 			count: reviewers.length,
-			data: reviewers.map((reviewer) => this.toEligibleReviewer(reviewer)),
-		};
-	}
-
-	/** Project a user onto the boundary shape the review endpoints are allowed to expose. */
-	private toEligibleReviewer(user: User): WorkflowReviewEligibleReviewer {
-		return {
-			id: user.id,
-			email: user.email,
-			firstName: user.firstName ?? null,
-			lastName: user.lastName ?? null,
+			data: reviewers.map(toEligibleReviewer),
 		};
 	}
 

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-requests.controller.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-requests.controller.ts
@@ -13,11 +13,15 @@ import { AuthenticatedRequest } from '@n8n/db';
 import { Body, Get, Licensed, Param, Post, Query, RestController } from '@n8n/decorators';
 import type { Response } from 'express';
 
+import { WorkflowReviewInboxService } from './workflow-review-inbox.service';
 import { WorkflowReviewRequestService } from './workflow-review-request.service';
 
 @RestController('/workflow-review-requests')
 export class WorkflowReviewRequestsController {
-	constructor(private readonly workflowReviewRequestService: WorkflowReviewRequestService) {}
+	constructor(
+		private readonly workflowReviewRequestService: WorkflowReviewRequestService,
+		private readonly workflowReviewInboxService: WorkflowReviewInboxService,
+	) {}
 
 	@Get('/')
 	@Licensed('feat:workflowReviews')
@@ -90,7 +94,7 @@ export class WorkflowReviewRequestsController {
 		_res: Response,
 		@Query query: ListWorkflowReviewInboxQueryDto,
 	): Promise<ListWorkflowReviewInboxResponse> {
-		return await this.workflowReviewRequestService.listForInbox(req.user, query);
+		return await this.workflowReviewInboxService.listForInbox(req.user, query);
 	}
 
 	@Get('/summary')
@@ -99,7 +103,7 @@ export class WorkflowReviewRequestsController {
 		req: AuthenticatedRequest,
 		_res: Response,
 	): Promise<GetWorkflowReviewInboxSummaryResponse> {
-		return await this.workflowReviewRequestService.getInboxSummaryForUser(req.user);
+		return await this.workflowReviewInboxService.getInboxSummaryForUser(req.user);
 	}
 
 	/**
@@ -116,6 +120,6 @@ export class WorkflowReviewRequestsController {
 		_res: Response,
 		@Param('workflowReviewRequestId') workflowReviewRequestId: string,
 	): Promise<WorkflowReviewRequestDetail> {
-		return await this.workflowReviewRequestService.getDetail(req.user, workflowReviewRequestId);
+		return await this.workflowReviewInboxService.getDetail(req.user, workflowReviewRequestId);
 	}
 }

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review.mapper.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review.mapper.ts
@@ -1,0 +1,16 @@
+import type { WorkflowReviewEligibleReviewer } from '@n8n/api-types';
+import type { User } from '@n8n/db';
+
+/**
+ * Project a user onto the boundary shape the review endpoints are allowed to expose.
+ * Shared by every review response that carries users, so the eligible-reviewer,
+ * inbox and detail payloads cannot drift apart.
+ */
+export function toEligibleReviewer(user: User): WorkflowReviewEligibleReviewer {
+	return {
+		id: user.id,
+		email: user.email,
+		firstName: user.firstName ?? null,
+		lastName: user.lastName ?? null,
+	};
+}


### PR DESCRIPTION
## Summary

Pure refactor of the `workflow-reviews.ee` module — no route, API-type, or behavior change.

`WorkflowReviewRequestService` had grown into two halves whose dependencies were almost disjoint, plus two competing feature-gate idioms. This splits the halves and unifies the gate. It was deliberately left out of the feature PRs (#35041, #35088) to keep those reviewable.

**1. New `WorkflowReviewInboxService`** (372 lines) — the reviewer-facing read side: `listForInbox`, `getInboxSummaryForUser`, `getDetail`, and their helpers.

The seam is *how visibility is resolved*, not read vs write: the inbox service starts from the user's projects (`resolveAccessibleProjectIds`), while the lifecycle service starts from a known workflow (`findWorkflowForUser`). That's why the workflow-scoped `list` and `getEligibleReviewers` — both reads — stay behind. `getDetail` moved here because it reuses three inbox helpers, and because `WorkflowReviewRequestDetail extends WorkflowReviewInboxItem` in `@n8n/api-types` — a detail response *is* an inbox item plus fields.

`WorkflowReviewRequestService` goes 736 → 538 lines and 16 → 14 constructor deps.

**2. New `WorkflowReviewFeatureGate`** (31 lines) — one `assertAvailable()` checking license (plus env flag) and instance policy. Previously the five lifecycle methods each inlined only the `policy.enabled` check while the inbox methods checked both via `assertFeatureAvailable()`. All entry points now check both, which also gates any future non-HTTP caller — the controller's `@Licensed` decorator only covers routes.

The only externally visible difference: the lifecycle methods' 403 message changes from "Workflow reviews are not enabled for this instance" to the inbox wording, "…are disabled on this instance". Same status code; no test or client asserts the string.

**3. Tests** — the two inbox test files are renamed to `workflow-review-inbox.{list,detail}.service.test.ts` and retargeted; the four lifecycle files only rewire their constructor calls. Lifecycle and detail tests build a *real* gate from their existing `licenseState` + `workflowReviewPolicyService` mocks rather than stubbing `assertAvailable`, so every gating assertion still exercises the real check.

## How to test

Nothing to click — this is behavior-neutral. From `packages/cli`:

```bash
pnpm vitest run src/modules/workflow-reviews.ee
N8N_LOG_LEVEL=silent DB_TYPE=sqlite pnpm vitest run --config vitest.config.integration.ts src/modules/workflow-reviews.ee
pnpm typecheck
```

79 unit tests and 109 integration tests pass **with zero assertion changes** — the integration suite exercises the HTTP surface, so an unchanged pass is the main evidence the refactor is behavior-preserving.

For reviewers who want to verify the move was mechanical rather than re-reading 740 lines: every one of the 26 moved and retained methods is byte-identical to `master` apart from the gate-call substitution, and exactly the 13 inbox members plus `assertFeatureAvailable` left the lifecycle service. `toEligibleReviewer` is intentionally duplicated in both services — a 4-line mapper, per the plan; no shared base class.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-896

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Internal refactor, no user-facing surface -->
- [x] Tests included. <!-- Existing suites moved/rewired; passing unchanged is the point -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35118">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

