### PR TITLE
fix(core): Clarify MCP trigger info for unsupported production triggers

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
@@ -12,10 +12,13 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { createWorkflow } from './mock.utils';
 import { getWorkflowDetails, createWorkflowDetailsTool } from '../tools/get-workflow-details.tool';
+import { getTriggerDetails } from '../tools/webhook-utils';
 
 vi.mock('../tools/webhook-utils', () => ({
 	getTriggerDetails: vi.fn().mockResolvedValue('MOCK_TRIGGER_DETAILS'),
 }));
+
+const getTriggerDetailsMock = vi.mocked(getTriggerDetails);
 
 describe('get-workflow-details MCP tool', () => {
 	const user = Object.assign(new User(), { id: 'user-1' });
@@ -161,6 +164,55 @@ describe('get-workflow-details MCP tool', () => {
 				expect.objectContaining({ includeTags: true }),
 			);
 			expect(payload.workflow.tags).toEqual(tags);
+		});
+
+		test('passes triggers MCP cannot execute directly to getTriggerDetails', async () => {
+			getTriggerDetailsMock.mockClear();
+			const workflow = createWorkflow({
+				activeVersionId: uuid(),
+				nodes: [
+					{
+						id: 'node-1',
+						name: 'Gmail Trigger',
+						type: 'n8n-nodes-base.gmailTrigger',
+						typeVersion: 1.4,
+						position: [0, 0],
+						disabled: false,
+						parameters: {},
+					},
+					{
+						id: 'node-2',
+						name: 'Disabled Trigger',
+						type: 'n8n-nodes-base.telegramTrigger',
+						typeVersion: 1,
+						position: [100, 0],
+						disabled: true,
+						parameters: {},
+					},
+				],
+			});
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: vi.fn().mockResolvedValue(workflow),
+			});
+			const credentialsService = mockInstance(CredentialsService, {});
+			const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };
+
+			await getWorkflowDetails(
+				user,
+				baseWebhookUrl,
+				workflowFinderService,
+				credentialsService,
+				nodeTypes,
+				endpoints,
+				roleService,
+				projectService,
+				{ workflowId: 'wf-1' },
+			);
+
+			const [, supportedTriggers, unsupportedTriggers] = getTriggerDetailsMock.mock.calls[0];
+			expect(supportedTriggers).toEqual([]);
+			// Only the enabled unsupported trigger is passed; the disabled one is excluded.
+			expect(unsupportedTriggers.map((t) => t.name)).toEqual(['Gmail Trigger']);
 		});
 
 		test('propagates errors from workflow validation', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
@@ -14,7 +14,7 @@ import { mock } from 'vitest-mock-extended';
 
 import { CredentialsService } from '@/credentials/credentials.service';
 
-import { getWebhookDetails } from '../tools/webhook-utils';
+import { getTriggerDetails, getWebhookDetails } from '../tools/webhook-utils';
 
 const mockCredentialsService = (
 	impl: (id: string) => ICredentialDataDecryptedObject | Promise<ICredentialDataDecryptedObject>,
@@ -306,5 +306,56 @@ describe('getWebhookDetails', () => {
 			workflowId,
 		);
 		expect(resDefault).toContain('Returns the JSON data of the first entry of the last node');
+	});
+});
+
+describe('getTriggerDetails', () => {
+	const user = createUser();
+	const baseUrl = 'https://example.com';
+	const workflowId = 'wf-1';
+	const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };
+	const credentialsService = mockCredentialsService(() => ({}));
+
+	const createTriggerNode = (overrides: Partial<INode> = {}): INode => ({
+		id: '1',
+		name: 'Gmail Trigger',
+		type: 'n8n-nodes-base.gmailTrigger',
+		typeVersion: 1.4,
+		position: [0, 0],
+		parameters: {},
+		...overrides,
+	});
+
+	it('reports manual-only when the workflow has no triggers at all', async () => {
+		const res = await getTriggerDetails(
+			user,
+			[],
+			[],
+			baseUrl,
+			credentialsService,
+			nodeTypes,
+			endpoints,
+			workflowId,
+		);
+		expect(res).toBe(
+			'This workflow has no production triggers (Schedule, Webhook, Form, or Chat). It can only be executed in manual mode.',
+		);
+	});
+
+	it('clarifies when the workflow has triggers that MCP cannot execute directly', async () => {
+		const res = await getTriggerDetails(
+			user,
+			[],
+			[createTriggerNode()],
+			baseUrl,
+			credentialsService,
+			nodeTypes,
+			endpoints,
+			workflowId,
+		);
+		expect(res).toContain('not supported for direct execution through MCP: Gmail Trigger');
+		expect(res).toContain('cannot be executed through MCP');
+		expect(res).not.toContain('no production triggers');
+		expect(res).not.toContain('manual mode');
 	});
 });

--- a/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
@@ -1,5 +1,5 @@
 import type { User } from '@n8n/db';
-import type { INodeTypes } from 'n8n-workflow';
+import { isTriggerNodeType, type INodeTypes } from 'n8n-workflow';
 import z from 'zod';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
@@ -149,13 +149,18 @@ export async function getWorkflowDetails(
 			: null;
 
 	const supportedTriggers = Object.keys(SUPPORTED_MCP_TRIGGERS);
-	const triggers = nodes.filter(
-		(node) => supportedTriggers.includes(node.type) && node.disabled !== true,
+	const activeNodes = nodes.filter((node) => node.disabled !== true);
+	const triggers = activeNodes.filter((node) => supportedTriggers.includes(node.type));
+	// Triggers the workflow does have but MCP can't execute directly (e.g. Gmail Trigger),
+	// so the notice can distinguish these from a workflow with no triggers at all.
+	const unsupportedTriggers = activeNodes.filter(
+		(node) => isTriggerNodeType(node.type) && !supportedTriggers.includes(node.type),
 	);
 
 	const triggerNotice = await getTriggerDetails(
 		user,
 		triggers,
+		unsupportedTriggers,
 		baseWebhookUrl,
 		credentialsService,
 		nodeTypes,

--- a/packages/cli/src/modules/mcp/tools/webhook-utils.ts
+++ b/packages/cli/src/modules/mcp/tools/webhook-utils.ts
@@ -69,6 +69,7 @@ const buildEndpointBaseUrl = (baseUrl: string, endpoint: string) => {
 export const getTriggerDetails = async (
 	user: User,
 	supportedTriggers: INode[],
+	unsupportedTriggers: INode[],
 	baseUrl: string,
 	credentialsService: CredentialsService,
 	nodeTypes: INodeTypes,
@@ -77,6 +78,10 @@ export const getTriggerDetails = async (
 	testBaseUrl: string = baseUrl,
 ): Promise<string> => {
 	if (supportedTriggers.length === 0) {
+		if (unsupportedTriggers.length > 0) {
+			const names = unsupportedTriggers.map((trigger) => trigger.name).join(', ');
+			return `This workflow's trigger(s) are not supported for direct execution through MCP: ${names}. Only Schedule, Webhook, Form, and Chat triggers can be executed directly through MCP, so this workflow cannot be executed through MCP. Its trigger(s) still run normally when the workflow is active.`;
+		}
 		return 'This workflow has no production triggers (Schedule, Webhook, Form, or Chat). It can only be executed in manual mode.';
 	}
 


### PR DESCRIPTION
## Summary

`get_workflow_details` (instance MCP) returned a misleading `triggerInfo` for workflows whose only trigger is one MCP cannot execute directly (e.g. Gmail Trigger). It reported:

> This workflow has no production triggers (Schedule, Webhook, Form, or Chat). It can only be executed in manual mode.

The workflow does have a production trigger; it just isn't one MCP can execute directly. The message read as if the workflow had no trigger at all.

## Changes

- `get-workflow-details.tool.ts` now also collects the workflow's enabled trigger nodes that are not in the MCP-supported set (detected with `isTriggerNodeType`) and passes them to `getTriggerDetails`.
- `getTriggerDetails` now distinguishes the two cases. When the workflow's only triggers are ones MCP can't execute directly, it names them and states the accurate consequence instead of claiming there are no production triggers:

> This workflow's trigger(s) are not supported for direct execution through MCP: Gmail Trigger. Only Schedule, Webhook, Form, and Chat triggers can be executed directly through MCP, so this workflow cannot be executed through MCP. Its trigger(s) still run normally when the workflow is active.

The genuine no-triggers case keeps the original message. When a supported trigger is also present, the response is unchanged (the actionable trigger info is already there), so unsupported triggers are only surfaced when every trigger is unsupported.

## Notes / follow-up

While in this code path I noticed a separate, pre-existing issue (not a regression from this change and left out of scope): a workflow whose only trigger is a **Manual Trigger** produces a bare, bodyless `"This workflow has the following trigger(s):"` header, because `getTriggerDetails` has no Manual-Trigger branch. Worth a small follow-up ticket.

## Testing

- Added unit tests for both branches of the empty-supported-triggers case in `webhook-utils.test.ts`.
- Added a caller test in `get-workflow-details.tool.test.ts` verifying enabled unsupported triggers are passed through and disabled ones are excluded.
- `pnpm test` (both files): 19 passed. `pnpm typecheck`: clean.

https://linear.app/n8n/issue/ADO-5665
