### PR TITLE
feat(core): Fence a poll trigger's cursor commit on its scheduler lease (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -54,7 +54,11 @@ export type {
 	DeleteFinishedTasksOptions,
 	ScheduledTaskMetricSnapshot,
 } from './scheduled-task.repository';
-export { PollerStateRepository, type PollerCursor } from './poller-state.repository';
+export {
+	PollerStateRepository,
+	type PollerCursor,
+	type PollLeaseFence,
+} from './poller-state.repository';
 export { ProcessedDataRepository } from './processed-data.repository';
 export { SettingsRepository } from './settings.repository';
 export { TagRepository } from './tag.repository';

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -129,9 +129,11 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 			.from(ScheduledTask, 'fenced_task')
 			.where('fenced_task.id = :fenceTaskId')
 			.andWhere('fenced_task.leaseEpoch = :fenceLeaseEpoch')
-			// `<> 'pending'`, not `= 'running'`: a fire-and-forget commit can land after
-			// the task already succeeded, and only a pending task's lease can be reclaimed.
-			.andWhere('fenced_task.status != :fenceExcludedStatus')
+			// A commit may only land while its poll still owns the task (`running`), or
+			// right after the task finished well (`succeeded`), since nothing waits on the
+			// commit and the status can flip first. Any other status means the poll lost
+			// the task, so a commit arriving now is late and must not land.
+			.andWhere('fenced_task.status IN (:...fenceAllowedStatuses)')
 			.getQuery();
 
 		return {
@@ -139,7 +141,7 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 			params: {
 				fenceTaskId: Number(fence.taskId),
 				fenceLeaseEpoch: fence.leaseEpoch,
-				fenceExcludedStatus: ScheduledTaskStatus.Pending,
+				fenceAllowedStatuses: [ScheduledTaskStatus.Running, ScheduledTaskStatus.Succeeded],
 			},
 		};
 	}

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -68,11 +68,20 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 	}
 
 	/**
-	 * Call inside the transaction that also inserts the execution the poll produced, so
-	 * neither commits without the other. Without a `fence`, throws if no row matched: the
-	 * row was read before `poll()` ran, so a miss means the workflow or node was removed
-	 * mid-poll. With a `fence`, a miss returns `false` instead. The write is unconditional
-	 * otherwise, so when two polls of one node overlap, the last transaction to commit wins.
+	 * Advances the stored cursor.
+	 *
+	 * @param workflowId - Workflow the poll node belongs to.
+	 * @param nodeId - Poll trigger node whose cursor is advancing.
+	 * @param cursor - New cursor value to store.
+	 * @param ctx - Transaction to run the update in.
+	 * @param fence - Lease to check before writing. If given, returns `false` instead of
+	 *   throwing when someone else now owns this poll.
+	 * @returns `true` if the cursor was advanced, `false` if `fence` no longer matches.
+	 * @throws {UnexpectedError} when no `fence` is given and the row is missing, since
+	 *   the only explanation left is that the workflow or node was deleted mid-poll.
+	 * @remarks Run this in the same transaction as the execution insert for the poll's result,
+	 * 	so the two commit or roll back together. If two polls of the same node overlap,
+	 * 	the last one to commit wins.
 	 */
 	async advanceCursor(
 		workflowId: string,
@@ -96,12 +105,13 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 		}
 
 		const result = await qb.execute();
+		if (result.affected === 1) {
+			return true;
+		}
 
-		// `affected` is typed optional, though both supported drivers populate it; only
-		// an exact single-row match counts as success.
-		if (result.affected === 1) return true;
-
-		if (fence) return false;
+		if (fence) {
+			return false;
+		}
 
 		throw new UnexpectedError('Poller cursor row disappeared while its poll was running', {
 			extra: { workflowId, nodeId },

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -74,10 +74,10 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 	 * @param nodeId - Poll trigger node whose cursor is advancing.
 	 * @param cursor - New cursor value to store.
 	 * @param ctx - Transaction to run the update in.
-	 * @param fence - Lease to check before writing. If given, returns `false` instead of
-	 *   throwing when someone else now owns this poll.
+	 * @param fence - Lease to check before writing. If given and no longer matching,
+	 *   the cursor is left untouched.
 	 * @returns `true` if the cursor was advanced, `false` if `fence` no longer matches.
-	 * @throws {UnexpectedError} when no `fence` is given and the row is missing, since
+	 * @throws {UnexpectedError} when the row is missing, with or without a `fence`, since
 	 *   the only explanation left is that the workflow or node was deleted mid-poll.
 	 * @remarks Run this in the same transaction as the execution insert for the poll's result,
 	 * 	so the two commit or roll back together. If two polls of the same node overlap,
@@ -109,7 +109,9 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 			return true;
 		}
 
-		if (fence) {
+		// The guarded UPDATE alone cannot tell a rejected fence from a missing row, so
+		// the failure path re-reads the row to keep the two outcomes distinct.
+		if (fence && (await manager.existsBy(PollerState, { workflowId, nodeId }))) {
 			return false;
 		}
 

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -1,3 +1,4 @@
+import { ScheduledTaskStatus } from '@n8n/constants';
 import { Service } from '@n8n/di';
 import { DataSource } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
@@ -97,11 +98,13 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 				.from(ScheduledTask, 'fenced_task')
 				.where('fenced_task.id = :fenceTaskId')
 				.andWhere('fenced_task.leaseEpoch = :fenceLeaseEpoch')
+				.andWhere('fenced_task.status != :fenceExcludedStatus')
 				.getQuery();
 
 			qb.andWhere(`EXISTS ${fenceExists}`, {
 				fenceTaskId: Number(fence.taskId),
 				fenceLeaseEpoch: fence.leaseEpoch,
+				fenceExcludedStatus: ScheduledTaskStatus.Pending,
 			});
 		}
 

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -3,13 +3,15 @@ import { DataSource } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import { UnexpectedError } from 'n8n-workflow';
 
-import { PollerState } from '../entities';
+import { PollerState, ScheduledTask } from '../entities';
 import { BaseRepository } from './base-repository';
 import type { PollerCursor } from '../entities/poller-state';
 import type { OperationContext } from '../services/transaction';
 import { TransactionRunner } from '../services/transaction';
 
 export type { PollerCursor } from '../entities/poller-state';
+
+export type PollLeaseFence = { taskId: string; leaseEpoch: number };
 
 @Service()
 export class PollerStateRepository extends BaseRepository<PollerState> {
@@ -76,17 +78,43 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 		nodeId: string,
 		cursor: PollerCursor,
 		ctx: OperationContext,
-	): Promise<void> {
-		// QueryDeepPartialEntity rejects `Record<string, unknown>`, so cast at this boundary.
-		const result = await this.managerFor(ctx).update(PollerState, { workflowId, nodeId }, {
-			cursor,
-			updatedAt: new Date(),
-		} as QueryDeepPartialEntity<PollerState>);
+		fence?: PollLeaseFence,
+	): Promise<boolean> {
+		const manager = this.managerFor(ctx);
 
-		if (result.affected !== 1) {
-			throw new UnexpectedError('Poller cursor row disappeared while its poll was running', {
-				extra: { workflowId, nodeId },
+		// QueryDeepPartialEntity rejects `Record<string, unknown>`, so cast at this boundary.
+		const qb = manager
+			.createQueryBuilder()
+			.update(PollerState)
+			.set({ cursor, updatedAt: new Date() } as QueryDeepPartialEntity<PollerState>)
+			.where({ workflowId, nodeId });
+
+		if (fence) {
+			const fenceExists = manager
+				.createQueryBuilder()
+				.subQuery()
+				.select('1')
+				.from(ScheduledTask, 'fenced_task')
+				.where('fenced_task.id = :fenceTaskId')
+				.andWhere('fenced_task.leaseEpoch = :fenceLeaseEpoch')
+				.getQuery();
+
+			qb.andWhere(`EXISTS ${fenceExists}`, {
+				fenceTaskId: Number(fence.taskId),
+				fenceLeaseEpoch: fence.leaseEpoch,
 			});
 		}
+
+		const result = await qb.execute();
+
+		// `affected` is optional and not reported by every driver, so only an exact
+		// single-row match counts as success.
+		if (result.affected === 1) return true;
+
+		if (fence) return false;
+
+		throw new UnexpectedError('Poller cursor row disappeared while its poll was running', {
+			extra: { workflowId, nodeId },
+		});
 	}
 }

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -12,6 +12,11 @@ import { TransactionRunner } from '../services/transaction';
 
 export type { PollerCursor } from '../entities/poller-state';
 
+/**
+ * A miss on this fence can't tell a reclaimed lease apart from a cursor row
+ * that's genuinely gone; both are reported as `null`/`false` by the commit
+ * methods that accept a fence, never as an error.
+ */
 export type PollLeaseFence = { taskId: string; leaseEpoch: number };
 
 @Service()

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -13,9 +13,9 @@ import { TransactionRunner } from '../services/transaction';
 export type { PollerCursor } from '../entities/poller-state';
 
 /**
- * A miss on this fence can't tell a reclaimed lease apart from a cursor row
- * that's genuinely gone; both are reported as `null`/`false` by the commit
- * methods that accept a fence, never as an error.
+ * A fence miss can't tell a reclaimed lease apart from a cursor row that's
+ * genuinely gone, so the commit methods that accept a fence report it as
+ * `null`/`false`, never as an error.
  */
 export type PollLeaseFence = { taskId: string; leaseEpoch: number };
 
@@ -25,7 +25,6 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 		super(PollerState, dataSource.manager, transactionRunner);
 	}
 
-	/** The node's stored cursor, or `null` if it has never polled. */
 	async findCursor(
 		workflowId: string,
 		nodeId: string,
@@ -40,8 +39,8 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 
 	/**
 	 * Returns the node's cursor, seeding it with `initial` on first read. Reads first
-	 * so a node past its first poll costs one query, not two; on a miss, racing
-	 * processes both try to insert, and the loser re-reads the winner's stored cursor.
+	 * so a node past its first poll costs one query, not two; on a miss, the loser of
+	 * a racing insert re-reads the winner's stored cursor.
 	 */
 	async getOrCreateCursor(
 		workflowId: string,
@@ -74,12 +73,10 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 
 	/**
 	 * Call inside the transaction that also inserts the execution the poll produced, so
-	 * neither commits without the other. Without a `fence`, throws if no row matched: the
-	 * row was read before `poll()` ran, so a miss means the workflow or node was removed
-	 * mid-poll, and the transaction must not commit. With a `fence`, a miss returns
-	 * `false` instead: under at-least-once redelivery, a lease this poll no longer holds
-	 * is an expected outcome, not an error. The write is unconditional otherwise, so when
-	 * two polls of one node overlap, the last transaction to commit wins.
+	 * neither commits without the other. Without a `fence`, throws on a miss: the row
+	 * was read before `poll()` ran, so a miss means the workflow or node was removed
+	 * mid-poll. With a `fence`, a miss returns `false` instead: under at-least-once
+	 * redelivery, a lease this poll no longer holds is expected, not an error.
 	 */
 	async advanceCursor(
 		workflowId: string,
@@ -98,11 +95,8 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 			.where({ workflowId, nodeId });
 
 		if (fence) {
-			// Fences on the task's own identity and epoch, not on this row's workflowId/nodeId:
-			// it proves the claim hasn't been superseded, not that it belongs to this node. A
-			// fence that never reaches this call falls back to the unfenced path rather than
-			// blocking every write, so a wiring mistake loses the guard instead of causing
-			// data loss.
+			// A missing fence falls back to the unfenced write rather than blocking every
+			// call, so a wiring mistake loses the guard instead of causing data loss.
 			const fenceExists = manager
 				.createQueryBuilder()
 				.subQuery()
@@ -111,18 +105,15 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 				.where('fenced_task.id = :fenceTaskId')
 				.andWhere('fenced_task.leaseEpoch = :fenceLeaseEpoch')
 				// Not `status = 'running'`: the emit-path commit is fire-and-forget and can land
-				// after the executor already marked the task succeeded, so requiring `running`
-				// would drop the cursor advance on an ordinary successful poll. `<> 'pending'`
-				// instead: two scheduler paths finish a task without bumping the epoch, fencing
-				// on `status` alone, so `leaseEpoch` on its own defends this write less than the
-				// scheduler defends its own state.
+				// after the executor already marked the task succeeded, which would drop an
+				// ordinary successful poll's cursor advance. `<> 'pending'` instead: only a
+				// pending task can still have its lease reclaimed by another worker.
 				.andWhere('fenced_task.status != :fenceExcludedStatus')
 				.getQuery();
 
-			// Binding `fence.taskId` through object criteria was tried and reverted: TypeORM's
-			// generated parameter names are per-builder, and merging the subquery's parameters
-			// into this builder overwrote its own workflowId/nodeId bindings. The raw
-			// where-string plus `Number(fence.taskId)` is deliberate.
+			// Binding via object criteria was tried and reverted: TypeORM's generated
+			// parameter names are per-builder, and merging the subquery's parameters into
+			// this builder overwrote its own workflowId/nodeId bindings.
 			qb.andWhere(`EXISTS ${fenceExists}`, {
 				fenceTaskId: Number(fence.taskId),
 				fenceLeaseEpoch: fence.leaseEpoch,
@@ -136,12 +127,10 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 		// single-row match counts as success.
 		if (result.affected === 1) return true;
 
-		// A miss here means either a reclaimed lease or a `poller_state` row that's genuinely
-		// gone; the two can't be told apart. The EXISTS read takes no lock, so on Postgres a
-		// reclaim committing between this statement and our commit still lands (zero window on
-		// SQLite, which holds the write lock for the whole transaction). Holds only at the
-		// default READ COMMITTED isolation level; a fixed transaction-start snapshot would
-		// silently disable it.
+		// The EXISTS read takes no lock, so on Postgres a reclaim committing between this
+		// statement and our commit still lands (zero window on SQLite, which holds the
+		// write lock for the whole transaction). Holds only at READ COMMITTED; a fixed
+		// transaction-start snapshot would silently disable it.
 		if (fence) return false;
 
 		throw new UnexpectedError('Poller cursor row disappeared while its poll was running', {

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -1,6 +1,6 @@
 import { ScheduledTaskStatus } from '@n8n/constants';
 import { Service } from '@n8n/di';
-import { DataSource } from '@n8n/typeorm';
+import { DataSource, type EntityManager, type ObjectLiteral } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import { UnexpectedError } from 'n8n-workflow';
 
@@ -92,25 +92,8 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 			.where({ workflowId, nodeId });
 
 		if (fence) {
-			const fenceExists = manager
-				.createQueryBuilder()
-				.subQuery()
-				.select('1')
-				.from(ScheduledTask, 'fenced_task')
-				.where('fenced_task.id = :fenceTaskId')
-				.andWhere('fenced_task.leaseEpoch = :fenceLeaseEpoch')
-				// `<> 'pending'`, not `= 'running'`: a fire-and-forget commit can land after
-				// the task already succeeded, and only a pending task's lease can be reclaimed.
-				.andWhere('fenced_task.status != :fenceExcludedStatus')
-				.getQuery();
-
-			// Binding via object criteria was reverted: TypeORM's per-builder parameter
-			// names made the subquery's binding overwrite this builder's own.
-			qb.andWhere(`EXISTS ${fenceExists}`, {
-				fenceTaskId: Number(fence.taskId),
-				fenceLeaseEpoch: fence.leaseEpoch,
-				fenceExcludedStatus: ScheduledTaskStatus.Pending,
-			});
+			const { sql, params } = this.buildFenceClause(manager, fence);
+			qb.andWhere(sql, params);
 		}
 
 		const result = await qb.execute();
@@ -124,5 +107,31 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 		throw new UnexpectedError('Poller cursor row disappeared while its poll was running', {
 			extra: { workflowId, nodeId },
 		});
+	}
+
+	private buildFenceClause(
+		manager: EntityManager,
+		fence: PollLeaseFence,
+	): { sql: string; params: ObjectLiteral } {
+		const fenceExists = manager
+			.createQueryBuilder()
+			.subQuery()
+			.select('1')
+			.from(ScheduledTask, 'fenced_task')
+			.where('fenced_task.id = :fenceTaskId')
+			.andWhere('fenced_task.leaseEpoch = :fenceLeaseEpoch')
+			// `<> 'pending'`, not `= 'running'`: a fire-and-forget commit can land after
+			// the task already succeeded, and only a pending task's lease can be reclaimed.
+			.andWhere('fenced_task.status != :fenceExcludedStatus')
+			.getQuery();
+
+		return {
+			sql: `EXISTS ${fenceExists}`,
+			params: {
+				fenceTaskId: Number(fence.taskId),
+				fenceLeaseEpoch: fence.leaseEpoch,
+				fenceExcludedStatus: ScheduledTaskStatus.Pending,
+			},
+		};
 	}
 }

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -12,11 +12,7 @@ import { TransactionRunner } from '../services/transaction';
 
 export type { PollerCursor } from '../entities/poller-state';
 
-/**
- * A fence miss can't tell a reclaimed lease apart from a cursor row that's
- * genuinely gone, so the commit methods that accept a fence report it as
- * `null`/`false`, never as an error.
- */
+/** A fence miss can't tell a reclaimed lease apart from a genuinely gone cursor row. */
 export type PollLeaseFence = { taskId: string; leaseEpoch: number };
 
 @Service()
@@ -25,6 +21,7 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 		super(PollerState, dataSource.manager, transactionRunner);
 	}
 
+	/** The node's stored cursor, or `null` if it has never polled. */
 	async findCursor(
 		workflowId: string,
 		nodeId: string,
@@ -39,8 +36,8 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 
 	/**
 	 * Returns the node's cursor, seeding it with `initial` on first read. Reads first
-	 * so a node past its first poll costs one query, not two; on a miss, the loser of
-	 * a racing insert re-reads the winner's stored cursor.
+	 * so a node past its first poll costs one query, not two; on a miss, racing
+	 * processes both try to insert, and the loser re-reads the winner's stored cursor.
 	 */
 	async getOrCreateCursor(
 		workflowId: string,
@@ -73,10 +70,10 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 
 	/**
 	 * Call inside the transaction that also inserts the execution the poll produced, so
-	 * neither commits without the other. Without a `fence`, throws on a miss: the row
-	 * was read before `poll()` ran, so a miss means the workflow or node was removed
-	 * mid-poll. With a `fence`, a miss returns `false` instead: under at-least-once
-	 * redelivery, a lease this poll no longer holds is expected, not an error.
+	 * neither commits without the other. Without a `fence`, throws if no row matched: the
+	 * row was read before `poll()` ran, so a miss means the workflow or node was removed
+	 * mid-poll. With a `fence`, a miss returns `false` instead. The write is unconditional
+	 * otherwise, so when two polls of one node overlap, the last transaction to commit wins.
 	 */
 	async advanceCursor(
 		workflowId: string,
@@ -95,8 +92,6 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 			.where({ workflowId, nodeId });
 
 		if (fence) {
-			// A missing fence falls back to the unfenced write rather than blocking every
-			// call, so a wiring mistake loses the guard instead of causing data loss.
 			const fenceExists = manager
 				.createQueryBuilder()
 				.subQuery()
@@ -104,16 +99,13 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 				.from(ScheduledTask, 'fenced_task')
 				.where('fenced_task.id = :fenceTaskId')
 				.andWhere('fenced_task.leaseEpoch = :fenceLeaseEpoch')
-				// Not `status = 'running'`: the emit-path commit is fire-and-forget and can land
-				// after the executor already marked the task succeeded, which would drop an
-				// ordinary successful poll's cursor advance. `<> 'pending'` instead: only a
-				// pending task can still have its lease reclaimed by another worker.
+				// `<> 'pending'`, not `= 'running'`: a fire-and-forget commit can land after
+				// the task already succeeded, and only a pending task's lease can be reclaimed.
 				.andWhere('fenced_task.status != :fenceExcludedStatus')
 				.getQuery();
 
-			// Binding via object criteria was tried and reverted: TypeORM's generated
-			// parameter names are per-builder, and merging the subquery's parameters into
-			// this builder overwrote its own workflowId/nodeId bindings.
+			// Binding via object criteria was reverted: TypeORM's per-builder parameter
+			// names made the subquery's binding overwrite this builder's own.
 			qb.andWhere(`EXISTS ${fenceExists}`, {
 				fenceTaskId: Number(fence.taskId),
 				fenceLeaseEpoch: fence.leaseEpoch,
@@ -127,10 +119,6 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 		// single-row match counts as success.
 		if (result.affected === 1) return true;
 
-		// The EXISTS read takes no lock, so on Postgres a reclaim committing between this
-		// statement and our commit still lands (zero window on SQLite, which holds the
-		// write lock for the whole transaction). Holds only at READ COMMITTED; a fixed
-		// transaction-start snapshot would silently disable it.
 		if (fence) return false;
 
 		throw new UnexpectedError('Poller cursor row disappeared while its poll was running', {

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -12,7 +12,6 @@ import { TransactionRunner } from '../services/transaction';
 
 export type { PollerCursor } from '../entities/poller-state';
 
-/** A fence miss can't tell a reclaimed lease apart from a genuinely gone cursor row. */
 export type PollLeaseFence = { taskId: string; leaseEpoch: number };
 
 @Service()
@@ -98,8 +97,8 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 
 		const result = await qb.execute();
 
-		// `affected` is optional and not reported by every driver, so only an exact
-		// single-row match counts as success.
+		// `affected` is typed optional, though both supported drivers populate it; only
+		// an exact single-row match counts as success.
 		if (result.affected === 1) return true;
 
 		if (fence) return false;

--- a/packages/@n8n/db/src/repositories/poller-state.repository.ts
+++ b/packages/@n8n/db/src/repositories/poller-state.repository.ts
@@ -69,10 +69,12 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 
 	/**
 	 * Call inside the transaction that also inserts the execution the poll produced, so
-	 * neither commits without the other. Throws if no row matched: the row was read
-	 * before `poll()` ran, so a miss means the workflow or node was removed mid-poll, and
-	 * the transaction must not commit. The write is unconditional, so when two polls of
-	 * one node overlap, the last transaction to commit wins.
+	 * neither commits without the other. Without a `fence`, throws if no row matched: the
+	 * row was read before `poll()` ran, so a miss means the workflow or node was removed
+	 * mid-poll, and the transaction must not commit. With a `fence`, a miss returns
+	 * `false` instead: under at-least-once redelivery, a lease this poll no longer holds
+	 * is an expected outcome, not an error. The write is unconditional otherwise, so when
+	 * two polls of one node overlap, the last transaction to commit wins.
 	 */
 	async advanceCursor(
 		workflowId: string,
@@ -91,6 +93,11 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 			.where({ workflowId, nodeId });
 
 		if (fence) {
+			// Fences on the task's own identity and epoch, not on this row's workflowId/nodeId:
+			// it proves the claim hasn't been superseded, not that it belongs to this node. A
+			// fence that never reaches this call falls back to the unfenced path rather than
+			// blocking every write, so a wiring mistake loses the guard instead of causing
+			// data loss.
 			const fenceExists = manager
 				.createQueryBuilder()
 				.subQuery()
@@ -98,9 +105,19 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 				.from(ScheduledTask, 'fenced_task')
 				.where('fenced_task.id = :fenceTaskId')
 				.andWhere('fenced_task.leaseEpoch = :fenceLeaseEpoch')
+				// Not `status = 'running'`: the emit-path commit is fire-and-forget and can land
+				// after the executor already marked the task succeeded, so requiring `running`
+				// would drop the cursor advance on an ordinary successful poll. `<> 'pending'`
+				// instead: two scheduler paths finish a task without bumping the epoch, fencing
+				// on `status` alone, so `leaseEpoch` on its own defends this write less than the
+				// scheduler defends its own state.
 				.andWhere('fenced_task.status != :fenceExcludedStatus')
 				.getQuery();
 
+			// Binding `fence.taskId` through object criteria was tried and reverted: TypeORM's
+			// generated parameter names are per-builder, and merging the subquery's parameters
+			// into this builder overwrote its own workflowId/nodeId bindings. The raw
+			// where-string plus `Number(fence.taskId)` is deliberate.
 			qb.andWhere(`EXISTS ${fenceExists}`, {
 				fenceTaskId: Number(fence.taskId),
 				fenceLeaseEpoch: fence.leaseEpoch,
@@ -114,6 +131,12 @@ export class PollerStateRepository extends BaseRepository<PollerState> {
 		// single-row match counts as success.
 		if (result.affected === 1) return true;
 
+		// A miss here means either a reclaimed lease or a `poller_state` row that's genuinely
+		// gone; the two can't be told apart. The EXISTS read takes no lock, so on Postgres a
+		// reclaim committing between this statement and our commit still lands (zero window on
+		// SQLite, which holds the write lock for the whole transaction). Holds only at the
+		// default READ COMMITTED isolation level; a fixed transaction-start snapshot would
+		// silently disable it.
 		if (fence) return false;
 
 		throw new UnexpectedError('Poller cursor row disappeared while its poll was running', {

--- a/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
@@ -143,6 +143,7 @@ describe('PollTriggerTaskHandler', () => {
 			expect(triggerExecutionContextFactory.createPollExecutionContext).toHaveBeenCalledWith(
 				buildWorkflowData(),
 				triggerNode,
+				{ taskId: 'task-1', leaseEpoch: 1 },
 			);
 			expect(triggersAndPollers.runPollFunction).toHaveBeenCalledWith(
 				workflow,

--- a/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
@@ -151,6 +151,16 @@ describe('PollTriggerTaskHandler', () => {
 			);
 		});
 
+		test('builds the poll execution context fence from the claimed task id and lease epoch', async () => {
+			await handler.execute(buildTask({ id: 'task-42', leaseEpoch: 7 }), report);
+
+			expect(triggerExecutionContextFactory.createPollExecutionContext).toHaveBeenCalledWith(
+				buildWorkflowData(),
+				triggerNode,
+				{ taskId: 'task-42', leaseEpoch: 7 },
+			);
+		});
+
 		test('reads workflow data fresh (non-cached) so the poll cursor is never stale', async () => {
 			await handler.execute(buildTask(), report);
 

--- a/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts
@@ -152,16 +152,6 @@ describe('PollTriggerTaskHandler', () => {
 			);
 		});
 
-		test('builds the poll execution context fence from the claimed task id and lease epoch', async () => {
-			await handler.execute(buildTask({ id: 'task-42', leaseEpoch: 7 }), report);
-
-			expect(triggerExecutionContextFactory.createPollExecutionContext).toHaveBeenCalledWith(
-				buildWorkflowData(),
-				triggerNode,
-				{ taskId: 'task-42', leaseEpoch: 7 },
-			);
-		});
-
 		test('reads workflow data fresh (non-cached) so the poll cursor is never stale', async () => {
 			await handler.execute(buildTask(), report);
 

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
@@ -56,7 +56,10 @@ export class PollTriggerTaskHandler implements TaskHandler {
 		const node = this.resolveTriggerNode(workflowData, nodeId, task);
 
 		const { workflow, pollFunctions } =
-			await this.triggerExecutionContextFactory.createPollExecutionContext(workflowData, node);
+			await this.triggerExecutionContextFactory.createPollExecutionContext(workflowData, node, {
+				taskId: task.id,
+				leaseEpoch: task.leaseEpoch,
+			});
 
 		// Poll and hand-off share one staging scope, so a cursor staged here can only
 		// be committed by this poll and never by a later occurrence.

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
@@ -1,5 +1,4 @@
 import { Logger } from '@n8n/backend-common';
-import type { PollLeaseFence } from '@n8n/db';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { ClaimedTask, DispatchDecision, DispatchReporter, TaskHandler } from '@n8n/scheduler';
@@ -20,11 +19,6 @@ import {
 	POLL_TRIGGER_TASK_TYPE,
 	type PollTriggerTaskPayload,
 } from './poll-trigger-task';
-
-const toPollLeaseFence = (task: ClaimedTask): PollLeaseFence => ({
-	taskId: task.id,
-	leaseEpoch: task.leaseEpoch,
-});
 
 /**
  * Runs a due poll occurrence's `poll()` once and dispatches only when it
@@ -62,11 +56,10 @@ export class PollTriggerTaskHandler implements TaskHandler {
 		const node = this.resolveTriggerNode(workflowData, nodeId, task);
 
 		const { workflow, pollFunctions } =
-			await this.triggerExecutionContextFactory.createPollExecutionContext(
-				workflowData,
-				node,
-				toPollLeaseFence(task),
-			);
+			await this.triggerExecutionContextFactory.createPollExecutionContext(workflowData, node, {
+				taskId: task.id,
+				leaseEpoch: task.leaseEpoch,
+			});
 
 		// Poll and hand-off share one staging scope, so a cursor staged here can only
 		// be committed by this poll and never by a later occurrence.
@@ -85,8 +78,8 @@ export class PollTriggerTaskHandler implements TaskHandler {
 					// poll() can run for a while (network I/O against the polled source), so
 					// the workflow may have been deactivated while it was in flight. There is
 					// no in-memory registration to check here, so re-read the stored active state.
-					// A cheap early-out: the cursor commit's own lease fence is what actually
-					// rejects a reclaimed poll's write.
+					// A cheap early-out, not the real guard: the cursor commit's own lease fence
+					// is what actually rejects a reclaimed poll's write.
 					if (!(await this.workflowRepository.isActive(workflowId))) {
 						this.logger.debug('Workflow deactivated during poll; discarding the result', {
 							taskId: task.id,
@@ -109,10 +102,8 @@ export class PollTriggerTaskHandler implements TaskHandler {
 				}
 
 				// A poll with no items may still have moved its cursor, committed here on
-				// its own. Active state is re-read first so a workflow deactivated mid-poll
-				// doesn't get its cursor moved; that is also just a cheap early-out, since
-				// the fenced commit inside `commitStagedCursor` is what actually rejects a
-				// reclaimed poll's write.
+				// its own. Active state is re-read first for the same cheap-early-out reason
+				// as above; `commitStagedCursor`'s own fenced commit is the real guard.
 				try {
 					if (await this.workflowRepository.isActive(workflowId))
 						await commitStagedCursor(pollFunctions);

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
@@ -85,6 +85,8 @@ export class PollTriggerTaskHandler implements TaskHandler {
 					// poll() can run for a while (network I/O against the polled source), so
 					// the workflow may have been deactivated while it was in flight. There is
 					// no in-memory registration to check here, so re-read the stored active state.
+					// A cheap early-out: the cursor commit's own lease fence is what actually
+					// rejects a reclaimed poll's write.
 					if (!(await this.workflowRepository.isActive(workflowId))) {
 						this.logger.debug('Workflow deactivated during poll; discarding the result', {
 							taskId: task.id,
@@ -108,7 +110,9 @@ export class PollTriggerTaskHandler implements TaskHandler {
 
 				// A poll with no items may still have moved its cursor, committed here on
 				// its own. Active state is re-read first so a workflow deactivated mid-poll
-				// doesn't get its cursor moved.
+				// doesn't get its cursor moved; that is also just a cheap early-out, since
+				// the fenced commit inside `commitStagedCursor` is what actually rejects a
+				// reclaimed poll's write.
 				try {
 					if (await this.workflowRepository.isActive(workflowId))
 						await commitStagedCursor(pollFunctions);

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
@@ -24,10 +24,11 @@ import {
  * Runs a due poll occurrence's `poll()` once and dispatches only when it
  * returns new data.
  *
- * Carries no `deduplicationKey`: under the scheduler's at-least-once contract
- * a poll occurrence can run twice, with the later cursor write winning. Two
- * polls at the same instant can legitimately return different data anyway,
- * so a repeated poll is tolerable without the duplicate-execution backstop.
+ * Carries no `deduplicationKey`, so it forgoes the execution-level duplicate
+ * backstop: under the scheduler's at-least-once contract, a poll occurrence
+ * can run twice, with the later cursor write winning. Accepted: two polls
+ * at the same instant can legitimately return different data anyway, so a
+ * repeated poll is tolerable.
  */
 @Service()
 export class PollTriggerTaskHandler implements TaskHandler {
@@ -47,7 +48,7 @@ export class PollTriggerTaskHandler implements TaskHandler {
 		// A setup failure here retries to N8N_SCHEDULER_MAX_ATTEMPTS then dead-letters,
 		// unlike a `poll()` runtime failure below, which routes to the error workflow instead.
 		const { workflowId, nodeId } = this.parsePayload(task);
-		// The poll cursor must be read live, not from the publish-time cache.
+		// bypassCache: the poll cursor in staticData must be read live, not from the publish-time cache.
 		const workflowData = await this.triggerExecutionContextFactory.loadPublishedWorkflowData(
 			workflowId,
 			{ bypassCache: true },
@@ -63,7 +64,8 @@ export class PollTriggerTaskHandler implements TaskHandler {
 		// Poll and hand-off share one staging scope, so a cursor staged here can only
 		// be committed by this poll and never by a later occurrence.
 		return await runPollInStagingScope(pollFunctions, async () => {
-			// Scheduled polls run outside any activation isolate window, so acquire one per tick.
+			// Scheduled polls run outside any activation isolate window, so acquire and
+			// release one per tick; the finally releases even when poll() throws.
 			await workflow.expression.acquireIsolate();
 			try {
 				const pollResponse = await this.triggersAndPollers.runPollFunction(
@@ -73,9 +75,9 @@ export class PollTriggerTaskHandler implements TaskHandler {
 				);
 
 				if (pollResponse !== null) {
-					// poll() can run for a while, so the workflow may have been deactivated while
-					// it was in flight; there is no in-memory registration to check, so re-read
-					// the stored active state.
+					// poll() can run for a while (network I/O against the polled source), so
+					// the workflow may have been deactivated while it was in flight. There is
+					// no in-memory registration to check here, so re-read the stored active state.
 					if (!(await this.workflowRepository.isActive(workflowId))) {
 						this.logger.debug('Workflow deactivated during poll; discarding the result', {
 							taskId: task.id,
@@ -86,6 +88,7 @@ export class PollTriggerTaskHandler implements TaskHandler {
 						return report.notDispatched();
 					}
 
+					// __emit saves the cursor and starts the run without waiting on it.
 					pollFunctions.__emit(pollResponse);
 					this.logger.debug('Poll returned new data; handed off to a new execution', {
 						taskId: task.id,
@@ -96,7 +99,9 @@ export class PollTriggerTaskHandler implements TaskHandler {
 					return report.dispatched();
 				}
 
-				// A poll with no items may still have moved its cursor, committed here on its own.
+				// A poll with no items may still have moved its cursor, committed here on
+				// its own. Active state is re-read first so a workflow deactivated mid-poll
+				// doesn't get its cursor moved.
 				try {
 					if (await this.workflowRepository.isActive(workflowId))
 						await commitStagedCursor(pollFunctions);

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
@@ -24,11 +24,10 @@ import {
  * Runs a due poll occurrence's `poll()` once and dispatches only when it
  * returns new data.
  *
- * Carries no `deduplicationKey`, so it forgoes the execution-level duplicate
- * backstop: under the scheduler's at-least-once contract, a poll occurrence
- * can run twice, with the later cursor write winning. Accepted: two polls
- * at the same instant can legitimately return different data anyway, so a
- * repeated poll is tolerable.
+ * Carries no `deduplicationKey`: under the scheduler's at-least-once contract
+ * a poll occurrence can run twice, with the later cursor write winning. Two
+ * polls at the same instant can legitimately return different data anyway,
+ * so a repeated poll is tolerable without the duplicate-execution backstop.
  */
 @Service()
 export class PollTriggerTaskHandler implements TaskHandler {
@@ -48,7 +47,7 @@ export class PollTriggerTaskHandler implements TaskHandler {
 		// A setup failure here retries to N8N_SCHEDULER_MAX_ATTEMPTS then dead-letters,
 		// unlike a `poll()` runtime failure below, which routes to the error workflow instead.
 		const { workflowId, nodeId } = this.parsePayload(task);
-		// bypassCache: the poll cursor in staticData must be read live, not from the publish-time cache.
+		// The poll cursor must be read live, not from the publish-time cache.
 		const workflowData = await this.triggerExecutionContextFactory.loadPublishedWorkflowData(
 			workflowId,
 			{ bypassCache: true },
@@ -64,8 +63,7 @@ export class PollTriggerTaskHandler implements TaskHandler {
 		// Poll and hand-off share one staging scope, so a cursor staged here can only
 		// be committed by this poll and never by a later occurrence.
 		return await runPollInStagingScope(pollFunctions, async () => {
-			// Scheduled polls run outside any activation isolate window, so acquire and
-			// release one per tick; the finally releases even when poll() throws.
+			// Scheduled polls run outside any activation isolate window, so acquire one per tick.
 			await workflow.expression.acquireIsolate();
 			try {
 				const pollResponse = await this.triggersAndPollers.runPollFunction(
@@ -75,11 +73,9 @@ export class PollTriggerTaskHandler implements TaskHandler {
 				);
 
 				if (pollResponse !== null) {
-					// poll() can run for a while (network I/O against the polled source), so
-					// the workflow may have been deactivated while it was in flight. There is
-					// no in-memory registration to check here, so re-read the stored active state.
-					// A cheap early-out, not the real guard: the cursor commit's own lease fence
-					// is what actually rejects a reclaimed poll's write.
+					// poll() can run for a while, so the workflow may have been deactivated while
+					// it was in flight; there is no in-memory registration to check, so re-read
+					// the stored active state.
 					if (!(await this.workflowRepository.isActive(workflowId))) {
 						this.logger.debug('Workflow deactivated during poll; discarding the result', {
 							taskId: task.id,
@@ -90,7 +86,6 @@ export class PollTriggerTaskHandler implements TaskHandler {
 						return report.notDispatched();
 					}
 
-					// __emit saves the cursor and starts the run without waiting on it.
 					pollFunctions.__emit(pollResponse);
 					this.logger.debug('Poll returned new data; handed off to a new execution', {
 						taskId: task.id,
@@ -101,9 +96,7 @@ export class PollTriggerTaskHandler implements TaskHandler {
 					return report.dispatched();
 				}
 
-				// A poll with no items may still have moved its cursor, committed here on
-				// its own. Active state is re-read first for the same cheap-early-out reason
-				// as above; `commitStagedCursor`'s own fenced commit is the real guard.
+				// A poll with no items may still have moved its cursor, committed here on its own.
 				try {
 					if (await this.workflowRepository.isActive(workflowId))
 						await commitStagedCursor(pollFunctions);

--- a/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/poll-trigger-node/poll-trigger-task-handler.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import type { PollLeaseFence } from '@n8n/db';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { ClaimedTask, DispatchDecision, DispatchReporter, TaskHandler } from '@n8n/scheduler';
@@ -19,6 +20,11 @@ import {
 	POLL_TRIGGER_TASK_TYPE,
 	type PollTriggerTaskPayload,
 } from './poll-trigger-task';
+
+const toPollLeaseFence = (task: ClaimedTask): PollLeaseFence => ({
+	taskId: task.id,
+	leaseEpoch: task.leaseEpoch,
+});
 
 /**
  * Runs a due poll occurrence's `poll()` once and dispatches only when it
@@ -56,10 +62,11 @@ export class PollTriggerTaskHandler implements TaskHandler {
 		const node = this.resolveTriggerNode(workflowData, nodeId, task);
 
 		const { workflow, pollFunctions } =
-			await this.triggerExecutionContextFactory.createPollExecutionContext(workflowData, node, {
-				taskId: task.id,
-				leaseEpoch: task.leaseEpoch,
-			});
+			await this.triggerExecutionContextFactory.createPollExecutionContext(
+				workflowData,
+				node,
+				toPollLeaseFence(task),
+			);
 
 		// Poll and hand-off share one staging scope, so a cursor staged here can only
 		// be committed by this poll and never by a later occurrence.

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -352,7 +352,7 @@ describe('WorkflowExecutionService', () => {
 			expect(responsePromise.resolve).not.toHaveBeenCalled();
 			expect(logger.debug).toHaveBeenCalledWith(
 				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
-				{ workflowId: 'wf-1', nodeName: 'Poll Node' },
+				{ workflowId: 'wf-1', nodeId: 'node-1', nodeName: 'Poll Node' },
 			);
 		});
 	});

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -351,7 +351,7 @@ describe('WorkflowExecutionService', () => {
 			expect(responsePromise.reject).toHaveBeenCalled();
 			expect(responsePromise.resolve).not.toHaveBeenCalled();
 			expect(logger.debug).toHaveBeenCalledWith(
-				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
+				'Poll cursor commit skipped: the poll no longer holds its lease',
 				{ workflowId: 'wf-1', nodeId: 'node-1', nodeName: 'Poll Node' },
 			);
 		});

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -341,14 +341,14 @@ describe('WorkflowExecutionService', () => {
 			);
 		});
 
-		test('starts no run and leaves the response promise untouched when the commit is fenced out', async () => {
+		test('starts no run and rejects the response promise when the commit is fenced out', async () => {
 			pollCursorService.commitWithExecution.mockResolvedValue(null);
 
 			const returned = await runPolledWorkflow();
 
 			expect(returned).toBeUndefined();
 			expect(workflowRunner.run).not.toHaveBeenCalled();
-			expect(responsePromise.reject).not.toHaveBeenCalled();
+			expect(responsePromise.reject).toHaveBeenCalled();
 			expect(responsePromise.resolve).not.toHaveBeenCalled();
 			expect(logger.debug).toHaveBeenCalledWith(
 				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -321,6 +321,36 @@ describe('WorkflowExecutionService', () => {
 			expect(executionRepository.markAsCrashed).not.toHaveBeenCalled();
 			expect(responsePromise.reject).not.toHaveBeenCalled();
 		});
+
+		test('passes the fence through to the cursor commit', async () => {
+			const fence = { taskId: 'task-1', leaseEpoch: 3 };
+
+			await workflowExecutionService.runPolledWorkflow(
+				workflow,
+				node,
+				pollItems,
+				additionalData,
+				'trigger',
+				cursor,
+				responsePromise,
+				fence,
+			);
+
+			expect(pollCursorService.commitWithExecution).toHaveBeenCalledWith(
+				expect.objectContaining({ fence }),
+			);
+		});
+
+		test('starts no run and leaves the response promise untouched when the commit is fenced out', async () => {
+			pollCursorService.commitWithExecution.mockResolvedValue(null);
+
+			const returned = await runPolledWorkflow();
+
+			expect(returned).toBeUndefined();
+			expect(workflowRunner.run).not.toHaveBeenCalled();
+			expect(responsePromise.reject).not.toHaveBeenCalled();
+			expect(responsePromise.resolve).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('executeManually()', () => {

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -350,6 +350,10 @@ describe('WorkflowExecutionService', () => {
 			expect(workflowRunner.run).not.toHaveBeenCalled();
 			expect(responsePromise.reject).not.toHaveBeenCalled();
 			expect(responsePromise.resolve).not.toHaveBeenCalled();
+			expect(logger.debug).toHaveBeenCalledWith(
+				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
+				{ workflowId: 'wf-1', nodeName: 'Poll Node' },
+			);
 		});
 	});
 

--- a/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
@@ -110,17 +110,18 @@ describe('PollCursorService', () => {
 	describe('commitWithExecution', () => {
 		it('advances the cursor and creates the execution in one transaction when the flag is on', async () => {
 			const service = buildService(true);
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
 			executionPersistence.create.mockResolvedValue('exec-1');
 			const createPayload = payload();
 
-			const { executionId } = await service.commitWithExecution({
+			const result = await service.commitWithExecution({
 				workflowId: 'wf-1',
 				nodeId: 'node-1',
 				cursor: { lastItemId: 'b' },
 				payload: createPayload,
 			});
 
-			expect(executionId).toBe('exec-1');
+			expect(result).toEqual({ executionId: 'exec-1' });
 			expect(txRunner.run).toHaveBeenCalledTimes(1);
 
 			const ctx = txRunner.run.mock.calls[0][0];
@@ -129,29 +130,32 @@ describe('PollCursorService', () => {
 				'node-1',
 				{ lastItemId: 'b' },
 				ctx,
+				undefined,
 			);
 			expect(executionPersistence.create).toHaveBeenCalledWith(createPayload, ctx);
 		});
 
 		it('advances the cursor and creates the execution as two separate writes when the flag is off', async () => {
 			const service = buildService(false);
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
 			executionPersistence.create.mockResolvedValue('exec-1');
 			const createPayload = payload();
 
-			const { executionId } = await service.commitWithExecution({
+			const result = await service.commitWithExecution({
 				workflowId: 'wf-1',
 				nodeId: 'node-1',
 				cursor: { lastItemId: 'b' },
 				payload: createPayload,
 			});
 
-			expect(executionId).toBe('exec-1');
+			expect(result).toEqual({ executionId: 'exec-1' });
 			expect(txRunner.run).not.toHaveBeenCalled();
 			expect(pollerStateRepository.advanceCursor).toHaveBeenCalledWith(
 				'wf-1',
 				'node-1',
 				{ lastItemId: 'b' },
 				{},
+				undefined,
 			);
 			expect(executionPersistence.create).toHaveBeenCalledWith(createPayload, {});
 		});
@@ -184,6 +188,7 @@ describe('PollCursorService', () => {
 			{ title: 'a duplicate execution', error: new DuplicateExecutionError('dedup-key') },
 		])('propagates $title to the caller', async ({ error }) => {
 			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
 			executionPersistence.create.mockRejectedValue(error);
 
 			await expect(
@@ -266,14 +271,16 @@ describe('PollCursorService', () => {
 
 		it('advances the cursor without creating an execution', async () => {
 			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
 
-			await commitCursorOnly(service);
+			await expect(commitCursorOnly(service)).resolves.toBe(true);
 
 			expect(pollerStateRepository.advanceCursor).toHaveBeenCalledWith(
 				'wf-1',
 				'node-1',
 				{ lastItemId: 'b' },
 				{},
+				undefined,
 			);
 			expect(executionPersistence.create).not.toHaveBeenCalled();
 		});

--- a/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
@@ -2,6 +2,7 @@ import type { PollerConfig } from '@n8n/config';
 import type {
 	CreateExecutionPayload,
 	OperationContext,
+	PollLeaseFence,
 	PollerStateRepository,
 	TransactionRunner,
 } from '@n8n/db';
@@ -194,14 +195,73 @@ describe('PollCursorService', () => {
 				}),
 			).rejects.toBe(error);
 		});
+
+		it('resolves null and does not create the execution when the fence rejects the advance', async () => {
+			const service = buildService(true);
+			pollerStateRepository.advanceCursor.mockResolvedValue(false);
+			const fence: PollLeaseFence = { taskId: 'task-1', leaseEpoch: 3 };
+
+			const result = await service.commitWithExecution({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				payload: payload(),
+				fence,
+			});
+
+			expect(result).toBeNull();
+			expect(executionPersistence.create).not.toHaveBeenCalled();
+		});
+
+		it('resolves null and does not create the execution when the fence rejects the advance and the flag is off', async () => {
+			const service = buildService(false);
+			pollerStateRepository.advanceCursor.mockResolvedValue(false);
+			const fence: PollLeaseFence = { taskId: 'task-1', leaseEpoch: 3 };
+
+			const result = await service.commitWithExecution({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				payload: payload(),
+				fence,
+			});
+
+			expect(result).toBeNull();
+			expect(executionPersistence.create).not.toHaveBeenCalled();
+		});
+
+		it('passes the fence through to the cursor advance', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
+			executionPersistence.create.mockResolvedValue('exec-1');
+			const fence: PollLeaseFence = { taskId: 'task-1', leaseEpoch: 3 };
+
+			await service.commitWithExecution({
+				workflowId: 'wf-1',
+				nodeId: 'node-1',
+				cursor: { lastItemId: 'b' },
+				payload: payload(),
+				fence,
+			});
+
+			const ctx = txRunner.run.mock.calls[0][0];
+			expect(pollerStateRepository.advanceCursor).toHaveBeenCalledWith(
+				'wf-1',
+				'node-1',
+				{ lastItemId: 'b' },
+				ctx,
+				fence,
+			);
+		});
 	});
 
 	describe('commitCursorOnly', () => {
-		const commitCursorOnly = async (service: PollCursorService) =>
+		const commitCursorOnly = async (service: PollCursorService, fence?: PollLeaseFence) =>
 			await service.commitCursorOnly({
 				workflowId: 'wf-1',
 				nodeId: 'node-1',
 				cursor: { lastItemId: 'b' },
+				fence,
 			});
 
 		it('advances the cursor without creating an execution', async () => {
@@ -224,6 +284,31 @@ describe('PollCursorService', () => {
 			pollerStateRepository.advanceCursor.mockRejectedValue(advanceError);
 
 			await expect(commitCursorOnly(service)).rejects.toBe(advanceError);
+		});
+
+		it('resolves false when the fence rejects the advance', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(false);
+
+			await expect(commitCursorOnly(service, { taskId: 'task-1', leaseEpoch: 3 })).resolves.toBe(
+				false,
+			);
+		});
+
+		it('passes the fence through to the cursor advance', async () => {
+			const service = buildService();
+			pollerStateRepository.advanceCursor.mockResolvedValue(true);
+			const fence: PollLeaseFence = { taskId: 'task-1', leaseEpoch: 3 };
+
+			await commitCursorOnly(service, fence);
+
+			expect(pollerStateRepository.advanceCursor).toHaveBeenCalledWith(
+				'wf-1',
+				'node-1',
+				{ lastItemId: 'b' },
+				{},
+				fence,
+			);
 		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/poll-cursor.service.test.ts
@@ -201,39 +201,28 @@ describe('PollCursorService', () => {
 			).rejects.toBe(error);
 		});
 
-		it('resolves null and does not create the execution when the fence rejects the advance', async () => {
-			const service = buildService(true);
-			pollerStateRepository.advanceCursor.mockResolvedValue(false);
-			const fence: PollLeaseFence = { taskId: 'task-1', leaseEpoch: 3 };
+		it.each([
+			{ title: 'the flag is on', durableCursorsEnabled: true },
+			{ title: 'the flag is off', durableCursorsEnabled: false },
+		])(
+			'resolves null and does not create the execution when the fence rejects the advance and $title',
+			async ({ durableCursorsEnabled }) => {
+				const service = buildService(durableCursorsEnabled);
+				pollerStateRepository.advanceCursor.mockResolvedValue(false);
+				const fence: PollLeaseFence = { taskId: 'task-1', leaseEpoch: 3 };
 
-			const result = await service.commitWithExecution({
-				workflowId: 'wf-1',
-				nodeId: 'node-1',
-				cursor: { lastItemId: 'b' },
-				payload: payload(),
-				fence,
-			});
+				const result = await service.commitWithExecution({
+					workflowId: 'wf-1',
+					nodeId: 'node-1',
+					cursor: { lastItemId: 'b' },
+					payload: payload(),
+					fence,
+				});
 
-			expect(result).toBeNull();
-			expect(executionPersistence.create).not.toHaveBeenCalled();
-		});
-
-		it('resolves null and does not create the execution when the fence rejects the advance and the flag is off', async () => {
-			const service = buildService(false);
-			pollerStateRepository.advanceCursor.mockResolvedValue(false);
-			const fence: PollLeaseFence = { taskId: 'task-1', leaseEpoch: 3 };
-
-			const result = await service.commitWithExecution({
-				workflowId: 'wf-1',
-				nodeId: 'node-1',
-				cursor: { lastItemId: 'b' },
-				payload: payload(),
-				fence,
-			});
-
-			expect(result).toBeNull();
-			expect(executionPersistence.create).not.toHaveBeenCalled();
-		});
+				expect(result).toBeNull();
+				expect(executionPersistence.create).not.toHaveBeenCalled();
+			},
+		);
 
 		it('passes the fence through to the cursor advance', async () => {
 			const service = buildService();

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1199,23 +1199,30 @@ describe('TriggerExecutionContextFactory', () => {
 
 			expect(scopedLogger.debug).toHaveBeenCalledWith(
 				expect.stringContaining('the poll no longer holds its lease, or its cursor row is gone'),
-				{ workflowId: 'wf-1', nodeId: 'node-1' },
+				{ workflowId: 'wf-1', nodeId: 'node-1', nodeName: 'Poll Node' },
 			);
 		});
 
-		test('does not recommit a cursor on a later poll after its own commit was fenced out', async () => {
+		test('does not retry a fenced-out cursor advance, while a later poll still commits its own', async () => {
 			pollCursorService.commitCursorOnly.mockResolvedValue(false);
 
 			await context.__runPoll(async () => {
 				Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
 				await context.__commitCursor();
-			});
-
-			await context.__runPoll(async () => {
 				await context.__commitCursor();
 			});
 
 			expect(pollCursorService.commitCursorOnly).toHaveBeenCalledTimes(1);
+
+			await context.__runPoll(async () => {
+				Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'b' });
+				await context.__commitCursor();
+			});
+
+			expect(pollCursorService.commitCursorOnly).toHaveBeenCalledTimes(2);
+			expect(pollCursorService.commitCursorOnly).toHaveBeenLastCalledWith(
+				expect.objectContaining({ cursor: { lastItemId: 'b' } }),
+			);
 		});
 
 		test('threads a fence through to both the polled run and the cursor-only commit', async () => {

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1198,7 +1198,7 @@ describe('TriggerExecutionContextFactory', () => {
 			});
 
 			expect(scopedLogger.debug).toHaveBeenCalledWith(
-				expect.stringContaining('the poll no longer holds its lease, or its cursor row is gone'),
+				expect.stringContaining('the poll no longer holds its lease'),
 				{ workflowId: 'wf-1', nodeId: 'node-1', nodeName: 'Poll Node' },
 			);
 		});

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1175,6 +1175,93 @@ describe('TriggerExecutionContextFactory', () => {
 				expect.objectContaining({ error: runError }),
 			);
 		});
+
+		test('resolves donePromise with undefined when the polled run is fenced out', async () => {
+			workflowExecutionService.runPolledWorkflow.mockResolvedValue(undefined);
+			const donePromise = createDeferredPromise<IRun>();
+
+			await context.__runPoll(async () => {
+				Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+				context.__emit(pollData, undefined, donePromise);
+			});
+
+			await expect(donePromise.promise).resolves.toBeUndefined();
+			expect(activeExecutions.getPostExecutePromise).not.toHaveBeenCalled();
+		});
+
+		test('does not throw and logs when a fenced cursor-only commit is rejected', async () => {
+			pollCursorService.commitCursorOnly.mockResolvedValue(false);
+
+			await context.__runPoll(async () => {
+				Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+				await context.__commitCursor();
+			});
+
+			expect(scopedLogger.debug).toHaveBeenCalledWith(
+				expect.stringContaining('fenced out by a reclaimed lease'),
+				{ workflowId: 'wf-1', nodeId: 'node-1' },
+			);
+		});
+
+		test('does not recommit a cursor on a later poll after its own commit was fenced out', async () => {
+			pollCursorService.commitCursorOnly.mockResolvedValue(false);
+
+			await context.__runPoll(async () => {
+				Object.assign(context.getWorkflowStaticData('node'), { lastItemId: 'a' });
+				await context.__commitCursor();
+			});
+
+			await context.__runPoll(async () => {
+				await context.__commitCursor();
+			});
+
+			expect(pollCursorService.commitCursorOnly).toHaveBeenCalledTimes(1);
+		});
+
+		test('threads a fence through to both the polled run and the cursor-only commit', async () => {
+			const fence = { taskId: 'task-1', leaseEpoch: 3 };
+			const getPollFunctions = factory.getExecutePollFunctions(
+				mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
+				additionalData,
+				mode,
+				activation,
+				async () => mock<IWorkflowBase>({ id: 'wf-1', name: 'Test Workflow' }),
+				fence,
+			);
+			const fencedContext = getPollFunctions(
+				workflow,
+				node,
+				additionalData,
+				mode,
+				activation,
+			) as RunnablePollFunctions;
+
+			await fencedContext.__runPoll(async () => {
+				Object.assign(fencedContext.getWorkflowStaticData('node'), { lastItemId: 'a' });
+				fencedContext.__emit(pollData);
+			});
+			await sleep(0);
+
+			expect(workflowExecutionService.runPolledWorkflow).toHaveBeenCalledWith(
+				expect.anything(),
+				node,
+				pollData,
+				additionalData,
+				mode,
+				{ lastItemId: 'a' },
+				undefined,
+				fence,
+			);
+
+			await fencedContext.__runPoll(async () => {
+				Object.assign(fencedContext.getWorkflowStaticData('node'), { lastItemId: 'b' });
+				await fencedContext.__commitCursor();
+			});
+
+			expect(pollCursorService.commitCursorOnly).toHaveBeenCalledWith(
+				expect.objectContaining({ fence }),
+			);
+		});
 	});
 
 	describe('createPollExecutionContext', () => {
@@ -1237,6 +1324,30 @@ describe('TriggerExecutionContextFactory', () => {
 				additionalData,
 				'trigger',
 				'update',
+			);
+		});
+
+		test('threads a given fence through to getExecutePollFunctions', async () => {
+			const workflowData = buildWorkflowData();
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
+
+			const pollFunctions = mock<IPollFunctions>();
+			const getPollFunctions = vi.fn().mockReturnValue(pollFunctions);
+			const getExecutePollFunctionsSpy = vi
+				.spyOn(factory, 'getExecutePollFunctions')
+				.mockReturnValue(getPollFunctions as unknown as IGetExecutePollFunctions);
+			const fence = { taskId: 'task-1', leaseEpoch: 3 };
+
+			await factory.createPollExecutionContext(workflowData, pollNode, fence);
+
+			expect(getExecutePollFunctionsSpy).toHaveBeenCalledWith(
+				workflowData,
+				additionalData,
+				'trigger',
+				'update',
+				expect.any(Function),
+				fence,
 			);
 		});
 

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1198,7 +1198,7 @@ describe('TriggerExecutionContextFactory', () => {
 			});
 
 			expect(scopedLogger.debug).toHaveBeenCalledWith(
-				expect.stringContaining('fenced out by a reclaimed lease'),
+				expect.stringContaining('the poll no longer holds its lease, or its cursor row is gone'),
 				{ workflowId: 'wf-1', nodeId: 'node-1' },
 			);
 		});

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -798,7 +798,7 @@ describe('TriggerExecutionContextFactory', () => {
 
 		beforeEach(() => {
 			pollCursorService.resolveCursor.mockResolvedValue({ migrated: true, cursor: {} });
-			pollCursorService.commitCursorOnly.mockResolvedValue(undefined);
+			pollCursorService.commitCursorOnly.mockResolvedValue(true);
 			workflowExecutionService.runPolledWorkflow.mockResolvedValue('exec-polled');
 
 			workflow = buildWorkflow();
@@ -894,6 +894,7 @@ describe('TriggerExecutionContextFactory', () => {
 				mode,
 				{ lastItemId: 'a' },
 				responsePromise,
+				undefined,
 			);
 			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
 		});
@@ -1024,6 +1025,7 @@ describe('TriggerExecutionContextFactory', () => {
 				additionalData,
 				mode,
 				{ lastItemId: 'first-only' },
+				undefined,
 				undefined,
 			);
 		});
@@ -1218,13 +1220,15 @@ describe('TriggerExecutionContextFactory', () => {
 			});
 
 			// Built with the activation path's execution/activation modes ('trigger'/'update').
-			// Exactly five args: no per-occurrence deduplication key is threaded as a sixth.
+			// No per-occurrence deduplication key is threaded; the trailing argument is the
+			// lease fence, which this path has none of.
 			expect(getExecutePollFunctionsSpy).toHaveBeenCalledWith(
 				workflowData,
 				additionalData,
 				'trigger',
 				'update',
 				expect.any(Function),
+				undefined,
 			);
 
 			expect(getPollFunctions).toHaveBeenCalledWith(

--- a/packages/cli/src/workflows/triggers/poll-cursor.service.ts
+++ b/packages/cli/src/workflows/triggers/poll-cursor.service.ts
@@ -23,12 +23,20 @@ export class PollCursorService {
 	}
 
 	/**
-	 * A node with a stored row is migrated for good and always preferred; an
-	 * unmigrated node checks the flag, so disabling it blocks new migrations
-	 * without affecting nodes that already migrated.
+	 * Decides whether this node should use the new cursor storage.
 	 *
-	 * Seeds the row from the node's static data on first migration, so it
-	 * resumes where it left off.
+	 * A node that already has a stored cursor keeps using it, no matter what the setting says.
+	 *
+	 * Otherwise:
+	 * - if the setting is on, a cursor is created from `nodeStaticData` and used from now on.
+	 * - if the setting is off, nothing changes.
+	 *
+	 * @param workflowId - Workflow the poll node belongs to.
+	 * @param nodeId - Poll trigger node to resolve the cursor for.
+	 * @param nodeStaticData - Node's current cursor value, used to seed the new
+	 *   storage the first time this node migrates.
+	 * @returns The cursor to use if this node is on the new storage, otherwise
+	 *   `{ migrated: false }` to keep using the node's own static data.
 	 */
 	async resolveCursor(
 		workflowId: string,
@@ -37,7 +45,9 @@ export class PollCursorService {
 	): Promise<{ migrated: true; cursor: PollCursor } | { migrated: false }> {
 		if (!this.enabled) {
 			const existing = await this.pollerStateRepository.findCursor(workflowId, nodeId);
-			if (existing === null) return { migrated: false };
+			if (existing === null) {
+				return { migrated: false };
+			}
 			return { migrated: true, cursor: toPollCursor(existing) };
 		}
 
@@ -50,10 +60,22 @@ export class PollCursorService {
 	}
 
 	/**
-	 * Commits the cursor advance and the execution row together, so a poll never
-	 * advances past items no execution carried. Atomic when the flag is on;
-	 * written as two sequential steps when it's off, reopening the race between
-	 * them as the cost of keeping the flag as a kill switch.
+	 * Advances the cursor and inserts the execution row for the poll, together.
+	 *
+	 * When the setting is on, both happen in one transaction: a poll never
+	 * 	advances its cursor past an item whose execution wasn't saved.
+	 *
+	 * When the setting is off, they happen as two separate steps instead, so a crash
+	 * 	between them can leave the cursor moved with no matching execution. This
+	 * 	gap only exists to let the setting double as a kill switch.
+	 *
+	 * @param args.workflowId - Workflow the poll node belongs to.
+	 * @param args.nodeId - Poll trigger node whose cursor is advancing.
+	 * @param args.cursor - New cursor value to store.
+	 * @param args.payload - Execution row to insert for the poll's result.
+	 * @param args.fence - Lease to check before writing; see `advanceCursor`.
+	 * @returns The new execution's id, or `null` if the cursor didn't advance.
+	 * @remarks A `null` result doesn't mean someone else already did this work, only that someone else now owns it.
 	 */
 	async commitWithExecution(args: {
 		workflowId: string;
@@ -73,9 +95,11 @@ export class PollCursorService {
 					ctx,
 					fence,
 				);
-				if (!advanced) return null;
-				const executionId = await this.executionPersistence.create(payload, ctx);
-				return { executionId };
+				if (advanced) {
+					const executionId = await this.executionPersistence.create(payload, ctx);
+					return { executionId };
+				}
+				return null;
 			});
 		}
 
@@ -86,9 +110,11 @@ export class PollCursorService {
 			{},
 			fence,
 		);
-		if (!advanced) return null;
-		const executionId = await this.executionPersistence.create(payload, {});
-		return { executionId };
+		if (advanced) {
+			const executionId = await this.executionPersistence.create(payload, {});
+			return { executionId };
+		}
+		return null;
 	}
 
 	/**

--- a/packages/cli/src/workflows/triggers/poll-cursor.service.ts
+++ b/packages/cli/src/workflows/triggers/poll-cursor.service.ts
@@ -1,5 +1,5 @@
 import { PollerConfig } from '@n8n/config';
-import type { CreateExecutionPayload, PollerCursor } from '@n8n/db';
+import type { CreateExecutionPayload, PollerCursor, PollLeaseFence } from '@n8n/db';
 import { PollerStateRepository, TransactionRunner } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { PollCursor } from 'n8n-workflow';
@@ -60,18 +60,33 @@ export class PollCursorService {
 		nodeId: string;
 		cursor: PollCursor;
 		payload: CreateExecutionPayload;
-	}): Promise<{ executionId: string }> {
-		const { workflowId, nodeId, cursor, payload } = args;
+		fence?: PollLeaseFence;
+	}): Promise<{ executionId: string } | null> {
+		const { workflowId, nodeId, cursor, payload, fence } = args;
 
 		if (this.enabled) {
 			return await this.transactionRunner.run({}, async (ctx) => {
-				await this.pollerStateRepository.advanceCursor(workflowId, nodeId, cursor, ctx);
+				const advanced = await this.pollerStateRepository.advanceCursor(
+					workflowId,
+					nodeId,
+					cursor,
+					ctx,
+					fence,
+				);
+				if (!advanced) return null;
 				const executionId = await this.executionPersistence.create(payload, ctx);
 				return { executionId };
 			});
 		}
 
-		await this.pollerStateRepository.advanceCursor(workflowId, nodeId, cursor, {});
+		const advanced = await this.pollerStateRepository.advanceCursor(
+			workflowId,
+			nodeId,
+			cursor,
+			{},
+			fence,
+		);
+		if (!advanced) return null;
 		const executionId = await this.executionPersistence.create(payload, {});
 		return { executionId };
 	}
@@ -84,8 +99,9 @@ export class PollCursorService {
 		workflowId: string;
 		nodeId: string;
 		cursor: PollCursor;
-	}): Promise<void> {
-		const { workflowId, nodeId, cursor } = args;
-		await this.pollerStateRepository.advanceCursor(workflowId, nodeId, cursor, {});
+		fence?: PollLeaseFence;
+	}): Promise<boolean> {
+		const { workflowId, nodeId, cursor, fence } = args;
+		return await this.pollerStateRepository.advanceCursor(workflowId, nodeId, cursor, {}, fence);
 	}
 }

--- a/packages/cli/src/workflows/triggers/poll-cursor.service.ts
+++ b/packages/cli/src/workflows/triggers/poll-cursor.service.ts
@@ -23,10 +23,12 @@ export class PollCursorService {
 	}
 
 	/**
-	 * A node with a stored row is migrated for good; an unmigrated node checks the
-	 * flag, so disabling it blocks new migrations without affecting nodes that
-	 * already migrated. Seeds the row from the node's static data on first
-	 * migration, so it resumes where it left off.
+	 * A node with a stored row is migrated for good and always preferred; an
+	 * unmigrated node checks the flag, so disabling it blocks new migrations
+	 * without affecting nodes that already migrated.
+	 *
+	 * Seeds the row from the node's static data on first migration, so it
+	 * resumes where it left off.
 	 */
 	async resolveCursor(
 		workflowId: string,
@@ -49,9 +51,9 @@ export class PollCursorService {
 
 	/**
 	 * Commits the cursor advance and the execution row together, so a poll never
-	 * advances past items no execution carried. Atomic when the flag is on; written
-	 * as two sequential steps when it's off, reopening the race as the cost of
-	 * keeping the flag as a kill switch.
+	 * advances past items no execution carried. Atomic when the flag is on;
+	 * written as two sequential steps when it's off, reopening the race between
+	 * them as the cost of keeping the flag as a kill switch.
 	 */
 	async commitWithExecution(args: {
 		workflowId: string;

--- a/packages/cli/src/workflows/triggers/poll-cursor.service.ts
+++ b/packages/cli/src/workflows/triggers/poll-cursor.service.ts
@@ -23,12 +23,10 @@ export class PollCursorService {
 	}
 
 	/**
-	 * A node with a stored row is migrated for good and always preferred; an
-	 * unmigrated node checks the flag, so disabling it blocks new migrations
-	 * without affecting nodes that already migrated.
-	 *
-	 * Seeds the row from the node's static data on first migration, so it
-	 * resumes where it left off.
+	 * A node with a stored row is migrated for good; an unmigrated node checks the
+	 * flag, so disabling it blocks new migrations without affecting nodes that
+	 * already migrated. Seeds the row from the node's static data on first
+	 * migration, so it resumes where it left off.
 	 */
 	async resolveCursor(
 		workflowId: string,
@@ -51,9 +49,9 @@ export class PollCursorService {
 
 	/**
 	 * Commits the cursor advance and the execution row together, so a poll never
-	 * advances past items no execution carried. Atomic when the flag is on;
-	 * written as two sequential steps when it's off, reopening the race between
-	 * them as the cost of keeping the flag as a kill switch.
+	 * advances past items no execution carried. Atomic when the flag is on; written
+	 * as two sequential steps when it's off, reopening the race as the cost of
+	 * keeping the flag as a kill switch.
 	 */
 	async commitWithExecution(args: {
 		workflowId: string;

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -378,7 +378,7 @@ export class TriggerExecutionContextFactory {
 				if (!committed) {
 					this.logger.debug(
 						`Poll node "${node.name}" cursor-only commit skipped: the poll no longer holds its lease, or its cursor row is gone`,
-						{ workflowId: workflowData.id, nodeId: node.id },
+						{ workflowId: workflowData.id, nodeId: node.id, nodeName: node.name },
 					);
 				}
 			};

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -377,7 +377,7 @@ export class TriggerExecutionContextFactory {
 				});
 				if (!committed) {
 					this.logger.debug(
-						`Poll node "${node.name}" cursor-only commit skipped: the poll no longer holds its lease, or its cursor row is gone`,
+						`Poll node "${node.name}" cursor-only commit skipped: the poll no longer holds its lease`,
 						{ workflowId: workflowData.id, nodeId: node.id, nodeName: node.name },
 					);
 				}

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -377,7 +377,7 @@ export class TriggerExecutionContextFactory {
 				});
 				if (!committed) {
 					this.logger.debug(
-						`Poll node "${node.name}" cursor-only commit was fenced out by a reclaimed lease`,
+						`Poll node "${node.name}" cursor-only commit skipped: the poll no longer holds its lease, or its cursor row is gone`,
 						{ workflowId: workflowData.id, nodeId: node.id },
 					);
 				}

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -151,8 +151,10 @@ export class TriggerExecutionContextFactory {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		activation: WorkflowActivateMode,
-		// TODO(CAT-3202): switches between in-memory and published-service data
-		// behind a flag; drop this parameter once the flag is removed.
+		// TODO(CAT-3202): this callback lets us switch between reading from
+		// the in-memory workflowData (flag off) and the workflow published data
+		// service (flag on). Once the feature flag is removed, we'll call the
+		// service directly and this parameter will go away.
 		resolveWorkflowData: () => Promise<IWorkflowBase>,
 		onTriggerFailure: TriggerFailureHandler,
 		// This activation attempt's rule-collection session. Owned by the caller
@@ -170,6 +172,9 @@ export class TriggerExecutionContextFactory {
 				this.logger.debug(`Received trigger for workflow "${workflow.name}"`);
 				void this.workflowStaticDataService.saveStaticData(workflow);
 
+				// TODO(CAT-3202): resolves workflow data via callback so we
+				// can feature-flag between in-memory data and the published data
+				// service. Once the flag is removed, we'll call the service directly.
 				const executePromise = resolveWorkflowData()
 					.then(
 						async (freshWorkflowData) =>
@@ -265,8 +270,10 @@ export class TriggerExecutionContextFactory {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		activation: WorkflowActivateMode,
-		// TODO(CAT-3202): switches between in-memory and published-service data
-		// behind a flag; drop this parameter once the flag is removed.
+		// TODO(CAT-3202): this callback lets us switch between reading from
+		// the in-memory workflowData (flag off) and the workflow published data
+		// service (flag on). Once the feature flag is removed, we'll call the
+		// service directly and this parameter will go away.
 		resolveWorkflowData: () => Promise<IWorkflowBase>,
 		fence?: PollLeaseFence,
 	): IGetExecutePollFunctions {
@@ -321,6 +328,9 @@ export class TriggerExecutionContextFactory {
 				// data, or an unmigrated node's own bucket, which still doubles as its cursor.
 				void this.workflowStaticDataService.saveStaticData(workflow);
 
+				// TODO(CAT-3202): resolves workflow data via callback so we
+				// can feature-flag between in-memory data and the published data
+				// service. Once the flag is removed, we'll call the service directly.
 				const executePromise = resolveWorkflowData().then(async (freshWorkflowData) =>
 					cursor === null
 						? await this.workflowExecutionService.runWorkflow(
@@ -374,7 +384,7 @@ export class TriggerExecutionContextFactory {
 			};
 
 			// Hands a migrated node its per-poll snapshot in place of the real
-			// static-data bucket, so mutations are captured by `takeStagedCursor`.
+			// static-data bucket, so mutations are captured for `takeStagedCursor` above.
 			// An unmigrated node gets the real bucket directly.
 			const resolveNodeStaticData = () => {
 				const staged = stagedCursorStore.getStore();

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -376,6 +376,7 @@ export class TriggerExecutionContextFactory {
 					fence,
 				});
 				if (!committed) {
+					// A miss can't tell a reclaimed lease apart from a cursor row that's genuinely gone.
 					this.logger.debug(
 						`Poll node "${node.name}" cursor-only commit skipped: the poll no longer holds its lease, or its cursor row is gone`,
 						{ workflowId: workflowData.id, nodeId: node.id },

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@n8n/backend-common';
-import type { IWorkflowDb } from '@n8n/db';
+import type { IWorkflowDb, PollLeaseFence } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
@@ -275,6 +275,7 @@ export class TriggerExecutionContextFactory {
 		// service (flag on). Once the feature flag is removed, we'll call the
 		// service directly and this parameter will go away.
 		resolveWorkflowData: () => Promise<IWorkflowBase>,
+		fence?: PollLeaseFence,
 	): IGetExecutePollFunctions {
 		return (workflow: Workflow, node: INode) => {
 			// A poll's staged snapshot lives in an async scope entered per poll, rather
@@ -348,6 +349,7 @@ export class TriggerExecutionContextFactory {
 								mode,
 								cursor,
 								responsePromise,
+								fence,
 							),
 				);
 
@@ -367,11 +369,18 @@ export class TriggerExecutionContextFactory {
 			const __commitCursor = async () => {
 				const cursor = takeStagedCursor();
 				if (cursor === null) return;
-				await this.pollCursorService.commitCursorOnly({
+				const committed = await this.pollCursorService.commitCursorOnly({
 					workflowId: workflowData.id,
 					nodeId: node.id,
 					cursor,
+					fence,
 				});
+				if (!committed) {
+					this.logger.debug(
+						`Poll node "${node.name}" cursor-only commit was fenced out by a reclaimed lease`,
+						{ workflowId: workflowData.id, nodeId: node.id },
+					);
+				}
 			};
 
 			// Hands a migrated node its per-poll snapshot in place of the real
@@ -411,6 +420,7 @@ export class TriggerExecutionContextFactory {
 	async createPollExecutionContext(
 		workflowData: IWorkflowBase,
 		node: INode,
+		fence?: PollLeaseFence,
 	): Promise<{ workflow: Workflow; pollFunctions: IPollFunctions }> {
 		const workflow = new Workflow({
 			id: workflowData.id,
@@ -437,6 +447,7 @@ export class TriggerExecutionContextFactory {
 			'trigger',
 			'update',
 			resolveWorkflowData,
+			fence,
 		);
 		// getPollFunctions already closed over these; its signature still requires them.
 		const pollFunctions = getPollFunctions(workflow, node, additionalData, 'trigger', 'update');

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -151,10 +151,8 @@ export class TriggerExecutionContextFactory {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		activation: WorkflowActivateMode,
-		// TODO(CAT-3202): this callback lets us switch between reading from
-		// the in-memory workflowData (flag off) and the workflow published data
-		// service (flag on). Once the feature flag is removed, we'll call the
-		// service directly and this parameter will go away.
+		// TODO(CAT-3202): switches between in-memory and published-service data
+		// behind a flag; drop this parameter once the flag is removed.
 		resolveWorkflowData: () => Promise<IWorkflowBase>,
 		onTriggerFailure: TriggerFailureHandler,
 		// This activation attempt's rule-collection session. Owned by the caller
@@ -172,9 +170,6 @@ export class TriggerExecutionContextFactory {
 				this.logger.debug(`Received trigger for workflow "${workflow.name}"`);
 				void this.workflowStaticDataService.saveStaticData(workflow);
 
-				// TODO(CAT-3202): resolves workflow data via callback so we
-				// can feature-flag between in-memory data and the published data
-				// service. Once the flag is removed, we'll call the service directly.
 				const executePromise = resolveWorkflowData()
 					.then(
 						async (freshWorkflowData) =>
@@ -270,10 +265,8 @@ export class TriggerExecutionContextFactory {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		activation: WorkflowActivateMode,
-		// TODO(CAT-3202): this callback lets us switch between reading from
-		// the in-memory workflowData (flag off) and the workflow published data
-		// service (flag on). Once the feature flag is removed, we'll call the
-		// service directly and this parameter will go away.
+		// TODO(CAT-3202): switches between in-memory and published-service data
+		// behind a flag; drop this parameter once the flag is removed.
 		resolveWorkflowData: () => Promise<IWorkflowBase>,
 		fence?: PollLeaseFence,
 	): IGetExecutePollFunctions {
@@ -328,9 +321,6 @@ export class TriggerExecutionContextFactory {
 				// data, or an unmigrated node's own bucket, which still doubles as its cursor.
 				void this.workflowStaticDataService.saveStaticData(workflow);
 
-				// TODO(CAT-3202): resolves workflow data via callback so we
-				// can feature-flag between in-memory data and the published data
-				// service. Once the flag is removed, we'll call the service directly.
 				const executePromise = resolveWorkflowData().then(async (freshWorkflowData) =>
 					cursor === null
 						? await this.workflowExecutionService.runWorkflow(
@@ -384,7 +374,7 @@ export class TriggerExecutionContextFactory {
 			};
 
 			// Hands a migrated node its per-poll snapshot in place of the real
-			// static-data bucket, so mutations are captured for `takeStagedCursor` above.
+			// static-data bucket, so mutations are captured by `takeStagedCursor`.
 			// An unmigrated node gets the real bucket directly.
 			const resolveNodeStaticData = () => {
 				const staged = stagedCursorStore.getStore();

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -376,7 +376,6 @@ export class TriggerExecutionContextFactory {
 					fence,
 				});
 				if (!committed) {
-					// A miss can't tell a reclaimed lease apart from a cursor row that's genuinely gone.
 					this.logger.debug(
 						`Poll node "${node.name}" cursor-only commit skipped: the poll no longer holds its lease, or its cursor row is gone`,
 						{ workflowId: workflowData.id, nodeId: node.id },

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -205,7 +205,7 @@ export class WorkflowExecutionService {
 		if (commitResult === null) {
 			this.logger.debug(
 				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
-				{ workflowId: workflowData.id, nodeName: node.name },
+				{ workflowId: workflowData.id, nodeId: node.id, nodeName: node.name },
 			);
 			responsePromise?.reject(
 				new OperationalError('Poll cursor commit skipped: the poll no longer holds its lease'),

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -203,10 +203,11 @@ export class WorkflowExecutionService {
 		});
 
 		if (commitResult === null) {
-			this.logger.debug(
-				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
-				{ workflowId: workflowData.id, nodeId: node.id, nodeName: node.name },
-			);
+			this.logger.debug('Poll cursor commit skipped: the poll no longer holds its lease', {
+				workflowId: workflowData.id,
+				nodeId: node.id,
+				nodeName: node.name,
+			});
 			responsePromise?.reject(
 				new OperationalError('Poll cursor commit skipped: the poll no longer holds its lease'),
 			);

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -202,10 +202,10 @@ export class WorkflowExecutionService {
 		});
 
 		if (commitResult === null) {
-			this.logger.debug('Poll cursor commit was fenced out by a reclaimed lease', {
-				workflowId: workflowData.id,
-				nodeName: node.name,
-			});
+			this.logger.debug(
+				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
+				{ workflowId: workflowData.id, nodeName: node.name },
+			);
 			return undefined;
 		}
 

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -202,7 +202,6 @@ export class WorkflowExecutionService {
 		});
 
 		if (commitResult === null) {
-			// A miss can't tell a reclaimed lease apart from a cursor row that's genuinely gone.
 			this.logger.debug(
 				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
 				{ workflowId: workflowData.id, nodeName: node.name },

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -206,9 +206,7 @@ export class WorkflowExecutionService {
 				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
 				{ workflowId: workflowData.id, nodeName: node.name },
 			);
-			// A fence miss is not a failure: no poll call site supplies a `responsePromise`, and
-			// `__emit`'s `donePromise` already resolves `undefined` when no execution id comes
-			// back, so leaving the promise unsettled here is correct.
+			// No poll call site supplies a `responsePromise`, so leaving it unsettled is fine.
 			return undefined;
 		}
 

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -1,6 +1,12 @@
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig, WorkflowsConfig } from '@n8n/config';
-import type { Project, User, CreateExecutionPayload, WorkflowEntity } from '@n8n/db';
+import type {
+	Project,
+	User,
+	CreateExecutionPayload,
+	WorkflowEntity,
+	PollLeaseFence,
+} from '@n8n/db';
 import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
@@ -126,6 +132,7 @@ export class WorkflowExecutionService {
 		mode: WorkflowExecuteMode,
 		cursor: PollCursor,
 		responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
+		fence?: PollLeaseFence,
 	): Promise<string | undefined> {
 		const nodeExecutionStack: IExecuteData[] = [
 			{
@@ -186,12 +193,23 @@ export class WorkflowExecutionService {
 			tracingContext: runData.tracingContext ?? null,
 		};
 
-		const { executionId } = await this.pollCursorService.commitWithExecution({
+		const commitResult = await this.pollCursorService.commitWithExecution({
 			workflowId: workflowData.id,
 			nodeId: node.id,
 			cursor,
 			payload,
+			fence,
 		});
+
+		if (commitResult === null) {
+			this.logger.debug('Poll cursor commit was fenced out by a reclaimed lease', {
+				workflowId: workflowData.id,
+				nodeName: node.name,
+			});
+			return undefined;
+		}
+
+		const { executionId } = commitResult;
 
 		// The row was committed at `new`; `expectedStatus` claims it and moves it to
 		// running, so a concurrent starter cannot run it a second time.

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -202,10 +202,14 @@ export class WorkflowExecutionService {
 		});
 
 		if (commitResult === null) {
+			// A miss can't tell a reclaimed lease apart from a cursor row that's genuinely gone.
 			this.logger.debug(
 				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
 				{ workflowId: workflowData.id, nodeName: node.name },
 			);
+			// A fence miss is not a failure: no poll call site supplies a `responsePromise`, and
+			// `__emit`'s `donePromise` already resolves `undefined` when no execution id comes
+			// back, so leaving the promise unsettled here is correct.
 			return undefined;
 		}
 

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -32,6 +32,7 @@ import type {
 	PollCursor,
 } from 'n8n-workflow';
 import {
+	OperationalError,
 	SubworkflowOperationError,
 	UnexpectedError,
 	Workflow,
@@ -206,7 +207,9 @@ export class WorkflowExecutionService {
 				'Poll cursor commit skipped: the poll no longer holds its lease, or its cursor row is gone',
 				{ workflowId: workflowData.id, nodeName: node.name },
 			);
-			// No poll call site supplies a `responsePromise`, so leaving it unsettled is fine.
+			responsePromise?.reject(
+				new OperationalError('Poll cursor commit skipped: the poll no longer holds its lease'),
+			);
 			return undefined;
 		}
 

--- a/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
+++ b/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
@@ -384,21 +384,22 @@ describe('poll cursor atomicity', () => {
 			});
 		});
 
-		it('leaves no poller_state row behind when a first-ever poll is fenced out', async () => {
+		it('throws and stores nothing when the cursor row disappeared mid-poll, even with a live fence', async () => {
+			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
 			const task = await seedRunningTask();
 			const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
-			await scheduledTaskRepository.update(task.id, { leaseEpoch: task.leaseEpoch + 1 });
+			await pollerStateRepository.delete({ workflowId: workflow.id, nodeId });
 
-			const result = await pollCursorService.commitWithExecution({
-				workflowId: workflow.id,
-				nodeId,
-				cursor: { lastItemId: 'b' },
-				payload: buildPayload(),
-				fence,
-			});
-
-			expect(result).toBeNull();
-			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toBeNull();
+			await expect(
+				pollCursorService.commitWithExecution({
+					workflowId: workflow.id,
+					nodeId,
+					cursor: { lastItemId: 'b' },
+					payload: buildPayload(),
+					fence,
+				}),
+			).rejects.toThrow('Poller cursor row disappeared while its poll was running');
+			expect(await executionRepository.find({ select: ['id'] })).toEqual([]);
 		});
 	});
 });

--- a/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
+++ b/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
@@ -302,6 +302,17 @@ describe('poll cursor atomicity', () => {
 				title: 'the fenced task id never existed',
 				prepareFence: (): PollLeaseFence => ({ taskId: '999999999', leaseEpoch: 1 }),
 			},
+			{
+				// Marking a task failed does not bump its lease epoch, so the status
+				// alone must stop the late commit.
+				title: 'the fenced task was marked failed, with its lease epoch unchanged',
+				prepareFence: async (): Promise<PollLeaseFence> => {
+					const task = await seedRunningTask();
+					const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
+					await scheduledTaskRepository.update(task.id, { status: ScheduledTaskStatus.Failed });
+					return fence;
+				},
+			},
 		])('does not commit when $title', async ({ prepareFence }) => {
 			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
 			const fence = await prepareFence();

--- a/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
+++ b/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
@@ -279,12 +279,32 @@ describe('poll cursor atomicity', () => {
 			});
 		};
 
-		it('does not commit when the fence lease epoch no longer matches the claimed task', async () => {
-			const task = await seedRunningTask();
+		it.each([
+			{
+				title: 'the fence lease epoch no longer matches the claimed task',
+				prepareFence: async (): Promise<PollLeaseFence> => {
+					const task = await seedRunningTask();
+					const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
+					await scheduledTaskRepository.update(task.id, { leaseEpoch: task.leaseEpoch + 1 });
+					return fence;
+				},
+			},
+			{
+				title: 'the fenced task row no longer exists',
+				prepareFence: async (): Promise<PollLeaseFence> => {
+					const task = await seedRunningTask();
+					const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
+					await scheduledTaskRepository.delete(task.id);
+					return fence;
+				},
+			},
+			{
+				title: 'the fenced task id never existed',
+				prepareFence: (): PollLeaseFence => ({ taskId: '999999999', leaseEpoch: 1 }),
+			},
+		])('does not commit when $title', async ({ prepareFence }) => {
 			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
-			const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
-
-			await scheduledTaskRepository.update(task.id, { leaseEpoch: task.leaseEpoch + 1 });
+			const fence = await prepareFence();
 
 			const result = await pollCursorService.commitWithExecution({
 				workflowId: workflow.id,
@@ -301,12 +321,39 @@ describe('poll cursor atomicity', () => {
 			expect(await executionRepository.find({ select: ['id'] })).toEqual([]);
 		});
 
-		it('does not commit when the fenced task row no longer exists', async () => {
-			const task = await seedRunningTask();
+		it.each([
+			{
+				title: 'the fence matches a task row still running',
+				buildFence: async (): Promise<PollLeaseFence> => {
+					const task = await seedRunningTask();
+					return { taskId: task.id, leaseEpoch: task.leaseEpoch };
+				},
+			},
+			{
+				title: 'the fenced task was already marked succeeded by its executor',
+				buildFence: async (): Promise<PollLeaseFence> => {
+					const task = await seedRunningTask({ status: ScheduledTaskStatus.Succeeded });
+					return { taskId: task.id, leaseEpoch: task.leaseEpoch };
+				},
+			},
+			{
+				title:
+					'the fence names a task unrelated to the cursor row being advanced, since the guard checks only the task id and lease epoch',
+				buildFence: async (): Promise<PollLeaseFence> => {
+					const unrelatedTask = await seedRunningTask();
+					return { taskId: unrelatedTask.id, leaseEpoch: unrelatedTask.leaseEpoch };
+				},
+			},
+			{
+				title: 'there is no fence at all, exactly as an unfenced call commits today',
+				buildFence: async (): Promise<PollLeaseFence | undefined> => {
+					await seedRunningTask();
+					return undefined;
+				},
+			},
+		])('commits when $title', async ({ buildFence }) => {
 			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
-			const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
-
-			await scheduledTaskRepository.delete(task.id);
+			const fence = await buildFence();
 
 			const result = await pollCursorService.commitWithExecution({
 				workflowId: workflow.id,
@@ -314,47 +361,6 @@ describe('poll cursor atomicity', () => {
 				cursor: { lastItemId: 'b' },
 				payload: buildPayload(),
 				fence,
-			});
-
-			expect(result).toBeNull();
-			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
-				lastItemId: 'a',
-			});
-			expect(await executionRepository.find({ select: ['id'] })).toEqual([]);
-		});
-
-		it('commits when the fence matches a task row still running', async () => {
-			const task = await seedRunningTask();
-			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
-
-			const result = await pollCursorService.commitWithExecution({
-				workflowId: workflow.id,
-				nodeId,
-				cursor: { lastItemId: 'b' },
-				payload: buildPayload(),
-				fence: { taskId: task.id, leaseEpoch: task.leaseEpoch },
-			});
-
-			expect(result).not.toBeNull();
-			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
-				lastItemId: 'b',
-			});
-			expect(await executionRepository.findOneBy({ id: result?.executionId })).toMatchObject({
-				status: 'new',
-				workflowId: workflow.id,
-			});
-		});
-
-		it('commits when the fenced task was already marked succeeded by its executor', async () => {
-			const task = await seedRunningTask({ status: ScheduledTaskStatus.Succeeded });
-			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
-
-			const result = await pollCursorService.commitWithExecution({
-				workflowId: workflow.id,
-				nodeId,
-				cursor: { lastItemId: 'b' },
-				payload: buildPayload(),
-				fence: { taskId: task.id, leaseEpoch: task.leaseEpoch },
 			});
 
 			expect(result).not.toBeNull();
@@ -382,64 +388,6 @@ describe('poll cursor atomicity', () => {
 
 			expect(result).toBeNull();
 			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toBeNull();
-		});
-
-		it('does not commit when the fenced task id never existed', async () => {
-			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
-			const fence: PollLeaseFence = { taskId: '999999999', leaseEpoch: 1 };
-
-			const result = await pollCursorService.commitWithExecution({
-				workflowId: workflow.id,
-				nodeId,
-				cursor: { lastItemId: 'b' },
-				payload: buildPayload(),
-				fence,
-			});
-
-			expect(result).toBeNull();
-			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
-				lastItemId: 'a',
-			});
-		});
-
-		it('commits when the fence names a task unrelated to the cursor row being advanced, since the guard checks only the task id and lease epoch', async () => {
-			const unrelatedTask = await seedRunningTask();
-			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
-
-			const result = await pollCursorService.commitWithExecution({
-				workflowId: workflow.id,
-				nodeId,
-				cursor: { lastItemId: 'b' },
-				payload: buildPayload(),
-				fence: { taskId: unrelatedTask.id, leaseEpoch: unrelatedTask.leaseEpoch },
-			});
-
-			expect(result).not.toBeNull();
-			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
-				lastItemId: 'b',
-			});
-		});
-
-		it('commits exactly as an unfenced call does today', async () => {
-			await seedRunningTask();
-			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
-
-			const result = await pollCursorService.commitWithExecution({
-				workflowId: workflow.id,
-				nodeId,
-				cursor: { lastItemId: 'b' },
-				payload: buildPayload(),
-			});
-			if (result === null) throw new Error('expected a commit result');
-			const { executionId } = result;
-
-			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
-				lastItemId: 'b',
-			});
-			expect(await executionRepository.findOneBy({ id: executionId })).toMatchObject({
-				status: 'new',
-				workflowId: workflow.id,
-			});
 		});
 	});
 });

--- a/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
+++ b/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
@@ -384,6 +384,60 @@ describe('poll cursor atomicity', () => {
 			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toBeNull();
 		});
 
+		it('commits when the fence lease epoch is 0 and matches the claimed task', async () => {
+			const task = await seedRunningTask({ leaseEpoch: 0 });
+			await pollCursorService.readCursor(workflow.id, nodeId, 'Poll Node', { lastItemId: 'a' });
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+				fence: { taskId: task.id, leaseEpoch: 0 },
+			});
+
+			expect(result).not.toBeNull();
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
+				lastItemId: 'b',
+			});
+		});
+
+		it('does not commit when the fenced task id never existed', async () => {
+			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
+			const fence: PollLeaseFence = { taskId: '999999999', leaseEpoch: 1 };
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+				fence,
+			});
+
+			expect(result).toBeNull();
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
+				lastItemId: 'a',
+			});
+		});
+
+		it('commits when the fence names a task claimed for a different workflow and node than the one being advanced', async () => {
+			const unrelatedTask = await seedRunningTask();
+			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+				fence: { taskId: unrelatedTask.id, leaseEpoch: unrelatedTask.leaseEpoch },
+			});
+
+			expect(result).not.toBeNull();
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
+				lastItemId: 'b',
+			});
+		});
+
 		it('commits exactly as an unfenced call does today', async () => {
 			await seedRunningTask();
 			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });

--- a/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
+++ b/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
@@ -1,17 +1,28 @@
 import { createWorkflow, testDb } from '@n8n/backend-test-utils';
 import { PollerConfig } from '@n8n/config';
-import type { CreateExecutionPayload, WorkflowEntity } from '@n8n/db';
+import type {
+	CreateExecutionPayload,
+	PollLeaseFence,
+	ScheduledTask,
+	WorkflowEntity,
+} from '@n8n/db';
 import {
 	ExecutionEntity,
 	ExecutionRepository,
 	PollerStateRepository,
+	ScheduledJobRepository,
+	ScheduledTaskRepository,
+	ScheduledTaskStatus,
 	TransactionRunner,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { createEmptyRunExecutionData } from 'n8n-workflow';
 
 import { ExecutionPersistence } from '@/executions/execution-persistence';
+import { POLL_TRIGGER_TASK_TYPE } from '@/scheduling/poll-trigger-node/poll-trigger-task';
 import { PollCursorService } from '@/workflows/triggers/poll-cursor.service';
+
+import { createDueJobFactory, seedDueTask } from '../scheduling/shared/job-factory';
 
 describe('poll cursor atomicity', () => {
 	const nodeId = 'node-1';
@@ -20,6 +31,8 @@ describe('poll cursor atomicity', () => {
 	let executionPersistence: ExecutionPersistence;
 	let executionRepository: ExecutionRepository;
 	let pollerStateRepository: PollerStateRepository;
+	let scheduledJobRepository: ScheduledJobRepository;
+	let scheduledTaskRepository: ScheduledTaskRepository;
 	let transactionRunner: TransactionRunner;
 	let pollerConfig: PollerConfig;
 	let workflow: WorkflowEntity;
@@ -30,12 +43,20 @@ describe('poll cursor atomicity', () => {
 		executionPersistence = Container.get(ExecutionPersistence);
 		executionRepository = Container.get(ExecutionRepository);
 		pollerStateRepository = Container.get(PollerStateRepository);
+		scheduledJobRepository = Container.get(ScheduledJobRepository);
+		scheduledTaskRepository = Container.get(ScheduledTaskRepository);
 		transactionRunner = Container.get(TransactionRunner);
 		pollerConfig = Container.get(PollerConfig);
 	});
 
 	beforeEach(async () => {
-		await testDb.truncate(['PollerState', 'ExecutionEntity', 'WorkflowEntity']);
+		await testDb.truncate([
+			'PollerState',
+			'ExecutionEntity',
+			'WorkflowEntity',
+			'ScheduledTask',
+			'ScheduledJob',
+		]);
 		workflow = await createWorkflow();
 		// Atomicity is flag-gated; enable it for these tests.
 		pollerConfig.durableCursorsEnabled = true;
@@ -68,12 +89,14 @@ describe('poll cursor atomicity', () => {
 	it('commits the cursor advance and the execution row together', async () => {
 		await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
 
-		const { executionId } = await pollCursorService.commitWithExecution({
+		const result = await pollCursorService.commitWithExecution({
 			workflowId: workflow.id,
 			nodeId,
 			cursor: { lastItemId: 'b' },
 			payload: buildPayload(),
 		});
+		if (result === null) throw new Error('expected a commit result');
+		const { executionId } = result;
 
 		expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
 			lastItemId: 'b',
@@ -227,6 +250,160 @@ describe('poll cursor atomicity', () => {
 			).rejects.toThrow('caller fails after work already ran');
 
 			expect(await executionRepository.findOneBy({ id: executionId })).toBeNull();
+		});
+	});
+
+	describe('fenced commits', () => {
+		let createDueJob: ReturnType<typeof createDueJobFactory>;
+
+		beforeEach(() => {
+			createDueJob = createDueJobFactory(
+				scheduledJobRepository,
+				POLL_TRIGGER_TASK_TYPE,
+				'poll-fence-job',
+			);
+		});
+
+		const seedRunningTask = async (
+			overrides: Partial<ScheduledTask> = {},
+		): Promise<ScheduledTask> => {
+			const job = await createDueJob();
+			const task = await seedDueTask(scheduledTaskRepository, POLL_TRIGGER_TASK_TYPE, job.id);
+			return await scheduledTaskRepository.save({
+				...task,
+				status: ScheduledTaskStatus.Running,
+				leaseEpoch: 1,
+				leaseExpiresAt: new Date(Date.now() + 60_000),
+				claimedBy: 'host-1',
+				...overrides,
+			});
+		};
+
+		it('does not commit when the fence lease epoch no longer matches the claimed task', async () => {
+			const task = await seedRunningTask();
+			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
+			const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
+
+			await scheduledTaskRepository.update(task.id, { leaseEpoch: task.leaseEpoch + 1 });
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+				fence,
+			});
+
+			expect(result).toBeNull();
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
+				lastItemId: 'a',
+			});
+			expect(await executionRepository.find({ select: ['id'] })).toEqual([]);
+		});
+
+		it('does not commit when the fenced task row no longer exists', async () => {
+			const task = await seedRunningTask();
+			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
+			const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
+
+			await scheduledTaskRepository.delete(task.id);
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+				fence,
+			});
+
+			expect(result).toBeNull();
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
+				lastItemId: 'a',
+			});
+			expect(await executionRepository.find({ select: ['id'] })).toEqual([]);
+		});
+
+		it('commits when the fence matches a task row still running', async () => {
+			const task = await seedRunningTask();
+			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+				fence: { taskId: task.id, leaseEpoch: task.leaseEpoch },
+			});
+
+			expect(result).not.toBeNull();
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
+				lastItemId: 'b',
+			});
+			expect(await executionRepository.findOneBy({ id: result?.executionId })).toMatchObject({
+				status: 'new',
+				workflowId: workflow.id,
+			});
+		});
+
+		it('commits when the fenced task was already marked succeeded by its executor', async () => {
+			const task = await seedRunningTask({ status: ScheduledTaskStatus.Succeeded });
+			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+				fence: { taskId: task.id, leaseEpoch: task.leaseEpoch },
+			});
+
+			expect(result).not.toBeNull();
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
+				lastItemId: 'b',
+			});
+			expect(await executionRepository.findOneBy({ id: result?.executionId })).toMatchObject({
+				status: 'new',
+				workflowId: workflow.id,
+			});
+		});
+
+		it('leaves no poller_state row behind when a first-ever poll is fenced out', async () => {
+			const task = await seedRunningTask();
+			const fence: PollLeaseFence = { taskId: task.id, leaseEpoch: task.leaseEpoch };
+			await scheduledTaskRepository.update(task.id, { leaseEpoch: task.leaseEpoch + 1 });
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+				fence,
+			});
+
+			expect(result).toBeNull();
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toBeNull();
+		});
+
+		it('commits exactly as an unfenced call does today', async () => {
+			await seedRunningTask();
+			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
+
+			const result = await pollCursorService.commitWithExecution({
+				workflowId: workflow.id,
+				nodeId,
+				cursor: { lastItemId: 'b' },
+				payload: buildPayload(),
+			});
+			if (result === null) throw new Error('expected a commit result');
+			const { executionId } = result;
+
+			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
+				lastItemId: 'b',
+			});
+			expect(await executionRepository.findOneBy({ id: executionId })).toMatchObject({
+				status: 'new',
+				workflowId: workflow.id,
+			});
 		});
 	});
 });

--- a/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
+++ b/packages/cli/test/integration/executions/poll-cursor-atomicity.test.ts
@@ -384,24 +384,6 @@ describe('poll cursor atomicity', () => {
 			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toBeNull();
 		});
 
-		it('commits when the fence lease epoch is 0 and matches the claimed task', async () => {
-			const task = await seedRunningTask({ leaseEpoch: 0 });
-			await pollCursorService.readCursor(workflow.id, nodeId, 'Poll Node', { lastItemId: 'a' });
-
-			const result = await pollCursorService.commitWithExecution({
-				workflowId: workflow.id,
-				nodeId,
-				cursor: { lastItemId: 'b' },
-				payload: buildPayload(),
-				fence: { taskId: task.id, leaseEpoch: 0 },
-			});
-
-			expect(result).not.toBeNull();
-			expect(await pollerStateRepository.findCursor(workflow.id, nodeId)).toEqual({
-				lastItemId: 'b',
-			});
-		});
-
 		it('does not commit when the fenced task id never existed', async () => {
 			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
 			const fence: PollLeaseFence = { taskId: '999999999', leaseEpoch: 1 };
@@ -420,7 +402,7 @@ describe('poll cursor atomicity', () => {
 			});
 		});
 
-		it('commits when the fence names a task claimed for a different workflow and node than the one being advanced', async () => {
+		it('commits when the fence names a task unrelated to the cursor row being advanced, since the guard checks only the task id and lease epoch', async () => {
 			const unrelatedTask = await seedRunningTask();
 			await pollCursorService.resolveCursor(workflow.id, nodeId, { lastItemId: 'a' });
 


### PR DESCRIPTION
## Summary

A poll trigger dispatched by the durable scheduler holds a lease on its `scheduled_task` row. `poll()` can outlive that lease, so the reaper can reclaim it while the poll is still in flight. The cursor commit then had no way to tell, and would advance the cursor and insert an execution under a lease it no longer held.

`advanceCursor` now takes an optional fence (`taskId` + `leaseEpoch`) and only commits when that task still holds the lease:

```sql
UPDATE poller_state SET cursor = ?, updatedAt = ?
 WHERE workflowId = ? AND nodeId = ?
   AND EXISTS (SELECT 1 FROM scheduled_task
                WHERE id = ? AND leaseEpoch = ? AND status <> 'pending')
```

`status <> 'pending'` rather than `= 'running'`: the emit-path commit is fire-and-forget and can land after the task already succeeded, and only a pending task's lease can still be reclaimed.

A rejected commit is not distinguishable from a `poller_state` row that's genuinely gone; both report `false`/`null` rather than throwing, since under at-least-once redelivery a lost lease is expected.

Fence is threaded through `PollTriggerTaskHandler` → `TriggerExecutionContextFactory` → `WorkflowExecutionService`/`PollCursorService` → `PollerStateRepository`. The two in-memory registration paths (`ActiveWorkflowManager`, the publication-service trigger registrar) pass no fence and behave exactly as before.

No migration, no new columns, no changes to `n8n-core` or `n8n-workflow`.

### Known limitations (follow-ups, not addressed here)

- A poll node that never stages a cursor (`__emit` with nothing staged) takes the plain `runWorkflow` path, not `runPolledWorkflow`, so no fence is passed and it can still double-execute after a reclaim.
- An unmigrated node's cursor is still its raw static-data bucket, saved unfenced; only a node migrated onto `poller_state` gets the guard in this PR.
- The `EXISTS` check takes no lock, so on Postgres a reclaim can still land between that read and this transaction's commit (zero window on SQLite, whose write lock spans the whole transaction).

## How to test

Both flags are off by default and both are required:

```
N8N_SCHEDULER_ENABLED=true
N8N_SCHEDULER_POLL_TRIGGERS_ENABLED=true
N8N_POLLER_DURABLE_CURSORS_ENABLED=true
```

```bash
cd packages/cli
pnpm test:sqlite test/integration/executions/poll-cursor-atomicity.test.ts
pnpm test:postgres:tc test/integration/executions/poll-cursor-atomicity.test.ts
pnpm test src/workflows/triggers/__tests__/poll-cursor.service.test.ts \
          src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts \
          src/workflows/__tests__/workflow-execution.service.test.ts \
          src/scheduling/poll-trigger-node/__tests__/poll-trigger-task-handler.test.ts \
          src/__tests__/active-workflow-manager.test.ts
```

Manual: enable the flags, activate a workflow with a poll trigger on a short interval, and set `N8N_SCHEDULER_LEASE_SECONDS` low enough for a slow `poll()` to outlive its lease. A reclaimed poll logs at debug that the commit was skipped, with the cursor and execution list unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3872

Fourth in a stack on top of `cat-3900-e2e-tests`, not `master`; cannot merge before the three below it:

1. #35128 — `poller_state` table, entity and repository
2. #35295 — cursor advance and execution row in one transaction
3. #35343 — end-to-end coverage for durable cursors
4. this PR

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/35372">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

