### PR TITLE
feat(editor): Inconsistent spacing of buttons on canvas (in top-right vs bottom-left)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.stories.ts
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+
+import N8nButton from '../N8nButton/Button.vue';
+import N8nIconButton from '../N8nIconButton/IconButton.vue';
+import N8nButtonList from './ButtonList.vue';
+
+const meta = {
+	title: 'Core/ButtonList',
+	component: N8nButtonList,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Layout wrapper that applies consistent spacing between a group of buttons or icon buttons.',
+			},
+			source: { type: 'dynamic' },
+		},
+	},
+	argTypes: {
+		orientation: {
+			control: 'select',
+			options: ['horizontal', 'vertical'],
+			description: 'Layout orientation of the buttons',
+		},
+	},
+} satisfies Meta<typeof N8nButtonList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { N8nButtonList, N8nButton },
+		setup() {
+			return { args };
+		},
+		template: `
+			<N8nButtonList v-bind="args">
+				<N8nButton variant="subtle">Save</N8nButton>
+				<N8nButton variant="solid">Publish</N8nButton>
+				<N8nButton variant="ghost">More</N8nButton>
+			</N8nButtonList>
+		`,
+	}),
+	args: {
+		orientation: 'horizontal',
+	},
+};
+
+export const IconButtons: Story = {
+	render: (args) => ({
+		components: { N8nButtonList, N8nIconButton },
+		setup() {
+			return { args };
+		},
+		template: `
+			<N8nButtonList v-bind="args">
+				<N8nIconButton variant="subtle" size="large" icon="maximize" aria-label="Zoom to fit" />
+				<N8nIconButton variant="subtle" size="large" icon="zoom-in" aria-label="Zoom in" />
+				<N8nIconButton variant="subtle" size="large" icon="zoom-out" aria-label="Zoom out" />
+			</N8nButtonList>
+		`,
+	}),
+	args: {
+		orientation: 'horizontal',
+	},
+};
+
+export const Vertical: Story = {
+	render: (args) => ({
+		components: { N8nButtonList, N8nIconButton },
+		setup() {
+			return { args };
+		},
+		template: `
+			<N8nButtonList v-bind="args">
+				<N8nIconButton variant="subtle" size="large" icon="plus" aria-label="Add" />
+				<N8nIconButton variant="subtle" size="large" icon="search" aria-label="Search" />
+				<N8nIconButton variant="subtle" size="large" icon="sticky-note" aria-label="Sticky note" />
+			</N8nButtonList>
+		`,
+	}),
+	args: {
+		orientation: 'vertical',
+	},
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 
+import N8nButtonList from './ButtonList.vue';
 import N8nButton from '../N8nButton/Button.vue';
 import N8nIconButton from '../N8nIconButton/IconButton.vue';
-import N8nButtonList from './ButtonList.vue';
 
 const meta = {
 	title: 'Core/ButtonList',

--- a/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.test.ts
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/vue';
+
+import N8nButtonList from './ButtonList.vue';
+
+describe('components', () => {
+	describe('N8nButtonList', () => {
+		it('should render with default horizontal orientation', () => {
+			const { container } = render(N8nButtonList, {
+				slots: {
+					default: '<button>One</button><button>Two</button>',
+				},
+			});
+
+			const group = container.querySelector('[role="group"]');
+			expect(group).toBeTruthy();
+			expect(group?.className).toMatch(/horizontal/);
+		});
+
+		it('should apply vertical orientation', () => {
+			const { container } = render(N8nButtonList, {
+				props: {
+					orientation: 'vertical',
+				},
+				slots: {
+					default: '<button>One</button><button>Two</button>',
+				},
+			});
+
+			const group = container.querySelector('[role="group"]');
+			expect(group?.className).toMatch(/vertical/);
+		});
+
+		it('should render slotted content', () => {
+			const { getByText } = render(N8nButtonList, {
+				slots: {
+					default: '<button>Save</button><button>Publish</button>',
+				},
+			});
+
+			expect(getByText('Save')).toBeTruthy();
+			expect(getByText('Publish')).toBeTruthy();
+		});
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.types.ts
@@ -1,0 +1,9 @@
+export type ButtonListOrientation = 'horizontal' | 'vertical';
+
+export type ButtonListProps = {
+	/**
+	 * Layout orientation.
+	 * @defaultValue 'horizontal'
+	 */
+	orientation?: ButtonListOrientation;
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButtonList/ButtonList.vue
@@ -1,0 +1,34 @@
+<script lang="ts" setup>
+import type { ButtonListProps } from './ButtonList.types';
+
+withDefaults(defineProps<ButtonListProps>(), {
+	orientation: 'horizontal',
+});
+</script>
+
+<template>
+	<div
+		:class="[$style.root, orientation === 'vertical' ? $style.vertical : $style.horizontal]"
+		role="group"
+	>
+		<slot />
+	</div>
+</template>
+
+<style lang="scss" module>
+.root {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--xs);
+}
+
+.horizontal {
+	flex-direction: row;
+	flex-wrap: nowrap;
+}
+
+.vertical {
+	flex-direction: column;
+	align-items: stretch;
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nButtonList/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButtonList/index.ts
@@ -1,0 +1,4 @@
+import N8nButtonList from './ButtonList.vue';
+
+export type { ButtonListOrientation, ButtonListProps } from './ButtonList.types';
+export default N8nButtonList;

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -31,6 +31,8 @@ export { default as N8nAvatar } from './N8nAvatar';
 export { default as N8nBadge } from './N8nBadge';
 export { default as N8nBlockUi } from './N8nBlockUi';
 export { default as N8nButton } from './N8nButton';
+export { default as N8nButtonList } from './N8nButtonList';
+export type { ButtonListOrientation, ButtonListProps } from './N8nButtonList';
 export { default as N8nCallout } from './N8nCallout';
 export { default as N8nCanvasThinkingPill } from './CanvasThinkingPill';
 export { default as N8nCanvasCollaborationPill } from './CanvasCollaborationPill';

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
@@ -26,7 +26,13 @@ import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
 
-import { N8nAssistantIcon, N8nButton, N8nIconButton, N8nTooltip } from '@n8n/design-system';
+import {
+	N8nAssistantIcon,
+	N8nButton,
+	N8nButtonList,
+	N8nIconButton,
+	N8nTooltip,
+} from '@n8n/design-system';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
@@ -159,7 +165,7 @@ function openCommandBar(event: MouseEvent) {
 </script>
 
 <template>
-	<div v-if="!createNodeActive" :class="$style.nodeButtonsWrapper">
+	<N8nButtonList v-if="!createNodeActive" orientation="vertical" :class="$style.nodeButtonsWrapper">
 		<NodeCreatorShortcutCoachmark :visible="shouldShowCoachmark" @dismiss="onDismissCoachmark">
 			<KeyboardShortcutTooltip
 				:label="i18n.baseText('nodeView.openNodesPanel')"
@@ -262,7 +268,7 @@ function openCommandBar(event: MouseEvent) {
 				</template>
 			</N8nButton>
 		</N8nTooltip>
-	</div>
+	</N8nButtonList>
 	<Suspense>
 		<LazyNodeCreator
 			:active="createNodeActive"
@@ -277,9 +283,6 @@ function openCommandBar(event: MouseEvent) {
 	position: absolute;
 	top: 0;
 	right: 0;
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--2xs);
 	padding: var(--spacing--sm);
 	pointer-events: all !important;
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
@@ -5,8 +5,9 @@ import { useI18n } from '@n8n/i18n';
 import { Controls } from '@vue-flow/controls';
 import { computed } from 'vue';
 import { useExperimentalNdvStore } from '../../../experimental/experimentalNdv.store';
-import { N8nButton, N8nIconButton, N8nTooltip } from '@n8n/design-system';
+import { N8nButton, N8nButtonList, N8nIconButton, N8nTooltip } from '@n8n/design-system';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+
 const props = withDefaults(
 	defineProps<{
 		zoom?: number;
@@ -65,117 +66,127 @@ function handleClickCollapseAll() {
 </script>
 <template>
 	<Controls :show-zoom="false" :show-fit-view="false">
-		<KeyboardShortcutTooltip
-			:label="i18n.baseText('nodeView.zoomToFit')"
-			:shortcut="{ keys: ['1'] }"
-		>
-			<N8nIconButton
-				variant="subtle"
-				size="large"
-				icon="maximize"
-				:aria-label="i18n.baseText('nodeView.zoomToFit')"
-				data-test-id="zoom-to-fit"
-				@click="onZoomToFit"
-			/>
-		</KeyboardShortcutTooltip>
-		<KeyboardShortcutTooltip :label="i18n.baseText('nodeView.zoomIn')" :shortcut="{ keys: ['+'] }">
-			<N8nIconButton
-				variant="subtle"
-				size="large"
-				icon="zoom-in"
-				:aria-label="i18n.baseText('nodeView.zoomIn')"
-				data-test-id="zoom-in-button"
-				@click="onZoomIn"
-			/>
-		</KeyboardShortcutTooltip>
-		<KeyboardShortcutTooltip :label="i18n.baseText('nodeView.zoomOut')" :shortcut="{ keys: ['-'] }">
-			<N8nIconButton
-				variant="subtle"
-				size="large"
-				icon="zoom-out"
-				:aria-label="i18n.baseText('nodeView.zoomOut')"
-				data-test-id="zoom-out-button"
-				@click="onZoomOut"
-			/>
-		</KeyboardShortcutTooltip>
-		<KeyboardShortcutTooltip
-			v-if="isToggleZoomVisible"
-			:label="
-				i18n.baseText(isExperimentalNdvActive ? 'nodeView.leaveZoomMode' : 'nodeView.enterZoomMode')
-			"
-			:shortcut="{ keys: ['Z'] }"
-		>
-			<N8nIconButton
-				variant="subtle"
-				iconOnly
-				size="large"
-				:class="$style.iconButton"
-				:icon="isExperimentalNdvActive ? 'undo-2' : 'crosshair'"
-				:aria-label="
+		<N8nButtonList>
+			<KeyboardShortcutTooltip
+				:label="i18n.baseText('nodeView.zoomToFit')"
+				:shortcut="{ keys: ['1'] }"
+			>
+				<N8nIconButton
+					variant="subtle"
+					size="large"
+					icon="maximize"
+					:aria-label="i18n.baseText('nodeView.zoomToFit')"
+					data-test-id="zoom-to-fit"
+					@click="onZoomToFit"
+				/>
+			</KeyboardShortcutTooltip>
+			<KeyboardShortcutTooltip
+				:label="i18n.baseText('nodeView.zoomIn')"
+				:shortcut="{ keys: ['+'] }"
+			>
+				<N8nIconButton
+					variant="subtle"
+					size="large"
+					icon="zoom-in"
+					:aria-label="i18n.baseText('nodeView.zoomIn')"
+					data-test-id="zoom-in-button"
+					@click="onZoomIn"
+				/>
+			</KeyboardShortcutTooltip>
+			<KeyboardShortcutTooltip
+				:label="i18n.baseText('nodeView.zoomOut')"
+				:shortcut="{ keys: ['-'] }"
+			>
+				<N8nIconButton
+					variant="subtle"
+					size="large"
+					icon="zoom-out"
+					:aria-label="i18n.baseText('nodeView.zoomOut')"
+					data-test-id="zoom-out-button"
+					@click="onZoomOut"
+				/>
+			</KeyboardShortcutTooltip>
+			<KeyboardShortcutTooltip
+				v-if="isToggleZoomVisible"
+				:label="
 					i18n.baseText(
 						isExperimentalNdvActive ? 'nodeView.leaveZoomMode' : 'nodeView.enterZoomMode',
 					)
 				"
-				@click="emit('toggle-zoom-mode')"
-			/>
-		</KeyboardShortcutTooltip>
-		<KeyboardShortcutTooltip
-			v-if="isResetZoomVisible"
-			:label="i18n.baseText('nodeView.resetZoom')"
-			:shortcut="{ keys: ['0'] }"
-		>
-			<N8nIconButton
-				variant="subtle"
-				size="large"
-				icon="undo-2"
-				:aria-label="i18n.baseText('nodeView.resetZoom')"
-				data-test-id="reset-zoom-button"
-				@click="onResetZoom"
-			/>
-		</KeyboardShortcutTooltip>
-		<KeyboardShortcutTooltip
-			v-if="!readOnly"
-			:label="i18n.baseText('nodeView.tidyUp')"
-			:shortcut="{ shiftKey: true, altKey: true, keys: ['T'] }"
-		>
-			<N8nButton
-				variant="subtle"
-				iconOnly
-				size="large"
-				:aria-label="i18n.baseText('nodeView.tidyUp')"
-				data-test-id="tidy-up-button"
-				:class="$style.iconButton"
-				@click="onTidyUp"
+				:shortcut="{ keys: ['Z'] }"
 			>
-				<TidyUpIcon />
-			</N8nButton>
-		</KeyboardShortcutTooltip>
-		<N8nTooltip
-			v-if="isExperimentalNdvActive"
-			placement="top"
-			:content="i18n.baseText('nodeView.expandAllNodes')"
-		>
-			<N8nIconButton
-				variant="subtle"
-				size="large"
-				icon="maximize-2"
-				:aria-label="i18n.baseText('nodeView.expandAllNodes')"
-				@click="experimentalNdvStore.expandAllNodes"
-			/>
-		</N8nTooltip>
-		<N8nTooltip
-			v-if="isExperimentalNdvActive"
-			placement="top"
-			:content="i18n.baseText('nodeView.collapseAllNodes')"
-		>
-			<N8nIconButton
-				variant="subtle"
-				size="large"
-				icon="minimize-2"
-				:aria-label="i18n.baseText('nodeView.collapseAllNodes')"
-				@click="handleClickCollapseAll"
-			/>
-		</N8nTooltip>
+				<N8nIconButton
+					variant="subtle"
+					iconOnly
+					size="large"
+					:class="$style.iconButton"
+					:icon="isExperimentalNdvActive ? 'undo-2' : 'crosshair'"
+					:aria-label="
+						i18n.baseText(
+							isExperimentalNdvActive ? 'nodeView.leaveZoomMode' : 'nodeView.enterZoomMode',
+						)
+					"
+					@click="emit('toggle-zoom-mode')"
+				/>
+			</KeyboardShortcutTooltip>
+			<KeyboardShortcutTooltip
+				v-if="isResetZoomVisible"
+				:label="i18n.baseText('nodeView.resetZoom')"
+				:shortcut="{ keys: ['0'] }"
+			>
+				<N8nIconButton
+					variant="subtle"
+					size="large"
+					icon="undo-2"
+					:aria-label="i18n.baseText('nodeView.resetZoom')"
+					data-test-id="reset-zoom-button"
+					@click="onResetZoom"
+				/>
+			</KeyboardShortcutTooltip>
+			<KeyboardShortcutTooltip
+				v-if="!readOnly"
+				:label="i18n.baseText('nodeView.tidyUp')"
+				:shortcut="{ shiftKey: true, altKey: true, keys: ['T'] }"
+			>
+				<N8nButton
+					variant="subtle"
+					iconOnly
+					size="large"
+					:aria-label="i18n.baseText('nodeView.tidyUp')"
+					data-test-id="tidy-up-button"
+					:class="$style.iconButton"
+					@click="onTidyUp"
+				>
+					<TidyUpIcon />
+				</N8nButton>
+			</KeyboardShortcutTooltip>
+			<N8nTooltip
+				v-if="isExperimentalNdvActive"
+				placement="top"
+				:content="i18n.baseText('nodeView.expandAllNodes')"
+			>
+				<N8nIconButton
+					variant="subtle"
+					size="large"
+					icon="maximize-2"
+					:aria-label="i18n.baseText('nodeView.expandAllNodes')"
+					@click="experimentalNdvStore.expandAllNodes"
+				/>
+			</N8nTooltip>
+			<N8nTooltip
+				v-if="isExperimentalNdvActive"
+				placement="top"
+				:content="i18n.baseText('nodeView.collapseAllNodes')"
+			>
+				<N8nIconButton
+					variant="subtle"
+					size="large"
+					icon="minimize-2"
+					:aria-label="i18n.baseText('nodeView.collapseAllNodes')"
+					@click="handleClickCollapseAll"
+				/>
+			</N8nTooltip>
+		</N8nButtonList>
 	</Controls>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/__snapshots__/CanvasControlButtons.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/__snapshots__/CanvasControlButtons.test.ts.snap
@@ -7,14 +7,16 @@ exports[`CanvasControlButtons > should render correctly 1`] = `
       <path d="M21.333 10.667H19.81V7.619C19.81 3.429 16.38 0 12.19 0c-4.114 1.828-1.37 2.133.305 2.438 1.676.305 4.42 2.59 4.42 5.181v3.048H3.047A3.056 3.056 0 0 0 0 13.714v15.238A3.056 3.056 0 0 0 3.048 32h18.285a3.056 3.056 0 0 0 3.048-3.048V13.714a3.056 3.056 0 0 0-3.048-3.047zM12.19 24.533a3.056 3.056 0 0 1-3.047-3.047 3.056 3.056 0 0 1 3.047-3.048 3.056 3.056 0 0 1 3.048 3.048 3.056 3.056 0 0 1-3.048 3.047z"></path>
     </svg>
     <!---->
-  </button><span class="" data-state="closed" data-grace-area-trigger=""><n8n-icon-button-stub variant="subtle" icon="maximize" size="large" loading="false" icononly="true" disabled="false" class="" aria-label="Zoom to Fit" data-test-id="zoom-to-fit"></n8n-icon-button-stub></span>
-  <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-icon-button-stub variant="subtle" icon="zoom-in" size="large" loading="false" icononly="true" disabled="false" class="" aria-label="Zoom In" data-test-id="zoom-in-button"></n8n-icon-button-stub></span>
-  <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-icon-button-stub variant="subtle" icon="zoom-out" size="large" loading="false" icononly="true" disabled="false" class="" aria-label="Zoom Out" data-test-id="zoom-out-button"></n8n-icon-button-stub></span>
-  <!--v-if-->
-  <!--v-if-->
-  <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-button-stub variant="subtle" size="large" loading="false" icononly="true" disabled="false" class="iconButton" aria-label="Tidy Up" data-test-id="tidy-up-button"></n8n-button-stub></span>
-  <!--v-if-->
-  <!--v-if-->
-  <!--v-if-->
+  </button>
+  <div class="root horizontal" role="group"><span class="" data-state="closed" data-grace-area-trigger=""><n8n-icon-button-stub variant="subtle" icon="maximize" size="large" loading="false" icononly="true" disabled="false" class="" aria-label="Zoom to Fit" data-test-id="zoom-to-fit"></n8n-icon-button-stub></span>
+    <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-icon-button-stub variant="subtle" icon="zoom-in" size="large" loading="false" icononly="true" disabled="false" class="" aria-label="Zoom In" data-test-id="zoom-in-button"></n8n-icon-button-stub></span>
+    <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-icon-button-stub variant="subtle" icon="zoom-out" size="large" loading="false" icononly="true" disabled="false" class="" aria-label="Zoom Out" data-test-id="zoom-out-button"></n8n-icon-button-stub></span>
+    <!--v-if-->
+    <!--v-if-->
+    <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-button-stub variant="subtle" size="large" loading="false" icononly="true" disabled="false" class="iconButton" aria-label="Tidy Up" data-test-id="tidy-up-button"></n8n-button-stub></span>
+    <!--v-if-->
+    <!--v-if-->
+    <!--v-if-->
+  </div>
 </div>"
 `;


### PR DESCRIPTION
## Summary

- Created a new `ButtonList` component that can be used to create consistent spacing throughout the UI
- Wrapped editor controls in component to fix the issue

## How to test

- Check editor controls render properly with the right spacing

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-523/inconsistent-spacing-of-buttons-on-canvas-in-top-right-vs-bottom-left

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->