### PR TITLE
fix(MCP Server Trigger Node): Save execution data only after tool call completes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -220,7 +220,15 @@ export class McpServer {
 			try {
 				await new Promise<void>((resolve) => {
 					this.resolveFunctions[callId] = resolve;
-					void transport.handleRequest(req, resp, message as IncomingMessage).finally(resolve);
+					const requestHandled = transport.handleRequest(req, resp, message as IncomingMessage);
+					if (isToolCall && transport.transportType === 'sse') {
+						// SSE answers the POST with 202 before the tool has run, so completing the
+						// request must not resolve here — the CallTool handler does that once the
+						// tool finished. A transport failure still resolves so we never hang.
+						void requestHandled.catch(() => resolve());
+					} else {
+						void requestHandled.finally(resolve);
+					}
 				});
 			} finally {
 				delete this.resolveFunctions[callId];
@@ -603,73 +611,77 @@ export class McpServer {
 		);
 
 		server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-			if (!request.params?.name || !request.params?.arguments) {
-				throw new OperationalError('Require a name and arguments for the tool call');
-			}
 			if (!extra.sessionId) {
 				throw new OperationalError('Require a sessionId for the tool call');
 			}
 
 			const callId = extra.requestId ? `${extra.sessionId}_${extra.requestId}` : extra.sessionId;
-			const toolName = request.params.name;
-			const toolArguments =
-				typeof request.params.arguments === 'object' && request.params.arguments !== null
-					? request.params.arguments
-					: {};
-
-			const tools = this.sessionManager.getTools(extra.sessionId) ?? [];
-			const requestedTool = tools.find((tool) => tool.name === toolName);
-			if (!requestedTool) {
-				throw new OperationalError('Tool not found');
-			}
-
-			// Eager pre-execution credential gate: if the caller has not connected a
-			// required private credential, surface the actionable connection URLs
-			// (via elicitation when supported, otherwise as text) instead of
-			// executing (or enqueuing) the workflow.
-			const gateResult = this.pendingGateResults[callId];
-			if (gateResult && !gateResult.readyToExecute) {
-				return await this.handleCredentialGate(server, gateResult, callId);
-			}
 
 			try {
-				if (this.executionCoordinator.isQueueMode()) {
-					const requestId = extra.requestId?.toString() ?? '';
-					this.storePendingResponse(extra.sessionId, requestId);
+				if (!request.params?.name || !request.params?.arguments) {
+					throw new OperationalError('Require a name and arguments for the tool call');
+				}
 
-					// Resolve handlePostMessage so webhook can return and enqueue execution.
-					// The handler continues running asynchronously, waiting for worker response.
-					if (this.resolveFunctions[callId]) {
-						this.resolveFunctions[callId]();
+				const toolName = request.params.name;
+				const toolArguments =
+					typeof request.params.arguments === 'object' && request.params.arguments !== null
+						? request.params.arguments
+						: {};
+
+				const tools = this.sessionManager.getTools(extra.sessionId) ?? [];
+				const requestedTool = tools.find((tool) => tool.name === toolName);
+				if (!requestedTool) {
+					throw new OperationalError('Tool not found');
+				}
+
+				// Eager pre-execution credential gate: if the caller has not connected a
+				// required private credential, surface the actionable connection URLs
+				// (via elicitation when supported, otherwise as text) instead of
+				// executing (or enqueuing) the workflow.
+				const gateResult = this.pendingGateResults[callId];
+				if (gateResult && !gateResult.readyToExecute) {
+					return await this.handleCredentialGate(server, gateResult, callId);
+				}
+
+				try {
+					if (this.executionCoordinator.isQueueMode()) {
+						const requestId = extra.requestId?.toString() ?? '';
+						this.storePendingResponse(extra.sessionId, requestId);
+
+						// Resolve handlePostMessage so webhook can return and enqueue execution.
+						// The handler continues running asynchronously, waiting for worker response.
+						if (this.resolveFunctions[callId]) {
+							this.resolveFunctions[callId]();
+						}
+
+						const strategy = this.executionCoordinator.getStrategy() as QueuedExecutionStrategy;
+						const result = await strategy.executeTool(requestedTool, toolArguments, {
+							sessionId: extra.sessionId,
+							messageId: requestId,
+						});
+
+						return MessageFormatter.formatToolResult(
+							result,
+							MessageFormatter.isErrorResult(result),
+						);
 					}
 
-					const strategy = this.executionCoordinator.getStrategy() as QueuedExecutionStrategy;
-					const result = await strategy.executeTool(requestedTool, toolArguments, {
+					const result = await this.executionCoordinator.executeTool(requestedTool, toolArguments, {
 						sessionId: extra.sessionId,
-						messageId: requestId,
+						messageId: extra.requestId?.toString(),
 					});
 
 					return MessageFormatter.formatToolResult(result, MessageFormatter.isErrorResult(result));
+				} catch (error) {
+					const errorObject = error instanceof Error ? error : new Error(String(error));
+					this.logger.error(`Error while executing Tool ${toolName}: ${errorObject.message}`, {
+						error: errorObject,
+					});
+					return MessageFormatter.formatError(errorObject);
 				}
-
-				const result = await this.executionCoordinator.executeTool(requestedTool, toolArguments, {
-					sessionId: extra.sessionId,
-					messageId: extra.requestId?.toString(),
-				});
-
-				if (this.resolveFunctions[callId]) {
-					this.resolveFunctions[callId]();
-				} else {
-					this.logger.warn(`No resolve function found for ${callId}`);
-				}
-
-				return MessageFormatter.formatToolResult(result, MessageFormatter.isErrorResult(result));
-			} catch (error) {
-				const errorObject = error instanceof Error ? error : new Error(String(error));
-				this.logger.error(`Error while executing Tool ${toolName}: ${errorObject.message}`, {
-					error: errorObject,
-				});
-				return MessageFormatter.formatError(errorObject);
+			} finally {
+				// No-op when already resolved (queue mode, credential gate, non-SSE).
+				this.resolveFunctions[callId]?.();
 			}
 		});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
@@ -170,6 +170,111 @@ describe('McpServer', () => {
 		});
 	});
 
+	describe('handlePostMessage resolution', () => {
+		const sessionId = 'sse-session';
+		const requestId = 'call-1';
+
+		type CallToolHandler = (
+			request: { params: { name: string; arguments: Record<string, unknown> } },
+			extra: { sessionId?: string; requestId?: string },
+		) => Promise<{ isError?: boolean; content: Array<{ text: string }> }>;
+
+		async function setupSseSession(tool: ReturnType<typeof createMockTool>) {
+			const transport = createMockTransport(sessionId, 'sse');
+			const server = createMockServer();
+			const internals = mcpServer as unknown as {
+				sessionManager: SessionManager;
+				setupHandlers(server: unknown): void;
+			};
+
+			await internals.sessionManager.registerSession(sessionId, server, transport, [tool]);
+			internals.setupHandlers(server);
+
+			const handler = server.setRequestHandler.mock.calls[1][1] as unknown as CallToolHandler;
+			let handlerResult: ReturnType<CallToolHandler> | undefined;
+			transport.handleRequest.mockImplementation(async () => {
+				handlerResult = handler(
+					{ params: { name: tool.name, arguments: {} } },
+					{ sessionId, requestId },
+				);
+			});
+
+			return {
+				transport,
+				getHandlerResult: (): ReturnType<CallToolHandler> | undefined => handlerResult,
+			};
+		}
+
+		const postToolCall = async (tool: ReturnType<typeof createMockTool>) =>
+			await mcpServer.handlePostMessage(
+				createMockRequestWithSessionId(
+					sessionId,
+					createValidToolCallMessage(tool.name, {}, requestId),
+				),
+				createMockResponse(),
+				[tool],
+			);
+
+		it('should keep an SSE tool call pending until the tool has finished', async () => {
+			let finishTool!: () => void;
+			const tool = createMockTool('get_weather');
+			tool.invoke.mockImplementation(async () => {
+				await new Promise<void>((resolve) => (finishTool = resolve));
+				return { ok: true };
+			});
+			await setupSseSession(tool);
+
+			let resolved = false;
+			const postPromise = postToolCall(tool).then((result) => {
+				resolved = true;
+				return result;
+			});
+
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(tool.invoke).toHaveBeenCalled();
+			expect(resolved).toBe(false);
+
+			finishTool();
+
+			expect((await postPromise).wasToolCall).toBe(true);
+		});
+
+		it('should resolve an SSE tool call whose tool throws', async () => {
+			const tool = createMockTool('get_weather', { invokeError: new Error('boom') });
+			const { getHandlerResult } = await setupSseSession(tool);
+
+			expect((await postToolCall(tool)).wasToolCall).toBe(true);
+
+			const handlerResult = await getHandlerResult();
+			expect(handlerResult?.isError).toBe(true);
+			expect(handlerResult?.content[0].text).toContain('boom');
+		});
+
+		it('should resolve an SSE tool call when the transport fails to handle the request', async () => {
+			const tool = createMockTool('get_weather');
+			const { transport } = await setupSseSession(tool);
+			transport.handleRequest.mockRejectedValue(new Error('SSE connection not established'));
+
+			expect((await postToolCall(tool)).wasToolCall).toBe(true);
+			expect(tool.invoke).not.toHaveBeenCalled();
+		});
+
+		it('should resolve a queue-mode tool call before the worker result arrives', async () => {
+			const tool = createMockTool('get_weather');
+			const { getHandlerResult } = await setupSseSession(tool);
+			mcpServer.setExecutionStrategy(
+				new QueuedExecutionStrategy(mcpServer.getPendingCallsManager()),
+			);
+
+			expect((await postToolCall(tool)).wasToolCall).toBe(true);
+			expect(mcpServer.hasPendingResponse(sessionId, requestId)).toBe(true);
+
+			mcpServer.handleWorkerResponse(sessionId, requestId, { ok: true });
+
+			expect((await getHandlerResult())?.isError).toBeUndefined();
+		});
+	});
+
 	describe('handleDeleteRequest', () => {
 		it('should return 400 when no sessionId provided', async () => {
 			const response = createMockResponse();


### PR DESCRIPTION
## Summary

MCP Server Trigger executions over **SSE** were saved before the tool had finished running, so the execution appeared in the list immediately and the tool sub-node had no output data recorded.

<img width="864" height="694" alt="image" src="https://github.com/user-attachments/assets/28be3648-54ad-4846-8b71-fe15053ea842" />

Before the tool was in running state and had no output data. Streamable HTTP transport is unchanged.

## How to test

1. Make a workflow with a  MCP Server Trigger
2. Activate and connect from an MCP Client of choice **through SSE**
3. Execute a tool
4. Verify that the execution has output data for the tool node

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5534

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35239">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

