### PR TITLE
docs: fix three stale paths in agent skill and AGENTS.md files

### DIFF
--- a/.agents/skills/protect-endpoints/SKILL.md
+++ b/.agents/skills/protect-endpoints/SKILL.md
@@ -70,8 +70,8 @@ Add the resource and ops in `packages/@n8n/permissions/`:
 4. **`src/roles/scopes/global-scopes.ee.ts`** — add to `GLOBAL_OWNER_SCOPES` (admin inherits via `concat()`). Do **not** add to member/chat-user globals — they get scopes via project relations.
 5. **Personal-space publishing**: if you add a `<resource>:publish` scope, also append it to `PERSONAL_SPACE_PUBLISHING_SETTING.scopes` in `constants.ee.ts` so personal-owner gating matches `workflow:publish`.
 6. **Frontend wiring** — three files in the editor; skipping any of them means the new scopes will not appear in the project-role configuration UI:
-   - `packages/frontend/editor-ui/src/app/stores/rbac.store.ts` — add `<resource>: {}` to `scopesByResourceId` (typecheck will fail otherwise).
-   - `packages/frontend/editor-ui/src/features/project-roles/projectRoleScopes.ts` — add the resource to `UI_OPERATIONS` (operations to render in the permissions matrix, in display order) **and** to `SCOPE_TYPES` (the order the resource group appears on the page).
+   - `packages/frontend/@n8n/stores/src/rbac.store.ts` — add `<resource>: {}` to `scopesByResourceId` (typecheck will fail otherwise).
+   - `packages/frontend/editor-ui/src/features/roles/project/projectRoleScopes.ts` — add the resource to `UI_OPERATIONS` (operations to render in the permissions matrix, in display order) **and** to `SCOPE_TYPES` (the order the resource group appears on the page).
    - `packages/frontend/@n8n/i18n/src/locales/en.json` — add `projectRoles.<resource>:<op>` (column label) and `projectRoles.<resource>:<op>.tooltip` (hover description) for every op, plus `projectRoles.type.<resource>` (the group header).
 7. **Snapshot** — update `packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap` to include the new `<resource>:*` entries.
 

--- a/packages/testing/playwright/AGENTS.md
+++ b/packages/testing/playwright/AGENTS.md
@@ -421,7 +421,7 @@ const requirements: TestRequirements = {
 };
 ```
 
-**Reference:** `config/TestRequirements.ts` for full interface definition.
+**Reference:** `Types.ts` for full interface definition.
 
 ## Shard Rebalancing
 

--- a/packages/testing/playwright/AGENTS.md
+++ b/packages/testing/playwright/AGENTS.md
@@ -383,7 +383,7 @@ test('API-only test', async ({ api }) => {
 To test features behind feature flags (experiments), use `TestRequirements` with storage overrides:
 
 ```typescript
-import type { TestRequirements } from '../config/TestRequirements';
+import type { TestRequirements } from '../../../Types';
 
 const requirements: TestRequirements = {
   storage: {


### PR DESCRIPTION
Fixes #35300

## Summary

Three paths in agent-facing documentation point at files that are no longer there. These files are read by coding agents, so a stale path sends them looking for something that doesn't exist.

Documentation only — no code, tests, or behavior changes.

## Changes

**`.agents/skills/protect-endpoints/SKILL.md`** — step 6, "Frontend wiring"

| Before | After |
|---|---|
| `packages/frontend/editor-ui/src/app/stores/rbac.store.ts` | `packages/frontend/@n8n/stores/src/rbac.store.ts` |
| `packages/frontend/editor-ui/src/features/project-roles/projectRoleScopes.ts` | `packages/frontend/editor-ui/src/features/roles/project/projectRoleScopes.ts` |

**`packages/testing/playwright/AGENTS.md`** — Feature Flag Overrides example

| Before | After |
|---|---|
| `import type { TestRequirements } from '../config/TestRequirements';` | `import type { TestRequirements } from '../../../Types';` |

## Verification

Each replacement was checked to still own the symbol the surrounding text names, not merely to match on filename:

- `packages/frontend/@n8n/stores/src/rbac.store.ts` defines `scopesByResourceId`, which the line tells you to extend.
- `packages/frontend/editor-ui/src/features/roles/project/projectRoleScopes.ts` exports `SCOPE_TYPES`, which the line tells you to add to.
- `TestRequirements` is declared in `packages/testing/playwright/Types.ts`; specs import it from `Types`, most commonly as `'../../../Types'`, which is the form used here.

## One thing deliberately left alone

The same `SKILL.md` line also says to add the resource to `UI_OPERATIONS`. That symbol no longer appears anywhere under `packages/frontend` — the file now exports `SCOPE_TYPES`, `SCOPES`, `UI_VISIBLE_SCOPES`, and `TOTAL_PROJECT_PERMISSIONS`. None is an obvious one-to-one successor (`UI_VISIBLE_SCOPES` is a `Set`, so it can't carry the display order the text describes), so rather than guess I've left the symbol name untouched and flagged it in #35300. Happy to fold in a correction if you tell me which it should be.

Found with [unrot](https://github.com/unrot-dev/unrot), an open-source linter for agent config files.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35301">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

