### PR TITLE
fix(core): Harden Instance AI sandbox acquisition (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
@@ -346,6 +346,70 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-stopped');
 	});
 
+	it('retries a transient 5xx create failure and succeeds', async () => {
+		const logger = makeLogger();
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Error 502: Bad gateway', 502),
+			makeMockSandbox('remote-after-retry'),
+		);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+			logger,
+		});
+
+		await sandbox.start();
+
+		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-after-retry');
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Sandbox create failed transiently; retrying',
+			expect.objectContaining({ sandboxName: 'sandbox-name', attempt: 1 }),
+		);
+	});
+
+	it('does not retry non-transient create failures', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(new DaytonaError('Forbidden', 403));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await expect(sandbox.start()).rejects.toThrow('Forbidden');
+		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
+	});
+
+	it('reattaches when a retried create collides with the sandbox the failed attempt created', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Error 502: Bad gateway', 502),
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		queuedGetResults.push(makeMockSandbox('remote-created-despite-502'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await sandbox.start();
+
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-created-despite-502');
+	});
+
 	it('rethrows a name conflict without falling back to image when reattach finds nothing', async () => {
 		queueNotFound('not found');
 		queuedCreateResults.push(

--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
@@ -361,7 +361,7 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe(`remote-${state}`);
 	});
 
-	it.each(['creating', 'starting', 'pending_build'])(
+	it.each(['creating', 'restoring', 'starting', 'pending_build', 'pulling_snapshot'])(
 		'waits for a %s sandbox after a concurrent create conflict',
 		async (state) => {
 			queueNotFound('not found');
@@ -386,14 +386,14 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		},
 	);
 
-	it('polls until a stopping sandbox can be resumed after a name conflict', async () => {
+	it('keeps polling until a long-running stop can be resumed after a name conflict', async () => {
 		queueNotFound('not found');
 		queuedCreateResults.push(
 			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
 		);
 		const stopping = makeMockSandbox('remote-transitioning', 'stopping');
 		const stopped = makeMockSandbox('remote-transitioning', 'stopped');
-		queuedGetResults.push(stopping, stopped);
+		queuedGetResults.push(stopping, stopping, stopping, stopping, stopping, stopped);
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
@@ -408,12 +408,13 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(stopping.start).not.toHaveBeenCalled();
 		expect(stopping.waitUntilStarted).not.toHaveBeenCalled();
 		expect(stopped.start).toHaveBeenCalled();
-		expect(clientLog[0].get).toHaveBeenCalledTimes(3);
+		expect(clientLog[0].get).toHaveBeenCalledTimes(7);
 	});
 
 	it('retries the lookup when a conflicted sandbox is not immediately visible', async () => {
 		queueNotFound('not found');
 		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
 			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
 		);
 		queueNotFound('not visible yet');
@@ -448,6 +449,34 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		await sandbox.start();
 
 		expect(dead.delete).toHaveBeenCalled();
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-replacement');
+	});
+
+	it('replaces a failed sandbox discovered after a name conflict', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+			makeMockSandbox('remote-replacement'),
+		);
+		const failed = makeMockSandbox('remote-failed', 'build_failed');
+		failed.delete.mockImplementation(async () => {
+			await Promise.resolve();
+			queuedGetErrors.push(new DaytonaNotFoundError('deleted'));
+		});
+		queuedGetResults.push(failed);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await sandbox.start();
+
+		expect(failed.delete).toHaveBeenCalled();
+		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-replacement');
 	});
 
@@ -518,6 +547,33 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
 	});
 
+	it('does not treat an unrelated already-exists message as a sandbox name conflict', async () => {
+		const errorReporter: ErrorReporter = { error: vi.fn() };
+		const snapshotError = new DaytonaError('Snapshot build failed: file already exists');
+		queueNotFound('not found');
+		queuedCreateResults.push(snapshotError, makeMockSandbox('remote-from-image'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			image: 'node:20',
+			errorReporter,
+		});
+
+		await sandbox.start();
+
+		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-from-image');
+		expect(errorReporter.error).toHaveBeenCalledWith(
+			snapshotError,
+			expect.objectContaining({
+				tags: expect.objectContaining({ strategy: 'snapshot' }),
+			}),
+		);
+	});
+
 	it('reattaches when a retried create collides with the sandbox the failed attempt created', async () => {
 		queueNotFound('not found');
 		queuedCreateResults.push(
@@ -539,14 +595,13 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-created-despite-502');
 	});
 
-	it('rethrows a name conflict without falling back to image when reattach finds nothing', async () => {
+	it('retries creation when a conflicted sandbox disappears before it becomes visible', async () => {
 		queueNotFound('not found');
 		queuedCreateResults.push(
 			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+			makeMockSandbox('remote-replacement'),
 		);
-		queueNotFound('gone by first reattach');
-		queueNotFound('gone by second reattach');
-		queueNotFound('gone by third reattach');
+		queueNotFound('gone before reattach');
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
@@ -557,8 +612,10 @@ describe('DaytonaSandbox (creation strategies)', () => {
 			createRetryBackoffBaseMs: 1,
 		});
 
-		await expect(sandbox.start()).rejects.toThrow('already exists');
-		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
+		await sandbox.start();
+
+		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-replacement');
 	});
 });
 

--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
@@ -12,6 +12,7 @@ interface MockSandbox {
 	process: { executeCommand: Mock };
 	fs: Record<string, Mock>;
 	start: Mock;
+	waitUntilStarted: Mock;
 	stop: Mock;
 	delete: Mock;
 	getWorkDir: Mock;
@@ -36,8 +37,10 @@ const {
 	queuedCreateResults,
 	makeMockSandbox,
 	Daytona,
+	DaytonaConnectionError,
 	DaytonaError,
 	DaytonaNotFoundError,
+	DaytonaTimeoutError,
 	resetDaytonaMockState,
 } = vi.hoisted(() => {
 	const clientLog: DaytonaClientLog[] = [];
@@ -71,6 +74,7 @@ const {
 				moveFiles: vi.fn(),
 			},
 			start: vi.fn().mockResolvedValue(undefined),
+			waitUntilStarted: vi.fn().mockResolvedValue(undefined),
 			stop: vi.fn().mockResolvedValue(undefined),
 			delete: vi.fn().mockResolvedValue(undefined),
 			getWorkDir: vi.fn().mockResolvedValue('/home/daytona/workspace'),
@@ -137,6 +141,8 @@ const {
 			super(message, 404);
 		}
 	}
+	class DaytonaConnectionError extends DaytonaError {}
+	class DaytonaTimeoutError extends DaytonaError {}
 
 	function resetDaytonaMockState(): void {
 		clientLog.length = 0;
@@ -154,14 +160,22 @@ const {
 		queuedCreateResults,
 		makeMockSandbox,
 		Daytona,
+		DaytonaConnectionError,
 		DaytonaError,
 		DaytonaNotFoundError,
+		DaytonaTimeoutError,
 		resetDaytonaMockState,
 	};
 });
 
 vi.mock('../../../workspace/sandbox/lazy-daytona', () => ({
-	loadDaytona: () => ({ Daytona, DaytonaError, DaytonaNotFoundError }),
+	loadDaytona: () => ({
+		Daytona,
+		DaytonaConnectionError,
+		DaytonaError,
+		DaytonaNotFoundError,
+		DaytonaTimeoutError,
+	}),
 }));
 
 import { DaytonaFilesystem } from '../../../workspace/filesystem/daytona-filesystem';
@@ -327,11 +341,11 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		);
 	});
 
-	it('resumes a stopped sandbox when reattaching after a name conflict', async () => {
+	it.each(['stopped', 'archived'])('resumes a %s sandbox after a name conflict', async (state) => {
 		queueNotFound('not found');
 		queuedCreateResults.push(new DaytonaError('Sandbox with name sandbox-name already exists'));
-		const stopped = makeMockSandbox('remote-stopped', 'stopped');
-		queuedGetResults.push(stopped);
+		const existing = makeMockSandbox(`remote-${state}`, state);
+		queuedGetResults.push(existing);
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
@@ -342,8 +356,99 @@ describe('DaytonaSandbox (creation strategies)', () => {
 
 		await sandbox.start();
 
+		expect(existing.start).toHaveBeenCalled();
+		expect(existing.waitUntilStarted).not.toHaveBeenCalled();
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe(`remote-${state}`);
+	});
+
+	it.each(['creating', 'starting', 'pending_build'])(
+		'waits for a %s sandbox after a concurrent create conflict',
+		async (state) => {
+			queueNotFound('not found');
+			queuedCreateResults.push(
+				new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+			);
+			const existing = makeMockSandbox(`remote-${state}`, state);
+			queuedGetResults.push(existing);
+
+			const sandbox = new DaytonaSandbox({
+				id: 'sandbox-id',
+				name: 'sandbox-name',
+				apiKey: 'api-key',
+				snapshot: 'n8n/instance-ai:1.123.0',
+			});
+
+			await sandbox.start();
+
+			expect(existing.waitUntilStarted).toHaveBeenCalled();
+			expect(existing.start).not.toHaveBeenCalled();
+			expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe(`remote-${state}`);
+		},
+	);
+
+	it('polls until a stopping sandbox can be resumed after a name conflict', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		const stopping = makeMockSandbox('remote-transitioning', 'stopping');
+		const stopped = makeMockSandbox('remote-transitioning', 'stopped');
+		queuedGetResults.push(stopping, stopped);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await sandbox.start();
+
+		expect(stopping.start).not.toHaveBeenCalled();
+		expect(stopping.waitUntilStarted).not.toHaveBeenCalled();
 		expect(stopped.start).toHaveBeenCalled();
-		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-stopped');
+		expect(clientLog[0].get).toHaveBeenCalledTimes(3);
+	});
+
+	it('retries the lookup when a conflicted sandbox is not immediately visible', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		queueNotFound('not visible yet');
+		queuedGetResults.push(makeMockSandbox('remote-eventually-visible'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await sandbox.start();
+
+		expect(clientLog[0].get).toHaveBeenCalledTimes(3);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-eventually-visible');
+	});
+
+	it('deletes a dead sandbox before creating a replacement', async () => {
+		const dead = makeMockSandbox('remote-dead', 'error');
+		queuedGetResults.push(dead);
+		queuedCreateResults.push(makeMockSandbox('remote-replacement'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+		});
+
+		await sandbox.start();
+
+		expect(dead.delete).toHaveBeenCalled();
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-replacement');
 	});
 
 	it('retries a transient 5xx create failure and succeeds', async () => {
@@ -371,6 +476,30 @@ describe('DaytonaSandbox (creation strategies)', () => {
 			'Sandbox create failed transiently; retrying',
 			expect.objectContaining({ sandboxName: 'sandbox-name', attempt: 1 }),
 		);
+	});
+
+	it.each([
+		['connection', DaytonaConnectionError],
+		['timeout', DaytonaTimeoutError],
+	])('retries a transient %s create failure', async (_kind, ErrorType) => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new ErrorType('transient create failure'),
+			makeMockSandbox('remote-after-retry'),
+		);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			createRetryBackoffBaseMs: 1,
+		});
+
+		await sandbox.start();
+
+		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-after-retry');
 	});
 
 	it('does not retry non-transient create failures', async () => {
@@ -415,7 +544,9 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		queuedCreateResults.push(
 			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
 		);
-		queueNotFound('gone by reattach');
+		queueNotFound('gone by first reattach');
+		queueNotFound('gone by second reattach');
+		queueNotFound('gone by third reattach');
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
@@ -423,6 +554,7 @@ describe('DaytonaSandbox (creation strategies)', () => {
 			apiKey: 'api-key',
 			snapshot: 'n8n/instance-ai:1.123.0',
 			image: 'node:20',
+			createRetryBackoffBaseMs: 1,
 		});
 
 		await expect(sandbox.start()).rejects.toThrow('already exists');

--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
@@ -297,6 +297,73 @@ describe('DaytonaSandbox (creation strategies)', () => {
 			}),
 		);
 	});
+
+	it('reattaches to the existing sandbox when creation reports a name conflict', async () => {
+		const logger = makeLogger();
+		const errorReporter: ErrorReporter = { error: vi.fn() };
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		queuedGetResults.push(makeMockSandbox('remote-existing'));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			logger,
+			errorReporter,
+		});
+
+		await sandbox.start();
+
+		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-existing');
+		expect(errorReporter.error).not.toHaveBeenCalled();
+		expect(logger.info).toHaveBeenCalledWith(
+			'Sandbox name already exists; reattached to existing sandbox',
+			expect.objectContaining({ sandboxName: 'sandbox-name', remoteSandboxId: 'remote-existing' }),
+		);
+	});
+
+	it('resumes a stopped sandbox when reattaching after a name conflict', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(new DaytonaError('Sandbox with name sandbox-name already exists'));
+		const stopped = makeMockSandbox('remote-stopped', 'stopped');
+		queuedGetResults.push(stopped);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+		});
+
+		await sandbox.start();
+
+		expect(stopped.start).toHaveBeenCalled();
+		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-stopped');
+	});
+
+	it('rethrows a name conflict without falling back to image when reattach finds nothing', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		queueNotFound('gone by reattach');
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+			image: 'node:20',
+		});
+
+		await expect(sandbox.start()).rejects.toThrow('already exists');
+		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe('DaytonaSandbox (direct mode)', () => {

--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
@@ -434,6 +434,43 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-eventually-visible');
 	});
 
+	it.each([
+		['server error', new DaytonaError('Bad Gateway', 502)],
+		['rate limit', new DaytonaError('Too Many Requests', 429)],
+	])('fails without creating when the initial lookup returns a %s', async (_kind, error) => {
+		queuedGetErrors.push(error);
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+		});
+
+		await expect(sandbox.start()).rejects.toThrow(error.message);
+		expect(clientLog[0].get).toHaveBeenCalledTimes(1);
+		expect(clientLog[0].create).not.toHaveBeenCalled();
+	});
+
+	it('fails without polling when the lookup after a name conflict errors', async () => {
+		queueNotFound('not found');
+		queuedCreateResults.push(
+			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
+		);
+		queuedGetErrors.push(new DaytonaError('Bad Gateway', 502));
+
+		const sandbox = new DaytonaSandbox({
+			id: 'sandbox-id',
+			name: 'sandbox-name',
+			apiKey: 'api-key',
+			snapshot: 'n8n/instance-ai:1.123.0',
+		});
+
+		await expect(sandbox.start()).rejects.toThrow('Bad Gateway');
+		expect(clientLog[0].get).toHaveBeenCalledTimes(2);
+		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
+	});
+
 	it('deletes a dead sandbox before creating a replacement', async () => {
 		const dead = makeMockSandbox('remote-dead', 'error');
 		queuedGetResults.push(dead);
@@ -480,55 +517,40 @@ describe('DaytonaSandbox (creation strategies)', () => {
 		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-replacement');
 	});
 
-	it('retries a transient 5xx create failure and succeeds', async () => {
-		const logger = makeLogger();
+	it.each([
+		['server', new DaytonaError('Bad Gateway', 502)],
+		['rate-limit', new DaytonaError('Too Many Requests', 429)],
+	])('does not retry a %s create failure', async (_kind, error) => {
 		queueNotFound('not found');
-		queuedCreateResults.push(
-			new DaytonaError('Error 502: Bad gateway', 502),
-			makeMockSandbox('remote-after-retry'),
-		);
+		queuedCreateResults.push(error);
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
 			name: 'sandbox-name',
 			apiKey: 'api-key',
 			snapshot: 'n8n/instance-ai:1.123.0',
-			createRetryBackoffBaseMs: 1,
-			logger,
 		});
 
-		await sandbox.start();
-
-		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
-		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-after-retry');
-		expect(logger.warn).toHaveBeenCalledWith(
-			'Sandbox create failed transiently; retrying',
-			expect.objectContaining({ sandboxName: 'sandbox-name', attempt: 1 }),
-		);
+		await expect(sandbox.start()).rejects.toThrow(error.message);
+		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
 	});
 
 	it.each([
 		['connection', DaytonaConnectionError],
 		['timeout', DaytonaTimeoutError],
-	])('retries a transient %s create failure', async (_kind, ErrorType) => {
+	])('does not retry a transient %s create failure', async (_kind, ErrorType) => {
 		queueNotFound('not found');
-		queuedCreateResults.push(
-			new ErrorType('transient create failure'),
-			makeMockSandbox('remote-after-retry'),
-		);
+		queuedCreateResults.push(new ErrorType('transient create failure'));
 
 		const sandbox = new DaytonaSandbox({
 			id: 'sandbox-id',
 			name: 'sandbox-name',
 			apiKey: 'api-key',
 			snapshot: 'n8n/instance-ai:1.123.0',
-			createRetryBackoffBaseMs: 1,
 		});
 
-		await sandbox.start();
-
-		expect(clientLog[0].create).toHaveBeenCalledTimes(2);
-		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-after-retry');
+		await expect(sandbox.start()).rejects.toThrow('transient create failure');
+		expect(clientLog[0].create).toHaveBeenCalledTimes(1);
 	});
 
 	it('does not retry non-transient create failures', async () => {
@@ -572,27 +594,6 @@ describe('DaytonaSandbox (creation strategies)', () => {
 				tags: expect.objectContaining({ strategy: 'snapshot' }),
 			}),
 		);
-	});
-
-	it('reattaches when a retried create collides with the sandbox the failed attempt created', async () => {
-		queueNotFound('not found');
-		queuedCreateResults.push(
-			new DaytonaError('Error 502: Bad gateway', 502),
-			new DaytonaError('Sandbox with name sandbox-name already exists', 409),
-		);
-		queuedGetResults.push(makeMockSandbox('remote-created-despite-502'));
-
-		const sandbox = new DaytonaSandbox({
-			id: 'sandbox-id',
-			name: 'sandbox-name',
-			apiKey: 'api-key',
-			snapshot: 'n8n/instance-ai:1.123.0',
-			createRetryBackoffBaseMs: 1,
-		});
-
-		await sandbox.start();
-
-		expect(sandbox.getInfo().metadata?.remoteSandboxId).toBe('remote-created-despite-502');
 	});
 
 	it('retries creation when a conflicted sandbox disappears before it becomes visible', async () => {

--- a/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
@@ -27,12 +27,21 @@ const SANDBOX_STATE_STARTED = 'started';
 const SANDBOX_STATE_STOPPED = 'stopped';
 const SANDBOX_STATE_ARCHIVED = 'archived';
 const SANDBOX_STATE_CREATING = 'creating';
+const SANDBOX_STATE_RESTORING = 'restoring';
 const SANDBOX_STATE_STARTING = 'starting';
 const SANDBOX_STATE_PENDING_BUILD = 'pending_build';
+const SANDBOX_STATE_PULLING_SNAPSHOT = 'pulling_snapshot';
+const SANDBOX_STATE_FORKING = 'forking';
+const SANDBOX_STATE_RESIZING = 'resizing';
+const SANDBOX_STATE_SNAPSHOTTING = 'snapshotting';
+const SANDBOX_STATE_BUILDING_SNAPSHOT = 'building_snapshot';
+const SANDBOX_STATE_STOPPING = 'stopping';
+const SANDBOX_STATE_ARCHIVING = 'archiving';
 const SANDBOX_STATE_DESTROYED = 'destroyed';
 const SANDBOX_STATE_DESTROYING = 'destroying';
 const SANDBOX_STATE_ERROR = 'error';
 const SANDBOX_STATE_BUILD_FAILED = 'build_failed';
+const MAX_ACQUISITION_RETRY_BACKOFF_MS = 5_000;
 
 /**
  * States a failed operation may recover from by resuming the sandbox: an idle sandbox that
@@ -44,16 +53,41 @@ const SANDBOX_STATE_BUILD_FAILED = 'build_failed';
  *    we don't want to trigger off an unrelated operation failure.
  * Deletion is handled separately as a `DaytonaNotFoundError` fast-path.
  */
-const RECOVERABLE_SANDBOX_STATES: ReadonlySet<string> = new Set([
+const RECOVERABLE_SANDBOX_STATES = new Set<SandboxState>([
 	SANDBOX_STATE_STOPPED,
 	SANDBOX_STATE_ARCHIVED,
 ]);
 
-const WAIT_FOR_STARTED_SANDBOX_STATES: ReadonlySet<string> = new Set([
+const WAIT_FOR_STARTED_SANDBOX_STATES = new Set<SandboxState>([
 	SANDBOX_STATE_CREATING,
+	SANDBOX_STATE_RESTORING,
 	SANDBOX_STATE_STARTING,
 	SANDBOX_STATE_PENDING_BUILD,
+	SANDBOX_STATE_PULLING_SNAPSHOT,
+	SANDBOX_STATE_FORKING,
+	SANDBOX_STATE_RESIZING,
+	SANDBOX_STATE_SNAPSHOTTING,
+	SANDBOX_STATE_BUILDING_SNAPSHOT,
 ]);
+
+const WAIT_FOR_RECOVERABLE_SANDBOX_STATES = new Set<SandboxState>([
+	SANDBOX_STATE_STOPPING,
+	SANDBOX_STATE_ARCHIVING,
+]);
+
+const FAILED_SANDBOX_STATES = new Set<SandboxState>([
+	SANDBOX_STATE_ERROR,
+	SANDBOX_STATE_BUILD_FAILED,
+]);
+
+const REMOVING_SANDBOX_STATES = new Set<SandboxState>([
+	SANDBOX_STATE_DESTROYED,
+	SANDBOX_STATE_DESTROYING,
+]);
+
+type ExistingSandboxLookup =
+	| { status: 'ready'; sandbox: Sandbox }
+	| { status: 'absent' | 'pending' };
 
 export interface DaytonaSandboxOptions {
 	id?: string;
@@ -121,7 +155,7 @@ function isSandboxNameConflictError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
 	const { DaytonaError } = loadDaytona();
 	if (error instanceof DaytonaError && error.statusCode === 409) return true;
-	return /already exists/i.test(error.message);
+	return /sandbox with name .+ already exists/i.test(error.message);
 }
 
 function isTransientCreateError(error: unknown): boolean {
@@ -132,13 +166,6 @@ function isTransientCreateError(error: unknown): boolean {
 }
 
 export class DaytonaSandbox extends BaseSandbox {
-	private static readonly DEAD_STATES: ReadonlySet<SandboxState> = new Set([
-		SANDBOX_STATE_DESTROYED,
-		SANDBOX_STATE_DESTROYING,
-		SANDBOX_STATE_ERROR,
-		SANDBOX_STATE_BUILD_FAILED,
-	]) as ReadonlySet<SandboxState>;
-
 	readonly id: string;
 	readonly name = 'DaytonaSandbox';
 	readonly provider = 'daytona';
@@ -199,18 +226,35 @@ export class DaytonaSandbox extends BaseSandbox {
 	 * concurrent create from another main). Deterministic names make reattach safe.
 	 */
 	private async createSandboxOrReattach(client: Daytona): Promise<Sandbox> {
-		try {
-			return await this.createSandbox(client);
-		} catch (error) {
-			if (!isSandboxNameConflictError(error)) throw error;
-			const existing = await this.findExistingSandboxAfterConflict(client);
-			if (!existing) throw error;
-			this.options.logger?.info('Sandbox name already exists; reattached to existing sandbox', {
-				sandboxName: this.sandboxName,
-				remoteSandboxId: existing.id,
-			});
-			return existing;
+		let conflictDeadline: number | undefined;
+		let conflictError: unknown;
+		let attempt = 0;
+
+		while (conflictDeadline === undefined || Date.now() < conflictDeadline) {
+			try {
+				return await this.createSandbox(client);
+			} catch (error) {
+				if (!isSandboxNameConflictError(error)) throw error;
+				conflictError = error;
+				conflictDeadline ??= Date.now() + this.timeout;
+
+				const existing = await this.findExistingSandboxAfterConflict(client, conflictDeadline);
+				if (existing) {
+					this.options.logger?.info('Sandbox name already exists; reattached to existing sandbox', {
+						sandboxName: this.sandboxName,
+						remoteSandboxId: existing.id,
+					});
+					return existing;
+				}
+
+				if (Date.now() >= conflictDeadline) break;
+				await this.waitBeforeAcquisitionRetry(attempt++, conflictDeadline);
+			}
 		}
+
+		throw conflictError instanceof Error
+			? conflictError
+			: new Error('Failed to reconcile Daytona sandbox name conflict');
 	}
 
 	override async stop(): Promise<void> {
@@ -431,33 +475,51 @@ export class DaytonaSandbox extends BaseSandbox {
 	}
 
 	private async findExistingSandbox(client: Daytona): Promise<Sandbox | null> {
+		const result = await this.lookupExistingSandbox(client);
+		return result.status === 'ready' ? result.sandbox : null;
+	}
+
+	private async lookupExistingSandbox(
+		client: Daytona,
+		deadline?: number,
+	): Promise<ExistingSandboxLookup> {
 		try {
 			const sandbox = await client.get(this.sandboxName);
-			if (sandbox.state && this.isDeadState(sandbox.state)) {
-				await sandbox.delete(Math.ceil(this.timeout / 1000));
-				return null;
+			const state = sandbox.state;
+			if (state === undefined) return { status: 'pending' };
+			if (FAILED_SANDBOX_STATES.has(state)) {
+				await sandbox.delete(this.operationTimeoutSeconds(deadline));
+				return { status: 'pending' };
 			}
-			if (sandbox.state && RECOVERABLE_SANDBOX_STATES.has(sandbox.state)) {
-				await sandbox.start(Math.ceil(this.timeout / 1000));
-			} else if (sandbox.state && WAIT_FOR_STARTED_SANDBOX_STATES.has(sandbox.state)) {
-				await sandbox.waitUntilStarted(Math.ceil(this.timeout / 1000));
-			} else if (sandbox.state !== SANDBOX_STATE_STARTED) {
-				return null;
+			if (REMOVING_SANDBOX_STATES.has(state)) return { status: 'pending' };
+			if (RECOVERABLE_SANDBOX_STATES.has(state)) {
+				await sandbox.start(this.operationTimeoutSeconds(deadline));
+			} else if (WAIT_FOR_STARTED_SANDBOX_STATES.has(state)) {
+				await sandbox.waitUntilStarted(this.operationTimeoutSeconds(deadline));
+			} else if (
+				WAIT_FOR_RECOVERABLE_SANDBOX_STATES.has(state) ||
+				state !== SANDBOX_STATE_STARTED
+			) {
+				return { status: 'pending' };
 			}
-			return sandbox;
+			return { status: 'ready', sandbox };
 		} catch (error) {
 			const { DaytonaNotFoundError } = loadDaytona();
-			if (error instanceof DaytonaNotFoundError) return null;
+			if (error instanceof DaytonaNotFoundError) return { status: 'absent' };
 			if (isDaytonaAuthError(error)) throw error;
-			return null;
+			return { status: 'pending' };
 		}
 	}
 
-	private async findExistingSandboxAfterConflict(client: Daytona): Promise<Sandbox | null> {
-		for (let attempt = 0; attempt < 3; attempt++) {
-			const existing = await this.findExistingSandbox(client);
-			if (existing) return existing;
-			if (attempt < 2) await this.waitBeforeRetry(attempt);
+	private async findExistingSandboxAfterConflict(
+		client: Daytona,
+		deadline: number,
+	): Promise<Sandbox | null> {
+		for (let attempt = 0; Date.now() < deadline; attempt++) {
+			const result = await this.lookupExistingSandbox(client, deadline);
+			if (result.status === 'ready') return result.sandbox;
+			if (result.status === 'absent') return null;
+			await this.waitBeforeAcquisitionRetry(attempt, deadline);
 		}
 		return null;
 	}
@@ -521,6 +583,21 @@ export class DaytonaSandbox extends BaseSandbox {
 	private async waitBeforeRetry(attempt: number): Promise<void> {
 		const baseDelayMs = this.options.createRetryBackoffBaseMs ?? 1_000;
 		await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+	}
+
+	private async waitBeforeAcquisitionRetry(attempt: number, deadline: number): Promise<void> {
+		const baseDelayMs = this.options.createRetryBackoffBaseMs ?? 1_000;
+		const delayMs = Math.min(
+			baseDelayMs * 2 ** attempt,
+			MAX_ACQUISITION_RETRY_BACKOFF_MS,
+			Math.max(0, deadline - Date.now()),
+		);
+		if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+	}
+
+	private operationTimeoutSeconds(deadline?: number): number {
+		if (deadline === undefined) return Math.ceil(this.timeout / 1000);
+		return Math.max(0.001, (deadline - Date.now()) / 1000);
 	}
 
 	private createSandboxParams(): Array<{
@@ -603,10 +680,6 @@ export class DaytonaSandbox extends BaseSandbox {
 		} catch {
 			this.workingDirectory = undefined;
 		}
-	}
-
-	private isDeadState(state: SandboxState): boolean {
-		return DaytonaSandbox.DEAD_STATES.has(state);
 	}
 
 	private compactEnv(env: NodeJS.ProcessEnv | undefined): Record<string, string> | undefined {

--- a/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
@@ -141,11 +141,6 @@ function toShellCommand(command: string, args: string[]): string {
 	return [command, ...args.map((arg) => shellEscape(arg))].join(' ');
 }
 
-function isDaytonaAuthError(error: unknown): boolean {
-	const { DaytonaError } = loadDaytona();
-	return error instanceof DaytonaError && (error.statusCode === 401 || error.statusCode === 403);
-}
-
 function isSandboxGone(error: unknown): boolean {
 	const { DaytonaNotFoundError } = loadDaytona();
 	return error instanceof DaytonaNotFoundError;
@@ -157,14 +152,6 @@ function isSandboxNameConflictError(error: unknown): boolean {
 	if (error instanceof DaytonaError && error.statusCode === 409) return true;
 	return /sandbox with name .+ already exists/i.test(error.message);
 }
-
-function isTransientCreateError(error: unknown): boolean {
-	const { DaytonaConnectionError, DaytonaError, DaytonaTimeoutError } = loadDaytona();
-	if (error instanceof DaytonaConnectionError || error instanceof DaytonaTimeoutError) return true;
-	if (!(error instanceof DaytonaError) || error.statusCode === undefined) return false;
-	return error.statusCode >= 500 || error.statusCode === 408 || error.statusCode === 429;
-}
-
 export class DaytonaSandbox extends BaseSandbox {
 	readonly id: string;
 	readonly name = 'DaytonaSandbox';
@@ -222,8 +209,8 @@ export class DaytonaSandbox extends BaseSandbox {
 
 	/**
 	 * Create the remote sandbox, reattaching by name on a name conflict — the sandbox
-	 * exists even though the initial lookup missed it (transient lookup failure, or a
-	 * concurrent create from another main). Deterministic names make reattach safe.
+	 * exists even though the initial lookup missed it due to a concurrent create from
+	 * another main. Deterministic names make reattach safe.
 	 */
 	private async createSandboxOrReattach(client: Daytona): Promise<Sandbox> {
 		let conflictDeadline: number | undefined;
@@ -506,8 +493,7 @@ export class DaytonaSandbox extends BaseSandbox {
 		} catch (error) {
 			const { DaytonaNotFoundError } = loadDaytona();
 			if (error instanceof DaytonaNotFoundError) return { status: 'absent' };
-			if (isDaytonaAuthError(error)) throw error;
-			return { status: 'pending' };
+			throw error;
 		}
 	}
 
@@ -530,7 +516,9 @@ export class DaytonaSandbox extends BaseSandbox {
 
 		for (const candidate of candidates) {
 			try {
-				return await this.createWithRetry(client, candidate.params);
+				return this.options.createTimeoutSeconds
+					? await client.create(candidate.params, { timeout: this.options.createTimeoutSeconds })
+					: await client.create(candidate.params);
 			} catch (error) {
 				// A name conflict is strategy-independent; let the caller reattach by name.
 				if (isSandboxNameConflictError(error)) throw error;
@@ -552,37 +540,6 @@ export class DaytonaSandbox extends BaseSandbox {
 		}
 
 		throw lastError instanceof Error ? lastError : new Error('Failed to create Daytona sandbox');
-	}
-
-	/**
-	 * Retry transient (connection/timeout/5xx/408/429) create failures with a short backoff. A create
-	 * that succeeded server-side despite the failed response surfaces as a name
-	 * conflict on retry, which the caller resolves by reattaching.
-	 */
-	private async createWithRetry(
-		client: Daytona,
-		params: CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams,
-	): Promise<Sandbox> {
-		for (let attempt = 0; ; attempt++) {
-			try {
-				return this.options.createTimeoutSeconds
-					? await client.create(params, { timeout: this.options.createTimeoutSeconds })
-					: await client.create(params);
-			} catch (error) {
-				if (attempt >= 2 || !isTransientCreateError(error)) throw error;
-				this.options.logger?.warn('Sandbox create failed transiently; retrying', {
-					sandboxName: this.sandboxName,
-					attempt: attempt + 1,
-					error: error instanceof Error ? error.message : String(error),
-				});
-				await this.waitBeforeRetry(attempt);
-			}
-		}
-	}
-
-	private async waitBeforeRetry(attempt: number): Promise<void> {
-		const baseDelayMs = this.options.createRetryBackoffBaseMs ?? 1_000;
-		await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
 	}
 
 	private async waitBeforeAcquisitionRetry(attempt: number, deadline: number): Promise<void> {

--- a/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
@@ -106,6 +106,13 @@ function isSandboxGone(error: unknown): boolean {
 	return error instanceof DaytonaNotFoundError;
 }
 
+function isSandboxNameConflictError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const { DaytonaError } = loadDaytona();
+	if (error instanceof DaytonaError && error.statusCode === 409) return true;
+	return /already exists/i.test(error.message);
+}
+
 export class DaytonaSandbox extends BaseSandbox {
 	private static readonly DEAD_STATES: ReadonlySet<SandboxState> = new Set([
 		SANDBOX_STATE_DESTROYED,
@@ -164,8 +171,28 @@ export class DaytonaSandbox extends BaseSandbox {
 			return;
 		}
 
-		this.sandbox = await this.createSandbox(client);
+		this.sandbox = await this.createSandboxOrReattach(client);
 		await this.detectWorkingDirectory();
+	}
+
+	/**
+	 * Create the remote sandbox, reattaching by name on a name conflict — the sandbox
+	 * exists even though the initial lookup missed it (transient lookup failure, or a
+	 * concurrent create from another main). Deterministic names make reattach safe.
+	 */
+	private async createSandboxOrReattach(client: Daytona): Promise<Sandbox> {
+		try {
+			return await this.createSandbox(client);
+		} catch (error) {
+			if (!isSandboxNameConflictError(error)) throw error;
+			const existing = await this.findExistingSandbox(client);
+			if (!existing) throw error;
+			this.options.logger?.info('Sandbox name already exists; reattached to existing sandbox', {
+				sandboxName: this.sandboxName,
+				remoteSandboxId: existing.id,
+			});
+			return existing;
+		}
 	}
 
 	override async stop(): Promise<void> {
@@ -414,6 +441,8 @@ export class DaytonaSandbox extends BaseSandbox {
 					? await client.create(candidate.params, { timeout: this.options.createTimeoutSeconds })
 					: await client.create(candidate.params);
 			} catch (error) {
+				// A name conflict is strategy-independent; let the caller reattach by name.
+				if (isSandboxNameConflictError(error)) throw error;
 				lastError = error;
 				this.reportCreateError(error, candidate.strategy);
 				if (

--- a/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
@@ -67,6 +67,8 @@ export interface DaytonaSandboxOptions {
 	target?: string;
 	timeout?: number;
 	createTimeoutSeconds?: number;
+	/** Base backoff for transient create retries. Defaults to 1s. */
+	createRetryBackoffBaseMs?: number;
 	language?: 'typescript' | 'javascript' | 'python';
 	resources?: Resources;
 	env?: Record<string, string>;
@@ -111,6 +113,12 @@ function isSandboxNameConflictError(error: unknown): boolean {
 	const { DaytonaError } = loadDaytona();
 	if (error instanceof DaytonaError && error.statusCode === 409) return true;
 	return /already exists/i.test(error.message);
+}
+
+function isTransientCreateError(error: unknown): boolean {
+	const { DaytonaError } = loadDaytona();
+	if (!(error instanceof DaytonaError) || error.statusCode === undefined) return false;
+	return error.statusCode >= 500 || error.statusCode === 408 || error.statusCode === 429;
 }
 
 export class DaytonaSandbox extends BaseSandbox {
@@ -437,9 +445,7 @@ export class DaytonaSandbox extends BaseSandbox {
 
 		for (const candidate of candidates) {
 			try {
-				return this.options.createTimeoutSeconds
-					? await client.create(candidate.params, { timeout: this.options.createTimeoutSeconds })
-					: await client.create(candidate.params);
+				return await this.createWithRetry(client, candidate.params);
 			} catch (error) {
 				// A name conflict is strategy-independent; let the caller reattach by name.
 				if (isSandboxNameConflictError(error)) throw error;
@@ -461,6 +467,33 @@ export class DaytonaSandbox extends BaseSandbox {
 		}
 
 		throw lastError instanceof Error ? lastError : new Error('Failed to create Daytona sandbox');
+	}
+
+	/**
+	 * Retry transient (5xx/408/429) create failures with a short backoff. A create
+	 * that succeeded server-side despite the failed response surfaces as a name
+	 * conflict on retry, which the caller resolves by reattaching.
+	 */
+	private async createWithRetry(
+		client: Daytona,
+		params: CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams,
+	): Promise<Sandbox> {
+		const baseDelayMs = this.options.createRetryBackoffBaseMs ?? 1_000;
+		for (let attempt = 0; ; attempt++) {
+			try {
+				return this.options.createTimeoutSeconds
+					? await client.create(params, { timeout: this.options.createTimeoutSeconds })
+					: await client.create(params);
+			} catch (error) {
+				if (attempt >= 2 || !isTransientCreateError(error)) throw error;
+				this.options.logger?.warn('Sandbox create failed transiently; retrying', {
+					sandboxName: this.sandboxName,
+					attempt: attempt + 1,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+			}
+		}
 	}
 
 	private createSandboxParams(): Array<{

--- a/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/daytona-sandbox.ts
@@ -26,6 +26,9 @@ import type { ErrorReporter, Logger } from './logger';
 const SANDBOX_STATE_STARTED = 'started';
 const SANDBOX_STATE_STOPPED = 'stopped';
 const SANDBOX_STATE_ARCHIVED = 'archived';
+const SANDBOX_STATE_CREATING = 'creating';
+const SANDBOX_STATE_STARTING = 'starting';
+const SANDBOX_STATE_PENDING_BUILD = 'pending_build';
 const SANDBOX_STATE_DESTROYED = 'destroyed';
 const SANDBOX_STATE_DESTROYING = 'destroying';
 const SANDBOX_STATE_ERROR = 'error';
@@ -44,6 +47,12 @@ const SANDBOX_STATE_BUILD_FAILED = 'build_failed';
 const RECOVERABLE_SANDBOX_STATES: ReadonlySet<string> = new Set([
 	SANDBOX_STATE_STOPPED,
 	SANDBOX_STATE_ARCHIVED,
+]);
+
+const WAIT_FOR_STARTED_SANDBOX_STATES: ReadonlySet<string> = new Set([
+	SANDBOX_STATE_CREATING,
+	SANDBOX_STATE_STARTING,
+	SANDBOX_STATE_PENDING_BUILD,
 ]);
 
 export interface DaytonaSandboxOptions {
@@ -67,7 +76,7 @@ export interface DaytonaSandboxOptions {
 	target?: string;
 	timeout?: number;
 	createTimeoutSeconds?: number;
-	/** Base backoff for transient create retries. Defaults to 1s. */
+	/** Base backoff for sandbox acquisition retries. Defaults to 1s. */
 	createRetryBackoffBaseMs?: number;
 	language?: 'typescript' | 'javascript' | 'python';
 	resources?: Resources;
@@ -116,7 +125,8 @@ function isSandboxNameConflictError(error: unknown): boolean {
 }
 
 function isTransientCreateError(error: unknown): boolean {
-	const { DaytonaError } = loadDaytona();
+	const { DaytonaConnectionError, DaytonaError, DaytonaTimeoutError } = loadDaytona();
+	if (error instanceof DaytonaConnectionError || error instanceof DaytonaTimeoutError) return true;
 	if (!(error instanceof DaytonaError) || error.statusCode === undefined) return false;
 	return error.statusCode >= 500 || error.statusCode === 408 || error.statusCode === 429;
 }
@@ -193,7 +203,7 @@ export class DaytonaSandbox extends BaseSandbox {
 			return await this.createSandbox(client);
 		} catch (error) {
 			if (!isSandboxNameConflictError(error)) throw error;
-			const existing = await this.findExistingSandbox(client);
+			const existing = await this.findExistingSandboxAfterConflict(client);
 			if (!existing) throw error;
 			this.options.logger?.info('Sandbox name already exists; reattached to existing sandbox', {
 				sandboxName: this.sandboxName,
@@ -427,8 +437,12 @@ export class DaytonaSandbox extends BaseSandbox {
 				await sandbox.delete(Math.ceil(this.timeout / 1000));
 				return null;
 			}
-			if (sandbox.state !== SANDBOX_STATE_STARTED) {
+			if (sandbox.state && RECOVERABLE_SANDBOX_STATES.has(sandbox.state)) {
 				await sandbox.start(Math.ceil(this.timeout / 1000));
+			} else if (sandbox.state && WAIT_FOR_STARTED_SANDBOX_STATES.has(sandbox.state)) {
+				await sandbox.waitUntilStarted(Math.ceil(this.timeout / 1000));
+			} else if (sandbox.state !== SANDBOX_STATE_STARTED) {
+				return null;
 			}
 			return sandbox;
 		} catch (error) {
@@ -437,6 +451,15 @@ export class DaytonaSandbox extends BaseSandbox {
 			if (isDaytonaAuthError(error)) throw error;
 			return null;
 		}
+	}
+
+	private async findExistingSandboxAfterConflict(client: Daytona): Promise<Sandbox | null> {
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const existing = await this.findExistingSandbox(client);
+			if (existing) return existing;
+			if (attempt < 2) await this.waitBeforeRetry(attempt);
+		}
+		return null;
 	}
 
 	private async createSandbox(client: Daytona): Promise<Sandbox> {
@@ -470,7 +493,7 @@ export class DaytonaSandbox extends BaseSandbox {
 	}
 
 	/**
-	 * Retry transient (5xx/408/429) create failures with a short backoff. A create
+	 * Retry transient (connection/timeout/5xx/408/429) create failures with a short backoff. A create
 	 * that succeeded server-side despite the failed response surfaces as a name
 	 * conflict on retry, which the caller resolves by reattaching.
 	 */
@@ -478,7 +501,6 @@ export class DaytonaSandbox extends BaseSandbox {
 		client: Daytona,
 		params: CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams,
 	): Promise<Sandbox> {
-		const baseDelayMs = this.options.createRetryBackoffBaseMs ?? 1_000;
 		for (let attempt = 0; ; attempt++) {
 			try {
 				return this.options.createTimeoutSeconds
@@ -491,9 +513,14 @@ export class DaytonaSandbox extends BaseSandbox {
 					attempt: attempt + 1,
 					error: error instanceof Error ? error.message : String(error),
 				});
-				await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+				await this.waitBeforeRetry(attempt);
 			}
 		}
+	}
+
+	private async waitBeforeRetry(attempt: number): Promise<void> {
+		const baseDelayMs = this.options.createRetryBackoffBaseMs ?? 1_000;
+		await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
 	}
 
 	private createSandboxParams(): Array<{

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
@@ -49,7 +49,7 @@ function createSandboxService(overrides: Overrides = {}) {
 		...overrides.backgroundTasks,
 	};
 	const settingsService: InstanceAiSandboxSettings = {
-		resolveDaytonaConfig: vi.fn(async () => ({})),
+		resolveDaytonaConfig: vi.fn(async () => ({ apiKey: 'test-daytona-key' })),
 		resolveN8nSandboxConfig: vi.fn(async () => ({})),
 		...overrides.settingsService,
 	};
@@ -110,6 +110,19 @@ describe('InstanceAiSandboxService', () => {
 				daytonaApiUrl: 'https://admin.daytona',
 				daytonaApiKey: 'admin-key',
 			});
+		});
+
+		it('fails with a setup error in direct mode when no Daytona API key is configured', async () => {
+			const resolveDaytonaConfig = vi.fn(async () => ({}));
+			const { service } = createSandboxService({
+				config: { sandboxEnabled: true, sandboxProvider: 'daytona' },
+				settingsService: { resolveDaytonaConfig },
+				aiService: { isProxyEnabled: vi.fn(() => false) },
+			});
+
+			await expect(service.resolveSandboxConfig(fakeUser)).rejects.toThrow(
+				'no API key is configured',
+			);
 		});
 
 		it('routes Daytona traffic through the assistant proxy when enabled', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
@@ -2,6 +2,7 @@ import type { Mock } from 'vitest';
 import type { InstanceAiConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import type { ErrorReporter } from 'n8n-core';
+import { OperationalError } from 'n8n-workflow';
 
 vi.mock('@n8n/instance-ai', () => ({
 	createSandbox: vi.fn(),
@@ -120,9 +121,12 @@ describe('InstanceAiSandboxService', () => {
 				aiService: { isProxyEnabled: vi.fn(() => false) },
 			});
 
-			await expect(service.resolveSandboxConfig(fakeUser)).rejects.toThrow(
-				'no API key is configured',
-			);
+			const resolution = service.resolveSandboxConfig(fakeUser);
+			await expect(resolution).rejects.toBeInstanceOf(OperationalError);
+			await expect(resolution).rejects.toMatchObject({
+				message: expect.stringContaining('no API key is configured'),
+				shouldReport: false,
+			});
 		});
 
 		it('routes Daytona traffic through the assistant proxy when enabled', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -966,7 +966,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 			},
 			backgroundTasks: { getRunningTasks: vi.fn(() => []) },
 			settingsService: {
-				resolveDaytonaConfig: vi.fn(async () => ({})),
+				resolveDaytonaConfig: vi.fn(async () => ({ apiKey: 'test-daytona-key' })),
 				resolveN8nSandboxConfig: vi.fn(async () => ({})),
 			},
 			aiService: { isProxyEnabled: vi.fn(() => false), getClient: vi.fn() },

--- a/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
+++ b/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
@@ -12,7 +12,7 @@ import {
 	type SandboxConfig,
 } from '@n8n/instance-ai';
 import type { ErrorReporter } from 'n8n-core';
-import { UnexpectedError } from 'n8n-workflow';
+import { OperationalError, UnexpectedError } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 
 import { N8N_VERSION } from '@/constants';
@@ -274,10 +274,16 @@ export class InstanceAiSandboxService {
 
 			// Direct mode: Daytona credentials from env vars or admin credential
 			const daytona = await this.options.settingsService.resolveDaytonaConfig();
+			const daytonaApiKey = daytona.apiKey ?? base.daytonaApiKey;
+			if (!daytonaApiKey) {
+				throw new OperationalError(
+					'The Daytona sandbox is enabled in direct mode but no API key is configured. Set the Daytona API key environment variable or connect the Daytona credential.',
+				);
+			}
 			return {
 				...base,
 				daytonaApiUrl: daytona.apiUrl ?? base.daytonaApiUrl,
-				daytonaApiKey: daytona.apiKey ?? base.daytonaApiKey,
+				daytonaApiKey,
 			};
 		}
 		const sandbox = await this.options.settingsService.resolveN8nSandboxConfig();


### PR DESCRIPTION
## Summary

Instance AI thread sandboxes use deterministic names so a restarted process or another main can reconnect to the same Daytona sandbox. This PR closes the production failure modes that could otherwise strand a thread after a transient control-plane error.

1. **State-aware reattachment after a name conflict.** A conflicting create now reconciles until the configured acquisition deadline instead of using three fixed polls. Started sandboxes are reused; stopped/archived sandboxes are started; create/start/restore/pull/fork/resize/snapshot transitions use the SDK readiness wait; stop/archive/removal transitions are re-read with capped backoff; and failed sandboxes are deleted and safely recreated.
~~2. **Bounded transient create retries.** Create now retries 5xx/408/429 responses plus the SDK's status-less `DaytonaConnectionError` and `DaytonaTimeoutError`. A create that succeeded server-side despite a failed response surfaces as a conflict on retry and is resolved by the reattachment path.~~
3. **Precise conflict handling.** HTTP 409 conflicts short-circuit snapshot-to-image fallback because the deterministic name is occupied regardless of creation strategy. The status-less compatibility matcher accepts only Daytona's sandbox-name conflict wording, so unrelated `file already exists` build failures still follow normal reporting and fallback behavior.
4. **Fail fast on direct-mode misconfiguration.** Daytona direct mode without an API key now raises a non-reportable `OperationalError` with setup guidance before constructing the SDK client.

## Production data

**LangSmith (Instance AI EU production, Jul 30–31):** 119 errored root runs across 86 threads with `Sandbox with name instance-ai-thread-<id> already exists`; 46 of 48 thread overlaps show a gateway 502 first, followed by collision retries.

**Sentry (last 14 days, `source:instance-ai`):**

| Issue | Events | Fix |
|---|---:|---|
| [INSTANCE-BACKEND-267Y](https://n8nio.sentry.io/issues/7577017348/) — Daytona 502 on create | 750 | Typed/status retry plus conflict reattachment |
| [INSTANCE-BACKEND-267K](https://n8nio.sentry.io/issues/7574743512/) — invalid Daytona auth construction | 33 | Early configuration validation |

## How to test

```bash
cd packages/@n8n/agents && pnpm test src/__tests__/workspace/sandbox/daytona-sandbox.test.ts
cd packages/cli && pnpm test src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts src/modules/instance-ai/__tests__/instance-ai.service.test.ts
```

Focused verification: all 190 targeted Daytona and Instance AI regression tests passed; exact-file ESLint, Biome, and `git diff --check` passed. This package has no file-scoped TypeScript project check, so no package-wide typecheck was run.

## Related Linear tickets, Github issues, and Community forum posts

None — found while analysing errored production traces.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
