### PR TITLE
refactor(core): Break folder and workflow service dependency cycle

### DIFF
--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -44,7 +44,8 @@ describe('ProjectService', () => {
 		projectRelationRepository,
 		roleService,
 		sharedCredentialsRepository,
-		mock(),
+		mock(), // folderRepository
+		mock(), // licenseState
 		moduleRegistry,
 		ownershipService,
 		logger,

--- a/packages/cli/src/services/folder.service.ts
+++ b/packages/cli/src/services/folder.service.ts
@@ -12,7 +12,6 @@ import { UserError, PROJECT_ROOT } from 'n8n-workflow';
 import { FolderNotFoundError } from '@/errors/folder-not-found.error';
 import { EventService } from '@/events/event.service';
 import type { ListQuery } from '@/requests';
-// eslint-disable-next-line import-x/no-cycle
 import { WorkflowService } from '@/workflows/workflow.service';
 
 export interface SimpleFolderNode {

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -3,6 +3,7 @@ import { LicenseState, Logger, ModuleRegistry } from '@n8n/backend-common';
 import { UNLIMITED_LICENSE_QUOTA } from '@n8n/constants';
 import {
 	type User,
+	FolderRepository,
 	Project,
 	ProjectRelation,
 	ProjectRelationRepository,
@@ -76,6 +77,7 @@ export class ProjectService {
 		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly roleService: RoleService,
 		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
+		private readonly folderRepository: FolderRepository,
 		private readonly licenseState: LicenseState,
 		private readonly moduleRegistry: ModuleRegistry,
 		private readonly ownershipService: OwnershipService,
@@ -91,12 +93,6 @@ export class ProjectService {
 	private get credentialsService() {
 		return import('@/credentials/credentials.service.js').then(({ CredentialsService }) =>
 			Container.get(CredentialsService),
-		);
-	}
-
-	private get folderService() {
-		return import('@/services/folder.service.js').then(({ FolderService }) =>
-			Container.get(FolderService),
 		);
 	}
 
@@ -210,8 +206,7 @@ export class ProjectService {
 
 		// 3. Move folders over to the target project, before deleting the project else cascading will delete workflows
 		if (targetProject) {
-			const folderService = await this.folderService;
-			await folderService.transferAllFoldersToProject(project.id, targetProject.id);
+			await this.folderRepository.transferAllFoldersToProject(project.id, targetProject.id);
 		}
 
 		// 4. delete shared credentials into this project

--- a/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.ee.test.ts
@@ -31,7 +31,6 @@ describe('EnterpriseWorkflowService', () => {
 			mock(), // credentialsFinderService
 			mock(), // enterpriseCredentialsService
 			mock(), // workflowFinderService
-			mock(), // folderService
 			mock(), // folderRepository
 			workflowPublishHistoryRepository,
 		);

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -35,10 +35,10 @@ import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { EnterpriseCredentialsService } from '@/credentials/credentials.service.ee';
+import { FolderNotFoundError } from '@/errors/folder-not-found.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { TransferWorkflowError } from '@/errors/response-errors/transfer-workflow.error';
-import { FolderService } from '@/services/folder.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { ProjectService } from '@/services/project.service.ee';
 
@@ -58,7 +58,6 @@ export class EnterpriseWorkflowService {
 		private readonly credentialsFinderService: CredentialsFinderService,
 		private readonly enterpriseCredentialsService: EnterpriseCredentialsService,
 		private readonly workflowFinderService: WorkflowFinderService,
-		private readonly folderService: FolderService,
 		private readonly folderRepository: FolderRepository,
 		private readonly workflowPublishHistoryRepository: WorkflowPublishHistoryRepository,
 	) {}
@@ -440,7 +439,7 @@ export class EnterpriseWorkflowService {
 
 		if (destinationParentFolderId) {
 			try {
-				parentFolder = await this.folderService.findFolderInProjectOrFail(
+				parentFolder = await this.folderRepository.findOneOrFailFolderInProject(
 					destinationParentFolderId,
 					destinationProjectId,
 				);
@@ -476,7 +475,11 @@ export class EnterpriseWorkflowService {
 	}
 
 	async getFolderUsedCredentials(user: User, folderId: string, projectId: string) {
-		await this.folderService.findFolderInProjectOrFail(folderId, projectId);
+		try {
+			await this.folderRepository.findOneOrFailFolderInProject(folderId, projectId);
+		} catch {
+			throw new FolderNotFoundError(folderId);
+		}
 
 		const workflows = await this.workflowFinderService.findAllWorkflowsForUser(
 			user,

--- a/packages/cli/test/integration/workflows/workflow.service.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.ee.test.ts
@@ -26,20 +26,19 @@ describe('EnterpriseWorkflowService', () => {
 		mockInstance(Telemetry);
 
 		service = new EnterpriseWorkflowService(
-			mock(),
+			mock(), // logger
 			Container.get(SharedWorkflowRepository),
 			Container.get(WorkflowRepository),
 			Container.get(CredentialsRepository),
-			mock(),
-			mock(),
-			mock(),
-			mock(),
-			mock(),
-			mock(),
-			mock(),
-			mock(),
-			mock(),
-			mock(),
+			mock(), // credentialsService
+			mock(), // ownershipService
+			mock(), // projectService
+			mock(), // activeWorkflowManager
+			mock(), // credentialsFinderService
+			mock(), // enterpriseCredentialsService
+			mock(), // workflowFinderService
+			mock(), // folderRepository
+			mock(), // workflowPublishHistoryRepository
 		);
 	});
 


### PR DESCRIPTION
## Summary

`FolderService` and the workflow/project services formed an import cycle that was hidden behind an inline `eslint-disable import-x/no-cycle` and lazy `Container.get(await import(...))` calls. This removes the cycle for real via dependency inversion at the data layer.

Both edges pointing *back* into `FolderService` were pure repository passthroughs, so they now resolve through `FolderRepository` directly instead of going back up through `FolderService`:

- **`EnterpriseWorkflowService`** used `FolderService` only for `findFolderInProjectOrFail` (2 call sites) → now `folderRepository.findOneOrFailFolderInProject` (the repo was already injected, and this is the same pattern `WorkflowService` already uses).
- **`ProjectService`** used `FolderService` only for `transferAllFoldersToProject` (1 call site) → now `folderRepository.transferAllFoldersToProject`; the lazy `folderService` getter is gone and `FolderRepository` is injected.

With both back-edges cut, `FolderService` no longer participates in a cycle, so the inline `eslint-disable` on its `WorkflowService` import is removed too.

The direction that stays is the correct one: a folder owns its workflows, so the folder-delete cascade (archiving a folder's workflows via `WorkflowService.archive`) remains in `FolderService`. `archive()` is real workflow-domain logic (permissions, unpublish, publish history, versioning, hooks), so it should not be reimplemented elsewhere. Only the reverse edges were removed.

### Scope note

This clears the folder/workflow cycle. A separate `project ↔ workflow ↔ credentials` hub cycle (the remaining lazy getters in `ProjectService`) is a different cluster and is out of scope here.

## Verification

- ESLint cycle check: `folder.service` reports **0** cycles (clean leaf)
- `pnpm typecheck`: clean
- Unit: `project.service.ee` (28) + `workflow.service.ee` (9)
- Integration: project deletion + folder transfer (25) + `workflow.service.ee` (18) + `folder.controller` delete cascade (107)

All green, no behavior change.


## Lint impact

Clears the **folder ↔ workflow** cycle in `packages/cli`:

- Removes **1** `import-x/no-cycle` warning (`workflows/workflow.service.ts`, the `@/services/folder.service` edge).
- Removes the inline `// eslint-disable-next-line import-x/no-cycle` suppression on `services/folder.service.ts`.

`folder.service` is now a genuinely clean leaf (0 cycles, no suppression).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35225">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


