### PR TITLE
fix(core): Refresh end-user credential connection status after save

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -114,6 +114,8 @@ describe('CredentialsController', () => {
 		ensureCanManageEndUserCredentialSpy = vi
 			.spyOn(credentialsService, 'ensureCanManageEndUserCredential')
 			.mockResolvedValue(undefined);
+		// stubbed by default: backed by connectionStatusProxy, which unit tests don't wire up
+		vi.spyOn(credentialsService, 'populateConnectedByMe').mockResolvedValue(undefined);
 		findCredentialOwningProjectSpy = sharedCredentialsRepository.findCredentialOwningProject;
 		emitSpy = eventService.emit;
 		// Set up credentialsRepository.create to return the input data
@@ -850,6 +852,7 @@ describe('CredentialsController', () => {
 			expect(getChangedSharedFieldsSpy).toHaveBeenCalled();
 			expect(updateSpy).toHaveBeenCalledWith(credentialId, expect.any(Object), expect.any(Object), {
 				deleteUserEntries: true,
+				user: ownerReq.user,
 			});
 			expect(emitSpy).toHaveBeenCalledWith('private-credential-connections-cleared', {
 				user: ownerReq.user,
@@ -879,6 +882,7 @@ describe('CredentialsController', () => {
 
 			expect(updateSpy).toHaveBeenCalledWith(credentialId, expect.any(Object), expect.any(Object), {
 				deleteUserEntries: false,
+				user: ownerReq.user,
 			});
 			const emittedEventNames = emitSpy.mock.calls.map((call) => call[0]);
 			expect(emittedEventNames).not.toContain('private-credential-connections-cleared');
@@ -906,6 +910,7 @@ describe('CredentialsController', () => {
 			expect(getChangedSharedFieldsSpy).not.toHaveBeenCalled();
 			expect(updateSpy).toHaveBeenCalledWith(credentialId, expect.any(Object), expect.any(Object), {
 				deleteUserEntries: true,
+				user: ownerReq.user,
 			});
 		});
 

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -1122,6 +1122,42 @@ describe('CredentialsService', () => {
 				encrypted,
 			);
 		});
+
+		it('enriches the returned credential with connectedByMe when a user is passed', async () => {
+			const credential = mock<CredentialsEntity>({
+				id: 'private-credential',
+				isResolvable: true,
+			});
+			const transactionManager = mock<EntityManager>();
+			transactionManager.findOneBy.mockResolvedValue(credential);
+			setRepositoryTransaction(transactionManager);
+			const encrypted = mock<ICredentialsDb>({ id: credential.id });
+			connectionStatusProxy.findConnectedCredentialIds.mockResolvedValue(new Set([credential.id]));
+
+			const result = await service.update(credential.id, encrypted, undefined, {
+				user: ownerUser,
+			});
+
+			expect(connectionStatusProxy.findConnectedCredentialIds).toHaveBeenCalledWith(ownerUser.id, [
+				credential.id,
+			]);
+			expect(result).toMatchObject({ connectedByMe: true });
+		});
+
+		it('does not enrich the returned credential when no user is passed', async () => {
+			const credential = mock<CredentialsEntity>({
+				id: 'private-credential',
+				isResolvable: true,
+			});
+			const transactionManager = mock<EntityManager>();
+			transactionManager.findOneBy.mockResolvedValue(credential);
+			setRepositoryTransaction(transactionManager);
+			const encrypted = mock<ICredentialsDb>({ id: credential.id });
+
+			await service.update(credential.id, encrypted);
+
+			expect(connectionStatusProxy.findConnectedCredentialIds).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('updateInstanceCredential', () => {

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -315,6 +315,7 @@ export class CredentialsController {
 			{
 				deleteUserEntries: isTogglingToStatic || sharedFieldsChanged,
 				instanceCredential: credential.usageScope === 'instance' ? credential : undefined,
+				user: req.user,
 			},
 		);
 

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -102,6 +102,8 @@ type UpdateOptions = {
 	deleteUserEntries?: boolean;
 	/** Existing instance credential whose hook-mutated payload must be revalidated. */
 	instanceCredential?: Pick<CredentialsEntity, 'id' | 'type'>;
+	/** When provided, the returned entity is enriched with `connectedByMe` for this user. */
+	user?: User;
 };
 
 type CreateCredentialOptions = CreateCredentialDto & {
@@ -908,23 +910,37 @@ export class CredentialsService {
 			return await transactionManager.findOneBy(CredentialsEntity, { id: credentialId });
 		};
 
+		let result: CredentialsEntity | null;
 		if (!options?.instanceCredential) {
-			return await this.credentialsRepository.manager.transaction(persist);
+			result = await this.credentialsRepository.manager.transaction(persist);
+		} else {
+			const instanceCredential = options.instanceCredential;
+			const hookedData = await this.getValidatedInstanceCredentialHookData(
+				newCredentialData,
+				instanceCredential.id,
+				instanceCredential.type,
+			);
+			result = await this.dbLockService.withLock(
+				DbLock.INSTANCE_AI_SETTINGS,
+				async (transactionManager, ctx) => {
+					await this.validateInstanceCredentialUpdate(
+						instanceCredential,
+						hookedData,
+						undefined,
+						ctx,
+					);
+					return await persist(transactionManager);
+				},
+			);
 		}
 
-		const instanceCredential = options.instanceCredential;
-		const hookedData = await this.getValidatedInstanceCredentialHookData(
-			newCredentialData,
-			instanceCredential.id,
-			instanceCredential.type,
-		);
-		return await this.dbLockService.withLock(
-			DbLock.INSTANCE_AI_SETTINGS,
-			async (transactionManager, ctx) => {
-				await this.validateInstanceCredentialUpdate(instanceCredential, hookedData, undefined, ctx);
-				return await persist(transactionManager);
-			},
-		);
+		// Reflect connections cleared above by deleteUserEntries, not a stale pre-update value.
+		const enriched: (CredentialsEntity & { connectedByMe?: boolean }) | null = result;
+		if (enriched && options?.user) {
+			await this.populateConnectedByMe([enriched], options.user);
+		}
+
+		return enriched;
 	}
 
 	/**

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -564,11 +564,14 @@ async function onResolvableChange(value: boolean) {
 	}
 
 	isResolvable.value = value;
-	// Switching sharing mode invalidates any carried-over connection state: a
-	// freshly-private credential has no per-user connection for the current
-	// user yet, so reset it to avoid rendering a stale "connected" state with a
-	// Disconnect button that has nothing to disconnect.
+	// Switching sharing mode invalidates any carried-over connection state: `connectedByMe`
+	// doesn't apply to the new mode, and `oauthTokenData` (mirrored true for a connected
+	// end-user credential) would otherwise be read as "connected" once static.
 	connectedByMe.value = false;
+	credentialData.value = {
+		...credentialData.value,
+		oauthTokenData: null as unknown as CredentialInformation,
+	};
 	hasUnsavedChanges.value = true;
 }
 
@@ -691,6 +694,8 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 	if (credential) {
 		credentialId.value = credential.id;
 		currentCredential.value = credential;
+		// Resync in case the save cleared this user's connection server-side.
+		connectedByMe.value = credential.connectedByMe === true;
 
 		// Re-fetch to display server-redacted JSON shape for credentials with leaf-redacted fields
 		if (credentialProperties.value.some((p) => p.typeOptions?.redactJsonLeaves)) {


### PR DESCRIPTION
## Summary

Fixes a UI bug where the "Account connected" banner and the node credential picker's connection row kept showing an end-user (private) credential as connected after a save that actually cleared the connection server-side — e.g. changing a shared OAuth field (client ID/secret/scope) or switching the credential from end-user to fixed. A page reload showed the correct state, confirming the backend was right but the frontend cache was stale.

Two gaps caused this:
- `PATCH /credentials/:id` never enriched its response with `connectedByMe`, so the frontend's cached credential list kept the pre-save value.
- The credential edit modal's own "Account connected" banner reads a separate, component-local `connectedByMe`/`oauthTokenData` state that was never resynced after save or after toggling end-user ↔ fixed.

`CredentialsService.update()` now enriches its response with `connectedByMe` when a `user` is passed in, and `CredentialEdit.vue` resyncs its local connection state after save and when the sharing mode toggle changes.

## How to test

This requires the `dynamic-credentials` module to be active (an Enterprise license with the `feat:dynamicCredentials` feature, or `N8N_ENV_FEAT_DYNAMIC_CREDENTIALS=true` in dev for the underlying resolvers).

1. Create an OAuth2 credential, mark it as an end-user credential, and connect your own account.
2. Edit the credential and change a shared field (e.g. client ID) and save — confirm the modal warning, then verify the "Account connected" banner and the node credential row immediately show "not connected" (no reload needed).
3. Reconnect, then switch the credential from end-user back to fixed and save — verify it doesn't show as connected afterwards.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1096

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35131">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->