### PR TITLE
fix(editor): quote non-identifier property keys in generated TypeScript interfaces

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/dynamicTypes.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/dynamicTypes.test.ts
@@ -2,6 +2,59 @@ import { schemaToTypescriptTypes } from './dynamicTypes';
 
 describe('typescript worker dynamicTypes', () => {
 	describe('schemaToTypescriptTypes', () => {
+		it('should quote property keys that are not valid identifiers', () => {
+			expect(
+				schemaToTypescriptTypes(
+					{
+						type: 'object',
+						value: [
+							{ key: 'hyphen-key', type: 'string', value: '', path: '.hyphen-key' },
+							{ key: 'space key', type: 'number', value: '', path: '.space key' },
+							{ key: '123numeric', type: 'boolean', value: '', path: '.123numeric' },
+							{ key: 'valid_key', type: 'string', value: '', path: '.valid_key' },
+							{ key: '$valid', type: 'string', value: '', path: '.$valid' },
+						],
+						path: '',
+					},
+					'TestInterface',
+				),
+			).toEqual(`interface TestInterface {
+  "hyphen-key": string;
+  "space key": number;
+  "123numeric": boolean;
+  valid_key: string;
+  $valid: string;
+}`);
+		});
+
+		it('should quote nested property keys that are not valid identifiers', () => {
+			expect(
+				schemaToTypescriptTypes(
+					{
+						type: 'object',
+						value: [
+							{
+								key: 'user-info',
+								type: 'object',
+								path: '.user-info',
+								value: [
+									{ key: 'first-name', type: 'string', value: '', path: '.first-name' },
+									{ key: 'age', type: 'number', value: '', path: '.age' },
+								],
+							},
+						],
+						path: '',
+					},
+					'TestInterface',
+				),
+			).toEqual(`interface TestInterface {
+  "user-info": {
+  "first-name": string;
+  age: number;
+};
+}`);
+		});
+
 		it('should convert a schema to a typescript type', () => {
 			expect(
 				schemaToTypescriptTypes(

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/dynamicTypes.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/worker/dynamicTypes.ts
@@ -2,6 +2,13 @@ import type { Schema } from '@/Interface';
 import { pascalCase } from 'change-case';
 import { globalTypeDefinition } from './utils';
 
+/** Returns true when name is a valid unquoted TypeScript property identifier. */
+function isValidIdentifier(name: string): boolean {
+	return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name);
+}
+
+const safeKey = (key: string): string => (isValidIdentifier(key) ? key : JSON.stringify(key));
+
 function processSchema(schema: Schema): string {
 	switch (schema.type) {
 		case 'string':
@@ -35,7 +42,7 @@ function processSchema(schema: Schema): string {
 				.map((prop) => {
 					const key = prop.key ?? 'unknown';
 					const type = processSchema(prop);
-					return `  ${key}: ${type};`;
+					return `  ${safeKey(key)}: ${type};`;
 				})
 				.join('\n');
 


### PR DESCRIPTION
`processSchema` emits object property keys verbatim:
```ts
return `  ${key}: ${type};`;
```

When a node's output JSON contains a key that is not a valid unquoted TS
identifier (e.g. `"testing Stuff"`, `"content-type"`, `"x-request-id"`), the
generated interface declaration is syntactically invalid TypeScript. The TS
language service fails to parse it, drops the entire type, and autocomplete
for `$('Node Name').` returns nothing.

Add `isValidIdentifier()` and `safeKey()` helpers that wrap non-identifier
keys with `JSON.stringify()` to produce quoted property keys (`"content-type":
string` instead of `content-type: string`).

Before: `  testing Stuff: string;` → syntax error, autocomplete broken
After:  `  "testing Stuff": string;` → valid TS, autocomplete works

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

