### PR TITLE
refactor(editor): Repoint useStyles imports to `@n8n/composables` and remove the `@/app shim` (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/App.vue
+++ b/packages/frontend/editor-ui/src/app/App.vue
@@ -22,7 +22,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import axios from 'axios';
 import { computed, onMounted, provide, ref, shallowRef, watch } from 'vue';
 import { useRoute } from 'vue-router';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 import { useExposeCssVar } from '@/app/composables/useExposeCssVar';
 import { useFloatingUiOffsets } from '@/app/composables/useFloatingUiOffsets';
 import { useWorkflowId } from '@/app/composables/useWorkflowId';

--- a/packages/frontend/editor-ui/src/app/components/Modal.vue
+++ b/packages/frontend/editor-ui/src/app/components/Modal.vue
@@ -4,7 +4,7 @@ import type { EventBus } from '@n8n/utils/event-bus';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { ModalKey } from '@/Interface';
 import { APP_MODALS_ELEMENT_ID } from '@/app/constants';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 
 import { ElDialog } from 'element-plus';
 import { N8nHeading, N8nSpinner } from '@n8n/design-system';

--- a/packages/frontend/editor-ui/src/app/components/NpsSurvey.vue
+++ b/packages/frontend/editor-ui/src/app/components/NpsSurvey.vue
@@ -8,7 +8,7 @@ import { ref, computed, watch } from 'vue';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 
 import { N8nButton, N8nHeading, N8nInput, N8nText } from '@n8n/design-system';
 const props = defineProps<{

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
@@ -3,7 +3,7 @@ import { N8nCommandBar } from '@n8n/design-system';
 import { computed, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { VIEWS } from '@/app/constants';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 import { useCommandBar } from '@/features/shared/commandBar/composables/useCommandBar';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { commandBarEventBus } from '@/features/shared/commandBar/commandBar.eventBus';

--- a/packages/frontend/editor-ui/src/app/composables/useStyles.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useStyles.ts
@@ -1,9 +1,0 @@
-/**
- * @deprecated Import from `@n8n/composables/useStyles` instead.
- *
- * Temporary compatibility shim for the frontend modularization effort
- * (CAT-3686). The composable now lives in `@n8n/composables`; this re-export
- * keeps existing call sites working while they are migrated per-directory.
- * Remove once all consumers import from the package directly. (N8N-64)
- */
-export { useStyles } from '@n8n/composables/useStyles';

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from '@n8n/i18n';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import { useBuilderStore } from '../../builder.store';
 import { useChatPanelStore } from '../../chatPanel.store';

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -34,7 +34,7 @@ import { usePinnedData } from '@/app/composables/usePinnedData';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useI18n } from '@n8n/i18n';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
 import { nodeViewEventBus } from '@/app/event-bus';
 import { ElDialog } from 'element-plus';

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -20,7 +20,7 @@ import { useNdvLayout } from '../../panel/composables/useNdvLayout';
 import { useNodeDocsUrl } from '@/app/composables/useNodeDocsUrl';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { usePinnedData } from '@/app/composables/usePinnedData';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import {

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/components/ContextMenu.vue
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/components/ContextMenu.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useContextMenu } from '../composables/useContextMenu';
 import { isFocusHandoffAction, type ContextMenuAction } from '../composables/useContextMenuItems';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 import { nextTick, ref, watch } from 'vue';
 import {
 	ContextMenuContent,

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
@@ -9,7 +9,7 @@ import ExpressionOutput from './ExpressionOutput.vue';
 import OutputItemSelect from './OutputItemSelect.vue';
 import InlineExpressionTip from './InlineExpressionTip.vue';
 import { outputTheme } from './theme';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 
 import { N8nPopover, N8nText } from '@n8n/design-system';
 interface InlineExpressionEditorOutputProps {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue
@@ -3,7 +3,7 @@ import InputPanel from '@/features/ndv/panel/components/InputPanel.vue';
 import type { INodeUi } from '@/Interface';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { onBeforeUnmount, watch, computed, ref, useTemplateRef } from 'vue';
-import { useStyles } from '@/app/composables/useStyles';
+import { useStyles } from '@n8n/composables/useStyles';
 import {
 	onClickOutside,
 	useElementHover,


### PR DESCRIPTION
## Summary

Completes the strangler started in N8N-64 (#34856): `useStyles` moved into `@n8n/composables` behind a thin `@/app` re-export shim so call sites did not have to change during the move. This repoints every consumer at the real package path and deletes the shim.

- 10 call sites: `import { useStyles } from '@/app/composables/useStyles'` → `'@n8n/composables/useStyles'`
- Deleted `packages/frontend/editor-ui/src/app/composables/useStyles.ts` (the shim and its `@deprecated`/CAT-3686 note)

Pure import-path swap — one line per file, no reordering (the repo has no import-order rule: `organizeImports` is off and there is no `import/order` lint rule). No behaviour change; types resolve identically.

**Enumerated on master `c9234737`** — a repo-wide grep for `composables/useStyles` now returns zero references to the old path (the only remaining mention is the doc comment in `@n8n/frontend-constants/src/z-indexes.ts`, which already points at the new path). No relative-path importers, no `vi.mock` of the shim path, no barrel re-export, no reference in `.github/test-metrics/e2e-impact-map.json`.

**Shim-delete safety check.** Swept all 1064 open PRs: none add a `composables/useStyles` import line, and none touch the shim file. Eight open PRs touch one of the ten consumer files (#34739, #31392, #30384, #24059, #27099, #28688, #29442, #29642) — all unrelated to the modularization wave, and each conflict would be a one-line import rebase. The one open wave PR, #35142 (N8N-70), touches six files, none of them a `useStyles` consumer.

### Consumers repointed

| File |
| --- |
| `src/app/App.vue` |
| `src/app/components/Modal.vue` |
| `src/app/components/NpsSurvey.vue` |
| `src/app/components/app/AppCommandBar.vue` |
| `src/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue` |
| `src/features/ndv/shared/views/NodeDetailsView.vue` |
| `src/features/ndv/shared/views/NodeDetailsViewV2.vue` |
| `src/features/shared/contextMenu/components/ContextMenu.vue` |
| `src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue` |
| `src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue` |

## How to test

Nothing to click — this is behaviour-neutral. Verified locally on `fb875857`:

```
pnpm --filter n8n-editor-ui typecheck            # exit 0
pnpm --filter @n8n/composables test              # 13 files / 86 tests passed
pnpm --filter n8n-editor-ui test <4 affected>    # 4 files / 21 tests passed
npx eslint --quiet <the 10 changed files>        # exit 0
```

Affected component tests run: `NodeDetailsView.test.ts`, `NodeDetailsViewV2.test.ts`, `InlineExpressionEditorOutput.test.ts`, `ExperimentalEmbeddedNdvMapper.test.ts`. The other six consumers have no test file.

The one runtime surface worth an eye in review: `App.vue` calls `setAppZIndexes()` on mount, which writes the `--*--z` CSS custom properties. Same function, same module — the import specifier is the only thing that changed.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #34856. Part of the CAT-3686 frontend modularization wave.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — n/a, internal import path
- [x] Tests included. — n/a, no new behaviour; existing suites cover the call sites
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35149">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

