### PR TITLE
fix(core): Keep external secrets available while provider connections reload

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -1310,7 +1310,7 @@ describe('ExternalSecretsManager', () => {
 				expect(providerRegistry.get('my-vault')).toBe(providerAtShutdown);
 			});
 
-			it('should stop serving stale secrets when replacement connection fails', async () => {
+			it('should keep serving secrets from the connected provider while a failed replacement retries', async () => {
 				class FailingConnectProvider extends DummyProvider {
 					protected override async doConnect(): Promise<void> {
 						throw new Error('Connection failed');
@@ -1336,8 +1336,8 @@ describe('ExternalSecretsManager', () => {
 				try {
 					await manager.reloadAllProviders();
 
-					expect(manager.getSecret('my-vault', 'test1')).toBeUndefined();
-					expect(providerRegistry.get('my-vault')?.state).toBe('error');
+					expect(manager.getSecret('my-vault', 'test1')).toBe('old-value');
+					expect(providerRegistry.get('my-vault')?.state).toBe('connected');
 				} finally {
 					manager.shutdown();
 				}

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -36,7 +36,6 @@ describe('ExternalSecretsManager', () => {
 	let mockSettingsStore: Mocked<ExternalSecretsSettingsStore>;
 	let mockProviderRegistry: Mocked<ExternalSecretsProviderRegistry>;
 	let mockProviderLifecycle: Mocked<ExternalSecretsProviderLifecycle>;
-	let mockRetryManager: Mocked<ExternalSecretsRetryManager>;
 	let mockProviderConnectionManager: Mocked<ExternalSecretsProviderConnectionManager>;
 	let mockSecretsCache: Mocked<ExternalSecretsSecretsCache>;
 	let mockSecretsProviderConnectionRepository: Mocked<SecretsProviderConnectionRepository>;
@@ -89,14 +88,9 @@ describe('ExternalSecretsManager', () => {
 		});
 		mockProviderLifecycle.connect.mockResolvedValue({ success: true });
 
-		// Mock RetryManager
-		mockRetryManager = mock<ExternalSecretsRetryManager>();
-		mockRetryManager.runWithRetry.mockImplementation(async (_key, operation) => {
-			const result = await operation();
-			return result;
-		});
-
 		mockProviderConnectionManager = mock<ExternalSecretsProviderConnectionManager>();
+		mockProviderConnectionManager.upsertProviderConnection.mockResolvedValue(undefined);
+		mockProviderConnectionManager.upsertProviderConnections.mockResolvedValue(undefined);
 
 		// Mock SecretsCache
 		mockSecretsCache = mock<ExternalSecretsSecretsCache>();
@@ -121,7 +115,6 @@ describe('ExternalSecretsManager', () => {
 			mockSettingsStore,
 			mockProviderRegistry,
 			mockProviderLifecycle,
-			mockRetryManager,
 			mockProviderConnectionManager,
 			mockSecretsCache,
 			mockSecretsProviderConnectionRepository,
@@ -145,13 +138,11 @@ describe('ExternalSecretsManager', () => {
 		it('should start secrets refresh interval', async () => {
 			await manager.init();
 
-			// refreshAll is called once during init
-			expect(mockSecretsCache.refreshAll).toHaveBeenCalledTimes(1);
+			expect(mockSecretsCache.refreshAll).not.toHaveBeenCalled();
 
 			vi.advanceTimersByTime(60000); // 60 seconds
 
-			// Should be called again after interval
-			expect(mockSecretsCache.refreshAll).toHaveBeenCalledTimes(2);
+			expect(mockSecretsCache.refreshAll).toHaveBeenCalledTimes(1);
 		});
 
 		it('should not initialize twice', async () => {
@@ -175,15 +166,13 @@ describe('ExternalSecretsManager', () => {
 
 			manager.shutdown();
 
-			expect(mockRetryManager.cancelAll).toHaveBeenCalled();
-			expect(mockProviderRegistry.disconnectAll).toHaveBeenCalled();
+			expect(mockProviderConnectionManager.shutdown).toHaveBeenCalled();
 			expect(manager.initialized).toBe(false);
 		});
 
 		it('should stop calling refresh after shutdown', async () => {
 			await manager.init();
 
-			// refreshAll called once during init
 			const callsAfterInit = mockSecretsCache.refreshAll.mock.calls.length;
 
 			vi.advanceTimersByTime(60000);
@@ -308,31 +297,24 @@ describe('ExternalSecretsManager', () => {
 			setUpdateDate: vi.fn(),
 		};
 
-		it('should upsert provider connection, refresh cache, and broadcast', async () => {
+		it('should upsert an enabled provider connection and broadcast', async () => {
 			const decryptedSettings = { key: 'value' };
 			mockSecretsProviderConnectionRepository.findOne.mockResolvedValue(mockConnection as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify(decryptedSettings));
 
-			const newProvider = new DummyProvider();
-			await newProvider.init({ connected: true, connectedAt: null, settings: {} });
-			await newProvider.connect();
-			mockProviderConnectionManager.upsertProviderConnection.mockImplementation(async () => {
-				mockProviderRegistry.set('my-vault', newProvider);
-			});
-
 			await manager.syncProviderConnection('my-vault');
 
 			expect(mockCipher.decryptV2).toHaveBeenCalledWith('encrypted-data');
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'my-vault',
-				'dummy',
-				{
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith({
+				providerKey: 'my-vault',
+				providerType: 'dummy',
+				config: {
 					connected: true,
 					connectedAt: null,
 					settings: decryptedSettings,
 				},
-			);
-			expect(mockSecretsCache.refreshProvider).toHaveBeenCalledWith('my-vault', newProvider);
+			});
+			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
 			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
 				command: 'reload-external-secrets-providers',
 			});
@@ -353,7 +335,7 @@ describe('ExternalSecretsManager', () => {
 			});
 		});
 
-		it('should skip cache refresh when provider is not available after upsert', async () => {
+		it('should leave provider readiness to the connection manager', async () => {
 			mockSecretsProviderConnectionRepository.findOne.mockResolvedValue(mockConnection as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
@@ -373,6 +355,30 @@ describe('ExternalSecretsManager', () => {
 			await manager.syncProviderConnection('my-vault');
 
 			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalled();
+			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
+				command: 'reload-external-secrets-providers',
+			});
+		});
+
+		it('should await provider readiness before broadcasting', async () => {
+			const readiness = createDeferred();
+			mockSecretsProviderConnectionRepository.findOne.mockResolvedValue(mockConnection as any);
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
+			mockProviderConnectionManager.upsertProviderConnection.mockImplementation(
+				async () => await readiness.promise,
+			);
+
+			const syncPromise = manager.syncProviderConnection('my-vault');
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
+			expect(mockPublisher.publishCommand).not.toHaveBeenCalled();
+
+			readiness.resolve();
+			await syncPromise;
+
+			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
 			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
 				command: 'reload-external-secrets-providers',
 			});
@@ -467,11 +473,11 @@ describe('ExternalSecretsManager', () => {
 			expect(mockSettingsStore.updateProvider).toHaveBeenCalledWith('dummy', {
 				settings: { key: 'new-value' },
 			});
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'dummy',
-				'dummy',
-				mockSettings.dummy,
-			);
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith({
+				providerKey: 'dummy',
+				providerType: 'dummy',
+				config: mockSettings.dummy,
+			});
 			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
 				command: 'reload-external-secrets-providers',
 			});
@@ -500,11 +506,16 @@ describe('ExternalSecretsManager', () => {
 	});
 
 	describe('setProviderConnected', () => {
-		it('should connect provider when set to connected', async () => {
+		it('should reload a provider when set to connected', async () => {
 			await manager.setProviderConnected('dummy', true);
 
 			expect(mockSettingsStore.updateProvider).toHaveBeenCalledWith('dummy', { connected: true });
-			expect(mockProviderConnectionManager.connectProviderWithRetry).toHaveBeenCalledWith('dummy');
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith({
+				providerKey: 'dummy',
+				providerType: 'dummy',
+				config: mockSettings.dummy,
+			});
+			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
 			expect(mockPublisher.publishCommand).toHaveBeenCalled();
 		});
 
@@ -678,11 +689,11 @@ describe('ExternalSecretsManager', () => {
 	});
 
 	describe('reloadAllProviders', () => {
-		it('should reload settings and refresh secrets', async () => {
+		it('should reload settings without refreshing the active registry', async () => {
 			await manager.reloadAllProviders();
 
 			expect(mockSettingsStore.reload).toHaveBeenCalled();
-			expect(mockSecretsCache.refreshAll).toHaveBeenCalled();
+			expect(mockSecretsCache.refreshAll).not.toHaveBeenCalled();
 		});
 
 		it('should upsert providers from settings', async () => {
@@ -699,22 +710,27 @@ describe('ExternalSecretsManager', () => {
 
 			await manager.reloadAllProviders();
 
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'dummy',
-				'dummy',
-				newSettings.dummy,
-			);
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith([
+				{
+					providerKey: 'dummy',
+					providerType: 'dummy',
+					config: newSettings.dummy,
+				},
+			]);
 		});
 
-		it('should refresh secrets after reloading providers from settings', async () => {
+		it('should leave batch provider readiness to the connection manager', async () => {
 			await manager.reloadAllProviders();
 
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'dummy',
-				'dummy',
-				mockSettings.dummy,
-			);
-			expect(mockSecretsCache.refreshAll).toHaveBeenCalled();
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith([
+				{
+					providerKey: 'dummy',
+					providerType: 'dummy',
+					config: mockSettings.dummy,
+				},
+			]);
+			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
+			expect(mockSecretsCache.refreshAll).not.toHaveBeenCalled();
 		});
 	});
 
@@ -763,7 +779,6 @@ describe('ExternalSecretsManager', () => {
 				mockSettingsStore,
 				mockProviderRegistry,
 				mockProviderLifecycle,
-				mockRetryManager,
 				mockProviderConnectionManager,
 				mockSecretsCache,
 				mockSecretsProviderConnectionRepository,
@@ -795,15 +810,17 @@ describe('ExternalSecretsManager', () => {
 
 			expect(mockSecretsProviderConnectionRepository.findAll).toHaveBeenCalled();
 			expect(mockSettingsStore.reload).not.toHaveBeenCalled();
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'my-vault-1',
-				'dummy',
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith([
 				{
-					connected: true,
-					connectedAt: null,
-					settings: { key: 'value' },
+					providerKey: 'my-vault-1',
+					providerType: 'dummy',
+					config: {
+						connected: true,
+						connectedAt: null,
+						settings: { key: 'value' },
+					},
 				},
-			);
+			]);
 		});
 
 		it('should remove disabled providers but not re-setup them', async () => {
@@ -841,20 +858,17 @@ describe('ExternalSecretsManager', () => {
 			expect(mockProviderConnectionManager.removeProviderConnection).toHaveBeenCalledWith(
 				'vault-disabled',
 			);
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'vault-enabled',
-				'dummy',
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith([
 				{
-					connected: true,
-					connectedAt: null,
-					settings: { key: 'value' },
+					providerKey: 'vault-enabled',
+					providerType: 'dummy',
+					config: {
+						connected: true,
+						connectedAt: null,
+						settings: { key: 'value' },
+					},
 				},
-			);
-			expect(mockProviderConnectionManager.upsertProviderConnection).not.toHaveBeenCalledWith(
-				'vault-disabled',
-				expect.anything(),
-				expect.anything(),
-			);
+			]);
 		});
 
 		it('should support multiple connections of the same provider type', async () => {
@@ -888,16 +902,18 @@ describe('ExternalSecretsManager', () => {
 
 			await managerWithProjectMode.reloadAllProviders();
 
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'vault-1',
-				'dummy',
-				expect.objectContaining({ settings: { key: 'value' } }),
-			);
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'vault-2',
-				'dummy',
-				expect.objectContaining({ settings: { key: 'value' } }),
-			);
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith([
+				{
+					providerKey: 'vault-1',
+					providerType: 'dummy',
+					config: expect.objectContaining({ settings: { key: 'value' } }),
+				},
+				{
+					providerKey: 'vault-2',
+					providerType: 'dummy',
+					config: expect.objectContaining({ settings: { key: 'value' } }),
+				},
+			]);
 		});
 
 		it('should decrypt settings from connections', async () => {
@@ -922,15 +938,17 @@ describe('ExternalSecretsManager', () => {
 			await managerWithProjectMode.reloadAllProviders();
 
 			expect(mockCipher.decryptV2).toHaveBeenCalledWith(encryptedSettings);
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'my-vault',
-				'dummy',
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith([
 				{
-					connected: true,
-					connectedAt: null,
-					settings: decryptedSettings,
+					providerKey: 'my-vault',
+					providerType: 'dummy',
+					config: {
+						connected: true,
+						connectedAt: null,
+						settings: decryptedSettings,
+					},
 				},
-			);
+			]);
 		});
 
 		it('should delegate enabled provider connections during reload', async () => {
@@ -951,11 +969,13 @@ describe('ExternalSecretsManager', () => {
 
 			await managerWithProjectMode.reloadAllProviders();
 
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'my-vault',
-				'dummy',
-				expect.objectContaining({ settings: { key: 'value' } }),
-			);
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith([
+				{
+					providerKey: 'my-vault',
+					providerType: 'dummy',
+					config: expect.objectContaining({ settings: { key: 'value' } }),
+				},
+			]);
 		});
 
 		it('should handle decryption errors gracefully', async () => {
@@ -988,7 +1008,7 @@ describe('ExternalSecretsManager', () => {
 			expect(managerWithProjectMode.initialized).toBe(false);
 		});
 
-		it('should refresh secrets after loading all connections', async () => {
+		it('should delegate provider readiness for all loaded connections', async () => {
 			const mockConnections = [
 				{
 					id: 1,
@@ -1028,11 +1048,62 @@ describe('ExternalSecretsManager', () => {
 			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue(mockConnections as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			mockSecretsCache.refreshAll.mockClear();
-
 			await managerWithProjectMode.reloadAllProviders();
 
-			expect(mockSecretsCache.refreshAll).toHaveBeenCalledTimes(1);
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledTimes(1);
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith(
+				expect.arrayContaining([
+					expect.objectContaining({ providerKey: 'vault-1' }),
+					expect.objectContaining({ providerKey: 'vault-2' }),
+					expect.objectContaining({ providerKey: 'vault-3' }),
+				]),
+			);
+			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
+			expect(mockSecretsCache.refreshAll).not.toHaveBeenCalled();
+		});
+
+		it('should await batch provider readiness', async () => {
+			const mockConnections = [
+				{
+					id: 1,
+					providerKey: 'vault-1',
+					type: 'dummy',
+					encryptedSettings: 'encrypted-data-1',
+					isEnabled: true,
+					projectAccess: [],
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					setUpdateDate: vi.fn(),
+				},
+				{
+					id: 2,
+					providerKey: 'vault-2',
+					type: 'dummy',
+					encryptedSettings: 'encrypted-data-2',
+					isEnabled: true,
+					projectAccess: [],
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					setUpdateDate: vi.fn(),
+				},
+			];
+			const batchCompletion = createDeferred();
+			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue(mockConnections as any);
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
+			mockProviderConnectionManager.upsertProviderConnections.mockImplementation(
+				async () => await batchCompletion.promise,
+			);
+
+			const reloadPromise = managerWithProjectMode.reloadAllProviders();
+			await vi.waitFor(() => {
+				expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledOnce();
+			});
+			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
+
+			batchCompletion.resolve();
+			await reloadPromise;
+
+			expect(mockSecretsCache.refreshAll).not.toHaveBeenCalled();
 		});
 
 		describe('provider reload consistency', () => {
@@ -1057,13 +1128,14 @@ describe('ExternalSecretsManager', () => {
 					providersFactory,
 				);
 				const retryManager = new ExternalSecretsRetryManager(mockLogger());
+				const secretsCache = new ExternalSecretsSecretsCache(mockLogger(), providerRegistry);
 				const providerConnectionManager = new ExternalSecretsProviderConnectionManager(
 					mockLogger(),
 					providerRegistry,
 					providerLifecycle,
 					retryManager,
+					secretsCache,
 				);
-				const secretsCache = new ExternalSecretsSecretsCache(mockLogger(), providerRegistry);
 
 				const repository = mock<SecretsProviderConnectionRepository>();
 				repository.findAll.mockResolvedValue(connections as never);
@@ -1084,7 +1156,6 @@ describe('ExternalSecretsManager', () => {
 					mockSettingsStore,
 					providerRegistry,
 					providerLifecycle,
-					retryManager,
 					providerConnectionManager,
 					secretsCache,
 					repository,
@@ -1146,6 +1217,97 @@ describe('ExternalSecretsManager', () => {
 					await reloadPromise;
 					manager.shutdown();
 				}
+			});
+
+			it('should resolve reload before hydration completes and keep serving existing secrets', async () => {
+				const updateStarted = createDeferred();
+				const allowUpdateToFinish = createDeferred();
+
+				class SlowUpdateProvider extends DummyProvider {
+					override async update(): Promise<void> {
+						updateStarted.resolve();
+						await allowUpdateToFinish.promise;
+						await super.update();
+					}
+				}
+
+				const { manager, providerRegistry } = createProviderReloadTestManager({
+					providerClass: SlowUpdateProvider,
+					connections: [
+						{
+							providerKey: 'my-vault',
+							type: 'dummy',
+							encryptedSettings: 'encrypted-data',
+							isEnabled: true,
+						},
+					],
+				});
+
+				await addConnectedProviderWithSecrets(providerRegistry, 'my-vault', {
+					test1: 'old-value',
+				});
+
+				const reloadPromise = manager.reloadAllProviders();
+				await updateStarted.promise;
+				// Replacement hydration is fire-and-forget: reload resolves while hydration is pending.
+				await reloadPromise;
+
+				try {
+					expect(manager.getSecret('my-vault', 'test1')).toBe('old-value');
+
+					allowUpdateToFinish.resolve();
+					await vi.waitFor(() => {
+						expect(manager.getSecret('my-vault', 'test1')).toBe('value1');
+					});
+				} finally {
+					allowUpdateToFinish.resolve();
+					manager.shutdown();
+				}
+			});
+
+			it('should not activate a pending replacement after shutdown', async () => {
+				const updateStarted = createDeferred();
+				const allowUpdateToFinish = createDeferred();
+				const replacementDisposed = createDeferred();
+
+				class SlowUpdateProvider extends DummyProvider {
+					override async update(): Promise<void> {
+						updateStarted.resolve();
+						await allowUpdateToFinish.promise;
+						await super.update();
+					}
+
+					override async disconnect(): Promise<void> {
+						replacementDisposed.resolve();
+					}
+				}
+
+				const { manager, providerRegistry } = createProviderReloadTestManager({
+					providerClass: SlowUpdateProvider,
+					connections: [
+						{
+							providerKey: 'my-vault',
+							type: 'dummy',
+							encryptedSettings: 'encrypted-data',
+							isEnabled: true,
+						},
+					],
+				});
+
+				await addConnectedProviderWithSecrets(providerRegistry, 'my-vault', {
+					test1: 'old-value',
+				});
+
+				const reloadPromise = manager.reloadAllProviders();
+				await updateStarted.promise;
+				await reloadPromise;
+				const providerAtShutdown = providerRegistry.get('my-vault');
+
+				manager.shutdown();
+				allowUpdateToFinish.resolve();
+				await replacementDisposed.promise;
+
+				expect(providerRegistry.get('my-vault')).toBe(providerAtShutdown);
 			});
 
 			it('should stop serving stale secrets when replacement connection fails', async () => {
@@ -1240,17 +1402,20 @@ describe('ExternalSecretsManager', () => {
 			await managerWithProjectMode.init();
 
 			expect(managerWithProjectMode.initialized).toBe(true);
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'vault-1',
-				'dummy',
-				expect.objectContaining({ settings: { key: 'value' } }),
-			);
-			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
-				'vault-2',
-				'dummy',
-				expect.objectContaining({ settings: { key: 'value' } }),
-			);
-			expect(mockSecretsCache.refreshAll).toHaveBeenCalled();
+			expect(mockProviderConnectionManager.upsertProviderConnections).toHaveBeenCalledWith([
+				{
+					providerKey: 'vault-1',
+					providerType: 'dummy',
+					config: expect.objectContaining({ settings: { key: 'value' } }),
+				},
+				{
+					providerKey: 'vault-2',
+					providerType: 'dummy',
+					config: expect.objectContaining({ settings: { key: 'value' } }),
+				},
+			]);
+			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
+			expect(mockSecretsCache.refreshAll).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
@@ -1,4 +1,4 @@
-import { mockLogger } from '@n8n/backend-test-utils';
+import type { Logger } from '@n8n/backend-common';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -8,14 +8,33 @@ import { ExternalSecretsProviderConnectionManager } from '../external-secrets-pr
 import type { ExternalSecretsProviderLifecycle } from '../provider-lifecycle.service';
 import type { ExternalSecretsProviderRegistry } from '../provider-registry.service';
 import type { ExternalSecretsRetryManager } from '../retry-manager.service';
+import type { ExternalSecretsSecretsCache } from '../secrets-cache.service';
 import type { SecretsProvider, SecretsProviderSettings } from '../types';
+
+const createDeferred = <T>() => {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+
+	return { promise, resolve, reject };
+};
+
+const flushPromises = async () => {
+	await Promise.resolve();
+	await Promise.resolve();
+};
 
 describe('ExternalSecretsProviderConnectionManager', () => {
 	let manager: ExternalSecretsProviderConnectionManager;
 	let mockProviderRegistry: Mocked<ExternalSecretsProviderRegistry>;
 	let mockProviderLifecycle: Mocked<ExternalSecretsProviderLifecycle>;
 	let mockRetryManager: Mocked<ExternalSecretsRetryManager>;
+	let mockSecretsCache: Mocked<ExternalSecretsSecretsCache>;
 	let providersMap: Map<string, SecretsProvider>;
+	let scopedLogger: Mocked<Logger>;
 
 	const providerSettings: SecretsProviderSettings = {
 		connected: true,
@@ -23,7 +42,15 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 		settings: { key: 'value' },
 	};
 
+	const upsertProvider = async (providerKey = 'my-vault', providerType = 'dummy') =>
+		await manager.upsertProviderConnection({
+			providerKey,
+			providerType,
+			config: providerSettings,
+		});
+
 	beforeEach(() => {
+		vi.useFakeTimers();
 		providersMap = new Map();
 
 		mockProviderRegistry = mock<ExternalSecretsProviderRegistry>();
@@ -48,67 +75,195 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 			return await operation();
 		});
 
+		mockSecretsCache = mock<ExternalSecretsSecretsCache>();
+
+		scopedLogger = mock<Logger>();
+		const logger = mock<Logger>({
+			scoped: vi.fn().mockReturnValue(scopedLogger),
+		});
 		manager = new ExternalSecretsProviderConnectionManager(
-			mockLogger(),
+			logger,
 			mockProviderRegistry,
 			mockProviderLifecycle,
 			mockRetryManager,
+			mockSecretsCache,
 		);
 	});
 
-	it('should add new provider and connect with retry', async () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should refresh a new provider before completing its initial upsert', async () => {
 		const provider = new DummyProvider();
 		mockProviderLifecycle.initialize.mockResolvedValue({ success: true, provider });
 
-		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
+		await upsertProvider();
 
-		expect(mockProviderLifecycle.initialize).toHaveBeenCalledWith('dummy', providerSettings);
 		expect(mockProviderRegistry.set).toHaveBeenCalledWith('my-vault', provider);
-		expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith('my-vault', expect.any(Function));
 		expect(mockProviderLifecycle.connect).toHaveBeenCalledWith(provider);
+		expect(mockSecretsCache.refreshProvider).toHaveBeenCalledWith('my-vault', provider);
 	});
 
-	it('should replace provider without removing the registry key first', async () => {
+	it('should prepare batch upserts in order and await their completions concurrently', async () => {
+		const firstProvider = new DummyProvider();
+		const secondProvider = new DummyProvider();
+		mockProviderLifecycle.initialize
+			.mockResolvedValueOnce({ success: true, provider: firstProvider })
+			.mockResolvedValueOnce({ success: true, provider: secondProvider });
+
+		const firstRefresh = createDeferred<undefined>();
+		const secondRefresh = createDeferred<undefined>();
+		mockSecretsCache.refreshProvider
+			.mockReturnValueOnce(firstRefresh.promise)
+			.mockReturnValueOnce(secondRefresh.promise);
+
+		const batchPromise = manager.upsertProviderConnections([
+			{
+				providerKey: 'first-vault',
+				providerType: 'first',
+				config: providerSettings,
+			},
+			{
+				providerKey: 'second-vault',
+				providerType: 'second',
+				config: providerSettings,
+			},
+		]);
+
+		await vi.waitFor(() => {
+			expect(mockSecretsCache.refreshProvider).toHaveBeenCalledTimes(2);
+		});
+		expect(
+			mockProviderLifecycle.initialize.mock.calls.map(([providerType]) => providerType),
+		).toEqual(['first', 'second']);
+
+		firstRefresh.resolve(undefined);
+		await flushPromises();
+
+		let completed = false;
+		void batchPromise.then(() => {
+			completed = true;
+		});
+		await flushPromises();
+		expect(completed).toBe(false);
+
+		secondRefresh.resolve(undefined);
+		await batchPromise;
+	});
+
+	it('should keep the old provider active while replacement initialization is pending', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.set('my-vault', existingProvider);
-		mockProviderRegistry.set.mockClear();
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		const initialization = createDeferred<{
+			success: boolean;
+			provider: SecretsProvider;
+		}>();
+		mockProviderLifecycle.initialize.mockReturnValue(initialization.promise);
+
+		const upsertPromise = upsertProvider();
+
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+
+		initialization.resolve({ success: true, provider: replacementProvider });
+		await upsertPromise;
+
+		await vi.waitFor(() => {
+			expect(providersMap.get('my-vault')).toBe(replacementProvider);
+		});
+	});
+
+	it('should keep the old provider active while replacement connection is pending', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
 
 		const replacementProvider = new DummyProvider();
 		mockProviderLifecycle.initialize.mockResolvedValue({
 			success: true,
 			provider: replacementProvider,
 		});
+		const connection = createDeferred<{ success: boolean }>();
+		mockProviderLifecycle.connect.mockReturnValue(connection.promise);
 
-		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
+		const upsertPromise = upsertProvider();
+		await flushPromises();
 
-		expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
-		expect(mockProviderRegistry.set).toHaveBeenCalledWith('my-vault', replacementProvider);
-		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+
+		connection.resolve({ success: true });
+		await upsertPromise;
+
+		await vi.waitFor(() => {
+			expect(providersMap.get('my-vault')).toBe(replacementProvider);
+		});
 	});
 
-	it('should cancel retry and remove existing provider when replacement initialization fails', async () => {
+	it('should resolve the upsert while hydration is pending and activate on completion', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.set('my-vault', existingProvider);
-		mockRetryManager.cancelRetry.mockClear();
+		providersMap.set('my-vault', existingProvider);
 
+		const replacementProvider = new DummyProvider();
+		const hydration = createDeferred<undefined>();
+		const updateSpy = vi.spyOn(replacementProvider, 'update').mockReturnValue(hydration.promise);
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		// The upsert resolves while hydration is still pending: the old provider stays active.
+		await upsertProvider();
+
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+		expect(mockProviderLifecycle.disconnect).not.toHaveBeenCalledWith(existingProvider);
+
+		hydration.resolve(undefined);
+
+		await vi.waitFor(() => {
+			expect(providersMap.get('my-vault')).toBe(replacementProvider);
+		});
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		expect(updateSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('should expose the newest provider in an error state when initialization fails', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const failedProvider = new DummyProvider();
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: false,
+			provider: failedProvider,
+			error: new Error('Init failed'),
+		});
+
+		await upsertProvider();
+
+		expect(providersMap.get('my-vault')).toBe(failedProvider);
+		expect(failedProvider.state).toBe('error');
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		expect(mockRetryManager.runWithRetry).not.toHaveBeenCalled();
+	});
+
+	it('should remove the old provider when initialization fails without an error instance', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
 		mockProviderLifecycle.initialize.mockResolvedValue({
 			success: false,
 			error: new Error('Init failed'),
 		});
 
-		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
+		await upsertProvider();
 
-		expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
+		expect(providersMap.has('my-vault')).toBe(false);
 		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-		expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
-		expect(mockRetryManager.runWithRetry).not.toHaveBeenCalled();
 	});
 
-	it('should register failed replacement without cancelling scheduled retry when connection fails', async () => {
+	it('should retire the old provider and publish a failed connection for retry', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.set('my-vault', existingProvider);
-		mockProviderRegistry.set.mockClear();
-		mockRetryManager.cancelRetry.mockClear();
+		providersMap.set('my-vault', existingProvider);
 
 		const replacementProvider = new DummyProvider();
 		mockProviderLifecycle.initialize.mockResolvedValue({
@@ -120,34 +275,341 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 			error: new Error('Connection failed'),
 		});
 
-		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
+		await upsertProvider();
 
-		expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith('my-vault', expect.any(Function));
-		expect(mockRetryManager.cancelRetry).not.toHaveBeenCalledWith('my-vault');
-		expect(mockProviderRegistry.set).toHaveBeenCalledWith('my-vault', replacementProvider);
+		expect(providersMap.get('my-vault')).toBe(replacementProvider);
+		expect(replacementProvider.state).toBe('error');
 		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-		expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
+		expect(scopedLogger.error).toHaveBeenCalledWith(
+			'External secrets provider replacement connection attempt failed',
+			expect.objectContaining({
+				providerKey: 'my-vault',
+				generation: 1,
+				phase: 'connection',
+				error: expect.any(Error),
+			}),
+		);
+		expect(scopedLogger.error).not.toHaveBeenCalledWith(
+			'External secrets provider replacement reached terminal failure',
+			expect.objectContaining({ phase: 'connection' }),
+		);
 	});
 
-	it('should cancel retry and remove provider', async () => {
+	it('should keep a connection retry off-registry until its hydration succeeds', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.set('my-vault', existingProvider);
+		providersMap.set('my-vault', existingProvider);
 
+		const replacementProvider = new DummyProvider();
+		const hydration = createDeferred<undefined>();
+		vi.spyOn(replacementProvider, 'update').mockReturnValue(hydration.promise);
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		let retryOperation!: () => Promise<{ success: boolean; error?: Error }>;
+		mockRetryManager.runWithRetry.mockImplementation(async (_key, operation) => {
+			retryOperation = operation;
+			return await operation();
+		});
+		mockProviderLifecycle.connect.mockResolvedValueOnce({
+			success: false,
+			error: new Error('Connection failed'),
+		});
+
+		await upsertProvider();
+		expect(providersMap.get('my-vault')).toBe(replacementProvider);
+
+		mockProviderLifecycle.connect.mockImplementationOnce(async (provider) => {
+			provider.setState('connected');
+			return { success: true };
+		});
+		await retryOperation();
+
+		expect(replacementProvider.state).toBe('connected');
+		expect(providersMap.has('my-vault')).toBe(false);
+
+		hydration.resolve(undefined);
+
+		await vi.waitFor(() => {
+			expect(providersMap.get('my-vault')).toBe(replacementProvider);
+		});
+	});
+
+	it('should publish a hydration failure and retire the old provider', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		vi.spyOn(replacementProvider, 'update').mockRejectedValue(new Error('Hydration failed'));
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		await upsertProvider();
+
+		await vi.waitFor(() => {
+			expect(providersMap.get('my-vault')).toBe(replacementProvider);
+		});
+		expect(replacementProvider.state).toBe('error');
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		expect(scopedLogger.error).toHaveBeenCalledWith(
+			'External secrets provider replacement reached terminal failure',
+			expect.objectContaining({
+				providerKey: 'my-vault',
+				generation: 1,
+				phase: 'hydration',
+				error: expect.any(Error),
+			}),
+		);
+	});
+
+	it('should ignore and dispose a superseded candidate that succeeds late', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const candidateA = new DummyProvider();
+		const candidateAHydration = createDeferred<undefined>();
+		const candidateAUpdate = vi
+			.spyOn(candidateA, 'update')
+			.mockReturnValue(candidateAHydration.promise);
+		const candidateB = new DummyProvider();
+		mockProviderLifecycle.initialize
+			.mockResolvedValueOnce({ success: true, provider: candidateA })
+			.mockResolvedValueOnce({ success: true, provider: candidateB });
+
+		const upsertA = upsertProvider();
+		await vi.waitFor(() => {
+			expect(candidateAUpdate).toHaveBeenCalled();
+		});
+		const upsertB = upsertProvider();
+		await upsertB;
+
+		await vi.waitFor(() => {
+			expect(providersMap.get('my-vault')).toBe(candidateB);
+		});
+
+		candidateAHydration.resolve(undefined);
+		await upsertA;
+
+		await vi.waitFor(() => {
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(candidateA);
+		});
+		expect(providersMap.get('my-vault')).toBe(candidateB);
+		expect(scopedLogger.debug).toHaveBeenCalledWith(
+			'External secrets provider superseded completion ignored and disposed',
+			expect.objectContaining({
+				providerKey: 'my-vault',
+				generation: 1,
+				phase: 'hydration',
+			}),
+		);
+	});
+
+	it('should ignore and dispose a superseded candidate that fails late', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const candidateA = new DummyProvider();
+		const candidateAHydration = createDeferred<undefined>();
+		const candidateAUpdate = vi
+			.spyOn(candidateA, 'update')
+			.mockReturnValue(candidateAHydration.promise);
+		const candidateB = new DummyProvider();
+		mockProviderLifecycle.initialize
+			.mockResolvedValueOnce({ success: true, provider: candidateA })
+			.mockResolvedValueOnce({ success: true, provider: candidateB });
+
+		const upsertA = upsertProvider();
+		await vi.waitFor(() => {
+			expect(candidateAUpdate).toHaveBeenCalled();
+		});
+		const upsertB = upsertProvider();
+		await upsertB;
+
+		candidateAHydration.reject(new Error('Hydration failed'));
+		await upsertA;
+
+		await vi.waitFor(() => {
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(candidateA);
+		});
+		expect(providersMap.get('my-vault')).toBe(candidateB);
+		expect(candidateB.state).not.toBe('error');
+	});
+
+	it('should remove access immediately and prevent pending hydration from restoring it', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		const hydration = createDeferred<undefined>();
+		const updateSpy = vi.spyOn(replacementProvider, 'update').mockReturnValue(hydration.promise);
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		const upsertPromise = upsertProvider();
+		await vi.waitFor(() => {
+			expect(updateSpy).toHaveBeenCalled();
+		});
 		await manager.removeProviderConnection('my-vault');
 
-		expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
-		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-		expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
+		expect(providersMap.has('my-vault')).toBe(false);
+
+		hydration.resolve(undefined);
+		await upsertPromise;
+
+		await vi.waitFor(() => {
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(replacementProvider);
+		});
+		expect(providersMap.has('my-vault')).toBe(false);
 	});
 
-	it('should disconnect provider without removing it', async () => {
+	it('should invalidate pending hydration when disconnecting the active provider', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.set('my-vault', existingProvider);
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		const hydration = createDeferred<undefined>();
+		const updateSpy = vi.spyOn(replacementProvider, 'update').mockReturnValue(hydration.promise);
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		const upsertPromise = upsertProvider();
+		await vi.waitFor(() => {
+			expect(updateSpy).toHaveBeenCalled();
+		});
+		await manager.disconnectProvider('my-vault');
+
+		hydration.resolve(undefined);
+		await upsertPromise;
+
+		await vi.waitFor(() => {
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(replacementProvider);
+		});
+		expect(providersMap.has('my-vault')).toBe(false);
+	});
+
+	it('should prevent activation after shutdown during initialization', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		const initialization = createDeferred<{
+			success: boolean;
+			provider: SecretsProvider;
+		}>();
+		mockProviderLifecycle.initialize.mockReturnValue(initialization.promise);
+
+		const upsertPromise = upsertProvider();
+		manager.shutdown();
+		initialization.resolve({ success: true, provider: replacementProvider });
+
+		await upsertPromise;
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(replacementProvider);
+	});
+
+	it('should prevent activation after shutdown during connection', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+		const connection = createDeferred<{ success: boolean }>();
+		mockProviderLifecycle.connect.mockReturnValue(connection.promise);
+
+		const upsertPromise = upsertProvider();
+		await flushPromises();
+		manager.shutdown();
+		connection.resolve({ success: true });
+
+		await upsertPromise;
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(replacementProvider);
+	});
+
+	it('should prevent late activation after shutdown during hydration', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		const hydration = createDeferred<undefined>();
+		const updateSpy = vi.spyOn(replacementProvider, 'update').mockReturnValue(hydration.promise);
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		const upsertPromise = upsertProvider();
+		await vi.waitFor(() => {
+			expect(updateSpy).toHaveBeenCalled();
+		});
+		manager.shutdown();
+		hydration.resolve(undefined);
+		await upsertPromise;
+
+		await vi.waitFor(() => {
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(replacementProvider);
+		});
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+	});
+
+	it('should use a generation for replacement lifecycle logs', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		await upsertProvider();
+
+		expect(scopedLogger.debug).toHaveBeenCalledWith(
+			'External secrets provider replacement started',
+			expect.objectContaining({
+				providerKey: 'my-vault',
+				providerType: 'dummy',
+				generation: 1,
+			}),
+		);
+		await vi.waitFor(() => {
+			expect(scopedLogger.debug).toHaveBeenCalledWith(
+				'External secrets provider replacement activated',
+				expect.objectContaining({
+					providerKey: 'my-vault',
+					providerType: 'dummy',
+					generation: 1,
+				}),
+			);
+		});
+	});
+
+	it('should cancel retries and disconnect providers on shutdown', () => {
+		manager.shutdown();
+
+		expect(mockRetryManager.cancelAll).toHaveBeenCalled();
+		expect(mockProviderRegistry.disconnectAll).toHaveBeenCalled();
+	});
+
+	it('should remove access before disconnecting a provider', async () => {
+		const existingProvider = new DummyProvider();
+		providersMap.set('my-vault', existingProvider);
 
 		await manager.disconnectProvider('my-vault');
 
 		expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
 		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-		expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
+		expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
+		expect(providersMap.has('my-vault')).toBe(false);
 	});
 });

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
@@ -261,7 +261,7 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
 	});
 
-	it('should retire the old provider and publish a failed connection for retry', async () => {
+	it('should retire an unconnected old provider and publish a failed connection for retry', async () => {
 		const existingProvider = new DummyProvider();
 		providersMap.set('my-vault', existingProvider);
 
@@ -292,6 +292,79 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 			'External secrets provider replacement reached terminal failure',
 			expect.objectContaining({ phase: 'connection' }),
 		);
+	});
+
+	it('should keep a connected old provider active while a replacement connection retries', async () => {
+		const existingProvider = new DummyProvider();
+		existingProvider.setState('connected');
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+		mockProviderLifecycle.connect.mockResolvedValue({
+			success: false,
+			error: new Error('Connection failed'),
+		});
+
+		await upsertProvider();
+
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+		expect(replacementProvider.state).toBe('error');
+		expect(mockProviderLifecycle.disconnect).not.toHaveBeenCalledWith(existingProvider);
+		expect(scopedLogger.error).toHaveBeenCalledWith(
+			'External secrets provider replacement connection attempt failed',
+			expect.objectContaining({
+				providerKey: 'my-vault',
+				phase: 'connection',
+				error: expect.any(Error),
+			}),
+		);
+	});
+
+	it('should activate a retried replacement over a preserved connected old provider', async () => {
+		const existingProvider = new DummyProvider();
+		existingProvider.setState('connected');
+		providersMap.set('my-vault', existingProvider);
+
+		const replacementProvider = new DummyProvider();
+		const hydration = createDeferred<undefined>();
+		vi.spyOn(replacementProvider, 'update').mockReturnValue(hydration.promise);
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		let retryOperation!: () => Promise<{ success: boolean; error?: Error }>;
+		mockRetryManager.runWithRetry.mockImplementation(async (_key, operation) => {
+			retryOperation = operation;
+			return await operation();
+		});
+		mockProviderLifecycle.connect.mockResolvedValueOnce({
+			success: false,
+			error: new Error('Connection failed'),
+		});
+
+		await upsertProvider();
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+
+		mockProviderLifecycle.connect.mockImplementationOnce(async (provider) => {
+			provider.setState('connected');
+			return { success: true };
+		});
+		await retryOperation();
+
+		// The old provider keeps serving secrets while the retried candidate hydrates.
+		expect(providersMap.get('my-vault')).toBe(existingProvider);
+
+		hydration.resolve(undefined);
+
+		await vi.waitFor(() => {
+			expect(providersMap.get('my-vault')).toBe(replacementProvider);
+		});
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
 	});
 
 	it('should keep a connection retry off-registry until its hydration succeeds', async () => {

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
@@ -284,7 +284,6 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 			'External secrets provider replacement connection attempt failed',
 			expect.objectContaining({
 				providerKey: 'my-vault',
-				generation: 1,
 				phase: 'connection',
 				error: expect.any(Error),
 			}),
@@ -358,7 +357,6 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 			'External secrets provider replacement reached terminal failure',
 			expect.objectContaining({
 				providerKey: 'my-vault',
-				generation: 1,
 				phase: 'hydration',
 				error: expect.any(Error),
 			}),
@@ -398,11 +396,11 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 		});
 		expect(providersMap.get('my-vault')).toBe(candidateB);
 		expect(scopedLogger.debug).toHaveBeenCalledWith(
-			'External secrets provider superseded completion ignored and disposed',
+			'External secrets provider superseded replacement discarded',
 			expect.objectContaining({
 				providerKey: 'my-vault',
-				generation: 1,
 				phase: 'hydration',
+				disposed: true,
 			}),
 		);
 	});
@@ -532,8 +530,10 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 		connection.resolve({ success: true });
 
 		await upsertPromise;
+		await vi.waitFor(() => {
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(replacementProvider);
+		});
 		expect(providersMap.get('my-vault')).toBe(existingProvider);
-		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(replacementProvider);
 	});
 
 	it('should prevent late activation after shutdown during hydration', async () => {
@@ -562,7 +562,7 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 		expect(providersMap.get('my-vault')).toBe(existingProvider);
 	});
 
-	it('should use a generation for replacement lifecycle logs', async () => {
+	it('should log replacement lifecycle transitions', async () => {
 		const existingProvider = new DummyProvider();
 		providersMap.set('my-vault', existingProvider);
 
@@ -579,7 +579,7 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 			expect.objectContaining({
 				providerKey: 'my-vault',
 				providerType: 'dummy',
-				generation: 1,
+				phase: 'initialization',
 			}),
 		);
 		await vi.waitFor(() => {
@@ -588,7 +588,7 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 				expect.objectContaining({
 					providerKey: 'my-vault',
 					providerType: 'dummy',
-					generation: 1,
+					phase: 'hydration',
 				}),
 			);
 		});

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -10,12 +10,14 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 
+import {
+	ExternalSecretsProviderConnectionManager,
+	type ProviderConnectionInput,
+} from './external-secrets-provider-connection-manager.ee';
 import { ExternalSecretsProviders } from './external-secrets-providers.ee';
 import { ExternalSecretsConfig } from './external-secrets.config';
-import { ExternalSecretsProviderConnectionManager } from './external-secrets-provider-connection-manager.ee';
 import { ExternalSecretsProviderLifecycle } from './provider-lifecycle.service';
 import { ExternalSecretsProviderRegistry } from './provider-registry.service';
-import { ExternalSecretsRetryManager } from './retry-manager.service';
 import { ExternalSecretsSecretsCache } from './secrets-cache.service';
 import { ExternalSecretsSettingsStore } from './settings-store.service';
 import type { ExternalSecretsSettings, SecretsProvider, SecretsProviderSettings } from './types';
@@ -41,7 +43,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		private readonly settingsStore: ExternalSecretsSettingsStore,
 		private readonly providerRegistry: ExternalSecretsProviderRegistry,
 		private readonly providerLifecycle: ExternalSecretsProviderLifecycle,
-		private readonly retryManager: ExternalSecretsRetryManager,
 		private readonly providerConnectionManager: ExternalSecretsProviderConnectionManager,
 		private readonly secretsCache: ExternalSecretsSecretsCache,
 		private readonly secretsProviderConnectionRepository: SecretsProviderConnectionRepository,
@@ -79,8 +80,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 	shutdown(): void {
 		this.stopSecretsRefresh();
-		this.retryManager.cancelAll();
-		void this.providerRegistry.disconnectAll();
+		this.providerConnectionManager.shutdown();
 		this.initialized = false;
 		this.logger.debug('External secrets manager shut down');
 	}
@@ -150,16 +150,11 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 				settings,
 			};
 
-			await this.providerConnectionManager.upsertProviderConnection(
+			await this.providerConnectionManager.upsertProviderConnection({
 				providerKey,
-				connection.type,
-				connectionSettings,
-			);
-
-			const provider = this.providerRegistry.get(providerKey);
-			if (provider) {
-				await this.secretsCache.refreshProvider(providerKey, provider);
-			}
+				providerType: connection.type,
+				config: connectionSettings,
+			});
 		} else {
 			await this.providerConnectionManager.removeProviderConnection(providerKey);
 		}
@@ -226,7 +221,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		await this.settingsStore.updateProvider(provider, { connected });
 
 		if (connected) {
-			await this.providerConnectionManager.connectProviderWithRetry(provider);
+			await this.reloadProvider(provider);
 		} else {
 			await this.providerConnectionManager.disconnectProvider(provider);
 		}
@@ -293,18 +288,19 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 		this.logger.debug('Reloading all external secrets providers');
 		const newSettings = await this.settingsStore.reload();
-
-		// Reload/add providers from new settings
-		for (const name of Object.keys(newSettings)) {
-			await this.reloadProvider(name);
-		}
-
-		await this.secretsCache.refreshAll();
+		await this.providerConnectionManager.upsertProviderConnections(
+			Object.entries(newSettings).map(([providerKey, config]) => ({
+				providerKey,
+				providerType: providerKey,
+				config,
+			})),
+		);
 		this.logger.debug('Reloaded all external secrets providers');
 	}
 
 	private async reloadProvidersFromConnectionsRepo(): Promise<void> {
 		const connections = await this.secretsProviderConnectionRepository.findAll();
+		const providerConnections: ProviderConnectionInput[] = [];
 
 		for (const connection of connections) {
 			if (!connection.isEnabled) {
@@ -322,14 +318,14 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 				settings,
 			};
 
-			await this.providerConnectionManager.upsertProviderConnection(
-				connection.providerKey,
-				connection.type,
-				connectionSettings,
-			);
+			providerConnections.push({
+				providerKey: connection.providerKey,
+				providerType: connection.type,
+				config: connectionSettings,
+			});
 		}
 
-		await this.secretsCache.refreshAll();
+		await this.providerConnectionManager.upsertProviderConnections(providerConnections);
 		this.logger.debug('Reloaded external secrets providers');
 	}
 
@@ -344,7 +340,11 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 			return;
 		}
 
-		await this.providerConnectionManager.upsertProviderConnection(name, name, config);
+		await this.providerConnectionManager.upsertProviderConnection({
+			providerKey: name,
+			providerType: name,
+			config,
+		});
 	}
 
 	private async decryptSettings(

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { UnexpectedError } from 'n8n-workflow';
 
 import {
@@ -8,39 +9,106 @@ import {
 } from './provider-lifecycle.service';
 import { ExternalSecretsProviderRegistry } from './provider-registry.service';
 import { ExternalSecretsRetryManager } from './retry-manager.service';
+import { ExternalSecretsSecretsCache } from './secrets-cache.service';
 import type { SecretsProvider, SecretsProviderSettings } from './types';
+
+export interface ProviderConnectionInput {
+	providerKey: string;
+	providerType: string;
+	config: SecretsProviderSettings;
+}
+
+interface PreparedProviderConnection {
+	completion: Promise<void>;
+}
+
+interface ReplacementCandidate {
+	providerKey: string;
+	providerType: string;
+	generation: number;
+	provider?: SecretsProvider;
+}
+
+type ReplacementOutcome =
+	| {
+			kind: 'ready';
+			phase: 'disconnected' | 'hydration';
+			provider: SecretsProvider;
+	  }
+	| {
+			kind: 'failed';
+			phase: 'initialization' | 'hydration';
+			provider?: SecretsProvider;
+			error: Error;
+	  };
+
+const COMPLETED_CONNECTION = {
+	completion: Promise.resolve(),
+} satisfies PreparedProviderConnection;
 
 @Service()
 export class ExternalSecretsProviderConnectionManager {
+	private replacementGeneration = 0;
+
+	private readonly replacementCandidates = new Map<string, ReplacementCandidate>();
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly providerRegistry: ExternalSecretsProviderRegistry,
 		private readonly providerLifecycle: ExternalSecretsProviderLifecycle,
 		private readonly retryManager: ExternalSecretsRetryManager,
+		private readonly secretsCache: ExternalSecretsSecretsCache,
 	) {
 		this.logger = this.logger.scoped('external-secrets');
 	}
 
-	async upsertProviderConnection(
-		providerKey: string,
-		providerType: string,
-		config: SecretsProviderSettings,
-	): Promise<void> {
-		if (this.providerRegistry.has(providerKey)) {
-			// When there is already a provider registered we want to prepare the replacement before swapping the registry.
-			// We tolerate a small time window where we keep the old provider while the new one is being prepared.
-			// This is important because this avoids executions failing intermittently during the reload phase.
-			await this.replaceProviderConnection(providerKey, providerType, config);
-			return;
+	/**
+	 * Makes a provider configuration ready. For a new provider this resolves after its initial
+	 * cache refresh. For a replacement it resolves once background hydration has started; the
+	 * new configuration activates only when that hydration settles.
+	 */
+	async upsertProviderConnection(input: ProviderConnectionInput): Promise<void> {
+		const { completion } = await this.prepareProviderConnection(input);
+		await completion;
+	}
+
+	async upsertProviderConnections(inputs: ProviderConnectionInput[]): Promise<void> {
+		const completions: Array<Promise<void>> = [];
+
+		for (const input of inputs) {
+			const { completion } = await this.prepareProviderConnection(input);
+			completions.push(completion);
 		}
 
-		await this.addProviderConnection(providerKey, providerType, config);
+		await Promise.all(completions);
+	}
+
+	shutdown(): void {
+		this.replacementCandidates.clear();
+		this.retryManager.cancelAll();
+		void this.providerRegistry.disconnectAll();
+	}
+
+	private async prepareProviderConnection({
+		providerKey,
+		providerType,
+		config,
+	}: ProviderConnectionInput): Promise<PreparedProviderConnection> {
+		if (this.providerRegistry.has(providerKey) || this.replacementCandidates.has(providerKey)) {
+			// Replacement hydration is fire-and-forget: the old provider stays active until the
+			// candidate settles in the background, so there is no completion left to await.
+			await this.replaceProviderConnection(providerKey, providerType, config);
+			return COMPLETED_CONNECTION;
+		}
+
+		return await this.addProviderConnection(providerKey, providerType, config);
 	}
 
 	async removeProviderConnection(providerKey: string): Promise<void> {
-		// cancelling retries is needed because we can have previous connections for the same provider key
-		// This is especially common during the setup phase when initial configurations might be wrong
-		// and there will be several changes to the configuration before settling for a valid one.
+		this.invalidateReplacement(providerKey);
+
+		// Cancelling retries is needed because setup commonly produces several configurations
+		// before settling on a valid one.
 		this.retryManager.cancelRetry(providerKey);
 
 		this.logger.debug('Removing external secrets provider connection', {
@@ -48,13 +116,14 @@ export class ExternalSecretsProviderConnectionManager {
 		});
 
 		const existingProvider = this.providerRegistry.get(providerKey);
+		this.providerRegistry.remove(providerKey);
+
 		if (existingProvider) {
 			await this.providerLifecycle.disconnect(existingProvider);
-			this.providerRegistry.remove(providerKey);
 		}
 	}
 
-	async connectProviderWithRetry(providerKey: string): Promise<ProviderConnectResult> {
+	private async connectProviderWithRetry(providerKey: string): Promise<ProviderConnectResult> {
 		return await this.retryManager.runWithRetry(
 			providerKey,
 			async () => await this.connectProvider(providerKey),
@@ -62,9 +131,12 @@ export class ExternalSecretsProviderConnectionManager {
 	}
 
 	async disconnectProvider(providerKey: string): Promise<void> {
+		this.invalidateReplacement(providerKey);
 		this.retryManager.cancelRetry(providerKey);
 
 		const provider = this.providerRegistry.get(providerKey);
+		this.providerRegistry.remove(providerKey);
+
 		if (provider) {
 			await this.providerLifecycle.disconnect(provider);
 		}
@@ -74,7 +146,7 @@ export class ExternalSecretsProviderConnectionManager {
 		providerKey: string,
 		providerType: string,
 		config: SecretsProviderSettings,
-	): Promise<void> {
+	): Promise<PreparedProviderConnection> {
 		this.logger.debug('Adding external secrets provider connection', {
 			providerKey,
 			providerType,
@@ -88,7 +160,7 @@ export class ExternalSecretsProviderConnectionManager {
 				providerType,
 				error: result.error,
 			});
-			return;
+			return COMPLETED_CONNECTION;
 		}
 
 		this.providerRegistry.set(providerKey, result.provider);
@@ -96,6 +168,10 @@ export class ExternalSecretsProviderConnectionManager {
 		if (config.connected) {
 			await this.connectProviderWithRetry(providerKey);
 		}
+
+		return {
+			completion: this.secretsCache.refreshProvider(providerKey, result.provider),
+		};
 	}
 
 	private async replaceProviderConnection(
@@ -103,85 +179,252 @@ export class ExternalSecretsProviderConnectionManager {
 		providerType: string,
 		config: SecretsProviderSettings,
 	): Promise<void> {
-		this.logger.debug('Replacing external secrets provider connection', {
-			providerKey,
-			providerType,
-		});
-
-		// Initialization validates local config, so retrying it would only repeat deterministic failures.
+		const candidate = this.beginReplacement(providerKey, providerType);
 		const initResult = await this.providerLifecycle.initialize(providerType, config);
+		candidate.provider = initResult.provider;
 
-		if (!initResult.success || !initResult.provider) {
-			const error =
-				initResult.error ?? new UnexpectedError(`Failed to initialize provider ${providerKey}`);
-			this.logger.error('Failed to initialize replacement external secrets provider connection', {
-				providerKey,
-				providerType,
-				error,
-			});
-			await this.removeProviderConnection(providerKey);
+		// initialize() can take a while; a newer upsert/remove may have superseded
+		// this candidate while we awaited. This is a safe guard against race conditions.
+		if (!this.isCurrentReplacement(candidate)) {
+			await this.disposeSupersededReplacement(candidate, 'initialization');
 			return;
 		}
 
-		const replacementProvider = initResult.provider;
-		if (config.connected) {
-			// Only connection is retried. A successful retry must also perform the registry swap.
-			const replacementResult = await this.retryManager.runWithRetry(
-				providerKey,
-				async () =>
-					await this.connectAndSwapProviderConnection(
-						providerKey,
-						providerType,
-						replacementProvider,
-					),
+		if (!initResult.success || !initResult.provider) {
+			await this.settleReplacement(candidate, {
+				kind: 'failed',
+				phase: 'initialization',
+				provider: initResult.provider,
+				error:
+					initResult.error ?? new UnexpectedError(`Failed to initialize provider ${providerKey}`),
+			});
+			return;
+		}
+
+		if (!config.connected) {
+			await this.settleReplacement(candidate, {
+				kind: 'ready',
+				phase: 'disconnected',
+				provider: initResult.provider,
+			});
+			return;
+		}
+
+		await this.retryManager.runWithRetry(
+			providerKey,
+			async () => await this.connectReplacement(candidate),
+		);
+	}
+
+	private beginReplacement(providerKey: string, providerType: string): ReplacementCandidate {
+		const candidate: ReplacementCandidate = {
+			providerKey,
+			providerType,
+			generation: ++this.replacementGeneration,
+		};
+
+		this.replacementCandidates.set(providerKey, candidate);
+		this.retryManager.cancelRetry(providerKey);
+		this.logger.debug('External secrets provider replacement started', {
+			providerKey,
+			providerType,
+			generation: candidate.generation,
+			phase: 'initialization',
+		});
+
+		return candidate;
+	}
+
+	private async connectReplacement(
+		candidate: ReplacementCandidate,
+	): Promise<ProviderConnectResult> {
+		const provider = candidate.provider;
+		if (!this.isCurrentReplacement(candidate) || !provider) {
+			await this.disposeSupersededReplacement(candidate, 'before-connection');
+			return { success: true };
+		}
+
+		// A failed candidate is execution-visible in its error state between retries. Remove it
+		// while the same mutable instance reconnects and hydrates off-registry.
+		if (this.providerRegistry.get(candidate.providerKey) === provider) {
+			this.providerRegistry.remove(candidate.providerKey);
+		}
+
+		const connectResult = await this.providerLifecycle.connect(provider);
+
+		if (!this.isCurrentReplacement(candidate)) {
+			await this.disposeSupersededReplacement(candidate, 'connection');
+			return { success: true };
+		}
+
+		if (!connectResult.success) {
+			await this.publishRetryableConnectionFailure(
+				candidate,
+				connectResult.error ??
+					new UnexpectedError(`Failed to connect provider ${candidate.providerKey}`),
 			);
 
-			if (!replacementResult.success) {
-				// The replacement reflects the latest config, even if connection failed. Register it
-				// in its error state so executions fail visibly instead of using stale secrets.
-				await this.swapProviderConnection(providerKey, providerType, replacementProvider);
-			}
+			// A newer request may have arrived while the previous provider was being retired.
+			return this.isCurrentReplacement(candidate) ? connectResult : { success: true };
+		}
+
+		this.startReplacementHydration(candidate, provider);
+		return { success: true };
+	}
+
+	// Hydration is fire-and-forget: the caller's upsert resolves once hydration has started,
+	// while the old provider stays active until the candidate settles in the background.
+	private startReplacementHydration(
+		candidate: ReplacementCandidate,
+		provider: SecretsProvider,
+	): void {
+		void this.runReplacementHydration(candidate, provider).catch((error: unknown) => {
+			this.logger.error('Unexpected error settling external secrets provider replacement', {
+				providerKey: candidate.providerKey,
+				providerType: candidate.providerType,
+				generation: candidate.generation,
+				phase: 'hydration-settlement',
+				error: ensureError(error),
+			});
+		});
+	}
+
+	private async runReplacementHydration(
+		candidate: ReplacementCandidate,
+		provider: SecretsProvider,
+	): Promise<void> {
+		if (!this.isCurrentReplacement(candidate)) {
+			await this.disposeSupersededReplacement(candidate, 'before-hydration');
+			return;
+		}
+
+		try {
+			await provider.update();
+		} catch (error) {
+			await this.settleReplacement(candidate, {
+				kind: 'failed',
+				phase: 'hydration',
+				provider,
+				error: ensureError(error),
+			});
+			return;
+		}
+
+		await this.settleReplacement(candidate, {
+			kind: 'ready',
+			phase: 'hydration',
+			provider,
+		});
+	}
+
+	private async settleReplacement(
+		candidate: ReplacementCandidate,
+		outcome: ReplacementOutcome,
+	): Promise<void> {
+		if (!this.isCurrentReplacement(candidate)) {
+			await this.disposeSupersededReplacement(candidate, outcome.phase);
+			return;
+		}
+
+		const existingProvider = this.providerRegistry.get(candidate.providerKey);
+
+		if (outcome.kind === 'ready') {
+			this.providerRegistry.set(candidate.providerKey, outcome.provider);
+			this.logger.debug('External secrets provider replacement activated', {
+				providerKey: candidate.providerKey,
+				providerType: candidate.providerType,
+				generation: candidate.generation,
+				phase: outcome.phase,
+			});
 		} else {
-			await this.swapProviderConnection(providerKey, providerType, replacementProvider);
-		}
-	}
+			outcome.provider?.setState('error', outcome.error);
+			if (outcome.provider) {
+				this.providerRegistry.set(candidate.providerKey, outcome.provider);
+			} else {
+				this.providerRegistry.remove(candidate.providerKey);
+			}
 
-	private async connectAndSwapProviderConnection(
-		providerKey: string,
-		providerType: string,
-		replacementProvider: SecretsProvider,
-	): Promise<ProviderConnectResult> {
-		const connectResult = await this.providerLifecycle.connect(replacementProvider);
-		if (!connectResult.success) {
-			this.logger.error('Failed to connect replacement external secrets provider connection', {
-				providerKey,
-				providerType,
-				error: connectResult.error,
+			this.logger.error('External secrets provider replacement reached terminal failure', {
+				providerKey: candidate.providerKey,
+				providerType: candidate.providerType,
+				generation: candidate.generation,
+				phase: outcome.phase,
+				error: outcome.error,
 			});
-			return connectResult;
 		}
 
-		return await this.swapProviderConnection(providerKey, providerType, replacementProvider);
-	}
+		this.replacementCandidates.delete(candidate.providerKey);
 
-	private async swapProviderConnection(
-		providerKey: string,
-		providerType: string,
-		replacementProvider: SecretsProvider,
-	): Promise<ProviderConnectResult> {
-		const existingProvider = this.providerRegistry.get(providerKey);
-
-		this.providerRegistry.set(providerKey, replacementProvider);
-
-		if (existingProvider && existingProvider !== replacementProvider) {
-			this.logger.debug('Disconnecting previous external secrets provider connection', {
-				providerKey,
-				providerType,
-			});
+		if (existingProvider && existingProvider !== outcome.provider) {
 			await this.providerLifecycle.disconnect(existingProvider);
 		}
+	}
 
-		return { success: true };
+	private async publishRetryableConnectionFailure(
+		candidate: ReplacementCandidate,
+		error: Error,
+	): Promise<void> {
+		if (!this.isCurrentReplacement(candidate) || !candidate.provider) {
+			await this.disposeSupersededReplacement(candidate, 'connection');
+			return;
+		}
+
+		candidate.provider.setState('error', error);
+		const existingProvider = this.providerRegistry.get(candidate.providerKey);
+		this.providerRegistry.set(candidate.providerKey, candidate.provider);
+
+		this.logger.error('External secrets provider replacement connection attempt failed', {
+			providerKey: candidate.providerKey,
+			providerType: candidate.providerType,
+			generation: candidate.generation,
+			phase: 'connection',
+			error,
+		});
+
+		if (existingProvider && existingProvider !== candidate.provider) {
+			await this.providerLifecycle.disconnect(existingProvider);
+		}
+	}
+
+	private async disposeSupersededReplacement(
+		candidate: ReplacementCandidate,
+		phase: string,
+	): Promise<void> {
+		const shouldDispose =
+			candidate.provider !== undefined &&
+			this.providerRegistry.get(candidate.providerKey) !== candidate.provider;
+
+		this.logSupersededCompletion(candidate, phase, shouldDispose);
+
+		if (shouldDispose && candidate.provider) {
+			await this.providerLifecycle.disconnect(candidate.provider);
+		}
+	}
+
+	private logSupersededCompletion(
+		candidate: ReplacementCandidate,
+		phase: string,
+		disposed = false,
+	): void {
+		this.logger.debug(
+			disposed
+				? 'External secrets provider superseded completion ignored and disposed'
+				: 'External secrets provider superseded completion ignored',
+			{
+				providerKey: candidate.providerKey,
+				providerType: candidate.providerType,
+				generation: candidate.generation,
+				phase,
+			},
+		);
+	}
+
+	private isCurrentReplacement(candidate: ReplacementCandidate): boolean {
+		return this.replacementCandidates.get(candidate.providerKey) === candidate;
+	}
+
+	private invalidateReplacement(providerKey: string): void {
+		this.replacementCandidates.delete(providerKey);
 	}
 
 	private async connectProvider(providerKey: string): Promise<ProviderConnectResult> {

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
@@ -25,7 +25,6 @@ interface PreparedProviderConnection {
 interface ReplacementCandidate {
 	providerKey: string;
 	providerType: string;
-	generation: number;
 	provider?: SecretsProvider;
 }
 
@@ -48,8 +47,6 @@ const COMPLETED_CONNECTION = {
 
 @Service()
 export class ExternalSecretsProviderConnectionManager {
-	private replacementGeneration = 0;
-
 	private readonly replacementCandidates = new Map<string, ReplacementCandidate>();
 
 	constructor(
@@ -183,13 +180,6 @@ export class ExternalSecretsProviderConnectionManager {
 		const initResult = await this.providerLifecycle.initialize(providerType, config);
 		candidate.provider = initResult.provider;
 
-		// initialize() can take a while; a newer upsert/remove may have superseded
-		// this candidate while we awaited. This is a safe guard against race conditions.
-		if (!this.isCurrentReplacement(candidate)) {
-			await this.disposeSupersededReplacement(candidate, 'initialization');
-			return;
-		}
-
 		if (!initResult.success || !initResult.provider) {
 			await this.settleReplacement(candidate, {
 				kind: 'failed',
@@ -210,6 +200,13 @@ export class ExternalSecretsProviderConnectionManager {
 			return;
 		}
 
+		// initialize() can take a while; a superseded candidate must not enter the retry loop,
+		// because runWithRetry() would cancel the retries of the replacement that superseded it.
+		if (!this.isCurrentReplacement(candidate)) {
+			await this.disposeSupersededCandidate(candidate, 'initialization');
+			return;
+		}
+
 		await this.retryManager.runWithRetry(
 			providerKey,
 			async () => await this.connectReplacement(candidate),
@@ -217,18 +214,13 @@ export class ExternalSecretsProviderConnectionManager {
 	}
 
 	private beginReplacement(providerKey: string, providerType: string): ReplacementCandidate {
-		const candidate: ReplacementCandidate = {
-			providerKey,
-			providerType,
-			generation: ++this.replacementGeneration,
-		};
+		const candidate: ReplacementCandidate = { providerKey, providerType };
 
 		this.replacementCandidates.set(providerKey, candidate);
 		this.retryManager.cancelRetry(providerKey);
 		this.logger.debug('External secrets provider replacement started', {
 			providerKey,
 			providerType,
-			generation: candidate.generation,
 			phase: 'initialization',
 		});
 
@@ -239,8 +231,7 @@ export class ExternalSecretsProviderConnectionManager {
 		candidate: ReplacementCandidate,
 	): Promise<ProviderConnectResult> {
 		const provider = candidate.provider;
-		if (!this.isCurrentReplacement(candidate) || !provider) {
-			await this.disposeSupersededReplacement(candidate, 'before-connection');
+		if (!provider) {
 			return { success: true };
 		}
 
@@ -252,24 +243,20 @@ export class ExternalSecretsProviderConnectionManager {
 
 		const connectResult = await this.providerLifecycle.connect(provider);
 
-		if (!this.isCurrentReplacement(candidate)) {
-			await this.disposeSupersededReplacement(candidate, 'connection');
+		if (connectResult.success) {
+			this.startReplacementHydration(candidate, provider);
 			return { success: true };
 		}
 
-		if (!connectResult.success) {
-			await this.publishRetryableConnectionFailure(
-				candidate,
-				connectResult.error ??
-					new UnexpectedError(`Failed to connect provider ${candidate.providerKey}`),
-			);
+		const published = await this.publishRetryableConnectionFailure(
+			candidate,
+			connectResult.error ??
+				new UnexpectedError(`Failed to connect provider ${candidate.providerKey}`),
+		);
 
-			// A newer request may have arrived while the previous provider was being retired.
-			return this.isCurrentReplacement(candidate) ? connectResult : { success: true };
-		}
-
-		this.startReplacementHydration(candidate, provider);
-		return { success: true };
+		// A superseded candidate must not report failure: that would re-schedule a retry the
+		// superseding operation has already cancelled.
+		return published ? connectResult : { success: true };
 	}
 
 	// Hydration is fire-and-forget: the caller's upsert resolves once hydration has started,
@@ -282,7 +269,6 @@ export class ExternalSecretsProviderConnectionManager {
 			this.logger.error('Unexpected error settling external secrets provider replacement', {
 				providerKey: candidate.providerKey,
 				providerType: candidate.providerType,
-				generation: candidate.generation,
 				phase: 'hydration-settlement',
 				error: ensureError(error),
 			});
@@ -293,11 +279,6 @@ export class ExternalSecretsProviderConnectionManager {
 		candidate: ReplacementCandidate,
 		provider: SecretsProvider,
 	): Promise<void> {
-		if (!this.isCurrentReplacement(candidate)) {
-			await this.disposeSupersededReplacement(candidate, 'before-hydration');
-			return;
-		}
-
 		try {
 			await provider.update();
 		} catch (error) {
@@ -321,8 +302,11 @@ export class ExternalSecretsProviderConnectionManager {
 		candidate: ReplacementCandidate,
 		outcome: ReplacementOutcome,
 	): Promise<void> {
+		// Initialization, connection and hydration all await slow calls; a newer upsert/remove may
+		// have superseded this candidate in the meantime. Discard its outcome here, at the single
+		// point where replacements publish to the registry.
 		if (!this.isCurrentReplacement(candidate)) {
-			await this.disposeSupersededReplacement(candidate, outcome.phase);
+			await this.disposeSupersededCandidate(candidate, outcome.phase);
 			return;
 		}
 
@@ -333,7 +317,6 @@ export class ExternalSecretsProviderConnectionManager {
 			this.logger.debug('External secrets provider replacement activated', {
 				providerKey: candidate.providerKey,
 				providerType: candidate.providerType,
-				generation: candidate.generation,
 				phase: outcome.phase,
 			});
 		} else {
@@ -347,7 +330,6 @@ export class ExternalSecretsProviderConnectionManager {
 			this.logger.error('External secrets provider replacement reached terminal failure', {
 				providerKey: candidate.providerKey,
 				providerType: candidate.providerType,
-				generation: candidate.generation,
 				phase: outcome.phase,
 				error: outcome.error,
 			});
@@ -360,13 +342,17 @@ export class ExternalSecretsProviderConnectionManager {
 		}
 	}
 
+	/**
+	 * Publishes a failed candidate to the registry so its error state is visible between retries.
+	 * Returns false when the candidate was superseded while connecting and was disposed instead.
+	 */
 	private async publishRetryableConnectionFailure(
 		candidate: ReplacementCandidate,
 		error: Error,
-	): Promise<void> {
+	): Promise<boolean> {
 		if (!this.isCurrentReplacement(candidate) || !candidate.provider) {
-			await this.disposeSupersededReplacement(candidate, 'connection');
-			return;
+			await this.disposeSupersededCandidate(candidate, 'connection');
+			return false;
 		}
 
 		candidate.provider.setState('error', error);
@@ -376,7 +362,6 @@ export class ExternalSecretsProviderConnectionManager {
 		this.logger.error('External secrets provider replacement connection attempt failed', {
 			providerKey: candidate.providerKey,
 			providerType: candidate.providerType,
-			generation: candidate.generation,
 			phase: 'connection',
 			error,
 		});
@@ -384,39 +369,28 @@ export class ExternalSecretsProviderConnectionManager {
 		if (existingProvider && existingProvider !== candidate.provider) {
 			await this.providerLifecycle.disconnect(existingProvider);
 		}
+
+		return true;
 	}
 
-	private async disposeSupersededReplacement(
+	private async disposeSupersededCandidate(
 		candidate: ReplacementCandidate,
 		phase: string,
 	): Promise<void> {
+		const { provider, providerKey, providerType } = candidate;
 		const shouldDispose =
-			candidate.provider !== undefined &&
-			this.providerRegistry.get(candidate.providerKey) !== candidate.provider;
+			provider !== undefined && this.providerRegistry.get(providerKey) !== provider;
 
-		this.logSupersededCompletion(candidate, phase, shouldDispose);
+		this.logger.debug('External secrets provider superseded replacement discarded', {
+			providerKey,
+			providerType,
+			phase,
+			disposed: shouldDispose,
+		});
 
-		if (shouldDispose && candidate.provider) {
-			await this.providerLifecycle.disconnect(candidate.provider);
+		if (shouldDispose) {
+			await this.providerLifecycle.disconnect(provider);
 		}
-	}
-
-	private logSupersededCompletion(
-		candidate: ReplacementCandidate,
-		phase: string,
-		disposed = false,
-	): void {
-		this.logger.debug(
-			disposed
-				? 'External secrets provider superseded completion ignored and disposed'
-				: 'External secrets provider superseded completion ignored',
-			{
-				providerKey: candidate.providerKey,
-				providerType: candidate.providerType,
-				generation: candidate.generation,
-				phase,
-			},
-		);
 	}
 
 	private isCurrentReplacement(candidate: ReplacementCandidate): boolean {

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
@@ -343,7 +343,9 @@ export class ExternalSecretsProviderConnectionManager {
 	}
 
 	/**
-	 * Publishes a failed candidate to the registry so its error state is visible between retries.
+	 * Publishes a failed candidate to the registry so its error state is visible between retries,
+	 * unless a still-connected predecessor occupies the slot — that one keeps serving secrets to
+	 * executions during the retry window, so the candidate stays off-registry until it succeeds.
 	 * Returns false when the candidate was superseded while connecting and was disposed instead.
 	 */
 	private async publishRetryableConnectionFailure(
@@ -356,8 +358,6 @@ export class ExternalSecretsProviderConnectionManager {
 		}
 
 		candidate.provider.setState('error', error);
-		const existingProvider = this.providerRegistry.get(candidate.providerKey);
-		this.providerRegistry.set(candidate.providerKey, candidate.provider);
 
 		this.logger.error('External secrets provider replacement connection attempt failed', {
 			providerKey: candidate.providerKey,
@@ -365,6 +365,18 @@ export class ExternalSecretsProviderConnectionManager {
 			phase: 'connection',
 			error,
 		});
+
+		const existingProvider = this.providerRegistry.get(candidate.providerKey);
+		const hasConnectedPredecessor =
+			existingProvider !== undefined &&
+			existingProvider !== candidate.provider &&
+			existingProvider.state === 'connected';
+
+		if (hasConnectedPredecessor) {
+			return true;
+		}
+
+		this.providerRegistry.set(candidate.providerKey, candidate.provider);
 
 		if (existingProvider && existingProvider !== candidate.provider) {
 			await this.providerLifecycle.disconnect(existingProvider);

--- a/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
@@ -13,7 +13,6 @@ import { ExternalSecretsConfig } from '@/modules/external-secrets.ee/external-se
 import { ExternalSecretsProviderConnectionManager } from '@/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee';
 import { ExternalSecretsProviderLifecycle } from '@/modules/external-secrets.ee/provider-lifecycle.service';
 import { ExternalSecretsProviderRegistry } from '@/modules/external-secrets.ee/provider-registry.service';
-import { ExternalSecretsRetryManager } from '@/modules/external-secrets.ee/retry-manager.service';
 import { ExternalSecretsSecretsCache } from '@/modules/external-secrets.ee/secrets-cache.service';
 import { ExternalSecretsSettingsStore } from '@/modules/external-secrets.ee/settings-store.service';
 import type {
@@ -70,7 +69,6 @@ const resetManager = async () => {
 	const settingsStore = Container.get(ExternalSecretsSettingsStore);
 	const providerRegistry = Container.get(ExternalSecretsProviderRegistry);
 	const providerLifecycle = Container.get(ExternalSecretsProviderLifecycle);
-	const retryManager = Container.get(ExternalSecretsRetryManager);
 	const providerConnectionManager = Container.get(ExternalSecretsProviderConnectionManager);
 	const secretsCache = Container.get(ExternalSecretsSecretsCache);
 	const secretsProviderConnectionRepository = Container.get(SecretsProviderConnectionRepository);
@@ -87,7 +85,6 @@ const resetManager = async () => {
 			settingsStore,
 			providerRegistry,
 			providerLifecycle,
-			retryManager,
 			providerConnectionManager,
 			secretsCache,
 			secretsProviderConnectionRepository,
@@ -143,7 +140,6 @@ beforeAll(async () => {
 	const settingsStore = Container.get(ExternalSecretsSettingsStore);
 	const providerRegistry = Container.get(ExternalSecretsProviderRegistry);
 	const providerLifecycle = Container.get(ExternalSecretsProviderLifecycle);
-	const retryManager = Container.get(ExternalSecretsRetryManager);
 	const providerConnectionManager = Container.get(ExternalSecretsProviderConnectionManager);
 	const secretsCache = Container.get(ExternalSecretsSecretsCache);
 	const secretsProviderConnectionRepository = Container.get(SecretsProviderConnectionRepository);
@@ -160,7 +156,6 @@ beforeAll(async () => {
 			settingsStore,
 			providerRegistry,
 			providerLifecycle,
-			retryManager,
 			providerConnectionManager,
 			secretsCache,
 			secretsProviderConnectionRepository,

--- a/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
@@ -68,6 +68,9 @@ const resetManager = async () => {
 	const config = Container.get(ExternalSecretsConfig);
 	const settingsStore = Container.get(ExternalSecretsSettingsStore);
 	const providerRegistry = Container.get(ExternalSecretsProviderRegistry);
+	// Simulate a fresh process: without this, providers from the previous test survive in the
+	// singleton registry and act as connected predecessors during replacement.
+	providerRegistry.clear();
 	const providerLifecycle = Container.get(ExternalSecretsProviderLifecycle);
 	const providerConnectionManager = Container.get(ExternalSecretsProviderConnectionManager);
 	const secretsCache = Container.get(ExternalSecretsSecretsCache);


### PR DESCRIPTION
## Summary

[demo video](https://www.loom.com/share/07b0aca3ce754337b5540a343646ea6b)

Fixes intermittent "error resolving credentials" during executions when an external secrets provider (e.g. 1Password) is reconfigured or reloaded. 

Reworks `ExternalSecretsProviderConnectionManager` so that a replacement provider is initialized, connected, and fully hydrated (secrets fetched) in the background before it is swapped into the registry — the old provider keeps serving secrets until then. Replacement candidates are generation-tracked so superseded reconfigurations are ignored and disposed, and disabling/removing a provider invalidates any pending replacement so it cannot restore access afterwards. New providers now block their upsert on the initial cache refresh, so startup completes with secrets already hydrated.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-821

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35237">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

