### PR TITLE
ci: Fetch base history without blobs when detecting changed paths

### DIFF
--- a/.github/actions/ci-filter/ci-filter.mjs
+++ b/.github/actions/ci-filter/ci-filter.mjs
@@ -105,7 +105,7 @@ export function getChangedFiles(baseRef) {
 	// "changed" — spuriously triggering path-filtered jobs. The merge base
 	// scopes the diff to PR-only changes.
 	fetchUntilMergeBase(baseRef);
-	const output = execSync('git diff --name-only --merge-base FETCH_HEAD HEAD', {
+	const output = execSync('git diff --name-only --no-renames --merge-base FETCH_HEAD HEAD', {
 		encoding: 'utf-8',
 	});
 	return output
@@ -120,9 +120,10 @@ export function getAddedFiles(baseRef) {
 	if (!SAFE_REF.test(baseRef)) {
 		throw new Error(`Unsafe base ref: "${baseRef}"`);
 	}
-	const output = execSync('git diff --name-only --diff-filter=A --merge-base FETCH_HEAD HEAD', {
-		encoding: 'utf-8',
-	});
+	const output = execSync(
+		'git diff --name-only --no-renames --diff-filter=A --merge-base FETCH_HEAD HEAD',
+		{ encoding: 'utf-8' },
+	);
 	return output
 		.split('\n')
 		.map((f) => f.trim())
@@ -161,7 +162,9 @@ function fetchUntilMergeBase(baseRef) {
 
 function deepenFetch(baseRef, step, maxDeepen) {
 	const flag = step > maxDeepen ? '--unshallow' : `--deepen=${step}`;
-	execSync(`git fetch --no-tags --prune ${flag} origin ${baseRef}`, { stdio: 'pipe' });
+	execSync(`git fetch --no-tags --prune --filter=blob:none ${flag} origin ${baseRef}`, {
+		stdio: 'pipe',
+	});
 }
 
 function isShallow() {


### PR DESCRIPTION
## Summary

The `Detect Changes` job on PR workflows intermittently ends as `cancelled`, and a rerun usually passes. Nothing is cancelling it — it is hitting the job's `timeout-minutes: 5`, and GitHub reports a timed-out job as `cancelled` rather than `failed`. Because the downstream jobs declare `needs: changes`, one slow fetch takes the whole run down.

Example: [run 30616371599](https://github.com/n8n-io/n8n/actions/runs/30616371599). The `Detect changed paths` step normally takes 3–4 seconds; there it ran for **4m57s** and was killed 3 seconds short of the limit.

The cause is on the critical path of every PR. `actions/checkout` clones at depth 1, so `ci-filter` has to deepen the clone over the network before it can compute a merge base. That fetch downloads commits, trees **and blobs** — the full contents of every file touched in the deepen window — even though the only thing done with the result is `git diff --name-only`, which reads trees and never opens a blob. On a repo this size the blobs are effectively the entire transfer, so a slow minute on GitHub's git backend blows the budget.

This fetches as a **blobless partial clone** (`--filter=blob:none`) instead: same commit graph, same tree data, same answer, a fraction of the bytes.

Two details worth a reviewer's attention:

- **Graceful degradation.** If a server does not support filtering, git prints `warning: filtering not recognized by server, ignoring` and completes normally. Verified against a local remote without `uploadpack.allowFilter`. The worst case is no speedup, never a broken run — and the fetch already uses `stdio: 'pipe'`, so the warning is not log noise.
- **`--no-renames` is required, not cosmetic.** Rename detection is on by default, and *inexact* rename detection reads file contents — in a blobless clone that fetches blobs back on demand, one round trip at a time, which could be slower than what we have today. Disabling it is also more accurate for path filtering: a renamed file should register under both its old and its new path so both sides' jobs run.

Not included, but worth considering as a follow-up: a retry with backoff around the fetch, and/or a larger `timeout-minutes`, so that a genuinely slow fetch costs seconds of retry instead of a full pipeline rerun.

## How to test

The action's suite covers the deepen loop against real git fixtures:

```bash
node --experimental-strip-types --test .github/actions/ci-filter/__tests__/ci-filter.test.ts
# 57 pass, 0 fail
```

Note this suite uses `node:test` (not vitest) and does not appear to be wired into any CI job — worth fixing separately.

Behaviour of the flag itself, if you want to confirm it locally:

```bash
# server without filter support -> warns, still succeeds
git fetch --no-tags --prune --filter=blob:none --deepen=2 origin master

# server with uploadpack.allowFilter=true -> accepted silently,
# and `git diff --name-only` still resolves paths with blobs absent
```

On this PR itself, the signal is the `Detect changed paths` step duration on a cold run, plus the absence of a `filtering not recognized` warning in the log.

## Related Linear tickets, Github issues, and Community forum posts

No ticket — CI reliability fix found while investigating cancelled runs on #35158.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- Existing ci-filter suite covers the deepen/diff paths; no new behaviour to test. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35352">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

