### PR TITLE
refactor(core): Keep a single exact tag name lookup function on TagService

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -92,7 +92,7 @@ describe('update-workflow MCP tool', () => {
 	let dataTableOps: DataTableOpsMock;
 	let tagService: TagService;
 	let findOrCreateByNamesMock: Mock;
-	let findByNamesMock: Mock;
+	let getByNamesMock: Mock;
 	let globalConfig: GlobalConfig;
 	let subworkflowPolicyChecker: SubworkflowPolicyChecker;
 	let policyCheckMock: Mock;
@@ -165,10 +165,10 @@ describe('update-workflow MCP tool', () => {
 		};
 
 		findOrCreateByNamesMock = vi.fn();
-		findByNamesMock = vi.fn();
+		getByNamesMock = vi.fn();
 		tagService = mockInstance(TagService, {
 			findOrCreateByNames: findOrCreateByNamesMock,
-			findByNames: findByNamesMock,
+			getByNames: getByNamesMock,
 		});
 		globalConfig = mockInstance(GlobalConfig, {
 			tags: { disabled: false },
@@ -2257,6 +2257,18 @@ describe('update-workflow MCP tool', () => {
 				expect(updateOptions.tagIds.sort()).toEqual(['tag-0', 'tag-new']);
 			});
 
+			test('collapses case-duplicate tag names before resolving', async () => {
+				findWorkflowMock.mockResolvedValue(workflowWithTags([]));
+				findOrCreateByNamesMock.mockResolvedValue([{ id: 'tag-0', name: 'Critical' }]);
+
+				await callHandler({
+					workflowId: 'wf-1',
+					operations: [{ type: 'addTags', names: ['Critical', ' critical ', 'CRITICAL'] }],
+				});
+
+				expect(findOrCreateByNamesMock).toHaveBeenCalledWith(['Critical']);
+			});
+
 			test('removeTags drops names from the resolved set', async () => {
 				findWorkflowMock.mockResolvedValue(workflowWithTags(['production', 'critical']));
 				findOrCreateByNamesMock.mockResolvedValue([{ id: 'tag-0', name: 'production' }]);
@@ -2320,7 +2332,7 @@ describe('update-workflow MCP tool', () => {
 			test('without tag:create scope, attaches only existing tags', async () => {
 				const memberUser = userWithScopes([]);
 				findWorkflowMock.mockResolvedValue(workflowWithTags([]));
-				findByNamesMock.mockResolvedValue([{ id: 'tag-existing', name: 'production' }]);
+				getByNamesMock.mockResolvedValue([{ id: 'tag-existing', name: 'production' }]);
 
 				const tool = createUpdateWorkflowTool(
 					memberUser,
@@ -2348,8 +2360,45 @@ describe('update-workflow MCP tool', () => {
 					tool,
 				);
 
-				expect(findByNamesMock).toHaveBeenCalledWith(['production']);
+				expect(getByNamesMock).toHaveBeenCalledWith(['production']);
 				expect(findOrCreateByNamesMock).not.toHaveBeenCalled();
+				const [, , , updateOptions] = updateMock.mock.calls[0];
+				expect(updateOptions.tagIds).toEqual(['tag-existing']);
+			});
+
+			test('without tag:create scope, case-duplicate input still attaches the existing tag', async () => {
+				const memberUser = userWithScopes([]);
+				findWorkflowMock.mockResolvedValue(workflowWithTags([]));
+				getByNamesMock.mockResolvedValue([{ id: 'tag-existing', name: 'Prod' }]);
+
+				const tool = createUpdateWorkflowTool(
+					memberUser,
+					workflowFinderService,
+					workflowService,
+					urlService,
+					telemetry,
+					nodeTypes,
+					credentialsService,
+					sharedWorkflowRepository,
+					collaborationService,
+					dataTableOps as never,
+					tagService,
+					globalConfig,
+					subworkflowPolicyChecker,
+					workflowPublishedDataService,
+					aiGatewayService,
+				);
+
+				const result = await callHandler(
+					{
+						workflowId: 'wf-1',
+						operations: [{ type: 'addTags', names: ['Prod', 'prod'] }],
+					},
+					tool,
+				);
+
+				expect(result.isError).toBeUndefined();
+				expect(getByNamesMock).toHaveBeenCalledWith(['Prod']);
 				const [, , , updateOptions] = updateMock.mock.calls[0];
 				expect(updateOptions.tagIds).toEqual(['tag-existing']);
 			});
@@ -2357,7 +2406,7 @@ describe('update-workflow MCP tool', () => {
 			test('without tag:create scope, fails when a tag name does not exist', async () => {
 				const memberUser = userWithScopes([]);
 				findWorkflowMock.mockResolvedValue(workflowWithTags([]));
-				findByNamesMock.mockResolvedValue([{ id: 'tag-existing', name: 'production' }]);
+				getByNamesMock.mockResolvedValue([{ id: 'tag-existing', name: 'production' }]);
 
 				const tool = createUpdateWorkflowTool(
 					memberUser,

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -219,6 +219,24 @@ type OperationInput = {
 
 const strictOperationsSchema = z.array(partialUpdateOperationSchema);
 
+// LLM-supplied tag batches routinely repeat a name in different casings; collapse
+// those (first-seen case wins) before hitting the tag API. Tag names are
+// case-sensitively unique, so this is an MCP-only semantic — the service itself
+// treats case-variant names as distinct tags.
+function dedupeNamesPreservingCase(names: string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const raw of names) {
+		const trimmed = raw.trim();
+		if (trimmed.length === 0) continue;
+		const key = trimmed.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		result.push(trimmed);
+	}
+	return result;
+}
+
 function parseStrictOperations(operations: OperationInput[]): PartialUpdateOperation[] {
 	const parsed = strictOperationsSchema.safeParse(operations);
 	if (parsed.success) return parsed.data;
@@ -814,15 +832,14 @@ export const createUpdateWorkflowTool = (
 
 			let tagIds: string[] | undefined;
 			if (result.tagNames !== undefined) {
+				const uniqueTagNames = dedupeNamesPreservingCase(result.tagNames);
 				if (hasGlobalScope(user, 'tag:create')) {
-					const resolvedTags = await tagService.findOrCreateByNames(result.tagNames);
+					const resolvedTags = await tagService.findOrCreateByNames(uniqueTagNames);
 					tagIds = resolvedTags.map((t) => t.id);
 				} else {
-					const resolvedTags = await tagService.findByNames(result.tagNames);
+					const resolvedTags = await tagService.getByNames(uniqueTagNames);
 					const resolvedNames = new Set(resolvedTags.map((t) => t.name));
-					const missing = result.tagNames
-						.map((n) => n.trim())
-						.filter((name) => name.length > 0 && !resolvedNames.has(name));
+					const missing = uniqueTagNames.filter((name) => !resolvedNames.has(name));
 					if (missing.length > 0) {
 						throw new Error(
 							`Cannot apply the following tags because they don't exist and your account does not have permission to create them: ${missing.join(', ')}`,

--- a/packages/cli/src/services/__tests__/tag.service.test.ts
+++ b/packages/cli/src/services/__tests__/tag.service.test.ts
@@ -1,6 +1,6 @@
 import type { Mock } from 'vitest';
 import type { TagEntity, TagRepository } from '@n8n/db';
-import { FindOperator, QueryFailedError } from '@n8n/typeorm';
+import { QueryFailedError } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
 import type { ExternalHooks } from '@/external-hooks';
@@ -76,14 +76,14 @@ describe('TagService', () => {
 			const result = await tagService.findOrCreateByNames([]);
 
 			expect(result).toEqual([]);
-			expect(tagRepository.find).not.toHaveBeenCalled();
+			expect(tagRepository.findManyByName).not.toHaveBeenCalled();
 		});
 
 		test('returns empty array when all inputs are whitespace', async () => {
 			const result = await tagService.findOrCreateByNames(['', '   ']);
 
 			expect(result).toEqual([]);
-			expect(tagRepository.find).not.toHaveBeenCalled();
+			expect(tagRepository.findManyByName).not.toHaveBeenCalled();
 		});
 
 		test('returns existing tags without creating', async () => {
@@ -91,7 +91,7 @@ describe('TagService', () => {
 				makeTag({ id: 'tag-1', name: 'production' }),
 				makeTag({ id: 'tag-2', name: 'critical' }),
 			];
-			tagRepository.find.mockResolvedValue(existing);
+			tagRepository.findManyByName.mockResolvedValue(existing);
 
 			const result = await tagService.findOrCreateByNames(['production', 'critical']);
 
@@ -100,25 +100,21 @@ describe('TagService', () => {
 		});
 
 		test('trims names and collapses exact duplicates before lookup', async () => {
-			tagRepository.find.mockResolvedValue([]);
+			tagRepository.findManyByName.mockResolvedValue([]);
 			const createdTag = makeTag({ id: 'tag-new', name: 'prod' });
 			tagRepository.create.mockReturnValue(createdTag);
 			tagRepository.save.mockResolvedValue(createdTag);
 
 			const result = await tagService.findOrCreateByNames(['  prod ', 'prod']);
 
-			expect(tagRepository.find).toHaveBeenCalledTimes(1);
-			const findArg = tagRepository.find.mock.calls[0][0] as unknown as {
-				where: { name: FindOperator<string[]> };
-			};
-			expect(findArg.where.name).toBeInstanceOf(FindOperator);
-			expect(findArg.where.name.value).toEqual(['prod']);
+			expect(tagRepository.findManyByName).toHaveBeenCalledTimes(1);
+			expect(tagRepository.findManyByName).toHaveBeenCalledWith(['prod']);
 			expect(tagRepository.save).toHaveBeenCalledTimes(1);
 			expect(result.map((t) => t.name)).toEqual(['prod']);
 		});
 
 		test('creates case-variant names as distinct tags', async () => {
-			tagRepository.find.mockResolvedValue([]);
+			tagRepository.findManyByName.mockResolvedValue([]);
 			tagRepository.create.mockImplementation((attrs) => makeTag(attrs as Partial<TagEntity>));
 			tagRepository.save.mockImplementation(async (tag) => tag as TagEntity);
 
@@ -129,7 +125,9 @@ describe('TagService', () => {
 		});
 
 		test('matches the DB case-sensitively (parity with REST tags API)', async () => {
-			tagRepository.find.mockResolvedValue([makeTag({ id: 'tag-1', name: 'Production' })]);
+			tagRepository.findManyByName.mockResolvedValue([
+				makeTag({ id: 'tag-1', name: 'Production' }),
+			]);
 			const createdTag = makeTag({ id: 'tag-new', name: 'production' });
 			tagRepository.create.mockReturnValue(createdTag);
 			tagRepository.save.mockResolvedValue(createdTag);
@@ -149,7 +147,7 @@ describe('TagService', () => {
 		};
 
 		test('returns the now-existing row when a concurrent caller wins the create race (postgres)', async () => {
-			tagRepository.find.mockResolvedValue([]);
+			tagRepository.findManyByName.mockResolvedValue([]);
 			const racedTag = makeTag({ id: 'tag-raced', name: 'critical' });
 
 			tagRepository.create.mockReturnValue(racedTag);
@@ -163,7 +161,7 @@ describe('TagService', () => {
 		});
 
 		test('recognises sqlite unique-constraint code', async () => {
-			tagRepository.find.mockResolvedValue([]);
+			tagRepository.findManyByName.mockResolvedValue([]);
 			const racedTag = makeTag({ id: 'tag-raced', name: 'critical' });
 
 			tagRepository.create.mockReturnValue(racedTag);
@@ -176,7 +174,7 @@ describe('TagService', () => {
 		});
 
 		test('rethrows unrelated QueryFailedError instead of masking it as a race', async () => {
-			tagRepository.find.mockResolvedValue([]);
+			tagRepository.findManyByName.mockResolvedValue([]);
 			tagRepository.create.mockReturnValue(makeTag({ name: 'critical' }));
 			const unrelated = new QueryFailedError('insert', undefined, new Error('connection lost'));
 			tagRepository.save.mockRejectedValueOnce(unrelated);
@@ -186,7 +184,7 @@ describe('TagService', () => {
 		});
 
 		test('rethrows when the loser of the race cannot find the row afterwards', async () => {
-			tagRepository.find.mockResolvedValue([]);
+			tagRepository.findManyByName.mockResolvedValue([]);
 			tagRepository.create.mockReturnValue(makeTag({ name: 'critical' }));
 			const err = uniqueViolationError('23505');
 			tagRepository.save.mockRejectedValueOnce(err);
@@ -196,7 +194,9 @@ describe('TagService', () => {
 		});
 
 		test('creates missing tags and merges with existing', async () => {
-			tagRepository.find.mockResolvedValue([makeTag({ id: 'tag-1', name: 'production' })]);
+			tagRepository.findManyByName.mockResolvedValue([
+				makeTag({ id: 'tag-1', name: 'production' }),
+			]);
 			const createdTag = makeTag({ id: 'tag-new', name: 'critical' });
 			tagRepository.create.mockReturnValue(createdTag);
 			tagRepository.save.mockResolvedValue(createdTag);

--- a/packages/cli/src/services/__tests__/tag.service.test.ts
+++ b/packages/cli/src/services/__tests__/tag.service.test.ts
@@ -71,28 +71,6 @@ describe('TagService', () => {
 		});
 	});
 
-	describe('findByNames', () => {
-		test('returns existing tags by name, preserving input order', async () => {
-			const tags = [
-				makeTag({ id: 'tag-1', name: 'production' }),
-				makeTag({ id: 'tag-2', name: 'critical' }),
-			];
-			tagRepository.find.mockResolvedValue(tags);
-
-			const result = await tagService.findByNames(['critical', 'production', 'missing']);
-
-			expect(result.map((t) => t.name)).toEqual(['critical', 'production']);
-			expect(tagRepository.save).not.toHaveBeenCalled();
-		});
-
-		test('returns empty for whitespace-only inputs without querying', async () => {
-			const result = await tagService.findByNames(['', '   ']);
-
-			expect(result).toEqual([]);
-			expect(tagRepository.find).not.toHaveBeenCalled();
-		});
-	});
-
 	describe('findOrCreateByNames', () => {
 		test('returns empty array for empty input', async () => {
 			const result = await tagService.findOrCreateByNames([]);
@@ -121,24 +99,33 @@ describe('TagService', () => {
 			expect(tagRepository.save).not.toHaveBeenCalled();
 		});
 
-		test('deduplicates the input case-insensitively before lookup', async () => {
+		test('trims names and collapses exact duplicates before lookup', async () => {
 			tagRepository.find.mockResolvedValue([]);
-			const createdTag = makeTag({ id: 'tag-new', name: 'Prod' });
+			const createdTag = makeTag({ id: 'tag-new', name: 'prod' });
 			tagRepository.create.mockReturnValue(createdTag);
 			tagRepository.save.mockResolvedValue(createdTag);
 
-			const result = await tagService.findOrCreateByNames(['Prod', 'prod', 'PROD']);
+			const result = await tagService.findOrCreateByNames(['  prod ', 'prod']);
 
 			expect(tagRepository.find).toHaveBeenCalledTimes(1);
 			const findArg = tagRepository.find.mock.calls[0][0] as unknown as {
 				where: { name: FindOperator<string[]> };
 			};
 			expect(findArg.where.name).toBeInstanceOf(FindOperator);
-			expect(findArg.where.name.value).toEqual(['Prod']);
-			// One create using the first-seen original case.
+			expect(findArg.where.name.value).toEqual(['prod']);
 			expect(tagRepository.save).toHaveBeenCalledTimes(1);
-			expect(tagRepository.create).toHaveBeenCalledWith({ name: 'Prod' });
-			expect(result.map((t) => t.name)).toEqual(['Prod']);
+			expect(result.map((t) => t.name)).toEqual(['prod']);
+		});
+
+		test('creates case-variant names as distinct tags', async () => {
+			tagRepository.find.mockResolvedValue([]);
+			tagRepository.create.mockImplementation((attrs) => makeTag(attrs as Partial<TagEntity>));
+			tagRepository.save.mockImplementation(async (tag) => tag as TagEntity);
+
+			const result = await tagService.findOrCreateByNames(['Prod', 'prod']);
+
+			expect(tagRepository.save).toHaveBeenCalledTimes(2);
+			expect(result.map((t) => t.name)).toEqual(['Prod', 'prod']);
 		});
 
 		test('matches the DB case-sensitively (parity with REST tags API)', async () => {

--- a/packages/cli/src/services/tag.service.ts
+++ b/packages/cli/src/services/tag.service.ts
@@ -10,24 +10,6 @@ type GetAllResult<T> = T extends { withUsageCount: true } ? ITagWithCountDb[] : 
 
 type Action = 'Create' | 'Update';
 
-// Trim and dedupe input names case-insensitively, keeping the first-seen case.
-// Inputs are matched against the DB exactly, so this only collapses obvious
-// duplicates like ['Prod','prod','PROD'] within a single batch — it does NOT
-// change the case-sensitive contract that the REST tag API exposes.
-function dedupeNamesPreservingCase(names: string[]): string[] {
-	const seen = new Set<string>();
-	const result: string[] = [];
-	for (const raw of names) {
-		const trimmed = raw.trim();
-		if (trimmed.length === 0) continue;
-		const key = trimmed.toLowerCase();
-		if (seen.has(key)) continue;
-		seen.add(key);
-		result.push(trimmed);
-	}
-	return result;
-}
-
 // n8n supports postgres (SQLSTATE 23505) and sqlite (SQLITE_CONSTRAINT_UNIQUE,
 // or the older SQLITE_CONSTRAINT with a "UNIQUE constraint" message).
 function isUniqueConstraintViolation(error: unknown): error is QueryFailedError {
@@ -125,11 +107,6 @@ export class TagService {
 		return await this.tagRepository.findMany(ids);
 	}
 
-	/**
-	 * Exact (case-sensitive) name lookup. Unlike `findByNames`, the input list
-	 * is passed through verbatim: case-variant names are distinct tags and must
-	 * all be looked up.
-	 */
 	async getByNames(names: string[]): Promise<TagEntity[]> {
 		if (names.length === 0) return [];
 		return await this.tagRepository.findManyByName(names);
@@ -163,31 +140,15 @@ export class TagService {
 	}
 
 	/**
-	 * Look up tags by name; never creates. Input is deduped case-insensitively
-	 * but matched against the DB exactly (REST tag API contract).
-	 */
-	async findByNames(names: string[]): Promise<TagEntity[]> {
-		const uniqueNames = dedupeNamesPreservingCase(names);
-		if (uniqueNames.length === 0) return [];
-
-		const existing = await this.tagRepository.find({ where: { name: In(uniqueNames) } });
-		const existingByName = new Map(existing.map((t) => [t.name, t]));
-
-		const result: TagEntity[] = [];
-		for (const name of uniqueNames) {
-			const hit = existingByName.get(name);
-			if (hit) result.push(hit);
-		}
-		return result;
-	}
-
-	/**
-	 * Resolve names to tag entities, creating any missing. Input is deduped
-	 * case-insensitively (first-seen case wins) but matched against the DB
-	 * exactly. Race-safe against concurrent same-name creates.
+	 * Resolve names to tag entities, creating any missing. Names are trimmed
+	 * and exact duplicates collapsed, matching how tags are stored; case-variant
+	 * names resolve as distinct tags. Race-safe against concurrent same-name
+	 * creates.
 	 */
 	async findOrCreateByNames(names: string[]): Promise<TagEntity[]> {
-		const uniqueNames = dedupeNamesPreservingCase(names);
+		const uniqueNames = [
+			...new Set(names.map((name) => name.trim()).filter((name) => name.length > 0)),
+		];
 		if (uniqueNames.length === 0) return [];
 
 		const existing = await this.tagRepository.find({ where: { name: In(uniqueNames) } });

--- a/packages/cli/src/services/tag.service.ts
+++ b/packages/cli/src/services/tag.service.ts
@@ -1,7 +1,7 @@
 import type { TagEntity, ITagWithCountDb } from '@n8n/db';
 import { TagRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { In, QueryFailedError } from '@n8n/typeorm';
+import { QueryFailedError } from '@n8n/typeorm';
 
 import { ExternalHooks } from '@/external-hooks';
 import { validateEntity } from '@/generic-helpers';
@@ -151,7 +151,7 @@ export class TagService {
 		];
 		if (uniqueNames.length === 0) return [];
 
-		const existing = await this.tagRepository.find({ where: { name: In(uniqueNames) } });
+		const existing = await this.tagRepository.findManyByName(uniqueNames);
 		const existingByName = new Map(existing.map((t) => [t.name, t]));
 
 		const result: TagEntity[] = [];


### PR DESCRIPTION
## Summary

`TagService` had two name lookups differing only in input handling: `getByNames` (exact) and `findByNames` (collapses case-variant input) which is a hidden side effect and prone to errors.

Fix: delete `findByNames`. Case-variant collapsing is an MCP-only semantic (LLMs repeat tag names in different casings), so it now lives solely in the MCP workflow-builder tool, which dedupes its batch and calls `getByNames`. `findOrCreateByNames` keeps only what matches its own write path: trims names and collapses exact duplicates, while case-variants resolve as distinct tags — same contract as the REST tags API.

## How to test

Unit tests: `tag.service.test.ts`, `update-workflow.tool.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35133

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)