### PR TITLE
fix: allow dots in organization name for n8n node packages

### DIFF
--- a/packages/@n8n/node-cli/src/utils/validation.ts
+++ b/packages/@n8n/node-cli/src/utils/validation.ts
@@ -2,7 +2,7 @@ export const validateNodeName = (name: string): string | undefined => {
 	if (!name) return;
 
 	// 1. Matches '@org/n8n-nodes-anything'
-	const regexScoped = /^@([a-z0-9]+(?:-[a-z0-9]+)*)\/n8n-nodes-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
+	const regexScoped = /^@([a-z0-9.]+(?:-[a-z0-9]+)*)\/n8n-nodes-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
 	// 2. Matches 'n8n-nodes-anything'
 	const regexUnscoped = /^n8n-nodes-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
 


### PR DESCRIPTION
## Summary

Allow dots in the organization name part of scoped n8n node package names (e.g., `@net.christianto/n8n-nodes-myapp`).

The regex for scoped packages previously only allowed lowercase alphanumeric characters and hyphens, rejecting valid npm org names that contain dots.

## Changes

- Modified `packages/@n8n/node-cli/src/utils/validation.ts`
- Changed regex from `[a-z0-9]+` to `[a-z0-9.]+` for the org name part in scoped packages

## Testing

Manually verified that `@net.christianto/n8n-nodes-test` now passes validation while keeping existing valid patterns working.

Fixes #34949

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35221">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

