### PR TITLE
fix(core): Preserve saved node positions when the assistant edits a workflow

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -457,8 +457,10 @@ never from `$now.weekday == N`, which silently no-ops on other days.
   such as `as const`.
 - Use string values directly for discriminator fields like `resource` and
   `operation`, for example `resource: 'message'`.
-- When editing a pre-loaded workflow, remove `position` arrays from node
-  configs; they are auto-calculated.
+- When editing a pre-loaded workflow, remove every `position` array — from node
+  configs and from `sticky()` options alike. Positions are auto-calculated, and
+  the saved workflow's own layout is restored on save, so nothing you drop here
+  is lost. Leaving some in place is worse than dropping all of them.
 - Use `placeholder('hint')` directly as the parameter value. Do not wrap
   placeholders in `expr()`, objects, or arrays unless the node definition
   explicitly expects an object and the placeholder is the direct value of one

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/preserve-node-positions.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/preserve-node-positions.test.ts
@@ -1,0 +1,192 @@
+import type { NodeJSON, WorkflowJSON } from '@n8n/workflow-sdk';
+
+import type { InstanceAiContext } from '../../../types';
+import { preserveExistingNodePositions } from '../preserve-node-positions';
+
+const node = (name: string, position: [number, number], type = 'n8n-nodes-base.set'): NodeJSON => ({
+	id: name.toLowerCase().replaceAll(' ', '-'),
+	name,
+	type,
+	typeVersion: 1,
+	position,
+	parameters: {},
+});
+
+const sticky = (name: string, position: [number, number]): NodeJSON =>
+	node(name, position, 'n8n-nodes-base.stickyNote');
+
+const workflow = (nodes: NodeJSON[], connections: WorkflowJSON['connections'] = {}): WorkflowJSON =>
+	({ name: 'Workflow', nodes, connections }) as WorkflowJSON;
+
+/** `A → B` on the main output. */
+const wire = (from: string, to: string) => ({
+	[from]: { main: [[{ node: to, type: 'main', index: 0 }]] },
+});
+
+const contextReturning = (existing: WorkflowJSON) =>
+	({
+		workflowService: { getAsWorkflowJSON: vi.fn().mockResolvedValue(existing) },
+	}) as unknown as InstanceAiContext;
+
+const positionsByName = (json: WorkflowJSON): Record<string, [number, number]> =>
+	Object.fromEntries(json.nodes.map((n) => [n.name ?? '', n.position]));
+
+describe('preserveExistingNodePositions', () => {
+	describe('surviving nodes', () => {
+		it('restores every saved position when the build re-laid out the whole canvas', async () => {
+			// Two disconnected nodes parked to the right of the flow, which the layout
+			// engine treats as their own components and collapses onto its origin column.
+			const saved = workflow([
+				node('Schedule Trigger', [320, 480]),
+				node('Settings', [528, 480]),
+				node('Notify owner', [4480, 800]),
+				node('Notify team', [4480, 592]),
+				sticky('Sticky Note', [1584, 160]),
+			]);
+			const built = workflow(
+				[
+					node('Schedule Trigger', [0, 0]),
+					node('Settings', [208, 0]),
+					node('Notify owner', [0, 300]),
+					node('Notify team', [0, 450]),
+					sticky('Sticky Note', [0, 600]),
+				],
+				wire('Schedule Trigger', 'Settings'),
+			);
+
+			await preserveExistingNodePositions(built, 'wf-1', contextReturning(saved));
+
+			expect(positionsByName(built)).toEqual(positionsByName(saved));
+		});
+
+		it('leaves positions untouched when the build already matched the saved canvas', async () => {
+			const saved = workflow([node('A', [320, 480]), node('B', [528, 480])]);
+			const built = workflow([node('A', [320, 480]), node('B', [528, 480])]);
+
+			await preserveExistingNodePositions(built, 'wf-1', contextReturning(saved));
+
+			expect(positionsByName(built)).toEqual({ A: [320, 480], B: [528, 480] });
+		});
+
+		it('ignores a workflow whose nodes were all renamed, leaving the fresh layout', async () => {
+			const saved = workflow([node('Old name', [4000, 900])]);
+			const built = workflow([node('New name', [0, 0])]);
+
+			await preserveExistingNodePositions(built, 'wf-1', contextReturning(saved));
+
+			expect(positionsByName(built)).toEqual({ 'New name': [0, 0] });
+		});
+	});
+
+	describe('added nodes', () => {
+		it('translates a node added by a full re-layout into the saved frame', async () => {
+			const saved = workflow([node('Schedule Trigger', [320, 480]), node('Settings', [528, 480])]);
+			const built = workflow(
+				[
+					node('Schedule Trigger', [0, 0]),
+					node('Settings', [208, 0]),
+					node('Read Sheet', [416, 0]),
+				],
+				{ ...wire('Schedule Trigger', 'Settings'), ...wire('Settings', 'Read Sheet') },
+			);
+
+			await preserveExistingNodePositions(built, 'wf-1', contextReturning(saved));
+
+			// Both survivors shifted by [320, 480], so the added node shifts with them.
+			expect(positionsByName(built)).toEqual({
+				'Schedule Trigger': [320, 480],
+				Settings: [528, 480],
+				'Read Sheet': [736, 480],
+			});
+		});
+
+		it('anchors on a wired neighbour when the build kept the survivors in place', async () => {
+			// The layout engine skips nodes that already carry a position, so the added
+			// node is the only one it placed — in a frame unrelated to the saved canvas.
+			const saved = workflow([node('Schedule Trigger', [320, 480]), node('Settings', [528, 480])]);
+			const built = workflow(
+				[
+					node('Schedule Trigger', [320, 480]),
+					node('Settings', [528, 480]),
+					node('Read Sheet', [416, 0]),
+				],
+				{ ...wire('Schedule Trigger', 'Settings'), ...wire('Settings', 'Read Sheet') },
+			);
+
+			await preserveExistingNodePositions(built, 'wf-1', contextReturning(saved));
+
+			// One full step to the right of its parent, not back at the layout origin.
+			expect(positionsByName(built)['Read Sheet']).toEqual([752, 480]);
+		});
+
+		it('parks an added node below the saved graph when nothing wires it to a survivor', async () => {
+			const saved = workflow([node('Schedule Trigger', [320, 480]), node('Settings', [528, 480])]);
+			const built = workflow([
+				node('Schedule Trigger', [320, 480]),
+				node('Settings', [528, 480]),
+				node('Orphan', [0, 0]),
+			]);
+
+			await preserveExistingNodePositions(built, 'wf-1', contextReturning(saved));
+
+			expect(positionsByName(built).Orphan).toEqual([320, 672]);
+		});
+
+		it('pushes an added node clear of a survivor it would have landed on', async () => {
+			// D was dragged well to the right, so the median translation drops the new
+			// node right on top of it.
+			const saved = workflow([node('A', [100, 100]), node('B', [300, 100]), node('D', [780, 100])]);
+			const built = workflow(
+				[node('A', [0, 0]), node('B', [224, 0]), node('D', [448, 0]), node('C', [672, 0])],
+				{ ...wire('B', 'C'), ...wire('C', 'D') },
+			);
+
+			await preserveExistingNodePositions(built, 'wf-1', contextReturning(saved));
+
+			expect(positionsByName(built).D).toEqual([780, 100]);
+			// Translated to x=772, snapped to the 16px grid, then pushed below D.
+			expect(positionsByName(built).C).toEqual([768, 288]);
+		});
+
+		it('does not push an added node off a sticky note', async () => {
+			const saved = workflow([node('A', [96, 96]), sticky('Sticky Note', [400, 96])]);
+			const built = workflow([
+				node('A', [0, 0]),
+				sticky('Sticky Note', [304, 0]),
+				node('C', [304, 0]),
+			]);
+
+			await preserveExistingNodePositions(built, 'wf-1', contextReturning(saved));
+
+			// C lands on the sticky and stays there — stickies sit behind nodes.
+			expect(positionsByName(built).C).toEqual([400, 96]);
+		});
+	});
+
+	describe('guards', () => {
+		it('skips new workflows without reading anything', async () => {
+			const getAsWorkflowJSON = vi.fn();
+			const context = { workflowService: { getAsWorkflowJSON } } as unknown as InstanceAiContext;
+			const built = workflow([node('A', [0, 0])]);
+
+			await preserveExistingNodePositions(built, undefined, context);
+
+			expect(getAsWorkflowJSON).not.toHaveBeenCalled();
+			expect(positionsByName(built)).toEqual({ A: [0, 0] });
+		});
+
+		it('fails the update when the saved workflow cannot be loaded', async () => {
+			const context = {
+				workflowService: {
+					getAsWorkflowJSON: vi.fn().mockRejectedValue(new Error('Workflow not found')),
+				},
+			} as unknown as InstanceAiContext;
+
+			await expect(
+				preserveExistingNodePositions(workflow([node('A', [0, 0])]), 'wf-1', context),
+			).rejects.toThrow(
+				'Failed to load existing workflow wf-1 to preserve node positions: Workflow not found',
+			);
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 
 import { planVerificationSimulation } from './plan-verification-simulation';
+import { preserveExistingNodePositions } from './preserve-node-positions';
 import {
 	buildCredentialMap,
 	buildCredentialResolutionNote,
@@ -739,6 +740,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				await preserveExistingSetupValues(json, targetWorkflowId, context);
 				await ensureWebhookIds(json, targetWorkflowId, context);
 				await preserveExistingNodeGroupIds(json, targetWorkflowId, context);
+				await preserveExistingNodePositions(json, targetWorkflowId, context);
 
 				const hasMockedCredentialNodes = mockResult.mockedNodeNames.length > 0;
 				const hasResolvedCredentials = Object.keys(mockResult.resolvedCredentialsByNode).length > 0;

--- a/packages/@n8n/instance-ai/src/tools/workflows/preserve-node-positions.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/preserve-node-positions.ts
@@ -1,0 +1,233 @@
+import { isRecord } from '@n8n/utils/is-record';
+import type { NodeJSON, WorkflowJSON } from '@n8n/workflow-sdk';
+import {
+	DEFAULT_NODE_SIZE,
+	GRID_SIZE,
+	NODE_X_SPACING,
+	NODE_Y_SPACING,
+	isStickyNoteType,
+} from '@n8n/workflow-sdk';
+
+import type { InstanceAiContext } from '../../types';
+
+type Position = [number, number];
+
+interface Box {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+const [NODE_WIDTH, NODE_HEIGHT] = DEFAULT_NODE_SIZE;
+
+/** Horizontal step between a node and the one wired after it. */
+const NODE_STEP_X = NODE_WIDTH + NODE_X_SPACING;
+
+/** Bound on the de-overlap walk so a pathological graph can't spin. */
+const MAX_SEPARATION_STEPS = 50;
+
+function snapToGrid(value: number): number {
+	return Math.round(value / GRID_SIZE) * GRID_SIZE;
+}
+
+function median(values: number[]): number {
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function boxOf(node: NodeJSON): Box {
+	return { x: node.position[0], y: node.position[1], width: NODE_WIDTH, height: NODE_HEIGHT };
+}
+
+/** Overlap test with a one-grid-cell gutter, so nodes never end up flush. */
+function intersects(a: Box, b: Box): boolean {
+	return !(
+		a.x + a.width + GRID_SIZE <= b.x ||
+		b.x + b.width + GRID_SIZE <= a.x ||
+		a.y + a.height + GRID_SIZE <= b.y ||
+		b.y + b.height + GRID_SIZE <= a.y
+	);
+}
+
+/** Direct predecessors and successors by node name, across all connection types. */
+function buildAdjacency(json: WorkflowJSON): {
+	parentsOf: Map<string, string[]>;
+	childrenOf: Map<string, string[]>;
+} {
+	const parentsOf = new Map<string, string[]>();
+	const childrenOf = new Map<string, string[]>();
+
+	for (const [source, connectionsByType] of Object.entries(json.connections ?? {})) {
+		if (!isRecord(connectionsByType)) continue;
+		for (const groups of Object.values(connectionsByType)) {
+			if (!Array.isArray(groups)) continue;
+			for (const group of groups) {
+				if (!Array.isArray(group)) continue;
+				for (const connection of group) {
+					if (!isRecord(connection) || typeof connection.node !== 'string') continue;
+					const target = connection.node;
+					childrenOf.set(source, [...(childrenOf.get(source) ?? []), target]);
+					parentsOf.set(target, [...(parentsOf.get(target) ?? []), source]);
+				}
+			}
+		}
+	}
+
+	return { parentsOf, childrenOf };
+}
+
+interface Survivor {
+	node: NodeJSON;
+	saved: Position;
+}
+
+/**
+ * Offset that carries the build's layout frame onto the saved canvas.
+ *
+ * The build runs in a sandbox with no view of the saved workflow, so whatever
+ * `toJSON({ tidyUp: true })` produced sits in the layout engine's own coordinate
+ * space (origin near 0) rather than wherever the user's nodes actually live.
+ * Added nodes keep their relative arrangement; only the frame moves.
+ */
+function resolveTranslation(
+	survivors: Survivor[],
+	added: NodeJSON[],
+	json: WorkflowJSON,
+): Position {
+	// The build re-laid out the whole graph, so survivors give us the mapping directly.
+	const relaidOut = survivors.some(
+		({ node, saved }) => node.position[0] !== saved[0] || node.position[1] !== saved[1],
+	);
+	if (relaidOut) {
+		return [
+			median(survivors.map(({ node, saved }) => saved[0] - node.position[0])),
+			median(survivors.map(({ node, saved }) => saved[1] - node.position[1])),
+		];
+	}
+
+	// The build kept the survivors' positions, so the layout engine skipped them and
+	// only the added nodes were placed — in a frame unrelated to the saved canvas.
+	// Anchor on a wired neighbour that did survive.
+	const savedByName = new Map(survivors.map(({ node, saved }) => [node.name ?? '', saved]));
+	const { parentsOf, childrenOf } = buildAdjacency(json);
+
+	for (const node of added) {
+		if (!node.name) continue;
+
+		for (const parent of parentsOf.get(node.name) ?? []) {
+			const anchor = savedByName.get(parent);
+			if (anchor) {
+				return [anchor[0] + NODE_STEP_X - node.position[0], anchor[1] - node.position[1]];
+			}
+		}
+
+		for (const child of childrenOf.get(node.name) ?? []) {
+			const anchor = savedByName.get(child);
+			if (anchor) {
+				return [anchor[0] - NODE_STEP_X - node.position[0], anchor[1] - node.position[1]];
+			}
+		}
+	}
+
+	// Nothing wired to an existing node — park the added set below the saved graph.
+	const savedMinX = Math.min(...survivors.map(({ saved }) => saved[0]));
+	const savedMaxY = Math.max(...survivors.map(({ saved }) => saved[1]));
+	const addedMinX = Math.min(...added.map((node) => node.position[0]));
+	const addedMinY = Math.min(...added.map((node) => node.position[1]));
+
+	return [savedMinX - addedMinX, savedMaxY + NODE_HEIGHT + NODE_Y_SPACING - addedMinY];
+}
+
+/**
+ * Push added nodes down until they clear everything already on the canvas.
+ * Sticky notes are ignored on both sides — they are meant to sit behind nodes.
+ */
+function separateAddedNodes(added: NodeJSON[], allNodes: NodeJSON[]): void {
+	const addedSet = new Set(added);
+	const occupied = allNodes
+		.filter((node) => !addedSet.has(node) && !isStickyNoteType(node.type))
+		.map(boxOf);
+
+	for (const node of added) {
+		if (isStickyNoteType(node.type)) continue;
+
+		for (let step = 0; step < MAX_SEPARATION_STEPS; step++) {
+			const collision = occupied.find((box) => intersects(box, boxOf(node)));
+			if (!collision) break;
+			node.position = [
+				node.position[0],
+				snapToGrid(collision.y + collision.height + NODE_Y_SPACING),
+			];
+		}
+
+		occupied.push(boxOf(node));
+	}
+}
+
+/**
+ * For updates, restore each surviving node's position from the saved workflow.
+ *
+ * The sandbox build has no view of the saved workflow, so `toJSON({ tidyUp: true })`
+ * lays the whole graph out from scratch and every node lands wherever the layout
+ * engine put it — scattering a canvas the user had arranged by hand. Reconciling by
+ * name here keeps the user's layout authoritative, mirroring ensureWebhookIds.
+ *
+ * Nodes the build added are translated into the saved canvas's frame, keeping the
+ * layout engine's relative arrangement, then nudged clear of anything they land on.
+ */
+export async function preserveExistingNodePositions(
+	json: WorkflowJSON,
+	workflowId: string | undefined,
+	ctx: InstanceAiContext,
+): Promise<void> {
+	if (!workflowId) return;
+
+	let existing: WorkflowJSON;
+	try {
+		existing = await ctx.workflowService.getAsWorkflowJSON(workflowId);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Failed to load existing workflow ${workflowId} to preserve node positions: ${message}`,
+			{ cause: error },
+		);
+	}
+
+	const savedPositionsByName = new Map<string, Position>();
+	for (const node of existing.nodes ?? []) {
+		if (node.name && Array.isArray(node.position)) {
+			savedPositionsByName.set(node.name, [node.position[0], node.position[1]]);
+		}
+	}
+	if (savedPositionsByName.size === 0) return;
+
+	const nodes = json.nodes ?? [];
+	const survivors: Survivor[] = [];
+	const added: NodeJSON[] = [];
+	for (const node of nodes) {
+		const saved = node.name ? savedPositionsByName.get(node.name) : undefined;
+		if (saved) survivors.push({ node, saved });
+		else added.push(node);
+	}
+
+	// Every node is new (or renamed) — there is no prior layout left to honour.
+	if (survivors.length === 0) return;
+
+	if (added.length > 0) {
+		const [deltaX, deltaY] = resolveTranslation(survivors, added, json);
+		for (const node of added) {
+			node.position = [
+				snapToGrid(node.position[0] + deltaX),
+				snapToGrid(node.position[1] + deltaY),
+			];
+		}
+	}
+
+	for (const { node, saved } of survivors) {
+		node.position = saved;
+	}
+
+	if (added.length > 0) separateAddedNodes(added, nodes);
+}

--- a/packages/@n8n/workflow-sdk/src/index.ts
+++ b/packages/@n8n/workflow-sdk/src/index.ts
@@ -221,3 +221,12 @@ export {
 	isWebhookType,
 	isDataTableType,
 } from './constants';
+
+// Canvas geometry — the same values the layout engine and the editor's canvas use.
+// Exported so consumers that place nodes themselves stay on the same grid.
+export {
+	GRID_SIZE,
+	DEFAULT_NODE_SIZE,
+	NODE_X_SPACING,
+	NODE_Y_SPACING,
+} from './workflow-builder/constants';


### PR DESCRIPTION
## Summary

This PR fixes the assistant rearranging a whole canvas when asked to change a
single node. Disconnected nodes were hit hardest, pulled out of wherever the
user had placed them and stacked at the bottom-left. Sticky notes had the
opposite problem, staying put while everything under them moved.

The sandbox that builds the workflow has no view of the saved canvas, so
`toJSON({ tidyUp: true })` lays the whole graph out from scratch on every edit.

The fix adds a position reconciler that runs after the build, alongside the
webhook-ID and node-group-ID passes that already work this way. Surviving nodes
get their saved position back untouched. Added nodes are translated into the
saved canvas's frame, keeping dagre's relative arrangement, then nudged clear
of anything they land on.

Two smaller changes ride along: the skill's strip-positions rule now covers
`sticky()`, and the canvas geometry constants are exported from
`@n8n/workflow-sdk` so the reconciler shares the layout engine's grid.

## How to test

1. Workflow with a chain of 4–5 nodes, one node dragged far right and left
   unconnected, plus a sticky over part of the chain. Save.
2. Ask for a small edit to one node in the chain. On `master` the orphan snaps
   bottom-left and the sticky drifts, with this, nothing moves.
3. Ask it to **add** a node mid-chain, should land one step right of its
   parent, overlapping nothing.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-999
- https://linear.app/n8n/issue/INS-964
- https://linear.app/n8n/issue/INS-597
- https://linear.app/n8n/issue/INS-374

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35268">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

