### PR TITLE
fix(editor): Guard optional fields when reading public settings

### DIFF
--- a/packages/frontend/@n8n/stores/src/settings.store.test.ts
+++ b/packages/frontend/@n8n/stores/src/settings.store.test.ts
@@ -75,6 +75,26 @@ const mockSettings = mock<FrontendSettings>({
 	},
 });
 
+const publicSettingsResponse = {
+	settingsMode: 'public',
+	defaultLocale: 'en',
+	userManagement: {
+		authenticationMethod: 'email',
+		showSetupOnFirstLoad: false,
+		smtpSetup: false,
+		passwordMinLength: 8,
+	},
+	sso: {
+		saml: { loginEnabled: false },
+		ldap: { loginEnabled: false, loginLabel: '' },
+		oidc: { loginEnabled: false, loginUrl: '' },
+	},
+	authCookie: { secure: true },
+	previewMode: false,
+	enterprise: { saml: true, ldap: true, oidc: true },
+	communityNodesEnabled: true,
+} as unknown as FrontendSettings;
+
 describe('settings.store', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -219,6 +239,32 @@ describe('settings.store', () => {
 		});
 	});
 
+	describe('reading every getter at once', () => {
+		it('should not throw before settings have been fetched', () => {
+			const settingsStore = useSettingsStore();
+
+			expect(() => ({ ...settingsStore })).not.toThrow();
+		});
+
+		it('should not throw after reset', async () => {
+			getSettings.mockResolvedValueOnce(mockSettings);
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			settingsStore.reset();
+
+			expect(() => ({ ...settingsStore })).not.toThrow();
+		});
+
+		it('should not throw for public settings', async () => {
+			getSettings.mockResolvedValueOnce(publicSettingsResponse);
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(() => ({ ...settingsStore })).not.toThrow();
+		});
+	});
+
 	describe('getSettings', () => {
 		describe('telemetry', () => {
 			it('should fetch settings and call sessionStarted if telemetry is enabled', async () => {
@@ -294,6 +340,21 @@ describe('settings.store', () => {
 
 				// side effects
 				expect(sessionStarted).not.toHaveBeenCalled();
+			});
+
+			it('should expose license- and security-derived getters without throwing when the public response omits them', async () => {
+				getSettings.mockResolvedValueOnce(publicSettingsResponse);
+				const settingsStore = useSettingsStore();
+
+				await settingsStore.getSettings();
+
+				expect(settingsStore.planName).toBe('Community');
+				expect(settingsStore.isCommunityPlan).toBe(true);
+				expect(settingsStore.consumerId).toBeUndefined();
+				expect(settingsStore.security).toEqual({
+					blockFileAccessToN8nFiles: undefined,
+					secureCookie: true,
+				});
 			});
 
 			it('should store full settings if settingsMode is not "minimal"', async () => {

--- a/packages/frontend/@n8n/stores/src/settings.store.ts
+++ b/packages/frontend/@n8n/stores/src/settings.store.ts
@@ -74,17 +74,17 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 
 	const databaseType = computed(() => settings.value?.databaseType);
 
-	const planName = computed(() => settings.value?.license.planName ?? 'Community');
+	const planName = computed(() => settings.value?.license?.planName ?? 'Community');
 
-	const consumerId = computed(() => settings.value?.license.consumerId);
+	const consumerId = computed(() => settings.value?.license?.consumerId);
 
 	const binaryDataMode = computed(() => settings.value?.binaryDataMode);
 
 	const pruning = computed(() => settings.value?.pruning);
 
 	const security = computed(() => ({
-		blockFileAccessToN8nFiles: settings.value.security.blockFileAccessToN8nFiles,
-		secureCookie: settings.value.authCookie.secure,
+		blockFileAccessToN8nFiles: settings.value?.security?.blockFileAccessToN8nFiles,
+		secureCookie: settings.value?.authCookie?.secure,
 	}));
 
 	const isEnterpriseFeatureEnabled = computed(() => settings.value.enterprise ?? {});
@@ -99,7 +99,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 
 	const isPublicApiEnabled = computed(() => api.value.enabled);
 
-	const isSwaggerUIEnabled = computed(() => api.value.swaggerUi.enabled);
+	const isSwaggerUIEnabled = computed(() => api.value.swaggerUi?.enabled ?? false);
 
 	const isPreviewMode = computed(() => settings.value.previewMode);
 

--- a/packages/frontend/editor-ui/src/app/composables/useExternalHooks.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExternalHooks.test.ts
@@ -1,0 +1,61 @@
+import type { FrontendSettings } from '@n8n/api-types';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { runExternalHook } from '@/app/composables/useExternalHooks';
+import { useSettingsStore } from '@/app/stores/settings.store';
+
+/**
+ * Payload `GET /rest/settings` returns to unauthenticated callers: no `license`,
+ * no `security`. Built as a plain object so the absent branches really are
+ * `undefined` (a `mock<FrontendSettings>()` auto-vivifies every nested key).
+ */
+const publicSettings = {
+	settingsMode: 'public',
+	defaultLocale: 'en',
+	userManagement: {
+		authenticationMethod: 'email',
+		showSetupOnFirstLoad: false,
+		smtpSetup: false,
+		passwordMinLength: 8,
+	},
+	sso: {
+		saml: { loginEnabled: false },
+		ldap: { loginEnabled: false, loginLabel: '' },
+		oidc: { loginEnabled: false, loginUrl: '' },
+	},
+	authCookie: { secure: false },
+	previewMode: false,
+	enterprise: { saml: true, ldap: true, oidc: true },
+	communityNodesEnabled: true,
+} as unknown as FrontendSettings;
+
+describe('runExternalHook', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		window.n8nExternalHooks = { app: { mount: [vi.fn()] } };
+	});
+
+	afterEach(() => {
+		delete window.n8nExternalHooks;
+	});
+
+	it('should pass the store to the hook when settings have not been fetched yet', async () => {
+		const hook = vi.fn();
+		window.n8nExternalHooks = { app: { mount: [hook] } };
+
+		await runExternalHook('app.mount');
+
+		expect(hook).toHaveBeenCalledTimes(1);
+	});
+
+	it('should pass the store to the hook when only public settings are available', async () => {
+		const hook = vi.fn();
+		window.n8nExternalHooks = { app: { mount: [hook] } };
+		useSettingsStore().setSettings(publicSettings);
+
+		await runExternalHook('app.mount');
+
+		expect(hook).toHaveBeenCalledTimes(1);
+		expect(hook.mock.calls[0][0]).toMatchObject({ planName: 'Community' });
+	});
+});


### PR DESCRIPTION
## Summary

`GET /rest/settings` has two response shapes.
The public one, served to unauthenticated callers, omits `license` and `security`. 

The settings store typed that payload as a complete `FrontendSettings` and dereferenced those branches directly:

Result: `TypeError: Cannot read properties of undefined (reading 'planName')`.

<img width="646" height="152" alt="Screenshot 2026-07-30 at 16 03 16" src="https://github.com/user-attachments/assets/22046f12-07b1-486c-835f-6ebca1cf6f40" />

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3885
- fixes #35194
- Related: #35193 (the 401 loop that puts an authenticated session on the public-settings path). Not addressed here.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35281">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

