### PR TITLE
fix(core): Clarify resource locator mode guidance in data persistence best practices (no-changelog)

### DIFF
--- a/packages/@n8n/workflow-sdk/src/prompts/best-practices/guides/data-persistence.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/best-practices/guides/data-persistence.ts
@@ -3,7 +3,7 @@ import { WorkflowTechnique } from '../types';
 
 export class DataPersistenceBestPractices implements BestPracticesDocument {
 	readonly technique = WorkflowTechnique.DATA_PERSISTENCE;
-	readonly version = '1.0.0';
+	readonly version = '1.0.1';
 
 	private readonly documentation = `# Best Practices: Data Persistence
 
@@ -163,8 +163,10 @@ Best for: Enrichment, validation, conditional logic based on stored data
 
 ## Referencing Documents, Sheets, or Tables
 
-When configuring storage nodes, use ResourceLocator mode "list". This will allow users to select from existing documents, sheets, or tables rather than passing IDs dynamically.
-Use modes "id", "url" or "name" only when user specifically mentions it in their prompt.
+When configuring storage nodes, pick the ResourceLocator mode by what you actually have:
+- A "list" mode value is the opaque internal ID the picker returns (e.g. the numeric gid of a Google Sheets sheet) — a human-readable name placed there can never resolve. Use mode "list" with a real ID from explored resources, or with an empty value ("") so users can pick from existing documents, sheets, or tables at setup.
+- If you only know the resource by its human-readable name (e.g. a sheet title like "Sheet1"), use mode "name" with that name. If the node offers no "name" mode, leave mode "list" empty instead of guessing an ID.
+- Use modes "id" or "url" only when a concrete ID or URL was provided.
 
 ## Important Distinctions
 


### PR DESCRIPTION
## Summary

The data-persistence best-practices doc — served verbatim by the instance MCP `n8n_get_workflow_best_practices` tool and materialized into the Instance AI builder's knowledge base — told builders to prefer ResourceLocator mode `"list"` for storage nodes and to use `"id"`/`"url"`/`"name"` "only when user specifically mentions it in their prompt".

It never stated that a `list`-mode value is the resource's opaque internal ID (e.g. the numeric gid of a Google Sheets sheet), so an agent holding only a human-readable sheet name got a "prefer list" nudge with no way to satisfy it correctly. The result was coin-flip behavior between putting the name in `list` mode (which can never resolve at runtime) and using `name` mode — visible as eval oscillation on unrelated commits.

This rewords the "Referencing Documents, Sheets, or Tables" section to state the semantics explicitly, aligning it with the three sources that already had the correct rule:

- the `sheetName` `builderHint` in the Google Sheets node
- the workflow-builder skill guidance
- the `WRONG_KIND_LIST_MODE_VALUE` validation warning

New guidance: use `list` mode only with a real explored ID or an empty value for the setup picker; use `name` mode when only a human-readable name is known (falling back to empty `list` mode for nodes without a `name` mode, e.g. Airtable); use `id`/`url` only when a concrete ID or URL was provided. Doc `version` bumped to `1.0.1`.

## How to test

1. Call the MCP `n8n_get_workflow_best_practices` tool with technique `data_persistence` and verify the returned doc contains the new "Referencing Documents, Sheets, or Tables" wording.
2. Ask an agent building via the instance MCP tools to create a workflow that appends to a Google Sheets sheet referenced only by title (e.g. "append rows to the 'Leads' sheet"). The generated `sheetName` locator should consistently use `mode: "name"` with the title (or empty `list` mode), never the title inside `list`/`id` mode.

Existing coverage: `packages/cli/src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts` passes (6/6).

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35358">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

