### PR TITLE
feat: Add ap-east-2 and ap-southeast-6 AWS regions

### DIFF
--- a/packages/nodes-base/credentials/common/aws/regions.ts
+++ b/packages/nodes-base/credentials/common/aws/regions.ts
@@ -20,6 +20,11 @@ export const regions: RegionData[] = [
 		location: 'Hong Kong',
 	},
 	{
+		name: 'ap-east-2',
+		displayName: 'Asia Pacific',
+		location: 'Taipei',
+	},
+	{
 		name: 'ap-south-1',
 		displayName: 'Asia Pacific',
 		location: 'Mumbai',
@@ -53,6 +58,11 @@ export const regions: RegionData[] = [
 		name: 'ap-southeast-5',
 		displayName: 'Asia Pacific',
 		location: 'Malaysia',
+	},
+	{
+		name: 'ap-southeast-6',
+		displayName: 'Asia Pacific',
+		location: 'New Zealand',
 	},
 	{
 		name: 'ap-southeast-7',

--- a/packages/nodes-base/credentials/common/aws/utils.test.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.test.ts
@@ -583,6 +583,8 @@ describe('assertSupportedAwsRegion', () => {
 		['cn-north-1'],
 		['us-gov-west-1'],
 		['eu-central-2'],
+		['ap-east-2'],
+		['ap-southeast-6'],
 	])('accepts the supported region %s', (region) => {
 		expect(() => assertSupportedAwsRegion(region)).not.toThrow();
 	});


### PR DESCRIPTION
## Summary

Adds `ap-east-2` and `ap-southeast-6` regions to AWS credentials. Addresses potential gap after the fix in https://github.com/n8n-io/n8n/pull/31374 where custom regions could be previously set via expressions. See the available regions at https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html

## How to test

1. Create a workflow and add any AWS node
2. Create AWS credentials with invalid key and select one of the newly added regions
3. run the node and observe that there is no `Unsupported AWS region` error (there will still be an authentication error due to invalid access key)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5616/add-ap-east-2-and-ap-southeast-6-to-the-aws-credential-region-list

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35278">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

