### PR TITLE
refactor(editor): Simplify per-agent MCP access wiring

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-mcp-access.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-mcp-access.service.test.ts
@@ -34,6 +34,7 @@ describe('AgentMcpAccessService', () => {
 			expect(agentRepository.findByProjectIdsPaginated).toHaveBeenCalledWith(
 				['project-1'],
 				expect.objectContaining({ filter: { availableInMCP: false } }),
+				{ withProject: true },
 			);
 		});
 
@@ -46,6 +47,7 @@ describe('AgentMcpAccessService', () => {
 			expect(agentRepository.findByProjectIdsPaginated).toHaveBeenCalledWith(
 				null,
 				expect.objectContaining({ filter: { availableInMCP: false } }),
+				{ withProject: true },
 			);
 		});
 
@@ -62,6 +64,7 @@ describe('AgentMcpAccessService', () => {
 			expect(agentRepository.findByProjectIdsPaginated).toHaveBeenCalledWith(
 				['project-1'],
 				expect.objectContaining({ filter: { availableInMCP: true } }),
+				{ withProject: true },
 			);
 		});
 
@@ -78,6 +81,7 @@ describe('AgentMcpAccessService', () => {
 			expect(agentRepository.findByProjectIdsPaginated).toHaveBeenCalledWith(
 				null,
 				expect.objectContaining({ filter: { availableInMCP: true } }),
+				{ withProject: true },
 			);
 		});
 	});

--- a/packages/cli/src/modules/agents/agent-mcp-access.service.ts
+++ b/packages/cli/src/modules/agents/agent-mcp-access.service.ts
@@ -39,13 +39,17 @@ export class AgentMcpAccessService {
 		options: ListAgentsQueryDto,
 	): Promise<{ count: number; data: Agent[] }> {
 		const projectIds = await this.projectScopeService.getProjectIds(user, ['agent:update']);
-		return await this.agentRepository.findByProjectIdsPaginated(projectIds, {
-			...options,
-			filter: {
-				...options.filter,
-				availableInMCP: options.filter?.availableInMCP ?? false,
+		return await this.agentRepository.findByProjectIdsPaginated(
+			projectIds,
+			{
+				...options,
+				filter: {
+					...options.filter,
+					availableInMCP: options.filter?.availableInMCP ?? false,
+				},
 			},
-		});
+			{ withProject: true },
+		);
 	}
 
 	async bulkSetAvailableInMCP(
@@ -71,7 +75,6 @@ export class AgentMcpAccessService {
 				? candidates
 				: candidates.filter((agent) => allowedProjectIds.has(agent.projectId));
 
-		const unchanged = accessible.filter((agent) => agent.availableInMCP === dto.availableInMCP);
 		const toUpdate = accessible.filter((agent) => agent.availableInMCP !== dto.availableInMCP);
 
 		const agentIds = toUpdate.map((agent) => agent.id);
@@ -84,10 +87,14 @@ export class AgentMcpAccessService {
 
 		return {
 			updatedCount: toUpdate.length,
+			// Per-id breakdown only for explicit `agentIds` requests; the caller
+			// uses it to confirm each requested agent landed in a known state.
 			...(dto.agentIds
 				? {
-						updatedIds: toUpdate.map((agent) => agent.id),
-						unchangedIds: unchanged.map((agent) => agent.id),
+						updatedIds: agentIds,
+						unchangedIds: accessible
+							.filter((agent) => agent.availableInMCP === dto.availableInMCP)
+							.map((agent) => agent.id),
 					}
 				: {}),
 		};

--- a/packages/cli/src/modules/agents/repositories/agent.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent.repository.ts
@@ -74,14 +74,20 @@ export class AgentRepository extends Repository<Agent> {
 	async findByProjectIdsPaginated(
 		projectIds: string[] | null,
 		options: ListAgentsQueryDto,
+		{ withProject = false }: { withProject?: boolean } = {},
 	): Promise<{ count: number; data: Agent[] }> {
 		if (projectIds?.length === 0) return { count: 0, data: [] };
 
-		const query = this.createQueryBuilder('agent')
-			.leftJoinAndSelect('agent.activeVersion', 'activeVersion')
-			// The home project rides along so cross-project lists (overview page,
-			// MCP settings) can label each agent without extra lookups.
-			.leftJoinAndSelect('agent.project', 'project');
+		const query = this.createQueryBuilder('agent').leftJoinAndSelect(
+			'agent.activeVersion',
+			'activeVersion',
+		);
+
+		// Only cross-project consumers (MCP settings) label each agent by its home
+		// project; the overview lists don't read it, so they skip the extra join.
+		if (withProject) {
+			query.leftJoinAndSelect('agent.project', 'project');
+		}
 
 		if (projectIds !== null) {
 			query.where('agent.projectId IN (:...projectIds)', { projectIds });
@@ -187,7 +193,7 @@ export class AgentRepository extends Repository<Agent> {
 
 		return await this.find({
 			select: ['id', 'projectId', 'availableInMCP'],
-			...(criteria ? { where: criteria } : {}),
+			where: criteria,
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/features/agents/agent.types.ts
+++ b/packages/frontend/editor-ui/src/features/agents/agent.types.ts
@@ -17,6 +17,7 @@ export interface CustomToolEntry {
 }
 
 import type { AgentVersionDto, AgentSkill, AgentJsonConfig } from '@n8n/api-types';
+import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 
 export type AgentVersion = AgentVersionDto;
 
@@ -26,7 +27,7 @@ export type Agent = {
 	projectId: string;
 	// Narrow declaration of the eagerly-loaded home project relation — only
 	// the fields list consumers (e.g. the MCP agents table) read are typed.
-	project?: { id: string; name: string; type: string } | null;
+	project?: Pick<ProjectSharingData, 'id' | 'name' | 'type'> | null;
 	availableInMCP?: boolean;
 	isCompiled: boolean;
 	isRunnable?: boolean;

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/MCPAgentsSelect.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/MCPAgentsSelect.vue
@@ -6,6 +6,7 @@ import { computed, onMounted, ref } from 'vue';
 import type { Agent } from '@/features/agents/agent.types';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
+import { sleep } from 'n8n-workflow';
 
 defineProps<{
 	placeholder?: string;
@@ -56,18 +57,10 @@ async function searchAgents(query?: string) {
 	} catch (e) {
 		toast.showError(e, i18n.baseText('settings.mcp.connectAgents.error'));
 	} finally {
-		await waitFor(LOADING_INDICATOR_TIMEOUT);
+		await sleep(LOADING_INDICATOR_TIMEOUT);
 		isLoading.value = false;
 		hasFetched.value = true;
 	}
-}
-
-async function waitFor(timeout: number) {
-	await new Promise<void>((resolve) => {
-		setTimeout(() => {
-			resolve();
-		}, timeout);
-	});
 }
 
 function focusOnInput() {

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
@@ -91,21 +91,29 @@ export const useMCPStore = defineStore(MCP_STORE, () => {
 	}
 
 	/**
-	 * Fetch a page of MCP-available workflows, clamping to the last non-empty
-	 * page when the requested one shrank away (e.g. after removing access).
-	 * Returns the effective 1-based page so callers can sync their table state.
+	 * Runs a page fetch, clamping to the last non-empty page when the requested
+	 * one shrank away (e.g. after removing access). Returns the effective 1-based
+	 * page so callers can sync their table state.
 	 */
+	async function clampToLastPage<T>(
+		fetchPage: (page: number, pageSize: number) => Promise<{ data: T[]; count: number }>,
+		page: number,
+		pageSize: number,
+	): Promise<{ data: T[]; count: number; page: number }> {
+		const response = await fetchPage(page, pageSize);
+		if (response.data.length === 0 && response.count > 0 && page > 1) {
+			const maxPage = Math.max(1, Math.ceil(response.count / pageSize));
+			const clamped = await fetchPage(maxPage, pageSize);
+			return { ...clamped, page: maxPage };
+		}
+		return { ...response, page };
+	}
+
 	async function fetchWorkflowsAvailableForMCPPage(
 		page: number,
 		pageSize: number,
 	): Promise<{ data: WorkflowListItem[]; count: number; page: number }> {
-		const response = await fetchWorkflowsAvailableForMCP(page, pageSize);
-		if (response.data.length === 0 && response.count > 0 && page > 1) {
-			const maxPage = Math.max(1, Math.ceil(response.count / pageSize));
-			const clamped = await fetchWorkflowsAvailableForMCP(maxPage, pageSize);
-			return { ...clamped, page: maxPage };
-		}
-		return { ...response, page };
+		return await clampToLastPage(fetchWorkflowsAvailableForMCP, page, pageSize);
 	}
 
 	async function fetchAgentsAvailableForMCP(
@@ -120,22 +128,11 @@ export const useMCPStore = defineStore(MCP_STORE, () => {
 		return { data, count };
 	}
 
-	/**
-	 * Fetch a page of MCP-available agents, clamping to the last non-empty page
-	 * when the requested one shrank away (e.g. after removing access). Returns
-	 * the effective 1-based page so callers can sync their table state.
-	 */
 	async function fetchAgentsAvailableForMCPPage(
 		page: number,
 		pageSize: number,
 	): Promise<{ data: Agent[]; count: number; page: number }> {
-		const response = await fetchAgentsAvailableForMCP(page, pageSize);
-		if (response.data.length === 0 && response.count > 0 && page > 1) {
-			const maxPage = Math.max(1, Math.ceil(response.count / pageSize));
-			const clamped = await fetchAgentsAvailableForMCP(maxPage, pageSize);
-			return { ...clamped, page: maxPage };
-		}
-		return { ...response, page };
+		return await clampToLastPage(fetchAgentsAvailableForMCP, page, pageSize);
 	}
 
 	async function setMcpAccessEnabled(enabled: boolean): Promise<boolean> {


### PR DESCRIPTION
## Summary

A quality-only cleanup **stacked on top of #34853**, offered as a suggestion for that PR. No behavior change — it's a `/simplify` pass over that diff (reuse / simplification / efficiency / altitude), so it targets #34853's branch rather than `master`. Feel free to cherry-pick individual commits/hunks or close if not wanted.

The changes:

- **Opt-in project join.** `AgentRepository.findByProjectIdsPaginated` unconditionally `leftJoinAndSelect('agent.project', …)` for all three callers, but only the MCP settings list reads it — the two agents-overview callers hydrated a `Project` per row that nothing renders. Made the join opt-in via a `{ withProject }` option, set only by `AgentMcpAccessService.getAgents`.
- **`bulkSetAvailableInMCP` tidy.** Dropped the always-computed `unchanged` array (only used on the `agentIds` path) and reused the already-built id list for `updatedIds` instead of re-mapping `toUpdate`.
- **`findMcpAvailabilityCandidates`.** `where: criteria` directly (`find({ where: undefined })` already means "no filter") instead of a conditional spread.
- **Shared `sleep`.** `MCPAgentsSelect.vue` used a local promise-wrapped `setTimeout`; swapped it for the shared `sleep` from `n8n-workflow`.
- **`clampToLastPage` helper.** `fetchAgentsAvailableForMCPPage` was a verbatim copy of `fetchWorkflowsAvailableForMCPPage`; extracted one generic helper both delegate to.
- **`Agent.project` type.** Tied the inline `{ id; name; type }` narrow to `Pick<ProjectSharingData, 'id' | 'name' | 'type'>` so it inherits the `ProjectType` union and correct `name` nullability.

## How to test

Pure refactor. Verified locally:

- `packages/cli`: typecheck + `agent.repository`, `agent-mcp-access.service`, `agent-tools.service` tests (115 passing).
- `packages/frontend/editor-ui`: typecheck + `mcp.store`, `mcp.api`, `AgentCard`, `SettingsMCPAgentsView` tests (53 passing).

## Related

Stacked on #34853 (https://linear.app/n8n/issue/ADO-5615).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35134">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

