### PR TITLE
fix(editor): Rename preview AI Agent node to V2

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.test.ts
@@ -76,7 +76,7 @@ describe('NodeItem', () => {
 			props: {
 				nodeType: mockSimplifiedNodeType({
 					name: MESSAGE_AN_AGENT_NODE_TYPE,
-					displayName: 'AI Agent V1',
+					displayName: 'AI Agent V2',
 					group: ['transform'],
 				}),
 			},

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/AgentsMode.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/AgentsMode.test.ts
@@ -57,7 +57,7 @@ const render = createComponentRenderer(AgentsMode);
 
 function pushAgentsViewStack() {
 	useViewStacks().pushViewStack({
-		title: 'AI Agent V1',
+		title: 'AI Agent V2',
 		hasSearch: true,
 		mode: 'agents',
 		items: [],

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.test.ts
@@ -42,7 +42,7 @@ function messageAnAgentElement(): NodeCreateElement {
 		subcategory: '*',
 		properties: mockSimplifiedNodeType({
 			name: MESSAGE_AN_AGENT_NODE_TYPE,
-			displayName: 'AI Agent V1',
+			displayName: 'AI Agent V2',
 			group: ['transform'],
 		}),
 	};
@@ -69,13 +69,13 @@ describe('NodesMode', () => {
 		const { emitted } = render({ pinia });
 		await nextTick();
 
-		await userEvent.click(screen.getByText('AI Agent V1'));
+		await userEvent.click(screen.getByText('AI Agent V2'));
 
 		expect(emitted('nodeTypeSelected')).toBeUndefined();
 
 		const activeStack = useViewStacks().activeViewStack;
 		expect(activeStack.mode).toBe('agents');
-		expect(activeStack.title).toBe('AI Agent V1');
+		expect(activeStack.title).toBe('AI Agent V2');
 		expect(activeStack.hasSearch).toBe(true);
 		expect(activeStack.rootView).toBe(REGULAR_NODE_CREATOR_VIEW);
 	});

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -916,7 +916,7 @@ describe('NodeCreator - utils', () => {
 			},
 		);
 
-		it('should show Preview badge on the AI Agent V1 node', () => {
+		it('should show Preview badge on the AI Agent V2 node', () => {
 			mockSettingsStore(true);
 			const [result] = finalizeItems([
 				makeAgentNode(MESSAGE_AN_AGENT_NODE_TYPE),
@@ -1214,9 +1214,9 @@ describe('NodeCreator - utils', () => {
 		});
 
 		// The legacy node is an exact "AI Agent" match and carries the popularity factor,
-		// so the AI Agent V1 successor ranking first proves the boost outweighs both.
+		// so the AI Agent V2 successor ranking first proves the boost outweighs both.
 		const legacyAgent = makeNode(AGENT_NODE_TYPE, 'AI Agent', ['agent']);
-		const messageAnAgent = makeNode(MESSAGE_AN_AGENT_NODE_TYPE, 'AI Agent V1', [
+		const messageAnAgent = makeNode(MESSAGE_AN_AGENT_NODE_TYPE, 'AI Agent V2', [
 			'agent',
 			'ai',
 			'sdk',
@@ -1224,7 +1224,7 @@ describe('NodeCreator - utils', () => {
 		]);
 		const popularity = { [AGENT_NODE_TYPE]: 98.2 };
 
-		it('should rank the AI Agent V1 node above the legacy agent despite its popularity', () => {
+		it('should rank the AI Agent V2 node above the legacy agent despite its popularity', () => {
 			const result = searchNodes('AI Agent', [legacyAgent, messageAnAgent], { popularity });
 			expect(result.map((item) => item.key)).toEqual([MESSAGE_AN_AGENT_NODE_TYPE, AGENT_NODE_TYPE]);
 		});

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
@@ -19,7 +19,7 @@ const getNodeType = vi.fn();
 const aiTransformNode = mockNodeTypeDescription({ name: AI_TRANSFORM_NODE_TYPE });
 const messageAnAgentNode = mockNodeTypeDescription({
 	name: MESSAGE_AN_AGENT_NODE_TYPE,
-	displayName: 'AI Agent V1',
+	displayName: 'AI Agent V2',
 	hidden: true,
 });
 

--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -9,7 +9,7 @@ import { MessageAnAgentV2 } from './v2/MessageAnAgentV2.node';
  * the `agentId` property, and (v1 only) the `listAgents` search method.
  */
 export const baseDescription: INodeTypeBaseDescription = {
-	displayName: 'AI Agent V1',
+	displayName: 'AI Agent V2',
 	name: 'messageAnAgent',
 	icon: 'node:ai-agent',
 	group: ['transform'],

--- a/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
@@ -810,10 +810,10 @@ describe('MessageAnAgent Node', () => {
 });
 
 describe('MessageAnAgent versioning', () => {
-	it('uses AI Agent V1 as the display and default name', () => {
-		expect(baseDescription.displayName).toBe('AI Agent V1');
-		expect(new MessageAnAgentV1(baseDescription).description.defaults.name).toBe('AI Agent V1');
-		expect(new MessageAnAgentV2(baseDescription).description.defaults.name).toBe('AI Agent V1');
+	it('uses AI Agent V2 as the display and default name', () => {
+		expect(baseDescription.displayName).toBe('AI Agent V2');
+		expect(new MessageAnAgentV1(baseDescription).description.defaults.name).toBe('AI Agent V2');
+		expect(new MessageAnAgentV2(baseDescription).description.defaults.name).toBe('AI Agent V2');
 	});
 
 	it('exposes v1, v2, and v3 with v3 as the default', () => {

--- a/packages/nodes-base/nodes/MessageAnAgent/shared.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/shared.ts
@@ -20,7 +20,7 @@ export const sharedVersionDescription: Pick<
 > = {
 	hidden: true,
 	defaults: {
-		name: 'AI Agent V1',
+		name: 'AI Agent V2',
 	},
 	codex: {
 		categories: ['AI'],


### PR DESCRIPTION
## Summary

Rename the preview AI Agent node from `AI Agent V1` to `AI Agent V2`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-518

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35285">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

