### PR TITLE
fix(client-oauth2): Add support for sending client_id and client_sec…

### DIFF
--- a/packages/@n8n/client-oauth2/src/code-flow.ts
+++ b/packages/@n8n/client-oauth2/src/code-flow.ts
@@ -11,6 +11,7 @@ interface CodeFlowBody {
 	grant_type: 'authorization_code';
 	redirect_uri?: string;
 	client_id?: string;
+	client_secret?: string;
 	resource?: string;
 	client_assertion_type?: string;
 	client_assertion?: string;
@@ -113,7 +114,13 @@ export class CodeFlow {
 				...options.clientCertificate,
 			});
 		} else if (options.clientSecret) {
-			headers.Authorization = auth(options.clientId, options.clientSecret);
+			// Confidential client (traditional OAuth2 or PKCE with client secret)
+			if (options.authentication === 'body') {
+				body.client_id = options.clientId;
+				body.client_secret = options.clientSecret;
+			} else {
+				headers.Authorization = auth(options.clientId, options.clientSecret);
+			}
 		} else {
 			// `client_id`: REQUIRED if the client is not authenticating with the
 			// authorization server. Reference: https://tools.ietf.org/html/rfc6749#section-3.2.1

--- a/packages/@n8n/client-oauth2/test/code-flow.test.ts
+++ b/packages/@n8n/client-oauth2/test/code-flow.test.ts
@@ -202,6 +202,61 @@ describe('CodeFlow', () => {
 			});
 		});
 
+		describe('with authentication: body', () => {
+			const bodyAuthClient = new ClientOAuth2({
+				clientId: config.clientId,
+				clientSecret: config.clientSecret,
+				accessTokenUri: config.accessTokenUri,
+				authorizationUri: config.authorizationUri,
+				authorizationGrants: ['code'],
+				redirectUri: config.redirectUri,
+				authentication: 'body',
+			});
+
+			const captureTokenCall = async () => {
+				const nockScope = nock(config.baseUrl)
+					.post('/login/oauth/access_token')
+					.once()
+					.reply(200, { access_token: config.accessToken, refresh_token: config.refreshToken });
+				return await new Promise<{ headers: Headers; body: URLSearchParams }>((resolve) => {
+					nockScope.once('request', (req) => {
+						const rawBody = (req.requestBodyBuffers as Buffer).toString('utf-8');
+						resolve({ headers: req.headers, body: new URLSearchParams(rawBody) });
+					});
+				});
+			};
+
+			it('sends client_id and client_secret in the body instead of a Basic auth header', async () => {
+				const requestPromise = captureTokenCall();
+				const token = await bodyAuthClient.code.getToken(uri, { state: config.state });
+
+				const { headers, body } = await requestPromise;
+				expect(body.get('grant_type')).toBe('authorization_code');
+				expect(body.get('client_id')).toBe(config.clientId);
+				expect(body.get('client_secret')).toBe(config.clientSecret);
+				expect(headers.authorization).toBeUndefined();
+				expect(token).toBeInstanceOf(ClientOAuth2Token);
+				expect(token.accessToken).toBe(config.accessToken);
+			});
+
+			it('sends client_id and client_secret in the body on refresh too', async () => {
+				const token = bodyAuthClient.createToken({
+					access_token: config.accessToken,
+					refresh_token: config.refreshToken,
+				});
+
+				const requestPromise = captureTokenCall();
+				const refreshed = await token.refresh();
+
+				const { headers, body } = await requestPromise;
+				expect(body.get('grant_type')).toBe('refresh_token');
+				expect(body.get('client_id')).toBe(config.clientId);
+				expect(body.get('client_secret')).toBe(config.clientSecret);
+				expect(headers.authorization).toBeUndefined();
+				expect(refreshed).toBeInstanceOf(ClientOAuth2Token);
+			});
+		});
+
 		describe('with certificate (private_key_jwt) client authentication', () => {
 			const certAuth = new ClientOAuth2({
 				clientId: config.clientId,


### PR DESCRIPTION
## Summary

Fixes OAuth2 Authorization Code (and PKCE) token exchange so it honors the
`Authentication: Body` credential setting.

Previously, `CodeFlow.getToken()` in `@n8n/client-oauth2` always sent
`client_id`/`client_secret` via an `Authorization: Basic` header whenever a
client secret was configured, regardless of the `authentication` option.
This meant credentials explicitly set to `Authentication = Body` still sent
a Basic auth header, which some OAuth2 authorization servers
(`client_secret_post`-only servers, e.g. HubSpot's Remote MCP Server) reject.

The fix makes the Authorization Code flow check `options.authentication`
the same way `CredentialsFlow` and `ClientOAuth2Token#refresh()` already do:
- `authentication: 'body'` → `client_id`/`client_secret` are sent as form
  body parameters.
- otherwise (default) → `Authorization: Basic` header, unchanged.

## How to test

1. Create an OAuth2 API credential (or MCP OAuth2 API credential) with
   `Authentication` set to `Body`, pointed at an authorization server that
   only accepts `client_secret_post`.
2. Complete the OAuth2 connection flow.
3. Before this fix: token exchange fails because the server rejects the
   `Authorization: Basic` header. After this fix: `client_id`/`client_secret`
   are sent in the request body and the flow completes successfully.

Also covered by new unit tests in
`packages/@n8n/client-oauth2/test/code-flow.test.ts`, which capture the
outgoing request and assert `client_id`/`client_secret` are in the body with
no `Authorization` header, for both the initial code exchange and refresh.

## Related Linear tickets, Github issues, and Community forum posts

fixes #35096

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35124">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

