### PR TITLE
fix(editor): Fix icon overlap in end-user credential connection banner

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/Banner.vue
+++ b/packages/frontend/editor-ui/src/app/components/Banner.vue
@@ -76,15 +76,17 @@ const messageClass = computed<Record<Theme, string>>(() => ({
 		:disable-transitions="true"
 		:class="[$style.container, theme === 'info' && $style.containerInfo]"
 	>
-		<N8nIcon v-if="icon" :icon="icon" :class="iconClass[props.theme]" />
 		<div :class="$style.banner">
 			<div :class="$style.content">
 				<div>
-					<span :class="messageClass[props.theme]"> {{ message }}&nbsp; </span>
-					<N8nLink v-if="details && !expanded" :bold="true" size="small" @click="expand">
-						<span :class="$style.moreDetails">More details</span>
-					</N8nLink>
-					<div v-if="$slots.subtitle" :class="$style.subtitle">
+					<div :class="$style.messageRow">
+						<N8nIcon v-if="icon" :icon="icon" :class="iconClass[props.theme]" />
+						<span :class="messageClass[props.theme]"> {{ message }}&nbsp; </span>
+						<N8nLink v-if="details && !expanded" :bold="true" size="small" @click="expand">
+							<span :class="$style.moreDetails">More details</span>
+						</N8nLink>
+					</div>
+					<div v-if="$slots.subtitle" :class="[$style.subtitle, icon && $style.subtitleWithIcon]">
 						<slot name="subtitle" />
 					</div>
 				</div>
@@ -113,11 +115,7 @@ const messageClass = computed<Record<Theme, string>>(() => ({
 
 <style module lang="scss">
 .icon {
-	position: absolute;
-	left: 14px;
-	top: 0;
-	bottom: 0;
-	margin: auto 0;
+	flex-shrink: 0;
 }
 
 .dangerIcon {
@@ -133,14 +131,11 @@ const messageClass = computed<Record<Theme, string>>(() => ({
 .container {
 	width: 100%;
 	position: relative;
-	padding-left: 40px;
 	border: none;
 }
 
-// `info` has no icon, so it drops the icon gutter and gets a neutral fill.
+// `info` gets a neutral fill instead of the themed one.
 .containerInfo {
-	padding-left: var(--spacing--sm);
-
 	// Match Element Plus's specificity to override the tag's fill + border.
 	// Alpha overlays read against the modal in both themes; the border steps one
 	// notch past the fill (darker in light mode, lighter in dark).
@@ -210,10 +205,22 @@ const messageClass = computed<Record<Theme, string>>(() => ({
 	font-size: var(--font-size--xs);
 }
 
+.messageRow {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--xs);
+}
+
 .subtitle {
 	margin-top: var(--spacing--4xs);
 	line-height: var(--line-height--md);
 	// ElTag defaults to nowrap; let the subtitle wrap instead of overflowing.
 	white-space: normal;
+}
+
+// Align with the message text rather than the icon above it.
+// `1em` mirrors the icon's default size, `--spacing--xs` mirrors .messageRow's gap.
+.subtitleWithIcon {
+	margin-left: calc(1em + var(--spacing--xs));
 }
 </style>


### PR DESCRIPTION
## Summary

The credential connection banner's leading icon was absolutely positioned and vertically centered against the whole banner container. That worked for single-line messages, but the end-user credential "connect"/"connected" states add a second-line subtitle ("This connection is only usable by you." + a Learn more link), which made the container taller — the icon ended up floating mid-block and overlapping that subtitle text. Fixed by moving the icon into the message row (so it only ever aligns with the message line) and indenting the subtitle to match the message text instead.

## How to test

1. Create/edit an OAuth2 credential and enable "End-user credential".
2. Connect the account (or view it already connected).
3. The success banner icon should sit next to "Connected as ..." with no overlap on the "This connection is only usable by you. Learn more" subtitle below it, at both normal and narrow modal widths.
4. Also check the plain (non end-user) OAuth2 connect/connected banners still render as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1095

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35130">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

