### PR TITLE
feat(core): Include workflow node groups in package import and export

### DIFF
--- a/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
@@ -1,0 +1,224 @@
+import { LicenseState } from '@n8n/backend-common';
+import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { WorkflowRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { GROUP_DESCRIPTION_MAX_LENGTH, jsonParse } from 'n8n-workflow';
+
+import { createOwner } from '@test-integration/db/users';
+import { LicenseMocker } from '@test-integration/license';
+import { initNodeTypes } from '@test-integration/utils';
+
+import { N8nPackagesService } from '../n8n-packages.service';
+import type { ImportPackageRequest } from '../n8n-packages.types';
+import { importPackageRequest } from './fixtures/import-request';
+import { buildImportPackageBuffer, serializedWorkflow } from './fixtures/package-fixtures';
+import { readExport, streamToBuffer } from './utils/tar-support';
+
+let service: N8nPackagesService;
+let workflowRepository: WorkflowRepository;
+
+const licenseMocker = new LicenseMocker();
+
+const nodes = [
+	{
+		id: 'manual-trigger',
+		name: 'Manual Trigger',
+		type: 'n8n-nodes-base.manualTrigger',
+		typeVersion: 1,
+		position: [0, 0] as [number, number],
+		parameters: {},
+	},
+	{
+		id: 'set-node',
+		name: 'Set',
+		type: 'n8n-nodes-base.set',
+		typeVersion: 3.4,
+		position: [200, 0] as [number, number],
+		parameters: {},
+	},
+	{
+		id: 'set-node-2',
+		name: 'Set 2',
+		type: 'n8n-nodes-base.set',
+		typeVersion: 3.4,
+		position: [400, 0] as [number, number],
+		parameters: {},
+	},
+];
+
+const groups = [
+	{ id: 'group-1', name: 'Shape', nodeIds: ['set-node'], description: 'Shapes the payload' },
+	{ id: 'group-2', name: 'Enrich', nodeIds: ['set-node-2'] },
+];
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+	await initNodeTypes();
+	licenseMocker.mockLicenseState(Container.get(LicenseState));
+	service = Container.get(N8nPackagesService);
+	workflowRepository = Container.get(WorkflowRepository);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'ProjectRelation', 'Project']);
+});
+
+type ImportParams = { user: User; packageBuffer: Buffer } & Partial<
+	Omit<ImportPackageRequest, 'user' | 'packageBuffer'>
+>;
+
+async function importPackage(params: ImportParams) {
+	return await service.importPackage(
+		importPackageRequest({ variableParentPolicy: 'project', ...params }),
+	);
+}
+
+describe('workflow package export — node groups', () => {
+	it('writes the workflow node groups into workflow.json', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const workflow = await createWorkflow(
+			{ name: 'Grouped workflow', nodes, connections: {}, nodeGroups: groups },
+			project,
+		);
+
+		const { stream } = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+		const { manifest, entries } = await readExport(stream);
+
+		const file = entries.find(
+			(entry) => entry.name === `${manifest.workflows![0].target}/workflow.json`,
+		);
+		const serialized = jsonParse<Record<string, unknown>>(file!.content.toString());
+
+		expect(serialized.nodeGroups).toEqual(groups);
+	});
+
+	it('omits nodeGroups for a workflow without groups', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const workflow = await createWorkflow(
+			{ name: 'Ungrouped workflow', nodes, connections: {} },
+			project,
+		);
+
+		const { stream } = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+		const { manifest, entries } = await readExport(stream);
+
+		const file = entries.find(
+			(entry) => entry.name === `${manifest.workflows![0].target}/workflow.json`,
+		);
+		const serialized = jsonParse<Record<string, unknown>>(file!.content.toString());
+
+		expect(serialized).not.toHaveProperty('nodeGroups');
+	});
+});
+
+describe('workflow package import — node groups', () => {
+	it('restores node groups on the imported workflow', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const source = await createWorkflow(
+			{ name: 'Grouped workflow', nodes, connections: {}, nodeGroups: groups },
+			project,
+		);
+
+		const { stream } = await service.exportPackage({ user: owner, workflowIds: [source.id] });
+		const packageBuffer = await streamToBuffer(stream);
+
+		const importer = await createOwner();
+		const result = await importPackage({ user: importer, packageBuffer });
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups).toEqual(groups);
+	});
+
+	it('imports without groups when the package predates node groups', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({ id: 'wf-legacy', name: 'Legacy workflow' }),
+			]),
+		});
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups).toEqual([]);
+	});
+
+	it('drops groups that reference nodes the workflow does not have, keeping the import', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({
+					id: 'wf-broken-groups',
+					name: 'Workflow with broken groups',
+					nodeGroups: [{ id: 'group-1', name: 'Ingest', nodeIds: ['node-that-is-not-here'] }],
+				}),
+			]),
+		});
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups).toEqual([]);
+	});
+
+	// The save path rejects a group holding a trigger node, so dropping it here is
+	// what keeps such a package importable at all.
+	it('drops groups that break a canvas grouping rule, keeping the import', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({
+					id: 'wf-trigger-group',
+					name: 'Workflow grouping a trigger',
+					nodes,
+					nodeGroups: [{ id: 'group-1', name: 'Ingest', nodeIds: ['manual-trigger'] }],
+				}),
+			]),
+		});
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups).toEqual([]);
+	});
+
+	it('truncates an over-long group description instead of rejecting the package', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({
+					id: 'wf-long-description',
+					name: 'Workflow with a chatty group',
+					nodes,
+					nodeGroups: [
+						{ id: 'group-1', name: 'Shape', nodeIds: ['set-node'], description: 'x'.repeat(200) },
+					],
+				}),
+			]),
+		});
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups[0].description).toHaveLength(GROUP_DESCRIPTION_MAX_LENGTH);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
@@ -156,7 +156,7 @@ describe('workflow package import — node groups', () => {
 		expect(imported.nodeGroups).toEqual([]);
 	});
 
-	it('drops groups that reference nodes the workflow does not have, keeping the import', async () => {
+	it('drops only the groups that reference nodes the workflow does not have, keeping the rest', async () => {
 		const owner = await createOwner();
 
 		const result = await importPackage({
@@ -165,7 +165,11 @@ describe('workflow package import — node groups', () => {
 				serializedWorkflow({
 					id: 'wf-broken-groups',
 					name: 'Workflow with broken groups',
-					nodeGroups: [{ id: 'group-1', name: 'Ingest', nodeIds: ['node-that-is-not-here'] }],
+					nodes,
+					nodeGroups: [
+						{ id: 'group-1', name: 'Ingest', nodeIds: ['node-that-is-not-here'] },
+						{ id: 'group-2', name: 'Shape', nodeIds: ['set-node'] },
+					],
 				}),
 			]),
 		});
@@ -173,7 +177,7 @@ describe('workflow package import — node groups', () => {
 		const imported = await workflowRepository.findOneByOrFail({
 			id: result.workflows[0].localId,
 		});
-		expect(imported.nodeGroups).toEqual([]);
+		expect(imported.nodeGroups).toEqual([{ id: 'group-2', name: 'Shape', nodeIds: ['set-node'] }]);
 	});
 
 	it('drops groups that break a canvas grouping rule, keeping the import', async () => {

--- a/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
@@ -176,8 +176,6 @@ describe('workflow package import — node groups', () => {
 		expect(imported.nodeGroups).toEqual([]);
 	});
 
-	// The save path rejects a group holding a trigger node, so dropping it here is
-	// what keeps such a package importable at all.
 	it('drops groups that break a canvas grouping rule, keeping the import', async () => {
 		const owner = await createOwner();
 

--- a/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
@@ -187,8 +187,6 @@ describe('workflow package import — node groups', () => {
 		expect(imported.nodeGroups).toEqual([]);
 	});
 
-	// The save path rejects a group holding a trigger node, so dropping it here is
-	// what keeps such a package importable at all.
 	it('drops groups that break a canvas grouping rule, keeping the import', async () => {
 		const owner = await createOwner();
 

--- a/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/workflow-node-groups.integration.test.ts
@@ -1,0 +1,235 @@
+import { LicenseState } from '@n8n/backend-common';
+import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { WorkflowRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { GROUP_DESCRIPTION_MAX_LENGTH, jsonParse } from 'n8n-workflow';
+
+import { createOwner } from '@test-integration/db/users';
+import { LicenseMocker } from '@test-integration/license';
+import { initNodeTypes } from '@test-integration/utils';
+
+import { N8nPackagesService } from '../n8n-packages.service';
+import type { ImportPackageRequest } from '../n8n-packages.types';
+import { buildImportPackageBuffer, serializedWorkflow } from './fixtures/package-fixtures';
+import { readExport, streamToBuffer } from './utils/tar-support';
+
+let service: N8nPackagesService;
+let workflowRepository: WorkflowRepository;
+
+const licenseMocker = new LicenseMocker();
+
+const nodes = [
+	{
+		id: 'manual-trigger',
+		name: 'Manual Trigger',
+		type: 'n8n-nodes-base.manualTrigger',
+		typeVersion: 1,
+		position: [0, 0] as [number, number],
+		parameters: {},
+	},
+	{
+		id: 'set-node',
+		name: 'Set',
+		type: 'n8n-nodes-base.set',
+		typeVersion: 3.4,
+		position: [200, 0] as [number, number],
+		parameters: {},
+	},
+	{
+		id: 'set-node-2',
+		name: 'Set 2',
+		type: 'n8n-nodes-base.set',
+		typeVersion: 3.4,
+		position: [400, 0] as [number, number],
+		parameters: {},
+	},
+];
+
+const groups = [
+	{ id: 'group-1', name: 'Shape', nodeIds: ['set-node'], description: 'Shapes the payload' },
+	{ id: 'group-2', name: 'Enrich', nodeIds: ['set-node-2'] },
+];
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+	await initNodeTypes();
+	licenseMocker.mockLicenseState(Container.get(LicenseState));
+	service = Container.get(N8nPackagesService);
+	workflowRepository = Container.get(WorkflowRepository);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'ProjectRelation', 'Project']);
+});
+
+type ImportParams = { user: User; packageBuffer: Buffer } & Partial<
+	Omit<ImportPackageRequest, 'user' | 'packageBuffer'>
+>;
+
+async function importPackage(params: ImportParams) {
+	return await service.importPackage({
+		credentialMatchingMode: 'id-only',
+		credentialMissingMode: 'must-preexist',
+		workflowConflictPolicy: 'fail',
+		workflowPublishingPolicy: 'preserve-published-state',
+		workflowIdPolicy: 'new',
+		folderConflictPolicy: 'merge',
+		dataTableMatchingMode: 'by-id',
+		dataTableMissingMode: 'create',
+		dataTableSchemaConflictPolicy: 'keep-existing',
+		variableMissingMode: 'do-nothing',
+		variableParentPolicy: 'project',
+		missingNodeTypeMode: 'fail',
+		...params,
+	});
+}
+
+describe('workflow package export — node groups', () => {
+	it('writes the workflow node groups into workflow.json', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const workflow = await createWorkflow(
+			{ name: 'Grouped workflow', nodes, connections: {}, nodeGroups: groups },
+			project,
+		);
+
+		const { stream } = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+		const { manifest, entries } = await readExport(stream);
+
+		const file = entries.find(
+			(entry) => entry.name === `${manifest.workflows![0].target}/workflow.json`,
+		);
+		const serialized = jsonParse<Record<string, unknown>>(file!.content.toString());
+
+		expect(serialized.nodeGroups).toEqual(groups);
+	});
+
+	it('omits nodeGroups for a workflow without groups', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const workflow = await createWorkflow(
+			{ name: 'Ungrouped workflow', nodes, connections: {} },
+			project,
+		);
+
+		const { stream } = await service.exportPackage({ user: owner, workflowIds: [workflow.id] });
+		const { manifest, entries } = await readExport(stream);
+
+		const file = entries.find(
+			(entry) => entry.name === `${manifest.workflows![0].target}/workflow.json`,
+		);
+		const serialized = jsonParse<Record<string, unknown>>(file!.content.toString());
+
+		expect(serialized).not.toHaveProperty('nodeGroups');
+	});
+});
+
+describe('workflow package import — node groups', () => {
+	it('restores node groups on the imported workflow', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const source = await createWorkflow(
+			{ name: 'Grouped workflow', nodes, connections: {}, nodeGroups: groups },
+			project,
+		);
+
+		const { stream } = await service.exportPackage({ user: owner, workflowIds: [source.id] });
+		const packageBuffer = await streamToBuffer(stream);
+
+		const importer = await createOwner();
+		const result = await importPackage({ user: importer, packageBuffer });
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups).toEqual(groups);
+	});
+
+	it('imports without groups when the package predates node groups', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({ id: 'wf-legacy', name: 'Legacy workflow' }),
+			]),
+		});
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups).toEqual([]);
+	});
+
+	it('drops groups that reference nodes the workflow does not have, keeping the import', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({
+					id: 'wf-broken-groups',
+					name: 'Workflow with broken groups',
+					nodeGroups: [{ id: 'group-1', name: 'Ingest', nodeIds: ['node-that-is-not-here'] }],
+				}),
+			]),
+		});
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups).toEqual([]);
+	});
+
+	// The save path rejects a group holding a trigger node, so dropping it here is
+	// what keeps such a package importable at all.
+	it('drops groups that break a canvas grouping rule, keeping the import', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({
+					id: 'wf-trigger-group',
+					name: 'Workflow grouping a trigger',
+					nodes,
+					nodeGroups: [{ id: 'group-1', name: 'Ingest', nodeIds: ['manual-trigger'] }],
+				}),
+			]),
+		});
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups).toEqual([]);
+	});
+
+	it('truncates an over-long group description instead of rejecting the package', async () => {
+		const owner = await createOwner();
+
+		const result = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({
+					id: 'wf-long-description',
+					name: 'Workflow with a chatty group',
+					nodes,
+					nodeGroups: [
+						{ id: 'group-1', name: 'Shape', nodeIds: ['set-node'], description: 'x'.repeat(200) },
+					],
+				}),
+			]),
+		});
+
+		const imported = await workflowRepository.findOneByOrFail({
+			id: result.workflows[0].localId,
+		});
+		expect(imported.nodeGroups[0].description).toHaveLength(GROUP_DESCRIPTION_MAX_LENGTH);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/n8n-package-parser.project.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/n8n-package-parser.project.test.ts
@@ -1,4 +1,7 @@
+import type { Logger } from '@n8n/backend-common';
 import { mock } from 'vitest-mock-extended';
+
+import type { NodeTypes } from '@/node-types';
 
 import type { WorkflowSerializer } from '../../entities/workflow/workflow.serializer';
 import type { PackageReader } from '../../io/package-reader';
@@ -28,7 +31,11 @@ function baseManifest(): PackageManifest {
 }
 
 describe('N8nPackageParser.getProjects — custom span attributes', () => {
-	const parser = new N8nPackageParser(mock<WorkflowSerializer>());
+	const parser = new N8nPackageParser(
+		mock<Logger>(),
+		mock<NodeTypes>(),
+		mock<WorkflowSerializer>(),
+	);
 
 	it('reads customTelemetryTags into the prepared project', async () => {
 		const reader = makeReader(baseManifest(), {

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -142,14 +142,12 @@ export class N8nPackageParser {
 
 	/** Drops groups that wouldn't survive the save path, so they can't fail the whole import. */
 	private normalizeNodeGroups(entity: WorkflowEntity, path: string): void {
-		try {
-			WorkflowHelpers.validateWorkflowNodeGroups(
-				entity,
-				WorkflowHelpers.makeGetNodeTypeForGrouping(this.nodeTypes),
-			);
-		} catch {
-			this.logger.warn(`Package workflow file at ${path} has invalid nodeGroups, dropping them.`);
-			entity.nodeGroups = [];
+		const dropped = WorkflowHelpers.dropInvalidNodeGroups(
+			entity,
+			WorkflowHelpers.makeGetNodeTypeForGrouping(this.nodeTypes),
+		);
+		for (const { groupName, message } of dropped) {
+			this.logger.warn(`Package workflow file at ${path} dropped group "${groupName}": ${message}`);
 		}
 
 		for (const warning of WorkflowHelpers.sanitizeNodeGroupDescriptions(entity)) {

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -140,14 +140,7 @@ export class N8nPackageParser {
 		};
 	}
 
-	/**
-	 * Node groups are cosmetic, so a package whose groups don't hold together
-	 * imports without them rather than failing outright.
-	 *
-	 * This runs the same rules the save path applies (hence the node-type
-	 * resolver, which the trigger-node rule needs) — a group this drops would
-	 * otherwise fail the whole package in `WorkflowCreationService`.
-	 */
+	/** Drops groups that wouldn't survive the save path, so they can't fail the whole import. */
 	private normalizeNodeGroups(entity: WorkflowEntity, path: string): void {
 		try {
 			WorkflowHelpers.validateWorkflowNodeGroups(

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -1,9 +1,11 @@
+import { Logger } from '@n8n/backend-common';
 import { WorkflowEntity } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { jsonParse, UserError } from 'n8n-workflow';
 import { ZodError } from 'zod';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NodeTypes } from '@/node-types';
 import * as WorkflowHelpers from '@/workflow-helpers';
 
 import { deriveParentFolderId, foldersInScope, workflowsInScope } from './package-layout';
@@ -32,7 +34,11 @@ import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
  */
 @Service()
 export class N8nPackageParser {
-	constructor(private readonly workflowSerializer: WorkflowSerializer) {}
+	constructor(
+		private readonly logger: Logger,
+		private readonly nodeTypes: NodeTypes,
+		private readonly workflowSerializer: WorkflowSerializer,
+	) {}
 
 	async getManifest(reader: PackageReader): Promise<PackageManifest> {
 		try {
@@ -123,6 +129,7 @@ export class N8nPackageParser {
 		}
 
 		WorkflowHelpers.validateWorkflowStructure(entity);
+		this.normalizeNodeGroups(entity, path);
 
 		return {
 			entity,
@@ -131,6 +138,30 @@ export class N8nPackageParser {
 			parentFolderId,
 			...(wire.tagIds !== undefined ? { tagIds: wire.tagIds } : {}),
 		};
+	}
+
+	/**
+	 * Node groups are cosmetic, so a package whose groups don't hold together
+	 * imports without them rather than failing outright.
+	 *
+	 * This runs the same rules the save path applies (hence the node-type
+	 * resolver, which the trigger-node rule needs) — a group this drops would
+	 * otherwise fail the whole package in `WorkflowCreationService`.
+	 */
+	private normalizeNodeGroups(entity: WorkflowEntity, path: string): void {
+		try {
+			WorkflowHelpers.validateWorkflowNodeGroups(
+				entity,
+				WorkflowHelpers.makeGetNodeTypeForGrouping(this.nodeTypes),
+			);
+		} catch {
+			this.logger.warn(`Package workflow file at ${path} has invalid nodeGroups, dropping them.`);
+			entity.nodeGroups = [];
+		}
+
+		for (const warning of WorkflowHelpers.sanitizeNodeGroupDescriptions(entity)) {
+			this.logger.warn(`Package workflow file at ${path}: ${warning}`);
+		}
 	}
 
 	private async readFolder(reader: PackageReader, entry: ManifestEntry): Promise<PreparedFolder> {

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
@@ -229,6 +229,48 @@ describe('WorkflowExporter', () => {
 		});
 	});
 
+	it('writes node groups into workflow.json', async () => {
+		const workflow = makeWorkflow({
+			nodeGroups: [
+				{ id: 'group-1', name: 'Ingest', nodeIds: ['node-1'], description: 'Pulls the data in' },
+			],
+		});
+		const { exporter } = makeExporter([workflow]);
+		const writer = new CapturingWriter();
+
+		await exporter.export({
+			user,
+			workflowIds: [workflow.id],
+			writer,
+			includeTags: true,
+			workflowVersionPolicy: 'latest',
+		});
+
+		const workflowFile = writer.files.find((f) => f.path === 'workflows/my-workflow/workflow.json');
+		expect(jsonParse<unknown>(workflowFile!.content)).toMatchObject({
+			nodeGroups: [
+				{ id: 'group-1', name: 'Ingest', nodeIds: ['node-1'], description: 'Pulls the data in' },
+			],
+		});
+	});
+
+	it('omits nodeGroups from workflow.json when the workflow has none', async () => {
+		const workflow = makeWorkflow({ nodeGroups: [] });
+		const { exporter } = makeExporter([workflow]);
+		const writer = new CapturingWriter();
+
+		await exporter.export({
+			user,
+			workflowIds: [workflow.id],
+			writer,
+			includeTags: true,
+			workflowVersionPolicy: 'latest',
+		});
+
+		const workflowFile = writer.files.find((f) => f.path === 'workflows/my-workflow/workflow.json');
+		expect(jsonParse<object>(workflowFile!.content)).not.toHaveProperty('nodeGroups');
+	});
+
 	it('nests output under `<basePrefix>/workflows` when a basePrefix is given', async () => {
 		// This is the seam the folder exporter uses to place contained workflows
 		// under their folder's directory.

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
@@ -196,6 +196,36 @@ describe('WorkflowExporter', () => {
 		});
 	});
 
+	it('writes node groups into workflow.json', async () => {
+		const workflow = makeWorkflow({
+			nodeGroups: [
+				{ id: 'group-1', name: 'Ingest', nodeIds: ['node-1'], description: 'Pulls the data in' },
+			],
+		});
+		const { exporter } = makeExporter([workflow]);
+		const writer = new CapturingWriter();
+
+		await exporter.export({ user, workflowIds: [workflow.id], writer, includeTags: true });
+
+		const workflowFile = writer.files.find((f) => f.path === 'workflows/my-workflow/workflow.json');
+		expect(jsonParse<unknown>(workflowFile!.content)).toMatchObject({
+			nodeGroups: [
+				{ id: 'group-1', name: 'Ingest', nodeIds: ['node-1'], description: 'Pulls the data in' },
+			],
+		});
+	});
+
+	it('omits nodeGroups from workflow.json when the workflow has none', async () => {
+		const workflow = makeWorkflow({ nodeGroups: [] });
+		const { exporter } = makeExporter([workflow]);
+		const writer = new CapturingWriter();
+
+		await exporter.export({ user, workflowIds: [workflow.id], writer, includeTags: true });
+
+		const workflowFile = writer.files.find((f) => f.path === 'workflows/my-workflow/workflow.json');
+		expect(jsonParse<object>(workflowFile!.content)).not.toHaveProperty('nodeGroups');
+	});
+
 	it('nests output under `<basePrefix>/workflows` when a basePrefix is given', async () => {
 		// This is the seam the folder exporter uses to place contained workflows
 		// under their folder's directory.

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.serializer.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.serializer.test.ts
@@ -62,6 +62,24 @@ describe('WorkflowSerializer.deserialize', () => {
 		expect(result.settings).toBeUndefined();
 	});
 
+	it('restores node groups from the wire', () => {
+		const result = serializer.deserialize(
+			wire({
+				nodeGroups: [
+					{ id: 'group-1', name: 'Ingest', nodeIds: ['node-1'], description: 'Pulls data in' },
+				],
+			}),
+		);
+
+		expect(result.nodeGroups).toEqual([
+			{ id: 'group-1', name: 'Ingest', nodeIds: ['node-1'], description: 'Pulls data in' },
+		]);
+	});
+
+	it('defaults node groups to empty when the wire has none', () => {
+		expect(serializer.deserialize(wire()).nodeGroups).toEqual([]);
+	});
+
 	it('does not carry instance-owned fields from the wire', () => {
 		const partial = serializer.deserialize(wire());
 

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -90,8 +90,6 @@ export class WorkflowSerializer {
 			name: parsed.name,
 			nodes: parsed.nodes as INode[],
 			connections: parsed.connections as IConnections,
-			// Package content wins over what's on the target, so a package with no
-			// groups clears the groups of a workflow it overwrites.
 			nodeGroups: parsed.nodeGroups ?? [],
 			isArchived: parsed.isArchived,
 			...(parsed.settings !== undefined ? { settings: parsed.settings } : {}),

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -22,7 +22,7 @@ type WorkflowPackageKeyHandling = {
 	settings: 'copy';
 	staticData: 'exclude';
 	meta: 'exclude';
-	nodeGroups: 'exclude';
+	nodeGroups: 'copy';
 	tags: 'transform';
 	tagMappings: 'exclude';
 	shared: 'exclude';
@@ -39,7 +39,7 @@ type WorkflowPackageKeyHandling = {
 
 type WorkflowPackageContent = Pick<
 	WorkflowEntity,
-	'name' | 'nodes' | 'connections' | 'isArchived' | 'settings'
+	'name' | 'nodes' | 'connections' | 'nodeGroups' | 'isArchived' | 'settings'
 >;
 
 const serializePayload = definePackageSerializationPayload<
@@ -68,6 +68,7 @@ export class WorkflowSerializer {
 				parentFolderId: workflow.parentFolder?.id ?? null,
 				isPublished: workflow.activeVersionId === workflow.versionId,
 				isArchived: workflow.isArchived,
+				...(workflow.nodeGroups?.length ? { nodeGroups: workflow.nodeGroups } : {}),
 				...(tags ? { tagIds: tags.map((tag) => tag.id) } : {}),
 			}),
 		);
@@ -89,6 +90,9 @@ export class WorkflowSerializer {
 			name: parsed.name,
 			nodes: parsed.nodes as INode[],
 			connections: parsed.connections as IConnections,
+			// Package content wins over what's on the target, so a package with no
+			// groups clears the groups of a workflow it overwrites.
+			nodeGroups: parsed.nodeGroups ?? [],
 			isArchived: parsed.isArchived,
 			...(parsed.settings !== undefined ? { settings: parsed.settings } : {}),
 		};

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -54,8 +54,6 @@ export class WorkflowSerializer {
 			name: parsed.name,
 			nodes: parsed.nodes as INode[],
 			connections: parsed.connections as IConnections,
-			// Package content wins over what's on the target, so a package with no
-			// groups clears the groups of a workflow it overwrites.
 			nodeGroups: parsed.nodeGroups ?? [],
 			isArchived: parsed.isArchived,
 			...(parsed.settings !== undefined ? { settings: parsed.settings } : {}),

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -11,7 +11,7 @@ import { compareTagsByName } from '../tag/tag.types';
 /** Fields restored from package workflow.json; the target instance assigns the rest. */
 type WorkflowPackageContent = Pick<
 	WorkflowEntity,
-	'name' | 'nodes' | 'connections' | 'isArchived' | 'settings'
+	'name' | 'nodes' | 'connections' | 'nodeGroups' | 'isArchived' | 'settings'
 >;
 
 @Service()
@@ -33,6 +33,7 @@ export class WorkflowSerializer {
 			parentFolderId: workflow.parentFolder?.id ?? null,
 			isPublished: workflow.activeVersionId === workflow.versionId,
 			isArchived: workflow.isArchived,
+			...(workflow.nodeGroups?.length ? { nodeGroups: workflow.nodeGroups } : {}),
 			...(tags ? { tagIds: tags.map((tag) => tag.id) } : {}),
 		});
 	}
@@ -53,6 +54,9 @@ export class WorkflowSerializer {
 			name: parsed.name,
 			nodes: parsed.nodes as INode[],
 			connections: parsed.connections as IConnections,
+			// Package content wins over what's on the target, so a package with no
+			// groups clears the groups of a workflow it overwrites.
+			nodeGroups: parsed.nodeGroups ?? [],
 			isArchived: parsed.isArchived,
 			...(parsed.settings !== undefined ? { settings: parsed.settings } : {}),
 		};

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/workflow.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/workflow.schema.ts
@@ -41,9 +41,6 @@ const connectionLeafSchema = z.object({
 
 const connectionsSchema = z.record(z.record(z.array(z.array(connectionLeafSchema).nullable())));
 
-// Mirrors `IWorkflowGroup`. The description length cap is deliberately not
-// enforced here — import truncates an over-long one rather than rejecting the
-// whole package.
 const nodeGroupSchema = z.object({
 	id: z.string().min(1),
 	name: z.string().min(1),
@@ -56,8 +53,6 @@ export const serializedWorkflowSchema = z.object({
 	name: z.string().min(1),
 	nodes: z.array(nodeSchema),
 	connections: connectionsSchema,
-	// Absent in packages written before node groups existed, and omitted for
-	// workflows without groups.
 	nodeGroups: z.array(nodeGroupSchema).optional(),
 	settings: z.record(z.unknown()).optional(),
 	versionId: z.string(),

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/workflow.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/workflow.schema.ts
@@ -41,11 +41,24 @@ const connectionLeafSchema = z.object({
 
 const connectionsSchema = z.record(z.record(z.array(z.array(connectionLeafSchema).nullable())));
 
+// Mirrors `IWorkflowGroup`. The description length cap is deliberately not
+// enforced here — import truncates an over-long one rather than rejecting the
+// whole package.
+const nodeGroupSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().min(1),
+	nodeIds: z.array(z.string().min(1)),
+	description: z.string().optional(),
+});
+
 export const serializedWorkflowSchema = z.object({
 	id: z.string().min(1),
 	name: z.string().min(1),
 	nodes: z.array(nodeSchema),
 	connections: connectionsSchema,
+	// Absent in packages written before node groups existed, and omitted for
+	// workflows without groups.
+	nodeGroups: z.array(nodeGroupSchema).optional(),
 	settings: z.record(z.unknown()).optional(),
 	versionId: z.string(),
 	parentFolderId: z.string().nullable(),


### PR DESCRIPTION
## Summary

Add node groups to n8n packages

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-900

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35181">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

