### PR TITLE
docs: Rewrite public-api agent skill and split reference (no-changelog)

### DIFF
--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -1,23 +1,62 @@
 ---
 name: n8n:public-api
 description: >-
-  Adds or updates n8n Public API v1 endpoints, OpenAPI specs, and handler wiring.
-  Use when creating public API handlers, registering paths in openapi.yml, or adding OpenAPI tags. Always use @PublicApiController for new endpoints (API-37+).
+  Adds, migrates, or updates n8n Public API v1 endpoints with @PublicApiController
+  — public DTOs, API-key and RBAC scopes, cursor pagination, OpenAPI + coverage
+  wiring, and tests. Use when working under packages/cli/src/public-api/v1/ or
+  when exposing an existing service through /api/v1.
 ---
 
 # Public API v1
 
-Public API lives under `packages/cli/src/public-api/v1/`.
+Public API v1 lives in `packages/cli/src/public-api/v1/`, mounted at `/api/v1`
+with API-key auth and public error formatting via `PublicApiControllerRegistry`
+(`packages/cli/src/public-api/public-api-controller.registry.ts`).
 
-**Always use `@PublicApiController` for new endpoints (API-37+).** Do not add new business logic to `express-openapi-validator` handlers. Controllers use the same decorator style as internal `@RestController`, mounted at `/api/v1` with API-key auth and public errors via `PublicApiControllerRegistry`.
+Two rule tiers: **invariants** (never break) and **team defaults** (follow unless
+an existing public contract forces otherwise). When this skill and the code
+disagree on a detail, the code wins — so open the files below. That is a reason to
+check the code, not license to drop a team default.
 
-**Legacy (existing endpoints only):** `express-openapi-validator` handlers under `handlers/`; OpenAPI path specs are YAML under each handler's `spec/` directory.
-When you touch a legacy endpoint, migrate it to `@PublicApiController` rather than extending the eov handler. Do not mix data-access styles within a new feature.
+## Non-negotiable rules
+
+- New endpoints are `@PublicApiController` classes under `v1/controllers/`, one
+  `*.public.controller.ts` per feature. A controller is a class — never
+  `export =` (the legacy tuple style; `require-public-api-controller` flags it).
+- Public API and internal REST are separate HTTP surfaces. A public controller
+  never calls an internal controller/endpoint; both reuse the same service.
+- Controllers and handlers delegate to a service — never import a repository or
+  `Container.get(…Repository)` (`no-repository-in-public-api-handler`).
+- Input/output go through DTOs from `@n8n/api-types`; every JSON route declares
+  `@ApiResponse(Dto)`.
+- Register each controller via a side-effect import in `v1/controllers/index.ts`
+  (`public-api-controllers.test.ts` fails otherwise).
+- Don't add business logic to legacy `express-openapi-validator` (EOV) handlers.
+- Migrating a legacy endpoint must not change its public contract.
+
+These are `n8n-local-rules` ESLint rules (see `packages/cli/eslint.config.mjs`)
+and can't be silenced inline (`no-public-api-guardrail-disable`). The `off`
+allowlist there covers pre-existing legacy files only — it's shrink-only, don't
+add to it.
+
+## Team defaults
+
+- List endpoints: cursor-based pagination (internal API uses both cursor- and
+  page-based — don't copy an internal endpoint's model).
+- Updates: full-object `PUT`, not `PATCH`. A successful `GET` body should be
+  acceptable as a `PUT` body for the same resource (round-trip), aside from
+  server-managed/immutable fields.
+- Strict input DTOs; output DTOs are an allowlist of public fields.
+- Never return real secrets/tokens in responses or error details — mask with the
+  resource's sentinel/placeholder (or omit). Echoing that sentinel on `PUT`
+  means keep; any other value replaces. Detail:
+  [Updates and write-only secrets](reference.md#updates-and-write-only-secrets).
+- "Test connection/config" endpoints validate the request body (test-before-save).
 
 ## Architecture
 
-Convergence is at the **service layer**, not HTTP. Public and internal stay as
-two sibling routes over one shared service — neither calls the other:
+Public and internal are sibling routes over one shared, HTTP-agnostic service;
+neither calls the other.
 
 ```
 GET /rest/tags    → TagsController         ┐  JWT auth, internal shape
@@ -25,95 +64,101 @@ GET /rest/tags    → TagsController         ┐  JWT auth, internal shape
 GET /api/v1/tags  → TagsPublicController   ┘  API-key auth, public DTO
 ```
 
-## Adding an endpoint (required: controller pattern)
+Reuse the service behavior. Reuse a DTO only when public and internal contracts
+are intentionally identical; otherwise make a public-specific DTO that doesn't
+depend on a UI-oriented internal shape.
 
-Reference: `v1/controllers/tags.public.controller.ts` (`GET /tags`).
+## Before editing
 
-1. **Public DTOs** in `@n8n/api-types` — input query/body + output resource DTO
-   (distinct from internal shapes when they diverge). Use `Z.class` so the
-   registry can validate/parse. Wrap list payloads as objects (e.g. `{ data: [...] }`),
-   same as `TagListPublicDto` / `WorkflowVersionHistoryListPublicDto`.
-2. **Controller** — `v1/controllers/<feature>.public.controller.ts`
-   ```ts
-   @PublicApiController('/tags')
-   export class TagsPublicController {
-     constructor(private readonly tagService: TagService) {}
+Open these — they are the source of truth, not this skill:
 
-     @Get('/')
-     @ApiKeyScope('tag:list')
-     @ApiResponse(TagListPublicDto)
-     async getTags(_req, _res, @Query q: ListTagsQueryDto) { /* call service */ }
-   }
-   ```
-   - Reuse `@Get/@Post/@Body/@Query/@Param/@GlobalScope/@ProjectScope` as-is.
-   - For `@ProjectScope` on workflow/credential routes, name the path param
-     `workflowId` / `credentialId` (or `projectId` / `dataTableId`) — the
-     registry passes `req.params` to `userHasScopes`, which does not remap `id`.
-   - `@ApiKeyScope` — string, or `{ anyOf }` / `{ allOf }` (no bare arrays).
-   - `@ApiResponse(Dto)` — registry `.parse()`s the return value (strips
-     undeclared fields). Shape is provisional until API-39 (doc-gen).
-   - Delegate to the same service as the internal REST controller.
-3. **Side-effect import** the controller from
-   `packages/cli/src/public-api/v1/controllers/index.ts` (re-exported via
-   `public-api/index.ts`) so metadata is registered before
-   `PublicApiControllerRegistry.activate`. Name the file
-   `*.public.controller.ts` — `public-api-controllers.test.ts` fails CI if a
-   controller file is missing from that barrel or lives outside `controllers/`.
-4. **OpenAPI path spec** — still required for docs + `scope-parity.test.ts`
-   (`handlers/<feature>/spec/paths/…`, `$ref` in `openapi.yml`). Set
-   `operationId`, `x-required-scope` matching `@ApiKeyScope`. **Do not** set
-   `x-eov-operation-id` / `x-eov-operation-handler` — those are legacy eov-only;
-   scope-parity and discover read `@ApiKeyScope` from the controller by matching
-   method + path.
-5. **Coverage manifest** — add every new OpenAPI endpoint to
-   `packages/nodes-base/nodes/N8n/n8n-api-coverage.json`.
+- `v1/controllers/` — copy structure from `tags.public.controller.ts` (list +
+  cursor) or `workflows.public.controller.ts` (`@Param` + `@ProjectScope`), and
+  `index.ts` for the barrel.
+- Decorators in `packages/@n8n/decorators/src/controller/`:
+  `public-api-controller.ts`, `api-key-scope.ts`, `api-response.ts`, `route.ts`,
+  `scoped.ts`, `args.ts`, `licensed.ts`.
+- Pagination helpers: `v1/shared/services/pagination.service.ts`
+  (`decodeCursor`, `encodeNextCursor`).
+- DTOs: `packages/@n8n/api-types/src/dto/`.
+- Gating tests: `v1/__tests__/public-api-controllers.test.ts`,
+  `v1/__tests__/scope-parity.test.ts`.
+- The internal controller for this resource and its neighboring functional tests.
 
-## Legacy eov handlers (do not use for new endpoints)
+## Declaring a controller
 
-Only for maintaining endpoints not yet migrated:
+A controller is a class marked `@PublicApiController('/base')` that injects the
+shared service via its constructor and delegates to it. Copy the shape from an
+existing controller in `v1/controllers/` with the same operation type and auth
+model; reuse only what applies. Decorators, all from `@n8n/decorators`:
 
-1. **Handler** — `handlers/<feature>/<feature>.handler.ts`
-   - Export middleware arrays keyed by `x-eov-operation-id`.
-   - For scope-protected endpoints, use `publicApiScope()` or
-     `apiKeyHasScopeWithGlobalScopeFallback()` (they tag the scope-enforcement
-     middleware with `__apiKeyScope`) and add matching `x-required-scope` in the
-     path YAML; use `none` for endpoints without an API-key scope (see
-     `scope-parity.test.ts`).
-   - **Delegate to the same service layer as the internal REST API.**
-     Parse input with `@n8n/api-types` DTOs, call `Container.get(SomeService)`,
-     map errors — do not reach into repositories or duplicate business logic.
-2. **OpenAPI path spec** — `handlers/<feature>/spec/paths/<path>.yml`
-   - Set `tags: [<TagName>]` matching a top-level tag in `openapi.yml`.
-3. **Register path** — add a `$ref` entry under `paths:` in `openapi.yml`.
-4. **Request types** — add a namespace in `packages/cli/src/public-api/types.ts`
-   when the handler needs typed query/body params.
-5. **Coverage manifest** — add every new OpenAPI endpoint to
-   `packages/nodes-base/nodes/N8n/n8n-api-coverage.json`.
+| Decorator | Use |
+|---|---|
+| `@PublicApiController('/base')` | Class marker; mounts routes at `/api/v1/base`. |
+| `@Get/@Post/@Put/@Patch/@Delete('/path')` | Route method. |
+| `@ApiKeyScope('res:action')` | API-key grant check. |
+| `@ProjectScope/@GlobalScope('res:action')` | User RBAC check. |
+| `@ApiResponse(Dto)` | Output DTO; registry `.parse()`s + strips the return value. |
+| `@Query` / `@Body` / `@Param('name')` | Bind + validate via a `Z.class` DTO / path param. |
+| `@Licensed('feat')` | Gate an EE-only endpoint. |
 
-## `tags` array in `openapi.yml`
+## Authorization (easy to get wrong)
 
-When adding or editing the top-level `tags:` array in
-`packages/cli/src/public-api/v1/openapi.yml`, **keep entries sorted
-alphabetically by `name`**. Insert the new tag in order; do not append to the end.
+- `@ApiKeyScope` (what the API key is granted) and `@ProjectScope`/`@GlobalScope`
+  (what the user may do) are independent. Use both when the model needs both.
+- `@ProjectScope` reads `req.params` as-is and does not remap `id` — name the path
+  param what the resolver expects (`workflowId`, `credentialId`, `projectId`,
+  `dataTableId`, …). A generic `id` often fails.
+- `@ApiKeyScope` takes a string, `{ anyOf: [...] }`, or `{ allOf: [...] }` — never
+  a bare array. The scope must exist in the permissions registry
+  (`API_KEY_RESOURCES` in `@n8n/permissions`); `scope-parity.test.ts` fails on an
+  orphan scope.
 
-```yaml
-tags:
-  - name: Audit
-    description: Operations about security audit
-  - name: CommunityPackage
-    description: Operations about community packages
-  # … remaining tags in A→Z order by name
-```
+## DTOs
 
-`scope-parity.test.ts` asserts this ordering — CI fails if tags drift out of
-sort order.
+- Build the public response shape explicitly; don't return an ORM entity and lean
+  on `@ApiResponse` stripping to hide fields.
+- Treat the output DTO as an allowlist. Re-check nested relations, ownership
+  fields, tokens, and encrypted values.
+- Make input DTOs strict so unknown/partial fields aren't silently accepted.
+- Secrets: never return a real secret; use the resource's sentinel/placeholder
+  (or omit). See [Updates and write-only secrets](reference.md#updates-and-write-only-secrets).
 
-## Reference
+## List endpoints (cursor pagination)
 
-- **Controller pattern (required for new work):** `v1/controllers/tags.public.controller.ts`, `v1/controllers/workflows.public.controller.ts`
-- **Registry:** `packages/cli/src/public-api/public-api-controller.registry.ts`
-- Legacy eov examples (migration targets, not templates for new endpoints):
-  `handlers/insights/`, `handlers/variables/`, `handlers/folders/`,
-  `handlers/projects/`, `handlers/data-tables/`, `handlers/workflows/`
-- Multipart: `handlers/n8n-packages/` (see also
-  `packages/cli/src/modules/n8n-packages/CLAUDE.md`)
+Copy the cursor flow from `tags.public.controller.ts`. Use `publicApiPaginationSchema`
+plus `decodeCursor` / `encodeNextCursor` from the shared pagination service; the
+cursor is opaque; return `{ data, nextCursor }` (never a bare array) with
+`nextCursor: null` on the last page; an invalid cursor is a `400`. Preserve an
+existing endpoint's pagination as-is. Detail:
+[List endpoints and cursor pagination](reference.md#list-endpoints-and-cursor-pagination).
+
+## Wiring checklist
+
+1. `v1/controllers/<feature>.public.controller.ts` + side-effect import in
+   `v1/controllers/index.ts`.
+2. Public DTO in `@n8n/api-types` + export from the barrel (`src/dto/`).
+3. `@ApiKeyScope` value exists in the permissions registry.
+4. OpenAPI path with `x-required-scope` matching `@ApiKeyScope`; do **not** set
+   `x-eov-operation-*` for controller routes; keep top-level `tags:` sorted A→Z.
+5. Add the route to `packages/nodes-base/nodes/N8n/n8n-api-coverage.json`.
+6. Tests.
+
+## Testing
+
+Always cover: happy path, input-validation failure, missing API-key scope, RBAC
+denial. Prefer covering the business path in
+`packages/cli/test/integration/public-api/` (real HTTP + DB); mocked-service unit
+tests don't replace that. Add the cases that apply (cursor pages,
+not-found/conflict, no sensitive fields, credential keep/replace, migration
+contract) — see [Testing matrix](reference.md#testing-matrix). Match the nearest
+existing tests.
+
+## More detail (reference.md)
+
+- [List endpoints and cursor pagination](reference.md#list-endpoints-and-cursor-pagination)
+- [Updates and write-only secrets](reference.md#updates-and-write-only-secrets)
+- [Test-before-save endpoints](reference.md#test-before-save-endpoints)
+- [Errors](reference.md#errors)
+- [Testing matrix](reference.md#testing-matrix)
+- [Migrating legacy EOV endpoints](reference.md#migrating-legacy-eov-endpoints)

--- a/.agents/skills/public-api/reference.md
+++ b/.agents/skills/public-api/reference.md
@@ -1,0 +1,115 @@
+# Public API v1 — reference
+
+Detail for tasks that need it. Essentials and the rule tiers are in
+[SKILL.md](SKILL.md). Open the cited files; they are the source of truth.
+
+## List endpoints and cursor pagination
+
+The internal API mixes cursor- and page-based pagination. New Public API list
+endpoints use **cursor-based** pagination — do not copy an internal controller's
+model.
+
+Copy the working flow from `v1/controllers/tags.public.controller.ts` (and
+`workflows.public.controller.ts` for a `@Param` list) rather than pasting a
+snippet here — a copy would drift. The moving parts:
+
+- Input DTO composes `publicApiPaginationSchema` from `@n8n/api-types` (a `limit`
+  plus an opaque `cursor`).
+- `decodeCursor` / `encodeNextCursor` live in
+  `v1/shared/services/pagination.service.ts`. Decode the incoming cursor to
+  `{ offset, limit }`, guard the decoded shape, and pass `offset`/`limit` to the
+  service.
+- Treat the cursor as opaque; never hand-encode a token.
+- Return an envelope `{ data, nextCursor }` — never a bare array.
+- `encodeNextCursor(...)` returns `null` when there is no further page; surface
+  that as `nextCursor: null`.
+- An invalid/undecodable cursor is a `400` via the existing bad-request error.
+- For an existing list endpoint, keep its current pagination semantics unchanged.
+
+The output DTO wraps the list as `{ data, nextCursor }` and is declared with
+`@ApiResponse(...)` so the registry strips undeclared fields.
+
+## Updates and write-only secrets
+
+- Default to `PUT`. The update DTO describes the full mutable object; the
+  validation layer rejects a partial payload (typically `400`). Don't implement
+  merge semantics behind a `PUT`.
+- Don't add a new `PATCH` unless the task explicitly requires partial-update
+  semantics or an established resource-specific exception applies.
+- Migrating an update endpoint keeps its current public HTTP semantics.
+
+Write-only secrets (credentials, tokens, keys) support GET→PUT round-trip via a
+resource-specific sentinel/placeholder (e.g. credentials use
+`CREDENTIAL_BLANKING_VALUE` / related helpers — do not invent a new format):
+
+- `GET` never returns the real secret; it returns that sentinel (or omits the
+  field). Never echo a real secret in responses or error details (including
+  test-connection and upstream error messages).
+- On `PUT`, sending the **exact** sentinel from `GET` means **keep** the stored
+  secret. Sending **any other** value means **replace** it. Do not treat
+  "looks masked" or "field omitted" as keep unless the resource helper/tests say
+  so.
+- Reuse the resource's redact/unredact (or equivalent) helper in the service —
+  don't reimplement sentinel detection or credential merge in the controller, and
+  never persist the sentinel as a real secret.
+- Sentinel support does not make the whole `PUT` a partial update; other required
+  client-manageable fields stay required. Server-managed/immutable fields from
+  `GET` (`id`, timestamps, …) follow the resource DTO (ignored or not required on
+  write).
+
+## Test-before-save endpoints
+
+A connection/config-test endpoint validates the config in the **request body**,
+not stored state — unless the endpoint explicitly verifies an already-saved
+resource. Secret handling is the same as any other endpoint — see above.
+
+## Errors
+
+- Don't leak persistence errors, stack traces, or internal messages. Reuse
+  existing domain errors when the registry already maps them to the right public
+  errors; otherwise map at the controller boundary.
+- Follow the error semantics of the nearest existing public controller; invalid
+  input and invalid cursors use the existing bad-request pattern.
+- When migrating, preserve the documented status codes and public error behavior.
+
+## Testing matrix
+
+Always (in SKILL.md): happy path, input-validation failure, missing API-key
+scope, RBAC denial. Add whichever apply, matching the nearest existing tests:
+
+- At least one integration test under `packages/cli/test/integration/public-api/`
+  that exercises the real service/DB path for the main success case (and
+  paging/RBAC where they matter). Controller unit tests with a mocked service are
+  fine for wiring/validation edges — not as the only coverage of behavior.
+- Cursor paging: first page, final page with `nextCursor: null`, invalid cursor,
+  `limit` handling.
+- Not-found and conflict semantics.
+- Response carries no sensitive/internal fields.
+- Credential resources: response has no real secret (sentinel or omitted);
+  `PUT` with the exact sentinel keeps the secret; any other value replaces it;
+  the sentinel is never persisted as a real secret.
+- Migration: path, method, status codes, scope, and response contract are
+  unchanged.
+
+## Migrating legacy EOV endpoints
+
+Legacy `express-openapi-validator` endpoints live under
+`v1/handlers/`, wired through `openapi.yml` with `x-eov-operation-*` and request
+types in `packages/cli/src/public-api/types.ts`. Treat these as migration targets,
+not templates.
+
+- Prefer migrating to `@PublicApiController` over extending the handler.
+- Preserve the public contract: path, method, scopes, status codes, response
+  shape, and pagination.
+- Move HTTP concerns into the controller and business orchestration into the
+  shared service; keep the controller a thin HTTP boundary.
+- A route must be served by either the EOV handler or a controller, not both —
+  `scope-parity.test.ts` rejects a duplicated route. Remove the legacy wiring
+  (its `x-eov-operation-*` entry and handler middleware) only after the new
+  controller is registered and the spec + tests are updated.
+- As a legacy file drops repository access / the `export =` tuple, remove its
+  entry from the `off` allowlists for `no-repository-in-public-api-handler` and
+  `require-public-api-controller` in `packages/cli/eslint.config.mjs` (shrink-only
+  — never extend them).
+- For complex legacy-only, multipart, or non-standard endpoints, study the
+  nearest existing handler first.


### PR DESCRIPTION
## Summary

Rewrites the `n8n:public-api` agent skill and moves depth into a new `reference.md` (progressive disclosure). This is a **rewrite/expansion**, not a line reduction: `SKILL.md` goes 119 → 164 lines and adds a 115-line `reference.md`.

Relative to the current `master` skill, it:
- Cites the CI-active local ESLint guardrails that master's skill did not mention: `no-repository-in-public-api-handler`, `require-public-api-controller`, `no-public-api-guardrail-disable` (registered in `packages/cli/eslint.config.mjs`), plus the note that their `off` allowlist is shrink-only.
- Adds an **Authorization** section separating `@ApiKeyScope` (API-key grant) from `@ProjectScope`/`@GlobalScope` (user RBAC), keeping master's `@ProjectScope` path-param-naming footgun.
- Adds explicit team defaults: cursor pagination, full-object `PUT` (with a GET→PUT round-trip note), strict input / allowlist output DTOs, and write-only-secret handling via the resource sentinel (`CREDENTIAL_BLANKING_VALUE`, as exercised by the LDAP public API integration tests).
- Moves updates/secrets, test-before-save, errors, the testing matrix, and legacy-EOV migration into `reference.md`.
- Replaces the inline code snippet with a pointer to the live `v1/controllers/` folder (no pasted controller in `SKILL.md`), and drops the version-context notes (API-37+/API-39).

Keeps master's substance: controller-pattern requirement, service-layer convergence, side-effect barrel import, OpenAPI + `x-required-scope` wiring, tags A→Z sort, and the coverage manifest.

Docs/skill only — no runtime code changes.

## How to test

- All cited paths, decorators, tests, lint rules, and `CREDENTIAL_BLANKING_VALUE` were verified to exist on current `master`.
- Pre-commit `skill_links_check` passes (reference.md anchor links are valid).
- Reviewers: diff against master's `SKILL.md` and open the cited files to confirm the claims.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-41

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI