### PR TITLE
fix(ai-builder): Report an unparseable LLM check verdict as errored (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/create-llm-check.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/create-llm-check.test.ts
@@ -36,4 +36,30 @@ describe('createLlmCheck', () => {
 			comment: 'LLM check "slow_check" timed out after 1ms',
 		});
 	});
+
+	it('marks an unparseable verdict as errored, not failed', async () => {
+		// Observed live: the judge answered with a markdown analysis that ticked the
+		// requirements off as satisfied, but carried no parseable verdict. Scoring
+		// that as a failure reports a defect in the workflow that isn't there.
+		mocks.generate.mockResolvedValue({
+			text: '## Analysis\n**Requirement 1** — satisfied ✓\n**Requirement 2** — satisfied ✓',
+		});
+
+		const check = createLlmCheck({
+			name: 'chatty_check',
+			description: 'chatty check',
+			dimension: 'intent_match',
+			systemPrompt: 'Judge the workflow.',
+			humanTemplate: 'Workflow: {generatedWorkflow}',
+		});
+
+		const result = await check.run({} as WorkflowResponse, {
+			prompt: 'Build a workflow',
+			modelId: 'anthropic/test',
+		});
+
+		expect(result.pass).toBe(false);
+		expect(result.errored).toBe(true);
+		expect(result.comment).toContain('Failed to parse LLM response');
+	});
 });

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/create-llm-check.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/create-llm-check.ts
@@ -116,8 +116,13 @@ export function createLlmCheck(options: LlmCheckOptions): BinaryCheck {
 			const parsed = parseJudgeVerdict(text);
 
 			if (!parsed) {
+				// Same class as a timeout above: the judge never returned a verdict, so
+				// there is nothing to score. Without `errored` this counts as a real
+				// failure and reads as a defect in the workflow — the raw text is often
+				// a markdown analysis that AGREED with the workflow.
 				return {
 					pass: false,
+					errored: true,
 					comment: `Failed to parse LLM response. Raw (first 500 chars): ${text.slice(0, 500)}`,
 				};
 			}


### PR DESCRIPTION
## Summary

An LLM binary check whose response can't be parsed returned `{pass: false}` without `errored`, so it scored as a **genuine failure** — counted in the denominator (`binaryChecks/index.ts:61` filters scored outcomes to `pass|fail`) and printed by the run summary's `Workflow checks: N failing` line. It reads as a defect in the built workflow.

It isn't one. The judge never returned a verdict, so there's nothing to score. Found on a real run while verifying something else: `fulfills_user_request` reported as failing, and its own recorded text was

```
Failed to parse LLM response. Raw (first 500 chars): ## Analysis
**Requirement 1: Loop over images in batches (one at a time)** — ✓
**Requirement 2: Download → Resize → Upload executes inside the loop** — …
```

— a markdown analysis that was ticking the requirements off as *satisfied*. The workflow was correct; only the output format wasn't.

The **timeout path six lines above already does this**, with a comment giving the reason (*"Timeouts are measurement failures, not inapplicability — report as errored so they stay out of both pass-rate and N/A counts"*). This makes the two agree; a parse failure is the same class.

**Effect on reported numbers, deliberately:** a parse failure now lands in `error` instead of `fail`, so it leaves both the pass rate and the N/A count. Check pass rates rise slightly wherever this was happening. Verified at every consumer — `binaryChecks/index.ts:61` (scored outcomes), `aggregate.ts:44` (per-check tallies), `langsmith-driver.ts:195` (skips `n_a` and `error`), and `cleanup.ts:219` (the "N failing" console line).

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm vitest run evaluations/binaryChecks   # 52 passed
pnpm typecheck && pnpm lint                # clean
```

The new test feeds the check a markdown-analysis response with no parseable verdict and asserts `errored: true` — a sibling to the existing timeout test, same mock harness.

## Related Linear tickets, Github issues, and Community forum posts

- Found while verifying https://linear.app/n8n/issue/TRUST-355 (see its verification comment, "Two side findings"). No ticket of its own — it's a two-line fix.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- n/a: internal eval scoring, no user-facing docs -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35198">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

