### PR TITLE
refactor(core): Extract ProjectDeletionService to break the project service dependency cycle

### DIFF
--- a/packages/cli/src/controllers/__tests__/project.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/project.controller.test.ts
@@ -7,6 +7,7 @@ import { mock } from 'vitest-mock-extended';
 import { ProjectController } from '@/controllers/project.controller';
 import type { EventService } from '@/events/event.service';
 import type { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
+import type { ProjectDeletionService } from '@/services/project-deletion.service.ee';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { UserManagementMailer } from '@/user-management/email';
 
@@ -16,6 +17,7 @@ describe('ProjectController', () => {
 	const projectRepository = mock<ProjectRepository>();
 	const userManagementMailer = mock<UserManagementMailer>();
 	const provisioningService = mock<ProvisioningService>();
+	const projectDeletionService = mock<ProjectDeletionService>();
 
 	const controller = new ProjectController(
 		projectsService as unknown as ProjectService,
@@ -23,6 +25,7 @@ describe('ProjectController', () => {
 		eventService as unknown as EventService,
 		userManagementMailer as unknown as UserManagementMailer,
 		provisioningService as unknown as ProvisioningService,
+		projectDeletionService as unknown as ProjectDeletionService,
 	);
 
 	const makeRes = () => {

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -31,6 +31,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import type { ProjectRequest } from '@/requests';
+import { ProjectDeletionService } from '@/services/project-deletion.service.ee';
 import {
 	ProjectService,
 	TeamProjectOverQuotaError,
@@ -46,6 +47,7 @@ export class ProjectController {
 		private readonly eventService: EventService,
 		private readonly userManagementMailer: UserManagementMailer,
 		private readonly provisioningService: ProvisioningService,
+		private readonly projectDeletionService: ProjectDeletionService,
 	) {}
 
 	@Get('/')
@@ -387,7 +389,7 @@ export class ProjectController {
 		@Query query: DeleteProjectDto,
 		@Param('projectId') projectId: string,
 	) {
-		await this.projectsService.deleteProject(req.user, projectId, {
+		await this.projectDeletionService.deleteProject(req.user, projectId, {
 			migrateToProject: query.transferId,
 		});
 

--- a/packages/cli/src/services/__tests__/project-deletion.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project-deletion.service.ee.test.ts
@@ -1,0 +1,183 @@
+import type { Logger, ModuleRegistry } from '@n8n/backend-common';
+import type {
+	FolderRepository,
+	Project,
+	ProjectRelationRepository,
+	ProjectRepository,
+	SharedCredentialsRepository,
+	SharedWorkflowRepository,
+} from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+import type { ICredentialConnectionStatusProvider } from '@/credentials/credential-connection-status-provider.interface';
+import type { AgentExecutionService } from '@/modules/agents/agent-execution.service';
+import type { AgentKnowledgeService } from '@/modules/agents/agent-knowledge.service';
+import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
+import type { WorkflowService } from '@/workflows/workflow.service';
+
+import { ProjectDeletionService } from '../project-deletion.service.ee';
+import type { ProjectService } from '../project.service.ee';
+
+describe('ProjectDeletionService', () => {
+	const projectService = mock<ProjectService>();
+	const workflowService = mock<WorkflowService>();
+	const credentialsService = mock<CredentialsService>();
+	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
+	const sharedCredentialsRepository = mock<SharedCredentialsRepository>();
+	const projectRelationRepository = mock<ProjectRelationRepository>();
+	const projectRepository = mock<ProjectRepository>();
+	const folderRepository = mock<FolderRepository>();
+	const moduleRegistry = mock<ModuleRegistry>();
+	const logger = mock<Logger>();
+	const agentRepository = mock<AgentRepository>();
+	const agentKnowledgeService = mock<AgentKnowledgeService>();
+	const agentExecutionService = mock<AgentExecutionService>();
+
+	const deletionService = new ProjectDeletionService(
+		projectService,
+		workflowService,
+		credentialsService,
+		sharedWorkflowRepository,
+		sharedCredentialsRepository,
+		projectRelationRepository,
+		projectRepository,
+		folderRepository,
+		moduleRegistry,
+		logger,
+	);
+
+	const user = { id: 'user-1', role: { scopes: [{ slug: 'project:delete' }] } } as any;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('calls cleanupOrphanedEntriesForUsers with member IDs after project is deleted', async () => {
+		// ARRANGE
+		const project = mock<Project>({ id: 'project-1', type: 'team' });
+		const mockProxy = mock<ICredentialConnectionStatusProvider>();
+		Object.defineProperty(deletionService, 'connectionStatusProxy', {
+			configurable: true,
+			get: async () => mockProxy,
+		});
+		projectService.getProjectWithScope.mockResolvedValueOnce(project);
+		projectRepository.remove.mockResolvedValueOnce(project);
+		sharedWorkflowRepository.find.mockResolvedValueOnce([]);
+		sharedCredentialsRepository.find.mockResolvedValueOnce([]);
+		moduleRegistry.isActive.mockReturnValue(false);
+		// Two members in the project
+		projectRelationRepository.findBy.mockResolvedValueOnce([
+			{ userId: 'member-1' },
+			{ userId: 'member-2' },
+		] as never);
+
+		// ACT
+		await deletionService.deleteProject(user, project.id);
+
+		// ASSERT — project removed first, then cleanup for former members
+		expect(projectRepository.remove).toHaveBeenCalledWith(project);
+		expect(mockProxy.cleanupOrphanedEntriesForUsers).toHaveBeenCalledWith(['member-1', 'member-2']);
+		expect(projectRepository.remove.mock.invocationCallOrder[0]).toBeLessThan(
+			mockProxy.cleanupOrphanedEntriesForUsers.mock.invocationCallOrder[0],
+		);
+	});
+
+	it('skips credential cleanup when the project had no members', async () => {
+		// ARRANGE
+		const project = mock<Project>({ id: 'project-1', type: 'team' });
+		const mockProxy = mock<ICredentialConnectionStatusProvider>();
+		Object.defineProperty(deletionService, 'connectionStatusProxy', {
+			configurable: true,
+			get: async () => mockProxy,
+		});
+		projectService.getProjectWithScope.mockResolvedValueOnce(project);
+		projectRepository.remove.mockResolvedValueOnce(project);
+		sharedWorkflowRepository.find.mockResolvedValueOnce([]);
+		sharedCredentialsRepository.find.mockResolvedValueOnce([]);
+		moduleRegistry.isActive.mockReturnValue(false);
+		projectRelationRepository.findBy.mockResolvedValueOnce([]);
+
+		// ACT
+		await deletionService.deleteProject(user, project.id);
+
+		// ASSERT — no members → cleanup must not be called
+		expect(projectRepository.remove).toHaveBeenCalledWith(project);
+		expect(mockProxy.cleanupOrphanedEntriesForUsers).not.toHaveBeenCalled();
+	});
+
+	it('cleans agent knowledge files before project deletion cascades agent files', async () => {
+		const project = mock<Project>({ id: 'project-1', type: 'team' });
+		Object.defineProperty(deletionService, 'agentRepository', {
+			configurable: true,
+			get: async () => agentRepository,
+		});
+		Object.defineProperty(deletionService, 'agentKnowledgeService', {
+			configurable: true,
+			get: async () => agentKnowledgeService,
+		});
+		Object.defineProperty(deletionService, 'agentExecutionService', {
+			configurable: true,
+			get: async () => agentExecutionService,
+		});
+		projectService.getProjectWithScope.mockResolvedValueOnce(project);
+		projectRepository.remove.mockResolvedValueOnce(project);
+		sharedWorkflowRepository.find.mockResolvedValueOnce([]);
+		sharedCredentialsRepository.find.mockResolvedValueOnce([]);
+		moduleRegistry.isActive.mockImplementation((moduleName) => moduleName === 'agents');
+		projectRelationRepository.findBy.mockResolvedValueOnce([]);
+		agentRepository.findByProjectId.mockResolvedValueOnce([
+			{ id: 'agent-1' },
+			{ id: 'agent-2' },
+		] as never);
+
+		await deletionService.deleteProject(user, project.id);
+
+		expect(agentRepository.findByProjectId).toHaveBeenCalledWith(project.id);
+		expect(agentKnowledgeService.deleteAllFilesForAgent).toHaveBeenCalledWith(
+			project.id,
+			'agent-1',
+		);
+		expect(agentKnowledgeService.deleteAllFilesForAgent).toHaveBeenCalledWith(
+			project.id,
+			'agent-2',
+		);
+		expect(agentKnowledgeService.deleteAllFilesForAgent.mock.invocationCallOrder[1]).toBeLessThan(
+			projectRepository.remove.mock.invocationCallOrder[0],
+		);
+		expect(agentKnowledgeService.destroySandbox).toHaveBeenCalledWith(project.id, 'agent-1');
+		expect(agentKnowledgeService.destroySandbox).toHaveBeenCalledWith(project.id, 'agent-2');
+		expect(agentExecutionService.deleteExecutionLogsForAgent).toHaveBeenCalledWith('agent-1');
+		expect(agentExecutionService.deleteExecutionLogsForAgent).toHaveBeenCalledWith('agent-2');
+	});
+
+	it('destroys agent sandboxes even when knowledge file cleanup fails', async () => {
+		const project = mock<Project>({ id: 'project-1', type: 'team' });
+		Object.defineProperty(deletionService, 'agentRepository', {
+			configurable: true,
+			get: async () => agentRepository,
+		});
+		Object.defineProperty(deletionService, 'agentKnowledgeService', {
+			configurable: true,
+			get: async () => agentKnowledgeService,
+		});
+		Object.defineProperty(deletionService, 'agentExecutionService', {
+			configurable: true,
+			get: async () => agentExecutionService,
+		});
+		projectService.getProjectWithScope.mockResolvedValueOnce(project);
+		projectRepository.remove.mockResolvedValueOnce(project);
+		sharedWorkflowRepository.find.mockResolvedValueOnce([]);
+		sharedCredentialsRepository.find.mockResolvedValueOnce([]);
+		moduleRegistry.isActive.mockImplementation((moduleName) => moduleName === 'agents');
+		projectRelationRepository.findBy.mockResolvedValueOnce([]);
+		agentRepository.findByProjectId.mockResolvedValueOnce([{ id: 'agent-1' }] as never);
+		agentKnowledgeService.deleteAllFilesForAgent.mockRejectedValueOnce(new Error('storage down'));
+
+		await expect(deletionService.deleteProject(user, project.id)).resolves.toBeUndefined();
+
+		expect(agentKnowledgeService.destroySandbox).toHaveBeenCalledWith(project.id, 'agent-1');
+		expect(agentExecutionService.deleteExecutionLogsForAgent).toHaveBeenCalledWith('agent-1');
+		expect(projectRepository.remove).toHaveBeenCalledWith(project);
+	});
+});

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -1,5 +1,4 @@
 import type { ProjectRelation } from '@n8n/api-types';
-import type { Logger, ModuleRegistry } from '@n8n/backend-common';
 import {
 	type Project,
 	type ProjectRepository,
@@ -17,9 +16,6 @@ import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import type { ICredentialConnectionStatusProvider } from '@/credentials/credential-connection-status-provider.interface';
-import type { AgentExecutionService } from '@/modules/agents/agent-execution.service';
-import type { AgentKnowledgeService } from '@/modules/agents/agent-knowledge.service';
-import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
 
 import type { OwnershipService } from '../ownership.service';
 import { ProjectService } from '../project.service.ee';
@@ -32,22 +28,14 @@ describe('ProjectService', () => {
 	const projectRelationRepository = mock<ProjectRelationRepository>({ manager });
 	const roleService = mock<RoleService>();
 	const sharedCredentialsRepository = mock<SharedCredentialsRepository>();
-	const moduleRegistry = mock<ModuleRegistry>({ entities: [] });
-	const agentRepository = mock<AgentRepository>();
-	const agentKnowledgeService = mock<AgentKnowledgeService>();
-	const agentExecutionService = mock<AgentExecutionService>();
 	const ownershipService = mock<OwnershipService>();
-	const logger = mock<Logger>();
 	const projectService = new ProjectService(
 		sharedWorkflowRepository,
 		projectRepository,
 		projectRelationRepository,
 		roleService,
-		sharedCredentialsRepository,
 		mock(),
-		moduleRegistry,
 		ownershipService,
-		logger,
 	);
 
 	beforeEach(() => {
@@ -524,152 +512,6 @@ describe('ProjectService', () => {
 				where: { id: projectId, type: 'team' },
 				relations: { projectRelations: { role: true } },
 			});
-		});
-	});
-
-	describe('deleteProject', () => {
-		const user = { id: 'user-1', role: { scopes: [{ slug: 'project:delete' }] } } as any;
-
-		beforeEach(() => {
-			Object.defineProperty(projectService, 'workflowService', {
-				configurable: true,
-				get: async () => ({ delete: vi.fn() }),
-			});
-			Object.defineProperty(projectService, 'credentialsService', {
-				configurable: true,
-				get: async () => ({ delete: vi.fn() }),
-			});
-		});
-
-		it('calls cleanupOrphanedEntriesForUsers with member IDs after project is deleted', async () => {
-			// ARRANGE
-			const project = mock<Project>({ id: 'project-1', type: 'team' });
-			const mockProxy = mock<ICredentialConnectionStatusProvider>();
-			Object.defineProperty(projectService, 'connectionStatusProxy', {
-				configurable: true,
-				get: async () => mockProxy,
-			});
-			manager.findOne.mockResolvedValueOnce(project);
-			projectRepository.remove.mockResolvedValueOnce(project);
-			sharedWorkflowRepository.find.mockResolvedValueOnce([]);
-			sharedCredentialsRepository.find.mockResolvedValueOnce([]);
-			moduleRegistry.isActive.mockReturnValue(false);
-			// Two members in the project
-			projectRelationRepository.findBy.mockResolvedValueOnce([
-				{ userId: 'member-1' },
-				{ userId: 'member-2' },
-			] as never);
-
-			// ACT
-			await projectService.deleteProject(user, project.id);
-
-			// ASSERT — project removed first, then cleanup for former members
-			expect(projectRepository.remove).toHaveBeenCalledWith(project);
-			expect(mockProxy.cleanupOrphanedEntriesForUsers).toHaveBeenCalledWith([
-				'member-1',
-				'member-2',
-			]);
-			expect(projectRepository.remove.mock.invocationCallOrder[0]).toBeLessThan(
-				mockProxy.cleanupOrphanedEntriesForUsers.mock.invocationCallOrder[0],
-			);
-		});
-
-		it('skips credential cleanup when the project had no members', async () => {
-			// ARRANGE
-			const project = mock<Project>({ id: 'project-1', type: 'team' });
-			const mockProxy = mock<ICredentialConnectionStatusProvider>();
-			Object.defineProperty(projectService, 'connectionStatusProxy', {
-				configurable: true,
-				get: async () => mockProxy,
-			});
-			manager.findOne.mockResolvedValueOnce(project);
-			projectRepository.remove.mockResolvedValueOnce(project);
-			sharedWorkflowRepository.find.mockResolvedValueOnce([]);
-			sharedCredentialsRepository.find.mockResolvedValueOnce([]);
-			moduleRegistry.isActive.mockReturnValue(false);
-			projectRelationRepository.findBy.mockResolvedValueOnce([]);
-
-			// ACT
-			await projectService.deleteProject(user, project.id);
-
-			// ASSERT — no members → cleanup must not be called
-			expect(projectRepository.remove).toHaveBeenCalledWith(project);
-			expect(mockProxy.cleanupOrphanedEntriesForUsers).not.toHaveBeenCalled();
-		});
-
-		it('cleans agent knowledge files before project deletion cascades agent files', async () => {
-			const project = mock<Project>({ id: 'project-1', type: 'team' });
-			Object.defineProperty(projectService, 'agentRepository', {
-				configurable: true,
-				get: async () => agentRepository,
-			});
-			Object.defineProperty(projectService, 'agentKnowledgeService', {
-				configurable: true,
-				get: async () => agentKnowledgeService,
-			});
-			Object.defineProperty(projectService, 'agentExecutionService', {
-				configurable: true,
-				get: async () => agentExecutionService,
-			});
-			manager.findOne.mockResolvedValueOnce(project);
-			projectRepository.remove.mockResolvedValueOnce(project);
-			sharedWorkflowRepository.find.mockResolvedValueOnce([]);
-			sharedCredentialsRepository.find.mockResolvedValueOnce([]);
-			moduleRegistry.isActive.mockImplementation((moduleName) => moduleName === 'agents');
-			projectRelationRepository.findBy.mockResolvedValueOnce([]);
-			agentRepository.findByProjectId.mockResolvedValueOnce([
-				{ id: 'agent-1' },
-				{ id: 'agent-2' },
-			] as never);
-
-			await projectService.deleteProject(user, project.id);
-
-			expect(agentRepository.findByProjectId).toHaveBeenCalledWith(project.id);
-			expect(agentKnowledgeService.deleteAllFilesForAgent).toHaveBeenCalledWith(
-				project.id,
-				'agent-1',
-			);
-			expect(agentKnowledgeService.deleteAllFilesForAgent).toHaveBeenCalledWith(
-				project.id,
-				'agent-2',
-			);
-			expect(agentKnowledgeService.deleteAllFilesForAgent.mock.invocationCallOrder[1]).toBeLessThan(
-				projectRepository.remove.mock.invocationCallOrder[0],
-			);
-			expect(agentKnowledgeService.destroySandbox).toHaveBeenCalledWith(project.id, 'agent-1');
-			expect(agentKnowledgeService.destroySandbox).toHaveBeenCalledWith(project.id, 'agent-2');
-			expect(agentExecutionService.deleteExecutionLogsForAgent).toHaveBeenCalledWith('agent-1');
-			expect(agentExecutionService.deleteExecutionLogsForAgent).toHaveBeenCalledWith('agent-2');
-		});
-
-		it('destroys agent sandboxes even when knowledge file cleanup fails', async () => {
-			const project = mock<Project>({ id: 'project-1', type: 'team' });
-			Object.defineProperty(projectService, 'agentRepository', {
-				configurable: true,
-				get: async () => agentRepository,
-			});
-			Object.defineProperty(projectService, 'agentKnowledgeService', {
-				configurable: true,
-				get: async () => agentKnowledgeService,
-			});
-			Object.defineProperty(projectService, 'agentExecutionService', {
-				configurable: true,
-				get: async () => agentExecutionService,
-			});
-			manager.findOne.mockResolvedValueOnce(project);
-			projectRepository.remove.mockResolvedValueOnce(project);
-			sharedWorkflowRepository.find.mockResolvedValueOnce([]);
-			sharedCredentialsRepository.find.mockResolvedValueOnce([]);
-			moduleRegistry.isActive.mockImplementation((moduleName) => moduleName === 'agents');
-			projectRelationRepository.findBy.mockResolvedValueOnce([]);
-			agentRepository.findByProjectId.mockResolvedValueOnce([{ id: 'agent-1' }] as never);
-			agentKnowledgeService.deleteAllFilesForAgent.mockRejectedValueOnce(new Error('storage down'));
-
-			await expect(projectService.deleteProject(user, project.id)).resolves.toBeUndefined();
-
-			expect(agentKnowledgeService.destroySandbox).toHaveBeenCalledWith(project.id, 'agent-1');
-			expect(agentExecutionService.deleteExecutionLogsForAgent).toHaveBeenCalledWith('agent-1');
-			expect(projectRepository.remove).toHaveBeenCalledWith(project);
 		});
 	});
 

--- a/packages/cli/src/services/project-deletion.service.ee.ts
+++ b/packages/cli/src/services/project-deletion.service.ee.ts
@@ -1,0 +1,217 @@
+import { Logger, ModuleRegistry } from '@n8n/backend-common';
+import {
+	type User,
+	Project,
+	ProjectRelationRepository,
+	ProjectRepository,
+	SharedCredentialsRepository,
+	SharedWorkflowRepository,
+	FolderRepository,
+} from '@n8n/db';
+import { Container, Service } from '@n8n/di';
+
+import { CredentialsService } from '@/credentials/credentials.service';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { WorkflowService } from '@/workflows/workflow.service';
+
+import { ProjectNotFoundError, ProjectService } from './project.service.ee';
+
+/**
+ * Orchestrates deletion (or migration) of a team project and everything it owns.
+ * Lives above ProjectService, WorkflowService and CredentialsService so the
+ * cascade can call them directly without those services depending back on it.
+ */
+@Service()
+export class ProjectDeletionService {
+	constructor(
+		private readonly projectService: ProjectService,
+		private readonly workflowService: WorkflowService,
+		private readonly credentialsService: CredentialsService,
+		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
+		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
+		private readonly projectRelationRepository: ProjectRelationRepository,
+		private readonly projectRepository: ProjectRepository,
+		private readonly folderRepository: FolderRepository,
+		private readonly moduleRegistry: ModuleRegistry,
+		private readonly logger: Logger,
+	) {}
+
+	private get dataTableService() {
+		return import('@/modules/data-table/data-table.service.js').then(({ DataTableService }) =>
+			Container.get(DataTableService),
+		);
+	}
+
+	private get secretsProvidersConnectionsService() {
+		return import('@/modules/external-secrets.ee/secrets-providers-connections.service.ee.js').then(
+			({ SecretsProvidersConnectionsService }) => Container.get(SecretsProvidersConnectionsService),
+		);
+	}
+
+	private get agentRepository() {
+		return import('@/modules/agents/repositories/agent.repository.js').then(({ AgentRepository }) =>
+			Container.get(AgentRepository),
+		);
+	}
+
+	private get agentKnowledgeService() {
+		return import('@/modules/agents/agent-knowledge.service.js').then(({ AgentKnowledgeService }) =>
+			Container.get(AgentKnowledgeService),
+		);
+	}
+
+	private get agentExecutionService() {
+		return import('@/modules/agents/agent-execution.service.js').then(({ AgentExecutionService }) =>
+			Container.get(AgentExecutionService),
+		);
+	}
+
+	private get connectionStatusProxy() {
+		return import('@/credentials/credential-connection-status-proxy.js').then(
+			({ CredentialConnectionStatusProxy }) => Container.get(CredentialConnectionStatusProxy),
+		);
+	}
+
+	async deleteProject(
+		user: User,
+		projectId: string,
+		{ migrateToProject }: { migrateToProject?: string } = {},
+	) {
+		if (projectId === migrateToProject) {
+			throw new BadRequestError(
+				'Request to delete a project failed because the project to delete and the project to migrate to are the same project',
+			);
+		}
+
+		const project = await this.projectService.getProjectWithScope(user, projectId, [
+			'project:delete',
+		]);
+		ProjectNotFoundError.isDefinedAndNotNull(project, projectId);
+
+		let targetProject: Project | null = null;
+		if (migrateToProject) {
+			targetProject = await this.projectService.getProjectWithScope(user, migrateToProject, [
+				'credential:create',
+				'workflow:create',
+				'dataTable:create',
+			]);
+
+			if (!targetProject) {
+				throw new NotFoundError(
+					`Could not find project to migrate to. ID: ${targetProject}. You may lack permissions to create workflow, credentials or data tables in the target project.`,
+				);
+			}
+		}
+
+		// 0. check if this is a team project
+		if (project.type !== 'team') {
+			throw new ForbiddenError(
+				`Can't delete project. Project with ID "${projectId}" is not a team project.`,
+			);
+		}
+
+		// 1. delete or migrate workflows owned by this project
+		const ownedSharedWorkflows = await this.sharedWorkflowRepository.find({
+			where: { projectId: project.id, role: 'workflow:owner' },
+		});
+
+		if (targetProject) {
+			await this.sharedWorkflowRepository.makeOwner(
+				ownedSharedWorkflows.map((sw) => sw.workflowId),
+				targetProject.id,
+			);
+		} else {
+			for (const sharedWorkflow of ownedSharedWorkflows) {
+				await this.workflowService.delete(user, sharedWorkflow.workflowId, true);
+			}
+		}
+
+		// 2. delete credentials owned by this project
+		const ownedCredentials = await this.sharedCredentialsRepository.find({
+			where: { projectId: project.id, role: 'credential:owner' },
+			relations: { credentials: true },
+		});
+
+		if (targetProject) {
+			await this.sharedCredentialsRepository.makeOwner(
+				ownedCredentials.map((sc) => sc.credentialsId),
+				targetProject.id,
+			);
+		} else {
+			for (const sharedCredential of ownedCredentials) {
+				await this.credentialsService.delete(user, sharedCredential.credentials.id);
+			}
+		}
+
+		// 3. Move folders over to the target project, before deleting the project else cascading will delete workflows
+		if (targetProject) {
+			await this.folderRepository.transferAllFoldersToProject(project.id, targetProject.id);
+		}
+
+		// 4. delete shared credentials into this project
+		// Cascading deletes take care of this.
+
+		// 5. delete shared workflows into this project
+		// Cascading deletes take care of this.
+
+		// 6. delete or migrate associated data tables
+		if (this.moduleRegistry.isActive('data-table')) {
+			const dataTableService = await this.dataTableService;
+
+			if (targetProject) {
+				await dataTableService.transferDataTablesByProjectId(project.id, targetProject.id);
+			} else {
+				await dataTableService.deleteDataTableByProjectId(project.id);
+			}
+		}
+
+		// 7. delete secrets providers connections that are owned by this project
+		if (this.moduleRegistry.isActive('external-secrets')) {
+			const secretsProvidersConnectionsService = await this.secretsProvidersConnectionsService;
+			await secretsProvidersConnectionsService.cleanupConnectionsForProjectDeletion(project.id);
+		}
+
+		// 8. delete agent knowledge files before project removal cascades delete agent_files rows.
+		if (this.moduleRegistry.isActive('agents')) {
+			const [agentRepository, agentKnowledgeService, agentExecutionService] = await Promise.all([
+				this.agentRepository,
+				this.agentKnowledgeService,
+				this.agentExecutionService,
+			]);
+			const agents = await agentRepository.findByProjectId(project.id);
+			for (const agent of agents) {
+				try {
+					await agentKnowledgeService.deleteAllFilesForAgent(project.id, agent.id);
+				} catch (error) {
+					this.logger.warn('Failed to delete knowledge files on project delete', {
+						agentId: agent.id,
+						projectId: project.id,
+						error: error instanceof Error ? error.message : error,
+					});
+				}
+
+				await agentKnowledgeService.destroySandbox(project.id, agent.id);
+				await agentExecutionService.deleteExecutionLogsForAgent(agent.id);
+			}
+		}
+
+		// Capture member user IDs before the project (and its relations) are removed,
+		// so we can clean up orphaned per-user credential entries afterward.
+		const projectMembers = await this.projectRelationRepository.findBy({ projectId: project.id });
+		const memberUserIds = projectMembers.map((pr) => pr.userId);
+
+		// 9. delete project
+		await this.projectRepository.remove(project);
+
+		// 10. delete project relations
+		// Cascading deletes take care of this.
+
+		// 11. delete orphaned per-user credential entries for former members
+		if (memberUserIds.length > 0) {
+			const proxy = await this.connectionStatusProxy;
+			await proxy.cleanupOrphanedEntriesForUsers(memberUserIds);
+		}
+	}
+}

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -1,5 +1,5 @@
 import type { CreateProjectDto, ProjectType, UpdateProjectDto } from '@n8n/api-types';
-import { LicenseState, Logger, ModuleRegistry } from '@n8n/backend-common';
+import { LicenseState } from '@n8n/backend-common';
 import { UNLIMITED_LICENSE_QUOTA } from '@n8n/constants';
 import {
 	type User,
@@ -7,7 +7,6 @@ import {
 	ProjectRelation,
 	ProjectRelationRepository,
 	ProjectRepository,
-	SharedCredentialsRepository,
 	SharedWorkflowRepository,
 	type ProjectListOptions,
 } from '@n8n/db';
@@ -26,7 +25,6 @@ import type { FindOptionsWhere, EntityManager } from '@n8n/typeorm';
 import { In } from '@n8n/typeorm';
 import { UserError } from 'n8n-workflow';
 
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
@@ -47,7 +45,7 @@ export class UnlicensedProjectRoleError extends UserError {
 	}
 }
 
-class ProjectNotFoundError extends NotFoundError {
+export class ProjectNotFoundError extends NotFoundError {
 	constructor(projectId: string) {
 		super(`Could not find project with ID: ${projectId}`);
 	}
@@ -75,208 +73,14 @@ export class ProjectService {
 		private readonly projectRepository: ProjectRepository,
 		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly roleService: RoleService,
-		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
 		private readonly licenseState: LicenseState,
-		private readonly moduleRegistry: ModuleRegistry,
 		private readonly ownershipService: OwnershipService,
-		private readonly logger: Logger,
 	) {}
-
-	private get workflowService() {
-		return import('@/workflows/workflow.service.js').then(({ WorkflowService }) =>
-			Container.get(WorkflowService),
-		);
-	}
-
-	private get credentialsService() {
-		return import('@/credentials/credentials.service.js').then(({ CredentialsService }) =>
-			Container.get(CredentialsService),
-		);
-	}
-
-	private get folderService() {
-		return import('@/services/folder.service.js').then(({ FolderService }) =>
-			Container.get(FolderService),
-		);
-	}
-
-	private get dataTableService() {
-		return import('@/modules/data-table/data-table.service.js').then(({ DataTableService }) =>
-			Container.get(DataTableService),
-		);
-	}
-
-	private get secretsProvidersConnectionsService() {
-		return import('@/modules/external-secrets.ee/secrets-providers-connections.service.ee.js').then(
-			({ SecretsProvidersConnectionsService }) => Container.get(SecretsProvidersConnectionsService),
-		);
-	}
-
-	private get agentRepository() {
-		return import('@/modules/agents/repositories/agent.repository.js').then(({ AgentRepository }) =>
-			Container.get(AgentRepository),
-		);
-	}
-
-	private get agentKnowledgeService() {
-		return import('@/modules/agents/agent-knowledge.service.js').then(({ AgentKnowledgeService }) =>
-			Container.get(AgentKnowledgeService),
-		);
-	}
-
-	private get agentExecutionService() {
-		return import('@/modules/agents/agent-execution.service.js').then(({ AgentExecutionService }) =>
-			Container.get(AgentExecutionService),
-		);
-	}
 
 	private get connectionStatusProxy() {
 		return import('@/credentials/credential-connection-status-proxy.js').then(
 			({ CredentialConnectionStatusProxy }) => Container.get(CredentialConnectionStatusProxy),
 		);
-	}
-
-	async deleteProject(
-		user: User,
-		projectId: string,
-		{ migrateToProject }: { migrateToProject?: string } = {},
-	) {
-		const workflowService = await this.workflowService;
-		const credentialsService = await this.credentialsService;
-
-		if (projectId === migrateToProject) {
-			throw new BadRequestError(
-				'Request to delete a project failed because the project to delete and the project to migrate to are the same project',
-			);
-		}
-
-		const project = await this.getProjectWithScope(user, projectId, ['project:delete']);
-		ProjectNotFoundError.isDefinedAndNotNull(project, projectId);
-
-		let targetProject: Project | null = null;
-		if (migrateToProject) {
-			targetProject = await this.getProjectWithScope(user, migrateToProject, [
-				'credential:create',
-				'workflow:create',
-				'dataTable:create',
-			]);
-
-			if (!targetProject) {
-				throw new NotFoundError(
-					`Could not find project to migrate to. ID: ${targetProject}. You may lack permissions to create workflow, credentials or data tables in the target project.`,
-				);
-			}
-		}
-
-		// 0. check if this is a team project
-		if (project.type !== 'team') {
-			throw new ForbiddenError(
-				`Can't delete project. Project with ID "${projectId}" is not a team project.`,
-			);
-		}
-
-		// 1. delete or migrate workflows owned by this project
-		const ownedSharedWorkflows = await this.sharedWorkflowRepository.find({
-			where: { projectId: project.id, role: 'workflow:owner' },
-		});
-
-		if (targetProject) {
-			await this.sharedWorkflowRepository.makeOwner(
-				ownedSharedWorkflows.map((sw) => sw.workflowId),
-				targetProject.id,
-			);
-		} else {
-			for (const sharedWorkflow of ownedSharedWorkflows) {
-				await workflowService.delete(user, sharedWorkflow.workflowId, true);
-			}
-		}
-
-		// 2. delete credentials owned by this project
-		const ownedCredentials = await this.sharedCredentialsRepository.find({
-			where: { projectId: project.id, role: 'credential:owner' },
-			relations: { credentials: true },
-		});
-
-		if (targetProject) {
-			await this.sharedCredentialsRepository.makeOwner(
-				ownedCredentials.map((sc) => sc.credentialsId),
-				targetProject.id,
-			);
-		} else {
-			for (const sharedCredential of ownedCredentials) {
-				await credentialsService.delete(user, sharedCredential.credentials.id);
-			}
-		}
-
-		// 3. Move folders over to the target project, before deleting the project else cascading will delete workflows
-		if (targetProject) {
-			const folderService = await this.folderService;
-			await folderService.transferAllFoldersToProject(project.id, targetProject.id);
-		}
-
-		// 4. delete shared credentials into this project
-		// Cascading deletes take care of this.
-
-		// 5. delete shared workflows into this project
-		// Cascading deletes take care of this.
-
-		// 6. delete or migrate associated data tables
-		if (this.moduleRegistry.isActive('data-table')) {
-			const dataTableService = await this.dataTableService;
-
-			if (targetProject) {
-				await dataTableService.transferDataTablesByProjectId(project.id, targetProject.id);
-			} else {
-				await dataTableService.deleteDataTableByProjectId(project.id);
-			}
-		}
-
-		// 7. delete secrets providers connections that are owned by this project
-		if (this.moduleRegistry.isActive('external-secrets')) {
-			const secretsProvidersConnectionsService = await this.secretsProvidersConnectionsService;
-			await secretsProvidersConnectionsService.cleanupConnectionsForProjectDeletion(project.id);
-		}
-
-		// 8. delete agent knowledge files before project removal cascades delete agent_files rows.
-		if (this.moduleRegistry.isActive('agents')) {
-			const [agentRepository, agentKnowledgeService, agentExecutionService] = await Promise.all([
-				this.agentRepository,
-				this.agentKnowledgeService,
-				this.agentExecutionService,
-			]);
-			const agents = await agentRepository.findByProjectId(project.id);
-			for (const agent of agents) {
-				try {
-					await agentKnowledgeService.deleteAllFilesForAgent(project.id, agent.id);
-				} catch (error) {
-					this.logger.warn('Failed to delete knowledge files on project delete', {
-						agentId: agent.id,
-						projectId: project.id,
-						error: error instanceof Error ? error.message : error,
-					});
-				}
-
-				await agentKnowledgeService.destroySandbox(project.id, agent.id);
-				await agentExecutionService.deleteExecutionLogsForAgent(agent.id);
-			}
-		}
-
-		// Capture member user IDs before the project (and its relations) are removed,
-		// so we can clean up orphaned per-user credential entries afterward.
-		const projectMembers = await this.projectRelationRepository.findBy({ projectId: project.id });
-		const memberUserIds = projectMembers.map((pr) => pr.userId);
-
-		// 9. delete project
-		await this.projectRepository.remove(project);
-
-		// 10. delete project relations
-		// Cascading deletes take care of this.
-
-		// 11. delete orphaned per-user credential entries for former members
-		if (memberUserIds.length > 0) {
-			const proxy = await this.connectionStatusProxy;
-			await proxy.cleanupOrphanedEntriesForUsers(memberUserIds);
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Part of the backend dependency-cycle initiative. This removes the **project ↔ workflow** and **project ↔ credentials** import cycles in `packages/cli`.

The team-project deletion cascade lived in `ProjectService.deleteProject` and reached back into `WorkflowService` and `CredentialsService` through lazy dynamic imports (`import('@/workflows/workflow.service.js')` etc.), while both of those services inject `ProjectService` directly via the constructor. That closed two import cycles.

## Change

- New `ProjectDeletionService` (`services/project-deletion.service.ee.ts`) owns the whole delete/migrate cascade. It sits *above* the leaf services and calls `WorkflowService` / `CredentialsService` directly, so `ProjectService` no longer imports them.
- `ProjectService` drops the `workflowService`, `credentialsService` and `folderService` lazy getters (and the three constructor deps that only the cascade used). It is now cycle-free.
- The folder move goes straight to `FolderRepository.transferAllFoldersToProject` (consistent with the folder/workflow cut).
- `ProjectController` calls the new service for deletion; every other project operation still goes through `ProjectService`.
- Optional-module cleanups (`data-table`, `external-secrets`, `agents`) keep their existing lazy `moduleRegistry.isActive` + `await import` blocks, moved verbatim. Generalising those into per-module deletion handlers is a separate follow-up.

The cascade behaviour and ordering are unchanged. Existing `deleteProject` unit tests moved to a dedicated `ProjectDeletionService` spec; coverage is preserved.

## Testing

- `pnpm typecheck` clean.
- Targeted `eslint` shows zero `import-x/no-cycle` warnings on `project.service.ee.ts`, `project-deletion.service.ee.ts` and `project.controller.ts`.
- 43 unit tests green across the project service, deletion service and controller specs.


## Lint impact

Removes **2** `import-x/no-cycle` warnings in `packages/cli`, both on `services/project.service.ee.ts` — the `workflowService` and `credentialsService` lazy getters, i.e. the project ↔ workflow and project ↔ credentials edges.

It also drops 3 now-dead injected dependencies from `ProjectService` (`sharedCredentialsRepository`, `moduleRegistry`, `logger`) that only the moved cascade used.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35230">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


