### PR TITLE
refactor(editor): Extract the MCP connect flow into a composable

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -6537,8 +6537,6 @@
 	"instanceAi.mcp.error.updateSettings": "Failed to update MCP server settings",
 	"instanceAi.mcp.error.disconnect": "Failed to disconnect MCP server",
 	"instanceAi.mcp.settings.saved": "MCP server settings saved",
-	"instanceAi.mcp.error.autoConnectAmbiguous.title": "Credential created",
-	"instanceAi.mcp.error.autoConnectAmbiguous.message": "Multiple new credentials appeared. Please pick the one you just created from the credential picker.",
 	"instanceAi.browserUse.modal.title": "Connect Browser Use",
 	"instanceAi.browserUse.modal.description": "Let the agent automate tasks in your browser. Install the n8n Browser Use extension and connect it - no other software needed.",
 	"instanceAi.browserUse.step.extension.title": "1. Install the Chrome extension",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiMcp.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiMcp.store.test.ts
@@ -29,7 +29,6 @@ vi.mock('@/features/credentials/credentials.store', () => ({
 	},
 }));
 
-/** Replays a successful `credentialsStore.deleteCredential` to its subscribers. */
 function emitCredentialDeleted(id: string): void {
 	for (const listener of deletionListeners) listener(id);
 }
@@ -243,8 +242,6 @@ describe('useInstanceAiMcpStore', () => {
 			store.connectionToolsById.set('conn-1', [{ name: 'search' }]);
 		});
 
-		// The connection row is cascaded away server-side, so the UI only has to
-		// stop showing it
 		it('drops connections that used the deleted credential', () => {
 			emitCredentialDeleted('cred-1');
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiMcp.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiMcp.store.test.ts
@@ -16,6 +16,24 @@ vi.mock('@/app/composables/useToast', () => ({
 	}),
 }));
 
+const deletionListeners = new Set<(credentialId: string) => void>();
+vi.mock('@/features/credentials/credentials.store', () => ({
+	useCredentialsStore: () => ({}),
+	listenForCredentialChanges: ({
+		onCredentialDeleted,
+	}: {
+		onCredentialDeleted: (credentialId: string) => void;
+	}) => {
+		deletionListeners.add(onCredentialDeleted);
+		return () => deletionListeners.delete(onCredentialDeleted);
+	},
+}));
+
+/** Replays a successful `credentialsStore.deleteCredential` to its subscribers. */
+function emitCredentialDeleted(id: string): void {
+	for (const listener of deletionListeners) listener(id);
+}
+
 vi.mock('@n8n/i18n', () => ({
 	i18n: { baseText: (key: string) => key },
 }));
@@ -81,6 +99,7 @@ describe('useInstanceAiMcpStore', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		deletionListeners.clear();
 		setActivePinia(createPinia());
 		store = useInstanceAiMcpStore();
 	});
@@ -211,6 +230,33 @@ describe('useInstanceAiMcpStore', () => {
 
 			expect(store.connectionsByServerSlug.get('linear')).toHaveLength(2);
 			expect(store.connectionsByServerSlug.get('notion')).toHaveLength(1);
+		});
+	});
+
+	describe('credential deletion', () => {
+		beforeEach(async () => {
+			mockFetchMcpConnections.mockResolvedValue([
+				makeConnection({ id: 'conn-1', serverSlug: 'linear', credentialId: 'cred-1' }),
+				makeConnection({ id: 'conn-2', serverSlug: 'notion', credentialId: 'cred-2' }),
+			]);
+			await store.fetchConnections();
+			store.connectionToolsById.set('conn-1', [{ name: 'search' }]);
+		});
+
+		// The connection row is cascaded away server-side, so the UI only has to
+		// stop showing it
+		it('drops connections that used the deleted credential', () => {
+			emitCredentialDeleted('cred-1');
+
+			expect(store.connections.map((c) => c.id)).toEqual(['conn-2']);
+			expect(store.connectionToolsById.get('conn-1')).toBeUndefined();
+		});
+
+		it('leaves connections alone when an unrelated credential is deleted', () => {
+			emitCredentialDeleted('cred-other');
+
+			expect(store.connections.map((c) => c.id)).toEqual(['conn-1', 'conn-2']);
+			expect(store.connectionToolsById.get('conn-1')).toEqual([{ name: 'search' }]);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/InstanceAiToolsConnectionModalWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/InstanceAiToolsConnectionModalWrapper.vue
@@ -5,7 +5,6 @@ import { useToast } from '@/app/composables/useToast';
 import { i18n } from '@n8n/i18n';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
-import { useCredentialOAuth } from '@/features/credentials/composables/useCredentialOAuth';
 import { useInstanceAiMcpConnectionsExperiment } from '@/experiments/instanceAiMcpConnections';
 import DefaultDetailBody from '@/features/shared/toolsConnection/DefaultDetailBody.vue';
 import McpDetailBody from '@/features/shared/toolsConnection/McpDetailBody.vue';
@@ -25,6 +24,7 @@ import {
 import { useInstanceAiMcpStore } from '../../instanceAiMcp.store';
 import { useInstanceAiMcpTelemetry } from '../../instanceAiMcp.telemetry';
 import { useInstanceAiSettingsStore } from '../../instanceAiSettings.store';
+import { useMcpServerConnect } from '../../composables/useMcpServerConnect';
 import type {
 	InstanceAiMcpConnectionResponse,
 	InstanceAiMcpConnectionToolResponse,
@@ -60,7 +60,6 @@ const mcpStore = useInstanceAiMcpStore();
 const mcpTelemetry = useInstanceAiMcpTelemetry();
 const settingsStore = useInstanceAiSettingsStore();
 const toast = useToast();
-const { canOAuthCredentialQuickConnect, createAndAuthorize } = useCredentialOAuth();
 const { isFeatureEnabled: isMcpFeatureEnabled } = useInstanceAiMcpConnectionsExperiment();
 const { isFeatureEnabled: isComputerUseFeatureEnabled } = useInstanceAiComputerUseExperiment();
 const { isFeatureEnabled: isBrowserUseFeatureEnabled } = useInstanceAiBrowserUseExperiment();
@@ -108,51 +107,20 @@ const detailMode = computed<'detail' | 'settings'>(() =>
 	detailItem.value?.kind === 'mcp-server' && detailItem.value.isConnected ? 'settings' : 'detail',
 );
 
-interface PendingCredentialContext {
-	serverSlug: string;
-	credentialType: string;
-	existingCredentialIds: Set<string>;
-}
-
-const pendingCredentialContext = ref<PendingCredentialContext | null>(null);
-
 type McpToolMetadata = McpRegistryServerToolResponse | InstanceAiMcpConnectionToolResponse;
 
-async function connectOrSwapCredential(serverSlug: string, credentialId: string): Promise<boolean> {
-	const existing = mcpStore.connections.find((c) => c.serverSlug === serverSlug);
-	if (!existing) {
-		const result = await mcpStore.connect({ serverSlug, credentialId });
-		if (result) {
-			toast.showMessage({
-				type: 'success',
-				title: i18n.baseText('instanceAi.mcp.success.connect'),
-			});
-		}
-		return Boolean(result);
-	}
+const { connectServer, connectWithCredential } = useMcpServerConnect();
 
-	if (existing.credentialId === credentialId) {
-		return false;
-	}
-
-	const updated = await mcpStore.updateConnection(existing.id, { credentialId });
-	if (updated) {
-		toast.showMessage({
-			type: 'success',
-			title: i18n.baseText('instanceAi.mcp.success.changeCredential'),
-		});
-	}
-	return Boolean(updated);
+/** Reveals the settings view of the server the user just connected */
+function showConnectedServer(connectionId: string | null): void {
+	if (connectionId) activeItemId.value = connectionId;
 }
 
 if (isMcpEnabled.value) {
 	void mcpStore.fetchCatalogLazy();
 	void mcpStore.fetchConnections();
+	void credentialsStore.fetchAllCredentials();
 }
-
-const credentialsPromise = isMcpEnabled.value
-	? credentialsStore.fetchAllCredentials()
-	: Promise.resolve([]);
 
 // Clear the state on close so the next open starts
 // fresh without every caller needing to pass `data: {}`
@@ -319,33 +287,6 @@ watch(
 	{ immediate: true },
 );
 
-async function openCredentialEditModal(server: McpRegistryServerResponse): Promise<void> {
-	await credentialsPromise;
-	pendingCredentialContext.value = {
-		serverSlug: server.slug,
-		credentialType: server.credentialType,
-		existingCredentialIds: new Set(
-			credentialsStore.getCredentialsByType(server.credentialType).map((c) => c.id),
-		),
-	};
-	uiStore.openNewCredential(server.credentialType);
-}
-
-function showSettingsForServer(serverSlug: string): void {
-	activeItemId.value = mcpStore.connections.find((c) => c.serverSlug === serverSlug)?.id ?? null;
-}
-
-async function createCredentialAndConnect(server: McpRegistryServerResponse): Promise<void> {
-	if (canOAuthCredentialQuickConnect(server.credentialType)) {
-		const credential = await createAndAuthorize(server.credentialType);
-		if (!credential) return;
-		const ok = await connectOrSwapCredential(server.slug, credential.id);
-		if (ok) showSettingsForServer(server.slug);
-		return;
-	}
-	await openCredentialEditModal(server);
-}
-
 const credentialAdapter: ToolConnectionCredentialAdapter = {
 	getCredentialsByType: (authType: string): readonly PickableCredential[] => {
 		const creds = credentialsStore.getCredentialsByType(authType);
@@ -361,7 +302,7 @@ const credentialAdapter: ToolConnectionCredentialAdapter = {
 				uiStore.openNewCredential(authType);
 				return;
 			}
-			await createCredentialAndConnect(server);
+			showConnectedServer(await connectServer(server));
 		})();
 	},
 	openExistingCredential: (credentialId: string) => {
@@ -370,38 +311,6 @@ const credentialAdapter: ToolConnectionCredentialAdapter = {
 };
 
 provide(TOOL_CONNECTION_CREDENTIAL_ADAPTER_KEY, credentialAdapter);
-
-// Once the credential modal is closed, if a new
-// credential was created, create a connection for it
-watch(
-	() => uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY]?.open,
-	async (isCredentialModalOpen, wasOpen) => {
-		if (!wasOpen || isCredentialModalOpen) return;
-
-		const ctx = pendingCredentialContext.value;
-		pendingCredentialContext.value = null;
-		await Promise.all([credentialsStore.fetchAllCredentials(), mcpStore.fetchConnections()]);
-
-		if (!ctx) return;
-
-		const current = credentialsStore.getCredentialsByType(ctx.credentialType);
-		const newCreds = current.filter((c) => !ctx.existingCredentialIds.has(c.id));
-
-		if (newCreds.length === 0) return;
-
-		if (newCreds.length > 1) {
-			toast.showMessage({
-				type: 'info',
-				title: i18n.baseText('instanceAi.mcp.error.autoConnectAmbiguous.title'),
-				message: i18n.baseText('instanceAi.mcp.error.autoConnectAmbiguous.message'),
-			});
-			return;
-		}
-
-		const ok = await connectOrSwapCredential(ctx.serverSlug, newCreds[0].id);
-		if (ok) showSettingsForServer(ctx.serverSlug);
-	},
-);
 
 function findServerForItem(item: McpServerConnectionItem): McpRegistryServerResponse | undefined {
 	const connection = mcpStore.connections.find((c) => c.id === item.id);
@@ -446,8 +355,7 @@ async function handleSelectCredential(
 	const server = findServerForItem(item);
 	if (!server) return;
 	mcpTelemetry.trackExistingCredentialSelected(server.slug);
-	const ok = await connectOrSwapCredential(server.slug, credentialId);
-	if (ok) showSettingsForServer(server.slug);
+	showConnectedServer(await connectWithCredential(server.slug, credentialId));
 }
 
 async function handleSave(item: ToolConnectionItem, settings?: ToolConnectionSettings) {
@@ -479,7 +387,7 @@ async function handleConnect(item: ToolConnectionItem) {
 		case 'mcp-server':
 			const server = findServerForItem(item);
 			if (server) {
-				await createCredentialAndConnect(server);
+				showConnectedServer(await connectServer(server));
 			}
 			break;
 	}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/InstanceAiToolsConnectionModalWrapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/InstanceAiToolsConnectionModalWrapper.test.ts
@@ -60,6 +60,13 @@ vi.mock('../../../instanceAiMcp.store', () => ({
 	useInstanceAiMcpStore: () => mcpStoreMock,
 }));
 
+vi.mock('../../../composables/useMcpServerConnect', () => ({
+	useMcpServerConnect: () => ({
+		connectServer: vi.fn().mockResolvedValue(null),
+		connectWithCredential: vi.fn().mockResolvedValue(null),
+	}),
+}));
+
 vi.mock('../../../instanceAiSettings.store', () => ({
 	useInstanceAiSettingsStore: () => ({
 		settings: { mcpAccessEnabled: true },

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.test.ts
@@ -32,8 +32,6 @@ vi.mock('@/features/credentials/composables/useCredentialOAuth', () => ({
 	}),
 }));
 
-// Creating a credential for real would mean driving the whole credential edit
-// modal, so its subscribers are replayed by hand
 const credentialCreatedListeners = new Set<(credential: ICredentialsResponse) => void>();
 vi.mock('@/features/credentials/credentials.store', async (importOriginal) => ({
 	...(await importOriginal<object>()),
@@ -75,7 +73,6 @@ describe('useMcpServerConnect', () => {
 		await flushPromises();
 	}
 
-	/** Starts a connect attempt, resolving once the credential modal is open. */
 	async function startConnect(): Promise<{ connecting: Promise<string | null> }> {
 		const connecting = useMcpServerConnect().connectServer(linear);
 		await flushPromises();
@@ -94,8 +91,6 @@ describe('useMcpServerConnect', () => {
 		mockCanQuickConnect.mockReturnValue(false);
 	});
 
-	// Attempts are deduped per server in module scope, so a test that leaves one
-	// pending would hand it to the next test
 	afterEach(async () => {
 		await closeCredentialModal();
 	});
@@ -164,6 +159,26 @@ describe('useMcpServerConnect', () => {
 			expect(uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY].open).toBe(false);
 		});
 
+		it('shares one attempt across concurrent quick-connect callers', async () => {
+			mockCanQuickConnect.mockReturnValue(true);
+			let authorize!: (credential: { id: string }) => void;
+			mockCreateAndAuthorize.mockReturnValue(
+				new Promise<{ id: string }>((resolve) => {
+					authorize = resolve;
+				}),
+			);
+			const { connectServer } = useMcpServerConnect();
+
+			const first = connectServer(linear);
+			const second = connectServer(linear);
+			authorize({ id: 'cred-new' });
+
+			await expect(first).resolves.toBe('conn-new');
+			await expect(second).resolves.toBe('conn-new');
+			expect(mockCreateAndAuthorize).toHaveBeenCalledTimes(1);
+			expect(mcpStore.connect).toHaveBeenCalledTimes(1);
+		});
+
 		it('stops when the user aborts the OAuth flow', async () => {
 			mockCanQuickConnect.mockReturnValue(true);
 			mockCreateAndAuthorize.mockResolvedValue(null);
@@ -191,8 +206,6 @@ describe('useMcpServerConnect', () => {
 				'modal unavailable',
 			);
 
-			// An attempt with no modal to close would reconcile against an
-			// unrelated close later on
 			emitCredentialCreated('cred-new');
 			await closeCredentialModal();
 
@@ -265,8 +278,6 @@ describe('useMcpServerConnect', () => {
 			expect(mcpStore.connect).toHaveBeenCalledTimes(1);
 		});
 
-		// Any surface can drive the flow, so an attempt must not be tied to the
-		// lifetime of the one that started it
 		it('finishes an attempt whose surface was torn down while the modal was open', async () => {
 			let connecting: Promise<string | null> | undefined;
 			const scope = effectScope();
@@ -287,8 +298,6 @@ describe('useMcpServerConnect', () => {
 			await expect(connecting).resolves.toBe('conn-new');
 		});
 
-		// Two surfaces connecting one server share the modal, so they must not
-		// both create a connection for it
 		it('shares one attempt when the same server is connected twice', async () => {
 			const { connectServer } = useMcpServerConnect();
 			const first = connectServer(linear);
@@ -318,8 +327,6 @@ describe('useMcpServerConnect', () => {
 			await expect(retried).resolves.toBe('conn-new');
 		});
 
-		// Credential types are per server, so overlapping attempts can't pick up
-		// each other's credential
 		it('keeps concurrent attempts for different servers apart', async () => {
 			const { connectServer } = useMcpServerConnect();
 			const connectingLinear = connectServer(linear);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { effectScope } from 'vue';
@@ -92,6 +92,12 @@ describe('useMcpServerConnect', () => {
 		mcpStore.connect.mockResolvedValue(makeConnection({ id: 'conn-new' }));
 		mcpStore.updateConnection.mockResolvedValue(makeConnection({ id: 'conn-1' }));
 		mockCanQuickConnect.mockReturnValue(false);
+	});
+
+	// Attempts are deduped per server in module scope, so a test that leaves one
+	// pending would hand it to the next test
+	afterEach(async () => {
+		await closeCredentialModal();
 	});
 
 	describe('connectWithCredential', () => {
@@ -279,6 +285,37 @@ describe('useMcpServerConnect', () => {
 				credentialId: 'cred-new',
 			});
 			await expect(connecting).resolves.toBe('conn-new');
+		});
+
+		// Two surfaces connecting one server share the modal, so they must not
+		// both create a connection for it
+		it('shares one attempt when the same server is connected twice', async () => {
+			const { connectServer } = useMcpServerConnect();
+			const first = connectServer(linear);
+			const second = connectServer(linear);
+			await flushPromises();
+
+			emitCredentialCreated('cred-new');
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).toHaveBeenCalledTimes(1);
+			await expect(first).resolves.toBe('conn-new');
+			await expect(second).resolves.toBe('conn-new');
+		});
+
+		it('starts a fresh attempt after the previous one settled', async () => {
+			const { connectServer } = useMcpServerConnect();
+			const cancelled = connectServer(linear);
+			await flushPromises();
+			await closeCredentialModal();
+			await expect(cancelled).resolves.toBeNull();
+
+			const retried = connectServer(linear);
+			await flushPromises();
+			emitCredentialCreated('cred-new');
+			await closeCredentialModal();
+
+			await expect(retried).resolves.toBe('conn-new');
 		});
 
 		// Credential types are per server, so overlapping attempts can't pick up

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { effectScope } from 'vue';
+import { flushPromises } from '@vue/test-utils';
+import type { InstanceAiMcpConnectionResponse } from '@n8n/api-types';
+import { mockedStore } from '@/__tests__/utils';
+import { useUIStore } from '@/app/stores/ui.store';
+import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
+import type { ICredentialsResponse } from '@/features/credentials/credentials.types';
+import { useInstanceAiMcpStore } from '../instanceAiMcp.store';
+import { useMcpServerConnect } from './useMcpServerConnect';
+
+vi.mock('@n8n/i18n', async (importOriginal) => ({
+	...(await importOriginal<object>()),
+	i18n: { baseText: (key: string) => key },
+}));
+
+const { mockShowMessage } = vi.hoisted(() => ({ mockShowMessage: vi.fn() }));
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: () => ({ showMessage: mockShowMessage, showError: vi.fn() }),
+}));
+
+const { mockCanQuickConnect, mockCreateAndAuthorize } = vi.hoisted(() => ({
+	mockCanQuickConnect: vi.fn(),
+	mockCreateAndAuthorize: vi.fn(),
+}));
+vi.mock('@/features/credentials/composables/useCredentialOAuth', () => ({
+	useCredentialOAuth: () => ({
+		canOAuthCredentialQuickConnect: mockCanQuickConnect,
+		createAndAuthorize: mockCreateAndAuthorize,
+	}),
+}));
+
+// Creating a credential for real would mean driving the whole credential edit
+// modal, so its subscribers are replayed by hand
+const credentialCreatedListeners = new Set<(credential: ICredentialsResponse) => void>();
+vi.mock('@/features/credentials/credentials.store', async (importOriginal) => ({
+	...(await importOriginal<object>()),
+	listenForCredentialChanges: ({
+		onCredentialCreated,
+	}: {
+		onCredentialCreated?: (credential: ICredentialsResponse) => void;
+	}) => {
+		if (onCredentialCreated) credentialCreatedListeners.add(onCredentialCreated);
+		return () => {
+			if (onCredentialCreated) credentialCreatedListeners.delete(onCredentialCreated);
+		};
+	},
+}));
+
+function emitCredentialCreated(id: string, type = 'linearMcpOAuth2Api'): void {
+	for (const listener of [...credentialCreatedListeners]) {
+		listener({ id, type } as ICredentialsResponse);
+	}
+}
+
+const makeConnection = (overrides: Partial<InstanceAiMcpConnectionResponse> = {}) =>
+	({
+		id: 'conn-1',
+		serverSlug: 'linear',
+		credentialId: 'cred-1',
+		credentialType: 'linearMcpOAuth2Api',
+		...overrides,
+	}) as InstanceAiMcpConnectionResponse;
+
+const linear = { slug: 'linear', credentialType: 'linearMcpOAuth2Api' };
+
+describe('useMcpServerConnect', () => {
+	let mcpStore: ReturnType<typeof mockedStore<typeof useInstanceAiMcpStore>>;
+	let uiStore: ReturnType<typeof useUIStore>;
+
+	async function closeCredentialModal(): Promise<void> {
+		uiStore.closeModal(CREDENTIAL_EDIT_MODAL_KEY);
+		await flushPromises();
+	}
+
+	/** Starts a connect attempt, resolving once the credential modal is open. */
+	async function startConnect(): Promise<{ connecting: Promise<string | null> }> {
+		const connecting = useMcpServerConnect().connectServer(linear);
+		await flushPromises();
+		return { connecting };
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		credentialCreatedListeners.clear();
+		setActivePinia(createTestingPinia({ stubActions: false }));
+
+		uiStore = useUIStore();
+		mcpStore = mockedStore(useInstanceAiMcpStore);
+		mcpStore.connect.mockResolvedValue(makeConnection({ id: 'conn-new' }));
+		mcpStore.updateConnection.mockResolvedValue(makeConnection({ id: 'conn-1' }));
+		mockCanQuickConnect.mockReturnValue(false);
+	});
+
+	describe('connectWithCredential', () => {
+		it('creates a connection when the server has none', async () => {
+			const { connectWithCredential } = useMcpServerConnect();
+
+			await expect(connectWithCredential('linear', 'cred-1')).resolves.toBe('conn-new');
+
+			expect(mcpStore.connect).toHaveBeenCalledWith({
+				serverSlug: 'linear',
+				credentialId: 'cred-1',
+			});
+			expect(mcpStore.updateConnection).not.toHaveBeenCalled();
+			expect(mockShowMessage).toHaveBeenCalledWith({
+				type: 'success',
+				title: 'instanceAi.mcp.success.connect',
+			});
+		});
+
+		it('swaps the credential when a connection already exists', async () => {
+			mcpStore.connections = [makeConnection({ id: 'conn-1', credentialId: 'cred-old' })];
+			const { connectWithCredential } = useMcpServerConnect();
+
+			await expect(connectWithCredential('linear', 'cred-new')).resolves.toBe('conn-1');
+
+			expect(mcpStore.connect).not.toHaveBeenCalled();
+			expect(mcpStore.updateConnection).toHaveBeenCalledWith('conn-1', {
+				credentialId: 'cred-new',
+			});
+			expect(mockShowMessage).toHaveBeenCalledWith({
+				type: 'success',
+				title: 'instanceAi.mcp.success.changeCredential',
+			});
+		});
+
+		it('does nothing when the connection already uses that credential', async () => {
+			mcpStore.connections = [makeConnection({ id: 'conn-1', credentialId: 'cred-1' })];
+			const { connectWithCredential } = useMcpServerConnect();
+
+			await expect(connectWithCredential('linear', 'cred-1')).resolves.toBeNull();
+
+			expect(mcpStore.updateConnection).not.toHaveBeenCalled();
+			expect(mockShowMessage).not.toHaveBeenCalled();
+		});
+
+		it('reports failure without a success message when the request fails', async () => {
+			mcpStore.connect.mockResolvedValue(null);
+			const { connectWithCredential } = useMcpServerConnect();
+
+			await expect(connectWithCredential('linear', 'cred-1')).resolves.toBeNull();
+
+			expect(mockShowMessage).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('connectServer', () => {
+		it('authorizes in place for a quick-connect OAuth credential type', async () => {
+			mockCanQuickConnect.mockReturnValue(true);
+			mockCreateAndAuthorize.mockResolvedValue({ id: 'cred-new' });
+
+			await expect(useMcpServerConnect().connectServer(linear)).resolves.toBe('conn-new');
+
+			expect(mockCreateAndAuthorize).toHaveBeenCalledWith('linearMcpOAuth2Api');
+			expect(uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY].open).toBe(false);
+		});
+
+		it('stops when the user aborts the OAuth flow', async () => {
+			mockCanQuickConnect.mockReturnValue(true);
+			mockCreateAndAuthorize.mockResolvedValue(null);
+
+			await expect(useMcpServerConnect().connectServer(linear)).resolves.toBeNull();
+
+			expect(mcpStore.connect).not.toHaveBeenCalled();
+		});
+
+		it('opens the credential modal for the server credential type', async () => {
+			await startConnect();
+
+			expect(uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY]).toMatchObject({
+				open: true,
+				activeId: 'linearMcpOAuth2Api',
+			});
+		});
+
+		it('rejects and stops listening when the credential modal fails to open', async () => {
+			vi.spyOn(uiStore, 'openNewCredential').mockImplementation(() => {
+				throw new Error('modal unavailable');
+			});
+
+			await expect(useMcpServerConnect().connectServer(linear)).rejects.toThrow(
+				'modal unavailable',
+			);
+
+			// An attempt with no modal to close would reconcile against an
+			// unrelated close later on
+			emitCredentialCreated('cred-new');
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('credential edit modal reconciliation', () => {
+		it('connects the credential the user created', async () => {
+			const { connecting } = await startConnect();
+
+			emitCredentialCreated('cred-new');
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).toHaveBeenCalledWith({
+				serverSlug: 'linear',
+				credentialId: 'cred-new',
+			});
+			await expect(connecting).resolves.toBe('conn-new');
+		});
+
+		it('ignores a credential created for another type', async () => {
+			const { connecting } = await startConnect();
+
+			emitCredentialCreated('cred-other', 'slackApi');
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).not.toHaveBeenCalled();
+			await expect(connecting).resolves.toBeNull();
+		});
+
+		it('does nothing when the user cancels without creating a credential', async () => {
+			const { connecting } = await startConnect();
+
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).not.toHaveBeenCalled();
+			expect(mockShowMessage).not.toHaveBeenCalled();
+			await expect(connecting).resolves.toBeNull();
+		});
+
+		it('swaps the credential when the server is already connected', async () => {
+			mcpStore.connections = [makeConnection({ id: 'conn-1', credentialId: 'cred-old' })];
+			const { connecting } = await startConnect();
+
+			emitCredentialCreated('cred-new');
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).not.toHaveBeenCalled();
+			expect(mcpStore.updateConnection).toHaveBeenCalledWith('conn-1', {
+				credentialId: 'cred-new',
+			});
+			await expect(connecting).resolves.toBe('conn-1');
+		});
+
+		it('does nothing when no attempt is pending', async () => {
+			emitCredentialCreated('cred-new');
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).not.toHaveBeenCalled();
+		});
+
+		it('only reconciles once per attempt', async () => {
+			await startConnect();
+
+			emitCredentialCreated('cred-new');
+			await closeCredentialModal();
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).toHaveBeenCalledTimes(1);
+		});
+
+		// Any surface can drive the flow, so an attempt must not be tied to the
+		// lifetime of the one that started it
+		it('finishes an attempt whose surface was torn down while the modal was open', async () => {
+			let connecting: Promise<string | null> | undefined;
+			const scope = effectScope();
+			scope.run(() => {
+				connecting = useMcpServerConnect().connectServer(linear);
+			});
+			await flushPromises();
+
+			scope.stop();
+
+			emitCredentialCreated('cred-new');
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).toHaveBeenCalledWith({
+				serverSlug: 'linear',
+				credentialId: 'cred-new',
+			});
+			await expect(connecting).resolves.toBe('conn-new');
+		});
+
+		// Credential types are per server, so overlapping attempts can't pick up
+		// each other's credential
+		it('keeps concurrent attempts for different servers apart', async () => {
+			const { connectServer } = useMcpServerConnect();
+			const connectingLinear = connectServer(linear);
+			const connectingNotion = connectServer({
+				slug: 'notion',
+				credentialType: 'notionMcpOAuth2Api',
+			});
+			await flushPromises();
+
+			emitCredentialCreated('cred-notion', 'notionMcpOAuth2Api');
+			await closeCredentialModal();
+
+			expect(mcpStore.connect).toHaveBeenCalledTimes(1);
+			expect(mcpStore.connect).toHaveBeenCalledWith({
+				serverSlug: 'notion',
+				credentialId: 'cred-notion',
+			});
+			await expect(connectingLinear).resolves.toBeNull();
+			await expect(connectingNotion).resolves.toBe('conn-new');
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.ts
@@ -15,6 +15,11 @@ export interface McpConnectTarget {
 	credentialType: string;
 }
 
+// The credential edit modal is app-wide, so without this two surfaces connecting
+// one server would both reconcile its close and race to create the same
+// connection — the loser fails the one-connection-per-server rule
+const attemptsByServerSlug = new Map<string, Promise<string | null>>();
+
 /**
  * The credential half of connecting an MCP server, shared by the tools
  * connection modal and the inline chat card. Connection state itself stays in
@@ -77,13 +82,16 @@ export function useMcpServerConnect() {
 	 * outside an attempt, so unrelated credential edits stay free.
 	 */
 	async function connectViaCredentialModal(server: McpConnectTarget): Promise<string | null> {
-		return await new Promise<string | null>((settle) => {
+		const inFlight = attemptsByServerSlug.get(server.slug);
+		if (inFlight) return await inFlight;
+
+		const attempt = new Promise<string | null>((settle) => {
 			let createdCredentialId: string | null = null;
 
 			// Detached because pinia disposes subscriptions with the effect scope they
 			// were created in, and an attempt outlives the surface that started it
-			const attempt = effectScope(true);
-			attempt.run(() => {
+			const listeners = effectScope(true);
+			listeners.run(() => {
 				listenForCredentialChanges({
 					store: credentialsStore,
 					onCredentialCreated: (credential) => {
@@ -96,7 +104,7 @@ export function useMcpServerConnect() {
 					store: uiStore,
 					onModalClosed: (modalName) => {
 						if (modalName !== CREDENTIAL_EDIT_MODAL_KEY) return;
-						attempt.stop();
+						listeners.stop();
 
 						if (createdCredentialId === null) {
 							settle(null);
@@ -113,10 +121,15 @@ export function useMcpServerConnect() {
 			try {
 				uiStore.openNewCredential(server.credentialType);
 			} catch (error) {
-				attempt.stop();
+				listeners.stop();
 				throw error;
 			}
 		});
+
+		attemptsByServerSlug.set(server.slug, attempt);
+		// Cleared however it ends, so the next connect for this server starts fresh
+		void attempt.catch(() => null).then(() => attemptsByServerSlug.delete(server.slug));
+		return await attempt;
 	}
 
 	return { connectServer, connectWithCredential };

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.ts
@@ -15,10 +15,7 @@ export interface McpConnectTarget {
 	credentialType: string;
 }
 
-// The credential edit modal is app-wide, so without this two surfaces connecting
-// one server would both reconcile its close and race to create the same
-// connection — the loser fails the one-connection-per-server rule
-const attemptsByServerSlug = new Map<string, Promise<string | null>>();
+const inFlightConnectsByServerSlug = new Map<string, Promise<string | null>>();
 
 /**
  * The credential half of connecting an MCP server, shared by the tools
@@ -69,6 +66,19 @@ export function useMcpServerConnect() {
 	 * modal. Resolves once the user is done, with null if they backed out.
 	 */
 	async function connectServer(server: McpConnectTarget): Promise<string | null> {
+		const inFlight = inFlightConnectsByServerSlug.get(server.slug);
+		if (inFlight) return await inFlight;
+
+		const attempt = startConnect(server);
+		inFlightConnectsByServerSlug.set(server.slug, attempt);
+		try {
+			return await attempt;
+		} finally {
+			inFlightConnectsByServerSlug.delete(server.slug);
+		}
+	}
+
+	async function startConnect(server: McpConnectTarget): Promise<string | null> {
 		if (canOAuthCredentialQuickConnect(server.credentialType)) {
 			const credential = await createAndAuthorize(server.credentialType);
 			return credential ? await connectWithCredential(server.slug, credential.id) : null;
@@ -82,10 +92,7 @@ export function useMcpServerConnect() {
 	 * outside an attempt, so unrelated credential edits stay free.
 	 */
 	async function connectViaCredentialModal(server: McpConnectTarget): Promise<string | null> {
-		const inFlight = attemptsByServerSlug.get(server.slug);
-		if (inFlight) return await inFlight;
-
-		const attempt = new Promise<string | null>((settle) => {
+		return await new Promise<string | null>((settle) => {
 			let createdCredentialId: string | null = null;
 
 			// Detached because pinia disposes subscriptions with the effect scope they
@@ -125,11 +132,6 @@ export function useMcpServerConnect() {
 				throw error;
 			}
 		});
-
-		attemptsByServerSlug.set(server.slug, attempt);
-		// Cleared however it ends, so the next connect for this server starts fresh
-		void attempt.catch(() => null).then(() => attemptsByServerSlug.delete(server.slug));
-		return await attempt;
 	}
 
 	return { connectServer, connectWithCredential };

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.ts
@@ -1,0 +1,123 @@
+import { effectScope } from 'vue';
+import { i18n } from '@n8n/i18n';
+import { useToast } from '@/app/composables/useToast';
+import { listenForModalChanges, useUIStore } from '@/app/stores/ui.store';
+import {
+	listenForCredentialChanges,
+	useCredentialsStore,
+} from '@/features/credentials/credentials.store';
+import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
+import { useCredentialOAuth } from '@/features/credentials/composables/useCredentialOAuth';
+import { useInstanceAiMcpStore } from '../instanceAiMcp.store';
+
+export interface McpConnectTarget {
+	slug: string;
+	credentialType: string;
+}
+
+/**
+ * The credential half of connecting an MCP server, shared by the tools
+ * connection modal and the inline chat card. Connection state itself stays in
+ * `useInstanceAiMcpStore`; this only drives the flow that fills it.
+ */
+export function useMcpServerConnect() {
+	const mcpStore = useInstanceAiMcpStore();
+	const uiStore = useUIStore();
+	const credentialsStore = useCredentialsStore();
+	const toast = useToast();
+	const { canOAuthCredentialQuickConnect, createAndAuthorize } = useCredentialOAuth();
+
+	/**
+	 * Patches the existing connection instead of creating a second one — the
+	 * backend allows only one per server. Null when nothing changed or failed.
+	 */
+	async function connectWithCredential(
+		serverSlug: string,
+		credentialId: string,
+	): Promise<string | null> {
+		const existing = mcpStore.connections.find((c) => c.serverSlug === serverSlug);
+
+		if (!existing) {
+			const created = await mcpStore.connect({ serverSlug, credentialId });
+			if (!created) return null;
+			toast.showMessage({
+				type: 'success',
+				title: i18n.baseText('instanceAi.mcp.success.connect'),
+			});
+			return created.id;
+		}
+
+		if (existing.credentialId === credentialId) return null;
+
+		const updated = await mcpStore.updateConnection(existing.id, { credentialId });
+		if (!updated) return null;
+		toast.showMessage({
+			type: 'success',
+			title: i18n.baseText('instanceAi.mcp.success.changeCredential'),
+		});
+		return updated.id;
+	}
+
+	/**
+	 * Connects a server the user has no credential for yet: OAuth types needing no
+	 * manual input are authorized in place, the rest go through the credential edit
+	 * modal. Resolves once the user is done, with null if they backed out.
+	 */
+	async function connectServer(server: McpConnectTarget): Promise<string | null> {
+		if (canOAuthCredentialQuickConnect(server.credentialType)) {
+			const credential = await createAndAuthorize(server.credentialType);
+			return credential ? await connectWithCredential(server.slug, credential.id) : null;
+		}
+		return await connectViaCredentialModal(server);
+	}
+
+	/**
+	 * Opens the credential edit modal for the server and connects whatever
+	 * credential the user created there once they close it. Nothing is listening
+	 * outside an attempt, so unrelated credential edits stay free.
+	 */
+	async function connectViaCredentialModal(server: McpConnectTarget): Promise<string | null> {
+		return await new Promise<string | null>((settle) => {
+			let createdCredentialId: string | null = null;
+
+			// Detached because pinia disposes subscriptions with the effect scope they
+			// were created in, and an attempt outlives the surface that started it
+			const attempt = effectScope(true);
+			attempt.run(() => {
+				listenForCredentialChanges({
+					store: credentialsStore,
+					onCredentialCreated: (credential) => {
+						// Credential types are per server, so this only ever matches ours
+						if (credential.type === server.credentialType) createdCredentialId = credential.id;
+					},
+				});
+
+				listenForModalChanges({
+					store: uiStore,
+					onModalClosed: (modalName) => {
+						if (modalName !== CREDENTIAL_EDIT_MODAL_KEY) return;
+						attempt.stop();
+
+						if (createdCredentialId === null) {
+							settle(null);
+							return;
+						}
+						// A failed connect settles the attempt rather than leaving it hanging
+						void connectWithCredential(server.slug, createdCredentialId)
+							.catch(() => null)
+							.then(settle);
+					},
+				});
+			});
+
+			try {
+				uiStore.openNewCredential(server.credentialType);
+			} catch (error) {
+				attempt.stop();
+				throw error;
+			}
+		});
+	}
+
+	return { connectServer, connectWithCredential };
+}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiMcp.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiMcp.store.ts
@@ -9,6 +9,10 @@ import type {
 import { useToast } from '@/app/composables/useToast';
 import { i18n } from '@n8n/i18n';
 import {
+	listenForCredentialChanges,
+	useCredentialsStore,
+} from '@/features/credentials/credentials.store';
+import {
 	createMcpConnection,
 	deleteMcpConnection,
 	fetchMcpConnectionTools,
@@ -22,6 +26,7 @@ import {
 export const useInstanceAiMcpStore = defineStore('instanceAiMcp', () => {
 	const rootStore = useRootStore();
 	const toast = useToast();
+	const credentialsStore = useCredentialsStore();
 
 	const connections = ref<InstanceAiMcpConnectionResponse[]>([]);
 	const catalog = ref<McpRegistryServerResponse[] | null>(null);
@@ -141,6 +146,19 @@ export const useInstanceAiMcpStore = defineStore('instanceAiMcp', () => {
 			return false;
 		}
 	}
+
+	// When a credential is deleted, drop its connections and tools, backend does the same.
+	listenForCredentialChanges({
+		store: credentialsStore,
+		onCredentialDeleted: (deletedCredentialId) => {
+			const orphaned = connections.value.filter((c) => c.credentialId === deletedCredentialId);
+			if (orphaned.length === 0) return;
+			connections.value = connections.value.filter((c) => c.credentialId !== deletedCredentialId);
+			for (const connection of orphaned) {
+				clearConnectionTools(connection.id);
+			}
+		},
+	});
 
 	function reset(): void {
 		connections.value = [];


### PR DESCRIPTION
## Summary

The whole "connect to an MCP server" flow lived inside `InstanceAiToolsConnectionModalWrapper.vue`. The inline chat card coming in a future PR needs the identical flow, so this PR moves it into `useMcpServerConnect()`.

Also includes some smaller improvements for listening to created/deleted credentials.

## How to test

Requires `N8N_MCP_ACCESS_ENABLED=true` and `window.featureFlags.override('089_instance_ai_mcp_connections', 'variant')`

Should not meaningfully change the behavior of the connections panel and MCP Servers for the AI assistant.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5575

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35258">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

