### PR TITLE
ci: Restrict Docker image strip to TypeScript declaration files (no-changelog)

### DIFF
--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -218,22 +218,27 @@ for (const pattern of phantomDirs) {
 }
 echo(chalk.green('✅ Phantom dirs stripped'));
 
-// Strip non-runtime files (Node never loads these) to cut the image's file count,
-// which dominates layer extraction time on constrained hosts. .js.map is kept —
+// Strip TypeScript declaration artifacts to cut the image's file count, which
+// dominates layer extraction time on constrained hosts. Only these two explicit
+// patterns are safe to remove by extension: several features read other
+// "source-looking" files off disk at request time (dist/node-definitions/**/*.ts
+// for AI node lookups, instance-ai skills/knowledge-base *.md), so broader globs
+// like '*.ts' or '*.md' must not come back here. .js.map is also kept —
 // source-map-support needs it for production stack traces.
-echo(chalk.yellow('INFO: Stripping non-runtime files (.ts/.d.ts/.md) from production closure...'));
-// `@n8n/instance-ai` reads these markdown trees off disk on every agent request,
-// so they are runtime data despite the extension. Excluded via `-not -path` and
-// not `-prune`: `-delete` implies `-depth`, which makes `-prune` a no-op.
-const runtimeAssetGlobs = ['*/@n8n/instance-ai/skills/*', '*/@n8n/instance-ai/knowledge-base/*'];
-const keepRuntimeAssets = runtimeAssetGlobs.flatMap((glob) => ['-not', '-path', glob]);
-await $`find ${config.compiledAppDir} -type f \\( -name '*.ts' -o -name '*.d.ts.map' -o -name '*.md' -o -name '*.test.js' -o -name '*.spec.js' \\) ${keepRuntimeAssets} -delete 2>/dev/null || true`;
-echo(chalk.green('✅ Non-runtime files stripped'));
+echo(chalk.yellow('INFO: Stripping TypeScript declaration files from production closure...'));
+await $`find ${config.compiledAppDir} -type f \\( -name '*.d.ts' -o -name '*.d.ts.map' \\) -delete 2>/dev/null || true`;
+echo(chalk.green('✅ Declaration files stripped'));
 
-// Stripping the trees above leaves a bootable image whose agent has no skills and
-// no knowledge base, so the damage only surfaces on the first request. Fail here.
+// A build that loses these runtime-data trees (a strip regression, a package.json
+// `files` change, a pnpm deploy change) still boots, so the damage only surfaces
+// on the first AI request. Fail the build here instead.
 // `.nothrow()` because zx runs with `pipefail`: one unreadable path would
 // otherwise turn a healthy build into an unhandled rejection.
+const runtimeAssetGlobs = [
+	'*/@n8n/instance-ai/skills/*',
+	'*/@n8n/instance-ai/knowledge-base/*',
+	'*/dist/node-definitions/*',
+];
 for (const glob of runtimeAssetGlobs) {
 	const found = await $`find ${config.compiledAppDir} -type f -path ${glob}`.nothrow();
 	if (found.stdout.split('\n').filter(Boolean).length === 0) {


### PR DESCRIPTION
## Summary

Follow-up to #35170 and #35223. The extension-glob strip has now deleted runtime data twice — instance-ai's markdown trees (fixed in #35223 via carve-outs), and a second case #35223 didn't cover:

**`dist/node-definitions/**/*.ts` (7,622 plain `.ts` files in `n8n-nodes-base` + `@n8n/n8n-nodes-langchain`) is runtime data.** `@n8n/ai-utilities` (`node-catalog/get.ts`) and `packages/cli`'s instance-ai `node-definition-resolver.ts` read these off disk on every AI node-type lookup. The current strip on master deletes all of them — same failure shape as the skills regression: the image boots, and breaks on first use.

Rather than adding a third carve-out, this inverts the approach: **the strip now explicitly lists what it removes, and only patterns that are compile-time artifacts by definition** — `*.d.ts` and `*.d.ts.map`. Nobody ships runtime data as a declaration file. Dropped from the strip: raw `*.ts` (bit us: node-definitions), `*.md` (bit us: instance-ai skills/knowledge-base), `*.test.js`/`*.spec.js` (170 loadable-JS files; not worth any risk). With no unsafe globs left, the `-not -path` carve-outs are gone too.

The #35223 post-strip guard is kept and extended with `*/dist/node-definitions/*` — it now protects all three known runtime-data trees against any regression class (strip changes, `files` field edits, pnpm deploy behavior), not just this script.

### Audit behind the pattern choice

Swept all backend workspace packages for runtime reads of the previously stripped extensions:
- `.d.ts`: no readers (TypeORM's directory loader explicitly excludes them; zero `.d.ts` inside `node-definitions`)
- `THIRD_PARTY_LICENSES.md` (served by `GET /third-party-licenses`): copied into the closure *after* the strip runs, unaffected
- `@n8n/tournament` ships `src/*.ts`: sourcemap references only, and no longer touched anyway

### Measured impact (deployed closure, same A/B method as #35170)

| Strip variant | Entries | Δ vs unstripped |
|---|---|---|
| none | 224,243 | — |
| #35170 globs (unsafe) | 153,505 | −31.5% |
| **this PR (`*.d.ts` + `*.d.ts.map`)** | **169,826** | **−24.3%** |

Keeps ~77% of the original file-count win while making the strip categorically safe instead of empirically safe.

## How to test

```bash
pnpm build:n8n
# runtime data intact (all currently 0 on master):
find compiled -path '*/dist/node-definitions/*' -name '*.ts' | wc -l          # 7622
find compiled -path '*/@n8n/instance-ai/skills/*' -name 'SKILL.md' | wc -l    # 10
find compiled -path '*/@n8n/instance-ai/knowledge-base/*' -name '*.md' | wc -l # 3
# strip still effective:
find compiled -name '*.d.ts' | wc -l                                          # 0
```

Then boot the image and use the AI builder's node-type lookup (`get-node-type-definition`) — it reads the node-definitions files at request time.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/DEVP-674
- Follow-up to #35170, #35223

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- No test harness exists for scripts/*.mjs; the in-script guard is the regression check. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

