### PR TITLE
fix(core): Resolve webhook OAuth resources to the trigger that fires (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/entities/webhook-entity.ts
+++ b/packages/@n8n/db/src/entities/webhook-entity.ts
@@ -29,10 +29,8 @@ export class WebhookEntity {
 	 * - Dynamic: `${uuid}/user/:id/posts`
 	 *
 	 * Appended to `${instanceUrl}/webhook/` or `${instanceUrl}/test-webhook/`.
-	 * For dynamic webhooks this is the templated path (placeholders intact), which
-	 * the OAuth resolver uses as the canonical, per-trigger resource identity.
 	 */
-	get uniquePath() {
+	private get uniquePath() {
 		return this.webhookPath.includes(':')
 			? [this.webhookId, this.webhookPath].join('/')
 			: this.webhookPath;

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.test.ts
@@ -36,9 +36,10 @@ const makeRes = () => {
 };
 
 // Express 5 delivers wildcard params as an array of segments; the handler also
-// tolerates a plain string. Only `params` is read, so a cast keeps the fixture small.
-const makeReq = (resourcePath: string | string[]): Request =>
-	({ params: { resourcePath } }) as unknown as Request;
+// tolerates a plain string. Only `params` and `originalUrl` are read, so a cast keeps
+// the fixture small.
+const makeReq = (resourcePath: string | string[], originalUrl?: string): Request =>
+	({ params: { resourcePath }, originalUrl }) as unknown as Request;
 
 const resource = (scopes: string[]): ProtectedResource => ({
 	id: 'instance-mcp',
@@ -78,6 +79,21 @@ describe('OAuthController', () => {
 			await controller.protectedResourceMetadata(makeReq(['mcp', 'wf-123', 'trigger']), makeRes());
 
 			expect(registry.getByResourcePath).toHaveBeenCalledWith('/mcp/wf-123/trigger');
+		});
+
+		test('forwards the raw query component, which the wildcard param drops', async () => {
+			// some resources select on a query (e.g. a webhook trigger's `?method=`)
+			registry.getByResourcePath.mockResolvedValue(resource([]));
+
+			await controller.protectedResourceMetadata(
+				makeReq(
+					['webhook', 'orders'],
+					'/.well-known/oauth-protected-resource/webhook/orders?method=GET',
+				),
+				makeRes(),
+			);
+
+			expect(registry.getByResourcePath).toHaveBeenCalledWith('/webhook/orders?method=GET');
 		});
 
 		test('returns the RFC 9728 metadata document for a resolved resource', async () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/workflow-webhook-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/workflow-webhook-trigger-resource.resolver.api.test.ts
@@ -444,6 +444,21 @@ describe('protected resource metadata for webhook triggers', () => {
 			expect(response.body.resource).toBe(resourceUrlFor(`${webhookId}/orders/:id`, 'POST'));
 		});
 
+		test('should refuse a selector-less probe a dynamic template also serves', async () => {
+			// The concrete path is static on GET and templated on POST, so without a method
+			// there is no single trigger to name — the lone static row must not answer.
+			const webhookId = randomUUID();
+			const concretePath = `${webhookId}/orders/42`;
+			await createPublishedWebhookWorkflow(concretePath, webhookNode(), { methods: ['GET'] });
+			await createPublishedDynamicWebhookWorkflow(webhookId, 'orders/:id', webhookNode(), {
+				methods: ['POST'],
+			});
+
+			const response = await testServer.restlessAgent.get(prmPathFor(concretePath));
+
+			expect(response.statusCode).toBe(404);
+		});
+
 		test('should mint a token whose audience is the template and reject another trigger', async () => {
 			// distinct triggers -> distinct templates (the (webhookPath, method) key is
 			// global, so two dynamic triggers can't share a template+method)

--- a/packages/cli/src/modules/oauth-server/__tests__/workflow-webhook-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/workflow-webhook-trigger-resource.resolver.api.test.ts
@@ -318,6 +318,17 @@ describe('protected resource metadata for webhook triggers', () => {
 		expect(response.statusCode).toBe(404);
 	});
 
+	test('should resolve a static path containing a literal colon', async () => {
+		// no dynamic segment, so the row has no webhookId to prefix the resource URL with
+		const webhookPath = `orders:${randomUUID()}`;
+		await createPublishedWebhookWorkflow(webhookPath, webhookNode());
+
+		const response = await testServer.restlessAgent.get(prmPathFor(webhookPath));
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.resource).toBe(resourceUrlFor(webhookPath));
+	});
+
 	test('should not resolve a workflow without a published version', async () => {
 		const node = webhookNode();
 		const webhookPath = randomUUID();
@@ -415,6 +426,22 @@ describe('protected resource metadata for webhook triggers', () => {
 			const response = await testServer.restlessAgent.get(prmPathFor(`${webhookId}/user/42/extra`));
 
 			expect(response.statusCode).toBe(404);
+		});
+
+		test('should not let a static row for another method shadow the routed template', async () => {
+			// A static GET row sits on the concrete path a POST template also serves. The
+			// router picks by method first, so the POST must resolve to the template.
+			const webhookId = randomUUID();
+			const concretePath = `${webhookId}/orders/42`;
+			await createPublishedWebhookWorkflow(concretePath, webhookNode(), { methods: ['GET'] });
+			await createPublishedDynamicWebhookWorkflow(webhookId, 'orders/:id', webhookNode(), {
+				methods: ['POST'],
+			});
+
+			const response = await testServer.restlessAgent.get(prmPathFor(concretePath, 'POST'));
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.resource).toBe(resourceUrlFor(`${webhookId}/orders/:id`, 'POST'));
 		});
 
 		test('should mint a token whose audience is the template and reject another trigger', async () => {

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -231,12 +231,12 @@ export class OAuthController {
 				? req.params.resourcePath.join('/')
 				: req.params.resourcePath); // Wildcard params are captured as arrays
 
-		// Some resources (e.g. webhook triggers) are selected by a `?method=…` query;
-		// the wildcard drops the query, so re-append it for the resolver to read.
-		const method = req.query?.method;
-		const resourcePathWithQuery =
-			typeof method === 'string' ? `${resourcePath}?method=${method}` : resourcePath;
-		const resource = await this.resourceRegistry.getByResourcePath(resourcePathWithQuery);
+		// The wildcard param drops the query, which some resources use as a selector
+		// (e.g. a webhook trigger's `?method=`), so forward it for the registry to route.
+		const queryStart = req.originalUrl?.indexOf('?') ?? -1;
+		const search = queryStart === -1 ? '' : req.originalUrl.slice(queryStart);
+
+		const resource = await this.resourceRegistry.getByResourcePath(resourcePath + search);
 		if (!resource) {
 			res.status(404).json({ message: 'Unknown protected resource' });
 			return;

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/__tests__/utils.test.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/__tests__/utils.test.ts
@@ -4,7 +4,24 @@ import {
 	resourceUrlToWebhookPath,
 	trimSlashes,
 	trimTrailingSlash,
+	webhookResourcePath,
 } from '../utils';
+
+describe('webhookResourcePath', () => {
+	test('should return the path itself for a static webhook', () => {
+		expect(webhookResourcePath('user/defined/path')).toBe('user/defined/path');
+	});
+
+	test('should prefix the webhookId for a dynamic webhook', () => {
+		expect(webhookResourcePath('user/:id/posts', 'wh-1')).toBe('wh-1/user/:id/posts');
+	});
+
+	test('should not prefix a static path that merely contains a colon', () => {
+		// a row only carries a webhookId when a segment *starts* with `:`
+		expect(webhookResourcePath('orders:2024')).toBe('orders:2024');
+		expect(webhookResourcePath('at/time:12')).toBe('at/time:12');
+	});
+});
 
 describe('resourceUrlToWebhookPath', () => {
 	test('should return the path for a URL under a root-mounted base URL', () => {
@@ -45,22 +62,17 @@ describe('resourceUrlToWebhookPath', () => {
 		expect(resourceUrlToWebhookPath('not-a-url', 'https://host.example/')).toBeUndefined();
 	});
 
-	test('should drop the query string by default', () => {
-		// only the webhook resolver reads a query; the others match exact paths, so a
-		// stray parameter must not turn into a lookup miss
+	test('should drop the query string', () => {
+		// the query reaches resolvers separately, so it must never end up in the path
 		expect(
 			resourceUrlToWebhookPath('https://host.example/mcp/abc?foo=bar', 'https://host.example/'),
 		).toBe('/mcp/abc');
-	});
-
-	test('should preserve the query string when asked (carries the method selector)', () => {
 		expect(
 			resourceUrlToWebhookPath(
 				'https://host.example/webhook/abc?method=GET',
 				'https://host.example/',
-				{ preserveQuery: true },
 			),
-		).toBe('/webhook/abc?method=GET');
+		).toBe('/webhook/abc');
 	});
 });
 

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/utils.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/utils.ts
@@ -56,14 +56,12 @@ export function trimSlashes(path: string): string {
  * same for sub-path deployments as for root deployments, and matches the path the
  * unauthenticated well-known route already receives (relative to the mount point).
  *
- * The query string is dropped unless `preserveQuery` is set: only webhook triggers
- * carry one (the `?method=` selector), and the other resolvers match on exact paths,
- * so keeping a query for them would turn a tolerated extra parameter into a miss.
+ * The query string is dropped — it reaches resolvers as a separate argument, so it
+ * never belongs in a path used for matching.
  */
 export function resourceUrlToWebhookPath(
 	resourceUrl: string,
 	webhookBaseUrl: string,
-	{ preserveQuery = false }: { preserveQuery?: boolean } = {},
 ): string | undefined {
 	let url: URL;
 	try {
@@ -82,7 +80,17 @@ export function resourceUrlToWebhookPath(
 		return undefined;
 	}
 
-	return url.pathname.slice(basePath.length) + (preserveQuery ? url.search : '');
+	return url.pathname.slice(basePath.length);
+}
+
+/**
+ * The canonical per-trigger path of a webhook row, relative to `/{endpoint}/`: the
+ * templated path for dynamic webhooks (`<webhookId>/user/:id`), the path itself for
+ * static ones. Keyed off `webhookId` — set exactly when a segment starts with `:` —
+ * since a static path may contain a colon that is not a route parameter.
+ */
+export function webhookResourcePath(webhookPath: string, webhookId?: string): string {
+	return webhookId ? `${webhookId}/${webhookPath}` : webhookPath;
 }
 
 /**

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/workflow-webhook-trigger-resource.resolver.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/workflow-webhook-trigger-resource.resolver.ts
@@ -19,6 +19,7 @@ import {
 	resourceUrlToWebhookPath,
 	trimSlashes,
 	trimTrailingSlash,
+	webhookResourcePath,
 } from './utils';
 
 /**
@@ -65,54 +66,37 @@ export class WorkflowWebhookTriggerResourceResolver implements ProtectedResource
 	readonly scopes = WEBHOOK_TRIGGER_SCOPES;
 
 	async resolveByUrl(resourceUrl: string) {
-		// `preserveQuery`: unlike the sibling resolvers, we need the `?method=` selector.
-		const pathname = resourceUrlToWebhookPath(resourceUrl, this.urlService.getWebhookBaseUrl(), {
-			preserveQuery: true,
-		});
+		const pathname = resourceUrlToWebhookPath(resourceUrl, this.urlService.getWebhookBaseUrl());
 		if (pathname === undefined) {
 			this.logger.debug(`Resource URL is not under the webhook base URL: ${resourceUrl}`);
 			return undefined;
 		}
-		return await this.resolveByPath(pathname);
+		// Can't throw — `resourceUrlToWebhookPath` already parsed the URL.
+		return await this.resolveByPath(pathname, new URL(resourceUrl).search);
 	}
 
-	async resolveByPath(pathname: string) {
+	async resolveByPath(pathname: string, search?: string) {
 		if (!isWebhookOAuth2Enabled()) {
 			return undefined;
 		}
 
-		// The `?method=` selector rides in the query string (see `methodQueryString`);
-		// split it off before the `/{endpoint}/…` path check and slug extraction.
-		const [rawPath, queryString] = pathname.split('?');
-		const requestedMethod = parseMethodParam(new URLSearchParams(queryString).get('method'));
-
-		if (!rawPath.startsWith(`/${this.config.endpoints.webhook}/`)) {
+		if (!pathname.startsWith(`/${this.config.endpoints.webhook}/`)) {
 			// we can quickly rule out non-webhook paths without doing any DB work, so check that first
 			return undefined;
 		}
 
-		const path = trimSlashes(rawPath.slice(this.config.endpoints.webhook.length + 1));
+		// The method being served selects the trigger (see `methodQueryString`).
+		const requestedMethod = parseMethodParam(new URLSearchParams(search).get('method'));
+
+		const path = trimSlashes(pathname.slice(this.config.endpoints.webhook.length + 1));
 
 		this.logger.debug(`Resolving workflow webhook trigger resource for path: ${path}`);
 
-		// Consider every static webhook registered at this path; if none, fall back to
-		// dynamic webhooks whose templated path matches (e.g. `<uuid>/user/:id`), so
-		// both `/user/:id` and a concrete `/user/42` resolve to the same trigger. A
-		// node listening on several methods registers one row per method.
-		const staticWebhooks = await this.webhookService.findStaticWebhooksByPath(path);
-		const webhooks =
-			staticWebhooks.length > 0
-				? staticWebhooks
-				: await this.webhookService.findDynamicWebhooksByPath(path);
+		// Selected the way the router selects, so the resource names the trigger that fires.
+		const webhooks = await this.webhookService.findTriggerWebhooksByPath(path, requestedMethod);
 
-		if (webhooks.length === 0) {
-			this.logger.debug(`No webhook found for path: ${path}`);
-			return undefined;
-		}
-
-		// `(webhookPath, method)` is the webhook primary key, so the requested method
-		// picks exactly one row — and therefore exactly one trigger. Without a method
-		// (a bare well-known probe) we can only answer when the path hosts a single row.
+		// The canonical URL names one method, so a bare probe only resolves a single-method
+		// trigger.
 		const row = requestedMethod
 			? webhooks.find((webhook) => webhook.method === requestedMethod)
 			: webhooks.length === 1
@@ -126,20 +110,13 @@ export class WorkflowWebhookTriggerResourceResolver implements ProtectedResource
 			return undefined;
 		}
 
-		// Every method of the *same* trigger becomes an accepted audience, so one token
-		// spans a multi-method node. A node listening on several methods registers one
-		// row per method, all sharing the same (workflow, node).
-		const triggerMethods = webhooks
-			.filter((webhook) => webhook.workflowId === row.workflowId && webhook.node === row.node)
-			.map((webhook) => webhook.method);
+		// Every method of the trigger becomes an audience, so one token spans the node.
+		const triggerMethods = webhooks.map((webhook) => webhook.method);
 
-		// The resource path is the templated `uniquePath` for dynamic webhooks
-		// (placeholders intact, concrete values discarded), so every instance of one
-		// trigger shares a single identity.
 		return await this.resolveWebhookNode(
 			row.workflowId,
 			row.node,
-			row.uniquePath,
+			webhookResourcePath(row.webhookPath, row.webhookId),
 			row.method,
 			triggerMethods,
 		);

--- a/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
+++ b/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
@@ -88,6 +88,12 @@ describe('ProtectedResourceRegistry', () => {
 			expect(await registry.getByResourcePath('/unknown')).toBeUndefined();
 		});
 
+		it('should match a static resource on the path, ignoring a query component', async () => {
+			// a resource that doesn't use a query selector must not be missed because of one
+			expect(await registry.getByResourcePath('/mcp-server/http?method=GET')).toBe(resourceA);
+			expect(await registry.getByResourcePath('/mcp-server/http/?foo=bar')).toBe(resourceA);
+		});
+
 		it('should resolve the default resource', () => {
 			expect(registry.getDefaultResource()).toBe(resourceA);
 		});
@@ -129,6 +135,30 @@ describe('ProtectedResourceRegistry', () => {
 				'tool:getWorkflowDetails',
 				'workflow:execute',
 			]);
+		});
+	});
+
+	describe('resolvers', () => {
+		it('should hand resolvers the path and the query component separately', async () => {
+			const resolverRegistry = new ProtectedResourceRegistry(mock<Logger>());
+			const resolver = mock<ProtectedResourceResolver>({ id: 'webhook', scopes: [] });
+			resolver.resolveByPath.mockResolvedValue(undefined);
+			resolverRegistry.registerResolver(resolver);
+
+			await resolverRegistry.getByResourcePath('/webhook/orders/?method=GET');
+
+			expect(resolver.resolveByPath).toHaveBeenCalledWith('/webhook/orders', '?method=GET');
+		});
+
+		it('should pass an empty query when the path carries none', async () => {
+			const resolverRegistry = new ProtectedResourceRegistry(mock<Logger>());
+			const resolver = mock<ProtectedResourceResolver>({ id: 'webhook', scopes: [] });
+			resolver.resolveByPath.mockResolvedValue(undefined);
+			resolverRegistry.registerResolver(resolver);
+
+			await resolverRegistry.getByResourcePath('/webhook/orders');
+
+			expect(resolver.resolveByPath).toHaveBeenCalledWith('/webhook/orders', '');
 		});
 	});
 

--- a/packages/cli/src/services/protected-resource.registry.ts
+++ b/packages/cli/src/services/protected-resource.registry.ts
@@ -105,13 +105,23 @@ export interface ProtectedResourceResolver {
 
 	/**
 	 * Resolve a resource by its URL path (e.g. `/webhook/wf-1/mcp`), or
-	 * `undefined` if this resolver owns no such resource. The input is
-	 * pre-normalized (trailing slash trimmed) by the registry.
+	 * `undefined` if this resolver owns no such resource. The path is
+	 * pre-normalized (query split off, trailing slash trimmed) by the registry.
+	 *
+	 * `search` is the resource identifier's query component (RFC 9728 §1.2), which
+	 * selects among resources sharing a path — e.g. the webhook resolver's
+	 * `?method=`. Resolvers keyed on path alone ignore it.
 	 */
-	resolveByPath(pathname: string): Promise<ProtectedResource | undefined>;
+	resolveByPath(pathname: string, search?: string): Promise<ProtectedResource | undefined>;
 }
 
 const trimTrailingSlash = (url: string): string => url.replace(/\/$/, '');
+
+/** Split a path into its path and query components, the latter keeping its `?`. */
+const splitQuery = (pathname: string): [string, string] => {
+	const index = pathname.indexOf('?');
+	return index === -1 ? [pathname, ''] : [pathname.slice(0, index), pathname.slice(index)];
+};
 
 const getResourceUrls = (resource: ProtectedResource): string[] =>
 	resource.getResourceUrls?.() ?? [resource.getResourceUrl()];
@@ -162,7 +172,10 @@ export class ProtectedResourceRegistry {
 
 	/** Look up a resource by its URL path (e.g. `/mcp-server/http`). */
 	async getByResourcePath(pathname: string): Promise<ProtectedResource | undefined> {
-		const normalized = trimTrailingSlash(pathname);
+		// Static resources match on the path alone, so a stray query parameter can't turn
+		// a match into a miss; only resolvers see the query.
+		const [rawPath, search] = splitQuery(pathname);
+		const normalized = trimTrailingSlash(rawPath);
 		for (const resource of this.resources.values()) {
 			for (const url of getResourceUrls(resource)) {
 				try {
@@ -177,7 +190,7 @@ export class ProtectedResourceRegistry {
 
 		for (const resolver of this.resolvers) {
 			try {
-				const resource = await resolver.resolveByPath(normalized);
+				const resource = await resolver.resolveByPath(normalized, search);
 				if (resource) return resource;
 			} catch (error) {
 				this.logResolverFailure(resolver, error);

--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -138,6 +138,86 @@ describe('WebhookService', () => {
 		});
 	});
 
+	describe('findTriggerWebhooksByPath()', () => {
+		const triggerRow = (fields: Partial<WebhookEntity>) =>
+			Object.assign(new WebhookEntity(), {
+				workflowId: 'wf-1',
+				node: 'Webhook',
+				method: 'POST',
+				...fields,
+			}) as WebhookEntity;
+
+		test('should return every method row of the static trigger serving the method', async () => {
+			const get = triggerRow({ webhookPath: 'orders', method: 'GET' });
+			const post = triggerRow({ webhookPath: 'orders', method: 'POST' });
+			webhookRepository.findStaticWebhooksByPath.mockResolvedValue([get, post]);
+
+			expect(await webhookService.findTriggerWebhooksByPath('orders', 'GET')).toEqual([get, post]);
+		});
+
+		test('should exclude rows of a different trigger sharing the path', async () => {
+			// two workflows can share a path under disjoint methods (the key is (path, method))
+			const mine = triggerRow({ webhookPath: 'orders', method: 'GET' });
+			const theirs = triggerRow({ webhookPath: 'orders', method: 'POST', workflowId: 'wf-2' });
+			webhookRepository.findStaticWebhooksByPath.mockResolvedValue([mine, theirs]);
+
+			expect(await webhookService.findTriggerWebhooksByPath('orders', 'GET')).toEqual([mine]);
+		});
+
+		test('should resolve an unambiguous path without a method', async () => {
+			const only = triggerRow({ webhookPath: 'orders' });
+			webhookRepository.findStaticWebhooksByPath.mockResolvedValue([only]);
+
+			expect(await webhookService.findTriggerWebhooksByPath('orders')).toEqual([only]);
+		});
+
+		test('should fall through to dynamic when no static row serves the method', async () => {
+			// a static row for *another* method must not shadow the routed template
+			const webhookId = uuid();
+			const staticGet = triggerRow({ webhookPath: `${webhookId}/orders`, method: 'GET' });
+			const dynamicPost = triggerRow({
+				webhookPath: 'orders/:id',
+				method: 'POST',
+				webhookId,
+				workflowId: 'wf-2',
+			});
+			webhookRepository.findStaticWebhooksByPath.mockResolvedValue([staticGet]);
+			webhookRepository.findDynamicWebhooksByWebhookId.mockResolvedValue([dynamicPost]);
+
+			expect(
+				await webhookService.findTriggerWebhooksByPath(`${webhookId}/orders/42`, 'POST'),
+			).toEqual([dynamicPost]);
+		});
+
+		test('should pick the dynamic template among rows serving the method', async () => {
+			// the winner must come from method-eligible candidates only
+			const webhookId = uuid();
+			const getTemplate = triggerRow({ webhookPath: 'user/:id', method: 'GET', webhookId });
+			const postTemplate = triggerRow({
+				webhookPath: ':id/user',
+				method: 'POST',
+				webhookId,
+				workflowId: 'wf-2',
+			});
+			webhookRepository.findStaticWebhooksByPath.mockResolvedValue([]);
+			webhookRepository.findDynamicWebhooksByWebhookId.mockResolvedValue([
+				getTemplate,
+				postTemplate,
+			]);
+
+			expect(
+				await webhookService.findTriggerWebhooksByPath(`${webhookId}/user/user`, 'POST'),
+			).toEqual([postTemplate]);
+		});
+
+		test('should return an empty array when nothing matches', async () => {
+			webhookRepository.findStaticWebhooksByPath.mockResolvedValue([]);
+			webhookRepository.findDynamicWebhooksByWebhookId.mockResolvedValue([]);
+
+			expect(await webhookService.findTriggerWebhooksByPath('orders', 'GET')).toEqual([]);
+		});
+	});
+
 	describe('findWebhookConflicts', () => {
 		test('should return conflicting webhooks', async () => {
 			const method = 'GET';

--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -167,8 +167,27 @@ describe('WebhookService', () => {
 		test('should resolve an unambiguous path without a method', async () => {
 			const only = triggerRow({ webhookPath: 'orders' });
 			webhookRepository.findStaticWebhooksByPath.mockResolvedValue([only]);
+			webhookRepository.findDynamicWebhooksByWebhookId.mockResolvedValue([]);
 
 			expect(await webhookService.findTriggerWebhooksByPath('orders')).toEqual([only]);
+		});
+
+		test('should refuse a selector-less path a dynamic template also serves', async () => {
+			// the concrete path is static on GET and templated on POST, so without a method
+			// there is no single trigger to name — a lone static row must not be accepted
+			const webhookId = uuid();
+			const concretePath = `${webhookId}/orders/42`;
+			const staticGet = triggerRow({ webhookPath: concretePath, method: 'GET' });
+			const dynamicPost = triggerRow({
+				webhookPath: 'orders/:id',
+				method: 'POST',
+				webhookId,
+				workflowId: 'wf-2',
+			});
+			webhookRepository.findStaticWebhooksByPath.mockResolvedValue([staticGet]);
+			webhookRepository.findDynamicWebhooksByWebhookId.mockResolvedValue([dynamicPost]);
+
+			expect(await webhookService.findTriggerWebhooksByPath(concretePath)).toEqual([]);
 		});
 
 		test('should fall through to dynamic when no static row serves the method', async () => {

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -106,56 +106,71 @@ export class WebhookService {
 	}
 
 	/**
-	 * Find every static webhook registered at the given path, regardless of HTTP
-	 * method. Used by the OAuth protected-resource resolver, which knows a resource
-	 * only by its path (the RFC 8707 resource URL carries no method) and so must
-	 * consider every method registered there. Bypasses the per-method cache.
+	 * Resolve a path (concrete or templated) to the rows of the one trigger that would
+	 * handle it — one per method it listens on, so callers can derive its method-set.
+	 *
+	 * Selection mirrors {@link findWebhook}, method first: narrowing by method only at
+	 * the end would let a static row for another method shadow the dynamic template that
+	 * actually routes. Without a method, only an unambiguous path resolves. `method` is
+	 * untrusted input, hence `string` rather than {@link Method}. Bypasses the cache.
 	 */
-	async findStaticWebhooksByPath(path: string) {
-		return await this.webhookRepository.findStaticWebhooksByPath(path);
-	}
+	async findTriggerWebhooksByPath(path: string, method?: string): Promise<WebhookEntity[]> {
+		const staticWebhooks = await this.webhookRepository.findStaticWebhooksByPath(path);
+		const staticMatch = this.pickServedWebhook(staticWebhooks, method);
+		if (staticMatch) return this.rowsOfSameTrigger(staticWebhooks, staticMatch);
 
-	/**
-	 * Find every dynamic webhook row (all HTTP methods) of the trigger a path
-	 * resolves to, e.g. `<uuid>/user/:id/posts`. The path may be templated
-	 * (`<uuid>/user/:id/posts`) or concrete (`<uuid>/user/42/posts`) — both match
-	 * the same template, because the routing matcher compares only static segments.
-	 * Used by the OAuth resolver, which (unlike {@link findDynamicWebhook}) needs
-	 * every method to derive the trigger's method-set, and the templated path — not
-	 * the concrete one — as the canonical resource identity. Selection mirrors
-	 * {@link findDynamicWebhook} so "which resource" equals "which trigger fires".
-	 */
-	async findDynamicWebhooksByPath(path: string): Promise<WebhookEntity[]> {
 		const [uuidSegment, ...otherSegments] = path.split('/');
-
 		const candidates = await this.webhookRepository.findDynamicWebhooksByWebhookId(
 			uuidSegment,
 			otherSegments.length,
 		);
 
-		if (candidates.length === 0) return [];
+		const eligible = method ? candidates.filter((dw) => dw.method === method) : candidates;
+		const dynamicMatch = this.pickMatchingTemplate(eligible, new Set(otherSegments));
+		if (!dynamicMatch) return [];
 
-		const requestSegments = new Set(otherSegments);
+		return this.rowsOfSameTrigger(candidates, dynamicMatch);
+	}
 
-		const { winner } = candidates.reduce<{ winner: string | null; maxMatches: number }>(
+	/** The row serving the given method, or the only row when no method is known. */
+	private pickServedWebhook(webhooks: WebhookEntity[], method?: string) {
+		if (method) return webhooks.find((webhook) => webhook.method === method);
+		return webhooks.length === 1 ? webhooks[0] : undefined;
+	}
+
+	/** Every row of the trigger `row` belongs to — one per method it listens on. */
+	private rowsOfSameTrigger(webhooks: WebhookEntity[], row: WebhookEntity) {
+		return webhooks.filter(
+			(webhook) =>
+				webhook.workflowId === row.workflowId &&
+				webhook.node === row.node &&
+				webhook.webhookPath === row.webhookPath,
+		);
+	}
+
+	/**
+	 * The candidate whose template best matches the request's segments: most static
+	 * segments wins, falling back to an all-wildcard template. Shared by the router and
+	 * the OAuth resolver so "which resource" cannot drift from "which trigger fires".
+	 */
+	private pickMatchingTemplate(candidates: WebhookEntity[], requestSegments: Set<string>) {
+		const { webhook } = candidates.reduce<{ webhook: WebhookEntity | null; maxMatches: number }>(
 			(acc, dw) => {
 				const allStaticSegmentsMatch = dw.staticSegments.every((s) => requestSegments.has(s));
 
 				if (allStaticSegmentsMatch && dw.staticSegments.length > acc.maxMatches) {
 					acc.maxMatches = dw.staticSegments.length;
-					acc.winner = dw.webhookPath;
-				} else if (dw.staticSegments.length === 0 && acc.winner === null) {
-					acc.winner = dw.webhookPath; // edge case: path is `:var`, matches anything
+					acc.webhook = dw;
+				} else if (dw.staticSegments.length === 0 && !acc.webhook) {
+					acc.webhook = dw; // edge case: if path is `:var`, match on anything
 				}
+
 				return acc;
 			},
-			{ winner: null, maxMatches: 0 },
+			{ webhook: null, maxMatches: 0 },
 		);
 
-		if (winner === null) return [];
-
-		// The winning template's rows are one trigger (shared webhookId), one row per method.
-		return candidates.filter((dw) => dw.webhookPath === winner);
+		return webhook ?? undefined;
 	}
 
 	/**
@@ -173,29 +188,7 @@ export class WebhookService {
 
 		if (dynamicWebhooks.length === 0) return null;
 
-		const requestSegments = new Set(otherSegments);
-
-		const { webhook } = dynamicWebhooks.reduce<{
-			webhook: WebhookEntity | null;
-			maxMatches: number;
-		}>(
-			(acc, dw) => {
-				const allStaticSegmentsMatch = dw.staticSegments.every((s) => requestSegments.has(s));
-
-				if (allStaticSegmentsMatch && dw.staticSegments.length > acc.maxMatches) {
-					acc.maxMatches = dw.staticSegments.length;
-					acc.webhook = dw;
-					return acc;
-				} else if (dw.staticSegments.length === 0 && !acc.webhook) {
-					acc.webhook = dw; // edge case: if path is `:var`, match on anything
-				}
-
-				return acc;
-			},
-			{ webhook: null, maxMatches: 0 },
-		);
-
-		return webhook;
+		return this.pickMatchingTemplate(dynamicWebhooks, new Set(otherSegments)) ?? null;
 	}
 
 	async findWebhook(method: Method, path: string) {

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -111,14 +111,35 @@ export class WebhookService {
 	 *
 	 * Selection mirrors {@link findWebhook}, method first: narrowing by method only at
 	 * the end would let a static row for another method shadow the dynamic template that
-	 * actually routes. Without a method, only an unambiguous path resolves. `method` is
-	 * untrusted input, hence `string` rather than {@link Method}. Bypasses the cache.
+	 * actually routes. Without a method, only a path naming exactly one trigger resolves,
+	 * which costs the dynamic probe even on a static hit. `method` is untrusted input,
+	 * hence `string` rather than {@link Method}. Bypasses the cache.
 	 */
 	async findTriggerWebhooksByPath(path: string, method?: string): Promise<WebhookEntity[]> {
 		const staticWebhooks = await this.webhookRepository.findStaticWebhooksByPath(path);
-		const staticMatch = this.pickServedWebhook(staticWebhooks, method);
-		if (staticMatch) return this.rowsOfSameTrigger(staticWebhooks, staticMatch);
 
+		if (method) {
+			const staticMatch = staticWebhooks.find((webhook) => webhook.method === method);
+			if (staticMatch) return this.rowsOfSameTrigger(staticWebhooks, staticMatch);
+			return await this.findDynamicTriggerWebhooks(path, method);
+		}
+
+		// Without a method the path must name one trigger across *both* kinds: a concrete
+		// path can be served statically on one method and by a dynamic template on
+		// another, so accepting a lone static row here would answer an ambiguous probe.
+		const candidates = [...staticWebhooks, ...(await this.findDynamicTriggerWebhooks(path))];
+		const [first] = candidates;
+		if (!first) return [];
+
+		const oneTrigger = this.rowsOfSameTrigger(candidates, first);
+		return oneTrigger.length === candidates.length ? oneTrigger : [];
+	}
+
+	/** Rows of the dynamic trigger whose template the path resolves to, if any. */
+	private async findDynamicTriggerWebhooks(
+		path: string,
+		method?: string,
+	): Promise<WebhookEntity[]> {
 		const [uuidSegment, ...otherSegments] = path.split('/');
 		const candidates = await this.webhookRepository.findDynamicWebhooksByWebhookId(
 			uuidSegment,
@@ -126,16 +147,9 @@ export class WebhookService {
 		);
 
 		const eligible = method ? candidates.filter((dw) => dw.method === method) : candidates;
-		const dynamicMatch = this.pickMatchingTemplate(eligible, new Set(otherSegments));
-		if (!dynamicMatch) return [];
+		const match = this.pickMatchingTemplate(eligible, new Set(otherSegments));
 
-		return this.rowsOfSameTrigger(candidates, dynamicMatch);
-	}
-
-	/** The row serving the given method, or the only row when no method is known. */
-	private pickServedWebhook(webhooks: WebhookEntity[], method?: string) {
-		if (method) return webhooks.find((webhook) => webhook.method === method);
-		return webhooks.length === 1 ? webhooks[0] : undefined;
+		return match ? this.rowsOfSameTrigger(candidates, match) : [];
 	}
 
 	/** Every row of the trigger `row` belongs to — one per method it listens on. */

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/webhook-trigger-private-credential.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/webhook-trigger-private-credential.spec.ts
@@ -1,0 +1,188 @@
+import { SYSTEM_RESOLVER_ID } from '@n8n/api-types';
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../fixtures/base';
+
+/**
+ * E2E proving an `n8nOAuth2` webhook runs *as the caller*: the private credential
+ * its HTTP Request node uses is resolved per-user, keyed to the identity in the
+ * bearer token rather than to the workflow's owner.
+ *
+ * One workflow, one credential, two callers, opposite outcomes — the member has
+ * not connected the credential so their run fails, while the owner's succeeds
+ * once connected. `requireExecuteAccess: false` lets the member mint a token for
+ * the trigger without holding `workflow:execute`.
+ *
+ * Combines the `dynamic-credentials` capability (Keycloak as the credential's
+ * OAuth2 provider, plus the seeded `system-n8n` resolver) with the webhook
+ * protected-resource flag, so the config is inlined rather than reusing the
+ * named capability.
+ */
+test.use({
+	capability: {
+		services: ['keycloak'],
+		env: {
+			N8N_ENV_FEAT_DYNAMIC_CREDENTIALS: 'true',
+			N8N_ENV_FEAT_WEBHOOK_PRIVATE_CREDENTIALS: 'true',
+			N8N_DYNAMIC_CREDENTIALS_ENDPOINT_AUTH_TOKEN: 'e2e-test-endpoint-token',
+		},
+	},
+	ignoreHTTPSErrors: true, // Keycloak uses a self-signed certificate
+});
+
+test.describe(
+	'Webhook Trigger n8nOAuth2 private credentials @capability:dynamic-credentials @licensed',
+	{
+		annotation: [{ type: 'owner', description: 'Identity & Access' }],
+	},
+	() => {
+		test("should resolve the calling user's private credential, not the owner's @auth:owner", async ({
+			api,
+			services,
+		}) => {
+			// The OAuth endpoints (register/authorize/token) require MCP access.
+			await api.setMcpAccess(true);
+
+			const keycloak = services.keycloak;
+			// authUrl is the EXTERNAL URL (this machine follows the redirect); the token
+			// URL is INTERNAL (n8n exchanges the code server-to-server).
+			const externalBase = keycloak.discoveryUrl.replace('/.well-known/openid-configuration', '');
+			const internalBase = keycloak.internalDiscoveryUrl.replace(
+				'/.well-known/openid-configuration',
+				'',
+			);
+
+			// Resolvable: the seeded `system-n8n` resolver stores its tokens per n8n user.
+			const credential = await api.credentials.createCredential({
+				name: `Webhook Private OAuth2 ${nanoid()}`,
+				type: 'oAuth2Api',
+				data: {
+					grantType: 'authorizationCode',
+					authUrl: `${externalBase}/protocol/openid-connect/auth`,
+					accessTokenUrl: `${internalBase}/protocol/openid-connect/token`,
+					clientId: keycloak.clientId,
+					clientSecret: keycloak.clientSecret,
+					scope: 'openid',
+					ignoreSSLIssues: true,
+				},
+				isResolvable: true,
+			});
+
+			const { workflowId, webhookPath, createdWorkflow } =
+				await api.workflows.createWorkflowFromDefinition({
+					name: `Webhook n8nOAuth2 Private Credential ${nanoid()}`,
+					nodes: [
+						{
+							id: nanoid(),
+							name: 'Webhook',
+							type: 'n8n-nodes-base.webhook',
+							typeVersion: 2.1,
+							position: [0, 0] as [number, number],
+							parameters: {
+								httpMethod: 'POST',
+								path: 'placeholder', // replaced with a unique value on create
+								authentication: 'n8nOAuth2',
+								// Any authenticated user may mint a token, so the member can call
+								// the trigger without being granted workflow:execute.
+								requireExecuteAccess: false,
+								responseMode: 'onReceived', // respond immediately; execution runs async
+								options: {},
+							},
+						},
+						{
+							id: nanoid(),
+							name: 'HTTP Request',
+							type: 'n8n-nodes-base.httpRequest',
+							typeVersion: 4.2,
+							position: [200, 0] as [number, number],
+							parameters: {
+								// Keycloak userinfo accepts the resolved Bearer token and returns 200
+								url: `${internalBase}/protocol/openid-connect/userinfo`,
+								authentication: 'predefinedCredentialType',
+								nodeCredentialType: 'oAuth2Api',
+							},
+							credentials: {
+								oAuth2Api: { id: credential.id, name: credential.name },
+							},
+						},
+					],
+					connections: {
+						Webhook: { main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]] },
+					},
+				});
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId as string);
+
+			try {
+				// The protected resource is registered with the trigger's webhook,
+				// asynchronously after activation.
+				let resource = '';
+				await expect
+					.poll(
+						async () => {
+							const response = await api.mcpOauth.getProtectedResourceMetadata(
+								`webhook/${webhookPath!}?method=POST`,
+							);
+							if (response.status() === 200) {
+								resource = ((await response.json()) as { resource: string }).resource;
+							}
+							return response.status();
+						},
+						{ timeout: 20_000, intervals: [500, 1000, 2000] },
+					)
+					.toBe(200);
+
+				// Leg 1 — a member who has never connected the credential. The run reaches
+				// the HTTP node, which cannot resolve a credential for them, and fails.
+				const member = await api.publicApi.createUser({
+					email: `webhook-oauth2-member-${nanoid(8)}@test.com`,
+					firstName: 'Webhook',
+					lastName: 'Member',
+					role: 'global:member',
+				});
+				const memberApi = await api.createApiForUser(member);
+				const { tokens: memberTokens } = await memberApi.mcpOauth.completeAuthorizationCodeFlow({
+					clientName: `webhook-private member ${nanoid(8)}`,
+					resource,
+				});
+
+				const memberResponse = await api.webhooks.trigger(`/webhook/${webhookPath!}`, {
+					method: 'POST',
+					headers: { Authorization: `Bearer ${memberTokens.access_token}` },
+					data: { caller: 'member' },
+				});
+				expect(memberResponse.status()).toBe(200); // onReceived — the run fails afterwards
+
+				const memberExecution = await api.workflows.waitForExecution(workflowId, 20_000);
+				expect((memberExecution as unknown as { status: string }).status).toBe('error');
+
+				// Leg 2 — the owner connects the credential for themselves, then calls the
+				// same trigger with their own token.
+				const { tokens: ownerTokens } = await api.mcpOauth.completeAuthorizationCodeFlow({
+					clientName: `webhook-private owner ${nanoid(8)}`,
+					resource,
+				});
+
+				const providerUrl = await api.dynamicCredentials.getAuthorizationUrl(
+					credential.id,
+					SYSTEM_RESOLVER_ID,
+					ownerTokens.access_token,
+				);
+				const callbackUrl = await keycloak.completeAuthorizationCodeFlow(providerUrl);
+				await api.dynamicCredentials.completeAuthorizationCallback(callbackUrl);
+
+				const ownerResponse = await api.webhooks.trigger(`/webhook/${webhookPath!}`, {
+					method: 'POST',
+					headers: { Authorization: `Bearer ${ownerTokens.access_token}` },
+					data: { caller: 'owner' },
+				});
+				expect(ownerResponse.status()).toBe(200);
+
+				const ownerExecution = await api.workflows.waitForExecution(workflowId, 20_000);
+				expect((ownerExecution as unknown as { status: string }).status).toBe('success');
+			} finally {
+				await api.workflows.deactivate(workflowId);
+			}
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/webhook-trigger-private-credential.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/webhook-trigger-private-credential.spec.ts
@@ -1,17 +1,20 @@
-import { SYSTEM_RESOLVER_ID } from '@n8n/api-types';
 import { nanoid } from 'nanoid';
 
 import { test, expect } from '../../../fixtures/base';
 
 /**
- * E2E proving an `n8nOAuth2` webhook runs *as the caller*: the private credential
- * its HTTP Request node uses is resolved per-user, keyed to the identity in the
- * bearer token rather than to the workflow's owner.
+ * E2E proving an `n8nOAuth2` webhook resolves end-user credentials *per caller*:
+ * the identity in the bearer token decides which stored credential is used, not
+ * the workflow's owner.
  *
- * One workflow, one credential, two callers, opposite outcomes — the member has
- * not connected the credential so their run fails, while the owner's succeeds
- * once connected. `requireExecuteAccess: false` lets the member mint a token for
- * the trigger without holding `workflow:execute`.
+ * The webhook path carries a reactive credential-status gate — once the trigger has
+ * established the caller's identity, an unconnected private credential is answered
+ * with 428 and a connect link instead of executing. So the same workflow and
+ * credential yield opposite outcomes for two callers: the owner succeeds once
+ * connected, while a member who never connected stays gated.
+ *
+ * `requireExecuteAccess: false` lets the member mint a token for the trigger
+ * without holding `workflow:execute`.
  *
  * Combines the `dynamic-credentials` capability (Keycloak as the credential's
  * OAuth2 provider, plus the seeded `system-n8n` resolver) with the webhook
@@ -29,6 +32,11 @@ test.use({
 	},
 	ignoreHTTPSErrors: true, // Keycloak uses a self-signed certificate
 });
+
+interface CredentialGateResponse {
+	readyToExecute: boolean;
+	credentials: Array<{ credentialName: string; status: string; authorizationUrl?: string }>;
+}
 
 test.describe(
 	'Webhook Trigger n8nOAuth2 private credentials @capability:dynamic-credentials @licensed',
@@ -85,7 +93,6 @@ test.describe(
 								// Any authenticated user may mint a token, so the member can call
 								// the trigger without being granted workflow:execute.
 								requireExecuteAccess: false,
-								responseMode: 'onReceived', // respond immediately; execution runs async
 								options: {},
 							},
 						},
@@ -132,8 +139,52 @@ test.describe(
 					)
 					.toBe(200);
 
-				// Leg 1 — a member who has never connected the credential. The run reaches
-				// the HTTP node, which cannot resolve a credential for them, and fails.
+				const callWebhook = async (accessToken: string, caller: string) =>
+					await api.webhooks.trigger(`/webhook/${webhookPath!}`, {
+						method: 'POST',
+						headers: { Authorization: `Bearer ${accessToken}` },
+						data: { caller },
+					});
+
+				// The owner has not connected the credential yet, so the gate answers 428
+				// with a connect link rather than executing.
+				const { tokens: ownerTokens } = await api.mcpOauth.completeAuthorizationCodeFlow({
+					clientName: `webhook-private owner ${nanoid(8)}`,
+					resource,
+				});
+
+				const gated = await callWebhook(ownerTokens.access_token, 'owner');
+				expect(gated.status()).toBe(428);
+
+				const gate = (await gated.json()) as CredentialGateResponse;
+				expect(gate.readyToExecute).toBe(false);
+				const missing = gate.credentials.find((c) => c.credentialName === credential.name);
+				expect(missing?.status).toBe('missing');
+				expect(missing?.authorizationUrl).toBeTruthy();
+				expect(await api.workflows.getExecutions(workflowId)).toHaveLength(0);
+
+				// The link is bound to the owner, so open it with the owner's session: n8n
+				// redirects to Keycloak, and the callback stores the owner's tokens against
+				// the resolver-keyed credential.
+				const providerUrl = await api.dynamicCredentials.resolveProviderUrlFromAuthorizeLink(
+					missing!.authorizationUrl!,
+				);
+				const callbackUrl = await keycloak.completeAuthorizationCodeFlow(providerUrl);
+				await api.dynamicCredentials.completeAuthorizationCallback(callbackUrl);
+
+				// Same token, same trigger — now the gate passes and the HTTP node resolves
+				// the owner's credential against Keycloak.
+				const ownerResponse = await callWebhook(ownerTokens.access_token, 'owner');
+				expect(ownerResponse.status()).toBe(200);
+
+				const ownerExecution = await api.workflows.waitForExecution(workflowId, 20_000);
+				expect((ownerExecution as unknown as { status: string }).status).toBe('success');
+
+				const executionsAfterOwner = (await api.workflows.getExecutions(workflowId)).length;
+
+				// A member who never connected the credential is still gated on the very same
+				// workflow and credential — the stored credential is keyed to the caller, not
+				// to the workflow's owner.
 				const member = await api.publicApi.createUser({
 					email: `webhook-oauth2-member-${nanoid(8)}@test.com`,
 					firstName: 'Webhook',
@@ -146,40 +197,12 @@ test.describe(
 					resource,
 				});
 
-				const memberResponse = await api.webhooks.trigger(`/webhook/${webhookPath!}`, {
-					method: 'POST',
-					headers: { Authorization: `Bearer ${memberTokens.access_token}` },
-					data: { caller: 'member' },
-				});
-				expect(memberResponse.status()).toBe(200); // onReceived — the run fails afterwards
-
-				const memberExecution = await api.workflows.waitForExecution(workflowId, 20_000);
-				expect((memberExecution as unknown as { status: string }).status).toBe('error');
-
-				// Leg 2 — the owner connects the credential for themselves, then calls the
-				// same trigger with their own token.
-				const { tokens: ownerTokens } = await api.mcpOauth.completeAuthorizationCodeFlow({
-					clientName: `webhook-private owner ${nanoid(8)}`,
-					resource,
-				});
-
-				const providerUrl = await api.dynamicCredentials.getAuthorizationUrl(
-					credential.id,
-					SYSTEM_RESOLVER_ID,
-					ownerTokens.access_token,
+				const memberResponse = await callWebhook(memberTokens.access_token, 'member');
+				expect(memberResponse.status()).toBe(428);
+				expect(((await memberResponse.json()) as CredentialGateResponse).readyToExecute).toBe(
+					false,
 				);
-				const callbackUrl = await keycloak.completeAuthorizationCodeFlow(providerUrl);
-				await api.dynamicCredentials.completeAuthorizationCallback(callbackUrl);
-
-				const ownerResponse = await api.webhooks.trigger(`/webhook/${webhookPath!}`, {
-					method: 'POST',
-					headers: { Authorization: `Bearer ${ownerTokens.access_token}` },
-					data: { caller: 'owner' },
-				});
-				expect(ownerResponse.status()).toBe(200);
-
-				const ownerExecution = await api.workflows.waitForExecution(workflowId, 20_000);
-				expect((ownerExecution as unknown as { status: string }).status).toBe('success');
+				expect(await api.workflows.getExecutions(workflowId)).toHaveLength(executionsAfterOwner);
 			} finally {
 				await api.workflows.deactivate(workflowId);
 			}

--- a/packages/testing/playwright/tests/e2e/webhooks/webhook-trigger-oauth2.spec.ts
+++ b/packages/testing/playwright/tests/e2e/webhooks/webhook-trigger-oauth2.spec.ts
@@ -1,0 +1,180 @@
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../fixtures/base';
+import type { ApiHelpers } from '../../../services/api-helper';
+
+/**
+ * E2E for the Webhook node's `n8nOAuth2` authentication: a production webhook
+ * becomes an OAuth 2.1 protected resource served by n8n's own authorization
+ * server, and only a bearer token whose audience names that trigger may call it.
+ *
+ * The method being served is part of the resource URL (`?method=POST`), since one
+ * path can host several triggers as long as their methods are disjoint.
+ *
+ * Requires `N8N_ENV_FEAT_WEBHOOK_PRIVATE_CREDENTIALS=true` — with the flag off the
+ * resolver never publishes the resource, so no token can be minted for it.
+ */
+test.use({
+	capability: { env: { N8N_ENV_FEAT_WEBHOOK_PRIVATE_CREDENTIALS: 'true' } },
+});
+
+interface ProtectedWebhook {
+	workflowId: string;
+	versionId: string;
+	webhookPath: string;
+	/** Canonical RFC 8707 resource URL, method selector included. */
+	resource: string;
+}
+
+/**
+ * Creates and activates a workflow whose Webhook node requires an `n8nOAuth2`
+ * bearer token, then waits for its protected resource to be published.
+ */
+async function createProtectedWebhook(api: ApiHelpers): Promise<ProtectedWebhook> {
+	const { workflowId, webhookPath, createdWorkflow } =
+		await api.workflows.createWorkflowFromDefinition({
+			name: `Webhook n8nOAuth2 ${nanoid()}`,
+			nodes: [
+				{
+					// `path` is replaced with a unique value by createWorkflowFromDefinition
+					parameters: {
+						httpMethod: 'POST',
+						path: 'webhook-oauth2',
+						authentication: 'n8nOAuth2',
+						options: {},
+					},
+					id: nanoid(),
+					name: 'Webhook',
+					type: 'n8n-nodes-base.webhook',
+					typeVersion: 2.1,
+					position: [0, 0],
+				},
+			],
+			connections: {},
+		});
+
+	const versionId = createdWorkflow.versionId as string;
+	await api.workflows.activate(workflowId, versionId);
+
+	// The resource is registered together with the trigger's webhook, which is
+	// asynchronous after activation, so poll the per-resource metadata document.
+	// Its `resource` field is the audience a caller token must carry.
+	let resource = '';
+	await expect
+		.poll(
+			async () => {
+				const response = await api.mcpOauth.getProtectedResourceMetadata(
+					`webhook/${webhookPath!}?method=POST`,
+				);
+				if (response.status() === 200) {
+					resource = ((await response.json()) as { resource: string }).resource;
+				}
+				return response.status();
+			},
+			{ timeout: 20_000, intervals: [500, 1000, 2000] },
+		)
+		.toBe(200);
+
+	expect(resource).toContain(webhookPath!);
+	expect(resource).toContain('?method=POST');
+
+	return { workflowId, versionId, webhookPath: webhookPath!, resource };
+}
+
+/** Mints a token scoped to the given protected resource, with the owner consenting. */
+async function mintTokenFor(api: ApiHelpers, resource: string): Promise<string> {
+	const { tokens } = await api.mcpOauth.completeAuthorizationCodeFlow({
+		clientName: `webhook-oauth2 e2e ${nanoid(8)}`,
+		resource,
+	});
+	return tokens.access_token;
+}
+
+test.describe(
+	'Webhook Trigger n8nOAuth2 authentication',
+	{
+		annotation: [{ type: 'owner', description: 'Identity & Access' }],
+	},
+	() => {
+		test.beforeEach(async ({ api }) => {
+			// The OAuth endpoints (register/authorize/token) require MCP access.
+			await api.setMcpAccess(true);
+		});
+
+		test('should challenge an unauthenticated request and not execute @auth:owner', async ({
+			api,
+		}) => {
+			const { workflowId, webhookPath } = await createProtectedWebhook(api);
+
+			try {
+				const response = await api.webhooks.trigger(`/webhook/${webhookPath}`, {
+					method: 'POST',
+					data: { hello: 'world' },
+				});
+
+				expect(response.status()).toBe(401);
+
+				// RFC 9728: the challenge points the client at this trigger's metadata
+				// document, method selector included, so it can discover where to get a
+				// token and for which audience.
+				const challenge = response.headers()['www-authenticate'];
+				expect(challenge).toContain('Bearer realm="n8n Webhook"');
+				expect(challenge).toContain(
+					`/.well-known/oauth-protected-resource/webhook/${webhookPath}?method=POST`,
+				);
+
+				expect(await api.workflows.getExecutions(workflowId)).toHaveLength(0);
+			} finally {
+				await api.workflows.deactivate(workflowId);
+			}
+		});
+
+		test('should execute when called with a token scoped to the trigger @auth:owner', async ({
+			api,
+		}) => {
+			const { workflowId, webhookPath, resource } = await createProtectedWebhook(api);
+
+			try {
+				const accessToken = await mintTokenFor(api, resource);
+
+				const response = await api.webhooks.trigger(`/webhook/${webhookPath}`, {
+					method: 'POST',
+					headers: { Authorization: `Bearer ${accessToken}` },
+					data: { hello: 'world' },
+				});
+
+				expect(response.status()).toBe(200);
+
+				const execution = await api.workflows.waitForExecution(workflowId, 15_000);
+				expect((execution as unknown as { status: string }).status).toBe('success');
+			} finally {
+				await api.workflows.deactivate(workflowId);
+			}
+		});
+
+		test('should reject a token minted for a different webhook trigger @auth:owner', async ({
+			api,
+		}) => {
+			// Per-trigger scoping is the point of the resource indicator: a token is
+			// bound to the trigger it was consented for and cannot be replayed at another.
+			const target = await createProtectedWebhook(api);
+			const other = await createProtectedWebhook(api);
+
+			try {
+				const otherToken = await mintTokenFor(api, other.resource);
+
+				const response = await api.webhooks.trigger(`/webhook/${target.webhookPath}`, {
+					method: 'POST',
+					headers: { Authorization: `Bearer ${otherToken}` },
+					data: { hello: 'world' },
+				});
+
+				expect(response.status()).toBe(401);
+				expect(await api.workflows.getExecutions(target.workflowId)).toHaveLength(0);
+			} finally {
+				await api.workflows.deactivate(target.workflowId);
+				await api.workflows.deactivate(other.workflowId);
+			}
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Follow-up to per-trigger OAuth protected resources for webhook triggers (#35186), from a review of that PR: three defects, each with a regression test, plus the end-to-end coverage the feature was missing.

### Fixes

**1. Canonical resource path used the wrong predicate.** The path was derived from `WebhookEntity.uniquePath`, which treats a path as dynamic when `webhookPath.includes(':')`. Registration (and `NodeHelpers.getNodeWebhookUrl`) instead set `webhookId` only when a segment *starts* with `:`. So a static path containing a non-parameter colon — `orders:2024` — took the dynamic branch with `webhookId` unset, publishing `…/webhook//orders:2024?method=POST` as the resource identifier. A client echoing that identifier back as the RFC 8707 `resource=` parameter fails with `invalid_target`, and the OAuth flow can never complete.

Now derived on the OAuth side via `webhookResourcePath()`, keyed off `webhookId`. This also means `uniquePath` no longer needs to be public — the entity is untouched by the feature again.

**2. Trigger selection narrowed by method last, diverging from the router.** Candidates were gathered method-agnostically, so a static row registered under a *different* method shadowed the dynamic template a request actually routes to, leaving that trigger permanently unresolvable (401). Selection now mirrors `findWebhook`: static-for-the-served-method first, then dynamic-for-that-method. The router's template matcher is extracted and shared by both paths so they cannot drift — the invariant the old comment claimed but didn't hold.

Consolidated into one use-case method, replacing `findStaticWebhooksByPath` + `findDynamicWebhooksByPath`:

```ts
async findTriggerWebhooksByPath(path: string, method?: string): Promise<WebhookEntity[]>
```

It also filters on `(workflowId, node, webhookPath)`, so a returned method-set can't span two workflows that share a `webhookId` (a duplicated workflow keeps its nodes' ids, and `(webhookPath, method)` is the primary key).

**3. The `?method=` query was re-appended in shared controller code.** It was appended for *every* well-known request, but only the webhook resolver strips a query — so a stray `method` parameter made static resources miss their path match. `GET /.well-known/oauth-protected-resource/mcp-server/http?method=GET` returned 200 before #35186 and 404 after it.

Moved to the seam: `ProtectedResourceRegistry` splits the query once, matches static resources on the path alone, and passes it to resolvers as `resolveByPath(pathname, search?)`. Resolvers keyed on path alone ignore it. The controller no longer knows about `method`, and `resourceUrlToWebhookPath`'s `preserveQuery` option is gone. Forwarding the raw query string also drops a re-encoding round-trip, so a duplicated `method` parameter no longer silently discards the selector.

### E2E coverage

There was none for `n8nOAuth2` webhooks, so this adds two specs (4 tests, API-level).

`tests/e2e/webhooks/webhook-trigger-oauth2.spec.ts` — no external services; the flag arrives as inline capability env:

- an unauthenticated call is answered 401 with `realm="n8n Webhook"` and a `resource_metadata` URL carrying the `?method=` selector, and creates no execution;
- a token minted for the trigger's own resource executes the workflow;
- a token minted for a *different* webhook trigger is rejected — the per-trigger scoping the resource indicator exists for.

`tests/e2e/dynamic-credentials/webhook-trigger-private-credential.spec.ts` — needs Keycloak, so it sits with its capability siblings. Proves end-user credentials resolve **per caller**: the owner is gated with 428 plus a connect link, connects through that link, and then succeeds; a member who never connected stays gated on the same workflow and credential. `requireExecuteAccess: false` lets the member mint a token without holding `workflow:execute`.

## How to test

CI covers all of it. Locally:

```bash
cd packages/cli && pnpm typecheck
cd packages/cli && pnpm test src/modules/oauth-server src/webhooks/__tests__/webhook.service.test.ts src/services/__tests__/protected-resource.registry.test.ts   # 446 tests / 21 files

pnpm build:docker
pnpm --filter=n8n-playwright test:container:sqlite:e2e --grep "Webhook Trigger n8nOAuth2"
```

Unit/integration additions: `webhookResourcePath` colon handling; `findTriggerWebhooksByPath` (static shadowing, method-eligible template selection, cross-trigger method-set isolation); registry path/query splitting; controller query forwarding; and two API-level tests — a literal-colon static path, and a static GET row not shadowing the POST template that routes.

Each fix's regression test was confirmed to fail with that fix reverted, so none of them pass vacuously. Same for the e2e spec: with the feature flag off, all three tests fail at the metadata poll.

The private-credential spec is `@licensed`, so it needs a license at boot — it can't run on a local checkout without one (its `dynamic-credentials` siblings can't either) and was verified in CI.

Optional manual check, with `N8N_ENV_FEAT_WEBHOOK_PRIVATE_CREDENTIALS=true` and a published workflow whose Webhook node uses `n8nOAuth2`:

1. Set the node's path to `orders:2024`. `GET /.well-known/oauth-protected-resource/webhook/orders:2024?method=POST` should report `resource` with a single slash before `orders:2024`.
2. `GET /.well-known/oauth-protected-resource/mcp-server/http?method=GET` should return 200, not 404.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35186.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
