### PR TITLE
feat(Form Trigger Node): Add credential connect UI for end-user credentials

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
@@ -71,6 +71,10 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 					);
 				}
 
+				if (status.status === 'configured' && status.resolverId) {
+					checkStatus.revokeUrl = this.generateRevokeUrl(status.credentialId, status.resolverId);
+				}
+
 				return checkStatus;
 			}),
 		);
@@ -87,6 +91,13 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 	 * fast and small. The caller identity is captured in a server-side intent so the
 	 * connection binds to the right subject regardless of who opens the link.
 	 */
+	/** Deletes the caller's own connection; mirrors `workflow-status.controller.ts`. */
+	private generateRevokeUrl(credentialId: string, resolverId: string): string {
+		const basePath = this.urlService.getInstanceBaseUrl();
+		const restPath = this.globalConfig.endpoints.rest;
+		return `${basePath}/${restPath}/credentials/${credentialId}/revoke?resolverId=${encodeURIComponent(resolverId)}`;
+	}
+
 	private async generateAuthorizationUrl(
 		credentialId: string,
 		resolverId: string,

--- a/packages/cli/templates/form-shell.handlebars
+++ b/packages/cli/templates/form-shell.handlebars
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang='en'>
+<!--
+	Form trigger — trusted hosting shell: n8n-controlled connect panel on the real
+	origin; the author's form renders unchanged in the sandboxed null-origin iframe
+	so author content can never touch the per-caller authorize links.
+-->
+
+<head>
+	<meta charset='UTF-8' />
+	<meta name='viewport' content='width=device-width, initial-scale=1.0' />
+	<link rel='icon' type='image/png' href='https://n8n.io/favicon.ico' />
+	<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
+	<title>{{formTitle}}</title>
+	<style>
+		:root {
+			--font-family: 'Open Sans', sans-serif;
+			--color-background: #fbfcfe;
+			--color-card-bg: #ffffff;
+			--color-card-border: #dbdfe7;
+			--color-card-shadow: rgba(99, 77, 255, 0.06);
+			--color-header: #525356;
+			--color-label: #555555;
+			--color-muted: #7e8186;
+			--color-primary: #ff6d5a;
+			--color-primary-text: #ffffff;
+			--color-ok: #2e9e5b;
+			--color-icon-bg: #f2f0ff;
+			--color-icon-text: #6a5bdd;
+			--border-radius-card: 8px;
+			--border-radius-input: 6px;
+			--container-width: 480px;
+			--box-shadow-card: 0px 4px 16px 0px var(--color-card-shadow);
+			--box-shadow-dialog: 0px 12px 48px rgba(0, 0, 0, 0.18);
+		}
+		*, ::before, ::after { box-sizing: border-box; margin: 0; padding: 0; }
+		body { font-family: var(--font-family); background: var(--color-background); min-height: 100vh; }
+		.shell { width: 100%; padding-top: 24px; }
+		/* Aligned to the form card's width, which centers itself in the iframe below. */
+		.req-card, .req-strip { width: var(--container-width); max-width: calc(100vw - 32px); margin: 0 auto 16px; }
+
+		/* --- Required-credentials card (1–2 credentials, inline) --- */
+		.req-card {
+			background: var(--color-card-bg);
+			border: 1px solid var(--color-card-border);
+			border-radius: var(--border-radius-card);
+			box-shadow: var(--box-shadow-card);
+			padding: 20px;
+		}
+		.req-title { font-size: 15px; font-weight: 600; color: var(--color-header); }
+		.req-sub { font-size: 13px; color: var(--color-muted); margin-top: 4px; margin-bottom: 14px; }
+
+		/* --- Compact strip (3+ credentials) --- */
+		.req-strip {
+			display: flex;
+			align-items: center;
+			gap: 14px;
+			background: var(--color-card-bg);
+			border: 1px solid var(--color-card-border);
+			border-radius: var(--border-radius-card);
+			box-shadow: var(--box-shadow-card);
+			padding: 16px 18px;
+		}
+		.stack { display: flex; align-items: center; }
+		.stack .cred-icon { margin-right: -8px; border: 2px solid var(--color-card-bg); }
+		.stack .more {
+			width: 28px; height: 28px; border-radius: 6px; border: 2px solid var(--color-card-bg);
+			background: #eceafd; color: var(--color-icon-text);
+			font-size: 11px; font-weight: 600; display: flex; align-items: center; justify-content: center;
+		}
+		.strip-meta { flex: 1; min-width: 0; }
+		.strip-title { font-size: 14px; font-weight: 600; color: var(--color-header); }
+		.strip-count { font-size: 13px; color: var(--color-muted); margin-top: 2px; }
+
+		/* --- Credential row (shared by card + dialog) --- */
+		.cred-row { display: flex; align-items: center; gap: 12px; padding: 10px 0; }
+		.req-card .cred-row + .cred-row,
+		.dialog .cred-row + .cred-row { border-top: 1px solid #f0f1f4; }
+		.cred-icon {
+			width: 28px; height: 28px; border-radius: 6px; flex-shrink: 0;
+			background: var(--color-icon-bg); color: var(--color-icon-text);
+			font-size: 13px; font-weight: 600; display: flex; align-items: center; justify-content: center;
+		}
+		.cred-meta { flex: 1; min-width: 0; }
+		.cred-name { display: block; font-size: 14px; font-weight: 600; color: var(--color-label); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+		.cred-sub { display: block; font-size: 12px; color: var(--color-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+		.cred-sub.connected { color: var(--color-ok); }
+
+		/* --- Buttons --- */
+		.btn {
+			font-family: var(--font-family); font-size: 13px; font-weight: 600;
+			padding: 8px 16px; border-radius: var(--border-radius-input); border: 1px solid transparent; cursor: pointer;
+		}
+		.btn-primary { background: var(--color-primary); color: var(--color-primary-text); }
+		.btn-primary:hover { opacity: 0.88; }
+		.btn-secondary { background: var(--color-card-bg); color: var(--color-label); border-color: var(--color-card-border); }
+		.btn-secondary:hover { border-color: var(--color-muted); }
+		.cred-connected { position: relative; }
+		.btn-connected { display: inline-flex; align-items: center; gap: 6px; background: none; border: 0; color: var(--color-ok); font-family: var(--font-family); font-size: 13px; font-weight: 600; cursor: pointer; padding: 6px 4px; }
+		.btn-connected .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--color-ok); }
+		/* Fixed so the menu escapes the dialog's overflow clipping; positioned by JS. */
+		.cred-menu { display: none; position: fixed; min-width: 150px; background: var(--color-card-bg); border: 1px solid var(--color-card-border); border-radius: 6px; box-shadow: var(--box-shadow-dialog); z-index: 30; }
+		.cred-menu.open { display: block; }
+		.btn-disconnect { display: block; width: 100%; text-align: left; white-space: nowrap; background: none; border: 0; padding: 8px 14px; font-family: var(--font-family); font-size: 13px; color: #a02f28; cursor: pointer; }
+		.btn-disconnect:hover { background: #fdeceb; }
+		.cred-status-ok { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 600; color: var(--color-ok); white-space: nowrap; }
+		.cred-status-ok .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--color-ok); }
+		.cred-blocked { font-size: 13px; color: var(--color-muted); }
+
+		/* --- Dialog --- */
+		.overlay { display: none; position: fixed; inset: 0; background: rgba(20, 20, 30, 0.28); backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px); align-items: center; justify-content: center; z-index: 10; padding: 16px; }
+		.overlay.open { display: flex; }
+		.dialog { width: 480px; max-width: 100%; max-height: calc(100vh - 48px); display: flex; flex-direction: column; background: var(--color-card-bg); border-radius: 12px; box-shadow: var(--box-shadow-dialog); overflow: hidden; }
+		.dialog-head { display: flex; align-items: center; justify-content: space-between; padding: 18px 20px 8px; }
+		.dialog-title { font-size: 16px; font-weight: 600; color: var(--color-header); }
+		.dialog-close { background: none; border: 0; font-size: 20px; line-height: 1; color: var(--color-muted); cursor: pointer; }
+		.dialog-sub { padding: 0 20px 8px; font-size: 13px; color: var(--color-muted); }
+		.dialog-list { padding: 0 20px; overflow-y: auto; }
+		.dialog-foot { display: flex; align-items: center; justify-content: space-between; padding: 14px 20px; border-top: 1px solid #f0f1f4; }
+		.dialog-count { font-size: 13px; color: var(--color-muted); }
+
+		/* --- The form itself, unchanged, in a null-origin sandboxed iframe --- */
+		#form-frame { display: block; width: 100%; height: calc(100vh - 40px); border: 0; background: transparent; }
+	</style>
+</head>
+
+<body>
+	<div class='shell' data-submitter-email='{{submitterEmail}}'>
+		{{#if useDialog}}
+			<div class='req-strip'>
+				<div class='stack'>
+					{{#each iconStack}}
+						<span class='cred-icon'>{{this}}</span>
+					{{/each}}
+					{{#if moreCount}}<span class='more'>+{{moreCount}}</span>{{/if}}
+				</div>
+				<div class='strip-meta'>
+					<div class='strip-title'>Required credentials</div>
+					<div class='strip-count'>{{connectedCount}} of {{total}} credentials connected</div>
+				</div>
+				<button class='btn btn-primary' id='open-dialog'>Connect</button>
+			</div>
+		{{else}}
+			<div class='req-card'>
+				<div class='req-title'>Required credentials</div>
+				<div class='req-sub'>Connect required credentials to run this form using your data.</div>
+				{{#each credentials}}
+					<div class='cred-row' data-cred-id='{{id}}' data-status='{{status}}' data-resolver-id='{{resolverId}}'{{#if connected}} data-connected='true'{{/if}}{{#if revokeUrl}} data-revoke-url='{{revokeUrl}}'{{/if}}>
+						<span class='cred-icon'>{{initial}}</span>
+						<span class='cred-meta'>
+							<span class='cred-name'>{{name}}</span>
+							<span class='cred-sub {{#if connected}}connected{{/if}}'>{{#if connected}}{{#if account}}Connected as {{account}}{{else}}Connected{{/if}}{{else}}Not connected{{/if}}{{#if usedBy}} · used by {{usedBy}}{{/if}}</span>
+						</span>
+						{{#if connected}}
+							<span class='cred-connected'><button type='button' class='btn-connected'><span class='dot'></span> Connected <span class='caret'>&#9662;</span></button><div class='cred-menu'><button type='button' class='btn-disconnect'>Disconnect</button></div></span>
+						{{else if authorizationUrl}}
+							<button class='btn btn-secondary connect' data-url='{{authorizationUrl}}'>{{#if (eq status 'expired')}}Reconnect{{else}}Connect{{/if}}</button>
+						{{else}}
+							<span class='cred-blocked'>Ask the form owner</span>
+						{{/if}}
+					</div>
+				{{/each}}
+			</div>
+		{{/if}}
+
+		<iframe
+			id='form-frame'
+			src='{{iframeSrc}}'
+			sandbox='allow-scripts allow-forms allow-modals allow-popups allow-downloads'
+		></iframe>
+	</div>
+
+	{{#if useDialog}}
+		<div class='overlay' id='overlay'>
+			<div class='dialog' role='dialog' aria-modal='true' aria-labelledby='dialog-title'>
+				<div class='dialog-head'>
+					<span class='dialog-title' id='dialog-title'>Required credentials</span>
+					<button class='dialog-close' id='close-dialog' aria-label='Close'>&times;</button>
+				</div>
+				<div class='dialog-sub'>Connect required credentials to run this form using your data.</div>
+				<div class='dialog-list'>
+					{{#each credentials}}
+						<div class='cred-row' data-cred-id='{{id}}' data-status='{{status}}' data-resolver-id='{{resolverId}}'{{#if connected}} data-connected='true'{{/if}}{{#if revokeUrl}} data-revoke-url='{{revokeUrl}}'{{/if}}>
+							<span class='cred-icon'>{{initial}}</span>
+							<span class='cred-meta'>
+								<span class='cred-name'>{{name}}</span>
+								<span class='cred-sub {{#if connected}}connected{{/if}}'>{{#if connected}}{{#if account}}Connected as {{account}}{{else}}Connected{{/if}}{{else}}Not connected{{/if}}{{#if usedBy}} · used by {{usedBy}}{{/if}}</span>
+							</span>
+							{{#if connected}}
+								<span class='cred-connected'><button type='button' class='btn-connected'><span class='dot'></span> Connected <span class='caret'>&#9662;</span></button><div class='cred-menu'><button type='button' class='btn-disconnect'>Disconnect</button></div></span>
+							{{else if authorizationUrl}}
+								<button class='btn btn-secondary connect' data-url='{{authorizationUrl}}'>{{#if (eq status 'expired')}}Reconnect{{else}}Connect{{/if}}</button>
+							{{else}}
+								<span class='cred-blocked'>Ask the form owner</span>
+							{{/if}}
+						</div>
+					{{/each}}
+				</div>
+				<div class='dialog-foot'>
+					<span class='dialog-count'>{{connectedCount}} of {{total}} credentials connected</span>
+					<button class='btn btn-primary' id='done-dialog'>Done</button>
+				</div>
+			</div>
+		</div>
+	{{/if}}
+
+	<script>
+		(function () {
+			// Rows update in place — a reload would bounce the submitter back through consent.
+			var frame = document.getElementById('form-frame');
+			var ids = {};
+			var connected = {};
+			document.querySelectorAll('.cred-row').forEach(function (row) {
+				var id = row.getAttribute('data-cred-id');
+				ids[id] = true;
+				if (row.getAttribute('data-connected') === 'true') connected[id] = true;
+			});
+			var total = Object.keys(ids).length;
+
+			function refresh() {
+				var count = Object.keys(connected).length;
+				var txt = count + ' of ' + total + ' credentials connected';
+				document.querySelectorAll('.strip-count, .dialog-count').forEach(function (el) {
+					el.textContent = txt;
+				});
+				// UX-only signal to the form iframe; the server-side POST gate is the guarantee.
+				if (frame && frame.contentWindow) {
+					frame.contentWindow.postMessage(
+						{ type: count >= total ? 'n8n-shell-credentials-ready' : 'n8n-shell-credentials-not-ready' },
+						'*',
+					);
+				}
+			}
+
+			var shellEl = document.querySelector('.shell');
+			var SUBMITTER_EMAIL = shellEl ? shellEl.getAttribute('data-submitter-email') || '' : '';
+			var CONNECTED_MENU_HTML =
+				'<button type="button" class="btn-connected"><span class="dot"></span> Connected <span class="caret">&#9662;</span></button>' +
+				'<div class="cred-menu"><button type="button" class="btn-disconnect">Disconnect</button></div>';
+
+			function markConnected(id) {
+				if (!id || connected[id]) return;
+				connected[id] = true;
+				// Card and dialog share the same data-cred-id; update both.
+				document.querySelectorAll('.cred-row[data-cred-id="' + id + '"]').forEach(function (row) {
+					row.setAttribute('data-connected', 'true');
+					var sub = row.querySelector('.cred-sub');
+					if (sub) {
+						sub.textContent = SUBMITTER_EMAIL ? 'Connected as ' + SUBMITTER_EMAIL : 'Connected';
+						sub.classList.add('connected');
+					}
+					var btn = row.querySelector('.connect');
+					if (btn) {
+						// Derive the revoke URL from the authorize link (same server-built base),
+						// so a just-connected row can disconnect without a reload.
+						var authUrl = btn.getAttribute('data-url');
+						var resolverId = row.getAttribute('data-resolver-id');
+						if (authUrl && resolverId && !row.getAttribute('data-revoke-url')) {
+							try {
+								var u = new URL(authUrl);
+								u.pathname = u.pathname.replace(/\/authorize$/, '/revoke');
+								u.search = '?resolverId=' + encodeURIComponent(resolverId);
+								row.setAttribute('data-revoke-url', u.toString());
+							} catch (e) {}
+						}
+						var wrap = document.createElement('span');
+						wrap.className = 'cred-connected';
+						wrap.innerHTML = CONNECTED_MENU_HTML;
+						btn.replaceWith(wrap);
+					}
+				});
+				refresh();
+			}
+
+			var pendingId = null;
+
+			// Connected only on the oauth-callback success signal — never on popup close,
+			// which also happens on provider-side failures.
+			function onSuccessSignal() { if (pendingId) markConnected(pendingId); }
+			try {
+				var channel = new BroadcastChannel('oauth-callback');
+				channel.addEventListener('message', function (event) {
+					if (event.data === 'success') onSuccessSignal();
+				});
+			} catch (e) {}
+			window.addEventListener('message', function (event) {
+				// Ignore the sandboxed form iframe so author content can't spoof a connect.
+				if (frame && event.source === frame.contentWindow) return;
+				if (event.data === 'success') onSuccessSignal();
+			});
+
+			function openConnect(id, url) {
+				if (!url) return;
+				pendingId = id;
+				// No popup-close handler: success is confirmed only by the signals above.
+				window.open(url, 'n8n-credential-connect', 'width=500,height=700,menubar=no,toolbar=no');
+			}
+
+			function markDisconnected(id) {
+				if (!id) return;
+				delete connected[id];
+				document.querySelectorAll('.cred-row[data-cred-id="' + id + '"]').forEach(function (row) {
+					row.removeAttribute('data-connected');
+					var sub = row.querySelector('.cred-sub');
+					if (sub) { sub.textContent = 'Not connected'; sub.classList.remove('connected'); }
+					var wrap = row.querySelector('.cred-connected');
+					if (wrap) {
+						var btn = document.createElement('button');
+						btn.className = 'btn btn-secondary connect';
+						// The one-time authorize link was consumed by the previous connect, so
+						// this Connect mints a fresh one instead of reloading (a reload would
+						// re-run the form's OAuth2 auth and re-show consent).
+						var revokeUrl = row.getAttribute('data-revoke-url');
+						if (revokeUrl) {
+							btn.setAttribute('data-authorize-url', revokeUrl.replace('/revoke?', '/authorize?'));
+						}
+						btn.textContent = 'Connect';
+						wrap.replaceWith(btn);
+					}
+				});
+				refresh();
+			}
+
+			// Session-cookie auth + the browser-id the session was issued with (stored in
+			// localStorage on this same origin by the editor/consent pages).
+			function authHeaders() {
+				try {
+					var browserId = localStorage.getItem('n8n-browserId');
+					if (browserId) return { 'browser-id': browserId };
+				} catch (e) {}
+				return {};
+			}
+
+			function disconnectCred(row) {
+				if (!row) return;
+				var id = row.getAttribute('data-cred-id');
+				var revokeUrl = row.getAttribute('data-revoke-url');
+				if (!id || !revokeUrl) return;
+				fetch(revokeUrl + '&authSource=cookie', {
+					method: 'DELETE',
+					credentials: 'include',
+					headers: authHeaders(),
+				})
+					.then(function (r) { if (r.ok) markDisconnected(id); })
+					.catch(function () {});
+			}
+
+			// Reconnect after a disconnect: mint a fresh authorize link and send the popup
+			// there. The popup opens synchronously so it isn't treated as a pop-under.
+			function reconnect(id, mintUrl) {
+				if (!id || !mintUrl) return;
+				var popup = window.open('', 'n8n-credential-connect', 'width=500,height=700,menubar=no,toolbar=no');
+				pendingId = id;
+				fetch(mintUrl + '&authSource=cookie', {
+					method: 'POST',
+					credentials: 'include',
+					headers: authHeaders(),
+				})
+					.then(function (r) { return r.ok ? r.json() : null; })
+					.then(function (body) {
+						var url = body && (body.data || body);
+						if (typeof url === 'string' && popup) popup.location = url;
+						else if (popup) popup.close();
+					})
+					.catch(function () { if (popup) popup.close(); });
+			}
+
+			// Delegated clicks so controls created after markConnected() also work.
+			document.addEventListener('click', function (e) {
+				var connectBtn = e.target.closest('.connect');
+				if (connectBtn) {
+					var row = connectBtn.closest('.cred-row');
+					var id = row ? row.getAttribute('data-cred-id') : null;
+					var mintUrl = connectBtn.getAttribute('data-authorize-url');
+					if (mintUrl) reconnect(id, mintUrl);
+					else openConnect(id, connectBtn.getAttribute('data-url'));
+					return;
+				}
+				var menuBtn = e.target.closest('.btn-connected');
+				if (menuBtn) {
+					e.stopPropagation();
+					var menu = menuBtn.parentElement.querySelector('.cred-menu');
+					var wasOpen = menu && menu.classList.contains('open');
+					document.querySelectorAll('.cred-menu.open').forEach(function (m) { m.classList.remove('open'); });
+					if (menu && !wasOpen) {
+						menu.classList.add('open');
+						// Anchor to the button; flip above when out of room below.
+						var r = menuBtn.getBoundingClientRect();
+						var flipUp = window.innerHeight - r.bottom < menu.offsetHeight + 12;
+						menu.style.top = (flipUp ? r.top - menu.offsetHeight - 4 : r.bottom + 4) + 'px';
+						menu.style.left = r.right - menu.offsetWidth + 'px';
+					}
+					return;
+				}
+				var disconnectBtn = e.target.closest('.btn-disconnect');
+				if (disconnectBtn) {
+					e.stopPropagation();
+					disconnectCred(disconnectBtn.closest('.cred-row'));
+					return;
+				}
+				// Click elsewhere closes any open menu.
+				document.querySelectorAll('.cred-menu.open').forEach(function (m) { m.classList.remove('open'); });
+			});
+
+			// Dialog (3+ credentials)
+			var overlay = document.getElementById('overlay');
+			var open = document.getElementById('open-dialog');
+			if (open && overlay) {
+				open.addEventListener('click', function () { overlay.classList.add('open'); });
+				document.getElementById('close-dialog').addEventListener('click', function () { overlay.classList.remove('open'); });
+				document.getElementById('done-dialog').addEventListener('click', function () { overlay.classList.remove('open'); });
+				overlay.addEventListener('click', function (e) { if (e.target === overlay) overlay.classList.remove('open'); });
+			}
+		})();
+	</script>
+</body>
+
+</html>

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -255,6 +255,16 @@
 				opacity: 0.7;
 			}
 
+			#submit-btn:disabled {
+				background-color: #e9eaec;
+				color: #9aa0a6;
+				cursor: not-allowed;
+			}
+
+			#submit-btn:disabled:hover {
+				opacity: 1;
+			}
+
 			.error-hidden {
 				display: block;
 				position: relative;
@@ -621,7 +631,7 @@
 						{{/each}}
 					</div>
 
-					<button id='submit-btn' type='submit'>
+					<button id='submit-btn' type='submit' {{#if shellInner}}disabled title='Connect the required credentials first'{{/if}}>
 						<span><svg
 								xmlns='http://www.w3.org/2000/svg'
 								height='18px'
@@ -1110,5 +1120,24 @@
 				}
 			});
 		</script>
+		{{#if shellInner}}
+		<script>
+			// Toggle submit on the hosting shell's readiness signals; the server-side
+			// POST gate is the real enforcement.
+			window.addEventListener('message', function (event) {
+				if (event.source !== window.parent) return;
+				if (!event.data) return;
+				var btn = document.getElementById('submit-btn');
+				if (!btn) return;
+				if (event.data.type === 'n8n-shell-credentials-ready') {
+					btn.disabled = false;
+					btn.removeAttribute('title');
+				} else if (event.data.type === 'n8n-shell-credentials-not-ready') {
+					btn.disabled = true;
+					btn.setAttribute('title', 'Connect the required credentials first');
+				}
+			});
+		</script>
+		{{/if}}
 	</body>
 </html>

--- a/packages/nodes-base/nodes/Form/interfaces.ts
+++ b/packages/nodes-base/nodes/Form/interfaces.ts
@@ -49,6 +49,10 @@ export type FormTriggerData = {
 	buttonLabel?: string;
 	dangerousCustomCss?: string;
 	authToken?: string;
+	// True when this form is rendered inside the hosting-shell iframe: the submit
+	// button starts disabled (the shell enables it once the submitter's required
+	// credentials are connected). Enforcement is server-side on POST regardless.
+	shellInner?: boolean;
 };
 
 export const FORM_TRIGGER_AUTHENTICATION_PROPERTY = 'authentication';

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -7,6 +7,7 @@ import jwt from 'jsonwebtoken';
 import { DateTime } from 'luxon';
 import { getHtmlSandboxCSP, InstanceSettings, isFormHtmlSandboxingDisabled } from 'n8n-core';
 import type {
+	CredentialCheckStatus,
 	INode,
 	INodeExecutionData,
 	IUser,
@@ -238,6 +239,7 @@ export function prepareFormData({
 	customCss,
 	nodeVersion,
 	authToken,
+	shellInner,
 }: {
 	formTitle: string;
 	formDescription: string;
@@ -254,6 +256,7 @@ export function prepareFormData({
 	customCss?: string;
 	nodeVersion?: number;
 	authToken?: string;
+	shellInner?: boolean;
 }) {
 	const utm_campaign = instanceId ? `&utm_campaign=${instanceId}` : '';
 	const n8nWebsiteLink = `https://n8n.io/?utm_source=n8n-internal&utm_medium=form-trigger${utm_campaign}`;
@@ -276,6 +279,8 @@ export function prepareFormData({
 		buttonLabel,
 		dangerousCustomCss: sanitizeCustomCss(customCss),
 		authToken,
+		// Only set inside the hosting shell, so the plain form's render data is unchanged.
+		shellInner: shellInner || undefined,
 	};
 
 	if (redirectUrl) {
@@ -564,6 +569,7 @@ export function renderForm({
 	buttonLabel,
 	customCss,
 	authToken,
+	shellInner,
 }: {
 	context: IWebhookFunctions;
 	res: Response;
@@ -578,6 +584,7 @@ export function renderForm({
 	buttonLabel?: string;
 	customCss?: string;
 	authToken?: string;
+	shellInner?: boolean;
 }) {
 	const instanceId = context.getInstanceId();
 
@@ -621,6 +628,7 @@ export function renderForm({
 		customCss,
 		nodeVersion: context.getNode().typeVersion,
 		authToken,
+		shellInner,
 	});
 
 	if (!isFormHtmlSandboxingDisabled()) {
@@ -925,6 +933,75 @@ export async function validateFormPageAuth(
 	return user ? { authedUser: user } : { responded: true };
 }
 
+/**
+ * Render the trusted hosting shell: an n8n-controlled page on the real origin
+ * that shows the author's form inside a sandboxed (null-origin) iframe with a
+ * credential-connect panel beside it. The form's submit stays disabled while any
+ * required credential is missing; enforcement is server-side on POST regardless.
+ *
+ * The shell holds the connect panel — with the real per-credential authorize
+ * links — OUTSIDE the author-scriptable iframe DOM (the security win over
+ * connecting inside the form). It carries a live session, so it refuses framing.
+ */
+function renderFormShell({
+	res,
+	req,
+	formTitle,
+	resourceUrl,
+	credentials,
+	submitterEmail,
+}: {
+	res: Response;
+	req: Request;
+	formTitle: string;
+	resourceUrl: string;
+	credentials: CredentialCheckStatus[];
+	submitterEmail?: string;
+}) {
+	// The iframe loads the same form via a real URL (so the form's relative POST
+	// works exactly as it does top-level today) flagged as the inner render.
+	const inner = new URL(buildAbsoluteFormUrl(req));
+	inner.searchParams.set('n8nShellInner', '1');
+
+	const initialOf = (name: string) => (name.trim().charAt(0) || '?').toUpperCase();
+	const rows = credentials.map((c) => ({
+		id: c.credentialId,
+		name: c.credentialName,
+		type: c.credentialType,
+		status: c.status,
+		connected: c.status === 'configured',
+		initial: initialOf(c.credentialName),
+		authorizationUrl: c.authorizationUrl,
+		revokeUrl: c.revokeUrl,
+		resolverId: c.resolverId,
+		// The connected identity shown as "Connected as …". For the system (n8n)
+		// resolver this is the submitter themselves; surfacing the exact OAuth
+		// provider account (when it differs) is a backend-enrichment follow-up.
+		account: c.status === 'configured' ? submitterEmail : undefined,
+		// `usedBy` (owning node) comes from the backend-enrichment follow-up.
+		usedBy: undefined as string | undefined,
+	}));
+
+	const total = rows.length;
+	const connectedCount = rows.filter((r) => r.connected).length;
+	// Design: 1–2 credentials render inline; 3+ collapse into a strip + dialog.
+	const useDialog = total >= 3;
+
+	res.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
+	res.render('form-shell', {
+		formTitle,
+		iframeSrc: `${inner.pathname}${inner.search}`,
+		resourceUrl,
+		credentials: rows,
+		total,
+		connectedCount,
+		useDialog,
+		submitterEmail,
+		iconStack: rows.slice(0, 3).map((r) => r.initial),
+		moreCount: total > 3 ? total - 3 : 0,
+	});
+}
+
 export async function formWebhook(
 	context: IWebhookFunctions,
 	authProperty = FORM_TRIGGER_AUTHENTICATION_PROPERTY,
@@ -1048,6 +1125,52 @@ export async function formWebhook(
 			responseMode = 'responseNode';
 		}
 
+		// The inner render is the form loaded inside the hosting-shell iframe. Honor the
+		// flag only for iframe navigations (per Sec-Fetch-Dest, absent on older browsers)
+		// so a hand-typed URL can't skip the connect UI; the POST gate enforces regardless.
+		const secFetchDest = req.headers?.['sec-fetch-dest'];
+		const shellInner =
+			req.query.n8nShellInner === '1' && (secFetchDest === undefined || secFetchDest === 'iframe');
+
+		// Connect-before-submit: when the workflow needs the submitter's own
+		// (private) credentials, establish their identity from the OAuth2 token and
+		// check readiness server-side. If anything is still missing — and we're not
+		// already rendering the inner iframe — wrap the form in the hosting shell
+		// (form + connect panel, submit disabled). No-op unless OAuth2 form auth and
+		// the dynamic-credentials module are both active.
+		if (
+			authentication === 'n8nUserAuth' &&
+			authedUser &&
+			isFormOAuth2Enabled() &&
+			oAuth2Token &&
+			!shellInner
+		) {
+			// Must name the endpoint actually being served (test vs production) — the
+			// OAuth2 token is bound to that resource, same as in the auth path above.
+			const resourceUrl = trimTrailingSlash(context.getWebhookResourceUrl('default') ?? '');
+			if (resourceUrl) {
+				await context.establishTriggerIdentity(oAuth2Token, resourceUrl);
+				const credentialStatus = await context.checkTriggerCredentialStatus();
+				if (credentialStatus && !credentialStatus.readyToExecute) {
+					// Hand the OAuth2 token to the same-site iframe GET via the one-hop
+					// cookie the OAuth2 flow already uses, so the inner form authenticates
+					// without re-running the provider redirect inside the frame.
+					setFormOAuthToken(res, req, resourceUrl, oAuth2Token);
+					// Pass ALL required credentials (connected + missing) so the card shows
+					// each one's state and the "{n} of {m} connected" progress.
+					renderFormShell({
+						res,
+						req,
+						formTitle,
+						resourceUrl,
+						credentials: credentialStatus.credentials,
+						submitterEmail: authedUser?.email,
+					});
+					return { noWebhookResponse: true };
+				}
+			}
+		}
+
 		let authToken: string | undefined;
 		if (node.typeVersion > 1) {
 			if (authentication === 'n8nUserAuth' && authedUser) {
@@ -1078,6 +1201,7 @@ export async function formWebhook(
 			buttonLabel,
 			customCss: options.customCss,
 			authToken,
+			shellInner,
 		});
 
 		return {
@@ -1089,6 +1213,17 @@ export async function formWebhook(
 
 	if (useWorkflowTimezone === undefined && node.typeVersion > 2) {
 		useWorkflowTimezone = true;
+	}
+
+	// Fail-closed submit gate: the shell panel / disabled button is UX only — this
+	// server-side re-check is the real guarantee (author script in the iframe can
+	// re-enable the button). Identity was established during POST authentication;
+	// reject if any required credential is still missing (also covers a credential
+	// revoked while the form was open — TOCTOU).
+	const submitGate = await context.checkTriggerCredentialStatus();
+	if (submitGate && !submitGate.readyToExecute) {
+		res.status(409).json({ message: 'Required credentials are not connected yet' });
+		return { noWebhookResponse: true };
 	}
 
 	const userForOutput = options.includeUserInOutput === false ? undefined : authedUser;


### PR DESCRIPTION
## Summary

The Form Trigger can now run a workflow with the **submitter's own** (end-user)<br>credentials. When a submitter opens a form whose workflow needs credentials they<br>haven't connected yet, n8n wraps the author's form in an n8n-controlled **hosting****<br>****shell**: a "Required credentials" panel lets them connect each credential, and<br>Submit stays disabled until all are connected.

The author's form renders unchanged inside a sandboxed, null-origin `<iframe>`;<br>the connect panel lives in the shell, outside the author-scriptable DOM. The<br>disabled Submit is UX only — enforcement is a server-side, fail-closed readiness<br>re-check on POST.

Implements the [IAM-1054](https://linear.app/n8n/issue/IAM-1054/spike-form-trigger-trusted-hosting-shell-for-credential-connect) spike outcome (trusted hosting shell) and the [IAM-1046](https://linear.app/n8n/issue/IAM-1046/form-trigger-end-user-credentials-design)<br>connect UI. Gated behind `og` + the dynamic-<br>credentials license; forms without end-user credentials are unaffected.

> Note for reviewers: the shell is server-rendered Handlebars (no Vue runtime),<br>so the connect/disconnect dropdown is a plain-HTML replica of `N8nActionDropdown`,<br>not the component itself. "Connected as {email}" uses the submitter's n8n email,<br>matching `NodeCredentials.vue` (`currentUser.email`).

### Screenshots

**0. Workflow state with end-user creds, consent screen**

<img src="https://github.com/user-attachments/assets/0d062e66-3675-48ed-9ad9-d7cc7d6c13f5 " alt="image" width="577" data-linear-height="393" />

<img src="https://github.com/user-attachments/assets/5e4252fb-8ce1-4b65-9842-0862b54908ba " alt="image" width="701" data-linear-height="848" />

**1. Connect-before-submit — credentials not connected, Submit disabled**

<img src="https://github.com/user-attachments/assets/9b048c1d-19df-4303-bfc4-ece1936a0061 " alt="image" width="697" data-linear-height="844" />

<img src="https://github.com/user-attachments/assets/a01c2dd2-6c58-48ff-8732-cc75152634b0 " alt="image" width="1110" data-linear-height="768" />

**2. Multiple credentials — compact strip + dialog (3+)**

<img src="https://github.com/user-attachments/assets/0fb6f94a-8d14-4ea6-9357-de628bb0f170 " alt="image" width="535" data-linear-height="596" />

<img src="https://github.com/user-attachments/assets/6d42a8f9-8728-4e85-902a-161c18e8bced " alt="image" width="658" data-linear-height="740" />

**3. Connected — "Connected as …" + disconnect dropdown**

<img src="https://github.com/user-attachments/assets/04b2ff9e-29fd-491d-a7fd-c511d592496b " alt="image" width="1123" data-linear-height="782" />

<img src="https://github.com/user-attachments/assets/cfe8dd35-01da-4d0f-8398-470b70ce7443 " alt="image" width="200" data-linear-height="158" />

<img src="https://github.com/user-attachments/assets/7f334b2e-3b97-4569-9863-d3a08d66edbb " alt="image" width="515" data-linear-height="199" />

<img src="https://github.com/user-attachments/assets/b2dc64ed-e45c-494e-9783-dba336700871 " alt="image" width="524" data-linear-height="344" />

<img src="https://github.com/user-attachments/assets/e25f3a15-764a-4c15-bd99-a148cad83396 " alt="image" width="524" data-linear-height="554" />

**4. All connected → plain form, Submit enabled**

<img src="https://github.com/user-attachments/assets/7ac6044a-0a19-4265-b126-3619266ee6cc " alt="image" width="573" data-linear-height="495" />

<img src="https://github.com/user-attachments/assets/408f92bd-138c-4260-b26b-82c49fa2d56e " alt="image" width="935" data-linear-height="230" />

<img src="https://github.com/user-attachments/assets/a3312de2-e637-465e-8f3f-2c8869e1dc9c " alt="image" width="511" data-linear-height="520" />

**5. Server-side fail-closed gate — a submit while credentials are missing is rejected (409), even if the disabled button is bypassed client-side**

<img src="https://github.com/user-attachments/assets/c70656f4-dfff-455f-a4ce-19c5ce7843d4 " alt="image" width="513" data-linear-height="346" />

## How to test

Prereqs: run n8n with `N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2=true` and a license that<br>includes dynamic credentials.

1. Create a workflow with a **Form Trigger** (Authentication = **n8n User Auth**,<br>node v2.6+) plus a node using an **end-user (resolvable)** credential (e.g. Gmail).
2. Publish it and open the production form URL as a submitter.
3. Complete the OAuth2 consent → the **Required credentials** card shows; Submit is disabled.
4. Click **Connect** on each credential → provider OAuth → row flips to<br>**Connected as {your n8n email}**; once all connected, Submit enables.
5. Open **● Connected ▾ → Disconnect** → the row reverts to *Not connected* in<br>place (no consent bounce) and Submit disables.
6. Try to submit while a credential is missing → server returns **409**, workflow does not run.
7. Reconnect all, reload → the plain form renders; submitting runs the workflow<br>with your credential.
8. A form whose workflow uses no end-user credentials renders exactly as before.

## Related Linear tickets, Github issues, and Community forum posts

[IAM-1058](https://linear.app/n8n/issue/IAM-1058)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport …` (if an urgent fix that needs backporting).

---

![Open in Stage](https://camo.githubusercontent.com/e3b46e319aace348a9c2eabc45f307a073a3bf5a08d5220b2027eac6649007b5/68747470733a2f2f73746167657265766965772e6170702f6173736574732f67682d6f70656e2d696e2d73746167652d6c696768742e737667)