### PR TITLE
fix(editor): Lock the AI Assistant canvas while the agent is working

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
@@ -2,7 +2,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { flushPromises, mount } from '@vue/test-utils';
 import { createRunExecutionData, type IPinData } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
-import { defineComponent, h, nextTick, reactive } from 'vue';
+import { defineComponent, h, inject, nextTick, reactive } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	usePushConnectionStore,
@@ -14,6 +14,7 @@ import {
 	useWorkflowExecutionStateStore,
 } from '@/app/stores/workflowExecutionState.store';
 import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+import { EditorEnabledFeaturesKey } from '@/app/constants/injectionKeys';
 import { useLogsStore } from '@/app/stores/logs.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
@@ -27,6 +28,9 @@ const rememberedManualExecutions = new Map<string, RememberedManualExecution>();
 
 const thread = reactive({
 	messages: [],
+	isStreaming: false,
+	isHydratingThread: false,
+	isSendingMessage: false,
 	consumePendingHandoff: vi.fn(),
 	sendMessage: vi.fn(),
 	rememberManualExecution: (
@@ -54,11 +58,14 @@ const WorkflowCanvasHostStub = defineComponent({
 	emits: ['workflow-loaded'],
 	setup(_, { emit, expose }) {
 		expose({ requestFitView: vi.fn() });
+		// Surfaces the host's read-only override so the editing lock is assertable.
+		const features = inject(EditorEnabledFeaturesKey, null);
 		return () =>
 			h(
 				'button',
 				{
 					'data-test-id': 'workflow-loaded',
+					'data-read-only': String(features?.value.readOnly ?? false),
 					onClick: () => emit('workflow-loaded', 'wf-1'),
 				},
 				'loaded',
@@ -151,9 +158,36 @@ async function mountPreview(options: MountPreviewOptions = {}) {
 describe('InstanceAiWorkflowPreview', () => {
 	beforeEach(() => {
 		thread.messages = [];
+		thread.isStreaming = false;
+		thread.isHydratingThread = false;
+		thread.isSendingMessage = false;
 		thread.consumePendingHandoff.mockReset();
 		thread.sendMessage.mockReset();
 		rememberedManualExecutions.clear();
+	});
+
+	describe('editing lock', () => {
+		const readOnly = (wrapper: Awaited<ReturnType<typeof mountPreview>>['wrapper']) =>
+			wrapper.find('[data-test-id="workflow-loaded"]').attributes('data-read-only');
+
+		it('leaves the canvas editable while the agent is idle', async () => {
+			const { wrapper } = await mountPreview();
+
+			expect(readOnly(wrapper)).toBe('false');
+		});
+
+		it.each([
+			['isStreaming', 'isStreaming'],
+			['isHydratingThread', 'isHydratingThread'],
+			['isSendingMessage', 'isSendingMessage'],
+		] as const)('locks the canvas while %s', async (_label, flag) => {
+			const { wrapper } = await mountPreview();
+
+			thread[flag] = true;
+			await nextTick();
+
+			expect(readOnly(wrapper)).toBe('true');
+		});
 	});
 
 	it('restores the cached agent execution after the artifact workflow reloads', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDataTablePreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDataTablePreview.vue
@@ -6,8 +6,7 @@ import DataTableTable from '@/features/core/dataTable/components/dataGrid/DataTa
 import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 import type { DataTable } from '@/features/core/dataTable/dataTable.types';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
-import { collectActiveBuilderAgents } from '../builderAgents';
-import { useThread } from '../instanceAi.store';
+import { useIsAgentWorking } from '../composables/useIsAgentWorking';
 
 const props = withDefaults(
 	defineProps<{
@@ -22,7 +21,6 @@ const props = withDefaults(
 const i18n = useI18n();
 const dataTableStore = useDataTableStore();
 const sourceControlStore = useSourceControlStore();
-const thread = useThread();
 
 const dataTable = ref<DataTable | null>(null);
 const isLoading = ref(false);
@@ -31,21 +29,8 @@ const fetchError = ref<string | null>(null);
 // === Editing lock ===
 // The grid is editable only while the AI is not running, so user edits can't
 // race agent mutations (each successful data-tables tool call re-fetches and
-// remounts the grid, which would discard an in-progress cell edit). Hydration
-// counts as busy: right after a reload an in-flight run isn't known until the
-// thread status resolves.
-// Note: a live confirmation keeps the run active (activeRunId stays set →
-// isStreaming), so isStreaming already covers "awaiting confirmation mid-run".
-// isAwaitingConfirmation is deliberately NOT used here — it can linger on
-// confirmations left unresolved by an already-finished run, which would keep
-// the grid locked while no run is active.
-const isAgentWorking = computed(
-	() =>
-		thread.isHydratingThread ||
-		thread.isStreaming ||
-		thread.isSendingMessage ||
-		collectActiveBuilderAgents(thread.messages).length > 0,
-);
+// remounts the grid, which would discard an in-progress cell edit).
+const isAgentWorking = useIsAgentWorking();
 
 // No client-side RBAC gate, mirroring DataTableDetailsView: the server
 // enforces write permissions and rejections surface as error toasts.

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
@@ -18,6 +18,7 @@ import {
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
 import { isAgentEditingWorkflow, type ExecutionResult } from '../canvasPreview.utils';
 import { buildInstanceAiArtifactCredentialQuestion } from '../composables/useInstanceAiHandoff';
+import { useIsAgentWorking } from '../composables/useIsAgentWorking';
 import { useInstanceAiWorkflowPreviewExecution } from '../composables/useInstanceAiWorkflowPreviewExecution';
 import type { FixWithAiError } from '../fixWithAi';
 import { useThread } from '../instanceAi.store';
@@ -108,10 +109,12 @@ const { restoreExecutionResult } = useInstanceAiWorkflowPreviewExecution({
 });
 
 // === Editing lock ===
-// Lock the artifact's editor while the agent is actively mutating THIS
-// workflow, so the user can't drag nodes into a mid-stream conflict.
-// `isAgentEditingWorkflow` defines the signals that trigger the lock.
+// Lock the artifact's editor while the agent is working, so the user can't
+// drag nodes into a mid-stream conflict. Thread-wide, since the per-workflow
+// signals below only fire around tool calls that name a workflowId — leaving
+// the canvas editable through workspace file edits and failed builds.
 const thread = useThread();
+const isAgentWorking = useIsAgentWorking();
 
 // The workflow + execution the editor handed off, applied once when this
 // preview first opens. Consumed (cleared) here, so it never re-applies on a
@@ -130,8 +133,8 @@ const isAgentEditingThisWorkflow = computed(() => {
 });
 
 // Per-editor host overrides for the embedded editor. Instance AI supersedes the
-// standalone AI helpers (`false`), forces the canvas read-only while a
-// workflow-builder agent is mutating this workflow, and suppresses workflow
+// standalone AI helpers (`false`), forces the canvas read-only while the agent
+// is working (see the editing lock above), and suppresses workflow
 // execution result toasts (success + error) — the agent surfaces run outcomes
 // in the thread UI, so the canvas would only duplicate them. The execute button
 // demotes to a secondary action — the conversation is the primary surface here.
@@ -142,7 +145,7 @@ const enabledFeatures = computed<EditorEnabledFeatures>(() => ({
 	aiAssistant: false,
 	aiBuilder: false,
 	askAi: false,
-	readOnly: isAgentEditingThisWorkflow.value,
+	readOnly: isAgentWorking.value || isAgentEditingThisWorkflow.value,
 	executionSuccessToasts: false,
 	executionErrorToasts: false,
 	executionButtonType: 'secondary',

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useIsAgentWorking.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useIsAgentWorking.ts
@@ -1,0 +1,28 @@
+import { computed, type ComputedRef } from 'vue';
+
+import { collectActiveBuilderAgents } from '../builderAgents';
+import { useThread } from '../instanceAi.store';
+
+/**
+ * Whether the agent is busy anywhere in this thread — the lock signal shared by
+ * every artifact preview, so user edits can't race agent mutations.
+ *
+ * Thread-wide rather than per-artifact: keying off tool calls that name a
+ * resource id left long stretches unlocked. Hydration counts as busy, since an
+ * in-flight run isn't known until thread status resolves after a reload.
+ *
+ * `isAwaitingConfirmation` is deliberately unused — it can linger on
+ * confirmations left unresolved by a finished run. A live confirmation keeps
+ * `activeRunId` set, so `isStreaming` already covers that case.
+ */
+export function useIsAgentWorking(): ComputedRef<boolean> {
+	const thread = useThread();
+
+	return computed(
+		() =>
+			thread.isHydratingThread ||
+			thread.isStreaming ||
+			thread.isSendingMessage ||
+			collectActiveBuilderAgents(thread.messages).length > 0,
+	);
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Instance AI artifact canvas stayed editable while the agent was mid-run, letting users drag nodes into a conflict with an in-flight build.

The lock only fired around tool calls naming a `workflowId`, which the current build flow rarely satisfies — workspace file edits carry a file path with no workflow id, and the sticky signals required a *successful* build, so a run stuck on failing builds never armed it.

Now it locks on thread-wide agent activity. The data table artifact already worked this way, so its predicate moves to a shared `useIsAgentWorking()` and both previews use it. The per-workflow signal stays as an OR.

## How to test

Open a workflow artifact in an Instance AI thread and ask the assistant to make a multi-step edit to it. While it's working — including between tool calls and while it's thinking — the canvas should be read-only: no node dragging, no add-node `+`, no undo. It unlocks when the run finishes.

Data tables should behave exactly as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-998

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35339">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

