### PR TITLE
fix(core): Classify no-op pseudo triggers as persisted

### DIFF
--- a/packages/@n8n/db/src/entities/workflow-publication-trigger-status.ts
+++ b/packages/@n8n/db/src/entities/workflow-publication-trigger-status.ts
@@ -11,7 +11,9 @@ export type WorkflowPublicationTriggerStatusType = 'activated' | 'failed';
  * or `trigger` function are registered `in-memory` on the owning instance,
  * nodes with only a `webhook` function are `persisted` rows in
  * `webhook_entity`. Reconciliation diffs the `in-memory` ones against the
- * registry.
+ * registry. `persisted` also covers the no-op pseudo triggers (manual,
+ * executeWorkflow, error): the execution engine fires them directly, so
+ * neither leader handoff nor reconciliation has registry work to redo.
  */
 export type WorkflowPublicationTriggerKind = 'in-memory' | 'persisted';
 

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-test-utils.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-test-utils.ts
@@ -40,6 +40,16 @@ export function createNodeTypes() {
 				trigger: vi.fn(),
 			} as never;
 		}
+		// The pseudo triggers under their real type names: they implement `trigger()`
+		// like any in-memory trigger, but it is a no-op (fired externally by the
+		// execution engine), so classification must tell them apart by node type.
+		if (
+			type === 'n8n-nodes-base.manualTrigger' ||
+			type === 'n8n-nodes-base.executeWorkflowTrigger' ||
+			type === 'n8n-nodes-base.errorTrigger'
+		) {
+			return { description: { ...description, name: type }, trigger: vi.fn() } as never;
+		}
 		if (type === 'poll') {
 			return { description: { ...description, name: 'poll' }, poll: vi.fn() } as never;
 		}

--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -163,6 +163,26 @@ describe('WorkflowTriggerActivator', () => {
 			expect(kinds.get('tw')).toBe('in-memory');
 			expect(kinds.size).toBe(5);
 		});
+
+		test('classifies the no-op pseudo triggers as persisted despite their trigger function', () => {
+			const activator = buildActivator();
+
+			const kinds = activator.getTriggerKinds([
+				node('manual', 'n8n-nodes-base.manualTrigger'),
+				node('sub-workflow', 'n8n-nodes-base.executeWorkflowTrigger'),
+				node('error', 'n8n-nodes-base.errorTrigger'),
+				node('t', 'trigger'),
+			]);
+
+			// Their trigger() is a no-op — manual runs, sub-workflow calls and error
+			// workflows are fired by the execution engine, never through the trigger
+			// registry — so the reconciler must not diff them against the registry.
+			expect(kinds.get('manual')).toBe('persisted');
+			expect(kinds.get('sub-workflow')).toBe('persisted');
+			expect(kinds.get('error')).toBe('persisted');
+			// A genuine trigger with the same capability shape stays in-memory.
+			expect(kinds.get('t')).toBe('in-memory');
+		});
 	});
 
 	describe('getNodesWithUnregisteredWebhooks', () => {

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -45,6 +45,14 @@ import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.serv
 
 export type WorkflowTriggerVersion = { nodes: INode[]; connections: IConnections };
 
+// Their trigger() is a no-op — fired by the execution engine, never the
+// registry — so reconciling them against the registry would re-enqueue forever.
+const PSEUDO_TRIGGER_NODE_TYPES = new Set<string>([
+	MANUAL_TRIGGER_NODE_TYPE,
+	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+	ERROR_TRIGGER_NODE_TYPE,
+]);
+
 /** A single trigger node that failed to (de)register during activation. */
 export type TriggerActivationFailure = {
 	nodeId: INode['id'];
@@ -134,14 +142,6 @@ export class WorkflowTriggerActivator {
 			active: false,
 			nodeTypes: this.nodeTypes,
 		});
-
-		// Their trigger() is a no-op — fired by the execution engine, never the
-		// registry — so reconciling them against the registry would re-enqueue forever.
-		const PSEUDO_TRIGGER_NODE_TYPES = new Set<string>([
-			MANUAL_TRIGGER_NODE_TYPE,
-			EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
-			ERROR_TRIGGER_NODE_TYPE,
-		]);
 
 		const inMemoryNodeIds = new Set(
 			[...workflow.getPollNodes(), ...workflow.getTriggerNodes()]

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -18,7 +18,13 @@ import type {
 	WorkflowExecuteMode,
 	WorkflowId,
 } from 'n8n-workflow';
-import { Workflow, WorkflowActivationError } from 'n8n-workflow';
+import {
+	ERROR_TRIGGER_NODE_TYPE,
+	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+	MANUAL_TRIGGER_NODE_TYPE,
+	Workflow,
+	WorkflowActivationError,
+} from 'n8n-workflow';
 
 import { ActivationErrorsService } from '@/activation-errors.service';
 import { TRIGGER_ACTIVATION_MAX_ATTEMPTS } from '@/constants';
@@ -113,8 +119,11 @@ export class WorkflowTriggerActivator {
 	 * Maps each node to where it lives once activated, decided by which functions
 	 * its node type implements: nodes with a `poll` or `trigger` function register
 	 * `in-memory`, nodes with only a `webhook` function are `persisted` rows in
-	 * `webhook_entity`. Used by reconciliation to tell which triggers should be in
-	 * the in-memory registry.
+	 * `webhook_entity`. The pseudo triggers (manual, executeWorkflow, error) are
+	 * `persisted` despite their `trigger` function: it is a no-op fired by the
+	 * execution engine, so the registry holds nothing worth reconciling for them.
+	 * Used by reconciliation to tell which triggers should be in the in-memory
+	 * registry.
 	 */
 	getTriggerKinds(nodes: INode[]): Map<INode['id'], WorkflowPublicationTriggerKind> {
 		const workflow = new Workflow({
@@ -126,8 +135,18 @@ export class WorkflowTriggerActivator {
 			nodeTypes: this.nodeTypes,
 		});
 
+		// Their trigger() is a no-op — fired by the execution engine, never the
+		// registry — so reconciling them against the registry would re-enqueue forever.
+		const PSEUDO_TRIGGER_NODE_TYPES = new Set<string>([
+			MANUAL_TRIGGER_NODE_TYPE,
+			EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+			ERROR_TRIGGER_NODE_TYPE,
+		]);
+
 		const inMemoryNodeIds = new Set(
-			[...workflow.getPollNodes(), ...workflow.getTriggerNodes()].map((node) => node.id),
+			[...workflow.getPollNodes(), ...workflow.getTriggerNodes()]
+				.filter((node) => !PSEUDO_TRIGGER_NODE_TYPES.has(node.type))
+				.map((node) => node.id),
 		);
 
 		const kinds = new Map<INode['id'], WorkflowPublicationTriggerKind>();

--- a/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { ActiveWorkflowTriggers, ExternalSecretsProxy, InstanceSettings } from 'n8n-core';
+import { ManualTrigger } from 'n8n-nodes-base/nodes/ManualTrigger/ManualTrigger.node';
 import { ScheduleTrigger } from 'n8n-nodes-base/nodes/Schedule/ScheduleTrigger.node';
 import type { INode, INodeTypeData } from 'n8n-workflow';
 
@@ -58,11 +59,21 @@ const scheduleNode = (suffix: string): INode => ({
 	parameters: {},
 });
 
+const manualTriggerNode = (suffix: string): INode => ({
+	id: `node-${suffix}`,
+	name: `Manual ${suffix}`,
+	type: 'n8n-nodes-base.manualTrigger',
+	typeVersion: 1,
+	position: [0, 0],
+	parameters: {},
+});
+
 beforeAll(async () => {
 	await testDb.init();
 
 	const nodes: INodeTypeData = {
 		'n8n-nodes-base.scheduleTrigger': { type: new ScheduleTrigger(), sourcePath: '' },
+		'n8n-nodes-base.manualTrigger': { type: new ManualTrigger(), sourcePath: '' },
 	};
 	await utils.initNodeTypes(nodes);
 
@@ -338,6 +349,42 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		// The exclusion also holds while the record is being processed (in_progress).
 		await outboxRepository.claimNextPendingRecord();
 		expect(await outboxRepository.findVersionSkewedWorkflowIds()).not.toContain(workflow.id);
+	});
+
+	test('records persisted rows for a pseudo-only workflow, keeping it out of leader handoff and reconciliation', async () => {
+		const owner = await createOwner();
+
+		const trigger = manualTriggerNode('pseudo');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+
+		// Activation is untouched: a genuine publish still registers the no-op
+		// trigger's registry slot, and the status row (whose presence drives the
+		// publication status API) exists — but classified `persisted`, because the
+		// node is fired by the execution engine, never through the registry.
+		expect(activeWorkflowTriggers.get(workflow.id)?.has(trigger.id)).toBe(true);
+		const rows = await triggerStatusRepository.findByWorkflowId(workflow.id);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			nodeId: trigger.id,
+			status: 'activated',
+			triggerKind: 'persisted',
+		});
+
+		// Leader handoff on a fresh leader: nothing is registered locally, but a
+		// pseudo-only workflow has no real trigger work to republish.
+		await activeWorkflowTriggers.remove(workflow.id);
+		await outboxRepository.enqueueForLeaderHandoff();
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+
+		// The reconciler ignores persisted rows even though the node is not
+		// registered — no re-enqueue loop.
+		await reconciler.reconcile();
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+		expect(activeWorkflowTriggers.get(workflow.id)).toBeUndefined();
 	});
 
 	test('a pass with nothing missing enqueues no work', async () => {


### PR DESCRIPTION
## Summary

`n8n-nodes-base.manualTrigger`, `n8n-nodes-base.executeWorkflowTrigger`, and `n8n-nodes-base.errorTrigger` implement `trigger()` as a no-op — the execution engine fires them directly (manual runs, sub-workflow calls, error workflows), never the trigger registry. The capability-based classification in `getTriggerKinds` still marked them `in-memory` in `workflow_publication_trigger_status`, so every leader handoff and every reconciler pass republished them for zero real work: on our internal instance, 1177 of 1696 "in-memory" workflows are pseudo-only.

This changes **only the classification**: the three node types now record `triggerKind: 'persisted'`, the bucket both `enqueueForLeaderHandoff` and the reconciler's `findActivatedInMemoryTriggers` ignore. Deliberately *not* filtered at enqueue/activation/detection instead — rows saying `in-memory` for never-registered nodes would make the reconciler re-enqueue forever (the applier's `buildTriggerStatuses` fallback documents `persisted` as the safe bucket for exactly this reason).

Unchanged by design:
- **Activation**: a genuine publish still registers their no-op registry slots via the capability-based path; surplus/ghost detection doesn't flag them (desired nodes of the active version).
- **Status API**: publication status derives from row presence, not `triggerKind` — sub-workflow and error-workflow workflows still read as published.

**No backfill migration**: every completed/partial/failed publication full-replaces a workflow's trigger-status rows with the new classification, and leader startup/takeover enqueues every workflow with stale `in-memory` rows. Existing rows therefore self-heal on the first post-deploy republish wave — which already happens on every deploy today; it just becomes the last one.

## How to test

- Unit (`packages/cli`): `pnpm test src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts` — the three pseudo types classify `persisted`, a genuine trigger with the same capability shape stays `in-memory`.
- Integration (`packages/cli`): `pnpm test:integration test/integration/workflows/workflow-publication-reconciler.test.ts` — a pseudo-only workflow published through the real pipeline records `persisted` rows, is skipped by `enqueueForLeaderHandoff`, and a reconcile pass enqueues nothing while the no-op registry slot still registers on publish.
- Manually: with `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`, activate a workflow whose only trigger is an Execute Workflow Trigger, restart the instance, and observe the publication outbox: no record is enqueued for it on startup.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35287">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

