### PR TITLE
ci: Fix Wrangler install in API schema publish workflow

### DIFF
--- a/.github/workflows/util-publish-api-schema.yml
+++ b/.github/workflows/util-publish-api-schema.yml
@@ -58,6 +58,14 @@ jobs:
             Content-Type: text/yaml; charset=utf-8
           EOF
 
+      # wrangler-action self-installs Wrangler with `pnpm add` at the workspace
+      # root, which pnpm rejects (ERR_PNPM_ADDING_TO_ROOT). Pre-install it and
+      # allow the root add so the action finds Wrangler and skips its own install.
+      - name: Setup Wrangler Pre-requisites
+        run: |
+          echo "ignore-workspace-root-check=true" >> .npmrc
+          pnpm add --global wrangler
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:


### PR DESCRIPTION
## Summary

The `util-publish-api-schema.yml` workflow failed on its first master run. `wrangler-action` installs Wrangler by running `pnpm add` at the workspace root, which pnpm rejects (`ERR_PNPM_ADDING_TO_ROOT`), so the deploy step never ran.

This restores the Wrangler pre-install step (removed in the original PR), matching the Storybook deploy workflow. It sets `ignore-workspace-root-check` and installs Wrangler up front, so the action finds it and skips its own broken install.

## How to test

Runs on master pushes touching the public API source, plus manual dispatch. After merge, trigger "Util: Publish API Schema" (or wait for the next qualifying push) and confirm the Deploy step completes and publishes to the `n8n-openapi` Pages project.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included.~
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35188">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

