### PR TITLE
feat(Kafka Node): Add v2 shared config conversion and lazy loading (no-changelog)

### DIFF
--- a/packages/nodes-base/eslint.config.mjs
+++ b/packages/nodes-base/eslint.config.mjs
@@ -3,9 +3,14 @@ import { nodeConfig } from '@n8n/eslint-config/node';
 import nodesBasePlugin from 'eslint-plugin-n8n-nodes-base';
 import { n8nCommunityNodesPlugin } from '@n8n/eslint-plugin-community-nodes';
 
+import { kafkaImportRestrictions } from './nodes/Kafka/eslint-import-restrictions.mjs';
+
 export default defineConfig(
 	nodeConfig,
-	globalIgnores(['scenarios/**', 'scripts/**']),
+	// This config fragment lives under nodes/ so it sits next to the code it
+	// governs, but it's not lintable TS source — same reason eslint.config.mjs
+	// itself is never linted.
+	globalIgnores(['scenarios/**', 'scripts/**', './nodes/Kafka/eslint-import-restrictions.mjs']),
 	{
 		plugins: {
 			'@n8n/community-nodes': n8nCommunityNodesPlugin,
@@ -187,4 +192,5 @@ export default defineConfig(
 			'n8n-nodes-base/node-filename-against-convention': 'off',
 		},
 	},
+	...kafkaImportRestrictions,
 );

--- a/packages/nodes-base/nodes/Kafka/eslint-import-restrictions.mjs
+++ b/packages/nodes-base/nodes/Kafka/eslint-import-restrictions.mjs
@@ -1,0 +1,74 @@
+// Restricts direct imports of the Kafka libraries to their sanctioned access
+// points: `@confluentinc/kafka-javascript` only through v2/transport/client.ts,
+// and v1's `kafkajs` never from v2 code. Spread into packages/nodes-base's
+// eslint.config.mjs, which is where `files`/`ignores` globs below are resolved
+// from (this file's own location doesn't affect path resolution).
+
+const KAFKA_V2_LIBRARY_MESSAGE =
+	'Import the Kafka library only through getKafkaLibrary() in v2/transport/client.ts.';
+const KAFKA_V1_LIBRARY_MESSAGE = 'v2 Kafka code must not depend on the v1 kafkajs library.';
+
+// Flat-config `rules` blocks replace, not merge, for any file matched by more
+// than one block — so every scoped `no-restricted-syntax` override below must
+// repeat the base config's raw-enum rule, or it silently stops applying there.
+const NO_RAW_ENUM_SYNTAX_RULE = {
+	selector: 'TSEnumDeclaration:not([const=true])',
+	message:
+		'Do not declare raw enums as it leads to runtime overhead. Use const enum instead. See https://www.typescriptlang.org/docs/handbook/enums.html#const-enums',
+};
+
+// One name/message pair drives the static-import, dynamic-import, and
+// require() checks, so they can't drift out of sync.
+function kafkaLibraryRestriction(name, message) {
+	return {
+		path: { name, allowTypeImports: true, message },
+		syntax: [
+			{ selector: `ImportExpression[source.value='${name}']`, message },
+			{ selector: `CallExpression[callee.name='require'][arguments.0.value='${name}']`, message },
+		],
+	};
+}
+
+const kafkaV2LibraryRestriction = kafkaLibraryRestriction(
+	'@confluentinc/kafka-javascript',
+	KAFKA_V2_LIBRARY_MESSAGE,
+);
+const kafkaV1LibraryRestriction = kafkaLibraryRestriction('kafkajs', KAFKA_V1_LIBRARY_MESSAGE);
+
+// Same reason as above: combine every restriction for one set of files into a
+// single rule config here, since a second block targeting those files would
+// replace these entries instead of adding to them.
+function kafkaRestrictionRules(...restrictions) {
+	return {
+		'@typescript-eslint/no-restricted-imports': [
+			'error',
+			{ paths: restrictions.map(({ path }) => path) },
+		],
+		'no-restricted-syntax': [
+			'error',
+			NO_RAW_ENUM_SYNTAX_RULE,
+			...restrictions.flatMap(({ syntax }) => syntax),
+		],
+	};
+}
+
+export const kafkaImportRestrictions = [
+	{
+		// v1 may keep using kafkajs, but can't reach for the new library directly.
+		files: ['./nodes/Kafka/**/*.ts'],
+		ignores: ['./nodes/Kafka/v2/**/*.ts'],
+		rules: kafkaRestrictionRules(kafkaV2LibraryRestriction),
+	},
+	{
+		// v2 code must go through client.ts's getKafkaLibrary() for the new
+		// library, and can't use v1's kafkajs at all.
+		files: ['./nodes/Kafka/v2/**/*.ts'],
+		ignores: ['./nodes/Kafka/v2/transport/client.ts'],
+		rules: kafkaRestrictionRules(kafkaV2LibraryRestriction, kafkaV1LibraryRestriction),
+	},
+	{
+		// client.ts is the one file allowed to import the new library directly.
+		files: ['./nodes/Kafka/v2/transport/client.ts'],
+		rules: kafkaRestrictionRules(kafkaV1LibraryRestriction),
+	},
+];

--- a/packages/nodes-base/nodes/Kafka/test/mocks/confluent-kafka.ts
+++ b/packages/nodes-base/nodes/Kafka/test/mocks/confluent-kafka.ts
@@ -1,0 +1,31 @@
+import { vi } from 'vitest';
+
+let accessCount = 0;
+
+/** vi.mock factory for '@confluentinc/kafka-javascript'. */
+export function confluentKafkaModuleMock(): { readonly KafkaJS: unknown } {
+	return {
+		get KafkaJS() {
+			accessCount += 1;
+			return {
+				Kafka: vi.fn().mockImplementation((config?: unknown) => ({
+					config,
+					connect: vi.fn(),
+					disconnect: vi.fn(),
+					producer: vi.fn(),
+					consumer: vi.fn(),
+					admin: vi.fn(),
+				})),
+				logLevel: { NOTHING: 0, ERROR: 1, WARN: 2, INFO: 3, DEBUG: 4 },
+			};
+		},
+	};
+}
+
+export function getConfluentKafkaAccessCount(): number {
+	return accessCount;
+}
+
+export function resetConfluentKafkaAccessCount(): void {
+	accessCount = 0;
+}

--- a/packages/nodes-base/nodes/Kafka/test/v2/transport/client.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/transport/client.test.ts
@@ -1,0 +1,23 @@
+import { getKafkaLibrary } from '../../../v2/transport/client';
+import {
+	confluentKafkaModuleMock,
+	getConfluentKafkaAccessCount,
+	resetConfluentKafkaAccessCount,
+} from '../../mocks/confluent-kafka';
+
+vi.mock('@confluentinc/kafka-javascript', () => confluentKafkaModuleMock());
+
+// accessCount is module-level state shared across every test in this file — reset
+// it so a future test case added here doesn't inherit another test's count.
+beforeEach(() => {
+	resetConfluentKafkaAccessCount();
+});
+
+it('loads the library lazily and caches the result', async () => {
+	expect(getConfluentKafkaAccessCount()).toBe(0);
+	const first = await getKafkaLibrary();
+	expect(getConfluentKafkaAccessCount()).toBe(1);
+	const second = await getKafkaLibrary();
+	expect(getConfluentKafkaAccessCount()).toBe(1);
+	expect(second).toBe(first);
+});

--- a/packages/nodes-base/nodes/Kafka/test/v2/transport/config.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/transport/config.test.ts
@@ -1,0 +1,202 @@
+import { UserError } from 'n8n-workflow';
+
+import type { KafkaCredentials } from '../../../utils';
+import { toKafkaJSConfig } from '../../../v2/transport/config';
+
+const { kafkajsLoadCount } = vi.hoisted(() => ({ kafkajsLoadCount: { value: 0 } }));
+
+// Counts module loads rather than property reads: this file's import graph reaches
+// `utils.ts` for a value (the shared PEM validator), which only stays free of v1's
+// library because `utils.ts` imports it lazily. A static import there trips this.
+vi.mock('kafkajs', () => {
+	kafkajsLoadCount.value += 1;
+	return { logLevel: { NOTHING: 0, ERROR: 1, WARN: 2, INFO: 4, DEBUG: 5 } };
+});
+
+const CERT_PEM = '-----BEGIN CERTIFICATE-----\nMIIBclientcertbody==\n-----END CERTIFICATE-----';
+const KEY_PEM = '-----BEGIN PRIVATE KEY-----\nMIIBclientkeybody==\n-----END PRIVATE KEY-----';
+const CA_PEM = '-----BEGIN CERTIFICATE-----\nMIIBcacertbody==\n-----END CERTIFICATE-----';
+
+const creds = (overrides: Partial<KafkaCredentials> = {}): KafkaCredentials => ({
+	clientId: 'test',
+	brokers: 'localhost:9092',
+	ssl: false,
+	authentication: false,
+	...overrides,
+});
+
+describe('toKafkaJSConfig', () => {
+	it('returns brokers/clientId/ssl only when authentication and SSL are both off', () => {
+		expect(toKafkaJSConfig(creds())).toStrictEqual({
+			kafkaJS: { brokers: ['localhost:9092'], clientId: 'test', ssl: false },
+		});
+	});
+
+	it.each(['plain', 'scram-sha-256', 'scram-sha-512'] as const)(
+		'adds kafkaJS.sasl for SASL mechanism %s, with SSL off',
+		(saslMechanism) => {
+			expect(
+				toKafkaJSConfig(
+					creds({ authentication: true, saslMechanism, username: 'user', password: 'pass' }),
+				),
+			).toStrictEqual({
+				kafkaJS: {
+					brokers: ['localhost:9092'],
+					clientId: 'test',
+					ssl: false,
+					sasl: { mechanism: saslMechanism, username: 'user', password: 'pass' },
+				},
+			});
+		},
+	);
+
+	it.each(['plain', 'scram-sha-256', 'scram-sha-512'] as const)(
+		'adds kafkaJS.sasl for SASL mechanism %s, with SSL on and no cert material',
+		(saslMechanism) => {
+			expect(
+				toKafkaJSConfig(
+					creds({
+						ssl: true,
+						authentication: true,
+						saslMechanism,
+						username: 'user',
+						password: 'pass',
+					}),
+				),
+			).toStrictEqual({
+				kafkaJS: {
+					brokers: ['localhost:9092'],
+					clientId: 'test',
+					ssl: true,
+					sasl: { mechanism: saslMechanism, username: 'user', password: 'pass' },
+				},
+			});
+		},
+	);
+
+	it('defaults kafkaJS.sasl.mechanism to plain when saslMechanism is omitted', () => {
+		const result = toKafkaJSConfig(
+			creds({ authentication: true, username: 'user', password: 'pass' }),
+		);
+
+		expect(result.kafkaJS?.sasl).toStrictEqual({
+			mechanism: 'plain',
+			username: 'user',
+			password: 'pass',
+		});
+	});
+
+	it('returns ssl: true with no flat TLS keys when SSL is on with no cert material', () => {
+		expect(toKafkaJSConfig(creds({ ssl: true }))).toStrictEqual({
+			kafkaJS: { brokers: ['localhost:9092'], clientId: 'test', ssl: true },
+		});
+	});
+
+	it('sets ssl.ca.pem alone when only a CA certificate is provided (no mTLS)', () => {
+		expect(toKafkaJSConfig(creds({ ssl: true, ca: CA_PEM }))).toStrictEqual({
+			kafkaJS: { brokers: ['localhost:9092'], clientId: 'test', ssl: true },
+			'ssl.ca.pem': CA_PEM,
+		});
+	});
+
+	it('sets ssl.certificate.pem and ssl.key.pem when cert and key are both provided (mTLS)', () => {
+		expect(toKafkaJSConfig(creds({ ssl: true, cert: CERT_PEM, key: KEY_PEM }))).toStrictEqual({
+			kafkaJS: { brokers: ['localhost:9092'], clientId: 'test', ssl: true },
+			'ssl.certificate.pem': CERT_PEM,
+			'ssl.key.pem': KEY_PEM,
+		});
+	});
+
+	it('throws when a client certificate is provided without a private key', () => {
+		expect(() => toKafkaJSConfig(creds({ ssl: true, cert: CERT_PEM }))).toThrow(UserError);
+		expect(() => toKafkaJSConfig(creds({ ssl: true, cert: CERT_PEM }))).toThrow(
+			'Kafka mTLS needs both a client certificate and a client private key',
+		);
+	});
+
+	it('throws when a client private key is provided without a certificate', () => {
+		expect(() => toKafkaJSConfig(creds({ ssl: true, key: KEY_PEM }))).toThrow(UserError);
+		expect(() => toKafkaJSConfig(creds({ ssl: true, key: KEY_PEM }))).toThrow(
+			'Kafka mTLS needs both a client certificate and a client private key',
+		);
+	});
+
+	it('sets enable.ssl.certificate.verification: false when allowUnauthorizedCerts is true', () => {
+		expect(toKafkaJSConfig(creds({ ssl: true, allowUnauthorizedCerts: true }))).toStrictEqual({
+			kafkaJS: { brokers: ['localhost:9092'], clientId: 'test', ssl: true },
+			'enable.ssl.certificate.verification': false,
+		});
+	});
+
+	it('ignores allowUnauthorizedCerts when SSL is off', () => {
+		const result = toKafkaJSConfig(creds({ ssl: false, allowUnauthorizedCerts: true }));
+
+		expect(result).toStrictEqual({
+			kafkaJS: { brokers: ['localhost:9092'], clientId: 'test', ssl: false },
+		});
+		expect(Object.keys(result)).not.toContain('enable.ssl.certificate.verification');
+	});
+
+	it('combines SASL and mTLS material, unclobbered, in the same result', () => {
+		expect(
+			toKafkaJSConfig(
+				creds({
+					ssl: true,
+					cert: CERT_PEM,
+					key: KEY_PEM,
+					ca: CA_PEM,
+					authentication: true,
+					saslMechanism: 'plain',
+					username: 'user',
+					password: 'pass',
+				}),
+			),
+		).toStrictEqual({
+			kafkaJS: {
+				brokers: ['localhost:9092'],
+				clientId: 'test',
+				ssl: true,
+				sasl: { mechanism: 'plain', username: 'user', password: 'pass' },
+			},
+			'ssl.certificate.pem': CERT_PEM,
+			'ssl.key.pem': KEY_PEM,
+			'ssl.ca.pem': CA_PEM,
+		});
+	});
+
+	it('treats empty-string cert/key/ca as absent, even with SSL on', () => {
+		expect(toKafkaJSConfig(creds({ ssl: true, cert: '', key: '', ca: '' }))).toStrictEqual({
+			kafkaJS: { brokers: ['localhost:9092'], clientId: 'test', ssl: true },
+		});
+	});
+
+	it('throws when authentication is enabled without a username and password', () => {
+		expect(() => toKafkaJSConfig(creds({ authentication: true }))).toThrow(UserError);
+	});
+
+	it.each([
+		['username', { username: 'user' }],
+		['password', { password: 'pass' }],
+	])('throws when authentication is enabled with only a %s and no counterpart', (_, partial) => {
+		expect(() => toKafkaJSConfig(creds({ authentication: true, ...partial }))).toThrow(UserError);
+	});
+
+	it('throws when a PEM value is malformed', () => {
+		expect(() => toKafkaJSConfig(creds({ ssl: true, ca: 'not-a-pem-block' }))).toThrow(
+			'The Kafka CA certificate is not a valid PEM block',
+		);
+	});
+
+	it('splits and trims a comma-separated brokers string', () => {
+		const result = toKafkaJSConfig(creds({ brokers: 'b1:9092, b2:9092 ' }));
+
+		expect(result.kafkaJS?.brokers).toStrictEqual(['b1:9092', 'b2:9092']);
+	});
+
+	it('never loads the v1 kafkajs library', () => {
+		// Exercises the PEM path, the one value imported from `utils.ts`.
+		toKafkaJSConfig(creds({ ssl: true, ca: CA_PEM }));
+
+		expect(kafkajsLoadCount.value).toBe(0);
+	});
+});

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -6,7 +6,6 @@ import type {
 	SASLOptions,
 	ConsumerConfig,
 } from 'kafkajs';
-import { logLevel } from 'kafkajs';
 import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
 import { formatPemBlock } from '@n8n/utils/format-pem-block';
 import type {
@@ -82,9 +81,9 @@ interface SchemaRegistryOptions {
 type ResolveOffsetMode = 'immediately' | 'onCompletion' | 'onSuccess' | 'onStatus';
 
 /**
- * Normalizes a PEM credential field and returns it as a Buffer, throwing a clear
- * error when the value is not a PEM block (the most common paste mistake) so the
- * failure surfaces at config time instead of as an opaque TLS handshake error.
+ * Normalizes a PEM credential field, throwing a clear error when the value is not
+ * a PEM block (the most common paste mistake) so the failure surfaces at config
+ * time instead of as an opaque TLS handshake error.
  *
  * The strict BEGIN/END check stays here rather than in the shared `formatPemBlock`
  * normalizer: that helper is a non-throwing, best-effort formatter used by many
@@ -93,7 +92,7 @@ type ResolveOffsetMode = 'immediately' | 'onCompletion' | 'onSuccess' | 'onStatu
  * @param value - The raw PEM string from the credential
  * @param fieldName - Human-readable field name used in the error message
  */
-function toPemBuffer(value: string, fieldName: string): Buffer {
+export function formatAndValidatePem(value: string, fieldName: string): string {
 	const formatted = formatPemBlock(value);
 	// Require a matching BEGIN/END pair with the same label — a lone BEGIN header
 	// (e.g. a truncated paste) would otherwise pass and only fail later as an
@@ -105,7 +104,12 @@ function toPemBuffer(value: string, fieldName: string): Buffer {
 				'Paste the full PEM, including the "-----BEGIN ...-----" and "-----END ...-----" lines.',
 		});
 	}
-	return Buffer.from(formatted);
+	return formatted;
+}
+
+/** kafkajs's `tls.ConnectionOptions` fields take Buffers, the v2 library takes strings. */
+function toPemBuffer(value: string, fieldName: string): Buffer {
+	return Buffer.from(formatAndValidatePem(value, fieldName));
 }
 
 /**
@@ -153,6 +157,10 @@ export function resolveKafkaSsl(credentials: KafkaCredentials): ConnectionOption
  * @returns Kafka configuration object with authentication settings
  */
 export async function createConfig(ctx: ITriggerFunctions) {
+	// Loaded lazily so importing this module (shared with the v2 node, which runs on
+	// a different Kafka library) never pulls `kafkajs` into the runtime.
+	const { logLevel } = await import('kafkajs');
+
 	const credentials = (await ctx.getCredentials('kafka')) as KafkaCredentials;
 	const clientId = credentials.clientId;
 	const brokers = (credentials.brokers ?? '').split(',').map((item) => item.trim());

--- a/packages/nodes-base/nodes/Kafka/v2/transport/client.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/transport/client.ts
@@ -1,0 +1,19 @@
+import type { KafkaJS as KafkaJSNamespace } from '@confluentinc/kafka-javascript';
+
+let _kafkaJS: typeof KafkaJSNamespace | null = null;
+
+/**
+ * The only file allowed to import '@confluentinc/kafka-javascript' at runtime
+ * (enforced by eslint.config.mjs) — all v2 Kafka code must go through this
+ * lazy access point instead of importing the library directly.
+ *
+ * A rejected import (e.g. the native binding failing to load) propagates
+ * unwrapped and leaves the cache empty, so the next call retries from scratch
+ * rather than permanently wedging on a transient failure.
+ */
+export async function getKafkaLibrary(): Promise<typeof KafkaJSNamespace> {
+	if (_kafkaJS) return _kafkaJS;
+	const mod = await import('@confluentinc/kafka-javascript');
+	_kafkaJS = mod.KafkaJS;
+	return _kafkaJS;
+}

--- a/packages/nodes-base/nodes/Kafka/v2/transport/config.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/transport/config.ts
@@ -1,0 +1,67 @@
+import type { KafkaJS } from '@confluentinc/kafka-javascript';
+import { UserError } from 'n8n-workflow';
+
+import { formatAndValidatePem, type KafkaCredentials } from '../../utils';
+
+/**
+ * Builds the flat, dotted-key TLS/mTLS properties the library expects at the
+ * top level of `CommonConstructorConfig` (native librdkafka config) — separate
+ * from the `kafkaJS` block, which only carries a plain `ssl: boolean`.
+ */
+function toTlsProperties(credentials: KafkaCredentials): Partial<KafkaJS.CommonConstructorConfig> {
+	if (!credentials.ssl) return {};
+
+	const cert = credentials.cert?.trim() ? credentials.cert : undefined;
+	const key = credentials.key?.trim() ? credentials.key : undefined;
+	const ca = credentials.ca?.trim() ? credentials.ca : undefined;
+
+	// A client certificate and its private key are only meaningful together.
+	if (Boolean(cert) !== Boolean(key)) {
+		throw new UserError('Kafka mTLS needs both a client certificate and a client private key', {
+			level: 'warning',
+			description:
+				'Set both the "Client Certificate" and "Client Private Key" credential fields, or clear both.',
+		});
+	}
+
+	return {
+		...(ca ? { 'ssl.ca.pem': formatAndValidatePem(ca, 'CA certificate') } : {}),
+		...(cert ? { 'ssl.certificate.pem': formatAndValidatePem(cert, 'client certificate') } : {}),
+		...(key ? { 'ssl.key.pem': formatAndValidatePem(key, 'client private key') } : {}),
+		...(credentials.allowUnauthorizedCerts ? { 'enable.ssl.certificate.verification': false } : {}),
+	};
+}
+
+/**
+ * Converts a decrypted Kafka credential into the library's
+ * `CommonConstructorConfig` — a `kafkaJS` block (app-level: brokers, clientId,
+ * ssl boolean, sasl) sitting alongside flat, dotted-key TLS/mTLS properties
+ * (native-librdkafka-level). No `security.protocol` is emitted: the library
+ * derives it from `kafkaJS.ssl` + presence of `kafkaJS.sasl` on its own.
+ */
+export function toKafkaJSConfig(
+	credentials: KafkaCredentials,
+	// `kafkaJS` is optional on `CommonConstructorConfig` but always set here, so
+	// callers can extend the block without re-widening it.
+): KafkaJS.CommonConstructorConfig & { kafkaJS: KafkaJS.KafkaConfig } {
+	const brokers = (credentials.brokers ?? '').split(',').map((broker) => broker.trim());
+
+	const kafkaJS: KafkaJS.KafkaConfig = {
+		brokers,
+		clientId: credentials.clientId,
+		ssl: credentials.ssl,
+	};
+
+	if (credentials.authentication) {
+		if (!(credentials.username && credentials.password)) {
+			throw new UserError('Username and password are required for authentication');
+		}
+		kafkaJS.sasl = {
+			mechanism: credentials.saslMechanism ?? 'plain',
+			username: credentials.username,
+			password: credentials.password,
+		};
+	}
+
+	return { kafkaJS, ...toTlsProperties(credentials) };
+}

--- a/packages/nodes-base/nodes/Kafka/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/transport/index.ts
@@ -1,0 +1,2 @@
+export { toKafkaJSConfig } from './config';
+export { getKafkaLibrary } from './client';


### PR DESCRIPTION
## Summary

Adds the version-2 code both Kafka nodes (send and trigger) will share, under `nodes/Kafka/v2/transport/`:

- **`config.ts`** — pure function converting our Kafka credential into `@confluentinc/kafka-javascript`'s config shape .Covers TLS on/off, mTLS cert+key, ignore-SSL-issues, and all three SASL mechanisms, never emitting `undefined` at any depth.
- **`client.ts`** — the single lazy-loading access point: importing it doesn't load the library; it loads on first use and is reused after.
- **ESLint enforcement** blocking any direct import of the library (static, dynamic, or `require()`) outside `client.ts`.
- **A reusable test fake** other v2 tests can `vi.mock` against.

Also makes that isolation actually hold. The ESLint rule only inspects *direct* import specifiers, and `utils.ts` — shared by v1, the trigger, and v2 — had a top-level **value** import of `kafkajs`, so any v2 file importing a value from it would pull the unmaintained library in transitively. 
## How to test

From `packages/nodes-base`:
```
pnpm typecheck
pnpm lint
pnpm exec vitest run nodes/Kafka   # 153 tests (24 new)
```
The v1 node and trigger suites are included, since this touches `utils.ts`. To confirm the guard isn't vacuous, restore the static `import { logLevel } from 'kafkajs'` in `utils.ts` — `never loads the v1 kafkajs library` should be the only failure.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-220

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35360">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
