### PR TITLE
test(core): Pin exact-name semantics of the credential overwrite skip list (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -186,6 +186,23 @@ describe('CredentialsOverwrites', () => {
 
 				expect(result).toEqual({ password: 'pass' });
 			});
+
+			it('should still apply overwrites to an extending type when only its parent is in the skip list', () => {
+				// The skip list is exact-name: a skip entry on 'parent' must not change how
+				// 'test' (which extends 'parent') is treated, even when 'test' has a
+				// customized field. This allows skipping a base type without affecting
+				// the concrete types that inherit its overwrite.
+				globalConfig.credentials.overwrite.skipTypes = [
+					'parent',
+				] as unknown as CommaSeparatedStringArray<string>;
+
+				const result = credentialsOverwrites.applyOverwrite('test', {
+					username: 'custom-user',
+					password: '',
+				});
+
+				expect(result).toEqual({ username: 'custom-user', password: 'pass' });
+			});
 		});
 	});
 

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -857,6 +857,50 @@ describe('FrontendService', () => {
 			expect(credential.__skipManagedCreation).toBeUndefined();
 		});
 
+		it('should not propagate __skipManagedCreation from a skip-listed parent to extending types', () => {
+			// An overwrite keyed at a base type is inherited by extending types
+			// (__overwrittenProperties), but the skip list is exact-name: skipping the
+			// base must not disable managed creation for the extending types.
+			const baseCredential = {
+				name: 'microsoftOAuth2Api',
+				displayName: 'Microsoft OAuth2 API',
+				properties: [],
+			} as ICredentialType;
+			const childCredential = {
+				name: 'microsoftOutlookOAuth2Api',
+				displayName: 'Microsoft Outlook OAuth2 API',
+				properties: [],
+			} as ICredentialType;
+
+			loadNodesAndCredentials.types = {
+				credentials: [baseCredential, childCredential],
+				nodes: [],
+			};
+			(globalConfig as any).credentials = {
+				overwrite: { skipTypes: ['microsoftOAuth2Api'] },
+			};
+			(credentialsOverwrites.getAll as Mock).mockReturnValue({
+				microsoftOAuth2Api: { clientId: 'id', clientSecret: 'secret' },
+			});
+			(credentialTypes.getParentTypes as Mock).mockImplementation((name: string) =>
+				name === 'microsoftOutlookOAuth2Api' ? ['microsoftOAuth2Api', 'oAuth2Api'] : ['oAuth2Api'],
+			);
+
+			const { service } = createMockService();
+			(service as any).overwriteCredentialsProperties();
+
+			// both are marked overwritten (the extending type inherits the base entry)
+			expect(baseCredential.__overwrittenProperties).toEqual(['clientId', 'clientSecret']);
+			expect(childCredential.__overwrittenProperties).toEqual(['clientId', 'clientSecret']);
+			// but only the exact skip-list entry loses managed creation
+			expect(baseCredential.__skipManagedCreation).toBe(true);
+			expect(childCredential.__skipManagedCreation).toBeUndefined();
+
+			// restore shared mock defaults for subsequent tests
+			(credentialsOverwrites.getAll as Mock).mockReturnValue({});
+			(credentialTypes.getParentTypes as Mock).mockReturnValue([]);
+		});
+
 		describe('JWKS URI injection', () => {
 			const expectedJwksUri = 'http://localhost:5678/rest/.well-known/jwks.json';
 


### PR DESCRIPTION
## Summary

`N8N_SKIP_CREDENTIAL_OVERWRITE` is checked by exact credential type name at both sites that read it: `overwriteCredentialsProperties` in `frontend.service.ts` (sets `__skipManagedCreation`) and `applyOverwrite` in `credentials-overwrites.ts` (the customized-credential skip branch). A skip entry on a base type therefore does not affect credential types that extend it: they keep inheriting the overwrite (`__overwrittenProperties`) and keep offering managed creation.

The rollout planned in ENT-282 relies on this exact-name behavior (skipping a base OAuth2 type on Cloud while its extending types keep managed auth), and it was raised in review discussion that the semantics could be read as intended-to-inherit. This PR adds unit tests that pin the exact-name contract at both sites so a future change to inherited semantics fails loudly instead of silently changing Cloud behavior. No production code changes.

## How to test

From `packages/cli`: `pnpm test src/__tests__/credentials-overwrites.test.ts src/services/__tests__/frontend.service.test.ts`

To see the behavior live, boot n8n with:

```
CREDENTIALS_OVERWRITE_DATA='{"microsoftOAuth2Api":{"clientId":"x","clientSecret":"y"}}'
N8N_SKIP_CREDENTIAL_OVERWRITE=microsoftOAuth2Api
```

and inspect the generated `types/credentials.json`: `microsoftOAuth2Api` carries `__skipManagedCreation: true`, while `microsoftOutlookOAuth2Api` / `microsoftTeamsOAuth2Api` etc. carry `__overwrittenProperties` and no `__skipManagedCreation`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-282

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35310">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

