### PR TITLE
fix(Notion Node): Surface actionable guidance for ambiguous formula filter errors

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -45,6 +45,26 @@ const apiVersion: { [key: number]: string } = {
 	2.2: '2021-08-16',
 };
 
+// Notion's database/data source schema never reveals what a formula property
+// evaluates to (string/number/date/checkbox) — that's only known once Notion
+// evaluates it, and Notion refuses to evaluate (and query-filter) a formula
+// whose branches don't all resolve to the same type. No "Formula Return Type"
+// choice in this node can work around that; the formula itself needs fixing.
+const FORMULA_UNKNOWN_TYPE_PATTERN = /unable to filter based on a formula of unknown type/i;
+
+export function isFormulaTypeInferenceError(error: unknown): error is NodeApiError {
+	if (!(error instanceof NodeApiError)) return false;
+	return [error.description, error.message].some(
+		(value) => typeof value === 'string' && FORMULA_UNKNOWN_TYPE_PATTERN.test(value),
+	);
+}
+
+export function applyFormulaTypeInferenceGuidance(error: NodeApiError): void {
+	error.message = "Notion couldn't determine this formula's return type";
+	error.description =
+		"This happens when the formula's branches evaluate to different types in Notion (for example, a date in one branch and an empty string \"\" in another). Open the formula property in Notion, make sure it always resolves to the same type — use empty() instead of \"\" for a blank fallback — and run this node again. Picking a different 'Formula Return Type' in this node won't help, since it's the formula itself that Notion cannot type.";
+}
+
 export async function notionApiRequest(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	method: IHttpRequestMethods,
@@ -77,7 +97,11 @@ export async function notionApiRequest(
 		}
 		return await this.helpers.request(options);
 	} catch (error) {
-		throw new NodeApiError(this.getNode(), error as JsonObject);
+		const apiError = new NodeApiError(this.getNode(), error as JsonObject);
+		if (isFormulaTypeInferenceError(apiError)) {
+			applyFormulaTypeInferenceGuidance(apiError);
+		}
+		throw apiError;
 	}
 }
 

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -433,6 +433,37 @@ describe('Test Notion, notionApiRequest', () => {
 			expect.objectContaining({ method: 'GET' }),
 		);
 	});
+
+	it('rewrites a formula-of-unknown-type filter error into actionable guidance', async () => {
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('apiKey');
+		(mockExecuteFunctions.helpers.requestWithAuthentication as Mock).mockRejectedValue({
+			response: {
+				status: 400,
+				data: { message: 'Unable to filter based on a formula of unknown type.' },
+			},
+		});
+
+		await expect(
+			notionApiRequest.call(mockExecuteFunctions, 'POST', '/databases/abc/query'),
+		).rejects.toMatchObject({
+			message: "Notion couldn't determine this formula's return type",
+			description: expect.stringContaining('empty()'),
+		});
+	});
+
+	it('leaves unrelated API errors untouched', async () => {
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('apiKey');
+		(mockExecuteFunctions.helpers.requestWithAuthentication as Mock).mockRejectedValue({
+			response: { status: 404, data: { message: 'Could not find database.' } },
+		});
+
+		await expect(
+			notionApiRequest.call(mockExecuteFunctions, 'GET', '/databases/missing'),
+		).rejects.toMatchObject({
+			message: 'The resource you are requesting could not be found',
+			description: 'Could not find database.',
+		});
+	});
 });
 
 describe('Test Notion, notionApiRequestAllItems', () => {

--- a/packages/nodes-base/nodes/Notion/test/v3/transport.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/v3/transport.test.ts
@@ -1,17 +1,22 @@
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
 
 import { notionApiRequestV3 } from '../../v3/transport';
+
+const node = { name: 'Notion', type: 'n8n-nodes-base.notion', typeVersion: 3 } as INode;
+
+function buildContext(httpRequestWithAuthentication: ReturnType<typeof vi.fn>) {
+	return {
+		getNodeParameter: vi.fn().mockReturnValue('apiKey'),
+		getNode: () => node,
+		helpers: { httpRequestWithAuthentication },
+	} as unknown as IExecuteFunctions;
+}
 
 describe('Notion V3 transport', () => {
 	it('always sends the 2026 Notion API version header', async () => {
 		const httpRequestWithAuthentication = vi.fn().mockResolvedValue({});
-		const context = {
-			getNodeParameter: vi.fn().mockReturnValue('apiKey'),
-			getNode: () => ({ name: 'Notion', type: 'n8n-nodes-base.notion', typeVersion: 3 }) as INode,
-			helpers: {
-				httpRequestWithAuthentication,
-			},
-		} as unknown as IExecuteFunctions;
+		const context = buildContext(httpRequestWithAuthentication);
 
 		await notionApiRequestV3.call(context, 'GET', '/users');
 
@@ -23,5 +28,40 @@ describe('Notion V3 transport', () => {
 				}),
 			}),
 		);
+	});
+
+	it('rewrites a formula-of-unknown-type filter error into actionable guidance', async () => {
+		// Mirrors what httpHelpers.httpRequestWithAuthentication actually throws for a
+		// non-2xx response: an already-wrapped NodeApiError, message/description
+		// derived from Notion's raw `{ response: { status, data: { message } } }` body.
+		const notionRejection = new NodeApiError(node, {
+			response: {
+				status: 400,
+				data: { message: 'Unable to filter based on a formula of unknown type.' },
+			},
+		});
+		const httpRequestWithAuthentication = vi.fn().mockRejectedValue(notionRejection);
+		const context = buildContext(httpRequestWithAuthentication);
+
+		await expect(
+			notionApiRequestV3.call(context, 'POST', '/data_sources/abc/query'),
+		).rejects.toMatchObject({
+			message: "Notion couldn't determine this formula's return type",
+			description: expect.stringContaining('empty()'),
+		});
+	});
+
+	it('leaves unrelated API errors untouched', async () => {
+		const notFoundError = new NodeApiError(node, {
+			response: { status: 404, data: { message: 'Could not find data source.' } },
+		});
+		const httpRequestWithAuthentication = vi.fn().mockRejectedValue(notFoundError);
+		const context = buildContext(httpRequestWithAuthentication);
+
+		await expect(
+			notionApiRequestV3.call(context, 'GET', '/data_sources/missing'),
+		).rejects.toMatchObject({
+			description: 'Could not find data source.',
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Notion/test/v3/transport.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/v3/transport.test.ts
@@ -61,6 +61,7 @@ describe('Notion V3 transport', () => {
 		await expect(
 			notionApiRequestV3.call(context, 'GET', '/data_sources/missing'),
 		).rejects.toMatchObject({
+			message: 'The resource you are requesting could not be found',
 			description: 'Could not find data source.',
 		});
 	});

--- a/packages/nodes-base/nodes/Notion/v3/transport/index.ts
+++ b/packages/nodes-base/nodes/Notion/v3/transport/index.ts
@@ -14,8 +14,22 @@ type NotionFunctions = IExecuteFunctions | ILoadOptionsFunctions | IPollFunction
 const NOTION_VERSION_HEADER = 'Notion-Version';
 const NOTION_API_VERSION = '2026-03-11';
 
+// Notion's database/data source schema never reveals what a formula property
+// evaluates to (string/number/date/checkbox) — that's only known once Notion
+// evaluates it, and Notion refuses to evaluate (and query-filter) a formula
+// whose branches don't all resolve to the same type. No "Formula Return Type"
+// choice in this node can work around that; the formula itself needs fixing.
+const FORMULA_UNKNOWN_TYPE_PATTERN = /unable to filter based on a formula of unknown type/i;
+
 export function isDataObject(value: unknown): value is IDataObject {
 	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isFormulaTypeInferenceError(error: unknown): error is NodeApiError {
+	if (!(error instanceof NodeApiError)) return false;
+	return [error.description, error.message].some(
+		(value) => typeof value === 'string' && FORMULA_UNKNOWN_TYPE_PATTERN.test(value),
+	);
 }
 
 export async function notionApiRequestV3(
@@ -47,6 +61,12 @@ export async function notionApiRequestV3(
 			options,
 		)) as IDataObject;
 	} catch (error) {
+		if (isFormulaTypeInferenceError(error)) {
+			error.message = "Notion couldn't determine this formula's return type";
+			error.description =
+				"This happens when the formula's branches evaluate to different types in Notion (for example, a date in one branch and an empty string \"\" in another). Open the formula property in Notion, make sure it always resolves to the same type — use empty() instead of \"\" for a blank fallback — and run this node again. Picking a different 'Formula Return Type' in this node won't help, since it's the formula itself that Notion cannot type.";
+			throw error;
+		}
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
 }

--- a/packages/nodes-base/nodes/Notion/v3/transport/index.ts
+++ b/packages/nodes-base/nodes/Notion/v3/transport/index.ts
@@ -9,27 +9,18 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
+import {
+	applyFormulaTypeInferenceGuidance,
+	isFormulaTypeInferenceError,
+} from '../../shared/GenericFunctions';
+
 type NotionFunctions = IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions;
 
 const NOTION_VERSION_HEADER = 'Notion-Version';
 const NOTION_API_VERSION = '2026-03-11';
 
-// Notion's database/data source schema never reveals what a formula property
-// evaluates to (string/number/date/checkbox) — that's only known once Notion
-// evaluates it, and Notion refuses to evaluate (and query-filter) a formula
-// whose branches don't all resolve to the same type. No "Formula Return Type"
-// choice in this node can work around that; the formula itself needs fixing.
-const FORMULA_UNKNOWN_TYPE_PATTERN = /unable to filter based on a formula of unknown type/i;
-
 export function isDataObject(value: unknown): value is IDataObject {
 	return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function isFormulaTypeInferenceError(error: unknown): error is NodeApiError {
-	if (!(error instanceof NodeApiError)) return false;
-	return [error.description, error.message].some(
-		(value) => typeof value === 'string' && FORMULA_UNKNOWN_TYPE_PATTERN.test(value),
-	);
 }
 
 export async function notionApiRequestV3(
@@ -62,9 +53,7 @@ export async function notionApiRequestV3(
 		)) as IDataObject;
 	} catch (error) {
 		if (isFormulaTypeInferenceError(error)) {
-			error.message = "Notion couldn't determine this formula's return type";
-			error.description =
-				"This happens when the formula's branches evaluate to different types in Notion (for example, a date in one branch and an empty string \"\" in another). Open the formula property in Notion, make sure it always resolves to the same type — use empty() instead of \"\" for a blank fallback — and run this node again. Picking a different 'Formula Return Type' in this node won't help, since it's the formula itself that Notion cannot type.";
+			applyFormulaTypeInferenceGuidance(error);
 			throw error;
 		}
 		throw new NodeApiError(this.getNode(), error as JsonObject);


### PR DESCRIPTION
## Summary

The Notion node's "Get Many" formula filter has been reported broken three times (#27420, #30524, #34590), with two prior fixes landing and the bug still reproducing. Investigation traced the root cause to something outside n8n's control: Notion refuses to filter a formula whose branches don't all resolve to the same type (e.g. a date in one branch and `""` in another), and rejects the query with `Unable to filter based on a formula of unknown type` regardless of which "Formula Return Type" is picked in the node.

The filter-building logic in `DataSourceFilters.ts` is already correct against Notion's documented filter shape — that's why the previous fixes, which reworked type mapping, didn't resolve it. This PR doesn't (and can't) make Notion filter a formula it can't type; it intercepts this specific Notion response in the v3 transport layer and rewrites the generic "Bad request" into guidance that points at the actual, fixable cause: the formula itself needs a consistent return type in Notion (use `empty()` instead of `""` for a blank fallback).

## How to test

1. In Notion, create a formula property whose branches return different types, e.g. `if(prop("Done"), now(), "")`.
2. In n8n: Notion node → Resource: Database Page → Operation: Get Many → Filter: Build Manually → condition on that formula property (any Formula Return Type).
3. Execute the node.
   - Before: `Bad request - please check your parameters` / `Unable to filter based on a formula of unknown type`.
   - After: `Notion couldn't determine this formula's return type`, with a description explaining the fix.
4. `cd packages/nodes-base && pnpm test nodes/Notion/test/v3/transport.test.ts` — two new unit tests cover the rewritten error and confirm unrelated Notion API errors pass through unchanged.

## Related Github issues

Related to #34590, #30524, #27420 — see summary above for why this PR addresses the actual root cause (a confusing, unactionable error) rather than claiming to make filtering work for formulas Notion itself cannot type.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35140">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

