### PR TITLE
fix(editor): Preserve line breaks in multiline secret credential fields

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -3465,6 +3465,34 @@ describe('CredentialsService', () => {
 		});
 	});
 
+	describe('unredact (field-level sentinel restore)', () => {
+		const saved = {
+			privateKey: '-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----',
+		};
+
+		it('should restore the saved value for an exact blanking sentinel', () => {
+			const result = service.unredact({ privateKey: CREDENTIAL_BLANKING_VALUE }, saved);
+			expect(result.privateKey).toBe(saved.privateKey);
+		});
+
+		it('should restore the saved value when the sentinel was switched to expression mode', () => {
+			// Toggling a redacted field to expression mode prepends `=`; the saved
+			// key must still be restored instead of persisting the sentinel.
+			const result = service.unredact({ privateKey: `=${CREDENTIAL_BLANKING_VALUE}` }, saved);
+			expect(result.privateKey).toBe(saved.privateKey);
+		});
+
+		it('should restore the saved value for an expression-prefixed empty sentinel', () => {
+			const result = service.unredact({ privateKey: `=${CREDENTIAL_EMPTY_VALUE}` }, saved);
+			expect(result.privateKey).toBe(saved.privateKey);
+		});
+
+		it('should keep a genuine new value that is not a sentinel', () => {
+			const result = service.unredact({ privateKey: '={{ $secrets.key }}' }, saved);
+			expect(result.privateKey).toBe('={{ $secrets.key }}');
+		});
+	});
+
 	describe('checkCredentialData', () => {
 		const testProjectId = 'test-project-id';
 

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -1311,7 +1311,11 @@ export class CredentialsService {
 	private unredactRestoreValues(unmerged: any, replacement: any) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		for (const [key, value] of Object.entries(unmerged)) {
-			if (value === CREDENTIAL_BLANKING_VALUE || value === CREDENTIAL_EMPTY_VALUE) {
+			// Strip a leading `=`: switching a redacted field to expression mode
+			// prepends it to the sentinel, which would otherwise defeat the match
+			// and persist the sentinel as the real value.
+			const sentinel = typeof value === 'string' && value.startsWith('=') ? value.slice(1) : value;
+			if (sentinel === CREDENTIAL_BLANKING_VALUE || sentinel === CREDENTIAL_EMPTY_VALUE) {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 				unmerged[key] = replacement[key];
 			} else if (

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.test.ts
@@ -123,6 +123,32 @@ describe('components/N8nInput', () => {
 			const container = wrapper.container.querySelector('div > div');
 			expect(container?.className).not.toContain('ph-no-capture');
 		});
+
+		it('should mask a textarea and add ph-no-capture when masked', () => {
+			const wrapper = render(Input, {
+				props: {
+					type: 'textarea',
+					masked: true,
+				},
+			});
+			const textarea = wrapper.container.querySelector('textarea');
+			expect(textarea).toBeInTheDocument();
+			expect(textarea?.className).toContain('masked');
+			const container = wrapper.container.querySelector('div > div');
+			expect(container?.className).toContain('ph-no-capture');
+		});
+
+		it('should not mask a plain textarea', () => {
+			const wrapper = render(Input, {
+				props: {
+					type: 'textarea',
+				},
+			});
+			const textarea = wrapper.container.querySelector('textarea');
+			expect(textarea?.className).not.toContain('masked');
+			const container = wrapper.container.querySelector('div > div');
+			expect(container?.className).not.toContain('ph-no-capture');
+		});
 	});
 
 	describe('v-model', () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.types.ts
@@ -19,6 +19,9 @@ export interface InputProps {
 	readonly?: boolean;
 	clearable?: boolean;
 	rows?: number;
+	// Masks a textarea's content (dots) for secrets that span multiple lines,
+	// where <input type="password"> can't be used because it strips newlines.
+	masked?: boolean;
 	maxlength?: number;
 	autosize?: boolean | { minRows?: number; maxRows?: number };
 	autofocus?: boolean;

--- a/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInput/Input.vue
@@ -20,6 +20,7 @@ const props = withDefaults(defineProps<InputProps>(), {
 	readonly: false,
 	clearable: false,
 	rows: 2,
+	masked: false,
 	maxlength: undefined,
 	autosize: false,
 	autofocus: false,
@@ -90,7 +91,7 @@ const containerClasses = computed(() => [
 		[$style.hasPrepend]: !!slots.prepend,
 		[$style.hasAppend]: !!slots.append,
 		[$style.isTextarea]: isTextarea.value,
-		'ph-no-capture': props.type === 'password',
+		'ph-no-capture': props.type === 'password' || props.masked,
 	},
 ]);
 
@@ -226,7 +227,7 @@ defineExpose({ focus, blur, select });
 				v-else
 				ref="inputRef"
 				:value="modelValue ?? ''"
-				:class="[$style.input, $style.textarea]"
+				:class="[$style.input, $style.textarea, { [$style.masked]: masked }]"
 				:placeholder="placeholder"
 				:disabled="disabled"
 				:readonly="readonly"
@@ -442,6 +443,14 @@ defineExpose({ focus, blur, select });
 .textarea:disabled {
 	cursor: not-allowed;
 	color: var(--color--text--tint-1);
+}
+
+/* Masks a multiline secret (e.g. a PEM private key) as dots via
+   -webkit-text-security (supported in Chromium, Safari, and Firefox 114+).
+   Display-only: the real value is never re-sent to the client (backend
+   redaction), and this masks rendering, not copy/paste. */
+.masked {
+	-webkit-text-security: disc;
 }
 
 .prefix,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -1513,6 +1513,49 @@ describe('ParameterInput.vue', () => {
 		});
 	});
 
+	describe('multi-line masked (password) fields', () => {
+		test('renders a masked textarea (not a single-line password input) for a multi-line secret', async () => {
+			const { container } = renderComponent({
+				props: {
+					path: 'privateKey',
+					parameter: createTestNodeProperties({
+						displayName: 'Private Key',
+						name: 'privateKey',
+						type: 'string',
+						typeOptions: { rows: 4, password: true },
+					}),
+					modelValue: '',
+				},
+			});
+
+			await nextTick();
+			// A single-line <input type="password"> strips newlines and corrupts keys.
+			expect(container.querySelector('input[type="password"]')).not.toBeInTheDocument();
+			expect(container.querySelector('textarea')).toBeInTheDocument();
+			// Kept out of PostHog capture even in a node (non-credential) context.
+			expect(container.querySelector('.ph-no-capture')).toBeInTheDocument();
+		});
+
+		test('still renders a single-line password input for a single-line secret', async () => {
+			const { container } = renderComponent({
+				props: {
+					path: 'passphrase',
+					parameter: createTestNodeProperties({
+						displayName: 'Passphrase',
+						name: 'passphrase',
+						type: 'string',
+						typeOptions: { password: true },
+					}),
+					modelValue: '',
+				},
+			});
+
+			await nextTick();
+			expect(container.querySelector('input[type="password"]')).toBeInTheDocument();
+			expect(container.querySelector('textarea')).not.toBeInTheDocument();
+		});
+	});
+
 	describe('sqlEditor sizing (ADO-5553)', () => {
 		// Converts a CSS length ('40vh' | '53.3em' | '120px') to pixels using the
 		// current jsdom viewport, so a min-height in `em` can be compared against a

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -547,12 +547,16 @@ const dependentParametersValues = computedAsync(async () => {
 }, null);
 
 const getStringInputType = computed(() => {
+	const rows = editorRows.value;
+	const isMultiline = rows !== undefined && rows > 1;
+
 	if (getTypeOption('password') === true) {
-		return 'password';
+		// A multiline masked field must be a textarea: a single-line
+		// <input type="password"> strips newlines and corrupts pasted keys.
+		return isMultiline ? 'textarea' : 'password';
 	}
 
-	const rows = editorRows.value;
-	if (rows !== undefined && rows > 1) {
+	if (isMultiline) {
 		return 'textarea';
 	}
 
@@ -562,6 +566,12 @@ const getStringInputType = computed(() => {
 
 	return 'text';
 });
+
+// A password field rendered as a textarea (multiline secret) still needs to be
+// visually masked and kept out of PostHog capture.
+const isMaskedTextarea = computed(
+	() => getStringInputType.value === 'textarea' && getTypeOption('password') === true,
+);
 
 const getIssues = computed<string[]>(() => {
 	const validationError = jsonValidationError.value;
@@ -741,7 +751,9 @@ const remoteParameterOptionsKeys = computed<string[]>(() => {
 });
 
 const shouldRedactValue = computed<boolean>(() => {
-	return getStringInputType.value === 'password' || props.isForCredential;
+	// Keyed off the field being a password (not the rendered control type) so a
+	// multiline masked field stays redacted even outside credential contexts.
+	return getTypeOption('password') === true || props.isForCredential;
 });
 
 const isCodeNode = computed(
@@ -1843,6 +1855,7 @@ onUpdated(async () => {
 					:class="{ 'input-with-opener': true, 'ph-no-capture': shouldRedactValue }"
 					:size="parameterInputSize"
 					:type="getStringInputType"
+					:masked="isMaskedTextarea"
 					:rows="editorRows"
 					:disabled="
 						isReadOnly ||


### PR DESCRIPTION
## Summary

Reported from the community forum: an **SSH Private Key** credential cannot be saved —
`SSH connection failed: Cannot parse privateKey: Unsupported key format`. Two coupled
defects caused it.

**1. Frontend (root cause).** A credential/node field that is both `password: true` and
multiline (`rows > 1`) was rendered as a single-line `<input type="password">`, because
the input-type decision short-circuited on `password` before ever checking `rows`. A
single-line `<input>` strips newlines by spec, so a pasted multi-line PEM key was
flattened onto one line and no longer parsed. This affected every masked multiline secret
field (SSH key, Snowflake / Salesforce JWT / Microsoft OAuth2 private keys, Crypto keys,
the SSH-tunnel option, etc.), not just SSH.

The fix checks `rows > 1` **before** the password branch, so a masked multiline field now
renders as a **masked `<textarea>`** — line breaks are preserved. Masking is unchanged:
the textarea is dot-masked via `-webkit-text-security` and stays out of PostHog capture
(`ph-no-capture`). Single-line secrets (API keys, tokens, passphrases) are untouched.

**2. Backend (permanent data loss).** When a user worked around defect 1 by switching the
field to expression mode, the credential was persisted as the redaction sentinel
`__n8n_BLANK_VALUE_…`, destroying the stored key. On read, the backend replaces a masked
value with that sentinel; on save it restores the real value only on an **exact** sentinel
match — but toggling to expression mode prepends `=`, so `=__n8n_BLANK_VALUE_…` failed the
match and the sentinel got saved and encrypted. The fix strips a single leading `=` before
the sentinel comparison, so the saved key is correctly restored.

<img width="966" height="470" alt="image" src="https://github.com/user-attachments/assets/18d503e4-3368-49c8-bdaa-9e4307053ea7" />


### How to test manually

Prerequisites: run n8n locally (`pnpm dev`, or against service containers).

1. Create an **SSH Private Key** credential. Paste a real multi-line PEM / OpenSSH private
   key into **Private Key**. Expected: the field is a multi-line **masked** textarea (dots),
   line breaks preserved; **Test connection** succeeds.
2. Save, reopen the credential (field now shows the masked/redacted value), and save again
   **without editing**. Expected: the key still works — it round-trips through the sentinel
   and is restored from storage.
3. Use the credential in an **SSH** node. Expected: connects, no `Unsupported key format`.
4. Regression for defect 2: with the field showing the redacted value, toggle it to
   **expression mode**, save, then reopen. Expected: the value is **not** `__n8n_BLANK_VALUE_…`
   — the original key is preserved.
5. Sanity: single-line secrets (e.g. the SSH **Passphrase**, any API-key credential) still
   render as single-line masked inputs.

Automated coverage added: backend `credentials.service` (restores the saved secret for an
exact sentinel and for an expression-prefixed `=`sentinel); design-system `N8nInput` (masked
textarea renders `-webkit-text-security` + `ph-no-capture`); editor-ui `ParameterInput`
(`password` + `rows > 1` → textarea; single-line `password` unchanged; redaction preserved
in a node context).

### Key implementation decisions

- **Masking preserved, not dropped.** Because a single-line `<input>` cannot hold newlines,
  the control must become a `<textarea>`. To keep the existing "secret" affordance it is
  masked with `-webkit-text-security: disc` (Chromium/Safari; Firefox shows plaintext in the
  textarea). This is display-only — the backend still redacts the value on every read, so the
  key is never re-sent to any browser.
- **`shouldRedactValue` is a compensating no-op.** It is re-keyed from the rendered control
  type to the `password` type-option so a multiline password field keeps `ph-no-capture`
  after the type flip — the true/false result is identical to before for every field, and no
  redaction behavior regresses.
- **Surgical backend fix.** Only the restore comparison is normalized (leading `=` stripped);
  the redaction guard is untouched, since widening it could expose previously-masked values.
- **Blast radius.** The only rendering change is `password` + multiline → masked textarea;
  no single-line secret, no `json`+`password` field, and no other `N8nInput` consumer is
  affected (the new `masked` prop defaults `false` and is only passed here).
- **Known follow-up (out of scope):** several masked secret fields hold multiline PEM/cert
  material but have **no** `rows` set (e.g. Microsoft Entra Service Principal private key, and
  the TLS cert bundles in Kafka/MongoDb/MySql/Mqtt/RabbitMQ/HttpSslAuth). They still render
  single-line and are tracked separately — adding `rows` lets them use this same masked-textarea
  path.

## Related links

- Linear: https://linear.app/n8n/issue/IAM-1069

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

