### PR TITLE
feat(core): Add node group descriptions to the workflow SDK (no-changelog)

### DIFF
--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
@@ -840,6 +840,22 @@ describe('AST Interpreter', () => {
 			interpretSDKCode(code, sdkFunctions);
 			expect(connectMock).toHaveBeenCalledWith('source', 0, 'target', 0);
 		});
+
+		it("should forward group()'s options object to the workflow builder", () => {
+			const groupMock = vi.fn();
+			sdkFunctions.workflow = vi.fn(() => ({
+				group: groupMock,
+			}));
+			// Members are irrelevant here — this pins the third argument surviving evaluation.
+			const code = `
+				const wf = workflow('id', 'name');
+				export default wf.group('Ingestion', [], { description: 'Pulls the CRM contacts' });
+			`;
+			interpretSDKCode(code, sdkFunctions);
+			expect(groupMock).toHaveBeenCalledWith('Ingestion', [], {
+				description: 'Pulls the CRM contacts',
+			});
+		});
 	});
 
 	describe('Security - dangerous globals (defense-in-depth)', () => {

--- a/packages/@n8n/workflow-sdk/src/codegen/code-generator.ts
+++ b/packages/@n8n/workflow-sdk/src/codegen/code-generator.ts
@@ -1458,7 +1458,14 @@ export function generateCode(
 				const nodeName = idToNodeName.get(id);
 				return nodeName !== undefined ? [getVarName(nodeName, ctx)] : [];
 			});
-			workflowCalls.push(`  .group('${escapeString(group.name)}', [${memberVars.join(', ')}])`);
+
+			const options = group.description
+				? `, { description: '${escapeString(group.description)}' }`
+				: '';
+
+			workflowCalls.push(
+				`  .group('${escapeString(group.name)}', [${memberVars.join(', ')}]${options})`,
+			);
 		}
 	}
 

--- a/packages/@n8n/workflow-sdk/src/node-groups.test.ts
+++ b/packages/@n8n/workflow-sdk/src/node-groups.test.ts
@@ -9,7 +9,7 @@ import { generateDeterministicGroupId } from './workflow-builder/string-utils';
 
 const WF_ID = 'wf-groups-1';
 
-function buildGroupedWorkflow() {
+function buildGroupedWorkflow(options: { description?: string } = {}) {
 	const start = trigger({
 		type: MANUAL_TRIGGER_NODE_TYPE,
 		version: 1,
@@ -26,11 +26,10 @@ function buildGroupedWorkflow() {
 		config: { name: 'Transform' },
 	});
 
-	return workflow(WF_ID, 'Grouped workflow')
-		.add(start)
-		.to(fetchNode)
-		.to(transform)
-		.group('Ingestion', [fetchNode, transform]);
+	const builder = workflow(WF_ID, 'Grouped workflow').add(start).to(fetchNode).to(transform);
+	return options.description === undefined
+		? builder.group('Ingestion', [fetchNode, transform])
+		: builder.group('Ingestion', [fetchNode, transform], { description: options.description });
 }
 
 describe('SDK node groups', () => {
@@ -396,6 +395,40 @@ describe('SDK node groups', () => {
 			// Deterministic ids mean the group survives identically across the round-trip.
 			expect(json2.nodeGroups![0].id).toBe(json1.nodeGroups![0].id);
 			expect(json2.nodeGroups![0].nodeIds).toEqual(json1.nodeGroups![0].nodeIds);
+		});
+
+		it('emits the description as the third argument and preserves it through a re-parse', () => {
+			const builder = buildGroupedWorkflow({ description: 'Pulls the CRM contacts' });
+			builder.regenerateNodeIds();
+
+			const code = generateWorkflowCode(builder.toJSON());
+			expect(code).toContain(
+				".group('Ingestion', [fetch_data, transform], { description: 'Pulls the CRM contacts' })",
+			);
+
+			const rebuilt = parseWorkflowCodeToBuilder(code);
+			rebuilt.regenerateNodeIds();
+
+			expect(rebuilt.toJSON().nodeGroups![0].description).toBe('Pulls the CRM contacts');
+		});
+
+		it('escapes a quote in the description so the emitted code re-parses', () => {
+			const builder = buildGroupedWorkflow({ description: "Bob's contacts" });
+			builder.regenerateNodeIds();
+
+			const code = generateWorkflowCode(builder.toJSON());
+			expect(code).toContain("{ description: 'Bob\\'s contacts' }");
+
+			const rebuilt = parseWorkflowCodeToBuilder(code);
+
+			expect(rebuilt.toJSON().nodeGroups![0].description).toBe("Bob's contacts");
+		});
+
+		it('emits a two-argument .group() call when the group has no description', () => {
+			const code = generateWorkflowCode(buildGroupedWorkflow().toJSON());
+
+			expect(code).toContain(".group('Ingestion', [fetch_data, transform])");
+			expect(code).not.toContain('description:');
 		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/node-groups.test.ts
+++ b/packages/@n8n/workflow-sdk/src/node-groups.test.ts
@@ -1,4 +1,4 @@
-import { MANUAL_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+import { GROUP_DESCRIPTION_MAX_LENGTH, MANUAL_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 
 import { generateWorkflowCode } from './codegen';
 import { parseWorkflowCodeToBuilder } from './codegen/parse-workflow-code';
@@ -89,13 +89,20 @@ describe('SDK node groups', () => {
 				: builder.group('G', [a], { description });
 		}
 
-		it('accepts the options argument without disturbing the group name or members', () => {
+		it('emits the description alongside the group name and members', () => {
 			const json = buildDescribedWorkflow('Pulls the CRM contacts').toJSON();
 
 			const idByName = new Map(json.nodes.map((n) => [n.name, n.id]));
 			expect(json.nodeGroups).toHaveLength(1);
 			expect(json.nodeGroups![0].name).toBe('G');
 			expect(json.nodeGroups![0].nodeIds).toEqual([idByName.get('A')]);
+			expect(json.nodeGroups![0].description).toBe('Pulls the CRM contacts');
+		});
+
+		it('caps the description at the canvas limit', () => {
+			const json = buildDescribedWorkflow('x'.repeat(GROUP_DESCRIPTION_MAX_LENGTH + 50)).toJSON();
+
+			expect(json.nodeGroups![0].description).toBe('x'.repeat(GROUP_DESCRIPTION_MAX_LENGTH));
 		});
 
 		it('leaves the description key off a group declared without options', () => {
@@ -104,7 +111,13 @@ describe('SDK node groups', () => {
 			expect(json.nodeGroups![0]).not.toHaveProperty('description');
 		});
 
-		it('builds authored code that passes a description to .group()', () => {
+		it('leaves the description key off when the authored description is blank', () => {
+			const json = buildDescribedWorkflow('').toJSON();
+
+			expect(json.nodeGroups![0]).not.toHaveProperty('description');
+		});
+
+		it('keeps a description authored in code through the build', () => {
 			const code = `
 				const start = trigger({ type: '${MANUAL_TRIGGER_NODE_TYPE}', version: 1, config: { name: 'Start' } });
 				const a = node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'A' } });
@@ -121,6 +134,7 @@ describe('SDK node groups', () => {
 			expect(json.nodeGroups).toHaveLength(1);
 			expect(json.nodeGroups![0].name).toBe('G');
 			expect(json.nodeGroups![0].nodeIds).toEqual([idByName.get('A')]);
+			expect(json.nodeGroups![0].description).toBe('Pulls the CRM contacts');
 		});
 	});
 

--- a/packages/@n8n/workflow-sdk/src/node-groups.test.ts
+++ b/packages/@n8n/workflow-sdk/src/node-groups.test.ts
@@ -103,6 +103,25 @@ describe('SDK node groups', () => {
 
 			expect(json.nodeGroups![0]).not.toHaveProperty('description');
 		});
+
+		it('builds authored code that passes a description to .group()', () => {
+			const code = `
+				const start = trigger({ type: '${MANUAL_TRIGGER_NODE_TYPE}', version: 1, config: { name: 'Start' } });
+				const a = node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'A' } });
+
+				export default workflow('${WF_ID}', 'wf')
+					.add(start)
+					.to(a)
+					.group('G', [a], { description: 'Pulls the CRM contacts' });
+			`;
+
+			const json = parseWorkflowCodeToBuilder(code).toJSON();
+
+			const idByName = new Map(json.nodes.map((n) => [n.name, n.id]));
+			expect(json.nodeGroups).toHaveLength(1);
+			expect(json.nodeGroups![0].name).toBe('G');
+			expect(json.nodeGroups![0].nodeIds).toEqual([idByName.get('A')]);
+		});
 	});
 
 	describe('regenerateNodeIds()', () => {

--- a/packages/@n8n/workflow-sdk/src/node-groups.test.ts
+++ b/packages/@n8n/workflow-sdk/src/node-groups.test.ts
@@ -136,6 +136,54 @@ describe('SDK node groups', () => {
 			expect(json.nodeGroups![0].nodeIds).toEqual([idByName.get('A')]);
 			expect(json.nodeGroups![0].description).toBe('Pulls the CRM contacts');
 		});
+
+		function describedWorkflowJSON(description?: unknown): WorkflowJSON {
+			return {
+				id: WF_ID,
+				name: 'wf',
+				nodes: [
+					{
+						id: 'id-a',
+						name: 'A',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3,
+						position: [0, 0],
+						parameters: {},
+					},
+				],
+				connections: {},
+				nodeGroups: [
+					{
+						id: 'random-uuid',
+						name: 'G',
+						nodeIds: ['id-a'],
+						...(description !== undefined ? { description: description as string } : {}),
+					},
+				],
+			};
+		}
+
+		it('preserves the description across a fromJSON round-trip', () => {
+			const json = workflow.fromJSON(describedWorkflowJSON('Pulls the CRM contacts')).toJSON();
+
+			expect(json.nodeGroups![0].description).toBe('Pulls the CRM contacts');
+		});
+
+		it('keeps the description when the imported workflow is edited', () => {
+			const builder = workflow.fromJSON(describedWorkflowJSON('Pulls the CRM contacts'));
+			builder.add(node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'B' } }));
+
+			const json = builder.toJSON();
+
+			expect(json.nodes.map((n) => n.name)).toContain('B');
+			expect(json.nodeGroups![0].description).toBe('Pulls the CRM contacts');
+		});
+
+		it('drops a description that the source JSON carries as a non-string', () => {
+			const json = workflow.fromJSON(describedWorkflowJSON(42)).toJSON();
+
+			expect(json.nodeGroups![0]).not.toHaveProperty('description');
+		});
 	});
 
 	describe('regenerateNodeIds()', () => {

--- a/packages/@n8n/workflow-sdk/src/node-groups.test.ts
+++ b/packages/@n8n/workflow-sdk/src/node-groups.test.ts
@@ -2,14 +2,14 @@ import { GROUP_DESCRIPTION_MAX_LENGTH, MANUAL_TRIGGER_NODE_TYPE } from 'n8n-work
 
 import { generateWorkflowCode } from './codegen';
 import { parseWorkflowCodeToBuilder } from './codegen/parse-workflow-code';
-import type { WorkflowJSON } from './types/base';
+import type { GroupOptions, WorkflowJSON } from './types/base';
 import { workflow } from './workflow-builder';
 import { node, trigger } from './workflow-builder/node-builders/node-builder';
 import { generateDeterministicGroupId } from './workflow-builder/string-utils';
 
 const WF_ID = 'wf-groups-1';
 
-function buildGroupedWorkflow(options: { description?: string } = {}) {
+function buildGroupedWorkflow(options?: GroupOptions) {
 	const start = trigger({
 		type: MANUAL_TRIGGER_NODE_TYPE,
 		version: 1,
@@ -26,10 +26,11 @@ function buildGroupedWorkflow(options: { description?: string } = {}) {
 		config: { name: 'Transform' },
 	});
 
-	const builder = workflow(WF_ID, 'Grouped workflow').add(start).to(fetchNode).to(transform);
-	return options.description === undefined
-		? builder.group('Ingestion', [fetchNode, transform])
-		: builder.group('Ingestion', [fetchNode, transform], { description: options.description });
+	return workflow(WF_ID, 'Grouped workflow')
+		.add(start)
+		.to(fetchNode)
+		.to(transform)
+		.group('Ingestion', [fetchNode, transform], options);
 }
 
 describe('SDK node groups', () => {
@@ -74,44 +75,34 @@ describe('SDK node groups', () => {
 	});
 
 	describe('group description', () => {
-		function buildDescribedWorkflow(description?: string) {
-			const start = trigger({
-				type: MANUAL_TRIGGER_NODE_TYPE,
-				version: 1,
-				config: { name: 'Start' },
-			});
-			const a = node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'A' } });
-
-			const builder = workflow(WF_ID, 'wf').add(start).to(a);
-			return description === undefined
-				? builder.group('G', [a])
-				: builder.group('G', [a], { description });
-		}
-
 		it('emits the description alongside the group name and members', () => {
-			const json = buildDescribedWorkflow('Pulls the CRM contacts').toJSON();
+			const json = buildGroupedWorkflow({ description: 'Pulls the CRM contacts' }).toJSON();
 
 			const idByName = new Map(json.nodes.map((n) => [n.name, n.id]));
 			expect(json.nodeGroups).toHaveLength(1);
-			expect(json.nodeGroups![0].name).toBe('G');
-			expect(json.nodeGroups![0].nodeIds).toEqual([idByName.get('A')]);
+			expect(json.nodeGroups![0].name).toBe('Ingestion');
+			expect(json.nodeGroups![0].nodeIds).toEqual([
+				idByName.get('Fetch data'),
+				idByName.get('Transform'),
+			]);
 			expect(json.nodeGroups![0].description).toBe('Pulls the CRM contacts');
 		});
 
 		it('caps the description at the canvas limit', () => {
-			const json = buildDescribedWorkflow('x'.repeat(GROUP_DESCRIPTION_MAX_LENGTH + 50)).toJSON();
+			const description = 'x'.repeat(GROUP_DESCRIPTION_MAX_LENGTH + 50);
+			const json = buildGroupedWorkflow({ description }).toJSON();
 
 			expect(json.nodeGroups![0].description).toBe('x'.repeat(GROUP_DESCRIPTION_MAX_LENGTH));
 		});
 
 		it('leaves the description key off a group declared without options', () => {
-			const json = buildDescribedWorkflow().toJSON();
+			const json = buildGroupedWorkflow().toJSON();
 
 			expect(json.nodeGroups![0]).not.toHaveProperty('description');
 		});
 
 		it('leaves the description key off when the authored description is blank', () => {
-			const json = buildDescribedWorkflow('').toJSON();
+			const json = buildGroupedWorkflow({ description: '' }).toJSON();
 
 			expect(json.nodeGroups![0]).not.toHaveProperty('description');
 		});
@@ -129,14 +120,10 @@ describe('SDK node groups', () => {
 
 			const json = parseWorkflowCodeToBuilder(code).toJSON();
 
-			const idByName = new Map(json.nodes.map((n) => [n.name, n.id]));
-			expect(json.nodeGroups).toHaveLength(1);
-			expect(json.nodeGroups![0].name).toBe('G');
-			expect(json.nodeGroups![0].nodeIds).toEqual([idByName.get('A')]);
 			expect(json.nodeGroups![0].description).toBe('Pulls the CRM contacts');
 		});
 
-		function describedWorkflowJSON(description?: unknown): WorkflowJSON {
+		function describedWorkflowJSON(description: unknown): WorkflowJSON {
 			return {
 				id: WF_ID,
 				name: 'wf',
@@ -152,12 +139,7 @@ describe('SDK node groups', () => {
 				],
 				connections: {},
 				nodeGroups: [
-					{
-						id: 'random-uuid',
-						name: 'G',
-						nodeIds: ['id-a'],
-						...(description !== undefined ? { description: description as string } : {}),
-					},
+					{ id: 'random-uuid', name: 'G', nodeIds: ['id-a'], description: description as string },
 				],
 			};
 		}

--- a/packages/@n8n/workflow-sdk/src/node-groups.test.ts
+++ b/packages/@n8n/workflow-sdk/src/node-groups.test.ts
@@ -1,3 +1,5 @@
+import { MANUAL_TRIGGER_NODE_TYPE } from 'n8n-workflow';
+
 import { generateWorkflowCode } from './codegen';
 import { parseWorkflowCodeToBuilder } from './codegen/parse-workflow-code';
 import type { WorkflowJSON } from './types/base';
@@ -9,7 +11,7 @@ const WF_ID = 'wf-groups-1';
 
 function buildGroupedWorkflow() {
 	const start = trigger({
-		type: 'n8n-nodes-base.manualTrigger',
+		type: MANUAL_TRIGGER_NODE_TYPE,
 		version: 1,
 		config: { name: 'Start' },
 	});
@@ -47,7 +49,7 @@ describe('SDK node groups', () => {
 
 		it('drops members that do not resolve to a node in the workflow', () => {
 			const start = trigger({
-				type: 'n8n-nodes-base.manualTrigger',
+				type: MANUAL_TRIGGER_NODE_TYPE,
 				version: 1,
 				config: { name: 'Start' },
 			});
@@ -63,12 +65,43 @@ describe('SDK node groups', () => {
 
 		it('omits nodeGroups entirely when no group was declared', () => {
 			const start = trigger({
-				type: 'n8n-nodes-base.manualTrigger',
+				type: MANUAL_TRIGGER_NODE_TYPE,
 				version: 1,
 				config: { name: 'Start' },
 			});
 			const json = workflow(WF_ID, 'wf').add(start).toJSON();
 			expect(json.nodeGroups).toBeUndefined();
+		});
+	});
+
+	describe('group description', () => {
+		function buildDescribedWorkflow(description?: string) {
+			const start = trigger({
+				type: MANUAL_TRIGGER_NODE_TYPE,
+				version: 1,
+				config: { name: 'Start' },
+			});
+			const a = node({ type: 'n8n-nodes-base.set', version: 3, config: { name: 'A' } });
+
+			const builder = workflow(WF_ID, 'wf').add(start).to(a);
+			return description === undefined
+				? builder.group('G', [a])
+				: builder.group('G', [a], { description });
+		}
+
+		it('accepts the options argument without disturbing the group name or members', () => {
+			const json = buildDescribedWorkflow('Pulls the CRM contacts').toJSON();
+
+			const idByName = new Map(json.nodes.map((n) => [n.name, n.id]));
+			expect(json.nodeGroups).toHaveLength(1);
+			expect(json.nodeGroups![0].name).toBe('G');
+			expect(json.nodeGroups![0].nodeIds).toEqual([idByName.get('A')]);
+		});
+
+		it('leaves the description key off a group declared without options', () => {
+			const json = buildDescribedWorkflow().toJSON();
+
+			expect(json.nodeGroups![0]).not.toHaveProperty('description');
 		});
 	});
 
@@ -87,7 +120,7 @@ describe('SDK node groups', () => {
 
 		it('resolves a grouped auto-renamed duplicate handle to the right node after regeneration', () => {
 			const start = trigger({
-				type: 'n8n-nodes-base.manualTrigger',
+				type: MANUAL_TRIGGER_NODE_TYPE,
 				version: 1,
 				config: { name: 'Start' },
 			});
@@ -210,7 +243,7 @@ describe('SDK node groups', () => {
 	describe('existingGroupIdsByName (toJSON option)', () => {
 		it('reuses an existing group id matched by name and derives one for a new group', () => {
 			const start = trigger({
-				type: 'n8n-nodes-base.manualTrigger',
+				type: MANUAL_TRIGGER_NODE_TYPE,
 				version: 1,
 				config: { name: 'Start' },
 			});

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -1,3 +1,5 @@
+import { GROUP_DESCRIPTION_MAX_LENGTH } from 'n8n-workflow';
+
 import { NODE_GROUPS_REFERENCE, SDK_LANGUAGE_REFERENCE } from './sdk-language';
 import {
 	SDK_METHODS,
@@ -78,8 +80,17 @@ describe('NODE_GROUPS_REFERENCE', () => {
 	});
 
 	it('explains how to declare a group', () => {
-		// The worked example: .group(name, [members]) declared on the workflow.
+		// The worked example: .group(name, [members], options?) declared on the workflow.
 		expect(NODE_GROUPS_REFERENCE).toMatch(/\.group\('[^']+', \[/);
+	});
+
+	it('documents the optional description and its length limit', () => {
+		expect(NODE_GROUPS_REFERENCE).toContain('description:');
+		expect(NODE_GROUPS_REFERENCE).toContain(`${GROUP_DESCRIPTION_MAX_LENGTH} characters`);
+	});
+
+	it('tells an editing agent to keep existing descriptions', () => {
+		expect(NODE_GROUPS_REFERENCE).toMatch(/descriptions\s+included/i);
 	});
 
 	it('states the single entry/exit boundary rule that grouping enforces', () => {

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.test.ts
@@ -90,7 +90,7 @@ describe('NODE_GROUPS_REFERENCE', () => {
 	});
 
 	it('tells an editing agent to keep existing descriptions', () => {
-		expect(NODE_GROUPS_REFERENCE).toMatch(/descriptions\s+included/i);
+		expect(NODE_GROUPS_REFERENCE).toMatch(/keep the .+ and their descriptions\s+intact/is);
 	});
 
 	it('states the single entry/exit boundary rule that grouping enforces', () => {

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -103,8 +103,8 @@ export default workflow('id', 'My workflow')
 \`description\` is optional and shown when the group is collapsed. Keep it to one
 sentence — anything past ${GROUP_DESCRIPTION_MAX_LENGTH} characters is cut off.
 
-When editing an existing workflow, **keep the \`.group(...)\` calls intact**, descriptions
-included, unless the change is specifically about grouping.
+When editing an existing workflow, **keep the \`.group(...)\` calls and their descriptions
+intact** unless the change is specifically about grouping.
 
 An invalid group is rejected on save, so these following rules MUST be followed when
 creating or editing groups.

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -2,7 +2,7 @@
  * Builder-facing SDK language reference, rendered from the interpreter's own
  * tables so guidance cannot drift from what the parser accepts.
  */
-import { NODE_GROUPING_RULES } from 'n8n-workflow';
+import { GROUP_DESCRIPTION_MAX_LENGTH, NODE_GROUPING_RULES } from 'n8n-workflow';
 
 import {
 	SDK_METHODS,
@@ -86,7 +86,7 @@ export const NODE_GROUPS_REFERENCE = `## Node groups
 
 A node group is a named, visual grouping of nodes (a frame on the canvas). It is
 purely organisational — nothing about execution depends on it. Declare one with
-\`.group(name, members)\` on the workflow. Members are the node handles (the
+\`.group(name, members, options?)\` on the workflow. Members are the node handles (the
 \`const\` from \`node(...)\`) — the same way connections reference nodes:
 
 \`\`\`typescript
@@ -95,11 +95,16 @@ const transform = node({ /* ... name: 'Transform' */ });
 export default workflow('id', 'My workflow')
   .add(fetch)
   .to(transform)
-  .group('Ingestion', [fetch, transform]);
+  .group('Ingestion', [fetch, transform], {
+    description: 'Pulls the CRM contacts and normalizes them',
+  });
 \`\`\`
 
-When editing an existing workflow, **keep the \`.group(...)\` calls intact** unless
-the change is specifically about grouping.
+\`description\` is optional and shown when the group is collapsed. Keep it to one
+sentence — anything past ${GROUP_DESCRIPTION_MAX_LENGTH} characters is cut off.
+
+When editing an existing workflow, **keep the \`.group(...)\` calls intact**, descriptions
+included, unless the change is specifically about grouping.
 
 An invalid group is rejected on save, so these following rules MUST be followed when
 creating or editing groups.

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -1024,6 +1024,16 @@ export interface ToJSONOptions {
  */
 export type GroupMember = NodeInstance<string, string, unknown>;
 
+/** Optional group settings passed as `.group()`'s third argument. */
+export type GroupOptions = {
+	/**
+	 * Description shown when the group is collapsed on the canvas. Capped to
+	 * `GROUP_DESCRIPTION_MAX_LENGTH` characters on serialization; blank is
+	 * treated as no description.
+	 */
+	description?: string;
+};
+
 export interface WorkflowBuilder {
 	readonly id: string;
 	readonly name: string;
@@ -1103,6 +1113,8 @@ export interface WorkflowBuilder {
 	 * Members resolve to the emitted node IDs in `toJSON()`, so groups survive
 	 * `regenerateNodeIds()` like connections do. Chainable.
 	 *
+	 * Pass `{ description }` to add the text shown when the group is collapsed.
+	 *
 	 * @example
 	 * ```typescript
 	 * const fetch = node({ ... });
@@ -1110,10 +1122,12 @@ export interface WorkflowBuilder {
 	 * workflow('id', 'Name')
 	 *   .add(fetch)
 	 *   .to(transform)
-	 *   .group('Data ingestion', [fetch, transform]);
+	 *   .group('Data ingestion', [fetch, transform], {
+	 *     description: 'Pulls the CRM contacts and normalizes them',
+	 *   });
 	 * ```
 	 */
-	group(name: string, members: GroupMember[]): WorkflowBuilder;
+	group(name: string, members: GroupMember[], options?: GroupOptions): WorkflowBuilder;
 
 	/**
 	 * Validate the workflow graph structure.

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -1034,6 +1034,16 @@ export type GroupOptions = {
 	description?: string;
 };
 
+/**
+ * A node group as authored: members are node handles, resolved to the emitted node
+ * IDs only at serialization. `id` is present for a group carried in from JSON.
+ */
+export type AuthoredNodeGroup = GroupOptions & {
+	id?: string;
+	name: string;
+	members: GroupMember[];
+};
+
 export interface WorkflowBuilder {
 	readonly id: string;
 	readonly name: string;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -8,6 +8,7 @@ import type {
 	ConnectionTarget,
 	GraphNode,
 	GroupMember,
+	GroupOptions,
 	IDataObject,
 	NodeChain,
 	GeneratePinDataOptions,
@@ -40,6 +41,13 @@ import { parseWorkflowJSON } from './workflow-builder/workflow-import';
 // Ensure default plugins are registered on module load
 registerDefaultPlugins(pluginRegistry);
 
+type InternalNodeGroup = {
+	id?: string;
+	name: string;
+	members: GroupMember[];
+	description?: string;
+};
+
 /**
  * Internal workflow builder implementation
  */
@@ -58,7 +66,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	private _dispatchedComposites = new WeakSet<object>();
 	private static readonly MAX_BRANCH_DEPTH = 500;
 	/** Node groups, carried by member node handle and resolved to IDs in toJSON(). */
-	private _nodeGroups: Array<{ id?: string; name: string; members: GroupMember[] }>;
+	private _nodeGroups: InternalNodeGroup[];
 
 	constructor(
 		id: string,
@@ -69,7 +77,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		pinData?: Record<string, IDataObject[]>,
 		meta?: { templateId?: string; instanceId?: string; [key: string]: unknown },
 		registry?: PluginRegistry,
-		nodeGroups?: Array<{ id?: string; name: string; members: GroupMember[] }>,
+		nodeGroups?: InternalNodeGroup[],
 	) {
 		this.id = id;
 		this.name = name;
@@ -81,7 +89,12 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		this._meta = meta;
 		this._registry = registry;
 		this._nodeGroups = nodeGroups
-			? nodeGroups.map((g) => ({ id: g.id, name: g.name, members: [...g.members] }))
+			? nodeGroups.map((g) => ({
+					id: g.id,
+					name: g.name,
+					members: [...g.members],
+					...(g.description !== undefined ? { description: g.description } : {}),
+				}))
 			: [];
 	}
 
@@ -499,8 +512,12 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		return this;
 	}
 
-	group(name: string, members: GroupMember[]): WorkflowBuilder {
-		this._nodeGroups.push({ name, members: [...members] });
+	group(name: string, members: GroupMember[], options?: GroupOptions): WorkflowBuilder {
+		this._nodeGroups.push({
+			name,
+			members: [...members],
+			...(options?.description !== undefined ? { description: options.description } : {}),
+		});
 		return this;
 	}
 
@@ -510,7 +527,12 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	 * _staleIdToKeyMap, exactly as connection targets do); the live instance under that
 	 * key holds the ID the serializer emits. Unresolvable members are dropped.
 	 */
-	private resolveNodeGroups(): Array<{ id?: string; name: string; memberIds: string[] }> {
+	private resolveNodeGroups(): Array<{
+		id?: string;
+		name: string;
+		memberIds: string[];
+		description?: string;
+	}> {
 		return this._nodeGroups.map((group) => {
 			const memberIds: string[] = [];
 			for (const member of group.members) {
@@ -520,7 +542,12 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 					memberIds.push(id);
 				}
 			}
-			return { id: group.id, name: group.name, memberIds };
+			return {
+				id: group.id,
+				name: group.name,
+				memberIds,
+				...(group.description !== undefined ? { description: group.description } : {}),
+			};
 		});
 	}
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -7,6 +7,7 @@ import type {
 	NodeInstance,
 	ConnectionTarget,
 	GraphNode,
+	AuthoredNodeGroup,
 	GroupMember,
 	GroupOptions,
 	IDataObject,
@@ -31,6 +32,7 @@ import { jsonSerializer } from './workflow-builder/plugins/serializers';
 import type {
 	PluginContext,
 	MutablePluginContext,
+	ResolvedNodeGroup,
 	ValidationIssue,
 	SerializerContext,
 } from './workflow-builder/plugins/types';
@@ -40,13 +42,6 @@ import { parseWorkflowJSON } from './workflow-builder/workflow-import';
 
 // Ensure default plugins are registered on module load
 registerDefaultPlugins(pluginRegistry);
-
-type InternalNodeGroup = {
-	id?: string;
-	name: string;
-	members: GroupMember[];
-	description?: string;
-};
 
 /**
  * Internal workflow builder implementation
@@ -66,7 +61,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	private _dispatchedComposites = new WeakSet<object>();
 	private static readonly MAX_BRANCH_DEPTH = 500;
 	/** Node groups, carried by member node handle and resolved to IDs in toJSON(). */
-	private _nodeGroups: InternalNodeGroup[];
+	private _nodeGroups: AuthoredNodeGroup[];
 
 	constructor(
 		id: string,
@@ -77,7 +72,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		pinData?: Record<string, IDataObject[]>,
 		meta?: { templateId?: string; instanceId?: string; [key: string]: unknown },
 		registry?: PluginRegistry,
-		nodeGroups?: InternalNodeGroup[],
+		nodeGroups?: AuthoredNodeGroup[],
 	) {
 		this.id = id;
 		this.name = name;
@@ -88,14 +83,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		this._pinData = pinData;
 		this._meta = meta;
 		this._registry = registry;
-		this._nodeGroups = nodeGroups
-			? nodeGroups.map((g) => ({
-					id: g.id,
-					name: g.name,
-					members: [...g.members],
-					...(g.description !== undefined ? { description: g.description } : {}),
-				}))
-			: [];
+		this._nodeGroups = nodeGroups ? nodeGroups.map((g) => ({ ...g, members: [...g.members] })) : [];
 	}
 
 	/**
@@ -513,11 +501,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	}
 
 	group(name: string, members: GroupMember[], options?: GroupOptions): WorkflowBuilder {
-		this._nodeGroups.push({
-			name,
-			members: [...members],
-			...(options?.description !== undefined ? { description: options.description } : {}),
-		});
+		this._nodeGroups.push({ ...options, name, members: [...members] });
 		return this;
 	}
 
@@ -527,27 +511,17 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	 * _staleIdToKeyMap, exactly as connection targets do); the live instance under that
 	 * key holds the ID the serializer emits. Unresolvable members are dropped.
 	 */
-	private resolveNodeGroups(): Array<{
-		id?: string;
-		name: string;
-		memberIds: string[];
-		description?: string;
-	}> {
-		return this._nodeGroups.map((group) => {
+	private resolveNodeGroups(): ResolvedNodeGroup[] {
+		return this._nodeGroups.map(({ members, ...group }) => {
 			const memberIds: string[] = [];
-			for (const member of group.members) {
+			for (const member of members) {
 				const key = this.resolveTargetNodeName(member, this._staleIdToKeyMap);
 				const id = key ? this._nodes.get(key)?.instance.id : undefined;
 				if (id && !memberIds.includes(id)) {
 					memberIds.push(id);
 				}
 			}
-			return {
-				id: group.id,
-				name: group.name,
-				memberIds,
-				...(group.description !== undefined ? { description: group.description } : {}),
-			};
+			return { ...group, memberIds };
 		});
 	}
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -290,7 +290,7 @@ export const jsonSerializer: SerializerPlugin<WorkflowJSON> = {
 				return {
 					id,
 					name: group.name,
-					nodeIds: group.memberIds.filter((id) => emittedIds.has(id)),
+					nodeIds: group.memberIds.filter((memberId) => emittedIds.has(memberId)),
 					...(description ? { description } : {}),
 				};
 			});

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/serializers/json-serializer.ts
@@ -4,7 +4,7 @@
  * Serializes workflows to n8n's standard JSON format.
  */
 
-import { deepCopy, normalizeNodeShape } from 'n8n-workflow';
+import { deepCopy, normalizeGroupDescription, normalizeNodeShape } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
 
 import { foldLegacyErrorConnections } from '../../../types/base';
@@ -280,14 +280,20 @@ export const jsonSerializer: SerializerPlugin<WorkflowJSON> = {
 		if (ctx.nodeGroups && ctx.nodeGroups.length > 0) {
 			const emittedIds = new Set(nodes.map((node) => node.id));
 
-			json.nodeGroups = ctx.nodeGroups.map((group) => ({
-				id:
+			json.nodeGroups = ctx.nodeGroups.map((group) => {
+				const description = normalizeGroupDescription(group.description);
+				const id =
 					group.id ??
 					ctx.existingGroupIdsByName?.get(group.name) ??
-					generateDeterministicGroupId(ctx.workflowId, group.name),
-				name: group.name,
-				nodeIds: group.memberIds.filter((id) => emittedIds.has(id)),
-			}));
+					generateDeterministicGroupId(ctx.workflowId, group.name);
+
+				return {
+					id,
+					name: group.name,
+					nodeIds: group.memberIds.filter((id) => emittedIds.has(id)),
+					...(description ? { description } : {}),
+				};
+			});
 		}
 
 		return json;

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/types.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/types.ts
@@ -5,7 +5,10 @@
  * WorkflowBuilder with custom validators, composite handlers, and serializers.
  */
 
-import type { GraphNode, NodeInstance, IDataObject } from '../../types/base';
+import type { AuthoredNodeGroup, GraphNode, NodeInstance, IDataObject } from '../../types/base';
+
+/** An authored group with its members resolved to the node IDs the serializer emits. */
+export type ResolvedNodeGroup = Omit<AuthoredNodeGroup, 'members'> & { memberIds: string[] };
 
 // =============================================================================
 // Utility Functions for Validators
@@ -362,12 +365,7 @@ export interface SerializerContext extends PluginContext {
 	 * nodes carry. `id`, when present, is the source group ID (from fromJSON); the serializer
 	 * reuses it, otherwise assigns one.
 	 */
-	readonly nodeGroups?: ReadonlyArray<{
-		id?: string;
-		name: string;
-		memberIds: string[];
-		description?: string;
-	}>;
+	readonly nodeGroups?: readonly ResolvedNodeGroup[];
 
 	/**
 	 * Existing group IDs keyed by group name. When a group name matches, the serializer

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/types.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/types.ts
@@ -362,7 +362,12 @@ export interface SerializerContext extends PluginContext {
 	 * nodes carry. `id`, when present, is the source group ID (from fromJSON); the serializer
 	 * reuses it, otherwise assigns one.
 	 */
-	readonly nodeGroups?: ReadonlyArray<{ id?: string; name: string; memberIds: string[] }>;
+	readonly nodeGroups?: ReadonlyArray<{
+		id?: string;
+		name: string;
+		memberIds: string[];
+		description?: string;
+	}>;
 
 	/**
 	 * Existing group IDs keyed by group name. When a group name matches, the serializer

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
@@ -10,6 +10,7 @@ import {
 	foldLegacyErrorConnections,
 	normalizeConnections,
 	generateUniqueName,
+	type AuthoredNodeGroup,
 	type WorkflowJSON,
 	type NodeInstance,
 	type GraphNode,
@@ -31,13 +32,7 @@ export interface ParsedWorkflow {
 	readonly pinData?: Record<string, IDataObject[]>;
 	readonly meta?: { templateId?: string; instanceId?: string; [key: string]: unknown };
 	/** Node groups reconstructed by mapping the JSON's member IDs back to node handles. */
-	readonly nodeGroups?: Array<{
-		/** Source group ID from the JSON. */
-		id?: string;
-		name: string;
-		members: Array<NodeInstance<string, string, unknown>>;
-		description?: string;
-	}>;
+	readonly nodeGroups?: AuthoredNodeGroup[];
 }
 
 /**
@@ -142,10 +137,14 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 		for (const [sourceName, nodeConns] of Object.entries(connections)) {
 			const mapKey = nameToKey.get(sourceName);
 			const graphNode = mapKey ? nodes.get(mapKey) : undefined;
-			if (!graphNode) continue;
+			if (!graphNode) {
+				continue;
+			}
 
 			for (const [connType, outputs] of Object.entries(nodeConns)) {
-				if (!outputs || !Array.isArray(outputs)) continue;
+				if (!outputs || !Array.isArray(outputs)) {
+					continue;
+				}
 
 				const typeMap =
 					graphNode.connections.get(connType) ?? new Map<number, ConnectionTarget[]>();
@@ -176,17 +175,15 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 		lastNode = name;
 	}
 
-	// Rebuild groups by mapping each member ID back to its node handle (unresolvable IDs
-	// are dropped). The group's `id` is carried through so a round-trip preserves it.
 	const nodeGroups = json.nodeGroups?.length
 		? json.nodeGroups.map((group) => ({
 				id: group.id,
 				name: group.name,
+				description: group.description,
 				members: group.nodeIds.flatMap((id) => {
 					const instance = idToInstance.get(id);
 					return instance !== undefined ? [instance] : [];
 				}),
-				...(group.description !== undefined ? { description: group.description } : {}),
 			}))
 		: undefined;
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/workflow-import.ts
@@ -36,6 +36,7 @@ export interface ParsedWorkflow {
 		id?: string;
 		name: string;
 		members: Array<NodeInstance<string, string, unknown>>;
+		description?: string;
 	}>;
 }
 
@@ -185,6 +186,7 @@ export function parseWorkflowJSON(json: WorkflowJSON): ParsedWorkflow {
 					const instance = idToInstance.get(id);
 					return instance !== undefined ? [instance] : [];
 				}),
+				...(group.description !== undefined ? { description: group.description } : {}),
 			}))
 		: undefined;
 


### PR DESCRIPTION
## Summary

A canvas node group can carry a **description** alongside its name. The canvas has supported this since #34219, and the MCP layer since #34852 — but the workflow SDK, which everything programmatic goes through, dropped it at every hop. So an agent could neither write a description, nor keep the ones it found: editing a workflow silently lost them, because the description was never read back and never rendered into the code the agent sees.

This threads `description` through the five hops it was missing from:

1. **`.group(name, members, { description })`** — the builder signature (`types/base.ts`, `workflow-builder.ts`). A new `GroupOptions` type carries it, so a future group setting is one edit.
2. **Serialization** (`json-serializer.ts`) — emits the key, capped via the existing `normalizeGroupDescription` from `n8n-workflow`. This is deliberately the *only* place the cap is applied: it is the funnel every write path (builder, authored code, imported JSON) passes through, so one check covers all three. Blank stays absent from the key, matching the editor and the CLI save path.
3. **Import** (`workflow-import.ts`) — carries it back into the builder. This is the fix for the actual data loss: editing an imported workflow used to drop it.
4. **Code generation** (`code-generator.ts`) — emits the third argument, escaped via `escapeString` (the generated code is re-parsed, so an apostrophe would otherwise break the round-trip). This is what makes preservation possible at all: generated code is the agent's only view of an existing workflow.
5. **SDK reference** (`sdk-language.ts`) — documents the three-argument form and instructs an editing agent to keep existing descriptions. The 145-char limit is interpolated from `GROUP_DESCRIPTION_MAX_LENGTH`, so raising the cap cannot leave a stale number in text a model reads.

No feature-flag work is needed. The granular group operations are already gated by `102_mcp_canvas_groups` through the allowed-operation enum (`update-workflow.tool.ts`), and the groups section of the reference is omitted entirely when the flag is off (`sdk-reference-content.ts`). The SDK changes are inert transport: they only emit a description when one exists, and groups only reach them from an already-gated surface.

Instance AI inherits all of this with no code of its own — it authors via `.group()` and preserves existing descriptions because the current workflow is rendered to code.

The last two commits are a `/simplify` pass: a group's shape was restated field by field at four hops (two of them byte-identical in different files, coupled only structurally — a field added to one and not the other would be dropped with no compile error). `AuthoredNodeGroup` and `ResolvedNodeGroup` replace all four.

## How to test

Requires the `102_mcp_canvas_groups` feature flag enabled on the instance.

Automated:

```bash
cd packages/@n8n/workflow-sdk
pnpm test src/node-groups.test.ts src/ast-interpreter/interpreter.test.ts src/prompts/sdk-reference/sdk-language.test.ts
pnpm test   # full package — the 2061 codegen round-trip fixtures are the regression net here
```

End to end against a real instance, via an MCP client:

1. Ask the builder for a workflow with clearly separated phases, **without mentioning groups or descriptions** — e.g. *"Every Monday at 08:00 review subscriptions expiring in the next 15 days: pull them from Postgres, fetch last month's usage from our internal API over HTTP, score renewal risk, then post a summary to Slack ordered by amount and, for high risk, create a follow-up task and email the account owner."*
2. `get_workflow_details` on the result — each `nodeGroups` entry should carry a `description`.
3. Now ask for a change **unrelated to grouping** — e.g. *"change the window from 15 to 30 days"*.
4. `get_workflow_details` again: the descriptions, group ids and members must be unchanged. Before this PR they were silently dropped at this step.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5627

Stacked on #35060 (base branch `ADO-5621-non-fatal-ops`) — retarget to `master` once that merges.

Builds on #34219 (canvas descriptions) and #34852 (MCP descriptions).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35254">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->