### PR TITLE
refactor(core): Trim narration-only descriptions from instance MCP tools

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/data-table/add-data-table-rows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/data-table/add-data-table-rows.tool.test.ts
@@ -37,7 +37,7 @@ describe('add_data_table_rows MCP tool', () => {
 
 		expect(tool.name).toBe('add_data_table_rows');
 		expect(tool.config).toBeDefined();
-		expect(typeof tool.config.description).toBe('string');
+		expect(tool.config.description).toBeUndefined();
 		expect(tool.config.inputSchema).toBeDefined();
 		expect(tool.config.outputSchema).toBeDefined();
 		expect(typeof tool.handler).toBe('function');

--- a/packages/cli/src/modules/mcp/__tests__/data-table/create-data-table.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/data-table/create-data-table.tool.test.ts
@@ -43,7 +43,7 @@ describe('create_data_table MCP tool', () => {
 
 		expect(tool.name).toBe('create_data_table');
 		expect(tool.config).toBeDefined();
-		expect(typeof tool.config.description).toBe('string');
+		expect(tool.config.description).toBeUndefined();
 		expect(tool.config.inputSchema).toBeDefined();
 		expect(tool.config.outputSchema).toBeDefined();
 		expect(typeof tool.handler).toBe('function');

--- a/packages/cli/src/modules/mcp/__tests__/data-table/search-data-tables.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/data-table/search-data-tables.tool.test.ts
@@ -49,7 +49,7 @@ describe('search_data_tables MCP tool', () => {
 
 		expect(tool.name).toBe('search_data_tables');
 		expect(tool.config).toBeDefined();
-		expect(typeof tool.config.description).toBe('string');
+		expect(tool.config.description).toBeUndefined();
 		expect(tool.config.inputSchema).toBeDefined();
 		expect(tool.config.outputSchema).toBeDefined();
 		expect(typeof tool.handler).toBe('function');

--- a/packages/cli/src/modules/mcp/__tests__/get-execution.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-execution.tool.test.ts
@@ -44,8 +44,7 @@ describe('get-execution MCP tool', () => {
 
 			expect(tool.name).toBe('get_execution');
 			expect(tool.config).toBeDefined();
-			expect(typeof tool.config.description).toBe('string');
-			expect(tool.config.description).toContain('Get execution details');
+			expect(tool.config.description).toBeUndefined();
 			expect(tool.config.inputSchema).toBeDefined();
 			expect(tool.config.outputSchema).toBeDefined();
 			expect(typeof tool.handler).toBe('function');

--- a/packages/cli/src/modules/mcp/__tests__/list-tags.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/list-tags.tool.test.ts
@@ -49,7 +49,7 @@ describe('list-tags MCP tool', () => {
 			const tool = createListTagsTool(user, tagService, telemetry);
 
 			expect(tool.name).toBe('list_tags');
-			expect(tool.config.description).toEqual(expect.any(String));
+			expect(tool.config.description).toBeUndefined();
 			expect(tool.config.inputSchema).toBeDefined();
 			expect(tool.config.outputSchema).toBeDefined();
 			expect(tool.config.annotations).toMatchObject({

--- a/packages/cli/src/modules/mcp/__tests__/search-folders.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-folders.tool.test.ts
@@ -60,7 +60,7 @@ describe('search-folders MCP tool', () => {
 
 		expect(tool.name).toBe('search_folders');
 		expect(tool.config).toBeDefined();
-		expect(typeof tool.config.description).toBe('string');
+		expect(tool.config.description).toBeUndefined();
 		expect(tool.config.inputSchema).toBeDefined();
 		expect(typeof tool.handler).toBe('function');
 	});

--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -47,7 +47,7 @@ describe('search-workflows MCP tool', () => {
 
 			expect(tool.name).toBe('search_workflows');
 			expect(tool.config).toBeDefined();
-			expect(typeof tool.config.description).toBe('string');
+			expect(tool.config.description).toBeUndefined();
 			expect(tool.config.inputSchema).toBeDefined();
 			expect(typeof tool.handler).toBe('function');
 		});

--- a/packages/cli/src/modules/mcp/__tests__/unpublish-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/unpublish-workflow.tool.test.ts
@@ -41,8 +41,7 @@ describe('unpublish-workflow MCP tool', () => {
 
 			expect(tool.name).toBe('unpublish_workflow');
 			expect(tool.config).toBeDefined();
-			expect(typeof tool.config.description).toBe('string');
-			expect(tool.config.description).toContain('Unpublish');
+			expect(tool.config.description).toBeUndefined();
 			expect(tool.config.inputSchema).toBeDefined();
 			expect(tool.config.outputSchema).toBeDefined();
 			expect(typeof tool.handler).toBe('function');

--- a/packages/cli/src/modules/mcp/tools/data-table/add-data-table-column.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/data-table/add-data-table-column.tool.ts
@@ -14,10 +14,10 @@ import {
 } from '../schemas';
 
 const inputSchema = {
-	dataTableId: z.string().describe('The ID of the data table to add a column to'),
+	dataTableId: z.string(),
 	projectId: dataTableProjectIdSchema,
 	name: columnNameSchema,
-	type: dataTableColumnTypeSchema.describe('The data type of the new column'),
+	type: dataTableColumnTypeSchema,
 } satisfies z.ZodRawShape;
 
 const outputSchema = {
@@ -33,7 +33,6 @@ export const createAddDataTableColumnTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'add_data_table_column',
 	config: {
-		description: 'Add a new column to an existing data table.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/data-table/add-data-table-rows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/data-table/add-data-table-rows.tool.ts
@@ -11,15 +11,13 @@ import { dataTableProjectIdSchema } from '../schemas';
 const ADD_ROWS_MAX = 1000;
 
 const addRowsInputSchema = {
-	dataTableId: z.string().describe('The ID of the data table to insert rows into'),
+	dataTableId: z.string(),
 	projectId: dataTableProjectIdSchema,
 	rows: z
 		.array(z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()])))
 		.min(1)
 		.max(ADD_ROWS_MAX)
-		.describe(
-			`Array of row objects to insert. Each object maps column names to values. Maximum ${ADD_ROWS_MAX} rows per call.`,
-		),
+		.describe('Row objects mapping column names to values.'),
 } satisfies z.ZodRawShape;
 
 const addRowsOutputSchema = {
@@ -34,8 +32,6 @@ export const createAddDataTableRowsTool = (
 ): ToolDefinition<typeof addRowsInputSchema> => ({
 	name: 'add_data_table_rows',
 	config: {
-		description:
-			'Insert rows into an existing data table. Each row is an object mapping column names to values. Use search_data_tables to find the data table ID first.',
 		inputSchema: addRowsInputSchema,
 		outputSchema: addRowsOutputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/data-table/create-data-table.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/data-table/create-data-table.tool.ts
@@ -14,16 +14,13 @@ const columnSchema = z.object({
 });
 
 const createInputSchema = {
-	projectId: z.string().describe('The project ID where the data table will be created'),
+	projectId: z.string(),
 	name: z
 		.string()
 		.min(1)
 		.max(128)
 		.describe('The name of the data table (must be unique within the project)'),
-	columns: z
-		.array(columnSchema)
-		.min(1)
-		.describe('The columns to create in the data table. At least one column is required.'),
+	columns: z.array(columnSchema).min(1),
 } satisfies z.ZodRawShape;
 
 const createOutputSchema = {
@@ -39,8 +36,6 @@ export const createCreateDataTableTool = (
 ): ToolDefinition<typeof createInputSchema> => ({
 	name: 'create_data_table',
 	config: {
-		description:
-			'Create a new data table with the specified columns. Use search_projects to find a project ID first.',
 		inputSchema: createInputSchema,
 		outputSchema: createOutputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/data-table/delete-data-table-column.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/data-table/delete-data-table-column.tool.ts
@@ -9,9 +9,9 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.ty
 import { dataTableProjectIdSchema, successMessageOutputSchema } from '../schemas';
 
 const inputSchema = {
-	dataTableId: z.string().describe('The ID of the data table containing the column'),
+	dataTableId: z.string(),
 	projectId: dataTableProjectIdSchema,
-	columnId: z.string().describe('The ID of the column to delete'),
+	columnId: z.string(),
 } satisfies z.ZodRawShape;
 
 const outputSchema = successMessageOutputSchema;
@@ -23,8 +23,7 @@ export const createDeleteDataTableColumnTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'delete_data_table_column',
 	config: {
-		description:
-			'Delete a column from a data table. This permanently removes the column and all its data.',
+		description: 'Permanently removes the column and all its data.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/data-table/rename-data-table-column.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/data-table/rename-data-table-column.tool.ts
@@ -14,10 +14,10 @@ import {
 } from '../schemas';
 
 const inputSchema = {
-	dataTableId: z.string().describe('The ID of the data table containing the column'),
+	dataTableId: z.string(),
 	projectId: dataTableProjectIdSchema,
-	columnId: z.string().describe('The ID of the column to rename'),
-	name: columnNameSchema.describe('The new column name'),
+	columnId: z.string(),
+	name: columnNameSchema,
 } satisfies z.ZodRawShape;
 
 const outputSchema = {
@@ -32,7 +32,6 @@ export const createRenameDataTableColumnTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'rename_data_table_column',
 	config: {
-		description: 'Rename a column in a data table.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/data-table/rename-data-table.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/data-table/rename-data-table.tool.ts
@@ -9,9 +9,9 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.ty
 import { dataTableProjectIdSchema, successMessageOutputSchema } from '../schemas';
 
 const inputSchema = {
-	dataTableId: z.string().describe('The ID of the data table to rename'),
+	dataTableId: z.string(),
 	projectId: dataTableProjectIdSchema,
-	name: z.string().min(1).max(128).describe('The new name for the data table'),
+	name: z.string().min(1).max(128),
 } satisfies z.ZodRawShape;
 
 const outputSchema = successMessageOutputSchema;
@@ -23,7 +23,6 @@ export const createRenameDataTableTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'rename_data_table',
 	config: {
-		description: 'Rename an existing data table.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/data-table/search-data-tables.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/data-table/search-data-tables.tool.ts
@@ -16,7 +16,7 @@ const searchInputSchema = {
 		.string()
 		.optional()
 		.describe('Filter data tables by name (case-insensitive partial match)'),
-	projectId: z.string().optional().describe('Filter by project ID'),
+	projectId: z.string().optional(),
 	limit: createLimitSchema(SEARCH_MAX_RESULTS),
 } satisfies z.ZodRawShape;
 
@@ -32,8 +32,6 @@ export const createSearchDataTablesTool = (
 ): ToolDefinition<typeof searchInputSchema> => ({
 	name: 'search_data_tables',
 	config: {
-		description:
-			'Search for data tables accessible to the current user. Use this to find a data table ID before modifying or adding data to it.',
 		inputSchema: searchInputSchema,
 		outputSchema: searchOutputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -39,7 +39,7 @@ import type { WorkflowPublishedDataService } from '@/workflows/workflow-publishe
 export { type FoundWorkflow };
 
 const inputSchema = z.object({
-	workflowId: z.string().describe('The ID of the workflow to execute'),
+	workflowId: z.string(),
 	executionMode: z
 		.enum(['manual', 'production'])
 		.describe(

--- a/packages/cli/src/modules/mcp/tools/get-execution.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-execution.tool.ts
@@ -15,8 +15,8 @@ import type { Telemetry } from '@/telemetry';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 const inputSchema = z.object({
-	workflowId: z.string().describe('The ID of the workflow the execution belongs to'),
-	executionId: z.string().describe('The ID of the execution to retrieve'),
+	workflowId: z.string(),
+	executionId: z.string(),
 	includeData: z
 		.boolean()
 		.optional()
@@ -70,8 +70,6 @@ export const createGetExecutionTool = (
 ): ToolDefinition<typeof inputSchema.shape> => ({
 	name: 'get_execution',
 	config: {
-		description:
-			'Get execution details by execution ID and workflow ID. By default returns metadata only. Set includeData to true to include node execution data, optionally filtered by nodeNames and truncated by truncateData.',
 		inputSchema: inputSchema.shape,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
@@ -19,7 +19,7 @@ import { getTriggerDetails, type WebhookEndpoints } from './webhook-utils';
 import { getMcpWorkflow } from './workflow-validation.utils';
 
 const inputSchema = {
-	workflowId: z.string().describe('The ID of the workflow to retrieve'),
+	workflowId: z.string(),
 } satisfies z.ZodRawShape;
 
 export type WorkflowDetailsOutputSchema = typeof workflowDetailsOutputSchema;
@@ -44,7 +44,7 @@ export const createWorkflowDetailsTool = (
 	return {
 		name: 'get_workflow_details',
 		config: {
-			description: 'Get detailed information about a specific workflow including trigger details',
+			description: "Get a workflow's full definition, including how to trigger it.",
 			inputSchema,
 			outputSchema,
 			annotations: {

--- a/packages/cli/src/modules/mcp/tools/get-workflow-history.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-history.tool.ts
@@ -15,7 +15,7 @@ import { getMcpWorkflow } from './workflow-validation.utils';
 const MAX_RESULTS = 50;
 
 const inputSchema = {
-	workflowId: z.string().describe('The ID of the workflow to read version history for'),
+	workflowId: z.string(),
 	limit: createLimitSchema(MAX_RESULTS),
 	offset: z
 		.number()
@@ -66,8 +66,7 @@ export const createGetWorkflowHistoryTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'get_workflow_history',
 	config: {
-		description:
-			'List the saved version history of a workflow (newest first), so you can inspect how it changed over time and pick a version to retrieve or restore.',
+		description: "List a workflow's saved versions, newest first.",
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/get-workflow-version.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-version.tool.ts
@@ -21,7 +21,7 @@ import { getMcpWorkflowVersion } from './workflow-history.utils';
 import { getMcpWorkflow } from './workflow-validation.utils';
 
 const inputSchema = {
-	workflowId: z.string().describe('The ID of the workflow the version belongs to'),
+	workflowId: z.string(),
 	versionId: z.string().describe('The version ID to retrieve, as returned by get_workflow_history'),
 } satisfies z.ZodRawShape;
 
@@ -80,8 +80,6 @@ export const createGetWorkflowVersionTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'get_workflow_version',
 	config: {
-		description:
-			'Retrieve the full content (nodes, connections, node groups) of a specific workflow version from its history. Use the versionId from get_workflow_history.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/list-tags.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/list-tags.tool.ts
@@ -64,7 +64,6 @@ export const createListTagsTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'list_tags',
 	config: {
-		description: 'List all workflow tags in the instance.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/prepare-workflow-pin-data.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/prepare-workflow-pin-data.tool.ts
@@ -20,7 +20,7 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../mcp.types
 import { getMcpWorkflow } from './workflow-validation.utils';
 
 const inputSchema = z.object({
-	workflowId: z.string().describe('The ID of the workflow to generate test pin data for'),
+	workflowId: z.string(),
 });
 
 const outputSchema = {

--- a/packages/cli/src/modules/mcp/tools/publish-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/publish-workflow.tool.ts
@@ -14,7 +14,7 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../mcp.types
 import { getMcpWorkflow } from './workflow-validation.utils';
 
 const inputSchema = z.object({
-	workflowId: z.string().describe('The ID of the workflow to publish'),
+	workflowId: z.string(),
 	versionId: z
 		.string()
 		.optional()
@@ -46,8 +46,7 @@ export const createPublishWorkflowTool = (
 ): ToolDefinition<typeof inputSchema.shape> => ({
 	name: 'publish_workflow',
 	config: {
-		description:
-			'Publish (activate) a workflow to make it available for production execution. This creates an active version from the current draft.',
+		description: 'Publish (activate) a workflow: creates an active version from the current draft.',
 		inputSchema: inputSchema.shape,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/schemas.ts
+++ b/packages/cli/src/modules/mcp/tools/schemas.ts
@@ -31,9 +31,7 @@ export const workflowMetaSchema = z
 	.custom<WorkflowFEMeta>((_value): _value is WorkflowFEMeta => true)
 	.nullable();
 
-export const dataTableColumnTypeSchema = z
-	.enum(['string', 'number', 'boolean', 'date'])
-	.describe('The data type of the column');
+export const dataTableColumnTypeSchema = z.enum(['string', 'number', 'boolean', 'date']);
 
 export const dataTableColumnSchema = z.object({
 	id: z.string().describe('The unique identifier of the column'),
@@ -53,18 +51,9 @@ export const dataTableSchema = z.object({
 	columns: z.array(dataTableColumnSchema).describe('The columns defined in this data table'),
 });
 
-export const createLimitSchema = (max: number) =>
-	z
-		.number()
-		.int()
-		.positive()
-		.max(max)
-		.optional()
-		.describe(`Limit the number of results (max ${max})`);
+export const createLimitSchema = (max: number) => z.number().int().positive().max(max).optional();
 
-export const dataTableProjectIdSchema = z
-	.string()
-	.describe('The project ID the data table belongs to');
+export const dataTableProjectIdSchema = z.string();
 
 export const columnNameSchema = z
 	.string()

--- a/packages/cli/src/modules/mcp/tools/search-executions.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-executions.tool.ts
@@ -15,21 +15,10 @@ import { getMcpWorkflow } from './workflow-validation.utils';
 const MAX_RESULTS = 200;
 
 const inputSchema = {
-	workflowId: z.string().optional().describe('Filter executions by workflow ID'),
-	status: z
-		.array(z.enum(ExecutionStatusList))
-		.optional()
-		.describe('Filter by execution status(es)'),
-	startedAfter: z
-		.string()
-		.datetime({ offset: true })
-		.optional()
-		.describe('ISO 8601 timestamp — only return executions that started after this time'),
-	startedBefore: z
-		.string()
-		.datetime({ offset: true })
-		.optional()
-		.describe('ISO 8601 timestamp — only return executions that started before this time'),
+	workflowId: z.string().optional(),
+	status: z.array(z.enum(ExecutionStatusList)).optional(),
+	startedAfter: z.string().datetime({ offset: true }).optional(),
+	startedBefore: z.string().datetime({ offset: true }).optional(),
 	limit: createLimitSchema(MAX_RESULTS),
 	lastId: z
 		.string()
@@ -69,8 +58,6 @@ export const createSearchExecutionsTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'search_executions',
 	config: {
-		description:
-			'Search for workflow executions with optional filters. Returns execution metadata including status, timing, and workflow ID.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/search-folders.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-folders.tool.ts
@@ -11,7 +11,7 @@ import { createLimitSchema } from './schemas';
 const MAX_RESULTS = 100;
 
 const inputSchema = {
-	projectId: z.string().describe('The ID of the project to search folders in'),
+	projectId: z.string(),
 	query: z.string().optional().describe('Filter folders by name (case-insensitive partial match)'),
 	limit: createLimitSchema(MAX_RESULTS),
 } satisfies z.ZodRawShape;
@@ -40,8 +40,6 @@ export const createSearchFoldersTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: 'search_folders',
 	config: {
-		description:
-			'Search for folders within a project. Use this to find a folder ID before creating a workflow in a specific folder. Requires a projectId — use search_projects first if needed.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
@@ -85,8 +85,6 @@ export const createSearchWorkflowsTool = (
 	return {
 		name: 'search_workflows',
 		config: {
-			description:
-				'Search for workflows with optional filters. Returns a preview of each workflow.',
 			inputSchema,
 			outputSchema,
 			annotations: {

--- a/packages/cli/src/modules/mcp/tools/test-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/test-workflow.tool.ts
@@ -31,7 +31,7 @@ import {
 import { getMcpWorkflow } from './workflow-validation.utils';
 
 const inputSchema = z.object({
-	workflowId: z.string().describe('The ID of the workflow to test'),
+	workflowId: z.string(),
 	pinData: z
 		.record(z.array(z.record(z.unknown())))
 		.describe(

--- a/packages/cli/src/modules/mcp/tools/unpublish-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/unpublish-workflow.tool.ts
@@ -14,7 +14,7 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../mcp.types
 import { getMcpWorkflow } from './workflow-validation.utils';
 
 const inputSchema = z.object({
-	workflowId: z.string().describe('The ID of the workflow to unpublish'),
+	workflowId: z.string(),
 });
 
 type UnpublishWorkflowOutput = {
@@ -38,8 +38,6 @@ export const createUnpublishWorkflowTool = (
 ): ToolDefinition<typeof inputSchema.shape> => ({
 	name: 'unpublish_workflow',
 	config: {
-		description:
-			'Unpublish (deactivate) a workflow to stop it from being available for production execution.',
 		inputSchema: inputSchema.shape,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/delete-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/delete-workflow.tool.ts
@@ -12,7 +12,7 @@ import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.ty
 import { getMcpWorkflow } from '../workflow-validation.utils';
 
 const inputSchema = {
-	workflowId: z.string().describe('The ID of the workflow to archive'),
+	workflowId: z.string(),
 } satisfies z.ZodRawShape;
 
 const outputSchema = {
@@ -33,7 +33,6 @@ export const createArchiveWorkflowTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: MCP_ARCHIVE_WORKFLOW_TOOL.toolName,
 	config: {
-		description: 'Archive a workflow in n8n by its ID.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/restore-workflow-version.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/restore-workflow-version.tool.ts
@@ -16,7 +16,7 @@ import { getMcpWorkflow } from '../workflow-validation.utils';
 import { buildRestoreVersionMetadata } from './version-metadata';
 
 const inputSchema = z.object({
-	workflowId: z.string().describe('The ID of the workflow to restore'),
+	workflowId: z.string(),
 	versionId: z.string().describe('The version ID to restore, as returned by get_workflow_history'),
 });
 
@@ -57,7 +57,7 @@ export const createRestoreWorkflowVersionTool = (
 	name: 'restore_workflow_version',
 	config: {
 		description:
-			'Restore a workflow to a previous version from its history. Re-applies that version as the current draft and records a new history entry. Use get_workflow_history to find the versionId.',
+			"Restore a previous version as the workflow's current draft; records a new history entry.",
 		inputSchema: inputSchema.shape,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -269,7 +269,7 @@ function collectTouchedNodes(operations: PartialUpdateOperation[]): Map<string, 
 // annotation is compile-checked against it via ToolCallback's parameter types.
 const buildInputSchema = (canvasGroupsEnabled: boolean) =>
 	({
-		workflowId: z.string().describe('The ID of the workflow to update.'),
+		workflowId: z.string(),
 		skillsUsed: z.array(z.string()).optional().describe(SKILLS_USED_PARAM_DESCRIPTION),
 		operations: z
 			.array(buildOperationInputSchema(canvasGroupsEnabled))


### PR DESCRIPTION
## Summary

Tier 1 of the instance-MCP token-slimming experiment: cut text from the published tool list that carries no information beyond what the tool name and JSON schema already convey, so we can eval whether trimming affects build quality before going further.

Two kinds of cuts, applied across the ~30 instance-MCP tools:

**Descriptions removed entirely** where they only narrated the tool name/params (e.g. `search_folders`: "Search for folders within a project. …", `list_tags`: "List all workflow tags in the instance.", `archive_workflow`, `unpublish_workflow`, `search_workflows`, `search_executions`, `get_execution`, `get_workflow_version`, and 6 of the 7 data-table tools).

**Descriptions reduced to their non-obvious content** where a real fact was buried in narration:
- `get_workflow_details` → keeps only the "including how to trigger it" pointer
- `publish_workflow` → keeps the draft→active-version semantics
- `restore_workflow_version` → keeps the "restores as current draft, records a new history entry" semantics (drops the `get_workflow_history` pointer that duplicates the `versionId` param description verbatim)
- `delete_data_table_column` → keeps only the destructive warning
- `get_workflow_history` → shortened to one clause

**Trivial param `describe()`s removed** where they restate the param name (`workflowId: 'The ID of the workflow to execute'` and friends) or a constraint already encoded in the schema (`createLimitSchema`'s "(max N)" — the schema already publishes `maximum: N`; `add_data_table_rows`' "Maximum 1000 rows per call" — already `maxItems`). Param descriptions carrying real information (match semantics, pagination cursors, defaults, cross-tool ID provenance like "as returned by get_workflow_history") are untouched.

Deliberately **not** touched in this tier (candidates for a follow-up "tier 2" dedup pass):
- the builder-tool sequencing imperatives (`get_sdk_reference`, `get_node_types`, `validate_workflow`, `search_nodes`)
- content duplicated between tool descriptions, param describes, server instructions, and runtime hints (`search_projects`, `create_workflow_from_code`, `test_workflow`/`prepare_test_pin_data` pin-data rules, n8nConnect boilerplate)
- output-schema `describe()`s (whether they even reach the model is client-dependent)

Net effect on the published `tools/list`: ~103 lines of description/describe text removed.

## How to test

- `cd packages/cli && pnpm test src/modules/mcp` — 63 files / 1010 tests pass (tests asserting the removed descriptions now assert they are absent)
- `pnpm typecheck` and `pnpm lint` in `packages/cli` pass
- Connect an MCP client to the instance MCP server and list tools: trimmed tools publish no `description`; input schemas keep only informative field descriptions
- Build-quality evals to be run against this branch to measure impact before merging

## Related Linear tickets, Github issues, and Community forum posts

Internal experiment — no ticket yet.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zz22Mze4HQVLEoD6HYjnz

---
_Generated by [Claude Code](https://claude.ai/code/session_016zz22Mze4HQVLEoD6HYjnz)_

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

