### PR TITLE
fix(SharePoint Node): Point delegated Sites.Selected users at URL or ID mode

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/site.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/site.test.ts
@@ -120,23 +120,53 @@ describe('Microsoft SharePoint v2 — site selection', () => {
 		expect(thrown?.description).toContain('Sites.Read.All application permission');
 	});
 
-	it('keeps the permission-naming message for delegated refusals', async () => {
+	it('points delegated sign-ins without search rights at URL or ID mode', async () => {
 		ctx.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
-		// Mirrors the transport's delegated 403 shape: the permission-naming
-		// message is set as the error option, as delegatedApiError does
+		// The old permission-naming message must be replaced, not merely unread —
+		// mock it present so a leak would show up in the assertions below
 		apiRequest.mockRejectedValue(
 			new NodeApiError(
 				mock<INode>(),
-				{ message: 'refused' },
-				{
-					httpCode: '403',
-					message: 'the credential may be missing the Sites.Read.All permission',
-				},
+				{},
+				{ httpCode: '403', message: 'the credential may be missing the Sites.Read.All permission' },
 			),
 		);
 
-		// URL paste would hit the same refusal — the accurate message must survive
-		await expect(getSites.call(ctx)).rejects.toThrow(/Sites\.Read\.All/);
+		let thrown: NodeApiError | undefined;
+		try {
+			await getSites.call(ctx);
+		} catch (error) {
+			thrown = error as NodeApiError;
+		}
+
+		expect(thrown).toBeInstanceOf(NodeApiError);
+		expect(thrown?.httpCode).toBe('403');
+		expect(thrown?.message).toBe('This credential cannot search sites');
+		const description = thrown?.description ?? '';
+		expect(description).toContain('URL or ID mode');
+		expect(description).toContain('Sites.Selected');
+		// Sites.Read.All is the optional, secondary path — not the primary instruction
+		expect(description.indexOf('URL or ID mode')).toBeLessThan(
+			description.indexOf('Sites.Read.All'),
+		);
+		// The transport's original wording must not survive into the new message
+		expect(thrown?.message).not.toContain('missing');
+		expect(description).not.toContain('missing');
+	});
+
+	it('passes through a non-403 delegated error unchanged', async () => {
+		ctx.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+		const original = new NodeApiError(mock<INode>(), { message: 'boom' }, { httpCode: '500' });
+		apiRequest.mockRejectedValue(original);
+
+		await expect(getSites.call(ctx)).rejects.toBe(original);
+	});
+
+	it('passes through a non-NodeApiError delegated rejection unchanged', async () => {
+		ctx.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+		apiRequest.mockRejectedValue(new Error('boom'));
+
+		await expect(getSites.call(ctx)).rejects.toThrow('boom');
 	});
 
 	it('offers search first, with URL and ID modes alongside', () => {

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/site/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/site/index.ts
@@ -4,6 +4,7 @@ import type {
 	INodeListSearchResult,
 	INodeParameterResourceLocator,
 	INodeProperties,
+	JsonObject,
 } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
@@ -93,18 +94,23 @@ export async function getSites(
 					},
 				)) as SiteSearchReply);
 	} catch (error) {
-		// An app with only per-site permissions can't list what it can't see —
-		// point at the URL mode. Delegated refusals keep the transport's message,
-		// which names the missing permission (URL paste would hit the same 403).
-		if (
-			error instanceof NodeApiError &&
-			error.httpCode === '403' &&
-			getSharePointCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH
-		) {
-			throw new NodeOperationError(this.getNode(), 'This app registration cannot search sites', {
-				description:
-					"An app registration with only per-site permissions can't list sites. Choose the site by pasting its URL instead — that still works — or grant the app the Sites.Read.All application permission to enable search.",
-			});
+		if (error instanceof NodeApiError && error.httpCode === '403') {
+			if (getSharePointCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+				throw new NodeOperationError(this.getNode(), 'This app registration cannot search sites', {
+					description:
+						"An app registration with only per-site permissions can't list sites. Choose the site by pasting its URL instead — that still works — or grant the app the Sites.Read.All application permission to enable search.",
+				});
+			}
+			throw new NodeApiError(
+				this.getNode(),
+				{ message: 'This credential cannot search sites' } as JsonObject,
+				{
+					message: 'This credential cannot search sites',
+					description:
+						"Switch the Site field to URL or ID mode — Microsoft Graph doesn't support site search under Sites.Selected, and neither mode needs that permission. If URL or ID mode also fails, the credential likely lacks a different permission or consent, not just Sites.Read.All.",
+					httpCode: '403',
+				},
+			);
 		}
 		throw error;
 	}


### PR DESCRIPTION
## Summary

Delegated (OAuth2) credentials scoped to `Sites.Selected` get a 403 when searching for a site in the resource picker's "From List" mode — expected, since Microsoft Graph's site search endpoint doesn't support `Sites.Selected` at all. The old error only suggested granting the tenant-wide `Sites.Read.All`, making `Sites.Selected` look unsupported by the node — when in reality only this one picker's search is affected; URL and ID mode already work fine.

This PR rewords that message to lead with the working path (switch to URL or ID mode) instead of the tenant-wide permission grant.

Before: 
<img width="406" height="269" alt="image" src="https://github.com/user-attachments/assets/bdaf2568-5efe-470c-a57f-f9825b8d067c" />

After:
<img width="523" height="642" alt="Screenshot 2026-08-03 at 10 44 14" src="https://github.com/user-attachments/assets/8c312675-ff7e-4d42-8ac5-9ad8ca8f5f4f" />


## How to test

1. Set up a SharePoint delegated (OAuth2) credential scoped to `Sites.Selected` (not `Sites.Read.All`/`Sites.ReadWrite.All`).
2. Add a SharePoint node, open any operation's **Site** field, and try the "From List" picker.
3. Before: error only suggests granting `Sites.Read.All`. After: error leads with switching to URL or ID mode.
4. Confirm **By URL** / **By ID** still work normally against a site the credential has access to.

```
cd packages/nodes-base && pnpm test site.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-303

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
