### PR TITLE
fix(core): Add reactions:write to Slack agent app manifest scopes

### DIFF
--- a/packages/cli/src/modules/agents/integrations/slack-app-setup.service.ts
+++ b/packages/cli/src/modules/agents/integrations/slack-app-setup.service.ts
@@ -60,6 +60,7 @@ const REQUIRED_BOT_SCOPES = [
 	'mpim:history',
 	'mpim:read',
 	'mpim:write',
+	'reactions:write',
 	'search:read.public',
 	'users:read',
 	'users:read.email',


### PR DESCRIPTION
## Summary
- Adds `reactions:write` to `REQUIRED_BOT_SCOPES` so newly created/manual Slack agent app manifests can use the existing `add_reaction` tool.
- Fixes [AGENT-514](https://linear.app/n8n/issue/AGENT-514/bug-slack-agent-add-reaction-tool-fails-app-manifest-missing-reaction).

## Test plan
- [ ] Create a Slack agent via automatic setup and confirm the generated app includes `reactions:write`
- [ ] Copy the manual manifest and confirm it includes `reactions:write`
- [ ] Ask the agent to add a reaction and confirm it succeeds without a missing-scope error


Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

