### PR TITLE
feat(ai-builder): Support end-user credentials in workflow builder

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -324,6 +324,8 @@ export const workflowSetupNodeSchema = z.object({
 	}),
 	credentialType: z.string().optional(),
 	existingCredentials: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
+	/** True when this credential type should resolve per-user ("End-user credential") rather than a single shared connection ("Fixed"). Pre-selects that mode when the user creates a new credential from this card. */
+	isResolvable: z.boolean().optional(),
 	isTrigger: z.boolean(),
 	isFirstTrigger: z.boolean().optional(),
 	isTestable: z.boolean().optional(),

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -293,6 +293,8 @@ export const credentialRequestSchema = z.object({
 	reason: z.string(),
 	existingCredentials: z.array(z.object({ id: z.string(), name: z.string() })),
 	suggestedName: z.string().optional(),
+	/** True when this credential should resolve per-user ("End-user credential") rather than a single shared connection ("Fixed"). Pre-selects that mode when the user creates a new credential from the setup card. */
+	isResolvable: z.boolean().optional(),
 });
 
 export type InstanceAiCredentialRequest = z.infer<typeof credentialRequestSchema>;

--- a/packages/@n8n/instance-ai/evaluations/harness/stub-services.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/stub-services.ts
@@ -132,7 +132,7 @@ export async function createStubServices(
 			return [];
 		},
 		async get(credentialId: string) {
-			return { id: credentialId, name: credentialId, type: 'unknown' };
+			return { id: credentialId, name: credentialId, type: 'unknown', isResolvable: false };
 		},
 		async delete() {},
 		async test() {

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -347,15 +347,17 @@ reference look exactly the same either way.
 
 **How to apply it:** this is chosen on the credential itself when the user
 creates or selects it (via the credential setup card's connection-mode
-toggle), not something `build-workflow` code controls. If a request clearly
-implies it, when calling `credentials(action="setup")` for that credential,
-set `isResolvable: true` on its entry (this pre-selects End-user mode when the
-setup card opens the create-credential modal) *and* say so in that entry's
-`reason` text (e.g. "Set this up as an End-user credential so files belong to
-whoever triggers the workflow") — the `reason` is what's shown when an
-existing-credentials dropdown renders instead of the create modal, so the
-`isResolvable` flag alone doesn't reach the user in that path. Do not attempt
-to set this via node parameters or SDK code.
+toggle), not something `build-workflow` code controls — do not attempt to set
+this via node parameters or SDK code. `analyzeWorkflow` (which powers
+`workflows(action="setup")`) only inspects the saved workflow graph; it cannot
+infer "for whoever triggers it" from a request's wording, so you must pass the
+hint explicitly on whichever setup tool call routes this credential:
+
+- **After a build (the common case, via post-build-flow's `workflows(action="setup")` call):** pass `credentialHints: [{ credentialType, isResolvable: true }]` for every credential type the request calls for End-user mode. This pre-selects End-user mode when the user creates a *new* credential of that type from the workflow setup card. There is no `reason` text on this card to fall back on — the hint is the only channel, so do not skip it when routing setup after a build that needs it.
+- **Standalone credential flows (no preceding build in this turn), via `credentials(action="setup")`:** set `isResolvable: true` on that entry *and* say so in its `reason` text (e.g. "Set this up as an End-user credential so files belong to whoever triggers the workflow") — the `reason` is what's shown when an existing-credentials dropdown renders instead of the create modal, so the `isResolvable` flag alone doesn't reach the user in that path.
+
+Either way, the hint only pre-selects the mode for a brand-new credential; it
+never changes a credential the user already selected or created.
 
 **Check, don't guess, the current mode.** `credentials(action="list")` and
 `credentials(action="get")` return an `isResolvable` field on every stored

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -331,6 +331,71 @@ decision after testing.
 - Always declare `output` on nodes that use unresolved credentials when mock
   data is needed for verification.
 
+## End-User Credentials
+
+"End-user credential" is the user-facing name for a credential *connection
+mode* (the alternative is "Fixed credential") — not a different node,
+resolver, or workflow architecture. A credential set to this mode resolves to
+whichever person triggered the workflow, instead of one shared stored
+connection.
+
+**Signal phrases** that imply the user wants this: "for the user who triggers
+it", "their own account", "per user", "each user's own credentials", "so
+everyone connects their own [service]". When you see this in a request, don't
+architect anything special in the workflow — the node and its credential
+reference look exactly the same either way.
+
+**How to apply it:** this is chosen on the credential itself when the user
+creates or selects it (via the credential setup card's connection-mode
+toggle), not something `build-workflow` code controls. If a request clearly
+implies it, when calling `credentials(action="setup")` for that credential,
+set `isResolvable: true` on its entry (this pre-selects End-user mode when the
+setup card opens the create-credential modal) *and* say so in that entry's
+`reason` text (e.g. "Set this up as an End-user credential so files belong to
+whoever triggers the workflow") — the `reason` is what's shown when an
+existing-credentials dropdown renders instead of the create modal, so the
+`isResolvable` flag alone doesn't reach the user in that path. Do not attempt
+to set this via node parameters or SDK code.
+
+**Check, don't guess, the current mode.** `credentials(action="list")` and
+`credentials(action="get")` return an `isResolvable` field on every stored
+credential — `true` means it's already set to End-user mode, `false` means
+Fixed. Always read this field before describing a credential's mode to the
+user; never assume "Fixed" (or any mode) by default. A credential can be
+End-user mode but not yet connected for the current user — those are two
+independent facts: report both accurately (e.g. "already set to End-user
+credential, but you haven't connected your own account yet") rather than
+conflating "not connected" with "not End-user mode".
+
+**How to describe connecting it — be precise, don't describe the setup flow
+from scratch.** Once a node already has an End-user credential selected (not
+"not yet configured"), a dedicated **"Connect"** button appears directly
+below the credential dropdown in the node panel — it's a separate row, not
+part of the dropdown itself. Clicking it immediately opens the OAuth popup;
+there's no need to reopen the credential or re-enter its setup fields. Tell
+the user: "open the node, then click Connect below the credential field" —
+not "click the credential field and follow the OAuth flow," which describes
+the wrong element and reads like the credential still needs to be
+created/configured from scratch.
+
+**Current constraint: OAuth-only.** Only OAuth-based credential types can be
+set to End-user mode today — the connection-mode toggle only appears for
+them, because they're the only ones with a managed authorize endpoint. If a
+request implies per-user credentials for a non-OAuth type (e.g. a plain
+API-key credential), say plainly that end-user mode isn't available for that
+credential type yet, rather than suggesting it as an option.
+
+**Constraint to flag:** end-user credentials require a trigger that can
+identify who is running the workflow — Manual, Chat, MCP server, or
+Sub-workflow triggers work; a Webhook trigger does not (unless a custom
+identity resolver is configured, which is an advanced/admin setup outside
+normal building). If the workflow's trigger is a Webhook, say so rather than
+silently building something that won't resolve credentials at runtime.
+
+**Vocabulary:** always say "End-user credential" (not "private credential",
+"dynamic credential", "per-user credential", or "resolvable credential" —
+those are internal/legacy names only).
+
 ## n8n credits Preference
 
 "n8n credits" is the user-facing name of n8n's managed credential

--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -148,9 +148,9 @@ describe('credentials tool', () => {
 	describe('list action', () => {
 		it('should call credentialService.list and return paginated results', async () => {
 			const credentials: CredentialSummary[] = [
-				{ id: '1', name: 'Slack Token', type: 'slackApi' },
-				{ id: '2', name: 'GitHub Token', type: 'githubApi' },
-				{ id: '3', name: 'Notion Key', type: 'notionApi' },
+				{ id: '1', name: 'Slack Token', type: 'slackApi', isResolvable: false },
+				{ id: '2', name: 'GitHub Token', type: 'githubApi', isResolvable: false },
+				{ id: '3', name: 'Notion Key', type: 'notionApi', isResolvable: true },
 			];
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
@@ -161,9 +161,9 @@ describe('credentials tool', () => {
 			expect(context.credentialService.list).toHaveBeenCalledWith({ type: undefined });
 			expect(result).toEqual({
 				credentials: [
-					{ id: '1', name: 'Slack Token', type: 'slackApi' },
-					{ id: '2', name: 'GitHub Token', type: 'githubApi' },
-					{ id: '3', name: 'Notion Key', type: 'notionApi' },
+					{ id: '1', name: 'Slack Token', type: 'slackApi', isResolvable: false },
+					{ id: '2', name: 'GitHub Token', type: 'githubApi', isResolvable: false },
+					{ id: '3', name: 'Notion Key', type: 'notionApi', isResolvable: true },
 				],
 				total: 3,
 				hasMore: false,
@@ -171,7 +171,9 @@ describe('credentials tool', () => {
 		});
 
 		it('should filter by type when provided', async () => {
-			const credentials: CredentialSummary[] = [{ id: '1', name: 'Slack Token', type: 'slackApi' }];
+			const credentials: CredentialSummary[] = [
+				{ id: '1', name: 'Slack Token', type: 'slackApi', isResolvable: false },
+			];
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
 
@@ -186,6 +188,7 @@ describe('credentials tool', () => {
 				id: String(i),
 				name: `Cred ${i}`,
 				type: 'testType',
+				isResolvable: false,
 			}));
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
@@ -199,8 +202,8 @@ describe('credentials tool', () => {
 
 			expect(result).toEqual({
 				credentials: [
-					{ id: '3', name: 'Cred 3', type: 'testType' },
-					{ id: '4', name: 'Cred 4', type: 'testType' },
+					{ id: '3', name: 'Cred 3', type: 'testType', isResolvable: false },
+					{ id: '4', name: 'Cred 4', type: 'testType', isResolvable: false },
 				],
 				total: 10,
 				hasMore: true,
@@ -213,6 +216,7 @@ describe('credentials tool', () => {
 				id: String(i),
 				name: `Cred ${i}`,
 				type: 'testType',
+				isResolvable: false,
 			}));
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
@@ -226,9 +230,9 @@ describe('credentials tool', () => {
 
 		it('should filter by query (case-insensitive name substring)', async () => {
 			const credentials: CredentialSummary[] = [
-				{ id: '1', name: 'Slack Work', type: 'slackApi' },
-				{ id: '2', name: 'Slack Personal', type: 'slackApi' },
-				{ id: '3', name: 'Notion Key', type: 'notionApi' },
+				{ id: '1', name: 'Slack Work', type: 'slackApi', isResolvable: false },
+				{ id: '2', name: 'Slack Personal', type: 'slackApi', isResolvable: false },
+				{ id: '3', name: 'Notion Key', type: 'notionApi', isResolvable: false },
 			];
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
@@ -242,8 +246,8 @@ describe('credentials tool', () => {
 
 			expect(result).toEqual({
 				credentials: [
-					{ id: '1', name: 'Slack Work', type: 'slackApi' },
-					{ id: '2', name: 'Slack Personal', type: 'slackApi' },
+					{ id: '1', name: 'Slack Work', type: 'slackApi', isResolvable: false },
+					{ id: '2', name: 'Slack Personal', type: 'slackApi', isResolvable: false },
 				],
 				total: 2,
 				hasMore: false,
@@ -255,6 +259,7 @@ describe('credentials tool', () => {
 				id: String(i),
 				name: i === 55 ? 'Production Notion' : `Cred ${i}`,
 				type: 'notionApi',
+				isResolvable: false,
 			}));
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
@@ -267,7 +272,9 @@ describe('credentials tool', () => {
 			);
 
 			expect(result).toEqual({
-				credentials: [{ id: '55', name: 'Production Notion', type: 'notionApi' }],
+				credentials: [
+					{ id: '55', name: 'Production Notion', type: 'notionApi', isResolvable: false },
+				],
 				total: 1,
 				hasMore: false,
 			});
@@ -278,6 +285,7 @@ describe('credentials tool', () => {
 				id: String(i),
 				name: `Cred ${i}`,
 				type: 'testType',
+				isResolvable: false,
 			}));
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
@@ -298,6 +306,7 @@ describe('credentials tool', () => {
 				id: String(i),
 				name: `Cred ${i}`,
 				type: 'slackApi',
+				isResolvable: false,
 			}));
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
@@ -313,9 +322,15 @@ describe('credentials tool', () => {
 			expect(result.hint).toBeUndefined();
 		});
 
-		it('should only return id, name, and type fields', async () => {
+		it('should only return id, name, type, and isResolvable fields', async () => {
 			const credentials = [
-				{ id: '1', name: 'Slack Token', type: 'slackApi', extraField: 'should-be-stripped' },
+				{
+					id: '1',
+					name: 'Slack Token',
+					type: 'slackApi',
+					isResolvable: false,
+					extraField: 'should-be-stripped',
+				},
 			];
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(credentials);
@@ -324,7 +339,7 @@ describe('credentials tool', () => {
 			const result = await executeTool(tool, { action: 'list' as const }, noSuspendCtx());
 
 			expect((result as { credentials: unknown[] }).credentials).toEqual([
-				{ id: '1', name: 'Slack Token', type: 'slackApi' },
+				{ id: '1', name: 'Slack Token', type: 'slackApi', isResolvable: false },
 			]);
 		});
 	});
@@ -411,6 +426,7 @@ describe('credentials tool', () => {
 				id: '42',
 				name: 'My Notion Key',
 				type: 'notionApi',
+				isResolvable: false,
 				nodesWithAccess: [{ nodeType: 'n8n-nodes-base.notion' }],
 			};
 			const context = createMockContext();
@@ -680,7 +696,7 @@ describe('credentials tool', () => {
 	describe('setup action', () => {
 		it('should suspend with credentialRequests on first call', async () => {
 			const existingCreds: CredentialSummary[] = [
-				{ id: 'c1', name: 'Existing Slack', type: 'slackApi' },
+				{ id: 'c1', name: 'Existing Slack', type: 'slackApi', isResolvable: false },
 			];
 			const context = createMockContext();
 			(context.credentialService.list as Mock).mockResolvedValue(existingCreds);
@@ -745,6 +761,59 @@ describe('credentials tool', () => {
 					],
 				}),
 			);
+		});
+
+		it('should include isResolvable in credentialRequests when true', async () => {
+			const context = createMockContext();
+			(context.credentialService.list as Mock).mockResolvedValue([]);
+
+			const suspendFn = vi.fn();
+			const tool = createCredentialsTool(context);
+			await executeTool(
+				tool,
+				{
+					action: 'setup' as const,
+					credentials: [
+						{
+							credentialType: 'googleDriveOAuth2Api',
+							reason: 'Set this up as an End-user credential',
+							isResolvable: true,
+						},
+					],
+				},
+				suspendCtx(suspendFn),
+			);
+
+			expect(suspendFn).toHaveBeenCalledTimes(1);
+			expect(suspendFn.mock.calls[0][0]).toEqual(
+				expect.objectContaining({
+					credentialRequests: [
+						expect.objectContaining({
+							isResolvable: true,
+						}),
+					],
+				}),
+			);
+		});
+
+		it('should omit isResolvable from credentialRequests when not provided', async () => {
+			const context = createMockContext();
+			(context.credentialService.list as Mock).mockResolvedValue([]);
+
+			const suspendFn = vi.fn();
+			const tool = createCredentialsTool(context);
+			await executeTool(
+				tool,
+				{
+					action: 'setup' as const,
+					credentials: [{ credentialType: 'slackApi', reason: 'For notifications' }],
+				},
+				suspendCtx(suspendFn),
+			);
+
+			expect(suspendFn).toHaveBeenCalledTimes(1);
+			const [request] = suspendFn.mock.calls[0][0].credentialRequests;
+			expect(request).not.toHaveProperty('isResolvable');
 		});
 
 		it('should use plural message for multiple credentials', async () => {

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -1214,13 +1214,35 @@ describe('workflows tool', () => {
 				resumeData: undefined,
 			} as never);
 
-			expect(analyzeWorkflow).toHaveBeenCalledWith(context, 'wf1');
+			expect(analyzeWorkflow).toHaveBeenCalledWith(context, 'wf1', undefined, undefined);
 			expect(suspend).toHaveBeenCalled();
 			expect(suspend.mock.calls[0][0]).toMatchObject({
 				message: 'Configure credentials for your workflow',
 				severity: 'info',
 				setupRequests,
 				workflowId: 'wf1',
+			});
+		});
+
+		it('should pass credentialHints through to analyzeWorkflow as a lookup map', async () => {
+			(analyzeWorkflow as Mock).mockResolvedValue([]);
+
+			const context = createMockContext();
+			const suspend = vi.fn();
+
+			const tool = createWorkflowsTool(context, 'full');
+			await executeTool(
+				tool,
+				{
+					action: 'setup',
+					workflowId: 'wf1',
+					credentialHints: [{ credentialType: 'googleDriveOAuth2Api', isResolvable: true }],
+				},
+				{ suspend, resumeData: undefined } as never,
+			);
+
+			expect(analyzeWorkflow).toHaveBeenCalledWith(context, 'wf1', undefined, {
+				googleDriveOAuth2Api: true,
 			});
 		});
 

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -438,12 +438,8 @@ async function handleSetup(
 	if (resumeData === undefined || resumeData === null) {
 		const credentialRequests = await Promise.all(
 			input.credentials.map(
-				async (req: {
-					credentialType: string;
-					reason?: string;
-					suggestedName?: string;
-					isResolvable?: boolean;
-				}) => {
+				// Shape comes from the zod schema — no hand-written duplicate to keep in sync.
+				async (req) => {
 					const existing = await context.credentialService.list({
 						type: req.credentialType,
 						...(context.projectId ? { projectId: context.projectId } : {}),
@@ -459,9 +455,7 @@ async function handleSetup(
 			),
 		);
 
-		const typeNames = input.credentials
-			.map((c: { credentialType: string }) => c.credentialType)
-			.join(', ');
+		const typeNames = input.credentials.map((c) => c.credentialType).join(', ');
 		return await ctx.suspend({
 			requestId: nanoid(),
 			message: isFinalize

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -107,12 +107,23 @@ const setupAction = z.object({
 				credentialType: z
 					.string()
 					.describe('n8n credential type name (e.g. "slackApi", "gmailOAuth2Api")'),
-				reason: z.string().optional().describe('Why this credential is needed (shown to user)'),
+				reason: z
+					.string()
+					.optional()
+					.describe(
+						'Why this credential is needed (shown to user). If `isResolvable` is true, say so here explicitly (e.g. "Set this up as an End-user credential so files belong to whoever triggers the workflow") — this is the only text the user sees on the setup card, and it is shown even when an existing-credentials dropdown (not the create-new modal) is rendered.',
+					),
 				suggestedName: z
 					.string()
 					.optional()
 					.describe(
 						'Suggested display name for the credential (e.g. "Linear API key"). Pre-fills the name field when creating a new credential.',
+					),
+				isResolvable: z
+					.boolean()
+					.optional()
+					.describe(
+						'Set true when this credential must resolve to whichever person triggers the workflow ("End-user credential" mode) rather than one shared connection ("Fixed"). When true and the user creates a new credential from this card, its setup modal opens pre-set to End-user mode. Only set this when the request or workflow design clearly calls for per-user credentials — see the End-User Credentials section of the workflow-builder skill.',
 					),
 			}),
 		)
@@ -248,6 +259,7 @@ const suspendSchema = z.object({
 				reason: z.string(),
 				existingCredentials: z.array(z.object({ id: z.string(), name: z.string() })),
 				suggestedName: z.string().optional(),
+				isResolvable: z.boolean().optional(),
 			}),
 		)
 		.optional(),
@@ -272,6 +284,7 @@ interface StoredCredentialListItem {
 	id: string;
 	name: string;
 	type: string;
+	isResolvable: boolean;
 }
 
 interface AiGatewayManagedListItem {
@@ -308,7 +321,9 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 			// and continue with stored credentials only.
 		}
 	}
-	for (const c of storedCredentials) items.push({ id: c.id, name: c.name, type: c.type });
+	for (const c of storedCredentials) {
+		items.push({ id: c.id, name: c.name, type: c.type, isResolvable: c.isResolvable });
+	}
 
 	const filtered = input.name
 		? items.filter((c) => c.name.toLowerCase().includes(input.name!.toLowerCase()))
@@ -326,7 +341,7 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 		credentials: page.map((c) =>
 			c.id === null
 				? { id: c.id, name: c.name, type: c.type, __aiGatewayManaged: c.__aiGatewayManaged }
-				: { id: c.id, name: c.name, type: c.type },
+				: { id: c.id, name: c.name, type: c.type, isResolvable: c.isResolvable },
 		),
 		total,
 		hasMore,
@@ -423,7 +438,12 @@ async function handleSetup(
 	if (resumeData === undefined || resumeData === null) {
 		const credentialRequests = await Promise.all(
 			input.credentials.map(
-				async (req: { credentialType: string; reason?: string; suggestedName?: string }) => {
+				async (req: {
+					credentialType: string;
+					reason?: string;
+					suggestedName?: string;
+					isResolvable?: boolean;
+				}) => {
 					const existing = await context.credentialService.list({
 						type: req.credentialType,
 						...(context.projectId ? { projectId: context.projectId } : {}),
@@ -433,6 +453,7 @@ async function handleSetup(
 						reason: req.reason ?? `Required for ${req.credentialType}`,
 						existingCredentials: existing.map((c) => ({ id: c.id, name: c.name })),
 						...(req.suggestedName ? { suggestedName: req.suggestedName } : {}),
+						...(req.isResolvable ? { isResolvable: true } : {}),
 					};
 				},
 			),

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -105,6 +105,23 @@ const setupAction = z.object({
 		),
 	workflowId: z.string().describe('ID of the workflow'),
 	projectId: z.string().optional().describe('Project ID to scope credential creation to'),
+	credentialHints: z
+		.array(
+			z.object({
+				credentialType: z
+					.string()
+					.describe('n8n credential type name (e.g. "googleDriveOAuth2Api")'),
+				isResolvable: z
+					.boolean()
+					.describe(
+						'True when this credential type should default to "End-user credential" mode (resolves to whoever triggers the workflow) instead of "Fixed". Set this when the build request clearly called for per-user credentials — see the End-User Credentials section of the workflow-builder skill. This only pre-selects the mode when the user creates a NEW credential of this type from the setup card; it does not change an already-selected credential.',
+					),
+			}),
+		)
+		.optional()
+		.describe(
+			'Per-credential-type connection-mode hints for this workflow\'s setup card. Analysis of the saved workflow has no way to know an "End-user credential" was intended — pass a hint here for every credential type that should default to that mode.',
+		),
 });
 
 const validateAction = z.object({
@@ -572,6 +589,14 @@ function collectCredentialTestFailures(
 	return failures;
 }
 
+/** Convert the tool input's `credentialHints` array into the lookup `analyzeWorkflow` expects. */
+function buildCredentialHintsMap(
+	input: Extract<Input, { action: 'setup' }>,
+): Record<string, boolean> | undefined {
+	if (!input.credentialHints || input.credentialHints.length === 0) return undefined;
+	return Object.fromEntries(input.credentialHints.map((h) => [h.credentialType, h.isResolvable]));
+}
+
 /** Setup state 3: persist setup, run the trigger, and re-suspend with the refreshed requests. */
 async function handleSetupTestTrigger(
 	context: InstanceAiContext,
@@ -601,9 +626,14 @@ async function handleSetupTestTrigger(
 
 	const triggerTestResult = await runTriggerTest(context, input.workflowId, testTriggerNode);
 
-	const refreshedRequests = await analyzeWorkflow(context, input.workflowId, {
-		[testTriggerNode]: triggerTestResult,
-	});
+	const refreshedRequests = await analyzeWorkflow(
+		context,
+		input.workflowId,
+		{
+			[testTriggerNode]: triggerTestResult,
+		},
+		buildCredentialHintsMap(input),
+	);
 
 	// Generate a new requestId so the frontend doesn't filter it
 	// as already-resolved from the previous suspend cycle
@@ -655,7 +685,12 @@ async function handleSetupApply(
 		// Re-analyze to determine if any nodes still need setup.
 		// Filter by needsAction to distinguish "render this card" from
 		// "this still requires user intervention".
-		const remainingRequests = await analyzeWorkflow(context, input.workflowId);
+		const remainingRequests = await analyzeWorkflow(
+			context,
+			input.workflowId,
+			undefined,
+			buildCredentialHintsMap(input),
+		);
 		const pendingRequests = remainingRequests.filter((r) => r.needsAction);
 		const completedNodes = buildCompletedReport(
 			resumeData.credentials,
@@ -723,7 +758,12 @@ async function handleSetup(
 
 	// State 1: Analyze workflow and suspend for user setup
 	if (resumeData === undefined || resumeData === null) {
-		const setupRequests = await analyzeWorkflow(context, input.workflowId);
+		const setupRequests = await analyzeWorkflow(
+			context,
+			input.workflowId,
+			undefined,
+			buildCredentialHintsMap(input),
+		);
 
 		if (setupRequests.length === 0) {
 			return { success: true, reason: 'No nodes require setup.' };

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -319,6 +319,26 @@ describe('buildSetupRequests', () => {
 		expect(result[0].needsAction).toBe(false);
 	});
 
+	it('treats an unverifiable test as unknown, not a failure', async () => {
+		(context.credentialService.list as Mock).mockResolvedValue([
+			{ id: 'cred-1', name: 'My Drive', updatedAt: '2025-01-01T00:00:00.000Z' },
+		]);
+		// Can't be checked either way, so it must not be reported broken.
+		(context.credentialService.test as Mock).mockResolvedValue({
+			success: false,
+			skipped: true,
+			message: 'Could not verify this end-user credential',
+		});
+
+		const node = makeNode({
+			credentials: { slackApi: { id: 'cred-1', name: 'My Drive' } },
+		});
+		const result = await buildSetupRequests(context, node);
+
+		expect(result[0]?.credentialTestResult).toBeUndefined();
+		expect(result[0]?.needsAction).toBe(false);
+	});
+
 	it('keeps AI Gateway-managed credentials complete without testing them', async () => {
 		(context.nodeService.getDescription as Mock).mockResolvedValue({
 			group: [],

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -142,6 +142,30 @@ describe('buildSetupRequests', () => {
 		expect(result[0].existingCredentials).toEqual([{ id: 'cred-1', name: 'My Slack' }]);
 	});
 
+	it('sets isResolvable when the credential type matches a credentialHints entry', async () => {
+		(context.credentialService.list as Mock).mockResolvedValue([]);
+
+		const node = makeNode();
+		const result = await buildSetupRequests(context, node, undefined, undefined, undefined, {
+			slackApi: true,
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0].isResolvable).toBe(true);
+	});
+
+	it('omits isResolvable when credentialHints does not mention the credential type', async () => {
+		(context.credentialService.list as Mock).mockResolvedValue([]);
+
+		const node = makeNode();
+		const result = await buildSetupRequests(context, node, undefined, undefined, undefined, {
+			notionApi: true,
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).not.toHaveProperty('isResolvable');
+	});
+
 	it('falls back to node description credentials when getNodeCredentialTypes returns empty', async () => {
 		// Simulate production: getNodeCredentialTypes is available but returns []
 		// (e.g. node lookup miss in the adapter). The fallback should still detect
@@ -740,6 +764,21 @@ describe('analyzeWorkflow', () => {
 		const result = await analyzeWorkflow(context, 'wf-1');
 		expect(result).toHaveLength(1);
 		expect(result[0].credentialType).toBe('slackApi');
+	});
+
+	it('threads credentialHints through to mark a credential type isResolvable', async () => {
+		(context.workflowService.getAsWorkflowJSON as Mock).mockResolvedValue(
+			makeWorkflowJSON([makeNode()]),
+		);
+		(context.nodeService.getDescription as Mock).mockResolvedValue({
+			group: [],
+			credentials: [{ name: 'slackApi' }],
+		});
+		(context.credentialService.list as Mock).mockResolvedValue([]);
+
+		const result = await analyzeWorkflow(context, 'wf-1', undefined, { slackApi: true });
+		expect(result).toHaveLength(1);
+		expect(result[0].isResolvable).toBe(true);
 	});
 
 	it('hides credential-only requests whose credential is already set and tests OK', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
@@ -566,6 +566,7 @@ async function buildRequestForCredentialType(
 	cache: CredentialCache | undefined,
 	workflowId: string | undefined,
 	nodeCtx: NodeSetupContext,
+	credentialHints?: Record<string, boolean>,
 ): Promise<SetupRequest | null> {
 	const nodeCredentials = node.credentials
 		? Object.fromEntries(
@@ -624,6 +625,7 @@ async function buildRequestForCredentialType(
 			),
 		},
 		...(credentialType ? { credentialType } : {}),
+		...(credentialType && credentialHints?.[credentialType] ? { isResolvable: true } : {}),
 		...(existingCredentials.length > 0 ? { existingCredentials } : {}),
 		isTrigger,
 		...(isTestable ? { isTestable } : {}),
@@ -644,6 +646,7 @@ export async function buildSetupRequests(
 	triggerTestResult?: { status: 'success' | 'error' | 'listening'; error?: string },
 	cache?: CredentialCache,
 	workflowId?: string,
+	credentialHints?: Record<string, boolean>,
 ): Promise<SetupRequest[]> {
 	if (!node.name) return [];
 	if (node.disabled) return [];
@@ -700,6 +703,7 @@ export async function buildSetupRequests(
 			cache,
 			workflowId,
 			nodeCtx,
+			credentialHints,
 		);
 		if (request) requests.push(request);
 	}
@@ -1261,6 +1265,7 @@ export async function analyzeWorkflow(
 	context: InstanceAiContext,
 	workflowId: string,
 	triggerResults?: Record<string, { status: 'success' | 'error' | 'listening'; error?: string }>,
+	credentialHints?: Record<string, boolean>,
 ): Promise<SetupRequest[]> {
 	const workflowJson = await context.workflowService.getAsWorkflowJSON(workflowId);
 
@@ -1273,6 +1278,7 @@ export async function analyzeWorkflow(
 				triggerResults?.[node.name ?? ''],
 				cache,
 				workflowId,
+				credentialHints,
 			);
 		}),
 	);

--- a/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
@@ -32,6 +32,9 @@ import type { InstanceAiContext } from '../../types';
 
 // ── Credential cache ────────────────────────────────────────────────────────
 
+/** Result of a credential connection test; `skipped` means "couldn't be verified either way". */
+type CredentialTestOutcome = { success: boolean; message?: string; skipped?: boolean };
+
 /** Cache for deduplicating credential fetches across nodes with the same types. */
 export interface CredentialCache {
 	/** Credential list promises, keyed by `${workflowId ?? ''}|${credentialType}` —
@@ -40,7 +43,7 @@ export interface CredentialCache {
 	/** Testability check promises, keyed by credential type (workflow-independent). */
 	testability: Map<string, Promise<boolean>>;
 	/** Credential test result promises, keyed by credential ID (workflow-independent). */
-	tests: Map<string, Promise<{ success: boolean; message?: string }>>;
+	tests: Map<string, Promise<CredentialTestOutcome>>;
 }
 
 export function createCredentialCache(): CredentialCache {
@@ -456,7 +459,7 @@ async function resolveCredentialState(
 	const canTest = await testabilityPromise;
 	if (!canTest) return { existingCredentials, isAutoApplied };
 
-	let testPromise = cache?.tests.get(credToTest);
+	let testPromise: Promise<CredentialTestOutcome> | undefined = cache?.tests.get(credToTest);
 	if (!testPromise) {
 		testPromise = context.credentialService.test(credToTest).catch((testError) => ({
 			success: false,
@@ -464,7 +467,10 @@ async function resolveCredentialState(
 		}));
 		cache?.tests.set(credToTest, testPromise);
 	}
-	const credentialTestResult = await testPromise;
+	const { skipped, ...credentialTestResult } = await testPromise;
+	// Unverifiable isn't a failure — omit the result so the card reads "untested"
+	// instead of marking a working credential broken.
+	if (skipped) return { existingCredentials, isAutoApplied };
 	return { existingCredentials, isAutoApplied, credentialTestResult };
 }
 

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -213,6 +213,11 @@ export interface CredentialSummary {
 	id: string;
 	name: string;
 	type: string;
+	/** True when this credential is set to "End-user credential" connection
+	 *  mode — it resolves to whoever triggers the workflow rather than one
+	 *  shared connection. Check this before describing a credential's mode;
+	 *  never assume "Fixed" by default. */
+	isResolvable: boolean;
 }
 
 export interface CredentialDetail extends CredentialSummary {

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -463,7 +463,10 @@ export interface InstanceAiCredentialService {
 	}): Promise<CredentialSummary[]>;
 	get(credentialId: string): Promise<CredentialDetail>;
 	delete(credentialId: string): Promise<void>;
-	test(credentialId: string): Promise<{ success: boolean; message?: string }>;
+	/** `skipped: true` means the connection couldn't be verified either way (e.g. no
+	 *  signed-in user to resolve an end-user credential against) — treat as unknown,
+	 *  not a failure, so a working credential isn't reported broken. */
+	test(credentialId: string): Promise<{ success: boolean; message?: string; skipped?: boolean }>;
 	/** Whether a credential type has a test function. When false, skip testing. */
 	isTestable?(credentialType: string): Promise<boolean>;
 	getDocumentationUrl?(credentialType: string): Promise<string | null>;

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
@@ -112,6 +112,8 @@ const eventService = mock<EventService>();
 const roleService = mock<RoleService>();
 const telemetry = mock<Telemetry>();
 const aiBuilderTemporaryWorkflowRepository = mock<AiBuilderTemporaryWorkflowRepository>();
+const executionContextService = mock<ExecutionContextService>();
+const dynamicCredentialsProxy = mock<DynamicCredentialsProxy>();
 
 const nodeResourceExplorerService = new NodeResourceExplorerService(
 	logger,
@@ -157,8 +159,8 @@ const service = new InstanceAiAdapterService(
 	mock<OutboundHttp>(),
 	mock<AiGatewayService>(),
 	mock<WorkflowTemplatesService>(),
-	mock<ExecutionContextService>(),
-	mock<DynamicCredentialsProxy>(),
+	executionContextService,
+	dynamicCredentialsProxy,
 );
 
 const user = mock<User>({
@@ -551,5 +553,107 @@ describe('credentialService.get — credential ownership revalidation', () => {
 			'Credential with ID "cred-other" could not be found.',
 		);
 		expect(credentialsService.getOne).toHaveBeenCalledWith(user, 'cred-other', false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// credentialService.test — end-user credential resolution
+// ---------------------------------------------------------------------------
+
+describe('credentialService.test — end-user credential resolution', () => {
+	const resolvableCredential = {
+		id: 'cred-eu',
+		name: 'My Drive',
+		type: 'googleDriveOAuth2Api',
+		isResolvable: true,
+		resolverId: 'resolver-1',
+	};
+
+	beforeEach(() => {
+		credentialsFinderService.findCredentialForUser.mockResolvedValue(resolvableCredential as never);
+		credentialsService.decrypt.mockResolvedValue({ stored: 'placeholder' } as never);
+		credentialsService.test.mockResolvedValue({ status: 'OK', message: 'Connection OK' } as never);
+	});
+
+	it('tests the resolved per-user connection, not the stored placeholder data', async () => {
+		executionContextService.buildManualExecutionContext.mockResolvedValue({
+			version: 1,
+			establishedAt: 0,
+			source: 'manual',
+			credentials: 'enc-identity',
+		} as never);
+		dynamicCredentialsProxy.resolveIfNeeded.mockResolvedValue({
+			data: { accessToken: 'the-users-own-token' },
+			isDynamic: true,
+		} as never);
+
+		const ctx = service.createContext(user, { n8nAuthCookie: 'cookie-abc' });
+		const result = await ctx.credentialService.test('cred-eu');
+
+		expect(executionContextService.buildManualExecutionContext).toHaveBeenCalledWith('cookie-abc');
+		expect(dynamicCredentialsProxy.resolveIfNeeded).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'cred-eu', isResolvable: true, resolverId: 'resolver-1' }),
+			{ stored: 'placeholder' },
+			expect.objectContaining({ credentials: 'enc-identity' }),
+			undefined,
+		);
+		expect(credentialsService.test).toHaveBeenCalledWith(
+			user.id,
+			expect.objectContaining({ data: { accessToken: 'the-users-own-token' } }),
+		);
+		expect(result).toEqual({ success: true, message: 'Connection OK' });
+	});
+
+	it('reports a connected credential as unverifiable, not broken, when no user identity is in scope', async () => {
+		executionContextService.buildManualExecutionContext.mockResolvedValue(undefined);
+
+		const ctx = service.createContext(user);
+		const result = await ctx.credentialService.test('cred-eu');
+
+		// Resolution can only fail without an identity, and that reads as a broken credential.
+		expect(dynamicCredentialsProxy.resolveIfNeeded).not.toHaveBeenCalled();
+		expect(credentialsService.test).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ success: false, skipped: true });
+	});
+
+	it('surfaces a resolution failure as a failed test', async () => {
+		executionContextService.buildManualExecutionContext.mockResolvedValue({
+			version: 1,
+			establishedAt: 0,
+			source: 'manual',
+			credentials: 'enc-identity',
+		} as never);
+		dynamicCredentialsProxy.resolveIfNeeded.mockRejectedValue(
+			new Error("'My Drive' end-user credential is not connected for you."),
+		);
+
+		const ctx = service.createContext(user, { n8nAuthCookie: 'cookie-abc' });
+		const result = await ctx.credentialService.test('cred-eu');
+
+		expect(credentialsService.test).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			success: false,
+			message: "'My Drive' end-user credential is not connected for you.",
+		});
+	});
+
+	it('skips resolution entirely for a fixed credential', async () => {
+		credentialsFinderService.findCredentialForUser.mockResolvedValue({
+			id: 'cred-fixed',
+			name: 'Shared Slack',
+			type: 'slackApi',
+			isResolvable: false,
+		} as never);
+
+		const ctx = service.createContext(user, { n8nAuthCookie: 'cookie-abc' });
+		const result = await ctx.credentialService.test('cred-fixed');
+
+		expect(dynamicCredentialsProxy.resolveIfNeeded).not.toHaveBeenCalled();
+		expect(executionContextService.buildManualExecutionContext).not.toHaveBeenCalled();
+		expect(credentialsService.test).toHaveBeenCalledWith(
+			user.id,
+			expect.objectContaining({ data: { stored: 'placeholder' } }),
+		);
+		expect(result).toEqual({ success: true, message: 'Connection OK' });
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
@@ -30,12 +30,13 @@ import type {
 	SharedWorkflowRepository,
 	WorkflowRepository,
 } from '@n8n/db';
-import type { InstanceSettings } from 'n8n-core';
+import type { ExecutionContextService, InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
 import type { ActiveExecutions } from '@/active-executions';
 import type { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import type { CredentialsService } from '@/credentials/credentials.service';
+import type { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { WorkflowRunner } from '@/workflow-runner';
 import type { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
 import { NodeResourceExplorerService } from '@/services/node-resource-explorer.service';
@@ -156,6 +157,8 @@ const service = new InstanceAiAdapterService(
 	mock<OutboundHttp>(),
 	mock<AiGatewayService>(),
 	mock<WorkflowTemplatesService>(),
+	mock<ExecutionContextService>(),
+	mock<DynamicCredentialsProxy>(),
 );
 
 const user = mock<User>({

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2992,10 +2992,19 @@ function createRunAdapterForTests(
 		postExecutePromise?: Promise<unknown>;
 		threadId?: string;
 		queueMode?: boolean;
+		n8nAuthCookie?: string;
 	},
 ) {
 	const mockWorkflowFinderService = {
 		findWorkflowForUser: vi.fn().mockResolvedValue(workflow),
+	};
+
+	const mockExecutionContextService = {
+		buildManualExecutionContext: vi.fn(async (cookie?: string) =>
+			cookie
+				? { version: 1, establishedAt: 0, source: 'manual', credentials: `enc(${cookie})` }
+				: undefined,
+		),
 	};
 
 	const mockWorkflowRunner = {
@@ -3068,11 +3077,16 @@ function createRunAdapterForTests(
 		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
-		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[35],
+		mockExecutionContextService as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[35],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[36],
 	);
 
-	const adapter = service.createContext(mockUser, { threadId: options?.threadId }).executionService;
+	const adapter = service.createContext(mockUser, {
+		threadId: options?.threadId,
+		n8nAuthCookie: options?.n8nAuthCookie,
+	}).executionService;
 
 	return {
 		adapter,
@@ -3080,6 +3094,7 @@ function createRunAdapterForTests(
 		mockExecutionPersistence,
 		mockTelemetry,
 		mockWorkflowRunner,
+		mockExecutionContextService,
 	};
 }
 
@@ -3110,6 +3125,47 @@ describe('createExecutionAdapter run()', () => {
 			saveDataSuccessExecution: 'all',
 			saveDataErrorExecution: 'all',
 		});
+	});
+
+	it('attaches the acting user identity so end-user credentials resolve', async () => {
+		const { adapter, mockWorkflowRunner, mockExecutionContextService } = createRunAdapterForTests(
+			{ id: 'wf-1', nodes: [] },
+			{ n8nAuthCookie: 'cookie-abc' },
+		);
+
+		await adapter.run('wf-1');
+
+		expect(mockExecutionContextService.buildManualExecutionContext).toHaveBeenCalledWith(
+			'cookie-abc',
+		);
+		expect(mockWorkflowRunner.run.mock.calls[0][0].encryptedRunnerIdentity).toBe('enc(cookie-abc)');
+	});
+
+	it('leaves the identity unset when no cookie is in scope', async () => {
+		const { adapter, mockWorkflowRunner } = createRunAdapterForTests({ id: 'wf-1', nodes: [] });
+
+		await adapter.run('wf-1');
+
+		expect(mockWorkflowRunner.run.mock.calls[0][0].encryptedRunnerIdentity).toBeUndefined();
+	});
+
+	it('reports the run as failed in telemetry when building the identity throws', async () => {
+		const { adapter, mockTelemetry, mockWorkflowRunner, mockExecutionContextService } =
+			createRunAdapterForTests(
+				{ id: 'wf-1', nodes: [] },
+				{ threadId: 'thread-1', n8nAuthCookie: 'cookie-abc' },
+			);
+		mockExecutionContextService.buildManualExecutionContext.mockRejectedValueOnce(
+			new Error('cipher unavailable'),
+		);
+
+		await expect(adapter.run('wf-1')).rejects.toThrow('cipher unavailable');
+
+		expect(mockWorkflowRunner.run).not.toHaveBeenCalled();
+		expect(mockTelemetry.track).toHaveBeenCalledWith(
+			'Builder executed workflow',
+			expect.objectContaining({ status: 'error' }),
+		);
 	});
 
 	it('still applies overrides when the workflow has no settings', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1311,6 +1311,8 @@ function createNodeAdapterServiceForTests(
 		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[35],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[36],
 		nodeCatalogService,
 	);
 
@@ -1667,6 +1669,8 @@ function createDataTableAdapterForTests(overrides?: {
 		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[35],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[36],
 	);
 
 	const adapter = service.createContext(mockUser, {
@@ -1993,6 +1997,8 @@ function createWorkflowAdapterForTests(overrides?: {
 		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[35],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[36],
 	);
 
 	const boundProjectId =
@@ -2798,6 +2804,8 @@ function createExecutionAdapterForTests(overrides?: { sharingEnabled?: boolean }
 		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[35],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[36],
 	);
 
 	const adapter = service.createContext(mockUser).executionService;
@@ -3060,6 +3068,8 @@ function createRunAdapterForTests(
 		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[33],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[34],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[35],
+		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[36],
 	);
 
 	const adapter = service.createContext(mockUser, { threadId: options?.threadId }).executionService;
@@ -3517,7 +3527,7 @@ function createAdapterWithGatewayMock(
 ): InstanceAiAdapterService {
 	const aiGatewayService = { getGatewayConfig };
 	const args = Array.from(
-		{ length: 35 },
+		{ length: 37 },
 		() => ({}) as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[number],
 	);
 	args[0] = {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -910,7 +910,29 @@ describe('InstanceAiController', () => {
 				ok: true,
 				runId: 'run-1',
 			});
-			expect(instanceAiService.resolveConfirmation).toHaveBeenCalledWith(USER_ID, 'req-1', body);
+			expect(instanceAiService.resolveConfirmation).toHaveBeenCalledWith(
+				USER_ID,
+				'req-1',
+				body,
+				undefined,
+			);
+		});
+
+		// Confirming can rebuild the run on a main that never saw the chat request.
+		it('should forward the n8n-auth cookie so end-user credentials still resolve', async () => {
+			instanceAiService.resolveConfirmation.mockResolvedValue({ ok: true });
+			authService.getCookieToken.mockReturnValueOnce('n8n-auth-cookie-value');
+			const body: InstanceAiConfirmRequest = { kind: 'approval', approved: true };
+			const reqWithBody = { ...req, body } as AuthenticatedRequest;
+
+			await controller.confirm(reqWithBody, res, 'req-1');
+
+			expect(instanceAiService.resolveConfirmation).toHaveBeenCalledWith(
+				USER_ID,
+				'req-1',
+				body,
+				'n8n-auth-cookie-value',
+			);
 		});
 
 		it('should pass resourceDecision through to resolveConfirmation', async () => {
@@ -923,7 +945,12 @@ describe('InstanceAiController', () => {
 
 			await controller.confirm(reqWithBody, res, 'req-1');
 
-			expect(instanceAiService.resolveConfirmation).toHaveBeenCalledWith(USER_ID, 'req-1', body);
+			expect(instanceAiService.resolveConfirmation).toHaveBeenCalledWith(
+				USER_ID,
+				'req-1',
+				body,
+				undefined,
+			);
 		});
 
 		it('should throw NotFoundError when confirmation not found', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -57,6 +57,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { AuthService } from '@/auth/auth.service';
 import type { CredentialsService } from '@/credentials/credentials.service';
 import type { Push } from '@/push';
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
@@ -105,6 +106,7 @@ describe('InstanceAiController', () => {
 	const moduleRegistry = mock<ModuleRegistry>();
 	const push = mock<Push>();
 	const publisher = mock<Publisher>();
+	const authService = mock<AuthService>();
 	const urlService = mock<UrlService>();
 	const globalConfig = mock<GlobalConfig>({
 		instanceAi: { gatewayApiKey: 'static-key', durableLog: false },
@@ -141,6 +143,7 @@ describe('InstanceAiController', () => {
 		projectService,
 		instanceAiErrorReporter,
 		publisher,
+		authService,
 		globalConfig,
 	);
 
@@ -179,6 +182,7 @@ describe('InstanceAiController', () => {
 				payload.context,
 				payload.timeZone,
 				payload.pushRef,
+				undefined,
 			);
 		});
 
@@ -213,6 +217,27 @@ describe('InstanceAiController', () => {
 				payloadWithPushRef.context,
 				payloadWithPushRef.timeZone,
 				'iframe-push-ref-123',
+				undefined,
+			);
+		});
+
+		it('should forward the n8n-auth cookie to startRun for end-user credential resolution', async () => {
+			memoryService.checkThreadOwnership.mockResolvedValue('owned');
+			instanceAiService.hasActiveRun.mockReturnValue(false);
+			instanceAiService.startRun.mockReturnValue('run-4');
+			authService.getCookieToken.mockReturnValueOnce('n8n-auth-cookie-value');
+
+			await controller.chat(req, res, THREAD_ID, payload);
+
+			expect(instanceAiService.startRun).toHaveBeenCalledWith(
+				req.user,
+				THREAD_ID,
+				payload.message,
+				payload.attachments,
+				payload.context,
+				payload.timeZone,
+				payload.pushRef,
+				'n8n-auth-cookie-value',
 			);
 		});
 
@@ -245,6 +270,7 @@ describe('InstanceAiController', () => {
 				payloadWithContext.context,
 				payloadWithContext.timeZone,
 				payloadWithContext.pushRef,
+				undefined,
 			);
 		});
 
@@ -1782,6 +1808,7 @@ describe('InstanceAiController — durable-log SSE replay (flag on)', () => {
 		mock<ProjectService>(),
 		mock<InstanceAiErrorReporterService>(),
 		mock<Publisher>(),
+		mock<AuthService>(),
 		globalConfig,
 	);
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -924,6 +924,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 			evalCredentialAllowlists: EvalThreadCredentialAllowlistService;
 			instanceAiErrorReporter: ReturnType<typeof createInstanceAiErrorReporterMock>;
 			creditService: { claimRunUsage: Mock };
+			threadN8nAuthCookie: Map<string, string>;
 		};
 		service.settingsService = {
 			getAdminSettings: vi.fn(() => ({ localGatewayDisabled: false, sandboxEnabled: true })),
@@ -993,6 +994,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 		service.evalCredentialAllowlists = new EvalThreadCredentialAllowlistService();
 		service.instanceAiErrorReporter = createInstanceAiErrorReporterMock();
 		service.creditService = { claimRunUsage: vi.fn() };
+		service.threadN8nAuthCookie = new Map();
 		(createAllTools as Mock).mockReturnValue(new Map());
 		const sandbox = { id: 'sandbox-1' };
 		const workspace = {
@@ -4537,6 +4539,7 @@ describe('InstanceAiService — cross-main task-control routing', () => {
 describe('InstanceAiService — clearThreadState agent-builder cleanup', () => {
 	type Internals = {
 		threadPushRef: Map<string, string>;
+		threadN8nAuthCookie: Map<string, string>;
 		planRequestsByThread: Map<string, number>;
 		runState: { clearThread: Mock };
 		backgroundTasks: { cancelThread: Mock };
@@ -4566,6 +4569,7 @@ describe('InstanceAiService — clearThreadState agent-builder cleanup', () => {
 		const service = Object.create(InstanceAiService.prototype) as unknown as Internals;
 
 		service.threadPushRef = new Map();
+		service.threadN8nAuthCookie = new Map();
 		service.planRequestsByThread = new Map();
 		service.runState = { clearThread: vi.fn(() => ({ active: undefined, suspended: undefined })) };
 		service.backgroundTasks = { cancelThread: vi.fn(() => []) };

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -924,7 +924,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 			evalCredentialAllowlists: EvalThreadCredentialAllowlistService;
 			instanceAiErrorReporter: ReturnType<typeof createInstanceAiErrorReporterMock>;
 			creditService: { claimRunUsage: Mock };
-			threadN8nAuthCookie: Map<string, string>;
+			userN8nAuthCookie: Map<string, string>;
 		};
 		service.settingsService = {
 			getAdminSettings: vi.fn(() => ({ localGatewayDisabled: false, sandboxEnabled: true })),
@@ -994,7 +994,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 		service.evalCredentialAllowlists = new EvalThreadCredentialAllowlistService();
 		service.instanceAiErrorReporter = createInstanceAiErrorReporterMock();
 		service.creditService = { claimRunUsage: vi.fn() };
-		service.threadN8nAuthCookie = new Map();
+		service.userN8nAuthCookie = new Map();
 		(createAllTools as Mock).mockReturnValue(new Map());
 		const sandbox = { id: 'sandbox-1' };
 		const workspace = {
@@ -4539,7 +4539,7 @@ describe('InstanceAiService — cross-main task-control routing', () => {
 describe('InstanceAiService — clearThreadState agent-builder cleanup', () => {
 	type Internals = {
 		threadPushRef: Map<string, string>;
-		threadN8nAuthCookie: Map<string, string>;
+		userN8nAuthCookie: Map<string, string>;
 		planRequestsByThread: Map<string, number>;
 		runState: { clearThread: Mock };
 		backgroundTasks: { cancelThread: Mock };
@@ -4569,7 +4569,7 @@ describe('InstanceAiService — clearThreadState agent-builder cleanup', () => {
 		const service = Object.create(InstanceAiService.prototype) as unknown as Internals;
 
 		service.threadPushRef = new Map();
-		service.threadN8nAuthCookie = new Map();
+		service.userN8nAuthCookie = new Map();
 		service.planRequestsByThread = new Map();
 		service.runState = { clearThread: vi.fn(() => ({ active: undefined, suspended: undefined })) };
 		service.backgroundTasks = { cancelThread: vi.fn(() => []) };

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
@@ -69,6 +69,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		// dependencies clearThreadState reaches.
 		type Internals = {
 			threadPushRef: Map<string, string>;
+			threadN8nAuthCookie: Map<string, string>;
 			planRequestsByThread: Map<string, number>;
 			runState: { clearThread: Mock };
 			backgroundTasks: { cancelThread: Mock };
@@ -95,6 +96,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		const service = Object.create(InstanceAiService.prototype) as unknown as Internals;
 
 		service.threadPushRef = new Map<string, string>([['thread-a', 'push-ref-a']]);
+		service.threadN8nAuthCookie = new Map<string, string>([['thread-a', 'cookie-a']]);
 		service.planRequestsByThread = new Map<string, number>([['thread-a', 2]]);
 		service.runState = {
 			clearThread: vi.fn(() => ({ active: undefined, suspended: undefined })),
@@ -123,6 +125,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		await service.clearThreadState('thread-a');
 
 		expect(service.threadPushRef.has('thread-a')).toBe(false);
+		expect(service.threadN8nAuthCookie.has('thread-a')).toBe(false);
 		expect(service.planRequestsByThread.has('thread-a')).toBe(false);
 		expect(service.evalCredentialAllowlists.get('thread-a')).toBeUndefined();
 	});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
@@ -69,7 +69,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		// dependencies clearThreadState reaches.
 		type Internals = {
 			threadPushRef: Map<string, string>;
-			threadN8nAuthCookie: Map<string, string>;
+			userN8nAuthCookie: Map<string, string>;
 			planRequestsByThread: Map<string, number>;
 			runState: { clearThread: Mock };
 			backgroundTasks: { cancelThread: Mock };
@@ -96,7 +96,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		const service = Object.create(InstanceAiService.prototype) as unknown as Internals;
 
 		service.threadPushRef = new Map<string, string>([['thread-a', 'push-ref-a']]);
-		service.threadN8nAuthCookie = new Map<string, string>([['thread-a', 'cookie-a']]);
+		service.userN8nAuthCookie = new Map<string, string>([['user-a', 'cookie-a']]);
 		service.planRequestsByThread = new Map<string, number>([['thread-a', 2]]);
 		service.runState = {
 			clearThread: vi.fn(() => ({ active: undefined, suspended: undefined })),
@@ -125,7 +125,8 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		await service.clearThreadState('thread-a');
 
 		expect(service.threadPushRef.has('thread-a')).toBe(false);
-		expect(service.threadN8nAuthCookie.has('thread-a')).toBe(false);
+		// Keyed by user: the user's other threads still need it.
+		expect(service.userN8nAuthCookie.get('user-a')).toBe('cookie-a');
 		expect(service.planRequestsByThread.has('thread-a')).toBe(false);
 		expect(service.evalCredentialAllowlists.get('thread-a')).toBeUndefined();
 	});

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -99,6 +99,7 @@ import {
 	type IConnections,
 	type IWorkflowSettings,
 	type IWorkflowExecutionDataProcess,
+	type IExecutionContext,
 	type DataTableFilter,
 	type DataTableRow,
 	type DataTableRows,
@@ -148,7 +149,8 @@ import { FolderService } from '@/services/folder.service';
 import { NodeResourceExplorerService } from '@/services/node-resource-explorer.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
-import { InstanceSettings } from 'n8n-core';
+import { ExecutionContextService, InstanceSettings } from 'n8n-core';
+import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import { TagService } from '@/services/tag.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -270,6 +272,8 @@ export class InstanceAiAdapterService {
 		private readonly outboundHttp: OutboundHttp,
 		private readonly aiGatewayService: AiGatewayService,
 		private readonly workflowTemplatesService: WorkflowTemplatesService,
+		private readonly executionContextService: ExecutionContextService,
+		private readonly dynamicCredentialsProxy: DynamicCredentialsProxy,
 		private readonly nodeCatalogService?: NodeCatalogService,
 		// Optional: absent only in package/test contexts constructed without DI.
 		// DI (by type, not position) always provides it in a running instance.
@@ -305,6 +309,13 @@ export class InstanceAiAdapterService {
 			/** Host-resolved model for the run — fallback for utility LLM calls
 			 *  (simulation fixtures, destructiveness classification). */
 			modelId?: ModelConfig;
+			/** n8n-auth cookie for the acting user, captured at the HTTP entry point.
+			 *  Threaded into executions/credential tests so end-user (dynamic)
+			 *  credentials can resolve this user's own connection. Undefined for
+			 *  runs with no live request in scope (e.g. suspended-run restoration
+			 *  after a restart) — dynamic resolution is then skipped gracefully,
+			 *  the same way it is for an editor run with no session. */
+			n8nAuthCookie?: string;
 		},
 	): InstanceAiContext {
 		const {
@@ -317,6 +328,7 @@ export class InstanceAiAdapterService {
 			agentId,
 			configEvalsEnabled,
 			modelId,
+			n8nAuthCookie,
 		} = options ?? {};
 
 		// Record gateway availability once per context. Fire-and-forget: the
@@ -330,12 +342,13 @@ export class InstanceAiAdapterService {
 			projectId,
 			modelId,
 			workflowService: this.createWorkflowAdapter(user, threadId, projectId),
-			executionService: this.createExecutionAdapter(user, pushRef, threadId),
+			executionService: this.createExecutionAdapter(user, pushRef, threadId, n8nAuthCookie),
 			credentialService: this.createCredentialAdapter(
 				user,
 				projectId,
 				credentialIdAllowlist,
 				shouldBypassCredentialTest,
+				n8nAuthCookie,
 			),
 			nodeService: this.createNodeAdapter(user),
 			dataTableService: this.createDataTableAdapter(user, projectId),
@@ -1039,6 +1052,7 @@ export class InstanceAiAdapterService {
 		user: User,
 		pushRef?: string,
 		threadId?: string,
+		n8nAuthCookie?: string,
 	): InstanceAiExecutionService {
 		const {
 			workflowFinderService,
@@ -1051,6 +1065,7 @@ export class InstanceAiAdapterService {
 			telemetry,
 			logger,
 			globalConfig,
+			executionContextService,
 		} = this;
 		const assertNotReadOnly = () => this.assertInstanceNotReadOnly('executions');
 
@@ -1279,6 +1294,13 @@ export class InstanceAiAdapterService {
 					});
 				};
 
+				// Mirrors workflow-execution.service.ts's executeManually: without this,
+				// end-user (dynamic) credentials silently skip resolution in manual mode
+				// and nodes fall back to static/placeholder data.
+				runData.encryptedRunnerIdentity = n8nAuthCookie
+					? await executionContextService.buildManualExecutionCredentials(n8nAuthCookie)
+					: undefined;
+
 				try {
 					const executionId = await workflowRunner.run(runData);
 					const pruneVerificationPins = async (executedNodeNames?: string[]) => {
@@ -1479,8 +1501,15 @@ export class InstanceAiAdapterService {
 		boundProjectId?: string,
 		credentialIdAllowlist?: string[],
 		shouldBypassCredentialTest?: (credentialId: string) => boolean,
+		n8nAuthCookie?: string,
 	): InstanceAiCredentialService {
-		const { credentialsService, credentialsFinderService, loadNodesAndCredentials } = this;
+		const {
+			credentialsService,
+			credentialsFinderService,
+			loadNodesAndCredentials,
+			executionContextService,
+			dynamicCredentialsProxy,
+		} = this;
 		const getGatewayConfig = async () => await this.getGatewayConfigOrNull();
 
 		const adapter: InstanceAiCredentialService = {
@@ -1494,7 +1523,14 @@ export class InstanceAiAdapterService {
 						projectId: boundProjectId,
 					});
 					const filtered = options?.type ? scoped.filter((c) => c.type === options.type) : scoped;
-					return filtered.map((c): CredentialSummary => ({ id: c.id, name: c.name, type: c.type }));
+					return filtered.map(
+						(c): CredentialSummary => ({
+							id: c.id,
+							name: c.name,
+							type: c.type,
+							isResolvable: c.isResolvable,
+						}),
+					);
 				}
 
 				// Unbound runs (temporary-workflow archiving, the only caller without a
@@ -1516,6 +1552,7 @@ export class InstanceAiAdapterService {
 							id: c.id,
 							name: c.name,
 							type: c.type,
+							isResolvable: c.isResolvable,
 						}),
 					);
 				}
@@ -1532,6 +1569,7 @@ export class InstanceAiAdapterService {
 						id: c.id,
 						name: c.name,
 						type: c.type,
+						isResolvable: c.isResolvable,
 					}),
 				);
 			},
@@ -1542,6 +1580,7 @@ export class InstanceAiAdapterService {
 					id: credential.id,
 					name: credential.name,
 					type: credential.type,
+					isResolvable: credential.isResolvable,
 				} satisfies CredentialDetail;
 			},
 
@@ -1573,11 +1612,53 @@ export class InstanceAiAdapterService {
 					return { success: true, message: 'Connection tested successfully' };
 				}
 
+				let data = await credentialsService.decrypt(credential, true);
+
+				// An end-user (dynamic) credential holds no real secret on the stored
+				// entity itself — the actual connection lives in a per-user resolver
+				// entry. Testing the raw decrypted data would always report a false
+				// failure, so resolve this user's own connection first, the same way
+				// a real execution would (see credentials-helper.ts).
+				if (credential.isResolvable) {
+					const encryptedRunnerIdentity = n8nAuthCookie
+						? await executionContextService.buildManualExecutionCredentials(n8nAuthCookie)
+						: undefined;
+					const executionContext: IExecutionContext | undefined = encryptedRunnerIdentity
+						? {
+								version: 1,
+								establishedAt: Date.now(),
+								source: 'manual',
+								credentials: encryptedRunnerIdentity,
+							}
+						: undefined;
+
+					try {
+						const resolveResult = await dynamicCredentialsProxy.resolveIfNeeded(
+							{
+								id: credential.id,
+								name: credential.name,
+								type: credential.type,
+								isResolvable: credential.isResolvable,
+								resolverId: credential.resolverId ?? undefined,
+							},
+							data,
+							executionContext,
+							undefined, // no workflowId in scope for a standalone credential test
+						);
+						data = resolveResult.data;
+					} catch (error) {
+						return {
+							success: false,
+							message: error instanceof Error ? error.message : String(error),
+						};
+					}
+				}
+
 				const credentialsToTest: ICredentialsDecrypted = {
 					id: credential.id,
 					name: credential.name,
 					type: credential.type,
-					data: await credentialsService.decrypt(credential, true),
+					data,
 				};
 
 				const result = await credentialsService.test(user.id, credentialsToTest);

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -99,7 +99,6 @@ import {
 	type IConnections,
 	type IWorkflowSettings,
 	type IWorkflowExecutionDataProcess,
-	type IExecutionContext,
 	type DataTableFilter,
 	type DataTableRow,
 	type DataTableRows,
@@ -1294,14 +1293,15 @@ export class InstanceAiAdapterService {
 					});
 				};
 
-				// Mirrors workflow-execution.service.ts's executeManually: without this,
-				// end-user (dynamic) credentials silently skip resolution in manual mode
-				// and nodes fall back to static/placeholder data.
-				runData.encryptedRunnerIdentity = n8nAuthCookie
-					? await executionContextService.buildManualExecutionCredentials(n8nAuthCookie)
-					: undefined;
-
 				try {
+					// Identify the acting user so end-user credentials resolve to their own
+					// connection; without it, nodes fall back to placeholder data. Not gated on
+					// `executionMode` — this is always an editor-initiated run, and the trigger
+					// modes above are set to force-save, not by a real inbound request.
+					const runnerContext =
+						await executionContextService.buildManualExecutionContext(n8nAuthCookie);
+					runData.encryptedRunnerIdentity = runnerContext?.credentials;
+
 					const executionId = await workflowRunner.run(runData);
 					const pruneVerificationPins = async (executedNodeNames?: string[]) => {
 						try {
@@ -1614,23 +1614,23 @@ export class InstanceAiAdapterService {
 
 				let data = await credentialsService.decrypt(credential, true);
 
-				// An end-user (dynamic) credential holds no real secret on the stored
-				// entity itself — the actual connection lives in a per-user resolver
-				// entry. Testing the raw decrypted data would always report a false
-				// failure, so resolve this user's own connection first, the same way
-				// a real execution would (see credentials-helper.ts).
+				// The real connection lives in a per-user resolver entry, not on the stored
+				// entity, so testing the raw decrypted data always reports a false failure.
 				if (credential.isResolvable) {
-					const encryptedRunnerIdentity = n8nAuthCookie
-						? await executionContextService.buildManualExecutionCredentials(n8nAuthCookie)
-						: undefined;
-					const executionContext: IExecutionContext | undefined = encryptedRunnerIdentity
-						? {
-								version: 1,
-								establishedAt: Date.now(),
-								source: 'manual',
-								credentials: encryptedRunnerIdentity,
-							}
-						: undefined;
+					const executionContext =
+						await executionContextService.buildManualExecutionContext(n8nAuthCookie);
+
+					// Without an identity, resolution can only fail — and that would be reported
+					// as a broken credential. Report "not verifiable" instead, mirroring
+					// credentials-helper.ts, which skips resolution rather than failing.
+					if (!executionContext) {
+						return {
+							success: false,
+							skipped: true,
+							message:
+								'Could not verify this end-user credential: no signed-in user is available for this run to resolve it against.',
+						};
+					}
 
 					try {
 						const resolveResult = await dynamicCredentialsProxy.resolveIfNeeded(
@@ -1643,7 +1643,9 @@ export class InstanceAiAdapterService {
 							},
 							data,
 							executionContext,
-							undefined, // no workflowId in scope for a standalone credential test
+							// No workflow in scope, so a workflow-level `credentialResolverId`
+							// override can't apply; the credential's own or system resolver is used.
+							undefined,
 						);
 						data = resolveResult.data;
 					} catch (error) {

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -597,6 +597,9 @@ export class InstanceAiController {
 			req.user.id,
 			requestId,
 			parseResult.data,
+			// Refreshes the acting user's identity for end-user credential resolution:
+			// confirming can resume a run, or rebuild one on a different main.
+			this.authService.getCookieToken(req),
 		);
 		if (!resolved) {
 			throw new NotFoundError('Confirmation request not found or not authorized');

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -59,6 +59,7 @@ import { InstanceAiGatewayService } from './instance-ai-gateway.service';
 import { InstanceAiMemoryService } from './instance-ai-memory.service';
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 import { InstanceAiService } from './instance-ai.service';
+import { AuthService } from '@/auth/auth.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -133,6 +134,7 @@ export class InstanceAiController {
 		private readonly projectService: ProjectService,
 		private readonly instanceAiErrorReporter: InstanceAiErrorReporterService,
 		private readonly publisher: Publisher,
+		private readonly authService: AuthService,
 		globalConfig: GlobalConfig,
 	) {
 		this.gatewayApiKey = globalConfig.instanceAi.gatewayApiKey;
@@ -204,6 +206,11 @@ export class InstanceAiController {
 			throw new ConflictError('A run is already active for this thread');
 		}
 
+		// Captured so end-user (dynamic) credentials can resolve the acting
+		// user's own connection when this thread runs/tests a workflow — mirrors
+		// how workflows.controller.ts threads the cookie into manual executions.
+		const n8nAuthCookie = this.authService.getCookieToken(req);
+
 		const runId = this.instanceAiService.startRun(
 			req.user,
 			threadId,
@@ -212,6 +219,7 @@ export class InstanceAiController {
 			payload.context,
 			payload.timeZone,
 			payload.pushRef,
+			n8nAuthCookie,
 		);
 		return { runId };
 	}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -517,13 +517,12 @@ export class InstanceAiService {
 	private readonly threadPushRef = new Map<string, string>();
 
 	/**
-	 * Tracks the n8n-auth cookie per thread, so end-user (dynamic) credentials
-	 * can resolve the acting user's own connection when this thread runs/tests
-	 * a workflow — including background continuations (planned tasks) within
-	 * the same thread. Mirrors threadPushRef's lifecycle: set on startRun, kept
-	 * alive across follow-ups/planned tasks, cleared on thread dispose.
+	 * Latest n8n-auth cookie per *user*, so end-user credentials resolve to that user's
+	 * own connection. Keyed by user, not thread, so every request refreshes it (a revoked
+	 * token can't linger) and a run rebuilt on another main still finds an identity.
+	 * Best-effort — callers must treat a miss as "no identity available".
 	 */
-	private readonly threadN8nAuthCookie = new Map<string, string>();
+	private readonly userN8nAuthCookie = new Map<string, string>();
 
 	/** Counts plan-review confirmations per thread, to tell the first plan apart from later revisions. */
 	private readonly planRequestsByThread = new Map<string, number>();
@@ -1066,9 +1065,7 @@ export class InstanceAiService {
 			this.threadPushRef.set(threadId, pushRef);
 		}
 
-		if (n8nAuthCookie !== undefined) {
-			this.threadN8nAuthCookie.set(threadId, n8nAuthCookie);
-		}
+		this.rememberUserAuthCookie(user.id, n8nAuthCookie);
 
 		this.startExecuteRun(
 			user,
@@ -1537,7 +1534,7 @@ export class InstanceAiService {
 		this.domainAccessTrackersByThread.delete(threadId);
 		this.evalCredentialAllowlists.clearThread(threadId);
 		this.threadPushRef.delete(threadId);
-		this.threadN8nAuthCookie.delete(threadId);
+		// Not userN8nAuthCookie: it's keyed by user, and their other threads still need it.
 		this.planRequestsByThread.delete(threadId);
 		this.memoryTaskRegistry.clearThread(threadId);
 		this.tracing.deleteTraceContextsForThread(threadId);
@@ -2132,7 +2129,7 @@ export class InstanceAiService {
 				this.evalCredentialAllowlists.shouldBypassTest(threadId, credentialId),
 			configEvalsEnabled,
 			modelId,
-			n8nAuthCookie: this.threadN8nAuthCookie.get(threadId),
+			n8nAuthCookie: this.userN8nAuthCookie.get(user.id),
 		});
 
 		// Merge both local gateway and direct browser-use into a single
@@ -4356,8 +4353,12 @@ export class InstanceAiService {
 		requestingUserId: string,
 		requestId: string,
 		request: InstanceAiConfirmRequest,
+		n8nAuthCookie?: string,
 	): Promise<InstanceAiConfirmResponse | null> {
 		const data = toConfirmationData(request);
+		// Confirming can rebuild the run on a main that never handled the original chat
+		// request, so refresh the identity before any of those paths build a context.
+		this.rememberUserAuthCookie(requestingUserId, n8nAuthCookie);
 		const freshUser = await this.revalidateActiveUser(requestingUserId);
 		if (!freshUser) {
 			this.runState.rejectPendingConfirmation(requestId);
@@ -4632,15 +4633,28 @@ export class InstanceAiService {
 		};
 	}
 
+	/**
+	 * Call from every entry point that can start or resume a run — refreshing on each
+	 * request is what keeps a revoked or rotated token from being replayed.
+	 */
+	private rememberUserAuthCookie(userId: string, n8nAuthCookie: string | undefined): void {
+		if (n8nAuthCookie === undefined) return;
+		this.userN8nAuthCookie.set(userId, n8nAuthCookie);
+	}
+
 	private async revalidateActiveUser(userId: string): Promise<User | null> {
 		try {
 			const user = await this.userRepository.findOne({
 				where: { id: userId },
 				relations: ['role'],
 			});
-			if (!user || user.disabled) return null;
+			if (!user || user.disabled) {
+				this.userN8nAuthCookie.delete(userId);
+				return null;
+			}
 			const hasInstanceAiMessageScope =
 				user.role?.scopes?.some((scope) => scope.slug === 'instanceAi:message') ?? false;
+			if (!hasInstanceAiMessageScope) this.userN8nAuthCookie.delete(userId);
 			return hasInstanceAiMessageScope ? user : null;
 		} catch (error: unknown) {
 			this.logger.warn('Failed to revalidate user', {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -516,6 +516,15 @@ export class InstanceAiService {
 	/** Tracks the iframe pushRef per thread for live execution push events. */
 	private readonly threadPushRef = new Map<string, string>();
 
+	/**
+	 * Tracks the n8n-auth cookie per thread, so end-user (dynamic) credentials
+	 * can resolve the acting user's own connection when this thread runs/tests
+	 * a workflow — including background continuations (planned tasks) within
+	 * the same thread. Mirrors threadPushRef's lifecycle: set on startRun, kept
+	 * alive across follow-ups/planned tasks, cleared on thread dispose.
+	 */
+	private readonly threadN8nAuthCookie = new Map<string, string>();
+
 	/** Counts plan-review confirmations per thread, to tell the first plan apart from later revisions. */
 	private readonly planRequestsByThread = new Map<string, number>();
 
@@ -1038,6 +1047,7 @@ export class InstanceAiService {
 		context?: InstanceAiHandoffContext,
 		timeZone?: string,
 		pushRef?: string,
+		n8nAuthCookie?: string,
 	): string {
 		this.liveness.clearThreadState(threadId);
 		const { runId, abortController, messageGroupId } = this.runState.startRun({
@@ -1054,6 +1064,10 @@ export class InstanceAiService {
 
 		if (pushRef !== undefined) {
 			this.threadPushRef.set(threadId, pushRef);
+		}
+
+		if (n8nAuthCookie !== undefined) {
+			this.threadN8nAuthCookie.set(threadId, n8nAuthCookie);
 		}
 
 		this.startExecuteRun(
@@ -1523,6 +1537,7 @@ export class InstanceAiService {
 		this.domainAccessTrackersByThread.delete(threadId);
 		this.evalCredentialAllowlists.clearThread(threadId);
 		this.threadPushRef.delete(threadId);
+		this.threadN8nAuthCookie.delete(threadId);
 		this.planRequestsByThread.delete(threadId);
 		this.memoryTaskRegistry.clearThread(threadId);
 		this.tracing.deleteTraceContextsForThread(threadId);
@@ -2117,6 +2132,7 @@ export class InstanceAiService {
 				this.evalCredentialAllowlists.shouldBypassTest(threadId, credentialId),
 			configEvalsEnabled,
 			modelId,
+			n8nAuthCookie: this.threadN8nAuthCookie.get(threadId),
 		});
 
 		// Merge both local gateway and direct browser-use into a single

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -329,6 +329,32 @@ describe('ExecutionContextService', () => {
 		});
 	});
 
+	describe('buildManualExecutionContext()', () => {
+		it('should wrap the encrypted identity in a manual execution context', async () => {
+			mockCipher.encryptV2.mockResolvedValue('encrypted-credential-blob');
+
+			const result = await service.buildManualExecutionContext('n8n-auth-cookie-jwt');
+
+			expect(result).toEqual({
+				version: 1,
+				establishedAt: expect.any(Number),
+				source: 'manual',
+				credentials: 'encrypted-credential-blob',
+			});
+		});
+
+		// Callers branch on undefined to mean "no identity available".
+		it.each([undefined, ''])(
+			'should return undefined when there is no cookie to identify anyone (%p)',
+			async (cookie) => {
+				const result = await service.buildManualExecutionContext(cookie);
+
+				expect(result).toBeUndefined();
+				expect(mockCipher.encryptV2).not.toHaveBeenCalled();
+			},
+		);
+	});
+
 	describe('buildTriggerIdentityCredentials()', () => {
 		it('should encrypt the credential context with the token as identity and resource in metadata', async () => {
 			mockCipher.encryptV2.mockResolvedValue('encrypted-credential-blob');

--- a/packages/core/src/execution-engine/execution-context.service.ts
+++ b/packages/core/src/execution-engine/execution-context.service.ts
@@ -58,6 +58,23 @@ export class ExecutionContextService {
 		return await this.cipher.encryptV2(payload);
 	}
 
+	/**
+	 * For callers resolving credentials outside a workflow run (e.g. testing one
+	 * credential as the acting user). Returns `undefined` with no cookie, so callers can
+	 * branch on "no identity available" without hand-rolling the context shape.
+	 */
+	async buildManualExecutionContext(
+		n8nAuthCookie: string | undefined,
+	): Promise<IExecutionContext | undefined> {
+		if (!n8nAuthCookie) return undefined;
+		return {
+			version: 1,
+			establishedAt: Date.now(),
+			source: 'manual',
+			credentials: await this.buildManualExecutionCredentials(n8nAuthCookie),
+		};
+	}
+
 	async buildTriggerIdentityCredentials(token: string, resource: string): Promise<string> {
 		const payload: ICredentialContext = {
 			version: 1,

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -668,6 +668,8 @@ export interface NewCredentialsModal extends ModalState {
 	hideAskAssistant?: boolean;
 	appendToBody?: boolean;
 	usageScope?: 'project' | 'instance';
+	/** Pre-select "End-user credential" connection mode when creating a new credential from this modal (new mode only). */
+	defaultIsResolvable?: boolean;
 	/** Behavior for the Instance AI credential setup-help button, supplied by the
 	 * surface that opened the modal (an editor capability, or the credentials list).
 	 * Resolves to whether the credential modal should close (false keeps it open for

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -565,6 +565,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 			closeOnSave?: boolean;
 			instanceAiCredentialHelp?: NewCredentialsModal['instanceAiCredentialHelp'];
 			usageScope?: NewCredentialsModal['usageScope'];
+			defaultIsResolvable?: boolean;
 		} = {},
 	) => {
 		setActiveId(CREDENTIAL_EDIT_MODAL_KEY, type);
@@ -581,6 +582,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 			appendToBody: options.appendToBody,
 			instanceAiCredentialHelp: options.instanceAiCredentialHelp,
 			usageScope: options.usageScope,
+			defaultIsResolvable: options.defaultIsResolvable,
 		} as NewCredentialsModal;
 		setMode(CREDENTIAL_EDIT_MODAL_KEY, 'new');
 		openModal(CREDENTIAL_EDIT_MODAL_KEY);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
@@ -235,7 +235,34 @@ describe('InstanceAiCredentialSetup', () => {
 				undefined,
 				undefined,
 				undefined,
-				{ closeOnSave: true },
+				{ closeOnSave: true, defaultIsResolvable: undefined },
+			);
+		});
+
+		it('opens credential modal pre-set to End-user mode when the request calls for it', async () => {
+			const requests = makeCredentialRequests(1);
+			requests[0].isResolvable = true;
+			const uiStore = useUIStore();
+			const openNewCredSpy = vi.spyOn(uiStore, 'openNewCredential');
+
+			const { getByTestId } = renderComponent({
+				props: {
+					requestId: 'req-1',
+					credentialRequests: requests,
+					message: 'Set up credentials',
+				},
+			});
+
+			await userEvent.click(getByTestId('instance-ai-credential-setup-button'));
+			expect(openNewCredSpy).toHaveBeenCalledWith(
+				'type1',
+				false,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				{ closeOnSave: true, defaultIsResolvable: true },
 			);
 		});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -285,6 +285,7 @@ function openNewCredentialModal() {
 		undefined,
 		{
 			closeOnSave: true,
+			defaultIsResolvable: req.isResolvable,
 		},
 	);
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -559,6 +559,7 @@ async function handleSetupAutomatically() {
 							:override-cred-type="currentRequest.credentialType"
 							:project-id="projectId"
 							:suggested-credential-name="currentRequest.suggestedName"
+							:default-is-resolvable="currentRequest.isResolvable"
 							standalone
 							hide-issues
 							hide-ask-assistant

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/__tests__/factories.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/__tests__/factories.ts
@@ -53,6 +53,7 @@ export function makeWorkflowSetupSection(
 	return {
 		id: overrides.id ?? buildSectionId(targetNodeName, credentialType),
 		...(credentialType ? { credentialType } : {}),
+		...(overrides.isResolvable !== undefined ? { isResolvable: overrides.isResolvable } : {}),
 		targetNodeName,
 		node: finalNode,
 		currentCredentialId: overrides.currentCredentialId ?? null,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupSectionBody.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupSectionBody.test.ts
@@ -31,6 +31,7 @@ const workflowDocumentStoreRef = vi.hoisted(() => ({
 const nodeCredentialsMock = vi.hoisted(() => ({
 	emitCredentialSelected: null as ((update: unknown) => void) | null,
 	lastNodeProp: null as unknown,
+	lastDefaultIsResolvableProp: undefined as boolean | undefined,
 }));
 const parameterListMock = vi.hoisted(() => ({
 	lastHiddenIssuesInputs: undefined as string[] | undefined,
@@ -52,11 +53,14 @@ vi.mock('@/features/credentials/components/NodeCredentials.vue', async () => {
 	const { defineComponent, h } = await import('vue');
 	return {
 		default: defineComponent({
-			props: ['node'],
+			props: ['node', 'defaultIsResolvable'],
 			emits: ['credentialSelected'],
 			setup(props, { emit, slots }) {
 				nodeCredentialsMock.emitCredentialSelected = (update) => emit('credentialSelected', update);
 				nodeCredentialsMock.lastNodeProp = props.node;
+				nodeCredentialsMock.lastDefaultIsResolvableProp = props.defaultIsResolvable as
+					| boolean
+					| undefined;
 				return () => h('div', { 'data-test-id': 'node-credentials' }, slots['label-postfix']?.());
 			},
 		}),
@@ -153,6 +157,7 @@ describe('WorkflowSetupSectionBody', () => {
 		workflowDocumentStoreRef.current = null;
 		nodeCredentialsMock.emitCredentialSelected = null;
 		nodeCredentialsMock.lastNodeProp = null;
+		nodeCredentialsMock.lastDefaultIsResolvableProp = undefined;
 		parameterListMock.lastHiddenIssuesInputs = undefined;
 		credentialsStore.getCredentialById.mockReturnValue({ id: 'cred-1', name: 'Typeform account' });
 		nodeTypesStore.getNodeType.mockReturnValue({
@@ -197,6 +202,29 @@ describe('WorkflowSetupSectionBody', () => {
 		await nextTick();
 
 		expect(renderedCredentials.at(-1)).toBe(credentialsBeforeParameterChange);
+	});
+
+	it('passes isResolvable through to NodeCredentials as defaultIsResolvable', async () => {
+		const section = makeWorkflowSetupSection({
+			credentialType: 'googleDriveOAuth2Api',
+			isResolvable: true,
+		});
+		workflowSetupContext.current = makeContext(section);
+
+		renderComponent({ props: { section } });
+		await nextTick();
+
+		expect(nodeCredentialsMock.lastDefaultIsResolvableProp).toBe(true);
+	});
+
+	it('leaves defaultIsResolvable undefined when the section has no isResolvable hint', async () => {
+		const section = makeWorkflowSetupSection({ credentialType: 'slackApi' });
+		workflowSetupContext.current = makeContext(section);
+
+		renderComponent({ props: { section } });
+		await nextTick();
+
+		expect(nodeCredentialsMock.lastDefaultIsResolvableProp).toBeUndefined();
 	});
 
 	it('reveals validation for setup parameters on mount so required fields show immediately', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupSectionBody.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupSectionBody.vue
@@ -201,6 +201,7 @@ function onParameterValueChanged(update: IUpdateInformation) {
 			:node="displayNode"
 			:override-cred-type="credentialType"
 			:project-id="ctx.projectId.value"
+			:default-is-resolvable="section.isResolvable"
 			standalone
 			hide-issues
 			hide-ask-assistant

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/composables/useWorkflowSetupSections.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/composables/useWorkflowSetupSections.test.ts
@@ -39,6 +39,24 @@ describe('useWorkflowSetupSections', () => {
 		expect(sections.value[0].credentialType).toBe('httpBasicAuth');
 	});
 
+	it('carries isResolvable from the setup request onto the section', () => {
+		const setupRequests = ref([
+			makeSetupRequest({ credentialType: 'googleDriveOAuth2Api', isResolvable: true }),
+		]);
+
+		const { sections } = useWorkflowSetupSections(setupRequests);
+
+		expect(sections.value[0].isResolvable).toBe(true);
+	});
+
+	it('omits isResolvable from the section when the setup request does not set it', () => {
+		const setupRequests = ref([makeSetupRequest({ credentialType: 'httpBasicAuth' })]);
+
+		const { sections } = useWorkflowSetupSections(setupRequests);
+
+		expect(sections.value[0]).not.toHaveProperty('isResolvable');
+	});
+
 	it('creates sections for editable parameter-only setup requests', () => {
 		const setupRequests = ref([
 			makeSetupRequest({

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/composables/useWorkflowSetupSections.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/composables/useWorkflowSetupSections.ts
@@ -53,6 +53,7 @@ export function useWorkflowSetupSections(
 			const section: WorkflowSetupSection = {
 				id: buildSectionId(req.node.name, credentialType),
 				...(credentialType ? { credentialType } : {}),
+				...(req.isResolvable ? { isResolvable: true } : {}),
 				targetNodeName: req.node.name,
 				node,
 				currentCredentialId,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/workflowSetup.types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/workflowSetup.types.ts
@@ -8,6 +8,8 @@ import type { INodeParameters } from 'n8n-workflow';
 export interface WorkflowSetupSection {
 	id: string;
 	credentialType?: string;
+	/** Pre-select "End-user credential" connection mode when creating a new credential for this section. */
+	isResolvable?: boolean;
 	targetNodeName: string;
 	node: InstanceAiWorkflowSetupNode['node'];
 	currentCredentialId: string | null;

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.test.ts
@@ -198,6 +198,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: false,
 					isOAuthType: true,
+					canUseEndUserMode: false,
 					isNewCredential: true,
 					credentialPermissions: {
 						create: true,
@@ -214,7 +215,7 @@ describe('CredentialConfig', () => {
 			expect(screen.queryByTestId('credential-type-selector')).not.toBeInTheDocument();
 		});
 
-		it('should not display dynamic credentials section when isOAuthType is false', async () => {
+		it('should not display dynamic credentials section when end-user mode is unavailable for the type', async () => {
 			renderComponent({
 				props: {
 					isManaged: false,
@@ -224,6 +225,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: false,
+					canUseEndUserMode: false,
 					isNewCredential: true,
 					credentialPermissions: {
 						create: true,
@@ -250,6 +252,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: false,
 					isNewCredential: true,
 					credentialPermissions: {
 						create: false,
@@ -276,6 +279,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: false,
 					isNewCredential: false,
 					credentialPermissions: {
 						create: false,
@@ -302,6 +306,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: true,
 					isNewCredential: true,
 					isResolvable: false,
 					credentialPermissions: {
@@ -331,6 +336,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: true,
 					isNewCredential: false,
 					isResolvable: false,
 					credentialPermissions: {
@@ -360,6 +366,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: true,
 					isNewCredential: false,
 					isResolvable: false,
 					credentialPermissions: {
@@ -389,6 +396,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: false,
 					isNewCredential: false,
 					isResolvable: false,
 					credentialPermissions: {
@@ -417,6 +425,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: false,
 					isNewCredential: false,
 					isResolvable: true,
 					credentialPermissions: {
@@ -445,6 +454,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: true,
 					isNewCredential: false,
 					isResolvable: true,
 					credentialPermissions: {
@@ -475,6 +485,7 @@ describe('CredentialConfig', () => {
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
+					canUseEndUserMode: true,
 					isNewCredential: false,
 					isResolvable: true,
 					credentialPermissions: {
@@ -686,6 +697,7 @@ describe('CredentialConfig', () => {
 					credentialProperties: [],
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isOAuthType: true,
+					canUseEndUserMode: false,
 					managedOauthAvailable: false,
 					useCustomOauth: false,
 					credentialPermissions: writePermissions,
@@ -714,6 +726,7 @@ describe('CredentialConfig', () => {
 					credentialProperties: [],
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isOAuthType: true,
+					canUseEndUserMode: false,
 					managedOauthAvailable: true,
 					useCustomOauth: true,
 					credentialPermissions: writePermissions,
@@ -742,6 +755,7 @@ describe('CredentialConfig', () => {
 					credentialProperties: [],
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isOAuthType: true,
+					canUseEndUserMode: false,
 					managedOauthAvailable: true,
 					useCustomOauth: false,
 					credentialPermissions: writePermissions,
@@ -760,6 +774,7 @@ describe('CredentialConfig', () => {
 					credentialProperties: [],
 					credentialData: {} as ICredentialDataDecryptedObject,
 					isOAuthType: false,
+					canUseEndUserMode: false,
 					managedOauthAvailable: false,
 					useCustomOauth: false,
 					credentialPermissions: writePermissions,

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -72,6 +72,8 @@ type Props = {
 	requiredPropertiesFilled?: boolean;
 	isManaged?: boolean;
 	isPrivateCredentialsEnabled?: boolean;
+	/** Whether End-user mode is offerable for this credential (OAuth type + permission). */
+	canUseEndUserMode?: boolean;
 	isResolvable?: boolean;
 	connectedByMe?: boolean;
 	isNewCredential?: boolean;
@@ -562,11 +564,9 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 				<CredentialTypeSelector
 					v-if="
 						isPrivateCredentialsEnabled &&
-						// Only OAuth credentials can be dynamic for now, as they are the only ones with the managed authorize endpoint
-						isOAuthType &&
-						// Only users who can manage end-user credentials see the selector at all;
-						// it's disabled for them when they lack edit access to the credential.
-						!!credentialPermissions.createEndUser
+						// Shared with the composable's `defaultIsResolvable` gate so the two can't
+						// disagree; still disabled below without edit access to the credential.
+						canUseEndUserMode
 					"
 					:model-value="Boolean(isResolvable)"
 					:disabled="!canSelectEndUserType"

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -211,6 +211,16 @@ const form = useCredentialForm({
 		const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
 		return isCredentialModalState(modalState) ? modalState.suggestedName : undefined;
 	},
+	// Ignored when private/end-user credentials aren't available (unlicensed, or an
+	// instance-scoped credential) — the connection-mode toggle wouldn't be shown either.
+	defaultIsResolvable: () => {
+		if (!isPrivateCredentialsEnabled.value) return undefined;
+		const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+		if (!isCredentialModalState(modalState) || modalState.usageScope === 'instance') {
+			return undefined;
+		}
+		return modalState.defaultIsResolvable;
+	},
 	// Scroll the auth-error/success banner into view after a test (parity with the
 	// modal's former testCredential, which ended with scrollToTop).
 	onTestComplete: scrollToTop,

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -211,15 +211,12 @@ const form = useCredentialForm({
 		const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
 		return isCredentialModalState(modalState) ? modalState.suggestedName : undefined;
 	},
-	// Ignored when private/end-user credentials aren't available (unlicensed, or an
-	// instance-scoped credential) — the connection-mode toggle wouldn't be shown either.
+	// Ignored when end-user credentials aren't available here (unlicensed, or instance
+	// scope). The composable also gates on `canUseEndUserMode` (OAuth type + permission).
 	defaultIsResolvable: () => {
-		if (!isPrivateCredentialsEnabled.value) return undefined;
+		if (!isPrivateCredentialsEnabled.value || isInstanceCredential.value) return undefined;
 		const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
-		if (!isCredentialModalState(modalState) || modalState.usageScope === 'instance') {
-			return undefined;
-		}
-		return modalState.defaultIsResolvable;
+		return isCredentialModalState(modalState) ? modalState.defaultIsResolvable : undefined;
 	},
 	// Scroll the auth-error/success banner into view after a test (parity with the
 	// modal's former testCredential, which ended with scrollToTop).
@@ -254,6 +251,7 @@ const {
 	requiredPropertiesFilled,
 	isCredentialTestable,
 	credentialPermissions,
+	canUseEndUserMode,
 	usesExternalSecrets,
 	homeProject,
 	setCredentialPropertyDefaults,
@@ -1422,6 +1420,7 @@ const { width } = useElementSize(credNameRef);
 							:mode="mode"
 							:selected-credential="selectedCredential"
 							:is-private-credentials-enabled="isPrivateCredentialsEnabled && !isInstanceCredential"
+							:can-use-end-user-mode="canUseEndUserMode"
 							:is-resolvable="isResolvable"
 							:connected-by-me="connectedByMe"
 							:is-new-credential="isNewCredential"

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -363,7 +363,32 @@ describe('NodeCredentials', () => {
 			undefined,
 			httpNode.name,
 			httpNode,
-			{ hideAskAssistant: false, closeOnSave: true },
+			{ hideAskAssistant: false, closeOnSave: true, defaultIsResolvable: false },
+		);
+	});
+
+	it('opens the new credential modal pre-set to End-user mode when defaultIsResolvable is true', async () => {
+		ndvStore.activeNode = httpNode;
+		credentialsStore.state.credentials = {
+			c8vqdPpPClh4TgIO: createCredential(),
+		};
+
+		renderComponent({ props: { defaultIsResolvable: true } });
+
+		const credentialsSelect = screen.getByTestId('node-credentials-select');
+
+		await userEvent.click(credentialsSelect);
+		await userEvent.click(screen.getByTestId('node-credentials-select-item-new'));
+
+		expect(uiStore.openNewCredential).toHaveBeenCalledWith(
+			'openAiApi',
+			false,
+			false,
+			undefined,
+			undefined,
+			httpNode.name,
+			httpNode,
+			{ hideAskAssistant: false, closeOnSave: true, defaultIsResolvable: true },
 		);
 	});
 
@@ -394,7 +419,7 @@ describe('NodeCredentials', () => {
 			undefined,
 			httpNode.name,
 			httpNode,
-			{ hideAskAssistant: true, closeOnSave: true },
+			{ hideAskAssistant: true, closeOnSave: true, defaultIsResolvable: false },
 		);
 	});
 
@@ -952,7 +977,7 @@ describe('NodeCredentials', () => {
 					name: slackNode.name,
 					type: slackNode.type,
 				}),
-				{ hideAskAssistant: false, closeOnSave: true },
+				{ hideAskAssistant: false, closeOnSave: true, defaultIsResolvable: false },
 			);
 		});
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -79,6 +79,8 @@ type Props = {
 	projectId?: string;
 	/** Pre-fill the credential name when creating a new credential. */
 	suggestedCredentialName?: string;
+	/** Pre-select "End-user credential" connection mode when creating a new credential. */
+	defaultIsResolvable?: boolean;
 	/** Hide the "Ask n8n AI" assistant button inside the credential editor.
 	 *  Used by surfaces (e.g. agents) where the assistant flow isn't wired up. */
 	hideAskAssistant?: boolean;
@@ -98,6 +100,7 @@ const props = withDefaults(defineProps<Props>(), {
 	skipAutoSelect: false,
 	standalone: false,
 	skipCredentialsFetch: false,
+	defaultIsResolvable: false,
 });
 
 const emit = defineEmits<{
@@ -526,6 +529,7 @@ function createNewCredential(
 			hideAskAssistant: hideAskAssistant.value,
 			closeOnSave: true,
 			instanceAiCredentialHelp: instanceAiCredentialHelp(),
+			defaultIsResolvable: props.defaultIsResolvable,
 		},
 	);
 	telemetry.track('User opened Credential modal', {

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
@@ -189,6 +189,26 @@ describe('useCredentialForm', () => {
 			expect(form.credentialData.value.user).toBe('alice');
 		});
 
+		it('defaults isResolvable to false for a new credential', async () => {
+			const form = useCredentialForm({ mode: 'new', activeId: 'httpBasicAuth' });
+
+			await form.initialize();
+
+			expect(form.isResolvable.value).toBe(false);
+		});
+
+		it('seeds isResolvable from defaultIsResolvable for a new credential', async () => {
+			const form = useCredentialForm({
+				mode: 'new',
+				activeId: 'privateOAuth2Api',
+				defaultIsResolvable: true,
+			});
+
+			await form.initialize();
+
+			expect(form.isResolvable.value).toBe(true);
+		});
+
 		it('flags custom OAuth when editing a credential with overridden client fields', async () => {
 			credentialsStore.getCredentialData.mockResolvedValue({
 				id: 'cred-2',

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
@@ -6,6 +6,7 @@ import type { ICredentialType, INode, INodeTypeDescription } from 'n8n-workflow'
 import { mockedStore } from '@/__tests__/utils';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useCredentialsStore } from '../../credentials.store';
 import type { ICredentialsDecryptedResponse } from '../../credentials.types';
 import { useCredentialForm } from '../useCredentialForm';
@@ -99,6 +100,25 @@ const betaApi: ICredentialType = {
 	properties: [],
 };
 
+// `isOAuthType` needs the oAuth2Api lineage plus an authorizationCode/pkce grant.
+const endUserOAuth: ICredentialType = {
+	name: 'endUserOAuth2Api',
+	displayName: 'End-user OAuth2 API',
+	extends: ['oAuth2Api'],
+	properties: [
+		{ displayName: 'Grant Type', name: 'grantType', type: 'hidden', default: 'authorizationCode' },
+		{ displayName: 'Client ID', name: 'clientId', type: 'string', default: '' },
+	],
+};
+
+const oAuth2Api: ICredentialType = {
+	name: 'oAuth2Api',
+	displayName: 'OAuth2 API',
+	properties: [
+		{ displayName: 'Grant Type', name: 'grantType', type: 'hidden', default: 'authorizationCode' },
+	],
+};
+
 const typesByName: Record<string, ICredentialType> = {
 	httpBasicAuth,
 	acmeOAuth2Api: managedOAuth,
@@ -107,11 +127,22 @@ const typesByName: Record<string, ICredentialType> = {
 	httpTemplatedCustomAuth: templatedCustomAuth,
 	alphaApi,
 	betaApi,
+	endUserOAuth2Api: endUserOAuth,
+	oAuth2Api,
 };
 
 describe('useCredentialForm', () => {
 	let credentialsStore: ReturnType<typeof mockedStore<typeof useCredentialsStore>>;
 	let settingsStore: ReturnType<typeof mockedStore<typeof useSettingsStore>>;
+
+	/** Credential permissions derive from the home project's scopes. */
+	function grantEndUserCredentialScope() {
+		const projectsStore = mockedStore(useProjectsStore);
+		projectsStore.currentProject = {
+			id: 'project-1',
+			scopes: ['credential:create', 'credential:createEndUser'],
+		} as unknown as typeof projectsStore.currentProject;
+	}
 
 	beforeEach(() => {
 		setActivePinia(createTestingPinia({ stubActions: false }));
@@ -198,15 +229,43 @@ describe('useCredentialForm', () => {
 		});
 
 		it('seeds isResolvable from defaultIsResolvable for a new credential', async () => {
+			grantEndUserCredentialScope();
 			const form = useCredentialForm({
 				mode: 'new',
-				activeId: 'privateOAuth2Api',
+				activeId: 'endUserOAuth2Api',
 				defaultIsResolvable: true,
 			});
 
 			await form.initialize();
 
 			expect(form.isResolvable.value).toBe(true);
+		});
+
+		// The selector only renders for OAuth types with the createEndUser scope; a hint
+		// that outran it would set a mode the user can't undo and the backend rejects.
+		it('ignores defaultIsResolvable for a non-OAuth credential type', async () => {
+			grantEndUserCredentialScope();
+			const form = useCredentialForm({
+				mode: 'new',
+				activeId: 'httpBasicAuth',
+				defaultIsResolvable: true,
+			});
+
+			await form.initialize();
+
+			expect(form.isResolvable.value).toBe(false);
+		});
+
+		it('ignores defaultIsResolvable when the user cannot manage end-user credentials', async () => {
+			const form = useCredentialForm({
+				mode: 'new',
+				activeId: 'endUserOAuth2Api',
+				defaultIsResolvable: true,
+			});
+
+			await form.initialize();
+
+			expect(form.isResolvable.value).toBe(false);
 		});
 
 		it('flags custom OAuth when editing a credential with overridden client fields', async () => {

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
@@ -61,6 +61,8 @@ export interface UseCredentialFormOptions {
 	showAuthSelector?: MaybeRefOrGetter<boolean>;
 	/** Preferred name for a new credential; falls back to a generated default. */
 	suggestedName?: MaybeRefOrGetter<string | undefined>;
+	/** Pre-select End-user credential mode for a freshly created credential (new mode only). */
+	defaultIsResolvable?: MaybeRefOrGetter<boolean | undefined>;
 	/** Ran after a connection test completes — host hook (e.g. scroll the result banner into view). */
 	onTestComplete?: () => void;
 }
@@ -499,6 +501,7 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 			detectCustomOAuth();
 			return;
 		}
+		isResolvable.value = toValue(options.defaultIsResolvable) ?? false;
 		credentialName.value =
 			toValue(options.suggestedName) ||
 			(credentialTypeName.value

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
@@ -324,6 +324,15 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 			).credential,
 	);
 
+	/**
+	 * Whether End-user mode is offerable here (OAuth-only, and only with permission).
+	 * Shared by the connection-mode selector and the `defaultIsResolvable` hint — if the
+	 * two disagree, `isResolvable` can be set with no control to unset it.
+	 */
+	const canUseEndUserMode = computed(
+		() => isOAuthType.value && !!credentialPermissions.value.createEndUser,
+	);
+
 	// --- helpers -----------------------------------------------------------
 	function getParentTypes(name: string): string[] {
 		const type = credentialsStore.getCredentialTypeByName(name);
@@ -501,7 +510,6 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 			detectCustomOAuth();
 			return;
 		}
-		isResolvable.value = toValue(options.defaultIsResolvable) ?? false;
 		credentialName.value =
 			toValue(options.suggestedName) ||
 			(credentialTypeName.value
@@ -510,6 +518,9 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 					})
 				: (credentialType.value?.displayName ?? ''));
 		setCredentialPropertyDefaults();
+		// Must run after defaults: `isOAuthType` reads `grantType`. Ignoring the hint when
+		// the mode isn't offerable keeps us from setting a flag the user can't see or undo.
+		isResolvable.value = !!toValue(options.defaultIsResolvable) && canUseEndUserMode.value;
 		if (homeProject.value) {
 			credentialData.value = { ...credentialData.value, homeProject: homeProject.value };
 		}
@@ -627,6 +638,7 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 		isCredentialTestable,
 		credentialPermissions,
 		canUseCustomOAuth,
+		canUseEndUserMode,
 		// helpers
 		getParentTypes,
 		getCredentialProperties,


### PR DESCRIPTION
## Summary

The AI assistant did not work with end-user (per-user) credentials: the workflow-builder skill had no awareness of them, manual test executions never injected the acting user's identity (so dynamic credentials silently fell back to placeholder data), and credential status reporting always showed "not connected" even when the user's own connection existed.

This PR:
- Threads the acting user's auth cookie from the controller into the adapter's execution and credential-test paths, mirroring how the editor's manual execution and credential test flows resolve dynamic credentials.
- Surfaces `isResolvable` on credential list/get results so the assistant can check a credential's actual connection mode instead of assuming "Fixed".
- Teaches the workflow-builder skill what an End-user credential is, when to use one, and how to describe connecting it.
- Adds an `isResolvable` hint to the credential setup tool: when set, the setup card's reason text tells the user to create the credential as End-user mode, and if they create a new credential from the card, its setup modal now opens pre-set to End-user mode instead of defaulting to Fixed.

## How to test

1. Start a chat with the AI assistant and ask it to build a workflow that should use "their own account" / "per user" credentials (e.g. "list files from Google Drive for whoever runs this").
2. Confirm the assistant's setup card explicitly says to create the credential as an "End-user credential", and that the credential-creation modal opens with End-user mode already selected.
3. Connect the credential as the acting user, then ask the assistant to test/run the workflow — it should now execute (and report credential status) using that connection instead of reporting "not connected".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-992

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35164">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

