### PR TITLE
refactor(editor): Single-source CloudPlanState (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -877,13 +877,6 @@ export type NodeAuthenticationOption = {
 	displayOptions?: IDisplayOptions;
 };
 
-export interface CloudPlanState {
-	initialized: boolean;
-	data: Cloud.PlanData | null;
-	usage: InstanceUsage | null;
-	loadingPlan: boolean;
-}
-
 export type CloudPlanAndUsageData = Cloud.PlanData & { usage: InstanceUsage };
 
 export type CloudUpdateLinkSourceType =

--- a/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.test.ts
@@ -9,7 +9,7 @@ import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHe
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useCloudPlanStore } from '@/app/stores/cloudPlan.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
-import type { CloudPlanState } from '@/Interface';
+import type { CloudPlanState } from '@n8n/stores/cloudPlan.store';
 
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
 import { AGENTS_MODULE_NAME } from '@/features/agents/constants';


### PR DESCRIPTION
## Summary

`CloudPlanState` was declared twice in the frontend under one name, with no relationship between the two declarations and nothing preventing them from diverging — same defect family as #35172 (`PERSONALIZATION_MODAL_KEY`) and #35168 (`IInviteResponse`).

**Verdict first: genuine duplicate, not a colliding name.** Established on master before touching anything:

| | Declaration |
|---|---|
| Canonical | `@n8n/stores/src/cloudPlan.store.ts:15` |
| Duplicate | `editor-ui/src/Interface.ts:880` |

The two bodies were byte-for-byte identical (`initialized`, `data`, `usage`, `loadingPlan`), and both resolved `Cloud.PlanData` / `InstanceUsage` from the *same* specifier — `@n8n/rest-api-client/api/cloudPlans`. There was no local view to preserve, so this is the delete-and-repoint case rather than the rename case.

**Why it mattered.** The duplicate was the one consumers actually resolved, so changing the package type's shape would have left the local copy silently compiling against the old contract. Nothing tested the two against each other.

The change is the declaration and its importers, nothing more:

- Deleted `export interface CloudPlanState` from `Interface.ts`. The `Cloud` / `InstanceUsage` import on line 43 stays — `CloudPlanAndUsageData`, immediately below, still uses both.
- Repointed the single live importer, `useGlobalEntityCreation.test.ts`, to `@n8n/stores/cloudPlan.store`. That matches the dominant idiom in `editor-ui` (240+ imports of `@n8n/stores/<name>.store`).

**Deliberately left alone:** the dead `export type { CloudPlanState }` re-export in the `app/stores/cloudPlan.store.ts` shim, and that file's `useCloudPlanStore` re-export — both belong to the shim retirements, and repointing them here would overlap those diffs. The test still imports `useCloudPlanStore` from the shim for exactly that reason; only the *type* import moved.

Type-only change. No runtime code moves, no behavior change. Net −7 lines across 2 files.

## How to test

Static change, nothing to click through — verification is the type/lint/test gate:

```bash
pnpm --filter "n8n-editor-ui^..." build
cd packages/frontend/editor-ui
pnpm typecheck
pnpm lint
pnpm test src/app/composables/useGlobalEntityCreation.test.ts
```

Local results on this branch:

- `pnpm typecheck` — clean (exit 0). This is the real gate: it covers all of `editor-ui`, so any file still resolving `CloudPlanState` through the deleted declaration would have failed here.
- `pnpm lint` — 0 errors on the changed files (`oxlint` exit 0, `eslint --quiet` exit 0). The two `Interface.ts` warnings visible without `--quiet` are pre-existing, at lines 104 and 332, unrelated to this edit. `biome` clean via pre-commit.
- `pnpm test src/app/composables/useGlobalEntityCreation.test.ts` — 34/34 passing.
- Post-change grep: the only remaining `CloudPlanState` references are the canonical declaration plus its two internal uses in `@n8n/stores`, and the shim's dead re-export left for the shim retirement.

## Related Linear tickets, Github issues, and Community forum posts

Continues the single-sourcing wave: #35172, #35168, #35182.

`Interface.ts` is a hot barrel file with other in-flight wave work against it, so this deletion may need a trivial rebase. The diff was kept to the declaration and its one importer for that reason.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- N/A — internal type deduplication, no user-facing surface. -->
- [x] Tests included. <!-- No new tests: type-only change with no behavior change. The existing useGlobalEntityCreation suite consumes the repointed type and passes; typecheck is the gate for the deletion. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35328">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

