### PR TITLE
fix(ai-builder): Keep model-provider outages out of eval builder scores (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -869,6 +869,41 @@ When a scenario fails, the verifier categorizes the root cause:
 
 Suite pass rates typically sit between 40–65%; most failures are `builder_issue` on scenarios that require error handling the agent doesn't produce by default.
 
+### Provider outages are never a builder verdict
+
+A model-provider 5xx/429/529 during the build happens upstream of the n8n
+instance, so the lane stays healthy and nothing looks broken locally — but the
+build fails, and unclassified it reads exactly like "the agent built it wrong".
+A ~15-minute Anthropic outage recorded 124 flat-zero units as a product
+regression in nightly sweep #57 (TRUST-374).
+
+`harness/transient-error.ts` classifies these from the run's `error` events
+(structured `statusCode`), falling back to the flattened `Agent error: …` text.
+A classified outage is:
+
+- **retried** up to `MAX_PROVIDER_BUILD_ATTEMPTS` times, waiting **30s then 90s
+  between attempts**. This is a delay between attempts, not a limit on build
+  duration — the build's own budget (`effectiveTimeoutMs`, 15+ minutes) is
+  untouched. It matters because a provider 5xx returns in ~3 seconds, so instant
+  cross-lane retries re-hit the same upstream and let one runner shred its whole
+  queue at ~60× normal speed;
+- reported as `framework_issue`, never `build_failure` (which LangTracer maps
+  straight to `builder_issue`);
+- stamped with `PROVIDER_OUTAGE_ROOT_CAUSE` on the row's `rootCause`. LangTracer
+  keys `infra_incomplete` attribution off that exact prefix, so the wording is a
+  cross-repo contract — same arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE`;
+- left **ungraded** by the expectation judge: a run that produced no agent output
+  has nothing to grade, so its expectations are recorded as `incomplete` rather
+  than judged against an empty transcript (`build-expectations/select.ts`).
+
+A `Tool errors: …` 5xx is deliberately **not** an outage — that is the built
+workflow's own (mocked) HTTP traffic, which is a real product signal.
+
+Still uncovered: the server-side LLM mock generator shares the same provider, so
+during an outage its failures surface as `_evalMockError` and land in the
+`mock_issue` bucket. Detecting that needs the server to expose the provider
+status.
+
 ## Troubleshooting
 
 **`Wrong username or password` on login.** Your instance has no owner. Run the `rest/e2e/reset` curl from [Quick start](#quick-start) (needs `E2E_TESTS=true` on the server).

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -857,17 +857,44 @@ Rules of thumb:
 - **One slot means the modes are mutually exclusive by construction** — there is no way to declare two. Both order strictly before the live turn: `replay` provides its own live turn (omit `conversation`), `inline` pairs with one.
 - **A suite-sourced case carrying a pre-union key (`conversationSeed`, `priorConversation`, `seedThread`, `seedFile`) fails the suite pull by name.** The normalizer whitelists a hosted case down to the schema's keys, so without that guard the key would be stripped and the case would run *unseeded* — passing or failing for reasons that have nothing to do with what it tests.
 
-## Failure categories
+## Failure categories and attribution
 
 When a scenario fails, the verifier categorizes the root cause:
 
 - **builder_issue** — the agent misconfigured a node, chose the wrong node type, or built the wrong structure.
 - **mock_issue** — the LLM mock returned incorrect data (`_evalMockError`, wrong response shape).
 - **framework_issue** — Phase 1 failed (empty trigger content) or the eval framework itself cascaded an error.
-- **verification_failure** — the verifier couldn't produce a valid result.
-- **build_failure** — Instance AI failed to build the workflow or a scenario timed out.
+- **verification_gap** — the verifier didn't have enough information in the artifact to decide.
+
+Harness code stamps three more onto rows the verifier never saw:
+
+- **build_failure** — Instance AI failed to build the workflow.
+- **verification_failure** — the verifier produced no result at all after every attempt (also back-filled onto a failing verdict that arrived without a category).
+- **expectations_failed** — a build-only case whose expectation verdicts failed.
 
 Suite pass rates typically sit between 40–65%; most failures are `builder_issue` on scenarios that require error handling the agent doesn't produce by default.
+
+### `attribution` — the field that carries the meaning
+
+`failureCategory` is a free-form string with three producers, so downstream
+consumers used to re-derive what it meant and drifted (TRUST-375). Every failed
+scenario iteration and build expectation now also carries an **`attribution`**,
+defined once in `harness/attribution.ts` and stored verbatim by LangTracer:
+
+| bucket | means |
+| -- | -- |
+| `builder_issue` | the agent built it wrong, including "runs as built, misses the criteria" |
+| `mock_issue` | the eval mock/fixture layer served data the scenario didn't describe |
+| `framework_issue` | the eval framework failed the test rather than the test failing — no trigger content, seed table missing, provider outage, transport error, budget abort, runner crash |
+| `verification_gap` | we couldn't measure it — verifier returned nothing, judge died, unit ungraded |
+
+Deliberately the same four names the verifier prompt already defines, so ingest
+is an identity map rather than a translation. The harness-code categories fold
+in: `build_failure` and `expectations_failed` → `builder_issue`,
+`verification_failure` → `verification_gap`, and a build that died on seeding,
+transport or a provider outage → `framework_issue`.
+
+`failureCategory` still ships unchanged for readers on the legacy contract.
 
 ### Provider outages are never a builder verdict
 
@@ -889,9 +916,11 @@ A classified outage is:
   queue at ~60× normal speed;
 - reported as `framework_issue`, never `build_failure` (which LangTracer maps
   straight to `builder_issue`);
-- stamped with `PROVIDER_OUTAGE_ROOT_CAUSE` on the row's `rootCause`. LangTracer
-  keys `infra_incomplete` attribution off that exact prefix, so the wording is a
-  cross-repo contract — same arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE`;
+- attributed **`framework_issue`**, and additionally stamped with
+  `PROVIDER_OUTAGE_ROOT_CAUSE` on the row's `rootCause`. LangTracer used to key
+  its infra bucket off that exact prefix; it now reads the attribution directly,
+  so the marker is the fallback for older pinned harness commits — same
+  arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE`;
 - left **ungraded** by the expectation judge: a run that produced no agent output
   has nothing to grade, so its expectations are recorded as `incomplete` rather
   than judged against an empty transcript (`build-expectations/select.ts`).

--- a/packages/@n8n/instance-ai/evaluations/__tests__/attribution.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/attribution.test.ts
@@ -1,0 +1,149 @@
+import {
+	attributionForExpectation,
+	attributionForScenario,
+	attributionFromVerifierCategory,
+	EVAL_ATTRIBUTIONS,
+	VERIFIER_CATEGORIES,
+} from '../harness/attribution';
+import { buildFailedOnInfra, type BuildResult } from '../harness/build-workflow';
+import { classifyScenarioExecutionError } from '../harness/transient-error';
+import { sentinelOutcomeFromVerdicts } from '../run/reshape';
+import { MOCK_EXECUTION_VERIFY_PROMPT } from '../system-prompts/mock-execution-verify';
+
+function build(overrides: Partial<BuildResult>): BuildResult {
+	return {
+		success: false,
+		workflowJsons: [],
+		createdWorkflowIds: [],
+		createdDataTableIds: [],
+		...overrides,
+	};
+}
+
+describe('attributionFromVerifierCategory', () => {
+	it('is an identity map over the categories the verifier prompt defines', () => {
+		// The verifier's enum IS the attribution vocabulary — nothing to translate,
+		// which is the point of TRUST-375.
+		for (const category of VERIFIER_CATEGORIES) {
+			expect(attributionFromVerifierCategory(category)).toBe(category);
+		}
+	});
+
+	it('treats an uncategorised or unknown verdict as the builder’s', () => {
+		// The verifier prompt is explicit that there is no "legitimate failure"
+		// bucket — a decided failure with no category is still the builder's.
+		expect(attributionFromVerifierCategory(undefined)).toBe('builder_issue');
+		expect(attributionFromVerifierCategory('verification_failure')).toBe('builder_issue');
+		expect(attributionFromVerifierCategory('brand_new_category')).toBe('builder_issue');
+	});
+
+	it('stays in step with the enum the verifier prompt actually defines', () => {
+		// The prompt is the verifier's only spec. If someone adds a category there
+		// without adding it here it silently falls through to builder_issue —
+		// exactly the drift this contract exists to stop.
+		for (const category of VERIFIER_CATEGORIES) {
+			expect(MOCK_EXECUTION_VERIFY_PROMPT).toContain(`**${category}**`);
+		}
+	});
+});
+
+describe('attributionForScenario', () => {
+	it('leaves a passing scenario unattributed', () => {
+		expect(
+			attributionForScenario({ passed: true, incomplete: false, failureCategory: undefined }),
+		).toBeUndefined();
+	});
+
+	it('marks a scenario the verifier never decided as a verification gap', () => {
+		// The harness excludes this run from scoring; recording it as a product
+		// failure is what TRUST-375 set out to stop.
+		expect(
+			attributionForScenario({
+				passed: false,
+				incomplete: true,
+				failureCategory: 'verification_failure',
+			}),
+		).toBe('verification_gap');
+	});
+
+	it('otherwise defers to the verifier', () => {
+		expect(
+			attributionForScenario({ passed: false, incomplete: false, failureCategory: 'mock_issue' }),
+		).toBe('mock_issue');
+	});
+});
+
+describe('attributionForExpectation', () => {
+	it('leaves a passing expectation unattributed', () => {
+		expect(attributionForExpectation({ pass: true })).toBeUndefined();
+		expect(attributionForExpectation({ pass: true }, true)).toBeUndefined();
+	});
+
+	it('treats a missed expectation as a builder miss', () => {
+		expect(attributionForExpectation({ pass: false })).toBe('builder_issue');
+	});
+
+	it('treats an ungraded expectation as unmeasured', () => {
+		expect(attributionForExpectation({ pass: false, incomplete: true })).toBe('verification_gap');
+	});
+
+	it('attributes every expectation of an infra-failed build to infra', () => {
+		expect(attributionForExpectation({ pass: false, incomplete: true }, true)).toBe(
+			'framework_issue',
+		);
+		expect(attributionForExpectation({ pass: false }, true)).toBe('framework_issue');
+	});
+});
+
+describe('buildFailedOnInfra', () => {
+	it('is false for a successful build', () => {
+		expect(buildFailedOnInfra(build({ success: true, transportFailure: true }))).toBe(false);
+	});
+
+	it('is false for a genuine agent build failure', () => {
+		expect(buildFailedOnInfra(build({ error: 'agent produced no workflow' }))).toBe(false);
+	});
+
+	it('covers seeding, transport and provider outages', () => {
+		expect(buildFailedOnInfra(build({ seedingFailed: true }))).toBe(true);
+		expect(buildFailedOnInfra(build({ transportFailure: true }))).toBe(true);
+		expect(buildFailedOnInfra(build({ providerOutage: 'provider HTTP 529' }))).toBe(true);
+	});
+});
+
+describe('harness-code producers', () => {
+	it('classifies anything thrown out of scenario execution as infra', () => {
+		expect(classifyScenarioExecutionError('socket hang up').attribution).toBe('framework_issue');
+		expect(
+			classifyScenarioExecutionError('The operation was aborted due to timeout').attribution,
+		).toBe('framework_issue');
+	});
+
+	it('attributes the build-only sentinel row from its expectation verdicts', () => {
+		expect(sentinelOutcomeFromVerdicts(undefined).attribution).toBe('verification_gap');
+		expect(
+			sentinelOutcomeFromVerdicts([{ expectation: 'a', pass: false, reason: '', incomplete: true }])
+				.attribution,
+		).toBe('verification_gap');
+		expect(
+			sentinelOutcomeFromVerdicts([{ expectation: 'a', pass: false, reason: 'missed' }])
+				.attribution,
+		).toBe('builder_issue');
+		expect(
+			sentinelOutcomeFromVerdicts([{ expectation: 'a', pass: true, reason: 'ok' }]).attribution,
+		).toBeUndefined();
+	});
+
+	it('only ever emits one of the four buckets', () => {
+		const emitted = [
+			attributionFromVerifierCategory('anything'),
+			attributionForExpectation({ pass: false }),
+			attributionForExpectation({ pass: false }, true),
+			classifyScenarioExecutionError('boom').attribution,
+			sentinelOutcomeFromVerdicts(undefined).attribution,
+		];
+		for (const attribution of emitted) {
+			expect(EVAL_ATTRIBUTIONS).toContain(attribution);
+		}
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/attribution.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/attribution.test.ts
@@ -38,12 +38,19 @@ describe('attributionFromVerifierCategory', () => {
 	});
 
 	it('stays in step with the enum the verifier prompt actually defines', () => {
-		// The prompt is the verifier's only spec. If someone adds a category there
-		// without adding it here it silently falls through to builder_issue —
-		// exactly the drift this contract exists to stop.
-		for (const category of VERIFIER_CATEGORIES) {
-			expect(MOCK_EXECUTION_VERIFY_PROMPT).toContain(`**${category}**`);
-		}
+		// BOTH directions. Code-missing-from-prompt means the verifier can never
+		// pick a bucket we handle; prompt-missing-from-code is worse and was the
+		// untested half — the verifier picks it, `attributionFromVerifierCategory`
+		// doesn't recognise it, and it silently lands on builder_issue, which is
+		// exactly the misattribution this contract exists to stop.
+		const declared = [...MOCK_EXECUTION_VERIFY_PROMPT.matchAll(/^- \*\*([a-z_]+)\*\*:/gm)].map(
+			(m) => m[1],
+		);
+
+		// Guard the parser itself: a prompt reformat that stops matching would
+		// otherwise turn this contract into an empty-set tautology.
+		expect(declared.length).toBeGreaterThan(0);
+		expect([...declared].sort()).toEqual([...VERIFIER_CATEGORIES].sort());
 	});
 });
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-orchestrator.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-orchestrator.test.ts
@@ -130,6 +130,8 @@ function makeDeps(
 		buildExpectationsByKey: new Map(),
 		runDebugByThreadId: new Map(),
 		agentContextByKey: new Map(),
+		// The provider-outage backoff is minutes long in production — never slept here.
+		sleep: vi.fn().mockResolvedValue(undefined),
 		...overrides,
 	};
 }
@@ -212,6 +214,92 @@ describe('createBuildOrchestrator', () => {
 		expect(first.build.transportFailure).toBe(false);
 		expect(orchestrator.buildCache.size).toBe(1);
 		expect(orchestrator.orphanedBuilds).toHaveLength(0);
+	});
+
+	it('retries a provider outage after a backoff, on a healthy lane', async () => {
+		// TRUST-374: the lane is fine — the model provider is not. Unclassified, this
+		// failure reads as a builder verdict and is neither retried nor re-attributed.
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+		const failing = vi
+			.fn()
+			.mockResolvedValue(
+				failedBuild(
+					'Agent error: Internal server error; No output generated. Check the stream for errors.',
+				),
+			);
+		const healthy = vi.fn().mockResolvedValue(okBuild());
+		const deps = makeDeps([makeLane(1, failing), makeLane(2, healthy)]);
+		const orchestrator = createBuildOrchestrator(deps);
+
+		const { build } = await orchestrator.getOrBuild(0, 'case-a');
+
+		expect(build.success).toBe(true);
+		expect(failing).toHaveBeenCalledTimes(1);
+		// An instant retry would just re-hit the same upstream.
+		expect(vi.mocked(deps.sleep!).mock.calls[0][0]).toBeGreaterThanOrEqual(30_000);
+	});
+
+	it('marks an unrecoverable provider outage as infra without rebuilding per scenario', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+		const providerError = 'Agent error: Overloaded; No output generated.';
+		const failing1 = vi.fn().mockResolvedValue(failedBuild(providerError));
+		const failing2 = vi.fn().mockResolvedValue(failedBuild(providerError));
+		const orchestrator = createBuildOrchestrator(
+			makeDeps([makeLane(1, failing1), makeLane(2, failing2)]),
+		);
+
+		const { build } = await orchestrator.getOrBuild(0, 'case-a');
+
+		expect(build.success).toBe(false);
+		expect(build.providerOutage).toBe(providerError);
+		// framework_issue, not build_failure — the builder never got to run.
+		expect(build.transportFailure).toBe(true);
+		expect(failing1.mock.calls.length + failing2.mock.calls.length).toBe(3);
+
+		// The retry budget is spent; a later scenario of the case must not pay it again.
+		await settleMicrotasks();
+		expect(orchestrator.buildCache.size).toBe(1);
+		await orchestrator.getOrBuild(0, 'case-a');
+		expect(failing1.mock.calls.length + failing2.mock.calls.length).toBe(3);
+	});
+
+	it('does not mistake the built workflow-s own upstream 5xx for a provider outage', async () => {
+		// A mocked API returning 500 to the workflow is a product signal, so it stays
+		// a cached build_failure verdict.
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+		const failing = vi.fn().mockResolvedValue(failedBuild('Tool errors: Stripe returned HTTP 500'));
+		const orchestrator = createBuildOrchestrator(makeDeps([makeLane(1, failing)]));
+
+		const { build } = await orchestrator.getOrBuild(0, 'case-a');
+
+		expect(build.providerOutage).toBeUndefined();
+		expect(build.transportFailure).toBe(false);
+		expect(failing).toHaveBeenCalledTimes(1);
+		await settleMicrotasks();
+		expect(orchestrator.buildCache.size).toBe(1);
+	});
+
+	it('records ungraded expectations when the build produced no agent output', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+		const providerError = 'Agent error: Overloaded; No output generated.';
+		const failing = vi.fn().mockResolvedValue(failedBuild(providerError));
+		const deps = makeDeps([makeLane(1, failing)], {
+			testCaseByFileSlug: new Map([
+				['case-a', baseCase({ outcomeExpectations: ['sends a digest'] })],
+			]),
+		});
+		const orchestrator = createBuildOrchestrator(deps);
+
+		await orchestrator.getOrBuild(0, 'case-a');
+
+		// Never handed to the judge, but still recorded — as incomplete.
+		expect(vi.mocked(verifyBuildExpectations)).not.toHaveBeenCalled();
+		const verdicts = await deps.buildExpectationsByKey.get('0:case-a');
+		expect(verdicts).toHaveLength(1);
+		expect(verdicts?.[0].expectation).toBe('sends a digest');
+		expect(verdicts?.[0].pass).toBe(false);
+		expect(verdicts?.[0].incomplete).toBe(true);
+		expect(verdicts?.[0].reason).toContain('no agent output');
 	});
 
 	it('serves prebuilt workflows by fetching them, never invoking the builder', async () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
@@ -2,6 +2,7 @@ import type { CliArgs } from '../cli/args';
 import type { BuildResult } from '../harness/build-workflow';
 import { cleanupBuild } from '../harness/cleanup';
 import type { EvalLogger } from '../harness/logger';
+import { PROVIDER_OUTAGE_ROOT_CAUSE } from '../harness/transient-error';
 import { BUILD_ONLY_SCENARIO_NAME } from '../langsmith/dataset-sync';
 import type { BuildOrchestrator, CachedBuild, LaneState } from '../run/build-orchestrator';
 import { createCasePipeline, type CasePipelineDeps } from '../run/case-pipeline';
@@ -239,6 +240,27 @@ describe('createCasePipeline', () => {
 		const output = await pipeline.runRow(rowInputs('happy-path'));
 
 		expect(output.failureCategory).toBe('framework_issue');
+	});
+
+	it('stamps the pinned root cause on a provider-outage build so LangTracer sees infra', async () => {
+		const lane = makeLane();
+		const orchestrator = makeOrchestrator({
+			build: okBuild({
+				success: false,
+				workflowId: undefined,
+				error: 'Agent error: Internal server error; No output generated.',
+				transportFailure: true,
+				providerOutage: 'provider HTTP 529: Overloaded',
+			}),
+			lane,
+			buildDurationMs: 5,
+		});
+		const pipeline = createCasePipeline(makeDeps(orchestrator));
+
+		const output = await pipeline.runRow(rowInputs('happy-path'));
+
+		expect(output.failureCategory).toBe('framework_issue');
+		expect(output.rootCause).toBe(`${PROVIDER_OUTAGE_ROOT_CAUSE}: provider HTTP 529: Overloaded`);
 	});
 
 	it('scores a build-only sentinel row from the expectation verdicts', async () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-compare.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-compare.test.ts
@@ -207,14 +207,16 @@ describe('compareBuckets', () => {
 			trialTotal: 10,
 		});
 		const cats = compareBuckets(pr, base).failureCategories;
-		// All five known categories are always present (some at 0/0 — renderer
-		// drops those). The unknown `-` category is dropped here with a warning.
+		// Every known category is always present (some at 0/0 — renderer drops
+		// those). The unknown `-` category is dropped here with a warning.
 		expect(cats.map((c) => c.category).sort()).toEqual([
 			'build_failure',
 			'builder_issue',
+			'expectations_failed',
 			'framework_issue',
 			'mock_issue',
 			'verification_failure',
+			'verification_gap',
 		]);
 		expect(warn).toHaveBeenCalledWith(expect.stringContaining('"-"'));
 		warn.mockRestore();

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -86,7 +86,12 @@ function iteration2(): WorkflowTestCaseResult {
 		workflowBuildSuccess: true,
 		buildError: 'agent stopped before producing a workflow',
 		buildExpectationResults: [
-			{ expectation: 'sends a digest', pass: false, reason: 'digest node missing' },
+			{
+				expectation: 'sends a digest',
+				pass: false,
+				reason: 'digest node missing',
+				attribution: 'builder_issue',
+			},
 		],
 		executionScenarioResults: [
 			{
@@ -95,6 +100,7 @@ function iteration2(): WorkflowTestCaseResult {
 				score: 0,
 				reasoning: 'no digest was produced',
 				failureCategory: 'mock_issue',
+				attribution: 'mock_issue',
 				rootCause: 'mock returned an empty page',
 				evalResult: { errors: ['HTTP 500 from the mocked API'] } as InstanceAiEvalExecutionResult,
 			},
@@ -118,6 +124,7 @@ interface DispatcherView {
 			expectation: string;
 			pass: boolean;
 			reason: string;
+			attribution?: string;
 		}> | null>;
 		buildCostUsdPerRun?: Array<number | null>;
 		buildTurnsPerRun?: Array<number | null>;
@@ -132,6 +139,7 @@ interface DispatcherView {
 				score: number;
 				reasoning: string;
 				failureCategory?: string;
+				attribution?: string;
 				rootCause?: string;
 				execErrors: string[];
 			}>;
@@ -181,7 +189,16 @@ describe('eval-results.json — dispatcher contract', () => {
 		});
 		expect(tc.buildExpectationResultsPerRun).toEqual([
 			[{ expectation: 'sends a digest', pass: true, reason: 'digest node present' }],
-			[{ expectation: 'sends a digest', pass: false, reason: 'digest node missing' }],
+			[
+				{
+					expectation: 'sends a digest',
+					pass: false,
+					reason: 'digest node missing',
+					// A missed expectation is a builder miss — the harness decides this,
+					// lang-tracer stores it (TRUST-375).
+					attribution: 'builder_issue',
+				},
+			],
 		]);
 		// Spend arrays are `--build-via-mcp`-only — absent when no iteration
 		// recorded `claude` spend, so non-MCP dispatcher output is unchanged.
@@ -220,9 +237,15 @@ describe('eval-results.json — dispatcher contract', () => {
 			score: 0,
 			reasoning: 'no digest was produced',
 			failureCategory: 'mock_issue',
+			// The attribution rides ALONGSIDE the legacy category — lang-tracer reads
+			// this one and only falls back to re-deriving from the category for rows
+			// written by an older pinned harness commit (TRUST-375).
+			attribution: 'mock_issue',
 			rootCause: 'mock returned an empty page',
 			execErrors: ['HTTP 500 from the mocked API'],
 		});
+		// A passing run carries no attribution at all — nobody owns a pass.
+		expect(sc.runs[0]).not.toHaveProperty('attribution');
 	});
 
 	it('serializes per-iteration `claude` build spend when a run recorded it', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/fixtures/eval-results.partial-abort.json
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/fixtures/eval-results.partial-abort.json
@@ -66,6 +66,7 @@
 							"score": 0,
 							"reasoning": "Scenario execution error: TimeoutError: The operation was aborted due to timeout",
 							"failureCategory": "framework_issue",
+							"attribution": "framework_issue",
 							"rootCause": "Scenario execution exceeded its per-iteration time budget and was aborted before a verdict: TimeoutError: The operation was aborted due to timeout",
 							"execErrors": []
 						}

--- a/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
@@ -255,8 +255,43 @@ describe('buildWorkflowViaMcp', () => {
 		const result = await buildWorkflowViaMcp(buildOpts());
 
 		expect(result.workflowId).toBeNull();
-		expect(result.failureReason).toBe('no-stdout');
+		// The session's result text is appended so an upstream provider error can
+		// be classified downstream; the subtype still leads.
+		expect(result.failureReason).toContain('no-stdout');
 		expect(vi.mocked(spawn)).toHaveBeenCalledTimes(3);
+	});
+
+	// TRUST-374: a provider outage inside `claude` reached the orchestrator as a
+	// bare subtype, so `findProviderOutage` had nothing to match and the run was
+	// filed as a BUILDER failure. The session's own error text has to ride along.
+	it('carries the provider error text out, not just the session subtype', async () => {
+		spawnReturning(() => {
+			const child = new FakeChild(1234);
+			setImmediate(() => {
+				child.stdout.emit(
+					'data',
+					Buffer.from(
+						JSON.stringify({
+							subtype: 'error_during_execution',
+							result: 'AI_APICallError: Overloaded (HTTP 529)',
+						}),
+					),
+				);
+				child.emit('close', 0, null);
+			});
+			return child;
+		});
+
+		// One attempt: the provider backoff between retries is exercised separately;
+		// this pins that the evidence survives into `failureReason`.
+		const result = await buildWorkflowViaMcp({
+			...buildOpts(),
+			settings: { ...settings, maxAttempts: 1 },
+		});
+
+		expect(result.workflowId).toBeNull();
+		expect(result.failureReason).toContain('error_during_execution');
+		expect(result.failureReason).toContain('AI_APICallError');
 	});
 
 	it('returns the workflow id from a successful first attempt', async () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -205,6 +205,9 @@ describe('reshapeLangSmithRuns', () => {
 		expect(s2.success).toBe(false);
 		expect(s2.reasoning).toBe('No run result for this scenario');
 		expect(s2.score).toBe(0);
+		// Unowned and unmeasured: visible as a gap, but out of the pass rate.
+		expect(s2.attribution).toBe('verification_gap');
+		expect(s2.incomplete).toBe(true);
 	});
 
 	it('skips a malformed run output rather than scoring it as a failure', () => {
@@ -216,6 +219,8 @@ describe('reshapeLangSmithRuns', () => {
 		const s1 = result[0][0].executionScenarioResults[0];
 		expect(s1.success).toBe(false);
 		expect(s1.reasoning).toBe('Malformed run output — skipped');
+		expect(s1.attribution).toBe('verification_gap');
+		expect(s1.incomplete).toBe(true);
 	});
 
 	it('groups runs into separate iterations by the injected _iteration index', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/select-expectations.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/select-expectations.test.ts
@@ -16,7 +16,12 @@ function makeLogger(): { logger: EvalLogger; warnings: string[] } {
 }
 
 const conversation: ConversationTurn[] = [{ role: 'user', text: 'build it' }];
-const realTranscript: TranscriptTurn[] = [{ userMessage: 'build it', steps: [] }];
+const realTranscript: TranscriptTurn[] = [
+	{ userMessage: 'build it', steps: [{ kind: 'agent-text', text: 'On it.' }] },
+];
+/** What a run that died before the agent acted leaves behind: one turn per user
+ *  message, and no agent steps at all. */
+const noOutputTranscript: TranscriptTurn[] = [{ userMessage: 'build it', steps: [] }];
 
 function testCase(
 	over: Partial<Pick<WorkflowTestCase, 'processExpectations' | 'outcomeExpectations'>> = {},
@@ -96,9 +101,9 @@ describe('selectAuthorExpectations', () => {
 		expect(warnings).toEqual([]);
 	});
 
-	it('judges nothing and does not warn when a build fails with no transcript', () => {
+	it('records expectations as ungraded when a build fails with no transcript', () => {
 		const { logger, warnings } = makeLogger();
-		const { expectations } = selectAuthorExpectations({
+		const { expectations, unjudged } = selectAuthorExpectations({
 			testCase: testCase({ processExpectations: ['p1'], outcomeExpectations: ['o1'] }),
 			transcript: undefined,
 			buildSucceeded: false,
@@ -106,6 +111,59 @@ describe('selectAuthorExpectations', () => {
 			logger,
 		});
 		expect(expectations).toEqual([]);
+		// Recorded, not dropped — incomplete keeps them out of every pass rate
+		// while the case keeps its unit count.
+		expect(unjudged.map((v) => [v.expectation, v.pass, v.incomplete])).toEqual([
+			['p1', false, true],
+			['o1', false, true],
+		]);
+		expect(unjudged[0].reason).toContain('nothing to grade');
+		expect(warnings[0]).toContain('no agent output');
+	});
+
+	it('leaves expectations ungraded when a failed build produced turns but no agent output', () => {
+		// TRUST-374: a provider outage still yields one turn per user message, so
+		// the transcript array is non-empty while the agent never wrote a thing.
+		// Judging it produced 538 confidently-wrong failures in sweep #57.
+		const { logger } = makeLogger();
+		const { expectations, unjudged } = selectAuthorExpectations({
+			testCase: testCase({ processExpectations: ['p1', 'p2'], outcomeExpectations: ['o1'] }),
+			transcript: noOutputTranscript,
+			buildSucceeded: false,
+			isPrebuilt: false,
+			logger,
+		});
+		expect(expectations).toEqual([]);
+		expect(unjudged).toHaveLength(3);
+		expect(unjudged.every((v) => v.incomplete)).toBe(true);
+	});
+
+	it('still judges a genuine build failure that produced agent activity', () => {
+		// The agent tried and got it wrong — that is a real product verdict.
+		const { logger } = makeLogger();
+		const { expectations, transcript, unjudged } = selectAuthorExpectations({
+			testCase: testCase({ processExpectations: ['p1'], outcomeExpectations: ['o1'] }),
+			transcript: realTranscript,
+			buildSucceeded: false,
+			isPrebuilt: false,
+			logger,
+		});
+		expect(expectations).toEqual(['p1', 'o1']);
+		expect(transcript).toBe(realTranscript);
+		expect(unjudged).toEqual([]);
+	});
+
+	it('records nothing extra when a failed no-output build declares no expectations', () => {
+		const { logger, warnings } = makeLogger();
+		const { expectations, unjudged } = selectAuthorExpectations({
+			testCase: testCase(),
+			transcript: noOutputTranscript,
+			buildSucceeded: false,
+			isPrebuilt: false,
+			logger,
+		});
+		expect(expectations).toEqual([]);
+		expect(unjudged).toEqual([]);
 		expect(warnings).toEqual([]);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/transient-error.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/transient-error.test.ts
@@ -1,7 +1,10 @@
 import {
 	extractErrorMessage,
+	findProviderOutage,
 	isTransientNetworkError,
+	isTransientProviderError,
 	MAX_EXEC_ATTEMPTS,
+	providerRetryBackoffMs,
 } from '../harness/transient-error';
 
 describe('transient-error', () => {
@@ -59,5 +62,93 @@ describe('transient-error', () => {
 	it('caps retries at a small positive number', () => {
 		expect(MAX_EXEC_ATTEMPTS).toBeGreaterThan(1);
 		expect(MAX_EXEC_ATTEMPTS).toBeLessThanOrEqual(5);
+	});
+
+	describe('isTransientProviderError', () => {
+		it.each([
+			// The exact shape nightly sweep #57 recorded 124 times (TRUST-374).
+			'Agent error: Internal server error; No output generated. Check the stream for errors.',
+			'Agent error: Overloaded',
+			'Agent error: provider returned status code 529',
+			'AI_APICallError: Internal server error',
+			'AI_RetryError: failed after 3 attempts',
+			'{"type":"overloaded_error","message":"Overloaded"}',
+		])('classifies %j as a provider outage', (message) => {
+			expect(isTransientProviderError(message)).toBe(true);
+		});
+
+		it.each([
+			// The built workflow's own (mocked) HTTP traffic — a product signal.
+			'Tool errors: Stripe API returned HTTP 500',
+			'Tool errors: Internal server error',
+			// n8n's own API, not the model provider.
+			'n8n API POST /rest/workflows failed (500): Internal error',
+			'Agent response: I could not find a suitable node',
+			'No workflow produced — no error details captured',
+		])('does not classify %j as a provider outage', (message) => {
+			expect(isTransientProviderError(message)).toBe(false);
+		});
+	});
+
+	describe('findProviderOutage', () => {
+		const errorEvent = (payload: Record<string, unknown>) => ({
+			type: 'error',
+			data: { type: 'error', payload },
+		});
+
+		it('reads the ai-sdk status code off a run-level error event', () => {
+			expect(
+				findProviderOutage({
+					success: false,
+					error: 'Agent error: something opaque',
+					events: [errorEvent({ content: 'Internal server error', statusCode: 529 })],
+				}),
+			).toBe('provider HTTP 529: Internal server error');
+		});
+
+		it('ignores a tool-error carrying a provider-shaped status', () => {
+			// The workflow calling a mocked API that 500s is the product failing.
+			expect(
+				findProviderOutage({
+					success: false,
+					error: 'Tool errors: upstream returned 503',
+					events: [
+						{ type: 'tool-error', data: { payload: { error: 'HTTP 503', statusCode: 503 } } },
+					],
+				}),
+			).toBeUndefined();
+		});
+
+		it('ignores a non-transient status on a run-level error event', () => {
+			expect(
+				findProviderOutage({
+					success: false,
+					error: 'Agent error: quota exhausted',
+					events: [errorEvent({ content: 'Have reached end of quota', statusCode: 403 })],
+				}),
+			).toBeUndefined();
+		});
+
+		it('falls back to the flattened error text when no events were captured', () => {
+			const error =
+				'Agent error: Internal server error; No output generated. Check the stream for errors.';
+			expect(findProviderOutage({ success: false, error })).toBe(error);
+		});
+
+		it('never reports an outage for a successful build', () => {
+			expect(
+				findProviderOutage({
+					success: true,
+					events: [errorEvent({ content: 'Overloaded', statusCode: 529 })],
+				}),
+			).toBeUndefined();
+		});
+	});
+
+	it('waits long enough between build retries for a provider blip to clear', () => {
+		// A delay BETWEEN attempts, not a cap on build duration: instant retries
+		// re-hit the same upstream and let the run queue drain.
+		expect(providerRetryBackoffMs(1)).toBeGreaterThanOrEqual(30_000);
+		expect(providerRetryBackoffMs(2)).toBeGreaterThan(providerRetryBackoffMs(1));
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/transient-error.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/transient-error.test.ts
@@ -151,4 +151,29 @@ describe('transient-error', () => {
 		expect(providerRetryBackoffMs(1)).toBeGreaterThanOrEqual(30_000);
 		expect(providerRetryBackoffMs(2)).toBeGreaterThan(providerRetryBackoffMs(1));
 	});
+
+	// TRUST-374: the MCP path composes its error as
+	// `MCP build produced no workflow (<subtype>: <session result>)`. The provider
+	// evidence is inside that string, so classification must survive the wrapper.
+	describe('MCP build failures', () => {
+		const mcpBuild = (reason: string) => ({
+			success: false,
+			error: `MCP build produced no workflow (${reason})`,
+		});
+
+		it('classifies a provider outage reported through the MCP wrapper', () => {
+			expect(
+				findProviderOutage(
+					mcpBuild('error_during_execution: AI_APICallError: Overloaded (HTTP 529)'),
+				),
+			).toBeDefined();
+		});
+
+		it('leaves an ordinary MCP build failure attributed to the builder', () => {
+			expect(
+				findProviderOutage(mcpBuild('no-stdout: built something, forgot the id')),
+			).toBeUndefined();
+			expect(findProviderOutage(mcpBuild('timeout'))).toBeUndefined();
+		});
+	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/workflow-report.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/workflow-report.test.ts
@@ -208,3 +208,55 @@ describe('transcript rendering', () => {
 		expect(html).toContain('ask-user (with answers)');
 	});
 });
+
+// The '1. Prompt' review stage was gated on `failureCategory === 'legitimate_failure'`
+// — a lang-tracer bucket this harness never emits — so it could NEVER fail. TRUST-375
+// rewired it (and the improvement suggestion) to `attribution`, making it reachable
+// for the first time. Pin the toggle so the unreachable-stage bug can't come back.
+describe('prompt review stage keys off attribution', () => {
+	function failedScenario(
+		over: Partial<WorkflowTestCaseResult['executionScenarioResults'][number]>,
+	): WorkflowTestCaseResult {
+		return {
+			testCase: TEST_CASE,
+			workflowBuildSuccess: true,
+			executionScenarioResults: [
+				{
+					scenario: TEST_CASE.executionScenarios![0],
+					success: false,
+					score: 0,
+					reasoning: 'the success criteria are ambiguous about the error branch',
+					...over,
+				},
+			],
+		} as WorkflowTestCaseResult;
+	}
+
+	it('fails the stage when the builder owns an under-specified prompt', () => {
+		const html = generateWorkflowReport([failedScenario({ attribution: 'builder_issue' })]);
+
+		expect(html).toContain('1. Prompt');
+		expect(html).toContain('under-specified request');
+	});
+
+	it('does not blame the prompt when the failure is not the builder’s', () => {
+		// Same evidence text; only the attribution differs. A mock or infra failure
+		// says nothing about the prompt.
+		for (const attribution of ['mock_issue', 'framework_issue', 'verification_gap'] as const) {
+			const html = generateWorkflowReport([failedScenario({ attribution })]);
+			expect(html).not.toContain('under-specified request');
+		}
+	});
+
+	it('offers an improvement suggestion keyed to each attribution bucket', () => {
+		// The old switch mixed our categories with lang-tracer bucket names, so two
+		// arms were unreachable. Each bucket must now produce its own advice.
+		const suggestions = (
+			['builder_issue', 'mock_issue', 'framework_issue', 'verification_gap'] as const
+		).map((attribution) => generateWorkflowReport([failedScenario({ attribution })]));
+		expect(suggestions[0]).toContain('observable acceptance conditions');
+		expect(suggestions[1]).toContain('response envelope');
+		expect(suggestions[2]).toContain('trigger preconditions');
+		expect(suggestions[3]).toContain('inspectable success evidence');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/build-expectations/select.ts
+++ b/packages/@n8n/instance-ai/evaluations/build-expectations/select.ts
@@ -1,7 +1,12 @@
+import { allFailVerdicts } from './assertion-judge';
 import { collectExpectations } from './collect';
 import type { EvalLogger } from '../harness/logger';
-import type { TranscriptTurn, WorkflowTestCase } from '../types';
+import type { BuildExpectationResult, TranscriptTurn, WorkflowTestCase } from '../types';
 import { conversationUserTurnsAsText } from '../utils/conversation-text';
+
+/** Recorded on expectations we refuse to judge, so the reason reaches the report. */
+const NO_AGENT_OUTPUT_REASON =
+	'not judged — the build produced no agent output, so there was nothing to grade';
 
 export interface SelectAuthorExpectationsArgs {
 	testCase: Pick<WorkflowTestCase, 'processExpectations' | 'outcomeExpectations' | 'conversation'>;
@@ -26,6 +31,13 @@ export interface SelectAuthorExpectationsArgs {
  *   This is the prebuilt/MCP path.
  * - Build failed with no transcript → judge nothing.
  *
+ * "No transcript" means no AGENT OUTPUT, not an empty array. A run that dies
+ * before the agent does anything (a provider outage, a crashed sandbox) still
+ * produces one turn per user message, each with zero steps. Judging those turns
+ * yields a full set of confidently-wrong verdicts describing a transcript the
+ * agent never got to write — 538 of them in nightly sweep #57 (TRUST-374). They
+ * come back as `unjudged` instead: recorded, but marked incomplete.
+ *
  * A successful full (non-prebuilt) build should always carry a transcript; if it
  * doesn't, `processExpectations` can't be judged. We still skip them (judging
  * them against no transcript would only produce false failures), but warn so the
@@ -34,26 +46,45 @@ export interface SelectAuthorExpectationsArgs {
 export function selectAuthorExpectations(args: SelectAuthorExpectationsArgs): {
 	expectations: string[];
 	transcript: TranscriptTurn[];
+	/** Expectations deliberately left ungraded, already shaped as `incomplete`
+	 *  verdicts. Recording them keeps the case's unit count stable across runs (so
+	 *  baselines stay comparable) while contributing nothing to any pass rate —
+	 *  this repo's scoring and LangTracer's both skip `incomplete` rows. */
+	unjudged: BuildExpectationResult[];
 } {
 	const { testCase, buildSucceeded, isPrebuilt, logger } = args;
-	const hasTranscript = (args.transcript?.length ?? 0) > 0;
+	const hasAgentOutput = (args.transcript ?? []).some((turn) => turn.steps.length > 0);
 	const processCount = testCase.processExpectations?.length ?? 0;
 
-	if (!isPrebuilt && !hasTranscript && buildSucceeded && processCount > 0) {
+	if (!isPrebuilt && !hasAgentOutput && buildSucceeded && processCount > 0) {
 		logger.warn(
 			`  Full build produced no transcript — skipping ${String(processCount)} process expectation(s); only outcome expectations will be judged (possible event-capture issue)`,
 		);
 	}
 
-	const expectations = hasTranscript
-		? collectExpectations(testCase)
-		: buildSucceeded
-			? (testCase.outcomeExpectations ?? [])
-			: [];
-
-	const transcript: TranscriptTurn[] = hasTranscript
+	const transcript: TranscriptTurn[] = hasAgentOutput
 		? args.transcript!
 		: [{ userMessage: conversationUserTurnsAsText(testCase.conversation), steps: [] }];
 
-	return { expectations, transcript };
+	// A failed build that produced nothing at all: record every expectation as
+	// ungraded rather than handing the judge an empty conversation to describe.
+	if (!hasAgentOutput && !buildSucceeded) {
+		const authored = collectExpectations(testCase);
+		if (authored.length > 0) {
+			logger.warn(
+				`  Build produced no agent output — leaving all ${String(authored.length)} expectation(s) ungraded; judging them would score an empty transcript`,
+			);
+		}
+		return {
+			expectations: [],
+			transcript,
+			unjudged: allFailVerdicts(authored, NO_AGENT_OUTPUT_REASON),
+		};
+	}
+
+	const expectations = hasAgentOutput
+		? collectExpectations(testCase)
+		: (testCase.outcomeExpectations ?? []);
+
+	return { expectations, transcript, unjudged: [] };
 }

--- a/packages/@n8n/instance-ai/evaluations/checklist/verifier.ts
+++ b/packages/@n8n/instance-ai/evaluations/checklist/verifier.ts
@@ -90,6 +90,8 @@ function buildChecklistResults(
 				pass: entry.pass,
 				reasoning: entry.reasoning ?? '',
 				strategy: 'llm',
+				// Ambiguous string: the harness stamps the same one when the verifier
+				// returns NOTHING. `attribution` is the meaning-bearing field.
 				failureCategory:
 					entry.failureCategory ?? (!entry.pass ? 'verification_failure' : undefined),
 				rootCause: entry.rootCause ?? undefined,

--- a/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
@@ -16,10 +16,12 @@
 
 import { spawn } from 'child_process';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { setTimeout as delay } from 'node:timers/promises';
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { z } from 'zod';
 
+import { isTransientProviderError, providerRetryBackoffMs } from '../harness/transient-error';
 import type { ConversationTurn, WorkflowTestCase } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -429,6 +431,16 @@ export interface McpBuildResult {
  * The log lines are surfaced through `log` (defaults to `console.log`) so the
  * standalone builder and the eval CLI can route them to their own sinks.
  */
+
+/** Provider-outage evidence lives in the session's free-text result; keep enough
+ *  of it to classify on without dragging a whole transcript into an error. */
+function truncateForReason(result: unknown): string | undefined {
+	if (typeof result !== 'string') return undefined;
+	const text = result.trim();
+	if (!text) return undefined;
+	return text.length > 300 ? `${text.slice(0, 300)}…` : text;
+}
+
 export async function buildWorkflowViaMcp(opts: {
 	conversation: ConversationTurn[];
 	slug: string;
@@ -492,10 +504,28 @@ export async function buildWorkflowViaMcp(opts: {
 			);
 			break;
 		}
-		failureReason = session?.subtype ?? 'no-stdout';
+		// The session's own result text, not just its subtype: a provider outage
+		// inside `claude` (AI_APICallError / overloaded_error / HTTP 529) shows up
+		// ONLY there, and the orchestrator classifies off this string. Without it
+		// `findProviderOutage` has nothing to match and an upstream outage is
+		// filed as a builder failure (TRUST-374). Truncated — it rides in an
+		// error message, and the tail is boilerplate.
+		failureReason = [session?.subtype ?? 'no-stdout', truncateForReason(session?.result)]
+			.filter(Boolean)
+			.join(': ');
 		log(
 			`  [${slug}#${String(iteration)}] attempt ${String(attempt)}: no WORKFLOW_ID (${failureReason}, log: ${logFile})`,
 		);
+		// A provider outage is upstream of every lane and every attempt, so an
+		// instant retry just re-hits it and burns the remaining attempts at the
+		// speed of the failures. Same backoff the non-MCP build path uses.
+		if (isTransientProviderError(failureReason) && attempt < settings.maxAttempts) {
+			const backoffMs = providerRetryBackoffMs(attempt);
+			log(
+				`  [${slug}#${String(iteration)}] provider outage — waiting ${String(Math.round(backoffMs / 1000))}s before attempt ${String(attempt + 1)}`,
+			);
+			await delay(backoffMs);
+		}
 	}
 
 	if (!workflowId) {

--- a/packages/@n8n/instance-ai/evaluations/comparison/compare.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/compare.ts
@@ -285,8 +285,15 @@ const KNOWN_FAILURE_CATEGORIES = new Set([
 	'builder_issue',
 	'mock_issue',
 	'framework_issue',
+	// The verifier's "not enough information to decide" arm. In its prompt enum
+	// from the start but missing here, so every one of these was dropped from the
+	// PR comment with a console warning (TRUST-375).
+	'verification_gap',
 	'verification_failure',
 	'build_failure',
+	// Build-only sentinel rows — reachable through a LangSmith baseline fetch,
+	// which reads run outputs rather than execution-scenario results.
+	'expectations_failed',
 ]);
 
 function isCategoryNotable(

--- a/packages/@n8n/instance-ai/evaluations/harness/agent-execution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/agent-execution.ts
@@ -11,6 +11,7 @@ import { isRecord } from '@n8n/utils/is-record';
 import { setTimeout as delay } from 'node:timers/promises';
 
 import { agentHandler } from './artifacts/agent-handler';
+import { attributionForScenario } from './attribution';
 import type { EvalLogger } from './logger';
 import { writeScenarioVerificationSnapshot, type VerificationArtifact } from './scenario-execution';
 import { isTransientExecutionAbort, MAX_EXEC_ATTEMPTS } from './transient-error';
@@ -142,6 +143,7 @@ export async function executeAgentScenario(
 		`No verification result — verifier exhausted all attempts${attemptErrors.length > 0 ? ` (${attemptErrors.join('; ')})` : ''}`;
 	const failureCategory = result?.failureCategory ?? (result ? undefined : 'verification_failure');
 	const rootCause = result?.rootCause;
+	const attribution = attributionForScenario({ passed, incomplete, failureCategory });
 
 	const categoryLabel = failureCategory ? ` [${failureCategory}]` : '';
 	const statusLabel = incomplete ? 'INCOMPLETE (excluded from scoring)' : passed ? 'PASS' : 'FAIL';
@@ -160,6 +162,7 @@ export async function executeAgentScenario(
 		score: passed ? 1 : 0,
 		reasoning,
 		failureCategory,
+		attribution,
 		rootCause,
 		...(incomplete ? { incomplete: true } : {}),
 	};

--- a/packages/@n8n/instance-ai/evaluations/harness/attribution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/attribution.ts
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------
+// Failure attribution — the cross-repo vocabulary (TRUST-375)
+//
+// The harness is the only place that knows which phase failed, what the model
+// provider returned, whether the lane was healthy and whether a judge produced
+// a verdict. So the harness decides the attribution and writes it to
+// `eval-results.json`; lang-tracer stores what we send verbatim and overrides
+// it only with cross-unit evidence one CLI process cannot have (many runners
+// failing at once ⇒ provider outage).
+//
+// Before this, lang-tracer re-derived attribution from our `failureCategory`
+// string in a hardcoded translation table between two vocabularies that were
+// never agreed on. `failureCategory` still ships unchanged — pinned older
+// harness commits emit it and lang-tracer's legacy map still reads it — but it
+// is no longer how the meaning travels.
+// ---------------------------------------------------------------------------
+
+/**
+ * Who owns a failed graded unit. Deliberately the SAME four names the verifier
+ * prompt already defines, so the enum the LLM picks from and the enum we store
+ * are one vocabulary rather than two that need translating — which is how the
+ * old contract drifted. The harness-code categories (`build_failure`,
+ * `verification_failure`, `expectations_failed`) fold into these.
+ */
+export const EVAL_ATTRIBUTIONS = [
+	/** The agent built it wrong — including "runs as built, misses the criteria". */
+	'builder_issue',
+	/** The eval mock/fixture layer served data the scenario did not describe. */
+	'mock_issue',
+	/** The eval framework failed the test rather than the test failing: no
+	 *  trigger content delivered, seed table missing, provider outage, transport
+	 *  error, budget abort, runner crash. Not a product signal. */
+	'framework_issue',
+	/** We could not measure: verifier returned nothing, judge died, unit ungraded. */
+	'verification_gap',
+] as const;
+
+export type EvalAttribution = (typeof EVAL_ATTRIBUTIONS)[number];
+
+export function isEvalAttribution(value: unknown): value is EvalAttribution {
+	return EVAL_ATTRIBUTIONS.includes(value as EvalAttribution);
+}
+
+/**
+ * The categories the LLM verifier picks from, as spelled out in
+ * `system-prompts/mock-execution-verify.ts`. Identical to `EVAL_ATTRIBUTIONS`
+ * on purpose — kept as its own name so the prompt's enum has a code-side
+ * counterpart that fails a test when the two drift.
+ */
+export const VERIFIER_CATEGORIES = EVAL_ATTRIBUTIONS;
+
+/**
+ * Attribution for a category the LLM verifier chose — an identity map, since
+ * the two enums are now the same list.
+ *
+ * Anything off-enum — including a failing verdict it left uncategorised, which
+ * `checklist/verifier.ts` back-fills as `verification_failure` — is the
+ * builder's. That is the verifier prompt's own stance: "a workflow that runs as
+ * built but doesn't meet the success criteria is a builder_issue — the builder
+ * owns satisfying the scenario as written; there is no separate 'legitimate
+ * failure' category."
+ */
+export function attributionFromVerifierCategory(category: string | undefined): EvalAttribution {
+	return isEvalAttribution(category) ? category : 'builder_issue';
+}
+
+/**
+ * Attribution for one verified scenario. Shared by the workflow and agent
+ * paths, which decide this identically and must not drift: a verifier that
+ * produced no verdict at all means we never measured, so the run is unowned
+ * (`verification_gap`) rather than a failure of the thing under test.
+ */
+export function attributionForScenario(outcome: {
+	passed: boolean;
+	incomplete: boolean;
+	failureCategory: string | undefined;
+}): EvalAttribution | undefined {
+	if (outcome.passed) return undefined;
+	if (outcome.incomplete) return 'verification_gap';
+	return attributionFromVerifierCategory(outcome.failureCategory);
+}
+
+/**
+ * Attribution for one author-written build expectation.
+ *
+ * The expectations judge emits only `pass` + `reason`, so this is a policy, not
+ * a mapping: an expectation the agent missed is a builder miss (same stance as
+ * the verifier prompt), and an ungraded one is unmeasured. `infraFailed` covers
+ * the build that never produced anything to judge — a provider outage or a
+ * transport/seeding failure — where neither of those is true.
+ */
+export function attributionForExpectation(
+	verdict: { pass: boolean; incomplete?: boolean },
+	infraFailed = false,
+): EvalAttribution | undefined {
+	if (verdict.pass) return undefined;
+	if (infraFailed) return 'framework_issue';
+	return verdict.incomplete ? 'verification_gap' : 'builder_issue';
+}

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -207,6 +207,21 @@ export interface BuildResult {
 	providerOutage?: string;
 }
 
+/**
+ * True when the build failed for a reason the agent doesn't own — seeding,
+ * transport or the model provider. Everything downstream that has to attribute
+ * a failure (the scenario row, the ungraded expectations) reads this one
+ * predicate so the three answers can't drift apart (TRUST-375).
+ */
+export function buildFailedOnInfra(build: BuildResult): boolean {
+	if (build.success) return false;
+	return (
+		build.seedingFailed === true ||
+		build.transportFailure === true ||
+		build.providerOutage !== undefined
+	);
+}
+
 export interface BuildWorkflowConfig {
 	client: N8nClient;
 	/** Hand-authored conversation (≥1 turn, first `user`; one user turn →

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -200,6 +200,11 @@ export interface BuildResult {
 	/** Transport-level failure (network error, or the lane unreachable right
 	 *  after failing — e.g. timed out against a dead lane). Routed to `framework_issue`. */
 	transportFailure?: boolean;
+	/** Evidence that the MODEL PROVIDER, not the builder, failed this build (a
+	 *  5xx/429 upstream of the n8n instance). Set only after the retry budget is
+	 *  spent. Routed to `framework_issue` with `PROVIDER_OUTAGE_ROOT_CAUSE`, so an
+	 *  outage never lands in the builder's baseline (TRUST-374). */
+	providerOutage?: string;
 }
 
 export interface BuildWorkflowConfig {

--- a/packages/@n8n/instance-ai/evaluations/harness/scenario-execution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/scenario-execution.ts
@@ -12,6 +12,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
+import { attributionForScenario } from './attribution';
 import type { EvalLogger } from './logger';
 import { reseedScenarioTables, type ScenarioSeedContext } from './seed-tables';
 import { isTransientExecutionAbort, MAX_EXEC_ATTEMPTS } from './transient-error';
@@ -360,6 +361,7 @@ async function runScenario(
 		`No verification result — verifier exhausted all attempts${attemptErrors.length > 0 ? ` (${attemptErrors.join('; ')})` : ''}`;
 	const failureCategory = result?.failureCategory ?? (result ? undefined : 'verification_failure');
 	const rootCause = result?.rootCause;
+	const attribution = attributionForScenario({ passed, incomplete, failureCategory });
 
 	const categoryLabel = failureCategory ? ` [${failureCategory}]` : '';
 	const statusLabel = incomplete ? 'INCOMPLETE (excluded from scoring)' : passed ? 'PASS' : 'FAIL';
@@ -378,6 +380,7 @@ async function runScenario(
 		score: passed ? 1 : 0,
 		reasoning,
 		failureCategory,
+		attribution,
 		rootCause,
 		...(incomplete ? { incomplete: true } : {}),
 	};

--- a/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
@@ -11,6 +11,8 @@
 // baseline instead of counting as silent failures.
 // ---------------------------------------------------------------------------
 
+import type { EvalAttribution } from './attribution';
+
 /** Max attempts (initial try + retries) for a scenario execution hitting transient errors. */
 export const MAX_EXEC_ATTEMPTS = 5;
 
@@ -62,9 +64,10 @@ export function shouldRetryScenarioExecution(message: string, attempt: number): 
 
 /**
  * Marker prefix for the rootCause stamped on a scenario whose execution was
- * aborted by the per-iteration budget/timeout. The lang-tracer side keys its
- * `infra_incomplete` attribution off `failureCategory: "framework_issue"` plus
- * a timeout-flavoured rootCause — keep the wording stable across both repos.
+ * aborted by the per-iteration budget/timeout. lang-tracer used to key an infra
+ * attribution off this plus `failureCategory: "framework_issue"`; it now reads
+ * our `attribution` directly and this is only the fallback for rows written by
+ * an older pinned harness commit. Keep the wording stable across both repos.
  */
 export const BUDGET_TIMEOUT_ROOT_CAUSE =
 	'Scenario execution exceeded its per-iteration time budget and was aborted before a verdict';
@@ -75,17 +78,20 @@ export const BUDGET_TIMEOUT_ROOT_CAUSE =
  * Any error that escapes `executeScenario` (after its own retries) is an
  * infra/framework problem, never an agent verdict, so it is always
  * `framework_issue`. A budget/timeout abort additionally carries a
- * timeout-flavoured `rootCause` so partial-result consumers can route it to an
- * infra/incomplete bucket instead of counting it against product quality.
+ * timeout-flavoured `rootCause`, kept for readers on the legacy contract.
  */
 export function classifyScenarioExecutionError(errorMessage: string): {
 	failureCategory: 'framework_issue';
+	/** Infra by construction — see above. Sent verbatim to lang-tracer, which no
+	 *  longer has to infer it from the timeout-flavoured rootCause. */
+	attribution: EvalAttribution;
 	rootCause: string | undefined;
 	reasoning: string;
 } {
 	const timedOut = isExecutionTimeout(errorMessage);
 	return {
 		failureCategory: 'framework_issue',
+		attribution: 'framework_issue',
 		rootCause: timedOut ? `${BUDGET_TIMEOUT_ROOT_CAUSE}: ${errorMessage}` : undefined,
 		reasoning: `Scenario execution error: ${errorMessage}`,
 	};
@@ -116,9 +122,10 @@ const TRANSIENT_FAILURE_TOKEN =
 	/\bInternal server error\b|\bOverloaded\b|\bService Unavailable\b|\bBad Gateway\b|\b(?:HTTP|status(?: code)?)\s*[:=]?\s*(?:429|500|502|503|529)\b/i;
 
 /**
- * Root cause stamped on a build that died on a provider outage. lang-tracer keys
- * `infra_incomplete` attribution off this exact prefix, so the wording is a
- * cross-repo contract — same arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE`.
+ * Root cause stamped on a build that died on a provider outage. lang-tracer keyed
+ * an infra attribution off this exact prefix; it now reads our `attribution`
+ * instead, so this is the legacy-contract fallback — same arrangement as
+ * `BUDGET_TIMEOUT_ROOT_CAUSE`.
  */
 export const PROVIDER_OUTAGE_ROOT_CAUSE =
 	'Model provider was unavailable during the build (transient upstream 5xx/429), so the agent produced no output';

--- a/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
@@ -91,6 +91,111 @@ export function classifyScenarioExecutionError(errorMessage: string): {
 	};
 }
 
+// ---------------------------------------------------------------------------
+// Provider outages (TRUST-374)
+//
+// A model-provider 5xx/529 during the BUILD is upstream of the n8n instance:
+// the lane stays healthy and the socket never breaks, so none of the checks
+// above see it. Left unclassified it reads as "the agent built it wrong" — and
+// because it fails in seconds rather than minutes, a 15-minute outage let each
+// runner shred its remaining queue at ~60x normal speed (sweep #57: 124 units
+// scored flat zero, with no product regression behind them).
+// ---------------------------------------------------------------------------
+
+/** Statuses a model provider returns when it is overloaded or briefly broken.
+ *  429 counts: provider-side throttling is not a builder defect either. */
+const PROVIDER_OUTAGE_STATUSES = new Set([429, 500, 502, 503, 529]);
+
+/** Shapes that need no corroboration — the ai-sdk error class and Anthropic's
+ *  overload code only appear on a genuine provider failure. */
+const PROVIDER_ERROR_TOKEN = /AI_APICallError|AI_RetryError|overloaded_error/i;
+
+/** Shapes that indicate an outage only once we know the text came from the model
+ *  call. "Internal server error" on its own is far too common to classify from. */
+const TRANSIENT_FAILURE_TOKEN =
+	/\bInternal server error\b|\bOverloaded\b|\bService Unavailable\b|\bBad Gateway\b|\b(?:HTTP|status(?: code)?)\s*[:=]?\s*(?:429|500|502|503|529)\b/i;
+
+/**
+ * Root cause stamped on a build that died on a provider outage. lang-tracer keys
+ * `infra_incomplete` attribution off this exact prefix, so the wording is a
+ * cross-repo contract — same arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE`.
+ */
+export const PROVIDER_OUTAGE_ROOT_CAUSE =
+	'Model provider was unavailable during the build (transient upstream 5xx/429), so the agent produced no output';
+
+/** Max attempts (initial + retries) for a build hitting a provider outage. Kept
+ *  separate from `MAX_BUILD_ATTEMPTS` because each of these retries also waits
+ *  out a backoff, so the two budgets are not interchangeable. */
+export const MAX_PROVIDER_BUILD_ATTEMPTS = 3;
+
+/**
+ * How long to wait BEFORE re-attempting a build that died on a provider outage.
+ * This is a delay between attempts, not a limit on how long a build may take —
+ * the build's own budget (`effectiveTimeoutMs`, 15+ minutes) is untouched.
+ *
+ * Deliberately long relative to the failure itself: a provider 5xx comes back in
+ * ~3 seconds, so instant cross-lane retries just re-hit the same upstream and
+ * the run queue drains at the speed of the outage. Absorbing ~2 minutes locally
+ * is the cheapest defence available, and it costs nothing when the provider is
+ * healthy because none of this runs.
+ */
+export function providerRetryBackoffMs(attempt: number): number {
+	return attempt === 1 ? 30_000 : 90_000;
+}
+
+/** True for error text that only a failing model provider produces. */
+export function isTransientProviderError(message: string): boolean {
+	if (PROVIDER_ERROR_TOKEN.test(message)) return true;
+	// `Agent error:` is summarizeMissingWorkflowError's prefix for run-level error
+	// events — i.e. the agent's own model call blew up. `Tool errors:` is
+	// deliberately excluded: that is the built workflow's own (mocked) HTTP
+	// traffic, and a 5xx there is a real product signal.
+	return /^Agent error:/i.test(message) && TRANSIENT_FAILURE_TOKEN.test(message);
+}
+
+/** Minimal view of a captured SSE event — avoids a cycle back through `types`. */
+interface ErrorEventLike {
+	type: string;
+	data: Record<string, unknown>;
+}
+
+/**
+ * Provider evidence read from the captured event stream. Preferred over the
+ * flattened error text because the agent's `error` events carry the ai-sdk
+ * `statusCode` verbatim, making this a structured check rather than a guess.
+ * Only run-level `error` events count — a `tool-error` carrying an HTTP 500 is
+ * the built workflow's own API call failing.
+ */
+export function providerOutageFromEvents(events: ErrorEventLike[] | undefined): string | undefined {
+	for (const event of events ?? []) {
+		if (event.type !== 'error') continue;
+		const payload = (event.data.payload ?? event.data) as Record<string, unknown>;
+		const status = payload.statusCode;
+		const content = typeof payload.content === 'string' ? payload.content : undefined;
+		if (typeof status === 'number' && PROVIDER_OUTAGE_STATUSES.has(status)) {
+			return `provider HTTP ${String(status)}${content ? `: ${content}` : ''}`;
+		}
+		if (content && PROVIDER_ERROR_TOKEN.test(content)) return content;
+	}
+	return undefined;
+}
+
+/**
+ * Provider-outage evidence for a failed build, structured signal first. Returns
+ * the evidence (for the root cause) or undefined when the failure is a genuine
+ * builder verdict.
+ */
+export function findProviderOutage(build: {
+	success: boolean;
+	error?: string;
+	events?: ErrorEventLike[];
+}): string | undefined {
+	if (build.success) return undefined;
+	const fromEvents = providerOutageFromEvents(build.events);
+	if (fromEvents) return fromEvents;
+	return build.error && isTransientProviderError(build.error) ? build.error : undefined;
+}
+
 /**
  * Eval-DB races abort an execution before any node runs. Two known shapes:
  * `SQLITE_CONSTRAINT: FOREIGN KEY constraint failed` and `Workflow <id> not

--- a/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
@@ -294,8 +294,12 @@ function firstPromptText(result: WorkflowTestCaseResult): string {
 
 function promptReview(result: WorkflowTestCaseResult, sr: ExecutionScenarioResult): StageReview {
 	const evidence = `${sr.reasoning} ${sr.rootCause ?? ''}`.toLowerCase();
+	// Gated on the failure being the builder's: a mock or infra failure says
+	// nothing about the prompt. Used to read `failureCategory ===
+	// 'legitimate_failure'` — a lang-tracer bucket the harness never emits, so
+	// this stage could never fail (TRUST-375).
 	const promptLooksUnderspecified =
-		sr.failureCategory === 'legitimate_failure' &&
+		sr.attribution === 'builder_issue' &&
 		['ambiguous', 'unclear', 'not specified', 'not define', 'does not specify'].some((needle) =>
 			evidence.includes(needle),
 		);
@@ -461,8 +465,11 @@ function verifierReview(sr: ExecutionScenarioResult): StageReview {
 	};
 }
 
+/** Keyed on the attribution buckets, not the raw verifier category: the old
+ *  switch mixed our categories with lang-tracer's bucket names, so two of its
+ *  arms were unreachable (TRUST-375). */
 function promptImprovementSuggestion(sr: ExecutionScenarioResult): string {
-	switch (sr.failureCategory) {
+	switch (sr.attribution) {
 		case 'builder_issue':
 			return 'For workflows with multiple required effects, branches, or error paths, state each required action explicitly and add observable acceptance conditions for every branch. This reduces silent omission during planning or build.';
 		case 'mock_issue':
@@ -471,8 +478,6 @@ function promptImprovementSuggestion(sr: ExecutionScenarioResult): string {
 			return 'Make trigger preconditions and scenario setup requirements explicit in the test prompt or fixture description so empty-input framework failures are easier to separate from workflow defects.';
 		case 'verification_gap':
 			return 'Add concrete, inspectable success evidence to the prompt, such as the exact side effect, branch behavior, or output field that should be observed, so the verifier has less room to infer.';
-		case 'legitimate_failure':
-			return 'If this behavior is required, move it from an implied expectation into an explicit prompt requirement with a clear fallback path and observable success criterion.';
 		default:
 			return 'Turn the failed behavior into a more explicit, testable requirement in future prompts: name the required step, the expected branch, and the observable evidence that proves it happened.';
 	}

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -33,7 +33,12 @@ import {
 } from '../harness/prebuilt-workflows';
 import type { executeScenario } from '../harness/scenario-execution';
 import type { ScenarioSeedContext } from '../harness/seed-tables';
-import { isTransientNetworkError } from '../harness/transient-error';
+import {
+	findProviderOutage,
+	isTransientNetworkError,
+	MAX_PROVIDER_BUILD_ATTEMPTS,
+	providerRetryBackoffMs,
+} from '../harness/transient-error';
 import type {
 	BuildExpectationResult,
 	ExecutionScenario,
@@ -221,6 +226,8 @@ export interface BuildOrchestratorDeps {
 	buildExpectationsByKey: Map<string, Promise<BuildExpectationResult[]>>;
 	runDebugByThreadId: Map<string, Promise<InstanceAiRunDebugResponse[]>>;
 	agentContextByKey: Map<string, Promise<string>>;
+	/** Injectable delay for the provider-outage retry backoff — tests pass a no-op. */
+	sleep?: (ms: number) => Promise<void>;
 }
 
 export interface BuildOrchestrator {
@@ -248,6 +255,8 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 		runDebugByThreadId,
 		agentContextByKey,
 	} = deps;
+	const sleep =
+		deps.sleep ?? (async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms)));
 
 	// A build that sat out its timeout against a dead lane reports "Run timed
 	// out", not "fetch failed" — so any failed build also health-probes its lane.
@@ -255,6 +264,30 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 		if (build.success) return false;
 		if (build.error !== undefined && isTransientNetworkError(build.error)) return true;
 		return !(await laneHealthy(lane));
+	}
+
+	/**
+	 * Classify a finished build and stamp the failure fields the row layer reads.
+	 * A provider outage is transient even though the lane is perfectly healthy —
+	 * the failure is upstream of it — so it has to be detected before the health
+	 * probe gets a vote (TRUST-374).
+	 */
+	async function classifyBuildFailure(
+		build: BuildResult,
+		lane: LaneState,
+		since: number,
+	): Promise<{ transient: boolean; providerOutage?: string }> {
+		if (build.success) return { transient: false };
+		const providerOutage = findProviderOutage(build);
+		if (providerOutage !== undefined) {
+			build.providerOutage = providerOutage;
+			build.transportFailure = true;
+			return { transient: true, providerOutage };
+		}
+		const transient =
+			(await isTransportFailure(build, lane)) || allocator.wasQuarantinedSince(lane, since);
+		build.transportFailure = transient;
+		return { transient };
 	}
 
 	const buildCache = new Map<string, Promise<CachedBuild>>();
@@ -299,13 +332,19 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 	): void {
 		const testCase = testCaseByFileSlug.get(fileSlug);
 		if (!testCase) return;
-		const { expectations, transcript } = selectAuthorExpectations({
+		const { expectations, transcript, unjudged } = selectAuthorExpectations({
 			testCase,
 			transcript: build.transcript,
 			buildSucceeded: build.success,
 			isPrebuilt,
 			logger,
 		});
+		// Recorded as incomplete rather than dropped, so the case keeps its unit
+		// count and the report says why they weren't graded.
+		if (unjudged.length > 0) {
+			buildExpectationsByKey.set(key, Promise.resolve(unjudged));
+			return;
+		}
 		if (expectations.length === 0) return;
 		buildExpectationsByKey.set(
 			key,
@@ -371,8 +410,7 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 				}
 				mcpBuildSpend.push(...caseSpend);
 				{
-					const transient = await isTransportFailure(build, lane);
-					if (!build.success) build.transportFailure = transient;
+					const { transient } = await classifyBuildFailure(build, lane, start);
 					allocator.reportBuildOutcome(lane, transient ? 'transient-failure' : 'ok');
 				}
 				const buildDurationMs = Date.now() - start;
@@ -457,15 +495,19 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 					allocator.release(lane, fileSlug);
 				}
 				buildDurationMs = Date.now() - start;
-				const transient =
-					(await isTransportFailure(build, lane)) ||
-					(!build.success && allocator.wasQuarantinedSince(lane, start));
-				if (!build.success) build.transportFailure = transient;
+				const { transient, providerOutage } = await classifyBuildFailure(build, lane, start);
 				allocator.reportBuildOutcome(lane, transient ? 'transient-failure' : 'ok');
-				if (!transient || attempt >= MAX_BUILD_ATTEMPTS) break;
+				const maxAttempts = providerOutage ? MAX_PROVIDER_BUILD_ATTEMPTS : MAX_BUILD_ATTEMPTS;
+				if (!transient || attempt >= maxAttempts) break;
+				// A provider outage is upstream of every lane, so an instant retry just
+				// re-hits it — and the queue then drains at the speed of the failures.
+				const backoffMs = providerOutage ? providerRetryBackoffMs(attempt) : 0;
 				logger.warn(
-					`Build ${fileSlug} attempt ${String(attempt)}/${String(MAX_BUILD_ATTEMPTS)} failed transiently on lane ${String(lane.laneNum)} (${build.error ?? 'unknown'}); retrying on another lane`,
+					providerOutage
+						? `Build ${fileSlug} attempt ${String(attempt)}/${String(maxAttempts)} hit a provider outage (${providerOutage}); waiting ${String(Math.round(backoffMs / 1000))}s before retrying`
+						: `Build ${fileSlug} attempt ${String(attempt)}/${String(maxAttempts)} failed transiently on lane ${String(lane.laneNum)} (${build.error ?? 'unknown'}); retrying on another lane`,
 				);
+				if (backoffMs > 0) await sleep(backoffMs);
 				lane = await allocator.acquire(fileSlug, { not: lane });
 			}
 			buildDurations.set(key, buildDurationMs);
@@ -484,9 +526,12 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 		buildCache.set(key, promise);
 		// Evict transport-failed builds so a later scenario rebuilds. Agent build
 		// failures stay cached — they are the verdict; rebuilding just multiplies cost.
+		// Provider outages also stay cached: the retry budget (with its backoff) is
+		// already spent, every scenario of the case would hit the same upstream, and
+		// recovery is the run dispatcher's job, not another local rebuild.
 		void promise.then(
 			({ build, lane }) => {
-				if (build.transportFailure) {
+				if (build.transportFailure && !build.providerOutage) {
 					orphanedBuilds.push({ build, client: lane.runner.client });
 					buildCache.delete(key);
 				}

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -9,6 +9,7 @@
 // ---------------------------------------------------------------------------
 
 import type { InstanceAiRunDebugResponse } from '@n8n/api-types';
+import { sleep } from '@n8n/utils/sleep';
 
 import type { LaneAllocator } from './lane-allocator';
 import { selectAuthorExpectations } from '../build-expectations/select';
@@ -255,8 +256,7 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 		runDebugByThreadId,
 		agentContextByKey,
 	} = deps;
-	const sleep =
-		deps.sleep ?? (async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms)));
+	const delay = deps.sleep ?? sleep;
 
 	// A build that sat out its timeout against a dead lane reports "Run timed
 	// out", not "fetch failed" — so any failed build also health-probes its lane.
@@ -507,7 +507,7 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 						? `Build ${fileSlug} attempt ${String(attempt)}/${String(maxAttempts)} hit a provider outage (${providerOutage}); waiting ${String(Math.round(backoffMs / 1000))}s before retrying`
 						: `Build ${fileSlug} attempt ${String(attempt)}/${String(maxAttempts)} failed transiently on lane ${String(lane.laneNum)} (${build.error ?? 'unknown'}); retrying on another lane`,
 				);
-				if (backoffMs > 0) await sleep(backoffMs);
+				if (backoffMs > 0) await delay(backoffMs);
 				lane = await allocator.acquire(fileSlug, { not: lane });
 			}
 			buildDurations.set(key, buildDurationMs);

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -23,7 +23,8 @@ import {
 	type executeAgentScenario,
 } from '../harness/agent-execution';
 import { resolveArtifactContext } from '../harness/artifacts/artifact-context';
-import type { BuildResult } from '../harness/build-workflow';
+import { attributionForExpectation } from '../harness/attribution';
+import { buildFailedOnInfra, type BuildResult } from '../harness/build-workflow';
 import { captureThreadRunDebug } from '../harness/capture-run-debug';
 import { effectiveTimeoutMs, runWorkflowChecks } from '../harness/cleanup';
 import type { EvalLogger } from '../harness/logger';
@@ -339,10 +340,17 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 			isPrebuilt,
 			logger,
 		});
+		// Attributed here, where we still know WHY the build ended: a build that
+		// died on infra produced nothing to judge, so its expectations are unowned
+		// rather than the agent's miss. Both readers of this map (the row outputs
+		// and reshape's side band) then carry the same verdict (TRUST-375).
+		const infraFailed = buildFailedOnInfra(build);
+		const attribute = (verdicts: BuildExpectationResult[]): BuildExpectationResult[] =>
+			verdicts.map((v) => ({ ...v, attribution: attributionForExpectation(v, infraFailed) }));
 		// Recorded as incomplete rather than dropped, so the case keeps its unit
 		// count and the report says why they weren't graded.
 		if (unjudged.length > 0) {
-			buildExpectationsByKey.set(key, Promise.resolve(unjudged));
+			buildExpectationsByKey.set(key, Promise.resolve(attribute(unjudged)));
 			return;
 		}
 		if (expectations.length === 0) return;
@@ -362,12 +370,14 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 						client,
 						logger,
 					}),
-				}))().catch((error: unknown) =>
-				allFailVerdicts(
-					expectations,
-					`judge error: ${error instanceof Error ? error.message : String(error)}`,
-				),
-			),
+				}))()
+				.catch((error: unknown) =>
+					allFailVerdicts(
+						expectations,
+						`judge error: ${error instanceof Error ? error.message : String(error)}`,
+					),
+				)
+				.then(attribute),
 		);
 	}
 

--- a/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
@@ -16,6 +16,7 @@ import type { BuildOrchestrator } from './build-orchestrator';
 import { sentinelOutcomeFromVerdicts, type TargetOutput } from './reshape';
 import type { CliArgs } from '../cli/args';
 import { findAgentArtifactRef } from '../harness/agent-execution';
+import { buildFailedOnInfra } from '../harness/build-workflow';
 import { cleanupBuild, effectiveTimeoutMs } from '../harness/cleanup';
 import type { EvalLogger } from '../harness/logger';
 import {
@@ -142,6 +143,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: 0,
 				reasoning: classified.reasoning,
 				failureCategory: classified.failureCategory,
+				attribution: classified.attribution,
 				rootCause: classified.rootCause,
 				execErrors: [message],
 				buildDurationMs: 0,
@@ -193,6 +195,8 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 		// Awaited only after each branch's own work is done, keeping the judge off
 		// the scenario critical path while persisting verdicts to run outputs.
 		const verdictsPromise = buildExpectationsByKey.get(cacheKey);
+		// Verdicts arrive already attributed (the orchestrator stamps them where it
+		// still knows why the build ended) — attach them as-is.
 		const attachExpectations = async (output: TargetOutput): Promise<TargetOutput> => {
 			const verdicts = await verdictsPromise;
 			return verdicts && verdicts.length > 0 ? { ...output, expectationResults: verdicts } : output;
@@ -215,6 +219,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: outcome.score,
 				reasoning: outcome.reasoning,
 				failureCategory: outcome.failureCategory,
+				attribution: outcome.attribution,
 				...(outcome.incomplete ? { incomplete: true } : {}),
 				execErrors: [],
 				buildDurationMs,
@@ -237,11 +242,14 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				reasoning: `Build failed: ${build.error ?? 'unknown'}`,
 				// Seeding, transport and provider failures are harness/infra problems,
 				// not agent build failures — keep them out of the build_failure bucket,
-				// which lang-tracer maps straight to `builder_issue`.
+				// which lang-tracer's legacy map reads straight as `builder_issue`.
 				failureCategory:
 					build.seedingFailed || build.transportFailure ? 'framework_issue' : 'build_failure',
-				// Pinned marker so lang-tracer attributes an outage to infra instead of
-				// recording it as a builder regression (TRUST-374).
+				// The verdict lang-tracer actually stores. A provider outage is infra
+				// at the source (TRUST-374/375) — it no longer has to be inferred from
+				// the rootCause below.
+				attribution: buildFailedOnInfra(build) ? 'framework_issue' : 'builder_issue',
+				// Pinned marker kept as the fallback for readers on the legacy contract.
 				...(build.providerOutage
 					? { rootCause: `${PROVIDER_OUTAGE_ROOT_CAUSE}: ${build.providerOutage}` }
 					: {}),
@@ -304,6 +312,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 						score: 0,
 						reasoning: `Agent scenario execution error: ${errorMessage}`,
 						failureCategory: 'framework_issue',
+						attribution: 'framework_issue',
 						execErrors: [errorMessage],
 						buildDurationMs,
 						...buildSpendFields,
@@ -318,6 +327,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 
 			const agentFailureCategory = agentResult.success ? undefined : agentResult.failureCategory;
 			const agentRootCause = agentResult.success ? undefined : agentResult.rootCause;
+			const agentAttribution = agentResult.success ? undefined : agentResult.attribution;
 			return await attachExpectations({
 				buildSuccess: true,
 				agentId: agentRef.id,
@@ -327,6 +337,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: agentResult.score,
 				reasoning: agentResult.reasoning,
 				failureCategory: agentFailureCategory,
+				attribution: agentAttribution,
 				rootCause: agentRootCause,
 				...(agentResult.incomplete ? { incomplete: true } : {}),
 				execErrors: agentResult.agentEvalResult?.errors ?? [],
@@ -367,6 +378,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: 0,
 				reasoning: reason,
 				failureCategory: 'framework_issue',
+				attribution: 'framework_issue',
 				execErrors: [reason],
 				buildDurationMs,
 				...buildSpendFields,
@@ -419,6 +431,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 						score: 0,
 						reasoning: classified.reasoning,
 						failureCategory: classified.failureCategory,
+						attribution: classified.attribution,
 						rootCause: classified.rootCause,
 						execErrors: [errorMessage],
 						buildDurationMs,
@@ -439,6 +452,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 			// placeholders instead of omitting them.
 			const failureCategory = result.success ? undefined : result.failureCategory;
 			const rootCause = result.success ? undefined : result.rootCause;
+			const attribution = result.success ? undefined : result.attribution;
 
 			return await attachExpectations({
 				buildSuccess: true,
@@ -448,6 +462,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: result.score,
 				reasoning: result.reasoning,
 				failureCategory,
+				attribution,
 				rootCause,
 				...(result.incomplete ? { incomplete: true } : {}),
 				execErrors: result.evalResult?.errors ?? [],

--- a/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
@@ -27,6 +27,7 @@ import {
 	classifyScenarioExecutionError,
 	extractErrorMessage,
 	MAX_EXEC_ATTEMPTS,
+	PROVIDER_OUTAGE_ROOT_CAUSE,
 	shouldRetryScenarioExecution,
 } from '../harness/transient-error';
 import { BUILD_ONLY_SCENARIO_NAME, type DatasetExampleInputs } from '../langsmith/dataset-sync';
@@ -234,10 +235,16 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				passed: false,
 				score: 0,
 				reasoning: `Build failed: ${build.error ?? 'unknown'}`,
-				// Seeding and transport failures are harness problems, not agent build
-				// failures — keep them out of the agent's build_failure bucket.
+				// Seeding, transport and provider failures are harness/infra problems,
+				// not agent build failures — keep them out of the build_failure bucket,
+				// which lang-tracer maps straight to `builder_issue`.
 				failureCategory:
 					build.seedingFailed || build.transportFailure ? 'framework_issue' : 'build_failure',
+				// Pinned marker so lang-tracer attributes an outage to infra instead of
+				// recording it as a builder regression (TRUST-374).
+				...(build.providerOutage
+					? { rootCause: `${PROVIDER_OUTAGE_ROOT_CAUSE}: ${build.providerOutage}` }
+					: {}),
 				execErrors: build.error ? [build.error] : [],
 				buildDurationMs,
 				...buildSpendFields,

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -460,6 +460,9 @@ export function writeEvalResults(
 					score: sr.score,
 					reasoning: sr.reasoning,
 					failureCategory: sr.failureCategory,
+					// Who owns the failure, decided here rather than re-derived
+					// downstream from the category string (TRUST-375).
+					attribution: sr.attribution,
 					rootCause: sr.rootCause,
 					execErrors: sr.evalResult?.errors ?? sr.agentEvalResult?.errors ?? [],
 					evalResult: sr.evalResult,

--- a/packages/@n8n/instance-ai/evaluations/run/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reshape.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import { CHECK_DIMENSIONS, type CheckOutcome } from '../binaryChecks/types';
 import type { WorkflowResponse } from '../clients/n8n-client';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
+import { EVAL_ATTRIBUTIONS, type EvalAttribution } from '../harness/attribution';
 import { BUILD_ONLY_SCENARIO_NAME } from '../langsmith/dataset-sync';
 import type {
 	BuildTrace,
@@ -44,6 +45,9 @@ export const expectationResultsSchema = z.array(
 		pass: z.boolean(),
 		reason: z.string().default(''),
 		incomplete: z.boolean().optional(),
+		/** Stamped in case-pipeline's `stampExpectations` — zod strips unknown
+		 *  keys, so an omission here silently drops it from `eval-results.json`. */
+		attribution: z.enum(EVAL_ATTRIBUTIONS).optional(),
 	}),
 );
 
@@ -57,6 +61,10 @@ const targetOutputSchema = z.object({
 	/** Set when the scenario ran against a built first-class Agent instead of a workflow. */
 	agentId: z.string().optional(),
 	failureCategory: z.string().optional(),
+	/** The harness's own verdict on who owns the failure — what lang-tracer
+	 *  stores. `failureCategory` stays alongside it for readers on the legacy
+	 *  contract (TRUST-375). */
+	attribution: z.enum(EVAL_ATTRIBUTIONS).optional(),
 	rootCause: z.string().optional(),
 	/** Verifier returned no verdict — run is excluded from scoring but stays visible. */
 	incomplete: z.boolean().optional(),
@@ -178,6 +186,9 @@ export function sentinelOutcomeFromVerdicts(verdicts: BuildExpectationResult[] |
 	/** Only on non-passing outcomes — without a category the feedback extractor
 	 *  files the row under 'unknown' in the LangSmith failure_category column. */
 	failureCategory?: 'expectations_failed' | 'verification_failure';
+	/** The bucket lang-tracer stores. A missed expectation is a builder miss —
+	 *  same stance the verifier prompt takes; no verdicts at all is unmeasured. */
+	attribution?: EvalAttribution;
 } {
 	const evaluated = (verdicts ?? []).filter((v) => !v.incomplete);
 	if (evaluated.length === 0) {
@@ -187,6 +198,7 @@ export function sentinelOutcomeFromVerdicts(verdicts: BuildExpectationResult[] |
 			reasoning: 'Build-only case — no expectation verdicts (judge incomplete)',
 			incomplete: true,
 			failureCategory: 'verification_failure',
+			attribution: 'verification_gap',
 		};
 	}
 	const failed = evaluated.filter((v) => !v.pass);
@@ -197,7 +209,9 @@ export function sentinelOutcomeFromVerdicts(verdicts: BuildExpectationResult[] |
 		reasoning: passed
 			? `Build-only case — all ${String(evaluated.length)} expectations passed`
 			: `Build-only case — failed expectations: ${failed.map((v) => v.expectation).join('; ')}`,
-		...(passed ? {} : { failureCategory: 'expectations_failed' as const }),
+		...(passed
+			? {}
+			: { failureCategory: 'expectations_failed' as const, attribution: 'builder_issue' as const }),
 	};
 }
 
@@ -270,6 +284,14 @@ export function reshapeLangSmithRuns(
 						success: false,
 						score: 0,
 						reasoning: run ? 'Malformed run output — skipped' : 'No run result for this scenario',
+						// The row never produced a verdict, so nobody owns it. Without this
+						// it reaches lang-tracer category-less and defaults to a product
+						// failure.
+						attribution: 'verification_gap',
+						// …and unowned has to mean unscored too, or the row is visible as a
+						// gap while still counting against the builder. Same pairing as
+						// `sentinelOutcomeFromVerdicts` and `attributionFor`.
+						incomplete: true,
 					});
 					continue;
 				}
@@ -296,6 +318,7 @@ export function reshapeLangSmithRuns(
 					score: output.score,
 					reasoning: output.reasoning,
 					failureCategory: output.failureCategory,
+					attribution: output.attribution,
 					rootCause: output.rootCause,
 					...(output.incomplete ? { incomplete: true } : {}),
 				});

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -11,6 +11,7 @@ import type {
 
 import type { CheckOutcome } from './binaryChecks/types';
 import type { WorkflowResponse } from './clients/n8n-client';
+import type { EvalAttribution } from './harness/attribution';
 import type { CaseSeed } from './harness/schema';
 
 // ---------------------------------------------------------------------------
@@ -265,10 +266,15 @@ export interface ExecutionScenarioResult {
 	workflowId?: string;
 	score: number;
 	reasoning: string;
-	/** Root cause category when the scenario fails */
+	/** Root cause category when the scenario fails. Free-form on purpose: it
+	 *  carries whatever the LLM verifier picked, and older harness commits used
+	 *  a different spelling. Read `attribution` for the meaning. */
 	failureCategory?: string;
 	/** Detailed root cause explanation */
 	rootCause?: string;
+	/** Who owns this failure — the harness's own verdict, and what LangTracer
+	 *  stores. Undefined on a pass. See `harness/attribution.ts`. */
+	attribution?: EvalAttribution;
 	/** Verifier returned no verdict after all attempts (infra failure, not a
 	 *  workflow failure). Rendered visibly but kept out of the pass-rate count,
 	 *  mirroring `BuildExpectationResult.incomplete`. */
@@ -283,6 +289,9 @@ export interface BuildExpectationResult {
 	reason: string;
 	/** Judge returned no verdict (flaky/partial). Rendered neutrally, kept out of the count. */
 	incomplete?: boolean;
+	/** Who owns a failed expectation. Stamped where the verdicts are attached to
+	 *  a row (the only place that also knows whether the build died on infra). */
+	attribution?: EvalAttribution;
 }
 
 export interface WorkflowTestCaseResult {


### PR DESCRIPTION
## Summary

A model-provider 5xx/429/529 during a build happens **upstream of the n8n instance**, so the lane stays healthy and the socket never breaks. None of the harness's existing transient checks could see it, so the failure was recorded as `build_failure` — which lang-tracer maps straight to `builder_issue`, i.e. "the agent built it wrong".

Worse, a provider error comes back in ~3 seconds instead of ~600, so each runner then shredded its remaining queue at ~60× normal speed. Nightly sweep #57 recorded **124 flat-zero units and 538 failed expectations with no product regression behind them**.

This PR makes the build phase aware of provider outages:

| Change | Why |
| --- | --- |
| Classify outages from the run's `error` events (structured `statusCode`), falling back to the flattened `Agent error: …` text | The lane health probe votes "healthy" during an outage, because the failure is upstream of it |
| Retry with a **30s then 90s wait between attempts** | A 3-second failure retried instantly just re-hits the same upstream; absorbing ~2 min locally is the cheapest defence, and it's what stops the queue draining |
| Report `framework_issue` + a pinned `PROVIDER_OUTAGE_ROOT_CAUSE` | `build_failure` maps to `builder_issue`. The pinned string is the cross-repo contract lang-tracer keys `infra_incomplete` from — same arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE` (TRUST-310) |
| Leave expectations **ungraded** when the build produced no agent output | A dead run still emits one turn per user message with zero steps, so `transcript.length > 0` was true and the judge dutifully described a transcript the agent never wrote. That's the 538 rows |

### Two things this deliberately does *not* do

- **The 30s/90s is a delay between attempts, not a build timeout.** Build budgets (`effectiveTimeoutMs` — 15 min, 22.5 min for `complexity: complex`) are untouched. When the provider is healthy none of this code runs.
- **`Tool errors: … HTTP 500` is not an outage.** That's the built workflow's own (mocked) HTTP traffic, which is a real product signal. Only run-level agent errors qualify, and there's a test pinning that.

### Ungraded ≠ dropped

Skipped expectations are recorded as `incomplete` rather than omitted, so the case keeps its unit count and baselines stay comparable. Both this repo's scoring and lang-tracer's already exclude `incomplete` rows from pass rates.

### Known gap (not in scope)

The server-side LLM mock generator shares the same provider, so during an outage its failures surface as `_evalMockError` and land in the `mock_issue` bucket. Catching that needs the server to expose the provider status — noted in the README.

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm vitest run evaluations   # 1114 pass
pnpm typecheck && pnpm lint
```

The new coverage is worth reading directly — it pins the behaviour that matters:

- `__tests__/transient-error.test.ts` — what counts as an outage, and what must never count (`Tool errors:`, n8n's own API 500, a 403 quota error)
- `__tests__/build-orchestrator.test.ts` — retries after a backoff on a healthy lane; an unrecoverable outage is marked infra and doesn't rebuild per scenario; expectations recorded ungraded
- `__tests__/select-expectations.test.ts` — a failed build that *did* produce agent activity is still judged normally (a genuine build failure stays a product verdict)
- `__tests__/case-pipeline.test.ts` — the pinned root cause reaches the row

A live eval run can't reproduce this without an actual provider outage. What a live run *can* prove is that the normal path is unaffected — happy to run a small suite before this comes out of draft.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-374

Pairs with the lang-tracer side, which adds a sweep-level circuit breaker and requeues contaminated units: https://github.com/n8n-io/lang-tracer/pull/110. That PR currently detects outages by regex over error prose; once the pinned root cause above is added to its `mapAttribution`, the text matching becomes a fallback rather than the primary path.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- evaluations/README.md -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35293">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

