### PR TITLE
fix(Notion Node): Mark title as required for database page create in v3

### DIFF
--- a/packages/nodes-base/nodes/Notion/v3/actions/databasePage/DatabasePage.resource.ts
+++ b/packages/nodes-base/nodes/Notion/v3/actions/databasePage/DatabasePage.resource.ts
@@ -408,6 +408,7 @@ export const description: INodeProperties[] = [
 		name: 'title',
 		type: 'string',
 		default: '',
+		required: true,
 		displayOptions: { show: { resource: ['databasePage'], operation: ['create'] } },
 		description: 'Page title',
 	},


### PR DESCRIPTION
## Summary

The v3 `databasePage:create` operation rejects an empty title at runtime (`Title is required to create a database page`), but the parameter description left `title` optional. Everything derived from the description therefore claimed the field was optional: the generated node type definitions surfaced `title?: string`, the generated Zod validation schemas allowed omitting it, and the editor did not mark the field as required.

This mismatch was latent since the v3 rewrite because AI builders resolved Notion's "latest" type definition as v2.2 (where the title is set through `propertiesUi`). Once #35206 fixed the version-directory sorting so v3 correctly wins, builders started consuming the v3 definition, sometimes omitted the optional-looking title, and built workflows that failed at runtime — surfacing as intermittent MCP builder eval failures on the Notion happy path.

This PR adds `required: true` to the parameter, matching the existing runtime check and the v3 `page:create` title. With it, the generated definition emits `title: string` (non-optional), the generated Zod schema requires the field so workflow validation catches a missing title at build time, and the editor shows the required marker.

## How to test

1. `pnpm build` in `packages/nodes-base`, then check `dist/node-definitions/nodes/n8n-nodes-base/notion/v3/resource_database_page/operation_create.ts` — `title: string | Expression<string>;` has no `?`, and the top-level `title` in `operation_create.schema.js` has no `.optional()`.
2. In the editor, open a Notion node (v3) → Database Page → Create: the Title field is now marked required.
3. `pnpm test NotionV3` in `packages/nodes-base` — 57 tests pass, including the existing runtime check that create throws without a title.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to https://github.com/n8n-io/n8n/pull/35206, which surfaced the mismatch by making builders resolve the v3 definitions.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- Runtime behavior is already covered by the existing 'Title is required to create a database page' test in NotionV3.node.test.ts; this change aligns the description with that behavior. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3QuP6UgaUU8vq9S1okbVv

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3QuP6UgaUU8vq9S1okbVv)_

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

