### PR TITLE
feat(core): Make Azure Key Vault provider endpoints configurable

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts
@@ -1,4 +1,4 @@
-import { AuthenticationError } from '@azure/identity';
+import { AuthenticationError, ClientSecretCredential } from '@azure/identity';
 import { SecretClient } from '@azure/keyvault-secrets';
 import type { KeyVaultSecret } from '@azure/keyvault-secrets';
 import type { Logger } from '@n8n/backend-common';
@@ -11,6 +11,17 @@ import type { AzureKeyVaultContext } from '../azure-key-vault/types';
 
 vi.mock('@azure/identity');
 vi.mock('@azure/keyvault-secrets');
+
+const baseSettings: AzureKeyVaultContext['settings'] = {
+	vaultName: 'my-vault',
+	tenantId: 'my-tenant-id',
+	clientId: 'my-client-id',
+	clientSecret: 'my-client-secret',
+};
+
+function createSettingsContext(settings: AzureKeyVaultContext['settings']): AzureKeyVaultContext {
+	return { connected: false, connectedAt: null, settings };
+}
 
 function createRestErrorLike(
 	message: string,
@@ -86,17 +97,124 @@ describe('AzureKeyVault', () => {
 		});
 	});
 
+	describe('endpoint resolution', () => {
+		const ClientSecretCredentialMock = ClientSecretCredential as unknown as Mock;
+		const SecretClientMock = SecretClient as unknown as Mock;
+
+		it('should use commercial endpoints when no environment is set', async () => {
+			await azureKeyVault.init(createSettingsContext(baseSettings));
+			await azureKeyVault.connect();
+
+			expect(ClientSecretCredentialMock).toHaveBeenCalledWith(
+				'my-tenant-id',
+				'my-client-id',
+				'my-client-secret',
+				{ authorityHost: 'https://login.microsoftonline.com' },
+			);
+			expect(SecretClientMock).toHaveBeenCalledWith(
+				'https://my-vault.vault.azure.net/',
+				expect.anything(),
+			);
+		});
+
+		it('should use commercial endpoints for the public environment', async () => {
+			await azureKeyVault.init(createSettingsContext({ ...baseSettings, environment: 'public' }));
+			await azureKeyVault.connect();
+
+			expect(ClientSecretCredentialMock).toHaveBeenCalledWith(
+				'my-tenant-id',
+				'my-client-id',
+				'my-client-secret',
+				{ authorityHost: 'https://login.microsoftonline.com' },
+			);
+			expect(SecretClientMock).toHaveBeenCalledWith(
+				'https://my-vault.vault.azure.net/',
+				expect.anything(),
+			);
+		});
+
+		it('should use US Government endpoints for the usGovernment environment', async () => {
+			await azureKeyVault.init(
+				createSettingsContext({ ...baseSettings, environment: 'usGovernment' }),
+			);
+			await azureKeyVault.connect();
+
+			expect(ClientSecretCredentialMock).toHaveBeenCalledWith(
+				'my-tenant-id',
+				'my-client-id',
+				'my-client-secret',
+				{ authorityHost: 'https://login.microsoftonline.us' },
+			);
+			expect(SecretClientMock).toHaveBeenCalledWith(
+				'https://my-vault.vault.usgovcloudapi.net/',
+				expect.anything(),
+			);
+		});
+
+		it('should use China endpoints for the china environment', async () => {
+			await azureKeyVault.init(createSettingsContext({ ...baseSettings, environment: 'china' }));
+			await azureKeyVault.connect();
+
+			expect(ClientSecretCredentialMock).toHaveBeenCalledWith(
+				'my-tenant-id',
+				'my-client-id',
+				'my-client-secret',
+				{ authorityHost: 'https://login.partner.microsoftonline.cn' },
+			);
+			expect(SecretClientMock).toHaveBeenCalledWith(
+				'https://my-vault.vault.azure.cn/',
+				expect.anything(),
+			);
+		});
+
+		it('should use the provided vault URL and authority host for the custom environment', async () => {
+			await azureKeyVault.init(
+				createSettingsContext({
+					...baseSettings,
+					environment: 'custom',
+					vaultUrl: 'https://my-vault.keyvault.internal.example.com ',
+					authorityHost: ' https://login.internal.example.com',
+				}),
+			);
+			await azureKeyVault.connect();
+
+			expect(ClientSecretCredentialMock).toHaveBeenCalledWith(
+				'my-tenant-id',
+				'my-client-id',
+				'my-client-secret',
+				{ authorityHost: 'https://login.internal.example.com' },
+			);
+			expect(SecretClientMock).toHaveBeenCalledWith(
+				'https://my-vault.keyvault.internal.example.com',
+				expect.anything(),
+			);
+		});
+
+		it('should fall back to the commercial authority host when the custom environment has none', async () => {
+			await azureKeyVault.init(
+				createSettingsContext({
+					...baseSettings,
+					environment: 'custom',
+					vaultUrl: 'https://my-vault.keyvault.internal.example.com',
+				}),
+			);
+			await azureKeyVault.connect();
+
+			expect(ClientSecretCredentialMock).toHaveBeenCalledWith(
+				'my-tenant-id',
+				'my-client-id',
+				'my-client-secret',
+				{ authorityHost: 'https://login.microsoftonline.com' },
+			);
+			expect(SecretClientMock).toHaveBeenCalledWith(
+				'https://my-vault.keyvault.internal.example.com',
+				expect.anything(),
+			);
+		});
+	});
+
 	it('should log failed client setup while preserving error state', async () => {
-		await azureKeyVault.init(
-			mock<AzureKeyVaultContext>({
-				settings: {
-					vaultName: 'my-vault',
-					tenantId: 'my-tenant-id',
-					clientId: 'my-client-id',
-					clientSecret: 'my-client-secret',
-				},
-			}),
-		);
+		await azureKeyVault.init(createSettingsContext(baseSettings));
 
 		const setupError = new Error('Invalid configuration');
 		const SecretClientMock = SecretClient as unknown as Mock;
@@ -121,16 +239,7 @@ describe('AzureKeyVault', () => {
 	});
 
 	it('should log test failures with Azure error context', async () => {
-		await azureKeyVault.init(
-			mock<AzureKeyVaultContext>({
-				settings: {
-					vaultName: 'my-vault',
-					tenantId: 'my-tenant-id',
-					clientId: 'my-client-id',
-					clientSecret: 'my-client-secret',
-				},
-			}),
-		);
+		await azureKeyVault.init(createSettingsContext(baseSettings));
 
 		await azureKeyVault.connect();
 
@@ -165,16 +274,7 @@ describe('AzureKeyVault', () => {
 		/**
 		 * Arrange
 		 */
-		await azureKeyVault.init(
-			mock<AzureKeyVaultContext>({
-				settings: {
-					vaultName: 'my-vault',
-					tenantId: 'my-tenant-id',
-					clientId: 'my-client-id',
-					clientSecret: 'my-client-secret',
-				},
-			}),
-		);
+		await azureKeyVault.init(createSettingsContext(baseSettings));
 
 		const listSpy = vi.spyOn(SecretClient.prototype, 'listPropertiesOfSecrets').mockImplementation(
 			() =>
@@ -213,16 +313,7 @@ describe('AzureKeyVault', () => {
 	});
 
 	it('should skip disabled secrets without calling getSecret', async () => {
-		await azureKeyVault.init(
-			mock<AzureKeyVaultContext>({
-				settings: {
-					vaultName: 'my-vault',
-					tenantId: 'my-tenant-id',
-					clientId: 'my-client-id',
-					clientSecret: 'my-client-secret',
-				},
-			}),
-		);
+		await azureKeyVault.init(createSettingsContext(baseSettings));
 
 		const listSpy = vi.spyOn(SecretClient.prototype, 'listPropertiesOfSecrets').mockImplementation(
 			() =>
@@ -249,16 +340,7 @@ describe('AzureKeyVault', () => {
 	});
 
 	it('should still load other secrets when one getSecret fails', async () => {
-		await azureKeyVault.init(
-			mock<AzureKeyVaultContext>({
-				settings: {
-					vaultName: 'my-vault',
-					tenantId: 'my-tenant-id',
-					clientId: 'my-client-id',
-					clientSecret: 'my-client-secret',
-				},
-			}),
-		);
+		await azureKeyVault.init(createSettingsContext(baseSettings));
 
 		vi.spyOn(SecretClient.prototype, 'listPropertiesOfSecrets').mockImplementation(
 			() =>
@@ -304,16 +386,7 @@ describe('AzureKeyVault', () => {
 	});
 
 	it('should throw when every getSecret fails and leave the previous cache unchanged', async () => {
-		await azureKeyVault.init(
-			mock<AzureKeyVaultContext>({
-				settings: {
-					vaultName: 'my-vault',
-					tenantId: 'my-tenant-id',
-					clientId: 'my-client-id',
-					clientSecret: 'my-client-secret',
-				},
-			}),
-		);
+		await azureKeyVault.init(createSettingsContext(baseSettings));
 
 		vi.spyOn(SecretClient.prototype, 'listPropertiesOfSecrets').mockImplementation(
 			() =>

--- a/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/azure-key-vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/azure-key-vault.ts
@@ -5,7 +5,7 @@ import { Container } from '@n8n/di';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { type INodeProperties, UnexpectedError } from 'n8n-workflow';
 
-import type { AzureKeyVaultContext } from './types';
+import type { AzureKeyVaultContext, AzureKeyVaultEnvironment } from './types';
 import { DOCS_HELP_NOTICE } from '../../constants';
 import {
 	buildFailureSummaryLogContext,
@@ -22,6 +22,26 @@ type AzureHttpLikeError = Error & {
 	code?: string;
 };
 
+const DEFAULT_AUTHORITY_HOST = 'https://login.microsoftonline.com';
+
+const AZURE_CLOUD_ENDPOINTS: Record<
+	Exclude<AzureKeyVaultEnvironment, 'custom'>,
+	{ vaultSuffix: string; authorityHost: string }
+> = {
+	public: {
+		vaultSuffix: 'vault.azure.net',
+		authorityHost: DEFAULT_AUTHORITY_HOST,
+	},
+	usGovernment: {
+		vaultSuffix: 'vault.usgovcloudapi.net',
+		authorityHost: 'https://login.microsoftonline.us',
+	},
+	china: {
+		vaultSuffix: 'vault.azure.cn',
+		authorityHost: 'https://login.partner.microsoftonline.cn',
+	},
+};
+
 export class AzureKeyVault extends SecretsProvider {
 	name = 'azureKeyVault';
 
@@ -29,6 +49,40 @@ export class AzureKeyVault extends SecretsProvider {
 
 	properties: INodeProperties[] = [
 		DOCS_HELP_NOTICE,
+		{
+			displayName: 'Azure Cloud',
+			name: 'environment',
+			hint: 'The Azure cloud environment your Key Vault is hosted in.',
+			type: 'options',
+			options: [
+				{
+					name: 'Azure Public Cloud',
+					value: 'public',
+					description:
+						'Uses <code>vault.azure.net</code> and <code>login.microsoftonline.com</code>',
+				},
+				{
+					name: 'Azure US Government',
+					value: 'usGovernment',
+					description:
+						'Uses <code>vault.usgovcloudapi.net</code> and <code>login.microsoftonline.us</code>',
+				},
+				{
+					name: 'Azure China',
+					value: 'china',
+					description:
+						'Uses <code>vault.azure.cn</code> and <code>login.partner.microsoftonline.cn</code>',
+				},
+				{
+					name: 'Custom',
+					value: 'custom',
+					description:
+						'Provide the vault URL and authority host directly, for setups such as Azure Stack or proxied environments',
+				},
+			],
+			default: 'public',
+			noDataExpression: true,
+		},
 		{
 			displayName: 'Vault Name',
 			hint: 'The name of your existing Azure Key Vault.',
@@ -38,6 +92,26 @@ export class AzureKeyVault extends SecretsProvider {
 			required: true,
 			placeholder: 'e.g. my-vault',
 			noDataExpression: true,
+			displayOptions: {
+				hide: {
+					environment: ['custom'],
+				},
+			},
+		},
+		{
+			displayName: 'Vault URL',
+			hint: 'The full URL of your existing Azure Key Vault.',
+			name: 'vaultUrl',
+			type: 'string',
+			default: '',
+			required: true,
+			placeholder: 'e.g. https://my-vault.vault.usgovcloudapi.net',
+			noDataExpression: true,
+			displayOptions: {
+				show: {
+					environment: ['custom'],
+				},
+			},
 		},
 		{
 			displayName: 'Tenant ID',
@@ -70,6 +144,20 @@ export class AzureKeyVault extends SecretsProvider {
 			typeOptions: { password: true },
 			noDataExpression: true,
 		},
+		{
+			displayName: 'Authority Host',
+			hint: 'The Microsoft Entra authority to authenticate against. Leave empty to use the default (https://login.microsoftonline.com).',
+			name: 'authorityHost',
+			type: 'string',
+			default: '',
+			placeholder: 'e.g. https://login.microsoftonline.us',
+			noDataExpression: true,
+			displayOptions: {
+				show: {
+					environment: ['custom'],
+				},
+			},
+		},
 	];
 
 	private cachedSecrets: Record<string, string> = {};
@@ -91,14 +179,17 @@ export class AzureKeyVault extends SecretsProvider {
 
 	protected async doConnect(): Promise<void> {
 		try {
-			const { vaultName, tenantId, clientId, clientSecret } = this.settings;
+			const { tenantId, clientId, clientSecret } = this.settings;
+			const { vaultUrl, authorityHost } = this.resolveEndpoints();
 
 			const { ClientSecretCredential } = await import('@azure/identity');
 			const { SecretClient } = await import('@azure/keyvault-secrets');
 
 			// TODO: Not routed through OutboundHttp for now. It would require `@azure/core-rest-pipeline`, which is not worth it just to share agents.
-			const credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
-			this.client = new SecretClient(`https://${vaultName}.vault.azure.net/`, credential);
+			const credential = new ClientSecretCredential(tenantId, clientId, clientSecret, {
+				authorityHost,
+			});
+			this.client = new SecretClient(vaultUrl, credential);
 
 			this.logger.debug('Azure Key Vault provider connected');
 		} catch (error) {
@@ -109,6 +200,24 @@ export class AzureKeyVault extends SecretsProvider {
 			});
 			throw error;
 		}
+	}
+
+	private resolveEndpoints(): { vaultUrl: string; authorityHost: string } {
+		const { environment = 'public', vaultName, vaultUrl, authorityHost } = this.settings;
+
+		if (environment === 'custom') {
+			const trimmedAuthorityHost = authorityHost?.trim();
+			return {
+				vaultUrl: (vaultUrl ?? '').trim(),
+				authorityHost: trimmedAuthorityHost ? trimmedAuthorityHost : DEFAULT_AUTHORITY_HOST,
+			};
+		}
+
+		const cloudEndpoints = AZURE_CLOUD_ENDPOINTS[environment];
+		return {
+			vaultUrl: `https://${vaultName}.${cloudEndpoints.vaultSuffix}/`,
+			authorityHost: cloudEndpoints.authorityHost,
+		};
 	}
 
 	async test(): Promise<[boolean] | [boolean, string]> {

--- a/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/types.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/azure-key-vault/types.ts
@@ -1,8 +1,13 @@
 import type { SecretsProviderSettings } from '../../types';
 
+export type AzureKeyVaultEnvironment = 'public' | 'usGovernment' | 'china' | 'custom';
+
 export type AzureKeyVaultContext = SecretsProviderSettings<{
 	vaultName: string;
 	tenantId: string;
 	clientId: string;
 	clientSecret: string;
+	environment?: AzureKeyVaultEnvironment;
+	vaultUrl?: string;
+	authorityHost?: string;
 }>;

--- a/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/components/ExternalSecretsProviderModal.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/components/ExternalSecretsProviderModal.ee.vue
@@ -29,6 +29,9 @@ const defaultProviderData: Record<string, Partial<ExternalSecretsProviderData>> 
 	infisical: {
 		siteURL: 'https://app.infisical.com',
 	},
+	azureKeyVault: {
+		environment: 'public',
+	},
 };
 
 const externalSecretsStore = useExternalSecretsStore();


### PR DESCRIPTION
## Summary

The Azure Key Vault external secrets provider hardcoded two commercial-cloud assumptions: the vault URL suffix (`vault.azure.net`) and the Microsoft Entra authority (`login.microsoftonline.com`). This made the provider unusable for vaults in sovereign clouds — for example Azure US Government vaults live at `{vault}.vault.usgovcloudapi.net` and authenticate against `login.microsoftonline.us`, so connections failed with DNS errors and there was no workaround.

This PR adds an **Azure Cloud** selector to the provider settings:

- **Azure Public Cloud** (default), **Azure US Government**, and **Azure China** set both the vault URL suffix and the authority host automatically.
- **Custom** replaces the Vault Name field with a full **Vault URL** field and adds an optional **Authority Host** field, covering Azure Stack, air-gapped, and proxied setups.

### Adding sovereign regions

<img width="1188" height="1027" alt="CleanShot 2026-07-29 at 18 09 16" src="https://github.com/user-attachments/assets/4c70473f-70a7-4262-a7fb-318d0e68e6b8" />

### Using custom vault URLs

<img width="1187" height="1029" alt="CleanShot 2026-07-29 at 18 10 27" src="https://github.com/user-attachments/assets/4964e103-3486-4b7f-a6de-940bf828ec93" />


Backwards compatibility: previously saved settings have no `environment` key, and an absent value resolves to the public cloud — identical behavior to before this change (covered by a regression test). No migration is needed since provider settings are stored as a schemaless encrypted blob.

The settings form is backend-driven, so the only frontend change is pre-selecting the default cloud in the provider modal (same pattern as the existing Infisical default).

## How to test

Requires a license with the external secrets feature enabled.

1. Go to **Settings → External secrets → Azure Key Vault**.
2. Check the **Azure Cloud** dropdown shows **Azure Public Cloud** pre-selected, including for a config saved before this change, and that connecting to an existing commercial vault works as before.
3. Select **Custom**: Vault Name is replaced by **Vault URL**, and an optional **Authority Host** field appears at the bottom. Switching back restores Vault Name.
4. Without a sovereign-cloud account you can still verify the endpoint switch: select **Azure US Government** with any vault name and test the connection — the error now references `<vault>.vault.usgovcloudapi.net` instead of `vault.azure.net`.
5. With an Azure Government (or China) vault: select the matching cloud, enter the vault name and app registration credentials, and confirm secrets are listed.

Unit tests: `packages/cli/src/modules/external-secrets.ee/providers/__tests__/azure-key-vault.test.ts` covers endpoint resolution for every environment, the custom overrides, and the back-compat default.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-791
Docs follow-up: https://linear.app/n8n/issue/LIGO-901

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (Follow-up: https://linear.app/n8n/issue/LIGO-901)
  - https://github.com/n8n-io/n8n-docs/pull/5130
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35214">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


