### PR TITLE
fix(editor): Remove invalid `:global()` from shipped design-system CSS (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/package.json
+++ b/packages/frontend/@n8n/design-system/package.json
@@ -3,7 +3,6 @@
   "name": "@n8n/design-system",
   "version": "2.32.0",
   "main": "src/index.ts",
-  "import": "src/index.ts",
   "scripts": {
     "dev": "pnpm run --dir=../storybook dev",
     "clean": "rimraf dist .turbo",
@@ -46,6 +45,7 @@
     "autoprefixer": "^10.4.19",
     "emojibase-data": "^17.0.0",
     "eslint-plugin-storybook": "catalog:storybook",
+    "pinia": "catalog:frontend",
     "postcss": "^8.4.38",
     "sass": "^1.71.1",
     "storybook": "catalog:storybook",
@@ -90,7 +90,6 @@
     "markdown-it-link-attributes": "catalog:",
     "markdown-it-task-lists": "^2.1.1",
     "parse-diff": "^0.11.1",
-    "pinia": "catalog:frontend",
     "reka-ui": "^2.5.0",
     "sanitize-html": "catalog:",
     "vue": "catalog:frontend",

--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.legacy.scss
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.legacy.scss
@@ -11,10 +11,15 @@
  * Usage:
  *   <N8nButton variant="solid" class="n8n-button--success">Save</N8nButton>
  *   <N8nButton variant="ghost" class="n8n-button--highlight">Info</N8nButton>
+ *
+ * Do not wrap these selectors in `:global()`. This file is `@use`d from
+ * Button.vue's plain (non-module) style block, where selectors are already
+ * global, so `:global()` is never transformed away — it ships as an invalid
+ * pseudo-class and browsers drop the whole rule.
  */
 
 /** @deprecated Use a semantic variant instead of success color */
-:global(.n8n-button--success) {
+.n8n-button--success {
 	--button--color--background: var(--color--success);
 	--button--color--background-hover: var(--color--success--shade-1);
 	--button--color--background-active: var(--color--success--shade-1);
@@ -31,7 +36,7 @@
 }
 
 /** @deprecated Use a semantic variant instead of warning color */
-:global(.n8n-button--warning) {
+.n8n-button--warning {
 	--button--color--background: var(--color--warning);
 	--button--color--background-hover: var(--color--warning--shade-1);
 	--button--color--background-active: var(--color--warning--shade-1);

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -111,6 +111,7 @@ export { default as N8nResizeWrapper } from './N8nResizeWrapper';
 export { default as N8nSelect } from './N8nSelect';
 export { default as N8nSpinner } from './N8nSpinner';
 export { default as N8nStatusDot } from './N8nStatusDot';
+export { default as N8nStepper } from './N8nStepper/Stepper.vue';
 export { default as N8nSticky } from './N8nSticky';
 export { default as N8nResizeableSticky } from './N8nResizeableSticky';
 export { default as N8nSuggestedActions } from './N8nSuggestedActions';

--- a/packages/frontend/@n8n/design-system/src/css/globalSelectorPlacement.test.ts
+++ b/packages/frontend/@n8n/design-system/src/css/globalSelectorPlacement.test.ts
@@ -1,0 +1,55 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * `:global()` is a CSS-Modules construct. It is only transformed away in a
+ * `<style module>` or `<style scoped>` block; anywhere else it survives into
+ * the emitted CSS as an invalid pseudo-class, which browsers respond to by
+ * dropping the whole rule (and lightningcss by warning). A standalone `.scss`
+ * can't know which kind of block will `@use` it, so it must not use `:global()`
+ * at all — the caller decides, and getting it wrong fails silently.
+ */
+
+const srcDir = resolve(process.cwd(), 'src');
+const styleBlock = /<style\b([^>]*)>([\s\S]*?)<\/style>/g;
+
+/** Only selectors matter here, so comments explaining this very rule shouldn't trip it. */
+const usesGlobal = (source: string) =>
+	source
+		.replace(/\/\*[\s\S]*?\*\//g, '')
+		.replace(/(^|\s)\/\/.*$/gm, '$1')
+		.includes(':global(');
+
+const allFiles = readdirSync(srcDir, { recursive: true, encoding: 'utf8' });
+
+const collect = (extension: string) => {
+	const files = allFiles.filter((file) => file.endsWith(extension));
+	// A wrong srcDir would make the assertions below vacuously pass.
+	expect(files.length).toBeGreaterThan(0);
+	return files.map((file) => [file, readFileSync(resolve(srcDir, file), 'utf8')] as const);
+};
+
+describe(':global() placement', () => {
+	it('is not used in .vue style blocks that do not transform it', () => {
+		const offenders: string[] = [];
+
+		for (const [file, source] of collect('.vue')) {
+			for (const [, attrs, body] of source.matchAll(styleBlock)) {
+				const transformed = /\bmodule\b/.test(attrs) || /\bscoped\b/.test(attrs);
+				if (!transformed && usesGlobal(body)) {
+					offenders.push(`${file} — <style${attrs}>`);
+				}
+			}
+		}
+
+		expect(offenders).toEqual([]);
+	});
+
+	it('is not used in standalone .scss files', () => {
+		const offenders = collect('.scss')
+			.filter(([, source]) => usesGlobal(source))
+			.map(([file]) => file);
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelLinearSetup.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelLinearSetup.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef } from 'vue';
-import { N8nButton, N8nIconButton, N8nInput, N8nText } from '@n8n/design-system';
-import N8nStepper from '@n8n/design-system/components/N8nStepper/Stepper.vue';
+import { N8nButton, N8nIconButton, N8nInput, N8nStepper, N8nText } from '@n8n/design-system';
 import type { ChatIntegrationDescriptor, AgentIntegrationSettings } from '@n8n/api-types';
 import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelSlackSetup.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelSlackSetup.vue
@@ -6,9 +6,9 @@ import {
 	N8nIcon,
 	N8nIconButton,
 	N8nInput,
+	N8nStepper,
 	N8nText,
 } from '@n8n/design-system';
-import N8nStepper from '@n8n/design-system/components/N8nStepper/Stepper.vue';
 import AgentChannelSlackSetupSnapshots from './AgentChannelSlackSetupSnapshots.vue';
 import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelTelegramSetup.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelTelegramSetup.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { N8nButton, N8nText } from '@n8n/design-system';
-import N8nStepper from '@n8n/design-system/components/N8nStepper/Stepper.vue';
+import { N8nButton, N8nStepper, N8nText } from '@n8n/design-system';
 import type { ChatIntegrationDescriptor, AgentIntegrationSettings } from '@n8n/api-types';
 import { useI18n } from '@n8n/i18n';
 import type { PermissionsRecord } from '@n8n/permissions';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5175,9 +5175,6 @@ importers:
       parse-diff:
         specifier: ^0.11.1
         version: 0.11.1
-      pinia:
-        specifier: catalog:frontend
-        version: 2.2.4(typescript@6.0.2)(vue@3.5.26(typescript@6.0.2))
       reka-ui:
         specifier: ^2.5.0
         version: 2.5.0(typescript@6.0.2)(vue@3.5.26(typescript@6.0.2))
@@ -5266,6 +5263,9 @@ importers:
       eslint-plugin-storybook:
         specifier: catalog:storybook
         version: 10.1.11(eslint@9.29.0(jiti@2.6.1))(storybook@10.1.11(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(utf-8-validate@5.0.10))(typescript@6.0.2)
+      pinia:
+        specifier: catalog:frontend
+        version: 2.2.4(typescript@6.0.2)(vue@3.5.26(typescript@6.0.2))
       postcss:
         specifier: 8.5.10
         version: 8.5.10


### PR DESCRIPTION
## Summary

Four standing defects in `@n8n/design-system`. **No artifact or resolution change** — `main` still points at `src/index.ts`, there is no `exports` map, and nothing about how any consumer resolves this package changes.

> [!IMPORTANT]
> **The commit body on this branch is superseded.** It says the legacy override classes "now apply at their intended specificity." That is false — measurement showed **0 of 512,000 pixels** change. The sentence survived two rounds of wrong framing before anyone measured; it is corrected here and dies at squash (this repo is squash-only with `squash_merge_commit_message = BLANK`), so it never reaches master's history. This body and the title are the authoritative description.

### 1. `Button.legacy.scss` shipped an invalid selector — build hygiene, zero pixels

`Button.legacy.scss` wrapped its two classes in `:global()`, but the file is `@use`d from `Button.vue`'s **plain** (non-module) `<style lang="scss">` block. `:global()` is a CSS-Modules construct: it is only transformed away in a `module` or `scoped` block. In a plain block nothing touches it, so it shipped verbatim as an invalid pseudo-class — and an unknown pseudo-class invalidates the selector, so browsers dropped the whole rule.

Removing the wrapper makes the rule parse and match. **It does not make it win.** Verified against the shipped `dist/design-system.css` — two rules set the same custom property, and both cascade tiebreakers go against the override:

| offset | specificity | selector | sets `--button--color--background` |
|---|---|---|---|
| 8,058 | **(0,1,0)** | `.n8n-button--success` | `var(--color--success)` → `#00a63e` |
| 18,754 | **(0,2,0)** | `._button_1vddc_268._solid_1vddc_350` | `var(--background--brand)` → `#ff6900` |

Lower specificity *and* earlier in source order. The `:disabled` / `[aria-disabled]` variant is (0,2,0) — it ties, and still loses on source order. So the V2 button refactor had already killed this override; the `:global()` wrapper was a second, independent cause of death. Removing one cause leaves the other standing.

Measured end-to-end by `@filter`: both real banners mounted through editor-ui's own Vite pipeline at this PR's head, then `Button.legacy.scss` swapped between master and PR and the page re-measured.

| | master (`:global()` present) | this PR (wrapper dropped) |
|---|---|---|
| wrapper in emitted CSS | yes | no |
| plain `.n8n-button--success` rule in emitted CSS | no | yes |
| button background, light | `#ff6900` | `#ff6900` |
| button background, dark | `#ff6900` | `#ff6900` |
| pixel diff (1280×400) | — | **0 / 512,000** |

The CSS text changed. The pixels did not. Enabled, `:disabled` and `[aria-disabled=true]` all verified unchanged.

**What this PR actually buys**, and the reason to do it: `dist/design-system.css` goes from **6** occurrences of `:global(` to **0**, and the build from **6** `[lightningcss minify] 'global' is not recognized` warnings to **0**. That unblocks any consumer that minifies our CSS — which is exactly how `@n8n/mcp-apps#build` failed during the spike. Strict improvement, no UI change.

`n8n-button--success` is now confirmed dead at both its call sites (`EmailConfirmationBanner.vue:46`, `TrialOverBanner.vue:22`) and `n8n-button--warning` has no call sites. Whether those classes should be revived, redefined or deleted is **N8N-129**, not this PR.

Audited the package rather than fixing just this file: all 24 `.vue` files using `:global()` have it inside a `module` block, including the three with both block types (Button, MarkdownEditor, Sticky). `Button.legacy.scss` was the only offender and the only standalone `.scss` with it. `globalSelectorPlacement.test.ts` enforces that for both shapes.

### 2. Removed the top-level `import` field from `package.json`

Not a valid manifest field. It has never done anything.

### 3. `pinia` → `devDependencies`

It appears only in three test files.

### 4. `N8nStepper` exported from the public index

Three editor-ui sites reached it by deep import because it was never exported. All three now use the root import; zero deep imports of it remain.

## How to test

This is a build-output change. There is nothing to look at in the UI — the two banners render identically before and after, which is the measured result above, not an assumption.

```bash
pnpm install
pnpm turbo run build --filter=@n8n/design-system --force
```

- Build log has no `[lightningcss minify] 'global' is not recognized` warnings.
- `grep -c ':global(' packages/frontend/@n8n/design-system/dist/design-system.css` → `0`.

Consumers that minify our CSS — note `--force`, or you are testing the turbo cache:

```bash
pnpm turbo run build --filter=@n8n/mcp-apps --filter=@n8n/mcp-browser-extension --force
pnpm turbo run typecheck --filter=n8n-editor-ui --filter=@n8n/storybook --filter=@n8n/design-system --force
```

To reproduce the cascade result yourself, in `dist/design-system.css` compare the two rules that set `--button--color--background` at offsets 8,058 and 18,754.

Guard test, and proof it isn't a tautology:

```bash
cd packages/frontend/@n8n/design-system
pnpm vitest run src/css/globalSelectorPlacement.test.ts     # green
git stash push -- src/components/N8nButton/Button.legacy.scss
pnpm vitest run src/css/globalSelectorPlacement.test.ts     # red, names the file
git stash pop
```

## Verification run locally

All with `--force`, so nothing was served from the turbo cache:

| Check | Result |
|---|---|
| `@n8n/design-system` build | green · 0 lightningcss warnings · 0 `:global(` in `dist` |
| `@n8n/mcp-apps` + `@n8n/mcp-browser-extension` build | green |
| typecheck — design-system, editor-ui, storybook | 0 errors |
| design-system tests | 119 files pass (118 + the new guard) |
| editor-ui `src/features/agents` tests | 102 files / 981 tests pass |
| lint · lint:styles · format:check | clean |
| rendered pixels at both call sites | **0 / 512,000 differ** (measured by `@filter`) |
| CSS bundle | +1,161 B raw / +157 B gzip — Stepper's styles entering the bundle via the new export |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-121

Step 1 of 7 toward publishing `@n8n/design-system` (parent N8N-110). Spike PR #35108 is reference only — do not merge.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
