### PR TITLE
feat(editor): Support per-field descriptions in the resourceMapper parameter

### DIFF
--- a/packages/frontend/editor-ui/src/app/utils/nodeTypeUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeTypeUtils.test.ts
@@ -44,6 +44,11 @@ describe('isResourceMapperFieldListStale', () => {
 			{ ...baseField, canBeUsedToMatch: false } as ResourceMapperField,
 		],
 		['type', { ...baseField }, { ...baseField, type: 'number' } as ResourceMapperField],
+		[
+			'description',
+			{ ...baseField },
+			{ ...baseField, description: 'changed' } as ResourceMapperField,
+		],
 	])('returns true when %s changes', (_property, oldField, newField) => {
 		expect(isResourceMapperFieldListStale([oldField], [newField])).toBe(true);
 	});

--- a/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
@@ -539,7 +539,8 @@ export const isResourceMapperFieldListStale = (
 			oldField.defaultMatch !== newField.defaultMatch ||
 			oldField.display !== newField.display ||
 			oldField.canBeUsedToMatch !== newField.canBeUsedToMatch ||
-			oldField.type !== newField.type
+			oldField.type !== newField.type ||
+			oldField.description !== newField.description
 		) {
 			return true;
 		}

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/MappingFields.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/MappingFields.vue
@@ -232,7 +232,8 @@ function getFieldDescription(field: ResourceMapperField): string {
 		);
 	}
 
-	return '';
+	// Fall back to the description the node supplied for this field, if any
+	return field.description ?? '';
 }
 
 function getParameterValue(parameterName: string): string | number | boolean | null {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.ts
@@ -1,11 +1,14 @@
 import {
 	DEFAULT_SETUP,
+	FIELD_DESCRIPTION,
 	MAPPING_COLUMNS_RESPONSE,
+	MAPPING_COLUMNS_RESPONSE_WITH_DESCRIPTIONS,
 	UPDATED_SCHEMA,
 	getLatestValueChangeEvent,
 } from './ResourceMapper.test.utils';
 import type { MockedStore } from '@/__tests__/utils';
-import { mockedStore, waitAllPromises } from '@/__tests__/utils';
+import { getTooltip, hoverTooltipTrigger, mockedStore, waitAllPromises } from '@/__tests__/utils';
+import { waitFor } from '@testing-library/vue';
 import ResourceMapper from './ResourceMapper.vue';
 import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
@@ -79,6 +82,88 @@ describe('ResourceMapper.vue', () => {
 		expect(
 			getByTestId('mapping-fields-container').querySelectorAll('.parameter-input input').length,
 		).toBe(MAPPING_COLUMNS_RESPONSE.fields.length + 1);
+	});
+
+	describe('field descriptions', () => {
+		// A copy of the default parameter switched to 'add' mode. Passed as a prop
+		// instead of via `{ merge: true }`, which mutates the shared DEFAULT_SETUP
+		// and would leak the mode into every test that follows.
+		const ADD_MODE_PARAMETER = createTestNodeProperties({
+			displayName: 'Columns',
+			name: 'columns',
+			type: 'resourceMapper',
+			default: { mappingMode: 'defineBelow', value: {} },
+			typeOptions: {
+				resourceMapper: {
+					resourceMapperMethod: 'getMappingColumns',
+					mode: 'add',
+					addAllFields: true,
+					fieldWords: { singular: 'column', plural: 'columns' },
+				} as ResourceMapperTypeOptions,
+			},
+		});
+
+		// Finds the rendered field whose label starts with the given display name
+		function getFieldItem(container: Element, displayName: string): Element {
+			const item = Array.from(container.querySelectorAll('.parameter-item')).find((element) =>
+				element.querySelector('div.title')?.textContent?.trim().startsWith(displayName),
+			);
+			if (!item) throw new Error(`Unable to find rendered field "${displayName}"`);
+			return item;
+		}
+
+		async function getFieldTooltip(container: Element, displayName: string) {
+			const infoIcon = getFieldItem(container, displayName).querySelector(
+				'[data-icon="circle-help"]',
+			);
+			if (!infoIcon) throw new Error(`Field "${displayName}" has no description tooltip`);
+			await hoverTooltipTrigger(infoIcon);
+			return await waitFor(() => getTooltip());
+		}
+
+		it('renders the description supplied by the node for a field', async () => {
+			fetchFieldsSpy.mockResolvedValueOnce(MAPPING_COLUMNS_RESPONSE_WITH_DESCRIPTIONS);
+			const { container } = renderComponent();
+			await waitAllPromises();
+
+			expect(await getFieldTooltip(container, 'Username')).toHaveTextContent(FIELD_DESCRIPTION);
+		});
+
+		it('does not render a description tooltip for a field without one', async () => {
+			fetchFieldsSpy.mockResolvedValueOnce(MAPPING_COLUMNS_RESPONSE_WITH_DESCRIPTIONS);
+			const { container } = renderComponent();
+			await waitAllPromises();
+
+			// 'Address' is the only field in the fixture with neither a node-supplied
+			// description nor a matching/mandatory state
+			expect(
+				getFieldItem(container, 'Address').querySelector('[data-icon="circle-help"]'),
+			).toBeNull();
+		});
+
+		it('prefers the matching column description over the one supplied by the node', async () => {
+			fetchFieldsSpy.mockResolvedValueOnce(MAPPING_COLUMNS_RESPONSE_WITH_DESCRIPTIONS);
+			const { container } = renderComponent();
+			await waitAllPromises();
+
+			// 'id' is the default matching column and also carries a description
+			const tooltip = await getFieldTooltip(container, 'id');
+			expect(tooltip).toHaveTextContent(
+				"This column won't be updated and can't be removed, as it's used for matching",
+			);
+			expect(tooltip).not.toHaveTextContent(FIELD_DESCRIPTION);
+		});
+
+		it('prefers the mandatory field description over the one supplied by the node', async () => {
+			fetchFieldsSpy.mockResolvedValueOnce(MAPPING_COLUMNS_RESPONSE_WITH_DESCRIPTIONS);
+			const { container } = renderComponent({ props: { parameter: ADD_MODE_PARAMETER } });
+			await waitAllPromises();
+
+			// 'First name' is required and also carries a description
+			const tooltip = await getFieldTooltip(container, 'First name');
+			expect(tooltip).toHaveTextContent('This column is mandatory and can’t be removed');
+			expect(tooltip).not.toHaveTextContent(FIELD_DESCRIPTION);
+		});
 	});
 
 	it('renders correctly in read only mode', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.utils.ts
@@ -201,6 +201,23 @@ export const MAPPING_COLUMNS_RESPONSE: ResourceMapperFields = {
 	],
 };
 
+// Description a node can supply per field via its `resourceMapperMethod`
+export const FIELD_DESCRIPTION = 'Rendered as the help tooltip for this field';
+
+/**
+ * Same response as `MAPPING_COLUMNS_RESPONSE`, but with a node-supplied
+ * `description` on a plain field ('Username'), on the default matching column
+ * ('id') and on a required field ('First name'), so the precedence between the
+ * three possible tooltip sources can be asserted.
+ */
+export const MAPPING_COLUMNS_RESPONSE_WITH_DESCRIPTIONS: ResourceMapperFields = {
+	fields: MAPPING_COLUMNS_RESPONSE.fields.map((field) =>
+		['Username', 'id', 'First name'].includes(field.id)
+			? { ...field, description: FIELD_DESCRIPTION }
+			: field,
+	),
+};
+
 // Gets the latest `valueChanged` event emitted by the component
 // This will be used to inspect current resource mapper value set in node parameters
 export function getLatestValueChangeEvent(emitted: Record<string, unknown[]>) {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -4025,6 +4025,8 @@ export interface ResourceMapperField {
 	readOnly?: boolean;
 	/** Pre-filled value applied when the field is first shown or re-added. Omit to leave the input empty. */
 	defaultValue?: string | number | boolean | null;
+	/** Help text shown in the "?" tooltip next to the field label, as for any other parameter's `description`. Ignored while the field is used to match or is a mandatory field in 'add' mode, since those states own the tooltip. */
+	description?: string;
 }
 
 export type FormFieldsParameter = Array<{

--- a/packages/workflow/src/schemas.ts
+++ b/packages/workflow/src/schemas.ts
@@ -359,6 +359,7 @@ export const ResourceMapperFieldSchema: z.ZodType<ResourceMapperField> = z.objec
 	removed: z.boolean().optional(),
 	options: z.array(INodePropertyOptionsSchema),
 	readOnly: z.boolean().optional(),
+	description: z.string().optional(),
 });
 
 export const ResourceMapperValueSchema: z.ZodType<ResourceMapperValue> = z.object({


### PR DESCRIPTION
## Summary

Every other parameter type in n8n can carry a `description`, which the NDV renders as the "?" tooltip next to the label. Fields inside a `resourceMapper` parameter cannot: `ResourceMapperField` has no `description` member, and `MappingFields.vue`'s `getFieldDescription()` can only return the "using to match" string, the "mandatory field" string, or `''`. Anything a node supplies is discarded.

This adds an optional `description` to `ResourceMapperField` and makes it the fallback in `getFieldDescription()`.

**Before** — the help text a node has for a mapped field has nowhere to go:

```ts
// resourceMapperMethod
return {
  fields: [
    { id: 'headline', displayName: 'Headline', type: 'string',
      required: true, defaultMatch: false, display: true },
  ],
};
```

**After**:

```ts
return {
  fields: [
    { id: 'headline', displayName: 'Headline', type: 'string',
      required: true, defaultMatch: false, display: true,
      description: 'Shown for 3s over the intro clip. Keep under 40 characters.' },
  ],
};
```

Existing precedence is unchanged: matching-column text wins, then mandatory-field text (in `add` mode), then the node-supplied description. A node that does not set the field behaves exactly as before.

### Motivation

I'm submitting the official node for JSON2Video (a video editing API service) that uses `resourceMapper` fields for the variables of a user-selected video template. Each variable already carries help text written by the template author (what the slot is for, expected length, expected format). Today that text has to be crammed into `displayName` or dropped, while the same node's non-mapped parameters show it properly in a tooltip.

### Changes

- `packages/workflow/src/interfaces.ts` — add optional `description?: string` to `ResourceMapperField`.
- `packages/workflow/src/schemas.ts` — add `description` to `ResourceMapperFieldSchema`, otherwise the zod object strips it wherever node parameters are parsed through `INodeSchema` (e.g. Chat Hub tool definitions). Note this schema is also missing `defaultValue`; I left that alone as it is unrelated.
- `MappingFields.vue` — `getFieldDescription()` falls back to `field.description ?? ''`.
- `nodeTypesUtils.ts` — include `description` in `isResourceMapperFieldListStale()`, so an edited description is detected like any other field change. Happy to drop this if you'd rather keep the staleness check narrow.

The value already survived the rest of the path unchanged: the resource-mapper-fields DTO only validates the *request*, the CLI service passes the loader's fields through verbatim, and `loadAndSetFieldsToMap` copies whole field objects.

## How to test

1. In any node with a `resourceMapper` parameter, add `description` to one of the fields returned by its `resourceMapperMethod` (e.g. `packages/nodes-base/nodes/Postgres/v2/methods/resourceMapping.ts`).
2. Open the node in the NDV. The field's label shows a "?" icon; hovering it shows the description.
3. Set a `description` on the field currently used as the matching column — the "using to match" tooltip still wins. Same for a required field in a node with `mode: 'add'`.
4. Fields without a `description` show no "?" icon, as before.

Automated coverage:

- `packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.ts` — a `field descriptions` block asserting the tooltip renders and that both precedence rules still hold.
- `packages/frontend/editor-ui/src/app/utils/nodeTypeUtils.test.ts` — `description` added to the staleness cases.

Ran locally, all green: `ResourceMapper.test.ts` (28 tests) and `nodeTypeUtils.test.ts` in `packages/frontend/editor-ui`, `test/schemas.test.ts` in `packages/workflow`, `vue-tsc --noEmit` for editor-ui, `tsc --noEmit` for workflow, plus biome, prettier and eslint on the changed files. I checked that the new tooltip test fails on `master` without the `MappingFields.vue` change.

Not run: the full monorepo test suite, and the stylelint pre-commit hook (it runs across all frontend packages and my working copy only has the affected packages installed). This change touches no styles.

## Related Linear tickets, Github issues, and Community forum posts

Community forum topic: [https://community.n8n.io/t/add-per-field-tooltips-in-the-resourcemapper-parameter/305475](https://community.n8n.io/t/add-per-field-tooltips-in-the-resourcemapper-parameter/305475)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

