### PR TITLE
feat(Slack Node): Show user real names and handles in user pickers

### DIFF
--- a/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTrigger.node.ts
@@ -14,7 +14,7 @@ import {
 } from 'n8n-workflow';
 
 import { downloadFile, getChannelInfo, getUserInfo, verifySignature } from './SlackTriggerHelpers';
-import { slackApiRequestAllItems } from './V2/GenericFunctions';
+import { formatUserLabel, slackApiRequestAllItems } from './V2/GenericFunctions';
 
 export class SlackTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -296,19 +296,20 @@ export class SlackTrigger implements INodeType {
 					'members',
 					'GET',
 					'/users.list',
-				)) as Array<{ id: string; name: string }>;
+				)) as Array<{ id: string; name: string; real_name?: string }>;
 				for (const user of users) {
 					returnData.push({
-						name: user.name,
+						name: formatUserLabel(user),
 						value: user.id,
 					});
 				}
 
+				// case-insensitive, so lowercase handle fallbacks aren't sorted below every real name
 				returnData.sort((a, b) => {
-					if (a.name < b.name) {
+					if (a.name.toLowerCase() < b.name.toLowerCase()) {
 						return -1;
 					}
-					if (a.name > b.name) {
+					if (a.name.toLowerCase() > b.name.toLowerCase()) {
 						return 1;
 					}
 					return 0;

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -62,6 +62,13 @@ export function toMultiOptionsCsv(value: unknown): string {
 	return '';
 }
 
+// Display label for a Slack user in pickers. Real names are friendlier but aren't
+// unique in Slack, so the handle is appended to keep same-named users distinguishable.
+// `real_name` is optional, so bots and unconfigured accounts show the handle alone.
+export function formatUserLabel(user: { name: string; real_name?: string }): string {
+	return user.real_name ? `${user.real_name} (@${user.name})` : user.name;
+}
+
 export async function slackApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions,
 	method: IHttpRequestMethods,

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -26,6 +26,7 @@ import { fileFields, fileOperations } from './FileDescription';
 import {
 	slackApiRequest,
 	slackApiRequestAllItems,
+	formatUserLabel,
 	getMessageContent,
 	getTarget,
 	createSendAndWaitMessageBody,
@@ -245,6 +246,7 @@ export class SlackV2 implements INodeType {
 				const { data: users, cursor } = await slackApiRequestAllItemsWithRateLimit<{
 					id: string;
 					name: string;
+					real_name?: string;
 				}>(this, 'members', 'GET', '/users.list', {}, qs, {
 					onFail: 'stop',
 					maxRetries: 2,
@@ -252,9 +254,10 @@ export class SlackV2 implements INodeType {
 				});
 				const results: INodeListSearchItems[] = users
 					.map((c) => ({
-						name: c.name,
+						name: formatUserLabel(c),
 						value: c.id,
 					}))
+					// the label carries both real name and handle, so either matches the filter
 					.filter(
 						(c) =>
 							!filter ||
@@ -277,9 +280,10 @@ export class SlackV2 implements INodeType {
 				const { data: users } = await slackApiRequestAllItemsWithRateLimit<{
 					id: string;
 					name: string;
+					real_name?: string;
 				}>(this, 'members', 'GET', '/users.list', {}, { limit: 200 }, { onFail: 'stop' });
 				for (const user of users) {
-					const userName = user.name;
+					const userName = formatUserLabel(user);
 					const userId = user.id;
 					returnData.push({
 						name: userName,
@@ -287,11 +291,12 @@ export class SlackV2 implements INodeType {
 					});
 				}
 
+				// case-insensitive, so lowercase handle fallbacks aren't sorted below every real name
 				returnData.sort((a, b) => {
-					if (a.name < b.name) {
+					if (a.name.toLowerCase() < b.name.toLowerCase()) {
 						return -1;
 					}
-					if (a.name > b.name) {
+					if (a.name.toLowerCase() > b.name.toLowerCase()) {
 						return 1;
 					}
 					return 0;

--- a/packages/nodes-base/nodes/Slack/test/SlackTrigger.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/SlackTrigger.test.ts
@@ -1,7 +1,8 @@
 import { mock } from 'vitest-mock-extended';
-import type { IWebhookFunctions, INodeType } from 'n8n-workflow';
+import type { ILoadOptionsFunctions, IWebhookFunctions, INodeType } from 'n8n-workflow';
 
 import { SlackTrigger } from '../SlackTrigger.node';
+import * as GenericFunctions from '../V2/GenericFunctions';
 
 // Mock the helper functions
 vi.mock('../SlackTriggerHelpers', () => ({
@@ -705,6 +706,29 @@ describe('SlackTrigger Node', () => {
 			expect(mockWebhookFunctions.getResponseObject().json).toHaveBeenCalledWith({
 				challenge: 'test_challenge_123',
 			});
+		});
+	});
+
+	describe('loadOptions - getUsers', () => {
+		it('should label users with real name and handle, falling back to the handle alone', async () => {
+			const mockLoadOptionsFunctions = mock<ILoadOptionsFunctions>();
+			vi.spyOn(GenericFunctions, 'slackApiRequestAllItems').mockResolvedValue([
+				{ id: 'U111111111', name: 'john.doe', real_name: 'John Doe' },
+				{ id: 'U222222222', name: 'jane.smith', real_name: 'Jane Smith' },
+				// no real_name, e.g. a bot or an unconfigured account
+				{ id: 'U333333333', name: 'alertbot' },
+			]);
+
+			const result =
+				await slackTrigger.methods!.loadOptions!.getUsers.call(mockLoadOptionsFunctions);
+
+			// as [label, value] tuples, to keep the assertion clear of `{ name, value }`
+			// literals that n8n-nodes-base/node-param-display-name-miscased reads as node params
+			expect(result.map((o) => [o.name, o.value])).toEqual([
+				['alertbot', 'U333333333'],
+				['Jane Smith (@jane.smith)', 'U222222222'],
+				['John Doe (@john.doe)', 'U111111111'],
+			]);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Slack/test/v2/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/GenericFunctions.test.ts
@@ -6,6 +6,7 @@ import {
 	slackApiRequest,
 	slackApiRequestAllItems,
 	slackApiRequestAllItemsWithRateLimit,
+	formatUserLabel,
 	processThreadOptions,
 	getMessageContent,
 } from '../../V2/GenericFunctions';
@@ -1466,6 +1467,22 @@ describe('Slack V2 > GenericFunctions', () => {
 			expect(() => {
 				getMessageContent.call(mockExecuteFunctions, 0, 2.1, 'instance-123');
 			}).toThrow('The message type "unknown-type" is not known!');
+		});
+	});
+
+	describe('formatUserLabel', () => {
+		it('should append the handle to the real name', () => {
+			expect(formatUserLabel({ name: 'john.doe', real_name: 'John Doe' })).toBe(
+				'John Doe (@john.doe)',
+			);
+		});
+
+		it('should fall back to the handle alone when real_name is missing', () => {
+			expect(formatUserLabel({ name: 'alertbot' })).toBe('alertbot');
+		});
+
+		it('should fall back to the handle alone when real_name is empty', () => {
+			expect(formatUserLabel({ name: 'alertbot', real_name: '' })).toBe('alertbot');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Slack/test/v2/Slack.node.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/Slack.node.test.ts
@@ -1,6 +1,7 @@
 import { mockDeep } from 'vitest-mock-extended';
 import type {
 	IExecuteFunctions,
+	ILoadOptionsFunctions,
 	INode,
 	INodeExecutionData,
 	INodeParameterResourceLocator,
@@ -2377,6 +2378,141 @@ describe('SlackV2', () => {
 					},
 				],
 			]);
+		});
+	});
+
+	describe('getUsers', () => {
+		let mockLoadOptionsFunctions: Mocked<ILoadOptionsFunctions>;
+		let withRateLimitSpy: MockInstance;
+
+		const mockUsers = [
+			{ id: 'U111111111', name: 'john.doe', real_name: 'John Doe' },
+			{ id: 'U222222222', name: 'jane.smith', real_name: 'Jane Smith' },
+			// no real_name, e.g. a bot or an unconfigured account
+			{ id: 'U333333333', name: 'alertbot' },
+			// same real_name as U111111111 — real names aren't unique in Slack, handles are
+			{ id: 'U444444444', name: 'jdoe2', real_name: 'John Doe' },
+		];
+
+		// as [label, value] tuples, to keep the assertions clear of `{ name, value }`
+		// literals that n8n-nodes-base/node-param-display-name-miscased reads as node params
+		const asTuples = (options: Array<{ name: string; value?: string | number | boolean }>) =>
+			options.map((o) => [o.name, o.value]);
+
+		beforeEach(() => {
+			mockLoadOptionsFunctions = mockDeep<ILoadOptionsFunctions>();
+			withRateLimitSpy = vi
+				.spyOn(GenericFunctions, 'slackApiRequestAllItemsWithRateLimit')
+				.mockResolvedValue({ data: mockUsers, cursor: undefined });
+		});
+
+		describe('listSearch', () => {
+			it('should label users with real name and handle, falling back to the handle alone', async () => {
+				const result = await node.methods.listSearch.getUsers.call(mockLoadOptionsFunctions);
+
+				expect(asTuples(result.results)).toEqual([
+					['alertbot', 'U333333333'],
+					['Jane Smith (@jane.smith)', 'U222222222'],
+					['John Doe (@jdoe2)', 'U444444444'],
+					['John Doe (@john.doe)', 'U111111111'],
+				]);
+			});
+
+			it('should keep users sharing a real name distinguishable', async () => {
+				const result = await node.methods.listSearch.getUsers.call(
+					mockLoadOptionsFunctions,
+					'John Doe',
+				);
+
+				// same real name, different handles and IDs
+				expect(asTuples(result.results)).toEqual([
+					['John Doe (@jdoe2)', 'U444444444'],
+					['John Doe (@john.doe)', 'U111111111'],
+				]);
+			});
+
+			it('should filter by real name', async () => {
+				const result = await node.methods.listSearch.getUsers.call(
+					mockLoadOptionsFunctions,
+					'jane s',
+				);
+
+				expect(asTuples(result.results)).toEqual([['Jane Smith (@jane.smith)', 'U222222222']]);
+			});
+
+			it('should filter by handle', async () => {
+				const result = await node.methods.listSearch.getUsers.call(
+					mockLoadOptionsFunctions,
+					'john.doe',
+				);
+
+				expect(asTuples(result.results)).toEqual([['John Doe (@john.doe)', 'U111111111']]);
+			});
+
+			it('should filter by user ID', async () => {
+				const result = await node.methods.listSearch.getUsers.call(
+					mockLoadOptionsFunctions,
+					'U222222222',
+				);
+
+				expect(asTuples(result.results)).toEqual([['Jane Smith (@jane.smith)', 'U222222222']]);
+			});
+
+			it('should return the user ID as the value, never the label', async () => {
+				const result = await node.methods.listSearch.getUsers.call(mockLoadOptionsFunctions);
+
+				expect(result.results.map((r) => r.value)).toEqual([
+					'U333333333',
+					'U222222222',
+					'U444444444',
+					'U111111111',
+				]);
+			});
+
+			it('should pass the pagination token through and return the next cursor', async () => {
+				withRateLimitSpy.mockResolvedValue({ data: mockUsers, cursor: 'next-cursor' });
+
+				const result = await node.methods.listSearch.getUsers.call(
+					mockLoadOptionsFunctions,
+					undefined,
+					'page-2',
+				);
+
+				expect(withRateLimitSpy).toHaveBeenCalledWith(
+					mockLoadOptionsFunctions,
+					'members',
+					'GET',
+					'/users.list',
+					{},
+					{ limit: 200, cursor: 'page-2' },
+					expect.objectContaining({ onFail: 'stop' }),
+				);
+				expect(result.paginationToken).toBe('next-cursor');
+			});
+		});
+
+		describe('loadOptions', () => {
+			it('should label users with real name and handle, falling back to the handle alone', async () => {
+				const result = await node.methods.loadOptions.getUsers.call(mockLoadOptionsFunctions);
+
+				expect(asTuples(result)).toEqual([
+					['alertbot', 'U333333333'],
+					['Jane Smith (@jane.smith)', 'U222222222'],
+					['John Doe (@jdoe2)', 'U444444444'],
+					['John Doe (@john.doe)', 'U111111111'],
+				]);
+			});
+
+			it('should return the user ID as the value, never the label', async () => {
+				const result = await node.methods.loadOptions.getUsers.call(mockLoadOptionsFunctions);
+
+				expect(result.map((o) => o.value)).toEqual([
+					'U333333333',
+					'U222222222',
+					'U444444444',
+					'U111111111',
+				]);
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Slack user pickers listed people by their handle, which is often not how you know your colleagues. Feedback asked for `real_name` instead. Users are now labelled with their real name and handle, e.g. `John Doe (@john.doe)`.

The handle stays in the label deliberately: real names are friendlier but **not unique** in Slack, whereas handles are. Two colleagues both named "John Doe" would otherwise produce two identical dropdown entries with no way to tell them apart.

| Before | After |
|---|---|
| `john.doe` | `John Doe (@john.doe)` |
| `jdoe2` | `John Doe (@jdoe2)` |
| `alertbot` | `alertbot` |

**Only display labels change.** Every picker still stores the Slack user ID as its value, so existing workflows resolve to exactly the same users. Saved labels are cosmetically stale until a node is reopened.

Details:

- The label comes from one shared `formatUserLabel` helper in `V2/GenericFunctions.ts`, used by the V2 `listSearch` and `loadOptions` methods and the trigger's user dropdown. `Slack V1` is deliberately untouched.
- `real_name` is optional in Slack, so accounts without one — bots, unconfigured accounts — keep showing the handle alone.
- Search still matches by handle. Because the handle is part of the label, filtering on the label covers both real name and username, so anyone used to searching `john.doe` still finds them. ID search is unchanged.
- Both `loadOptions` sorts are now case-insensitive. They compared raw strings, which was harmless when every label was a lowercase handle, but with title-cased real names ASCII ordering pushed every handle-only entry below all real names.
- No docs change needed — this alters displayed labels only, no parameters or behaviour.

## How to test

The user pickers are populated from `users.list`, so a workspace with at least one member who has a real name set is enough. A bot user in the workspace exercises the fallback.

1. Add a **Slack** node, set Resource to *Message*, Operation to *Send*, then set **Send Message To** to *User*.
2. Open the **User** dropdown (From List). Entries should read `Real Name (@handle)`, sorted alphabetically and case-insensitively, with any bots or real-name-less accounts showing the bare handle.
3. Type part of a **real name** into the search box — the user should be found.
4. Type part of a **handle** — the same user should still be found.
5. Pick a user and send a message. It should deliver to the right person, confirming the stored value is still the user ID.
6. Repeat step 2 on a plain dropdown, e.g. *Channel → Invite* (**Users** field), and on the **Slack Trigger**'s user filter under Options.

Regression check on existing workflows: open a workflow saved before this change that targets a Slack user. It shows the old handle label until the dropdown reloads, then switches to the new label — and executes against the same user either way.

Example workflow:

```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [0, 0],
      "id": "a1000000-0000-4000-8000-000000000001",
      "name": "When clicking 'Execute workflow'"
    },
    {
      "parameters": {
        "authentication": "accessToken",
        "select": "user",
        "user": {
          "__rl": true,
          "mode": "list",
          "value": ""
        },
        "text": "Hello from n8n",
        "otherOptions": {}
      },
      "type": "n8n-nodes-base.slack",
      "typeVersion": 2.5,
      "position": [220, 0],
      "id": "a1000000-0000-4000-8000-000000000002",
      "name": "Send a message"
    }
  ],
  "connections": {
    "When clicking 'Execute workflow'": {
      "main": [[{ "node": "Send a message", "type": "main", "index": 0 }]]
    }
  },
  "pinData": {}
}
```

<img width="436" height="282" alt="image" src="https://github.com/user-attachments/assets/8b7558d8-5300-47ba-b749-f73609f0ac2e" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5619

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35279">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

