### PR TITLE
fix(core): Sort node version directories by numeric version

### DIFF
--- a/packages/@n8n/ai-utilities/src/node-catalog/__tests__/get-node-type-definition.test.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/__tests__/get-node-type-definition.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { getNodeTypeDefinition } from '../get';
+import { getNodeTypeDefinition, versionDirToNumber } from '../get';
 
 describe('getNodeTypeDefinition — split-node discriminator handling', () => {
 	let defsDir: string;
@@ -58,23 +58,42 @@ describe('getNodeTypeDefinition — split-node discriminator handling', () => {
 	});
 });
 
+describe('versionDirToNumber', () => {
+	it('reads a two-digit suffix as major.minor, not a plain integer', () => {
+		// The bug: v22 (2.2) must rank below v3 (3), not above it.
+		expect(versionDirToNumber('v3')).toBeGreaterThan(versionDirToNumber('v22'));
+		expect(versionDirToNumber('v22')).toBe(2.2);
+		expect(versionDirToNumber('v21')).toBe(2.1);
+		expect(versionDirToNumber('v3')).toBe(3);
+		expect(versionDirToNumber('v1')).toBe(1);
+	});
+
+	it('leaves the known two-digit-major limitation documented', () => {
+		// v10 is ambiguous under the dot-dropping encoding and reads as 1.0;
+		// no node is near a two-digit major, so this is an accepted limitation.
+		expect(versionDirToNumber('v10')).toBe(1);
+	});
+});
+
 describe('getNodeTypeDefinition — latest version resolution', () => {
 	let defsDir: string;
 
 	beforeAll(() => {
 		defsDir = mkdtempSync(join(tmpdir(), 'ai-utils-node-defs-versions-'));
-		// Notion ships versions 1, 2, 2.1, 2.2 and 3, so its dirs are
+		// Notion is a split (resource/operation) node shipping versions
+		// 1, 2, 2.1, 2.2 and 3, so on disk its version dirs are
 		// v1, v2, v21, v22, v3 (the dot is dropped when naming).
 		const notionDir = join(defsDir, 'nodes', 'n8n-nodes-base', 'notion');
-		mkdirSync(notionDir, { recursive: true });
-		for (const [file, content] of [
-			['v1.ts', '// notion v1 def'],
-			['v2.ts', '// notion v2 def'],
-			['v21.ts', '// notion v2.1 def'],
-			['v22.ts', '// notion v2.2 def'],
-			['v3.ts', '// notion v3 def'],
+		for (const [version, content] of [
+			['v1', '// notion v1 get def'],
+			['v2', '// notion v2 get def'],
+			['v21', '// notion v2.1 get def'],
+			['v22', '// notion v2.2 get def'],
+			['v3', '// notion v3 get def'],
 		]) {
-			writeFileSync(join(notionDir, file), content);
+			const opDir = join(notionDir, version, 'resource_database_page');
+			mkdirSync(opDir, { recursive: true });
+			writeFileSync(join(opDir, 'operation_get.ts'), content);
 		}
 	});
 
@@ -83,10 +102,13 @@ describe('getNodeTypeDefinition — latest version resolution', () => {
 	});
 
 	it('treats v3 as latest, not v2.2, when no version is requested', () => {
-		const result = getNodeTypeDefinition('n8n-nodes-base.notion', undefined, [defsDir]);
+		const result = getNodeTypeDefinition('n8n-nodes-base.notion', undefined, [defsDir], {
+			resource: 'databasePage',
+			operation: 'get',
+		});
 
 		expect(result.error).toBeUndefined();
 		expect(result.version).toBe('v3');
-		expect(result.content).toBe('// notion v3 def');
+		expect(result.content).toBe('// notion v3 get def');
 	});
 });

--- a/packages/@n8n/ai-utilities/src/node-catalog/__tests__/get-node-type-definition.test.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/__tests__/get-node-type-definition.test.ts
@@ -57,3 +57,36 @@ describe('getNodeTypeDefinition — split-node discriminator handling', () => {
 		expect(result.error).toContain('message (post, update)');
 	});
 });
+
+describe('getNodeTypeDefinition — latest version resolution', () => {
+	let defsDir: string;
+
+	beforeAll(() => {
+		defsDir = mkdtempSync(join(tmpdir(), 'ai-utils-node-defs-versions-'));
+		// Notion ships versions 1, 2, 2.1, 2.2 and 3, so its dirs are
+		// v1, v2, v21, v22, v3 (the dot is dropped when naming).
+		const notionDir = join(defsDir, 'nodes', 'n8n-nodes-base', 'notion');
+		mkdirSync(notionDir, { recursive: true });
+		for (const [file, content] of [
+			['v1.ts', '// notion v1 def'],
+			['v2.ts', '// notion v2 def'],
+			['v21.ts', '// notion v2.1 def'],
+			['v22.ts', '// notion v2.2 def'],
+			['v3.ts', '// notion v3 def'],
+		]) {
+			writeFileSync(join(notionDir, file), content);
+		}
+	});
+
+	afterAll(() => {
+		rmSync(defsDir, { recursive: true, force: true });
+	});
+
+	it('treats v3 as latest, not v2.2, when no version is requested', () => {
+		const result = getNodeTypeDefinition('n8n-nodes-base.notion', undefined, [defsDir]);
+
+		expect(result.error).toBeUndefined();
+		expect(result.version).toBe('v3');
+		expect(result.content).toBe('// notion v3 def');
+	});
+});

--- a/packages/@n8n/ai-utilities/src/node-catalog/get.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/get.ts
@@ -180,6 +180,21 @@ export function parseNodeId(nodeId: string): { packageName: string; nodeName: st
 }
 
 /**
+ * Turn a `v{digits}` directory name into a comparable numeric version.
+ *
+ * Version dirs drop the dot (2.2 -> v22, 3.1 -> v31, 3 -> v3), so a naive
+ * `parseInt` reads v22 as 22 and ranks it above v3. A two-digit suffix is a
+ * major.minor pair; anything else is the number as-is.
+ */
+function versionDirToNumber(versionDir: string): number {
+	const digits = versionDir.slice(1);
+	if (/^\d{2}$/.test(digits)) {
+		return Number(`${digits[0]}.${digits[1]}`);
+	}
+	return Number.parseFloat(digits);
+}
+
+/**
  * Get available versions for a node
  * Returns array of version strings like ['v34', 'v2'] sorted by version descending
  */
@@ -220,11 +235,7 @@ function getNodeVersions(nodeId: string, nodeDefinitionDirs?: string[]): string[
 		}
 
 		// Sort by numeric version descending
-		versions.sort((a, b) => {
-			const aNum = parseInt(a.slice(1), 10);
-			const bNum = parseInt(b.slice(1), 10);
-			return bNum - aNum;
-		});
+		versions.sort((a, b) => versionDirToNumber(b) - versionDirToNumber(a));
 
 		return versions;
 	} catch {

--- a/packages/@n8n/ai-utilities/src/node-catalog/get.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/get.ts
@@ -185,8 +185,12 @@ export function parseNodeId(nodeId: string): { packageName: string; nodeName: st
  * Version dirs drop the dot (2.2 -> v22, 3.1 -> v31, 3 -> v3), so a naive
  * `parseInt` reads v22 as 22 and ranks it above v3. A two-digit suffix is a
  * major.minor pair; anything else is the number as-is.
+ *
+ * The encoding stays ambiguous for a two-digit major (a future `v10` reads as
+ * 1.0), but no node is anywhere near that, and this matches the `parseRequestedVersion`
+ * convention used elsewhere. Fixing it properly means an unambiguous dir name at generation time.
  */
-function versionDirToNumber(versionDir: string): number {
+export function versionDirToNumber(versionDir: string): number {
 	const digits = versionDir.slice(1);
 	if (/^\d{2}$/.test(digits)) {
 		return Number(`${digits[0]}.${digits[1]}`);

--- a/packages/@n8n/ai-utilities/src/node-catalog/index.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/index.ts
@@ -26,6 +26,7 @@ export {
 	validatePathWithinBase,
 	parseNodeId,
 	toSnakeCase,
+	versionDirToNumber,
 } from './get';
 export type { NodeRequest, CodeBuilderGetToolOptions } from './get';
 

--- a/packages/cli/src/modules/instance-ai/__tests__/node-definition-resolver.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/node-definition-resolver.test.ts
@@ -76,3 +76,40 @@ describe('resolveNodeTypeDefinition — resource/operation split', () => {
 		expect(result.content).toBe('// slack post def');
 	});
 });
+
+describe('resolveNodeTypeDefinition — latest version resolution', () => {
+	let defsDir: string;
+
+	beforeAll(() => {
+		defsDir = mkdtempSync(join(tmpdir(), 'node-defs-versions-'));
+		// Notion ships versions 1, 2, 2.1, 2.2 and 3, so on disk its version
+		// dirs are v1, v2, v21, v22, v3 (the dot is dropped when naming).
+		const notionDir = join(defsDir, 'nodes', 'n8n-nodes-base', 'notion');
+		for (const [version, content] of [
+			['v1', '// notion v1 get def'],
+			['v2', '// notion v2 get def'],
+			['v21', '// notion v2.1 get def'],
+			['v22', '// notion v2.2 get def'],
+			['v3', '// notion v3 get def'],
+		]) {
+			const opDir = join(notionDir, version, 'resource_database_page');
+			mkdirSync(opDir, { recursive: true });
+			writeFileSync(join(opDir, 'operation_get.ts'), content);
+		}
+	});
+
+	afterAll(() => {
+		rmSync(defsDir, { recursive: true, force: true });
+	});
+
+	it('treats v3 as latest, not v2.2, when no version is requested', () => {
+		const result = resolveNodeTypeDefinition('n8n-nodes-base.notion', [defsDir], {
+			resource: 'databasePage',
+			operation: 'get',
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.version).toBe('v3');
+		expect(result.content).toBe('// notion v3 get def');
+	});
+});

--- a/packages/cli/src/modules/instance-ai/node-definition-resolver.ts
+++ b/packages/cli/src/modules/instance-ai/node-definition-resolver.ts
@@ -6,7 +6,12 @@
  * pure functions without LangChain dependencies.
  */
 
-import { parseNodeId, toSnakeCase, isValidPathComponent } from '@n8n/ai-utilities/node-catalog';
+import {
+	parseNodeId,
+	toSnakeCase,
+	isValidPathComponent,
+	versionDirToNumber,
+} from '@n8n/ai-utilities/node-catalog';
 import { safeJoinPath } from '@n8n/backend-common';
 import { BUILTIN_NODES_PACKAGES } from '@n8n/constants';
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
@@ -69,11 +74,8 @@ function getNodeVersions(nodeId: string, nodeDefinitionDirs: string[]): string[]
 			}
 		}
 
-		versions.sort((a, b) => {
-			const aNum = parseInt(a.slice(1), 10);
-			const bNum = parseInt(b.slice(1), 10);
-			return bNum - aNum;
-		});
+		// Sort by numeric version descending (v22 is 2.2, not 22, so it ranks below v3)
+		versions.sort((a, b) => versionDirToNumber(b) - versionDirToNumber(a));
 
 		return versions;
 	} catch {


### PR DESCRIPTION
## Summary

MCP and AIA surfaced Notion node **v2.2** as the latest version instead of **v3**.

The type-definition generator names per-version directories with the dot stripped (`versionToFileName`: `2.2` → `v22`, `3` → `v3`). Two separate copies of `getNodeVersions` then sorted those directory names to pick the latest, but parsed them with a naive `parseInt`:

```ts
const aNum = parseInt(a.slice(1), 10); // "v22" → 22, "v3" → 3
```

So `v22` ranked above `v3`, and a version-less lookup returned v2.2 as latest.

**Fix:** a shared `versionDirToNumber` helper (exported from `@n8n/ai-utilities/node-catalog`) reconstructs the real numeric version from the dot-dropped directory name (a two-digit suffix is a `major.minor` pair), matching the `parseRequestedVersion` convention already used in `node-catalog.service.ts`. Both copies of the sort now use it so they can't drift apart again:

- `packages/@n8n/ai-utilities/src/node-catalog/get.ts` — the MCP / workflow-builder path.
- `packages/cli/src/modules/instance-ai/node-definition-resolver.ts` — the AIA / instance-ai path (also fixes `listNodeDiscriminators`, which selects the latest version too).

MCP's `search_nodes` was already correct (it uses `Math.max` on the real numeric `version`), so only the `get_node_types` / type-definition-resolution path was affected.

### Known limitation (unchanged)

The `v22` encoding is inherently ambiguous, so a future node at a two-digit **major** version (`v10`) would read as `1.0`. No node is anywhere near that, and this matches the existing `parseRequestedVersion` behavior. Removing the ambiguity would mean changing the dir naming at generation time, which is out of scope here.

## How to test

Request the Notion node type definition through MCP (`get_node_types`) or AIA without specifying a version and confirm v3 is returned as latest (previously v2.2).

Automated coverage:

```bash
cd packages/@n8n/ai-utilities && pnpm test get-node-type-definition
cd packages/cli && pnpm test node-definition-resolver
```

- A direct unit test on `versionDirToNumber` (`v3 > v22 > v21 > v2 > v1`, plus the documented `v10` limitation).
- A Notion-shaped regression test in **each** consumer using the real split (resource/operation) directory structure, asserting a version-less lookup resolves to `v3`. These fail before the fix (`expected 'v22' to be 'v3'`) and pass after.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5661

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI