### PR TITLE
feat(core): Gate n8n-auth webhook runs on the caller's private-credential status

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -17,17 +17,22 @@ import { createDeferredPromise, type IDeferredPromise } from '@n8n/utils/promise
 import type {
 	Workflow,
 	INode,
+	INodeType,
 	IDataObject,
 	IWebhookResponseData,
 	IN8nHttpFullResponse,
 	IWorkflowBase,
 	IRunExecutionData,
 	IExecuteData,
+	IWebhookData,
+	IWorkflowExecuteAdditionalData,
+	CredentialCheckResult,
 } from 'n8n-workflow';
 import {
 	FORM_NODE_TYPE,
 	WAIT_NODE_TYPE,
 	CHAT_TRIGGER_NODE_TYPE,
+	WEBHOOK_NODE_TYPE,
 	WorkflowConfigurationError,
 	NodeOperationError,
 	MICROSOFT_AGENT365_TRIGGER_NODE_TYPE,
@@ -42,9 +47,16 @@ import {
 	setupResponseNodePromise,
 	prepareExecutionData,
 	handleHostedChatResponse,
+	executeWebhook,
 	_privateGetWebhookErrorMessage,
 } from '../webhook-helpers';
-import type { IWebhookResponseCallbackData } from '../webhook.types';
+import type { IWebhookResponseCallbackData, WebhookRequest } from '../webhook.types';
+import type { Project } from '@n8n/db';
+import { AuthService } from '@/auth/auth.service';
+import { OwnershipService } from '@/services/ownership.service';
+import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import { WebhookService } from '../webhook.service';
 
 vi.mock('stream/promises', () => ({
 	finished: vi.fn(),
@@ -932,5 +944,174 @@ describe('getWebhookErrorMessage', () => {
 		expect(_privateGetWebhookErrorMessage(err, 'Webhook')).toContain(
 			'Error: Workflow could not be started',
 		);
+	});
+});
+
+describe('executeWebhook credential-status gate', () => {
+	const ownershipService = mockInstance(OwnershipService);
+	const webhookService = mockInstance(WebhookService);
+	mockInstance(AuthService);
+	mockInstance(WorkflowStatisticsService);
+
+	const WORKFLOW_ID = 'wf-1';
+
+	const missingGateResult: CredentialCheckResult = {
+		readyToExecute: false,
+		credentials: [
+			{
+				credentialId: 'cred-1',
+				credentialName: 'My Gmail',
+				credentialType: 'gmailOAuth2',
+				resolverId: 'resolver-1',
+				status: 'missing',
+				authorizationUrl:
+					'https://n8n.test/rest/credentials/cred-1/authorize?token=signed-connect-token',
+			},
+		],
+	};
+
+	const readyGateResult: CredentialCheckResult = {
+		readyToExecute: true,
+		credentials: [
+			{
+				credentialId: 'cred-1',
+				credentialName: 'My Gmail',
+				credentialType: 'gmailOAuth2',
+				resolverId: 'resolver-1',
+				status: 'configured',
+			},
+		],
+	};
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.clearAllMocks();
+
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(mock<Project>({ id: 'project-1' }));
+		// The gate runs *after* the webhook node executes, so `runWebhook` must resolve.
+		// `noWebhookResponse` lets execution return before reaching the workflow runner,
+		// keeping the test focused on the gate itself.
+		webhookService.runWebhook.mockResolvedValue({ noWebhookResponse: true });
+	});
+
+	/**
+	 * Drives `executeWebhook` for a Webhook node with the given authentication mode and
+	 * wires the dynamic-credentials credential-check proxy to return `gateResult`.
+	 * Returns the spied proxy and the captured `responseCallback`.
+	 */
+	const runGate = async (options: {
+		authentication: string;
+		gateResult?: CredentialCheckResult;
+	}) => {
+		const checkCredentialStatus = vi.fn().mockResolvedValue(options.gateResult);
+
+		const additionalData = {
+			'dynamic-credentials': { credentialCheckProxy: { checkCredentialStatus } },
+			encryptedRunnerIdentity: 'encrypted-runner-identity',
+		} as unknown as IWorkflowExecuteAdditionalData;
+		vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
+
+		const workflowStartNode = mock<INode>({
+			name: 'Webhook',
+			type: WEBHOOK_NODE_TYPE,
+			typeVersion: 2,
+			parameters: { authentication: options.authentication },
+		});
+
+		// Force a valid `onReceived` response mode; the deep mock would otherwise return undefined.
+		const workflow = mock<Workflow>({
+			id: WORKFLOW_ID,
+			nodeTypes: {
+				getByNameAndVersion: vi
+					.fn()
+					.mockReturnValue(mock<INodeType>({ description: { name: 'webhook' } })),
+			},
+			expression: {
+				getSimpleParameterValue: vi.fn().mockReturnValue('onReceived'),
+				getComplexParameterValue: vi.fn().mockReturnValue('firstEntryJson'),
+			},
+		});
+
+		const webhookData = {
+			webhookDescription: { name: 'default' },
+			workflowId: WORKFLOW_ID,
+		} as unknown as IWebhookData;
+
+		const workflowData = mock<IWorkflowBase>({ id: WORKFLOW_ID });
+		const req = mock<WebhookRequest>({ method: 'POST', contentType: undefined });
+		const res = mock<express.Response>({ headersSent: false });
+		const responseCallback = vi.fn();
+
+		await executeWebhook(
+			workflow,
+			webhookData,
+			workflowData,
+			workflowStartNode,
+			'manual',
+			undefined,
+			undefined,
+			undefined,
+			req,
+			res,
+			responseCallback,
+		);
+
+		return { checkCredentialStatus, responseCallback };
+	};
+
+	it('responds 428 with the missing-credential list and signed connect links when the caller has unconnected credentials', async () => {
+		const { checkCredentialStatus, responseCallback } = await runGate({
+			authentication: 'n8nOAuth2',
+			gateResult: missingGateResult,
+		});
+
+		// Checked using the established identity and the workflow being called.
+		expect(checkCredentialStatus).toHaveBeenCalledWith(WORKFLOW_ID, {
+			credentials: 'encrypted-runner-identity',
+		});
+
+		expect(responseCallback).toHaveBeenCalledWith(null, {
+			data: missingGateResult,
+			responseCode: 428,
+		});
+
+		// The 428 body carries a valid signed connect link for each missing credential.
+		const [, callbackData] = responseCallback.mock.calls[0] as [
+			unknown,
+			IWebhookResponseCallbackData,
+		];
+		expect(callbackData.data).toBe(missingGateResult);
+		expect(missingGateResult.credentials[0].authorizationUrl).toContain(
+			'/credentials/cred-1/authorize?token=',
+		);
+	});
+
+	it('proceeds without a 428 when all resolvable credentials are connected', async () => {
+		const { checkCredentialStatus, responseCallback } = await runGate({
+			authentication: 'n8nOAuth2',
+			gateResult: readyGateResult,
+		});
+
+		expect(checkCredentialStatus).toHaveBeenCalledTimes(1);
+		expect(responseCallback).not.toHaveBeenCalledWith(
+			null,
+			expect.objectContaining({ responseCode: 428 }),
+		);
+		// Execution continued past the gate to the normal webhook response.
+		expect(responseCallback).toHaveBeenCalledWith(null, { noWebhookResponse: true });
+	});
+
+	it('does not gate webhooks that do not establish a triggering identity', async () => {
+		const { checkCredentialStatus, responseCallback } = await runGate({
+			authentication: 'none',
+			gateResult: missingGateResult,
+		});
+
+		expect(checkCredentialStatus).not.toHaveBeenCalled();
+		expect(responseCallback).not.toHaveBeenCalledWith(
+			null,
+			expect.objectContaining({ responseCode: 428 }),
+		);
+		expect(responseCallback).toHaveBeenCalledWith(null, { noWebhookResponse: true });
 	});
 });

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -52,9 +52,12 @@ import {
 } from '../webhook-helpers';
 import type { IWebhookResponseCallbackData, WebhookRequest } from '../webhook.types';
 import type { Project } from '@n8n/db';
+import { ActiveExecutions } from '@/active-executions';
 import { AuthService } from '@/auth/auth.service';
+import { EventService } from '@/events/event.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
+import { WorkflowRunner } from '@/workflow-runner';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { WebhookService } from '../webhook.service';
 
@@ -950,10 +953,14 @@ describe('getWebhookErrorMessage', () => {
 describe('executeWebhook credential-status gate', () => {
 	const ownershipService = mockInstance(OwnershipService);
 	const webhookService = mockInstance(WebhookService);
+	const workflowRunner = mockInstance(WorkflowRunner);
+	const activeExecutions = mockInstance(ActiveExecutions);
 	mockInstance(AuthService);
+	mockInstance(EventService);
 	mockInstance(WorkflowStatisticsService);
 
 	const WORKFLOW_ID = 'wf-1';
+	const EXECUTION_ID = 'exec-1';
 
 	const missingGateResult: CredentialCheckResult = {
 		readyToExecute: false,
@@ -987,11 +994,14 @@ describe('executeWebhook credential-status gate', () => {
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
 
-		ownershipService.getWorkflowProjectCached.mockResolvedValue(mock<Project>({ id: 'project-1' }));
-		// The gate runs *after* the webhook node executes, so `runWebhook` must resolve.
-		// `noWebhookResponse` lets execution return before reaching the workflow runner,
-		// keeping the test focused on the gate itself.
-		webhookService.runWebhook.mockResolvedValue({ noWebhookResponse: true });
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(
+			mock<Project>({ id: 'project-1', name: 'Project 1' }),
+		);
+		// The gate only runs when the webhook decided the workflow should execute
+		// (workflowData present). Cases that pass the gate continue into WorkflowRunner.
+		webhookService.runWebhook.mockResolvedValue({ workflowData: [[{ json: {} }]] });
+		workflowRunner.run.mockResolvedValue(EXECUTION_ID);
+		activeExecutions.getPostExecutePromise.mockReturnValue(new Promise(() => {}));
 	});
 
 	/**
@@ -1002,14 +1012,21 @@ describe('executeWebhook credential-status gate', () => {
 	const runGate = async (options: {
 		authentication: string;
 		gateResult?: CredentialCheckResult;
+		webhookResult?: IWebhookResponseData;
 	}) => {
 		const checkCredentialStatus = vi.fn().mockResolvedValue(options.gateResult);
 
 		const additionalData = {
 			'dynamic-credentials': { credentialCheckProxy: { checkCredentialStatus } },
 			encryptedRunnerIdentity: 'encrypted-runner-identity',
+			webhookWaitingBaseUrl: 'https://n8n.test/webhook-waiting',
+			formWaitingBaseUrl: 'https://n8n.test/form-waiting',
 		} as unknown as IWorkflowExecuteAdditionalData;
 		vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
+
+		if (options.webhookResult !== undefined) {
+			webhookService.runWebhook.mockResolvedValue(options.webhookResult);
+		}
 
 		const workflowStartNode = mock<INode>({
 			name: 'Webhook',
@@ -1021,6 +1038,7 @@ describe('executeWebhook credential-status gate', () => {
 		// Force a valid `onReceived` response mode; the deep mock would otherwise return undefined.
 		const workflow = mock<Workflow>({
 			id: WORKFLOW_ID,
+			name: 'Test Workflow',
 			nodeTypes: {
 				getByNameAndVersion: vi
 					.fn()
@@ -1037,7 +1055,7 @@ describe('executeWebhook credential-status gate', () => {
 			workflowId: WORKFLOW_ID,
 		} as unknown as IWebhookData;
 
-		const workflowData = mock<IWorkflowBase>({ id: WORKFLOW_ID });
+		const workflowData = mock<IWorkflowBase>({ id: WORKFLOW_ID, name: 'Test Workflow' });
 		const req = mock<WebhookRequest>({ method: 'POST', contentType: undefined });
 		const res = mock<express.Response>({ headersSent: false });
 		const responseCallback = vi.fn();
@@ -1084,6 +1102,7 @@ describe('executeWebhook credential-status gate', () => {
 		expect(missingGateResult.credentials[0].authorizationUrl).toContain(
 			'/credentials/cred-1/authorize?token=',
 		);
+		expect(workflowRunner.run).not.toHaveBeenCalled();
 	});
 
 	it('proceeds without a 428 when all resolvable credentials are connected', async () => {
@@ -1097,8 +1116,8 @@ describe('executeWebhook credential-status gate', () => {
 			null,
 			expect.objectContaining({ responseCode: 428 }),
 		);
-		// Execution continued past the gate to the normal webhook response.
-		expect(responseCallback).toHaveBeenCalledWith(null, { noWebhookResponse: true });
+		// Execution continued past the gate into the workflow runner.
+		expect(workflowRunner.run).toHaveBeenCalled();
 	});
 
 	it('does not gate webhooks that do not establish a triggering identity', async () => {
@@ -1112,6 +1131,28 @@ describe('executeWebhook credential-status gate', () => {
 			null,
 			expect.objectContaining({ responseCode: 428 }),
 		);
-		expect(responseCallback).toHaveBeenCalledWith(null, { noWebhookResponse: true });
+		expect(workflowRunner.run).toHaveBeenCalled();
+	});
+
+	it('does not gate when Only Run If prevents the workflow from executing', async () => {
+		const { checkCredentialStatus, responseCallback } = await runGate({
+			authentication: 'n8nOAuth2',
+			gateResult: missingGateResult,
+			// Bare `{}` is what Webhook.node returns when Only Run If evaluates falsy.
+			webhookResult: {},
+		});
+
+		expect(checkCredentialStatus).not.toHaveBeenCalled();
+		expect(responseCallback).not.toHaveBeenCalledWith(
+			null,
+			expect.objectContaining({ responseCode: 428 }),
+		);
+		expect(responseCallback).toHaveBeenCalledWith(
+			null,
+			expect.objectContaining({
+				data: { message: 'Webhook call received' },
+			}),
+		);
+		expect(workflowRunner.run).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -737,23 +737,6 @@ export async function executeWebhook(
 			};
 		}
 
-		// Reactive credential-status gate. Once the webhook node has established the
-		// triggering user's identity (n8nOAuth2 mode), block the run if any of that
-		// user's resolvable (private) credentials are still unconnected, responding
-		// 428 Precondition Required with the missing-credential list and a signed
-		// connect link for each.
-		if (!didSendResponse && !res.headersSent && shouldEstablishTriggerIdentity(workflowStartNode)) {
-			const credentialGate = await additionalData.checkTriggerCredentialStatus?.();
-			if (credentialGate && !credentialGate.readyToExecute) {
-				responseCallback(null, {
-					data: credentialGate,
-					responseCode: 428,
-				});
-				didSendResponse = true;
-				return;
-			}
-		}
-
 		const responseHeaders = evaluateResponseHeaders(context);
 
 		if (!res.headersSent && responseHeaders) {
@@ -794,6 +777,25 @@ export async function executeWebhook(
 				}
 			}
 			return;
+		}
+
+		// Reactive credential-status gate. Runs only once we know the workflow will
+		// execute (workflowData is defined), so a falsy "Only Run If" short-circuits
+		// above without surfacing a misleading 428. Once the webhook node has established
+		// the triggering user's identity (n8nOAuth2 mode), block the run if any of that
+		// user's resolvable (private) credentials are still unconnected, responding
+		// 428 Precondition Required with the missing-credential list and a signed
+		// connect link for each.
+		if (!didSendResponse && !res.headersSent && shouldEstablishTriggerIdentity(workflowStartNode)) {
+			const credentialGate = await additionalData.checkTriggerCredentialStatus?.();
+			if (credentialGate && !credentialGate.readyToExecute) {
+				responseCallback(null, {
+					data: credentialGate,
+					responseCode: 428,
+				});
+				didSendResponse = true;
+				return;
+			}
 		}
 
 		// For "onReceived" mode, we need to defer response sending until after the execution

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -737,6 +737,23 @@ export async function executeWebhook(
 			};
 		}
 
+		// Reactive credential-status gate. Once the webhook node has established the
+		// triggering user's identity (n8nOAuth2 mode), block the run if any of that
+		// user's resolvable (private) credentials are still unconnected, responding
+		// 428 Precondition Required with the missing-credential list and a signed
+		// connect link for each.
+		if (!didSendResponse && !res.headersSent && shouldEstablishTriggerIdentity(workflowStartNode)) {
+			const credentialGate = await additionalData.checkTriggerCredentialStatus?.();
+			if (credentialGate && !credentialGate.readyToExecute) {
+				responseCallback(null, {
+					data: credentialGate,
+					responseCode: 428,
+				});
+				didSendResponse = true;
+				return;
+			}
+		}
+
 		const responseHeaders = evaluateResponseHeaders(context);
 
 		if (!res.headersSent && responseHeaders) {


### PR DESCRIPTION
## Summary

When a webhook runs with **n8n User Auth (OAuth2)** (`n8nOAuth2`), the run needs
the caller's private credentials merged in — but some may not be connected yet
(the user never linked their Gmail, or a new credential was added to the
workflow). Previously the run would fail opaquely.

This PR wires the existing credential-status mechanism — the one the MCP trigger
already uses — onto the webhook path. **No new logic; just wiring.** Two ways the
caller learns about missing credentials, both reusing
`checkTriggerCredentialStatus` and the existing signed connect-link generation:

- **Proactive** — `GET /workflows/:workflowId/execution-status` already reports
  ready-vs-missing with a signed `authorizationUrl` per missing credential. It is
  trigger-agnostic, so it works for webhook workflows with no change.
- **Reactive** — calling a webhook whose caller has unconnected credentials now
  returns **HTTP 428 Precondition Required** with the same missing-credentials
  list + connect links, instead of a generic 4xx/5xx. The gate runs after the
  webhook node establishes the caller's identity but before the workflow executes,
  and is a no-op for webhooks that don't establish an identity or when the
  dynamic-credentials module is disabled.

After the user opens a connect link and links the credential, a retry passes the
gate and the run merges the now-connected credential.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1074

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35242">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

