### PR TITLE
perf(core): Ungate skip persisting run data for discarded executions

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1509,12 +1509,7 @@ describe('Execution Lifecycle Hooks', () => {
 				return executionPersistence.updateExistingExecution.mock.calls[0][1];
 			};
 
-			beforeEach(() => {
-				process.env.N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES = 'true';
-			});
-
 			afterEach(() => {
-				delete process.env.N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES;
 				workflowData.settings = {};
 			});
 
@@ -1528,18 +1523,6 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(payload.data).toBeUndefined();
 				expect(payload.workflowData).toBeUndefined();
 				expect(payload.status).toBe('success');
-			});
-
-			it('should write run data when the flag is not enabled', async () => {
-				delete process.env.N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES;
-				workflowData.settings = { saveDataSuccessExecution: 'none' };
-				const lifecycleHooks = createHooks('trigger');
-
-				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
-
-				const payload = getUpdatePayload();
-				expect(payload.data).toBeDefined();
-				expect(payload.workflowData).toBeDefined();
 			});
 
 			it('should write run data when successful executions are saved', async () => {
@@ -1589,6 +1572,17 @@ describe('Execution Lifecycle Hooks', () => {
 			it('should write run data for integrated executions so the parent workflow can read it', async () => {
 				workflowData.settings = { saveDataSuccessExecution: 'none' };
 				const lifecycleHooks = createHooks('integrated');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeDefined();
+				expect(payload.workflowData).toBeDefined();
+			});
+
+			it('should write run data for manual executions so the editor can read it back', async () => {
+				workflowData.settings = { saveDataSuccessExecution: 'none' };
+				const lifecycleHooks = createHooks('manual');
 
 				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
 

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -662,12 +662,14 @@ function hookFunctionsSave(
 	});
 }
 
+/**
+ * Modes whose run data may be skipped when main is certain to discard it.
+ */
 const DISCARDABLE_DATA_MODES: WorkflowExecuteMode[] = ['trigger', 'cli', 'error', 'internal'];
 
 /**
  * Returns hook functions to save workflow execution and call error workflow
- * for running with queues. Manual executions should never run on queues as
- * they are always executed in the main process.
+ * for running with queues.
  */
 function hookFunctionsSaveWorker(
 	hooks: ExecutionLifecycleHooks,
@@ -724,7 +726,6 @@ function hookFunctionsSaveWorker(
 				runDataAttemptedDynamicCredentials(resultRunData);
 
 			const mainWillDiscardData =
-				process.env.N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES === 'true' &&
 				fullRunData.status === 'success' &&
 				!saveSettings.success &&
 				!fullRunData.waitTill &&


### PR DESCRIPTION
## Summary

Follow-up to #33939, which taught the worker's save hook to strip `data` and `workflowData` when main is certain to discard the execution anyway, but gated it behind `N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES`. That gate has been on internal for a week with no complaints, so this removes it: the skip now always applies when the execution succeeded, save settings say not to keep successes, it is not waiting, its mode is in `DISCARDABLE_DATA_MODES` and no `workflow.postExecute` external hook is registered. Every other case (failed, waiting, manual, webhook, sub-workflow) writes exactly as before, and deletion remains main's job.

Two comment fixes ride along, both about why `manual` must stay out of `DISCARDABLE_DATA_MODES`:

- `DISCARDABLE_DATA_MODES` now documents that the editor reads run data back from the DB, so a manual execution must always leave a readable row behind. Adding `manual` to the list looks like an obvious extension of the same optimization and would break that read-back, including the reconnect replay we are planning for clients that miss the `executionFinished` push.
- The docblock above `hookFunctionsSaveWorker` claimed manual executions never run on queues. That has not been true since manual executions started being offloaded to workers.

## Related Linear tickets, Github issues, and Community forum posts

No ticket, this is the rollout half of #33939.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
