### PR TITLE
build: Add Debian (glibc) variants of the Docker base and n8n images (no-changelog)

### DIFF
--- a/docker/images/n8n-base/Dockerfile.debian
+++ b/docker/images/n8n-base/Dockerfile.debian
@@ -1,0 +1,37 @@
+# Debian (glibc) variant of the base image. The Alpine image (./Dockerfile)
+# remains the default; this variant exists for native vendor client libraries
+# that are glibc-only and can never run on musl (e.g. Oracle Instant Client,
+# IBM DB2 clidriver). Vendor libraries are NOT shipped here — customers layer
+# them on top; this image's contract is the glibc runtime plus a working
+# package manager.
+#
+# Pinned to a multi-arch index digest (linux/amd64 + linux/arm64) for
+# reproducible builds. Bump the tag and digest together when updating.
+FROM dhi.io/node:24.18.0-debian13-dev@sha256:f840f3c488c579e78e6dffdf62dda5d9560eeac9f9d685778c7e14e6822e5b76
+
+# Differences from the Alpine base:
+# - libc6-compat and busybox-binsh dropped: they exist to paper over musl.
+# - openssl added: provides c_rehash for the /opt/custom-certificates
+#   entrypoint flow (Alpine provides it transitively).
+# - msttcorefonts omitted: Debian's ttf-mscorefonts-installer lives in
+#   contrib and requires EULA acceptance; the DHI mirror serves main only.
+# - apt is kept, unlike the Alpine base which deletes apk-tools: extending
+#   this image with vendor libraries is its purpose.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openssh-client \
+        graphicsmagick \
+        tini \
+        tzdata \
+        ca-certificates \
+        openssl \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# DHI Debian ships node at /usr/bin; symlink it to /usr/local/bin so the path
+# matches what the cloud launch and AppArmor profile expect.
+RUN mkdir -p /usr/local/bin && ln -sf /usr/bin/node /usr/local/bin/node
+
+WORKDIR /home/node
+# This base image installs global npm modules under /usr/local; set NODE_PATH
+# so packages added via `npm install -g` are require()-able at runtime.
+ENV NODE_PATH=/usr/local/lib/node_modules
+EXPOSE 5678/tcp

--- a/docker/images/n8n-base/Dockerfile.debian
+++ b/docker/images/n8n-base/Dockerfile.debian
@@ -1,22 +1,12 @@
-# Debian (glibc) variant of the base image. The Alpine image (./Dockerfile)
-# remains the default; this variant exists for native vendor client libraries
-# that are glibc-only and can never run on musl (e.g. Oracle Instant Client,
-# IBM DB2 clidriver). Vendor libraries are NOT shipped here — customers layer
-# them on top; this image's contract is the glibc runtime plus a working
-# package manager.
-#
+# Debian (glibc) variant of ./Dockerfile, for glibc-only vendor client
+# libraries (e.g. Oracle Instant Client) that customers layer on top.
 # Pinned to a multi-arch index digest (linux/amd64 + linux/arm64) for
 # reproducible builds. Bump the tag and digest together when updating.
 FROM dhi.io/node:24.18.0-debian13-dev@sha256:f840f3c488c579e78e6dffdf62dda5d9560eeac9f9d685778c7e14e6822e5b76
 
-# Differences from the Alpine base:
-# - libc6-compat and busybox-binsh dropped: they exist to paper over musl.
-# - openssl added: provides c_rehash for the /opt/custom-certificates
-#   entrypoint flow (Alpine provides it transitively).
-# - msttcorefonts omitted: Debian's ttf-mscorefonts-installer lives in
-#   contrib and requires EULA acceptance; the DHI mirror serves main only.
-# - apt is kept, unlike the Alpine base which deletes apk-tools: extending
-#   this image with vendor libraries is its purpose.
+# openssl provides c_rehash for the /opt/custom-certificates entrypoint flow.
+# msttcorefonts omitted: Debian's installer needs contrib + EULA, and the DHI
+# mirror serves main only. apt is kept — extending this image is its purpose.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         openssh-client \
         graphicsmagick \
@@ -26,12 +16,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         openssl \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
-# DHI Debian ships node at /usr/bin; symlink it to /usr/local/bin so the path
-# matches what the cloud launch and AppArmor profile expect.
+# Node ships at /usr/bin; symlink it to /usr/local/bin so the path matches
+# what the cloud launch and AppArmor profile expect.
 RUN mkdir -p /usr/local/bin && ln -sf /usr/bin/node /usr/local/bin/node
 
 WORKDIR /home/node
-# This base image installs global npm modules under /usr/local; set NODE_PATH
-# so packages added via `npm install -g` are require()-able at runtime.
+# Global npm modules install under /usr/local; set NODE_PATH so packages
+# added via `npm install -g` are require()-able at runtime.
 ENV NODE_PATH=/usr/local/lib/node_modules
 EXPOSE 5678/tcp

--- a/docker/images/n8n/Dockerfile.debian
+++ b/docker/images/n8n/Dockerfile.debian
@@ -1,0 +1,56 @@
+ARG NODE_VERSION=24.18.0
+ARG N8N_VERSION=snapshot
+
+# Debian (glibc) variant of the n8n image. The Alpine image (./Dockerfile)
+# remains the default; see docker/images/n8n-base/Dockerfile.debian for why
+# this variant exists.
+#
+# Builder differences from the Alpine variant:
+# - sqlite3 still needs a rebuild: its install downloads a platform-specific
+#   binary and ./compiled is produced on the host.
+# - the isolated-vm musl workaround is gone: its bundled glibc prebuilds load
+#   as-is. The require() smoke test fails the build if a prebuild is missing.
+# Pinned to a multi-arch index digest (linux/amd64 + linux/arm64) for
+# reproducible builds. Bump the tag and digest together when updating.
+FROM node:24.18.0-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS builder
+COPY ./compiled /usr/local/lib/node_modules/n8n
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ ca-certificates && \
+    cd /usr/local/lib/node_modules/n8n && \
+    npm rebuild sqlite3 && \
+    node -e "require('sqlite3'); require('isolated-vm')"
+
+# Not digest-pinned yet: n8nio/base debian tags are not published until the
+# base-image workflow builds this variant. Pin the digest here once the first
+# base publish exists, mirroring the Alpine Dockerfile.
+FROM n8nio/base:24.18.0-debian
+
+ARG N8N_VERSION
+ARG N8N_RELEASE_TYPE=dev
+ENV NODE_ENV=production
+ENV N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE}
+ENV SHELL=/bin/sh
+# glibc's malloc grows per-thread arenas that add ~70 MB idle RSS over the
+# Alpine image at cloud-starter quotas (measured; scales with visible cores).
+# Capping arenas recovers roughly a third of that for no observed cost.
+ENV MALLOC_ARENA_MAX=2
+
+WORKDIR /home/node
+
+COPY --from=builder /usr/local/lib/node_modules/n8n /usr/local/lib/node_modules/n8n
+COPY docker/images/n8n/docker-entrypoint.sh /
+
+RUN mkdir -p /usr/local/bin && \
+    ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
+    mkdir -p /home/node/.n8n && \
+    chown -R node:node /home/node && \
+    rm -rf /root/.npm /tmp/*
+
+EXPOSE 5678/tcp
+USER node
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
+
+LABEL org.opencontainers.image.title="n8n" \
+      org.opencontainers.image.description="Workflow Automation Tool (glibc variant)" \
+      org.opencontainers.image.source="https://github.com/n8n-io/n8n" \
+      org.opencontainers.image.url="https://n8n.io" \
+      org.opencontainers.image.version=${N8N_VERSION}

--- a/docker/images/n8n/Dockerfile.debian
+++ b/docker/images/n8n/Dockerfile.debian
@@ -1,17 +1,11 @@
 ARG NODE_VERSION=24.18.0
 ARG N8N_VERSION=snapshot
 
-# Debian (glibc) variant of the n8n image. The Alpine image (./Dockerfile)
-# remains the default; see docker/images/n8n-base/Dockerfile.debian for why
-# this variant exists.
-#
-# Builder differences from the Alpine variant:
-# - sqlite3 still needs a rebuild: its install downloads a platform-specific
-#   binary and ./compiled is produced on the host.
-# - the isolated-vm musl workaround is gone: its bundled glibc prebuilds load
-#   as-is. The require() smoke test fails the build if a prebuild is missing.
-# Pinned to a multi-arch index digest (linux/amd64 + linux/arm64) for
-# reproducible builds. Bump the tag and digest together when updating.
+# Debian (glibc) variant of ./Dockerfile; see n8n-base/Dockerfile.debian.
+# sqlite3 needs a rebuild (its install downloads a platform-specific binary
+# and ./compiled is produced on the host); isolated-vm's bundled glibc
+# prebuilds load as-is, enforced by the require() gate.
+# Pinned to a multi-arch index digest for reproducible builds.
 FROM node:24.18.0-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS builder
 COPY ./compiled /usr/local/lib/node_modules/n8n
 RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ ca-certificates && \
@@ -19,9 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 make g+
     npm rebuild sqlite3 && \
     node -e "require('sqlite3'); require('isolated-vm')"
 
-# Not digest-pinned yet: n8nio/base debian tags are not published until the
-# base-image workflow builds this variant. Pin the digest here once the first
-# base publish exists, mirroring the Alpine Dockerfile.
+# Pin the digest once the base-image workflow publishes this variant.
 FROM n8nio/base:24.18.0-debian
 
 ARG N8N_VERSION
@@ -29,9 +21,8 @@ ARG N8N_RELEASE_TYPE=dev
 ENV NODE_ENV=production
 ENV N8N_RELEASE_TYPE=${N8N_RELEASE_TYPE}
 ENV SHELL=/bin/sh
-# glibc's malloc grows per-thread arenas that add ~70 MB idle RSS over the
-# Alpine image at cloud-starter quotas (measured; scales with visible cores).
-# Capping arenas recovers roughly a third of that for no observed cost.
+# glibc malloc arenas add ~70 MB idle RSS over the Alpine image (measured);
+# capping them recovers about a third at no observed cost.
 ENV MALLOC_ARENA_MAX=2
 
 WORKDIR /home/node


### PR DESCRIPTION
## Summary

Adds Debian (glibc) variant Dockerfiles for the base and main images, alongside the existing Alpine defaults. Dockerfiles only — no CI wiring, nothing is published by this PR, and the default images are unchanged.

**Why:** several enterprise database integrations require vendor client libraries that are glibc-only and cannot run on musl — Oracle Instant Client (Thick Mode, required for TDE-encrypted databases) and IBM's DB2 clidriver (#31106). No amount of layering on the Alpine image can fix this (glibc binaries under musl compat shims produce memory corruption, e.g. `ORA-24960` on short passwords). The variant's contract: glibc runtime + package manager retained; vendor libraries are layered on top by customers, never shipped in the image.

**Design notes:**
- Base pinned to the DHI Debian 13 image (`dhi.io/node:24.18.0-debian13-dev`) by multi-arch digest — same hardened-image framework and pinning workflow as the Alpine base. amd64 + arm64 both published under the pinned index digest.
- The `isolated-vm` musl rebuild workaround is not needed on glibc — bundled prebuilds load as-is, enforced by a `require()` smoke test in the builder. Only `sqlite3` needs a rebuild (platform-specific binary).
- `MALLOC_ARENA_MAX=2` is baked in: glibc's per-thread malloc arenas add ~70 MB idle RSS over Alpine at cloud-starter quotas (measured, n=5 per image, zero overlap between samples: Alpine mean 412.5 MB, Debian mean 488.2 MB); capping arenas recovers roughly a third. The delta is entirely anonymous memory (`Pss_Anon`), so it is a per-instance cost that page sharing cannot amortize — which is why this ships as an opt-in variant and the Alpine default is untouched.
- `msttcorefonts` is omitted for now: Debian's installer lives in `contrib` (EULA acceptance required) and the DHI mirror serves `main` only.
- `apt` is retained (the Alpine base deletes `apk-tools`): extensibility is the purpose of this variant.
- The main image's `FROM n8nio/base:24.18.0-debian` is intentionally not digest-pinned yet — no published digest exists until the base-image workflow builds this variant.

## How to test

```bash
# base variant
docker build -t n8nio/base:24.18.0-debian -f docker/images/n8n-base/Dockerfile.debian docker/images/n8n-base

# main variant (needs ./compiled from `pnpm build:docker`'s build step)
docker build -t n8nio/n8n:local-debian -f docker/images/n8n/Dockerfile.debian .

docker run --rm --entrypoint n8n n8nio/n8n:local-debian --version

# full E2E harness against the variant
cd packages/testing/playwright
TEST_IMAGE_N8N=n8nio/n8n:local-debian TEST_IMAGE_TASK_RUNNER=n8nio/runners:local \
  npx playwright test --project=performance memory-consumption-cloud --grep "Idle baseline" --reporter=list
```

Executed locally (arm64): both images build; `n8n --version` returns 2.33.0; the Playwright container harness idle-memory baseline passes against the variant unmodified (5/5 runs); native modules verified via the in-build `require()` gate.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-122
- Related community contribution blocked on the same constraint: #31106

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35169">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

