### PR TITLE
Add per-tool MCP call attribution to build evaluations

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/ARCHITECTURE.md
+++ b/packages/@n8n/instance-ai/evaluations/ARCHITECTURE.md
@@ -78,8 +78,8 @@ split them out of the old `runner.ts` monolith):
   `### Instance AI Workflow Eval` prefix.
 - **LangSmith feedback keys** (`scenario_pass`, `failure_category`,
   `evals.workflows.*`, `pass_at_k`, `pass_hat_k` — plus `build_cost_usd` /
-  `build_turns` on `--build-via-mcp` rows) and the traced span names
-  feed the LangSmith→BigQuery analytics.
+  `build_turns` / `build_tool_errors` on `--build-via-mcp` rows) and the
+  traced span names feed the LangSmith→BigQuery analytics.
 - **`pnpm eval:*` script names** are invoked by CI workflows and
   `run-eval-lanes.sh`.
 

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -454,7 +454,11 @@ How it differs from the manifest flow:
   `buildToolCallsPerRun` per case and `summary.mcpBuild.toolCalls` run-wide in
   `eval-results.json` (plus `build_tool_calls` in LangSmith experiment
   metadata) — answering *what the turns were spent on*, including the partial
-  stream of a timed-out build. For builder cost comparisons across any runs
+  stream of a timed-out build. Errored calls are additionally recorded with
+  their (truncated) error text: `buildToolErrorsPerRun` per case, per-tool
+  error counts in `summary.mcpBuild.toolErrors` and LangSmith
+  `build_tool_errors` experiment metadata, and a `build_tool_errors` count as
+  row feedback — the wasted-turns signal. For builder cost comparisons across any runs
   (MCP vs AIA, builder-model A/Bs), the un-wired helper
   `evaluations/cli/build-cost-report.ts` (run via `pnpm tsx`, one `--results`
   per arm) auto-detects each arm's cost source — these persisted fields, or

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -446,7 +446,15 @@ How it differs from the manifest flow:
   attempts — failed attempts cost money too) land as `build_cost_usd` /
   `build_turns` row feedback in LangSmith and as `buildCostUsdPerRun` /
   `buildTurnsPerRun` per case in `eval-results.json`, alongside the run-level
-  `summary.mcpBuild` totals. For builder cost comparisons across any runs
+  `summary.mcpBuild` totals.
+- **Per-tool turn attribution.** Builds run `claude` with
+  `--output-format stream-json`, so the per-attempt log under
+  `mcp-build-logs/` is the verbatim NDJSON event stream (`.jsonl`), and each
+  build's `tool_use` calls are counted per MCP tool. The counts land as
+  `buildToolCallsPerRun` per case and `summary.mcpBuild.toolCalls` run-wide in
+  `eval-results.json` (plus `build_tool_calls` in LangSmith experiment
+  metadata) — answering *what the turns were spent on*, including the partial
+  stream of a timed-out build. For builder cost comparisons across any runs
   (MCP vs AIA, builder-model A/Bs), the un-wired helper
   `evaluations/cli/build-cost-report.ts` (run via `pnpm tsx`, one `--results`
   per arm) auto-detects each arm's cost source — these persisted fields, or

--- a/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
@@ -140,7 +140,11 @@ describe('createCasePipeline', () => {
 			build: okBuild(),
 			lane,
 			buildDurationMs: 42,
-			buildSpend: { costUsd: 0.42, turns: 6 },
+			buildSpend: {
+				costUsd: 0.42,
+				turns: 6,
+				toolCalls: { 'mcp__n8n-local__create_workflow_from_code': 2 },
+			},
 		};
 		const orchestrator = makeOrchestrator(cached);
 		const pipeline = createCasePipeline(makeDeps(orchestrator));
@@ -158,6 +162,7 @@ describe('createCasePipeline', () => {
 			// `claude` spend (--build-via-mcp) rides on every row of the case's build.
 			buildCostUsd: 0.42,
 			buildTurns: 6,
+			buildToolCalls: { 'mcp__n8n-local__create_workflow_from_code': 2 },
 		});
 		// Single-scenario case → this was the last row → artifacts deleted eagerly.
 		expect(vi.mocked(cleanupBuild)).toHaveBeenCalledTimes(1);

--- a/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
@@ -144,6 +144,9 @@ describe('createCasePipeline', () => {
 				costUsd: 0.42,
 				turns: 6,
 				toolCalls: { 'mcp__n8n-local__create_workflow_from_code': 2 },
+				toolErrors: [
+					{ tool: 'mcp__n8n-local__create_workflow_from_code', message: 'validation failed' },
+				],
 			},
 		};
 		const orchestrator = makeOrchestrator(cached);
@@ -163,6 +166,9 @@ describe('createCasePipeline', () => {
 			buildCostUsd: 0.42,
 			buildTurns: 6,
 			buildToolCalls: { 'mcp__n8n-local__create_workflow_from_code': 2 },
+			buildToolErrors: [
+				{ tool: 'mcp__n8n-local__create_workflow_from_code', message: 'validation failed' },
+			],
 		});
 		// Single-scenario case → this was the last row → artifacts deleted eagerly.
 		expect(vi.mocked(cleanupBuild)).toHaveBeenCalledTimes(1);

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -121,6 +121,7 @@ interface DispatcherView {
 		}> | null>;
 		buildCostUsdPerRun?: Array<number | null>;
 		buildTurnsPerRun?: Array<number | null>;
+		buildToolCallsPerRun?: Array<Record<string, number> | null>;
 		transcriptPerRun: Array<TranscriptTurn[] | null>;
 		buildErrorPerRun: Array<string | null>;
 		scenarios: Array<{
@@ -187,6 +188,7 @@ describe('eval-results.json — dispatcher contract', () => {
 		// recorded `claude` spend, so non-MCP dispatcher output is unchanged.
 		expect(tc).not.toHaveProperty('buildCostUsdPerRun');
 		expect(tc).not.toHaveProperty('buildTurnsPerRun');
+		expect(tc).not.toHaveProperty('buildToolCallsPerRun');
 
 		// Per-iteration conversation transcript — one entry per run, null when
 		// the iteration captured none. A present transcript keeps the full
@@ -227,7 +229,17 @@ describe('eval-results.json — dispatcher contract', () => {
 
 	it('serializes per-iteration `claude` build spend when a run recorded it', () => {
 		const evaluation = aggregateResults(
-			[[{ ...iteration1(), buildCostUsd: 0.31, buildTurns: 5 }], [iteration2()]],
+			[
+				[
+					{
+						...iteration1(),
+						buildCostUsd: 0.31,
+						buildTurns: 5,
+						buildToolCalls: { 'mcp__n8n-local__search_nodes': 3 },
+					},
+				],
+				[iteration2()],
+			],
 			2,
 		);
 		const dir = mkdtempSync(join(tmpdir(), 'eval-results-contract-'));
@@ -247,5 +259,6 @@ describe('eval-results.json — dispatcher contract', () => {
 		const tc = report.testCases[0];
 		expect(tc.buildCostUsdPerRun).toEqual([0.31, null]);
 		expect(tc.buildTurnsPerRun).toEqual([5, null]);
+		expect(tc.buildToolCallsPerRun).toEqual([{ 'mcp__n8n-local__search_nodes': 3 }, null]);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/eval-results-dispatcher-contract.test.ts
@@ -122,6 +122,7 @@ interface DispatcherView {
 		buildCostUsdPerRun?: Array<number | null>;
 		buildTurnsPerRun?: Array<number | null>;
 		buildToolCallsPerRun?: Array<Record<string, number> | null>;
+		buildToolErrorsPerRun?: Array<Array<{ tool: string; message: string }> | null>;
 		transcriptPerRun: Array<TranscriptTurn[] | null>;
 		buildErrorPerRun: Array<string | null>;
 		scenarios: Array<{
@@ -189,6 +190,7 @@ describe('eval-results.json — dispatcher contract', () => {
 		expect(tc).not.toHaveProperty('buildCostUsdPerRun');
 		expect(tc).not.toHaveProperty('buildTurnsPerRun');
 		expect(tc).not.toHaveProperty('buildToolCallsPerRun');
+		expect(tc).not.toHaveProperty('buildToolErrorsPerRun');
 
 		// Per-iteration conversation transcript — one entry per run, null when
 		// the iteration captured none. A present transcript keeps the full
@@ -236,6 +238,7 @@ describe('eval-results.json — dispatcher contract', () => {
 						buildCostUsd: 0.31,
 						buildTurns: 5,
 						buildToolCalls: { 'mcp__n8n-local__search_nodes': 3 },
+						buildToolErrors: [{ tool: 'mcp__n8n-local__search_nodes', message: 'timed out' }],
 					},
 				],
 				[iteration2()],
@@ -260,5 +263,9 @@ describe('eval-results.json — dispatcher contract', () => {
 		expect(tc.buildCostUsdPerRun).toEqual([0.31, null]);
 		expect(tc.buildTurnsPerRun).toEqual([5, null]);
 		expect(tc.buildToolCallsPerRun).toEqual([{ 'mcp__n8n-local__search_nodes': 3 }, null]);
+		expect(tc.buildToolErrorsPerRun).toEqual([
+			[{ tool: 'mcp__n8n-local__search_nodes', message: 'timed out' }],
+			null,
+		]);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder-timeout.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder-timeout.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
-import { mkdtempSync } from 'fs';
+import { mkdtempSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -41,9 +41,30 @@ describe('buildWorkflowViaMcp — build timeout', () => {
 	});
 
 	it('kills a hung build at the timeout, reports it, and does NOT retry', async () => {
-		// Child never emits close on its own → only the timeout can end it.
+		// Child never emits close on its own → only the timeout can end it. It
+		// gets one tool call into its event stream before hanging.
 		const child = makeFakeChild();
 		vi.mocked(spawn).mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+		setImmediate(() => {
+			child.stdout.emit(
+				'data',
+				Buffer.from(
+					JSON.stringify({
+						type: 'assistant',
+						message: {
+							content: [
+								{
+									type: 'tool_use',
+									id: 'toolu_0',
+									name: 'mcp__n8n-local__search_nodes',
+									input: {},
+								},
+							],
+						},
+					}) + '\n',
+				),
+			);
+		});
 
 		const result = await buildWorkflowViaMcp({
 			conversation: [{ role: 'user', text: 'build a contact form' }],
@@ -60,6 +81,11 @@ describe('buildWorkflowViaMcp — build timeout', () => {
 		expect(child.kill).toHaveBeenCalledWith('SIGTERM');
 		// maxAttempts is 3, but a timeout must not retry — exactly one spawn.
 		expect(vi.mocked(spawn)).toHaveBeenCalledTimes(1);
+		// The partial stream still attributes what the hung build was doing…
+		expect(result.toolCalls).toEqual({ 'mcp__n8n-local__search_nodes': 1 });
+		// …and the persisted stream ends with the timeout marker line.
+		const logged = readFileSync(String(result.logFile), 'utf-8');
+		expect(logged.trimEnd().split('\n').at(-1)).toBe('{"subtype":"timeout"}');
 	});
 
 	it('does not arm a killer when buildTimeoutMs is 0 (disabled)', async () => {
@@ -69,7 +95,13 @@ describe('buildWorkflowViaMcp — build timeout', () => {
 		setImmediate(() => {
 			child.stdout.emit(
 				'data',
-				Buffer.from(JSON.stringify({ result: 'created\nWORKFLOW_ID=W1', subtype: 'success' })),
+				Buffer.from(
+					JSON.stringify({
+						type: 'result',
+						result: 'created\nWORKFLOW_ID=W1',
+						subtype: 'success',
+					}) + '\n',
+				),
 			);
 			child.emit('close', 0);
 		});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
@@ -9,6 +9,8 @@ import {
 	buildPromptFromConversation,
 	buildWorkflowViaMcp,
 	MCP_BUILD_KEY_SUPPORT,
+	mergeToolCalls,
+	parseClaudeStream,
 	sanitizeServerName,
 	stageLaneMcpConfig,
 	tailWorkflowId,
@@ -171,6 +173,98 @@ describe('unsupportedMcpBuildSetupFields', () => {
 	});
 });
 
+// --- stream-json fixtures: one NDJSON line per emitted `claude` event ---
+
+/** The stream's trailing `result` event (session totals + final text). */
+const resultLine = (session: Record<string, unknown>): string =>
+	JSON.stringify({ type: 'result', ...session });
+
+/** An assistant turn spending itself on `tool_use` calls to the named tools. */
+const assistantLine = (...toolNames: string[]): string =>
+	JSON.stringify({
+		type: 'assistant',
+		message: {
+			content: toolNames.map((name, i) => ({
+				type: 'tool_use',
+				id: `toolu_${String(i)}`,
+				name,
+				input: {},
+			})),
+		},
+	});
+
+const stream = (...lines: string[]): string => lines.join('\n') + '\n';
+
+describe('parseClaudeStream', () => {
+	it('extracts the session from the trailing result event', () => {
+		const { session } = parseClaudeStream(
+			stream(
+				assistantLine('mcp__n8n-local__search_nodes'),
+				resultLine({ result: 'done\nWORKFLOW_ID=wf1', num_turns: 3, subtype: 'success' }),
+			),
+		);
+		expect(session?.result).toBe('done\nWORKFLOW_ID=wf1');
+		expect(session?.num_turns).toBe(3);
+		expect(session?.subtype).toBe('success');
+	});
+
+	it('counts tool_use blocks per tool across assistant turns', () => {
+		const { toolCalls } = parseClaudeStream(
+			stream(
+				assistantLine('mcp__n8n-local__search_nodes'),
+				assistantLine('mcp__n8n-local__search_nodes', 'mcp__n8n-local__get_node_details'),
+				assistantLine('mcp__n8n-local__create_workflow_from_code'),
+				resultLine({ result: 'done' }),
+			),
+		);
+		expect(toolCalls).toEqual({
+			'mcp__n8n-local__search_nodes': 2,
+			'mcp__n8n-local__get_node_details': 1,
+			'mcp__n8n-local__create_workflow_from_code': 1,
+		});
+	});
+
+	it('ignores text-only assistant turns and non-assistant events', () => {
+		const textTurn = JSON.stringify({
+			type: 'assistant',
+			message: { content: [{ type: 'text', text: 'thinking about it' }] },
+		});
+		const userEvent = JSON.stringify({
+			type: 'user',
+			message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_0', content: 'ok' }] },
+		});
+		const initEvent = JSON.stringify({ type: 'system', subtype: 'init' });
+		const { session, toolCalls } = parseClaudeStream(
+			stream(initEvent, textTurn, userEvent, resultLine({ result: 'done' })),
+		);
+		expect(toolCalls).toEqual({});
+		expect(session?.result).toBe('done');
+	});
+
+	it('yields partial attribution from a truncated stream (no result event)', () => {
+		const truncated =
+			stream(assistantLine('mcp__n8n-local__create_workflow_from_code')) +
+			'{"type":"assistant","message":{"conte'; // cut mid-write by a kill
+		const { session, toolCalls } = parseClaudeStream(truncated);
+		expect(session).toBeUndefined();
+		expect(toolCalls).toEqual({ 'mcp__n8n-local__create_workflow_from_code': 1 });
+	});
+
+	it('returns no session for empty or non-JSON output', () => {
+		expect(parseClaudeStream('').session).toBeUndefined();
+		expect(parseClaudeStream('claude: command failed\n').session).toBeUndefined();
+	});
+});
+
+describe('mergeToolCalls', () => {
+	it('accumulates counts across records', () => {
+		const into = { a: 1 };
+		mergeToolCalls(into, { a: 2, b: 1 });
+		mergeToolCalls(into, { b: 1 });
+		expect(into).toEqual({ a: 3, b: 2 });
+	});
+});
+
 /** Minimal stand-in for the `claude` child process: event surface only.
  *  `pid === undefined` mirrors Node's contract for a process that failed
  *  to spawn (the 'error' → 'close' sequence still fires). */
@@ -243,7 +337,10 @@ describe('buildWorkflowViaMcp', () => {
 		spawnReturning(() => {
 			const child = new FakeChild(1234);
 			setImmediate(() => {
-				child.stdout.emit('data', Buffer.from('{"result":"built something, forgot the id"}'));
+				child.stdout.emit(
+					'data',
+					Buffer.from(stream(resultLine({ result: 'built something, forgot the id' }))),
+				);
 				child.emit('close', 0, null);
 			});
 			return child;
@@ -256,14 +353,16 @@ describe('buildWorkflowViaMcp', () => {
 		expect(vi.mocked(spawn)).toHaveBeenCalledTimes(3);
 	});
 
-	it('returns the workflow id from a successful first attempt', async () => {
+	it('returns the workflow id and per-tool attribution from a successful first attempt', async () => {
+		const events = stream(
+			assistantLine('mcp__n8n-local__search_nodes'),
+			assistantLine('mcp__n8n-local__create_workflow_from_code'),
+			resultLine({ result: 'done\nWORKFLOW_ID=wf123' }),
+		);
 		spawnReturning(() => {
 			const child = new FakeChild(1234);
 			setImmediate(() => {
-				child.stdout.emit(
-					'data',
-					Buffer.from(JSON.stringify({ result: 'done\nWORKFLOW_ID=wf123' })),
-				);
+				child.stdout.emit('data', Buffer.from(events));
 				child.emit('close', 0, null);
 			});
 			return child;
@@ -273,30 +372,48 @@ describe('buildWorkflowViaMcp', () => {
 
 		expect(result.workflowId).toBe('wf123');
 		expect(result.failureReason).toBeUndefined();
+		expect(result.toolCalls).toEqual({
+			'mcp__n8n-local__search_nodes': 1,
+			'mcp__n8n-local__create_workflow_from_code': 1,
+		});
 		expect(vi.mocked(spawn)).toHaveBeenCalledTimes(1);
+		// The stream flag pair is what makes the persisted log per-event.
+		const claudeArgs = vi.mocked(spawn).mock.calls[0][1] as string[];
+		expect(claudeArgs).toContain('stream-json');
+		expect(claudeArgs).toContain('--verbose');
+		// The event stream is persisted verbatim, as NDJSON.
+		expect(result.logFile).toMatch(/\.jsonl$/);
+		expect(readFileSync(String(result.logFile), 'utf-8')).toBe(events);
 	});
 
-	it('sums cost, turns and duration across attempts — failed attempts cost money too', async () => {
+	it('sums cost, turns, duration and tool calls across attempts — failed attempts cost money too', async () => {
 		let call = 0;
 		spawnReturning(() => {
 			const child = new FakeChild(1234);
 			call++;
-			const session =
+			const events =
 				call === 1
-					? {
-							result: 'built something, forgot the id',
-							total_cost_usd: 0.1,
-							num_turns: 2,
-							duration_ms: 1000,
-						}
-					: {
-							result: 'done\nWORKFLOW_ID=wf42',
-							total_cost_usd: 0.25,
-							num_turns: 5,
-							duration_ms: 3000,
-						};
+					? stream(
+							assistantLine('mcp__n8n-local__create_workflow_from_code'),
+							resultLine({
+								result: 'built something, forgot the id',
+								total_cost_usd: 0.1,
+								num_turns: 2,
+								duration_ms: 1000,
+							}),
+						)
+					: stream(
+							assistantLine('mcp__n8n-local__search_nodes'),
+							assistantLine('mcp__n8n-local__create_workflow_from_code'),
+							resultLine({
+								result: 'done\nWORKFLOW_ID=wf42',
+								total_cost_usd: 0.25,
+								num_turns: 5,
+								duration_ms: 3000,
+							}),
+						);
 			setImmediate(() => {
-				child.stdout.emit('data', Buffer.from(JSON.stringify(session)));
+				child.stdout.emit('data', Buffer.from(events));
 				child.emit('close', 0, null);
 			});
 			return child;
@@ -308,6 +425,10 @@ describe('buildWorkflowViaMcp', () => {
 		expect(result.cost).toBeCloseTo(0.35);
 		expect(result.turns).toBe(7);
 		expect(result.durationMs).toBe(4000);
+		expect(result.toolCalls).toEqual({
+			'mcp__n8n-local__create_workflow_from_code': 2,
+			'mcp__n8n-local__search_nodes': 1,
+		});
 		expect(vi.mocked(spawn)).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/mcp-builder.test.ts
@@ -14,6 +14,7 @@ import {
 	sanitizeServerName,
 	stageLaneMcpConfig,
 	tailWorkflowId,
+	TOOL_ERROR_MESSAGE_CAP,
 	uniqueProjectScopes,
 	unsupportedMcpBuildSetupFields,
 } from '../cli/mcp-builder';
@@ -193,6 +194,23 @@ const assistantLine = (...toolNames: string[]): string =>
 		},
 	});
 
+/** A single-call assistant turn with an explicit `tool_use` id, for pairing
+ *  with toolResultLine in error-correlation fixtures. */
+const toolUseLine = (id: string, name: string): string =>
+	JSON.stringify({
+		type: 'assistant',
+		message: { content: [{ type: 'tool_use', id, name, input: {} }] },
+	});
+
+/** The `user` event closing a `tool_use` call, optionally as an error. */
+const toolResultLine = (toolUseId: string, content: unknown, isError = false): string =>
+	JSON.stringify({
+		type: 'user',
+		message: {
+			content: [{ type: 'tool_result', tool_use_id: toolUseId, is_error: isError, content }],
+		},
+	});
+
 const stream = (...lines: string[]): string => lines.join('\n') + '\n';
 
 describe('parseClaudeStream', () => {
@@ -253,6 +271,61 @@ describe('parseClaudeStream', () => {
 	it('returns no session for empty or non-JSON output', () => {
 		expect(parseClaudeStream('').session).toBeUndefined();
 		expect(parseClaudeStream('claude: command failed\n').session).toBeUndefined();
+	});
+
+	it('records errored tool calls with the error message, matched by tool_use_id', () => {
+		const { toolCalls, toolErrors } = parseClaudeStream(
+			stream(
+				toolUseLine('toolu_a', 'mcp__n8n-local__create_workflow_from_code'),
+				toolResultLine('toolu_a', 'Invalid workflow: node "Slack" is missing credentials', true),
+				toolUseLine('toolu_b', 'mcp__n8n-local__create_workflow_from_code'),
+				toolResultLine('toolu_b', 'Created workflow wf1'),
+				resultLine({ result: 'done\nWORKFLOW_ID=wf1' }),
+			),
+		);
+		// Errored calls still count as calls — errors are the failure subset.
+		expect(toolCalls).toEqual({ 'mcp__n8n-local__create_workflow_from_code': 2 });
+		expect(toolErrors).toEqual([
+			{
+				tool: 'mcp__n8n-local__create_workflow_from_code',
+				message: 'Invalid workflow: node "Slack" is missing credentials',
+			},
+		]);
+	});
+
+	it('flattens array-form tool_result content into the error message', () => {
+		const { toolErrors } = parseClaudeStream(
+			stream(
+				toolUseLine('toolu_a', 'mcp__n8n-local__search_nodes'),
+				toolResultLine(
+					'toolu_a',
+					[
+						{ type: 'text', text: 'MCP error -32603:' },
+						{ type: 'text', text: 'request timed out' },
+					],
+					true,
+				),
+			),
+		);
+		expect(toolErrors).toEqual([
+			{ tool: 'mcp__n8n-local__search_nodes', message: 'MCP error -32603:\nrequest timed out' },
+		]);
+	});
+
+	it('caps recorded error messages at TOOL_ERROR_MESSAGE_CAP', () => {
+		const { toolErrors } = parseClaudeStream(
+			stream(
+				toolUseLine('toolu_a', 'mcp__n8n-local__create_workflow_from_code'),
+				toolResultLine('toolu_a', 'x'.repeat(TOOL_ERROR_MESSAGE_CAP + 100), true),
+			),
+		);
+		expect(toolErrors[0].message).toHaveLength(TOOL_ERROR_MESSAGE_CAP + 1); // cap + ellipsis
+		expect(toolErrors[0].message.endsWith('…')).toBe(true);
+	});
+
+	it('attributes an error whose tool_use_id was never seen to "(unknown)"', () => {
+		const { toolErrors } = parseClaudeStream(stream(toolResultLine('toolu_orphan', 'boom', true)));
+		expect(toolErrors).toEqual([{ tool: '(unknown)', message: 'boom' }]);
 	});
 });
 
@@ -394,7 +467,8 @@ describe('buildWorkflowViaMcp', () => {
 			const events =
 				call === 1
 					? stream(
-							assistantLine('mcp__n8n-local__create_workflow_from_code'),
+							toolUseLine('toolu_a', 'mcp__n8n-local__create_workflow_from_code'),
+							toolResultLine('toolu_a', 'validation failed: unknown node type', true),
 							resultLine({
 								result: 'built something, forgot the id',
 								total_cost_usd: 0.1,
@@ -429,6 +503,13 @@ describe('buildWorkflowViaMcp', () => {
 			'mcp__n8n-local__create_workflow_from_code': 2,
 			'mcp__n8n-local__search_nodes': 1,
 		});
+		// The failed attempt's errored call is part of the build's record too.
+		expect(result.toolErrors).toEqual([
+			{
+				tool: 'mcp__n8n-local__create_workflow_from_code',
+				message: 'validation failed: unknown node type',
+			},
+		]);
 		expect(vi.mocked(spawn)).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -152,6 +152,9 @@ describe('reshapeLangSmithRuns', () => {
 					buildCostUsd: 0.37,
 					buildTurns: 6,
 					buildToolCalls: { 'mcp__n8n-local__create_workflow_from_code': 1 },
+					buildToolErrors: [
+						{ tool: 'mcp__n8n-local__create_workflow_from_code', message: 'validation failed' },
+					],
 				},
 			),
 		];
@@ -163,6 +166,9 @@ describe('reshapeLangSmithRuns', () => {
 		expect(result[0][0].buildToolCalls).toEqual({
 			'mcp__n8n-local__create_workflow_from_code': 1,
 		});
+		expect(result[0][0].buildToolErrors).toEqual([
+			{ tool: 'mcp__n8n-local__create_workflow_from_code', message: 'validation failed' },
+		]);
 	});
 
 	it('attaches build-expectation verdicts by iteration:fileSlug even with no threadId (prebuilt/MCP path)', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -151,6 +151,7 @@ describe('reshapeLangSmithRuns', () => {
 					reasoning: 'ok',
 					buildCostUsd: 0.37,
 					buildTurns: 6,
+					buildToolCalls: { 'mcp__n8n-local__create_workflow_from_code': 1 },
 				},
 			),
 		];
@@ -159,6 +160,9 @@ describe('reshapeLangSmithRuns', () => {
 
 		expect(result[0][0].buildCostUsd).toBe(0.37);
 		expect(result[0][0].buildTurns).toBe(6);
+		expect(result[0][0].buildToolCalls).toEqual({
+			'mcp__n8n-local__create_workflow_from_code': 1,
+		});
 	});
 
 	it('attaches build-expectation verdicts by iteration:fileSlug even with no threadId (prebuilt/MCP path)', () => {

--- a/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
@@ -11,8 +11,10 @@ import { z } from 'zod';
 
 import {
 	buildWorkflowViaMcp,
+	mergeToolCalls,
 	stageMcpConfigFromClaudeJson,
 	uniqueProjectScopes,
+	type ToolCallCounts,
 } from './mcp-builder';
 import { runWithConcurrency } from '../harness/cleanup';
 import { createLogger } from '../harness/logger';
@@ -61,7 +63,8 @@ interface CliArgs {
 const HELP = `
 Build n8n workflows for each test case using \`claude -p\` driving an MCP
 server, write a manifest the eval CLI's --prebuilt-workflows flag accepts,
-plus a build-stats sidecar with per-cohort cost/turn/duration aggregates.
+plus a build-stats sidecar with per-cohort cost/turn/duration aggregates and
+per-tool call counts (which MCP tools the turns were spent on).
 
 Prerequisites:
   * \`claude\` CLI installed (https://docs.claude.com/claude-code)
@@ -283,6 +286,8 @@ interface BuildOutcome {
 	workflowId: string | null;
 	cost: number;
 	turns: number;
+	/** Per-tool `tool_use` counts — attributes `turns` to specific MCP tools. */
+	toolCalls: ToolCallCounts;
 	durationMs: number;
 }
 
@@ -327,6 +332,7 @@ async function buildOne(
 		workflowId: result.workflowId,
 		cost: result.cost,
 		turns: result.turns,
+		toolCalls: result.toolCalls,
 		durationMs: result.durationMs,
 	};
 }
@@ -379,6 +385,10 @@ function writeStats(args: CliArgs, results: BuildOutcome[]): void {
 	const sum = (selector: (r: BuildOutcome) => number) =>
 		successful.reduce((s, r) => s + selector(r), 0);
 
+	// Per-tool call totals across successful builds — where the turns went.
+	const toolCallTotals: ToolCallCounts = {};
+	for (const r of successful) mergeToolCalls(toolCallTotals, r.toolCalls);
+
 	const stats = {
 		version: 1 as const,
 		builder: args.builder,
@@ -388,12 +398,14 @@ function writeStats(args: CliArgs, results: BuildOutcome[]): void {
 			avgCostUSD: total > 0 ? sum((r) => r.cost) / total : 0,
 			totalCostUSD: sum((r) => r.cost),
 			avgDurationMs: total > 0 ? sum((r) => r.durationMs) / total : 0,
+			toolCallTotals,
 		},
 		builds: successful.map((r) => ({
 			slug: r.slug,
 			iteration: r.iteration,
 			workflowId: r.workflowId,
 			turns: r.turns,
+			toolCalls: r.toolCalls,
 			costUSD: r.cost,
 			durationMs: r.durationMs,
 		})),

--- a/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
@@ -15,6 +15,7 @@ import {
 	stageMcpConfigFromClaudeJson,
 	uniqueProjectScopes,
 	type ToolCallCounts,
+	type ToolCallError,
 } from './mcp-builder';
 import { runWithConcurrency } from '../harness/cleanup';
 import { createLogger } from '../harness/logger';
@@ -288,6 +289,8 @@ interface BuildOutcome {
 	turns: number;
 	/** Per-tool `tool_use` counts — attributes `turns` to specific MCP tools. */
 	toolCalls: ToolCallCounts;
+	/** Failed tool calls (tool + truncated error text) — subset of toolCalls. */
+	toolErrors: ToolCallError[];
 	durationMs: number;
 }
 
@@ -333,6 +336,7 @@ async function buildOne(
 		cost: result.cost,
 		turns: result.turns,
 		toolCalls: result.toolCalls,
+		toolErrors: result.toolErrors,
 		durationMs: result.durationMs,
 	};
 }
@@ -385,9 +389,14 @@ function writeStats(args: CliArgs, results: BuildOutcome[]): void {
 	const sum = (selector: (r: BuildOutcome) => number) =>
 		successful.reduce((s, r) => s + selector(r), 0);
 
-	// Per-tool call totals across successful builds — where the turns went.
+	// Per-tool call/error totals across successful builds — where the turns
+	// went, and which tools kept failing (messages stay on the per-build rows).
 	const toolCallTotals: ToolCallCounts = {};
-	for (const r of successful) mergeToolCalls(toolCallTotals, r.toolCalls);
+	const toolErrorTotals: ToolCallCounts = {};
+	for (const r of successful) {
+		mergeToolCalls(toolCallTotals, r.toolCalls);
+		for (const { tool } of r.toolErrors) toolErrorTotals[tool] = (toolErrorTotals[tool] ?? 0) + 1;
+	}
 
 	const stats = {
 		version: 1 as const,
@@ -399,6 +408,7 @@ function writeStats(args: CliArgs, results: BuildOutcome[]): void {
 			totalCostUSD: sum((r) => r.cost),
 			avgDurationMs: total > 0 ? sum((r) => r.durationMs) / total : 0,
 			toolCallTotals,
+			toolErrorTotals,
 		},
 		builds: successful.map((r) => ({
 			slug: r.slug,
@@ -406,6 +416,7 @@ function writeStats(args: CliArgs, results: BuildOutcome[]): void {
 			workflowId: r.workflowId,
 			turns: r.turns,
 			toolCalls: r.toolCalls,
+			toolErrors: r.toolErrors,
 			costUSD: r.cost,
 			durationMs: r.durationMs,
 		})),

--- a/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
@@ -220,6 +220,17 @@ export function mergeToolCalls(into: ToolCallCounts, from: ToolCallCounts): void
 	}
 }
 
+/** One failed tool call: which tool errored and what `claude` saw. */
+export interface ToolCallError {
+	tool: string;
+	/** Error text of the `tool_result`, truncated to TOOL_ERROR_MESSAGE_CAP. */
+	message: string;
+}
+
+/** Cap on a recorded tool-error message — enough to diagnose (validation
+ *  errors, HTTP failures) without letting a huge payload bloat run outputs. */
+export const TOOL_ERROR_MESSAGE_CAP = 500;
+
 /** The stream's trailing `result` event — same shape the old `--output-format
  *  json` single object had, plus the event-type discriminator. */
 const resultEventSchema = claudeSessionSchema.extend({ type: z.literal('result') });
@@ -231,11 +242,57 @@ const assistantEventSchema = z
 		type: z.literal('assistant'),
 		message: z
 			.object({
-				content: z.array(z.object({ type: z.string(), name: z.string().optional() }).passthrough()),
+				content: z.array(
+					z
+						.object({ type: z.string(), id: z.string().optional(), name: z.string().optional() })
+						.passthrough(),
+				),
 			})
 			.passthrough(),
 	})
 	.passthrough();
+
+/** A `user` event carrying `tool_result` blocks — each closes a `tool_use`
+ *  (matched by id) and flags failure via `is_error`. */
+const toolResultEventSchema = z
+	.object({
+		type: z.literal('user'),
+		message: z
+			.object({
+				content: z.array(
+					z
+						.object({
+							type: z.string(),
+							tool_use_id: z.string().optional(),
+							is_error: z.boolean().optional(),
+							content: z.unknown().optional(),
+						})
+						.passthrough(),
+				),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+/** Flatten a `tool_result`'s content (string, or array of text blocks) into
+ *  the error text, capped at TOOL_ERROR_MESSAGE_CAP. */
+function toolResultText(content: unknown): string {
+	let text = '';
+	if (typeof content === 'string') {
+		text = content;
+	} else if (Array.isArray(content)) {
+		const textBlockSchema = z.object({ text: z.string() });
+		text = content
+			.map((block) => {
+				const parsed = textBlockSchema.safeParse(block);
+				return parsed.success ? parsed.data.text : '';
+			})
+			.filter((t) => t.length > 0)
+			.join('\n');
+	}
+	text = text.trim();
+	return text.length > TOOL_ERROR_MESSAGE_CAP ? `${text.slice(0, TOOL_ERROR_MESSAGE_CAP)}…` : text;
+}
 
 export interface ParsedClaudeStream {
 	/** Session totals from the trailing `result` event; undefined when the
@@ -243,19 +300,26 @@ export interface ParsedClaudeStream {
 	session: ClaudeSession | undefined;
 	/** `tool_use` blocks counted per tool name across all assistant turns. */
 	toolCalls: ToolCallCounts;
+	/** Failed tool calls (`tool_result` with `is_error`), in stream order, each
+	 *  with the tool name and truncated error text. Errored calls are also
+	 *  counted in `toolCalls` — this is the failure subset. */
+	toolErrors: ToolCallError[];
 }
 
 /**
  * Parse `claude --output-format stream-json` NDJSON output. The trailing
  * `result` event carries the session totals (result text, num_turns, cost);
  * the assistant events' `tool_use` blocks attribute those turns to the
- * specific MCP tools they were spent on. Unrecognized or truncated lines are
- * skipped, so a stream cut short by a kill still yields the attribution it
- * recorded up to that point.
+ * specific MCP tools they were spent on, and the `tool_result` events flag
+ * which of those calls errored (matched back to the tool by `tool_use_id`).
+ * Unrecognized or truncated lines are skipped, so a stream cut short by a
+ * kill still yields the attribution it recorded up to that point.
  */
 export function parseClaudeStream(stdout: string): ParsedClaudeStream {
 	let session: ClaudeSession | undefined;
 	const toolCalls: ToolCallCounts = {};
+	const toolErrors: ToolCallError[] = [];
+	const toolNameById = new Map<string, string>();
 	for (const line of stdout.split('\n')) {
 		const trimmed = line.trim();
 		if (!trimmed) continue;
@@ -270,14 +334,26 @@ export function parseClaudeStream(stdout: string): ParsedClaudeStream {
 			for (const block of assistant.data.message.content) {
 				if (block.type === 'tool_use' && block.name) {
 					toolCalls[block.name] = (toolCalls[block.name] ?? 0) + 1;
+					if (block.id) toolNameById.set(block.id, block.name);
 				}
+			}
+			continue;
+		}
+		const toolResult = toolResultEventSchema.safeParse(event);
+		if (toolResult.success) {
+			for (const block of toolResult.data.message.content) {
+				if (block.type !== 'tool_result' || !block.is_error) continue;
+				// An id with no registered tool_use can only come from a corrupted
+				// stream — attribute it anyway rather than dropping the failure.
+				const tool = (block.tool_use_id && toolNameById.get(block.tool_use_id)) ?? '(unknown)';
+				toolErrors.push({ tool, message: toolResultText(block.content) });
 			}
 			continue;
 		}
 		const result = resultEventSchema.safeParse(event);
 		if (result.success) session = result.data;
 	}
-	return { session, toolCalls };
+	return { session, toolCalls, toolErrors };
 }
 
 /** Default per-attempt wall-clock cap for a `claude` build. Generous enough for
@@ -314,6 +390,8 @@ interface BuildAttempt {
 	/** Per-tool `tool_use` counts parsed from the attempt's event stream —
 	 *  populated even for timed-out attempts (partial streams still attribute). */
 	toolCalls: ToolCallCounts;
+	/** Failed tool calls from the attempt's stream, same partial-stream rules. */
+	toolErrors: ToolCallError[];
 	logFile: string;
 	/** True when the attempt was killed by the build timeout rather than exiting. */
 	timedOut: boolean;
@@ -367,11 +445,22 @@ async function runClaude(
 
 		// Resolve only once, and only after the process is actually dead (so the
 		// caller — and the lane allocator — never overlaps with a live subprocess).
-		const settle = (session: ClaudeSession | undefined, toolCalls: ToolCallCounts) => {
+		const settle = (
+			session: ClaudeSession | undefined,
+			toolCalls: ToolCallCounts,
+			toolErrors: ToolCallError[],
+		) => {
 			if (settled) return;
 			settled = true;
 			clearTimers();
-			resolve({ session, toolCalls, logFile, timedOut, spawnError: spawnError?.message });
+			resolve({
+				session,
+				toolCalls,
+				toolErrors,
+				logFile,
+				timedOut,
+				spawnError: spawnError?.message,
+			});
 		};
 
 		child.stdout.on('data', (chunk: Buffer) => {
@@ -396,6 +485,7 @@ async function runClaude(
 			writeFileSync(logFile, stream || stderr || fallback);
 			let session: ClaudeSession | undefined;
 			let toolCalls: ToolCallCounts = {};
+			let toolErrors: ToolCallError[] = [];
 			if (!spawnError) {
 				// Parse even a timed-out stream: what a hung build spent its turns on
 				// is exactly the forensic signal we want. `session` stays undefined on
@@ -403,9 +493,10 @@ async function runClaude(
 				// stray one must not turn a killed attempt into a success.
 				const parsed = parseClaudeStream(stdout);
 				toolCalls = parsed.toolCalls;
+				toolErrors = parsed.toolErrors;
 				if (!timedOut) session = parsed.session;
 			}
-			settle(session, toolCalls);
+			settle(session, toolCalls, toolErrors);
 		});
 		child.on('error', (error) => {
 			// No pid = the process never spawned (e.g. `claude` not on PATH). Node
@@ -417,7 +508,7 @@ async function runClaude(
 				spawnError = error;
 				return;
 			}
-			settle(undefined, {});
+			settle(undefined, {}, []);
 		});
 
 		if (settings.buildTimeoutMs && settings.buildTimeoutMs > 0) {
@@ -504,6 +595,10 @@ export interface McpBuildResult {
 	 *  to the specific MCP tools they were spent on. Timed-out attempts
 	 *  contribute the calls their partial stream recorded. */
 	toolCalls: ToolCallCounts;
+	/** Failed tool calls across every attempt, in stream order, with truncated
+	 *  error text — the failure subset of `toolCalls` (turns burned on retries
+	 *  after validation/HTTP errors show up here). */
+	toolErrors: ToolCallError[];
 	/** `claude` wall-clock summed across every attempt (ms). */
 	durationMs: number;
 	/** Path to the last attempt's captured `claude` event stream (NDJSON), for post-mortem. */
@@ -541,6 +636,7 @@ export async function buildWorkflowViaMcp(opts: {
 	let totalTurns = 0;
 	let totalDurationMs = 0;
 	const totalToolCalls: ToolCallCounts = {};
+	const totalToolErrors: ToolCallError[] = [];
 
 	for (let attempt = 1; attempt <= settings.maxAttempts; attempt++) {
 		const ts = new Date().toISOString().replace(/[:.]/g, '-');
@@ -550,7 +646,7 @@ export async function buildWorkflowViaMcp(opts: {
 			`${slug}-iter${String(iteration)}-attempt${String(attempt)}-${ts}.jsonl`,
 		);
 		lastLogFile = logFile;
-		const { session, toolCalls, timedOut, spawnError } = await runClaude(
+		const { session, toolCalls, toolErrors, timedOut, spawnError } = await runClaude(
 			userMessage,
 			settings,
 			mcpConfigPath,
@@ -561,6 +657,7 @@ export async function buildWorkflowViaMcp(opts: {
 		totalTurns += session?.num_turns ?? 0;
 		totalDurationMs += session?.duration_ms ?? 0;
 		mergeToolCalls(totalToolCalls, toolCalls);
+		totalToolErrors.push(...toolErrors);
 		const id = session?.result ? tailWorkflowId(session.result) : null;
 		if (id) {
 			workflowId = id;
@@ -603,6 +700,7 @@ export async function buildWorkflowViaMcp(opts: {
 		cost: totalCostUsd,
 		turns: totalTurns,
 		toolCalls: totalToolCalls,
+		toolErrors: totalToolErrors,
 		durationMs: totalDurationMs,
 		logFile: lastLogFile,
 		failureReason: workflowId ? undefined : failureReason,

--- a/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
@@ -209,6 +209,77 @@ const claudeSessionSchema = z
 	.passthrough();
 export type ClaudeSession = z.infer<typeof claudeSessionSchema>;
 
+/** Per-tool call counts, keyed by the full tool name as `claude` reports it
+ *  (e.g. `mcp__n8n-local__create_workflow_from_code`). */
+export type ToolCallCounts = Record<string, number>;
+
+/** Accumulate per-tool call counts from `from` into `into` (mutates `into`). */
+export function mergeToolCalls(into: ToolCallCounts, from: ToolCallCounts): void {
+	for (const [tool, count] of Object.entries(from)) {
+		into[tool] = (into[tool] ?? 0) + count;
+	}
+}
+
+/** The stream's trailing `result` event — same shape the old `--output-format
+ *  json` single object had, plus the event-type discriminator. */
+const resultEventSchema = claudeSessionSchema.extend({ type: z.literal('result') });
+
+/** An `assistant` event: one model turn; its `tool_use` blocks name the tools
+ *  the turn was spent on. Only the fields the counter reads are modeled. */
+const assistantEventSchema = z
+	.object({
+		type: z.literal('assistant'),
+		message: z
+			.object({
+				content: z.array(z.object({ type: z.string(), name: z.string().optional() }).passthrough()),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+export interface ParsedClaudeStream {
+	/** Session totals from the trailing `result` event; undefined when the
+	 *  stream never finished (killed/hung run). */
+	session: ClaudeSession | undefined;
+	/** `tool_use` blocks counted per tool name across all assistant turns. */
+	toolCalls: ToolCallCounts;
+}
+
+/**
+ * Parse `claude --output-format stream-json` NDJSON output. The trailing
+ * `result` event carries the session totals (result text, num_turns, cost);
+ * the assistant events' `tool_use` blocks attribute those turns to the
+ * specific MCP tools they were spent on. Unrecognized or truncated lines are
+ * skipped, so a stream cut short by a kill still yields the attribution it
+ * recorded up to that point.
+ */
+export function parseClaudeStream(stdout: string): ParsedClaudeStream {
+	let session: ClaudeSession | undefined;
+	const toolCalls: ToolCallCounts = {};
+	for (const line of stdout.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		let event: unknown;
+		try {
+			event = JSON.parse(trimmed);
+		} catch {
+			continue;
+		}
+		const assistant = assistantEventSchema.safeParse(event);
+		if (assistant.success) {
+			for (const block of assistant.data.message.content) {
+				if (block.type === 'tool_use' && block.name) {
+					toolCalls[block.name] = (toolCalls[block.name] ?? 0) + 1;
+				}
+			}
+			continue;
+		}
+		const result = resultEventSchema.safeParse(event);
+		if (result.success) session = result.data;
+	}
+	return { session, toolCalls };
+}
+
 /** Default per-attempt wall-clock cap for a `claude` build. Generous enough for
  *  legitimately slow builds (the heaviest mcp cases average ~18 min) while still
  *  bounding a wedged subprocess so it can't hold an eval lane indefinitely. */
@@ -240,6 +311,9 @@ export interface McpBuildSettings {
 
 interface BuildAttempt {
 	session: ClaudeSession | undefined;
+	/** Per-tool `tool_use` counts parsed from the attempt's event stream —
+	 *  populated even for timed-out attempts (partial streams still attribute). */
+	toolCalls: ToolCallCounts;
 	logFile: string;
 	/** True when the attempt was killed by the build timeout rather than exiting. */
 	timedOut: boolean;
@@ -266,8 +340,12 @@ async function runClaude(
 			'--strict-mcp-config',
 			'--allowedTools',
 			...allowedTools,
+			// stream-json (which requires --verbose in -p mode) instead of json:
+			// the per-event stream is what lets us attribute turns to the MCP
+			// tools they were spent on, and is persisted verbatim for forensics.
 			'--output-format',
-			'json',
+			'stream-json',
+			'--verbose',
 		];
 		const child = spawn('claude', claudeArgs, {
 			env: { ...process.env, MCP_TIMEOUT: String(settings.mcpTimeoutMs) },
@@ -289,11 +367,11 @@ async function runClaude(
 
 		// Resolve only once, and only after the process is actually dead (so the
 		// caller — and the lane allocator — never overlaps with a live subprocess).
-		const settle = (session: ClaudeSession | undefined) => {
+		const settle = (session: ClaudeSession | undefined, toolCalls: ToolCallCounts) => {
 			if (settled) return;
 			settled = true;
 			clearTimers();
-			resolve({ session, logFile, timedOut, spawnError: spawnError?.message });
+			resolve({ session, toolCalls, logFile, timedOut, spawnError: spawnError?.message });
 		};
 
 		child.stdout.on('data', (chunk: Buffer) => {
@@ -303,25 +381,31 @@ async function runClaude(
 			stderr += chunk.toString();
 		});
 		child.on('close', () => {
-			// Persist stdout (or a structured fallback) for forensics regardless of
-			// parse success — including spawn failures, whose error is recorded here
-			// so the log path reported to the caller stays truthful.
+			// Persist the raw event stream (or a structured fallback) for forensics
+			// regardless of parse success — including spawn failures, whose error is
+			// recorded here so the log path reported to the caller stays truthful.
 			const fallback = spawnError
 				? JSON.stringify({ subtype: 'spawn-error', error: spawnError.message })
 				: timedOut
 					? '{"subtype":"timeout"}'
 					: '{}';
-			writeFileSync(logFile, stdout || stderr || fallback);
+			// A killed build's stream ends without a `result` event — append the
+			// timeout marker as a trailing line so the log itself says why it stopped.
+			const stream =
+				timedOut && stdout ? `${stdout.replace(/\n$/, '')}\n{"subtype":"timeout"}\n` : stdout;
+			writeFileSync(logFile, stream || stderr || fallback);
 			let session: ClaudeSession | undefined;
-			if (!timedOut && !spawnError) {
-				try {
-					const parsed = claudeSessionSchema.safeParse(JSON.parse(stdout));
-					if (parsed.success) session = parsed.data;
-				} catch {
-					// stdout wasn't JSON — caller treats undefined session as failure.
-				}
+			let toolCalls: ToolCallCounts = {};
+			if (!spawnError) {
+				// Parse even a timed-out stream: what a hung build spent its turns on
+				// is exactly the forensic signal we want. `session` stays undefined on
+				// timeout — the killed process never emitted its `result` event, and a
+				// stray one must not turn a killed attempt into a success.
+				const parsed = parseClaudeStream(stdout);
+				toolCalls = parsed.toolCalls;
+				if (!timedOut) session = parsed.session;
 			}
-			settle(session);
+			settle(session, toolCalls);
 		});
 		child.on('error', (error) => {
 			// No pid = the process never spawned (e.g. `claude` not on PATH). Node
@@ -333,7 +417,7 @@ async function runClaude(
 				spawnError = error;
 				return;
 			}
-			settle(undefined);
+			settle(undefined, {});
 		});
 
 		if (settings.buildTimeoutMs && settings.buildTimeoutMs > 0) {
@@ -415,9 +499,14 @@ export interface McpBuildResult {
 	cost: number;
 	/** Assistant turns summed across every attempt. */
 	turns: number;
+	/** `tool_use` calls summed across every attempt, keyed by full tool name
+	 *  (e.g. `mcp__n8n-local__create_workflow_from_code`) — attributes `turns`
+	 *  to the specific MCP tools they were spent on. Timed-out attempts
+	 *  contribute the calls their partial stream recorded. */
+	toolCalls: ToolCallCounts;
 	/** `claude` wall-clock summed across every attempt (ms). */
 	durationMs: number;
-	/** Path to the last attempt's captured `claude` output, for post-mortem. */
+	/** Path to the last attempt's captured `claude` event stream (NDJSON), for post-mortem. */
 	logFile: string | null;
 	/** Short reason for the final failure (e.g. `no-stdout`, a claude subtype). */
 	failureReason?: string;
@@ -451,15 +540,17 @@ export async function buildWorkflowViaMcp(opts: {
 	let totalCostUsd = 0;
 	let totalTurns = 0;
 	let totalDurationMs = 0;
+	const totalToolCalls: ToolCallCounts = {};
 
 	for (let attempt = 1; attempt <= settings.maxAttempts; attempt++) {
 		const ts = new Date().toISOString().replace(/[:.]/g, '-');
+		// .jsonl: the persisted log is the verbatim stream-json event stream.
 		const logFile = join(
 			logDir,
-			`${slug}-iter${String(iteration)}-attempt${String(attempt)}-${ts}.json`,
+			`${slug}-iter${String(iteration)}-attempt${String(attempt)}-${ts}.jsonl`,
 		);
 		lastLogFile = logFile;
-		const { session, timedOut, spawnError } = await runClaude(
+		const { session, toolCalls, timedOut, spawnError } = await runClaude(
 			userMessage,
 			settings,
 			mcpConfigPath,
@@ -469,6 +560,7 @@ export async function buildWorkflowViaMcp(opts: {
 		totalCostUsd += session?.total_cost_usd ?? 0;
 		totalTurns += session?.num_turns ?? 0;
 		totalDurationMs += session?.duration_ms ?? 0;
+		mergeToolCalls(totalToolCalls, toolCalls);
 		const id = session?.result ? tailWorkflowId(session.result) : null;
 		if (id) {
 			workflowId = id;
@@ -510,6 +602,7 @@ export async function buildWorkflowViaMcp(opts: {
 		workflowId,
 		cost: totalCostUsd,
 		turns: totalTurns,
+		toolCalls: totalToolCalls,
 		durationMs: totalDurationMs,
 		logFile: lastLogFile,
 		failureReason: workflowId ? undefined : failureReason,

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -18,6 +18,7 @@ import {
 	buildWorkflowViaMcp,
 	type McpBuildSettings,
 	type ToolCallCounts,
+	type ToolCallError,
 } from '../cli/mcp-builder';
 import type { N8nClient } from '../clients/n8n-client';
 import {
@@ -75,6 +76,9 @@ export interface McpBuildSpend {
 	/** `tool_use` calls per tool name across the build's attempts — attributes
 	 *  `turns` to the specific MCP tools they were spent on. */
 	toolCalls: ToolCallCounts;
+	/** Failed tool calls (tool name + truncated error text), in stream order —
+	 *  the failure subset of `toolCalls`. */
+	toolErrors: ToolCallError[];
 }
 
 export type BuildArgs = Pick<
@@ -169,7 +173,12 @@ async function buildWorkflowViaMcpOnLane(config: {
 
 	// Record spend whether or not the build produced a workflow — failed builds
 	// cost money too, and this is the run's spend record.
-	buildSpend.push({ costUsd: result.cost, turns: result.turns, toolCalls: result.toolCalls });
+	buildSpend.push({
+		costUsd: result.cost,
+		turns: result.turns,
+		toolCalls: result.toolCalls,
+		toolErrors: result.toolErrors,
+	});
 
 	// Register for cleanup the moment the id exists. If the fetch-back below
 	// fails, the failure BuildResult carries no workflowId, so success-guarded

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -14,7 +14,11 @@ import type { LaneAllocator } from './lane-allocator';
 import { selectAuthorExpectations } from '../build-expectations/select';
 import { allFailVerdicts, verifyBuildExpectations } from '../build-expectations/verifier';
 import type { CliArgs } from '../cli/args';
-import { buildWorkflowViaMcp, type McpBuildSettings } from '../cli/mcp-builder';
+import {
+	buildWorkflowViaMcp,
+	type McpBuildSettings,
+	type ToolCallCounts,
+} from '../cli/mcp-builder';
 import type { N8nClient } from '../clients/n8n-client';
 import {
 	fetchAgentScenarioContext,
@@ -68,6 +72,9 @@ export interface Lane {
 export interface McpBuildSpend {
 	costUsd: number;
 	turns: number;
+	/** `tool_use` calls per tool name across the build's attempts — attributes
+	 *  `turns` to the specific MCP tools they were spent on. */
+	toolCalls: ToolCallCounts;
 }
 
 export type BuildArgs = Pick<
@@ -162,7 +169,7 @@ async function buildWorkflowViaMcpOnLane(config: {
 
 	// Record spend whether or not the build produced a workflow — failed builds
 	// cost money too, and this is the run's spend record.
-	buildSpend.push({ costUsd: result.cost, turns: result.turns });
+	buildSpend.push({ costUsd: result.cost, turns: result.turns, toolCalls: result.toolCalls });
 
 	// Register for cleanup the moment the id exists. If the fetch-back below
 	// fails, the failure BuildResult carries no workflowId, so success-guarded

--- a/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
@@ -180,7 +180,11 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 		// every row of the case like buildDurationMs — dedupe per (iteration, case)
 		// when summing (persist takes the first defined value per iteration).
 		const buildSpendFields = buildSpend
-			? { buildCostUsd: buildSpend.costUsd, buildTurns: buildSpend.turns }
+			? {
+					buildCostUsd: buildSpend.costUsd,
+					buildTurns: buildSpend.turns,
+					buildToolCalls: buildSpend.toolCalls,
+				}
 			: {};
 
 		// Agent-anchored build: scenarios target the agent and a missing workflow is

--- a/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/case-pipeline.ts
@@ -184,6 +184,7 @@ export function createCasePipeline(deps: CasePipelineDeps): CasePipeline {
 					buildCostUsd: buildSpend.costUsd,
 					buildTurns: buildSpend.turns,
 					buildToolCalls: buildSpend.toolCalls,
+					buildToolErrors: buildSpend.toolErrors,
 				}
 			: {};
 

--- a/packages/@n8n/instance-ai/evaluations/run/langsmith-driver.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/langsmith-driver.ts
@@ -384,7 +384,14 @@ async function updateExperimentAggregates(config: {
 		unique_builds: uniqueBuilds,
 		pass_rate_per_iter: computePassRatePerIter(evaluation),
 		...(config.buildModel ? { build_model: config.buildModel } : {}),
-		...(spend ? { total_build_cost_usd: spend.totalCostUsd, avg_build_turns: spend.avgTurns } : {}),
+		...(spend
+			? {
+					total_build_cost_usd: spend.totalCostUsd,
+					avg_build_turns: spend.avgTurns,
+					// Per-tool call totals across all builds — what the turns were spent on.
+					build_tool_calls: spend.toolCalls,
+				}
+			: {}),
 	};
 
 	try {

--- a/packages/@n8n/instance-ai/evaluations/run/langsmith-driver.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/langsmith-driver.ts
@@ -184,6 +184,11 @@ export async function runWithLangSmith(config: RunConfig): Promise<{
 		if (output.buildTurns !== undefined) {
 			feedback.push({ key: 'build_turns', score: output.buildTurns });
 		}
+		// Errored tool calls during the build — the wasted-turns signal (full
+		// per-tool detail lives in eval-results.json buildToolErrorsPerRun).
+		if (output.buildToolErrors !== undefined) {
+			feedback.push({ key: 'build_tool_errors', score: output.buildToolErrors.length });
+		}
 		// Deterministic conversation counter (per evals rubric) — a navigation/feature
 		// signal for the HOW judges, not a gating check.
 		if (output.planRejections !== undefined) {
@@ -388,8 +393,10 @@ async function updateExperimentAggregates(config: {
 			? {
 					total_build_cost_usd: spend.totalCostUsd,
 					avg_build_turns: spend.avgTurns,
-					// Per-tool call totals across all builds — what the turns were spent on.
+					// Per-tool call/error totals across all builds — what the turns were
+					// spent on, and which tools kept failing.
 					build_tool_calls: spend.toolCalls,
+					build_tool_errors: spend.toolErrors,
 				}
 			: {}),
 	};

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -14,6 +14,7 @@ import { parseTargetOutput, reshapeLangSmithRuns, type ReshapeRunRow } from './r
 import { roundRobinCaseRows } from './rows';
 import { aggregateWorkflowChecks, statusMap } from '../binaryChecks/aggregate';
 import type { CliArgs } from '../cli/args';
+import { mergeToolCalls } from '../cli/mcp-builder';
 import type { ComparisonOutcome, ComparisonResult } from '../comparison/compare';
 import { formatComparisonMarkdown, type RerunHint } from '../comparison/format';
 import { evaluateGate, isGatedTier, type GateResult } from '../comparison/gate';
@@ -35,16 +36,25 @@ import { caseDisplayPrompt } from '../utils/conversation-text';
  * Each entry already sums every attempt of its build (see McpBuildSpend), so
  * the totals are the run's true spend.
  */
-export function summarizeMcpBuildSpend(
-	spend: McpBuildSpend[] | undefined,
-): { builds: number; totalCostUsd: number; avgTurns: number } | undefined {
+export function summarizeMcpBuildSpend(spend: McpBuildSpend[] | undefined):
+	| {
+			builds: number;
+			totalCostUsd: number;
+			avgTurns: number;
+			toolCalls: Record<string, number>;
+	  }
+	| undefined {
 	if (!spend || spend.length === 0) return undefined;
 	const totalCost = spend.reduce((sum, s) => sum + s.costUsd, 0);
 	const totalTurns = spend.reduce((sum, s) => sum + s.turns, 0);
+	// Per-tool call totals across every build — where the run's turns went.
+	const toolCalls: Record<string, number> = {};
+	for (const s of spend) mergeToolCalls(toolCalls, s.toolCalls);
 	return {
 		builds: spend.length,
 		totalCostUsd: Math.round(totalCost * 100) / 100,
 		avgTurns: Math.round((totalTurns / spend.length) * 10) / 10,
+		toolCalls,
 	};
 }
 
@@ -441,6 +451,7 @@ export function writeEvalResults(
 				? {
 						buildCostUsdPerRun: tc.runs.map((run) => run.buildCostUsd ?? null),
 						buildTurnsPerRun: tc.runs.map((run) => run.buildTurns ?? null),
+						buildToolCallsPerRun: tc.runs.map((run) => run.buildToolCalls ?? null),
 					}
 				: {}),
 			scenarios: tc.executionScenarios.map((sa) => ({

--- a/packages/@n8n/instance-ai/evaluations/run/persist.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/persist.ts
@@ -42,6 +42,7 @@ export function summarizeMcpBuildSpend(spend: McpBuildSpend[] | undefined):
 			totalCostUsd: number;
 			avgTurns: number;
 			toolCalls: Record<string, number>;
+			toolErrors: Record<string, number>;
 	  }
 	| undefined {
 	if (!spend || spend.length === 0) return undefined;
@@ -50,11 +51,17 @@ export function summarizeMcpBuildSpend(spend: McpBuildSpend[] | undefined):
 	// Per-tool call totals across every build — where the run's turns went.
 	const toolCalls: Record<string, number> = {};
 	for (const s of spend) mergeToolCalls(toolCalls, s.toolCalls);
+	// Per-tool error counts (messages stay per case in buildToolErrorsPerRun).
+	const toolErrors: Record<string, number> = {};
+	for (const s of spend) {
+		for (const { tool } of s.toolErrors) toolErrors[tool] = (toolErrors[tool] ?? 0) + 1;
+	}
 	return {
 		builds: spend.length,
 		totalCostUsd: Math.round(totalCost * 100) / 100,
 		avgTurns: Math.round((totalTurns / spend.length) * 10) / 10,
 		toolCalls,
+		toolErrors,
 	};
 }
 
@@ -452,6 +459,7 @@ export function writeEvalResults(
 						buildCostUsdPerRun: tc.runs.map((run) => run.buildCostUsd ?? null),
 						buildTurnsPerRun: tc.runs.map((run) => run.buildTurns ?? null),
 						buildToolCallsPerRun: tc.runs.map((run) => run.buildToolCalls ?? null),
+						buildToolErrorsPerRun: tc.runs.map((run) => run.buildToolErrors ?? null),
 					}
 				: {}),
 			scenarios: tc.executionScenarios.map((sa) => ({

--- a/packages/@n8n/instance-ai/evaluations/run/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reshape.ts
@@ -74,6 +74,9 @@ const targetOutputSchema = z.object({
 	buildCostUsd: z.number().optional(),
 	/** Assistant turns across the `claude` build's attempts (--build-via-mcp only). */
 	buildTurns: z.number().optional(),
+	/** Per-tool `tool_use` counts across the build's attempts (--build-via-mcp
+	 *  only) — attributes `buildTurns` to specific MCP tools. */
+	buildToolCalls: z.record(z.number()).optional(),
 	execDurationMs: z.number().default(0),
 	nodeCount: z.number().default(0),
 	/** The thread id used during the build — keys the LangSmith trace lookup. */
@@ -260,6 +263,7 @@ export function reshapeLangSmithRuns(
 			let buildTrace: BuildTrace | undefined;
 			let buildCostUsd: number | undefined;
 			let buildTurns: number | undefined;
+			let buildToolCalls: Record<string, number> | undefined;
 
 			for (const scenario of testCase.executionScenarios ?? []) {
 				const run = byKey.get(`${String(iter)}/${fileSlug}/${scenario.name}`);
@@ -286,6 +290,7 @@ export function reshapeLangSmithRuns(
 				// Every row of the case repeats the build's spend — first defined wins.
 				buildCostUsd ??= output.buildCostUsd;
 				buildTurns ??= output.buildTurns;
+				buildToolCalls ??= output.buildToolCalls;
 				executionScenarioResults.push({
 					scenario,
 					success: output.passed,
@@ -317,6 +322,7 @@ export function reshapeLangSmithRuns(
 					buildTrace = output.buildTrace;
 					buildCostUsd = output.buildCostUsd;
 					buildTurns = output.buildTurns;
+					buildToolCalls = output.buildToolCalls;
 				}
 			}
 
@@ -339,6 +345,7 @@ export function reshapeLangSmithRuns(
 				buildTrace,
 				buildCostUsd,
 				buildTurns,
+				buildToolCalls,
 				n8nBaseUrl,
 				runDebug: threadId ? runDebugByThreadId.get(threadId) : undefined,
 			});

--- a/packages/@n8n/instance-ai/evaluations/run/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/reshape.ts
@@ -77,6 +77,9 @@ const targetOutputSchema = z.object({
 	/** Per-tool `tool_use` counts across the build's attempts (--build-via-mcp
 	 *  only) — attributes `buildTurns` to specific MCP tools. */
 	buildToolCalls: z.record(z.number()).optional(),
+	/** Failed tool calls (tool + truncated error text) across the build's
+	 *  attempts (--build-via-mcp only) — the failure subset of buildToolCalls. */
+	buildToolErrors: z.array(z.object({ tool: z.string(), message: z.string() })).optional(),
 	execDurationMs: z.number().default(0),
 	nodeCount: z.number().default(0),
 	/** The thread id used during the build — keys the LangSmith trace lookup. */
@@ -264,6 +267,7 @@ export function reshapeLangSmithRuns(
 			let buildCostUsd: number | undefined;
 			let buildTurns: number | undefined;
 			let buildToolCalls: Record<string, number> | undefined;
+			let buildToolErrors: Array<{ tool: string; message: string }> | undefined;
 
 			for (const scenario of testCase.executionScenarios ?? []) {
 				const run = byKey.get(`${String(iter)}/${fileSlug}/${scenario.name}`);
@@ -291,6 +295,7 @@ export function reshapeLangSmithRuns(
 				buildCostUsd ??= output.buildCostUsd;
 				buildTurns ??= output.buildTurns;
 				buildToolCalls ??= output.buildToolCalls;
+				buildToolErrors ??= output.buildToolErrors;
 				executionScenarioResults.push({
 					scenario,
 					success: output.passed,
@@ -323,6 +328,7 @@ export function reshapeLangSmithRuns(
 					buildCostUsd = output.buildCostUsd;
 					buildTurns = output.buildTurns;
 					buildToolCalls = output.buildToolCalls;
+					buildToolErrors = output.buildToolErrors;
 				}
 			}
 
@@ -346,6 +352,7 @@ export function reshapeLangSmithRuns(
 				buildCostUsd,
 				buildTurns,
 				buildToolCalls,
+				buildToolErrors,
 				n8nBaseUrl,
 				runDebug: threadId ? runDebugByThreadId.get(threadId) : undefined,
 			});

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -315,6 +315,9 @@ export interface WorkflowTestCaseResult {
 	buildCostUsd?: number;
 	/** Assistant turns across the `claude` build's attempts (--build-via-mcp only). */
 	buildTurns?: number;
+	/** Per-tool `tool_use` counts across the `claude` build's attempts
+	 *  (--build-via-mcp only) — attributes `buildTurns` to specific MCP tools. */
+	buildToolCalls?: Record<string, number>;
 	/** Per-expectation verdicts from the build-expectations judge. Aggregated as
 	 *  scoring units alongside execution scenarios. */
 	buildExpectationResults?: BuildExpectationResult[];

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -318,6 +318,9 @@ export interface WorkflowTestCaseResult {
 	/** Per-tool `tool_use` counts across the `claude` build's attempts
 	 *  (--build-via-mcp only) — attributes `buildTurns` to specific MCP tools. */
 	buildToolCalls?: Record<string, number>;
+	/** Failed tool calls (tool + truncated error text) across the `claude`
+	 *  build's attempts (--build-via-mcp only) — failure subset of buildToolCalls. */
+	buildToolErrors?: Array<{ tool: string; message: string }>;
 	/** Per-expectation verdicts from the build-expectations judge. Aggregated as
 	 *  scoring units alongside execution scenarios. */
 	buildExpectationResults?: BuildExpectationResult[];


### PR DESCRIPTION
## Summary

This PR adds per-tool call attribution to MCP-based workflow builds, enabling detailed analysis of which MCP tools consume the most assistant turns during the build process.

**Key changes:**

1. **Stream-based event parsing**: Switched `claude` invocations from `--output-format json` (single object) to `--output-format stream-json` (NDJSON), which emits per-event data. This allows tracking individual `tool_use` blocks and their outcomes.

2. **New parsing functions**:
   - `parseClaudeStream()`: Parses NDJSON event streams to extract session totals, per-tool call counts, and failed tool calls (matched by `tool_use_id`)
   - `mergeToolCalls()`: Accumulates per-tool counts across multiple build attempts

3. **Tool call tracking**: 
   - `toolCalls`: Record of `tool_use` counts per MCP tool (e.g., `mcp__n8n-local__search_nodes: 3`)
   - `toolErrors`: Array of failed tool calls with truncated error messages (capped at 500 chars), in stream order
   - Both are accumulated across all build attempts and included in `McpBuildResult`

4. **Improved forensics**:
   - Log files now preserve the verbatim NDJSON event stream (`.jsonl` extension) instead of a single JSON object
   - Timed-out builds append a `{"subtype":"timeout"}` marker to the stream, making the kill reason explicit in the log
   - Partial streams from killed/hung builds still yield tool call attribution

5. **Result propagation**: Tool call counts and errors flow through the evaluation pipeline:
   - `McpBuildResult` → `McpBuildSpend` → `WorkflowTestCaseResult` → `eval-results.json`
   - Aggregated per-run in `summary.mcpBuild.toolCalls` and `summary.mcpBuild.toolErrors`
   - Exported to LangSmith experiment metadata as `build_tool_calls` and `build_tool_errors`

## How to test

The changes are covered by comprehensive unit tests:
- `parseClaudeStream` tests: 10 test cases covering normal streams, truncated streams, error attribution, message capping, and edge cases
- `mergeToolCalls` tests: Accumulation across records
- `buildWorkflowViaMcp` integration tests: Updated to verify tool call counts and error tracking across single and multi-attempt builds
- Timeout test: Verifies partial stream attribution and timeout marker in logs

All existing tests pass with the new stream format. The test fixtures use helper functions (`assistantLine`, `toolUseLine`, `toolResultLine`, `resultLine`, `stream`) to construct realistic NDJSON event sequences.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included (10 new test cases for `parseClaudeStream`, updated integration tests for `buildWorkflowViaMcp`).

https://claude.ai/code/session_01GA23ytEUfHpzkv7meRdVAJ

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35333">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

