### PR TITLE
feat(core): Validate trigger node id uniqueness before publish (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -1460,4 +1460,55 @@ describe('WorkflowValidationService', () => {
 			expect(result.error).toMatch(/Slack/);
 		});
 	});
+
+	describe('validateTriggerNodeIds', () => {
+		const triggerNode = (name: string, id?: string): INode =>
+			({
+				name,
+				id,
+				type: 'n8n-nodes-base.cron',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			}) as INode;
+
+		it('accepts trigger nodes that each carry a distinct id', () => {
+			const result = service.validateTriggerNodeIds([
+				triggerNode('Cron', 'node-1'),
+				triggerNode('Webhook', 'node-2'),
+			]);
+
+			expect(result.isValid).toBe(true);
+		});
+
+		it('accepts a workflow with no trigger nodes', () => {
+			const result = service.validateTriggerNodeIds([]);
+
+			expect(result.isValid).toBe(true);
+		});
+
+		it('rejects trigger nodes that share an id, naming each node and the id', () => {
+			const result = service.validateTriggerNodeIds([
+				triggerNode('Cron', 'node-1'),
+				triggerNode('Webhook', 'node-1'),
+			]);
+
+			expect(result.isValid).toBe(false);
+			expect(result.error).toContain('Cannot publish workflow');
+			expect(result.error).toContain('"Cron"');
+			expect(result.error).toContain('"Webhook"');
+			expect(result.error).toContain('"node-1"');
+		});
+
+		it('rejects a trigger node that carries no id', () => {
+			const result = service.validateTriggerNodeIds([
+				triggerNode('Cron', 'node-1'),
+				triggerNode('Webhook', undefined),
+			]);
+
+			expect(result.isValid).toBe(false);
+			expect(result.error).toContain('Cannot publish workflow');
+			expect(result.error).toContain('"Webhook"');
+		});
+	});
 });

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -1131,11 +1131,13 @@ describe('WorkflowService', () => {
 				_validateNodes: () => void;
 				_validateDynamicCredentials: () => Promise<void>;
 				_validateSubWorkflowReferences: () => Promise<void>;
+				_validateTriggerNodeIds: () => void;
 			};
 			vi.spyOn(internals, '_detectWebhookConflicts').mockResolvedValue(undefined);
 			vi.spyOn(internals, '_validateNodes').mockReturnValue(undefined);
 			vi.spyOn(internals, '_validateDynamicCredentials').mockResolvedValue(undefined);
 			vi.spyOn(internals, '_validateSubWorkflowReferences').mockResolvedValue(undefined);
+			vi.spyOn(internals, '_validateTriggerNodeIds').mockReturnValue(undefined);
 		});
 
 		test.each([

--- a/packages/cli/src/workflows/triggers/enabled-trigger-nodes.ts
+++ b/packages/cli/src/workflows/triggers/enabled-trigger-nodes.ts
@@ -1,0 +1,36 @@
+import type { IConnections, INode, INodeTypes } from 'n8n-workflow';
+import { Workflow } from 'n8n-workflow';
+
+export type WorkflowTriggerVersion = { nodes: INode[]; connections: IConnections };
+
+/**
+ * Returns the enabled trigger-like nodes (active, poll, schedule and webhook
+ * triggers) of a workflow version. Disabled nodes are excluded, so the result
+ * is the set of nodes that actually drive trigger registration.
+ *
+ * A free function rather than a method so callers that only need the
+ * classification — the publish-time node id check on the API side — can reuse it
+ * without depending on `WorkflowTriggerActivator`, which owns trigger
+ * registration and only constructs when the publication service is enabled.
+ * One implementation keeps that check and publication agreeing on which nodes
+ * get a trigger status row.
+ */
+export function getEnabledTriggerNodes(
+	version: WorkflowTriggerVersion | null,
+	nodeTypes: INodeTypes,
+): INode[] {
+	if (!version) return [];
+
+	const workflow = new Workflow({
+		id: 'trigger-diff',
+		name: 'trigger-diff',
+		nodes: version.nodes,
+		connections: version.connections,
+		active: false,
+		nodeTypes,
+	});
+
+	return workflow.queryNodes(
+		(nodeType) => !!nodeType.trigger || !!nodeType.poll || !!nodeType.webhook,
+	);
+}

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -9,7 +9,6 @@ import { ErrorReporter, SpanStatus, Tracing } from 'n8n-core';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { createResultError, createResultOk, type Result } from '@n8n/utils/result';
 import type {
-	IConnections,
 	INode,
 	IWebhookData,
 	IWorkflowBase,
@@ -35,6 +34,8 @@ import type {
 } from '@/events/maps/workflow-publication-metrics.event-map';
 import { NodeTypes } from '@/node-types';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import type { WorkflowTriggerVersion } from '@/workflows/triggers/enabled-trigger-nodes';
+import { getEnabledTriggerNodes } from '@/workflows/triggers/enabled-trigger-nodes';
 import type { PreparedNonWebhookTriggerRegistration } from '@/workflows/triggers/non-webhook-trigger-registrar';
 import { NonWebhookTriggerRegistrar } from '@/workflows/triggers/non-webhook-trigger-registrar';
 import { retryTriggerActivation } from '@/workflows/triggers/trigger-activation-retry';
@@ -43,7 +44,7 @@ import { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-exe
 import { WebhookTriggerRegistrar } from '@/workflows/triggers/webhook-trigger-registrar';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
-export type WorkflowTriggerVersion = { nodes: INode[]; connections: IConnections };
+export type { WorkflowTriggerVersion };
 
 // Their trigger() is a no-op — fired by the execution engine, never the
 // registry — so reconciling them against the registry would re-enqueue forever.
@@ -101,26 +102,12 @@ export class WorkflowTriggerActivator {
 	}
 
 	/**
-	 * Returns the enabled trigger-like nodes (active, poll, schedule and webhook
-	 * triggers) of a workflow version. Disabled nodes are excluded, so the result
-	 * is the set of nodes that actually drive trigger registration. Used to
-	 * compute the trigger-level diff during publication.
+	 * The enabled trigger-like nodes of a workflow version, used to compute the
+	 * trigger-level diff during publication. See `getEnabledTriggerNodes`, shared
+	 * with the publish-time node id check.
 	 */
 	getEnabledTriggerNodes(version: WorkflowTriggerVersion | null): INode[] {
-		if (!version) return [];
-
-		const workflow = new Workflow({
-			id: 'trigger-diff',
-			name: 'trigger-diff',
-			nodes: version.nodes,
-			connections: version.connections,
-			active: false,
-			nodeTypes: this.nodeTypes,
-		});
-
-		return workflow.queryNodes(
-			(nodeType) => !!nodeType.trigger || !!nodeType.poll || !!nodeType.webhook,
-		);
+		return getEnabledTriggerNodes(version, this.nodeTypes);
 	}
 
 	/**

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -230,6 +230,53 @@ export class WorkflowValidationService {
 	}
 
 	/**
+	 * Rejects trigger nodes whose ids do not uniquely identify them.
+	 *
+	 * Publication records one `workflow_publication_trigger_status` row per
+	 * enabled trigger node, keyed by the composite primary key
+	 * `(workflowId, nodeId)`. A shared or absent id therefore collapses two
+	 * triggers onto one key: the diff in `computeTriggerDiff` loses one of them,
+	 * and the row insert fails on the constraint. Catching it here turns a
+	 * constraint violation raised mid-publication into a message naming the
+	 * offending nodes.
+	 *
+	 * An absent id is the same defect as a shared one — `undefined` is just an id
+	 * that every id-less node has in common — so both are reported together.
+	 */
+	validateTriggerNodeIds(triggerNodes: INode[]): WorkflowValidationResult {
+		const violations: string[] = [];
+		const namesById = new Map<string, string[]>();
+
+		for (const node of triggerNodes) {
+			if (!node.id) {
+				violations.push(`trigger "${node.name}" has no node ID`);
+				continue;
+			}
+
+			const names = namesById.get(node.id);
+			if (names) {
+				names.push(node.name);
+			} else {
+				namesById.set(node.id, [node.name]);
+			}
+		}
+
+		for (const [nodeId, names] of namesById) {
+			if (names.length < 2) continue;
+
+			const nameList = names.map((name) => `"${name}"`).join(', ');
+			violations.push(`triggers ${nameList} share the node ID "${nodeId}"`);
+		}
+
+		if (violations.length === 0) return { isValid: true };
+
+		return {
+			isValid: false,
+			error: `Cannot publish workflow: ${violations.join('; ')}. Remove and re-add the affected nodes to give them new IDs.`,
+		};
+	}
+
+	/**
 	 * Returns the credential types that are actively in use on a node — the
 	 * subset of `node.credentials` keys we should validate against.
 	 *

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -29,6 +29,7 @@ import { PROJECT_ROOT, Workflow, assert, calculateWorkflowChecksum } from 'n8n-w
 import { v4 as uuid } from 'uuid';
 
 import { WorkflowPublicationNotifier } from './publication/workflow-publication-notifier';
+import { getEnabledTriggerNodes } from './triggers/enabled-trigger-nodes';
 import { getErrorDescription, getErrorNodeId, getRequiredRedactionScopes } from './utils';
 import { WorkflowFinderService } from './workflow-finder.service';
 import { WorkflowHistoryService } from './workflow-history/workflow-history.service';
@@ -836,6 +837,9 @@ export class WorkflowService {
 		this._validateNodes(workflowId, versionToActivate.nodes, versionToActivate.connections);
 		await this._validateDynamicCredentials(workflowId, versionToActivate.nodes, workflow.settings);
 		await this._validateSubWorkflowReferences(workflowId, versionToActivate.nodes);
+		if (this.globalConfig.workflows.useWorkflowPublicationService) {
+			this._validateTriggerNodeIds(workflowId, versionToActivate);
+		}
 
 		// Run hook before destructive state changes so a rejection leaves
 		// the previous active version running instead of deactivating it.
@@ -1452,6 +1456,20 @@ export class WorkflowService {
 				error: validation.error,
 			});
 			throw new WorkflowValidationError(validation.error ?? 'Workflow validation failed');
+		}
+	}
+
+	private _validateTriggerNodeIds(workflowId: string, version: WorkflowHistory) {
+		const validation = this.workflowValidationService.validateTriggerNodeIds(
+			getEnabledTriggerNodes(version, this.nodeTypes),
+		);
+
+		if (!validation.isValid) {
+			this.logger.warn('Workflow activation failed trigger node id validation', {
+				workflowId,
+				error: validation.error,
+			});
+			throw new WorkflowValidationError(validation.error ?? 'Trigger node id validation failed');
 		}
 	}
 

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -19,7 +19,7 @@ import {
 	ProjectRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { INode } from 'n8n-workflow';
+import type { INode, INodeType } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 import { mock } from 'vitest-mock-extended';
 
@@ -42,6 +42,13 @@ import { WorkflowService } from '@/workflows/workflow.service';
 import { createCustomRoleWithScopeSlugs, cleanupRolesAndScopes } from '../shared/db/roles';
 import { createOwner, createMember } from '../shared/db/users';
 import { createWorkflowHistoryItem } from '../shared/db/workflow-history';
+
+/**
+ * A node type that classifies as a trigger. `properties` must be a real array:
+ * `getEnabledTriggerNodes` builds a `Workflow`, which reads it.
+ */
+const triggerNodeType = () =>
+	({ description: { properties: [] }, trigger: async () => ({}) }) as unknown as INodeType;
 
 let globalConfig: GlobalConfig;
 let workflowRepository: WorkflowRepository;
@@ -105,6 +112,10 @@ beforeAll(async () => {
 
 beforeEach(() => {
 	workflowPublishGuard.assertCanPublish.mockResolvedValue(undefined);
+	// Leaks into `_detectWebhookConflicts` in later tests otherwise, which builds a real Workflow.
+	nodeTypes.getByNameAndVersion.mockReset();
+	workflowValidationService.validateTriggerNodeIds.mockReset();
+	workflowValidationService.validateTriggerNodeIds.mockReturnValue({ isValid: true });
 	workflowValidationService.validateForActivation.mockReturnValue({ isValid: true });
 	workflowValidationService.validateDynamicCredentials.mockResolvedValue({ isValid: true });
 	workflowValidationService.validateSubWorkflowReferences.mockResolvedValue({ isValid: true });
@@ -786,9 +797,103 @@ describe('workflow publication outbox', () => {
 				'Cannot delete a published workflow. Unpublish it before deleting.',
 			);
 		});
+
+		test('should reject the publish before any write when trigger node ids are not unique', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			workflowValidationService.validateTriggerNodeIds.mockReturnValue({
+				isValid: false,
+				error: 'Cannot publish workflow: triggers "Cron", "Webhook" share the node ID "node-1".',
+			});
+
+			await expect(workflowService.activateWorkflow(owner, workflow.id)).rejects.toThrow(
+				'share the node ID',
+			);
+
+			// The gate sits before the transaction, so neither half of it may have run.
+			const updated = await workflowRepository.findOne({ where: { id: workflow.id } });
+			expect(updated?.activeVersionId).toBeNull();
+			expect(updated?.active).toBe(false);
+
+			const outboxCount = await outboxRepository.count();
+			expect(outboxCount).toBe(0);
+		});
+
+		test('should check the trigger nodes of the version being published, not the current draft', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			const newVersionId = uuid();
+			await createWorkflowHistoryItem(workflow.id, {
+				versionId: newVersionId,
+				nodes: [
+					{
+						id: 'node-in-new-version',
+						name: 'Cron',
+						parameters: {},
+						position: [0, 0],
+						type: 'n8n-nodes-base.cron',
+						typeVersion: 1,
+					},
+				],
+			});
+			nodeTypes.getByNameAndVersion.mockReturnValue(triggerNodeType());
+
+			await workflowService.activateWorkflow(owner, workflow.id, { versionId: newVersionId });
+
+			expect(workflowValidationService.validateTriggerNodeIds).toHaveBeenCalledWith([
+				expect.objectContaining({ id: 'node-in-new-version' }),
+			]);
+		});
+
+		test('should skip disabled trigger nodes, which publication never records a row for', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			const newVersionId = uuid();
+			await createWorkflowHistoryItem(workflow.id, {
+				versionId: newVersionId,
+				nodes: [
+					{
+						id: 'shared-id',
+						name: 'Cron',
+						parameters: {},
+						position: [0, 0],
+						type: 'n8n-nodes-base.cron',
+						typeVersion: 1,
+					},
+					{
+						id: 'shared-id',
+						name: 'Disabled Cron',
+						parameters: {},
+						position: [0, 0],
+						type: 'n8n-nodes-base.cron',
+						typeVersion: 1,
+						disabled: true,
+					},
+				],
+			});
+			nodeTypes.getByNameAndVersion.mockReturnValue(triggerNodeType());
+
+			await workflowService.activateWorkflow(owner, workflow.id, { versionId: newVersionId });
+
+			expect(workflowValidationService.validateTriggerNodeIds).toHaveBeenCalledWith([
+				expect.objectContaining({ name: 'Cron' }),
+			]);
+		});
 	});
 
 	describe('when feature flag is disabled', () => {
+		test('should not run the trigger node id check', async () => {
+			const owner = await createOwner();
+			const workflow = await createWorkflowWithHistory({}, owner);
+
+			await workflowService.activateWorkflow(owner, workflow.id);
+
+			expect(workflowValidationService.validateTriggerNodeIds).not.toHaveBeenCalled();
+		});
+
 		test('should not enqueue an outbox record on activation', async () => {
 			const owner = await createOwner();
 			const workflow = await createWorkflowWithHistory({}, owner);


### PR DESCRIPTION
## Summary

Publication records one `workflow_publication_trigger_status` row per enabled
trigger node, keyed by the composite primary key `(workflowId, nodeId)`. Node ids
were never validated anywhere — `id` is optional in the workflow structure schema,
`addNodeIds` only fills blanks rather than de-duplicating, and there is no database
constraint.

So two enabled trigger nodes sharing an id collapse onto one key: `computeTriggerDiff`
loses one of them, and the row insert fails on the constraint inside the outbox
consumer, long after the request returned. A node with no id behaves identically —
`undefined` is an id every id-less node has in common.

This rejects both in `activateWorkflow`, alongside the existing publish validations,
with a message naming the offending nodes.

## Two things a reviewer will probably ask

**Why only trigger nodes, not every node?** The check is scoped to the enabled trigger
nodes of the version being published — exactly the set publication writes a row per. So
it rejects only publishes that already fail today, and replaces a constraint violation
with something the user can act on. Widening it to all nodes would start rejecting
publishes that currently succeed; worth doing, but as its own decision.

**Why did `getEnabledTriggerNodes` move out of `WorkflowTriggerActivator`?** The check
needs the same node classification the applier uses, but the activator asserts the
publication service is enabled in its constructor, so depending on it from
`WorkflowService` would break every instance with the flag off. The classification needs
nothing but `NodeTypes`, so it is now a free function both callers share — which also
keeps the check and publication from drifting on which nodes count.

Gated behind `N8N_USE_WORKFLOW_PUBLICATION_SERVICE`; instances on the legacy publication
path are unaffected.

## How to test

```sh
cd packages/cli
pnpm test src/workflows/__tests__/workflow-validation.service.test.ts
pnpm test:integration test/integration/workflows/workflow.service.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3907

Publish-time half only. #35129 covers the save-time half and stays open — it puts the
rule in the shared workflow structure validator, which is also where the scope question
above (all nodes vs. trigger nodes) gets settled. The two are independent; this one does
not depend on it landing.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


