### PR TITLE
ci: Keep Instance AI runtime assets when stripping the Docker image (no-changelog)

### DIFF
--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -222,8 +222,26 @@ echo(chalk.green('✅ Phantom dirs stripped'));
 // which dominates layer extraction time on constrained hosts. .js.map is kept —
 // source-map-support needs it for production stack traces.
 echo(chalk.yellow('INFO: Stripping non-runtime files (.ts/.d.ts/.md) from production closure...'));
-await $`find ${config.compiledAppDir} \\( -name '*.ts' -o -name '*.d.ts.map' -o -name '*.md' -o -name '*.test.js' -o -name '*.spec.js' \\) -type f -delete 2>/dev/null || true`;
+// `@n8n/instance-ai` reads these markdown trees off disk on every agent request,
+// so they are runtime data despite the extension. Excluded via `-not -path` and
+// not `-prune`: `-delete` implies `-depth`, which makes `-prune` a no-op.
+const runtimeAssetGlobs = ['*/@n8n/instance-ai/skills/*', '*/@n8n/instance-ai/knowledge-base/*'];
+const keepRuntimeAssets = runtimeAssetGlobs.flatMap((glob) => ['-not', '-path', glob]);
+await $`find ${config.compiledAppDir} -type f \\( -name '*.ts' -o -name '*.d.ts.map' -o -name '*.md' -o -name '*.test.js' -o -name '*.spec.js' \\) ${keepRuntimeAssets} -delete 2>/dev/null || true`;
 echo(chalk.green('✅ Non-runtime files stripped'));
+
+// Stripping the trees above leaves a bootable image whose agent has no skills and
+// no knowledge base, so the damage only surfaces on the first request. Fail here.
+for (const glob of runtimeAssetGlobs) {
+	const kept = Number(
+		(await $`find ${config.compiledAppDir} -type f -path ${glob} | wc -l`).stdout.trim(),
+	);
+	if (kept === 0) {
+		echo(chalk.red(`ERROR: no files left under ${glob} — runtime assets were stripped`));
+		process.exit(1);
+	}
+}
+echo(chalk.green('✅ Runtime assets intact'));
 
 await fs.ensureDir(config.compiledTaskRunnerDir);
 

--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -232,11 +232,11 @@ echo(chalk.green('✅ Non-runtime files stripped'));
 
 // Stripping the trees above leaves a bootable image whose agent has no skills and
 // no knowledge base, so the damage only surfaces on the first request. Fail here.
+// `.nothrow()` because zx runs with `pipefail`: one unreadable path would
+// otherwise turn a healthy build into an unhandled rejection.
 for (const glob of runtimeAssetGlobs) {
-	const kept = Number(
-		(await $`find ${config.compiledAppDir} -type f -path ${glob} | wc -l`).stdout.trim(),
-	);
-	if (kept === 0) {
+	const found = await $`find ${config.compiledAppDir} -type f -path ${glob}`.nothrow();
+	if (found.stdout.split('\n').filter(Boolean).length === 0) {
 		echo(chalk.red(`ERROR: no files left under ${glob} — runtime assets were stripped`));
 		process.exit(1);
 	}


### PR DESCRIPTION
## Summary

Follow-up to #35170. That PR strips `*.md` (among others) from the deployed closure to cut the image's file count. `@n8n/instance-ai` ships two markdown trees that are **runtime data, not docs** — it reads them off disk on every agent request:

- `skills/**` — all 15 files are `SKILL.md`
- `knowledge-base/reference/*.md`

With them gone, the image still boots, so nothing failed until the first Instance AI request:

- `loadRuntimeSkillSourceFromDirectory` returns an empty registry → `Agent.skills()` early-returns at `agent.ts:307` → **`load_skill` is never registered** → the model calls it anyway (the system prompt instructs it to) → `AI_NoSuchToolError: Model tried to call unavailable tool 'load_skill'`
- `materialize-knowledge-base.ts:169` → `ENOENT … knowledge-base/reference/trigger-input-data-shapes.md` → sandbox workspace setup dies

Every Instance AI eval run since #35170 merged is red on this, on unrelated PRs (#35198, #35206). `docker-build-push.yml` uses the same `pnpm build:n8n`, so tonight's nightly image would ship it too.

This excludes the two trees from the strip and adds a post-strip guard that fails the build if either ends up empty.

It keeps the win of #35170 intact: 18 files preserved out of the ~70k it removes (0.03%), and `find compiled -name '*.d.ts' | wc -l` still returns 0 — neither directory contains anything but `.md`.

Two details worth flagging for review:

- Excluded with `-not -path` rather than `-prune`, because `-delete` implies `-depth`, which silently makes `-prune` a no-op.
- The guard is a zero-check on these two globs. It catches this regression class, but it won't catch a *future* package that starts shipping runtime markdown. Longer term the strip probably wants an allowlist derived from each package's `files` field.

Worth noting for CI hygiene: the Instance AI eval gate is path-filtered to `packages/@n8n/instance-ai/**` and two other paths, so a change to `scripts/build-n8n.mjs` doesn't trigger it. `Docker Build (no cache)` passed on #35170 because it only checks that the image builds, and the nightly smoke only checks that it boots and answers `--version`. Missing runtime data files pass both.

## How to test

```bash
pnpm build:docker
# both must be non-zero (0 before this change)
find compiled -path '*/@n8n/instance-ai/skills/*' -name 'SKILL.md' | wc -l
find compiled -path '*/@n8n/instance-ai/knowledge-base/*' -name '*.md' | wc -l
# still 0 — the #35170 acceptance check is unaffected
find compiled -name '*.d.ts' | wc -l
```

Then boot the image and send one Instance AI request: the agent should call `load_skill` successfully and sandbox setup should complete.

I verified the exact zx-generated `find` invocations against a mock closure: the excluded trees survive while a stray `README.md`, `index.d.ts` and `a.test.js` are removed, and the guard exits 1 when the exclusions are dropped.

## Related Linear tickets, Github issues, and Community forum posts

- Follow-up to #35170 (https://linear.app/n8n/issue/DEVP-674)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- No test harness exists for scripts/*.mjs; the in-script guard is the regression check. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35223">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

