### PR TITLE
feat(Postgres PGVector Store): add opt-in "Create Extension" option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -130,6 +130,9 @@ describe('VectorStorePGVector.node', () => {
 			expect(mockClient.release).toHaveBeenCalled();
 			// table creation runs after the extension is created
 			expect(vs.ensureTableInDatabase).toHaveBeenCalled();
+			const extensionCallOrder = mockClient.query.mock.invocationCallOrder[0];
+			const tableInitCallOrder = (vs.ensureTableInDatabase as any).mock.invocationCallOrder[0];
+			expect(extensionCallOrder).toBeLessThan(tableInitCallOrder);
 		});
 	});
 
@@ -157,6 +160,9 @@ describe('VectorStorePGVector.node', () => {
 			).toBe(true);
 			expect(mockClient.release).toHaveBeenCalled();
 			expect(MockPGVectorStore.fromDocuments).toHaveBeenCalled();
+			const extensionCallOrder = mockClient.query.mock.invocationCallOrder[0];
+			const fromDocsCallOrder = (MockPGVectorStore.fromDocuments as any).mock.invocationCallOrder[0];
+			expect(extensionCallOrder).toBeLessThan(fromDocsCallOrder);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -98,7 +98,7 @@ describe('VectorStorePGVector.node', () => {
 	}
 
 	beforeEach(() => {
-		vi.resetAllMocks();
+		vi.clearAllMocks();
 		MockConfigurePostgres.mockResolvedValue({ db: { $pool: mockPool } } as never);
 		MockPGVectorStore.fromDocuments = vi.fn().mockResolvedValue({ client: { release: vi.fn() } });
 	});
@@ -109,7 +109,8 @@ describe('VectorStorePGVector.node', () => {
 			const node = new PGVectorNode.VectorStorePGVector();
 			const vs = await (node as any).getVectorStoreClient(context, undefined, {}, 0);
 
-			expect(mockPool.query).not.toHaveBeenCalled();
+			expect(mockPool.connect).not.toHaveBeenCalled();
+			expect(mockClient.query).not.toHaveBeenCalled();
 			// initialize() ran (table setup happens before table creation)
 			expect(vs._initializeClient).toHaveBeenCalled();
 			expect(vs.ensureTableInDatabase).toHaveBeenCalled();
@@ -138,7 +139,8 @@ describe('VectorStorePGVector.node', () => {
 			const node = new PGVectorNode.VectorStorePGVector();
 			await (node as any).populateVectorStore(context, {}, [{ pageContent: 'x', metadata: {} }], 0);
 
-			expect(mockPool.query).not.toHaveBeenCalled();
+			expect(mockPool.connect).not.toHaveBeenCalled();
+			expect(mockClient.query).not.toHaveBeenCalled();
 			expect(MockPGVectorStore.fromDocuments).toHaveBeenCalled();
 		});
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -66,8 +66,13 @@ describe('VectorStorePGVector.node', () => {
 		password: 'test',
 	};
 
+	const mockClient = {
+		query: vi.fn().mockResolvedValue({ rows: [] }),
+		release: vi.fn(),
+	};
 	const mockPool = {
 		query: vi.fn().mockResolvedValue({ rows: [] }),
+		connect: vi.fn().mockResolvedValue(mockClient),
 	};
 
 	const defaultParams: Record<string, unknown> = {
@@ -115,8 +120,13 @@ describe('VectorStorePGVector.node', () => {
 			const node = new PGVectorNode.VectorStorePGVector();
 			const vs = await (node as any).getVectorStoreClient(context, undefined, {}, 0);
 
-			expect(mockPool.query).toHaveBeenCalledTimes(1);
-			expect(mockPool.query).toHaveBeenCalledWith(EXTENSION_SQL);
+			expect(mockPool.connect).toHaveBeenCalledTimes(1);
+			const queries = mockClient.query.mock.calls.map((c) => c[0]);
+			expect(queries).toContain(EXTENSION_SQL);
+			expect(
+				queries.some((q) => typeof q === 'string' && q.includes('pg_advisory_xact_lock')),
+			).toBe(true);
+			expect(mockClient.release).toHaveBeenCalled();
 			// table creation runs after the extension is created
 			expect(vs.ensureTableInDatabase).toHaveBeenCalled();
 		});
@@ -137,8 +147,13 @@ describe('VectorStorePGVector.node', () => {
 			const node = new PGVectorNode.VectorStorePGVector();
 			await (node as any).populateVectorStore(context, {}, [{ pageContent: 'x', metadata: {} }], 0);
 
-			expect(mockPool.query).toHaveBeenCalledTimes(1);
-			expect(mockPool.query).toHaveBeenCalledWith(EXTENSION_SQL);
+			expect(mockPool.connect).toHaveBeenCalledTimes(1);
+			const queries = mockClient.query.mock.calls.map((c) => c[0]);
+			expect(queries).toContain(EXTENSION_SQL);
+			expect(
+				queries.some((q) => typeof q === 'string' && q.includes('pg_advisory_xact_lock')),
+			).toBe(true);
+			expect(mockClient.release).toHaveBeenCalled();
 			expect(MockPGVectorStore.fromDocuments).toHaveBeenCalled();
 		});
 	});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -1,0 +1,145 @@
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+// Mock external modules that are not needed for these unit tests
+vi.mock('@langchain/community/vectorstores/pgvector', () => {
+	const state: { ctorArgs?: unknown[] } = { ctorArgs: undefined };
+	class PGVectorStore {
+		static fromDocuments = vi.fn().mockResolvedValue({ client: { release: vi.fn() } });
+		_initializeClient = vi.fn();
+		ensureTableInDatabase = vi.fn();
+		ensureCollectionTableInDatabase = vi.fn();
+		similaritySearchVectorWithScore = vi.fn();
+		constructor(...args: unknown[]) {
+			state.ctorArgs = args;
+		}
+	}
+	return { PGVectorStore, __state: state };
+});
+
+vi.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
+	configurePostgres: vi.fn(),
+}));
+
+vi.mock('@n8n/ai-utilities', () => ({
+	metadataFilterField: {},
+	createVectorStoreNode: (config: {
+		getVectorStoreClient: (...args: unknown[]) => unknown;
+		populateVectorStore: (...args: unknown[]) => unknown;
+	}) =>
+		class BaseNode {
+			async getVectorStoreClient(...args: unknown[]) {
+				return config.getVectorStoreClient.apply(config, args);
+			}
+			async populateVectorStore(...args: unknown[]) {
+				return config.populateVectorStore.apply(config, args);
+			}
+		},
+}));
+
+import { PGVectorStore } from '@langchain/community/vectorstores/pgvector';
+import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
+import * as PGVectorNode from './VectorStorePGVector.node';
+import type { MockedClass, MockedFunction } from 'vitest';
+
+const MockConfigurePostgres = configurePostgres as MockedFunction<typeof configurePostgres>;
+const MockPGVectorStore = PGVectorStore as MockedClass<typeof PGVectorStore>;
+
+const EXTENSION_SQL = 'CREATE EXTENSION IF NOT EXISTS vector';
+
+describe('VectorStorePGVector.node', () => {
+	const helpers = mock<ISupplyDataFunctions['helpers']>();
+	const dataFunctions = mock<ISupplyDataFunctions>({ helpers });
+	dataFunctions.logger = {
+		info: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		verbose: vi.fn(),
+	} as unknown as ISupplyDataFunctions['logger'];
+
+	const baseCredentials = {
+		host: 'localhost',
+		port: 5432,
+		database: 'test',
+		user: 'test',
+		password: 'test',
+	};
+
+	const mockPool = {
+		query: vi.fn().mockResolvedValue({ rows: [] }),
+	};
+
+	const defaultParams: Record<string, unknown> = {
+		tableName: 'n8n_vectors',
+		'options.collection.values': {},
+		'options.columnNames.values': {
+			idColumnName: 'id',
+			vectorColumnName: 'embedding',
+			contentColumnName: 'text',
+			metadataColumnName: 'metadata',
+		},
+		'options.distanceStrategy': 'cosine',
+		createExtension: false,
+	};
+
+	function makeContext(params: Record<string, unknown> = {}) {
+		return {
+			getCredentials: vi.fn().mockResolvedValue(baseCredentials),
+			getNodeParameter: vi.fn((name: string) => params[name]),
+			getNode: () => ({ name: 'VectorStorePGVector' }),
+			logger: dataFunctions.logger,
+		} as never;
+	}
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		MockConfigurePostgres.mockResolvedValue({ db: { $pool: mockPool } } as never);
+		MockPGVectorStore.fromDocuments = vi.fn().mockResolvedValue({ client: { release: vi.fn() } });
+	});
+
+	describe('getVectorStoreClient', () => {
+		it('does not run CREATE EXTENSION when Create Extension is off', async () => {
+			const context = makeContext({ ...defaultParams, createExtension: false });
+			const node = new PGVectorNode.VectorStorePGVector();
+			const vs = await (node as any).getVectorStoreClient(context, undefined, {}, 0);
+
+			expect(mockPool.query).not.toHaveBeenCalled();
+			// initialize() ran (table setup happens before table creation)
+			expect(vs._initializeClient).toHaveBeenCalled();
+			expect(vs.ensureTableInDatabase).toHaveBeenCalled();
+		});
+
+		it('runs CREATE EXTENSION before table creation when Create Extension is on', async () => {
+			const context = makeContext({ ...defaultParams, createExtension: true });
+			const node = new PGVectorNode.VectorStorePGVector();
+			const vs = await (node as any).getVectorStoreClient(context, undefined, {}, 0);
+
+			expect(mockPool.query).toHaveBeenCalledTimes(1);
+			expect(mockPool.query).toHaveBeenCalledWith(EXTENSION_SQL);
+			// table creation runs after the extension is created
+			expect(vs.ensureTableInDatabase).toHaveBeenCalled();
+		});
+	});
+
+	describe('populateVectorStore', () => {
+		it('does not run CREATE EXTENSION when Create Extension is off', async () => {
+			const context = makeContext({ ...defaultParams, createExtension: false });
+			const node = new PGVectorNode.VectorStorePGVector();
+			await (node as any).populateVectorStore(context, {}, [{ pageContent: 'x', metadata: {} }], 0);
+
+			expect(mockPool.query).not.toHaveBeenCalled();
+			expect(MockPGVectorStore.fromDocuments).toHaveBeenCalled();
+		});
+
+		it('runs CREATE EXTENSION before inserting documents when Create Extension is on', async () => {
+			const context = makeContext({ ...defaultParams, createExtension: true });
+			const node = new PGVectorNode.VectorStorePGVector();
+			await (node as any).populateVectorStore(context, {}, [{ pageContent: 'x', metadata: {} }], 0);
+
+			expect(mockPool.query).toHaveBeenCalledTimes(1);
+			expect(mockPool.query).toHaveBeenCalledWith(EXTENSION_SQL);
+			expect(MockPGVectorStore.fromDocuments).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -24,6 +24,13 @@ type ColumnOptions = {
 	metadataColumnName: string;
 };
 
+async function createVectorExtension(pool: pg.Pool, extensionSchemaName?: string) {
+	const sql = extensionSchemaName
+		? `CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA "${extensionSchemaName}"`
+		: 'CREATE EXTENSION IF NOT EXISTS vector';
+	await pool.query(sql);
+}
+
 const sharedFields: INodeProperties[] = [
 	{
 		displayName: 'Table Name',
@@ -32,6 +39,14 @@ const sharedFields: INodeProperties[] = [
 		default: 'n8n_vectors',
 		description:
 			'The table name to store the vectors in. If table does not exist, it will be created.',
+	},
+	{
+		displayName: 'Create Extension',
+		name: 'createExtension',
+		type: 'boolean',
+		default: false,
+		description:
+			'Whether to create the pgvector (vector) extension if it doesn\'t already exist. Requires superuser privileges. Off by default.',
 	},
 ];
 
@@ -270,6 +285,13 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			'cosine',
 		) as DistanceStrategy;
 
+		if (context.getNodeParameter('createExtension', itemIndex, false)) {
+			await createVectorExtension(
+				pool,
+				(config as { extensionSchemaName?: string }).extensionSchemaName,
+			);
+		}
+
 		return await ExtendedPGVectorStore.initialize(embeddings, config);
 	},
 
@@ -305,6 +327,13 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			contentColumnName: 'text',
 			metadataColumnName: 'metadata',
 		}) as ColumnOptions;
+
+		if (context.getNodeParameter('createExtension', itemIndex, false)) {
+			await createVectorExtension(
+				pool,
+				(config as { extensionSchemaName?: string }).extensionSchemaName,
+			);
+		}
 
 		const vectorStore = await PGVectorStore.fromDocuments(documents, embeddings, config);
 		vectorStore.client?.release();

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -24,8 +24,26 @@ type ColumnOptions = {
 	metadataColumnName: string;
 };
 
+// Advisory lock key used to serialize the `CREATE EXTENSION` DDL across
+// concurrent executions against a fresh database. Without it, two transactions
+// can both reach `CREATE EXTENSION IF NOT EXISTS vector` before either commits
+// and PostgreSQL may raise a duplicate-key/race error.
+const CREATE_EXTENSION_ADVISORY_LOCK = 979021312;
+
 async function createVectorExtension(pool: pg.Pool) {
-	await pool.query('CREATE EXTENSION IF NOT EXISTS vector');
+	const client = await pool.connect();
+	try {
+		await client.query('BEGIN');
+		// Serialize concurrent DDL attempts so parallel workflows don't race.
+		await client.query('SELECT pg_advisory_xact_lock($1)', [CREATE_EXTENSION_ADVISORY_LOCK]);
+		await client.query('CREATE EXTENSION IF NOT EXISTS vector');
+		await client.query('COMMIT');
+	} catch (error) {
+		await client.query('ROLLBACK').catch(() => undefined);
+		throw error;
+	} finally {
+		client.release();
+	}
 }
 
 const sharedFields: INodeProperties[] = [

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -24,11 +24,8 @@ type ColumnOptions = {
 	metadataColumnName: string;
 };
 
-async function createVectorExtension(pool: pg.Pool, extensionSchemaName?: string) {
-	const sql = extensionSchemaName
-		? `CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA "${extensionSchemaName}"`
-		: 'CREATE EXTENSION IF NOT EXISTS vector';
-	await pool.query(sql);
+async function createVectorExtension(pool: pg.Pool) {
+	await pool.query('CREATE EXTENSION IF NOT EXISTS vector');
 }
 
 const sharedFields: INodeProperties[] = [
@@ -286,10 +283,7 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 		) as DistanceStrategy;
 
 		if (context.getNodeParameter('createExtension', itemIndex, false)) {
-			await createVectorExtension(
-				pool,
-				(config as { extensionSchemaName?: string }).extensionSchemaName,
-			);
+			await createVectorExtension(pool);
 		}
 
 		return await ExtendedPGVectorStore.initialize(embeddings, config);
@@ -329,10 +323,7 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 		}) as ColumnOptions;
 
 		if (context.getNodeParameter('createExtension', itemIndex, false)) {
-			await createVectorExtension(
-				pool,
-				(config as { extensionSchemaName?: string }).extensionSchemaName,
-			);
+			await createVectorExtension(pool);
 		}
 
 		const vectorStore = await PGVectorStore.fromDocuments(documents, embeddings, config);


### PR DESCRIPTION
## Description

Adds an opt-in **Create Extension** option to the Postgres PGVector Store node. When enabled, the node runs `CREATE EXTENSION IF NOT EXISTS vector` **before** creating the vector table — restoring the previous auto-creation behaviour for users with superuser privileges.

This is the paired code PR for the documentation change in n8n-docs#5145.

## Root Cause

The node no longer auto-creates the `vector` extension (it now expects a database administrator to install `pgvector` beforehand). Users who previously relied on automatic creation had no in-node way to opt back in. The docs (n8n-docs#5145) describe this option, but the implementation was missing.

## Changes

- `packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts`
  - Added a `Create Extension` boolean option (default `false`) to `sharedFields`, so it applies to all operation modes (load / insert / retrieve / retrieve-as-tool).
  - Added a `createVectorExtension(pool)` helper that runs `CREATE EXTENSION IF NOT EXISTS vector`.
  - Called it in `getVectorStoreClient` (before `ExtendedPGVectorStore.initialize`) and `populateVectorStore` (before `PGVectorStore.fromDocuments`) — i.e. before table creation in both code paths.
- `packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts`
  - Added unit tests (following the existing `VectorStoreQdrant.node.test.ts` pattern) asserting `pool.query('CREATE EXTENSION IF NOT EXISTS vector')` is invoked exactly once when the option is on, and not invoked when off, in both insert and retrieve/load paths.

## Testing

- New vitest unit tests cover the option in both `getVectorStoreClient` and `populateVectorStore`.
- The change is isolated to this node and follows the existing option/connection patterns (no new dependencies, no public API changes).

> Note: the full monorepo lint/typecheck/build could not be executed in the contribution environment; CI will run the complete suite.

## Related

- Documentation: n8n-docs#5145


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Notes
- **DDL serialization:** `Create Extension` wraps `CREATE EXTENSION IF NOT EXISTS vector` in a transaction-scoped advisory lock (`pg_advisory_xact_lock`) so concurrent executions against a fresh database don't race on the extension creation (addresses the codex P2 review comment).
