### PR TITLE
fix(core): Respect secure cookie config for OAuth sessions

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-session.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-session.service.test.ts
@@ -1,0 +1,32 @@
+import type { GlobalConfig } from '@n8n/config';
+import type { Response } from 'express';
+import { mock } from 'vitest-mock-extended';
+
+import type { JwtService } from '@/services/jwt.service';
+
+import { OAuthSessionService, type OAuthSessionPayload } from '../oauth-session.service';
+
+const payload: OAuthSessionPayload = {
+	clientId: 'client-id',
+	redirectUri: 'https://example.com/callback',
+	codeChallenge: 'code-challenge',
+	state: 'state',
+};
+
+describe('OAuthSessionService', () => {
+	it.each([true, false])('sets secure=%s from the auth cookie config', (secure) => {
+		const jwtService = mock<JwtService>();
+		jwtService.sign.mockReturnValue('session-token');
+		const globalConfig = mock<GlobalConfig>({ auth: { cookie: { secure } } });
+		const response = mock<Response>();
+		const service = new OAuthSessionService(jwtService, globalConfig);
+
+		service.createSession(response, payload);
+
+		expect(response.cookie).toHaveBeenCalledWith(
+			'n8n-oauth-session',
+			'session-token',
+			expect.objectContaining({ secure }),
+		);
+	});
+});

--- a/packages/cli/src/modules/oauth-server/oauth-session.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-session.service.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { Service } from '@n8n/di';
 import { Response } from 'express';
@@ -23,7 +24,10 @@ const SESSION_EXPIRY_MS = 10 * Time.minutes.toMilliseconds; // 10 minutes
  */
 @Service()
 export class OAuthSessionService {
-	constructor(private readonly jwtService: JwtService) {}
+	constructor(
+		private readonly jwtService: JwtService,
+		private readonly globalConfig: GlobalConfig,
+	) {}
 
 	/**
 	 * Create OAuth session token and set it as a cookie
@@ -35,7 +39,7 @@ export class OAuthSessionService {
 
 		res.cookie(COOKIE_NAME, sessionToken, {
 			httpOnly: true,
-			secure: process.env.NODE_ENV === 'production',
+			secure: this.globalConfig.auth.cookie.secure,
 			sameSite: 'lax',
 			maxAge: SESSION_EXPIRY_MS,
 		});


### PR DESCRIPTION
## Summary

Respect the configured secure-cookie setting when creating OAuth authorization sessions. This allows the consent flow to retain its session cookie on HTTP instances that explicitly set `N8N_SECURE_COOKIE=false`.

Add regression coverage for both secure-cookie configuration values.

## How to test

1. Run the OAuth session service unit test and confirm both secure-cookie cases pass.
2. Start n8n over HTTP with `N8N_SECURE_COOKIE=false`.
3. Begin an OAuth consent flow and confirm the `n8n-oauth-session` cookie is issued without the `Secure` attribute.

Validation performed:
- Focused unit test: 2 passed
- CLI lint
- CLI typecheck
- Scoped Biome check

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GHC-9094

Fixes #34955

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs are not required; this aligns the OAuth session cookie with the existing documented setting.
- [x] Tests included.
- [ ] PR labeled for backport if maintainers consider this urgent.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

