### PR TITLE
ci: Guard weekly minor release PR creation with a cadence check

### DIFF
--- a/.agents/skills/conventions/SKILL.md
+++ b/.agents/skills/conventions/SKILL.md
@@ -46,6 +46,10 @@ throw new UnexpectedError('message', { extra: { context } });
 - SQLite/PostgreSQL only (app DB)
 - Exception: DB nodes (MySQL Node, etc.) can use DB-specific features
 
+**GitHub Workflows:**
+- Every workflow declares a least-privilege top-level `permissions:` block
+  (usually `contents: read`); jobs needing more override at job level
+
 **Commands:**
 ```bash
 pnpm build > build.log 2>&1  # Always redirect

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -30,7 +30,12 @@ Reusable workflows: add `-reusable` or `-callable` suffix.
 
 ### Common Tasks
 
-**Add workflow:** Create in `workflows/`, document in `WORKFLOWS.md`
+**Add workflow:** Create in `workflows/`, document in `WORKFLOWS.md`.
+Always declare a least-privilege top-level `permissions:` block (usually
+`contents: read`) — without one the workflow runs with the repo's broad
+default token and review flags it. Jobs needing more override at job level;
+a job calling a reusable workflow must grant at least what that workflow
+declares.
 
 **Add script:** Create `.mjs` in `scripts/`, document in `WORKFLOWS.md`
 

--- a/.github/workflows/release-create-minor-pr.yml
+++ b/.github/workflows/release-create-minor-pr.yml
@@ -10,6 +10,9 @@ on:
   # schedule:
   #   - cron: 0 8 * * 2 # 9am CET (UTC+1), Tuesday
 
+permissions:
+  contents: read
+
 jobs:
   check-cadence:
     name: Check release cadence
@@ -36,6 +39,10 @@ jobs:
   create-release-pr:
     name: Create release PR
     needs: [check-cadence]
+    # The called workflow requires these; a caller cannot grant less than it requests.
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/release-create-pr.yml
     secrets: inherit
     with:

--- a/.github/workflows/release-create-minor-pr.yml
+++ b/.github/workflows/release-create-minor-pr.yml
@@ -2,12 +2,40 @@ name: 'Release: Create Minor Release PR'
 
 on:
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Create the release PR even if a minor release already went live this week.'
+        type: boolean
+        default: false
   # schedule:
   #   - cron: 0 8 * * 2 # 9am CET (UTC+1), Tuesday
 
 jobs:
+  check-cadence:
+    name: Check release cadence
+    runs-on: ubuntu-latest
+    steps:
+      # Guards against a misbehaving scheduler dispatching this workflow more than once a week.
+      - name: Fail if a minor release already went live this week
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          if [ "$FORCE" = "true" ]; then
+            echo "Force input set, skipping cadence check."
+            exit 0
+          fi
+          LAST_LIVE=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,publishedAt \
+            --jq '[.[] | select(.publishedAt != null and (.tagName | test("^n8n@[0-9]+\\.[0-9]+\\.0$")))] | max_by(.publishedAt).publishedAt // empty')
+          if [ -n "$LAST_LIVE" ] && [ "$(date -u -d "$LAST_LIVE" +%G-%V)" = "$(date -u +%G-%V)" ]; then
+            echo "::error::A minor release already went live this week ($LAST_LIVE). Re-run with the 'force' input to override."
+            exit 1
+          fi
+          echo "No minor release this week yet (last went live: ${LAST_LIVE:-never}), proceeding."
+
   create-release-pr:
     name: Create release PR
+    needs: [check-cadence]
     uses: ./.github/workflows/release-create-pr.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Yesterday's scheduler misfire re-dispatched `release-create-minor-pr.yml` a day after the legitimate weekly run, creating a duplicate minor release PR that had to be closed manually. This adds a `check-cadence` job that fails the workflow when a minor release (`n8n@X.Y.0` GitHub release) already went live in the current ISO calendar week, so a runaway dispatch can't start an unintended release. A new `force` dispatch input bypasses the check for deliberate off-cadence releases.

## How to test

Dispatch the workflow without `force`: the cadence check fails this week (2.33.0 went live Tuesday) and no PR is created. Dispatch with `force: true`: the check is skipped and the release PR is created as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-673

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

