### PR TITLE
fix(core): Emit OTel spans for queue mode executions

### DIFF
--- a/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
+++ b/packages/@n8n/decorators/src/execution-lifecycle/lifecycle-metadata.ts
@@ -7,6 +7,7 @@ import type {
 	ITaskStartedData,
 	IWorkflowBase,
 	Workflow,
+	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
 import type { Class } from '../types';
@@ -18,6 +19,7 @@ export type LifecycleHandlerClass = Class<
 export type NodeExecuteBeforeContext = {
 	type: 'nodeExecuteBefore';
 	workflow: IWorkflowBase;
+	mode: WorkflowExecuteMode;
 	nodeName: string;
 	taskData: ITaskStartedData;
 	executionId: string;
@@ -26,6 +28,7 @@ export type NodeExecuteBeforeContext = {
 export type NodeExecuteAfterContext = {
 	type: 'nodeExecuteAfter';
 	workflow: IWorkflowBase;
+	mode: WorkflowExecuteMode;
 	nodeName: string;
 	taskData: ITaskData;
 	executionData: IRunExecutionData;
@@ -35,6 +38,7 @@ export type NodeExecuteAfterContext = {
 export type WorkflowExecuteBeforeContext = {
 	type: 'workflowExecuteBefore';
 	workflow: IWorkflowBase;
+	mode: WorkflowExecuteMode;
 	workflowInstance: Workflow;
 	executionData?: IRunExecutionData;
 	executionId: string;
@@ -43,6 +47,7 @@ export type WorkflowExecuteBeforeContext = {
 export type WorkflowExecuteAfterContext = {
 	type: 'workflowExecuteAfter';
 	workflow: IWorkflowBase;
+	mode: WorkflowExecuteMode;
 	runData: IRun;
 	newStaticData: IDataObject;
 	executionId: string;
@@ -52,6 +57,7 @@ export type WorkflowExecuteAfterContext = {
 export type WorkflowExecuteResumeContext = {
 	type: 'workflowExecuteResume';
 	workflow: IWorkflowBase;
+	mode: WorkflowExecuteMode;
 	workflowInstance: Workflow;
 	executionData: IRunExecutionData;
 	executionId: string;

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -63,6 +63,7 @@ class ModulesHooksRegistry {
 						const context = {
 							type: 'workflowExecuteAfter' as const,
 							workflow: this.workflowData,
+							mode: this.mode,
 							runData,
 							newStaticData,
 							executionId: this.executionId,
@@ -78,6 +79,7 @@ class ModulesHooksRegistry {
 						const context = {
 							type: 'nodeExecuteBefore' as const,
 							workflow: this.workflowData,
+							mode: this.mode,
 							nodeName,
 							taskData,
 							executionId: this.executionId,
@@ -92,6 +94,7 @@ class ModulesHooksRegistry {
 						const context = {
 							type: 'nodeExecuteAfter' as const,
 							workflow: this.workflowData,
+							mode: this.mode,
 							nodeName,
 							taskData,
 							executionData,
@@ -107,6 +110,7 @@ class ModulesHooksRegistry {
 						const context = {
 							type: 'workflowExecuteBefore' as const,
 							workflow: this.workflowData,
+							mode: this.mode,
 							workflowInstance,
 							executionData,
 							executionId: this.executionId,
@@ -121,6 +125,7 @@ class ModulesHooksRegistry {
 						const context = {
 							type: 'workflowExecuteResume' as const,
 							workflow: this.workflowData,
+							mode: this.mode,
 							workflowInstance,
 							executionData,
 							executionId: this.executionId,

--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub.service.integration.test.ts
@@ -1478,6 +1478,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -1595,6 +1596,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -1726,6 +1728,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -1866,6 +1869,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -1921,6 +1925,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: capturedWorkflowData,
 								runData,
 								newStaticData: {},
@@ -2054,6 +2059,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -2194,6 +2200,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -2281,6 +2288,7 @@ describe('chatHub', () => {
 								});
 								await watcherService.handleWorkflowExecuteAfter({
 									type: 'workflowExecuteAfter',
+									mode: runData.mode,
 									workflow: capturedWorkflowData,
 									runData,
 									newStaticData: {},
@@ -2494,6 +2502,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -2628,6 +2637,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -2743,6 +2753,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},
@@ -2858,6 +2869,7 @@ describe('chatHub', () => {
 							});
 							await watcherService.handleWorkflowExecuteAfter({
 								type: 'workflowExecuteAfter',
+								mode: runData.mode,
 								workflow: workflowData,
 								runData,
 								newStaticData: {},

--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -7,7 +7,7 @@ import type {
 } from '@n8n/decorators';
 import { mock } from 'vitest-mock-extended';
 import { Workflow } from 'n8n-workflow';
-import type { INodeTypes, IRun, IRunExecutionData } from 'n8n-workflow';
+import type { INodeTypes, IRun, IRunExecutionData, WorkflowExecuteMode } from 'n8n-workflow';
 
 import type { OwnershipService } from '@/services/ownership.service';
 
@@ -92,6 +92,7 @@ describe('OtelLifecycleHandler', () => {
 				updatedAt: new Date(),
 				activeVersionId: null,
 			},
+			mode: 'trigger',
 			workflowInstance: createWorkflowInstance(),
 			executionId: 'exec-sub',
 		};
@@ -801,53 +802,82 @@ describe('productionExecutionsOnly filter', () => {
 	const licenseState = mock<LicenseState>();
 	let handler: OtelLifecycleHandler;
 
-	const inactiveWorkflow = {
+	const node1 = {
+		id: 'node-1',
+		name: 'Node1',
+		type: 'n8n-nodes-base.set',
+		typeVersion: 1,
+		position: [0, 0] as [number, number],
+		parameters: {},
+	};
+
+	const publishedWorkflow = {
 		id: 'wf-1',
 		name: 'Test',
 		versionId: 'v1',
-		nodes: [],
+		nodes: [node1],
 		connections: {},
-		active: false,
+		active: true,
 		isArchived: false,
 		createdAt: new Date(),
 		updatedAt: new Date(),
-		activeVersionId: null,
+		activeVersionId: 'av-1',
 	};
 
-	const activeWorkflow = { ...inactiveWorkflow, active: true };
+	const snapshot = {
+		id: 'wf-1',
+		name: 'Test',
+		nodes: [node1],
+		connections: {},
+		settings: {},
+		nodeGroups: [],
+	};
 
-	const makeWorkflowStartCtx = (workflow: object): WorkflowExecuteBeforeContext => ({
+	const makeWorkflowStartCtx = (
+		workflow: object,
+		mode: WorkflowExecuteMode,
+	): WorkflowExecuteBeforeContext => ({
 		type: 'workflowExecuteBefore',
 		workflow: workflow as never,
+		mode,
 		workflowInstance: undefined as never,
 		executionId: 'exec-1',
 	});
 
-	const makeWorkflowEndCtx = (workflow: object): WorkflowExecuteAfterContext =>
+	const makeWorkflowEndCtx = (
+		workflow: object,
+		mode: WorkflowExecuteMode,
+	): WorkflowExecuteAfterContext =>
 		({
 			type: 'workflowExecuteAfter',
 			workflow,
+			mode,
 			executionId: 'exec-1',
 			newStaticData: {},
 			runData: {
 				status: 'success',
-				mode: 'manual',
+				mode,
 				data: { resultData: { runData: {}, pinData: {} } },
 			},
 		}) as unknown as WorkflowExecuteAfterContext;
 
-	const makeNodeStartCtx = (workflow: object): NodeExecuteBeforeContext =>
+	const makeNodeStartCtx = (
+		workflow: object,
+		mode: WorkflowExecuteMode,
+	): NodeExecuteBeforeContext =>
 		({
 			type: 'nodeExecuteBefore',
 			workflow,
+			mode,
 			nodeName: 'Node1',
 			executionId: 'exec-1',
 		}) as unknown as NodeExecuteBeforeContext;
 
-	const makeNodeEndCtx = (workflow: object): NodeExecuteAfterContext =>
+	const makeNodeEndCtx = (workflow: object, mode: WorkflowExecuteMode): NodeExecuteAfterContext =>
 		({
 			type: 'nodeExecuteAfter',
 			workflow,
+			mode,
 			nodeName: 'Node1',
 			executionId: 'exec-1',
 			taskData: {
@@ -880,11 +910,11 @@ describe('productionExecutionsOnly filter', () => {
 		licenseState.isOtelCustomSpanAttributesLicensed.mockReturnValue(true);
 	});
 
-	it('should not start spans for an inactive workflow when productionExecutionsOnly is true, but still call endWorkflow', async () => {
-		await handler.onWorkflowStart(makeWorkflowStartCtx(inactiveWorkflow));
-		handler.onWorkflowEnd(makeWorkflowEndCtx(inactiveWorkflow));
-		handler.onNodeStart(makeNodeStartCtx(inactiveWorkflow));
-		handler.onNodeEnd(makeNodeEndCtx(inactiveWorkflow));
+	it('should not start spans for a manual execution when productionExecutionsOnly is true, but still call endWorkflow', async () => {
+		await handler.onWorkflowStart(makeWorkflowStartCtx(publishedWorkflow, 'manual'));
+		handler.onWorkflowEnd(makeWorkflowEndCtx(publishedWorkflow, 'manual'));
+		handler.onNodeStart(makeNodeStartCtx(publishedWorkflow, 'manual'));
+		handler.onNodeEnd(makeNodeEndCtx(publishedWorkflow, 'manual'));
 
 		expect(tracer.startWorkflow).not.toHaveBeenCalled();
 		expect(traceContextService.persist).not.toHaveBeenCalled();
@@ -893,44 +923,64 @@ describe('productionExecutionsOnly filter', () => {
 		expect(tracer.endWorkflow).toHaveBeenCalled();
 	});
 
-	it('should close a span even when settings change to exclude the workflow mid-execution', async () => {
+	it('should close a span even when settings change to exclude the execution mid-run', async () => {
+		otelSettingsService._settings.productionExecutionsOnly = false;
 		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
 
-		await handler.onWorkflowStart(makeWorkflowStartCtx(activeWorkflow));
+		await handler.onWorkflowStart(makeWorkflowStartCtx(publishedWorkflow, 'manual'));
 		expect(tracer.startWorkflow).toHaveBeenCalled();
 
 		// Simulate settings change mid-execution
 		otelSettingsService._settings.productionExecutionsOnly = true;
 
-		handler.onWorkflowEnd(makeWorkflowEndCtx(activeWorkflow));
+		handler.onWorkflowEnd(makeWorkflowEndCtx(publishedWorkflow, 'manual'));
 		expect(tracer.endWorkflow).toHaveBeenCalled();
 	});
 
-	it('should trace an active workflow when productionExecutionsOnly is true', async () => {
-		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
+	it.each<WorkflowExecuteMode>(['trigger', 'webhook', 'integrated', 'retry', 'error', 'cli'])(
+		'should trace a %s execution when productionExecutionsOnly is true',
+		async (mode) => {
+			tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
 
-		await handler.onWorkflowStart(makeWorkflowStartCtx(activeWorkflow));
+			await handler.onWorkflowStart(makeWorkflowStartCtx(publishedWorkflow, mode));
 
-		expect(tracer.startWorkflow).toHaveBeenCalled();
-		expect(traceContextService.persist).toHaveBeenCalled();
-	});
+			expect(tracer.startWorkflow).toHaveBeenCalled();
+			expect(traceContextService.persist).toHaveBeenCalled();
+		},
+	);
 
-	it('should trace an inactive workflow when productionExecutionsOnly is false', async () => {
+	it('should trace a manual execution when productionExecutionsOnly is false', async () => {
 		otelSettingsService._settings.productionExecutionsOnly = false;
 		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
 
-		await handler.onWorkflowStart(makeWorkflowStartCtx(inactiveWorkflow));
+		await handler.onWorkflowStart(makeWorkflowStartCtx(publishedWorkflow, 'manual'));
 
 		expect(tracer.startWorkflow).toHaveBeenCalled();
 	});
 
-	it('should also treat activeVersionId as published', async () => {
-		const workflowWithVersionId = { ...inactiveWorkflow, active: false, activeVersionId: 'v123' };
-		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
+	describe('when the context holds a persisted workflow snapshot (scaling worker)', () => {
+		it('should trace the workflow even though the snapshot has no published markers', async () => {
+			tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
 
-		await handler.onWorkflowStart(makeWorkflowStartCtx(workflowWithVersionId));
+			await handler.onWorkflowStart(makeWorkflowStartCtx(snapshot, 'webhook'));
 
-		expect(tracer.startWorkflow).toHaveBeenCalled();
+			expect(tracer.startWorkflow).toHaveBeenCalled();
+			expect(traceContextService.persist).toHaveBeenCalled();
+		});
+
+		it('should emit node spans for the snapshot', () => {
+			handler.onNodeStart(makeNodeStartCtx(snapshot, 'webhook'));
+			handler.onNodeEnd(makeNodeEndCtx(snapshot, 'webhook'));
+
+			expect(tracer.startNode).toHaveBeenCalled();
+			expect(tracer.endNode).toHaveBeenCalled();
+		});
+
+		it('should still skip a manual execution carried on a snapshot', async () => {
+			await handler.onWorkflowStart(makeWorkflowStartCtx(snapshot, 'manual'));
+
+			expect(tracer.startWorkflow).not.toHaveBeenCalled();
+		});
 	});
 });
 

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -8,7 +8,7 @@ import type {
 	NodeExecuteAfterContext,
 } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import type { ICustomTelemetryTag, IWorkflowBase } from 'n8n-workflow';
+import type { ICustomTelemetryTag, WorkflowExecuteMode } from 'n8n-workflow';
 
 import { ExecutionLevelTracer } from './execution-level-tracer';
 import type { CustomAttributes } from './execution-level-tracer.types';
@@ -54,15 +54,11 @@ export class OtelLifecycleHandler {
 		this.tracer.refreshTracer();
 	}
 
-	private isPublishedWorkflow(workflow: IWorkflowBase): boolean {
-		return !!(workflow.activeVersionId ?? workflow.active);
-	}
-
-	private shouldTrace(ctx: { type: string; workflow: IWorkflowBase }): boolean {
+	private shouldTrace(ctx: { type: string; mode: WorkflowExecuteMode }): boolean {
 		const { enabled, productionExecutionsOnly, includeNodeSpans } =
 			this.otelSettingsService.getSettings();
 		if (!enabled) return false;
-		if (productionExecutionsOnly && !this.isPublishedWorkflow(ctx.workflow)) return false;
+		if (productionExecutionsOnly && ctx.mode === 'manual') return false;
 		if ((ctx.type === 'nodeExecuteBefore' || ctx.type === 'nodeExecuteAfter') && !includeNodeSpans)
 			return false;
 		return true;


### PR DESCRIPTION
## Summary

In queue mode, our OTel integration was emitting a `workflow.execute` span per execution, without any node spans.

The cause is that `productionExecutionsOnly` decided whether an execution was production by inspecting the workflow:

```ts
return !!(workflow.activeVersionId ?? workflow.active);
```

A scaling worker rebuilds `execution.workflowData` from the persisted snapshot, and that type doesn't include either field:

```ts
export type WorkflowSnapshot = Pick<
  IWorkflowBase,
  'id' | 'name' | 'nodes' | 'connections' | 'settings' | 'nodeGroups'
>;
```

So every worker-side lifecycle event was dropped: `workflowExecuteBefore`, `nodeExecuteBefore`, `nodeExecuteAfter`. Only main's span survived, and main's node hooks are cleared in scaling mode. Subworkflows were the exception, becausethe worker loads those from the DB in full.

This PR has the check look for execution mode instead to determine if it's a production execution.

## How to test

Requires queue mode plus an OTLP collector (the Jaeger compose in the OTel module README works).

1. Publish a workflow with several nodes and a webhook trigger.
2. Leave `N8N_OTEL_TRACES_PRODUCTION_ONLY` at its default (`true`) and enable OTel.
3. Trigger it via the webhook so a worker picks up the job.
4. Before: 1 `workflow.execute` span, no children, despite a non-zero node count. After: `workflow.execute` with one child span per node.
5. Run the same workflow manually from the canvas and confirm it is still not traced.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

