### PR TITLE
fix(editor): Do not use whole file name as extension for extensionless uploads

### DIFF
--- a/packages/frontend/editor-ui/src/app/utils/fileUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/fileUtils.test.ts
@@ -1,0 +1,53 @@
+import { convertFileToBinaryData } from './fileUtils';
+
+describe('fileUtils', () => {
+	describe('convertFileToBinaryData', () => {
+		it('should convert a file with an extension', async () => {
+			const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+
+			expect(await convertFileToBinaryData(file)).toEqual({
+				data: btoa('hello'),
+				mimeType: 'application/pdf',
+				fileName: 'report.pdf',
+				fileSize: '5 bytes',
+				fileExtension: 'pdf',
+				fileType: 'pdf',
+			});
+		});
+
+		it('should use the last extension for a file name with multiple dots', async () => {
+			const file = new File(['hello'], 'archive.tar.gz', { type: 'application/gzip' });
+
+			const binaryData = await convertFileToBinaryData(file);
+
+			expect(binaryData.fileExtension).toBe('gz');
+		});
+
+		it('should not set a file extension for a file name without an extension', async () => {
+			const file = new File(['hello'], 'README', { type: 'text/plain' });
+
+			const binaryData = await convertFileToBinaryData(file);
+
+			expect(binaryData.fileExtension).toBeUndefined();
+			expect(binaryData.fileName).toBe('README');
+			expect(binaryData.fileType).toBe('text');
+		});
+
+		it('should not set a file extension for a dotfile', async () => {
+			const file = new File(['hello'], '.env', { type: 'text/plain' });
+
+			const binaryData = await convertFileToBinaryData(file);
+
+			expect(binaryData.fileExtension).toBeUndefined();
+			expect(binaryData.fileName).toBe('.env');
+		});
+
+		it('should not set a file type when the mime type is missing', async () => {
+			const file = new File(['hello'], 'README', { type: '' });
+
+			const binaryData = await convertFileToBinaryData(file);
+
+			expect(binaryData.fileType).toBeUndefined();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/utils/fileUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/fileUtils.ts
@@ -1,16 +1,18 @@
-import type { BinaryFileType, IBinaryData } from 'n8n-workflow';
+import { fileTypeFromMimeType, type IBinaryData } from 'n8n-workflow';
 
 export async function convertFileToBinaryData(file: File): Promise<IBinaryData> {
 	const reader = new FileReader();
 	return await new Promise((resolve, reject) => {
 		reader.onload = () => {
+			const lastDotIndex = file.name.lastIndexOf('.');
+			const fileExtension = lastDotIndex > 0 ? file.name.slice(lastDotIndex + 1) : '';
 			const binaryData: IBinaryData = {
 				data: (reader.result as string).split('base64,')?.[1] ?? '',
 				mimeType: file.type,
 				fileName: file.name,
 				fileSize: `${file.size} bytes`,
-				fileExtension: file.name.split('.').pop() ?? '',
-				fileType: file.type.split('/')[0] as BinaryFileType,
+				fileExtension: fileExtension || undefined,
+				fileType: fileTypeFromMimeType(file.type),
 			};
 			resolve(binaryData);
 		};


### PR DESCRIPTION
Fixes #35125, reported by @sobol-sudo.

`convertFileToBinaryData` in editor-ui derived `fileExtension` with `file.name.split('.').pop()`, so an extensionless upload like `README` reported its whole name as the extension, and `.env` reported `env`, diverging from the backend's `path.parse`-based behavior. It also cast `file.type.split('/')[0]` (including the empty string) straight to `BinaryFileType`.

The fix derives the extension from the last dot only when it appears after position 0 (omitting the field otherwise, matching the backend for extensionless names, dotfiles, and trailing dots) and replaces the unsafe cast with the shared `fileTypeFromMimeType()` helper from `n8n-workflow`, the same function the backend uses.

Five regression tests cover a normal extension, multi-dot names, extensionless names, dotfiles, and a missing MIME type; four of them fail without the fix. ESLint clean, zero new failures in neighboring util suites.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35139">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


