### PR TITLE
docs: Correct stale paths and symbols in agent-facing docs

### DIFF
--- a/.agents/skills/design-system/SKILL.md
+++ b/.agents/skills/design-system/SKILL.md
@@ -17,7 +17,7 @@ Reference these guidelines when:
 
 ## Rules
 - Follow guidelines in `packages/frontend/@n8n/design-system/src/styleguide/*.mdx`
-- ALWAYS use CSS variables for styles from `packages/frontend/@n8n/design-system/src/css/_tokens.scss` or `packages/frontend/@n8n/design-system/src/css/_primtivies.scss`. Use hard-coded values only when no suitable tokens.
+- ALWAYS use CSS variables for styles from `packages/frontend/@n8n/design-system/src/css/_tokens.scss` or `packages/frontend/@n8n/design-system/src/css/_primitives.scss`. Use hard-coded values only when no suitable tokens.
 - ALWAYS prefer using existing components from `packages/frontend/@n8n/design-system/src/components`. Prefer components that aren't marked `@deprecated`.
 - Use `light-dark()` when alternating colors for ligh/dark mode
 - When working with animations or transitions, ALWAYS prefer using mixins from `packages/frontend/@n8n/design-system/src/css/mixins/motion.scss`

--- a/.agents/skills/protect-endpoints/SKILL.md
+++ b/.agents/skills/protect-endpoints/SKILL.md
@@ -69,11 +69,12 @@ Add the resource and ops in `packages/@n8n/permissions/`:
    - `PROJECT_CHAT_USER_SCOPES` → execute only (if applicable).
 4. **`src/roles/scopes/global-scopes.ee.ts`** — add to `GLOBAL_OWNER_SCOPES` (admin inherits via `concat()`). Do **not** add to member/chat-user globals — they get scopes via project relations.
 5. **Personal-space publishing**: if you add a `<resource>:publish` scope, also append it to `PERSONAL_SPACE_PUBLISHING_SETTING.scopes` in `constants.ee.ts` so personal-owner gating matches `workflow:publish`.
-6. **Frontend wiring** — three files in the editor; skipping any of them means the new scopes will not appear in the project-role configuration UI:
-   - `packages/frontend/editor-ui/src/app/stores/rbac.store.ts` — add `<resource>: {}` to `scopesByResourceId` (typecheck will fail otherwise).
-   - `packages/frontend/editor-ui/src/features/project-roles/projectRoleScopes.ts` — add the resource to `UI_OPERATIONS` (operations to render in the permissions matrix, in display order) **and** to `SCOPE_TYPES` (the order the resource group appears on the page).
+6. **`src/roles/custom-role-scopes.ee.ts`** — add the resource to `PROJECT_CUSTOM_ROLE_OPERATIONS` with the ops to render in the permissions matrix, in display order. The editor's `SCOPES`/`SCOPE_TYPES` and the save-time whitelist `PROJECT_CUSTOM_ROLE_SCOPES` both derive from it: a resource missing here cannot reach the UI, and a scope missing from it is rejected on save.
+7. **Frontend wiring** — three files; skipping any of them means the new scopes will not appear in the project-role configuration UI:
+   - `packages/frontend/@n8n/stores/src/rbac.store.ts` — add `<resource>: {}` to `scopesByResourceId` (typecheck will fail otherwise).
+   - `packages/frontend/editor-ui/src/features/roles/project/projectRoleScopes.ts` — add the resource to `SCOPE_TYPES` (the order the resource group appears on the page).
    - `packages/frontend/@n8n/i18n/src/locales/en.json` — add `projectRoles.<resource>:<op>` (column label) and `projectRoles.<resource>:<op>.tooltip` (hover description) for every op, plus `projectRoles.type.<resource>` (the group header).
-7. **Snapshot** — update `packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap` to include the new `<resource>:*` entries.
+8. **Snapshot** — update `packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap` to include the new `<resource>:*` entries.
 
 No DB migration needed — `AuthRolesService.init()` syncs scopes/roles on every startup. Custom team roles created in the UI are **not** auto-updated; mention this in the PR description.
 

--- a/.agents/skills/reproduce-bug/SKILL.md
+++ b/.agents/skills/reproduce-bug/SKILL.md
@@ -30,7 +30,7 @@ Based on the affected area, pick the test layer and pattern:
 | Binary data | Vitest unit | NodeTestHarness assertBinaryData | `packages/core/nodes-testing/` |
 | Execution engine | Vitest integration | WorkflowRunner + DI container | `packages/cli/src/__tests__/` |
 | CLI / API | Vitest integration | setupTestServer + supertest | `packages/cli/test/integration/` |
-| Config | Vitest unit | GlobalConfig + Container | `packages/@n8n/config/src/__tests__/` |
+| Config | Vitest unit | GlobalConfig + Container | `packages/@n8n/config/src/configs/__tests__/` |
 | Editor UI | Vitest | Vue Test Utils + Pinia | `packages/frontend/editor-ui/src/**/__tests__/` |
 | E2E / Canvas | Playwright | Test containers + composables | `packages/testing/playwright/` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,8 @@ The monorepo is organized into these key packages:
 - **`packages/workflow`**: Core workflow interfaces and types
 - **`packages/core`**: Workflow execution engine
 - **`packages/cli`**: Express server, REST API, and CLI commands
-- **`packages/editor-ui`**: Vue 3 frontend application
-- **`packages/@n8n/i18n`**: Internationalization for UI text
+- **`packages/frontend/editor-ui`**: Vue 3 frontend application
+- **`packages/frontend/@n8n/i18n`**: Internationalization for UI text
 - **`packages/nodes-base`**: Built-in nodes for integrations
 - **`packages/@n8n/nodes-langchain`**: AI/LangChain nodes
 - **`packages/@n8n/instance-ai`**: "AI Assistant" in the UI, "Instance AI" in code — AI assistant backend. See its `CLAUDE.md` for architecture docs.
@@ -264,9 +264,9 @@ What we use for testing and writing tests:
 When implementing features:
 1. Define API types in `packages/@n8n/api-types`
 2. Implement backend logic in `packages/cli` module, follow
-   `@packages/cli/scripts/backend-module/backend-module-guide.md`
+   `scripts/backend-module/backend-module-guide.md`
 3. Add API endpoints via controllers
-4. Update frontend in `packages/editor-ui` with i18n support
+4. Update frontend in `packages/frontend/editor-ui` with i18n support
 5. Write tests with proper mocks
 6. Run `pnpm typecheck` to verify types
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,7 +305,7 @@ N8N_DEV_RELOAD=true pnpm dev
 pnpm start
 
 # Terminal 2: Run frontend dev server
-cd packages/editor-ui
+cd packages/frontend/editor-ui
 pnpm dev
 ```
 

--- a/packages/testing/playwright/AGENTS.md
+++ b/packages/testing/playwright/AGENTS.md
@@ -383,7 +383,7 @@ test('API-only test', async ({ api }) => {
 To test features behind feature flags (experiments), use `TestRequirements` with storage overrides:
 
 ```typescript
-import type { TestRequirements } from '../config/TestRequirements';
+import type { TestRequirements } from '../../../Types';
 
 const requirements: TestRequirements = {
   storage: {
@@ -421,7 +421,9 @@ const requirements: TestRequirements = {
 };
 ```
 
-**Reference:** `config/TestRequirements.ts` for full interface definition.
+**Reference:** `Types.ts` for the full interface definition. Import depth follows
+the spec's own nesting. The example above assumes `tests/e2e/<area>/`; add one
+`../` per extra level down.
 
 ## Shard Rebalancing
 


### PR DESCRIPTION
## Summary

Paths and one symbol in agent-facing docs had drifted from the tree, so an agent
following them looked for files that are not there.

Reported in #35300:

| File | Was | Now |
|---|---|---|
| `protect-endpoints/SKILL.md` | `editor-ui/src/app/stores/rbac.store.ts` | `@n8n/stores/src/rbac.store.ts` |
| `protect-endpoints/SKILL.md` | `src/features/project-roles/projectRoleScopes.ts` | `src/features/roles/project/projectRoleScopes.ts` |
| `playwright/AGENTS.md` | `'../config/TestRequirements'` | `'../../../Types'` (2 spots) |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3897

closes #35300

Overlaps #35301 by @SVOG23, which fixes the three reported paths. Their report and
verification are what made this findable; this PR additionally resolves the
`UI_OPERATIONS` question they flagged and the three paths found while sweeping.
Happy to close this in favour of theirs plus a follow-up if preferred.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35349">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

