### PR TITLE
refactor(core): Break scaling and mcp service dependency cycle

### DIFF
--- a/packages/cli/src/events/event.service.ts
+++ b/packages/cli/src/events/event.service.ts
@@ -4,6 +4,7 @@ import { Service } from '@n8n/di';
 import type { AiEventMap } from './maps/ai.event-map';
 import type { ExecutionDataEventMap } from './maps/execution-data.event-map';
 import type { InstanceAiEventMap } from './maps/instance-ai.event-map';
+import type { McpEventMap } from './maps/mcp.event-map';
 import type { QueueMetricsEventMap } from './maps/queue-metrics.event-map';
 import type { RelayEventMap } from './maps/relay.event-map';
 import type { WorkflowPublicationMetricsEventMap } from './maps/workflow-publication-metrics.event-map';
@@ -13,6 +14,7 @@ type EventMap = RelayEventMap &
 	AiEventMap &
 	ExecutionDataEventMap &
 	InstanceAiEventMap &
+	McpEventMap &
 	WorkflowPublicationMetricsEventMap;
 
 @Service()

--- a/packages/cli/src/events/maps/mcp.event-map.ts
+++ b/packages/cli/src/events/maps/mcp.event-map.ts
@@ -1,0 +1,8 @@
+import type { IRun } from 'n8n-workflow';
+
+export type McpEventMap = {
+	'mcp-worker-response': {
+		executionId: string;
+		runData: IRun;
+	};
+};

--- a/packages/cli/src/modules/mcp/__tests__/mcp-scopes.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-scopes.test.ts
@@ -24,6 +24,7 @@ import { registerMcpAppTool, registerWorkflowPreviewApp } from '@n8n/mcp-apps/se
 import { ActiveExecutions } from '@/active-executions';
 import { CollaborationService } from '@/collaboration/collaboration.service';
 import { CredentialsService } from '@/credentials/credentials.service';
+import { EventService } from '@/events/event.service';
 import { ExecutionService } from '@/executions/execution.service';
 import { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks/subworkflow-policy-checker';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
@@ -128,6 +129,7 @@ describe('McpService scope enforcement', () => {
 				isAvailable: vi.fn().mockResolvedValue({ available: false }),
 			}),
 			mockInstance(ModuleRegistry),
+			mockInstance(EventService),
 		);
 
 	beforeEach(() => {

--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -38,6 +38,7 @@ import { MCP_PREVIEW_RENDER_REQUESTED_EVENT } from '../mcp.constants';
 import { ActiveExecutions } from '@/active-executions';
 import { CollaborationService } from '@/collaboration/collaboration.service';
 import { CredentialsService } from '@/credentials/credentials.service';
+import { EventService } from '@/events/event.service';
 import { ExecutionService } from '@/executions/execution.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { NodeCatalogService } from '@/node-catalog';
@@ -77,8 +78,11 @@ describe('McpService', () => {
 	let executionsConfig: ExecutionsConfig;
 	let instanceSettings: InstanceSettings;
 	let logger: Logger;
+	// Real instance so the constructor's event subscription is exercised.
+	let eventService: EventService;
 
 	beforeEach(() => {
+		eventService = new EventService();
 		activeExecutions = mockInstance(ActiveExecutions);
 		executionsConfig = mockInstance(ExecutionsConfig, {
 			mode: 'regular',
@@ -125,6 +129,7 @@ describe('McpService', () => {
 			mockInstance(SubworkflowPolicyChecker),
 			mockAiGatewayService(),
 			mockInstance(ModuleRegistry),
+			eventService,
 		);
 	});
 
@@ -175,6 +180,7 @@ describe('McpService', () => {
 				mockInstance(SubworkflowPolicyChecker),
 				mockAiGatewayService(),
 				mockInstance(ModuleRegistry),
+				mockInstance(EventService),
 			);
 
 			expect(queueMcpService.isQueueMode).toBe(true);
@@ -242,6 +248,27 @@ describe('McpService', () => {
 				expect(logger.warn).toHaveBeenCalledWith('Received MCP response for unknown execution', {
 					executionId: 'unknown-exec',
 				});
+			});
+
+			it('should resolve a pending response when a mcp-worker-response event is emitted', async () => {
+				// In queue mode ScalingService forwards worker responses as this event
+				// instead of calling McpService directly.
+				const executionId = 'exec-evt';
+				const deferred = mcpService.createPendingResponse(executionId);
+
+				const runData: IRun = {
+					status: 'success',
+					mode: 'trigger',
+					startedAt: new Date(),
+					finished: true,
+					storedAt: 'db',
+					data: createEmptyRunExecutionData(),
+				};
+
+				eventService.emit('mcp-worker-response', { executionId, runData });
+
+				await expect(deferred.promise).resolves.toBe(runData);
+				expect(mcpService.pendingExecutionCount).toBe(0);
 			});
 		});
 
@@ -380,6 +407,7 @@ describe('McpService', () => {
 				mockInstance(SubworkflowPolicyChecker),
 				mockAiGatewayService(),
 				mockInstance(ModuleRegistry),
+				mockInstance(EventService),
 			);
 
 		const user = Object.assign(new User(), { id: 'user-1' });
@@ -575,6 +603,7 @@ describe('McpService', () => {
 				mockInstance(SubworkflowPolicyChecker),
 				mockAiGatewayService(),
 				mockInstance(ModuleRegistry),
+				mockInstance(EventService),
 			);
 
 			const server = await service.getServer(user, mcpFeatureFlags());
@@ -627,6 +656,7 @@ describe('McpService', () => {
 				mockInstance(SubworkflowPolicyChecker),
 				mockAiGatewayService(),
 				mockInstance(ModuleRegistry),
+				mockInstance(EventService),
 			);
 
 			const server = await service.getServer(user, mcpFeatureFlags());
@@ -704,6 +734,7 @@ describe('McpService', () => {
 					mockInstance(SubworkflowPolicyChecker),
 					mockAiGatewayService(),
 					mockInstance(ModuleRegistry),
+					mockInstance(EventService),
 				);
 			};
 

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -30,6 +30,7 @@ import { ActiveExecutions } from '@/active-executions';
 import { CollaborationService } from '@/collaboration/collaboration.service';
 import { N8N_VERSION } from '@/constants';
 import { CredentialsService } from '@/credentials/credentials.service';
+import { EventService } from '@/events/event.service';
 import { ExecutionService } from '@/executions/execution.service';
 import { SubworkflowPolicyChecker } from '@/executions/pre-execution-checks/subworkflow-policy-checker';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
@@ -161,7 +162,13 @@ export class McpService {
 		private readonly subworkflowPolicyChecker: SubworkflowPolicyChecker,
 		private readonly aiGatewayService: AiGatewayService,
 		private readonly moduleRegistry: ModuleRegistry,
-	) {}
+		private readonly eventService: EventService,
+	) {
+		// In queue mode, worker responses arrive via ScalingService as this event.
+		this.eventService.on('mcp-worker-response', ({ executionId, runData }) => {
+			this.handleWorkerResponse(executionId, runData);
+		});
+	}
 
 	/**
 	 * Resolves every PostHog-gated MCP feature for a user with a single flags

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -476,9 +476,9 @@ export class ScalingService {
 					storedAt: executionData.storedAt,
 				};
 
-				const { McpService } = await import('@/modules/mcp/mcp.service.js');
-				const mcpService = Container.get(McpService);
-				mcpService.handleWorkerResponse(executionId, runData);
+				// Decoupled via event so scaling doesn't depend on the mcp module.
+				// The mcp module subscribes and forwards to its pending response.
+				this.eventService.emit('mcp-worker-response', { executionId, runData });
 			} else {
 				const { McpServer } = await import('@n8n/n8n-nodes-langchain/mcp/core');
 				const mcpServer = McpServer.instance(this.logger);


### PR DESCRIPTION
## Summary

In queue mode, `ScalingService`'s job-finished handler lazily imported `McpService` (`await import('@/modules/mcp/mcp.service.js')`) to forward a worker response, while `McpService` statically imports `WorkflowRunner`, which in turn lazily boots `ScalingService`. That closed a `runner → scaling → mcp → runner` import cycle, papered over with lazy `Container.get(await import(...))` calls.

The `scaling → mcp` call is a fire-and-forget notification (the return value was never awaited), so this decouples it with an event:

- A new `mcp-worker-response` event (`{ executionId, runData }`) is added to the `EventService` typed map.
- `ScalingService` emits it instead of importing `McpService`.
- The mcp module subscribes in `McpService`'s constructor and forwards to `handleWorkerResponse`.

`ScalingService` no longer references the mcp module, which breaks the loop. The `mcpType === 'trigger'` branch is unchanged (it uses an external package, not a cli cycle).

The event is delivered **in-memory within the same instance** — it is not a queue/pub-sub message. The worker→main hop still goes through Bull/Redis as before; this event is only the main-internal forward that used to be a direct method call.

### Why a constructor subscription is safe

`McpService` only receives a response for an execution it dispatched, and it registers the pending response at dispatch time, so it is always instantiated (and therefore subscribed) before any response for it can arrive. When no `McpService` has been constructed, there is no pending response to deliver anyway, matching the previous "unknown execution" no-op.

This is behaviour, not data, so it is broken by inversion (an event) rather than by reaching into a repository.

## Verification

- ESLint cycle check: `scaling.service`, `mcp.service`, and `workflow-runner` (excluding the separate agents-module cycle) report **0** cycles
- `pnpm typecheck`: clean
- Unit: `mcp.service.test.ts`, `mcp-scopes.test.ts`, `scaling.service.test.ts` — including a new test that emitting `mcp-worker-response` on a real `EventService` resolves the pending response through `handleWorkerResponse`

## Lint impact

Removes **3** `import-x/no-cycle` warnings in `packages/cli` — the full `runner → scaling → mcp` loop, reported at `scaling/scaling.service.ts`, `modules/mcp/mcp.service.ts` and `workflow-runner.ts`.

The one remaining cycle warning on `workflow-runner.ts` belongs to the separate agents-module cluster and is out of scope here.

