### PR TITLE
refactor(editor): Correct fileExtension and fileType for uploaded files

### DIFF
--- a/packages/frontend/editor-ui/src/app/utils/fileUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/fileUtils.test.ts
@@ -1,0 +1,86 @@
+import {
+	convertFileToBinaryData,
+	getBinaryDataFileName,
+	getFileExtension,
+} from '@/app/utils/fileUtils';
+
+describe('getFileExtension', () => {
+	test.each([
+		['report.pdf', 'pdf'],
+		['archive.tar.gz', 'gz'],
+		['README', ''],
+		['.env', ''],
+		['.gitignore', ''],
+		['trailing.', ''],
+		['', ''],
+	])('derives %j as %j', (fileName, expected) => {
+		expect(getFileExtension(fileName)).toBe(expected);
+	});
+});
+
+describe('getBinaryDataFileName', () => {
+	it('keeps a name that already carries the extension', () => {
+		expect(getBinaryDataFileName({ fileName: 'report.pdf', fileExtension: 'pdf' })).toBe(
+			'report.pdf',
+		);
+	});
+
+	it('appends the extension when the name has none', () => {
+		expect(getBinaryDataFileName({ fileName: 'report', fileExtension: 'pdf' })).toBe('report.pdf');
+	});
+
+	it('leaves the name alone when there is no extension', () => {
+		expect(getBinaryDataFileName({ fileName: 'README' })).toBe('README');
+	});
+
+	it('falls back to "file" without a name', () => {
+		expect(getBinaryDataFileName({ fileExtension: 'pdf' })).toBe('file.pdf');
+		expect(getBinaryDataFileName({})).toBe('file');
+	});
+});
+
+describe('convertFileToBinaryData', () => {
+	test.each([
+		['report.pdf', 'application/pdf', 'pdf', 'pdf'],
+		['README', 'text/plain', '', 'text'],
+		['.env', 'text/plain', '', 'text'],
+		['README', '', '', undefined],
+		['archive.tar.gz', 'application/gzip', 'gz', undefined],
+		['data.json', 'application/json', 'json', 'json'],
+		['page.html', 'text/html', 'html', 'html'],
+		['trailing.', 'text/plain', '', 'text'],
+	])(
+		'derives %j (%j) as fileExtension %j and fileType %j',
+		async (fileName, mimeType, fileExtension, fileType) => {
+			const file = new File(['hello'], fileName, { type: mimeType });
+
+			const binaryData = await convertFileToBinaryData(file);
+
+			expect(binaryData.fileExtension).toBe(fileExtension);
+			expect(binaryData.fileType).toBe(fileType);
+		},
+	);
+
+	it('carries over the file name, size, mime type and base64 data', async () => {
+		const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+
+		const binaryData = await convertFileToBinaryData(file);
+
+		expect(binaryData).toMatchObject({
+			data: btoa('hello'),
+			mimeType: 'application/pdf',
+			fileName: 'report.pdf',
+			fileSize: '5 bytes',
+		});
+	});
+
+	it('rejects when the file cannot be read', async () => {
+		vi.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function (this: FileReader) {
+			this.onerror?.(new ProgressEvent('error') as ProgressEvent<FileReader>);
+		});
+
+		await expect(convertFileToBinaryData(new File([], 'README'))).rejects.toThrow(
+			'Failed to convert file to binary data',
+		);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/utils/fileUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/fileUtils.test.ts
@@ -1,22 +1,4 @@
-import {
-	convertFileToBinaryData,
-	getBinaryDataFileName,
-	getFileExtension,
-} from '@/app/utils/fileUtils';
-
-describe('getFileExtension', () => {
-	test.each([
-		['report.pdf', 'pdf'],
-		['archive.tar.gz', 'gz'],
-		['README', ''],
-		['.env', ''],
-		['.gitignore', ''],
-		['trailing.', ''],
-		['', ''],
-	])('derives %j as %j', (fileName, expected) => {
-		expect(getFileExtension(fileName)).toBe(expected);
-	});
-});
+import { convertFileToBinaryData, getBinaryDataFileName } from '@/app/utils/fileUtils';
 
 describe('getBinaryDataFileName', () => {
 	it('keeps a name that already carries the extension', () => {

--- a/packages/frontend/editor-ui/src/app/utils/fileUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/fileUtils.ts
@@ -1,4 +1,20 @@
-import type { BinaryFileType, IBinaryData } from 'n8n-workflow';
+import { fileTypeFromMimeType, type IBinaryData } from 'n8n-workflow';
+
+/** Matches `path.parse().ext`: a leading dot (`.env`) or no dot (`README`) means no extension. */
+export function getFileExtension(fileName: string): string {
+	const dotIndex = fileName.lastIndexOf('.');
+	return dotIndex > 0 ? fileName.slice(dotIndex + 1) : '';
+}
+
+/** Display/download name for binary data; `fileName` usually already carries the extension. */
+export function getBinaryDataFileName({
+	fileName,
+	fileExtension,
+}: Pick<IBinaryData, 'fileName' | 'fileExtension'>): string {
+	const name = fileName ?? 'file';
+	if (name.includes('.') || !fileExtension) return name;
+	return `${name}.${fileExtension}`;
+}
 
 export async function convertFileToBinaryData(file: File): Promise<IBinaryData> {
 	const reader = new FileReader();
@@ -9,8 +25,8 @@ export async function convertFileToBinaryData(file: File): Promise<IBinaryData> 
 				mimeType: file.type,
 				fileName: file.name,
 				fileSize: `${file.size} bytes`,
-				fileExtension: file.name.split('.').pop() ?? '',
-				fileType: file.type.split('/')[0] as BinaryFileType,
+				fileExtension: getFileExtension(file.name),
+				fileType: fileTypeFromMimeType(file.type),
 			};
 			resolve(binaryData);
 		};

--- a/packages/frontend/editor-ui/src/app/utils/fileUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/fileUtils.ts
@@ -1,7 +1,7 @@
 import { fileTypeFromMimeType, type IBinaryData } from 'n8n-workflow';
 
 /** Matches `path.parse().ext`: a leading dot (`.env`) or no dot (`README`) means no extension. */
-export function getFileExtension(fileName: string): string {
+function getFileExtension(fileName: string): string {
 	const dotIndex = fileName.lastIndexOf('.');
 	return dotIndex > 0 ? fileName.slice(dotIndex + 1) : '';
 }

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/BinaryEntryDataTable.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/BinaryEntryDataTable.vue
@@ -8,6 +8,7 @@ import { computed } from 'vue';
 import type { BinaryMetadata } from '@/Interface';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
+import { getBinaryDataFileName } from '@/app/utils/fileUtils';
 
 const BYTES_THRESHOLD = 1048576; // 1MB
 
@@ -30,12 +31,7 @@ const tablePreview = computed(() => {
 	return isImageType && passThreshold;
 });
 
-const fileName = computed(() => {
-	const { fileName, fileExtension } = props.value;
-	const name = fileName ?? 'file';
-	if (name?.includes('.')) return name;
-	return fileExtension ? `${name}.${fileExtension}` : name;
-});
+const fileName = computed(() => getBinaryDataFileName(props.value));
 
 const fileUrl = computed(() => {
 	const { id, mimeType } = props.value;

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataBinary.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataBinary.vue
@@ -4,6 +4,7 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { WORKFLOW_SETTINGS_MODAL_KEY } from '@/app/constants/modals';
+import { getBinaryDataFileName } from '@/app/utils/fileUtils';
 import { ViewableMimeTypes } from '@n8n/api-types';
 import { useI18n } from '@n8n/i18n';
 import type { IBinaryKeyData } from 'n8n-workflow';
@@ -44,16 +45,18 @@ function isDownloadable(index: number, key: string | number): boolean {
 }
 
 async function downloadBinaryData(index: number, key: string | number) {
-	const { id, data, fileName, fileExtension, mimeType } = binaryData[index][key];
+	const entry = binaryData[index][key];
+	const { id, data, fileName, mimeType } = entry;
+	const name = getBinaryDataFileName(entry);
 
 	if (id) {
 		const url = workflowsStore.getBinaryUrl(id, 'download', fileName ?? '', mimeType);
-		saveAs(url, [fileName, fileExtension].join('.'));
+		saveAs(url, name);
 		return;
 	} else {
 		const bufferString = 'data:' + mimeType + ';base64,' + data;
 		const blob = await fetch(bufferString).then(async (d) => await d.blob());
-		saveAs(blob, fileName);
+		saveAs(blob, name);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchemaItem.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchemaItem.vue
@@ -8,6 +8,7 @@ import { BINARY_DATA_VIEW_MODAL_KEY } from '@/app/constants';
 import type { BinaryMetadata } from '@n8n/design-system';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
+import { getBinaryDataFileName } from '@/app/utils/fileUtils';
 
 import { N8nIcon, N8nTooltip } from '@n8n/design-system';
 type Props = {
@@ -40,12 +41,9 @@ const i18n = useI18n();
 async function downloadBinaryData() {
 	if (!props.binaryData) return;
 	try {
-		const { id, fileName, mimeType, fileExtension } = props.binaryData;
+		const { id, fileName, mimeType } = props.binaryData;
 		const url = useWorkflowsStore().getBinaryUrl(id, 'download', fileName ?? '', mimeType);
-		let name = fileName ?? 'file';
-		if (!name.includes('.') && fileExtension) {
-			name = [name, fileExtension].join('.');
-		}
+		const name = getBinaryDataFileName(props.binaryData);
 		const response = await fetch(url);
 		if (!response.ok) throw new Error('Error downloading file');
 		const blob = await response.blob();


### PR DESCRIPTION
## Summary

`RunDataBinary.vue`, `BinaryEntryDataTable.vue`, and `VirtualSchemaItem.vue` each had their own copy of the binary download-name logic. The copy in `RunDataBinary.vue` had drifted and was missing the "name already carries the extension" guard, producing `report.pdf.pdf` and `README.undefined`. All three now use a shared `getBinaryDataFileName()`.

Scope note: #35139 landed the `convertFileToBinaryData` fix first (and closed #35125), so that half of this PR is now master's — it will read as near-identical. Resolving the merge, I kept master's `fileExtension: … || undefined` and deduped its inline extension logic into `getFileExtension()`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3877

Context (already fixed by #35139): #35125

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35185">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


