### PR TITLE
fix(ai-builder): Emit failure attribution from the eval harness (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -831,17 +831,44 @@ Rules of thumb:
 - **A seeded case is only worth shipping with `buildExpectations` that detect the misbehaviour recurring** — without them it passes vacuously. Sanity-check by running the case once with the seed removed: it should fail.
 - `seedThread`, `priorConversation` and `conversationSeed` are mutually exclusive; all order strictly before the live turn. `seedThread` provides its own live turn (omit `conversation`); the other two pair with `conversation`.
 
-## Failure categories
+## Failure categories and attribution
 
 When a scenario fails, the verifier categorizes the root cause:
 
 - **builder_issue** — the agent misconfigured a node, chose the wrong node type, or built the wrong structure.
 - **mock_issue** — the LLM mock returned incorrect data (`_evalMockError`, wrong response shape).
 - **framework_issue** — Phase 1 failed (empty trigger content) or the eval framework itself cascaded an error.
-- **verification_failure** — the verifier couldn't produce a valid result.
-- **build_failure** — Instance AI failed to build the workflow or a scenario timed out.
+- **verification_gap** — the verifier didn't have enough information in the artifact to decide.
+
+Harness code stamps three more onto rows the verifier never saw:
+
+- **build_failure** — Instance AI failed to build the workflow.
+- **verification_failure** — the verifier produced no result at all after every attempt (also back-filled onto a failing verdict that arrived without a category).
+- **expectations_failed** — a build-only case whose expectation verdicts failed.
 
 Suite pass rates typically sit between 40–65%; most failures are `builder_issue` on scenarios that require error handling the agent doesn't produce by default.
+
+### `attribution` — the field that carries the meaning
+
+`failureCategory` is a free-form string with three producers, so downstream
+consumers used to re-derive what it meant and drifted (TRUST-375). Every failed
+scenario iteration and build expectation now also carries an **`attribution`**,
+defined once in `harness/attribution.ts` and stored verbatim by LangTracer:
+
+| bucket | means |
+| -- | -- |
+| `builder_issue` | the agent built it wrong, including "runs as built, misses the criteria" |
+| `mock_issue` | the eval mock/fixture layer served data the scenario didn't describe |
+| `framework_issue` | the eval framework failed the test rather than the test failing — no trigger content, seed table missing, provider outage, transport error, budget abort, runner crash |
+| `verification_gap` | we couldn't measure it — verifier returned nothing, judge died, unit ungraded |
+
+Deliberately the same four names the verifier prompt already defines, so ingest
+is an identity map rather than a translation. The harness-code categories fold
+in: `build_failure` and `expectations_failed` → `builder_issue`,
+`verification_failure` → `verification_gap`, and a build that died on seeding,
+transport or a provider outage → `framework_issue`.
+
+`failureCategory` still ships unchanged for readers on the legacy contract.
 
 ### Provider outages are never a builder verdict
 
@@ -863,9 +890,11 @@ A classified outage is:
   queue at ~60× normal speed;
 - reported as `framework_issue`, never `build_failure` (which LangTracer maps
   straight to `builder_issue`);
-- stamped with `PROVIDER_OUTAGE_ROOT_CAUSE` on the row's `rootCause`. LangTracer
-  keys `infra_incomplete` attribution off that exact prefix, so the wording is a
-  cross-repo contract — same arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE`;
+- attributed **`framework_issue`**, and additionally stamped with
+  `PROVIDER_OUTAGE_ROOT_CAUSE` on the row's `rootCause`. LangTracer used to key
+  its infra bucket off that exact prefix; it now reads the attribution directly,
+  so the marker is the fallback for older pinned harness commits — same
+  arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE`;
 - left **ungraded** by the expectation judge: a run that produced no agent output
   has nothing to grade, so its expectations are recorded as `incomplete` rather
   than judged against an empty transcript (`build-expectations/select.ts`).

--- a/packages/@n8n/instance-ai/evaluations/__tests__/attribution.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/attribution.test.ts
@@ -1,0 +1,149 @@
+import {
+	attributionForExpectation,
+	attributionForScenario,
+	attributionFromVerifierCategory,
+	EVAL_ATTRIBUTIONS,
+	VERIFIER_CATEGORIES,
+} from '../harness/attribution';
+import { buildFailedOnInfra, type BuildResult } from '../harness/build-workflow';
+import { classifyScenarioExecutionError } from '../harness/transient-error';
+import { sentinelOutcomeFromVerdicts } from '../run/reshape';
+import { MOCK_EXECUTION_VERIFY_PROMPT } from '../system-prompts/mock-execution-verify';
+
+function build(overrides: Partial<BuildResult>): BuildResult {
+	return {
+		success: false,
+		workflowJsons: [],
+		createdWorkflowIds: [],
+		createdDataTableIds: [],
+		...overrides,
+	};
+}
+
+describe('attributionFromVerifierCategory', () => {
+	it('is an identity map over the categories the verifier prompt defines', () => {
+		// The verifier's enum IS the attribution vocabulary — nothing to translate,
+		// which is the point of TRUST-375.
+		for (const category of VERIFIER_CATEGORIES) {
+			expect(attributionFromVerifierCategory(category)).toBe(category);
+		}
+	});
+
+	it('treats an uncategorised or unknown verdict as the builder’s', () => {
+		// The verifier prompt is explicit that there is no "legitimate failure"
+		// bucket — a decided failure with no category is still the builder's.
+		expect(attributionFromVerifierCategory(undefined)).toBe('builder_issue');
+		expect(attributionFromVerifierCategory('verification_failure')).toBe('builder_issue');
+		expect(attributionFromVerifierCategory('brand_new_category')).toBe('builder_issue');
+	});
+
+	it('stays in step with the enum the verifier prompt actually defines', () => {
+		// The prompt is the verifier's only spec. If someone adds a category there
+		// without adding it here it silently falls through to builder_issue —
+		// exactly the drift this contract exists to stop.
+		for (const category of VERIFIER_CATEGORIES) {
+			expect(MOCK_EXECUTION_VERIFY_PROMPT).toContain(`**${category}**`);
+		}
+	});
+});
+
+describe('attributionForScenario', () => {
+	it('leaves a passing scenario unattributed', () => {
+		expect(
+			attributionForScenario({ passed: true, incomplete: false, failureCategory: undefined }),
+		).toBeUndefined();
+	});
+
+	it('marks a scenario the verifier never decided as a verification gap', () => {
+		// The harness excludes this run from scoring; recording it as a product
+		// failure is what TRUST-375 set out to stop.
+		expect(
+			attributionForScenario({
+				passed: false,
+				incomplete: true,
+				failureCategory: 'verification_failure',
+			}),
+		).toBe('verification_gap');
+	});
+
+	it('otherwise defers to the verifier', () => {
+		expect(
+			attributionForScenario({ passed: false, incomplete: false, failureCategory: 'mock_issue' }),
+		).toBe('mock_issue');
+	});
+});
+
+describe('attributionForExpectation', () => {
+	it('leaves a passing expectation unattributed', () => {
+		expect(attributionForExpectation({ pass: true })).toBeUndefined();
+		expect(attributionForExpectation({ pass: true }, true)).toBeUndefined();
+	});
+
+	it('treats a missed expectation as a builder miss', () => {
+		expect(attributionForExpectation({ pass: false })).toBe('builder_issue');
+	});
+
+	it('treats an ungraded expectation as unmeasured', () => {
+		expect(attributionForExpectation({ pass: false, incomplete: true })).toBe('verification_gap');
+	});
+
+	it('attributes every expectation of an infra-failed build to infra', () => {
+		expect(attributionForExpectation({ pass: false, incomplete: true }, true)).toBe(
+			'framework_issue',
+		);
+		expect(attributionForExpectation({ pass: false }, true)).toBe('framework_issue');
+	});
+});
+
+describe('buildFailedOnInfra', () => {
+	it('is false for a successful build', () => {
+		expect(buildFailedOnInfra(build({ success: true, transportFailure: true }))).toBe(false);
+	});
+
+	it('is false for a genuine agent build failure', () => {
+		expect(buildFailedOnInfra(build({ error: 'agent produced no workflow' }))).toBe(false);
+	});
+
+	it('covers seeding, transport and provider outages', () => {
+		expect(buildFailedOnInfra(build({ seedingFailed: true }))).toBe(true);
+		expect(buildFailedOnInfra(build({ transportFailure: true }))).toBe(true);
+		expect(buildFailedOnInfra(build({ providerOutage: 'provider HTTP 529' }))).toBe(true);
+	});
+});
+
+describe('harness-code producers', () => {
+	it('classifies anything thrown out of scenario execution as infra', () => {
+		expect(classifyScenarioExecutionError('socket hang up').attribution).toBe('framework_issue');
+		expect(
+			classifyScenarioExecutionError('The operation was aborted due to timeout').attribution,
+		).toBe('framework_issue');
+	});
+
+	it('attributes the build-only sentinel row from its expectation verdicts', () => {
+		expect(sentinelOutcomeFromVerdicts(undefined).attribution).toBe('verification_gap');
+		expect(
+			sentinelOutcomeFromVerdicts([{ expectation: 'a', pass: false, reason: '', incomplete: true }])
+				.attribution,
+		).toBe('verification_gap');
+		expect(
+			sentinelOutcomeFromVerdicts([{ expectation: 'a', pass: false, reason: 'missed' }])
+				.attribution,
+		).toBe('builder_issue');
+		expect(
+			sentinelOutcomeFromVerdicts([{ expectation: 'a', pass: true, reason: 'ok' }]).attribution,
+		).toBeUndefined();
+	});
+
+	it('only ever emits one of the four buckets', () => {
+		const emitted = [
+			attributionFromVerifierCategory('anything'),
+			attributionForExpectation({ pass: false }),
+			attributionForExpectation({ pass: false }, true),
+			classifyScenarioExecutionError('boom').attribution,
+			sentinelOutcomeFromVerdicts(undefined).attribution,
+		];
+		for (const attribution of emitted) {
+			expect(EVAL_ATTRIBUTIONS).toContain(attribution);
+		}
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-compare.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-compare.test.ts
@@ -207,14 +207,16 @@ describe('compareBuckets', () => {
 			trialTotal: 10,
 		});
 		const cats = compareBuckets(pr, base).failureCategories;
-		// All five known categories are always present (some at 0/0 — renderer
-		// drops those). The unknown `-` category is dropped here with a warning.
+		// Every known category is always present (some at 0/0 — renderer drops
+		// those). The unknown `-` category is dropped here with a warning.
 		expect(cats.map((c) => c.category).sort()).toEqual([
 			'build_failure',
 			'builder_issue',
+			'expectations_failed',
 			'framework_issue',
 			'mock_issue',
 			'verification_failure',
+			'verification_gap',
 		]);
 		expect(warn).toHaveBeenCalledWith(expect.stringContaining('"-"'));
 		warn.mockRestore();

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -86,7 +86,12 @@ function iteration2(): WorkflowTestCaseResult {
 		workflowBuildSuccess: true,
 		buildError: 'agent stopped before producing a workflow',
 		buildExpectationResults: [
-			{ expectation: 'sends a digest', pass: false, reason: 'digest node missing' },
+			{
+				expectation: 'sends a digest',
+				pass: false,
+				reason: 'digest node missing',
+				attribution: 'builder_issue',
+			},
 		],
 		executionScenarioResults: [
 			{
@@ -95,6 +100,7 @@ function iteration2(): WorkflowTestCaseResult {
 				score: 0,
 				reasoning: 'no digest was produced',
 				failureCategory: 'mock_issue',
+				attribution: 'mock_issue',
 				rootCause: 'mock returned an empty page',
 				evalResult: { errors: ['HTTP 500 from the mocked API'] } as InstanceAiEvalExecutionResult,
 			},
@@ -118,6 +124,7 @@ interface DispatcherView {
 			expectation: string;
 			pass: boolean;
 			reason: string;
+			attribution?: string;
 		}> | null>;
 		buildCostUsdPerRun?: Array<number | null>;
 		buildTurnsPerRun?: Array<number | null>;
@@ -132,6 +139,7 @@ interface DispatcherView {
 				score: number;
 				reasoning: string;
 				failureCategory?: string;
+				attribution?: string;
 				rootCause?: string;
 				execErrors: string[];
 			}>;
@@ -181,7 +189,16 @@ describe('eval-results.json — dispatcher contract', () => {
 		});
 		expect(tc.buildExpectationResultsPerRun).toEqual([
 			[{ expectation: 'sends a digest', pass: true, reason: 'digest node present' }],
-			[{ expectation: 'sends a digest', pass: false, reason: 'digest node missing' }],
+			[
+				{
+					expectation: 'sends a digest',
+					pass: false,
+					reason: 'digest node missing',
+					// A missed expectation is a builder miss — the harness decides this,
+					// lang-tracer stores it (TRUST-375).
+					attribution: 'builder_issue',
+				},
+			],
 		]);
 		// Spend arrays are `--build-via-mcp`-only — absent when no iteration
 		// recorded `claude` spend, so non-MCP dispatcher output is unchanged.
@@ -220,9 +237,15 @@ describe('eval-results.json — dispatcher contract', () => {
 			score: 0,
 			reasoning: 'no digest was produced',
 			failureCategory: 'mock_issue',
+			// The attribution rides ALONGSIDE the legacy category — lang-tracer reads
+			// this one and only falls back to re-deriving from the category for rows
+			// written by an older pinned harness commit (TRUST-375).
+			attribution: 'mock_issue',
 			rootCause: 'mock returned an empty page',
 			execErrors: ['HTTP 500 from the mocked API'],
 		});
+		// A passing run carries no attribution at all — nobody owns a pass.
+		expect(sc.runs[0]).not.toHaveProperty('attribution');
 	});
 
 	it('serializes per-iteration `claude` build spend when a run recorded it', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/fixtures/eval-results.partial-abort.json
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/fixtures/eval-results.partial-abort.json
@@ -66,6 +66,7 @@
 							"score": 0,
 							"reasoning": "Scenario execution error: TimeoutError: The operation was aborted due to timeout",
 							"failureCategory": "framework_issue",
+							"attribution": "framework_issue",
 							"rootCause": "Scenario execution exceeded its per-iteration time budget and was aborted before a verdict: TimeoutError: The operation was aborted due to timeout",
 							"execErrors": []
 						}

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -205,6 +205,9 @@ describe('reshapeLangSmithRuns', () => {
 		expect(s2.success).toBe(false);
 		expect(s2.reasoning).toBe('No run result for this scenario');
 		expect(s2.score).toBe(0);
+		// Unowned and unmeasured: visible as a gap, but out of the pass rate.
+		expect(s2.attribution).toBe('verification_gap');
+		expect(s2.incomplete).toBe(true);
 	});
 
 	it('skips a malformed run output rather than scoring it as a failure', () => {
@@ -216,6 +219,8 @@ describe('reshapeLangSmithRuns', () => {
 		const s1 = result[0][0].executionScenarioResults[0];
 		expect(s1.success).toBe(false);
 		expect(s1.reasoning).toBe('Malformed run output — skipped');
+		expect(s1.attribution).toBe('verification_gap');
+		expect(s1.incomplete).toBe(true);
 	});
 
 	it('groups runs into separate iterations by the injected _iteration index', () => {

--- a/packages/@n8n/instance-ai/evaluations/checklist/verifier.ts
+++ b/packages/@n8n/instance-ai/evaluations/checklist/verifier.ts
@@ -90,6 +90,8 @@ function buildChecklistResults(
 				pass: entry.pass,
 				reasoning: entry.reasoning ?? '',
 				strategy: 'llm',
+				// Ambiguous string: the harness stamps the same one when the verifier
+				// returns NOTHING. `attribution` is the meaning-bearing field.
 				failureCategory:
 					entry.failureCategory ?? (!entry.pass ? 'verification_failure' : undefined),
 				rootCause: entry.rootCause ?? undefined,

--- a/packages/@n8n/instance-ai/evaluations/comparison/compare.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/compare.ts
@@ -285,8 +285,15 @@ const KNOWN_FAILURE_CATEGORIES = new Set([
 	'builder_issue',
 	'mock_issue',
 	'framework_issue',
+	// The verifier's "not enough information to decide" arm. In its prompt enum
+	// from the start but missing here, so every one of these was dropped from the
+	// PR comment with a console warning (TRUST-375).
+	'verification_gap',
 	'verification_failure',
 	'build_failure',
+	// Build-only sentinel rows — reachable through a LangSmith baseline fetch,
+	// which reads run outputs rather than execution-scenario results.
+	'expectations_failed',
 ]);
 
 function isCategoryNotable(

--- a/packages/@n8n/instance-ai/evaluations/harness/agent-execution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/agent-execution.ts
@@ -11,6 +11,7 @@ import { isRecord } from '@n8n/utils/is-record';
 import { setTimeout as delay } from 'node:timers/promises';
 
 import { agentHandler } from './artifacts/agent-handler';
+import { attributionForScenario } from './attribution';
 import type { EvalLogger } from './logger';
 import { writeScenarioVerificationSnapshot, type VerificationArtifact } from './scenario-execution';
 import { isTransientExecutionAbort, MAX_EXEC_ATTEMPTS } from './transient-error';
@@ -142,6 +143,7 @@ export async function executeAgentScenario(
 		`No verification result — verifier exhausted all attempts${attemptErrors.length > 0 ? ` (${attemptErrors.join('; ')})` : ''}`;
 	const failureCategory = result?.failureCategory ?? (result ? undefined : 'verification_failure');
 	const rootCause = result?.rootCause;
+	const attribution = attributionForScenario({ passed, incomplete, failureCategory });
 
 	const categoryLabel = failureCategory ? ` [${failureCategory}]` : '';
 	const statusLabel = incomplete ? 'INCOMPLETE (excluded from scoring)' : passed ? 'PASS' : 'FAIL';
@@ -160,6 +162,7 @@ export async function executeAgentScenario(
 		score: passed ? 1 : 0,
 		reasoning,
 		failureCategory,
+		attribution,
 		rootCause,
 		...(incomplete ? { incomplete: true } : {}),
 	};

--- a/packages/@n8n/instance-ai/evaluations/harness/attribution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/attribution.ts
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------
+// Failure attribution — the cross-repo vocabulary (TRUST-375)
+//
+// The harness is the only place that knows which phase failed, what the model
+// provider returned, whether the lane was healthy and whether a judge produced
+// a verdict. So the harness decides the attribution and writes it to
+// `eval-results.json`; lang-tracer stores what we send verbatim and overrides
+// it only with cross-unit evidence one CLI process cannot have (many runners
+// failing at once ⇒ provider outage).
+//
+// Before this, lang-tracer re-derived attribution from our `failureCategory`
+// string in a hardcoded translation table between two vocabularies that were
+// never agreed on. `failureCategory` still ships unchanged — pinned older
+// harness commits emit it and lang-tracer's legacy map still reads it — but it
+// is no longer how the meaning travels.
+// ---------------------------------------------------------------------------
+
+/**
+ * Who owns a failed graded unit. Deliberately the SAME four names the verifier
+ * prompt already defines, so the enum the LLM picks from and the enum we store
+ * are one vocabulary rather than two that need translating — which is how the
+ * old contract drifted. The harness-code categories (`build_failure`,
+ * `verification_failure`, `expectations_failed`) fold into these.
+ */
+export const EVAL_ATTRIBUTIONS = [
+	/** The agent built it wrong — including "runs as built, misses the criteria". */
+	'builder_issue',
+	/** The eval mock/fixture layer served data the scenario did not describe. */
+	'mock_issue',
+	/** The eval framework failed the test rather than the test failing: no
+	 *  trigger content delivered, seed table missing, provider outage, transport
+	 *  error, budget abort, runner crash. Not a product signal. */
+	'framework_issue',
+	/** We could not measure: verifier returned nothing, judge died, unit ungraded. */
+	'verification_gap',
+] as const;
+
+export type EvalAttribution = (typeof EVAL_ATTRIBUTIONS)[number];
+
+export function isEvalAttribution(value: unknown): value is EvalAttribution {
+	return EVAL_ATTRIBUTIONS.includes(value as EvalAttribution);
+}
+
+/**
+ * The categories the LLM verifier picks from, as spelled out in
+ * `system-prompts/mock-execution-verify.ts`. Identical to `EVAL_ATTRIBUTIONS`
+ * on purpose — kept as its own name so the prompt's enum has a code-side
+ * counterpart that fails a test when the two drift.
+ */
+export const VERIFIER_CATEGORIES = EVAL_ATTRIBUTIONS;
+
+/**
+ * Attribution for a category the LLM verifier chose — an identity map, since
+ * the two enums are now the same list.
+ *
+ * Anything off-enum — including a failing verdict it left uncategorised, which
+ * `checklist/verifier.ts` back-fills as `verification_failure` — is the
+ * builder's. That is the verifier prompt's own stance: "a workflow that runs as
+ * built but doesn't meet the success criteria is a builder_issue — the builder
+ * owns satisfying the scenario as written; there is no separate 'legitimate
+ * failure' category."
+ */
+export function attributionFromVerifierCategory(category: string | undefined): EvalAttribution {
+	return isEvalAttribution(category) ? category : 'builder_issue';
+}
+
+/**
+ * Attribution for one verified scenario. Shared by the workflow and agent
+ * paths, which decide this identically and must not drift: a verifier that
+ * produced no verdict at all means we never measured, so the run is unowned
+ * (`verification_gap`) rather than a failure of the thing under test.
+ */
+export function attributionForScenario(outcome: {
+	passed: boolean;
+	incomplete: boolean;
+	failureCategory: string | undefined;
+}): EvalAttribution | undefined {
+	if (outcome.passed) return undefined;
+	if (outcome.incomplete) return 'verification_gap';
+	return attributionFromVerifierCategory(outcome.failureCategory);
+}
+
+/**
+ * Attribution for one author-written build expectation.
+ *
+ * The expectations judge emits only `pass` + `reason`, so this is a policy, not
+ * a mapping: an expectation the agent missed is a builder miss (same stance as
+ * the verifier prompt), and an ungraded one is unmeasured. `infraFailed` covers
+ * the build that never produced anything to judge — a provider outage or a
+ * transport/seeding failure — where neither of those is true.
+ */
+export function attributionForExpectation(
+	verdict: { pass: boolean; incomplete?: boolean },
+	infraFailed = false,
+): EvalAttribution | undefined {
+	if (verdict.pass) return undefined;
+	if (infraFailed) return 'framework_issue';
+	return verdict.incomplete ? 'verification_gap' : 'builder_issue';
+}

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -185,6 +185,21 @@ export interface BuildResult {
 	providerOutage?: string;
 }
 
+/**
+ * True when the build failed for a reason the agent doesn't own — seeding,
+ * transport or the model provider. Everything downstream that has to attribute
+ * a failure (the scenario row, the ungraded expectations) reads this one
+ * predicate so the three answers can't drift apart (TRUST-375).
+ */
+export function buildFailedOnInfra(build: BuildResult): boolean {
+	if (build.success) return false;
+	return (
+		build.seedingFailed === true ||
+		build.transportFailure === true ||
+		build.providerOutage !== undefined
+	);
+}
+
 export interface BuildWorkflowConfig {
 	client: N8nClient;
 	/** Hand-authored conversation (≥1 turn, first `user`; one user turn →

--- a/packages/@n8n/instance-ai/evaluations/harness/scenario-execution.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/scenario-execution.ts
@@ -12,6 +12,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
+import { attributionForScenario } from './attribution';
 import type { EvalLogger } from './logger';
 import { reseedScenarioTables, type ScenarioSeedContext } from './seed-tables';
 import { isTransientExecutionAbort, MAX_EXEC_ATTEMPTS } from './transient-error';
@@ -360,6 +361,7 @@ async function runScenario(
 		`No verification result — verifier exhausted all attempts${attemptErrors.length > 0 ? ` (${attemptErrors.join('; ')})` : ''}`;
 	const failureCategory = result?.failureCategory ?? (result ? undefined : 'verification_failure');
 	const rootCause = result?.rootCause;
+	const attribution = attributionForScenario({ passed, incomplete, failureCategory });
 
 	const categoryLabel = failureCategory ? ` [${failureCategory}]` : '';
 	const statusLabel = incomplete ? 'INCOMPLETE (excluded from scoring)' : passed ? 'PASS' : 'FAIL';
@@ -378,6 +380,7 @@ async function runScenario(
 		score: passed ? 1 : 0,
 		reasoning,
 		failureCategory,
+		attribution,
 		rootCause,
 		...(incomplete ? { incomplete: true } : {}),
 	};

--- a/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
@@ -11,6 +11,8 @@
 // baseline instead of counting as silent failures.
 // ---------------------------------------------------------------------------
 
+import type { EvalAttribution } from './attribution';
+
 /** Max attempts (initial try + retries) for a scenario execution hitting transient errors. */
 export const MAX_EXEC_ATTEMPTS = 5;
 
@@ -62,9 +64,10 @@ export function shouldRetryScenarioExecution(message: string, attempt: number): 
 
 /**
  * Marker prefix for the rootCause stamped on a scenario whose execution was
- * aborted by the per-iteration budget/timeout. The lang-tracer side keys its
- * `infra_incomplete` attribution off `failureCategory: "framework_issue"` plus
- * a timeout-flavoured rootCause — keep the wording stable across both repos.
+ * aborted by the per-iteration budget/timeout. lang-tracer used to key an infra
+ * attribution off this plus `failureCategory: "framework_issue"`; it now reads
+ * our `attribution` directly and this is only the fallback for rows written by
+ * an older pinned harness commit. Keep the wording stable across both repos.
  */
 export const BUDGET_TIMEOUT_ROOT_CAUSE =
 	'Scenario execution exceeded its per-iteration time budget and was aborted before a verdict';
@@ -75,17 +78,20 @@ export const BUDGET_TIMEOUT_ROOT_CAUSE =
  * Any error that escapes `executeScenario` (after its own retries) is an
  * infra/framework problem, never an agent verdict, so it is always
  * `framework_issue`. A budget/timeout abort additionally carries a
- * timeout-flavoured `rootCause` so partial-result consumers can route it to an
- * infra/incomplete bucket instead of counting it against product quality.
+ * timeout-flavoured `rootCause`, kept for readers on the legacy contract.
  */
 export function classifyScenarioExecutionError(errorMessage: string): {
 	failureCategory: 'framework_issue';
+	/** Infra by construction — see above. Sent verbatim to lang-tracer, which no
+	 *  longer has to infer it from the timeout-flavoured rootCause. */
+	attribution: EvalAttribution;
 	rootCause: string | undefined;
 	reasoning: string;
 } {
 	const timedOut = isExecutionTimeout(errorMessage);
 	return {
 		failureCategory: 'framework_issue',
+		attribution: 'framework_issue',
 		rootCause: timedOut ? `${BUDGET_TIMEOUT_ROOT_CAUSE}: ${errorMessage}` : undefined,
 		reasoning: `Scenario execution error: ${errorMessage}`,
 	};
@@ -116,9 +122,10 @@ const TRANSIENT_FAILURE_TOKEN =
 	/\bInternal server error\b|\bOverloaded\b|\bService Unavailable\b|\bBad Gateway\b|\b(?:HTTP|status(?: code)?)\s*[:=]?\s*(?:429|500|502|503|529)\b/i;
 
 /**
- * Root cause stamped on a build that died on a provider outage. lang-tracer keys
- * `infra_incomplete` attribution off this exact prefix, so the wording is a
- * cross-repo contract — same arrangement as `BUDGET_TIMEOUT_ROOT_CAUSE`.
+ * Root cause stamped on a build that died on a provider outage. lang-tracer keyed
+ * an infra attribution off this exact prefix; it now reads our `attribution`
+ * instead, so this is the legacy-contract fallback — same arrangement as
+ * `BUDGET_TIMEOUT_ROOT_CAUSE`.
  */
 export const PROVIDER_OUTAGE_ROOT_CAUSE =
 	'Model provider was unavailable during the build (transient upstream 5xx/429), so the agent produced no output';

--- a/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
@@ -294,8 +294,12 @@ function firstPromptText(result: WorkflowTestCaseResult): string {
 
 function promptReview(result: WorkflowTestCaseResult, sr: ExecutionScenarioResult): StageReview {
 	const evidence = `${sr.reasoning} ${sr.rootCause ?? ''}`.toLowerCase();
+	// Gated on the failure being the builder's: a mock or infra failure says
+	// nothing about the prompt. Used to read `failureCategory ===
+	// 'legitimate_failure'` — a lang-tracer bucket the harness never emits, so
+	// this stage could never fail (TRUST-375).
 	const promptLooksUnderspecified =
-		sr.failureCategory === 'legitimate_failure' &&
+		sr.attribution === 'builder_issue' &&
 		['ambiguous', 'unclear', 'not specified', 'not define', 'does not specify'].some((needle) =>
 			evidence.includes(needle),
 		);
@@ -461,8 +465,11 @@ function verifierReview(sr: ExecutionScenarioResult): StageReview {
 	};
 }
 
+/** Keyed on the attribution buckets, not the raw verifier category: the old
+ *  switch mixed our categories with lang-tracer's bucket names, so two of its
+ *  arms were unreachable (TRUST-375). */
 function promptImprovementSuggestion(sr: ExecutionScenarioResult): string {
-	switch (sr.failureCategory) {
+	switch (sr.attribution) {
 		case 'builder_issue':
 			return 'For workflows with multiple required effects, branches, or error paths, state each required action explicitly and add observable acceptance conditions for every branch. This reduces silent omission during planning or build.';
 		case 'mock_issue':
@@ -471,8 +478,6 @@ function promptImprovementSuggestion(sr: ExecutionScenarioResult): string {
 			return 'Make trigger preconditions and scenario setup requirements explicit in the test prompt or fixture description so empty-input framework failures are easier to separate from workflow defects.';
 		case 'verification_gap':
 			return 'Add concrete, inspectable success evidence to the prompt, such as the exact side effect, branch behavior, or output field that should be observed, so the verifier has less room to infer.';
-		case 'legitimate_failure':
-			return 'If this behavior is required, move it from an implied expectation into an explicit prompt requirement with a clear fallback path and observable success criterion.';
 		default:
 			return 'Turn the failed behavior into a more explicit, testable requirement in future prompts: name the required step, the expected branch, and the observable evidence that proves it happened.';
 	}

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -23,7 +23,8 @@ import {
 	type executeAgentScenario,
 } from '../harness/agent-execution';
 import { resolveArtifactContext } from '../harness/artifacts/artifact-context';
-import type { BuildResult } from '../harness/build-workflow';
+import { attributionForExpectation } from '../harness/attribution';
+import { buildFailedOnInfra, type BuildResult } from '../harness/build-workflow';
 import { captureThreadRunDebug } from '../harness/capture-run-debug';
 import { effectiveTimeoutMs, runWorkflowChecks } from '../harness/cleanup';
 import type { EvalLogger } from '../harness/logger';
@@ -341,10 +342,17 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 			isPrebuilt,
 			logger,
 		});
+		// Attributed here, where we still know WHY the build ended: a build that
+		// died on infra produced nothing to judge, so its expectations are unowned
+		// rather than the agent's miss. Both readers of this map (the row outputs
+		// and reshape's side band) then carry the same verdict (TRUST-375).
+		const infraFailed = buildFailedOnInfra(build);
+		const attribute = (verdicts: BuildExpectationResult[]): BuildExpectationResult[] =>
+			verdicts.map((v) => ({ ...v, attribution: attributionForExpectation(v, infraFailed) }));
 		// Recorded as incomplete rather than dropped, so the case keeps its unit
 		// count and the report says why they weren't graded.
 		if (unjudged.length > 0) {
-			buildExpectationsByKey.set(key, Promise.resolve(unjudged));
+			buildExpectationsByKey.set(key, Promise.resolve(attribute(unjudged)));
 			return;
 		}
 		if (expectations.length === 0) return;
@@ -364,12 +372,14 @@ export function createBuildOrchestrator(deps: BuildOrchestratorDeps): BuildOrche
 						client,
 						logger,
 					}),
-				}))().catch((error: unknown) =>
-				allFailVerdicts(
-					expectations,
-					`judge error: ${error instanceof Error ? error.message : String(error)}`,
-				),
-			),
+				}))()
+				.catch((error: unknown) =>
+					allFailVerdicts(
+						expectations,
+						`judge error: ${error instanceof Error ? error.message : String(error)}`,
+					),
+				)
+				.then(attribute),
 		);
 	}
 

--- a/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
@@ -16,6 +16,7 @@ import type { BuildOrchestrator } from './build-orchestrator';
 import { sentinelOutcomeFromVerdicts, type TargetOutput } from './reshape';
 import type { CliArgs } from '../cli/args';
 import { findAgentArtifactRef } from '../harness/agent-execution';
+import { buildFailedOnInfra } from '../harness/build-workflow';
 import { cleanupBuild, effectiveTimeoutMs } from '../harness/cleanup';
 import type { EvalLogger } from '../harness/logger';
 import {
@@ -142,6 +143,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: 0,
 				reasoning: classified.reasoning,
 				failureCategory: classified.failureCategory,
+				attribution: classified.attribution,
 				rootCause: classified.rootCause,
 				execErrors: [message],
 				buildDurationMs: 0,
@@ -193,6 +195,8 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 		// Awaited only after each branch's own work is done, keeping the judge off
 		// the scenario critical path while persisting verdicts to run outputs.
 		const verdictsPromise = buildExpectationsByKey.get(cacheKey);
+		// Verdicts arrive already attributed (the orchestrator stamps them where it
+		// still knows why the build ended) — attach them as-is.
 		const attachExpectations = async (output: TargetOutput): Promise<TargetOutput> => {
 			const verdicts = await verdictsPromise;
 			return verdicts && verdicts.length > 0 ? { ...output, expectationResults: verdicts } : output;
@@ -215,6 +219,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: outcome.score,
 				reasoning: outcome.reasoning,
 				failureCategory: outcome.failureCategory,
+				attribution: outcome.attribution,
 				...(outcome.incomplete ? { incomplete: true } : {}),
 				execErrors: [],
 				buildDurationMs,
@@ -237,11 +242,14 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				reasoning: `Build failed: ${build.error ?? 'unknown'}`,
 				// Seeding, transport and provider failures are harness/infra problems,
 				// not agent build failures — keep them out of the build_failure bucket,
-				// which lang-tracer maps straight to `builder_issue`.
+				// which lang-tracer's legacy map reads straight as `builder_issue`.
 				failureCategory:
 					build.seedingFailed || build.transportFailure ? 'framework_issue' : 'build_failure',
-				// Pinned marker so lang-tracer attributes an outage to infra instead of
-				// recording it as a builder regression (TRUST-374).
+				// The verdict lang-tracer actually stores. A provider outage is infra
+				// at the source (TRUST-374/375) — it no longer has to be inferred from
+				// the rootCause below.
+				attribution: buildFailedOnInfra(build) ? 'framework_issue' : 'builder_issue',
+				// Pinned marker kept as the fallback for readers on the legacy contract.
 				...(build.providerOutage
 					? { rootCause: `${PROVIDER_OUTAGE_ROOT_CAUSE}: ${build.providerOutage}` }
 					: {}),
@@ -304,6 +312,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 						score: 0,
 						reasoning: `Agent scenario execution error: ${errorMessage}`,
 						failureCategory: 'framework_issue',
+						attribution: 'framework_issue',
 						execErrors: [errorMessage],
 						buildDurationMs,
 						...buildSpendFields,
@@ -318,6 +327,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 
 			const agentFailureCategory = agentResult.success ? undefined : agentResult.failureCategory;
 			const agentRootCause = agentResult.success ? undefined : agentResult.rootCause;
+			const agentAttribution = agentResult.success ? undefined : agentResult.attribution;
 			return await attachExpectations({
 				buildSuccess: true,
 				agentId: agentRef.id,
@@ -327,6 +337,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: agentResult.score,
 				reasoning: agentResult.reasoning,
 				failureCategory: agentFailureCategory,
+				attribution: agentAttribution,
 				rootCause: agentRootCause,
 				...(agentResult.incomplete ? { incomplete: true } : {}),
 				execErrors: agentResult.agentEvalResult?.errors ?? [],
@@ -367,6 +378,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: 0,
 				reasoning: reason,
 				failureCategory: 'framework_issue',
+				attribution: 'framework_issue',
 				execErrors: [reason],
 				buildDurationMs,
 				...buildSpendFields,
@@ -419,6 +431,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 						score: 0,
 						reasoning: classified.reasoning,
 						failureCategory: classified.failureCategory,
+						attribution: classified.attribution,
 						rootCause: classified.rootCause,
 						execErrors: [errorMessage],
 						buildDurationMs,
@@ -439,6 +452,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 			// placeholders instead of omitting them.
 			const failureCategory = result.success ? undefined : result.failureCategory;
 			const rootCause = result.success ? undefined : result.rootCause;
+			const attribution = result.success ? undefined : result.attribution;
 
 			return await attachExpectations({
 				buildSuccess: true,
@@ -448,6 +462,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 				score: result.score,
 				reasoning: result.reasoning,
 				failureCategory,
+				attribution,
 				rootCause,
 				...(result.incomplete ? { incomplete: true } : {}),
 				execErrors: result.evalResult?.errors ?? [],

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -460,6 +460,9 @@ export function writeEvalResults(
 					score: sr.score,
 					reasoning: sr.reasoning,
 					failureCategory: sr.failureCategory,
+					// Who owns the failure, decided here rather than re-derived
+					// downstream from the category string (TRUST-375).
+					attribution: sr.attribution,
 					rootCause: sr.rootCause,
 					execErrors: sr.evalResult?.errors ?? sr.agentEvalResult?.errors ?? [],
 					evalResult: sr.evalResult,

--- a/packages/@n8n/instance-ai/evaluations/run/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reshape.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import { CHECK_DIMENSIONS, type CheckOutcome } from '../binaryChecks/types';
 import type { WorkflowResponse } from '../clients/n8n-client';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
+import { EVAL_ATTRIBUTIONS, type EvalAttribution } from '../harness/attribution';
 import { BUILD_ONLY_SCENARIO_NAME } from '../langsmith/dataset-sync';
 import type {
 	BuildTrace,
@@ -44,6 +45,9 @@ export const expectationResultsSchema = z.array(
 		pass: z.boolean(),
 		reason: z.string().default(''),
 		incomplete: z.boolean().optional(),
+		/** Stamped in case-pipeline's `stampExpectations` — zod strips unknown
+		 *  keys, so an omission here silently drops it from `eval-results.json`. */
+		attribution: z.enum(EVAL_ATTRIBUTIONS).optional(),
 	}),
 );
 
@@ -57,6 +61,10 @@ const targetOutputSchema = z.object({
 	/** Set when the scenario ran against a built first-class Agent instead of a workflow. */
 	agentId: z.string().optional(),
 	failureCategory: z.string().optional(),
+	/** The harness's own verdict on who owns the failure — what lang-tracer
+	 *  stores. `failureCategory` stays alongside it for readers on the legacy
+	 *  contract (TRUST-375). */
+	attribution: z.enum(EVAL_ATTRIBUTIONS).optional(),
 	rootCause: z.string().optional(),
 	/** Verifier returned no verdict — run is excluded from scoring but stays visible. */
 	incomplete: z.boolean().optional(),
@@ -178,6 +186,9 @@ export function sentinelOutcomeFromVerdicts(verdicts: BuildExpectationResult[] |
 	/** Only on non-passing outcomes — without a category the feedback extractor
 	 *  files the row under 'unknown' in the LangSmith failure_category column. */
 	failureCategory?: 'expectations_failed' | 'verification_failure';
+	/** The bucket lang-tracer stores. A missed expectation is a builder miss —
+	 *  same stance the verifier prompt takes; no verdicts at all is unmeasured. */
+	attribution?: EvalAttribution;
 } {
 	const evaluated = (verdicts ?? []).filter((v) => !v.incomplete);
 	if (evaluated.length === 0) {
@@ -187,6 +198,7 @@ export function sentinelOutcomeFromVerdicts(verdicts: BuildExpectationResult[] |
 			reasoning: 'Build-only case — no expectation verdicts (judge incomplete)',
 			incomplete: true,
 			failureCategory: 'verification_failure',
+			attribution: 'verification_gap',
 		};
 	}
 	const failed = evaluated.filter((v) => !v.pass);
@@ -197,7 +209,9 @@ export function sentinelOutcomeFromVerdicts(verdicts: BuildExpectationResult[] |
 		reasoning: passed
 			? `Build-only case — all ${String(evaluated.length)} expectations passed`
 			: `Build-only case — failed expectations: ${failed.map((v) => v.expectation).join('; ')}`,
-		...(passed ? {} : { failureCategory: 'expectations_failed' as const }),
+		...(passed
+			? {}
+			: { failureCategory: 'expectations_failed' as const, attribution: 'builder_issue' as const }),
 	};
 }
 
@@ -270,6 +284,10 @@ export function reshapeLangSmithRuns(
 						success: false,
 						score: 0,
 						reasoning: run ? 'Malformed run output — skipped' : 'No run result for this scenario',
+						// The row never produced a verdict, so nobody owns it. Without this
+						// it reaches lang-tracer category-less and defaults to a product
+						// failure.
+						attribution: 'verification_gap',
 					});
 					continue;
 				}
@@ -296,6 +314,7 @@ export function reshapeLangSmithRuns(
 					score: output.score,
 					reasoning: output.reasoning,
 					failureCategory: output.failureCategory,
+					attribution: output.attribution,
 					rootCause: output.rootCause,
 					...(output.incomplete ? { incomplete: true } : {}),
 				});

--- a/packages/@n8n/instance-ai/evaluations/run/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reshape.ts
@@ -288,6 +288,10 @@ export function reshapeLangSmithRuns(
 						// it reaches lang-tracer category-less and defaults to a product
 						// failure.
 						attribution: 'verification_gap',
+						// …and unowned has to mean unscored too, or the row is visible as a
+						// gap while still counting against the builder. Same pairing as
+						// `sentinelOutcomeFromVerdicts` and `attributionFor`.
+						incomplete: true,
 					});
 					continue;
 				}

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -11,6 +11,7 @@ import type {
 
 import type { CheckOutcome } from './binaryChecks/types';
 import type { WorkflowResponse } from './clients/n8n-client';
+import type { EvalAttribution } from './harness/attribution';
 import type { ConversationSeed } from './harness/conversation-seed';
 
 // ---------------------------------------------------------------------------
@@ -271,10 +272,15 @@ export interface ExecutionScenarioResult {
 	workflowId?: string;
 	score: number;
 	reasoning: string;
-	/** Root cause category when the scenario fails */
+	/** Root cause category when the scenario fails. Free-form on purpose: it
+	 *  carries whatever the LLM verifier picked, and older harness commits used
+	 *  a different spelling. Read `attribution` for the meaning. */
 	failureCategory?: string;
 	/** Detailed root cause explanation */
 	rootCause?: string;
+	/** Who owns this failure — the harness's own verdict, and what LangTracer
+	 *  stores. Undefined on a pass. See `harness/attribution.ts`. */
+	attribution?: EvalAttribution;
 	/** Verifier returned no verdict after all attempts (infra failure, not a
 	 *  workflow failure). Rendered visibly but kept out of the pass-rate count,
 	 *  mirroring `BuildExpectationResult.incomplete`. */
@@ -289,6 +295,9 @@ export interface BuildExpectationResult {
 	reason: string;
 	/** Judge returned no verdict (flaky/partial). Rendered neutrally, kept out of the count. */
 	incomplete?: boolean;
+	/** Who owns a failed expectation. Stamped where the verdicts are attached to
+	 *  a row (the only place that also knows whether the build died on infra). */
+	attribution?: EvalAttribution;
 }
 
 export interface WorkflowTestCaseResult {


### PR DESCRIPTION
## Summary

The harness makes every judgement about an eval run — which phase failed, what the model provider returned, whether the lane was healthy, whether a judge produced a verdict. It then wrote only a `failureCategory` string, and lang-tracer **re-derived the meaning from it** in a hardcoded translation table between two vocabularies that had drifted. No LLM on either side of that boundary — just a switch statement guessing at semantics we already knew.

This PR emits the verdict instead. Every failed scenario iteration and build expectation now carries an `attribution`, defined once in `evaluations/harness/attribution.ts`.

The buckets are **deliberately the same four names the verifier prompt already defines**, so ingest becomes an identity map rather than a translation — that is the fix:

| bucket | means |
| --- | --- |
| `builder_issue` | the agent built it wrong, including "runs as built, misses the criteria" |
| `mock_issue` | the eval mock/fixture layer served data the scenario didn't describe |
| `framework_issue` | the eval framework failed the test rather than the test failing — no trigger content, seed table missing, provider outage, transport error, budget abort, runner crash |
| `verification_gap` | we couldn't measure it — verifier returned nothing, judge died, unit ungraded |

The harness-code categories fold in: `build_failure` and `expectations_failed` → `builder_issue`, `verification_failure` → `verification_gap`, and a build that died on seeding, transport or a provider outage → `framework_issue`.

**`failureCategory` is unchanged on the wire.** Pinned older harness commits emit it and lang-tracer's legacy map still reads it, so nothing regresses on old refs.

### Two in-repo consumers had drifted too

Found while enumerating the real vocabulary rather than the documented one:

- **`comparison/compare.ts`** — `KNOWN_FAILURE_CATEGORIES` had no `verification_gap`, an arm the verifier prompt has defined from the start. Every one of those was dropped from the PR comment with a `[comparison] dropping unknown failureCategory` warning.
- **`report/workflow-report.ts`** — switched on `legitimate_failure`, a *lang-tracer* bucket the harness never emits, so its prompt-review stage could never fail and two arms of `promptImprovementSuggestion` were unreachable.

### One scoring bug this closes

`computeCaseStatus` is CASE-level, so a case that verified *some* of its scenarios stays `status: "verified"`. A scenario whose verifier died therefore reached lang-tracer with `passCount: 0 / totalRuns: N` and no incomplete flag, and was scored as a real product failure — even though the harness explicitly excludes it. `evaluatedCount` was already on the wire; the companion lang-tracer PR now reads it.

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm vitest run evaluations   # 1130 pass
pnpm typecheck && pnpm lint
```

Worth reading directly:

- `__tests__/attribution.test.ts` — the vocabulary, including a **drift tripwire** asserting every `VERIFIER_CATEGORIES` entry is still defined in the verifier prompt
- `__tests__/eval-results-dispatcher-contract.test.ts` — the new field on both scenario runs and expectation verdicts, and that a *passing* run carries no attribution at all

Verified against a real run, not just unit tests — one case dispatched end to end, the resulting `eval-results.json` carries the field on all five graded units, and driving that file through lang-tracer's real ingest chain writes it to `case_runs` unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-375

Companion PR: n8n-io/lang-tracer#115 — must land together.

**Stacked on #35293** (TRUST-374), which touches the same files. Retarget to `master` once that merges.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35305">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->