### PR TITLE
fix(core): Tolerate JSON Schema patterns incompatible with the regex u flag

### DIFF
--- a/packages/@n8n/agents/src/utils/__tests__/parse.test.ts
+++ b/packages/@n8n/agents/src/utils/__tests__/parse.test.ts
@@ -124,6 +124,20 @@ describe('parseWithSchema — JSON Schema', () => {
 		expect(valid.success).toBe(true);
 	});
 
+	it('tolerates patterns that are invalid under the regex u flag', async () => {
+		const schema = {
+			type: 'object' as const,
+			properties: { url: { type: 'string', pattern: '^https\\:\\/\\/' } },
+			required: ['url'],
+		} as JSONSchema7;
+
+		const valid = await parseWithSchema(schema, { url: 'https://example.com' });
+		expect(valid.success).toBe(true);
+
+		const invalid = await parseWithSchema(schema, { url: 'ftp://example.com' });
+		expect(invalid.success).toBe(false);
+	});
+
 	it('validates nested object properties', async () => {
 		const schema = {
 			type: 'object' as const,

--- a/packages/@n8n/agents/src/utils/__tests__/parse.test.ts
+++ b/packages/@n8n/agents/src/utils/__tests__/parse.test.ts
@@ -124,17 +124,29 @@ describe('parseWithSchema — JSON Schema', () => {
 		expect(valid.success).toBe(true);
 	});
 
+	it('uses Unicode regex semantics by default', async () => {
+		const schema = {
+			type: 'object' as const,
+			properties: { value: { type: 'string', pattern: '^.$' } },
+			required: ['value'],
+		} as JSONSchema7;
+
+		const result = await parseWithSchema(schema, { value: '😀' });
+
+		expect(result.success).toBe(true);
+	});
+
 	it('tolerates patterns that are invalid under the regex u flag', async () => {
 		const schema = {
 			type: 'object' as const,
-			properties: { url: { type: 'string', pattern: '^https\\:\\/\\/' } },
-			required: ['url'],
+			properties: { value: { type: 'string', pattern: '[\\w-.]' } },
+			required: ['value'],
 		} as JSONSchema7;
 
-		const valid = await parseWithSchema(schema, { url: 'https://example.com' });
+		const valid = await parseWithSchema(schema, { value: 'a' });
 		expect(valid.success).toBe(true);
 
-		const invalid = await parseWithSchema(schema, { url: 'ftp://example.com' });
+		const invalid = await parseWithSchema(schema, { value: '@' });
 		expect(invalid.success).toBe(false);
 	});
 

--- a/packages/@n8n/agents/src/utils/parse.ts
+++ b/packages/@n8n/agents/src/utils/parse.ts
@@ -1,4 +1,5 @@
 import type AjvType from 'ajv';
+import type { ValidateFunction } from 'ajv';
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodType } from 'zod';
 
@@ -9,16 +10,21 @@ export type ParseResult<T = unknown> =
 	| { success: false; error: string };
 
 let ajvInstance: InstanceType<typeof AjvType> | undefined;
+let nonUnicodeAjvInstance: InstanceType<typeof AjvType> | undefined;
 
-function getAjv(): InstanceType<typeof AjvType> {
-	if (!ajvInstance) {
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
-		const { default: Ajv } = require('ajv') as { default: typeof AjvType };
-		// unicodeRegExp: false — external (MCP) schemas often carry patterns that
-		// are invalid under the regex `u` flag, e.g. `^https\:\/\/`.
-		ajvInstance = new Ajv({ strict: false, unicodeRegExp: false });
-	}
-	return ajvInstance;
+function getAjv(unicodeRegExp = true): InstanceType<typeof AjvType> {
+	const instance = unicodeRegExp ? ajvInstance : nonUnicodeAjvInstance;
+	if (instance) return instance;
+
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const { default: Ajv } = require('ajv') as { default: typeof AjvType };
+	const newInstance = new Ajv({
+		strict: false,
+		...(unicodeRegExp ? {} : { unicodeRegExp: false }),
+	});
+	if (unicodeRegExp) ajvInstance = newInstance;
+	else nonUnicodeAjvInstance = newInstance;
+	return newInstance;
 }
 
 /**
@@ -35,8 +41,15 @@ export async function parseWithSchema(
 		return { success: false, error: result.error.message };
 	}
 
-	const ajv = getAjv();
-	const validate = ajv.compile(schema);
+	let ajv = getAjv();
+	let validate: ValidateFunction;
+	try {
+		validate = ajv.compile(schema);
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) throw error;
+		ajv = getAjv(false);
+		validate = ajv.compile(schema);
+	}
 	if (validate(data)) return { success: true, data };
 	return { success: false, error: ajv.errorsText(validate.errors) };
 }

--- a/packages/@n8n/agents/src/utils/parse.ts
+++ b/packages/@n8n/agents/src/utils/parse.ts
@@ -14,7 +14,9 @@ function getAjv(): InstanceType<typeof AjvType> {
 	if (!ajvInstance) {
 		// eslint-disable-next-line @typescript-eslint/no-require-imports
 		const { default: Ajv } = require('ajv') as { default: typeof AjvType };
-		ajvInstance = new Ajv({ strict: false });
+		// unicodeRegExp: false — external (MCP) schemas often carry patterns that
+		// are invalid under the regex `u` flag, e.g. `^https\:\/\/`.
+		ajvInstance = new Ajv({ strict: false, unicodeRegExp: false });
 	}
 	return ajvInstance;
 }


### PR DESCRIPTION
## Summary

AJV 8 defaults to `unicodeRegExp: true`, compiling every JSON Schema `pattern` as `new RegExp(pattern, 'u')`. Real-world MCP servers ship patterns that are invalid under the `u` flag — e.g. PayPal's MCP server declares `pattern: "^https\:\/\/"` (`\:` is an illegal escape in unicode mode), which makes `parseWithSchema` throw:

```
SyntaxError: Invalid regular expression: /^https\:\/\//u: Invalid escape
```

In production this surfaced as errored Instance AI runs (`MCP connection failed: mcp_pay-pal: Invalid regular expression …`) on agents 0.17.2, where an MCP failure still aborted the turn. On current master the failure moved to tool-call time (`validateToolInput` runs `parseWithSchema` on every MCP tool call), so the affected server's tools throw the moment they are used.

This sets `unicodeRegExp: false` on the shared AJV instance — the option AJV documents for compatibility with schemas whose patterns are not `u`-clean. Trade-off: patterns using `\p{…}` unicode property escapes no longer match as unicode classes; that is a rarer and softer failure than throwing on every call for the affected server.

## How to test

```bash
cd packages/@n8n/agents && pnpm test parse.test.ts
```

The new test uses the real-world pattern and fails without the one-line fix (verified red/green).

## Related Linear tickets, Github issues, and Community forum posts

None — found while analysing errored production traces.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35320">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Production traces (LangSmith, Instance AI EU production)

Three errored root runs on 2026-07-30, all failing with `MCP connection failed: mcp_pay-pal: Invalid regular expression: /^https\:\/\//u: Invalid escape`:

| Time (UTC) | Trace |
|---|---|
| 18:06:14 | [00000000-0000-0000-a858-c675d535f13c](https://eu.smith.langchain.com/o/df8b0b69-354e-412c-bfbd-8f8f9e06fdb0/projects/p/e55f36c9-17c9-46b6-a141-a3ac51f74140/r/00000000-0000-0000-a858-c675d535f13c) |
| 18:33:16 | [00000000-0000-0000-ef84-8fc8d8bfa282](https://eu.smith.langchain.com/o/df8b0b69-354e-412c-bfbd-8f8f9e06fdb0/projects/p/e55f36c9-17c9-46b6-a141-a3ac51f74140/r/00000000-0000-0000-ef84-8fc8d8bfa282) |
| 18:34:34 | [00000000-0000-0000-0447-16d2439826c7](https://eu.smith.langchain.com/o/df8b0b69-354e-412c-bfbd-8f8f9e06fdb0/projects/p/e55f36c9-17c9-46b6-a141-a3ac51f74140/r/00000000-0000-0000-0447-16d2439826c7) |
