### PR TITLE
ci: Strip non-runtime files from Docker image build (no-changelog)

### DIFF
--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -218,6 +218,13 @@ for (const pattern of phantomDirs) {
 }
 echo(chalk.green('✅ Phantom dirs stripped'));
 
+// Strip non-runtime files (Node never loads these) to cut the image's file count,
+// which dominates layer extraction time on constrained hosts. .js.map is kept —
+// source-map-support needs it for production stack traces.
+echo(chalk.yellow('INFO: Stripping non-runtime files (.ts/.d.ts/.md) from production closure...'));
+await $`find ${config.compiledAppDir} \\( -name '*.ts' -o -name '*.d.ts.map' -o -name '*.md' -o -name '*.test.js' -o -name '*.spec.js' \\) -type f -delete 2>/dev/null || true`;
+echo(chalk.green('✅ Non-runtime files stripped'));
+
 await fs.ensureDir(config.compiledTaskRunnerDir);
 
 echo(


### PR DESCRIPTION
## Summary

The production Docker image ships tens of thousands of files Node never loads at runtime: `.d.ts` declarations, raw third-party `.ts` sources, `.d.ts.map` declaration maps, markdown, and stray test files. On resource-constrained hosts (small VMs, NAS-backed storage), layer **extraction** — not download — dominates `docker pull` time, and extraction cost scales with filesystem entry count, not bytes.

This adds a strip step in `scripts/build-n8n.mjs` right after the `pnpm deploy` prune, mirroring the existing phantom-dirs strip.

**Runtime sourcemaps (`.js.map`) are deliberately kept**: `packages/cli/bin/n8n` installs `source-map-support`, so they drive production stack-trace mapping. Stripping raw `.ts` does not affect our own code's traces — our packages ship only `dist` (no `src/`), so position mapping comes entirely from the `.js.map` mappings. The stripped raw `.ts` are all third-party (rxjs, openai, zod, …).

### Measured impact (full deployed closure, local A/B)

| Metric | Before | After | Δ |
|---|---|---|---|
| Entries (files+dirs) | 224,243 | 153,505 | −31.5% |
| Uncompressed size | 1.8 G | 1.4 G | −22% |
| Compressed (gzip) | 319 M | 282 M | −11.6% |
| Extraction time (median of 3) | 158 s | 99 s | **−38%** |

## How to test

```bash
pnpm build > build.log 2>&1
pnpm build:docker
docker run --rm -p 5678:5678 n8nio/n8n:snapshot   # boots, editor loads
find compiled -name '*.d.ts' | wc -l               # 0
find compiled -name '*.js.map' | wc -l             # ~23k (kept)
```

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/DEVP-674
- Community report: https://community.n8n.io/t/production-docker-image-ships-40-non-runtime-files-sourcemaps-d-ts-slows-down-pulls-on-constrained-hosts/305283
- Related: https://linear.app/n8n/issue/DEVP-268 (its byte-equivalence baseline shifts once this lands), https://linear.app/n8n/issue/DEVP-284

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35170">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

