### PR TITLE
fix: Publish named prop declarations for three design-system components (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/ConditionalRouterLink/CondtionalRouterLink.vue
+++ b/packages/frontend/@n8n/design-system/src/components/ConditionalRouterLink/CondtionalRouterLink.vue
@@ -4,9 +4,12 @@
  * just the slot content based on whether the `to` or `href` prop is
  * passed or not.
  */
-import type { PropType } from 'vue';
 import { useAttrs } from 'vue';
-import type { RouterLinkProps } from 'vue-router';
+import type {
+	RouteLocationAsPathGeneric,
+	RouteLocationAsRelativeGeneric,
+	RouterLinkProps,
+} from 'vue-router';
 import { RouterLink } from 'vue-router';
 
 defineOptions({
@@ -15,26 +18,31 @@ defineOptions({
 });
 
 /**
- * Declared explicitly rather than spread from `RouterLink.props`, which is
- * typed as `any` and so collapsed this component's whole props type to `{}` in
- * the emitted declarations. Mirrors RouterLink's runtime prop declarations
- * exactly, except that `to` is optional here — without it the component falls
- * back to an `<a>` or to the bare slot.
+ * Declared here rather than spread from `RouterLink.props`, which is typed as
+ * `any` and so collapsed this component's whole props type to `{}` in the
+ * emitted declarations. Mirrors RouterLink's runtime prop declarations exactly,
+ * except that `to` is optional — without it the component falls back to an
+ * `<a>` or to the bare slot.
  */
-const props = defineProps({
-	to: {
-		type: [String, Object] as PropType<RouterLinkProps['to'] | undefined>,
-		default: undefined,
-	},
-	replace: Boolean,
-	activeClass: String,
-	exactActiveClass: String,
-	custom: Boolean,
-	ariaCurrentValue: {
-		type: String as PropType<RouterLinkProps['ariaCurrentValue']>,
-		default: 'page',
-	},
+type Props = {
+	/**
+	 * `RouteLocationRaw` expanded by hand. It is a conditional type, which Vue's
+	 * compile-time resolver cannot evaluate — leaving `to` with no runtime prop
+	 * type at all. This union is what it resolves to without typed routes, and
+	 * regenerates the original `[String, Object]`.
+	 */
+	to?: string | RouteLocationAsRelativeGeneric | RouteLocationAsPathGeneric;
+	replace?: boolean;
+	activeClass?: string;
+	exactActiveClass?: string;
+	custom?: boolean;
+	ariaCurrentValue?: RouterLinkProps['ariaCurrentValue'];
 	// <a> element "props" are passed as attributes
+};
+
+const props = withDefaults(defineProps<Props>(), {
+	to: undefined,
+	ariaCurrentValue: 'page',
 });
 const attrs = useAttrs();
 </script>

--- a/packages/frontend/@n8n/design-system/src/components/ConditionalRouterLink/CondtionalRouterLink.vue
+++ b/packages/frontend/@n8n/design-system/src/components/ConditionalRouterLink/CondtionalRouterLink.vue
@@ -4,6 +4,7 @@
  * just the slot content based on whether the `to` or `href` prop is
  * passed or not.
  */
+import type { PropType } from 'vue';
 import { useAttrs } from 'vue';
 import type { RouterLinkProps } from 'vue-router';
 import { RouterLink } from 'vue-router';
@@ -13,16 +14,28 @@ defineOptions({
 	inheritAttrs: false,
 });
 
+/**
+ * Declared explicitly rather than spread from `RouterLink.props`, which is
+ * typed as `any` and so collapsed this component's whole props type to `{}` in
+ * the emitted declarations. Mirrors RouterLink's runtime prop declarations
+ * exactly, except that `to` is optional here — without it the component falls
+ * back to an `<a>` or to the bare slot.
+ */
 const props = defineProps({
-	// @ts-expect-error TS doesn't understand this but it works
-	...RouterLink.props,
-	// Make to optional
 	to: {
-		type: [String, Object] as unknown as () => string | RouterLinkProps['to'] | undefined,
+		type: [String, Object] as PropType<RouterLinkProps['to'] | undefined>,
 		default: undefined,
 	},
+	replace: Boolean,
+	activeClass: String,
+	exactActiveClass: String,
+	custom: Boolean,
+	ariaCurrentValue: {
+		type: String as PropType<RouterLinkProps['ariaCurrentValue']>,
+		default: 'page',
+	},
 	// <a> element "props" are passed as attributes
-}) as Partial<RouterLinkProps>;
+});
 const attrs = useAttrs();
 </script>
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nSelect/Select.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSelect/Select.vue
@@ -8,8 +8,23 @@ import { isEventBindingElementAttribute } from '../../utils';
 
 type InnerSelectRef = InstanceType<typeof ElSelect>;
 
+/**
+ * `ElSelect.props` is typed as `any`, and spreading `any` collapses this whole
+ * object literal to `any` — which is why the emitted declarations published no
+ * prop names for this component. Casting the spread to element-plus' own
+ * resolved prop types restores the names. The cast is erased at build time, so
+ * the runtime prop declarations remain exactly the spread: every prop
+ * element-plus accepts is still declared here, and still forwarded.
+ */
+type ElSelectPropsOptions = {
+	[K in Exclude<
+		keyof InnerSelectRef['$props'],
+		`on${string}` | 'key' | 'ref' | 'ref_for' | 'ref_key' | 'class' | 'style'
+	>]-?: { type: PropType<InnerSelectRef['$props'][K]> };
+};
+
 const props = defineProps({
-	...ElSelect.props,
+	...(ElSelect.props as ElSelectPropsOptions),
 	modelValue: {},
 	size: {
 		type: String as PropType<SelectSize>,

--- a/packages/frontend/@n8n/design-system/src/v2/components/Select/Select.types.ts
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Select/Select.types.ts
@@ -10,7 +10,12 @@ import type {
 
 type VueCssClass = undefined | string | Record<string, boolean> | Array<string | VueCssClass>;
 
-export type SelectItemProps = {
+/**
+ * The props `N8nSelect2Item` declares. Kept free of the index signature below
+ * so the emitted declarations name them — a component typed with an index
+ * signature publishes no prop names at all.
+ */
+export type SelectItemBaseProps = {
 	label?: string;
 	/**
 	 * The item type.
@@ -23,6 +28,13 @@ export type SelectItemProps = {
 	icon?: IconName;
 	class?: VueCssClass;
 	strokeWidth?: number;
+};
+
+/**
+ * An entry in `N8nSelect2`'s `items`. Open by design: callers attach their own
+ * payload and read it back in the item slots.
+ */
+export type SelectItemProps = SelectItemBaseProps & {
 	[key: string]: unknown;
 };
 

--- a/packages/frontend/@n8n/design-system/src/v2/components/Select/SelectItem.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Select/SelectItem.vue
@@ -1,13 +1,22 @@
 <script setup lang="ts">
-import { SelectItem, SelectItemIndicator, SelectItemText, type AcceptableValue } from 'reka-ui';
+// Aliased: this SFC is itself named `SelectItem`, so an unaliased import leaves
+// `<SelectItem>` in the template ambiguous with the component's own
+// self-reference. Runtime always picked reka-ui's, but the type checker resolved
+// it to this component's own props during declaration emit.
+import {
+	SelectItem as RekaSelectItem,
+	SelectItemIndicator,
+	SelectItemText,
+	type AcceptableValue,
+} from 'reka-ui';
 import { computed, useCssModule } from 'vue';
 
 import Icon from '@n8n/design-system/components/N8nIcon/Icon.vue';
 
-import type { SelectItemProps, SelectValue } from './Select.types';
+import type { SelectItemBaseProps, SelectValue } from './Select.types';
 
 defineOptions({ inheritAttrs: false });
-const props = defineProps<SelectItemProps>();
+const props = defineProps<SelectItemBaseProps>();
 const $style = useCssModule();
 
 function isAcceptable(value?: SelectValue) {
@@ -25,7 +34,7 @@ const trailingProps = computed(() => ({
 </script>
 
 <template>
-	<SelectItem
+	<RekaSelectItem
 		:disabled="props.disabled"
 		:value="isAcceptable(props.value)"
 		:class="props.class"
@@ -45,7 +54,7 @@ const trailingProps = computed(() => ({
 		<SelectItemIndicator as-child>
 			<Icon icon="check" :class="$style.itemIndicator" />
 		</SelectItemIndicator>
-	</SelectItem>
+	</RekaSelectItem>
 </template>
 
 <style module>

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/MCPWorkflowsSelect.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/MCPWorkflowsSelect.vue
@@ -2,7 +2,7 @@
 import { useMCPStore } from '@/features/ai/mcpAccess/mcp.store';
 import { LOADING_INDICATOR_TIMEOUT } from '@/features/ai/mcpAccess/mcp.constants';
 import { N8nSelect, N8nOption } from '@n8n/design-system';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, useCssModule } from 'vue';
 import type { WorkflowListItem } from '@/Interface';
 import WorkflowLocation from '@/features/ai/mcpAccess/components/WorkflowLocation.vue';
 import { useI18n } from '@n8n/i18n';
@@ -35,6 +35,19 @@ let loadingTimeoutId: ReturnType<typeof setTimeout> | null = null;
 const showEmptyState = computed(() => {
 	return !isLoading.value && hasFetched.value && workflowOptions.value.length === 0;
 });
+
+const $style = useCssModule();
+
+// `popper-class` is a string prop, so the classes are joined here rather than
+// passed as an object binding.
+const popperClass = computed(() =>
+	[
+		isLoading.value ? $style['mcp-workflows-select-loading'] : '',
+		showEmptyState.value ? $style['mcp-workflows-select-empty'] : '',
+	]
+		.filter(Boolean)
+		.join(' '),
+);
 
 async function searchWorkflows(query?: string) {
 	if (loadingTimeoutId) {
@@ -111,10 +124,7 @@ defineExpose({
 			:remote="true"
 			:remote-method="searchWorkflows"
 			size="medium"
-			:popper-class="{
-				[$style['mcp-workflows-select-loading']]: isLoading,
-				[$style['mcp-workflows-select-empty']]: showEmptyState,
-			}"
+			:popper-class="popperClass"
 			@visible-change="onVisibleChange"
 		>
 			<N8nOption v-if="showEmptyState" value="" disabled :class="$style['empty-option']">


### PR DESCRIPTION
> **Closed as superseded — not abandoned.** Every change in this PR landed on
> `master` via #35447 (merged 2026-08-04): `ElSelectPropsOptions`,
> `SelectItemBaseProps`, the `RekaSelectItem` alias and the `popperClass` string
> fix. Re-applying them here produced a duplicate `type ElSelectPropsOptions`
> block, which is why `mergeStateStatus` went `DIRTY`.
>
> The one piece `master` did *not* have — the type-based `defineProps`
> conversion for `ConditionalRouterLink` — continues in **#35604**, cut fresh
> off `master`. Branch retained; nothing here is lost.

---

## Summary

Three of the 157 `@n8n/design-system` components emitted `DefineComponent<{}>` in their declarations — empty props — so external consumers get no prop names and no autocomplete on `N8nSelect`, `ConditionalRouterLink` or `N8nSelect2Item`. Pre-existing source debt, surfaced only because the package is being prepared to ship declarations anyone reads.

**The root cause is not the same for all three.** The issue described them as one "`...Foo.props` spread family with an index signature"; measurement says otherwise:

| Component | Root cause | Fix |
|---|---|---|
| `N8nSelect` | `ElSelect.props` is typed **`any`**, and spreading `any` collapses the whole `defineProps` object literal to `any` | Keep the runtime spread, cast it to element-plus' own resolved prop types |
| `ConditionalRouterLink` | `RouterLink.props` is typed **`any`** (hence the `@ts-expect-error` that was sitting on it) | Declare its six props explicitly, type-based |
| `N8nSelect2Item` | `SelectItemProps` carried an **index signature**, which publishes no names | Split the type — see below |

### Prop declaration style

`ConditionalRouterLink` now uses `withDefaults(defineProps<Props>(), { … })`, matching the 115 components in this package that already do. It was one of only three left on the runtime object form.

That conversion is **not** cosmetic — type-based declaration regenerates the runtime props from the types. Declaring `to` as `RouterLinkProps['to']` resolves to `RouteLocationRaw`, a *conditional* type that Vue's compile-time resolver cannot evaluate; it silently emitted **no runtime prop type at all**, dropping `[String, Object]`. `to` is therefore declared as the union `RouteLocationRaw` expands to without typed routes (`string | RouteLocationAsRelativeGeneric | RouteLocationAsPathGeneric`), which regenerates the original type. The repo has no `RouteMap` augmentation, so that union is exactly equivalent here.

`N8nSelect` stays on the runtime form. **Measured, not assumed:**

- The SFC compiler rejects mixing the forms outright — `[@vue/compiler-sfc] defineProps() cannot accept both type and non-type arguments at the same time. Use one or the other.` So keeping the spread rules out a type argument.
- Type-based declaration generates only `{ type, required, default }` — inspecting the compiler output for a type-based component shows no `validator` key is ever produced. So converting would drop the `tagType` validator element-plus declares, which is a runtime prop change.

(One correction worth recording: element-plus validates `size` *and* `tagType`, but this component already overrides `size` without a validator, so exactly **one** validator survives today, not two.)

### Why `N8nSelect` keeps the spread at all

Faithfully hand-enumerating element-plus' 40 props would mean duplicating two `validator` functions and two defaults that are element-plus icon *components* (`clearIcon` → `CircleClose`, `suffixIcon` → `ArrowDown`), which would add `@element-plus/icons-vue` as a new dependency and silently drift on every element-plus upgrade. Casting the spread instead is erased at build time, so the runtime prop declarations stay exactly the spread — every prop element-plus accepts is still declared and still forwarded — while the emitted type gains real names.

### Why `SelectItemProps` is split, not narrowed

Call sites deliberately extend it and read the extra keys back in slots (`RoleSelectItem extends SelectItemProps { role, requiresUpgrade }`, then `<N8nSelect2Item v-bind="item">`). So the open type stays open:

- `SelectItemBaseProps` — the named props the component declares.
- `SelectItemProps = SelectItemBaseProps & { [key: string]: unknown }` — an entry in `items`, still open for caller payloads.

The index signature contributed **zero** runtime props (Vue cannot enumerate one), so this is a type-only change. It was already type-based (`defineProps<SelectItemBaseProps>()`) with no defaults to supply, so it is left alone.

## Evidence

**No change to accepted runtime props.** Each component's `props` option was dumped before and after and diffed — `42 / 6 / 8` props, identical key sets, types, defaults, `required` flags and validators. Re-run from scratch after the `withDefaults` conversion, since type-based declaration regenerates them: still identical, `to` still `[String, Object]`.

**Emitted declarations.** `ConditionalRouterLink` verified end-to-end:

```diff
-declare const __VLS_component: DefineComponent<{}, …>
+declare const __VLS_component: DefineComponent<Props, …>
+// with, emitted alongside:
+type Props = {
+    to?: string | RouteLocationAsRelativeGeneric | RouteLocationAsPathGeneric;
+    replace?: boolean;
+    activeClass?: string;
+    exactActiveClass?: string;
+    custom?: boolean;
+    ariaCurrentValue?: RouterLinkProps['ariaCurrentValue'];
+};
```

`N8nSelect2Item` emits `DefineComponent<SelectItemBaseProps, …>` with all eight props named.

**Deferred, and why —** master has no declaration pipeline yet (that is step 2 of the publication work), so two criteria cannot be closed here:

- `N8nSelect`'s declaration still does not emit at all, blocked by a pre-existing `TS7056` (`inferred type … exceeds the maximum length the compiler will serialize`) on the component type. **Verified independent of this PR:** the failure is present with *and* without this change, and is not cleared by the template-ref/`defineExpose` fixes scoped for step 2 either. Its props-object type is now precisely named, which is the input the emit needs; the emit itself needs an explicit annotation that belongs with the pipeline work.
- The "bogus-prop probe errors from the packed tarball" criterion needs the published declarations, so it stays open until the pipeline lands.

## Two latent defects this surfaced

Both were invisible only because the types were `any`:

1. **`SelectItem.vue` imported reka-ui's `SelectItem` unaliased**, leaving `<SelectItem>` in its own template ambiguous with the SFC's self-reference. Runtime always resolved reka-ui's — it renders and its tests pass — but the type checker resolved it to *this component's own props* during declaration emit. Now imported as `RekaSelectItem`.
2. **`MCPWorkflowsSelect` passed an object to `:popper-class`**, which is declared `{ type: String }`. Joined into a space-separated string; same classes land on the dropdown, minus a dev-mode prop-validation warning.

⚠️ Defect 2 is a change to a call site outside the design system. It is the only one in the repo — `editor-ui` typecheck is 0 errors on master and 0 errors here.

## How to test

No user-visible behaviour should change; this is a typing fix.

```bash
pnpm --filter @n8n/design-system typecheck   # 0 errors
pnpm --filter @n8n/design-system lint        # clean
pnpm --filter @n8n/design-system test        # 118 files, 1385 tests
pnpm --filter n8n-editor-ui typecheck        # 0 errors
pnpm --filter @n8n/storybook typecheck       # 0 errors
```

Manually: open Settings → MCP, connect workflows, and confirm the dropdown still shows its loading and empty states with the right styling. `ConditionalRouterLink` is exercised through the navigation dropdown — check that menu items with and without a route still render as links, anchors and plain content respectively.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Note on tests: no new test is included. The change is type-only with provably identical runtime props, and the existing suites for all four touched components pass unchanged (`ConditionalRouterLink`, `N8nSelect`, `v2/Select`, `MCPWorkflowsSelect`). The regression guard that would have real value here — asserting the declarations name their props — requires the declaration pipeline from step 2 and belongs with it.

🤖 PR Summary generated by AI

