### PR TITLE
feat(ai-builder): Add a Google Drive credential template to the eval seeder (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
+++ b/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
@@ -44,6 +44,11 @@ const CREDENTIAL_TEMPLATES: Record<string, CredentialTemplate> = {
 		envVar: 'EVAL_GMAIL_ACCESS_TOKEN',
 		buildData: (token) => ({ oauthTokenData: { access_token: token } }),
 	},
+	googleDriveOAuth2Api: {
+		defaultName: '[eval] Google Drive',
+		envVar: 'EVAL_GOOGLE_DRIVE_ACCESS_TOKEN',
+		buildData: (token) => ({ oauthTokenData: { access_token: token } }),
+	},
 	// MCP-registry-synthesized credential types (agent MCP servers). Creating
 	// them requires the backend to run with the `mcp-registry` module enabled;
 	// placeholder tokens are fine — agent eval runs mock the MCP wire.


### PR DESCRIPTION
## Summary

A test case declares the credentials its build should see (`credentials` in the case JSON), and the seeder **throws on any type it has no template for** — validated at case-load time, so an unsupported type fails the case rather than the build. There were 12 templates and no Google Drive.

Hit while verifying https://linear.app/n8n/issue/TRUST-355: a seeded repair case whose workflow uploads to Drive couldn't be made publishable, because `restore-thread` strips node credentials by design and there was no `googleDriveOAuth2Api` template to re-supply them. Any seeded case touching a service outside those 12 hits the same wall.

Five lines, same OAuth token shape as the existing `gmailOAuth2` template.

## How to test

Shipped exercised rather than on faith — the template is only reachable via a case that declares it, so I ran one against a local instance:

```
[VERBOSE]   Creating credential Header Auth account (httpHeaderAuth)
[VERBOSE]   Creating credential [eval] Google Drive (googleDriveOAuth2Api)
[INFO]      Seeded 15 prior message(s), 1 workflow(s)
```

`POST /rest/credentials` accepts the payload and the build proceeds. (`pnpm typecheck && pnpm lint` clean.)

**Worth knowing for whoever needs this next:** declaring the credential is necessary but *not sufficient* to make a seeded workflow publishable. Restore strips node credentials, so the credential now exists on the instance but isn't **attached** to any node — attaching is what `workflows(action="setup")` does, and the eval harness never fills a credential setup card. In that run publishing still failed. So this unblocks *declaring* Drive; it doesn't by itself make a "publish the existing workflow" case gradeable. Noted on TRUST-354.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/TRUST-355 — where the gap surfaced
- https://linear.app/n8n/issue/TRUST-361 — the authoring recipe should pre-flight "every credential my seed's workflow needs has a template"
- **Paired lang-tracer PR: n8n-io/lang-tracer#107**: `packages/shared/src/types/suites.ts` mirrors this list, and `scripts/check-upstream-drift.ts` re-derives the template keys from this file and diffs them against `SUPPORTED_CREDENTIAL_TYPES`. LT's drift check goes red until it carries the entry, and its `upstream-pins.json` wants re-pinning once this merges.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- n/a: internal eval fixture; the supported-type list is self-documenting -->
- [ ] Tests included. <!-- no unit test: asserting the literal template shape would be tautological, and the real contract (does n8n accept this credential type) is only provable against a live instance — done above -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->