### PR TITLE
feat(ai-builder): Let eval runs exercise the builder's web search (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Start n8n containers
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
-          EVALS_BRAVE_SEARCH_KEY: ${{ secrets.EVALS_BRAVE_SEARCH_KEY }}
+          INSTANCE_AI_BRAVE_SEARCH_API_KEY: ${{ secrets.INSTANCE_AI_BRAVE_SEARCH_API_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
@@ -225,7 +225,7 @@ jobs:
               -e N8N_ENABLED_MODULES=instance-ai \
               -e N8N_AI_ENABLED=true \
               -e N8N_INSTANCE_AI_MODEL_API_KEY="$EVALS_ANTHROPIC_KEY" \
-              -e INSTANCE_AI_BRAVE_SEARCH_API_KEY="$EVALS_BRAVE_SEARCH_KEY" \
+              -e INSTANCE_AI_BRAVE_SEARCH_API_KEY="$INSTANCE_AI_BRAVE_SEARCH_API_KEY" \
               -e N8N_AI_ASSISTANT_BASE_URL="" \
               -e N8N_INSTANCE_AI_SANDBOX_ENABLED=true \
               "${SANDBOX_ARGS[@]}" \

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -164,6 +164,8 @@ jobs:
       - name: Start n8n containers
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
+          # Unset = the builder's web-search action silently returns zero results.
+          EVALS_BRAVE_SEARCH_KEY: ${{ secrets.EVALS_BRAVE_SEARCH_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
@@ -224,6 +226,7 @@ jobs:
               -e N8N_ENABLED_MODULES=instance-ai \
               -e N8N_AI_ENABLED=true \
               -e N8N_INSTANCE_AI_MODEL_API_KEY="$EVALS_ANTHROPIC_KEY" \
+              -e INSTANCE_AI_BRAVE_SEARCH_API_KEY="$EVALS_BRAVE_SEARCH_KEY" \
               -e N8N_AI_ASSISTANT_BASE_URL="" \
               -e N8N_INSTANCE_AI_SANDBOX_ENABLED=true \
               "${SANDBOX_ARGS[@]}" \

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -164,7 +164,6 @@ jobs:
       - name: Start n8n containers
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
-          # Unset = the builder's web-search action silently returns zero results.
           EVALS_BRAVE_SEARCH_KEY: ${{ secrets.EVALS_BRAVE_SEARCH_KEY }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}

--- a/packages/@n8n/ai-utilities/src/web-search/__tests__/brave-search.test.ts
+++ b/packages/@n8n/ai-utilities/src/web-search/__tests__/brave-search.test.ts
@@ -137,6 +137,26 @@ describe('braveSearch', () => {
 		expect(result.results).toHaveLength(2);
 	});
 
+	it('stops waiting out the retry backoff when the search is aborted', async () => {
+		vi.useFakeTimers();
+		try {
+			const controller = new AbortController();
+			mockFetch.mockImplementation(async (_url: string, init: RequestInit) => {
+				if (init.signal?.aborted) throw new Error('aborted');
+				controller.abort();
+				return { ok: false, status: 429, statusText: 'Too Many Requests' };
+			});
+
+			const search = braveSearch('BSA-key', 'test', { abortSignal: controller.signal });
+
+			// No timer is advanced — only an abort-aware backoff lets this settle.
+			await expect(search).rejects.toThrow('aborted');
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it('gives up after the retry budget and throws the last status', async () => {
 		mockFetch.mockResolvedValue({
 			ok: false,

--- a/packages/@n8n/ai-utilities/src/web-search/__tests__/brave-search.test.ts
+++ b/packages/@n8n/ai-utilities/src/web-search/__tests__/brave-search.test.ts
@@ -113,16 +113,41 @@ describe('braveSearch', () => {
 		expect(q).toBe('webhooks -site:reddit.com');
 	});
 
-	it('throws on non-OK response', async () => {
+	it('throws on non-OK response without retrying', async () => {
 		mockFetch.mockResolvedValue({
 			ok: false,
-			status: 429,
-			statusText: 'Too Many Requests',
+			status: 401,
+			statusText: 'Unauthorized',
 		});
 
 		await expect(braveSearch('BSA-key', 'test', {})).rejects.toThrow(
-			'Brave search failed: 429 Too Many Requests',
+			'Brave search failed: 401 Unauthorized',
 		);
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('retries a rate-limited request and returns the eventual success', async () => {
+		mockFetch
+			.mockResolvedValueOnce({ ok: false, status: 429, statusText: 'Too Many Requests' })
+			.mockResolvedValueOnce({ ok: true, json: async () => MOCK_BRAVE_RESPONSE });
+
+		const result = await braveSearch('BSA-key', 'test', {});
+
+		expect(mockFetch).toHaveBeenCalledTimes(2);
+		expect(result.results).toHaveLength(2);
+	});
+
+	it('gives up after the retry budget and throws the last status', async () => {
+		mockFetch.mockResolvedValue({
+			ok: false,
+			status: 503,
+			statusText: 'Service Unavailable',
+		});
+
+		await expect(braveSearch('BSA-key', 'test', {})).rejects.toThrow(
+			'Brave search failed: 503 Service Unavailable',
+		);
+		expect(mockFetch).toHaveBeenCalledTimes(3);
 	});
 
 	it('handles empty results gracefully', async () => {

--- a/packages/@n8n/ai-utilities/src/web-search/brave-search.ts
+++ b/packages/@n8n/ai-utilities/src/web-search/brave-search.ts
@@ -3,6 +3,10 @@ import type { WebSearchOptions, WebSearchResponse } from './types';
 const BRAVE_SEARCH_PATH = '/res/v1/web/search';
 const BRAVE_SEARCH_URL = `https://api.search.brave.com${BRAVE_SEARCH_PATH}`;
 
+/** Brave rate-limits per second, so concurrent searches trip 429 rather than failing outright. */
+const MAX_ATTEMPTS = 3;
+const RETRY_BASE_MS = 250;
+
 interface BraveWebResult {
 	title: string;
 	url: string;
@@ -60,10 +64,23 @@ export async function braveSearch(
 		...(proxyHeaders ?? { 'X-Subscription-Token': apiKey }),
 	};
 
-	const response = await fetch(`${baseUrl}?${params}`, {
-		headers,
-		...(options.abortSignal ? { signal: options.abortSignal } : {}),
-	});
+	const runSearch = async () =>
+		await fetch(`${baseUrl}?${params}`, {
+			headers,
+			...(options.abortSignal ? { signal: options.abortSignal } : {}),
+		});
+	const isRetryable = (status: number) => status === 429 || status >= 500;
+
+	let response = await runSearch();
+	for (
+		let attempt = 1;
+		attempt < MAX_ATTEMPTS && !response.ok && isRetryable(response.status);
+		attempt++
+	) {
+		const backoffMs = RETRY_BASE_MS * 2 ** (attempt - 1);
+		await new Promise((resolve) => setTimeout(resolve, backoffMs));
+		response = await runSearch();
+	}
 
 	if (!response.ok) {
 		throw new Error(`Brave search failed: ${response.status} ${response.statusText}`);

--- a/packages/@n8n/ai-utilities/src/web-search/brave-search.ts
+++ b/packages/@n8n/ai-utilities/src/web-search/brave-search.ts
@@ -3,7 +3,7 @@ import type { WebSearchOptions, WebSearchResponse } from './types';
 const BRAVE_SEARCH_PATH = '/res/v1/web/search';
 const BRAVE_SEARCH_URL = `https://api.search.brave.com${BRAVE_SEARCH_PATH}`;
 
-/** Brave rate-limits per second, so concurrent searches trip 429 rather than failing outright. */
+/** Brave rate-limits per second — retry so a burst of searches doesn't fail the caller. */
 const MAX_ATTEMPTS = 3;
 const RETRY_BASE_MS = 250;
 

--- a/packages/@n8n/ai-utilities/src/web-search/brave-search.ts
+++ b/packages/@n8n/ai-utilities/src/web-search/brave-search.ts
@@ -70,6 +70,25 @@ export async function braveSearch(
 			...(options.abortSignal ? { signal: options.abortSignal } : {}),
 		});
 	const isRetryable = (status: number) => status === 429 || status >= 500;
+	/** Abort-aware so a cancelled run doesn't sit out the delay; the retried fetch
+	 *  then rejects on the aborted signal. */
+	const backoff = async (ms: number) =>
+		await new Promise<void>((resolve) => {
+			const signal = options.abortSignal;
+			if (signal?.aborted) {
+				resolve();
+				return;
+			}
+			const timer = setTimeout(() => {
+				signal?.removeEventListener('abort', onAbort);
+				resolve();
+			}, ms);
+			function onAbort() {
+				clearTimeout(timer);
+				resolve();
+			}
+			signal?.addEventListener('abort', onAbort, { once: true });
+		});
 
 	let response = await runSearch();
 	for (
@@ -77,8 +96,7 @@ export async function braveSearch(
 		attempt < MAX_ATTEMPTS && !response.ok && isRetryable(response.status);
 		attempt++
 	) {
-		const backoffMs = RETRY_BASE_MS * 2 ** (attempt - 1);
-		await new Promise((resolve) => setTimeout(resolve, backoffMs));
+		await backoff(RETRY_BASE_MS * 2 ** (attempt - 1));
 		response = await runSearch();
 	}
 

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -715,8 +715,9 @@ Write the turns as a screenplay of what the user wants, keeping concrete values 
 | Withhold a value until asked | `[Don't bring up the channel unless the agent asks where to post; then say 'Slack #growth.']` |
 | Refuse and hold firm on re-ask | `[The user has no channel and won't provide one. If asked — question or setup card, even repeatedly — skip it; never invent one.]` |
 | Keep the conversation going | `[After each change lands, send the next one from the list, one at a time, until done.]` |
+| Refuse network access | `[Deny the web-search request — the user doesn't want it searching the web.]` |
 
-A direction governs only what it covers; otherwise the proxy answers every question (inventing plausible placeholders) and never sets credentials. Setup cards (the "configure your workflow" card) are filled via the wizard — or dismissed when a direction withholds the value — not answered as questions.
+A direction governs only what it covers; otherwise the proxy answers every question (inventing plausible placeholders) and never sets credentials. Network-access prompts (`web-search`, `fetch-url`) are the one gate that's granted **without** consulting the proxy LLM, so they cost nothing by default — but while any stage direction is still pending the decision goes to the LLM, which is what makes the refusal above reachable. Setup cards (the "configure your workflow" card) are filled via the wizard — or dismissed when a direction withholds the value — not answered as questions.
 
 **Prompt / conversation tips**
 

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -306,6 +306,7 @@ Not yet covered: an automatic "unexpected artifact" fail (a build producing an a
 | `LANGSMITH_BRANCH` | No | Branch name to tag the experiment with (auto-set in CI) |
 | `CONTEXT7_API_KEY` | No | Context7 key for API-doc lookups. Improves mock realism for less-common services; the LLM falls back to training data when unset |
 | `N8N_AI_ASSISTANT_BASE_URL` | No | Set to `""` to bypass the hosted AI proxy and hit Anthropic directly — useful to avoid per-tenant quota during large batch runs |
+| `INSTANCE_AI_BRAVE_SEARCH_API_KEY` | No | Set on the **target n8n instance** (note: no `N8N_` prefix) to enable the builder's `web-search` action. Unset = the action returns zero results, which reads to the agent as "nothing found". A licensed instance with `N8N_AI_ASSISTANT_BASE_URL` set routes search through the AI proxy instead and ignores this key |
 | `N8N_INSTANCE_AI_RUN_DEBUG_ENABLED` | No | Set to `true` on the target n8n instance to capture orchestrator LLM steps and workflow code for the eval LLM debug report (`workflow-eval-llm-debug.html`). Off by default. |
 
 **LangSmith caveat:** if `LANGSMITH_API_KEY` is set in `.env.local`, local runs also land in the shared `instance-ai-workflow-evals` dataset. Unset it (or run without `dotenvx`) to keep exploratory runs out of team results.

--- a/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
@@ -560,6 +560,42 @@ describe('UserProxyLlm.respondToConfirmation', () => {
 		expect(agent.callCount).toBe(0);
 	});
 
+	it('defers an access gate to the LLM while a stage direction is pending, so a case can deny', async () => {
+		const agent = new FakeAgent();
+		agent.enqueue({ action: 'respond_to_domain_access', response: 'deny' });
+		const proxy = new UserProxyLlm({
+			conversation: [
+				{ role: 'user', text: 'go' },
+				{
+					role: 'user',
+					text: '[Refuse the web-search request — the user does not want it searching.]',
+				},
+			],
+			agent,
+		});
+
+		const response = await proxy.respondToConfirmation(webSearchEvent('req-deny'));
+
+		expect(agent.callCount).toBe(1);
+		expect(response.kind).toBe('domainAccessDeny');
+	});
+
+	it('still grants an access gate deterministically when the pending script has no stage direction', async () => {
+		const agent = new FakeAgent();
+		const proxy = new UserProxyLlm({
+			conversation: [
+				{ role: 'user', text: 'go' },
+				{ role: 'user', text: 'also add a retry' },
+			],
+			agent,
+		});
+
+		const response = await proxy.respondToConfirmation(webSearchEvent('req-allow'));
+
+		expect(response.kind).toBe('domainAccessApprove');
+		expect(agent.callCount).toBe(0);
+	});
+
 	it('handles resource-decision events deterministically with first allow option', async () => {
 		const agent = new FakeAgent();
 		const proxy = new UserProxyLlm({

--- a/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
@@ -160,6 +160,25 @@ function domainAccessEvent(requestId: string): CapturedEvent {
 	};
 }
 
+function webSearchEvent(requestId: string): CapturedEvent {
+	return {
+		timestamp: 100,
+		type: 'confirmation-request',
+		data: {
+			type: 'confirmation-request',
+			payload: {
+				requestId,
+				toolCallId: 'tc-y',
+				toolName: 'research',
+				args: {},
+				severity: 'info',
+				message: 'n8n AI wants to search the web for: stripe webhook signing',
+				webSearch: { query: 'stripe webhook signing' },
+			},
+		},
+	};
+}
+
 function resourceDecisionEvent(requestId: string, options: string[]): CapturedEvent {
 	return {
 		timestamp: 100,
@@ -519,6 +538,21 @@ describe('UserProxyLlm.respondToConfirmation', () => {
 		});
 
 		const response = await proxy.respondToConfirmation(domainAccessEvent('req-dom'));
+		expect(response.kind).toBe('domainAccessApprove');
+		if (response.kind === 'domainAccessApprove') {
+			expect(response.domainAccessAction).toBe('allow_all');
+		}
+		expect(agent.callCount).toBe(0);
+	});
+
+	it('handles web-search events deterministically with allow_all', async () => {
+		const agent = new FakeAgent();
+		const proxy = new UserProxyLlm({
+			conversation: [{ role: 'user', text: 'go' }],
+			agent,
+		});
+
+		const response = await proxy.respondToConfirmation(webSearchEvent('req-search'));
 		expect(response.kind).toBe('domainAccessApprove');
 		if (response.kind === 'domainAccessApprove') {
 			expect(response.domainAccessAction).toBe('allow_all');

--- a/packages/@n8n/instance-ai/evaluations/harness/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/schema.ts
@@ -15,7 +15,15 @@ export const DEFAULT_DATASETS = ['full'];
  *  (e.g. the mcp-manifest builder) normalize identically. */
 export const conversationTurnTextSchema = z
 	.union([z.string(), z.array(z.string())])
-	.transform((t) => (Array.isArray(t) ? t.join('\n') : t));
+	.transform((t) => (Array.isArray(t) ? t.join('\n') : t))
+	// An unclosed `[` fails silently and expensively: the proxy stops seeing a
+	// stage direction, so it sends the text as dialogue and the case grades a
+	// conversation it was never meant to have. Easy to do in the array form,
+	// where the closing bracket lands on a different line from the opening one.
+	.refine((t) => !t.includes('[') || t.includes(']'), {
+		message:
+			'unbalanced stage direction — text opens `[` but never closes it, so the proxy would send it as dialogue instead of treating it as a direction',
+	});
 
 export const ConversationTurnSchema = z.object({
 	role: z.enum(['user', 'assistant']),

--- a/packages/@n8n/instance-ai/evaluations/utils/confirmation-payload.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/confirmation-payload.ts
@@ -10,9 +10,9 @@ import type { CapturedEvent } from '../types';
 
 /**
  * Handle confirmation events that carry no user-intent signal — domain access,
- * resource decisions, standalone credential requests. The eval grants all
- * access, has no credentials, and picks the most-permissive option for
- * resource gates. Returns `undefined` for events that need caller-specific
+ * web search, resource decisions, standalone credential requests. The eval
+ * grants all access, has no credentials, and picks the most-permissive option
+ * for resource gates. Returns `undefined` for events that need caller-specific
  * handling: setup wizards, ask-user questions, plan reviews.
  */
 export function tryInfrastructureResponse(
@@ -20,7 +20,8 @@ export function tryInfrastructureResponse(
 ): InstanceAiConfirmRequest | undefined {
 	const payload = getNestedRecord(event.data, 'payload') ?? {};
 
-	if (getNestedRecord(payload, 'domainAccess')) {
+	// Web search shares domain access's approval shape; `allow_all` grants it for the thread.
+	if (getNestedRecord(payload, 'domainAccess') || getNestedRecord(payload, 'webSearch')) {
 		return { kind: 'domainAccessApprove', domainAccessAction: 'allow_all' };
 	}
 

--- a/packages/@n8n/instance-ai/evaluations/utils/confirmation-payload.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/confirmation-payload.ts
@@ -20,7 +20,7 @@ export function tryInfrastructureResponse(
 ): InstanceAiConfirmRequest | undefined {
 	const payload = getNestedRecord(event.data, 'payload') ?? {};
 
-	// Web search shares domain access's approval shape; `allow_all` grants it for the thread.
+	// Web search reuses domain access's approval shape.
 	if (getNestedRecord(payload, 'domainAccess') || getNestedRecord(payload, 'webSearch')) {
 		return { kind: 'domainAccessApprove', domainAccessAction: 'allow_all' };
 	}

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
@@ -131,7 +131,7 @@ export class UserProxyLlm {
 		}
 
 		const det = tryDeterministicConfirmationResponse(event);
-		if (det) {
+		if (det && !this.deferAccessGateToScript(event)) {
 			this.bumpStat('deterministic');
 			return this.rememberResponse(requestId, det);
 		}
@@ -259,6 +259,15 @@ export class UserProxyLlm {
 
 	private fallbackConfirmationResponse(event: CapturedEvent): InstanceAiConfirmRequest {
 		return this.tryScriptedConfirmationResponse(event) ?? buildAutoApprovePayload(event);
+	}
+
+	/** Network-access gates (fetch-url domain, web search) are granted deterministically so the
+	 *  common case spends no LLM call. A pending stage direction may instruct a refusal though,
+	 *  so hand those to the LLM the way plan review already is. */
+	private deferAccessGateToScript(event: CapturedEvent): boolean {
+		const payload = getEventPayload(event);
+		if (!payload.domainAccess && !payload.webSearch) return false;
+		return this.remainingUserScriptTurns().some((turn) => hasStageDirection(turn.text));
 	}
 
 	private tryScriptedConfirmationResponse(

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
@@ -111,7 +111,7 @@ export const CONFIRMATION_TOOL_DESCRIPTIONS = `Available actions — confirmatio
 
 - approve_or_reject(approved, userInput?): A plan-review or free-text confirmation widget is on screen (the event's inputType is plan-review or text). Approve if the plan matches user intent; reject with reason if it diverges. This action only exists as a response to such a widget.
 
-- respond_to_domain_access(response): The agent is asking for domain access permissions. Pick allow_once, allow_all, or deny. Default to allow_all unless the user would deny.
+- respond_to_domain_access(response): The agent is asking permission to reach the network — either a specific domain (fetch-url) or a web search. Pick allow_once, allow_all, or deny. Default to allow_all; pick deny ONLY when a [stage direction] tells the user to refuse this kind of access.
 
 - pick_resource_decision(decision): The agent is asking the user to pick a gateway resource access option. Pick the option the user would choose.`;
 

--- a/packages/@n8n/instance-ai/src/tools/__tests__/research.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/research.tool.test.ts
@@ -350,6 +350,39 @@ describe('research tool', () => {
 			expect(tracker.approveWebSearchOnce).not.toHaveBeenCalled();
 		});
 
+		// The payload both the UI's approval widget and the eval user-proxy send.
+		it('should grant persistent approval and run the search on resume with allow_all', async () => {
+			const tracker = {
+				isHostAllowed: vi.fn(),
+				approveDomain: vi.fn(),
+				approveAllDomains: vi.fn(),
+				approveOnce: vi.fn(),
+				isWebSearchAllowed: vi.fn().mockReturnValue(false),
+				approveWebSearch: vi.fn(),
+				approveWebSearchOnce: vi.fn(),
+			};
+			const context = createMockContext({ domainAccessTracker: tracker as never });
+			context.webResearchService!.search = vi.fn().mockResolvedValue({
+				query: 'q',
+				results: [{ title: 'T', url: 'https://example.com/a', snippet: 'S' }],
+			});
+			const suspend = vi.fn();
+
+			const tool = createResearchTool(context);
+			const result = (await tool.handler!(
+				{ action: 'web-search' as const, query: 'q' },
+				createAgentCtx({
+					resumeData: { approved: true, domainAccessAction: 'allow_all' },
+					suspend,
+				}) as never,
+			)) as { results: unknown[] };
+
+			expect(tracker.approveWebSearch).toHaveBeenCalled();
+			expect(suspend).not.toHaveBeenCalled();
+			expect(context.webResearchService!.search).toHaveBeenCalledWith('q', expect.anything());
+			expect(result.results).toHaveLength(1);
+		});
+
 		it('should return empty results when resumed with denial', async () => {
 			const tracker = {
 				isHostAllowed: vi.fn(),

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1332,6 +1332,89 @@ function createNodeAdapterForTests(
 	return createNodeAdapterServiceForTests(nodes, { nodeCatalogService }).nodeService;
 }
 
+// ---------------------------------------------------------------------------
+// Web-search provider selection
+// ---------------------------------------------------------------------------
+
+import { braveSearch, searxngSearch } from '@n8n/ai-utilities';
+
+describe('web-search provider selection', () => {
+	type SearchFn = (query: string, options?: Record<string, unknown>) => Promise<unknown>;
+	type ProxyConfig = { apiUrl: string; getAuthHeaders: () => Promise<Record<string, string>> };
+
+	/** `buildSearchMethod` is private, but the precedence it encodes is exactly what
+	 *  the `INSTANCE_AI_BRAVE_SEARCH_API_KEY` wiring relies on — assert it directly. */
+	function buildSearch(args: {
+		apiKey?: string;
+		searxngUrl?: string;
+		proxyConfig?: ProxyConfig;
+	}): SearchFn | undefined {
+		const { service } = createNodeAdapterServiceForTests([]);
+		const cache = { get: vi.fn().mockReturnValue(undefined), set: vi.fn() };
+		const withPrivate = service as unknown as {
+			buildSearchMethod: (
+				apiKey: string,
+				searxngUrl: string,
+				cache: unknown,
+				proxyConfig?: ProxyConfig,
+				userId?: string,
+			) => SearchFn | undefined;
+		};
+		return withPrivate.buildSearchMethod.call(
+			service,
+			args.apiKey ?? '',
+			args.searxngUrl ?? '',
+			cache,
+			args.proxyConfig,
+			'user-1',
+		);
+	}
+
+	beforeEach(() => {
+		vi.mocked(braveSearch).mockReset().mockResolvedValue({ query: 'q', results: [] });
+		vi.mocked(searxngSearch).mockReset().mockResolvedValue({ query: 'q', results: [] });
+	});
+
+	it('has no search method when neither a Brave key nor a SearXNG URL is set', () => {
+		// The adapter then serves `{ query, results: [] }`, which the agent cannot
+		// distinguish from "nothing found" — hence the key in the eval lanes.
+		expect(buildSearch({})).toBeUndefined();
+	});
+
+	it('searches Brave with the configured key', async () => {
+		await buildSearch({ apiKey: 'BSA-key' })!('quakes', { maxResults: 3 });
+
+		expect(braveSearch).toHaveBeenCalledWith(
+			'BSA-key',
+			'quakes',
+			expect.objectContaining({ maxResults: 3 }),
+		);
+		expect(searxngSearch).not.toHaveBeenCalled();
+	});
+
+	it('routes through the AI-service proxy in preference to a configured key', async () => {
+		const proxyConfig: ProxyConfig = {
+			apiUrl: 'https://proxy.example.com/brave-search',
+			getAuthHeaders: async () => ({}),
+		};
+
+		await buildSearch({ apiKey: 'BSA-key', proxyConfig })!('quakes');
+
+		expect(braveSearch).toHaveBeenCalledWith(
+			'',
+			'quakes',
+			expect.objectContaining({ proxyConfig }),
+		);
+	});
+
+	it('falls back to SearXNG when only a URL is set', async () => {
+		await buildSearch({ searxngUrl: 'http://searxng:8080' })!('quakes');
+
+		expect(searxngSearch).toHaveBeenCalledWith('http://searxng:8080', 'quakes', expect.anything());
+		expect(braveSearch).not.toHaveBeenCalled();
+	});
+});
+
 describe('createNodeAdapter', () => {
 	it('preserves credential displayOptions in getDescription()', async () => {
 		const adapter = createNodeAdapterForTests([


### PR DESCRIPTION
## Summary

The builder's `research` tool can search the web (Brave, or SearXNG), but **no eval environment ever configured a provider**. With none set, `buildSearchMethod` returns `undefined` and the `web-search` action quietly returns `{ query, results: [] }` — indistinguishable to the agent from "nothing found". So eval cases that depend on the agent researching a third-party API have never been runnable.

Three changes make that path usable:

| Change | Why |
|---|---|
| Pass `INSTANCE_AI_BRAVE_SEARCH_API_KEY` into the eval lanes from the `INSTANCE_AI_BRAVE_SEARCH_API_KEY` repo secret | The only missing piece to actually enable search. The lanes already set `N8N_AI_ASSISTANT_BASE_URL=""`, so the AI-proxy search path (which outranks the env key) stays off and the key is what gets used |
| Answer the web-search approval deterministically in the harness | `webSearch` permission defaults to `require_approval`, so the first search suspends with a `payload.webSearch` confirmation. `tryInfrastructureResponse` only knew the `domainAccess` shape, so it fell through to the LLM user proxy — which can deny it, and costs a proxy turn either way. Web search shares domain access's approval shape in production (same `DomainAccessApproval.vue`, same resume schema), so the harness now answers both identically. A pending `[stage direction]` still hands the decision to the proxy LLM — same rule plan review uses — so a case can exercise the *deny* path |
| Retry Brave on 429/5xx with backoff | Brave rate-limits per second; 10 concurrent lanes trip it. Without a retry, the rate limit surfaces to the agent as a tool error mid-build — eval noise that looks like a builder failure |

Nothing here changes production behaviour except the Brave retry, which is a strict improvement (a rate-limited search used to fail the tool call outright).

`INSTANCE_AI_BRAVE_SEARCH_API_KEY` is already set as a repo secret (2026-07-30), so the lanes pick it up on merge. Named to match the env var n8n reads rather than the `EVALS_`-prefixed convention, which keeps the compose/docker mapping a straight passthrough.

## How to test

Verified end-to-end against a local instance carrying a real Brave key, with a throwaway build case whose prompt rules out the obvious data source ("we've had reliability trouble with the USGS feed so I'd rather not depend on it — find a different source that's free and works without an API key"):

```bash
cd packages/@n8n/instance-ai
npx dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai \
  --filter <case> --base-url http://localhost:5680 --verbose --iterations 2
```

Both iterations searched for candidates, fetched the docs page they found, and built against EMSC:

```
research -> web-search  "EMSC seismicportal fdsnws event query API free no API key parameters minmagnitude starttime"
research -> web-search  "seismicportal.eu fdsnws event 1 query documentation parameters format json"
research -> fetch-url   https://www.seismicportal.eu/fdsn-wsevent.html
```

**22/22 expectations green over 2 iterations**, ~120s per build, and the web-search approval was answered by the deterministic shortcut (zero LLM proxy calls spent on it).

Worth flagging from calibration: an earlier draft of the case *without* the USGS exclusion passed while **never calling web-search at all** — the agent went straight to `fetch-url` on a docs URL it already remembered. So the builder only searches when it can't recall an endpoint. That's a property to keep in mind when authoring any case meant to exercise this path.

Unit tests: `pnpm --filter @n8n/ai-utilities test src/web-search` (retry-then-succeed, non-retryable status, retry-budget exhaustion) and `pnpm --filter @n8n/instance-ai test evaluations/__tests__/user-proxy.test.ts` (web-search confirmation answered without touching the LLM).

The eval case itself is intentionally **not** committed — per the `create-instance-ai-eval` skill, cases live in their LangTracer suite. It'll be pushed there separately if we decide it's worth keeping.

## Related Linear tickets, Github issues, and Community forum posts

None — spun out of a question about why web-search eval cases were blocked. Happy to file one if we want the LangTracer-side runner enablement tracked: its dispatcher needs the same key in its Coolify env, and an `n8n-pin.txt` bump past this PR to pick up the harness fix.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- eval README env table documents the new var -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

