### PR TITLE
fix: Enable Save and clear stale OAuth state on auth method switch

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -445,6 +445,56 @@ describe('CredentialsController', () => {
 			expect(prepareUpdateDataSpy).not.toHaveBeenCalled();
 		});
 
+		it('should clear the OAuth token when switching a credential to a different auth type', async () => {
+			// A previous OAuth connection on `existingCredential.type` must not carry over once
+			// the credential is switched to a different auth method (e.g. Service Account -> OAuth).
+			const ownerReq = {
+				user: { id: 'owner-id', role: GLOBAL_OWNER_ROLE },
+				params: { credentialId },
+				body: {
+					name: 'Updated Credential',
+					type: 'oAuth2Api',
+					data: { clientId: 'cid' },
+				},
+			} as unknown as CredentialRequest.Update;
+
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(existingCredential);
+			updateSpy.mockResolvedValue({ ...existingCredential, name: 'Updated Credential' });
+
+			await credentialsController.updateCredentials(ownerReq);
+
+			expect(prepareUpdateDataSpy).toHaveBeenCalledWith(
+				ownerReq.user,
+				ownerReq.body,
+				existingCredential,
+				{ clearOauthTokenData: true },
+			);
+		});
+
+		it('should not clear the OAuth token when the auth type is unchanged', async () => {
+			const ownerReq = {
+				user: { id: 'owner-id', role: GLOBAL_OWNER_ROLE },
+				params: { credentialId },
+				body: {
+					name: 'Updated Credential',
+					type: existingCredential.type,
+					data: { apiKey: 'updated-key' },
+				},
+			} as unknown as CredentialRequest.Update;
+
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(existingCredential);
+			updateSpy.mockResolvedValue({ ...existingCredential, name: 'Updated Credential' });
+
+			await credentialsController.updateCredentials(ownerReq);
+
+			expect(prepareUpdateDataSpy).toHaveBeenCalledWith(
+				ownerReq.user,
+				ownerReq.body,
+				existingCredential,
+				{ clearOauthTokenData: false },
+			);
+		});
+
 		it('should emit "credentials-updated" with jweEnabled true when JWE is enabled in payload', async () => {
 			// ARRANGE
 			const ownerReq = {

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -253,11 +253,9 @@ export class CredentialsController {
 			throw new BadRequestError('Managed credentials cannot be updated');
 		}
 
-		if (
-			credential.usageScope === 'instance' &&
-			body.type !== undefined &&
-			body.type !== credential.type
-		) {
+		const isChangingAuthType = body.type !== undefined && body.type !== credential.type;
+
+		if (credential.usageScope === 'instance' && isChangingAuthType) {
 			throw new BadRequestError(
 				'Provider connection type cannot be changed. Create a new connection instead.',
 			);
@@ -290,7 +288,9 @@ export class CredentialsController {
 			req.user,
 			req.body,
 			credential,
-			{ clearOauthTokenData: isTogglingToPrivate },
+			// Switching auth method (e.g. Google Service Account -> OAuth) changes the
+			// credential's type; the previous type's OAuth token no longer applies to it.
+			{ clearOauthTokenData: isTogglingToPrivate || isChangingAuthType },
 		);
 
 		const newCredentialData = await this.credentialsService.createEncryptedData({

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -66,6 +66,35 @@ vi.mock('./TypeToConfirmDialog.vue', () => ({
 	},
 }));
 
+// N8nDropdownMenu (reka-ui) doesn't render its portalled menu items in jsdom, so stub the
+// auth-mode selector with plain buttons that emit the same event.
+vi.mock('./CredentialModeSelector.vue', () => ({
+	default: {
+		name: 'CredentialModeSelector',
+		props: [
+			'credentialType',
+			'useCustomOauth',
+			'showManagedOauthOptions',
+			'quickConnectAvailable',
+			'isQuickConnectMode',
+			'contextNode',
+		],
+		emits: ['update:authType'],
+		template: `
+			<div data-test-id="credential-mode-selector-stub">
+				<button
+					data-test-id="select-service-account-auth"
+					@click="$emit('update:authType', { type: 'serviceAccount' })"
+				>Service Account</button>
+				<button
+					data-test-id="select-managed-oauth-auth"
+					@click="$emit('update:authType', { type: 'oAuth2' })"
+				>Managed OAuth</button>
+			</div>
+		`,
+	},
+}));
+
 const oAuth2Api: ICredentialType = {
 	name: 'oAuth2Api',
 	displayName: 'OAuth2 API',
@@ -1003,6 +1032,168 @@ describe('CredentialEdit', () => {
 				credentialTypeName: 'betaApi',
 			}),
 		);
+	});
+
+	describe('switching auth type on an existing credential', () => {
+		const serviceAccountApi: ICredentialType = {
+			name: 'serviceAccountApi',
+			displayName: 'Service Account',
+			properties: [{ displayName: 'Private Key', name: 'privateKey', type: 'string', default: '' }],
+		};
+
+		const managedOAuthApi: ICredentialType = {
+			name: 'managedOAuthApi',
+			extends: ['oAuth2Api'],
+			displayName: 'Managed OAuth2 API',
+			__overwrittenProperties: ['clientId', 'clientSecret'],
+			properties: [
+				{
+					displayName: 'Grant Type',
+					name: 'grantType',
+					type: 'hidden',
+					default: 'authorizationCode',
+				},
+				{
+					displayName: 'Authorization URL',
+					name: 'authUrl',
+					type: 'hidden',
+					default: 'https://example.com/auth',
+				},
+				{
+					displayName: 'Access Token URL',
+					name: 'accessTokenUrl',
+					type: 'hidden',
+					default: 'https://example.com/token',
+				},
+			],
+			iconUrl: '',
+			supportedNodes: [],
+		};
+
+		const dualAuthNodeType = {
+			displayName: 'Dual Auth Switch Test',
+			name: 'n8n-nodes-base.dualAuthSwitchTest',
+			group: ['transform'],
+			version: 1,
+			description: 'Test node',
+			defaults: { name: 'Dual Auth Switch Test' },
+			inputs: ['main'],
+			outputs: ['main'],
+			credentials: [
+				{
+					name: 'serviceAccountApi',
+					required: true,
+					displayOptions: { show: { authentication: ['serviceAccount'] } },
+				},
+				{
+					name: 'managedOAuthApi',
+					required: true,
+					displayOptions: { show: { authentication: ['oAuth2'] } },
+				},
+			],
+			properties: [
+				{
+					displayName: 'Authentication',
+					name: 'authentication',
+					type: 'options',
+					options: [
+						{ name: 'Service Account', value: 'serviceAccount' },
+						{ name: 'OAuth2', value: 'oAuth2' },
+					],
+					default: 'serviceAccount',
+				},
+			],
+		} as unknown as INodeTypeDescription;
+
+		// The credential was saved as a Service Account; its data carries no OAuth
+		// token of its own, but a prior connection under a different auth method
+		// can still leak into `oauthTokenData` (see credentials.service.ts unredact).
+		const setupStores = () => {
+			const pinia = createTestingPinia({
+				initialState: {
+					[STORES.UI]: {
+						modalsById: {
+							[CREDENTIAL_EDIT_MODAL_KEY]: { open: true },
+						},
+					},
+					[STORES.SETTINGS]: {
+						settings: {
+							enterprise: { sharing: true, externalSecrets: false },
+							templates: { host: '' },
+						},
+					},
+				},
+			});
+
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialData.mockResolvedValueOnce({
+				// @ts-expect-error data is decrypted
+				data: { privateKey: 'secret-key', oauthTokenData: { access_token: 'stale-token' } },
+				createdAt: '2026-06-01T10:00:00.000Z',
+				updatedAt: '2026-06-01T10:00:00.000Z',
+				id: 'cred-switch',
+				name: 'Dual Auth account',
+				type: 'serviceAccountApi',
+				isManaged: false,
+				sharedWithProjects: [],
+				scopes: ['credential:update'],
+				oauthTokenData: false,
+			});
+
+			credentialsStore.state.credentialTypes = {
+				[oAuth2Api.name]: oAuth2Api,
+				[serviceAccountApi.name]: serviceAccountApi,
+				[managedOAuthApi.name]: managedOAuthApi,
+			};
+			credentialsStore.getNewCredentialName.mockResolvedValue('Dual Auth account');
+
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			workflowsStore.workflowId = 'test-workflow-id';
+			const ndvStore = mockedStore(useNDVStore, createWorkflowDocumentId('test-workflow-id'));
+			ndvStore.activeNode = {
+				id: 'dual-auth-switch-test-node',
+				name: 'DualAuthSwitchTest',
+				type: 'n8n-nodes-base.dualAuthSwitchTest',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: { authentication: 'serviceAccount' },
+			} as INode;
+
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+			nodeTypesStore.getNodeType = () => dualAuthNodeType;
+
+			return { credentialsStore, pinia };
+		};
+
+		test('enables Save and clears the stale connection banner after switching auth method', async () => {
+			const { credentialsStore, pinia } = setupStores();
+
+			const { getByTestId, queryByTestId } = renderComponent({
+				props: {
+					activeId: 'cred-switch',
+					modalName: CREDENTIAL_EDIT_MODAL_KEY,
+					mode: 'edit',
+				},
+				pinia,
+			});
+
+			await retry(() => expect(credentialsStore.getCredentialData).toHaveBeenCalled());
+			await retry(() => expect(getByTestId('select-managed-oauth-auth')).toBeInTheDocument());
+
+			// Nothing has been edited on the loaded credential yet: Save stays disabled.
+			await retry(() =>
+				expect(within(getByTestId('credential-save-button')).getByRole('button')).toBeDisabled(),
+			);
+
+			await userEvent.click(getByTestId('select-managed-oauth-auth'));
+
+			await retry(() =>
+				expect(
+					within(getByTestId('credential-save-button')).getByRole('button'),
+				).not.toBeDisabled(),
+			);
+			await retry(() => expect(queryByTestId('oauth-connect-success-banner')).not.toBeVisible());
+		});
 	});
 
 	describe('saving credentials', () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1235,9 +1235,20 @@ async function onAuthTypeChanged(payload: CredentialModeOption): Promise<void> {
 
 		restoreOrReset();
 
+		// A freshly selected auth mode has no confirmed connection yet — without this,
+		// stale `oauthTokenData`/`connectedByMe` restored from a mode cached earlier in
+		// this session (or carried over from the loaded credential) makes the banner
+		// misreport "connected" for a mode that was never actually saved.
+		connectedByMe.value = false;
+		credentialData.value = {
+			...credentialData.value,
+			oauthTokenData: null as unknown as CredentialInformation,
+		};
+
 		pendingAuthType.value = payload.type;
+		hasUnsavedChanges.value = true;
 		// Also update credential name but only if the default name is still used
-		if (hasUnsavedChanges.value && !hasUserSpecifiedName.value) {
+		if (!hasUserSpecifiedName.value) {
 			const newDefaultName = await credentialsStore.getNewCredentialName({
 				credentialTypeName: defaultCredentialTypeName.value,
 			});


### PR DESCRIPTION
## Summary

Switching a saved credential's auth method (e.g. Google Service Account → OAuth) never marked the form dirty, so the Save button stayed disabled even though the connection banner reported "connected." Root cause was two-fold:

- **Frontend** (`CredentialEdit.vue`): `onAuthTypeChanged` never set `hasUnsavedChanges = true`, and it could leave stale `oauthTokenData`/`connectedByMe` from a previously loaded or cached auth mode in the form state, making the banner misreport a connection that was never established for the newly selected mode.
- **Backend** (`credentials.controller.ts`): on every credential update, the server re-attaches the credential's existing `oauthTokenData` to the saved data (to avoid losing a token on unrelated edits) — but it did this even when the auth method (`type`) itself changed, so saving under a new method silently carried over the old method's token.

The fix marks the form dirty and clears stale connection state on a real auth-method switch, and has the backend clear `oauthTokenData` when `body.type` differs from the credential's current type.

## How to test

1. Open a Google credential (or any node credential with multiple auth methods, e.g. Service Account and OAuth2).
2. Configure and save it using one auth method.
3. Switch to a different auth method in the same modal.
4. Confirm the Save button becomes enabled and the connection banner no longer reports a stale "connected" state for the new method.
5. Save, reopen the credential, and confirm the connection state still reflects reality (no carried-over OAuth token from the previous method).

Regression tests were added in `CredentialEdit.test.ts` (frontend dirty-tracking/banner state) and `credentials.controller.test.ts` (backend `clearOauthTokenData` on auth-type change).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1080

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35367">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

