### PR TITLE
refactor(core): Break credentials-overwrites and frontend service cycle

### DIFF
--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -630,16 +630,15 @@ describe('CredentialsOverwrites', () => {
 				settingsRepository.findByKey.mockResolvedValue(settingData);
 				cipher.decryptV2.mockResolvedValue(JSON.stringify(overwriteData));
 
-				// Mock the reloadFrontendService to avoid circular dependency issues
-				const mockReloadFrontendService = vi.fn();
-				(pubsubCredentialsOverwrites as any).reloadFrontendService = mockReloadFrontendService;
+				const mockReloadHandler = vi.fn();
+				pubsubCredentialsOverwrites.registerReloadHandler(mockReloadHandler);
 
 				await pubsubCredentialsOverwrites.reloadOverwriteCredentials();
 
 				expect(settingsRepository.findByKey).toHaveBeenCalledWith('credentialsOverwrite');
 				expect(cipher.decryptV2).toHaveBeenCalledWith('encrypted-data');
 				expect(pubsubCredentialsOverwrites.getAll()).toEqual(overwriteData);
-				expect(mockReloadFrontendService).toHaveBeenCalled();
+				expect(mockReloadHandler).toHaveBeenCalled();
 			});
 
 			it('should handle database loading errors gracefully', async () => {
@@ -698,9 +697,7 @@ describe('CredentialsOverwrites', () => {
 				});
 				cipher.decryptV2.mockResolvedValue(JSON.stringify(overwriteData));
 
-				// Mock the reloadFrontendService
-				const mockReloadFrontendService = vi.fn();
-				(pubsubCredentialsOverwrites as any).reloadFrontendService = mockReloadFrontendService;
+				pubsubCredentialsOverwrites.registerReloadHandler(vi.fn());
 
 				// Start first reload
 				const firstReload = pubsubCredentialsOverwrites.reloadOverwriteCredentials();
@@ -757,9 +754,7 @@ describe('CredentialsOverwrites', () => {
 				settingsRepository.findByKey.mockResolvedValue(settingData);
 				cipher.decryptV2.mockResolvedValue(JSON.stringify(overwriteData));
 
-				// Mock the reloadFrontendService
-				const mockReloadFrontendService = vi.fn();
-				(pubsubCredentialsOverwrites as any).reloadFrontendService = mockReloadFrontendService;
+				pubsubCredentialsOverwrites.registerReloadHandler(vi.fn());
 
 				await expect(
 					pubsubCredentialsOverwrites.reloadOverwriteCredentials(),
@@ -875,33 +870,29 @@ describe('CredentialsOverwrites', () => {
 			vi.restoreAllMocks();
 		});
 
-		describe('reloadFrontendService via setData', () => {
+		describe('reload handler via setData', () => {
+			let reloadHandler: Mock;
+
 			beforeEach(() => {
-				// Mock the reloadFrontendService method directly to test through setData
-				vi.spyOn(frontendCredentialsOverwrites as any, 'reloadFrontendService').mockResolvedValue(
-					undefined,
-				);
+				reloadHandler = vi.fn().mockResolvedValue(undefined);
+				frontendCredentialsOverwrites.registerReloadHandler(reloadHandler);
 			});
 
-			it('should call reloadFrontendService when reloadFrontend is true', async () => {
+			it('should call the reload handler when reloadFrontend is true', async () => {
 				const testData = { test: { username: 'frontendUser' } };
-				const reloadSpy = frontendCredentialsOverwrites['reloadFrontendService'] as Mock;
 
 				await frontendCredentialsOverwrites.setData(testData, false, true);
 
-				// Verify reloadFrontendService was called
-				expect(reloadSpy).toHaveBeenCalledTimes(1);
+				expect(reloadHandler).toHaveBeenCalledTimes(1);
 				expect(frontendCredentialsOverwrites.getAll()).toEqual(testData);
 			});
 
-			it('should skip reloadFrontendService when reloadFrontend is false', async () => {
+			it('should skip the reload handler when reloadFrontend is false', async () => {
 				const testData = { test: { username: 'noReloadUser' } };
-				const reloadSpy = frontendCredentialsOverwrites['reloadFrontendService'] as Mock;
 
 				await frontendCredentialsOverwrites.setData(testData, false, false);
 
-				// Verify reloadFrontendService was NOT called
-				expect(reloadSpy).not.toHaveBeenCalled();
+				expect(reloadHandler).not.toHaveBeenCalled();
 				expect(frontendCredentialsOverwrites.getAll()).toEqual(testData);
 			});
 

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -28,6 +28,17 @@ export class CredentialsOverwrites {
 		private readonly cipher: Cipher,
 	) {}
 
+	/**
+	 * Reload hook registered by FrontendService to regenerate credential types
+	 * after overwrites change. Kept as a callback so this module doesn't depend
+	 * on FrontendService. No-op until (and unless) a frontend is present.
+	 */
+	private reloadHandler?: () => Promise<void>;
+
+	registerReloadHandler(handler: () => Promise<void>) {
+		this.reloadHandler = handler;
+	}
+
 	async init() {
 		const data = this.globalConfig.credentials.overwrite.data;
 		if (data) {
@@ -126,15 +137,8 @@ export class CredentialsOverwrites {
 		}
 
 		if (reloadFrontend) {
-			await this.reloadFrontendService();
+			await this.reloadHandler?.();
 		}
-	}
-
-	private async reloadFrontendService() {
-		// FrontendService has CredentialOverwrites injected via the constructor
-		// to break the circular dependency we need to use the container to get the instance
-		const { FrontendService } = await import('./services/frontend.service.js');
-		await Container.get(FrontendService)?.generateTypes();
 	}
 
 	applyOverwrite(type: string, data: ICredentialDataDecryptedObject) {

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -28,11 +28,7 @@ export class CredentialsOverwrites {
 		private readonly cipher: Cipher,
 	) {}
 
-	/**
-	 * Reload hook registered by FrontendService to regenerate credential types
-	 * after overwrites change. Kept as a callback so this module doesn't depend
-	 * on FrontendService. No-op until (and unless) a frontend is present.
-	 */
+	/** Registered by FrontendService to regenerate credential types after overwrites change, without this module depending on it. */
 	private reloadHandler?: () => Promise<void>;
 
 	registerReloadHandler(handler: () => Promise<void>) {

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -236,6 +236,25 @@ describe('FrontendService', () => {
 		process.env = originalEnv;
 	});
 
+	describe('credentials overwrite reload handler', () => {
+		it('registers a reload handler that regenerates types', async () => {
+			const { service } = createMockService();
+
+			expect(credentialsOverwrites.registerReloadHandler).toHaveBeenCalledWith(
+				expect.any(Function),
+			);
+
+			// The registered handler is what CredentialsOverwrites invokes after a
+			// reload; it must regenerate the credential types.
+			const handler = vi.mocked(credentialsOverwrites.registerReloadHandler).mock.calls[0][0];
+			const generateTypesSpy = vi.spyOn(service, 'generateTypes').mockResolvedValue();
+
+			await handler();
+
+			expect(generateTypesSpy).toHaveBeenCalled();
+		});
+	});
+
 	describe('getSettings', () => {
 		it('should return frontend settings', async () => {
 			const { service } = createMockService();

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -143,6 +143,7 @@ export class FrontendService {
 		private readonly workflowReviewPolicyService: WorkflowReviewPolicyService,
 	) {
 		loadNodesAndCredentials.addPostProcessor(async () => await this.generateTypes());
+		credentialsOverwrites.registerReloadHandler(async () => await this.generateTypes());
 		void this.generateTypes();
 		// @TODO: Move to community-packages module
 		if (Container.get(CommunityPackagesConfig).enabled) {


### PR DESCRIPTION
## Summary

`CredentialsOverwrites` and `FrontendService` referenced each other: `FrontendService` injects `CredentialsOverwrites` through its constructor, while `CredentialsOverwrites` lazily imported `FrontendService` (`await import('./services/frontend.service.js')`) to call `generateTypes()` after overwrites changed. That mutual reference was a dependency cycle papered over with a lazy `Container.get(await import(...))`.

This inverts the back-edge with a registered callback:

- `CredentialsOverwrites` exposes `registerReloadHandler(handler)` and calls the handler (awaited) after a reload, instead of importing `FrontendService`.
- `FrontendService` registers `generateTypes` into it at construction, right next to the existing `loadNodesAndCredentials.addPostProcessor(...)` registration.

The reload stays **awaited**, so ordering is unchanged. When no frontend is present the handler is simply unregistered and the call is a no-op, which matches the previous `Container.get(FrontendService)?.generateTypes()` optional-chaining behaviour.

This is behaviour, not data, so it is broken by inversion (a registered callback) rather than by reaching into a repository.

## Verification

- ESLint cycle check: `frontend.service` and `credentials-overwrites` report **0** cycles
- `pnpm typecheck`: clean
- Unit: `credentials-overwrites.test.ts` (48)
- Integration: `credentials-overwrites.integration.test.ts` (13)

No behaviour change.


## Lint impact

Removes **2** `import-x/no-cycle` warnings in `packages/cli`, one at each end of the cycle: `credentials-overwrites.ts` and `services/frontend.service.ts`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35226">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


