### PR TITLE
refactor(editor): Remove dead page-redirection compat re-exports (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/stores/src/composables/useBasePageRedirectionHelper.test.ts
+++ b/packages/frontend/@n8n/stores/src/composables/useBasePageRedirectionHelper.test.ts
@@ -28,10 +28,9 @@ vi.mock('@n8n/composables/useTelemetry', () => {
 });
 
 /** Only `deployment.type` steers this composable; the rest of the settings object is stubbed. */
-const settingsFor = (type: string, environment = 'production') =>
+const settingsFor = (type: string) =>
 	mock<FrontendSettings>({
 		deployment: { type },
-		license: { environment } as FrontendSettings['license'],
 	});
 
 describe('useBasePageRedirectionHelper', () => {
@@ -75,19 +74,11 @@ describe('useBasePageRedirectionHelper', () => {
 	test.each([
 		[
 			'default',
-			'production',
-			ROLE.Owner,
-			'https://n8n.io/pricing?utm_campaign=upgrade-api&source=advanced-permissions',
-		],
-		[
-			'default',
-			'development',
 			ROLE.Owner,
 			'https://n8n.io/pricing?utm_campaign=upgrade-api&source=advanced-permissions',
 		],
 		[
 			'cloud',
-			'production',
 			ROLE.Owner,
 			`https://app.n8n.cloud/login?code=123&returnPath=${encodeURIComponent(
 				'/account/change-plan',
@@ -95,13 +86,12 @@ describe('useBasePageRedirectionHelper', () => {
 		],
 		[
 			'cloud',
-			'production',
 			ROLE.Member,
 			'https://n8n.io/pricing?utm_campaign=upgrade-api&source=advanced-permissions',
 		],
 	])(
-		'"goToUpgrade" should generate the correct URL for "%s" deployment and "%s" license environment and user role "%s"',
-		async (type, environment, role, expectation) => {
+		'"goToUpgrade" should generate the correct URL for "%s" deployment and user role "%s"',
+		async (type, role, expectation) => {
 			// Arrange
 
 			usersStore.addUsers([
@@ -116,7 +106,7 @@ describe('useBasePageRedirectionHelper', () => {
 
 			const telemetry = useTelemetry();
 
-			settingsStore.setSettings(settingsFor(type, environment));
+			settingsStore.setSettings(settingsFor(type));
 
 			// Act
 
@@ -145,7 +135,7 @@ describe('useBasePageRedirectionHelper', () => {
 			usersStore.addUsers([{ id: '1', isPending: false, role: ROLE.Owner }]);
 			usersStore.currentUserId = '1';
 
-			settingsStore.setSettings(settingsFor('cloud', 'production'));
+			settingsStore.setSettings(settingsFor('cloud'));
 
 			const windowOpenSpy = vi.spyOn(window, 'open').mockReturnValue(null);
 
@@ -165,7 +155,7 @@ describe('useBasePageRedirectionHelper', () => {
 			usersStore.addUsers([{ id: '1', isPending: false, role }]);
 			usersStore.currentUserId = '1';
 
-			settingsStore.setSettings(settingsFor(type, 'production'));
+			settingsStore.setSettings(settingsFor(type));
 
 			const initialHref = location.href;
 			const windowOpenSpy = vi.spyOn(window, 'open').mockReturnValue(null);
@@ -184,14 +174,13 @@ describe('useBasePageRedirectionHelper', () => {
 	test.each([
 		[
 			'cloud',
-			'production',
 			ROLE.Owner,
 			`https://app.n8n.cloud/login?code=123&returnPath=${encodeURIComponent('/dashboard')}`,
 		],
-		['cloud', 'production', ROLE.Member, 'https://test.app.n8n.cloud'],
+		['cloud', ROLE.Member, 'https://test.app.n8n.cloud'],
 	])(
-		'"goToDashboard" should generate the correct URL for "%s" deployment and "%s" license environment and user role "%s"',
-		async (type, environment, role, expectation) => {
+		'"goToDashboard" should generate the correct URL for "%s" deployment and user role "%s"',
+		async (type, role, expectation) => {
 			// Arrange
 
 			usersStore.addUsers([
@@ -204,7 +193,7 @@ describe('useBasePageRedirectionHelper', () => {
 
 			usersStore.currentUserId = '1';
 
-			settingsStore.setSettings(settingsFor(type, environment));
+			settingsStore.setSettings(settingsFor(type));
 
 			// Act
 
@@ -221,7 +210,7 @@ describe('useBasePageRedirectionHelper', () => {
 			usersStore.addUsers([{ id: '1', isPending: false, role: ROLE.Owner }]);
 			usersStore.currentUserId = '1';
 
-			settingsStore.setSettings(settingsFor('cloud', 'production'));
+			settingsStore.setSettings(settingsFor('cloud'));
 		});
 
 		test('aborts the redirect and skips telemetry when the guard resolves false', async () => {

--- a/packages/frontend/@n8n/stores/src/types/pageRedirection.ts
+++ b/packages/frontend/@n8n/stores/src/types/pageRedirection.ts
@@ -1,7 +1,7 @@
 /**
  * Vocabulary for the upgrade/redirect CTAs driven by `useBasePageRedirectionHelper`.
  * Relocated here from editor-ui's `@/Interface` so the composable carries its own
- * parameter types; `@/Interface` re-exports both for existing importers.
+ * parameter types. The composable is their only consumer.
  */
 
 /** Which surface the user clicked an upgrade CTA from. Reported to telemetry and as the `source` query param. */

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -875,11 +875,6 @@ export type NodeAuthenticationOption = {
 
 export type CloudPlanAndUsageData = Cloud.PlanData & { usage: InstanceUsage };
 
-// The upgrade-CTA vocabulary moved to `@n8n/stores/types/pageRedirection`, alongside
-// the composable that consumes it; re-exported here so existing importers stay
-// unchanged.
-export type { CloudUpdateLinkSourceType, UTMCampaign } from '@n8n/stores/types/pageRedirection';
-
 export type AddedNode = {
 	type: string;
 	openDetail?: boolean;

--- a/packages/frontend/editor-ui/src/app/constants/urls.ts
+++ b/packages/frontend/editor-ui/src/app/constants/urls.ts
@@ -1,7 +1,3 @@
-// Moved to `@n8n/frontend-constants/urls` so `@n8n/stores` can reach it;
-// re-exported here so existing `@/app/constants` importers stay unchanged.
-export { N8N_PRICING_PAGE_URL } from '@n8n/frontend-constants/urls';
-
 export const DOCS_DOMAIN = 'docs.n8n.io';
 export const BUILTIN_NODES_DOCS_URL = `https://${DOCS_DOMAIN}/integrations/builtin/`;
 export const BUILTIN_CREDENTIALS_DOCS_URL = `https://${DOCS_DOMAIN}/integrations/builtin/credentials/`;


### PR DESCRIPTION
## Summary

Follow-up to #35174, cleaning up two non-blocking findings from that PR's review, plus one comment this PR's own first commit falsified. Deletions and a one-line comment correction — no behaviour change.

### 1. Two re-exports whose comments promised a consumer set that never existed

| File | Claimed |
| --- | --- |
| `packages/frontend/editor-ui/src/Interface.ts` | `CloudUpdateLinkSourceType` / `UTMCampaign` re-exported *"so existing importers stay unchanged"* |
| `packages/frontend/editor-ui/src/app/constants/urls.ts` | `N8N_PRICING_PAGE_URL` re-exported *"so existing `@/app/constants` importers stay unchanged"* |

There are no such importers. A repo-wide search for all three symbols returns
**10 hits: the declarations, the composable's own imports, and these two
re-export lines.** Nothing else. No namespace imports of `@/Interface` or
`@/app/constants` exist either, so nothing reached them indirectly — worth
checking for the pricing URL in particular, since `app/constants/index.ts`
star-re-exports `urls.ts` and it is a *value*, not just a type, so a dynamic
consumer could have hidden from typecheck.

Rewriting the comments truthfully would leave 8 lines reading "re-exported for
no one", so the lines go instead. Anything that needs these later imports from
the real home, exactly as the composable already does. Two-way door: a revert
restores them.

### 2. A dead `license` stub in the moved composable's test

`useBasePageRedirectionHelper.test.ts` stubbed `license: { environment } as FrontendSettings['license']`
— the file's only `as` cast, and it existed purely to launder `string` into the
license-environment union. Nothing on the composable's path reads `license`: it
steers on `deployment.type` alone, `settings.store` reads `license` only for
`planName` / `consumerId`, and `cloudPlan.store` never touches it.

Removing the stub left `environment` as a no-op axis threaded through three
`test.each` tables and *named in two test titles* — the same false promise the
comments above made, so it goes too. With that axis gone, the `goToUpgrade`
`default`/production and `default`/development cases were byte-identical, so
they collapse into one: **4 cases → 3, suite 12 → 11 tests.** That is a
duplicate removed, not coverage dropped — same input, same expectation, twice.

### 3. The doc comment this PR itself falsified

`@n8n/stores/src/types/pageRedirection.ts` opened with *"`@/Interface`
re-exports both for existing importers"*. True before this PR; false the moment
commit 1 deleted that re-export. It never appears in the diff, which is exactly
why a diff-only review can't catch it — the change is what makes the untouched
line wrong.

Replaced with the verified fact: `useBasePageRedirectionHelper` is the only
consumer. Repo-wide, both types resolve to their declarations plus that
composable's import, and nothing else imports the module.

## How to test

Verified at head `8900e48f`, based on master `4e03a078` (which contains
`5b31425`, the merge commit of #35174):

| Check | Result |
| --- | --- |
| `editor-ui` typecheck (`vue-tsc --noEmit`) | exit 0, **0 TS errors** |
| `editor-ui` lint (`oxlint && eslint`) | exit 0, **0 errors**; neither changed file appears in output |
| Page-redirection consumer tests (the 16 `editor-ui` test files referencing `usePageRedirectionHelper`) | **16 files / 374 passed** |
| `@n8n/stores` full suite | **11 files / 173 passed** |
| `@n8n/stores` typecheck + lint | exit 0 / exit 0 |

```bash
# from packages/frontend/editor-ui
pnpm typecheck && pnpm lint

# from packages/frontend/@n8n/stores
pnpm test && pnpm typecheck && pnpm lint
```

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35174. Findings 1 and 2 were raised in that PR's review and
deliberately deferred rather than folded in, to avoid reopening its merge window.

A third dead-surface finding — a chained pair of `NotificationOptions`
re-exports in `Interface.ts` and `@n8n/stores/notifications.store.ts`, each
claiming importers that don't exist — was found while reviewing this PR and is
tracked separately, gated on this one merging. Deliberately out of scope here.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- N/A: no user-facing or documented surface changes -->
- [x] Tests included. <!-- Deletions only; existing suites cover the surface and are green. One duplicate test case collapsed, detailed above. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
