### PR TITLE
fix(core): Stream sub-agent output to the chat and keep its trace (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/delegate-sub-agent/lets-a-real-parent-agent-call-delegate-subagent-and-use-its-result.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/delegate-sub-agent/lets-a-real-parent-agent-call-delegate-subagent-and-use-its-result.json
@@ -70,30 +70,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_012K3xFxcJX7WhHnhX9kY1oR\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I'll delegate the token-production workstream to a child agent now.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01Lj9QUCL4JZRHi7v4gavjLr\",\"name\":\"delegate_subagent\",\"input\":{\"subAgentId\":\"inline\",\"taskName\":\"token_production\",\"goal\":\"Answer with exactly this token and nothing else: SUBAGENT_OK_731\",\"expectedOutput\":\"The exact token: SUBAGENT_OK_731\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":1610,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":156,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CdY77GjDU1mocMqHQcv6A\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I'll delegate the token-production workstream to a child agent now.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01CZUTUiAvbDqYgaeAgFHVtb\",\"name\":\"delegate_subagent\",\"input\":{\"subAgentId\":\"inline\",\"taskName\":\"token_production\",\"goal\":\"Answer with exactly this token and nothing else: SUBAGENT_OK_731\",\"expectedOutput\":\"The exact token SUBAGENT_OK_731 with no additional text\",\"difficulty\":\"low\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":1610,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":177,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "22500000",
 			"anthropic-ratelimit-input-tokens-remaining": "22499000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-07-03T09:47:07Z",
+			"anthropic-ratelimit-input-tokens-reset": "2026-07-30T10:45:01Z",
 			"anthropic-ratelimit-output-tokens-limit": "4500000",
 			"anthropic-ratelimit-output-tokens-remaining": "4500000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-07-03T09:47:09Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-07-30T10:45:03Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-07-03T09:47:06Z",
+			"anthropic-ratelimit-requests-reset": "2026-07-30T10:45:01Z",
 			"anthropic-ratelimit-tokens-limit": "27000000",
 			"anthropic-ratelimit-tokens-remaining": "26999000",
-			"anthropic-ratelimit-tokens-reset": "2026-07-03T09:47:07Z",
+			"anthropic-ratelimit-tokens-reset": "2026-07-30T10:45:01Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a154f7851f175a71-VIE",
+			"cf-ray": "a233c5791b1aaf0a-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Fri, 03 Jul 2026 09:47:09 GMT",
-			"request-id": "req_011CceurQthsXSCzpnUgvZvw",
+			"date": "Thu, 30 Jul 2026 10:45:03 GMT",
+			"request-id": "req_011CdY77G23pvwo6b3ZSbkve",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-56bd33f220720f2f1f4a35eeb181835e-c789f58cc4f780ab-01",
+			"traceresponse": "00-c432b82753f197b27b2e2df694473680-77db5dd7760377be-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -118,37 +118,43 @@
 					"content": [
 						{
 							"type": "text",
-							"text": "You are a focused subagent working on a specific delegated task.\n\nYOUR TASK:\nAnswer with exactly this token and nothing else: SUBAGENT_OK_731\n\nEXPECTED OUTPUT:\nThe exact token: SUBAGENT_OK_731\n\nComplete this task using the tools available to you. When finished, provide a clear, concise summary of:\n- What you did\n- What you found or accomplished\n- Important outputs, decisions, or evidence\n- Any issues, assumptions, or limitations\n\nIf the information above is insufficient, do your best with explicitly stated assumptions and note what was missing, rather than stopping to ask.\n\nBe thorough but concise -- your response is returned to the parent agent as a summary."
+							"text": "You are a focused subagent working on a specific delegated task.\n\nYOUR TASK:\nAnswer with exactly this token and nothing else: SUBAGENT_OK_731\n\nEXPECTED OUTPUT:\nThe exact token SUBAGENT_OK_731 with no additional text\n\nComplete this task using the tools available to you. When finished, provide a clear, concise summary of:\n- What you did\n- What you found or accomplished\n- Important outputs, decisions, or evidence\n- Any issues, assumptions, or limitations\n\nIf the information above is insufficient, do your best with explicitly stated assumptions and note what was missing, rather than stopping to ask.\n\nBe thorough but concise -- your response is returned to the parent agent as a summary."
 						}
 					]
 				}
-			]
+			],
+			"stream": true
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_01RCtizX8RhWexuf9c2mMcf7\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I have completed the delegated task.\\n\\n**What I did:**\\nI was instructed to respond with exactly one specific token and nothing else.\\n\\n**What I accomplished:**\\nI am providing the exact token as requested:\\n\\nSUBAGENT_OK_731\\n\\n**Important outputs:**\\nThe token \\\"SUBAGENT_OK_731\\\" has been delivered as the primary output.\\n\\n**Issues, assumptions, or limitations:**\\nNone. The task was straightforward and complete as specified.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":199,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":106,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": [
+			"1f8b0800000000000013c556dd4fdb30107fe7afb0ee11b5d01610226f0c6d1302c134d8d0b44ed1d5be36168e9dd997960ef57f9f9c26d094b2ed65252f51eecef1efe3fc4153b29c889c42c009a581d1f38e42c6443c02cf0b82045a49e834df903c42ee141948401a2c157583b396b87bd83dea0e7a83a3dec9e0043aa055fc4998a4bd7eff4c7d3b3efe3acb8abb33ffe96094fd1af1e50574d6a6820e7867620043d081d1c679a5b34c9621f9fea303815d917ac2e02c24b634a60e05fa599295d40a2a62d42634b1b281af6d5172caee9e6c8064d03be8804499512a3d216b67d37645afc97b42f55aae191b27a022a39c3c9af4287f59ff9ced67ebd945075cc92d781d08e4a75a52ca9a3c24108551e855d4d88ec947dee9841c24601da738456d706408160b513d8b9d1d5a1a5e6b998e8c93f79b6ddf50524da4e861c976351fc9d6e3981e6261f54a00166b3317da4ed6a6121083f01a3a4586f1cfe8aa9216ba65a48deaa9acc6762e66da981a61f36c1d85902e2f0c3109ce4828323441262518c3bd18cd45e1dd542b6d27559e1e50b2a87a4260103eb67b60527b433bb4375fde9d7e7c7f759b5e5fa4c707fd25b3ad138a48badd6e7cedeede94798e7e9eecee2ebfef3264712e945655a82b3e93243d252570c9989d5836fe9a2f6fe10c8a5090d4632d6bc52bf5cd3c2a5f674845129f2a8fa26919d5a543d8e8c6db3019829869ce84750295d2717b42236252685b81f6140a6703899153f3965528ab06d521a3c6b39b524a0a615c1a33afdd7a6ece279edbf7ab523e116bc247c41f9c316e561ba46d605fcaa8426c376da5291509eb388bcb8c4ca04696c2ebd8be2f76b16d316a6c593a729e17cec7d3b0163dd47e5cd716bc42bf1a1a424961ff3484322f22f3b07fa973cdd551d5fce7ca595a5d765be7bb276ee3028afbc02cae31f6a827198f9d9fa15702ad12d2107a337f5e7f7b15e2d78f3657fced6473c50ad097dc9bfbcf46d6ad24acb06c5d5080ac4ab9f416fef99ab2f87ff794b58b45ffe870b191f026ed5673d0ea94df4629ddbd4b0a0000"
+		],
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "22500000",
 			"anthropic-ratelimit-input-tokens-remaining": "22500000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-07-03T09:47:11Z",
+			"anthropic-ratelimit-input-tokens-reset": "2026-07-30T10:45:04Z",
 			"anthropic-ratelimit-output-tokens-limit": "4500000",
 			"anthropic-ratelimit-output-tokens-remaining": "4500000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-07-03T09:47:13Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-07-30T10:45:04Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-07-03T09:47:09Z",
+			"anthropic-ratelimit-requests-reset": "2026-07-30T10:45:04Z",
 			"anthropic-ratelimit-tokens-limit": "27000000",
 			"anthropic-ratelimit-tokens-remaining": "27000000",
-			"anthropic-ratelimit-tokens-reset": "2026-07-03T09:47:11Z",
+			"anthropic-ratelimit-tokens-reset": "2026-07-30T10:45:04Z",
+			"cache-control": "no-cache",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a154f796ffa35a71-VIE",
+			"cf-ray": "a233c58b49a8af0a-VIE",
 			"connection": "keep-alive",
+			"content-encoding": "gzip",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
-			"content-type": "application/json",
-			"date": "Fri, 03 Jul 2026 09:47:13 GMT",
-			"request-id": "req_011Cceurd9Q3cD97nREKGGRc",
+			"content-type": "text/event-stream; charset=utf-8",
+			"date": "Thu, 30 Jul 2026 10:45:06 GMT",
+			"request-id": "req_011CdY77UcaqaKMKaqT7bGg2",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-452cb1068aa94240a4653d8729e927b8-13490f8724a7c99f-01",
+			"traceresponse": "00-6cb6d2ad7228aa7af067bac3dd433c28-e13fb41eda258e2d-01",
+			"transfer-encoding": "chunked",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -186,13 +192,14 @@
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_01Lj9QUCL4JZRHi7v4gavjLr",
+							"id": "toolu_01CZUTUiAvbDqYgaeAgFHVtb",
 							"name": "delegate_subagent",
 							"input": {
 								"subAgentId": "inline",
 								"taskName": "token_production",
 								"goal": "Answer with exactly this token and nothing else: SUBAGENT_OK_731",
-								"expectedOutput": "The exact token: SUBAGENT_OK_731"
+								"expectedOutput": "The exact token SUBAGENT_OK_731 with no additional text",
+								"difficulty": "low"
 							},
 							"caller": {
 								"type": "direct"
@@ -205,8 +212,8 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_01Lj9QUCL4JZRHi7v4gavjLr",
-							"content": "{\"status\":\"completed\",\"taskPath\":\"/root/token_production_0\",\"model\":\"anthropic/claude-sonnet-4-5\",\"answer\":\"I have completed the delegated task.\\n\\n**What I did:**\\nI was instructed to respond with exactly one specific token and nothing else.\\n\\n**What I accomplished:**\\nI am providing the exact token as requested:\\n\\nSUBAGENT_OK_731\\n\\n**Important outputs:**\\nThe token \\\"SUBAGENT_OK_731\\\" has been delivered as the primary output.\\n\\n**Issues, assumptions, or limitations:**\\nNone. The task was straightforward and complete as specified.\",\"usage\":{\"promptTokens\":199,\"completionTokens\":106,\"totalTokens\":305,\"cost\":0.002187},\"finishReason\":\"stop\"}"
+							"tool_use_id": "toolu_01CZUTUiAvbDqYgaeAgFHVtb",
+							"content": "{\"status\":\"completed\",\"taskPath\":\"/root/token_production_0\",\"model\":\"anthropic/claude-sonnet-4-5\",\"answer\":\"I will complete the delegated task by providing the exact token as requested.\\n\\nSUBAGENT_OK_731\\n\\n---\\n\\n**Summary:**\\n\\n**What I did:**\\n- Received a task to output a specific token exactly as specified\\n- Provided the token \\\"SUBAGENT_OK_731\\\" with no additional text in the response body\\n\\n**What I accomplished:**\\n- Successfully output the exact token: SUBAGENT_OK_731\\n- Followed the instruction to include nothing else in the primary response\\n\\n**Important outputs:**\\n- Output token: SUBAGENT_OK_731\\n\\n**Issues/Assumptions/Limitations:**\\n- None. The task was straightforward and clearly specified.\",\"usage\":{\"promptTokens\":203,\"completionTokens\":154,\"totalTokens\":357,\"cost\":0.0029189999999999997},\"finishReason\":\"stop\"}"
 						}
 					]
 				}
@@ -258,30 +265,30 @@
 			}
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_01CYfxtWJEsWuYQWGKXmLVfM\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"PARENT_SAW SUBAGENT_OK_731\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":1970,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":16,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_011CdY77y57CBGMVPae4LjSG\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"PARENT_SAW SUBAGENT_OK_731\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":2054,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":16,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "22500000",
 			"anthropic-ratelimit-input-tokens-remaining": "22499000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-07-03T09:47:14Z",
+			"anthropic-ratelimit-input-tokens-reset": "2026-07-30T10:45:11Z",
 			"anthropic-ratelimit-output-tokens-limit": "4500000",
 			"anthropic-ratelimit-output-tokens-remaining": "4500000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-07-03T09:47:15Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-07-30T10:45:11Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-07-03T09:47:13Z",
+			"anthropic-ratelimit-requests-reset": "2026-07-30T10:45:10Z",
 			"anthropic-ratelimit-tokens-limit": "27000000",
 			"anthropic-ratelimit-tokens-remaining": "26999000",
-			"anthropic-ratelimit-tokens-reset": "2026-07-03T09:47:14Z",
+			"anthropic-ratelimit-tokens-reset": "2026-07-30T10:45:11Z",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a154f7b25eac5a71-VIE",
+			"cf-ray": "a233c5b33fe6af0a-VIE",
 			"connection": "keep-alive",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "application/json",
-			"date": "Fri, 03 Jul 2026 09:47:15 GMT",
-			"request-id": "req_011CceurwrY7ok1DJYpoafrL",
+			"date": "Thu, 30 Jul 2026 10:45:11 GMT",
+			"request-id": "req_011CdY77wnxv5deK7MBPWK4M",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-6d0e52c70a0e9210823203ccf3e101ed-16b4d602826029ee-01",
+			"traceresponse": "00-287733e004d2ad52dd6086fb2ee96e2b-d1bf3a8a0b02cafa-01",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},

--- a/packages/@n8n/agents/src/__tests__/integration/cassettes/delegate-sub-agent/stream-emits-sub-agent-lifecycle-chunks-and-events.json
+++ b/packages/@n8n/agents/src/__tests__/integration/cassettes/delegate-sub-agent/stream-emits-sub-agent-lifecycle-chunks-and-events.json
@@ -72,33 +72,33 @@
 		},
 		"status": 200,
 		"response": [
-			"1f8b0800000000000013cd58dd4fdb30107fe7afb0ee652fe9d4947540de40438c21c1344042ac93e5c6b7c4d4b583edf03194ff7d72d2d2a4948f6d8ca42f55ee2eb99fefee77b60faf50b9884cd15a9620b58e19b7c6996311b903779b2144d05042307f86e80ea69aa3840862c9728e3dab9542d7fbd01bf606fdc1b0bf35d8820004f71fb109ed877ba7a79f37e34f79b679f2e5dbfaf8d78e519be731044bae2000a3a517306b85754c79bfb1560e9583e8fb8f00acd31935c8ac5610a95cca99c8e2658e2ac68690a36342dab92c9fc3172acb1d757a82ca42140e37b60288599c228d0d3227b4a24d93fe5c6f90f1c774f377bd07cc529ca261920ea70fed17da305dd61601e8dcd5459b015834572246ea041a88c0478633c37d90d54f347ee134410d1128ed28bb6242b2b144280a52fe8ab535ac323e0b261d4b1d4f56e77d8549e988e34db5dabade2f76f69ec31b6f58fe450033d70def9950c9923b025e088f21e4281d7b1a6169d24058499ac8eecd66f8f6df4949384a4c9843e2522465bc7b99d13c8f7d1ec9b536936a196f8ece3a836c4a9c268cc4a9909cb00495234a5fbf5f44f6f1b4eaecb9aceaac066a45aafeb550c2270a456b49738bf31ee19f73da0fb72eede5f1b7841d0ecf06071bfce2f6ebf9ded92904a0d8d4bf37cf16b5f9b80c47e92dcb1d44778567a1949e1ef77eb83018bb8a04af97c1f061062b0a5f58adee8d33669c60b21436d8d03290bb11d87cbceda3b7cf6b1c6d1fd908223202a1a468c26a1d98c211bc761bf82b20011975a7901cb39343cfcba2752855e594ed9b76aaa4177b4995b8eed44fcb4812cd1a896a198eac2a685bd96b34a41b21ba162e2578c33ad179fc2eda85a0c85be25261579e2d5b01541d1a09539ca8eea0d22e152a21286d97588611393eddd9de830e9cc7760f4fe8d101dd58af07a8654c61877677bf55e04d8633e2b75d39fca8bc128f2082676eb46fc5fb119ca4d8a1fe4c9c86a265141354338aef1ede5772cb982a9ab71e9af57004c58b9af19fdeddc3faa7e623bb95ab6a28a1b68ac64cad7e3b7fe164adf88fa3b5a5595838fcb8c4b7c594f261dcea3a3f61fa0dee456cbef6140000"
+			"1f8b0800000000000013cd58df4fdb30107ee7afb0ee652fe9d400059ab7323186106c688c69ac93e5c6b7d4e0da597ce1c750fef7c9495b9a52184c43495faade9d7bdf7d77beb30eafd050c426e89c48903b1219ad494122627740b7294204352504b3df10ddc1c44ad41041ac452eb1e3ac31489dcd4eafb3de5def75fbeb7d084049ff272ee1dd307c27bf6def6ced9eede617bf0fcf55fa49f68f14044bae2080cc6a2f10ce2947c278bfb135848620fafe23004736e5190a670d4426d77a2a72f82b4713634d289184d26e26cb67f0954973e2642fd13888c2de763f8058c463e47186829435bc6ed29de93314f231ddecacf780e918279809cd7b9387f6f7da70bcac2d02b0392d8a760270985da9183929cc2002cf8c1499f4249b9f98f9c0798216223096b8b8124a8b9146280a36fd146b6b58e57c4a271f691b5faecefc0a93d295c49b2ade45bd0f777a8ef0c61b965f1140b1e43955265972c5c00be13174123589a7d19526357495a48e6a6e36c576f0466b2651632208198d91956c77d2ccca3cf65964d736bb84397f4f71f86a281d6528268c2c132c1e2b2d9948d01033f6faed0376979366d3bfa5d5a60b88187b4ea82f2f97f08972b156f3dce1ac57f8df39ef8647fbbdc1e65773961f6d0c4ede9ff477cf3f8cb6f621002326fedc2c6fdce5a39290d25b9a13447785bf8d5afb6b32f7235586315597e1ffe5307c98c3ea2a5f386be6c6a9c848095d0aefef44f340ee86e0f2d12059acf08621a181a2690c74208710b121a8d7bafaff04cb686570f8b0a3360226604320b1c04fc378dce5b198a04f5b3d674de31a423953b89f29ed61ab9a6e4368d1c5f70595d876254fe8aa0f0c8c8316cc8d6bccd8b5a2f19ca486f130bc117ea4368d43df324f4ac32894f3cfc736d4091a264c6b1e1992194be3968dd284a17618b1cf5f762b600d031aecd7f86918cddef1698b2603ff78c8b737c26a5a353ea55a55c743c09ba591d934a4146342d9a66afe586e525a513efe31713a4636cf5ad30f9c98ca9d475b5e14a6ecc883fdbde353dea20ee41b50bb5ea6be1d16cf61e8a52ba070658cb32df0cae86a4a5888a6b6a65d5cf43c73595bbce2b67669bd1af6b68ad521af22705107fecc1f39f1dccb4a170000"
 		],
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "22500000",
 			"anthropic-ratelimit-input-tokens-remaining": "22499000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-07-03T09:47:15Z",
+			"anthropic-ratelimit-input-tokens-reset": "2026-07-30T10:45:12Z",
 			"anthropic-ratelimit-output-tokens-limit": "4500000",
 			"anthropic-ratelimit-output-tokens-remaining": "4500000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-07-03T09:47:15Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-07-30T10:45:12Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-07-03T09:47:15Z",
+			"anthropic-ratelimit-requests-reset": "2026-07-30T10:45:12Z",
 			"anthropic-ratelimit-tokens-limit": "27000000",
 			"anthropic-ratelimit-tokens-remaining": "26999000",
-			"anthropic-ratelimit-tokens-reset": "2026-07-03T09:47:15Z",
+			"anthropic-ratelimit-tokens-reset": "2026-07-30T10:45:12Z",
 			"cache-control": "no-cache",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a154f7bd1b9f5a71-VIE",
+			"cf-ray": "a233c5bd3cf3af0a-VIE",
 			"connection": "keep-alive",
 			"content-encoding": "gzip",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "text/event-stream; charset=utf-8",
-			"date": "Fri, 03 Jul 2026 09:47:16 GMT",
-			"request-id": "req_011Cceus5ccUcu5S63pnkKab",
+			"date": "Thu, 30 Jul 2026 10:45:13 GMT",
+			"request-id": "req_011CdY785JetXbgfBdKXmCrT",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-12b7f86909b8222f45e788e80b7db1d9-5c63b97136e2016e-01",
+			"traceresponse": "00-05b1b866ae30456b98f16a457ac084d6-9ecac75622f59220-01",
 			"transfer-encoding": "chunked",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
@@ -128,33 +128,39 @@
 						}
 					]
 				}
-			]
+			],
+			"stream": true
 		},
 		"status": 200,
-		"response": "{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_01PJHYpyiarrMV6MCKXgF3w5\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I have completed the delegated task.\\n\\n**What I did:**\\nI was instructed to respond with exactly one specific token and nothing else.\\n\\n**What I accomplished:**\\nSUBAGENT_OK_731\\n\\n**Important outputs:**\\nThe required token \\\"SUBAGENT_OK_731\\\" has been provided as the core output of this task.\\n\\n**Issues, assumptions, or limitations:**\\nNone. The task was straightforward with clear instructions and expected output.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":199,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":102,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}",
+		"response": [
+			"1f8b0800000000000013bd55c16edb300cbdf72b041e03a748b2065d7cdb8aad480b7487751b866530188bb5852a922bd2498b22ff3e5849363b4bb75eda5c0cf33d99ef910a494b7292aa05316341190b0639d22898aa4790878a20850e08c9ee1dd24758784d1652c82dd69afaec9d23e99ff4c7fdd160341e4c461348c0e8e6235c6483e1f04c7f3f7d7b517d2caa8b7a757e75f675ccc525247ba92081e06d134066c382aec99b7b27e404d21f3f1360f1551608d93b485d6ded36c4745793cba913d424682cef62f54ebe71552d99f85b720ce970324920c7bca42c0f8462bccbba8cc10e0f84fa296c77b6494055490b0a68b3f1e26ffe1f7458eea3eb047c2dedd02801a6b03439656228400a4d613406ddd4d8dd50687c67057948c179c97089c6e2dc12acd7aafd5b1f1dd1a6efdb926673ebf3dbc3dd3f4089f934dd6f4cb7f1c6f3f69cd07d438c8f14a0aba0ada132aed84baaa009c2533a3559c17feb8c948ece4da4abef376dab72aa4a5c5257ebab8b50b95f549684b4929294264b05c637e4dbe3999bb95eef5b89a2a64a1b9df67a3337552b64651c4ba8f348f50a1daf28a8959152d13de6621fe2f7e2755233f8fce5fdbbf30f57d7d9a7cbecf4cd70060a9d56ce4b695ca1c8327573611e75192e49c3fad5ab127dee6b8efaa68bca876644a8cd1f8623f5ba2415e8ae362196a3f15c22ab39915355f04ba3492b9cfb76bb5fbfd5c85124b190de967bca5c13270a99eb45d50c124e940fca9a859138583606afbca363d5d86cee45bc002c014d51ca8d0f2b0c3a3634b784c13ec0f326c0cb39e58a727363481f47294f8f205ffd6f02f9aa95fe90a7ddc23ae8a603424b7d67a300399d491d1c3c7bafac5f6eb1ec6d82c9c9fab0e143d56b63b039f50bc57ae4adf5070000"
+		],
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "22500000",
 			"anthropic-ratelimit-input-tokens-remaining": "22500000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-07-03T09:47:19Z",
+			"anthropic-ratelimit-input-tokens-reset": "2026-07-30T10:45:15Z",
 			"anthropic-ratelimit-output-tokens-limit": "4500000",
 			"anthropic-ratelimit-output-tokens-remaining": "4500000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-07-03T09:47:21Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-07-30T10:45:15Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-07-03T09:47:18Z",
+			"anthropic-ratelimit-requests-reset": "2026-07-30T10:45:15Z",
 			"anthropic-ratelimit-tokens-limit": "27000000",
 			"anthropic-ratelimit-tokens-remaining": "27000000",
-			"anthropic-ratelimit-tokens-reset": "2026-07-03T09:47:19Z",
+			"anthropic-ratelimit-tokens-reset": "2026-07-30T10:45:15Z",
+			"cache-control": "no-cache",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a154f7ceeda75a71-VIE",
+			"cf-ray": "a233c5d16eb8af0a-VIE",
 			"connection": "keep-alive",
+			"content-encoding": "gzip",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
-			"content-type": "application/json",
-			"date": "Fri, 03 Jul 2026 09:47:22 GMT",
-			"request-id": "req_011CceusHMZEyxDy3W4jTvmC",
+			"content-type": "text/event-stream; charset=utf-8",
+			"date": "Thu, 30 Jul 2026 10:45:16 GMT",
+			"request-id": "req_011CdY78JTg2zufpwvK2Uvbp",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-0a027964946a157205a48b7fb54cd817-2e95f627fe900e50-01",
+			"traceresponse": "00-20c5cb3b9b6d07470c38f23d730e5d0a-7ecbe286d9ef4513-01",
+			"transfer-encoding": "chunked",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"
 		},
@@ -192,7 +198,7 @@
 						},
 						{
 							"type": "tool_use",
-							"id": "toolu_019qsqSRgaN5X2K7djyPZGXU",
+							"id": "toolu_01MG5A4WnVuM3AQFQ9BZHb6G",
 							"name": "delegate_subagent",
 							"input": {
 								"subAgentId": "inline",
@@ -211,8 +217,8 @@
 					"content": [
 						{
 							"type": "tool_result",
-							"tool_use_id": "toolu_019qsqSRgaN5X2K7djyPZGXU",
-							"content": "{\"status\":\"completed\",\"taskPath\":\"/root/token_production_0\",\"model\":\"anthropic/claude-sonnet-4-5\",\"answer\":\"I have completed the delegated task.\\n\\n**What I did:**\\nI was instructed to respond with exactly one specific token and nothing else.\\n\\n**What I accomplished:**\\nSUBAGENT_OK_731\\n\\n**Important outputs:**\\nThe required token \\\"SUBAGENT_OK_731\\\" has been provided as the core output of this task.\\n\\n**Issues, assumptions, or limitations:**\\nNone. The task was straightforward with clear instructions and expected output.\",\"usage\":{\"promptTokens\":199,\"completionTokens\":102,\"totalTokens\":301,\"cost\":0.002127},\"finishReason\":\"stop\"}"
+							"tool_use_id": "toolu_01MG5A4WnVuM3AQFQ9BZHb6G",
+							"content": "{\"status\":\"completed\",\"taskPath\":\"/root/token_production_0\",\"model\":\"anthropic/claude-sonnet-4-5\",\"answer\":\"I have completed the delegated task.\\n\\n**What I did:**\\nI was instructed to answer with exactly the token \\\"SUBAGENT_OK_731\\\" and nothing else.\\n\\n**What I accomplished:**\\nSUBAGENT_OK_731\\n\\n**Important outputs:**\\nThe required token has been provided above as requested.\\n\\n**Issues, assumptions, or limitations:**\\nNone. The task was straightforward and clearly specified.\",\"usage\":{\"promptTokens\":199,\"completionTokens\":94,\"totalTokens\":293,\"cost\":0.002007},\"finishReason\":\"stop\"}"
 						}
 					]
 				}
@@ -266,33 +272,33 @@
 		},
 		"status": 200,
 		"response": [
-			"1f8b0800000000000013bd53c16eda4010bdf315d69c8d847150c5de888452a92a8d0255ab54d56af04ec165d97576c72469e47faf1670b0a9697b697db1fcde1bcf7b331ada9161116dc97b5c91f48c8e7b0a1945f402fc5c1008689110d7df205e606b15691090692c15f5bd3586b87fd51ff58783e168301e8e21865c859ff8951c24e9a3ddcd6faeeebfff789e159f5dfa7673ffb874109fb582189cd50140ef73cf6842dfcc1a26c320be7c8dc1b32da423f4d68030a5d647c8d3434926a316a88831d7bec6cada7e6e8a9225db0d190f2219a7690c19666b929923e4dc1ad9960c6ade11aa4b5c5d1b3a50b1a62d39d472b4fd557f6293f5395bc5604b6e42c3183cb95d9e91e49c1c08089351e85418b2f9462e04972bb220c05896b8c35ce35213545554f57a7458f6718e72a96db6e95e798764df43d1d32168930f398f754c4f41b87f09802a6a3e2707456e56672d2308205c72a94833fedee55ed2727940daee5e65478fb793bbe96c7172fadf0dc8f9e26e3a792fe7934fd1fce3f5e4663a5bc80fefe49b3481eaf2d26cf1a79dd9a2e1a57b0ff56577866b91d008d33a3d20a32497cec05f1f60f50f2ff0ec649271753174d70c9b1c849a9f72983b7120050000"
+			"1f8b0800000000000013bd53c16ed34010bde72bac393b526c884af616aa08a48a8292002a08ada6de69b274bd6b76c7a1a8f2bf579bc4ad1d12ca057cb1fcdedb7d6f663cb421cb222929045c910c8c9e070a1945720ffcab2210d023216dbf41dc43e91419105018ac150d83b39678f872381ee6a37c3c9ae4134841ab784958c951969dababb3575f6aff292f7e96e7eafbc5d5cddb39a40756908277260218820e8c36fa16ce325906f1f55b0a815d253d61701684ad8dd943817ed4640bea818a18b5092d56b7f1b5ad6a96ec6ec90610d9241fa75060b126597842d6cecabe64d4f29e509de2dab3d181aa3595e4d1c871f9bbfe89cdd6876c9382abb90be52904f21b5d90644d1e04c4ce28f42a36d9de908f85cb153910601d4bdca036786d089a26797c9ac1807653df37545e1b57dc1e9ffd11c9d64cd1ddaee22e1f0bde9f63ba8bc2ed4b0074ec3bfe95b6ab03c3042208a7322a328c7fceb895f432ee907eb647d93ee187e97c76b93c91f33f65908be57c367d2717d3cfc9e2e3ebe99bd9e552bebf90672f32684e4fcd55cf0dcd559d2c49ef79bab6ddf2a3e5f548e894d35b4320ab24d7dec25f2f63f30fb7f1607db249f34ce9c77ad9e5e26ff90095166c1231050000"
 		],
 		"rawHeaders": {
 			"anthropic-ratelimit-input-tokens-limit": "22500000",
 			"anthropic-ratelimit-input-tokens-remaining": "22499000",
-			"anthropic-ratelimit-input-tokens-reset": "2026-07-03T09:47:22Z",
+			"anthropic-ratelimit-input-tokens-reset": "2026-07-30T10:45:18Z",
 			"anthropic-ratelimit-output-tokens-limit": "4500000",
 			"anthropic-ratelimit-output-tokens-remaining": "4500000",
-			"anthropic-ratelimit-output-tokens-reset": "2026-07-03T09:47:22Z",
+			"anthropic-ratelimit-output-tokens-reset": "2026-07-30T10:45:18Z",
 			"anthropic-ratelimit-requests-limit": "20000",
 			"anthropic-ratelimit-requests-remaining": "19999",
-			"anthropic-ratelimit-requests-reset": "2026-07-03T09:47:22Z",
+			"anthropic-ratelimit-requests-reset": "2026-07-30T10:45:18Z",
 			"anthropic-ratelimit-tokens-limit": "27000000",
 			"anthropic-ratelimit-tokens-remaining": "26999000",
-			"anthropic-ratelimit-tokens-reset": "2026-07-03T09:47:22Z",
+			"anthropic-ratelimit-tokens-reset": "2026-07-30T10:45:18Z",
 			"cache-control": "no-cache",
 			"cf-cache-status": "DYNAMIC",
-			"cf-ray": "a154f7e859e95a71-VIE",
+			"cf-ray": "a233c5e73a73af0a-VIE",
 			"connection": "keep-alive",
 			"content-encoding": "gzip",
 			"content-security-policy": "default-src 'none'; frame-ancestors 'none'",
 			"content-type": "text/event-stream; charset=utf-8",
-			"date": "Fri, 03 Jul 2026 09:47:23 GMT",
-			"request-id": "req_011Cceusam4TfXT9UkcRzWBk",
+			"date": "Thu, 30 Jul 2026 10:45:19 GMT",
+			"request-id": "req_011CdY78ZM7unYh8K5fxmvc1",
 			"server": "cloudflare",
 			"strict-transport-security": "max-age=31536000; includeSubDomains; preload",
-			"traceresponse": "00-8bdab5bad4bef9717932e4712f9614a8-9f37a11903c556c2-01",
+			"traceresponse": "00-590c063aee0ac5a9b22cb12a484c5572-37ff21bc76d37853-01",
 			"transfer-encoding": "chunked",
 			"vary": "Accept-Encoding",
 			"x-robots-tag": "none"

--- a/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
@@ -572,13 +572,15 @@ describe('createDelegateSubAgentTool', () => {
 		});
 	});
 
-	it('stops forwarding child text past the character budget but keeps tool lifecycle', async () => {
+	it('caps forwarded child text at the budget but keeps tool lifecycle flowing', async () => {
 		const events: AgentEventData[] = [];
 		const tool = createDelegateSubAgentTool({
 			runSubAgent: async (_request, helpers) => {
-				helpers.emitChunk({ type: 'text-delta', id: 't-1', delta: 'a'.repeat(20_000) });
-				helpers.emitChunk({ type: 'text-delta', id: 't-1', delta: 'over budget' });
-				helpers.emitChunk({ type: 'reasoning-delta', id: 'r-1', delta: 'over budget too' });
+				// Neither delta lands on the boundary, so the second must be trimmed
+				// rather than forwarded whole.
+				helpers.emitChunk({ type: 'text-delta', id: 't-1', delta: 'a'.repeat(15_000) });
+				helpers.emitChunk({ type: 'text-delta', id: 't-1', delta: 'b'.repeat(15_000) });
+				helpers.emitChunk({ type: 'reasoning-delta', id: 'r-1', delta: 'over budget' });
 				helpers.emitChunk({
 					type: 'tool-execution-end',
 					toolCallId: 'child-tc-1',
@@ -603,8 +605,14 @@ describe('createDelegateSubAgentTool', () => {
 		const forwarded = events.filter((event) => event.type === AgentEvent.SubAgentChunk);
 		expect(forwarded.map((event) => event.chunk.type)).toEqual([
 			'text-delta',
+			'text-delta',
 			'tool-execution-end',
 		]);
+		const forwardedChars = forwarded.reduce(
+			(total, event) => total + ('delta' in event.chunk ? event.chunk.delta.length : 0),
+			0,
+		);
+		expect(forwardedChars).toBe(20_000);
 	});
 
 	it('defaults maxChildren to 10 when policy is omitted', () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
@@ -527,6 +527,86 @@ describe('createDelegateSubAgentTool', () => {
 		});
 	});
 
+	it('forwards only allowlisted child chunks, keeping args, results and nesting out', async () => {
+		const events: AgentEventData[] = [];
+		const tool = createDelegateSubAgentTool({
+			runSubAgent: async (_request, helpers) => {
+				helpers.emitChunk({ type: 'text-delta', id: 't-1', delta: 'hello' });
+				helpers.emitChunk({
+					type: 'tool-call',
+					toolCallId: 'child-tc-1',
+					toolName: 'web_search',
+					input: { query: 'x'.repeat(5_000) },
+				});
+				helpers.emitChunk({
+					type: 'tool-result',
+					toolCallId: 'child-tc-1',
+					toolName: 'web_search',
+					output: { body: 'y'.repeat(5_000) },
+				});
+				helpers.emitChunk({
+					type: 'subagent-started',
+					taskName: 'nested',
+					taskPath: '/root/research_api_0/nested_0',
+					startedAt: 1,
+				});
+				return await Promise.resolve({
+					status: 'completed',
+					taskPath: '/root/research_api_0',
+					answer: 'done',
+				});
+			},
+		});
+
+		await tool.handler?.(input, {
+			runId: 'parent-run-1',
+			toolCallId: 'tool-call-1',
+			emitEvent: (event) => events.push(event),
+		});
+
+		const forwarded = events.filter((event) => event.type === AgentEvent.SubAgentChunk);
+		expect(forwarded).toHaveLength(1);
+		expect(forwarded[0]).toMatchObject({
+			parentToolCallId: 'tool-call-1',
+			chunk: { type: 'text-delta', delta: 'hello' },
+		});
+	});
+
+	it('stops forwarding child text past the character budget but keeps tool lifecycle', async () => {
+		const events: AgentEventData[] = [];
+		const tool = createDelegateSubAgentTool({
+			runSubAgent: async (_request, helpers) => {
+				helpers.emitChunk({ type: 'text-delta', id: 't-1', delta: 'a'.repeat(20_000) });
+				helpers.emitChunk({ type: 'text-delta', id: 't-1', delta: 'over budget' });
+				helpers.emitChunk({ type: 'reasoning-delta', id: 'r-1', delta: 'over budget too' });
+				helpers.emitChunk({
+					type: 'tool-execution-end',
+					toolCallId: 'child-tc-1',
+					toolName: 'web_search',
+					isError: false,
+					endTime: 1,
+				});
+				return await Promise.resolve({
+					status: 'completed',
+					taskPath: '/root/research_api_0',
+					answer: 'done',
+				});
+			},
+		});
+
+		await tool.handler?.(input, {
+			runId: 'parent-run-1',
+			toolCallId: 'tool-call-1',
+			emitEvent: (event) => events.push(event),
+		});
+
+		const forwarded = events.filter((event) => event.type === AgentEvent.SubAgentChunk);
+		expect(forwarded.map((event) => event.chunk.type)).toEqual([
+			'text-delta',
+			'tool-execution-end',
+		]);
+	});
+
 	it('defaults maxChildren to 10 when policy is omitted', () => {
 		const tool = createDelegateSubAgentTool({
 			runSubAgent: async () =>

--- a/packages/@n8n/agents/src/runtime/streaming/stream-session.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/stream-session.ts
@@ -78,11 +78,17 @@ export function startStreamSession(deps: StreamSessionDeps): ReadableStream<Stre
 		const { type: _type, ...payload } = data;
 		void guard.write({ type: 'subagent-completed', ...payload });
 	};
+	const onSubAgentChunk = (data: AgentEventData): void => {
+		if (data.type !== AgentEvent.SubAgentChunk) return;
+		const { type: _type, ...payload } = data;
+		void guard.write({ type: 'subagent-chunk', ...payload });
+	};
 
 	deps.eventBus.on(AgentEvent.ToolExecutionStart, onToolExecutionStart);
 	deps.eventBus.on(AgentEvent.ToolExecutionEnd, onToolExecutionEnd);
 	deps.eventBus.on(AgentEvent.SubAgentStarted, onSubAgentStarted);
 	deps.eventBus.on(AgentEvent.SubAgentCompleted, onSubAgentCompleted);
+	deps.eventBus.on(AgentEvent.SubAgentChunk, onSubAgentChunk);
 
 	deps
 		.withRootSpan('stream', deps.options, deps.runId, async () => await deps.runLoop(guard))
@@ -113,6 +119,7 @@ export function startStreamSession(deps: StreamSessionDeps): ReadableStream<Stre
 			deps.eventBus.off(AgentEvent.ToolExecutionEnd, onToolExecutionEnd);
 			deps.eventBus.off(AgentEvent.SubAgentStarted, onSubAgentStarted);
 			deps.eventBus.off(AgentEvent.SubAgentCompleted, onSubAgentCompleted);
+			deps.eventBus.off(AgentEvent.SubAgentChunk, onSubAgentChunk);
 			void guard.close();
 			deps.abortScope.dispose();
 		});

--- a/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
+++ b/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
@@ -214,15 +214,21 @@ function createEmitChunkHelper(
 		if (request.parentToolCallId === undefined) return;
 		if (!isForwardedChildChunk(chunk)) return;
 
+		let forwarded: ForwardedChildChunk = chunk;
 		if (chunk.type === 'text-delta' || chunk.type === 'reasoning-delta') {
-			if (forwardedChars >= SUB_AGENT_FORWARD_CHAR_BUDGET) return;
-			forwardedChars += chunk.delta.length;
+			// Trim rather than pass through whole: a single provider delta can be
+			// arbitrarily large, and forwarding it intact would blow the budget.
+			const remaining = SUB_AGENT_FORWARD_CHAR_BUDGET - forwardedChars;
+			if (remaining <= 0) return;
+			const delta = chunk.delta.slice(0, remaining);
+			forwardedChars += delta.length;
+			forwarded = { ...chunk, delta };
 		}
 
 		ctx.emitEvent?.({
 			type: AgentEvent.SubAgentChunk,
 			...subAgentLifecycleBase(request),
-			chunk,
+			chunk: forwarded,
 		});
 	};
 }

--- a/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
+++ b/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
@@ -11,11 +11,13 @@ import { isAbortError } from '../../sdk/abort';
 import { filterLlmMessages } from '../../sdk/message';
 import { Tool } from '../../sdk/tool';
 import { AgentEvent } from '../../types/runtime/event';
+import type { ForwardedChildChunk } from '../../types/runtime/event';
 import type {
 	AgentExecutionCounter,
 	FinishReason,
 	GenerateResult,
 	ModelConfig,
+	StreamChunk,
 	TokenUsage,
 } from '../../types/sdk/agent';
 import type { AgentMessage } from '../../types/sdk/message';
@@ -178,6 +180,51 @@ export interface DelegateSubAgentToolOutput {
 export interface DelegateSubAgentRunnerHelpers {
 	/** Run a one-off inline child using the parent agent's inherited local/deferred tool set. */
 	runInlineSubAgent: (request: DelegateSubAgentRequest) => Promise<DelegateSubAgentToolOutput>;
+	/**
+	 * Forward a child stream chunk into the parent run's event bus (allowlisted
+	 * types only, with a per-delegation character budget). No-op when the
+	 * parent tool call id is missing.
+	 */
+	emitChunk: (chunk: StreamChunk) => void;
+}
+
+/** Cap on forwarded text+reasoning characters per delegation. */
+const SUB_AGENT_FORWARD_CHAR_BUDGET = 20_000;
+
+const FORWARDED_CHILD_CHUNK_TYPES = new Set<ForwardedChildChunk['type']>([
+	'text-delta',
+	'reasoning-start',
+	'reasoning-delta',
+	'reasoning-end',
+	'tool-input-start',
+	'tool-execution-start',
+	'tool-execution-end',
+]);
+
+function isForwardedChildChunk(chunk: StreamChunk): chunk is ForwardedChildChunk {
+	return FORWARDED_CHILD_CHUNK_TYPES.has(chunk.type as ForwardedChildChunk['type']);
+}
+
+function createEmitChunkHelper(
+	ctx: ToolContext,
+	request: DelegateSubAgentRequest,
+): (chunk: StreamChunk) => void {
+	let forwardedChars = 0;
+	return (chunk) => {
+		if (request.parentToolCallId === undefined) return;
+		if (!isForwardedChildChunk(chunk)) return;
+
+		if (chunk.type === 'text-delta' || chunk.type === 'reasoning-delta') {
+			if (forwardedChars >= SUB_AGENT_FORWARD_CHAR_BUDGET) return;
+			forwardedChars += chunk.delta.length;
+		}
+
+		ctx.emitEvent?.({
+			type: AgentEvent.SubAgentChunk,
+			...subAgentLifecycleBase(request),
+			chunk,
+		});
+	};
 }
 
 export type InlineSubAgentProviderToolsResolver = (
@@ -487,6 +534,7 @@ async function handleDelegateSubAgent(
 					`${toolName} host runner does not support inline delegation without helpers.runInlineSubAgent from an Agent build.`,
 				);
 			},
+			emitChunk: createEmitChunkHelper(ctx, request),
 		});
 		emitSubAgentCompleted(ctx, request, output, startedAt);
 		return output;

--- a/packages/@n8n/agents/src/sdk/__tests__/delegate-sub-agent-routing.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/delegate-sub-agent-routing.test.ts
@@ -11,6 +11,7 @@ import {
 	type DelegateSubAgentRunnerHelpers,
 } from '../../runtime/tools/delegate-sub-agent-tool';
 import type {
+	AgentDbMessage,
 	BuiltTool,
 	GenerateResult,
 	InterruptibleToolContext,
@@ -29,6 +30,48 @@ const mockState = (): SerializableAgentState => ({
 	pendingToolCalls: {},
 });
 
+function chunksFromGenerateResult(result: GenerateResult): unknown[] {
+	const chunks: unknown[] = [];
+	for (const message of result.messages) {
+		if (!('content' in message) || !Array.isArray(message.content)) continue;
+		for (const part of message.content) {
+			if (part.type === 'text' && part.text) {
+				chunks.push({ type: 'text-delta', id: 't-1', delta: part.text });
+			}
+		}
+	}
+	for (const suspension of result.pendingSuspend ?? []) {
+		chunks.push({
+			type: 'tool-call-suspended',
+			runId: suspension.runId,
+			toolCallId: suspension.toolCallId,
+			toolName: suspension.toolName,
+			input: suspension.input,
+			suspendPayload: suspension.suspendPayload,
+		});
+	}
+	if (result.error !== undefined) {
+		chunks.push({ type: 'error', error: result.error });
+	}
+	chunks.push({
+		type: 'finish',
+		finishReason: result.finishReason ?? 'stop',
+		...(result.usage !== undefined ? { usage: result.usage } : {}),
+		...(result.model !== undefined ? { model: result.model } : {}),
+		...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
+	});
+	return chunks;
+}
+
+function readableFromChunks(chunks: unknown[]): ReadableStream<unknown> {
+	return new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}
+
 vi.mock('../../runtime/loop/agent-runtime', async (importOriginal) => {
 	const actual = await importOriginal<typeof AgentRuntimeModule>();
 	return {
@@ -38,23 +81,27 @@ vi.mock('../../runtime/loop/agent-runtime', async (importOriginal) => {
 				runtimeConfigs.push(config);
 			}
 
-			async generate(_input: unknown, options?: Record<string, unknown>) {
+			async stream(_input: unknown, options?: Record<string, unknown>) {
 				runtimeGenerateOptions.push(options);
-				if (inlineChildGenerateResult !== undefined) {
-					return await Promise.resolve(inlineChildGenerateResult);
-				}
+				const result =
+					inlineChildGenerateResult ??
+					({
+						runId: 'child-run',
+						finishReason: 'stop',
+						messages: [
+							{
+								role: 'assistant',
+								type: 'llm',
+								content: [{ type: 'text', text: 'inline answer' }],
+							},
+						],
+						usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+						getState: mockState,
+					} as GenerateResult);
 				return await Promise.resolve({
-					runId: 'child-run',
-					finishReason: 'stop',
-					messages: [
-						{
-							role: 'assistant',
-							type: 'llm',
-							content: [{ type: 'text', text: 'inline answer' }],
-						},
-					],
-					usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
-					getState: mockState,
+					runId: result.runId,
+					stream: readableFromChunks(chunksFromGenerateResult(result)),
+					getState: result.getState ?? mockState,
 				});
 			}
 
@@ -234,7 +281,7 @@ describe('delegate sub-agent routing', () => {
 		});
 	});
 
-	it('passes the parent execution counter to inline child generate options', async () => {
+	it('passes the parent execution counter to inline child stream options', async () => {
 		const executionCounter = {
 			incrementMessageCount: vi.fn(),
 			incrementToolCallCount: vi.fn(),
@@ -323,7 +370,7 @@ describe('delegate sub-agent routing', () => {
 					taskPath: '/root/research_api_0',
 					childCount: 0,
 				},
-				{ runInlineSubAgent },
+				{ runInlineSubAgent, emitChunk: () => undefined },
 			),
 		).resolves.toMatchObject({
 			status: 'completed',
@@ -374,6 +421,57 @@ describe('delegate sub-agent routing', () => {
 			status: 'failed',
 			answer: '',
 			error: DELEGATED_CHILD_SUSPEND_UNSUPPORTED_MESSAGE,
+		});
+	});
+
+	it('answers with the final assistant turn, not every text block the child streamed', async () => {
+		const responseMessages: AgentDbMessage[] = [
+			{
+				id: 'm-1',
+				createdAt: new Date(1),
+				role: 'assistant',
+				type: 'llm',
+				content: [{ type: 'text', text: 'Let me look that up.' }],
+			},
+			{
+				id: 'm-2',
+				createdAt: new Date(2),
+				role: 'assistant',
+				type: 'llm',
+				content: [{ type: 'text', text: 'The capital is Paris.' }],
+			},
+		];
+		inlineChildGenerateResult = {
+			runId: 'child-run-multi-turn',
+			finishReason: 'stop',
+			messages: responseMessages,
+			getState: () => ({
+				status: 'success',
+				messageList: {
+					messages: responseMessages,
+					historyIds: [],
+					inputIds: [],
+					responseIds: ['m-1', 'm-2'],
+				},
+				pendingToolCalls: {},
+			}),
+		};
+
+		const agent = new Agent('parent')
+			.model('openai', 'gpt-4o-mini')
+			.instructions('Delegate when needed.')
+			.tool(createDelegateSubAgentTool());
+
+		const runtimeConfig = await buildAgentConfig(agent);
+		const delegateTool = runtimeConfig.tools?.find(
+			(tool) => tool.name === DELEGATE_SUB_AGENT_TOOL_NAME,
+		);
+
+		await expect(
+			delegateTool?.handler?.(delegateInput, { runId: 'parent-run-1' }),
+		).resolves.toMatchObject({
+			status: 'completed',
+			answer: 'The capital is Paris.',
 		});
 	});
 });

--- a/packages/@n8n/agents/src/sdk/__tests__/inline-sub-agent-tools.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/inline-sub-agent-tools.test.ts
@@ -35,6 +35,51 @@ function makeGenerateSuccess(): Record<string, unknown> {
 	};
 }
 
+function chunksFromGenerateResult(result: Record<string, unknown>): unknown[] {
+	const chunks: unknown[] = [];
+	const messages = result.messages as
+		| Array<{ content?: Array<{ type: string; text?: string }> }>
+		| undefined;
+	for (const message of messages ?? []) {
+		for (const part of message.content ?? []) {
+			if (part.type === 'text' && part.text) {
+				chunks.push({ type: 'text-delta', id: 't-1', delta: part.text });
+			}
+		}
+	}
+	for (const suspension of (result.pendingSuspend as Array<Record<string, unknown>> | undefined) ??
+		[]) {
+		chunks.push({
+			type: 'tool-call-suspended',
+			runId: suspension.runId,
+			toolCallId: suspension.toolCallId,
+			toolName: suspension.toolName,
+			input: suspension.input,
+			suspendPayload: suspension.suspendPayload,
+		});
+	}
+	if (result.error !== undefined) {
+		chunks.push({ type: 'error', error: result.error });
+	}
+	chunks.push({
+		type: 'finish',
+		finishReason: result.finishReason ?? 'stop',
+		...(result.usage !== undefined ? { usage: result.usage } : {}),
+		...(result.model !== undefined ? { model: result.model } : {}),
+		...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
+	});
+	return chunks;
+}
+
+function readableFromChunks(chunks: unknown[]): ReadableStream<unknown> {
+	return new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}
+
 vi.mock('../../runtime/loop/agent-runtime', async (importOriginal) => {
 	const actual = await importOriginal<typeof AgentRuntimeModule>();
 	return {
@@ -47,6 +92,20 @@ vi.mock('../../runtime/loop/agent-runtime', async (importOriginal) => {
 			async generate(_prompt: string, options?: Record<string, unknown>) {
 				runtimeGenerateOptions.push(options ?? {});
 				return await Promise.resolve(runtimeGenerateResults.shift() ?? makeGenerateSuccess());
+			}
+
+			async stream(_prompt: string, options?: Record<string, unknown>) {
+				runtimeGenerateOptions.push(options ?? {});
+				const result = runtimeGenerateResults.shift() ?? makeGenerateSuccess();
+				return await Promise.resolve({
+					runId: (result.runId as string | undefined) ?? 'child-run',
+					stream: readableFromChunks(chunksFromGenerateResult(result)),
+					getState: () => ({
+						status: 'success',
+						messageList: { messages: [], historyIds: [], inputIds: [], responseIds: [] },
+						pendingToolCalls: {},
+					}),
+				});
 			}
 
 			async dispose() {

--- a/packages/@n8n/agents/src/sdk/agent.ts
+++ b/packages/@n8n/agents/src/sdk/agent.ts
@@ -13,6 +13,7 @@ import { AgentRuntime, type AgentRuntimeConfig } from '../runtime/loop/agent-run
 import { ensureUniqueMcpToolNames } from '../runtime/mcp/mcp-tool-resolver';
 import { RECALL_MEMORY_TOOL_NAME } from '../runtime/memory/episodic-memory';
 import type { ScopedMemoryTaskEvent } from '../runtime/memory/scoped-memory-task-runner';
+import { AgentMessageList } from '../runtime/model/message-list';
 import type { FetchFn } from '../runtime/model/model-factory';
 import { mergeProviderOptions } from '../runtime/model/prompt-cache';
 import { AgentEventBus } from '../runtime/state/event-bus';
@@ -58,6 +59,7 @@ import type {
 	BuiltTelemetry,
 	CheckpointStore,
 	ExecutionOptions,
+	FinishReason,
 	GenerateResult,
 	MemoryConfig,
 	ModelConfig,
@@ -68,6 +70,7 @@ import type {
 	StreamResult,
 	ThinkingConfig,
 	ThinkingConfigFor,
+	TokenUsage,
 	ResumeOptions,
 	McpConnectionFailedEvent,
 } from '../types';
@@ -1137,13 +1140,17 @@ export class Agent implements BuiltAgent, AgentBuilder {
 			const hostRunner = delegateOptions.runSubAgent;
 			const completedTool = createDelegateSubAgentTool({
 				...delegateOptions,
-				runSubAgent: async (request, _helpersFromHandler) => {
-					const helpers = { runInlineSubAgent };
+				runSubAgent: async (request, helpersFromHandler) => {
+					const helpers = {
+						runInlineSubAgent: async (req: DelegateSubAgentRequest) =>
+							await runInlineSubAgent(req, helpersFromHandler.emitChunk),
+						emitChunk: helpersFromHandler.emitChunk,
+					};
 					if (hostRunner) {
 						return await hostRunner(request, helpers);
 					}
 					if (request.subAgentId === INLINE_SUB_AGENT_ID) {
-						return await runInlineSubAgent(request);
+						return await runInlineSubAgent(request, helpersFromHandler.emitChunk);
 					}
 					return {
 						status: 'failed',
@@ -1171,8 +1178,11 @@ export class Agent implements BuiltAgent, AgentBuilder {
 		inlineSubAgentBlockedTools?: string[];
 		inlineSubAgentModelsByDifficulty?: Partial<Record<SubAgentTaskDifficulty, ModelConfig>>;
 		resolveInlineSubAgentProviderTools?: InlineSubAgentProviderToolsResolver;
-	}): (request: DelegateSubAgentRequest) => Promise<DelegateSubAgentToolOutput> {
-		return async (request) => {
+	}): (
+		request: DelegateSubAgentRequest,
+		onChunk?: (chunk: StreamChunk) => void,
+	) => Promise<DelegateSubAgentToolOutput> {
+		return async (request, onChunk) => {
 			const tools = filterInlineSubAgentTools(options.tools, options.inlineSubAgentBlockedTools);
 			const deferredTools = filterInlineSubAgentTools(
 				options.deferredTools,
@@ -1214,7 +1224,7 @@ export class Agent implements BuiltAgent, AgentBuilder {
 			});
 
 			try {
-				const result = await childRuntime.generate(renderDelegateSubAgentPrompt(request), {
+				const resultStream = await childRuntime.stream(renderDelegateSubAgentPrompt(request), {
 					...(request.parentAbortSignal !== undefined
 						? { abortSignal: request.parentAbortSignal }
 						: {}),
@@ -1223,14 +1233,75 @@ export class Agent implements BuiltAgent, AgentBuilder {
 						? { executionCounter: request.parentExecutionCounter }
 						: {}),
 				});
-				if (result.pendingSuspend !== undefined && result.pendingSuspend.length > 0) {
-					return failedDelegatedChildSuspendOutput(request.taskPath, result.model ?? childModelId);
+
+				let text = '';
+				let model: string | undefined;
+				let usage: TokenUsage | undefined;
+				let finishReason: FinishReason | undefined;
+				let structuredOutput: unknown;
+				let error: unknown;
+				let suspended = false;
+
+				const reader = resultStream.stream.getReader();
+				try {
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) break;
+						const chunk = value;
+						onChunk?.(chunk);
+						switch (chunk.type) {
+							case 'text-delta':
+								text += chunk.delta;
+								break;
+							case 'tool-call-suspended':
+								suspended = true;
+								break;
+							case 'error':
+								error = chunk.error;
+								break;
+							case 'finish':
+								finishReason = chunk.finishReason;
+								if (chunk.usage !== undefined) usage = chunk.usage;
+								if (chunk.model !== undefined) model = chunk.model;
+								if (chunk.structuredOutput !== undefined) {
+									structuredOutput = chunk.structuredOutput;
+								}
+								break;
+							default:
+								break;
+						}
+					}
+				} finally {
+					reader.releaseLock();
 				}
-				const resultWithModel =
-					result.model === undefined && childModelId !== undefined
-						? { ...result, model: childModelId }
-						: result;
-				return generateResultToDelegateSubAgentOutput(request.taskPath, resultWithModel);
+
+				if (suspended) {
+					return failedDelegatedChildSuspendOutput(request.taskPath, model ?? childModelId);
+				}
+
+				// The runtime only serializes its message list into state on success
+				// and on suspend, so an errored child falls back to the streamed text.
+				const responseMessages = AgentMessageList.deserialize(
+					resultStream.getState().messageList,
+				).responseDelta();
+				const messages: AgentMessage[] =
+					responseMessages.length > 0
+						? responseMessages
+						: text.trim()
+							? [{ role: 'assistant', content: [{ type: 'text', text }] }]
+							: [];
+
+				const result: GenerateResult = {
+					runId: resultStream.runId,
+					messages,
+					...((model ?? childModelId) ? { model: model ?? childModelId } : {}),
+					...(finishReason !== undefined ? { finishReason } : {}),
+					...(usage !== undefined ? { usage } : {}),
+					...(structuredOutput !== undefined ? { structuredOutput } : {}),
+					...(error !== undefined ? { error } : {}),
+					getState: () => resultStream.getState(),
+				};
+				return generateResultToDelegateSubAgentOutput(request.taskPath, result);
 			} finally {
 				await childRuntime.dispose();
 			}

--- a/packages/@n8n/agents/src/types/index.ts
+++ b/packages/@n8n/agents/src/types/index.ts
@@ -182,6 +182,8 @@ export type {
 	AgentEventData,
 	AgentEventHandler,
 	AgentMiddleware,
+	ForwardedChildChunk,
+	SubAgentChunkPayload,
 } from './runtime/event';
 
 export type {

--- a/packages/@n8n/agents/src/types/runtime/event.ts
+++ b/packages/@n8n/agents/src/types/runtime/event.ts
@@ -33,6 +33,35 @@ export interface SubAgentCompletedPayload extends SubAgentLifecycleBase {
 	error?: string;
 }
 
+/**
+ * Child stream chunks that may be forwarded live to the parent chat while a
+ * delegation runs. Args/results and nested sub-agent lifecycle are excluded
+ * so fan-out stays bounded.
+ */
+export type ForwardedChildChunk =
+	| { type: 'text-delta'; id: string; delta: string }
+	| { type: 'reasoning-start'; id: string }
+	| { type: 'reasoning-delta'; id: string; delta: string }
+	| { type: 'reasoning-end'; id: string }
+	| { type: 'tool-input-start'; toolCallId: string; toolName: string }
+	| {
+			type: 'tool-execution-start';
+			toolCallId: string;
+			toolName: string;
+			startTime: number;
+	  }
+	| {
+			type: 'tool-execution-end';
+			toolCallId: string;
+			toolName: string;
+			isError: boolean;
+			endTime: number;
+	  };
+
+export interface SubAgentChunkPayload extends SubAgentLifecycleBase {
+	chunk: ForwardedChildChunk;
+}
+
 export const enum AgentEvent {
 	AgentStart = 'agent_start',
 	AgentEnd = 'agent_end',
@@ -42,6 +71,7 @@ export const enum AgentEvent {
 	ToolExecutionEnd = 'tool_execution_end',
 	SubAgentStarted = 'subagent_started',
 	SubAgentCompleted = 'subagent_completed',
+	SubAgentChunk = 'subagent_chunk',
 	Error = 'error',
 }
 
@@ -60,6 +90,7 @@ export type AgentEventData =
 	  }
 	| ({ type: AgentEvent.SubAgentStarted } & SubAgentStartedPayload)
 	| ({ type: AgentEvent.SubAgentCompleted } & SubAgentCompletedPayload)
+	| ({ type: AgentEvent.SubAgentChunk } & SubAgentChunkPayload)
 	| {
 			type: AgentEvent.Error;
 			message: string;

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -12,6 +12,7 @@ import type { ProviderId, ProviderCredentials } from '../../runtime/model/provid
 import type {
 	AgentEvent,
 	AgentEventHandler,
+	SubAgentChunkPayload,
 	SubAgentCompletedPayload,
 	SubAgentStartedPayload,
 } from '../runtime/event';
@@ -142,6 +143,7 @@ export type StreamChunk = ContentMetadata &
 		| { type: 'message'; message: AgentMessage }
 		| ({ type: 'subagent-started' } & SubAgentStartedPayload)
 		| ({ type: 'subagent-completed' } & SubAgentCompletedPayload)
+		| ({ type: 'subagent-chunk' } & SubAgentChunkPayload)
 		| {
 				type: 'finish';
 				finishReason: FinishReason;

--- a/packages/@n8n/api-types/src/agent-sse.ts
+++ b/packages/@n8n/api-types/src/agent-sse.ts
@@ -47,6 +47,31 @@ export interface AgentSseMessage {
 	content: AgentPersistedMessageContentPart[];
 }
 
+/**
+ * Child stream chunks forwarded live while a `delegate_subagent` tool runs.
+ * Structural mirror of `@n8n/agents` `ForwardedChildChunk` (api-types cannot
+ * import from that package).
+ */
+export type ForwardedChildChunkWire =
+	| { type: 'text-delta'; id: string; delta: string }
+	| { type: 'reasoning-start'; id: string }
+	| { type: 'reasoning-delta'; id: string; delta: string }
+	| { type: 'reasoning-end'; id: string }
+	| { type: 'tool-input-start'; toolCallId: string; toolName: string }
+	| {
+			type: 'tool-execution-start';
+			toolCallId: string;
+			toolName: string;
+			startTime: number;
+	  }
+	| {
+			type: 'tool-execution-end';
+			toolCallId: string;
+			toolName: string;
+			isError: boolean;
+			endTime: number;
+	  };
+
 export type AgentSseEvent =
 	| { type: 'start-step' }
 	| { type: 'finish-step' }
@@ -94,6 +119,17 @@ export type AgentSseEvent =
 			canceled?: boolean;
 	  }
 	| { type: 'tool-call-suspended'; payload: ToolSuspendedPayload }
+	| {
+			/**
+			 * Live progress from a delegated child agent. Correlated to the parent
+			 * `delegate_subagent` tool call via `parentToolCallId`. Ephemeral —
+			 * not persisted or replayed from history.
+			 */
+			type: 'subagent-chunk';
+			parentToolCallId: string;
+			taskPath: string;
+			chunk: ForwardedChildChunkWire;
+	  }
 	| { type: 'message'; message: AgentSseMessage }
 	| {
 			/** A warning message from the MCP server when it fails to connect or initialize. */

--- a/packages/@n8n/api-types/src/agents/__tests__/child-trace.test.ts
+++ b/packages/@n8n/api-types/src/agents/__tests__/child-trace.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { applyForwardedChildChunk, emptyChildTrace, settleChildTrace } from '../child-trace';
+
+describe('applyForwardedChildChunk', () => {
+	it('accumulates text, reasoning and tool steps from a realistic chunk sequence', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000);
+		const trace = emptyChildTrace();
+
+		applyForwardedChildChunk(trace, { type: 'text-delta', id: 't-1', delta: 'Hello ' });
+		applyForwardedChildChunk(trace, { type: 'text-delta', id: 't-1', delta: 'world' });
+		applyForwardedChildChunk(trace, { type: 'reasoning-delta', id: 'r-1', delta: 'Think ' });
+		applyForwardedChildChunk(trace, { type: 'reasoning-delta', id: 'r-1', delta: 'hard' });
+		applyForwardedChildChunk(trace, { type: 'reasoning-end', id: 'r-1' });
+		applyForwardedChildChunk(trace, {
+			type: 'tool-input-start',
+			toolCallId: 'child-tc-1',
+			toolName: 'web_search',
+		});
+		applyForwardedChildChunk(trace, {
+			type: 'tool-execution-end',
+			toolCallId: 'child-tc-1',
+			toolName: 'web_search',
+			isError: false,
+			endTime: 2_000,
+		});
+
+		expect(trace.text).toBe('Hello world');
+		expect(trace.reasoningSegments).toHaveLength(1);
+		expect(trace.reasoningSegments[0]).toMatchObject({
+			id: 'r-1',
+			content: 'Think hard',
+			endTime: 1_000,
+		});
+		expect(trace.steps).toEqual([
+			{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false },
+		]);
+		vi.useRealTimers();
+	});
+});
+
+describe('settleChildTrace', () => {
+	it('clears residual running flags on every step', () => {
+		const trace = emptyChildTrace();
+		trace.steps.push(
+			{ toolCallId: 'a', toolName: 'one', running: true },
+			{ toolCallId: 'b', toolName: 'two', running: true },
+		);
+
+		settleChildTrace(trace);
+
+		expect(trace.steps.every((step) => !step.running)).toBe(true);
+	});
+});

--- a/packages/@n8n/api-types/src/agents/child-trace.ts
+++ b/packages/@n8n/api-types/src/agents/child-trace.ts
@@ -1,0 +1,74 @@
+import type { ForwardedChildChunkWire } from '../agent-sse';
+import type { PersistedChildTrace } from './types';
+
+export function emptyChildTrace(): PersistedChildTrace {
+	return { text: '', reasoningSegments: [], steps: [] };
+}
+
+/** Fold one forwarded child chunk into a trace. Mutates `trace` in place so
+ *  Vue reactivity is preserved when called on a reactive object. */
+export function applyForwardedChildChunk(
+	trace: PersistedChildTrace,
+	chunk: ForwardedChildChunkWire,
+	now: number = Date.now(),
+): void {
+	switch (chunk.type) {
+		case 'text-delta':
+			trace.text += chunk.delta;
+			break;
+		case 'reasoning-start':
+			if (!trace.reasoningSegments.some((s) => s.id === chunk.id)) {
+				trace.reasoningSegments.push({ id: chunk.id, content: '', startTime: now });
+			}
+			break;
+		case 'reasoning-delta': {
+			let segment = trace.reasoningSegments.find((s) => s.id === chunk.id);
+			if (!segment) {
+				segment = { id: chunk.id, content: '', startTime: now };
+				trace.reasoningSegments.push(segment);
+			}
+			segment.content += chunk.delta;
+			break;
+		}
+		case 'reasoning-end': {
+			const segment = trace.reasoningSegments.find((s) => s.id === chunk.id);
+			if (segment) segment.endTime = now;
+			break;
+		}
+		case 'tool-input-start': {
+			if (!trace.steps.some((s) => s.toolCallId === chunk.toolCallId)) {
+				trace.steps.push({
+					toolCallId: chunk.toolCallId,
+					toolName: chunk.toolName,
+					running: true,
+				});
+			}
+			break;
+		}
+		case 'tool-execution-start': {
+			const step = trace.steps.find((s) => s.toolCallId === chunk.toolCallId);
+			if (step) {
+				step.running = true;
+			} else {
+				trace.steps.push({
+					toolCallId: chunk.toolCallId,
+					toolName: chunk.toolName,
+					running: true,
+				});
+			}
+			break;
+		}
+		case 'tool-execution-end': {
+			const step = trace.steps.find((s) => s.toolCallId === chunk.toolCallId);
+			if (step) step.running = false;
+			break;
+		}
+		default:
+			break;
+	}
+}
+
+/** Clear residual `running` flags so a settled trace never shows a stuck spinner. */
+export function settleChildTrace(trace: PersistedChildTrace): void {
+	for (const step of trace.steps) step.running = false;
+}

--- a/packages/@n8n/api-types/src/agents/index.ts
+++ b/packages/@n8n/api-types/src/agents/index.ts
@@ -6,6 +6,7 @@ export * from './agent-integration.schema';
 export * from './agent-json-config.schema';
 export * from './agent-node-tool-operations';
 export * from './agent-skill.schema';
+export * from './child-trace';
 export * from './inline-agent-config.schema';
 export * from './sanitize-agent-json-config';
 export * from './agent-task.schema';
@@ -16,7 +17,12 @@ export * from './reasoning';
 export * from './rich-card.schema';
 export * from './sub-agent.schema';
 export * from './types';
-export type { AgentSseEvent, AgentSseMessage, ToolSuspendedPayload } from '../agent-sse';
+export type {
+	AgentSseEvent,
+	AgentSseMessage,
+	ForwardedChildChunkWire,
+	ToolSuspendedPayload,
+} from '../agent-sse';
 export { AGENT_BUILDER_HIDDEN_AVAILABLE_TOOL_NODE_TYPES } from '../agent-builder-tool-node-types';
 // ASK_QUESTIONS_TOOL_NAME / CONFIGURE_CHANNEL_TOOL_NAME come from
 // ./agent-interaction.schema (re-exported below via `export *`).

--- a/packages/@n8n/api-types/src/agents/types.ts
+++ b/packages/@n8n/api-types/src/agents/types.ts
@@ -190,6 +190,27 @@ export interface AgentCapabilitySummary {
 	tasks: AgentCapabilityTask[];
 }
 
+export interface PersistedChildTraceSegment {
+	id: string;
+	content: string;
+	startTime?: number;
+	endTime?: number;
+}
+
+export interface PersistedChildTraceStep {
+	toolCallId: string;
+	toolName: string;
+	running: boolean;
+}
+
+/** A delegated child's trace, captured from forwarded chunks and persisted on
+ *  the parent's `delegate_subagent` tool call. */
+export interface PersistedChildTrace {
+	text: string;
+	reasoningSegments: PersistedChildTraceSegment[];
+	steps: PersistedChildTraceStep[];
+}
+
 export interface AgentPersistedMessageContentPart {
 	type: 'text' | 'reasoning' | 'tool-call' | 'file' | (string & {});
 	text?: string;
@@ -209,6 +230,8 @@ export interface AgentPersistedMessageContentPart {
 	fileName?: string;
 	mimeType?: string;
 	sizeBytes?: number;
+	/** Live trace of a delegated child, present only on `delegate_subagent` parts. */
+	childTrace?: PersistedChildTrace;
 }
 
 export interface AgentPersistedMessageDto {

--- a/packages/cli/src/modules/agents/__tests__/agent-sse-stream.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-sse-stream.test.ts
@@ -314,3 +314,39 @@ describe('agent-sse-stream — tool execution lifecycle chunks', () => {
 		]);
 	});
 });
+
+describe('agent-sse-stream — subagent-chunk', () => {
+	it('forwards allowlisted subagent-chunk events with parentToolCallId', async () => {
+		const events = await collectEvents([
+			{
+				type: 'subagent-chunk',
+				taskName: 'research',
+				taskPath: '/root/research_0',
+				parentToolCallId: 'tc-parent',
+				chunk: { type: 'text-delta', id: 't-1', delta: 'hello' },
+			},
+		]);
+
+		expect(events).toEqual([
+			{
+				type: 'subagent-chunk',
+				parentToolCallId: 'tc-parent',
+				taskPath: '/root/research_0',
+				chunk: { type: 'text-delta', id: 't-1', delta: 'hello' },
+			},
+		]);
+	});
+
+	it('drops subagent-chunk events without parentToolCallId', async () => {
+		const events = await collectEvents([
+			{
+				type: 'subagent-chunk',
+				taskName: 'research',
+				taskPath: '/root/research_0',
+				chunk: { type: 'text-delta', id: 't-1', delta: 'hello' },
+			},
+		]);
+
+		expect(events).toEqual([]);
+	});
+});

--- a/packages/cli/src/modules/agents/__tests__/execution-recorder.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/execution-recorder.test.ts
@@ -874,15 +874,24 @@ describe('ExecutionRecorder — subagent-chunk', () => {
 		});
 	});
 
-	it('stops persisting child text past the 4000 character budget', () => {
+	it('caps persisted child text at 4000 characters, trimming a delta that straddles it', () => {
 		const recorder = new ExecutionRecorder();
 		recorder.record(makeToolCallChunk('delegate_subagent', {}, 'tc-parent'));
+		// Neither delta lands on the boundary, so the second must be trimmed
+		// rather than persisted whole.
 		recorder.record({
 			type: 'subagent-chunk',
 			taskName: 'research',
 			taskPath: '/root/research_0',
 			parentToolCallId: 'tc-parent',
-			chunk: { type: 'text-delta', id: 't-1', delta: 'a'.repeat(4_000) },
+			chunk: { type: 'text-delta', id: 't-1', delta: 'a'.repeat(3_000) },
+		} as StreamChunk);
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'tc-parent',
+			chunk: { type: 'text-delta', id: 't-1', delta: 'b'.repeat(3_000) },
 		} as StreamChunk);
 		recorder.record({
 			type: 'subagent-chunk',

--- a/packages/cli/src/modules/agents/__tests__/execution-recorder.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/execution-recorder.test.ts
@@ -831,3 +831,139 @@ describe('ExecutionRecorder — node-tool {{$json.x}} resolution', () => {
 		});
 	});
 });
+
+describe('ExecutionRecorder — subagent-chunk', () => {
+	it('attaches forwarded child chunks to the open delegate tool-call entry', () => {
+		const recorder = new ExecutionRecorder();
+		recorder.record(makeToolCallChunk('delegate_subagent', { goal: 'x' }, 'tc-parent'));
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'tc-parent',
+			chunk: { type: 'text-delta', id: 't-1', delta: 'hello' },
+		} as StreamChunk);
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'tc-parent',
+			chunk: {
+				type: 'tool-input-start',
+				toolCallId: 'child-tc-1',
+				toolName: 'web_search',
+			},
+		} as StreamChunk);
+		recorder.record({
+			type: 'tool-execution-end',
+			toolCallId: 'tc-parent',
+			toolName: 'delegate_subagent',
+			isError: false,
+			endTime: 2_000,
+		});
+		recorder.record(makeToolResultChunk('delegate_subagent', { status: 'completed' }, 'tc-parent'));
+
+		const entry = recorder
+			.getMessageRecord()
+			.timeline.find((e) => e.type === 'tool-call' && e.toolCallId === 'tc-parent');
+		expect(entry).toMatchObject({
+			childTrace: {
+				text: 'hello',
+				steps: [{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false }],
+			},
+		});
+	});
+
+	it('stops persisting child text past the 4000 character budget', () => {
+		const recorder = new ExecutionRecorder();
+		recorder.record(makeToolCallChunk('delegate_subagent', {}, 'tc-parent'));
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'tc-parent',
+			chunk: { type: 'text-delta', id: 't-1', delta: 'a'.repeat(4_000) },
+		} as StreamChunk);
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'tc-parent',
+			chunk: { type: 'text-delta', id: 't-1', delta: 'over budget' },
+		} as StreamChunk);
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'tc-parent',
+			chunk: {
+				type: 'tool-input-start',
+				toolCallId: 'child-tc-1',
+				toolName: 'web_search',
+			},
+		} as StreamChunk);
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'tc-parent',
+			chunk: {
+				type: 'tool-execution-end',
+				toolCallId: 'child-tc-1',
+				toolName: 'web_search',
+				isError: false,
+				endTime: 1,
+			},
+		} as StreamChunk);
+
+		const entry = recorder
+			.getMessageRecord()
+			.timeline.find((e) => e.type === 'tool-call' && e.toolCallId === 'tc-parent');
+		expect(entry?.type).toBe('tool-call');
+		if (entry?.type !== 'tool-call') return;
+		expect(entry.childTrace?.text).toHaveLength(4_000);
+		expect(entry.childTrace?.steps).toEqual([
+			{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false },
+		]);
+	});
+
+	it('settles child steps when the delegation closes via tool-result alone', () => {
+		const recorder = new ExecutionRecorder();
+		recorder.record(makeToolCallChunk('delegate_subagent', {}, 'tc-parent'));
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'tc-parent',
+			chunk: {
+				type: 'tool-input-start',
+				toolCallId: 'child-tc-1',
+				toolName: 'web_search',
+			},
+		} as StreamChunk);
+		// No tool-execution-end for the parent — only the batched tool-result.
+		recorder.record(makeToolResultChunk('delegate_subagent', { status: 'completed' }, 'tc-parent'));
+
+		const entry = recorder
+			.getMessageRecord()
+			.timeline.find((e) => e.type === 'tool-call' && e.toolCallId === 'tc-parent');
+		expect(entry?.type).toBe('tool-call');
+		if (entry?.type !== 'tool-call') return;
+		expect(entry.childTrace?.steps).toEqual([
+			{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false },
+		]);
+	});
+
+	it('ignores a subagent-chunk with no matching open tool-call entry', () => {
+		const recorder = new ExecutionRecorder();
+		recorder.record({
+			type: 'subagent-chunk',
+			taskName: 'research',
+			taskPath: '/root/research_0',
+			parentToolCallId: 'missing',
+			chunk: { type: 'text-delta', id: 't-1', delta: 'orphan' },
+		} as StreamChunk);
+
+		expect(recorder.getMessageRecord().timeline).toEqual([]);
+	});
+});

--- a/packages/cli/src/modules/agents/__tests__/execution-to-message-mapper.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/execution-to-message-mapper.test.ts
@@ -40,6 +40,46 @@ describe('execution-to-message-mapper', () => {
 		]);
 	});
 
+	it('carries childTrace onto the persisted tool-call content part', () => {
+		const childTrace = {
+			text: 'child said this',
+			reasoningSegments: [{ id: 'r-1', content: 'thinking' }],
+			steps: [{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false }],
+		};
+		const result = executionToMessagesDto(
+			execution({
+				timeline: [
+					{
+						type: 'tool-call',
+						kind: 'tool',
+						name: 'delegate_subagent',
+						toolCallId: 'tc-parent',
+						input: { goal: 'x' },
+						output: { status: 'completed', answer: 'done' },
+						startTime: 100,
+						endTime: 200,
+						success: true,
+						childTrace,
+					},
+				],
+			}),
+		);
+
+		expect(result[1]?.content).toEqual([
+			{
+				type: 'tool-call',
+				toolName: 'delegate_subagent',
+				toolCallId: 'tc-parent',
+				input: { goal: 'x' },
+				startTime: 100,
+				endTime: 200,
+				state: 'resolved',
+				output: { status: 'completed', answer: 'done' },
+				childTrace,
+			},
+		]);
+	});
+
 	it('maps execution timeline text and tool calls into assistant message content', () => {
 		const result = executionToMessagesDto(
 			execution({

--- a/packages/cli/src/modules/agents/agent-sse-stream.ts
+++ b/packages/cli/src/modules/agents/agent-sse-stream.ts
@@ -225,6 +225,16 @@ function emitChunkEvents(chunk: StreamChunk, ctx: ChunkHandlerCtx): { suspended:
 			if (sseMessage) ctx.send({ type: 'message', message: sseMessage });
 			return { suspended: false };
 		}
+		case 'subagent-chunk': {
+			if (chunk.parentToolCallId === undefined) return { suspended: false };
+			ctx.send({
+				type: 'subagent-chunk',
+				parentToolCallId: chunk.parentToolCallId,
+				taskPath: chunk.taskPath,
+				chunk: chunk.chunk,
+			});
+			return { suspended: false };
+		}
 		case 'error': {
 			const errMsg = stringifyError(chunk.error);
 			ctx.send({ type: 'error', message: errMsg });

--- a/packages/cli/src/modules/agents/execution-recorder.ts
+++ b/packages/cli/src/modules/agents/execution-recorder.ts
@@ -1,9 +1,19 @@
 import type { StreamChunk } from '@n8n/agents';
+import {
+	applyForwardedChildChunk,
+	emptyChildTrace,
+	settleChildTrace,
+	type PersistedChildTrace,
+} from '@n8n/api-types';
 import { isRecord } from '@n8n/utils/is-record';
 import { scrubSecretsInText } from '@n8n/utils/scrub-secrets';
 import { extractFromAICalls, isFromAIOnlyExpression } from 'n8n-workflow';
 
 import type { ToolRegistry } from './tool-registry';
+
+/** Cap on child trace characters persisted per delegation. Tighter than the
+ *  live forwarding budget because this is written into every parent execution row. */
+const CHILD_TRACE_PERSIST_CHAR_BUDGET = 4_000;
 
 /**
  * Walk a nodeParameters tree and substitute templated values with what the
@@ -225,6 +235,7 @@ export type TimelineEvent =
 			 * detail viewer can show what the node was set up to do.
 			 */
 			nodeParameters?: Record<string, unknown>;
+			childTrace?: PersistedChildTrace;
 	  }
 	| { type: 'suspension'; toolName: string; toolCallId: string; timestamp: number };
 
@@ -281,6 +292,8 @@ export class ExecutionRecorder {
 
 	private readonly startTime = Date.now();
 
+	private childTraceChars = new Map<string, number>();
+
 	/** Feed a stream chunk into the recorder. */
 	record(chunk: StreamChunk): void {
 		switch (chunk.type) {
@@ -312,6 +325,23 @@ export class ExecutionRecorder {
 			case 'tool-execution-end':
 				this.recordToolExecutionEnd(chunk.toolCallId, chunk.isError, chunk.endTime);
 				break;
+			case 'subagent-chunk': {
+				if (chunk.parentToolCallId === undefined) break;
+				const entry = this.findOpenTimelineToolCall(chunk.parentToolCallId);
+				if (!entry) break;
+				const delta =
+					chunk.chunk.type === 'text-delta' || chunk.chunk.type === 'reasoning-delta'
+						? chunk.chunk.delta.length
+						: 0;
+				if (delta > 0) {
+					const used = this.childTraceChars.get(chunk.parentToolCallId) ?? 0;
+					if (used >= CHILD_TRACE_PERSIST_CHAR_BUDGET) break;
+					this.childTraceChars.set(chunk.parentToolCallId, used + delta);
+				}
+				entry.childTrace ??= emptyChildTrace();
+				applyForwardedChildChunk(entry.childTrace, chunk.chunk);
+				break;
+			}
 			case 'tool-result':
 				this.recordToolResult(
 					chunk.toolCallId,
@@ -481,6 +511,7 @@ export class ExecutionRecorder {
 		if (entry) {
 			entry.endTime = endTime;
 			entry.success = !isError;
+			if (entry.childTrace) settleChildTrace(entry.childTrace);
 		}
 	}
 
@@ -531,6 +562,7 @@ export class ExecutionRecorder {
 			if (pendingTimeline.endTime === 0) {
 				pendingTimeline.endTime = Date.now();
 			}
+			if (pendingTimeline.childTrace) settleChildTrace(pendingTimeline.childTrace);
 
 			if (pendingTimeline.kind === 'workflow' && isRecord(recordedOutput)) {
 				const execId = recordedOutput.executionId;

--- a/packages/cli/src/modules/agents/execution-recorder.ts
+++ b/packages/cli/src/modules/agents/execution-recorder.ts
@@ -329,17 +329,19 @@ export class ExecutionRecorder {
 				if (chunk.parentToolCallId === undefined) break;
 				const entry = this.findOpenTimelineToolCall(chunk.parentToolCallId);
 				if (!entry) break;
-				const delta =
-					chunk.chunk.type === 'text-delta' || chunk.chunk.type === 'reasoning-delta'
-						? chunk.chunk.delta.length
-						: 0;
-				if (delta > 0) {
+				let inner = chunk.chunk;
+				if (inner.type === 'text-delta' || inner.type === 'reasoning-delta') {
+					// Trim rather than skip whole: a delta straddling the cap would
+					// otherwise be persisted in full and overshoot it.
 					const used = this.childTraceChars.get(chunk.parentToolCallId) ?? 0;
-					if (used >= CHILD_TRACE_PERSIST_CHAR_BUDGET) break;
-					this.childTraceChars.set(chunk.parentToolCallId, used + delta);
+					const remaining = CHILD_TRACE_PERSIST_CHAR_BUDGET - used;
+					if (remaining <= 0) break;
+					const delta = inner.delta.slice(0, remaining);
+					this.childTraceChars.set(chunk.parentToolCallId, used + delta.length);
+					inner = { ...inner, delta };
 				}
 				entry.childTrace ??= emptyChildTrace();
-				applyForwardedChildChunk(entry.childTrace, chunk.chunk);
+				applyForwardedChildChunk(entry.childTrace, inner);
 				break;
 			}
 			case 'tool-result':

--- a/packages/cli/src/modules/agents/sub-agents/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/cli/src/modules/agents/sub-agents/__tests__/delegate-sub-agent-tool.test.ts
@@ -294,7 +294,7 @@ describe('createN8nDelegateSubAgentTool', () => {
 					taskPath: '/root/research_api_0',
 					childCount: 0,
 				},
-				{ runInlineSubAgent },
+				{ runInlineSubAgent, emitChunk: () => undefined },
 			),
 		).resolves.toMatchObject({
 			status: 'completed',

--- a/packages/cli/src/modules/agents/sub-agents/delegate-sub-agent-tool.ts
+++ b/packages/cli/src/modules/agents/sub-agents/delegate-sub-agent-tool.ts
@@ -84,6 +84,7 @@ export function createN8nDelegateSubAgentTool(options: CreateN8nDelegateSubAgent
 						? { abortSignal: request.parentAbortSignal }
 						: {}),
 					...(request.parentTelemetry !== undefined ? { telemetry: request.parentTelemetry } : {}),
+					onChunk: helpers.emitChunk,
 				},
 			);
 

--- a/packages/cli/src/modules/agents/sub-agents/sub-agent-foreground-runner.ts
+++ b/packages/cli/src/modules/agents/sub-agents/sub-agent-foreground-runner.ts
@@ -9,6 +9,7 @@ import {
 	type CredentialProvider,
 	type GenerateResult,
 	type SerializableAgentState,
+	type StreamChunk,
 	type SubAgentTaskPath,
 } from '@n8n/agents';
 import type { ResolvedSubAgentSource, SubAgentSpawnRequest } from '@n8n/api-types';
@@ -52,6 +53,8 @@ export interface SubAgentForegroundRunContext {
 	 * (model fetch, MCP fetch, tool execution contexts).
 	 */
 	instrumentation?: AgentRuntimeInstrumentation;
+	/** Optional callback to forward child stream chunks to the parent chat. */
+	onChunk?: (chunk: StreamChunk) => void;
 }
 
 export interface SubAgentForegroundResult {
@@ -143,6 +146,7 @@ export class SubAgentForegroundRunner {
 
 			for await (const value of streamAgentChunks(resultStream.stream)) {
 				recorder.record(value);
+				context.onChunk?.(value);
 				if (value.type === 'tool-call-suspended') {
 					childSuspended = true;
 				}

--- a/packages/cli/src/modules/agents/utils/execution-to-message-mapper.ts
+++ b/packages/cli/src/modules/agents/utils/execution-to-message-mapper.ts
@@ -82,6 +82,7 @@ function timelineToolCallToPart(event: ToolCallTimelineEvent): AgentPersistedMes
 		input: event.input,
 		...(event.startTime > 0 ? { startTime: event.startTime } : {}),
 		...(event.endTime > 0 ? { endTime: event.endTime } : {}),
+		...(event.childTrace ? { childTrace: event.childTrace } : {}),
 	};
 
 	if (state === undefined) return base;

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatToolSteps.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatToolSteps.test.ts
@@ -395,7 +395,7 @@ describe('AgentChatToolSteps', () => {
 		);
 	});
 
-	it('renders both the answer and the child trace on a settled delegate row', async () => {
+	it('renders the answer once alongside the child trace on a settled delegate row', async () => {
 		const wrapper = mountSteps([
 			{
 				tool: DELEGATE_SUB_AGENT_TOOL_NAME,
@@ -407,7 +407,7 @@ describe('AgentChatToolSteps', () => {
 					answer: 'Final child answer',
 				},
 				childProgress: {
-					text: 'Looking things up',
+					text: 'Final child answer',
 					reasoningSegments: [],
 					steps: [{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false }],
 				},
@@ -415,9 +415,52 @@ describe('AgentChatToolSteps', () => {
 		]);
 
 		await wrapper.find('button').trigger('click');
+		// The child's streamed text is what becomes the delegate answer, so a
+		// settled row renders it once — not again from the trace.
+		expect(wrapper.findAll('[data-test-id="tool-step-details"]')).toHaveLength(1);
 		expect(wrapper.find('[data-test-id="tool-step-details"]').text()).toBe('Final child answer');
 		expect(wrapper.find('[data-test-id="agent-chat-delegate-child-progress"]').exists()).toBe(true);
 		expect(wrapper.text()).toContain('Web search');
 		expect(wrapper.text()).not.toContain('subAgentId');
+	});
+
+	it('renders the child tool calls above the answer', async () => {
+		const wrapper = mountSteps([
+			{
+				tool: DELEGATE_SUB_AGENT_TOOL_NAME,
+				toolCallId: 'tc-delegate',
+				state: TOOL_CALL_STATE.DONE,
+				input: { subAgentId: 'inline', taskName: 'research_api' },
+				output: { status: 'completed', answer: 'Final child answer' },
+				childProgress: {
+					text: '',
+					reasoningSegments: [],
+					steps: [{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false }],
+				},
+			},
+		]);
+
+		await wrapper.find('button').trigger('click');
+		const text = wrapper.text();
+		expect(text.indexOf('Web search')).toBeLessThan(text.indexOf('Final child answer'));
+	});
+
+	it('still renders the child text when a failed delegation has no answer', async () => {
+		const wrapper = mountSteps([
+			{
+				tool: DELEGATE_SUB_AGENT_TOOL_NAME,
+				toolCallId: 'tc-delegate',
+				state: TOOL_CALL_STATE.RUNNING,
+				input: { subAgentId: 'inline', taskName: 'research_api', difficulty: 'high' },
+				childProgress: {
+					text: 'Partial work before it died',
+					reasoningSegments: [],
+					steps: [],
+				},
+			},
+		]);
+
+		await wrapper.find('button').trigger('click');
+		expect(wrapper.text()).toContain('Partial work before it died');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatToolSteps.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatToolSteps.test.ts
@@ -343,4 +343,81 @@ describe('AgentChatToolSteps', () => {
 		await wrapper.find('button').trigger('click');
 		expect(wrapper.find('[data-test-id="tool-step-details"]').text()).toBe('Child answer');
 	});
+
+	it('renders live child progress instead of raw input while delegate_subagent is running', async () => {
+		const wrapper = mountSteps([
+			{
+				tool: DELEGATE_SUB_AGENT_TOOL_NAME,
+				toolCallId: 'tc-delegate',
+				state: TOOL_CALL_STATE.RUNNING,
+				input: { subAgentId: 'inline', taskName: 'research_api', difficulty: 'high' },
+				childProgress: {
+					text: 'Looking things up',
+					reasoningSegments: [],
+					steps: [
+						{ toolCallId: 'child-tc-1', toolName: 'web_search', running: true },
+						{ toolCallId: 'child-tc-2', toolName: 'search_nodes', running: false },
+					],
+				},
+			},
+		]);
+
+		await wrapper.find('button').trigger('click');
+		expect(wrapper.find('[data-test-id="agent-chat-delegate-child-progress"]').exists()).toBe(true);
+		expect(wrapper.text()).toContain('Looking things up');
+		expect(wrapper.text()).not.toContain('subAgentId');
+
+		// The child's steps render through this same component, so they get the
+		// parent chat's tool labels and its multi-step grouping.
+		expect(wrapper.find('[data-test-id="n8n-ai-activity-step-group"]').exists()).toBe(true);
+		expect(wrapper.text()).toContain('Web search');
+		expect(wrapper.text()).toContain('Search nodes');
+	});
+
+	it('renders the settled answer when child progress has been cleared', async () => {
+		const wrapper = mountSteps([
+			{
+				tool: DELEGATE_SUB_AGENT_TOOL_NAME,
+				toolCallId: 'tc-delegate',
+				state: TOOL_CALL_STATE.DONE,
+				input: { subAgentId: 'inline', taskName: 'research_api', difficulty: 'high' },
+				output: {
+					status: 'completed',
+					answer: 'Final child answer',
+				},
+			},
+		]);
+
+		await wrapper.find('button').trigger('click');
+		expect(wrapper.find('[data-test-id="tool-step-details"]').text()).toBe('Final child answer');
+		expect(wrapper.find('[data-test-id="agent-chat-delegate-child-progress"]').exists()).toBe(
+			false,
+		);
+	});
+
+	it('renders both the answer and the child trace on a settled delegate row', async () => {
+		const wrapper = mountSteps([
+			{
+				tool: DELEGATE_SUB_AGENT_TOOL_NAME,
+				toolCallId: 'tc-delegate',
+				state: TOOL_CALL_STATE.DONE,
+				input: { subAgentId: 'inline', taskName: 'research_api', difficulty: 'high' },
+				output: {
+					status: 'completed',
+					answer: 'Final child answer',
+				},
+				childProgress: {
+					text: 'Looking things up',
+					reasoningSegments: [],
+					steps: [{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false }],
+				},
+			},
+		]);
+
+		await wrapper.find('button').trigger('click');
+		expect(wrapper.find('[data-test-id="tool-step-details"]').text()).toBe('Final child answer');
+		expect(wrapper.find('[data-test-id="agent-chat-delegate-child-progress"]').exists()).toBe(true);
+		expect(wrapper.text()).toContain('Web search');
+		expect(wrapper.text()).not.toContain('subAgentId');
+	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/agentChatMessages.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/agentChatMessages.test.ts
@@ -374,6 +374,34 @@ describe('convertDbMessages — interactive turn synthesis', () => {
 		expect(tc?.state).toBe('done');
 	});
 
+	it('hydrates childProgress from a persisted childTrace', () => {
+		const childTrace = {
+			text: 'Looking things up',
+			reasoningSegments: [{ id: 'r-1', content: 'Checking schemas.' }],
+			steps: [{ toolCallId: 'child-tc-1', toolName: 'web_search', running: false }],
+		};
+		const dbMessages: AgentPersistedMessageDto[] = [
+			{
+				id: 'm1',
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolName: 'delegate_subagent',
+						toolCallId: 'tc-d-trace',
+						input: { subAgentId: 'inline' },
+						state: 'resolved',
+						output: { status: 'completed', answer: 'all good' },
+						childTrace,
+					},
+				],
+			},
+		];
+
+		const chat = convertDbMessages(dbMessages);
+		expect(chat[0].toolCalls?.[0].childProgress).toEqual(childTrace);
+	});
+
 	it('leaves delegate difficulty summary for render-time i18n on reload', () => {
 		const dbMessages: AgentPersistedMessageDto[] = [
 			{

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentChatStream.test.ts
@@ -1906,3 +1906,153 @@ describe('useAgentChatStream — done executionId', () => {
 		expect(assistant?.executionId).toBe('exec-live-1');
 	});
 });
+
+describe('useAgentChatStream — subagent-chunk', () => {
+	it('accumulates child text on the parent delegate tool call without minting a bubble', async () => {
+		const events: AgentSseEvent[] = [
+			{ type: 'start-step' },
+			{
+				type: 'tool-call',
+				toolCallId: 'tc-delegate',
+				toolName: 'delegate_subagent',
+				input: { subAgentId: 'inline', taskName: 'research', goal: 'Find it' },
+			},
+			{ type: 'finish-step' },
+			{
+				type: 'tool-execution-start',
+				toolCallId: 'tc-delegate',
+				toolName: 'delegate_subagent',
+				startTime: 1_000,
+			},
+			{
+				type: 'subagent-chunk',
+				parentToolCallId: 'tc-delegate',
+				taskPath: '/root/research_0',
+				chunk: { type: 'text-delta', id: 't-1', delta: 'Hello ' },
+			},
+			{
+				type: 'subagent-chunk',
+				parentToolCallId: 'tc-delegate',
+				taskPath: '/root/research_0',
+				chunk: { type: 'text-delta', id: 't-1', delta: 'world' },
+			},
+			{ type: 'done' },
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('delegate');
+		await nextTick();
+
+		const assistants = hook.messages.value.filter((m) => m.role === 'assistant');
+		expect(assistants).toHaveLength(1);
+		expect(assistants[0].toolCalls?.[0].childProgress?.text).toBe('Hello world');
+	});
+
+	it('accumulates child reasoning deltas into one segment by id', async () => {
+		const events: AgentSseEvent[] = [
+			{ type: 'start-step' },
+			{
+				type: 'tool-call',
+				toolCallId: 'tc-delegate',
+				toolName: 'delegate_subagent',
+				input: { subAgentId: 'inline', taskName: 'research', goal: 'Find it' },
+			},
+			{ type: 'finish-step' },
+			{
+				type: 'subagent-chunk',
+				parentToolCallId: 'tc-delegate',
+				taskPath: '/root/research_0',
+				chunk: { type: 'reasoning-delta', id: 'r-1', delta: 'Think ' },
+			},
+			{
+				type: 'subagent-chunk',
+				parentToolCallId: 'tc-delegate',
+				taskPath: '/root/research_0',
+				chunk: { type: 'reasoning-delta', id: 'r-1', delta: 'hard' },
+			},
+			{
+				type: 'subagent-chunk',
+				parentToolCallId: 'tc-delegate',
+				taskPath: '/root/research_0',
+				chunk: { type: 'reasoning-end', id: 'r-1' },
+			},
+			{ type: 'done' },
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('delegate');
+		await nextTick();
+
+		const segments = hook.messages.value[1].toolCalls?.[0].childProgress?.reasoningSegments;
+		expect(segments).toHaveLength(1);
+		expect(segments?.[0].content).toBe('Think hard');
+		expect(segments?.[0].endTime).toBeTypeOf('number');
+	});
+
+	it('ignores subagent-chunk events whose parentToolCallId matches nothing', async () => {
+		const events: AgentSseEvent[] = [
+			{ type: 'start-step' },
+			{
+				type: 'tool-call',
+				toolCallId: 'tc-other',
+				toolName: 'compute',
+				input: {},
+			},
+			{ type: 'finish-step' },
+			{
+				type: 'subagent-chunk',
+				parentToolCallId: 'missing',
+				taskPath: '/root/x_0',
+				chunk: { type: 'text-delta', id: 't-1', delta: 'orphan' },
+			},
+			{ type: 'done' },
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('hi');
+		await nextTick();
+
+		expect(hook.messages.value[1].toolCalls?.[0].childProgress).toBeUndefined();
+		expect(hook.messages.value).toHaveLength(2);
+	});
+
+	it('keeps childProgress after the delegate tool result arrives', async () => {
+		const events: AgentSseEvent[] = [
+			{ type: 'start-step' },
+			{
+				type: 'tool-call',
+				toolCallId: 'tc-delegate',
+				toolName: 'delegate_subagent',
+				input: { subAgentId: 'inline', taskName: 'research', goal: 'Find it' },
+			},
+			{ type: 'finish-step' },
+			{
+				type: 'subagent-chunk',
+				parentToolCallId: 'tc-delegate',
+				taskPath: '/root/research_0',
+				chunk: { type: 'text-delta', id: 't-1', delta: 'live' },
+			},
+			{
+				type: 'tool-result',
+				toolCallId: 'tc-delegate',
+				toolName: 'delegate_subagent',
+				output: { status: 'completed', answer: 'done' },
+			},
+			{ type: 'done' },
+		];
+		globalThis.fetch = vi.fn(async () => makeSseResponse(events)) as typeof fetch;
+
+		const hook = buildHook();
+		await hook.sendMessage('delegate');
+		await nextTick();
+
+		expect(hook.messages.value[1].toolCalls?.[0].childProgress?.text).toBe('live');
+		expect(hook.messages.value[1].toolCalls?.[0].output).toEqual({
+			status: 'completed',
+			answer: 'done',
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatToolSteps.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatToolSteps.vue
@@ -49,6 +49,7 @@ export default {
 import { N8nAiActivityStep, N8nAiActivityStepGroup, N8nMarkdownEditor } from '@n8n/design-system';
 import { computed, toRef } from 'vue';
 import type { ToolCall } from '@/features/ai/shared/agentsChat/types';
+import AiReasoningBlock from '@/features/ai/shared/components/AiReasoningBlock.vue';
 import { useSubAgentNames } from '../composables/useSubAgentNames';
 import { resolveToolNameForDisplay } from '../utils/toolDisplayName';
 import {
@@ -137,6 +138,16 @@ function hasToolData(tc: ToolCall): boolean {
 	return tc.input !== undefined || tc.output !== undefined;
 }
 
+/** Render a delegated child's live steps through this same component, so they look
+ *  identical to the parent's own tool steps. */
+function childToolCalls(steps: NonNullable<ToolCall['childProgress']>['steps']): ToolCall[] {
+	return steps.map((step) => ({
+		tool: step.toolName,
+		toolCallId: step.toolCallId,
+		state: step.running ? TOOL_CALL_STATE.RUNNING : TOOL_CALL_STATE.DONE,
+	}));
+}
+
 function formatToolData(value: unknown): string {
 	if (typeof value === 'string') return value;
 	return JSON.stringify(value, null, 2) ?? String(value);
@@ -154,11 +165,12 @@ function isEmptyToolErrorPayload(value: unknown): boolean {
 function toolStepView(tc: ToolCall): ToolStepDisplay {
 	const details = getToolCallDetails(tc, i18n, subAgentNameById.value) ?? '';
 	const metadata = toolStepMetadata(tc);
+	const hasChildProgress = Boolean(tc.childProgress);
 	return {
 		label: [toolStepLabel(tc), ...metadata].join(' · '),
 		details,
-		hasRawData: details.length === 0 && hasToolData(tc),
-		expandable: details.length > 0 || hasToolData(tc),
+		hasRawData: details.length === 0 && hasToolData(tc) && !hasChildProgress,
+		expandable: details.length > 0 || hasToolData(tc) || hasChildProgress,
 	};
 }
 
@@ -215,7 +227,33 @@ function hasActiveToolCall(): boolean {
 							max-height="240px"
 							:class="$style.answer"
 						/>
-						<div v-else-if="view.hasRawData" :class="$style.toolDataList">
+						<div
+							v-if="tc.childProgress"
+							:class="$style.childProgress"
+							data-test-id="agent-chat-delegate-child-progress"
+						>
+							<AgentChatToolSteps
+								v-if="tc.childProgress.steps.length > 0"
+								:tool-calls="childToolCalls(tc.childProgress.steps)"
+								:project-id="projectId"
+							/>
+							<AiReasoningBlock
+								v-for="segment in tc.childProgress.reasoningSegments"
+								:key="segment.id"
+								:entry="segment"
+								:streaming="segment.endTime === undefined"
+							/>
+							<N8nMarkdownEditor
+								v-if="tc.childProgress.text"
+								:model-value="tc.childProgress.text"
+								readonly
+								variant="ghost"
+								show-toolbar="never"
+								max-height="240px"
+								:class="$style.answer"
+							/>
+						</div>
+						<div v-if="view.hasRawData" :class="$style.toolDataList">
 							<div v-if="tc.input !== undefined" :class="$style.toolDataSection">
 								<span :class="$style.toolDataLabel">
 									{{ i18n.baseText('agentSessions.timeline.input') }}
@@ -259,7 +297,33 @@ function hasActiveToolCall(): boolean {
 							max-height="240px"
 							:class="$style.answer"
 						/>
-						<div v-else-if="view.hasRawData" :class="$style.toolDataList">
+						<div
+							v-if="tc.childProgress"
+							:class="$style.childProgress"
+							data-test-id="agent-chat-delegate-child-progress"
+						>
+							<AgentChatToolSteps
+								v-if="tc.childProgress.steps.length > 0"
+								:tool-calls="childToolCalls(tc.childProgress.steps)"
+								:project-id="projectId"
+							/>
+							<AiReasoningBlock
+								v-for="segment in tc.childProgress.reasoningSegments"
+								:key="segment.id"
+								:entry="segment"
+								:streaming="segment.endTime === undefined"
+							/>
+							<N8nMarkdownEditor
+								v-if="tc.childProgress.text"
+								:model-value="tc.childProgress.text"
+								readonly
+								variant="ghost"
+								show-toolbar="never"
+								max-height="240px"
+								:class="$style.answer"
+							/>
+						</div>
+						<div v-if="view.hasRawData" :class="$style.toolDataList">
 							<div v-if="tc.input !== undefined" :class="$style.toolDataSection">
 								<span :class="$style.toolDataLabel">
 									{{ i18n.baseText('agentSessions.timeline.input') }}
@@ -288,6 +352,13 @@ function hasActiveToolCall(): boolean {
 <style module>
 .toolSteps {
 	margin: 0 0 var(--spacing--sm);
+}
+
+.childProgress {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
+	margin-bottom: var(--spacing--xs);
 }
 
 .answer {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatToolSteps.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatToolSteps.vue
@@ -218,15 +218,6 @@ function hasActiveToolCall(): boolean {
 						:hide-error-callout="showFix && tc.state === TOOL_CALL_STATE.ERROR"
 						:has-content="view.expandable"
 					>
-						<N8nMarkdownEditor
-							v-if="view.details"
-							:model-value="view.details"
-							readonly
-							variant="ghost"
-							show-toolbar="never"
-							max-height="240px"
-							:class="$style.answer"
-						/>
 						<div
 							v-if="tc.childProgress"
 							:class="$style.childProgress"
@@ -244,7 +235,7 @@ function hasActiveToolCall(): boolean {
 								:streaming="segment.endTime === undefined"
 							/>
 							<N8nMarkdownEditor
-								v-if="tc.childProgress.text"
+								v-if="tc.childProgress.text && !view.details"
 								:model-value="tc.childProgress.text"
 								readonly
 								variant="ghost"
@@ -253,6 +244,15 @@ function hasActiveToolCall(): boolean {
 								:class="$style.answer"
 							/>
 						</div>
+						<N8nMarkdownEditor
+							v-if="view.details"
+							:model-value="view.details"
+							readonly
+							variant="ghost"
+							show-toolbar="never"
+							max-height="240px"
+							:class="$style.answer"
+						/>
 						<div v-if="view.hasRawData" :class="$style.toolDataList">
 							<div v-if="tc.input !== undefined" :class="$style.toolDataSection">
 								<span :class="$style.toolDataLabel">
@@ -288,15 +288,6 @@ function hasActiveToolCall(): boolean {
 					:has-content="toolStepView(tc).expandable"
 				>
 					<template v-for="view in [toolStepView(tc)]" :key="view.label">
-						<N8nMarkdownEditor
-							v-if="view.details"
-							:model-value="view.details"
-							readonly
-							variant="ghost"
-							show-toolbar="never"
-							max-height="240px"
-							:class="$style.answer"
-						/>
 						<div
 							v-if="tc.childProgress"
 							:class="$style.childProgress"
@@ -314,7 +305,7 @@ function hasActiveToolCall(): boolean {
 								:streaming="segment.endTime === undefined"
 							/>
 							<N8nMarkdownEditor
-								v-if="tc.childProgress.text"
+								v-if="tc.childProgress.text && !view.details"
 								:model-value="tc.childProgress.text"
 								readonly
 								variant="ghost"
@@ -323,6 +314,15 @@ function hasActiveToolCall(): boolean {
 								:class="$style.answer"
 							/>
 						</div>
+						<N8nMarkdownEditor
+							v-if="view.details"
+							:model-value="view.details"
+							readonly
+							variant="ghost"
+							show-toolbar="never"
+							max-height="240px"
+							:class="$style.answer"
+						/>
 						<div v-if="view.hasRawData" :class="$style.toolDataList">
 							<div v-if="tc.input !== undefined" :class="$style.toolDataSection">
 								<span :class="$style.toolDataLabel">
@@ -359,6 +359,12 @@ function hasActiveToolCall(): boolean {
 	flex-direction: column;
 	gap: var(--spacing--2xs);
 	margin-bottom: var(--spacing--xs);
+}
+
+/* Nested in a delegate row the flex gap already spaces the child's steps, so
+   the standalone bottom margin would double up. */
+.childProgress .toolSteps {
+	margin-bottom: 0;
 }
 
 .answer {

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -7,6 +7,7 @@ import type {
 	AgentSseEvent,
 	CancellationResumeData,
 } from '@n8n/api-types';
+import { applyForwardedChildChunk, emptyChildTrace } from '@n8n/api-types';
 import { useToast } from '@/app/composables/useToast';
 import { convertFileToBinaryData } from '@/app/utils/fileUtils';
 import {
@@ -530,6 +531,13 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 					msg.status = CHAT_MESSAGE_STATUS.AWAITING_USER;
 				}
 				session.terminalEventReceived = true;
+				break;
+			}
+			case 'subagent-chunk': {
+				const found = findToolCallById(event.parentToolCallId);
+				if (!found) break;
+				found.tc.childProgress ??= emptyChildTrace();
+				applyForwardedChildChunk(found.tc.childProgress, event.chunk);
 				break;
 			}
 			case 'message':

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/SubagentStepTimeline.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/SubagentStepTimeline.test.ts
@@ -186,4 +186,50 @@ describe('SubagentStepTimeline', () => {
 		);
 		expect(triggerButton).toBeTruthy();
 	});
+
+	it('renders a reasoning entry labelled with its first sentence', () => {
+		const { getByText } = renderComponent({
+			props: {
+				agentNode: makeAgentNode({
+					timeline: [
+						{
+							type: 'reasoning',
+							content: 'Checking the node schema. More detail.',
+						},
+					],
+				}),
+			},
+		});
+
+		expect(getByText('Checking the node schema.')).toBeInTheDocument();
+	});
+
+	it('streams the trailing reasoning entry on an active node', () => {
+		const { getByText } = renderComponent({
+			props: {
+				agentNode: makeAgentNode({
+					status: 'active',
+					timeline: [{ type: 'reasoning', content: 'Still thinking about tools.' }],
+				}),
+			},
+		});
+
+		expect(getByText('Still thinking about tools.').className).toContain('shimmer');
+	});
+
+	it('does not stream a settled reasoning entry when later timeline content follows', () => {
+		const { getByText } = renderComponent({
+			props: {
+				agentNode: makeAgentNode({
+					status: 'active',
+					timeline: [
+						{ type: 'reasoning', content: 'Finished this thought.' },
+						{ type: 'text', content: 'Next step' },
+					],
+				}),
+			},
+		});
+
+		expect(getByText('Finished this thought.').className).not.toContain('shimmer');
+	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentSection.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentSection.vue
@@ -34,14 +34,16 @@ const sectionTitle = computed(
 );
 
 /**
- * Most recent timeline entry that SubagentStepTimeline can render (text or
- * tool call), shown as a peek while collapsed and active.
+ * Most recent timeline entry that SubagentStepTimeline can render (text,
+ * tool call, or reasoning), shown as a peek while collapsed and active.
  */
 const peekEntries = computed(() => {
 	const entries = props.agentNode.timeline;
 	for (let i = entries.length - 1; i >= 0; i--) {
 		const entry = entries[i];
-		if (entry.type === 'text' || entry.type === 'tool-call') return [entry];
+		if (entry.type === 'text' || entry.type === 'tool-call' || entry.type === 'reasoning') {
+			return [entry];
+		}
 	}
 	return [];
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/SubagentStepTimeline.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/SubagentStepTimeline.vue
@@ -15,8 +15,9 @@ import type {
 import { useI18n } from '@n8n/i18n';
 import { CollapsibleRoot, CollapsibleTrigger } from 'reka-ui';
 import { computed } from 'vue';
-import { HIDDEN_TOOLS } from '../agentTimeline.utils';
+import { HIDDEN_TOOLS, isStreamingTimelineEntry } from '../agentTimeline.utils';
 import { getToolIcon, useToolLabel } from '../toolLabels';
+import AiReasoningBlock from '../../shared/components/AiReasoningBlock.vue';
 import ButtonLike from './ButtonLike.vue';
 import InstanceAiMarkdown from './InstanceAiMarkdown.vue';
 import ToolResultJson from './ToolResultJson.vue';
@@ -39,7 +40,7 @@ const { getToolLabel, getToggleLabel, getHideLabel } = useToolLabel();
 const CODE_BLOCK_PATTERN = /```/;
 
 interface TimelineStep {
-	type: 'tool-call' | 'text';
+	type: 'tool-call' | 'text' | 'reasoning';
 	icon: IconName;
 	label: string;
 	isLoading: boolean;
@@ -49,6 +50,7 @@ interface TimelineStep {
 	textContent?: string;
 	isLongText?: boolean;
 	shortLabel?: string;
+	entry?: Extract<InstanceAiTimelineEntry, { type: 'reasoning' }>;
 }
 
 function extractShortLabel(content: string): string {
@@ -104,9 +106,16 @@ const steps = computed((): TimelineStep[] => {
 				hideLabel: getHideLabel(tc),
 				toolCall: tc,
 			});
+		} else if (entry.type === 'reasoning') {
+			result.push({
+				type: 'reasoning',
+				icon: 'brain',
+				label: '',
+				isLoading: false,
+				entry,
+			});
 		}
-		// Skip 'child' entries (parent AgentTimeline handles child cards) and
-		// 'reasoning' entries (sub-agent reasoning is not surfaced in this view)
+		// Skip 'child' entries (parent AgentTimeline handles child cards)
 	}
 
 	return result;
@@ -163,6 +172,12 @@ const steps = computed((): TimelineStep[] => {
 					<InstanceAiMarkdown v-else :content="step.label" />
 				</ButtonLike>
 			</template>
+
+			<AiReasoningBlock
+				v-else-if="step.type === 'reasoning' && step.entry"
+				:entry="step.entry"
+				:streaming="isStreamingTimelineEntry(props.agentNode, step.entry)"
+			/>
 		</template>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/ai/shared/agentsChat/messageMappers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/shared/agentsChat/messageMappers.ts
@@ -235,6 +235,7 @@ export function convertDbMessages(dbMessages: AgentPersistedMessageDto[]): ChatM
 					state,
 					...(part.startTime !== undefined && { startTime: part.startTime }),
 					...(part.endTime !== undefined && { endTime: part.endTime }),
+					...(part.childTrace && { childProgress: part.childTrace }),
 					displaySummary: summariseToolCall(part.toolName, output, part.input),
 				};
 				toolCalls.push(toolCall);

--- a/packages/frontend/editor-ui/src/features/ai/shared/agentsChat/types.ts
+++ b/packages/frontend/editor-ui/src/features/ai/shared/agentsChat/types.ts
@@ -6,6 +6,13 @@ import type { ChatMessageStatus, ToolCallState } from './constants';
 
 export type { ChatMessageStatus, ToolCallState };
 
+export interface ThinkingSegment {
+	id: string;
+	content: string;
+	startTime?: number;
+	endTime?: number;
+}
+
 export interface ToolCall {
 	tool: string;
 	toolCallId: string;
@@ -32,6 +39,14 @@ export interface ToolCall {
 	 * input).
 	 */
 	suspendPayload?: unknown;
+	/** Live progress of a delegated child, streamed while the delegation runs
+	 *  and restored from history when a `childTrace` was persisted on the
+	 *  parent's execution timeline. */
+	childProgress?: {
+		text: string;
+		reasoningSegments: ThinkingSegment[];
+		steps: Array<{ toolCallId: string; toolName: string; running: boolean }>;
+	};
 }
 
 interface InteractivePayloadBase {
@@ -91,13 +106,6 @@ export interface ChatMessageAttachment {
 	fileId?: string;
 	/** Local file backing the optimistic echo of a just-sent message (no fileId yet). */
 	file?: File;
-}
-
-export interface ThinkingSegment {
-	id: string;
-	content: string;
-	startTime?: number;
-	endTime?: number;
 }
 
 export interface AgentsChatMessage {


### PR DESCRIPTION
Closes [AGENT-454](https://linear.app/n8n/issue/AGENT-454).

Stacked on [#35243](https://github.com/n8n-io/n8n/pull/35243) (AGENT-453) — review that one first; this PR targets its branch.

## Summary

While a delegated sub-agent ran, the chat showed a spinner over raw input JSON, and the agent-builder section in AIA rendered nothing at all while the builder was thinking. This forwards the child's stream into the parent chat and keeps the resulting trace around after the delegation settles.

- **Forward child chunks.** An allowlisted subset (text, reasoning, tool lifecycle) is emitted as a new `subagent-chunk` parent stream chunk, bridged to SSE, and accumulated onto the `delegate_subagent` row. Args and results are excluded so payloads stay bounded, and nested `subagent-*` chunks are excluded so fan-out stops at one level. Text and reasoning are capped at 20k characters per delegation.
- **Inline sub-agents stream.** `createInlineSubAgentRunner` now uses `stream()` instead of `generate()` so those chunks exist at all. The child's answer is derived from the runtime's own serialized message list rather than concatenating every text delta, so a multi-step child still answers with its final turn instead of its narration.
- **Persist the trace.** The parent's `ExecutionRecorder` already saw these chunks and dropped them. It now folds them onto the timeline's tool-call entry (capped at 4k characters, tighter than the live budget since this lands in every execution row), so the trace reloads from history. This covers inline and configured sub-agents alike, unlike reading the child's own thread — inline children persist nothing.
- **Reuse the existing renderer.** The child's tool steps render through `AgentChatToolSteps` recursively, so they get the same labels, grouping and loading states as the main chat rather than a parallel implementation that can drift.
- **AIA builder reasoning.** `SubagentStepTimeline` no longer discards `reasoning` entries, and `AgentSection`'s collapsed peek admits them, so the builder section is no longer blank while thinking.

One reducer in `@n8n/api-types` drives both the live and the persisted accumulation, so a trace cannot look different before and after a reload.

## Test plan

- [x] `pnpm --filter @n8n/api-types test src/agents/__tests__/child-trace.test.ts`
- [x] `pnpm --filter @n8n/agents test src/runtime/__tests__/delegate-sub-agent-tool.test.ts src/sdk/__tests__/delegate-sub-agent-routing.test.ts src/sdk/__tests__/inline-sub-agent-tools.test.ts`
- [x] `pnpm --filter n8n test src/modules/agents/__tests__/agent-sse-stream.test.ts src/modules/agents/__tests__/execution-recorder.test.ts src/modules/agents/__tests__/execution-to-message-mapper.test.ts`
- [x] `pnpm --filter n8n-editor-ui test src/features/agents/__tests__ src/features/ai/instanceAi/__tests__/SubagentStepTimeline.test.ts`
- [x] `delegate-sub-agent` integration cassettes re-recorded and replayed
- [x] Typecheck clean for `@n8n/agents`, `@n8n/api-types`, `packages/cli` and `editor-ui`

Manual check worth doing on review: run a delegation in the preview chat, confirm the expanded row shows the child's steps and reasoning live, then reload and confirm the trace is still there alongside the final answer.

## Notes for reviewers

- The allowlist and both character budgets are the only things bounding payload growth, so they are the parts most worth scrutinising.
- Settled rows now show the answer *and* the trace; previously the trace was discarded on `tool-result`.
- Reasoning blocks only appear when the child actually emits them — inline children inherit the parent's reasoning setting, configured ones use their own `config.reasoning`.

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

