### PR TITLE
fix(core): Only wake the publication outbox consumer on the leader (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -407,6 +407,16 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			expect(outboxRepository.claimNextPendingRecord).not.toHaveBeenCalled();
 			expect(vi.getTimerCount()).toBe(0);
 		});
+
+		test('on a follower, neither polls nor claims a record', async () => {
+			outboxRepository.claimNextPendingRecord.mockResolvedValue(makeRecord({ id: 1 }));
+			consumer = createConsumer(true, false);
+
+			await consumer.wakeUp();
+
+			expect(outboxRepository.claimNextPendingRecord).not.toHaveBeenCalled();
+			expect(vi.getTimerCount()).toBe(0);
+		});
 	});
 
 	describe('poll cycle', () => {

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -95,6 +95,10 @@ export class WorkflowPublicationOutboxConsumer {
 	@OnPubSubEvent('workflow-publish-wake-up', { instanceType: 'main', instanceRole: 'leader' })
 	async wakeUp(): Promise<void> {
 		if (!this.workflowsConfig.useWorkflowPublicationService) return;
+		// Direct callers (e.g. a short-lived CLI process waking its own local consumer)
+		// bypass the pubsub role filter, and a non-leader claiming a record it can never
+		// apply would strand it `in_progress` until its lease expires.
+		if (!this.instanceSettings.isLeader) return;
 
 		this.startPolling();
 		await this.drainPending();


### PR DESCRIPTION
## Summary

`WorkflowPublicationOutboxConsumer.wakeUp()` had no leadership guard. The `@OnPubSubEvent` role filter only covers pubsub delivery — `WorkflowPublicationNotifier.wakeLocalConsumer()` calls `wakeUp()` directly in single-main setups, so a short-lived CLI process (e.g. `n8n import:workflow`) could claim outbox records it can never apply; if it exited between claiming and `returnToPending`, the record was stranded `in_progress` until its lease expired (default 120s), delaying convergence. This adds `if (!this.instanceSettings.isLeader) return;` to `wakeUp()`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3894 (defensive fix found while investigating; does not close the ticket)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35261">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

