### PR TITLE
feat(core): Detect and heal trigger-status drift and unreported published workflows in reconciliation

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -278,6 +278,12 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 	 * reporter only writes rows while its record is `in_progress`, so row drift
 	 * with no in-flight record is a real divergence, never a normal mid-flight
 	 * state.
+	 *
+	 * Workflows whose most recent record is terminal `failed` are excluded for
+	 * the same reason as in {@link findUnreportedPublishedWorkflowIds}: a
+	 * publication that deterministically fails before reporting leaves the rows
+	 * drifted forever, so re-enqueueing would loop every pass. A user republish
+	 * (a fresh pending record) still recovers.
 	 */
 	async findTriggerStatusDriftedWorkflowIds(): Promise<string[]> {
 		const outboxTableName = this.getTableName('workflow_publication_outbox');
@@ -296,7 +302,12 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 				 SELECT 1 FROM ${outboxTableName} o
 				 WHERE o."workflowId" = w."id"
 				 AND o."status" IN ('${Status.Pending}', '${Status.InProgress}')
-			 )`,
+			 )
+			 AND COALESCE((
+				 SELECT o."status" FROM ${outboxTableName} o
+				 WHERE o."workflowId" = w."id"
+				 ORDER BY o."id" DESC LIMIT 1
+			 ), '') <> '${Status.Failed}'`,
 		);
 
 		return rows.map((row) => row.workflowId);

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -267,6 +267,92 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 	}
 
 	/**
+	 * Published workflows where any trigger-status row was recorded for a version
+	 * other than the workflow's canonical `activeVersionId`. Catches a crash or a
+	 * stale (zombie) writer between the published-version advance and the status
+	 * report: the `workflow_published_version` mapping may already be correct, so
+	 * {@link findVersionSkewedWorkflowIds} cannot see it — only the rows lag.
+	 *
+	 * Workflows with an in-flight (pending/in_progress) record are excluded in
+	 * the same statement, for the same reason as the version-skew check: the
+	 * reporter only writes rows while its record is `in_progress`, so row drift
+	 * with no in-flight record is a real divergence, never a normal mid-flight
+	 * state.
+	 */
+	async findTriggerStatusDriftedWorkflowIds(): Promise<string[]> {
+		const outboxTableName = this.getTableName('workflow_publication_outbox');
+		const workflowTableName = this.getTableName('workflow_entity');
+		const triggerStatusTableName = this.getTableName('workflow_publication_trigger_status');
+
+		// Both compared columns are non-null here (`activeVersionId` is filtered,
+		// `versionId` is NOT NULL), so plain `<>` needs no null-emulation.
+		const rows: Array<{ workflowId: string }> = await this.query(
+			`SELECT DISTINCT w."id" AS "workflowId"
+			 FROM ${workflowTableName} w
+			 INNER JOIN ${triggerStatusTableName} ts ON ts."workflowId" = w."id"
+			 WHERE w."activeVersionId" IS NOT NULL
+			 AND ts."versionId" <> w."activeVersionId"
+			 AND NOT EXISTS (
+				 SELECT 1 FROM ${outboxTableName} o
+				 WHERE o."workflowId" = w."id"
+				 AND o."status" IN ('${Status.Pending}', '${Status.InProgress}')
+			 )`,
+		);
+
+		return rows.map((row) => row.workflowId);
+	}
+
+	/**
+	 * Published, non-archived workflows with no trigger-status rows at all — no
+	 * publication was ever reported for them. Two populations: workflows
+	 * published while the publication service flag was off (only the reporter
+	 * writes rows), and publications that terminally failed before reporting any
+	 * per-trigger status (a consumer-wrapped unexpected throw, `version-missing`).
+	 *
+	 * The failed population is why workflows whose most recent outbox record is
+	 * terminal `failed` are excluded: re-enqueueing them would fail before
+	 * reporting again, still leave zero rows, and so be re-detected on every
+	 * pass forever, reporting an error each round. Recovery is not lost — a user
+	 * republish enqueues a fresh pending record, which is excluded here as
+	 * in-flight while it processes normally. `partial_success` always writes
+	 * rows, so it never reaches this bucket.
+	 *
+	 * Same in-flight exclusion, in the same statement, as
+	 * {@link findVersionSkewedWorkflowIds}.
+	 */
+	async findUnreportedPublishedWorkflowIds(): Promise<string[]> {
+		const outboxTableName = this.getTableName('workflow_publication_outbox');
+		const workflowTableName = this.getTableName('workflow_entity');
+		const triggerStatusTableName = this.getTableName('workflow_publication_trigger_status');
+
+		// "Most recent" is the highest id: ids are monotonically assigned, the
+		// same FIFO assumption the claim query relies on. Sqlite (>= 3.23) accepts
+		// the `false` literal, so one statement serves both dialects.
+		const rows: Array<{ workflowId: string }> = await this.query(
+			`SELECT w."id" AS "workflowId"
+			 FROM ${workflowTableName} w
+			 WHERE w."activeVersionId" IS NOT NULL
+			 AND w."isArchived" = false
+			 AND NOT EXISTS (
+				 SELECT 1 FROM ${triggerStatusTableName} ts
+				 WHERE ts."workflowId" = w."id"
+			 )
+			 AND NOT EXISTS (
+				 SELECT 1 FROM ${outboxTableName} o
+				 WHERE o."workflowId" = w."id"
+				 AND o."status" IN ('${Status.Pending}', '${Status.InProgress}')
+			 )
+			 AND COALESCE((
+				 SELECT o."status" FROM ${outboxTableName} o
+				 WHERE o."workflowId" = w."id"
+				 ORDER BY o."id" DESC LIMIT 1
+			 ), '') <> '${Status.Failed}'`,
+		);
+
+		return rows.map((row) => row.workflowId);
+	}
+
+	/**
 	 * Atomically claim the oldest pending record by transitioning its status to
 	 * `in_progress`. Postgres uses `FOR UPDATE SKIP LOCKED` so concurrent
 	 * consumers never receive the same row; SQLite serializes the find-then-update

--- a/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
+++ b/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
@@ -55,6 +55,10 @@ export type WorkflowPublicationMetricsEventMap = {
 		surplusCount: number;
 		/** Workflows re-enqueued because their published version diverged from the active version. */
 		versionSkewCount: number;
+		/** Workflows re-enqueued because a trigger-status row was recorded for a version other than the active one. */
+		statusDriftCount: number;
+		/** Published workflows re-enqueued because no publication ever reported trigger statuses for them. */
+		unreportedCount: number;
 		durationMs: number;
 	};
 

--- a/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
@@ -210,6 +210,16 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 			help: 'Total number of workflows re-enqueued by reconciliation because their published version diverged from the active version.',
 		});
 
+		const statusDrift = new promClient.Counter({
+			name: `${prefix}workflow_publication_reconciliation_status_drift_workflows_total`,
+			help: 'Total number of workflows re-enqueued by reconciliation because a trigger-status row was recorded for a version other than the active one.',
+		});
+
+		const unreported = new promClient.Counter({
+			name: `${prefix}workflow_publication_reconciliation_unreported_workflows_total`,
+			help: 'Total number of published workflows re-enqueued by reconciliation because no publication had reported trigger statuses for them.',
+		});
+
 		const duration = new promClient.Histogram({
 			name: `${prefix}workflow_publication_reconciliation_duration_seconds`,
 			help: 'Duration in seconds of a trigger reconciliation pass by result.',
@@ -219,10 +229,20 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 
 		this.eventService.on(
 			'workflow-publication-reconciliation',
-			({ result, deficientCount, surplusCount, versionSkewCount, durationMs }) => {
+			({
+				result,
+				deficientCount,
+				surplusCount,
+				versionSkewCount,
+				statusDriftCount,
+				unreportedCount,
+				durationMs,
+			}) => {
 				deficient.inc(deficientCount);
 				surplus.inc(surplusCount);
 				versionSkew.inc(versionSkewCount);
+				statusDrift.inc(statusDriftCount);
+				unreported.inc(unreportedCount);
 				duration.observe({ result }, durationMs * Time.milliseconds.toSeconds);
 			},
 		);

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
@@ -62,6 +62,8 @@ beforeEach(() => {
 	outboxRepository.enqueueByWorkflowIds.mockResolvedValue();
 	outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 	outboxRepository.findVersionSkewedWorkflowIds.mockResolvedValue([]);
+	outboxRepository.findTriggerStatusDriftedWorkflowIds.mockResolvedValue([]);
+	outboxRepository.findUnreportedPublishedWorkflowIds.mockResolvedValue([]);
 	outboxConsumer.drainPending.mockResolvedValue(0);
 	setRegistered({});
 	activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([]);
@@ -189,6 +191,32 @@ describe('WorkflowPublicationReconciler', () => {
 			expect(eventService.emit).toHaveBeenCalledWith(
 				'workflow-publication-reconciliation',
 				expect.objectContaining({ result: 'success', versionSkewCount: 1, deficientCount: 0 }),
+			);
+		});
+
+		it('re-enqueues a workflow whose trigger-status rows lag the active version', async () => {
+			outboxRepository.findTriggerStatusDriftedWorkflowIds.mockResolvedValue(['wf-drift']);
+
+			await service.reconcile();
+
+			expect(outboxRepository.enqueueByWorkflowIds).toHaveBeenCalledWith(['wf-drift']);
+			expect(outboxConsumer.drainPending).toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'workflow-publication-reconciliation',
+				expect.objectContaining({ result: 'success', statusDriftCount: 1, versionSkewCount: 0 }),
+			);
+		});
+
+		it('re-enqueues a published workflow that has no trigger-status rows', async () => {
+			outboxRepository.findUnreportedPublishedWorkflowIds.mockResolvedValue(['wf-unreported']);
+
+			await service.reconcile();
+
+			expect(outboxRepository.enqueueByWorkflowIds).toHaveBeenCalledWith(['wf-unreported']);
+			expect(outboxConsumer.drainPending).toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'workflow-publication-reconciliation',
+				expect.objectContaining({ result: 'success', unreportedCount: 1, statusDriftCount: 0 }),
 			);
 		});
 

--- a/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
@@ -42,6 +42,11 @@ import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox
  * `activeVersionId` (a rolled-back or lost publication, or a missed unpublish)
  * is invisible to the node-id diffs when the trigger set is unchanged, so it is
  * detected in the database directly and healed through the same enqueue path.
+ * Two further database detections complete the coverage: trigger-status rows
+ * recorded for a version other than the active one (the mapping may already be
+ * correct while the rows lag), and published workflows with no trigger-status
+ * rows at all (published before the service was enabled, or a publication that
+ * failed before reporting).
  */
 @Service()
 export class WorkflowPublicationReconciler {
@@ -136,10 +141,22 @@ export class WorkflowPublicationReconciler {
 						await this.outboxRepository.findVersionSkewedWorkflowIds(),
 						'Re-enqueuing workflows whose published version diverged from the active version',
 					);
+					// Also after the earlier drains, for the same reason: rows those
+					// passes already converged must not be re-detected here.
+					const statusDrift = await this.republishWorkflows(
+						await this.outboxRepository.findTriggerStatusDriftedWorkflowIds(),
+						'Re-enqueuing workflows whose trigger-status rows lag the active version',
+					);
+					const unreported = await this.republishWorkflows(
+						await this.outboxRepository.findUnreportedPublishedWorkflowIds(),
+						'Re-enqueuing published workflows that no publication reported trigger statuses for',
+					);
 
 					span.setAttribute('n8n.publication.deficient_workflows', missing);
 					span.setAttribute('n8n.publication.surplus_workflows', surplus);
 					span.setAttribute('n8n.publication.version_skewed_workflows', versionSkew);
+					span.setAttribute('n8n.publication.status_drifted_workflows', statusDrift);
+					span.setAttribute('n8n.publication.unreported_workflows', unreported);
 
 					span.setStatus({ code: SpanStatus.ok });
 					this.eventService.emit('workflow-publication-reconciliation', {
@@ -147,6 +164,8 @@ export class WorkflowPublicationReconciler {
 						deficientCount: missing,
 						surplusCount: surplus,
 						versionSkewCount: versionSkew,
+						statusDriftCount: statusDrift,
+						unreportedCount: unreported,
 						durationMs: Date.now() - startedAt,
 					});
 				} catch (error) {
@@ -157,6 +176,8 @@ export class WorkflowPublicationReconciler {
 						deficientCount: 0,
 						surplusCount: 0,
 						versionSkewCount: 0,
+						statusDriftCount: 0,
+						unreportedCount: 0,
 						durationMs: Date.now() - startedAt,
 					});
 				}

--- a/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
@@ -429,6 +429,39 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		expect(await triggerStatusRepository.findByWorkflowId(workflow.id)).toHaveLength(0);
 	});
 
+	test('leaves a drifted workflow whose most recent publication failed before reporting alone', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('drift-failed-terminal');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+
+		// A v2 publish that crashed after advancing the mapping but before the
+		// reporter rewrote the rows: mapping equals `activeVersionId`, the record
+		// is terminal `failed`, and the rows still carry v1. If the failure is
+		// deterministic, re-enqueueing loops — the pass must leave it for a user
+		// republish to recover, exactly like the zero-rows case.
+		const newVersionId = 'version-2-drift-failed';
+		await createWorkflowHistory(workflow, owner, undefined, {
+			versionId: newVersionId,
+			nodes: [{ ...trigger, parameters: { rule: { interval: [{ field: 'hours' }] } } }],
+		});
+		await setActiveVersion(workflow.id, newVersionId);
+		await publishedVersionRepository.setPublishedVersion(workflow.id, newVersionId);
+		await outboxRepository.enqueue(workflow.id, newVersionId);
+		const record = await outboxRepository.claimNextPendingRecord();
+		await outboxRepository.markFailed(record!.id, 'unexpected error before reporting');
+
+		await reconciler.reconcile();
+
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+		const rows = await triggerStatusRepository.findByWorkflowId(workflow.id);
+		expect(rows[0].versionId).toBe(workflow.versionId);
+	});
+
 	test('leaves drifted and unreported workflows with an in-flight record for that record to converge', async () => {
 		const owner = await createOwner();
 

--- a/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
@@ -351,6 +351,125 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		expect(await outboxRepository.findVersionSkewedWorkflowIds()).not.toContain(workflow.id);
 	});
 
+	test('re-writes trigger-status rows recorded for a version other than the active one', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('status-drift');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+
+		const newVersionId = 'version-2-status-drift';
+		await createWorkflowHistory(workflow, owner, undefined, {
+			versionId: newVersionId,
+			nodes: [{ ...trigger, parameters: { rule: { interval: [{ field: 'hours' }] } } }],
+		});
+		await setActiveVersion(workflow.id, newVersionId);
+		await outboxRepository.enqueue(workflow.id, newVersionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+
+		// A zombie writer rewrites the status rows for the old version after its
+		// record already resolved. The mapping still agrees with `activeVersionId`,
+		// so the version-skew check cannot see this — only the rows lag.
+		await triggerStatusRepository.update(
+			{ workflowId: workflow.id },
+			{ versionId: workflow.versionId },
+		);
+		expect(await outboxRepository.findVersionSkewedWorkflowIds()).not.toContain(workflow.id);
+
+		await reconciler.reconcile();
+
+		const rows = await triggerStatusRepository.findByWorkflowId(workflow.id);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].versionId).toBe(newVersionId);
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
+	test('publishes a workflow that was published while the publication service was off', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('pre-flag');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+		// Legacy activation maintains the published-version mapping, but only the
+		// publication reporter writes trigger-status rows — so a workflow published
+		// while the flag was off has none, and no outbox record either.
+		await publishedVersionRepository.setPublishedVersion(workflow.id, workflow.versionId);
+
+		await reconciler.reconcile();
+
+		expect(activeWorkflowTriggers.get(workflow.id)?.has(trigger.id)).toBe(true);
+		const rows = await triggerStatusRepository.findByWorkflowId(workflow.id);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ nodeId: trigger.id, status: 'activated' });
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
+	test('leaves a workflow whose most recent publication failed before reporting statuses alone', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('failed-terminal');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+		// A publish that crashed after advancing the mapping but before the
+		// reporter wrote any rows: mapping equals `activeVersionId`, the record is
+		// terminal `failed`, zero rows. Re-enqueueing would fail before reporting
+		// again and still leave zero rows — an every-pass loop — so the pass must
+		// leave it for a user republish (a fresh pending record) to recover.
+		await publishedVersionRepository.setPublishedVersion(workflow.id, workflow.versionId);
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		const record = await outboxRepository.claimNextPendingRecord();
+		await outboxRepository.markFailed(record!.id, 'unexpected error before reporting');
+
+		await reconciler.reconcile();
+
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+		expect(await triggerStatusRepository.findByWorkflowId(workflow.id)).toHaveLength(0);
+	});
+
+	test('leaves drifted and unreported workflows with an in-flight record for that record to converge', async () => {
+		const owner = await createOwner();
+
+		// Drifted rows, but a pending publish owns the convergence.
+		const driftTrigger = scheduleNode('drift-in-flight');
+		const drifted = await createWorkflowWithHistory({ active: true, nodes: [driftTrigger] }, owner);
+		await setActiveVersion(drifted.id, drifted.versionId);
+		await outboxRepository.enqueue(drifted.id, drifted.versionId);
+		await consumer.processRecord((await outboxRepository.claimNextPendingRecord())!);
+		const newVersionId = 'version-2-drift-in-flight';
+		await createWorkflowHistory(drifted, owner, undefined, {
+			versionId: newVersionId,
+			nodes: [{ ...driftTrigger, parameters: { rule: { interval: [{ field: 'hours' }] } } }],
+		});
+		await setActiveVersion(drifted.id, newVersionId);
+		await outboxRepository.enqueue(drifted.id, newVersionId);
+
+		// No rows yet, but the first publish is still pending.
+		const unreportedTrigger = scheduleNode('unreported-in-flight');
+		const unreported = await createWorkflowWithHistory(
+			{ active: true, nodes: [unreportedTrigger] },
+			owner,
+		);
+		await setActiveVersion(unreported.id, unreported.versionId);
+		await outboxRepository.enqueue(unreported.id, unreported.versionId);
+
+		expect(await outboxRepository.findTriggerStatusDriftedWorkflowIds()).not.toContain(drifted.id);
+		expect(await outboxRepository.findUnreportedPublishedWorkflowIds()).not.toContain(
+			unreported.id,
+		);
+
+		await reconciler.reconcile();
+
+		// Untouched: both records are still pending — reconciliation neither
+		// enqueued nor drained.
+		expect((await outboxRepository.findInFlightByWorkflowId(drifted.id))?.status).toBe('pending');
+		expect((await outboxRepository.findInFlightByWorkflowId(unreported.id))?.status).toBe(
+			'pending',
+		);
+	});
+
 	test('records persisted rows for a pseudo-only workflow, keeping it out of leader handoff and reconciliation', async () => {
 		const owner = await createOwner();
 


### PR DESCRIPTION
## Summary

**What & why.** The publication reconciler (leader-only, behind `N8N_USE_WORKFLOW_PUBLICATION_SERVICE`) periodically repairs disagreements between what should be published and what actually is. It already detects missing and ghost in-memory triggers, and a published-version mapping that disagrees with `workflow_entity.activeVersionId` (#34877). Two inconsistencies were still invisible to it:

1. **Stale trigger-status rows** — rows recorded for an older version than the workflow's `activeVersionId`, left behind when a writer crashes or stalls between advancing the published version and reporting the per-trigger statuses.
2. **No trigger-status rows at all** — an active workflow nothing was ever reported for. In practice: every workflow published while the flag was off. Today the leader-takeover bulk enqueue picks those up; a follow-up PR replaces that enqueue with reconciliation, so the reconciler must cover this population first.

**How.** Two new detection queries on the outbox repository, in the same style as the version-skew one (#34877): a single portable SQL statement each, run at the end of every reconcile pass; hits are re-enqueued through the existing outbox path and healed by an ordinary re-publish, which rewrites the rows. Workflows with a pending/in-progress publication are excluded inside the same statement — that publication is about to fix them anyway. One new counter per detection on the reconciliation metrics event and in Prometheus.

**The one non-obvious detail: workflows whose last publication failed are skipped.** Both detections ignore a workflow whose most recent outbox record is terminal `failed`. Without this, a publication that keeps failing *before* it reports any statuses would be re-detected and re-enqueued on every pass (default 10s), forever, logging an error each round. Recovery still works: a user republish creates a fresh pending record, which processes normally. The accepted trade-off: a publication that failed *transiently* before reporting also waits for a republish now instead of self-healing — the two cases are indistinguishable in SQL; a time-based backoff can replace the blanket skip later if churn data warrants it. An integration test pins the no-loop behavior for each detection, and removing the exclusion makes it fail.

## How to test

From `packages/cli`:

```bash
pnpm vitest run src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
pnpm test:integration test/integration/workflows/workflow-publication-reconciler.test.ts
pnpm test:postgres:integration:tc test/integration/workflows/workflow-publication-reconciler.test.ts
```

New integration cases: stale rows converge after one pass; a flag-off-published workflow gets published and gains rows; a workflow whose latest publication failed pre-reporting is left alone (zero-rows and drifted variants); workflows with an in-flight record are not touched.

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket for this roadmap item — context in the review discussion on #35066. Prior art: #34877 (version-skew detection), #35273 (failure-contained passes), #35287 (pseudo-trigger reclassification, which this builds on).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)