### PR TITLE
fix(ai-builder): Treat bound stored credentials as settled in setup analysis

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -1279,6 +1279,51 @@ describe('workflows tool', () => {
 				['HTTP Request'],
 			);
 		});
+
+		it('reports a just-applied credential whose test failed as a failed node', async () => {
+			// A bound credential is settled (needsAction=false) even when its test
+			// fails, so the apply path must re-analyze with includeSettled to keep
+			// the failure reportable instead of silently marking the node complete.
+			(analyzeWorkflow as Mock).mockResolvedValue([
+				{
+					node: { name: 'Slack', type: 'n8n-nodes-base.slack' },
+					credentialType: 'slackApi',
+					needsAction: false,
+					credentialTestResult: { success: false, message: 'Invalid token' },
+				},
+			]);
+			(applyNodeChanges as Mock).mockResolvedValue({ applied: ['Slack'], failed: [] });
+			(buildCompletedReport as Mock).mockReturnValue([
+				{ nodeName: 'Slack', credentialType: 'slackApi' },
+			]);
+
+			const context = createMockContext();
+
+			const tool = createWorkflowsTool(context, 'full');
+			const result = await executeTool(tool, { action: 'setup', workflowId: 'wf1' }, {
+				resumeData: {
+					approved: true,
+					action: 'apply',
+					credentials: { Slack: { slackApi: 'cred-1' } },
+				},
+			} as never);
+
+			expect(analyzeWorkflow).toHaveBeenCalledWith(context, 'wf1', undefined, {
+				includeSettled: true,
+			});
+			expect(result).toMatchObject({
+				success: true,
+				completedNodes: [],
+				failedNodes: [
+					{
+						nodeName: 'Slack',
+						error: 'Credential test failed for slackApi: Invalid token',
+					},
+				],
+			});
+			// Settled requests never count as pending, so the apply is not partial.
+			expect(result).not.toHaveProperty('partial');
+		});
 	});
 
 	describe('unpublish action', () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -654,8 +654,12 @@ async function handleSetupApply(
 
 		// Re-analyze to determine if any nodes still need setup.
 		// Filter by needsAction to distinguish "render this card" from
-		// "this still requires user intervention".
-		const remainingRequests = await analyzeWorkflow(context, input.workflowId);
+		// "this still requires user intervention". Settled requests are kept so
+		// a just-applied credential whose test failed stays reportable below —
+		// a bound credential is settled for routing even when its test fails.
+		const remainingRequests = await analyzeWorkflow(context, input.workflowId, undefined, {
+			includeSettled: true,
+		});
 		const pendingRequests = remainingRequests.filter((r) => r.needsAction);
 		const completedNodes = buildCompletedReport(
 			resumeData.credentials,

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -323,7 +323,7 @@ describe('buildSetupRequests', () => {
 		expect(context.credentialService.test).not.toHaveBeenCalled();
 	});
 
-	it('sets needsAction=true when credential test fails', async () => {
+	it('keeps needsAction=false when a bound stored credential fails its live test', async () => {
 		(context.credentialService.list as Mock).mockResolvedValue([
 			{ id: 'cred-1', name: 'My Slack', updatedAt: '2025-01-01T00:00:00.000Z' },
 		]);
@@ -334,6 +334,24 @@ describe('buildSetupRequests', () => {
 
 		const node = makeNode({
 			credentials: { slackApi: { id: 'cred-1', name: 'My Slack' } },
+		});
+		const result = await buildSetupRequests(context, node);
+
+		expect(result[0].needsAction).toBe(false);
+		expect(result[0].credentialTestResult).toEqual({ success: false, message: 'Invalid token' });
+	});
+
+	it('sets needsAction=true when the bound credential id is not a stored credential', async () => {
+		(context.credentialService.list as Mock).mockResolvedValue([
+			{ id: 'cred-1', name: 'My Slack', updatedAt: '2025-01-01T00:00:00.000Z' },
+		]);
+		(context.credentialService.test as Mock).mockResolvedValue({
+			success: false,
+			message: 'Credential not found',
+		});
+
+		const node = makeNode({
+			credentials: { slackApi: { id: 'cred-gone', name: 'Imported Slack' } },
 		});
 		const result = await buildSetupRequests(context, node);
 
@@ -761,7 +779,7 @@ describe('analyzeWorkflow', () => {
 		expect(result).toHaveLength(0);
 	});
 
-	it('keeps credential-only requests whose credential test fails', async () => {
+	it('drops credential-only requests whose bound stored credential fails its test', async () => {
 		const node = makeNode({
 			credentials: { slackApi: { id: 'cred-1', name: 'My Slack' } },
 		});
@@ -776,6 +794,28 @@ describe('analyzeWorkflow', () => {
 		(context.credentialService.test as Mock).mockResolvedValue({
 			success: false,
 			message: 'Invalid token',
+		});
+
+		const result = await analyzeWorkflow(context, 'wf-1');
+
+		expect(result).toHaveLength(0);
+	});
+
+	it('keeps credential-only requests whose bound credential id is not stored', async () => {
+		const node = makeNode({
+			credentials: { slackApi: { id: 'cred-gone', name: 'Imported Slack' } },
+		});
+		(context.workflowService.getAsWorkflowJSON as Mock).mockResolvedValue(makeWorkflowJSON([node]));
+		(context.nodeService.getDescription as Mock).mockResolvedValue({
+			group: [],
+			credentials: [{ name: 'slackApi' }],
+		});
+		(context.credentialService.list as Mock).mockResolvedValue([
+			{ id: 'cred-1', name: 'My Slack', updatedAt: '2025-01-01T00:00:00.000Z' },
+		]);
+		(context.credentialService.test as Mock).mockResolvedValue({
+			success: false,
+			message: 'Credential not found',
 		});
 
 		const result = await analyzeWorkflow(context, 'wf-1');

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -801,6 +801,30 @@ describe('analyzeWorkflow', () => {
 		expect(result).toHaveLength(0);
 	});
 
+	it('keeps settled failing-test requests when includeSettled is set', async () => {
+		const node = makeNode({
+			credentials: { slackApi: { id: 'cred-1', name: 'My Slack' } },
+		});
+		(context.workflowService.getAsWorkflowJSON as Mock).mockResolvedValue(makeWorkflowJSON([node]));
+		(context.nodeService.getDescription as Mock).mockResolvedValue({
+			group: [],
+			credentials: [{ name: 'slackApi' }],
+		});
+		(context.credentialService.list as Mock).mockResolvedValue([
+			{ id: 'cred-1', name: 'My Slack', updatedAt: '2025-01-01T00:00:00.000Z' },
+		]);
+		(context.credentialService.test as Mock).mockResolvedValue({
+			success: false,
+			message: 'Invalid token',
+		});
+
+		const result = await analyzeWorkflow(context, 'wf-1', undefined, { includeSettled: true });
+
+		expect(result).toHaveLength(1);
+		expect(result[0].needsAction).toBe(false);
+		expect(result[0].credentialTestResult).toEqual({ success: false, message: 'Invalid token' });
+	});
+
 	it('keeps credential-only requests whose bound credential id is not stored', async () => {
 		const node = makeNode({
 			credentials: { slackApi: { id: 'cred-gone', name: 'Imported Slack' } },

--- a/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
@@ -592,16 +592,27 @@ async function buildRequestForCredentialType(
 	if (!credentialType && isTrigger && !isTestable && !hasParamIssues) return null;
 
 	// Determine whether this request still needs user intervention.
-	// A credential request needs action if no credential is set or the test failed.
+	// A credential request needs action only when the slot leaves something to
+	// collect: nothing bound, or a bound id that doesn't resolve to a stored
+	// credential in scope (e.g. an imported workflow referencing another
+	// instance's credential). A resolvable bound credential is settled even if
+	// its live test fails — tests fail transiently and re-asking for an
+	// already-connected credential is redundant friction; the failure still
+	// rides along in credentialTestResult for display.
 	// A parameter request needs action if issues remain.
 	// A trigger-only request (no credential, no param issues) never blocks apply.
 	let needsAction = false;
 	if (credentialType) {
 		const existingOnNode = node.credentials?.[credentialType];
-		const hasValidCredential =
-			(typeof existingOnNode?.id === 'string' || isAiGatewayManagedCredential(existingOnNode)) &&
-			(credentialTestResult === undefined || credentialTestResult.success);
-		needsAction = !hasValidCredential;
+		const boundId =
+			typeof existingOnNode?.id === 'string' && existingOnNode.id !== ''
+				? existingOnNode.id
+				: undefined;
+		const isSettled =
+			isAiGatewayManagedCredential(existingOnNode) ||
+			(boundId !== undefined &&
+				existingCredentials.some((credential) => credential.id === boundId));
+		needsAction = !isSettled;
 	}
 	if (hasParamIssues) {
 		needsAction = true;

--- a/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
@@ -1272,6 +1272,13 @@ export async function analyzeWorkflow(
 	context: InstanceAiContext,
 	workflowId: string,
 	triggerResults?: Record<string, { status: 'success' | 'error' | 'listening'; error?: string }>,
+	options?: {
+		/** Keep settled requests (needsAction=false) in the result. For reporting
+		 *  consumers only (e.g. the apply path surfacing a just-applied credential
+		 *  whose test failed) — never for card rendering, where settled slots must
+		 *  stay hidden. */
+		includeSettled?: boolean;
+	},
 ): Promise<SetupRequest[]> {
 	const workflowJson = await context.workflowService.getAsWorkflowJSON(workflowId);
 
@@ -1296,11 +1303,16 @@ export async function analyzeWorkflow(
 				req.isTrigger ||
 				(req.parameterIssues && Object.keys(req.parameterIssues).length > 0),
 		)
-		// Hide cards the user has nothing to do on: credentials already set and
-		// tested, no parameter issues, not a trigger awaiting testing. Trigger
-		// steps are always kept — triggers require user testing regardless of
+		// Hide cards the user has nothing to do on: credentials already set,
+		// no parameter issues, not a trigger awaiting testing. Trigger steps
+		// are always kept — triggers require user testing regardless of
 		// credential state.
-		.filter((req) => !!req.needsAction || (req.isTrigger && !!req.isTestable));
+		.filter(
+			(req) =>
+				options?.includeSettled === true ||
+				!!req.needsAction ||
+				(req.isTrigger && !!req.isTestable),
+		);
 
 	sortByExecutionOrder(
 		setupRequests,


### PR DESCRIPTION
## Summary

A workflow whose nodes already carry bound, stored credentials could still be routed through credential setup. `buildSetupRequests` marked a credential slot as `needsAction` whenever its live credential test failed, even though the slot was bound to a real stored credential. The test result maps any failure to `success: false` (network errors, egress restrictions, rate limits, service hiccups), so valid, connected credentials were re-asked: the build outcome flagged `setupRequirement: required` with reason `workflow-needs-setup`, the post-build flow then dutifully opened the setup card for credentials that were already bound, and the agent closed with 'double-check your credentials' caveats after publishing.

This changes the `needsAction` contract to 'something to collect':

- Nothing bound on the slot: still needs action.
- Bound id that does not resolve to a stored credential (e.g. a workflow imported from another instance): still needs action.
- Bound id that resolves to a stored credential (or the managed AI gateway credential): settled, regardless of the live test outcome.

The credential test still runs and its result still rides on the setup request (`credentialTestResult`) for display, and the apply path still reports credentials that were applied but failed testing. A genuinely broken credential still surfaces through verification or execution with the service's real error, which the verification analyzer already routes to setup with evidence.

All consumers share this flag, so the fix covers the build-outcome routing (`workflowNeedsSetup`), the `workflows(action="setup")` card filter, the `complete-checkpoint` gate, and the `<workflow-setup-required>` follow-up.

## How to test

- Unit tests: `pnpm vitest run src/tools/workflows/__tests__/setup-workflow.service.test.ts` in `packages/@n8n/instance-ai` (two tests re-pinned to the new contract, two added: bound credential with failing test stays settled, dangling credential id still requires action).
- Eval reproduction (lang-tracer case `publishes-without-reasking-connected-credentials`, baseline suite): on master the case fails deterministically on the credential re-ask expectation (4/5, the build outcome carries `setupRequirement: required / workflow-needs-setup` with both credentials bound). With this change the same scenario passes 5/5 and the build outcome reports `setupRequirement: not_required`; the agent binds both stored credentials, publishes on request, and never opens a credential setup card.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1008

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35340">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

