### PR TITLE
fix(core): Add incremental SSE response headers

### DIFF
--- a/packages/cli/src/push/__tests__/sse.push.test.ts
+++ b/packages/cli/src/push/__tests__/sse.push.test.ts
@@ -49,6 +49,8 @@ describe('SSEPush', () => {
 			);
 			expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
 			expect(res.setHeader).toHaveBeenCalledWith('Connection', 'keep-alive');
+			expect(res.setHeader).toHaveBeenCalledWith('Incremental', '?1');
+			expect(res.setHeader).toHaveBeenCalledWith('X-Accel-Buffering', 'no');
 			expect(res.writeHead).toHaveBeenCalledWith(200);
 
 			expect(res.write).toHaveBeenCalledWith(':ok\n\n');

--- a/packages/cli/src/push/sse.push.ts
+++ b/packages/cli/src/push/sse.push.ts
@@ -18,6 +18,8 @@ export class SSEPush extends AbstractPush<Connection> {
 		res.setHeader('Content-Type', 'text/event-stream; charset=UTF-8');
 		res.setHeader('Cache-Control', 'no-cache');
 		res.setHeader('Connection', 'keep-alive');
+		res.setHeader('Incremental', '?1');
+		res.setHeader('X-Accel-Buffering', 'no');
 		res.writeHead(200);
 		res.write(':ok\n\n');
 		res.flush();


### PR DESCRIPTION
## Summary

Adds response headers to SSE push streams so HTTP intermediaries can forward events as they arrive:

- `Incremental: ?1` provides the standards-track incremental forwarding signal.
- `X-Accel-Buffering: no` disables response buffering in Nginx-based proxies.

## How to test

- Run `pnpm test src/push/__tests__/sse.push.test.ts` from `packages/cli`.
- Run n8n with `N8N_PUSH_BACKEND=sse` behind an HTTP intermediary and verify push events arrive without response buffering.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35327.

Specification: https://datatracker.ietf.org/doc/draft-ietf-httpbis-incremental/

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---
🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

