### PR TITLE
feat(core): Validate node id uniqueness in workflow structure (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -535,6 +535,20 @@ describe('WorkflowService', () => {
 			expect(WorkflowHelpers.validateWorkflowNodeGroups).not.toHaveBeenCalled();
 		});
 
+		test('skips structure validation on a metadata-only edit so legacy graphs stay editable', async () => {
+			setupExistingWorkflow();
+
+			const user = mock<User>();
+			await workflowService.update(
+				user,
+				{ name: 'Renamed workflow' } as unknown as WorkflowEntity,
+				'workflow-1',
+				{ forceSave: true },
+			);
+
+			expect(WorkflowHelpers.validateWorkflowStructure).not.toHaveBeenCalled();
+		});
+
 		test('backfills existing nodeGroups into the saved history version when omitted', async () => {
 			const existingNodeGroups = [{ id: 'g1', name: 'Group 1', nodeIds: ['n1'] }];
 			const existingWorkflow = setupExistingWorkflow();

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -442,13 +442,14 @@ export class WorkflowService {
 
 		WorkflowHelpers.addNodeIds(workflowUpdateData);
 		WorkflowHelpers.resolveNodeWebhookIds(workflowUpdateData, this.nodeTypes);
-		WorkflowHelpers.validateWorkflowStructure({
-			nodes: workflowUpdateData.nodes ?? workflow.nodes,
-			connections: workflowUpdateData.connections ?? workflow.connections,
-		});
-		// Validate node groups only for structural changes; a metadata-only edit re-persists
-		// already-validated groups, so re-checking is redundant and could block on legacy data.
+		// Validate structure and node groups only for structural changes; a metadata-only edit
+		// re-persists an already-validated graph, so re-checking is redundant and could block on
+		// legacy data. Both are safe to read off workflowUpdateData: it was backfilled above.
 		if (saveNewVersion) {
+			WorkflowHelpers.validateWorkflowStructure({
+				nodes: workflowUpdateData.nodes,
+				connections: workflowUpdateData.connections,
+			});
 			WorkflowHelpers.validateWorkflowNodeGroups(
 				{
 					nodes: workflowUpdateData.nodes,

--- a/packages/cli/test/integration/public-api/endpoints-with-scopes-enabled.test.ts
+++ b/packages/cli/test/integration/public-api/endpoints-with-scopes-enabled.test.ts
@@ -1683,7 +1683,7 @@ describe('Public API endpoints with API key scopes', () => {
 								position: [240, 300],
 							},
 							{
-								id: 'uuid-1234',
+								id: 'uuid-5678',
 								parameters: {},
 								name: 'Cron',
 								type: 'n8n-nodes-base.cron',
@@ -1764,7 +1764,7 @@ describe('Public API endpoints with API key scopes', () => {
 								position: [240, 300],
 							},
 							{
-								id: 'uuid-1234',
+								id: 'uuid-5678',
 								parameters: {},
 								name: 'Cron',
 								type: 'n8n-nodes-base.cron',

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -2565,7 +2565,7 @@ describe('PUT /workflows/:id', () => {
 					position: [240, 300],
 				},
 				{
-					id: 'uuid-1234',
+					id: 'uuid-5678',
 					parameters: {},
 					name: 'Cron',
 					type: 'n8n-nodes-base.cron',

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -1538,7 +1538,7 @@ describe('PATCH /workflows/:workflowId', () => {
 						position: [240, 300],
 					},
 					{
-						id: 'uuid-1234',
+						id: 'uuid-5678',
 						parameters: {},
 						name: 'Cron',
 						type: 'n8n-nodes-base.cron',

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -3294,7 +3294,7 @@ describe('PATCH /workflows/:workflowId', () => {
 					position: [240, 300],
 				},
 				{
-					id: 'uuid-1234',
+					id: 'uuid-5678',
 					parameters: {},
 					name: 'Cron',
 					type: 'n8n-nodes-base.cron',
@@ -3352,6 +3352,70 @@ describe('PATCH /workflows/:workflowId', () => {
 		expect(updated.staticData).toEqual({
 			'node:Trello Trigger': { webhookId: 'registered-by-the-engine' },
 		});
+	});
+
+	test('should allow a metadata-only update of a workflow whose stored nodes share a node id', async () => {
+		const workflow = await createWorkflow(
+			{
+				nodes: [
+					{
+						id: 'uuid-1234',
+						parameters: {},
+						name: 'Start',
+						type: 'n8n-nodes-base.manualTrigger',
+						typeVersion: 1,
+						position: [240, 300],
+					},
+					{
+						id: 'uuid-1234',
+						parameters: {},
+						name: 'Cron',
+						type: 'n8n-nodes-base.cron',
+						typeVersion: 1,
+						position: [400, 300],
+					},
+				],
+				connections: {},
+			},
+			owner,
+		);
+
+		const response = await authOwnerAgent
+			.patch(`/workflows/${workflow.id}`)
+			.send({ name: 'name updated' });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data.name).toBe('name updated');
+	});
+
+	test('should reject an update that sends nodes sharing a node id', async () => {
+		const workflow = await createWorkflow({}, owner);
+
+		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send({
+			versionId: workflow.versionId,
+			nodes: [
+				{
+					id: 'uuid-1234',
+					parameters: {},
+					name: 'Start',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [240, 300],
+				},
+				{
+					id: 'uuid-1234',
+					parameters: {},
+					name: 'Cron',
+					type: 'n8n-nodes-base.cron',
+					typeVersion: 1,
+					position: [400, 300],
+				},
+			],
+			connections: {},
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.body.message).toContain('Duplicate node id "uuid-1234"');
 	});
 
 	test('should broadcast workflow update to collaborators', async () => {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -180,6 +180,39 @@ describe('POST /workflows', () => {
 		expect(created.staticData).toBeNull();
 	});
 
+	test('should reject a workflow whose nodes share a node id', async () => {
+		const payload = {
+			name: 'duplicate node ids',
+			nodes: [
+				{
+					id: 'uuid-1234',
+					parameters: {},
+					name: 'Start',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [240, 300],
+				},
+				{
+					id: 'uuid-1234',
+					parameters: {},
+					name: 'Cron',
+					type: 'n8n-nodes-base.cron',
+					typeVersion: 1,
+					position: [400, 300],
+				},
+			],
+			connections: {},
+			staticData: null,
+			settings: {},
+			active: false,
+		};
+
+		const response = await authOwnerAgent.post('/workflows').send(payload);
+
+		expect(response.statusCode).toBe(400);
+		expect(response.body.message).toContain('share the node ID "uuid-1234"');
+	});
+
 	test('should retain accept `workflow.id`', async () => {
 		const payload = {
 			id: 'HDssU5Ce250UWyLg_MNG4',
@@ -3415,7 +3448,7 @@ describe('PATCH /workflows/:workflowId', () => {
 		});
 
 		expect(response.statusCode).toBe(400);
-		expect(response.body.message).toContain('Duplicate node id "uuid-1234"');
+		expect(response.body.message).toContain('share the node ID "uuid-1234"');
 	});
 
 	test('should broadcast workflow update to collaborators', async () => {

--- a/packages/workflow/src/workflow-structure-validation.ts
+++ b/packages/workflow/src/workflow-structure-validation.ts
@@ -10,8 +10,9 @@ import { z } from 'zod';
  * presence, known node types, credential issues, etc.).
  *
  * Lives in n8n-workflow so it can be shared by:
- *   - Backend: create/update/import reject malformed payloads (400)
- *   - Frontend: open path warns but still renders; import path blocks
+ *   - Backend: create, import, and structural updates reject malformed payloads (400).
+ *     Metadata-only updates skip the check so legacy data stays editable.
+ *   - Frontend: open path warns but still renders; the sample-template JSON route blocks
  *
  * Validates:
  *   - Required node fields (name, type, position)
@@ -131,33 +132,31 @@ export function safeParseWorkflowStructure(input: unknown): WorkflowStructureVal
 	const { nodes, connections } = parsed.data;
 	const issues: WorkflowStructureIssue[] = [];
 	const nodeNames = new Set<string>();
-	const nodeIds = new Set<string>();
-
-	const rejectDuplicate = (
-		seen: Set<string>,
-		value: string,
-		issue: WorkflowStructureGraphIssue,
-	) => {
-		if (seen.has(value)) issues.push(issue);
-		else seen.add(value);
-	};
+	const nodeNameById = new Map<string, string>();
 
 	for (const [index, node] of nodes.entries()) {
-		// Ids are optional here because they're filled in on save. A supplied id must be
-		// unique because it identifies the node on its own, wherever a name cannot.
+		// Ids are optional in the schema because the backend fills them in on save. A supplied
+		// id must be unique: it identifies a node independently of its name, and per-node state
+		// keyed on it would otherwise be shared between two nodes.
 		if (node.id !== undefined) {
-			rejectDuplicate(nodeIds, node.id, {
-				path: ['nodes', index, 'id'],
-				message: `Duplicate node id "${node.id}"`,
-				code: 'duplicate_node_id',
-			});
+			const firstNodeName = nodeNameById.get(node.id);
+
+			if (firstNodeName === undefined) nodeNameById.set(node.id, node.name);
+			else
+				issues.push({
+					path: ['nodes', index, 'id'],
+					message: `Duplicate node id "${node.id}" on nodes "${firstNodeName}" and "${node.name}"`,
+					code: 'duplicate_node_id',
+				});
 		}
 
-		rejectDuplicate(nodeNames, node.name, {
-			path: ['nodes', index, 'name'],
-			message: `Duplicate node name "${node.name}"`,
-			code: 'duplicate_node_name',
-		});
+		if (nodeNames.has(node.name))
+			issues.push({
+				path: ['nodes', index, 'name'],
+				message: `Duplicate node name "${node.name}"`,
+				code: 'duplicate_node_name',
+			});
+		else nodeNames.add(node.name);
 	}
 
 	for (const sourceNodeName of Object.keys(connections)) {

--- a/packages/workflow/src/workflow-structure-validation.ts
+++ b/packages/workflow/src/workflow-structure-validation.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
  *   - Position is a 2-number tuple
  *   - Connection entries have valid node/type/index
  *   - No duplicate node names
+ *   - No duplicate node ids, where present
  *   - Connection source/target keys reference existing nodes
  *
  * Does NOT validate:
@@ -66,6 +67,7 @@ type WorkflowStructureData = z.infer<typeof workflowStructureSchema>;
 
 type WorkflowStructureGraphIssueCode =
 	| 'duplicate_node_name'
+	| 'duplicate_node_id'
 	| 'unknown_connection_source'
 	| 'unknown_connection_target';
 
@@ -129,18 +131,33 @@ export function safeParseWorkflowStructure(input: unknown): WorkflowStructureVal
 	const { nodes, connections } = parsed.data;
 	const issues: WorkflowStructureIssue[] = [];
 	const nodeNames = new Set<string>();
+	const nodeIds = new Set<string>();
+
+	const rejectDuplicate = (
+		seen: Set<string>,
+		value: string,
+		issue: WorkflowStructureGraphIssue,
+	) => {
+		if (seen.has(value)) issues.push(issue);
+		else seen.add(value);
+	};
 
 	for (const [index, node] of nodes.entries()) {
-		if (nodeNames.has(node.name)) {
-			issues.push({
-				path: ['nodes', index, 'name'],
-				message: `Duplicate node name "${node.name}"`,
-				code: 'duplicate_node_name',
+		// Ids are optional here because they're filled in on save. A supplied id must be
+		// unique because it identifies the node on its own, wherever a name cannot.
+		if (node.id !== undefined) {
+			rejectDuplicate(nodeIds, node.id, {
+				path: ['nodes', index, 'id'],
+				message: `Duplicate node id "${node.id}"`,
+				code: 'duplicate_node_id',
 			});
-			continue;
 		}
 
-		nodeNames.add(node.name);
+		rejectDuplicate(nodeNames, node.name, {
+			path: ['nodes', index, 'name'],
+			message: `Duplicate node name "${node.name}"`,
+			code: 'duplicate_node_name',
+		});
 	}
 
 	for (const sourceNodeName of Object.keys(connections)) {

--- a/packages/workflow/src/workflow-structure-validation.ts
+++ b/packages/workflow/src/workflow-structure-validation.ts
@@ -135,17 +135,17 @@ export function safeParseWorkflowStructure(input: unknown): WorkflowStructureVal
 	const nodeNameById = new Map<string, string>();
 
 	for (const [index, node] of nodes.entries()) {
-		// Ids are optional in the schema because the backend fills them in on save. A supplied
-		// id must be unique: it identifies a node independently of its name, and per-node state
-		// keyed on it would otherwise be shared between two nodes.
-		if (node.id !== undefined) {
+		// Ids are optional in the schema because the backend fills in absent and empty ones on
+		// save. A supplied id must be unique: it identifies a node independently of its name, and
+		// per-node state keyed on it would otherwise be shared between two nodes.
+		if (node.id !== undefined && node.id !== '') {
 			const firstNodeName = nodeNameById.get(node.id);
 
 			if (firstNodeName === undefined) nodeNameById.set(node.id, node.name);
 			else
 				issues.push({
 					path: ['nodes', index, 'id'],
-					message: `Duplicate node id "${node.id}" on nodes "${firstNodeName}" and "${node.name}"`,
+					message: `Nodes "${firstNodeName}" and "${node.name}" share the node ID "${node.id}"`,
 					code: 'duplicate_node_id',
 				});
 		}

--- a/packages/workflow/test/workflow-structure-validation.test.ts
+++ b/packages/workflow/test/workflow-structure-validation.test.ts
@@ -198,8 +198,51 @@ describe('workflow-structure-validation', () => {
 			expect.objectContaining({
 				code: 'duplicate_node_id',
 				path: ['nodes', 1, 'id'],
+				message: 'Duplicate node id "node-1" on nodes "Start" and "Set"',
 			}),
 		);
+	});
+
+	test('reports every node after the first sharing an id', () => {
+		const result = safeParseWorkflowStructure({
+			...validWorkflow,
+			nodes: [
+				validWorkflow.nodes[0],
+				{ ...validWorkflow.nodes[1], id: 'node-1' },
+				{ ...validWorkflow.nodes[1], id: 'node-1', name: 'Set1' },
+			],
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+
+		expect(result.issues.filter(({ code }) => code === 'duplicate_node_id')).toHaveLength(2);
+	});
+
+	test('reports both issues for a node duplicating another node id and name', () => {
+		const result = safeParseWorkflowStructure({
+			nodes: [validWorkflow.nodes[0], { ...validWorkflow.nodes[0] }],
+			connections: {},
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+
+		expect(result.issues).toEqual([
+			expect.objectContaining({ code: 'duplicate_node_id', path: ['nodes', 1, 'id'] }),
+			expect.objectContaining({ code: 'duplicate_node_name', path: ['nodes', 1, 'name'] }),
+		]);
+	});
+
+	test('accepts duplicate-free ids mixed with nodes that have no id', () => {
+		const { id: _id, ...idlessNode } = validWorkflow.nodes[1];
+
+		const result = safeParseWorkflowStructure({
+			...validWorkflow,
+			nodes: [validWorkflow.nodes[0], idlessNode, { ...idlessNode, name: 'Set1' }],
+		});
+
+		expect(result.success).toBe(true);
 	});
 
 	test('accepts several nodes without ids', () => {

--- a/packages/workflow/test/workflow-structure-validation.test.ts
+++ b/packages/workflow/test/workflow-structure-validation.test.ts
@@ -179,6 +179,38 @@ describe('workflow-structure-validation', () => {
 		);
 	});
 
+	test('rejects duplicate node ids', () => {
+		const result = safeParseWorkflowStructure({
+			...validWorkflow,
+			nodes: [
+				validWorkflow.nodes[0],
+				{
+					...validWorkflow.nodes[1],
+					id: 'node-1',
+				},
+			],
+		});
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+
+		expect(result.issues).toContainEqual(
+			expect.objectContaining({
+				code: 'duplicate_node_id',
+				path: ['nodes', 1, 'id'],
+			}),
+		);
+	});
+
+	test('accepts several nodes without ids', () => {
+		const result = safeParseWorkflowStructure({
+			...validWorkflow,
+			nodes: validWorkflow.nodes.map(({ id: _id, ...node }) => node),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
 	test('rejects unknown connection sources', () => {
 		const result = safeParseWorkflowStructure({
 			...validWorkflow,

--- a/packages/workflow/test/workflow-structure-validation.test.ts
+++ b/packages/workflow/test/workflow-structure-validation.test.ts
@@ -198,7 +198,7 @@ describe('workflow-structure-validation', () => {
 			expect.objectContaining({
 				code: 'duplicate_node_id',
 				path: ['nodes', 1, 'id'],
-				message: 'Duplicate node id "node-1" on nodes "Start" and "Set"',
+				message: 'Nodes "Start" and "Set" share the node ID "node-1"',
 			}),
 		);
 	});
@@ -249,6 +249,15 @@ describe('workflow-structure-validation', () => {
 		const result = safeParseWorkflowStructure({
 			...validWorkflow,
 			nodes: validWorkflow.nodes.map(({ id: _id, ...node }) => node),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	test('accepts several nodes with empty-string ids', () => {
+		const result = safeParseWorkflowStructure({
+			...validWorkflow,
+			nodes: validWorkflow.nodes.map((node) => ({ ...node, id: '' })),
 		});
 
 		expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary

`safeParseWorkflowStructure` already rejects duplicate node **names**. Node
**ids** were never checked, anywhere: `id` is optional in the schema, `addNodeIds`
and `ImportService` only fill blanks rather than de-duplicating, and there is no
database constraint. A payload with two nodes sharing an id is accepted today.

This adds the missing check. Ids stay optional, since they are filled in on save;
only a supplied duplicate is rejected.

Split out of the durable poll-cursor work, where it came up: that feature keys
per-node state on the node id, so two nodes sharing one would share a row and
overwrite each other's cursor. The rule is worth having on its own, independent of
that feature — an id that does not identify a node is not an id.

## Related tickets

https://linear.app/n8n/issue/CAT-3902

## Review notes

**This is a live behaviour change.** Create, update and import now return 400 for
a payload carrying duplicate node ids; previously they succeeded.

We now have data on how common duplicates are. On internal: 7 workflows carry
duplicate node ids. None are active, 3 are archived. Rejection (option 1 from the
earlier draft of this description) stands — it is the smallest change and matches
the sibling duplicate-name rule.

Two things soften the change:

- Metadata-only updates skip structure validation. A legacy workflow with
  duplicate ids can still be renamed, tagged, and have its settings changed. Only
  a save that changes nodes, connections or node groups is rejected.
- The error names both nodes. The fix is to remove and re-add the affected nodes —
  copy-paste works too, since pasting assigns fresh ids.

What this PR does not do: heal workflows that already carry duplicates. An active
workflow keeps its published version until its next publish. A follow-up will fix
duplicate ids automatically before a version is activated:
https://linear.app/n8n/issue/CAT-4056

Also in this PR:

- Empty-string ids count as absent, matching the backend, which fills them in on
  save. Two id-less nodes no longer trip a duplicate warning on the editor's open
  path.
- The duplicate-id message uses the same wording as the publish-time gate:
  `Nodes "A" and "B" share the node ID "x"`.

## How to test

```sh
cd packages/workflow
pnpm test workflow-structure-validation
```

42 tests green (21 per engine). New: a duplicate id is rejected, id-less and
empty-string-id nodes are accepted.

Integration tests cover rejection on create and update, plus the metadata-only
escape hatch:

```sh
cd packages/cli
pnpm test:integration workflows.controller.test -t 'node id'
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35129">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





