### PR TITLE
feat(core): Persist step results in @n8n/engine (no-changelog)

### DIFF
--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -3,6 +3,7 @@ import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testconta
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import type { StepStatus } from '../../execution/execution.types';
+import { StepNotFoundError } from '../../execution/step-store';
 import { createDataSource } from '../data-source';
 import { WorkflowExecution } from '../entities/workflow-execution.entity';
 import { WorkflowStepExecution } from '../entities/workflow-step-execution.entity';
@@ -46,7 +47,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const created = repo.create({ executionId, nodeId: 'node-a', status: 'queued' });
 		await repo.save(created);
 
-		const found = await repo.findOneByOrFail({ id: created.id });
+		const found = await repo.findOneOrFail({ where: { id: created.id } });
 		expect(found.executionId).toBe(executionId);
 		expect(found.nodeId).toBe('node-a');
 		expect(found.status).toBe('queued');
@@ -59,7 +60,9 @@ describe('workflow_step_execution table (integration)', () => {
 
 		const { id } = await store.createStep({ executionId, nodeId: 'x', status: 'queued' });
 
-		const found = await dataSource.getRepository(WorkflowStepExecution).findOneByOrFail({ id });
+		const found = await dataSource
+			.getRepository(WorkflowStepExecution)
+			.findOneOrFail({ where: { id } });
 		expect(found.nodeId).toBe('x');
 		expect(found.status).toBe('queued');
 	});
@@ -71,7 +74,7 @@ describe('workflow_step_execution table (integration)', () => {
 
 		await dataSource.getRepository(WorkflowExecution).delete({ id: executionId });
 
-		expect(await stepRepo.countBy({ executionId })).toBe(0);
+		expect(await stepRepo.count({ where: { executionId } })).toBe(0);
 	});
 
 	it('rejects a step referencing a non-existent execution (foreign key)', async () => {
@@ -83,6 +86,93 @@ describe('workflow_step_execution table (integration)', () => {
 				status: 'queued',
 			}),
 		).rejects.toThrow();
+	});
+
+	it('TypeOrmStepStore.loadStep returns the step, or throws when absent', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id } = await store.createStep({ executionId, nodeId: 'node-a', status: 'queued' });
+
+		const step = await store.loadStep(id);
+
+		// `toMatchObject`: the adapter returns the entity, which carries columns the
+		// `StepRecord` interface doesn't expose.
+		expect(step).toMatchObject({
+			id,
+			executionId,
+			nodeId: 'node-a',
+			status: 'queued',
+			outputs: null,
+		});
+		await expect(store.loadStep('00000000-0000-7000-8000-000000000000')).rejects.toThrow(
+			StepNotFoundError,
+		);
+	});
+
+	it('TypeOrmStepStore.transitionStepStatus only transitions from the expected status', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id } = await store.createStep({ executionId, nodeId: 'a', status: 'queued' });
+
+		expect(await store.transitionStepStatus(id, 'queued', 'running')).toBe(true);
+		// second claim of the same step loses the race
+		expect(await store.transitionStepStatus(id, 'queued', 'running')).toBe(false);
+		expect((await store.loadStep(id)).status).toBe('running');
+	});
+
+	it('TypeOrmStepStore.completeStep persists outputs and marks the step completed', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id } = await store.createStep({ executionId, nodeId: 'a', status: 'running' });
+
+		expect(await store.completeStep(id, [[{ json: { ok: true } }]])).toBe(true);
+
+		const step = await store.loadStep(id);
+		expect(step.status).toBe('completed');
+		expect(step.outputs).toEqual([[{ json: { ok: true } }]]);
+	});
+
+	it('TypeOrmStepStore.completeStep and failStep only record a step that is running', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id } = await store.createStep({ executionId, nodeId: 'a', status: 'queued' });
+
+		expect(await store.completeStep(id, [[{ json: { ok: true } }]])).toBe(false);
+		expect(await store.failStep(id, { name: 'Error', message: 'node blew up' })).toBe(false);
+
+		// neither the status nor the result columns moved
+		const found = await dataSource
+			.getRepository(WorkflowStepExecution)
+			.findOneOrFail({ where: { id } });
+		expect(found.status).toBe('queued');
+		expect(found.outputs).toBeNull();
+		expect(found.error).toBeNull();
+	});
+
+	it('TypeOrmStepStore.failStep persists the error and marks the step failed', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id } = await store.createStep({ executionId, nodeId: 'a', status: 'running' });
+
+		expect(await store.failStep(id, { name: 'Error', message: 'node blew up' })).toBe(true);
+
+		const found = await dataSource
+			.getRepository(WorkflowStepExecution)
+			.findOneOrFail({ where: { id } });
+		expect(found.status).toBe('failed');
+		expect(found.error).toEqual({ name: 'Error', message: 'node blew up' });
+	});
+
+	it('TypeOrmStepStore.loadStepOutputs returns outputs keyed by node id', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id: aId } = await store.createStep({ executionId, nodeId: 'a', status: 'running' });
+		await store.completeStep(aId, [[{ json: { from: 'a' } }]]);
+		await store.createStep({ executionId, nodeId: 'b', status: 'queued' });
+
+		const outputs = await store.loadStepOutputs(executionId, ['a', 'b']);
+
+		expect(outputs).toEqual({ a: [[{ json: { from: 'a' } }]], b: null });
 	});
 
 	it('rejects an invalid status (check constraint)', async () => {

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -3,7 +3,7 @@ import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testconta
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import type { StepStatus } from '../../execution/execution.types';
-import { StepNotFoundError } from '../../execution/step-store';
+import { StepNotFoundError, type NewStepRecord } from '../../execution/step-store';
 import { createDataSource } from '../data-source';
 import { WorkflowExecution } from '../entities/workflow-execution.entity';
 import { WorkflowStepExecution } from '../entities/workflow-step-execution.entity';
@@ -40,6 +40,15 @@ describe('workflow_step_execution table (integration)', () => {
 		return execution.id;
 	}
 
+	/** Most cases need one step; the store's API is the batch `createSteps`. */
+	async function createStep(
+		store: TypeOrmStepStore,
+		record: NewStepRecord,
+	): Promise<{ id: string }> {
+		const [step] = await store.createSteps([record]);
+		return step;
+	}
+
 	it('persists and retrieves a step row', async () => {
 		const executionId = await createExecution();
 		const repo = dataSource.getRepository(WorkflowStepExecution);
@@ -54,17 +63,46 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(found.createdAt).toBeInstanceOf(Date);
 	});
 
-	it('TypeOrmStepStore.createStep persists a queued step and returns its id', async () => {
+	it('TypeOrmStepStore.createSteps persists a queued step and returns its id', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
-		const { id } = await store.createStep({ executionId, nodeId: 'x', status: 'queued' });
+		const { id } = await createStep(store, { executionId, nodeId: 'x', status: 'queued' });
 
 		const found = await dataSource
 			.getRepository(WorkflowStepExecution)
 			.findOneOrFail({ where: { id } });
 		expect(found.nodeId).toBe('x');
 		expect(found.status).toBe('queued');
+	});
+
+	it('TypeOrmStepStore.createSteps persists a batch and returns ids in input order', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+
+		const ids = await store.createSteps([
+			{ executionId, nodeId: 'trigger', status: 'completed' },
+			{ executionId, nodeId: 'a', status: 'queued' },
+			{ executionId, nodeId: 'b', status: 'queued' },
+		]);
+
+		expect(ids).toHaveLength(3);
+		expect(new Set(ids.map(({ id }) => id)).size).toBe(3);
+		// the returned ids line up positionally with the records passed in
+		const repo = dataSource.getRepository(WorkflowStepExecution);
+		const rows = await Promise.all(
+			ids.map(async ({ id }) => await repo.findOneOrFail({ where: { id } })),
+		);
+		expect(rows.map((r) => [r.nodeId, r.status])).toEqual([
+			['trigger', 'completed'],
+			['a', 'queued'],
+			['b', 'queued'],
+		]);
+	});
+
+	it('TypeOrmStepStore.createSteps is a no-op for an empty batch', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		expect(await store.createSteps([])).toEqual([]);
 	});
 
 	it('cascades step deletion when the parent execution is deleted', async () => {
@@ -80,7 +118,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('rejects a step referencing a non-existent execution (foreign key)', async () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		await expect(
-			store.createStep({
+			createStep(store, {
 				executionId: '00000000-0000-7000-8000-000000000000',
 				nodeId: 'a',
 				status: 'queued',
@@ -91,7 +129,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.loadStep returns the step, or throws when absent', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await store.createStep({ executionId, nodeId: 'node-a', status: 'queued' });
+		const { id } = await createStep(store, { executionId, nodeId: 'node-a', status: 'queued' });
 
 		const step = await store.loadStep(id);
 
@@ -112,7 +150,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.transitionStepStatus only transitions from the expected status', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await store.createStep({ executionId, nodeId: 'a', status: 'queued' });
+		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
 
 		expect(await store.transitionStepStatus(id, 'queued', 'running')).toBe(true);
 		// second claim of the same step loses the race
@@ -123,7 +161,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.completeStep persists outputs and marks the step completed', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await store.createStep({ executionId, nodeId: 'a', status: 'running' });
+		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
 
 		expect(await store.completeStep(id, [[{ json: { ok: true } }]])).toBe(true);
 
@@ -135,7 +173,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.completeStep and failStep only record a step that is running', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await store.createStep({ executionId, nodeId: 'a', status: 'queued' });
+		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
 
 		expect(await store.completeStep(id, [[{ json: { ok: true } }]])).toBe(false);
 		expect(await store.failStep(id, { name: 'Error', message: 'node blew up' })).toBe(false);
@@ -152,7 +190,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.failStep persists the error and marks the step failed', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await store.createStep({ executionId, nodeId: 'a', status: 'running' });
+		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
 
 		expect(await store.failStep(id, { name: 'Error', message: 'node blew up' })).toBe(true);
 
@@ -166,9 +204,9 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.loadStepOutputs returns outputs keyed by node id', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id: aId } = await store.createStep({ executionId, nodeId: 'a', status: 'running' });
+		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
 		await store.completeStep(aId, [[{ json: { from: 'a' } }]]);
-		await store.createStep({ executionId, nodeId: 'b', status: 'queued' });
+		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
 
 		const outputs = await store.loadStepOutputs(executionId, ['a', 'b']);
 

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -141,20 +141,21 @@ describe('workflow_step_execution table (integration)', () => {
 			nodeId: 'node-a',
 			status: 'queued',
 			outputs: null,
+			error: null,
 		});
 		await expect(store.loadStep('00000000-0000-7000-8000-000000000000')).rejects.toThrow(
 			StepNotFoundError,
 		);
 	});
 
-	it('TypeOrmStepStore.transitionStepStatus only transitions from the expected status', async () => {
+	it('TypeOrmStepStore.claimStep only claims a queued step', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
 
-		expect(await store.transitionStepStatus(id, 'queued', 'running')).toBe(true);
+		expect(await store.claimStep(id)).toBe(true);
 		// second claim of the same step loses the race
-		expect(await store.transitionStepStatus(id, 'queued', 'running')).toBe(false);
+		expect(await store.claimStep(id)).toBe(false);
 		expect((await store.loadStep(id)).status).toBe('running');
 	});
 
@@ -192,25 +193,38 @@ describe('workflow_step_execution table (integration)', () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
 
-		expect(await store.failStep(id, { name: 'Error', message: 'node blew up' })).toBe(true);
+		const error = {
+			name: 'Error',
+			message: 'node blew up',
+			stack: 'Error: node blew up\n    at somewhere',
+			details: { httpCode: '500' },
+		};
+		expect(await store.failStep(id, error)).toBe(true);
 
 		const found = await dataSource
 			.getRepository(WorkflowStepExecution)
 			.findOneOrFail({ where: { id } });
 		expect(found.status).toBe('failed');
-		expect(found.error).toEqual({ name: 'Error', message: 'node blew up' });
+		expect(found.error).toEqual(error);
 	});
 
-	it('TypeOrmStepStore.loadStepOutputs returns outputs keyed by node id', async () => {
+	it('TypeOrmStepStore.loadStepOutputs returns only completed outputs, keyed by node id', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
 		await store.completeStep(aId, [[{ json: { from: 'a' } }]]);
 		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
+		const { id: cId } = await createStep(store, { executionId, nodeId: 'c', status: 'running' });
+		await store.failStep(cId, { name: 'Error', message: 'node blew up' });
 
-		const outputs = await store.loadStepOutputs(executionId, ['a', 'b']);
+		const outputs = await store.loadStepOutputs(executionId, ['a', 'b', 'c', 'd']);
 
-		expect(outputs).toEqual({ a: [[{ json: { from: 'a' } }]], b: null });
+		expect(outputs).toEqual({
+			a: [[{ json: { from: 'a' } }]],
+			b: null, // queued
+			c: null, // failed
+			d: null, // no step row
+		});
 	});
 
 	it('rejects an invalid status (check constraint)', async () => {

--- a/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
+++ b/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
@@ -14,7 +14,7 @@ import type { StepError } from '../../execution/step-store';
 import { generateId } from '../generate-id';
 
 @Entity('workflow_step_execution')
-@Index('idx_workflow_step_execution_execution_id', ['executionId'])
+@Index('idx_workflow_step_execution_execution_id_node_id', ['executionId', 'nodeId'])
 export class WorkflowStepExecution {
 	@PrimaryColumn('uuid')
 	id!: string;

--- a/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
+++ b/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
@@ -8,7 +8,9 @@ import {
 	UpdateDateColumn,
 } from '@n8n/typeorm';
 
+import type { JsonValue } from '../../common';
 import type { StepStatus } from '../../execution/execution.types';
+import type { StepError } from '../../execution/step-store';
 import { generateId } from '../generate-id';
 
 @Entity('workflow_step_execution')
@@ -25,6 +27,12 @@ export class WorkflowStepExecution {
 
 	@Column('varchar', { length: 32 })
 	status!: StepStatus;
+
+	@Column('jsonb', { nullable: true })
+	outputs!: JsonValue | null;
+
+	@Column('jsonb', { nullable: true })
+	error!: StepError | null;
 
 	@CreateDateColumn({ name: 'created_at', type: 'timestamptz', precision: 3 })
 	createdAt!: Date;

--- a/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
+++ b/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
@@ -14,6 +14,19 @@ export class CreateWorkflowStepExecution1784890100000 implements MigrationInterf
 					{ name: 'node_id', type: 'varchar' },
 					{ name: 'status', type: 'varchar', length: '32' },
 					{
+						name: 'outputs',
+						type: 'jsonb',
+						isNullable: true,
+						comment:
+							'Step outputs, persisted without inspection and reloaded as downstream inputs. Shape is step-type-specific.',
+					},
+					{
+						name: 'error',
+						type: 'jsonb',
+						isNullable: true,
+						comment: 'Name and message of the error that failed this step.',
+					},
+					{
 						name: 'created_at',
 						type: 'timestamptz',
 						precision: 3,

--- a/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
+++ b/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
@@ -40,7 +40,13 @@ export class CreateWorkflowStepExecution1784890100000 implements MigrationInterf
 					},
 				],
 				indices: [
-					{ name: 'idx_workflow_step_execution_execution_id', columnNames: ['execution_id'] },
+					// Composite: steps are looked up per execution, usually narrowed to
+					// specific nodes. The leading column also serves execution-only
+					// lookups and the FK's cascading delete.
+					{
+						name: 'idx_workflow_step_execution_execution_id_node_id',
+						columnNames: ['execution_id', 'node_id'],
+					},
 				],
 				foreignKeys: [
 					{

--- a/packages/@n8n/engine/src/database/typeorm-execution-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-execution-store.ts
@@ -9,13 +9,22 @@ import {
 } from '../execution/execution-store';
 import type { ExecutionStatus } from '../execution/execution.types';
 
+/**
+ * Insert payload accepted by the repository. Derived from the method rather than
+ * imported: TypeORM's `QueryDeepPartialEntity` has no root export.
+ */
+type InsertValues = Parameters<Repository<WorkflowExecution>['insert']>[0];
+
 /** TypeORM-backed `ExecutionStore` adapter. */
 export class TypeOrmExecutionStore implements ExecutionStore {
 	constructor(private readonly repo: Repository<WorkflowExecution>) {}
 
 	async createExecution(record: NewExecutionRecord): Promise<{ id: string }> {
 		const execution = this.repo.create({ ...record, finishedAt: null });
-		await this.repo.save(execution);
+		// The cast is needed because the insert payload type recurses into the
+		// opaque `graph` jsonb and rejects `StepConfig`'s deliberate `unknown`.
+		// NOTE: prefer insert to save for performance reasons.
+		await this.repo.insert(execution as InsertValues);
 		return { id: execution.id };
 	}
 

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -15,14 +15,15 @@ import {
 export class TypeOrmStepStore implements StepStore {
 	constructor(private readonly repo: Repository<WorkflowStepExecution>) {}
 
-	async createStep(record: NewStepRecord): Promise<{ id: string }> {
-		const step = this.repo.create(record);
-		await this.repo.save(step);
-		return { id: step.id };
+	async createSteps(records: NewStepRecord[]): Promise<Array<{ id: string }>> {
+		const steps = records.map((record) => this.repo.create(record));
+		// NOTE: prefer insert to save for performance reasons.
+		await this.repo.insert(steps);
+		return steps.map(({ id }) => ({ id }));
 	}
 
 	async loadStep(id: string): Promise<StepRecord> {
-		// `findOne({ where })`, not `findOneBy`: the latter's overload exceeds
+		// NOTE: `findOne({ where })`, not `findOneBy`: the latter's overload exceeds
 		// TypeScript's instantiation depth on the recursive `outputs` column type.
 		const row = await this.repo.findOne({ where: { id } });
 		if (!row) throw new StepNotFoundError(id);

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -30,8 +30,8 @@ export class TypeOrmStepStore implements StepStore {
 		return row;
 	}
 
-	async transitionStepStatus(id: string, from: StepStatus, to: StepStatus): Promise<boolean> {
-		return await this.transition(id, from, to);
+	async claimStep(id: string): Promise<boolean> {
+		return await this.transition(id, 'queued', 'running');
 	}
 
 	async completeStep(id: string, outputs: JsonValue): Promise<boolean> {
@@ -64,8 +64,10 @@ export class TypeOrmStepStore implements StepStore {
 		for (const nodeId of nodeIds) outputsByNodeId[nodeId] = null;
 		if (nodeIds.length === 0) return outputsByNodeId;
 
+		// Filter on `completed` rather than relying on non-completed rows having a
+		// null `outputs` column, so the contract holds however writes are ordered.
 		const rows = await this.repo.find({
-			where: { executionId, nodeId: In(nodeIds) },
+			where: { executionId, nodeId: In(nodeIds), status: 'completed' },
 			select: ['nodeId', 'outputs'],
 		});
 		for (const row of rows) outputsByNodeId[row.nodeId] = row.outputs;

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -1,7 +1,15 @@
-import type { Repository } from '@n8n/typeorm';
+import { In, type Repository } from '@n8n/typeorm';
 
 import type { WorkflowStepExecution } from './entities';
-import type { NewStepRecord, StepStore } from '../execution/step-store';
+import type { JsonValue } from '../common';
+import type { StepStatus } from '../execution/execution.types';
+import {
+	StepNotFoundError,
+	type NewStepRecord,
+	type StepError,
+	type StepRecord,
+	type StepStore,
+} from '../execution/step-store';
 
 /** TypeORM-backed `StepStore` adapter. */
 export class TypeOrmStepStore implements StepStore {
@@ -11,5 +19,56 @@ export class TypeOrmStepStore implements StepStore {
 		const step = this.repo.create(record);
 		await this.repo.save(step);
 		return { id: step.id };
+	}
+
+	async loadStep(id: string): Promise<StepRecord> {
+		// `findOne({ where })`, not `findOneBy`: the latter's overload exceeds
+		// TypeScript's instantiation depth on the recursive `outputs` column type.
+		const row = await this.repo.findOne({ where: { id } });
+		if (!row) throw new StepNotFoundError(id);
+		return row;
+	}
+
+	async transitionStepStatus(id: string, from: StepStatus, to: StepStatus): Promise<boolean> {
+		return await this.transition(id, from, to);
+	}
+
+	async completeStep(id: string, outputs: JsonValue): Promise<boolean> {
+		return await this.transition(id, 'running', 'completed', { outputs });
+	}
+
+	async failStep(id: string, error: StepError): Promise<boolean> {
+		return await this.transition(id, 'running', 'failed', { error });
+	}
+
+	/**
+	 * Compare-and-set on `status`, writing any result columns in the same
+	 * statement so a step's status and its outcome can't be observed apart.
+	 */
+	private async transition(
+		id: string,
+		from: StepStatus,
+		to: StepStatus,
+		fields: { outputs?: JsonValue; error?: StepError } = {},
+	): Promise<boolean> {
+		const result = await this.repo.update({ id, status: from }, { ...fields, status: to });
+		return result.affected === 1;
+	}
+
+	async loadStepOutputs(
+		executionId: string,
+		nodeIds: string[],
+	): Promise<Record<string, JsonValue | null>> {
+		const outputsByNodeId: Record<string, JsonValue | null> = {};
+		for (const nodeId of nodeIds) outputsByNodeId[nodeId] = null;
+		if (nodeIds.length === 0) return outputsByNodeId;
+
+		const rows = await this.repo.find({
+			where: { executionId, nodeId: In(nodeIds) },
+			select: ['nodeId', 'outputs'],
+		});
+		for (const row of rows) outputsByNodeId[row.nodeId] = row.outputs;
+
+		return outputsByNodeId;
 	}
 }

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -24,7 +24,7 @@ function makeStepStore(createSteps = vi.fn()): StepStore {
 	return {
 		createSteps,
 		loadStep: vi.fn(),
-		transitionStepStatus: vi.fn(),
+		claimStep: vi.fn(),
 		completeStep: vi.fn(),
 		failStep: vi.fn(),
 		loadStepOutputs: vi.fn(),

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -19,10 +19,10 @@ function makeStepQueue(): WorkQueue<StepMessage> {
 	return { publish: vi.fn(), start: vi.fn(), stop: vi.fn() };
 }
 
-/** Only `createStep` is exercised here; the rest belong to the step worker. */
-function makeStepStore(createStep = vi.fn()): StepStore {
+/** Only `createSteps` is exercised here; the rest belong to the step worker. */
+function makeStepStore(createSteps = vi.fn()): StepStore {
 	return {
-		createStep,
+		createSteps,
 		loadStep: vi.fn(),
 		transitionStepStatus: vi.fn(),
 		completeStep: vi.fn(),
@@ -58,34 +58,23 @@ describe('ExecutionStartHandler', () => {
 		const executionStore = makeExecutionStore({
 			loadExecution: vi.fn().mockResolvedValue(record(graph)),
 		});
-		const createStep = vi
+		const createSteps = vi
 			.fn()
-			.mockResolvedValueOnce({ id: 'step-trigger' })
-			.mockResolvedValueOnce({ id: 'step-a' })
-			.mockResolvedValueOnce({ id: 'step-b' });
-		const stepStore = makeStepStore(createStep);
+			.mockResolvedValue([{ id: 'step-trigger' }, { id: 'step-a' }, { id: 'step-b' }]);
+		const stepStore = makeStepStore(createSteps);
 		const stepQueue = makeStepQueue();
 		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
 
 		await handler.handle({ type: 'execution:enqueued', executionId: 'exec-1' });
 
 		expect(executionStore.transitionStatus).toHaveBeenCalledWith('exec-1', 'queued', 'running');
-		// trigger recorded completed, then each successor recorded queued
-		expect(createStep).toHaveBeenNthCalledWith(1, {
-			executionId: 'exec-1',
-			nodeId: 'trigger',
-			status: 'completed',
-		});
-		expect(createStep).toHaveBeenNthCalledWith(2, {
-			executionId: 'exec-1',
-			nodeId: 'a',
-			status: 'queued',
-		});
-		expect(createStep).toHaveBeenNthCalledWith(3, {
-			executionId: 'exec-1',
-			nodeId: 'b',
-			status: 'queued',
-		});
+		// one batch: the trigger completed, then each successor queued
+		expect(createSteps).toHaveBeenCalledTimes(1);
+		expect(createSteps).toHaveBeenCalledWith([
+			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed' },
+			{ executionId: 'exec-1', nodeId: 'a', status: 'queued' },
+			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
+		]);
 		// step:ready references the queued step-record ids
 		expect(stepQueue.publish).toHaveBeenNthCalledWith(1, {
 			type: 'step:ready',
@@ -110,7 +99,7 @@ describe('ExecutionStartHandler', () => {
 		await handler.handle({ type: 'execution:enqueued', executionId: 'exec-1' });
 
 		expect(executionStore.loadExecution).not.toHaveBeenCalled();
-		expect(stepStore.createStep).not.toHaveBeenCalled();
+		expect(stepStore.createSteps).not.toHaveBeenCalled();
 		expect(stepQueue.publish).not.toHaveBeenCalled();
 	});
 
@@ -126,7 +115,7 @@ describe('ExecutionStartHandler', () => {
 		await handler.handle({ type: 'execution:enqueued', executionId: 'exec-1' });
 
 		expect(executionStore.transitionStatus).toHaveBeenCalledWith('exec-1', 'running', 'failed');
-		expect(stepStore.createStep).not.toHaveBeenCalled();
+		expect(stepStore.createSteps).not.toHaveBeenCalled();
 		expect(stepQueue.publish).not.toHaveBeenCalled();
 	});
 
@@ -138,8 +127,8 @@ describe('ExecutionStartHandler', () => {
 		const executionStore = makeExecutionStore({
 			loadExecution: vi.fn().mockResolvedValue(record(graph)),
 		});
-		const createStep = vi.fn().mockResolvedValue({ id: 'step-trigger' });
-		const stepStore = makeStepStore(createStep);
+		const createSteps = vi.fn().mockResolvedValue([{ id: 'step-trigger' }]);
+		const stepStore = makeStepStore(createSteps);
 		const stepQueue = makeStepQueue();
 		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
 
@@ -148,12 +137,10 @@ describe('ExecutionStartHandler', () => {
 		// claimed (queued -> running) but not failed
 		expect(executionStore.transitionStatus).toHaveBeenCalledWith('exec-1', 'queued', 'running');
 		expect(executionStore.transitionStatus).not.toHaveBeenCalledWith('exec-1', 'running', 'failed');
-		expect(createStep).toHaveBeenCalledTimes(1);
-		expect(createStep).toHaveBeenCalledWith({
-			executionId: 'exec-1',
-			nodeId: 'trigger',
-			status: 'completed',
-		});
+		expect(createSteps).toHaveBeenCalledTimes(1);
+		expect(createSteps).toHaveBeenCalledWith([
+			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed' },
+		]);
 		expect(stepQueue.publish).not.toHaveBeenCalled();
 	});
 });

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -19,6 +19,18 @@ function makeStepQueue(): WorkQueue<StepMessage> {
 	return { publish: vi.fn(), start: vi.fn(), stop: vi.fn() };
 }
 
+/** Only `createStep` is exercised here; the rest belong to the step worker. */
+function makeStepStore(createStep = vi.fn()): StepStore {
+	return {
+		createStep,
+		loadStep: vi.fn(),
+		transitionStepStatus: vi.fn(),
+		completeStep: vi.fn(),
+		failStep: vi.fn(),
+		loadStepOutputs: vi.fn(),
+	};
+}
+
 function record(graph: WorkflowGraph): ExecutionRecord {
 	return {
 		id: 'exec-1',
@@ -51,7 +63,7 @@ describe('ExecutionStartHandler', () => {
 			.mockResolvedValueOnce({ id: 'step-trigger' })
 			.mockResolvedValueOnce({ id: 'step-a' })
 			.mockResolvedValueOnce({ id: 'step-b' });
-		const stepStore: StepStore = { createStep };
+		const stepStore = makeStepStore(createStep);
 		const stepQueue = makeStepQueue();
 		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
 
@@ -91,7 +103,7 @@ describe('ExecutionStartHandler', () => {
 		const executionStore = makeExecutionStore({
 			transitionStatus: vi.fn().mockResolvedValue(false),
 		});
-		const stepStore: StepStore = { createStep: vi.fn() };
+		const stepStore = makeStepStore();
 		const stepQueue = makeStepQueue();
 		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
 
@@ -107,7 +119,7 @@ describe('ExecutionStartHandler', () => {
 		const executionStore = makeExecutionStore({
 			loadExecution: vi.fn().mockResolvedValue(record(graph)),
 		});
-		const stepStore: StepStore = { createStep: vi.fn() };
+		const stepStore = makeStepStore();
 		const stepQueue = makeStepQueue();
 		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
 
@@ -127,7 +139,7 @@ describe('ExecutionStartHandler', () => {
 			loadExecution: vi.fn().mockResolvedValue(record(graph)),
 		});
 		const createStep = vi.fn().mockResolvedValue({ id: 'step-trigger' });
-		const stepStore: StepStore = { createStep };
+		const stepStore = makeStepStore(createStep);
 		const stepQueue = makeStepQueue();
 		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
 

--- a/packages/@n8n/engine/src/execution/execution-start-handler.ts
+++ b/packages/@n8n/engine/src/execution/execution-start-handler.ts
@@ -35,19 +35,19 @@ export class ExecutionStartHandler {
 
 		// The trigger's output was captured at execution start; record it as
 		// already completed so successors can treat it as a satisfied predecessor.
-		await this.stepStore.createStep({
-			executionId: event.executionId,
-			nodeId: trigger.id,
-			status: 'completed',
-		});
-
+		// Planned together with the successors so a fan-out is one round trip.
 		const successorNodeIds = getSuccessorNodeIds(execution.graph, trigger.id);
-		for (const nodeId of successorNodeIds) {
-			const { id: stepId } = await this.stepStore.createStep({
+		const [, ...successorSteps] = await this.stepStore.createSteps([
+			{ executionId: event.executionId, nodeId: trigger.id, status: 'completed' },
+			...successorNodeIds.map((nodeId) => ({
 				executionId: event.executionId,
 				nodeId,
-				status: 'queued',
-			});
+				status: 'queued' as const,
+			})),
+		]);
+
+		// Published only after the rows exist, so a consumer can always load the step.
+		for (const { id: stepId } of successorSteps) {
 			await this.stepQueue.publish({
 				type: 'step:ready',
 				executionId: event.executionId,

--- a/packages/@n8n/engine/src/execution/index.ts
+++ b/packages/@n8n/engine/src/execution/index.ts
@@ -6,6 +6,7 @@ export type {
 export type { ExecutionMode, ExecutionStatus, StepStatus } from './execution.types';
 export { ExecutionNotFoundError } from './execution-store';
 export type { ExecutionRecord, ExecutionStore, NewExecutionRecord } from './execution-store';
-export type { NewStepRecord, StepStore } from './step-store';
+export { StepNotFoundError } from './step-store';
+export type { NewStepRecord, StepError, StepRecord, StepStore } from './step-store';
 export { ExecutionStartHandler } from './execution-start-handler';
 export { OrchestrationWorker } from './orchestration-worker';

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -1,3 +1,4 @@
+import type { JsonValue } from '../common';
 import type { StepStatus } from './execution.types';
 
 /** A new step to persist. `id` and timestamps are assigned by the store. */
@@ -7,8 +8,61 @@ export interface NewStepRecord {
 	status: StepStatus;
 }
 
+/** The error that failed a step, as persisted on its row. */
+export interface StepError {
+	name: string;
+	message: string;
+}
+
+/** A step record. */
+export interface StepRecord {
+	id: string;
+	executionId: string;
+	nodeId: string;
+	status: StepStatus;
+	/** Outputs of a completed step; `null` until it completes. */
+	outputs: JsonValue | null;
+}
+
+/** Thrown by `loadStep` when no step exists for the given id. */
+export class StepNotFoundError extends Error {
+	constructor(readonly stepId: string) {
+		super(`Step not found: ${stepId}`);
+		this.name = 'StepNotFoundError';
+	}
+}
+
 /** Persistence interface for step records. */
 export interface StepStore {
 	/** Persist a new step record; returns its generated id. */
 	createStep(record: NewStepRecord): Promise<{ id: string }>;
+
+	/** Load a single step by id. Throws `StepNotFoundError` if absent. */
+	loadStep(id: string): Promise<StepRecord>;
+
+	/**
+	 * Compare-and-set status transition. Returns `true` iff this call performed
+	 * the transition, so duplicate/redelivered events are handled idempotently.
+	 */
+	transitionStepStatus(id: string, from: StepStatus, to: StepStatus): Promise<boolean>;
+
+	/**
+	 * Record a successful run: persist `outputs` and mark the step completed.
+	 * A compare-and-set on `running`, so it returns `false` if the caller no
+	 * longer holds the claim — the outcome and the status are written together,
+	 * which a bare `transitionStepStatus` can't do.
+	 */
+	completeStep(id: string, outputs: JsonValue): Promise<boolean>;
+
+	/** Record a failed run: persist `error` and mark the step failed. As `completeStep`. */
+	failStep(id: string, error: StepError): Promise<boolean>;
+
+	/**
+	 * Outputs of the given nodes within an execution, keyed by node id. A node
+	 * with no step row, or one that hasn't completed, maps to `null`.
+	 */
+	loadStepOutputs(
+		executionId: string,
+		nodeIds: string[],
+	): Promise<Record<string, JsonValue | null>>;
 }

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -12,6 +12,13 @@ export interface NewStepRecord {
 export interface StepError {
 	name: string;
 	message: string;
+	stack?: string;
+	/**
+	 * Step-type-specific error detail, persisted without inspection — the engine
+	 * owns only `name`/`message`/`stack`. Unpopulated until executors have a way
+	 * to hand structured detail across the seam; they only throw today.
+	 */
+	details?: JsonValue;
 }
 
 /** A step record. */
@@ -22,6 +29,8 @@ export interface StepRecord {
 	status: StepStatus;
 	/** Outputs of a completed step; `null` until it completes. */
 	outputs: JsonValue | null;
+	/** The error that failed the step; `null` unless it failed. */
+	error: StepError | null;
 }
 
 /** Thrown by `loadStep` when no step exists for the given id. */
@@ -45,16 +54,21 @@ export interface StepStore {
 	loadStep(id: string): Promise<StepRecord>;
 
 	/**
-	 * Compare-and-set status transition. Returns `true` iff this call performed
-	 * the transition, so duplicate/redelivered events are handled idempotently.
+	 * Claim a queued step for execution (`queued → running`). A compare-and-set,
+	 * so it returns `true` for at most one caller and duplicate/redelivered
+	 * events are handled idempotently.
+	 *
+	 * Transitions are exposed one named method at a time rather than as a generic
+	 * `(from, to)` pair, so the interface can't express a transition the
+	 * lifecycle doesn't allow.
 	 */
-	transitionStepStatus(id: string, from: StepStatus, to: StepStatus): Promise<boolean>;
+	claimStep(id: string): Promise<boolean>;
 
 	/**
 	 * Record a successful run: persist `outputs` and mark the step completed.
 	 * A compare-and-set on `running`, so it returns `false` if the caller no
 	 * longer holds the claim — the outcome and the status are written together,
-	 * which a bare `transitionStepStatus` can't do.
+	 * so they can't be observed apart.
 	 */
 	completeStep(id: string, outputs: JsonValue): Promise<boolean>;
 
@@ -62,8 +76,13 @@ export interface StepStore {
 	failStep(id: string, error: StepError): Promise<boolean>;
 
 	/**
-	 * Outputs of the given nodes within an execution, keyed by node id. A node
-	 * with no step row, or one that hasn't completed, maps to `null`.
+	 * Outputs of the given nodes' *completed* steps within an execution, keyed by
+	 * node id. A node whose step is absent or hasn't completed maps to `null`.
+	 *
+	 * This is for gathering a step's inputs, so it deliberately can't answer
+	 * "have all predecessors completed?" — the two are indistinguishable from a
+	 * `null` here. Readiness belongs to whoever plans the next step
+	 * (TODO(CAT-2871)), and will need its own method.
 	 */
 	loadStepOutputs(
 		executionId: string,

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -34,8 +34,12 @@ export class StepNotFoundError extends Error {
 
 /** Persistence interface for step records. */
 export interface StepStore {
-	/** Persist a new step record; returns its generated id. */
-	createStep(record: NewStepRecord): Promise<{ id: string }>;
+	/**
+	 * Persist new step records; returns their generated ids, in input order.
+	 * Batched rather than one-per-call so planning a fan-out costs a single
+	 * round trip and cannot half-persist.
+	 */
+	createSteps(records: NewStepRecord[]): Promise<Array<{ id: string }>>;
 
 	/** Load a single step by id. Throws `StepNotFoundError` if absent. */
 	loadStep(id: string): Promise<StepRecord>;

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -35,7 +35,12 @@ export type {
 	WorkQueue,
 } from './queue';
 
-export { ExecutionNotFoundError, ExecutionStartHandler, OrchestrationWorker } from './execution';
+export {
+	ExecutionNotFoundError,
+	ExecutionStartHandler,
+	OrchestrationWorker,
+	StepNotFoundError,
+} from './execution';
 export type {
 	ExecutionMode,
 	ExecutionRecord,
@@ -43,6 +48,8 @@ export type {
 	ExecutionStore,
 	NewExecutionRecord,
 	NewStepRecord,
+	StepError,
+	StepRecord,
 	StepStatus,
 	StepStore,
 } from './execution';


### PR DESCRIPTION
## Summary

Introduce persistence for step results - outputs/errors.

#35184 is stacked on top to use this to implement the step execution handler.

NOTE: modified the existing migration instead of adding a new one, since this remains nowhere deployed.

## How to test

```
cd packages/@n8n/engine
pnpm typecheck && pnpm lint && pnpm test && pnpm test:integration
```

Integration tests need Docker (testcontainers Postgres). 18 unit, 18 integration passing.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3855

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35192">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

