### PR TITLE
fix(editor): Wait for animated zoom-in transition to settle

### DIFF
--- a/packages/testing/playwright/composables/CanvasComposer.ts
+++ b/packages/testing/playwright/composables/CanvasComposer.ts
@@ -76,35 +76,40 @@ export class CanvasComposer {
 	async zoomInAndCheckNodes(): Promise<void> {
 		await this.n8n.canvas.getCanvasNodes().first().waitFor();
 
-		const initialNodeSize = await this.n8n.page.evaluate(() => {
-			const firstNode = document.querySelector('[data-test-id="canvas-node"]');
-			if (!firstNode) {
-				throw new Error('Canvas node not found during initial measurement');
-			}
-			return firstNode.getBoundingClientRect().width;
-		});
+		const measureFirstNodeWidth = async () =>
+			await this.n8n.page.evaluate(() => {
+				const firstNode = document.querySelector('[data-test-id="canvas-node"]');
+				if (!firstNode) {
+					throw new Error('Canvas node not found during measurement');
+				}
+				return firstNode.getBoundingClientRect().width;
+			});
+
+		// Wait for the animated fit-to-view to settle before capturing the baseline.
+		let previousWidth = Number.NaN;
+		await expect
+			.poll(async () => {
+				const width = await measureFirstNodeWidth();
+				const settled = width === previousWidth;
+				previousWidth = width;
+				return settled;
+			})
+			.toBe(true);
+
+		const initialNodeSize = await measureFirstNodeWidth();
 
 		for (let i = 0; i < 4; i++) {
 			await this.n8n.canvas.clickZoomInButton();
 		}
 
-		const finalNodeSize = await this.n8n.page.evaluate(() => {
-			const firstNode = document.querySelector('[data-test-id="canvas-node"]');
-			if (!firstNode) {
-				throw new Error('Canvas node not found during final measurement');
-			}
-			return firstNode.getBoundingClientRect().width;
-		});
-
-		// Validate zoom increased node sizes by at least 50%
-		const zoomWorking = finalNodeSize > initialNodeSize * 1.5;
-
-		if (!zoomWorking) {
-			throw new Error(
-				"Zoom functionality not working: nodes didn't scale properly. " +
-					`Initial: ${initialNodeSize.toFixed(1)}px, Final: ${finalNodeSize.toFixed(1)}px`,
-			);
-		}
+		// Poll the width until the animated zoom transition settles.
+		await expect
+			.poll(measureFirstNodeWidth, {
+				message:
+					"Zoom functionality not working: nodes didn't scale properly. " +
+					`Initial: ${initialNodeSize.toFixed(1)}px`,
+			})
+			.toBeGreaterThan(initialNodeSize * 1.5);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Replaced the single-shot measurement + manual throw with expect.poll(...).toBeGreaterThan(initialNodeSize * 1.5), which waits for the animated zoom-in transition to settle.
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-5659/flaky-test-quarantined-should-maintain-zoom-functionality-after
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35244">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

