### PR TITLE
fix(Grist Node): Restore the stored base URL of legacy credentials

### DIFF
--- a/packages/nodes-base/credentials/GristApi.credentials.ts
+++ b/packages/nodes-base/credentials/GristApi.credentials.ts
@@ -22,10 +22,30 @@ export class GristApi implements ICredentialType {
 			displayName: 'Grist URL',
 			name: 'url',
 			type: 'string',
-			default: 'https://api.getgrist.com',
-			required: true,
+			// Must default to empty: n8n injects field defaults into any saved credential
+			// missing the field, so a non-empty default would shadow the legacy fields
+			// below. Empty means hosted Grist. Optional on purpose: if required, editing a
+			// legacy credential (e.g. to rotate the API key) would force a URL into it,
+			// overriding the stored host it still relies on.
+			default: '',
+			placeholder: 'https://api.getgrist.com',
 			description:
-				'Defaults to hosted Grist. Use https://YOUR_TEAM.getgrist.com for a single team, or your own URL if self-managed. Do not include /api.',
+				'Leave empty for hosted Grist (https://api.getgrist.com). Use https://YOUR_TEAM.getgrist.com for a single team, or your own URL if self-managed. Do not include /api.',
+		},
+		// Fields from before the single Grist URL field. They must stay declared: execution
+		// strips any stored value whose field is not declared, so removing these would cut
+		// old credentials off from the base URL they store. Hidden keeps them out of the UI.
+		{
+			displayName: 'Custom Subdomain',
+			name: 'customSubdomain',
+			type: 'hidden',
+			default: '',
+		},
+		{
+			displayName: 'Self-Hosted URL',
+			name: 'selfHostedUrl',
+			type: 'hidden',
+			default: '',
 		},
 	];
 }

--- a/packages/nodes-base/nodes/Grist/test/gristBaseUrl.test.ts
+++ b/packages/nodes-base/nodes/Grist/test/gristBaseUrl.test.ts
@@ -1,4 +1,9 @@
+import type { INodeParameters } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
+
+import { GristApi } from '../../../credentials/GristApi.credentials';
 import { gristBaseUrl } from '../GenericFunctions';
+import type { GristCredentials } from '../types';
 
 describe('Grist gristBaseUrl', () => {
 	it('uses the unified url field, stripping a trailing slash', () => {
@@ -45,6 +50,50 @@ describe('Grist gristBaseUrl', () => {
 			expect(
 				gristBaseUrl({ selfHostedUrl: 'https://grist.example.com', customSubdomain: 'acme' }),
 			).toBe('https://grist.example.com');
+		});
+	});
+
+	// Before a node sees credential data, n8n merges in the defaults of the declared
+	// credential fields and drops any stored value whose field is not declared. These
+	// tests resolve the base URL through that same step, so they fail if a default
+	// shadows the legacy fields or if the legacy fields stop being declared.
+	describe('after credential defaults are applied, as at execution time', () => {
+		const resolveThroughDefaults = (stored: INodeParameters) => {
+			const decrypted = NodeHelpers.getNodeParameters(
+				new GristApi().properties,
+				stored,
+				true,
+				false,
+				null,
+				null,
+			);
+			return gristBaseUrl(decrypted as GristCredentials);
+		};
+
+		it('keeps a legacy self-hosted credential on its own host', () => {
+			expect(
+				resolveThroughDefaults({
+					apiKey: 'k',
+					planType: 'selfHosted',
+					selfHostedUrl: 'https://grist.example.com',
+				}),
+			).toBe('https://grist.example.com');
+		});
+
+		it('keeps a legacy team credential on its subdomain host', () => {
+			expect(
+				resolveThroughDefaults({ apiKey: 'k', planType: 'paid', customSubdomain: 'acme' }),
+			).toBe('https://acme.getgrist.com');
+		});
+
+		it('uses the stored url when one has been saved', () => {
+			expect(resolveThroughDefaults({ apiKey: 'k', url: 'https://grist.example.com' })).toBe(
+				'https://grist.example.com',
+			);
+		});
+
+		it('sends a new credential with the url left empty to the SaaS API host', () => {
+			expect(resolveThroughDefaults({ apiKey: 'k', url: '' })).toBe('https://api.getgrist.com');
 		});
 	});
 });


### PR DESCRIPTION
Fixes #35213. Grist credentials created before #34190 introduced the single `Grist URL` field stopped resolving their stored host in 2.32.x, and every request went to `https://api.getgrist.com` instead. Hosted accounts kept working, since that host serves them all, but self-hosted instances failed on every execution with "Authorization failed - please check your credentials".

#34190 was based on a wrong understanding of how credential field defaults work. It kept a fallback that reads the legacy `selfHostedUrl` and `customSubdomain` values, but that fallback is unreachable in a running instance. Before a node sees credential data, `CredentialsHelper.applyDefaultsAndOverwrites` runs the stored data through `NodeHelpers.getNodeParameters(..., returnDefaults: true)`, which does two things the fallback didn't survive:

- it fills in the `Grist URL` field's default, `https://api.getgrist.com`, for any credential that never stored a `url`, so the fallback's "no url stored" branch never runs, and
- it drops any stored value whose field is no longer declared, so the legacy `selfHostedUrl` and `customSubdomain` values were gone from the data anyway.

This PR fixes both:

- The `Grist URL` field now defaults to empty (with `https://api.getgrist.com` as a placeholder) and is optional, so editing a legacy credential (e.g. rotating the API key) doesn't force a URL that would override its stored host. Empty resolves to hosted Grist, so the effective default is unchanged.
- The two legacy fields are declared again as `hidden` properties, so their stored values survive into the node and the fallback from #34190 works as intended.

## How to test

The reported upgrade path was reproduced:

1. Ran n8n **2.31.4** (docker) against a self-hosted Grist. Created a Grist credential the old way (plan type **Self-Hosted**, URL `http://localhost:8585`) and a workflow reading rows from a test document. It succeeded.
2. Swapped the image to **2.32.5** on the same data directory, changing nothing else. The same workflow failed with `Authorization failed - please check your credentials`; the underlying response was `api.getgrist.com` rejecting an API key that is only valid on the local instance, so the request had left for the wrong host. This matches #35213 exactly.
3. On that same 2.32.5 container, replaced only `dist/credentials/GristApi.credentials.js` with this PR's build and restarted. The same workflow succeeded again; the stored credential was untouched throughout.
4. In the fixed container, created a new credential with an explicit **Grist URL** and ran the same workflow over it: success.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #35213 (internal tracker GHC-9130). Regression from #34190, part of splitting up #33133.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. No docs change needed: the docs describe entering a Grist URL, which is unchanged; only the prefill became a placeholder.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (regression ships in 2.32.x; suggest `Backport to Stable`, needs a maintainer).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35229">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

