### PR TITLE
fix(AWS Bedrock Chat Model Node): Enable TCP keepalive on Bedrock runtime connections

### DIFF
--- a/packages/@n8n/ai-utilities/src/__tests__/utils/http-proxy-agent.test.ts
+++ b/packages/@n8n/ai-utilities/src/__tests__/utils/http-proxy-agent.test.ts
@@ -1,7 +1,7 @@
 import { Agent, ProxyAgent } from 'undici';
 import type { MockedFunction } from 'vitest';
 
-import { getProxyAgent, proxyFetch } from 'src/utils/http-proxy-agent';
+import { getNodeProxyAgent, getProxyAgent, proxyFetch } from 'src/utils/http-proxy-agent';
 
 // Mock the dependencies
 vi.mock('undici', () => ({
@@ -519,5 +519,37 @@ describe('proxyFetch', () => {
 			expect(result).toBe(errorResponse);
 			expect(result.status).toBe(404);
 		});
+	});
+});
+
+describe('getNodeProxyAgent', () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		delete process.env.HTTPS_PROXY;
+		delete process.env.https_proxy;
+		delete process.env.NO_PROXY;
+		delete process.env.no_proxy;
+	});
+
+	afterAll(() => {
+		process.env = originalEnv;
+	});
+
+	it('returns undefined when no proxy is configured', () => {
+		expect(getNodeProxyAgent('https://example.com')).toBeUndefined();
+	});
+
+	it('applies agent options (e.g. TCP keepalive) to the proxy agent', () => {
+		process.env.HTTPS_PROXY = 'http://proxy.example.com:8080';
+
+		const agent = getNodeProxyAgent('https://example.com', {
+			keepAlive: true,
+			keepAliveMsecs: 30_000,
+		});
+
+		expect(agent).toBeDefined();
+		expect(agent).toMatchObject({ keepAlive: true, keepAliveMsecs: 30_000 });
 	});
 });

--- a/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
+++ b/packages/@n8n/ai-utilities/src/utils/http-proxy-agent.ts
@@ -18,6 +18,7 @@
  * raw dispatcher). See CAT-3377 for the consolidation this completes.
  */
 import { createHttpsProxyAgent, resolveProxyUrl } from '@n8n/backend-network/proxy'; // `@n8n/backend-network/proxy` is a DI-free subpath: it pulls in only the proxy-agent libs
+import type { AgentOptions } from 'node:https';
 import type { LookupFunction } from 'node:net';
 /* eslint-disable n8n-local-rules/no-uncentralized-http -- langchain consumers pin undici v6, incompatible with backend-network's v7 dispatchers; see block comment below */
 import { Agent, ProxyAgent } from 'undici';
@@ -124,14 +125,15 @@ export async function proxyFetch(
  * AWS SDK v3 requires Node.js http.Agent/https.Agent instances (not undici ProxyAgent).
  *
  * @param targetUrl - The target URL to check proxy configuration for
+ * @param agentOptions - Optional agent options (e.g. TCP keepalive settings) applied to the proxy agent
  * @returns An https.Agent proxy instance or undefined if no proxy is configured
  */
-export function getNodeProxyAgent(targetUrl?: string) {
+export function getNodeProxyAgent(targetUrl?: string, agentOptions?: AgentOptions) {
 	const proxyUrl = resolveProxyUrl(targetUrl, PROXY_FALLBACK_TARGET);
 
 	if (!proxyUrl) {
 		return undefined;
 	}
 
-	return createHttpsProxyAgent(targetUrl ?? PROXY_FALLBACK_TARGET, proxyUrl);
+	return createHttpsProxyAgent(targetUrl ?? PROXY_FALLBACK_TARGET, proxyUrl, agentOptions);
 }

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAwsBedrock/test/EmbeddingsAwsBedrock.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAwsBedrock/test/EmbeddingsAwsBedrock.test.ts
@@ -43,6 +43,8 @@ const MockedNodeHttpHandler = vi.mocked(NodeHttpHandler);
 const mockedGetNodeProxyAgent = vi.mocked(getNodeProxyAgent);
 const mockedResolveAwsCredentials = vi.mocked(resolveAwsCredentials);
 
+const keepAliveAgentOptions = { keepAlive: true, keepAliveMsecs: 30_000 };
+
 describe('EmbeddingsAwsBedrock', () => {
 	const mockNode: INode = {
 		id: '1',
@@ -115,6 +117,7 @@ describe('EmbeddingsAwsBedrock', () => {
 		await node.supplyData.call(mockContext('amazon.titan-embed-text-v1'), 0);
 		expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
 			'https://bedrock-runtime.eu-west-2.amazonaws.com',
+			keepAliveAgentOptions,
 		);
 	});
 
@@ -127,6 +130,7 @@ describe('EmbeddingsAwsBedrock', () => {
 		await node.supplyData.call(mockContext('amazon.titan-embed-text-v1'), 0);
 		expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
 			'https://bedrock-runtime.cn-north-1.amazonaws.com.cn',
+			keepAliveAgentOptions,
 		);
 	});
 
@@ -208,13 +212,17 @@ describe('EmbeddingsAwsBedrock', () => {
 			);
 		});
 
-		it('leaves maxAttempts and request handler unset without options', async () => {
+		it('leaves maxAttempts unset and installs a keepalive handler without options', async () => {
 			const node = new EmbeddingsAwsBedrock();
 			await node.supplyData.call(mockContext('amazon.titan-embed-text-v1'), 0);
 
 			const lastConfig = MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0];
 			expect(lastConfig?.maxAttempts).toBeUndefined();
-			expect(lastConfig?.requestHandler).toBeUndefined();
+			expect(lastConfig?.requestHandler).toBe(MockedNodeHttpHandler.mock.instances.at(-1));
+			expect(MockedNodeHttpHandler).toHaveBeenCalledWith({
+				httpAgent: keepAliveAgentOptions,
+				httpsAgent: keepAliveAgentOptions,
+			});
 		});
 
 		it('passes parsed additional model request fields to the embeddings', async () => {
@@ -282,7 +290,7 @@ describe('EmbeddingsAwsBedrock', () => {
 			await node.supplyData.call(mockContext('amazon.titan-embed-text-v1'), 0);
 
 			const expected = 'https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com';
-			expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(expected);
+			expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(expected, keepAliveAgentOptions);
 			expect(MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0]?.endpoint).toBe(expected);
 		});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
@@ -43,6 +43,8 @@ const mockedMakeN8nLlmFailedAttemptHandler = vi.mocked(makeN8nLlmFailedAttemptHa
 const mockedGetNodeProxyAgent = vi.mocked(getNodeProxyAgent);
 const mockedResolveAwsCredentials = vi.mocked(resolveAwsCredentials);
 
+const keepAliveAgentOptions = { keepAlive: true, keepAliveMsecs: 30_000 };
+
 describe('LmChatAwsBedrock', () => {
 	let node: LmChatAwsBedrock;
 	let mockContext: Mocked<ISupplyDataFunctions>;
@@ -207,6 +209,7 @@ describe('LmChatAwsBedrock', () => {
 
 			expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
 				'https://bedrock-runtime.cn-north-1.amazonaws.com.cn',
+				keepAliveAgentOptions,
 			);
 			expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
 				expect.objectContaining({ region: 'cn-north-1' }),
@@ -229,6 +232,7 @@ describe('LmChatAwsBedrock', () => {
 
 			expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
 				'https://bedrock-runtime.us-gov-west-1.amazonaws.com',
+				keepAliveAgentOptions,
 			);
 			expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
 				expect.objectContaining({ region: 'us-gov-west-1' }),
@@ -419,11 +423,12 @@ describe('LmChatAwsBedrock', () => {
 				expect(clientConfig).not.toHaveProperty('endpoint');
 				expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
 					'https://bedrock-runtime.eu-west-3.amazonaws.com',
+					keepAliveAgentOptions,
 				);
 			});
 		});
 
-		describe('request handler (timeout & proxy)', () => {
+		describe('request handler (keepalive, timeout & proxy)', () => {
 			const setNodeParameters = (options: Record<string, unknown>) => {
 				mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
 					if (paramName === 'model') return 'amazon.nova-pro-v1:0';
@@ -432,13 +437,15 @@ describe('LmChatAwsBedrock', () => {
 				});
 			};
 
-			it('creates a handler with requestTimeout when timeout is set and no proxy is configured', async () => {
+			it('creates a keepalive handler with requestTimeout when timeout is set and no proxy is configured', async () => {
 				const ctx = setupMockContext();
 				setNodeParameters({ timeout: 120000 });
 
 				await node.supplyData.call(ctx, 0);
 
 				expect(MockedNodeHttpHandler).toHaveBeenCalledWith({
+					httpAgent: keepAliveAgentOptions,
+					httpsAgent: keepAliveAgentOptions,
 					requestTimeout: 120000,
 					throwOnRequestTimeout: true,
 				});
@@ -463,6 +470,20 @@ describe('LmChatAwsBedrock', () => {
 				});
 			});
 
+			it('requests keepalive on the proxy agent', async () => {
+				const ctx = setupMockContext();
+				const fakeAgent = { fake: 'agent' } as unknown as ReturnType<typeof getNodeProxyAgent>;
+				mockedGetNodeProxyAgent.mockReturnValue(fakeAgent);
+				setNodeParameters({});
+
+				await node.supplyData.call(ctx, 0);
+
+				expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
+					'https://bedrock-runtime.us-east-1.amazonaws.com',
+					keepAliveAgentOptions,
+				);
+			});
+
 			it('creates a proxy-only handler without timeout keys when timeout is unset', async () => {
 				const ctx = setupMockContext();
 				const fakeAgent = { fake: 'agent' } as unknown as ReturnType<typeof getNodeProxyAgent>;
@@ -478,15 +499,22 @@ describe('LmChatAwsBedrock', () => {
 				expect(handlerOptions).not.toHaveProperty('throwOnRequestTimeout');
 			});
 
-			it('creates no handler at all when neither timeout nor proxy is configured', async () => {
+			it('installs a keepalive handler even when neither timeout nor proxy is configured', async () => {
 				const ctx = setupMockContext();
 				setNodeParameters({});
 
 				await node.supplyData.call(ctx, 0);
 
-				expect(MockedNodeHttpHandler).not.toHaveBeenCalled();
-				const clientConfig = MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0] ?? {};
-				expect(clientConfig).not.toHaveProperty('requestHandler');
+				expect(MockedNodeHttpHandler).toHaveBeenCalledTimes(1);
+				const handlerOptions = MockedNodeHttpHandler.mock.calls.at(-1)?.[0] ?? {};
+				expect(handlerOptions).toEqual({
+					httpAgent: keepAliveAgentOptions,
+					httpsAgent: keepAliveAgentOptions,
+				});
+				expect(handlerOptions).not.toHaveProperty('requestTimeout');
+				expect(handlerOptions).not.toHaveProperty('throwOnRequestTimeout');
+				const clientConfig = MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0];
+				expect(clientConfig?.requestHandler).toBe(MockedNodeHttpHandler.mock.instances.at(-1));
 			});
 
 			it('passes timeout 0 through as a disabled requestTimeout', async () => {
@@ -495,10 +523,12 @@ describe('LmChatAwsBedrock', () => {
 
 				await node.supplyData.call(ctx, 0);
 
-				expect(MockedNodeHttpHandler).toHaveBeenCalledWith({
-					requestTimeout: 0,
-					throwOnRequestTimeout: true,
-				});
+				expect(MockedNodeHttpHandler).toHaveBeenCalledWith(
+					expect.objectContaining({
+						requestTimeout: 0,
+						throwOnRequestTimeout: true,
+					}),
+				);
 			});
 		});
 
@@ -557,6 +587,7 @@ describe('LmChatAwsBedrock', () => {
 
 				expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
 					'https://bedrock-runtime.eu-central-1.amazonaws.com',
+					keepAliveAgentOptions,
 				);
 			});
 		});
@@ -582,7 +613,7 @@ describe('LmChatAwsBedrock', () => {
 				await node.supplyData.call(ctx, 0);
 
 				const expected = 'https://vpce-abc.bedrock-runtime.us-east-1.vpce.amazonaws.com';
-				expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(expected);
+				expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(expected, keepAliveAgentOptions);
 				expect(MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0]?.endpoint).toBe(expected);
 			});
 
@@ -595,6 +626,7 @@ describe('LmChatAwsBedrock', () => {
 				expect(MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0]?.endpoint).toBeUndefined();
 				expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
 					'https://bedrock-runtime.us-east-1.amazonaws.com',
+					keepAliveAgentOptions,
 				);
 			});
 

--- a/packages/@n8n/nodes-langchain/utils/aws/createBedrockRuntimeClient.ts
+++ b/packages/@n8n/nodes-langchain/utils/aws/createBedrockRuntimeClient.ts
@@ -11,12 +11,21 @@ import {
 	type AWSRegion,
 } from 'n8n-nodes-base/aws-credentials';
 
+// Arm TCP keepalive well before common NAT/LB idle timeouts reap the socket
+// (Azure SNAT defaults to 4 minutes); probes keep the flow alive during long generations.
+const KEEP_ALIVE_AGENT_OPTIONS = { keepAlive: true, keepAliveMsecs: 30_000 };
+
 /**
  * Builds a Bedrock runtime SDK client shared by the chat and embeddings nodes.
  * The runtime plane bypasses n8n's credential `authenticate()` (the SDK does its own
  * signing/transport), so the endpoint override is injected into the client config here.
  * Retries (`maxRetries`) and request `timeout` are also applied on the SDK client because
  * ChatBedrockConverse calls `client.send()` directly, bypassing LangChain's retrying AsyncCaller.
+ *
+ * The HTTP/1.1 `NodeHttpHandler` is always installed, replacing the Bedrock SDK's default
+ * HTTP/2 handler: the HTTP/2 handler never arms TCP keepalive (and sends no PING frames),
+ * so a response idle longer than an on-path NAT/LB idle timeout is silently blackholed and
+ * the node hangs. The HTTP/1.1 handler arms keepalive per request from the agent's settings.
  */
 export function createBedrockRuntimeClient(params: {
 	region: AWSRegion;
@@ -31,7 +40,7 @@ export function createBedrockRuntimeClient(params: {
 	const endpoint = bedrockRuntimeEndpoint
 		? validateBedrockEndpointOverride(bedrockRuntimeEndpoint, region)
 		: `https://bedrock-runtime.${region}.${getAwsDomain(region)}`;
-	const proxyAgent = getNodeProxyAgent(endpoint);
+	const proxyAgent = getNodeProxyAgent(endpoint, KEEP_ALIVE_AGENT_OPTIONS);
 
 	const clientConfig: BedrockRuntimeClientConfig = {
 		region,
@@ -43,11 +52,10 @@ export function createBedrockRuntimeClient(params: {
 	// maxAttempts counts the initial try, so it's maxRetries + 1.
 	if (maxRetries !== undefined) clientConfig.maxAttempts = maxRetries + 1;
 
-	const requestHandlerOptions: NodeHttpHandlerOptions = {};
-	if (proxyAgent) {
-		requestHandlerOptions.httpAgent = proxyAgent;
-		requestHandlerOptions.httpsAgent = proxyAgent;
-	}
+	const requestHandlerOptions: NodeHttpHandlerOptions = {
+		httpAgent: proxyAgent ?? KEEP_ALIVE_AGENT_OPTIONS,
+		httpsAgent: proxyAgent ?? KEEP_ALIVE_AGENT_OPTIONS,
+	};
 	if (timeout !== undefined) {
 		requestHandlerOptions.requestTimeout = timeout;
 		// requestTimeout alone is a no-op. When the timeout is exceeded,
@@ -55,9 +63,7 @@ export function createBedrockRuntimeClient(params: {
 		// only this flag makes it destroy the request and reject with a TimeoutError.
 		requestHandlerOptions.throwOnRequestTimeout = true;
 	}
-	if (Object.keys(requestHandlerOptions).length > 0) {
-		clientConfig.requestHandler = new NodeHttpHandler(requestHandlerOptions);
-	}
+	clientConfig.requestHandler = new NodeHttpHandler(requestHandlerOptions);
 
 	return new BedrockRuntimeClient(clientConfig);
 }


### PR DESCRIPTION
## Summary

The AWS Bedrock Chat Model and Embeddings nodes could hang indefinitely when a stateful NAT or load balancer on the egress path reaped an idle connection mid-generation (Azure's SNAT default idle timeout is 4 minutes, shorter than many long generations). The response was silently blackholed and the node waited forever with no error.

Root cause is a handler mismatch in the AWS SDK: the Bedrock Runtime client defaults to the SDK's HTTP/2 handler, but the SDK's TCP keepalive logic exists only in the HTTP/1.1 handler (`NodeHttpHandler`). The HTTP/2 handler opens the session with no socket options and sends no PING frames, so no keepalive is ever armed — pod-level `tcp_keepalive_*` sysctls have no effect either, because nothing arms keepalive to inherit them.

This PR makes `createBedrockRuntimeClient` (shared by both nodes) always install the HTTP/1.1 `NodeHttpHandler` with keepalive-enabled agents (`keepAlive: true, keepAliveMsecs: 30_000`), replacing the SDK's default HTTP/2 handler in every configuration:

- **Default (no proxy, no Timeout option):** previously HTTP/2 with no keepalive — the hang. Now HTTP/1.1 with keepalive probes every ~30s, well under common NAT/LB idle timeouts.
- **Timeout option set:** previously this incidentally switched to HTTP/1.1 (with keepalive) as a side effect. That switch is now deliberate and consistent.
- **Proxy configured:** previously HTTP/1.1 but the proxy agent was constructed without `keepAlive`, so keepalive was still never armed. `getNodeProxyAgent` now accepts optional agent options (backward-compatible; other callers unchanged) and the Bedrock client passes the keepalive settings through.

Switching Bedrock from HTTP/2 to HTTP/1.1 costs nothing in practice: the SDK's default HTTP/2 config uses `disableConcurrentStreams: true` (one session per request, no multiplexing), and HTTP/1.1 is what the AWS CLI/botocore use against Bedrock. The HTTP/1.1 agent additionally pools keepalive sockets, so connections are reused more, not less.

Verified against `@aws-sdk/client-bedrock-runtime@3.938.0` / `@smithy/node-http-handler@4.5.0` (the versions in our lockfile), and matches an enterprise customer's reproduction on AKS where the identical call hung with keepalive off and completed (15m+ generation) with keepalive on.

## How to test

Unit tests cover the handler matrix for both nodes (default, timeout, proxy, timeout+proxy) plus the agent-options passthrough in `@n8n/ai-utilities`:

```bash
pushd packages/@n8n/nodes-langchain
pnpm vitest run nodes/llms/LmChatAwsBedrock nodes/embeddings/EmbeddingsAwsBedrock utils/aws/test
popd
pushd packages/@n8n/ai-utilities
pnpm vitest run src/__tests__/utils/http-proxy-agent.test.ts
popd
```

To verify the transport change live: run a workflow with an AI Agent using the Bedrock Chat Model, and while a generation is in flight inspect the socket with `ss -tnope 'dport = :443'` — the connection to `bedrock-runtime.<region>.amazonaws.com` now shows a `timer:(keepalive,...)` entry (previously absent). Long generations complete even behind a NAT/LB with a short idle timeout (e.g. Azure SNAT at 4 minutes).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-284

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35323">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

