### PR TITLE
refactor(editor): Single-source PERSONALIZATION_MODAL_KEY

### DIFF
--- a/packages/frontend/@n8n/frontend-constants/src/users.ts
+++ b/packages/frontend/@n8n/frontend-constants/src/users.ts
@@ -1,9 +1,1 @@
-/**
- * Constants consumed by `users.store` (`@n8n/stores`). The modal key lives here
- * because it has two consumers on opposite sides of the package boundary — the
- * store's `showPersonalizationSurvey`, and the app-side registration in
- * editor-ui's `users.constants` — and this package is a leaf both already
- * depend on, so nothing can invert.
- */
-
 export const PERSONALIZATION_MODAL_KEY = 'personalization';

--- a/packages/frontend/@n8n/frontend-constants/src/users.ts
+++ b/packages/frontend/@n8n/frontend-constants/src/users.ts
@@ -1,0 +1,10 @@
+/**
+ * Constants consumed by `users.store` (`@n8n/stores`). The modal key lives here
+ * because it has two consumers on opposite sides of the package boundary — the
+ * store's `showPersonalizationSurvey`, and the app-side registration in
+ * editor-ui's `users.constants` — and this package is a leaf both already
+ * depend on, so nothing can invert. Previously duplicated as two literals that
+ * had to stay equal, with nothing enforcing it (N8N-126).
+ */
+
+export const PERSONALIZATION_MODAL_KEY = 'personalization';

--- a/packages/frontend/@n8n/frontend-constants/src/users.ts
+++ b/packages/frontend/@n8n/frontend-constants/src/users.ts
@@ -3,8 +3,7 @@
  * because it has two consumers on opposite sides of the package boundary — the
  * store's `showPersonalizationSurvey`, and the app-side registration in
  * editor-ui's `users.constants` — and this package is a leaf both already
- * depend on, so nothing can invert. Previously duplicated as two literals that
- * had to stay equal, with nothing enforcing it (N8N-126).
+ * depend on, so nothing can invert.
  */
 
 export const PERSONALIZATION_MODAL_KEY = 'personalization';

--- a/packages/frontend/@n8n/stores/src/users.store.ts
+++ b/packages/frontend/@n8n/stores/src/users.store.ts
@@ -9,6 +9,7 @@ import {
 	type UsersListFilterDto,
 } from '@n8n/api-types';
 import { BROWSER_ID_STORAGE_KEY } from '@n8n/constants';
+import { PERSONALIZATION_MODAL_KEY } from '@n8n/frontend-constants/users';
 import type { AssignableGlobalRole } from '@n8n/permissions';
 import * as cloudApi from '@n8n/rest-api-client/api/cloudPlans';
 import * as mfaApi from '@n8n/rest-api-client/api/mfa';
@@ -31,13 +32,6 @@ import type { ModalOpeners } from './modalOpeners';
 import * as onboardingApi from './onboarding.api';
 import { useSettingsStore } from './settings.store';
 import { useRootStore } from './useRootStore';
-
-/**
- * Registration key of the app's personalization modal, passed to the injected
- * modal opener. Mirrors `PERSONALIZATION_MODAL_KEY` in editor-ui's
- * `users.constants`; kept as a literal so the store carries no `@/app` import.
- */
-const PERSONALIZATION_MODAL_KEY = 'personalization';
 
 const _isPendingUser = (user: IUserResponse | null) => !!user?.isPending;
 const _isInstanceOwner = (user: IUserResponse | null) => user?.role === ROLE.Owner;

--- a/packages/frontend/editor-ui/src/features/settings/users/users.constants.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/users.constants.test.ts
@@ -1,0 +1,60 @@
+import type { FrontendSettings } from '@n8n/api-types';
+import { useSettingsStore } from '@n8n/stores/settings.store';
+import { useUsersStore } from '@n8n/stores/users.store';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useUIStore } from '@/app/stores/ui.store';
+
+import { PERSONALIZATION_MODAL_KEY } from './users.constants';
+
+/**
+ * `users.store` lives in `@n8n/stores` and opens the personalization modal through
+ * an injected opener, so its key and the key the app registers under sit on
+ * opposite sides of a package boundary. `openModal` *creates* a missing entry
+ * rather than throwing, so a divergence between the two is silent: the survey
+ * simply never appears. This drives the real wiring from `init.ts` end to end so
+ * that divergence fails here instead. (N8N-126)
+ *
+ * The complementary check — every key used in `Modals.vue` is registered in
+ * `modalsById` — lives in `ui.store.registration.spec.ts`.
+ */
+describe('PERSONALIZATION_MODAL_KEY', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('opens the modal the app registered when users.store fires its opener', () => {
+		const uiStore = useUIStore();
+		const usersStore = useUsersStore();
+
+		// Assign the settings ref directly; setSettings() runs extra bootstrap logic
+		// (auth cookie handling) that a partial fixture can't satisfy.
+		useSettingsStore().settings = {
+			// `isPersonalizationSurveyEnabled` requires both flags.
+			telemetry: { enabled: true },
+			personalizationSurveyEnabled: true,
+		} as unknown as FrontendSettings;
+		usersStore.usersById['1'] = {
+			id: '1',
+			firstName: 'John Doe',
+			role: 'global:owner',
+			isPending: false,
+			isDefaultUser: false,
+			isPendingUser: false,
+			mfaEnabled: false,
+		};
+		usersStore.currentUserId = '1';
+
+		expect(uiStore.modalsById[PERSONALIZATION_MODAL_KEY].open).toBe(false);
+
+		// Exactly what app bootstrap injects (see `init.ts`).
+		usersStore.registerModalOpeners({
+			openModal: uiStore.openModal,
+			openModalWithData: uiStore.openModalWithData,
+		});
+
+		usersStore.showPersonalizationSurvey();
+
+		expect(uiStore.modalsById[PERSONALIZATION_MODAL_KEY].open).toBe(true);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/settings/users/users.constants.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/users.constants.ts
@@ -1,6 +1,9 @@
 export const DELETE_USER_MODAL_KEY = 'deleteUser';
 export const INVITE_USER_MODAL_KEY = 'inviteUser';
-export const PERSONALIZATION_MODAL_KEY = 'personalization';
+// Shared with `users.store` in `@n8n/stores`, which opens this modal through its
+// injected opener; re-exported here so app-side registration and openers keep
+// resolving from `users.constants`. (N8N-126)
+export { PERSONALIZATION_MODAL_KEY } from '@n8n/frontend-constants/users';
 
 /** PERSONALIZATION SURVEY */
 export const EMAIL_KEY = 'email';

--- a/packages/frontend/editor-ui/src/features/settings/users/users.constants.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/users.constants.ts
@@ -1,8 +1,6 @@
 export const DELETE_USER_MODAL_KEY = 'deleteUser';
 export const INVITE_USER_MODAL_KEY = 'inviteUser';
-// Shared with `users.store` in `@n8n/stores`, which opens this modal through its
-// injected opener; re-exported here so app-side registration and openers keep
-// resolving from `users.constants`. (N8N-126)
+
 export { PERSONALIZATION_MODAL_KEY } from '@n8n/frontend-constants/users';
 
 /** PERSONALIZATION SURVEY */


### PR DESCRIPTION
## Summary

`PERSONALIZATION_MODAL_KEY = 'personalization'` existed as **two independent literals that had to stay equal, with no test enforcing it**:

- `packages/frontend/@n8n/stores/src/users.store.ts` — a private `const`, passed to the injected modal opener. Its own comment said it "Mirrors `PERSONALIZATION_MODAL_KEY` in editor-ui's `users.constants`".
- `packages/frontend/editor-ui/src/features/settings/users/users.constants.ts` — the exported constant the app registers the modal under.

Change either one and the personalization survey silently stops opening. `ui.store`'s `openModal` *creates* a missing entry rather than throwing, so there is no throw, no console error, and nothing red. Latent today only because the values happen to match.

This is pre-existing from #34639 / #34727 — **not** introduced by #35142, where Filter found it during review.

### The fix

One definition, in `@n8n/frontend-constants` (`src/users.ts` → `@n8n/frontend-constants/users`), imported by both sides. That package has **zero runtime dependencies** and is already a `workspace:*` dependency of both `@n8n/stores` and `editor-ui`, so no new package edge is introduced and nothing can invert.

Same per-symbol relocation and flat naming as the versions constants in `fcdc5b7152` (N8N-70).

`users.constants` **re-exports** the key, so all four app-side call sites — modal registration in `ui.store`, `Modals.vue`, and `PersonalizationModal.vue` — are untouched. No call-site codemod. The shim stays in place for N8N-92.

### The guard test

Criterion 3 asks for a test that the store opens the modal under the key the app registers. `users.constants.test.ts` drives the **real `init.ts` wiring end to end** — real `users.store`, real `ui.store` openers — and asserts the entry the app registered is the one that flips open.

I took the single definition, not the fallback, so there is nothing blocked to report. Two notes on why the test is shaped this way:

- **A type-level guard is not available.** `ModalKey = keyof Modals`, and `Modals` carries an index signature (`[key: string]: ModalState`), so `ModalKey` collapses to `string`. A compile error would have been louder; the type system can't express it here.
- **The complementary check already exists.** "Every key used in `Modals.vue` is registered in `modalsById`" is covered by `ui.store.registration.spec.ts`, so this test deliberately does not duplicate it — it covers the axis that spec cannot see, across the package boundary.

I verified the guard actually fails, in both drift directions, rather than trusting that it would:

| Injected drift | Result |
| --- | --- |
| editor-ui re-export replaced by its own divergent `const` | ❌ fails |
| `users.store` re-adds a divergent private literal | ❌ fails |
| unmodified | ✅ passes |

## How to test

Automated — no UI behaviour changes (the key's value is unchanged, so nothing user-facing moves).

```bash
pnpm --filter @n8n/frontend-constants build   # emits dist/users.* from the existing entry glob

cd packages/frontend/@n8n/stores      && pnpm test          # 160 passed
cd packages/frontend/editor-ui        && pnpm test src/features/settings/users src/app/stores/ui.store.test.ts src/app/stores/ui.store.registration.spec.ts src/app/init.test.ts   # 140 passed
```

To see the guard bite, change the literal in `@n8n/frontend-constants/src/users.ts` on one side only — e.g. replace the `export { … }` in `users.constants.ts` with its own `const` — and `users.constants.test.ts` goes red.

Verified green: `lint` + `typecheck` on `@n8n/frontend-constants`, `@n8n/stores`, and `editor-ui`; `biome`/`prettier` format checks; and `pnpm turbo run build --filter=n8n-editor-ui`, which confirms the new cross-package import also resolves in the production bundle (editor-ui aliases `@n8n/stores` to source in tests but not in the real build, so this mattered).

## Related Linear tickets, Github issues, and Community forum posts

N8N-126 · parent plan N8N-60 · found by Filter reviewing #35142 (N8N-70)

Out of scope, tracked separately: the CJS `import.meta.env` build artifact and the `SEMVER_REGEX` shim cleanup from the same review.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35172">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

