### PR TITLE
fix(core): Import security audit risk reporters with a file extension

### DIFF
--- a/packages/@n8n/eslint-config/src/rules/no-dynamic-import-template.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-dynamic-import-template.test.ts
@@ -1,0 +1,43 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { NoDynamicImportTemplateRule } from './no-dynamic-import-template.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-dynamic-import-template', NoDynamicImportTemplateRule, {
+	valid: [
+		{
+			code: 'await import(`./reporters/${name}.js`)',
+		},
+		{
+			code: 'await import(`../reporters/${name}.mjs`)',
+		},
+		{
+			code: 'await import(`./data/${name}.json`)',
+		},
+		{
+			code: "await import('./reporters/credentials.js')",
+		},
+		{
+			code: 'await import(`n8n-nodes-base/${name}`)',
+		},
+	],
+	invalid: [
+		{
+			code: 'await import(`@/security-audit/${name}.js`)',
+			errors: [{ messageId: 'noDynamicImportTemplate' }],
+		},
+		{
+			code: 'await import(`./reporters/${name}`)',
+			errors: [{ messageId: 'missingExtension' }],
+		},
+		{
+			code: 'await import(`../reporters/${name}`)',
+			errors: [{ messageId: 'missingExtension' }],
+		},
+		{
+			code: 'await import(`./reporters/${name}.ts`)',
+			errors: [{ messageId: 'missingExtension' }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-config/src/rules/no-dynamic-import-template.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-dynamic-import-template.ts
@@ -1,16 +1,20 @@
 import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
 
+const MODULE_EXTENSIONS = ['.js', '.mjs', '.cjs', '.json', '.node'];
+
 export const NoDynamicImportTemplateRule = ESLintUtils.RuleCreator.withoutDocs({
 	meta: {
 		type: 'problem',
 		docs: {
 			description:
-				'Disallow non-relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve aliased paths in this scenario.',
+				'Disallow non-relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve aliased paths in this scenario. Also require an explicit file extension, because `module: NodeNext` emits a native `import()` whose specifier Node resolves without extension inference.',
 		},
 		schema: [],
 		messages: {
 			noDynamicImportTemplate:
 				'Use relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve aliased paths in this scenario.',
+			missingExtension:
+				'End the template string argument to `await import()` with an explicit file extension (e.g. `.js`). Under `module: NodeNext` this compiles to a native `import()`, and Node throws ERR_MODULE_NOT_FOUND for an extensionless relative specifier.',
 		},
 	},
 	defaultOptions: [],
@@ -25,6 +29,23 @@ export const NoDynamicImportTemplateRule = ESLintUtils.RuleCreator.withoutDocs({
 					node,
 					messageId: 'noDynamicImportTemplate',
 				});
+			},
+
+			'AwaitExpression > ImportExpression > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
+				const head = node.quasis[0].value.cooked;
+
+				if (!head?.startsWith('./') && !head?.startsWith('../')) {
+					return;
+				}
+
+				const tail = node.quasis[node.quasis.length - 1].value.cooked ?? '';
+
+				if (!MODULE_EXTENSIONS.some((extension) => tail.endsWith(extension))) {
+					context.report({
+						node,
+						messageId: 'missingExtension',
+					});
+				}
 			},
 		};
 	},

--- a/packages/cli/src/security-audit/security-audit.service.ts
+++ b/packages/cli/src/security-audit/security-audit.service.ts
@@ -63,11 +63,10 @@ export class SecurityAuditService {
 			};
 
 			// `@vite-ignore` keeps vite's dynamic-import-vars plugin from analyzing this
-			// runtime-only import: without a static file extension it otherwise errors,
-			// which surfaces fatally during v8 coverage's uncovered-file walk.
+			// runtime-only import, which surfaces fatally during v8 coverage's uncovered-file walk.
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			const RiskReporterModule = await import(
-				/* @vite-ignore */ `./risk-reporters/${toFilename[className]}`
+				/* @vite-ignore */ `./risk-reporters/${toFilename[className]}.js`
 			);
 
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
## Summary

Generating a security audit has been failing with a bare HTTP 500 since `2.32.0`, on both Cloud and self-hosted, for every instance.

```
Cannot find module '/usr/local/lib/node_modules/n8n/dist/security-audit/risk-reporters/credentials-risk-reporter'
imported from  /usr/local/lib/node_modules/n8n/dist/security-audit/security-audit.service.js
```

The n8n node and the Public API surface this as `500 {"message":"Internal server error"}`.

**Why CI did not catch this:** the security-audit tests run under Vitest against `.ts` sources, where Vite's resolver accepts an extensionless specifier.

## Additional changes

Lint rule added: `no-dynamic-import-template`

## Affected versions

`2.32.0` through `2.33.x`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3891
- fixes #35234
- Same root cause as #35211 (already closed)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35263">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

