### PR TITLE
feat(core): Stop persisting empty agents until they have configuration

### DIFF
--- a/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
+++ b/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
@@ -514,6 +514,16 @@ export const RunnableAgentJsonConfigSchema = AgentJsonConfigBaseSchema.extend({
 
 export type AgentJsonConfig = z.infer<typeof AgentJsonConfigSchema>;
 export type RunnableAgentJsonConfig = z.infer<typeof RunnableAgentJsonConfigSchema>;
+
+/**
+ * The config every agent starts from. Shared because the builder hashes this
+ * shape while the row does not exist yet and compares it against the row it
+ * later creates — a second copy drifting would reject the first `write_config`
+ * with a stale-hash error.
+ */
+export function blankAgentConfig(name: string): AgentJsonConfig {
+	return { name, model: '', instructions: '', tools: [], skills: [] };
+}
 export type AgentJsonToolConfig = z.infer<typeof AgentJsonToolConfigSchema>;
 export type AgentJsonWorkflowToolConfig = Extract<AgentJsonToolConfig, { type: 'workflow' }>;
 export type AgentJsonNodeToolConfig = Extract<AgentJsonToolConfig, { type: 'node' }>;

--- a/packages/@n8n/api-types/src/agents/dto.ts
+++ b/packages/@n8n/api-types/src/agents/dto.ts
@@ -81,6 +81,19 @@ export class UpdateAgentsMcpAvailabilityDto extends Z.class({
 
 export class CreateAgentDto extends Z.class({
 	name: z.string().min(1),
+	/**
+	 * Client-minted id for an agent drafted in the browser. Sending it keeps the
+	 * id stable from the moment the draft opens, so the thread binding, artifact
+	 * tab and any node reference taken before the first save stay valid.
+	 */
+	id: z.string().min(1).max(36).optional(),
+	/**
+	 * Initial config, so a draft's first content and its row land in one request
+	 * rather than leaving an empty agent behind if the follow-up write fails.
+	 * Left untyped like `UpdateAgentConfigDto` — `AgentConfigService.validateConfig`
+	 * owns validation for both paths.
+	 */
+	config: z.record(z.unknown()).optional(),
 }) {}
 
 export class UpdateAgentConfigDto extends Z.class({

--- a/packages/@n8n/api-types/src/agents/dto.ts
+++ b/packages/@n8n/api-types/src/agents/dto.ts
@@ -85,8 +85,13 @@ export class CreateAgentDto extends Z.class({
 	 * Client-minted id for an agent drafted in the browser. Sending it keeps the
 	 * id stable from the moment the draft opens, so the thread binding, artifact
 	 * tab and any node reference taken before the first save stay valid.
+	 * Becomes a primary key and is interpolated into `:`-delimited cache keys and
+	 * webhook URLs, so the charset is constrained deliberately.
 	 */
-	id: z.string().min(1).max(36).optional(),
+	id: z
+		.string()
+		.regex(/^[A-Za-z0-9_-]{1,36}$/, 'Agent id must be alphanumeric with - or _')
+		.optional(),
 	/**
 	 * Initial config, so a draft's first content and its row land in one request
 	 * rather than leaving an empty agent behind if the follow-up write fails.

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-handler.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/agent-handler.ts
@@ -8,6 +8,7 @@ import { sanitizeAgentJsonConfig } from '@n8n/api-types';
 
 import { renderAgentArtifact } from './render-agent';
 import type { AgentArtifact, ArtifactHandler } from './types';
+import { N8nApiError } from '../../clients/n8n-client';
 
 export const agentHandler: ArtifactHandler<AgentArtifact> = {
 	type: 'agent',
@@ -20,11 +21,22 @@ export const agentHandler: ArtifactHandler<AgentArtifact> = {
 	async fetch(ref, client) {
 		// Agent routes are project-scoped; the harness builds in the user's personal project.
 		const projectId = await client.getPersonalProjectId();
-		const [config, skills] = await Promise.all([
-			client.getAgentConfig(projectId, ref.id),
-			client.getAgentSkills(projectId, ref.id),
-		]);
-		return { config: sanitizeAgentJsonConfig(config), skills }; // sanitize at fetch -> no secrets retained
+		try {
+			const [config, skills] = await Promise.all([
+				client.getAgentConfig(projectId, ref.id),
+				client.getAgentSkills(projectId, ref.id),
+			]);
+			return { config: sanitizeAgentJsonConfig(config), skills }; // sanitize at fetch -> no secrets retained
+		} catch (error) {
+			// The ref comes from `agent-spawned`, published when the builder session
+			// is constructed — before it has written anything. An agent row only
+			// exists once the builder writes config, so a 404 here means the build
+			// produced no agent. That's a gradeable outcome, not a harness failure.
+			if (error instanceof N8nApiError && error.status === 404) {
+				return { config: null, skills: {}, notCreated: true };
+			}
+			throw error;
+		}
 	},
 	renderArtifact(artifact) {
 		return renderAgentArtifact(artifact);

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/render-agent.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/render-agent.ts
@@ -2,6 +2,14 @@ import type { AgentArtifact } from './types';
 
 /** Render the agent artifact: sanitized config + every authored skill's full content. */
 export function renderAgentArtifact(artifact: AgentArtifact): string {
+	if (artifact.notCreated) {
+		return [
+			'## Agent config',
+			'',
+			'(the builder started on this agent but never wrote any configuration, so no agent was created)',
+		].join('\n');
+	}
+
 	const lines: string[] = ['## Agent config', ''];
 	lines.push('```json', JSON.stringify(artifact.config, null, 2), '```', '');
 

--- a/packages/@n8n/instance-ai/evaluations/harness/artifacts/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/artifacts/types.ts
@@ -59,6 +59,11 @@ export interface ArtifactHandler<TArtifact = unknown> {
 export interface AgentArtifact {
 	config: unknown;
 	skills: Record<string, AgentSkill>;
+	/**
+	 * The builder announced this agent but never wrote any config, so no row was
+	 * ever created. Distinct from a fetch failure — this is what the build did.
+	 */
+	notCreated?: boolean;
 }
 
 /**

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.cascade-restart.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.cascade-restart.test.ts
@@ -276,6 +276,8 @@ function createBuilderDelegate(
 		listAgents: async () => await Promise.resolve([]),
 
 		resolveAgentName: async () => await Promise.resolve(undefined),
+
+		agentExists: async () => await Promise.resolve(false),
 	};
 }
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.cascade-restart.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.cascade-restart.test.ts
@@ -276,8 +276,6 @@ function createBuilderDelegate(
 		listAgents: async () => await Promise.resolve([]),
 
 		resolveAgentName: async () => await Promise.resolve(undefined),
-
-		agentExists: async () => await Promise.resolve(false),
 	};
 }
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
@@ -293,6 +293,8 @@ describe('build-agent tool', () => {
 			runId: 'run-1',
 			modelConfig: context.modelId,
 			abortSignal: context.abortSignal,
+			// The row is written by the builder's first config tool, not by the create.
+			pendingAgent: { name: 'Support Agent' },
 		});
 	});
 
@@ -623,6 +625,61 @@ describe('build-agent tool', () => {
 		});
 	});
 
+	describe('reserved draft from the New Agent page', () => {
+		function reservedTarget(): AgentBuilderTarget {
+			return {
+				agentId: 'reserved-1',
+				projectId: 'proj-1',
+				name: 'New Agent',
+				pending: true,
+			};
+		}
+
+		it('names the reserved draft instead of creating a second agent behind the open panel', async () => {
+			const { context, delegate } = makeContext();
+			context.domainContext!.agentBuilderTarget = reservedTarget();
+			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Built it.'));
+
+			await runTool(context, { message: 'Build an agent that does XY', name: 'XY Bot' });
+
+			expect(delegate.createAgent).not.toHaveBeenCalled();
+			expect(delegate.streamBuild).toHaveBeenCalledWith(
+				'reserved-1',
+				'Build an agent that does XY',
+				expect.objectContaining({ pendingAgent: { name: 'XY Bot' } }),
+			);
+			expect(saveAgentBuilderTarget).toHaveBeenCalledWith(
+				context.domainContext,
+				expect.objectContaining({ agentId: 'reserved-1', name: 'XY Bot', ref: 'xy-bot' }),
+			);
+		});
+
+		it('creates a second agent once the reservation has been spent', async () => {
+			const { context, delegate } = makeContext();
+			// No `pending`: the draft already materialized on an earlier turn.
+			context.domainContext!.agentBuilderTarget = {
+				agentId: 'reserved-1',
+				projectId: 'proj-1',
+				name: 'XY Bot',
+				ref: 'xy-bot',
+			};
+			vi.mocked(delegate.createAgent).mockResolvedValue({
+				agentId: 'agent-2',
+				projectId: 'proj-1',
+			});
+			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Built it.'));
+
+			await runTool(context, { message: 'Now build a second one', name: 'Other Bot' });
+
+			expect(delegate.createAgent).toHaveBeenCalledWith('Other Bot');
+			expect(delegate.streamBuild).toHaveBeenCalledWith(
+				'agent-2',
+				'Now build a second one',
+				expect.anything(),
+			);
+		});
+	});
+
 	describe('deferred agentId-path binding', () => {
 		it('does not persist the target when the agentId path fails before the stream settles', async () => {
 			const { context, delegate } = makeContext();
@@ -674,6 +731,8 @@ describe('build-agent tool', () => {
 				projectId: 'proj-1',
 				name: 'New Agent',
 				ref: 'new-agent',
+				// Still reserved: the turn never got far enough to write the row.
+				pending: true,
 			});
 		});
 
@@ -810,8 +869,8 @@ describe('build-agent tool', () => {
 			});
 		});
 
-		it('does not republish or re-save when the resolved name matches the current target name', async () => {
-			const { context, delegate, publishedEvents } = makeContext();
+		it('re-saves without the reservation once the agent exists, even when the name is unchanged', async () => {
+			const { context, delegate } = makeContext();
 			vi.mocked(delegate.createAgent).mockResolvedValue({
 				agentId: 'agent-1',
 				projectId: 'proj-1',
@@ -821,9 +880,14 @@ describe('build-agent tool', () => {
 
 			await runTool(context, { message: 'Build it', name: 'New Agent' });
 
-			expect(publishedEvents.filter((event) => event.type === 'agent-spawned')).toHaveLength(1);
-			// Only the create-path bind — no refresh save.
-			expect(saveAgentBuilderTarget).toHaveBeenCalledTimes(1);
+			// Two saves: the create-path bind, then the post-turn one that clears the
+			// reservation so the next create makes a second agent instead of
+			// adopting this one.
+			expect(saveAgentBuilderTarget).toHaveBeenCalledTimes(2);
+			expect(saveAgentBuilderTarget).toHaveBeenLastCalledWith(
+				context.domainContext,
+				expect.not.objectContaining({ pending: true }),
+			);
 		});
 
 		it('keeps a successful turn intact and logs a warning when the post-turn refresh fails', async () => {
@@ -899,6 +963,7 @@ describe('build-agent tool', () => {
 				projectId: 'proj-1',
 				name: 'Support Triage',
 				ref: 'support-triage',
+				pending: true,
 			});
 			expect(result).toMatchObject({
 				ok: true,
@@ -1018,6 +1083,7 @@ describe('build-agent tool', () => {
 				projectId: 'proj-1',
 				name: 'Second',
 				ref: 'second',
+				pending: true,
 			});
 		});
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
@@ -638,7 +638,8 @@ describe('build-agent tool', () => {
 		it('names the reserved draft instead of creating a second agent behind the open panel', async () => {
 			const { context, delegate } = makeContext();
 			context.domainContext!.agentBuilderTarget = reservedTarget();
-			vi.mocked(delegate.agentExists).mockResolvedValue(false);
+			// No name resolves for the reserved id: its row does not exist yet.
+			vi.mocked(delegate.resolveAgentName).mockResolvedValue(undefined);
 			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Built it.'));
 
 			await runTool(context, { message: 'Build an agent that does XY', name: 'XY Bot' });
@@ -658,7 +659,8 @@ describe('build-agent tool', () => {
 		it('does not adopt a reservation whose agent already exists', async () => {
 			const { context, delegate } = makeContext();
 			context.domainContext!.agentBuilderTarget = reservedTarget();
-			vi.mocked(delegate.agentExists).mockResolvedValue(true);
+			// A name resolves for the reserved id, so its row already exists.
+			vi.mocked(delegate.resolveAgentName).mockResolvedValue('Reserved Agent');
 			vi.mocked(delegate.createAgent).mockResolvedValue({
 				agentId: 'agent-2',
 				projectId: 'proj-1',

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
@@ -638,6 +638,7 @@ describe('build-agent tool', () => {
 		it('names the reserved draft instead of creating a second agent behind the open panel', async () => {
 			const { context, delegate } = makeContext();
 			context.domainContext!.agentBuilderTarget = reservedTarget();
+			vi.mocked(delegate.agentExists).mockResolvedValue(false);
 			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Built it.'));
 
 			await runTool(context, { message: 'Build an agent that does XY', name: 'XY Bot' });
@@ -651,6 +652,26 @@ describe('build-agent tool', () => {
 			expect(saveAgentBuilderTarget).toHaveBeenCalledWith(
 				context.domainContext,
 				expect.objectContaining({ agentId: 'reserved-1', name: 'XY Bot', ref: 'xy-bot' }),
+			);
+		});
+
+		it('does not adopt a reservation whose agent already exists', async () => {
+			const { context, delegate } = makeContext();
+			context.domainContext!.agentBuilderTarget = reservedTarget();
+			vi.mocked(delegate.agentExists).mockResolvedValue(true);
+			vi.mocked(delegate.createAgent).mockResolvedValue({
+				agentId: 'agent-2',
+				projectId: 'proj-1',
+			});
+			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Built it.'));
+
+			await runTool(context, { message: 'Build a different agent', name: 'Other Bot' });
+
+			expect(delegate.createAgent).toHaveBeenCalledWith('Other Bot');
+			expect(delegate.streamBuild).toHaveBeenCalledWith(
+				'agent-2',
+				'Build a different agent',
+				expect.anything(),
 			);
 		});
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/agent-target-binding.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/agent-target-binding.ts
@@ -29,6 +29,15 @@ const agentBuilderTargetSchema = z.object({
 	 * bindings persisted before this field existed carry none.
 	 */
 	ref: z.string().optional(),
+	/**
+	 * This conversation minted the id, so the row may not exist yet — the
+	 * builder's first config-mutating tool creates it. Stays set after the agent
+	 * materializes: the create is guarded by an existence check, so a later turn
+	 * costs nothing, and a target the user deleted mid-conversation is rebuilt
+	 * rather than hard-failing. Never set for an adopted `agentId`, where a
+	 * missing agent must still be an error.
+	 */
+	pending: z.boolean().optional(),
 });
 
 export type AgentBuilderTarget = z.infer<typeof agentBuilderTargetSchema>;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -817,9 +817,14 @@ async function resolveTargetForCall(
 			// "New Agent" reserves an id and opens the artifact panel on it before
 			// the user has said what to build. The first create in that conversation
 			// is that agent being named, not a second one — minting a fresh id here
-			// would build into an agent the user cannot see. The reservation is
-			// cleared once the row exists, so a later create still makes a new agent.
-			const reserved = boundTarget?.pending === true ? boundTarget : undefined;
+			// would build into an agent the user cannot see. The `pending` flag alone
+			// is not trusted: clearing it is best-effort (skipped on turn failure /
+			// cancel, and never runs when the config panel created the row), so also
+			// require the row to still be absent before adopting the reservation.
+			const reserved =
+				boundTarget?.pending === true && !(await delegate.agentExists(boundTarget.agentId))
+					? boundTarget
+					: undefined;
 			const created = reserved ?? (await delegate.createAgent(input.name));
 			const target: AgentBuilderTarget = {
 				agentId: created.agentId,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -130,7 +130,11 @@ function buildOutboundMessage(message: string, workflowContext?: SessionWorkflow
 
 /** Builder sessions are keyed per assistant thread + target agent; the resume
  *  leg must reconstruct the same `threadId` byte-identically after a restart. */
-function builderSessionFor(context: OrchestrationContext, agentId: string) {
+function builderSessionFor(
+	context: OrchestrationContext,
+	agentId: string,
+	target?: AgentBuilderTarget,
+) {
 	const telemetry = context.tracing?.getTelemetry?.({
 		agentRole: BUILDER_SUB_AGENT_ROLE,
 		functionId: 'instance-ai.subagent.agent-builder',
@@ -147,6 +151,7 @@ function builderSessionFor(context: OrchestrationContext, agentId: string) {
 			? { memoryTaskObserver: context.tracing.onMemoryTaskEvent }
 			: {}),
 		abortSignal: context.abortSignal,
+		...(target?.pending ? { pendingAgent: { name: target.name ?? 'New Agent' } } : {}),
 	};
 }
 
@@ -484,7 +489,12 @@ async function runBuilderConsumeLoop(params: {
 	// should not wait on display-name I/O.
 	try {
 		const freshName = await delegate.resolveAgentName(target.agentId);
-		if (freshName && freshName !== target.name) {
+		// A name resolves only once the row exists, which is also the moment the
+		// reservation is spent: from here a fresh `name` must create a second
+		// agent rather than adopt this one.
+		const materialized = Boolean(freshName) && target.pending === true;
+		if (materialized) delete target.pending;
+		if (freshName && (freshName !== target.name || materialized)) {
 			target.name = freshName;
 			publishAgentSpawned(context, builderAgentId, target);
 			if (context.domainContext) {
@@ -618,7 +628,7 @@ async function handleResume(
 		};
 	}
 
-	const session = builderSessionFor(context, target.agentId);
+	const session = builderSessionFor(context, target.agentId, target);
 
 	const openSuspensions = await delegate.findOpenSuspensions(target.agentId, session);
 	if (openSuspensions.length === 0) {
@@ -804,12 +814,19 @@ async function resolveTargetForCall(
 		}
 
 		if (input.name) {
-			const created = await delegate.createAgent(input.name);
+			// "New Agent" reserves an id and opens the artifact panel on it before
+			// the user has said what to build. The first create in that conversation
+			// is that agent being named, not a second one — minting a fresh id here
+			// would build into an agent the user cannot see. The reservation is
+			// cleared once the row exists, so a later create still makes a new agent.
+			const reserved = boundTarget?.pending === true ? boundTarget : undefined;
+			const created = reserved ?? (await delegate.createAgent(input.name));
 			const target: AgentBuilderTarget = {
 				agentId: created.agentId,
 				projectId: created.projectId,
 				name: input.name,
 				ref: key,
+				pending: true,
 			};
 			domainContext.agentBuilderTarget = target;
 			await saveAgentBuilderTarget(domainContext, target);
@@ -915,7 +932,7 @@ export function createBuildAgentTool(context: OrchestrationContext) {
 			const boundTarget = resolution.target;
 			const bindAfterTurn = resolution.bindAfterTurn;
 
-			const session = builderSessionFor(context, boundTarget.agentId);
+			const session = builderSessionFor(context, boundTarget.agentId, boundTarget);
 			const outboundMessage = buildOutboundMessage(input.message, input.workflowContext);
 			const builderAgentId = builderAgentIdFor(boundTarget.agentId);
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -822,7 +822,8 @@ async function resolveTargetForCall(
 			// cancel, and never runs when the config panel created the row), so also
 			// require the row to still be absent before adopting the reservation.
 			const reserved =
-				boundTarget?.pending === true && !(await delegate.agentExists(boundTarget.agentId))
+				boundTarget?.pending === true &&
+				(await delegate.resolveAgentName(boundTarget.agentId)) === undefined
 					? boundTarget
 					: undefined;
 			const created = reserved ?? (await delegate.createAgent(input.name));

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -962,6 +962,11 @@ export interface InstanceAiBuilderDelegate {
 	>;
 	/** Current display name of the agent, or undefined when not found. */
 	resolveAgentName(agentId: string): Promise<string | undefined>;
+	/** Whether the agent row exists. Used to tell a still-unspent id reservation
+	 *  apart from one whose agent has since been created. Rejects (rather than
+	 *  answering false) when the lookup itself fails, so a transient error cannot
+	 *  be mistaken for "does not exist". */
+	agentExists(agentId: string): Promise<boolean>;
 }
 
 // ── Local gateway status ─────────────────────────────────────────────────────

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -960,13 +960,14 @@ export interface InstanceAiBuilderDelegate {
 	listAgents(): Promise<
 		Array<{ agentId: string; name: string; published: boolean; updatedAt: string }>
 	>;
-	/** Current display name of the agent, or undefined when not found. */
+	/**
+	 * Current display name of the agent, or undefined when not found. Doubles as
+	 * the existence check that tells a still-unspent id reservation apart from one
+	 * whose agent has since been created. Rejects (rather than answering
+	 * undefined) when the lookup itself fails, so a transient error cannot be
+	 * mistaken for "does not exist".
+	 */
 	resolveAgentName(agentId: string): Promise<string | undefined>;
-	/** Whether the agent row exists. Used to tell a still-unspent id reservation
-	 *  apart from one whose agent has since been created. Rejects (rather than
-	 *  answering false) when the lookup itself fails, so a transient error cannot
-	 *  be mistaken for "does not exist". */
-	agentExists(agentId: string): Promise<boolean>;
 }
 
 // ── Local gateway status ─────────────────────────────────────────────────────

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -908,6 +908,14 @@ export interface BuilderDelegateSession {
 	memoryTaskObserver?: (event: ScopedMemoryTaskEvent) => void;
 	/** Host run's abort signal, so a user stop ends the builder's own loop rather than only our consumption of it. */
 	abortSignal: AbortSignal;
+	/**
+	 * The target agent id was minted for this conversation and has no row yet —
+	 * the builder's first config-mutating tool creates it under this name, so a
+	 * turn that only converses leaves no empty agent behind. Set only for targets
+	 * this conversation created; an adopted `agentId` must still fail when it does
+	 * not exist.
+	 */
+	pendingAgent?: { name: string };
 }
 
 /** A builder turn stream: consumable by normalizeStreamSource, plus final text. */

--- a/packages/@n8n/telemetry/src/events/agents.ts
+++ b/packages/@n8n/telemetry/src/events/agents.ts
@@ -334,10 +334,11 @@ export const AGENTS_TELEMETRY = defineTelemetryEvents({
 	USER_CREATED_AGENT: {
 		name: 'User created agent',
 		description:
-			'A draft agent was created, from the blank new-agent page or inline from a workflow surface (source carries the entry point).',
+			'An agent row was created. Rows are only written once real configuration exists — clicking a new-agent entry point and walking away creates nothing — so this counts agents people actually built, not entry-point clicks. Emitted from the backend, covering the editor, the Instance AI builder, and MCP alike. Use "User clicked new agent" for entry-point questions.',
 		properties: z.object({
 			agent_id: z.string(),
-			source: z.string(),
+			project_id: z.string(),
+			user_id: z.string().optional(),
 		}),
 	},
 	USER_SUBMITTED_MESSAGE_TO_AGENT: {

--- a/packages/@n8n/telemetry/src/events/agents.ts
+++ b/packages/@n8n/telemetry/src/events/agents.ts
@@ -181,7 +181,7 @@ export const AGENTS_TELEMETRY = defineTelemetryEvents({
 	BUILDER_CREATED_AGENT: {
 		name: 'Builder created agent',
 		description:
-			'The Instance AI builder created an agent through its delegate. Only fires inside a thread context; the frontend "User created agent" twin covers the UI create paths.',
+			'The Instance AI builder\'s first config-mutating tool created the agent row. Only fires in a thread context. Strict subset of "User created agent" — both fire from the same materialization path, so the two must not be summed.',
 		properties: z.object({
 			agent_id: z.string(),
 			project_id: z.string(),

--- a/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
@@ -312,6 +312,7 @@ describe('AgentRuntimeReconstructionService integration tools', () => {
 			mock<SubAgentCleanupService>(),
 			mock<EventService>(),
 			agentExecutionService,
+			telemetry,
 		);
 		service = agentExecutionOrchestratorService;
 		markSharedTestSetupAsUsed(

--- a/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
@@ -18,6 +18,7 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { CredentialTypes } from '@/credential-types';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
 import type { McpRegistryService } from '@/modules/mcp-registry/registry/mcp-registry.service';
 import type { NodeTypes } from '@/node-types';
 import type { AiGatewayService } from '@/services/ai-gateway.service';
@@ -347,6 +348,31 @@ describe('AgentsBuilderToolsService', () => {
 				);
 
 				expect(agentsService.create).not.toHaveBeenCalled();
+			});
+
+			it('write_config proceeds when create races with the config panel', async () => {
+				const { service, agentsService } = makeService();
+				vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
+				agentsService.findById.mockResolvedValue(null);
+				agentsService.create.mockRejectedValue(
+					new ConflictError(`Agent with id ${agentId} exists already.`),
+				);
+				agentsService.updateConfig.mockResolvedValue({
+					config: { ...templateConfig, instructions: 'Triage inbound tickets.' },
+					updatedAt: '2026-01-01T00:00:00.000Z',
+					versionId: 'v2',
+				});
+
+				const result = await getPendingJsonTool(service, BUILDER_TOOLS.WRITE_CONFIG).handler!(
+					{
+						baseConfigHash: getAgentConfigHash(templateConfig),
+						json: JSON.stringify({ ...templateConfig, instructions: 'Triage inbound tickets.' }),
+					},
+					ctx,
+				);
+
+				expect(result).toMatchObject({ ok: true });
+				expect(agentsService.updateConfig).toHaveBeenCalled();
 			});
 		});
 

--- a/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
@@ -50,14 +50,14 @@ const ctx = {
 	parentTelemetry: undefined,
 };
 
-type BuilderPurposeServices = Pick<AgentsService, 'findById' | 'findByProjectId'> &
+type BuilderPurposeServices = Pick<AgentsService, 'findById' | 'findByProjectId' | 'create'> &
 	Pick<AgentConfigService, 'updateConfig'> &
 	Pick<AgentCustomToolsService, 'buildCustomTool'> &
 	Pick<AgentIntegrationPersistenceService, 'listChatIntegrations'> &
 	Pick<AgentSkillsService, 'createSkills'>;
 
 function makeService() {
-	const agentsService = mock<Pick<AgentsService, 'findById' | 'findByProjectId'>>();
+	const agentsService = mock<Pick<AgentsService, 'findById' | 'findByProjectId' | 'create'>>();
 	const agentConfigService = mock<Pick<AgentConfigService, 'updateConfig'>>();
 	const agentCustomToolsService = mock<Pick<AgentCustomToolsService, 'buildCustomTool'>>();
 	const agentIntegrationPersistenceService =
@@ -66,6 +66,7 @@ function makeService() {
 	const purposeServices = {
 		findById: agentsService.findById,
 		findByProjectId: agentsService.findByProjectId,
+		create: agentsService.create,
 		updateConfig: agentConfigService.updateConfig,
 		buildCustomTool: agentCustomToolsService.buildCustomTool,
 		listChatIntegrations: agentIntegrationPersistenceService.listChatIntegrations,
@@ -249,6 +250,105 @@ describe('AgentsBuilderToolsService', () => {
 				.getTools(agentId, projectId, credentialProvider, user)
 				.json.find((tool) => tool.name === name)!;
 		}
+
+		function getPendingJsonTool(
+			service: AgentsBuilderToolsService,
+			name: string,
+			pendingName = 'Triage Bot',
+		) {
+			return service
+				.getTools(agentId, projectId, credentialProvider, user, undefined, { name: pendingName })
+				.json.find((tool) => tool.name === name)!;
+		}
+
+		describe('pending target', () => {
+			const templateConfig: AgentJsonConfig = {
+				name: 'Triage Bot',
+				model: '',
+				instructions: '',
+				tools: [],
+				skills: [],
+			};
+
+			it('read_config returns the template for an agent that has no row yet', async () => {
+				const { service, agentsService } = makeService();
+				agentsService.findById.mockResolvedValue(null);
+
+				const result = (await getPendingJsonTool(service, BUILDER_TOOLS.READ_CONFIG).handler!(
+					{},
+					ctx,
+				)) as { ok: boolean; config: AgentJsonConfig };
+
+				expect(result.ok).toBe(true);
+				expect(result.config).toEqual(templateConfig);
+			});
+
+			it('write_config creates the agent under the minted id before persisting its config', async () => {
+				const { service, agentsService } = makeService();
+				vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
+				agentsService.findById.mockResolvedValue(null);
+				agentsService.updateConfig.mockResolvedValue({
+					config: { ...templateConfig, instructions: 'Triage inbound tickets.' },
+					updatedAt: '2026-01-01T00:00:00.000Z',
+					versionId: 'v2',
+				});
+
+				const result = await getPendingJsonTool(service, BUILDER_TOOLS.WRITE_CONFIG).handler!(
+					{
+						baseConfigHash: getAgentConfigHash(templateConfig),
+						json: JSON.stringify({ ...templateConfig, instructions: 'Triage inbound tickets.' }),
+					},
+					ctx,
+				);
+
+				expect(result).toMatchObject({ ok: true });
+				expect(agentsService.create).toHaveBeenCalledWith(projectId, 'Triage Bot', {
+					id: agentId,
+					user,
+				});
+				expect(agentsService.create.mock.invocationCallOrder[0]).toBeLessThan(
+					agentsService.updateConfig.mock.invocationCallOrder[0],
+				);
+			});
+
+			it('refuses to materialize a draft for a user without agent:create', async () => {
+				const { service, agentsService } = makeService();
+				vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(false);
+				agentsService.findById.mockResolvedValue(null);
+
+				const result = await getPendingJsonTool(service, BUILDER_TOOLS.WRITE_CONFIG).handler!(
+					{
+						baseConfigHash: getAgentConfigHash(templateConfig),
+						json: JSON.stringify({ ...templateConfig, instructions: 'Triage inbound tickets.' }),
+					},
+					ctx,
+				);
+
+				expect(result).toMatchObject({ ok: false });
+				expect(agentsService.create).not.toHaveBeenCalled();
+			});
+
+			it('does not create a second agent once the row exists', async () => {
+				const { service, agentsService } = makeService();
+				vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
+				agentsService.findById.mockResolvedValue(makeAgent(templateConfig));
+				agentsService.updateConfig.mockResolvedValue({
+					config: { ...templateConfig, instructions: 'Triage inbound tickets.' },
+					updatedAt: '2026-01-01T00:00:00.000Z',
+					versionId: 'v2',
+				});
+
+				await getPendingJsonTool(service, BUILDER_TOOLS.WRITE_CONFIG).handler!(
+					{
+						baseConfigHash: getAgentConfigHash(templateConfig),
+						json: JSON.stringify({ ...templateConfig, instructions: 'Triage inbound tickets.' }),
+					},
+					ctx,
+				);
+
+				expect(agentsService.create).not.toHaveBeenCalled();
+			});
+		});
 
 		it('registers MCP-specific tools in the builder toolset', () => {
 			const { service } = makeService();

--- a/packages/cli/src/modules/agents/__tests__/agents-builder.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-builder.service.test.ts
@@ -8,7 +8,10 @@ import type { NodeCatalogService } from '@/node-catalog';
 import type { InstanceAiCreditService } from '../../instance-ai/instance-ai-credit.service';
 import type { AgentsService } from '../agents.service';
 import type { AgentsBuilderToolsService } from '../builder/agents-builder-tools.service';
-import { AgentsBuilderService } from '../builder/agents-builder.service';
+import {
+	AgentsBuilderService,
+	type InstanceAiBuilderSessionOptions,
+} from '../builder/agents-builder.service';
 import type { AgentCheckpoint } from '../entities/agent-checkpoint.entity';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
 import type { N8nMemory } from '../integrations/n8n-memory';
@@ -36,10 +39,13 @@ function checkpointRow(
 	} as AgentCheckpoint;
 }
 
-function makeService(agentCheckpointRepository: Mocked<AgentCheckpointRepository>) {
+function makeService(
+	agentCheckpointRepository: Mocked<AgentCheckpointRepository>,
+	agentsService: Mocked<AgentsService> = mock<AgentsService>(),
+) {
 	return new AgentsBuilderService(
 		mock<Logger>(),
-		mock<AgentsService>(),
+		agentsService,
 		mock<NodeCatalogService>(),
 		mock<AgentsBuilderToolsService>(),
 		mock<N8nMemory>(),
@@ -47,6 +53,23 @@ function makeService(agentCheckpointRepository: Mocked<AgentCheckpointRepository
 		mock<N8NCheckpointStorage>(),
 		agentCheckpointRepository,
 	);
+}
+
+function buildSession(overrides: Partial<InstanceAiBuilderSessionOptions> = {}) {
+	return {
+		threadId: 'ia-builder:thread-1:agent-1',
+		hostThreadId: 'thread-1',
+		runId: 'run-1',
+		modelConfig: 'anthropic/claude-sonnet-4-5',
+		abortSignal: new AbortController().signal,
+		...overrides,
+	} as InstanceAiBuilderSessionOptions;
+}
+
+async function drain(stream: AsyncGenerator<unknown>): Promise<void> {
+	for await (const _chunk of stream) {
+		// consume
+	}
 }
 
 describe('AgentsBuilderService checkpoint lookup', () => {
@@ -91,5 +114,38 @@ describe('AgentsBuilderService checkpoint lookup', () => {
 		});
 
 		expect(result?.persistence?.threadId).toBe('thread-target');
+	});
+});
+
+describe('AgentsBuilderService pending targets', () => {
+	it('refuses to build against an agent that does not exist', async () => {
+		const agentsService = mock<AgentsService>();
+		agentsService.findById.mockResolvedValue(null);
+		const service = makeService(mock<AgentCheckpointRepository>(), agentsService);
+
+		await expect(
+			drain(service.buildAgent('agent-1', 'project-1', 'hi', mock(), mock(), buildSession())),
+		).rejects.toThrow('Agent "agent-1" not found');
+	});
+
+	it('builds against a pending target, so the row is only written by the first config tool', async () => {
+		const agentsService = mock<AgentsService>();
+		agentsService.findById.mockResolvedValue(null);
+		const service = makeService(mock<AgentCheckpointRepository>(), agentsService);
+
+		// Fails later, at model resolution — the point is that the missing-agent
+		// guard no longer rejects the turn before any tool can run.
+		await expect(
+			drain(
+				service.buildAgent(
+					'agent-1',
+					'project-1',
+					'build me a triage bot',
+					mock(),
+					mock(),
+					buildSession({ pendingAgent: { name: 'Triage Bot' } }),
+				),
+			),
+		).rejects.not.toThrow('Agent "agent-1" not found');
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
@@ -26,7 +26,7 @@ function makeController({
 	agentPublishService = mock<AgentPublishService>(),
 	agentValidationService = mock<AgentValidationService>(),
 	credentialsService = mock<CredentialsService>(),
-	agentConfigService = mock<Pick<AgentConfigService, 'updateConfig'>>(),
+	agentConfigService = mock<Pick<AgentConfigService, 'updateConfig' | 'validateConfig'>>(),
 }: {
 	agentsService?: Mocked<
 		Pick<
@@ -37,7 +37,7 @@ function makeController({
 	agentPublishService?: Mocked<AgentPublishService>;
 	agentValidationService?: Mocked<AgentValidationService>;
 	credentialsService?: Mocked<CredentialsService>;
-	agentConfigService?: Mocked<Pick<AgentConfigService, 'updateConfig'>>;
+	agentConfigService?: Mocked<Pick<AgentConfigService, 'updateConfig' | 'validateConfig'>>;
 } = {}) {
 	const agentRunnableStateService = new AgentRunnableStateService(
 		credentialsService,
@@ -164,6 +164,10 @@ describe('AgentsController create', () => {
 			agentPublishService,
 		} = makeController();
 		stubRunnableState(agentValidationService, agentPublishService);
+		agentConfigService.validateConfig.mockResolvedValue({
+			valid: true,
+			config: { instructions: 'Triage inbound tickets.', name: 'Triage Bot' },
+		} as never);
 		agentsService.create.mockResolvedValue({ id: 'minted-id', projectId: 'project-1' } as never);
 		agentsService.findById.mockResolvedValue({
 			id: 'minted-id',
@@ -180,6 +184,10 @@ describe('AgentsController create', () => {
 			} as never,
 		);
 
+		expect(agentConfigService.validateConfig).toHaveBeenCalledWith({
+			instructions: 'Triage inbound tickets.',
+			name: 'Triage Bot',
+		});
 		expect(agentConfigService.updateConfig).toHaveBeenCalledWith(
 			'minted-id',
 			'project-1',
@@ -188,8 +196,35 @@ describe('AgentsController create', () => {
 		);
 	});
 
+	it('rejects an invalid initial config without creating the agent', async () => {
+		const { controller, agentsService, agentConfigService } = makeController();
+		agentConfigService.validateConfig.mockResolvedValue({
+			valid: false,
+			error: 'model is required',
+		});
+
+		await expect(
+			controller.create(
+				req,
+				undefined as never,
+				{
+					name: 'Triage Bot',
+					id: 'minted-id',
+					config: { model: 'nope' },
+				} as never,
+			),
+		).rejects.toThrow('Invalid initial Agent config: model is required');
+
+		expect(agentsService.create).not.toHaveBeenCalled();
+		expect(agentConfigService.updateConfig).not.toHaveBeenCalled();
+	});
+
 	it('removes the agent again when its initial config is rejected', async () => {
 		const { controller, agentsService, agentConfigService } = makeController();
+		agentConfigService.validateConfig.mockResolvedValue({
+			valid: true,
+			config: { model: 'nope', name: 'Triage Bot' },
+		} as never);
 		agentsService.create.mockResolvedValue({ id: 'minted-id', projectId: 'project-1' } as never);
 		agentConfigService.updateConfig.mockRejectedValue(new Error('Invalid agent config'));
 

--- a/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
@@ -5,6 +5,7 @@ import { mock } from 'vitest-mock-extended';
 import type { CredentialsService } from '@/credentials/credentials.service';
 
 import { AgentsCredentialProvider } from '../adapters/agents-credential-provider';
+import type { AgentConfigService } from '../agent-config.service';
 import type { AgentPublishService } from '../agent-publish.service';
 import { AgentRunnableStateService } from '../agent-runnable-state.service';
 import type { AgentsService } from '../agents.service';
@@ -25,6 +26,7 @@ function makeController({
 	agentPublishService = mock<AgentPublishService>(),
 	agentValidationService = mock<AgentValidationService>(),
 	credentialsService = mock<CredentialsService>(),
+	agentConfigService = mock<Pick<AgentConfigService, 'updateConfig'>>(),
 }: {
 	agentsService?: Mocked<
 		Pick<
@@ -35,6 +37,7 @@ function makeController({
 	agentPublishService?: Mocked<AgentPublishService>;
 	agentValidationService?: Mocked<AgentValidationService>;
 	credentialsService?: Mocked<CredentialsService>;
+	agentConfigService?: Mocked<Pick<AgentConfigService, 'updateConfig'>>;
 } = {}) {
 	const agentRunnableStateService = new AgentRunnableStateService(
 		credentialsService,
@@ -46,10 +49,12 @@ function makeController({
 		controller: new AgentsController(
 			agentsService as unknown as AgentsService,
 			agentRunnableStateService,
+			agentConfigService as unknown as AgentConfigService,
 		),
 		agentsService,
 		agentPublishService,
 		agentValidationService,
+		agentConfigService,
 	};
 }
 
@@ -110,6 +115,97 @@ describe('AgentsController list', () => {
 		expect(agentsService.findByProjectIdPaginated).toHaveBeenCalledWith('project-1', query);
 		expect(agentsService.findByProjectId).not.toHaveBeenCalled();
 		expect(res.json).toHaveBeenCalledWith(response);
+	});
+});
+
+describe('AgentsController create', () => {
+	const user = { id: 'user-1' };
+	const req = { params: { projectId: 'project-1' }, user } as never;
+
+	function stubRunnableState(
+		agentValidationService: Mocked<AgentValidationService>,
+		agentPublishService: Mocked<AgentPublishService>,
+	) {
+		agentValidationService.validateLoadedAgentConfiguration.mockResolvedValue({
+			status: 'invalid',
+			issues: [],
+		});
+		agentPublishService.hasPublishHistory.mockResolvedValue(false);
+	}
+
+	it('forwards the client-minted id and acting user to the service', async () => {
+		const { controller, agentsService, agentValidationService, agentPublishService } =
+			makeController();
+		stubRunnableState(agentValidationService, agentPublishService);
+		agentsService.create.mockResolvedValue({ id: 'minted-id', projectId: 'project-1' } as never);
+		agentsService.findById.mockResolvedValue(null);
+
+		await controller.create(
+			req,
+			undefined as never,
+			{
+				name: 'Triage Bot',
+				id: 'minted-id',
+			} as never,
+		);
+
+		expect(agentsService.create).toHaveBeenCalledWith('project-1', 'Triage Bot', {
+			id: 'minted-id',
+			user,
+		});
+	});
+
+	it('applies an initial config so the row and its first content land together', async () => {
+		const {
+			controller,
+			agentsService,
+			agentConfigService,
+			agentValidationService,
+			agentPublishService,
+		} = makeController();
+		stubRunnableState(agentValidationService, agentPublishService);
+		agentsService.create.mockResolvedValue({ id: 'minted-id', projectId: 'project-1' } as never);
+		agentsService.findById.mockResolvedValue({
+			id: 'minted-id',
+			projectId: 'project-1',
+		} as never);
+
+		await controller.create(
+			req,
+			undefined as never,
+			{
+				name: 'Triage Bot',
+				id: 'minted-id',
+				config: { instructions: 'Triage inbound tickets.' },
+			} as never,
+		);
+
+		expect(agentConfigService.updateConfig).toHaveBeenCalledWith(
+			'minted-id',
+			'project-1',
+			{ instructions: 'Triage inbound tickets.', name: 'Triage Bot' },
+			user,
+		);
+	});
+
+	it('removes the agent again when its initial config is rejected', async () => {
+		const { controller, agentsService, agentConfigService } = makeController();
+		agentsService.create.mockResolvedValue({ id: 'minted-id', projectId: 'project-1' } as never);
+		agentConfigService.updateConfig.mockRejectedValue(new Error('Invalid agent config'));
+
+		await expect(
+			controller.create(
+				req,
+				undefined as never,
+				{
+					name: 'Triage Bot',
+					id: 'minted-id',
+					config: { model: 'nope' },
+				} as never,
+			),
+		).rejects.toThrow('Invalid agent config');
+
+		expect(agentsService.delete).toHaveBeenCalledWith('minted-id', 'project-1');
 	});
 });
 

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -3,6 +3,7 @@
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { ProjectRelationRepository, User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { mock } from 'vitest-mock-extended';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -21,6 +22,7 @@ import type { AgentTaskRepository } from '../repositories/agent-task.repository'
 import type { AgentRepository } from '../repositories/agent.repository';
 import type { SubAgentCleanupService } from '../sub-agents/sub-agent-cleanup.service';
 import type { EventService } from '@/events/event.service';
+import type { Telemetry } from '@/telemetry';
 
 const agentId = 'agent-1';
 const projectId = 'project-1';
@@ -63,6 +65,8 @@ function makeService() {
 	Container.set(AgentTaskService, agentTaskService);
 	Container.set(ChatIntegrationService, chatIntegrationService);
 
+	const telemetry = mock<Telemetry>();
+
 	const service = new AgentsService(
 		mockLogger(),
 		agentRepository,
@@ -75,10 +79,12 @@ function makeService() {
 		subAgentCleanupService,
 		eventService,
 		agentExecutionService,
+		telemetry,
 	);
 
 	return {
 		service,
+		telemetry,
 		agentRepository,
 		projectRelationRepository,
 		agentKnowledgeService,
@@ -123,6 +129,47 @@ describe('AgentsService', () => {
 			},
 			versionId: expect.any(String),
 			availableInMCP: false,
+		});
+	});
+
+	it('persists under a client-minted id so references taken before the first save stay valid', async () => {
+		const { service, agentRepository } = makeService();
+		const saved = makeAgent({ id: 'minted-id' });
+
+		agentRepository.existsBy.mockResolvedValue(false);
+		agentRepository.create.mockReturnValue(saved);
+		agentRepository.save.mockResolvedValue(saved);
+
+		await service.create(projectId, 'Support Agent', { id: 'minted-id' });
+
+		expect(agentRepository.create).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'minted-id' }),
+		);
+	});
+
+	it('rejects a minted id that is already taken instead of overwriting the agent', async () => {
+		const { service, agentRepository } = makeService();
+		agentRepository.existsBy.mockResolvedValue(true);
+
+		await expect(service.create(projectId, 'Support Agent', { id: 'taken' })).rejects.toThrow(
+			'Agent with id taken exists already.',
+		);
+		expect(agentRepository.save).not.toHaveBeenCalled();
+	});
+
+	it('reports agent creation with the project and acting user', async () => {
+		const { service, agentRepository, telemetry } = makeService();
+		const saved = makeAgent();
+
+		agentRepository.create.mockReturnValue(saved);
+		agentRepository.save.mockResolvedValue(saved);
+
+		await service.create(projectId, 'Support Agent', { user: mock<User>({ id: 'user-1' }) });
+
+		expect(telemetry.track).toHaveBeenCalledWith(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
+			agent_id: agentId,
+			project_id: projectId,
+			user_id: 'user-1',
 		});
 	});
 

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -6,7 +6,9 @@ import { Container } from '@n8n/di';
 import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { mock } from 'vitest-mock-extended';
 
+import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { QueryFailedError } from '@n8n/typeorm';
 
 import type { AgentChatAttachmentService } from '../agent-chat-attachment.service';
 import type { AgentKnowledgeService } from '../agent-knowledge.service';
@@ -58,6 +60,7 @@ function makeService() {
 	const agentExecutionService = mock<AgentExecutionService>();
 
 	agentRepository.save.mockImplementation(async (agent) => agent as Agent);
+	agentRepository.insert.mockResolvedValue({ identifiers: [], generatedMaps: [], raw: [] });
 	agentTaskService.requestReconcile.mockResolvedValue();
 	chatIntegrationService.disconnectChannel.mockResolvedValue();
 	testChatService.clearAllTestChatMessages.mockResolvedValue();
@@ -114,9 +117,9 @@ describe('AgentsService', () => {
 		const saved = makeAgent();
 
 		agentRepository.create.mockReturnValue(saved);
-		agentRepository.save.mockResolvedValue(saved);
 
 		await expect(service.create(projectId, 'Support Agent')).resolves.toBe(saved);
+		expect(agentRepository.insert).toHaveBeenCalledWith(saved);
 		expect(agentRepository.create).toHaveBeenCalledWith({
 			name: 'Support Agent',
 			projectId,
@@ -138,23 +141,36 @@ describe('AgentsService', () => {
 
 		agentRepository.existsBy.mockResolvedValue(false);
 		agentRepository.create.mockReturnValue(saved);
-		agentRepository.save.mockResolvedValue(saved);
 
 		await service.create(projectId, 'Support Agent', { id: 'minted-id' });
 
 		expect(agentRepository.create).toHaveBeenCalledWith(
 			expect.objectContaining({ id: 'minted-id' }),
 		);
+		expect(agentRepository.insert).toHaveBeenCalledWith(saved);
 	});
 
 	it('rejects a minted id that is already taken instead of overwriting the agent', async () => {
 		const { service, agentRepository } = makeService();
 		agentRepository.existsBy.mockResolvedValue(true);
 
-		await expect(service.create(projectId, 'Support Agent', { id: 'taken' })).rejects.toThrow(
-			'Agent with id taken exists already.',
-		);
-		expect(agentRepository.save).not.toHaveBeenCalled();
+		await expect(
+			service.create(projectId, 'Support Agent', { id: 'taken' }),
+		).rejects.toBeInstanceOf(ConflictError);
+		expect(agentRepository.insert).not.toHaveBeenCalled();
+	});
+
+	it('maps a lost insert race on a minted id to ConflictError instead of a 500', async () => {
+		const { service, agentRepository } = makeService();
+		const saved = makeAgent({ id: 'minted-id' });
+		agentRepository.existsBy.mockResolvedValue(false);
+		agentRepository.create.mockReturnValue(saved);
+		const driverError = Object.assign(new Error('duplicate'), { code: '23505' });
+		agentRepository.insert.mockRejectedValue(new QueryFailedError('insert', [], driverError));
+
+		await expect(
+			service.create(projectId, 'Support Agent', { id: 'minted-id' }),
+		).rejects.toBeInstanceOf(ConflictError);
 	});
 
 	it('reports agent creation with the project and acting user', async () => {
@@ -162,10 +178,10 @@ describe('AgentsService', () => {
 		const saved = makeAgent();
 
 		agentRepository.create.mockReturnValue(saved);
-		agentRepository.save.mockResolvedValue(saved);
 
 		await service.create(projectId, 'Support Agent', { user: mock<User>({ id: 'user-1' }) });
 
+		expect(agentRepository.insert).toHaveBeenCalledWith(saved);
 		expect(telemetry.track).toHaveBeenCalledWith(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
 			agent_id: agentId,
 			project_id: projectId,

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -139,7 +139,6 @@ describe('AgentsService', () => {
 		const { service, agentRepository } = makeService();
 		const saved = makeAgent({ id: 'minted-id' });
 
-		agentRepository.existsBy.mockResolvedValue(false);
 		agentRepository.create.mockReturnValue(saved);
 
 		await service.create(projectId, 'Support Agent', { id: 'minted-id' });
@@ -152,18 +151,7 @@ describe('AgentsService', () => {
 
 	it('rejects a minted id that is already taken instead of overwriting the agent', async () => {
 		const { service, agentRepository } = makeService();
-		agentRepository.existsBy.mockResolvedValue(true);
-
-		await expect(
-			service.create(projectId, 'Support Agent', { id: 'taken' }),
-		).rejects.toBeInstanceOf(ConflictError);
-		expect(agentRepository.insert).not.toHaveBeenCalled();
-	});
-
-	it('maps a lost insert race on a minted id to ConflictError instead of a 500', async () => {
-		const { service, agentRepository } = makeService();
 		const saved = makeAgent({ id: 'minted-id' });
-		agentRepository.existsBy.mockResolvedValue(false);
 		agentRepository.create.mockReturnValue(saved);
 		const driverError = Object.assign(new Error('duplicate'), { code: '23505' });
 		agentRepository.insert.mockRejectedValue(new QueryFailedError('insert', [], driverError));

--- a/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
@@ -354,15 +354,17 @@ describe('InstanceAiBuilderDelegateAdapterService', () => {
 	});
 
 	describe('createAgent', () => {
-		it('enforces agent:create scope and delegates to AgentsService', async () => {
+		it('mints an id without writing a row, so an abandoned build leaves no empty agent', async () => {
 			const { delegate, agentsService } = setup();
 			vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
-			agentsService.create.mockResolvedValue(mock<Agent>({ id: 'agent-9', name: 'New agent' }));
 
 			const result = await delegate.createAgent('New agent');
 
-			expect(agentsService.create).toHaveBeenCalledWith('project-1', 'New agent');
-			expect(result).toEqual({ agentId: 'agent-9', projectId: 'project-1' });
+			expect(agentsService.create).not.toHaveBeenCalled();
+			expect(result).toEqual({
+				agentId: expect.stringMatching(/^[\w-]{16}$/),
+				projectId: 'project-1',
+			});
 		});
 
 		it('rejects when the user lacks agent:create scope', async () => {

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -14,6 +14,7 @@ import type { Response } from 'express';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
+import { AgentConfigService } from './agent-config.service';
 import { AgentRunnableStateService } from './agent-runnable-state.service';
 import { AgentsService } from './agents.service';
 
@@ -22,6 +23,7 @@ export class AgentsController {
 	constructor(
 		private readonly agentsService: AgentsService,
 		private readonly agentRunnableStateService: AgentRunnableStateService,
+		private readonly agentConfigService: AgentConfigService,
 	) {}
 
 	@Post('/')
@@ -33,8 +35,30 @@ export class AgentsController {
 	) {
 		const { projectId } = req.params;
 
-		const agent = await this.agentsService.create(projectId, payload.name);
-		return await this.agentRunnableStateService.addRunnableState(agent, projectId, req.user);
+		const agent = await this.agentsService.create(projectId, payload.name, {
+			id: payload.id,
+			user: req.user,
+		});
+
+		if (payload.config) {
+			// A draft's first content arrives with the row. If applying it fails the
+			// agent is removed again, so a rejected config can't leave an empty agent
+			// behind — the same rollback the MCP create path uses.
+			try {
+				await this.agentConfigService.updateConfig(
+					agent.id,
+					projectId,
+					{ ...payload.config, name: payload.name },
+					req.user,
+				);
+			} catch (error) {
+				await this.agentsService.delete(agent.id, projectId);
+				throw error;
+			}
+		}
+
+		const created = (await this.agentsService.findById(agent.id, projectId)) ?? agent;
+		return await this.agentRunnableStateService.addRunnableState(created, projectId, req.user);
 	}
 
 	@Get('/')

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@n8n/decorators';
 import type { Response } from 'express';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentConfigService } from './agent-config.service';
@@ -35,24 +36,32 @@ export class AgentsController {
 	) {
 		const { projectId } = req.params;
 
+		// Validate before create so a rejected config cannot emit USER_CREATED_AGENT
+		// for a row that is then rolled back. Mirrors the MCP create path.
+		const initialConfig = payload.config ? { ...payload.config, name: payload.name } : undefined;
+		if (initialConfig) {
+			const validation = await this.agentConfigService.validateConfig(initialConfig);
+			if (!validation.valid) {
+				throw new BadRequestError(`Invalid initial Agent config: ${validation.error}`);
+			}
+		}
+
 		const agent = await this.agentsService.create(projectId, payload.name, {
 			id: payload.id,
 			user: req.user,
 		});
 
-		if (payload.config) {
-			// A draft's first content arrives with the row. If applying it fails the
-			// agent is removed again, so a rejected config can't leave an empty agent
-			// behind — the same rollback the MCP create path uses.
+		if (initialConfig) {
+			// Backstop for failures validation cannot catch — remove the row so a
+			// rejected config can't leave an empty agent behind.
 			try {
-				await this.agentConfigService.updateConfig(
-					agent.id,
-					projectId,
-					{ ...payload.config, name: payload.name },
-					req.user,
-				);
+				await this.agentConfigService.updateConfig(agent.id, projectId, initialConfig, req.user);
 			} catch (error) {
-				await this.agentsService.delete(agent.id, projectId);
+				try {
+					await this.agentsService.delete(agent.id, projectId);
+				} catch {
+					// Cleanup failed; still surface the original config error.
+				}
 				throw error;
 			}
 		}

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -9,8 +9,10 @@ import { Logger } from '@n8n/backend-common';
 import { In, ProjectRelationRepository, type User } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { v4 as uuid } from 'uuid';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentChatAttachmentService } from './agent-chat-attachment.service';
@@ -28,6 +30,7 @@ import {
 } from './repositories/agent.repository';
 import { SubAgentCleanupService } from './sub-agents/sub-agent-cleanup.service';
 import { EventService } from '@/events/event.service';
+import { Telemetry } from '@/telemetry';
 
 @Service()
 export class AgentsService {
@@ -43,13 +46,28 @@ export class AgentsService {
 		private readonly subAgentCleanupService: SubAgentCleanupService,
 		private readonly eventService: EventService,
 		private readonly agentExecutionService: AgentExecutionService,
+		private readonly telemetry: Telemetry,
 	) {}
 
+	/**
+	 * `id` lets a caller supply an id it minted earlier — a browser draft, or a
+	 * builder target bound to a thread before any config existed. The entity's
+	 * `@BeforeInsert` only generates one when it is absent, so the supplied id
+	 * becomes the primary key.
+	 */
 	async create(
 		projectId: string,
 		name: string,
-		{ availableInMCP = false }: { availableInMCP?: boolean } = {},
+		{
+			availableInMCP = false,
+			id,
+			user,
+		}: { availableInMCP?: boolean; id?: string; user?: User } = {},
 	): Promise<Agent> {
+		if (id && (await this.agentRepository.existsBy({ id }))) {
+			throw new BadRequestError(`Agent with id ${id} exists already.`);
+		}
+
 		const defaultConfig: AgentJsonConfig = {
 			name,
 			model: '',
@@ -59,6 +77,7 @@ export class AgentsService {
 		};
 
 		const agent = this.agentRepository.create({
+			...(id ? { id } : {}),
 			name,
 			projectId,
 			schema: defaultConfig,
@@ -69,6 +88,16 @@ export class AgentsService {
 		const saved = await this.agentRepository.save(agent);
 
 		this.logger.debug('Created SDK agent', { agentId: saved.id, projectId });
+
+		// Emitted here rather than at the entry points so every origin — editor,
+		// Instance AI builder, MCP — is counted once, and only when a row actually
+		// exists. Drafts that are abandoned before their first write never reach
+		// this line, which is the point of the event.
+		this.telemetry.track(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
+			agent_id: saved.id,
+			project_id: projectId,
+			...(user ? { user_id: user.id } : {}),
+		});
 
 		return saved;
 	}

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -1,18 +1,19 @@
 import { splitModelId } from '@n8n/ai-utilities/agent-config';
 import {
+	blankAgentConfig,
 	type AgentCapabilitySummary,
 	type AgentCapabilityTool,
-	type AgentJsonConfig,
 	type ListAgentsQueryDto,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import { In, ProjectRelationRepository, type User } from '@n8n/db';
+import { In, isUniqueConstraintError, ProjectRelationRepository, type User } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
 import { TELEMETRY_EVENT } from '@n8n/telemetry';
+import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import { v4 as uuid } from 'uuid';
 
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentChatAttachmentService } from './agent-chat-attachment.service';
@@ -65,41 +66,43 @@ export class AgentsService {
 		}: { availableInMCP?: boolean; id?: string; user?: User } = {},
 	): Promise<Agent> {
 		if (id && (await this.agentRepository.existsBy({ id }))) {
-			throw new BadRequestError(`Agent with id ${id} exists already.`);
+			throw new ConflictError(`Agent with id ${id} exists already.`);
 		}
-
-		const defaultConfig: AgentJsonConfig = {
-			name,
-			model: '',
-			instructions: '',
-			tools: [],
-			skills: [],
-		};
 
 		const agent = this.agentRepository.create({
 			...(id ? { id } : {}),
 			name,
 			projectId,
-			schema: defaultConfig,
+			schema: blankAgentConfig(name),
 			versionId: uuid(),
 			availableInMCP,
 		});
 
-		const saved = await this.agentRepository.save(agent);
+		try {
+			await this.agentRepository.insert(agent as QueryDeepPartialEntity<Agent>);
+		} catch (error) {
+			// The pre-check above and this insert are not atomic, and two writers
+			// sharing one minted id is the normal case here — not a rare race. Both
+			// callers branch on 409, so a lost race must not surface as a 500.
+			if (isUniqueConstraintError(error)) {
+				throw new ConflictError(`Agent with id ${agent.id} exists already.`);
+			}
+			throw error;
+		}
 
-		this.logger.debug('Created SDK agent', { agentId: saved.id, projectId });
+		this.logger.debug('Created SDK agent', { agentId: agent.id, projectId });
 
 		// Emitted here rather than at the entry points so every origin — editor,
 		// Instance AI builder, MCP — is counted once, and only when a row actually
 		// exists. Drafts that are abandoned before their first write never reach
 		// this line, which is the point of the event.
 		this.telemetry.track(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
-			agent_id: saved.id,
+			agent_id: agent.id,
 			project_id: projectId,
 			...(user ? { user_id: user.id } : {}),
 		});
 
-		return saved;
+		return agent;
 	}
 
 	async findByProjectId(projectId: string): Promise<Agent[]> {

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -65,10 +65,6 @@ export class AgentsService {
 			user,
 		}: { availableInMCP?: boolean; id?: string; user?: User } = {},
 	): Promise<Agent> {
-		if (id && (await this.agentRepository.existsBy({ id }))) {
-			throw new ConflictError(`Agent with id ${id} exists already.`);
-		}
-
 		const agent = this.agentRepository.create({
 			...(id ? { id } : {}),
 			name,
@@ -81,9 +77,11 @@ export class AgentsService {
 		try {
 			await this.agentRepository.insert(agent as QueryDeepPartialEntity<Agent>);
 		} catch (error) {
-			// The pre-check above and this insert are not atomic, and two writers
-			// sharing one minted id is the normal case here — not a rare race. Both
-			// callers branch on 409, so a lost race must not surface as a 500.
+			// Two writers sharing one minted id is the normal case here, not a rare
+			// race: the config panel and the builder both hold it. `insert` rather
+			// than `save` so the loser hits the unique constraint instead of
+			// overwriting the winner, and both callers branch on 409, so it must not
+			// surface as a 500.
 			if (isUniqueConstraintError(error)) {
 				throw new ConflictError(`Agent with id ${agent.id} exists already.`);
 			}

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -27,7 +27,9 @@ import { OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { SsrfProtectionConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import type { Operation } from 'fast-json-patch';
+import { UserError } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { CredentialTypes } from '@/credential-types';
@@ -119,6 +121,14 @@ interface AgentConfigSnapshotWithStatus extends AgentConfigSnapshot {
 interface BuilderTelemetryContext {
 	threadId?: string;
 	runId?: string;
+}
+
+/**
+ * A build target whose id exists but whose row does not — the agent is created
+ * by the first config-mutating tool. Absent for targets that already exist.
+ */
+export interface PendingBuilderAgent {
+	name: string;
 }
 
 function snapshotFromConfig(config: AgentJsonConfig | null): AgentConfigSnapshot {
@@ -250,10 +260,25 @@ export class AgentsBuilderToolsService {
 		credentialProvider: CredentialProvider,
 		user: User,
 		telemetryContext?: BuilderTelemetryContext,
+		pendingAgent?: PendingBuilderAgent,
 	): BuilderTools {
 		return {
-			json: this.getJsonTools(agentId, projectId, credentialProvider, user, telemetryContext),
-			shared: this.getSharedTools(agentId, projectId, credentialProvider, user, telemetryContext),
+			json: this.getJsonTools(
+				agentId,
+				projectId,
+				credentialProvider,
+				user,
+				telemetryContext,
+				pendingAgent,
+			),
+			shared: this.getSharedTools(
+				agentId,
+				projectId,
+				credentialProvider,
+				user,
+				telemetryContext,
+				pendingAgent,
+			),
 		};
 	}
 
@@ -263,6 +288,7 @@ export class AgentsBuilderToolsService {
 		credentialProvider: CredentialProvider,
 		user: User,
 		telemetryContext?: BuilderTelemetryContext,
+		pendingAgent?: PendingBuilderAgent,
 	): BuiltTool[] {
 		const track: BuilderTrackFn = (entry, properties) =>
 			this.telemetry.track(entry, {
@@ -283,7 +309,11 @@ export class AgentsBuilderToolsService {
 			.handler(async () => {
 				try {
 					// `status` is telemetry plumbing — keep it out of the LLM-facing result.
-					const { status: _status, ...snapshot } = await this.getConfigSnapshot(agentId, projectId);
+					const { status: _status, ...snapshot } = await this.getConfigSnapshot(
+						agentId,
+						projectId,
+						pendingAgent,
+					);
 					return { ok: true, ...snapshot };
 				} catch (e) {
 					return {
@@ -323,7 +353,7 @@ export class AgentsBuilderToolsService {
 					}
 					let snapshot: AgentConfigSnapshotWithStatus;
 					try {
-						snapshot = await this.getConfigSnapshot(agentId, projectId);
+						snapshot = await this.getConfigSnapshot(agentId, projectId, pendingAgent);
 					} catch (e) {
 						return {
 							ok: false,
@@ -365,6 +395,13 @@ export class AgentsBuilderToolsService {
 						applyNativeWebSearchDefaultOn(zodResult.data),
 					);
 					try {
+						await this.materializeIfPending(
+							agentId,
+							projectId,
+							pendingAgent,
+							user,
+							telemetryContext,
+						);
 						const { config: persistedConfig } = await this.agentConfigService.updateConfig(
 							agentId,
 							projectId,
@@ -428,7 +465,7 @@ export class AgentsBuilderToolsService {
 
 					let snapshot: AgentConfigSnapshotWithStatus;
 					try {
-						snapshot = await this.getConfigSnapshot(agentId, projectId);
+						snapshot = await this.getConfigSnapshot(agentId, projectId, pendingAgent);
 					} catch (e) {
 						return {
 							ok: false,
@@ -492,6 +529,13 @@ export class AgentsBuilderToolsService {
 					);
 
 					try {
+						await this.materializeIfPending(
+							agentId,
+							projectId,
+							pendingAgent,
+							user,
+							telemetryContext,
+						);
 						const { config: persistedConfig } = await this.agentConfigService.updateConfig(
 							agentId,
 							projectId,
@@ -769,6 +813,7 @@ export class AgentsBuilderToolsService {
 		credentialProvider: CredentialProvider,
 		user: User,
 		telemetryContext?: BuilderTelemetryContext,
+		pendingAgent?: PendingBuilderAgent,
 	): BuiltTool[] {
 		const buildCustomToolTool = new Tool(BUILDER_TOOLS.BUILD_CUSTOM_TOOL)
 			.description(
@@ -791,6 +836,7 @@ export class AgentsBuilderToolsService {
 			.handler(async ({ code }: { code: string }, ctx) => {
 				try {
 					const descriptor = await this.secureRuntime.describeToolSecurely(code);
+					await this.materializeIfPending(agentId, projectId, pendingAgent, user, telemetryContext);
 					const built = await this.agentCustomToolsService.buildCustomTool(
 						agentId,
 						projectId,
@@ -850,6 +896,7 @@ export class AgentsBuilderToolsService {
 				// Each skill is already validated against `.input()` (agentSkillSchema
 				// shapes) by the tool runtime before the handler runs.
 				try {
+					await this.materializeIfPending(agentId, projectId, pendingAgent, user, telemetryContext);
 					const created = await this.agentSkillsService.createSkills(agentId, projectId, skills);
 					return {
 						ok: true,
@@ -918,13 +965,20 @@ export class AgentsBuilderToolsService {
 					// a failed read must not block the mutation.
 					let oldSnapshot: AgentConfigSnapshotWithStatus | null = null;
 					try {
-						oldSnapshot = await this.getConfigSnapshot(agentId, projectId);
+						oldSnapshot = await this.getConfigSnapshot(agentId, projectId, pendingAgent);
 					} catch {
 						// Skip diff telemetry; the mutation below must still run.
 					}
 
 					let created: Awaited<ReturnType<AgentTaskService['createTasks']>>;
 					try {
+						await this.materializeIfPending(
+							agentId,
+							projectId,
+							pendingAgent,
+							user,
+							telemetryContext,
+						);
 						// Adds a `{ type:'task', id, enabled }` ref per task to the agent config
 						// and creates every body in one transaction. Enabled by default; each
 						// task starts running once the agent is (re)published via publish_agent.
@@ -1006,12 +1060,65 @@ export class AgentsBuilderToolsService {
 		];
 	}
 
+	/**
+	 * Create the row for a pending target on its first mutation. Until then the
+	 * builder works against a minted id with nothing on disk, so a turn that only
+	 * converses — or fails before writing anything — leaves no empty agent behind.
+	 *
+	 * Re-checks existence rather than trusting `pendingAgent`, since the config
+	 * panel sharing this id may have created the row first.
+	 *
+	 * This is the only place a builder run inserts an agent — the id may have
+	 * been reserved by the UI rather than handed out by the delegate — so
+	 * `agent:create` is enforced here rather than at whoever minted the id.
+	 */
+	private async materializeIfPending(
+		agentId: string,
+		projectId: string,
+		pendingAgent: PendingBuilderAgent | undefined,
+		user: User,
+		telemetryContext?: BuilderTelemetryContext,
+	): Promise<void> {
+		if (!pendingAgent) return;
+		if (await this.agentsService.findById(agentId, projectId)) return;
+
+		if (!(await userHasScopes(user, ['agent:create'], false, { projectId }))) {
+			throw new UserError('You do not have permission to create agents in this project.');
+		}
+
+		await this.agentsService.create(projectId, pendingAgent.name, { id: agentId, user });
+
+		if (telemetryContext?.threadId) {
+			this.telemetry.track(TELEMETRY_EVENT.AGENTS.BUILDER_CREATED_AGENT, {
+				thread_id: telemetryContext.threadId,
+				agent_id: agentId,
+				project_id: projectId,
+			});
+		}
+	}
+
 	private async getConfigSnapshot(
 		agentId: string,
 		projectId: string,
+		pendingAgent?: PendingBuilderAgent,
 	): Promise<AgentConfigSnapshotWithStatus> {
 		const agent = await this.agentsService.findById(agentId, projectId);
-		if (!agent) throw new Error('Agent not found');
+		if (!agent) {
+			// A pending target has no row yet, but its config is known: the template
+			// every agent starts from. Returning it keeps `read_config` and the
+			// baseConfigHash handshake working on the first build turn.
+			if (pendingAgent) {
+				const template: AgentJsonConfig = {
+					name: pendingAgent.name,
+					model: '',
+					instructions: '',
+					tools: [],
+					skills: [],
+				};
+				return { ...snapshotFromConfig(template), status: 'draft' };
+			}
+			throw new Error('Agent not found');
+		}
 
 		const config = composeJsonConfig(agent);
 		const status: 'draft' | 'production' =

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -12,6 +12,7 @@ import {
 import {
 	agentSkillSchema,
 	agentTaskSchema,
+	blankAgentConfig,
 	formatZodErrors,
 	PROVIDER_CAPABILITIES,
 	resolvePromptCaching,
@@ -33,6 +34,7 @@ import { UserError } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { CredentialTypes } from '@/credential-types';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { McpRegistryService } from '@/modules/mcp-registry/registry/mcp-registry.service';
 import { NodeTypes } from '@/node-types';
 import { OauthService } from '@/oauth/oauth.service';
@@ -402,6 +404,16 @@ export class AgentsBuilderToolsService {
 							user,
 							telemetryContext,
 						);
+					} catch (e) {
+						return {
+							ok: false,
+							// Only the agent:create scope check is a permission problem; anything
+							// else is a real failure the model may legitimately retry.
+							stage: e instanceof UserError ? 'forbidden' : 'schema',
+							errors: [{ path: '(root)', message: e instanceof Error ? e.message : String(e) }],
+						};
+					}
+					try {
 						const { config: persistedConfig } = await this.agentConfigService.updateConfig(
 							agentId,
 							projectId,
@@ -436,7 +448,7 @@ export class AgentsBuilderToolsService {
 					'Returns { ok: true, configMutated: true, agentId } on success — no config, hash, or timestamps are returned; call ' +
 					'read_config again before any later inspection or mutation — or ' +
 					'{ ok: false, stage, errors } on failure. ' +
-					'stage is "parse", "stale", "patch", or "schema". On stage: "stale", call read_config and retry ' +
+					'stage is "parse", "stale", "patch", "schema", or "forbidden". On stage: "stale", call read_config and retry ' +
 					'once using its fresh config and configHash.',
 			)
 			.input(
@@ -536,6 +548,16 @@ export class AgentsBuilderToolsService {
 							user,
 							telemetryContext,
 						);
+					} catch (e) {
+						return {
+							ok: false,
+							// Only the agent:create scope check is a permission problem; anything
+							// else is a real failure the model may legitimately retry.
+							stage: e instanceof UserError ? 'forbidden' : 'schema',
+							errors: [{ path: '(root)', message: e instanceof Error ? e.message : String(e) }],
+						};
+					}
+					try {
 						const { config: persistedConfig } = await this.agentConfigService.updateConfig(
 							agentId,
 							projectId,
@@ -1086,7 +1108,15 @@ export class AgentsBuilderToolsService {
 			throw new UserError('You do not have permission to create agents in this project.');
 		}
 
-		await this.agentsService.create(projectId, pendingAgent.name, { id: agentId, user });
+		try {
+			await this.agentsService.create(projectId, pendingAgent.name, { id: agentId, user });
+		} catch (error) {
+			// Someone else — in practice the config panel sharing this minted id —
+			// created the row first. The postcondition is satisfied either way, so the
+			// caller's write proceeds instead of failing.
+			if (error instanceof ConflictError) return;
+			throw error;
+		}
 
 		if (telemetryContext?.threadId) {
 			this.telemetry.track(TELEMETRY_EVENT.AGENTS.BUILDER_CREATED_AGENT, {
@@ -1108,14 +1138,7 @@ export class AgentsBuilderToolsService {
 			// every agent starts from. Returning it keeps `read_config` and the
 			// baseConfigHash handshake working on the first build turn.
 			if (pendingAgent) {
-				const template: AgentJsonConfig = {
-					name: pendingAgent.name,
-					model: '',
-					instructions: '',
-					tools: [],
-					skills: [],
-				};
-				return { ...snapshotFromConfig(template), status: 'draft' };
+				return { ...snapshotFromConfig(blankAgentConfig(pendingAgent.name)), status: 'draft' };
 			}
 			throw new Error('Agent not found');
 		}

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -75,6 +75,13 @@ export interface InstanceAiBuilderSessionOptions {
 	memoryTaskObserver?: (event: ScopedMemoryTaskEvent) => void;
 	/** Host run's abort signal, so a user stop ends the builder's own loop rather than only the host's consumption of it. */
 	abortSignal: AbortSignal;
+	/**
+	 * The target agent was minted for this conversation and has no row yet — the
+	 * first config-mutating tool creates it under this name. Set only for targets
+	 * the orchestrator created itself; an adopted `agentId` must keep 404-ing, or
+	 * a hallucinated id would silently conjure an agent.
+	 */
+	pendingAgent?: { name: string };
 }
 
 @Service()
@@ -206,8 +213,11 @@ export class AgentsBuilderService {
 		user: User,
 		session: InstanceAiBuilderSessionOptions,
 	): Promise<RuntimeAgent> {
+		// Nothing below reads the entity — the prompt, tools, memory and checkpoint
+		// storage all key off the id string. This is purely a guard, so a pending
+		// target (id minted, row not written until the first config write) passes.
 		const agent = await this.agentsService.findById(agentId, projectId);
-		if (!agent) {
+		if (!agent && !session.pendingAgent) {
 			throw new NotFoundError(`Agent "${agentId}" not found`);
 		}
 
@@ -240,6 +250,7 @@ export class AgentsBuilderService {
 			credentialProvider,
 			user,
 			{ threadId: session.hostThreadId, runId: session.runId },
+			session.pendingAgent,
 		);
 
 		const { Agent, Memory, createPlannerTodosTool } = await import('@n8n/agents');

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -26,7 +26,10 @@ import { AgentsService } from '../agents.service';
 import { buildAgentPreviewPath } from './agent-builder-preview-path';
 import { getModelRecommendationsSection } from './agents-builder-model-recommendations';
 import { buildBuilderPrompt } from './agents-builder-prompts';
-import { AgentsBuilderToolsService } from './agents-builder-tools.service';
+import {
+	AgentsBuilderToolsService,
+	type PendingBuilderAgent,
+} from './agents-builder-tools.service';
 import { BuilderCheckpointUnavailableError } from './errors';
 import {
 	BUILDER_PLANNER_TODOS_DESCRIPTION,
@@ -81,7 +84,7 @@ export interface InstanceAiBuilderSessionOptions {
 	 * the orchestrator created itself; an adopted `agentId` must keep 404-ing, or
 	 * a hallucinated id would silently conjure an agent.
 	 */
-	pendingAgent?: { name: string };
+	pendingAgent?: PendingBuilderAgent;
 }
 
 @Service()

--- a/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
+++ b/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
@@ -183,11 +183,6 @@ export class InstanceAiBuilderDelegateAdapterService {
 				await assertProjectScope('agent:read');
 				return (await this.agentsService.findById(agentId, projectId))?.name;
 			},
-
-			agentExists: async (agentId) => {
-				await assertProjectScope('agent:read');
-				return (await this.agentsService.findById(agentId, projectId)) !== null;
-			},
 		};
 	}
 

--- a/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
+++ b/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
@@ -183,6 +183,11 @@ export class InstanceAiBuilderDelegateAdapterService {
 				await assertProjectScope('agent:read');
 				return (await this.agentsService.findById(agentId, projectId))?.name;
 			},
+
+			agentExists: async (agentId) => {
+				await assertProjectScope('agent:read');
+				return (await this.agentsService.findById(agentId, projectId)) !== null;
+			},
 		};
 	}
 

--- a/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
+++ b/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
@@ -9,6 +9,7 @@ import type {
 } from '@n8n/instance-ai';
 import { type Scope } from '@n8n/permissions';
 import { Like } from '@n8n/typeorm';
+import { generateNanoId } from '@n8n/utils/generate-nano-id';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { userHasScopes } from '@/permissions.ee/check-access';
@@ -91,6 +92,7 @@ export class InstanceAiBuilderDelegateAdapterService {
 			...(session.telemetry ? { telemetry: session.telemetry } : {}),
 			...(session.memoryTaskObserver ? { memoryTaskObserver: session.memoryTaskObserver } : {}),
 			abortSignal: session.abortSignal,
+			...(session.pendingAgent ? { pendingAgent: session.pendingAgent } : {}),
 		};
 	}
 
@@ -110,10 +112,13 @@ export class InstanceAiBuilderDelegateAdapterService {
 		};
 
 		return {
-			createAgent: async (name) => {
+			// Mints the id without writing a row. The agent is created by the
+			// builder's first config-mutating tool, so a build that only converses,
+			// errors, or is abandoned leaves nothing behind. The scope check still
+			// runs here so a user without `agent:create` cannot start the flow.
+			createAgent: async (_name) => {
 				await assertProjectScope('agent:create');
-				const agent = await this.agentsService.create(projectId, name);
-				return { agentId: agent.id, projectId };
+				return { agentId: generateNanoId(), projectId };
 			},
 
 			streamBuild: async (agentId, message, session) => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1236,11 +1236,8 @@ import type { License } from '@/license';
 import type { RoleService } from '@/services/role.service';
 
 import type { OutboundHttp } from '@n8n/backend-network';
-import { ModuleRegistry } from '@n8n/backend-common';
-import type { InstanceAiBuilderDelegate } from '@n8n/instance-ai';
 
 import { InstanceAiAdapterService } from '../instance-ai.adapter.service';
-import { InstanceAiBuilderDelegateAdapterService } from '@/modules/agents/instance-ai-builder-delegate.adapter';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
 const mockedUserHasScopes = vi.mocked(userHasScopes);
@@ -3918,82 +3915,6 @@ describe('resolveMetricProviders', () => {
 				llmJudgeProviderRegistry: undefined,
 			}),
 		).rejects.toThrow(UnexpectedError);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// createContext — builder delegate telemetry ("Builder created agent")
-// ---------------------------------------------------------------------------
-
-describe('createContext — builder delegate telemetry', () => {
-	const mockUser = { id: 'user-1', role: { slug: 'global:member' } } as unknown as User;
-
-	afterEach(() => {
-		// Container.get is globally spied below (multiple tokens routed through
-		// one mockImplementation) — restore it so later tests keep the real,
-		// module-inactive-by-default ModuleRegistry.
-		vi.restoreAllMocks();
-	});
-
-	/** Route Container.get for the two tokens createContext resolves when wiring the builder delegate. */
-	function mockBuilderModuleActive(delegate: InstanceAiBuilderDelegate) {
-		const moduleRegistry = { isActive: vi.fn().mockReturnValue(true) };
-		const builderDelegateAdapter = { createDelegate: vi.fn().mockReturnValue(delegate) };
-		vi.spyOn(Container, 'get').mockImplementation((token: unknown) => {
-			if (token === ModuleRegistry) return moduleRegistry;
-			if (token === InstanceAiBuilderDelegateAdapterService) return builderDelegateAdapter;
-			throw new Error(`Unexpected Container.get call in test: ${String(token)}`);
-		});
-	}
-
-	it('tracks "Builder created agent" after a successful delegate createAgent, in a thread context', async () => {
-		const mockTelemetry = { track: vi.fn() };
-		const service = createAdapterWithGatewayMock(vi.fn(), { telemetry: mockTelemetry });
-		const delegate = mock<InstanceAiBuilderDelegate>();
-		delegate.createAgent.mockResolvedValue({ agentId: 'agent-9', projectId: 'proj-1' });
-		mockBuilderModuleActive(delegate);
-
-		const context = service.createContext(mockUser, { threadId: 'thread-1', projectId: 'proj-1' });
-		const created = await context.builderDelegate?.createAgent('New agent');
-
-		expect(created).toEqual({ agentId: 'agent-9', projectId: 'proj-1' });
-		expect(mockTelemetry.track).toHaveBeenCalledWith(TELEMETRY_EVENT.AGENTS.BUILDER_CREATED_AGENT, {
-			thread_id: 'thread-1',
-			agent_id: 'agent-9',
-			project_id: 'proj-1',
-		});
-	});
-
-	it('does not track when the context has no threadId', async () => {
-		const mockTelemetry = { track: vi.fn() };
-		const service = createAdapterWithGatewayMock(vi.fn(), { telemetry: mockTelemetry });
-		const delegate = mock<InstanceAiBuilderDelegate>();
-		delegate.createAgent.mockResolvedValue({ agentId: 'agent-9', projectId: 'proj-1' });
-		mockBuilderModuleActive(delegate);
-
-		const context = service.createContext(mockUser, { projectId: 'proj-1' });
-		await context.builderDelegate?.createAgent('New agent');
-
-		expect(mockTelemetry.track).not.toHaveBeenCalledWith(
-			TELEMETRY_EVENT.AGENTS.BUILDER_CREATED_AGENT,
-			expect.anything(),
-		);
-	});
-
-	it('passes listAgents through to the underlying delegate unchanged', async () => {
-		const service = createAdapterWithGatewayMock(vi.fn(), { telemetry: { track: vi.fn() } });
-		const delegate = mock<InstanceAiBuilderDelegate>();
-		const agents = [
-			{ agentId: 'agent-1', name: 'Agent', published: true, updatedAt: '2026-07-14T00:00:00.000Z' },
-		];
-		delegate.listAgents.mockResolvedValue(agents);
-		mockBuilderModuleActive(delegate);
-
-		const context = service.createContext(mockUser, { threadId: 'thread-1', projectId: 'proj-1' });
-		const result = await context.builderDelegate?.listAgents();
-
-		expect(result).toEqual(agents);
-		expect(delegate.listAgents).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -37,7 +37,6 @@ vi.mock('@n8n/ai-utilities', () => ({
 }));
 
 import { Container } from '@n8n/di';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { mock } from 'vitest-mock-extended';
 import { Expression } from 'n8n-workflow';
 import type {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -41,7 +41,6 @@ import type {
 	EvaluationConfigSummary,
 	EvaluationConfigDetail,
 	UpsertEvaluationConfigInput,
-	InstanceAiBuilderDelegate,
 	ModelConfig,
 } from '@n8n/instance-ai';
 import { braveSearch, searxngSearch, type WebSearchResponse } from '@n8n/ai-utilities';
@@ -88,7 +87,6 @@ import { Logger, ModuleRegistry } from '@n8n/backend-common';
 import { OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { Container, Service } from '@n8n/di';
 import { hasGlobalScope, type Scope } from '@n8n/permissions';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { LessThan } from '@n8n/typeorm';
 import {
 	type ICredentialsDecrypted,
@@ -353,37 +351,13 @@ export class InstanceAiAdapterService {
 				: {}),
 			...(builderDelegateAdapter && projectId
 				? {
-						builderDelegate: this.withBuilderCreateTelemetry(
-							builderDelegateAdapter.createDelegate(
-								user,
-								projectId,
-								new AgentsCredentialProvider(this.credentialsService, projectId, user),
-							),
-							threadId,
+						builderDelegate: builderDelegateAdapter.createDelegate(
+							user,
+							projectId,
+							new AgentsCredentialProvider(this.credentialsService, projectId, user),
 						),
 					}
 				: {}),
-		};
-	}
-
-	/** Mirror of the workflow-adapter telemetry: track agent creation via the
-	 *  builder sub-agent at the delegate boundary, only in a thread context. */
-	private withBuilderCreateTelemetry(
-		delegate: InstanceAiBuilderDelegate,
-		threadId: string | undefined,
-	): InstanceAiBuilderDelegate {
-		if (!threadId) return delegate;
-		return {
-			...delegate,
-			createAgent: async (name) => {
-				const created = await delegate.createAgent(name);
-				this.telemetry.track(TELEMETRY_EVENT.AGENTS.BUILDER_CREATED_AGENT, {
-					thread_id: threadId,
-					agent_id: created.agentId,
-					project_id: created.projectId,
-				});
-				return created;
-			},
 		};
 	}
 

--- a/packages/cli/src/modules/mcp/__tests__/agent-tools.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/agent-tools.service.test.ts
@@ -703,6 +703,7 @@ describe('McpAgentToolsService', () => {
 			});
 			expect(agentsService.create).toHaveBeenCalledWith('project-1', 'My Agent', {
 				availableInMCP: true,
+				user,
 			});
 			expect(agentConfigService.updateConfig).toHaveBeenCalledWith(
 				'agent-1',

--- a/packages/cli/src/modules/mcp/tools/agents/agent-tools.service.ts
+++ b/packages/cli/src/modules/mcp/tools/agents/agent-tools.service.ts
@@ -523,6 +523,7 @@ export class McpAgentToolsService {
 					// Agents created over MCP stay operable over MCP.
 					const agent = await this.agentsService.create(projectId, name, {
 						availableInMCP: true,
+						user,
 					});
 					let configHash: string | null;
 					let versionId = agent.versionId;

--- a/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.test.ts
@@ -12,6 +12,7 @@ import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/
 import type { CloudPlanState } from '@n8n/stores/cloudPlan.store';
 
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { AGENTS_MODULE_NAME } from '@/features/agents/constants';
 import { instanceAiCreateAgentRoute } from '@/features/ai/instanceAi/createAgentRoute';
 import { INSTANCE_AI_VIEW } from '@/features/ai/instanceAi/constants';
@@ -379,6 +380,23 @@ describe('useGlobalEntityCreation', () => {
 
 			const teamWithoutScope = agentEntry?.submenu?.find((s) => s.id === 'agent-3');
 			expect(teamWithoutScope?.disabled).toBe(true);
+		});
+
+		it('tracks the new-agent click on select, but not for the submenu title', () => {
+			enableAgentsModule();
+
+			const { handleSelect } = useGlobalEntityCreation();
+			handleSelect('agent-personal');
+
+			expect(trackMock).toHaveBeenCalledWith(
+				TELEMETRY_EVENT.AGENTS.USER_CLICKED_NEW_AGENT,
+				expect.objectContaining({ source: 'dropdown' }),
+			);
+
+			trackMock.mockReset();
+			handleSelect('agent-title');
+
+			expect(trackMock).not.toHaveBeenCalled();
 		});
 
 		it('omits the agent entry from the global shape when the module is inactive', () => {

--- a/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from 'vue';
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
 import { AGENTS_MODULE_NAME } from '@/features/agents/constants';
+import { useAgentTelemetry } from '@/features/agents/composables/useAgentTelemetry';
 import { instanceAiCreateAgentRoute } from '@/features/ai/instanceAi/createAgentRoute';
 import { INSTANCE_AI_VIEW } from '@/features/ai/instanceAi/constants';
 import { useRouter } from 'vue-router';
@@ -70,6 +71,7 @@ export const useGlobalEntityCreation = () => {
 	const i18n = useI18n();
 	const toast = useToast();
 	const telemetry = useTelemetry();
+	const agentTelemetry = useAgentTelemetry();
 
 	const isCreatingProject = ref(false);
 
@@ -452,6 +454,15 @@ export const useGlobalEntityCreation = () => {
 
 		if (id.startsWith(DATA_TABLE_MENU_ID) && id !== 'data-table-title') {
 			telemetry.track('User clicked sidebar add data table button');
+			return;
+		}
+
+		// Navigation happens through the item's `route`; this only records the
+		// intent half of the create-agent funnel, which is otherwise invisible for
+		// this menu — the agent row itself is not written until the user
+		// configures something.
+		if (id.startsWith(AGENTS_MENU_ID) && id !== 'agent-title') {
+			agentTelemetry.trackClickedNewAgent('dropdown');
 			return;
 		}
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
@@ -26,6 +26,11 @@ vi.mock('../composables/useProjectAgentsList', () => ({
 	}),
 }));
 
+const trackClickedNewAgent = vi.fn();
+vi.mock('../composables/useAgentTelemetry', () => ({
+	useAgentTelemetry: () => ({ trackClickedNewAgent }),
+}));
+
 vi.mock('@n8n/i18n', () => ({
 	useI18n: () => ({ baseText: (k: string) => k }),
 	i18n: { baseText: (k: string) => k },
@@ -157,6 +162,7 @@ describe('AgentBuilderHeader', () => {
 		ensureLoadedMock.mockReset();
 		routerPush.mockReset();
 		routerResolve.mockClear();
+		trackClickedNewAgent.mockReset();
 		agentsListRef.value = null;
 	});
 
@@ -341,5 +347,6 @@ describe('AgentBuilderHeader', () => {
 		await wrapper.find('[data-testid="agent-header-new-agent"]').trigger('click');
 
 		expect(routerPush).toHaveBeenCalledWith(instanceAiCreateAgentRoute('p1'));
+		expect(trackClickedNewAgent).toHaveBeenCalledWith('dropdown');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -1536,7 +1536,8 @@ describe('AgentBuilderView — three-column shell', () => {
 		await flushPromises();
 
 		expect(getAgentMock).toHaveBeenCalledTimes(2);
-		expect(fetchConfigMock).toHaveBeenCalledTimes(2);
+		// init fetchConfig + runAgentScopedLoads fetchConfig + replayed external refresh
+		expect(fetchConfigMock).toHaveBeenCalledTimes(3);
 		expect(getAgentMock).toHaveBeenLastCalledWith(
 			{ baseUrl: 'http://localhost:5678' },
 			'p-bus-init',

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -117,6 +117,7 @@ const createAgentSkillMock = vi.fn();
 const getIntegrationStatusMock = vi.fn();
 const publishAgentMock = vi.fn();
 const getAgentMock = vi.fn();
+const createAgentMock = vi.fn();
 const updateConfigMock = vi.fn();
 const fetchConfigMock = vi.fn();
 const deleteAgentMock = vi.fn().mockResolvedValue(undefined);
@@ -128,6 +129,7 @@ const sessionThreads: Array<{ id: string; updatedAt: string }> = [];
 
 vi.mock('../composables/useAgentApi', () => ({
 	getAgent: getAgentMock,
+	createAgent: createAgentMock,
 	updateAgent: updateAgentMock,
 	updateAgentSkill: updateAgentSkillMock,
 	createAgentSkill: createAgentSkillMock,
@@ -278,6 +280,8 @@ vi.mock('../composables/useProjectAgentsList', () => ({
 		ensureLoaded: vi.fn().mockResolvedValue([]),
 		refresh: vi.fn(),
 	}),
+	upsertProjectAgentsListCache: vi.fn(),
+	removeProjectAgentFromListCache: vi.fn(),
 }));
 
 const instanceAiAvailableRef = ref(true);
@@ -523,7 +527,10 @@ function resetViewMocks() {
 	mockConfig.value = withDefaultLlm(intendedConfig);
 	updateConfigMock.mockReset();
 	updateConfigMock.mockResolvedValue({ versionId: 'v1', stale: false });
+	getAgentMock.mockReset();
 	getAgentMock.mockResolvedValue(makeAgentResponse());
+	createAgentMock.mockReset();
+	createAgentMock.mockResolvedValue(makeAgentResponse());
 	getIntegrationStatusMock.mockResolvedValue({ status: 'ok', integrations: [] });
 	getAgentConfigValidationMock.mockReset();
 	getAgentConfigValidationMock.mockResolvedValue({ status: 'valid', issues: [] });
@@ -1569,6 +1576,74 @@ describe('AgentBuilderView — three-column shell', () => {
 		await flushPromises();
 
 		expect(showErrorMock).toHaveBeenCalledWith(replayError, 'agents.builder.loadError');
+		wrapper.unmount();
+	});
+
+	it('renders the template config for a draft agent that has no row yet', async () => {
+		const { ResponseError } = await import('@n8n/rest-api-client');
+		getAgentMock.mockRejectedValue(new ResponseError('not found', { httpStatusCode: 404 }));
+
+		const wrapper = await renderView({
+			props: {
+				artifactMode: true,
+				artifactProjectId: 'p-draft',
+				artifactAgentId: 'a-draft',
+				artifactAgentName: 'Triage Bot',
+			},
+		});
+
+		// A draft renders instead of erroring, and nothing agent-scoped is fetched.
+		expect(showErrorMock).not.toHaveBeenCalled();
+		expect(listAgentFilesMock).not.toHaveBeenCalled();
+		expect(warmAgentKnowledgeSandboxMock).not.toHaveBeenCalled();
+
+		const vm = wrapper.vm as unknown as {
+			isPendingAgent: boolean;
+			localConfig: { name: string; model: string; instructions: string };
+		};
+		expect(vm.isPendingAgent).toBe(true);
+		expect(vm.localConfig).toMatchObject({ name: 'Triage Bot', model: '', instructions: '' });
+
+		wrapper.unmount();
+	});
+
+	it('creates the draft on its first config save instead of updating a missing agent', async () => {
+		const { ResponseError } = await import('@n8n/rest-api-client');
+		getAgentMock.mockRejectedValue(new ResponseError('not found', { httpStatusCode: 404 }));
+		createAgentMock.mockResolvedValue(makeAgentResponse({ id: 'a-draft', name: 'Triage Bot' }));
+
+		const wrapper = await renderView({
+			props: {
+				artifactMode: true,
+				artifactProjectId: 'p-draft',
+				artifactAgentId: 'a-draft',
+				artifactAgentName: 'Triage Bot',
+			},
+		});
+
+		const vm = wrapper.vm as unknown as {
+			saveConfig: (snapshot: {
+				type: 'config';
+				projectId: string;
+				agentId: string;
+				config: TestAgentConfig;
+			}) => Promise<void>;
+		};
+		await vm.saveConfig({
+			type: 'config',
+			projectId: 'p-draft',
+			agentId: 'a-draft',
+			config: { ...intendedConfig, instructions: 'Triage inbound tickets.' } as TestAgentConfig,
+		});
+
+		expect(createAgentMock).toHaveBeenCalledWith(
+			{ baseUrl: 'http://localhost:5678' },
+			'p-draft',
+			'Triage Bot',
+			expect.objectContaining({ id: 'a-draft' }),
+		);
+		expect(updateConfigMock).not.toHaveBeenCalled();
+
 		wrapper.unmount();
 	});
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
@@ -11,9 +11,7 @@ const mocks = vi.hoisted(() => ({
 	showError: vi.fn(),
 	syncThread: vi.fn(),
 	updateThreadMetadata: vi.fn(),
-	getOrCreateRuntime: vi.fn(() => ({ sendMessage: vi.fn() })),
 	stashPendingAgentAttachment: vi.fn(),
-	createAgent: vi.fn(),
 }));
 
 vi.mock('vue-router', () => ({
@@ -30,7 +28,6 @@ vi.mock('@/features/ai/instanceAi/instanceAi.store', () => ({
 	useInstanceAiStore: () => ({
 		syncThread: mocks.syncThread,
 		updateThreadMetadata: mocks.updateThreadMetadata,
-		getOrCreateRuntime: mocks.getOrCreateRuntime,
 	}),
 }));
 vi.mock('@/features/ai/instanceAi/composables/useInstanceAiHandoff', () => ({
@@ -38,7 +35,6 @@ vi.mock('@/features/ai/instanceAi/composables/useInstanceAiHandoff', () => ({
 }));
 vi.mock('uuid', () => ({ v4: () => 'thread-1' }));
 vi.mock('@n8n/utils/generate-nano-id', () => ({ generateNanoId: () => 'minted-agent-id' }));
-vi.mock('../composables/useAgentApi', () => ({ createAgent: mocks.createAgent }));
 
 describe('NewAgentView', () => {
 	beforeEach(() => {
@@ -49,9 +45,6 @@ describe('NewAgentView', () => {
 	it('opens a thread bound to a minted agent id without creating the agent', async () => {
 		mount(NewAgentView);
 		await flushPromises();
-
-		// The whole point: clicking "New agent" and walking away must leave no row.
-		expect(mocks.createAgent).not.toHaveBeenCalled();
 
 		expect(mocks.syncThread).toHaveBeenCalledWith('thread-1', 'project-1', {
 			source: 'agent_builder_page',

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
@@ -1,37 +1,27 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
 
 import NewAgentView from '../views/NewAgentView.vue';
 import { INSTANCE_AI_THREAD_VIEW } from '@/features/ai/instanceAi/constants';
 import { AGENTS_LIST_VIEW, PROJECT_AGENTS } from '../constants';
-import type { AgentResource } from '../types';
 
 const mocks = vi.hoisted(() => ({
 	route: { query: { projectId: 'project-1' } as Record<string, string> },
 	replace: vi.fn(),
-	createAgent: vi.fn(),
-	upsertProjectAgentsListCache: vi.fn(),
-	track: vi.fn(),
 	showError: vi.fn(),
 	syncThread: vi.fn(),
 	updateThreadMetadata: vi.fn(),
 	getOrCreateRuntime: vi.fn(() => ({ sendMessage: vi.fn() })),
 	stashPendingAgentAttachment: vi.fn(),
+	createAgent: vi.fn(),
 }));
 
 vi.mock('vue-router', () => ({
 	useRoute: () => mocks.route,
 	useRouter: () => ({ replace: mocks.replace }),
 }));
-vi.mock('@n8n/stores/useRootStore', () => ({
-	useRootStore: () => ({ restApiContext: { baseUrl: '/rest', pushRef: 'push-ref' } }),
-}));
 vi.mock('@n8n/i18n', () => ({
 	useI18n: () => ({ baseText: (key: string) => key }),
-}));
-vi.mock('@n8n/composables/useTelemetry', () => ({
-	useTelemetry: () => ({ track: mocks.track }),
 }));
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: () => ({ showError: mocks.showError }),
@@ -47,10 +37,8 @@ vi.mock('@/features/ai/instanceAi/composables/useInstanceAiHandoff', () => ({
 	stashPendingAgentAttachment: mocks.stashPendingAgentAttachment,
 }));
 vi.mock('uuid', () => ({ v4: () => 'thread-1' }));
+vi.mock('@n8n/utils/generate-nano-id', () => ({ generateNanoId: () => 'minted-agent-id' }));
 vi.mock('../composables/useAgentApi', () => ({ createAgent: mocks.createAgent }));
-vi.mock('../composables/useProjectAgentsList', () => ({
-	upsertProjectAgentsListCache: mocks.upsertProjectAgentsListCache,
-}));
 
 describe('NewAgentView', () => {
 	beforeEach(() => {
@@ -58,43 +46,32 @@ describe('NewAgentView', () => {
 		mocks.route.query = { projectId: 'project-1' };
 	});
 
-	it('creates a blank agent and opens it in an empty Instance AI thread', async () => {
-		const agent = { id: 'agent-1', name: 'New agent' } as AgentResource;
-		mocks.createAgent.mockResolvedValue(agent);
-
+	it('opens a thread bound to a minted agent id without creating the agent', async () => {
 		mount(NewAgentView);
 		await flushPromises();
 
-		expect(mocks.createAgent).toHaveBeenCalledOnce();
-		expect(mocks.createAgent).toHaveBeenCalledWith(
-			{ baseUrl: '/rest', pushRef: 'push-ref' },
-			'project-1',
-			'agents.new.defaultName',
-		);
-		expect(mocks.upsertProjectAgentsListCache).toHaveBeenCalledWith('project-1', agent);
-		expect(mocks.track).toHaveBeenCalledWith(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
-			agent_id: 'agent-1',
-			source: 'create_blank',
-		});
+		// The whole point: clicking "New agent" and walking away must leave no row.
+		expect(mocks.createAgent).not.toHaveBeenCalled();
+
 		expect(mocks.syncThread).toHaveBeenCalledWith('thread-1', 'project-1', {
 			source: 'agent_builder_page',
 			origin: 'internal',
-			sourceContext: { agentId: 'agent-1' },
+			sourceContext: { agentId: 'minted-agent-id' },
 		});
 		expect(mocks.updateThreadMetadata).toHaveBeenCalledWith('thread-1', {
 			instanceAiAgentBuilderTarget: {
-				agentId: 'agent-1',
+				agentId: 'minted-agent-id',
 				projectId: 'project-1',
-				name: 'New agent',
+				name: 'agents.new.defaultName',
+				pending: true,
 			},
 		});
 		expect(mocks.stashPendingAgentAttachment).toHaveBeenCalledWith('thread-1', {
 			type: 'agent',
-			id: 'agent-1',
-			name: 'New agent',
+			id: 'minted-agent-id',
+			name: 'agents.new.defaultName',
 			projectId: 'project-1',
 		});
-		expect(mocks.getOrCreateRuntime).not.toHaveBeenCalled();
 		expect(mocks.replace).toHaveBeenCalledWith({
 			name: INSTANCE_AI_THREAD_VIEW,
 			params: { threadId: 'thread-1' },
@@ -107,7 +84,7 @@ describe('NewAgentView', () => {
 		mount(NewAgentView);
 		await flushPromises();
 
-		expect(mocks.createAgent).not.toHaveBeenCalled();
+		expect(mocks.syncThread).not.toHaveBeenCalled();
 		expect(mocks.showError).toHaveBeenCalledWith(
 			expect.any(Error),
 			'agentSelector.createAgentFailed',
@@ -115,9 +92,9 @@ describe('NewAgentView', () => {
 		expect(mocks.replace).toHaveBeenCalledWith({ name: AGENTS_LIST_VIEW });
 	});
 
-	it('returns to the project agents list when creation fails', async () => {
-		const error = new Error('create failed');
-		mocks.createAgent.mockRejectedValue(error);
+	it('returns to the project agents list when the thread cannot be opened', async () => {
+		const error = new Error('sync failed');
+		mocks.syncThread.mockRejectedValue(error);
 
 		mount(NewAgentView);
 		await flushPromises();

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
@@ -25,6 +25,7 @@ import { AGENT_PREVIEW_VIEW, PROJECT_AGENTS } from '@/features/agents/constants'
 import { instanceAiCreateAgentRoute } from '@/features/ai/instanceAi/createAgentRoute';
 
 import AgentPublishButton from './AgentPublishButton.vue';
+import { useAgentTelemetry } from '../composables/useAgentTelemetry';
 import { useProjectAgentsList } from '../composables/useProjectAgentsList';
 import type { AgentResource } from '../types';
 
@@ -56,6 +57,7 @@ const emit = defineEmits<{
 
 const i18n = useI18n();
 const router = useRouter();
+const agentTelemetry = useAgentTelemetry();
 
 const { list: agentsList, ensureLoaded } = useProjectAgentsList(computed(() => props.projectId));
 onMounted(() => {
@@ -119,6 +121,7 @@ function onSwitcherSelect(id: string) {
 }
 
 function onCreateAgent() {
+	agentTelemetry.trackClickedNewAgent('dropdown');
 	void router.push(instanceAiCreateAgentRoute(props.projectId));
 }
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -250,15 +250,7 @@ watch([() => props.reloadKey, () => props.projectId, () => props.agentId], () =>
 	if (showSection('tasks')) void reloadTasks();
 });
 
-async function openTaskModal(task: TaskRow | null) {
-	// The modal writes straight to `/:agentId/tasks`, so a draft has to exist
-	// before it opens rather than failing on confirm.
-	try {
-		await draft.ensurePersisted();
-	} catch (error) {
-		toast.showError(error, i18n.baseText('agents.builder.tasks.loadError'));
-		return;
-	}
+function openTaskModal(task: TaskRow | null) {
 	uiStore.openModalWithData({
 		name: AGENT_TASK_MODAL_KEY,
 		data: {
@@ -273,6 +265,9 @@ async function openTaskModal(task: TaskRow | null) {
 				: undefined,
 			onToggle: (payload: { id: string; enabled: boolean }) => emit('toggle-task', payload),
 			onSaved: () => emit('tasks-changed'),
+			// Persist on save, not on open — cancelling the modal must not create
+			// an empty agent for a draft.
+			ensurePersisted: draft.ensurePersisted,
 		},
 	});
 }

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -13,6 +13,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import type { AgentJsonConfig, AgentJsonMcpServerConfig, AgentJsonToolRef } from '../types';
 import type { AgentSkill, CustomToolEntry } from '../types';
 import { getAgentTasks } from '../composables/useAgentApi';
+import { useAgentDraftContext } from '../composables/useAgentDraftContext';
 import { useProjectAgentsList } from '../composables/useProjectAgentsList';
 import { toolRefToNode } from '../composables/useAgentToolRefAdapter';
 import { AGENT_SUB_AGENTS_MODAL_KEY, AGENT_TASK_MODAL_KEY } from '../constants';
@@ -74,6 +75,7 @@ const toast = useToast();
 const rootStore = useRootStore();
 const uiStore = useUIStore();
 const nodeTypesStore = useNodeTypesStore();
+const draft = useAgentDraftContext();
 
 const projectIdRef = computed(() => props.projectId);
 const { list: projectAgents, ensureLoaded: ensureProjectAgentsLoaded } =
@@ -218,6 +220,12 @@ const subAgentIssueMessages = computed(() =>
 );
 
 async function reloadTasks() {
+	// A draft has no row and therefore no tasks; fetching would 404 and render
+	// "Agent not found" where the empty list belongs.
+	if (draft.isPending.value) {
+		taskBodies.value = [];
+		return;
+	}
 	taskErrorMessage.value = '';
 	try {
 		taskBodies.value = await getAgentTasks(
@@ -242,7 +250,15 @@ watch([() => props.reloadKey, () => props.projectId, () => props.agentId], () =>
 	if (showSection('tasks')) void reloadTasks();
 });
 
-function openTaskModal(task: TaskRow | null) {
+async function openTaskModal(task: TaskRow | null) {
+	// The modal writes straight to `/:agentId/tasks`, so a draft has to exist
+	// before it opens rather than failing on confirm.
+	try {
+		await draft.ensurePersisted();
+	} catch (error) {
+		toast.showError(error, i18n.baseText('agents.builder.tasks.loadError'));
+		return;
+	}
 	uiStore.openModalWithData({
 		name: AGENT_TASK_MODAL_KEY,
 		data: {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentTaskModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentTaskModal.vue
@@ -33,6 +33,7 @@ import {
 	updateAgentTask,
 } from '../composables/useAgentApi';
 import { useAgentConfirmationModal } from '../composables/useAgentConfirmationModal';
+import type { EnsurePersisted } from '../composables/useAgentEnsurePersisted';
 import {
 	buildCron,
 	DEFAULT_SCHEDULE_PARTS,
@@ -54,6 +55,8 @@ export type AgentTaskModalData = {
 	};
 	onToggle?: (payload: { id: string; enabled: boolean }) => void;
 	onSaved: () => void;
+	/** Creates the agent row when saving against a client-side draft. */
+	ensurePersisted?: EnsurePersisted;
 };
 
 type FrequencyOption = ScheduleFrequency | 'custom';
@@ -320,6 +323,7 @@ async function onSave() {
 	};
 
 	try {
+		await props.data.ensurePersisted?.();
 		if (task.value) {
 			await updateAgentTask(
 				rootStore.restApiContext,

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
@@ -99,12 +99,17 @@ export const createAgent = async (
 	context: IRestApiContext,
 	projectId: string,
 	name: string,
+	options: { id?: string; config?: AgentJsonConfig } = {},
 ): Promise<AgentResource> => {
 	return await makeRestApiRequest<AgentResource>(
 		context,
 		'POST',
 		`/projects/${projectId}/agents/v2`,
-		{ name },
+		{
+			name,
+			...(options.id ? { id: options.id } : {}),
+			...(options.config ? { config: options.config } : {}),
+		},
 	);
 };
 

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentCapabilitiesActions.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentCapabilitiesActions.ts
@@ -6,6 +6,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { AI_MCP_TOOL_NODE_TYPE } from '@/app/constants/nodeTypes';
 import { createAgentSkill } from './useAgentApi';
+import { useAgentDraftContext } from './useAgentDraftContext';
 import { mcpServerToNode } from './useMcpServerAdapter';
 import {
 	AGENT_TOOLS_MODAL_KEY,
@@ -109,6 +110,7 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 	const uiStore = useUIStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const { showError, showMessage } = useToast();
+	const draft = useAgentDraftContext();
 
 	function onOpenAddToolModal() {
 		// Capture the target at open time: a confirm landing after an agent/node
@@ -435,6 +437,9 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 						let versionId: string | null;
 						let skillId: string;
 						try {
+							// Creating a skill can be the very first thing done to a draft, so
+							// the agent may still need writing before it can own one.
+							await draft.ensurePersisted();
 							const result = await createAgentSkill(
 								rootStore.restApiContext,
 								targetProjectId,

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentCapabilitiesActions.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentCapabilitiesActions.ts
@@ -6,7 +6,6 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { AI_MCP_TOOL_NODE_TYPE } from '@/app/constants/nodeTypes';
 import { createAgentSkill } from './useAgentApi';
-import { useAgentDraftContext } from './useAgentDraftContext';
 import { mcpServerToNode } from './useMcpServerAdapter';
 import {
 	AGENT_TOOLS_MODAL_KEY,
@@ -24,6 +23,7 @@ import type {
 	AgentJsonToolConfig,
 	AgentSkill,
 } from '../types';
+import type { EnsurePersisted } from './useAgentEnsurePersisted';
 
 /**
  * Telemetry seam for the capability actions.
@@ -83,6 +83,14 @@ export interface UseAgentCapabilitiesActionsDeps {
 	 */
 	supportsToolApproval?: boolean;
 	telemetry?: AgentCapabilitiesTelemetry;
+	/**
+	 * Creates the agent when it is still a client-side draft, so a skill can be
+	 * the first thing written to it. Injected rather than taken from the draft
+	 * context because this composable runs inside the providing component, where
+	 * `inject` cannot see that component's own `provide`. Optional: hosts with no
+	 * draft concept (the agent node's NDV) omit it.
+	 */
+	ensurePersisted?: EnsurePersisted;
 }
 
 /**
@@ -103,6 +111,7 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 		localSkills,
 		supportsToolApproval,
 		telemetry,
+		ensurePersisted,
 	} = deps;
 
 	const locale = useI18n();
@@ -110,7 +119,6 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 	const uiStore = useUIStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const { showError, showMessage } = useToast();
-	const draft = useAgentDraftContext();
 
 	function onOpenAddToolModal() {
 		// Capture the target at open time: a confirm landing after an agent/node
@@ -439,7 +447,7 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 						try {
 							// Creating a skill can be the very first thing done to a draft, so
 							// the agent may still need writing before it can own one.
-							await draft.ensurePersisted();
+							await ensurePersisted?.();
 							const result = await createAgentSkill(
 								rootStore.restApiContext,
 								targetProjectId,

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentCreate.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentCreate.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
 
 import { useAgentCreate } from './useAgentCreate';
 import type { AgentResource } from '../types';
@@ -9,7 +8,6 @@ const { upsertProjectAgentsListCache } = vi.hoisted(() => ({
 	upsertProjectAgentsListCache: vi.fn(),
 }));
 const { showError } = vi.hoisted(() => ({ showError: vi.fn() }));
-const { track } = vi.hoisted(() => ({ track: vi.fn() }));
 const { openBuilder } = vi.hoisted(() => ({ openBuilder: vi.fn() }));
 const { saveCurrentWorkflow } = vi.hoisted(() => ({ saveCurrentWorkflow: vi.fn() }));
 
@@ -19,7 +17,6 @@ vi.mock('./useAgentNavigation', () => ({
 	useAgentNavigation: () => ({ openBuilder }),
 }));
 vi.mock('@/app/composables/useToast', () => ({ useToast: () => ({ showError }) }));
-vi.mock('@n8n/composables/useTelemetry', () => ({ useTelemetry: () => ({ track }) }));
 vi.mock('@/app/composables/useWorkflowSaving', () => ({
 	useWorkflowSaving: () => ({ saveCurrentWorkflow }),
 }));
@@ -45,7 +42,6 @@ describe('useAgentCreate', () => {
 		const onCreated = vi.fn();
 		const { createAndSelect } = useAgentCreate({
 			projectId: 'project-1',
-			telemetrySource: 'ndv_banner',
 			setReference,
 			onCreated,
 		});
@@ -65,10 +61,6 @@ describe('useAgentCreate', () => {
 		expect(setReference.mock.invocationCallOrder[0]).toBeLessThan(
 			onCreated.mock.invocationCallOrder[0],
 		);
-		expect(track).toHaveBeenCalledWith(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
-			agent_id: 'agent-1',
-			source: 'ndv_banner',
-		});
 		expect(showError).not.toHaveBeenCalled();
 		// Staying in flow: no workflow save, no builder navigation.
 		expect(saveCurrentWorkflow).not.toHaveBeenCalled();
@@ -79,7 +71,6 @@ describe('useAgentCreate', () => {
 		const setReference = vi.fn();
 		const { createAndOpenBuilder } = useAgentCreate({
 			projectId: 'project-1',
-			telemetrySource: 'ndv_banner',
 			getOriginNodeId: () => 'node-7',
 			setReference,
 		});
@@ -102,7 +93,6 @@ describe('useAgentCreate', () => {
 		const setReference = vi.fn();
 		const { createAndOpenBuilder, isCreating } = useAgentCreate({
 			projectId: 'project-1',
-			telemetrySource: 'ndv_banner',
 			setReference,
 		});
 
@@ -117,7 +107,6 @@ describe('useAgentCreate', () => {
 		const setReference = vi.fn();
 		const { createAndSelect } = useAgentCreate({
 			projectId: '',
-			telemetrySource: 'node_picker',
 			setReference,
 		});
 
@@ -133,7 +122,6 @@ describe('useAgentCreate', () => {
 		const setReference = vi.fn();
 		const { createAndSelect, isCreating } = useAgentCreate({
 			projectId: 'project-1',
-			telemetrySource: 'node_picker',
 			setReference,
 		});
 
@@ -151,7 +139,6 @@ describe('useAgentCreate', () => {
 		);
 		const { createAndSelect } = useAgentCreate({
 			projectId: 'project-1',
-			telemetrySource: 'node_picker',
 			setReference: vi.fn(),
 		});
 

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentCreate.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentCreate.ts
@@ -2,9 +2,7 @@ import { ref, toValue, type MaybeRefOrGetter } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
 
-import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { useWorkflowSaving } from '@/app/composables/useWorkflowSaving';
 
@@ -18,7 +16,6 @@ import type { AgentResource } from '../types';
  */
 export function useAgentCreate(options: {
 	projectId: MaybeRefOrGetter<string>;
-	telemetrySource: string;
 	/** Origin node for the builder's "Back to workflow" return context. */
 	getOriginNodeId?: () => string | undefined;
 	setReference: (agent: AgentResource) => void;
@@ -27,7 +24,6 @@ export function useAgentCreate(options: {
 	const i18n = useI18n();
 	const rootStore = useRootStore();
 	const toast = useToast();
-	const telemetry = useTelemetry();
 	const nav = useAgentNavigation();
 	const router = useRouter();
 	const { saveCurrentWorkflow } = useWorkflowSaving({ router });
@@ -54,11 +50,6 @@ export function useAgentCreate(options: {
 
 		options.setReference(agent);
 		options.onCreated?.(agent);
-
-		telemetry.track(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
-			agent_id: agent.id,
-			source: options.telemetrySource,
-		});
 
 		return agent;
 	}

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentDraftContext.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentDraftContext.ts
@@ -1,0 +1,33 @@
+import { inject, provide, type InjectionKey, type Ref } from 'vue';
+
+/**
+ * Shared state for an agent that has an id but no row yet.
+ *
+ * The config panel and its capability sections sit several components apart but
+ * all need the same two things: whether the agent still needs creating, and the
+ * call that creates it. Provided rather than drilled so a new write surface only
+ * has to inject, and so surfaces that never see a draft (the full-page route,
+ * the node NDV) get the inert default.
+ */
+export interface AgentDraftContext {
+	/** True while the agent id has no row behind it. */
+	isPending: Ref<boolean> | { value: boolean };
+	/** Creates the agent if it is still pending; a no-op otherwise. */
+	ensurePersisted: () => Promise<void>;
+}
+
+const AGENT_DRAFT_CONTEXT: InjectionKey<AgentDraftContext> = Symbol('agentDraftContext');
+
+const INERT: AgentDraftContext = {
+	isPending: { value: false },
+	ensurePersisted: async () => {},
+};
+
+export function provideAgentDraftContext(context: AgentDraftContext): void {
+	provide(AGENT_DRAFT_CONTEXT, context);
+}
+
+/** Defaults to "already persisted" so hosts that never deal with drafts need no wiring. */
+export function useAgentDraftContext(): AgentDraftContext {
+	return inject(AGENT_DRAFT_CONTEXT, INERT);
+}

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentDraftContext.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentDraftContext.ts
@@ -1,5 +1,6 @@
-import { inject, provide, type InjectionKey, type Ref } from 'vue';
+import { inject, provide, ref, type InjectionKey, type Ref } from 'vue';
 
+import { type EnsurePersisted } from './useAgentEnsurePersisted';
 /**
  * Shared state for an agent that has an id but no row yet.
  *
@@ -8,19 +9,28 @@ import { inject, provide, type InjectionKey, type Ref } from 'vue';
  * call that creates it. Provided rather than drilled so a new write surface only
  * has to inject, and so surfaces that never see a draft (the full-page route,
  * the node NDV) get the inert default.
+ *
+ * Consume this only from **descendant** components. A composable that runs
+ * inside the providing component itself will get the inert default — Vue's
+ * `inject` resolves against the parent chain, never the component's own
+ * `provide`.
  */
 export interface AgentDraftContext {
 	/** True while the agent id has no row behind it. */
-	isPending: Ref<boolean> | { value: boolean };
-	/** Creates the agent if it is still pending; a no-op otherwise. */
-	ensurePersisted: () => Promise<void>;
+	isPending: Ref<boolean>;
+	/**
+	 * Creates the agent if it is still pending.
+	 * Returns which of the three outcomes occurred so callers can decide whether
+	 * their snapshot is still safe to write.
+	 */
+	ensurePersisted: EnsurePersisted;
 }
 
 const AGENT_DRAFT_CONTEXT: InjectionKey<AgentDraftContext> = Symbol('agentDraftContext');
 
 const INERT: AgentDraftContext = {
-	isPending: { value: false },
-	ensurePersisted: async () => {},
+	isPending: ref(false),
+	ensurePersisted: async () => 'already-persisted',
 };
 
 export function provideAgentDraftContext(context: AgentDraftContext): void {

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentEnsurePersisted.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentEnsurePersisted.test.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ResponseError } from '@n8n/rest-api-client';
 
 import { useAgentEnsurePersisted } from './useAgentEnsurePersisted';
 import type { AgentJsonConfig, AgentResource } from '../types';
@@ -13,9 +14,17 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 
 const created = { id: 'minted-id', name: 'Triage Bot' } as AgentResource;
 
-function setup(config: AgentJsonConfig | null = null) {
+function setup(
+	config: AgentJsonConfig | null = null,
+	options: {
+		onConflict?: () => void | Promise<void>;
+		isStale?: (projectId: string, agentId: string) => boolean;
+	} = {},
+) {
 	const isPending = ref(true);
 	const onCreated = vi.fn();
+	const onConflict = options.onConflict ?? vi.fn();
+	const isStale = options.isStale ?? (() => false);
 	const { ensurePersisted } = useAgentEnsurePersisted({
 		projectId: () => 'project-1',
 		agentId: () => 'minted-id',
@@ -23,8 +32,10 @@ function setup(config: AgentJsonConfig | null = null) {
 		getConfig: () => config,
 		getName: () => 'Triage Bot',
 		onCreated,
+		onConflict,
+		isStale,
 	});
-	return { ensurePersisted, isPending, onCreated };
+	return { ensurePersisted, isPending, onCreated, onConflict };
 }
 
 describe('useAgentEnsurePersisted', () => {
@@ -37,7 +48,7 @@ describe('useAgentEnsurePersisted', () => {
 		const config = { name: 'Triage Bot', model: '', instructions: 'Triage tickets.' };
 		const { ensurePersisted, isPending, onCreated } = setup(config as AgentJsonConfig);
 
-		await ensurePersisted();
+		await expect(ensurePersisted()).resolves.toBe('created');
 
 		expect(createAgent).toHaveBeenCalledWith(
 			{ baseUrl: '/rest', pushRef: 'push-ref' },
@@ -55,6 +66,18 @@ describe('useAgentEnsurePersisted', () => {
 		await Promise.all([ensurePersisted(), ensurePersisted(), ensurePersisted()]);
 
 		expect(createAgent).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns created only for the caller that performed the create', async () => {
+		const { ensurePersisted } = setup();
+
+		const results = await Promise.all([ensurePersisted(), ensurePersisted(), ensurePersisted()]);
+
+		expect(results.filter((r) => r === 'created')).toHaveLength(1);
+		expect(results.filter((r) => r === 'already-persisted')).toHaveLength(2);
+
+		// Already persisted after the race above — subsequent calls must report that.
+		expect(await ensurePersisted()).toBe('already-persisted');
 	});
 
 	it('does nothing once the agent exists', async () => {
@@ -75,7 +98,47 @@ describe('useAgentEnsurePersisted', () => {
 		expect(isPending.value).toBe(true);
 
 		createAgent.mockResolvedValue(created);
-		await ensurePersisted();
+		await expect(ensurePersisted()).resolves.toBe('created');
 		expect(isPending.value).toBe(false);
+	});
+
+	it('treats a 409 as a conflict so later writes discard the stale draft snapshot', async () => {
+		createAgent.mockRejectedValue(new ResponseError('exists', { httpStatusCode: 409 }));
+		const { ensurePersisted, isPending, onCreated, onConflict } = setup();
+
+		await expect(ensurePersisted()).resolves.toBe('conflict');
+
+		expect(isPending.value).toBe(false);
+		expect(onCreated).not.toHaveBeenCalled();
+		expect(onConflict).toHaveBeenCalledTimes(1);
+	});
+
+	it('propagates conflict to waiters sharing the in-flight create', async () => {
+		createAgent.mockRejectedValue(new ResponseError('exists', { httpStatusCode: 409 }));
+		const { ensurePersisted, onConflict } = setup();
+
+		const results = await Promise.all([ensurePersisted(), ensurePersisted(), ensurePersisted()]);
+
+		expect(results.every((r) => r === 'conflict')).toBe(true);
+		expect(onConflict).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not apply create results when the target became stale while in flight', async () => {
+		let resolveCreate!: (value: AgentResource) => void;
+		createAgent.mockReturnValue(
+			new Promise<AgentResource>((resolve) => {
+				resolveCreate = resolve;
+			}),
+		);
+		const { ensurePersisted, isPending, onCreated } = setup(null, {
+			isStale: () => true,
+		});
+
+		const pending = ensurePersisted();
+		resolveCreate(created);
+		await expect(pending).resolves.toBe('created');
+
+		expect(isPending.value).toBe(true);
+		expect(onCreated).not.toHaveBeenCalled();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentEnsurePersisted.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentEnsurePersisted.test.ts
@@ -1,0 +1,81 @@
+import { ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAgentEnsurePersisted } from './useAgentEnsurePersisted';
+import type { AgentJsonConfig, AgentResource } from '../types';
+
+const { createAgent } = vi.hoisted(() => ({ createAgent: vi.fn() }));
+
+vi.mock('./useAgentApi', () => ({ createAgent }));
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: () => ({ restApiContext: { baseUrl: '/rest', pushRef: 'push-ref' } }),
+}));
+
+const created = { id: 'minted-id', name: 'Triage Bot' } as AgentResource;
+
+function setup(config: AgentJsonConfig | null = null) {
+	const isPending = ref(true);
+	const onCreated = vi.fn();
+	const { ensurePersisted } = useAgentEnsurePersisted({
+		projectId: () => 'project-1',
+		agentId: () => 'minted-id',
+		isPending,
+		getConfig: () => config,
+		getName: () => 'Triage Bot',
+		onCreated,
+	});
+	return { ensurePersisted, isPending, onCreated };
+}
+
+describe('useAgentEnsurePersisted', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		createAgent.mockResolvedValue(created);
+	});
+
+	it('creates the agent under the minted id, carrying the current config', async () => {
+		const config = { name: 'Triage Bot', model: '', instructions: 'Triage tickets.' };
+		const { ensurePersisted, isPending, onCreated } = setup(config as AgentJsonConfig);
+
+		await ensurePersisted();
+
+		expect(createAgent).toHaveBeenCalledWith(
+			{ baseUrl: '/rest', pushRef: 'push-ref' },
+			'project-1',
+			'Triage Bot',
+			{ id: 'minted-id', config },
+		);
+		expect(isPending.value).toBe(false);
+		expect(onCreated).toHaveBeenCalledWith(created);
+	});
+
+	it('creates once for callers racing in the same tick', async () => {
+		const { ensurePersisted } = setup();
+
+		await Promise.all([ensurePersisted(), ensurePersisted(), ensurePersisted()]);
+
+		expect(createAgent).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing once the agent exists', async () => {
+		const { ensurePersisted } = setup();
+
+		await ensurePersisted();
+		await ensurePersisted();
+
+		expect(createAgent).toHaveBeenCalledTimes(1);
+	});
+
+	it('stays pending after a failure so the next write retries', async () => {
+		createAgent.mockRejectedValue(new Error('boom'));
+		const { ensurePersisted, isPending } = setup();
+
+		await expect(ensurePersisted()).rejects.toThrow('boom');
+
+		expect(isPending.value).toBe(true);
+
+		createAgent.mockResolvedValue(created);
+		await ensurePersisted();
+		expect(isPending.value).toBe(false);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentEnsurePersisted.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentEnsurePersisted.ts
@@ -1,0 +1,59 @@
+import type { Ref } from 'vue';
+import { useRootStore } from '@n8n/stores/useRootStore';
+
+import { createAgent } from './useAgentApi';
+import type { AgentJsonConfig, AgentResource } from '../types';
+
+/**
+ * Creates the agent row for a draft on its first write.
+ *
+ * A draft opened from "New Agent" has an id but no row: nothing is persisted
+ * until the user actually configures something, so opening the page and walking
+ * away leaves nothing behind. Every write path in the builder calls
+ * `ensurePersisted()` first, which POSTs the minted id together with the current
+ * config — row and content land in one request, so a rejected config cannot
+ * leave an empty agent.
+ *
+ * Concurrent callers share one in-flight request: the config autosave and a
+ * modal confirm can fire in the same tick, and two POSTs with the same id would
+ * make the second fail.
+ */
+export function useAgentEnsurePersisted(options: {
+	projectId: () => string;
+	agentId: () => string;
+	isPending: Ref<boolean>;
+	getConfig: () => AgentJsonConfig | null;
+	getName: () => string;
+	onCreated: (agent: AgentResource) => void;
+}) {
+	const rootStore = useRootStore();
+
+	let inFlight: Promise<void> | null = null;
+
+	async function create(): Promise<void> {
+		const config = options.getConfig();
+		const agent = await createAgent(
+			rootStore.restApiContext,
+			options.projectId(),
+			options.getName(),
+			{ id: options.agentId(), ...(config ? { config } : {}) },
+		);
+		options.isPending.value = false;
+		options.onCreated(agent);
+	}
+
+	async function ensurePersisted(): Promise<void> {
+		if (!options.isPending.value) return;
+		if (inFlight) return await inFlight;
+
+		// Cleared in `finally` rather than on success only: a failed create must
+		// leave `isPending` true so the next edit retries instead of writing
+		// against an agent that was never created.
+		inFlight = create().finally(() => {
+			inFlight = null;
+		});
+		return await inFlight;
+	}
+
+	return { ensurePersisted };
+}

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentEnsurePersisted.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentEnsurePersisted.ts
@@ -1,8 +1,14 @@
 import type { Ref } from 'vue';
+import { ResponseError } from '@n8n/rest-api-client';
 import { useRootStore } from '@n8n/stores/useRootStore';
 
 import { createAgent } from './useAgentApi';
 import type { AgentJsonConfig, AgentResource } from '../types';
+
+export type EnsurePersistedResult = 'created' | 'already-persisted' | 'conflict';
+
+/** The single shape every consumer of the draft-create hook should use. */
+export type EnsurePersisted = () => Promise<EnsurePersistedResult>;
 
 /**
  * Creates the agent row for a draft on its first write.
@@ -25,34 +31,72 @@ export function useAgentEnsurePersisted(options: {
 	getConfig: () => AgentJsonConfig | null;
 	getName: () => string;
 	onCreated: (agent: AgentResource) => void;
+	/** Called when the row turned out to already exist. The caller's snapshot is
+	 *  by definition older than whatever created it, so it must be discarded
+	 *  rather than written. */
+	onConflict?: () => void | Promise<void>;
+	/** True when the captured target is no longer the one on screen — the host
+	 *  switched agents while the create was in flight, so the result must not be
+	 *  applied. */
+	isStale: (projectId: string, agentId: string) => boolean;
 }) {
 	const rootStore = useRootStore();
 
-	let inFlight: Promise<void> | null = null;
+	let inFlight: { agentId: string; promise: Promise<EnsurePersistedResult> } | null = null;
 
-	async function create(): Promise<void> {
-		const config = options.getConfig();
-		const agent = await createAgent(
-			rootStore.restApiContext,
-			options.projectId(),
-			options.getName(),
-			{ id: options.agentId(), ...(config ? { config } : {}) },
-		);
-		options.isPending.value = false;
-		options.onCreated(agent);
+	async function create(): Promise<EnsurePersistedResult> {
+		const targetProjectId = options.projectId();
+		const targetAgentId = options.agentId();
+		try {
+			const config = options.getConfig();
+			const agent = await createAgent(
+				rootStore.restApiContext,
+				targetProjectId,
+				options.getName(),
+				{ id: targetAgentId, ...(config ? { config } : {}) },
+			);
+			if (options.isStale(targetProjectId, targetAgentId)) {
+				return 'created';
+			}
+			options.isPending.value = false;
+			options.onCreated(agent);
+			return 'created';
+		} catch (error) {
+			// The builder materialized the row first. The agent exists, which is all
+			// the caller needed — clear the draft state and let it fall through to a
+			// normal update instead of retrying a create that can never succeed.
+			if (error instanceof ResponseError && error.httpStatusCode === 409) {
+				if (options.isStale(targetProjectId, targetAgentId)) {
+					return 'conflict';
+				}
+				options.isPending.value = false;
+				await options.onConflict?.();
+				return 'conflict';
+			}
+			throw error;
+		}
 	}
 
-	async function ensurePersisted(): Promise<void> {
-		if (!options.isPending.value) return;
-		if (inFlight) return await inFlight;
+	async function ensurePersisted(): Promise<EnsurePersistedResult> {
+		if (!options.isPending.value) return 'already-persisted';
+		const currentAgentId = options.agentId();
+		if (inFlight && inFlight.agentId === currentAgentId) {
+			const result = await inFlight.promise;
+			// Waiters did not perform the create. Propagate conflict so they do
+			// not fall through and overwrite the newer server config; a successful
+			// create still reports already-persisted so only the leader claims it.
+			return result === 'created' ? 'already-persisted' : result;
+		}
 
-		// Cleared in `finally` rather than on success only: a failed create must
-		// leave `isPending` true so the next edit retries instead of writing
-		// against an agent that was never created.
-		inFlight = create().finally(() => {
-			inFlight = null;
+		// Cleared in `finally` rather than on success only: a rejected create must
+		// not leave a poisoned promise that every later caller awaits.
+		const promise = create().finally(() => {
+			if (inFlight?.agentId === currentAgentId) {
+				inFlight = null;
+			}
 		});
-		return await inFlight;
+		inFlight = { agentId: currentAgentId, promise };
+		return await promise;
 	}
 
 	return { ensurePersisted };

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentIntegrationStatus.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentIntegrationStatus.ts
@@ -4,6 +4,7 @@ import { ResponseError } from '@n8n/rest-api-client';
 import { useRootStore } from '@n8n/stores/useRootStore';
 
 import { connectIntegration, disconnectIntegration, getIntegrationStatus } from './useAgentApi';
+import { useAgentDraftContext } from './useAgentDraftContext';
 
 type Status = 'connected' | 'disconnected' | 'unknown';
 
@@ -77,6 +78,7 @@ export function syncAgentIntegrationStatusCache(
 
 export function useAgentIntegrationStatus(projectId: string, agentId: string) {
 	const rootStore = useRootStore();
+	const draft = useAgentDraftContext();
 	const state = getOrCreate(projectId, agentId);
 
 	async function fetchStatus(integrationTypes: string[]): Promise<void> {
@@ -111,6 +113,9 @@ export function useAgentIntegrationStatus(projectId: string, agentId: string) {
 		credId: string,
 		settings?: AgentIntegrationSettings,
 	): Promise<{ status: string; agent?: Awaited<ReturnType<typeof connectIntegration>>['agent'] }> {
+		// The agent may still be a client-side draft; the channel cannot attach to a
+		// row that does not exist yet.
+		await draft.ensurePersisted();
 		state.loadingMap.value[type] = true;
 		state.errorMessages.value[type] = '';
 		state.errorIsConflict.value[type] = false;

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -696,16 +696,14 @@ async function saveConfig(snapshot: ConfigAutosaveSnapshot): Promise<'skipped' |
 	// The AI may be mutating this agent right now — a save queued just before
 	// the lock engaged must not persist its now-stale full config over it.
 	if (props.artifactEditingLocked) return 'skipped';
-	// First save of a draft: the create carries the config, so there is no
-	// separate update to make afterwards.
-	if (isPendingAgent.value) {
-		const outcome = await ensurePersisted();
-		// The create carried this snapshot; nothing left to write.
-		if (outcome === 'created') return undefined;
-		// The row already existed with content newer than this draft snapshot —
-		// writing it would clobber what the builder just produced.
-		if (outcome === 'conflict') return 'skipped';
-	}
+	// No-op unless this is a draft's first save.
+	const outcome = await ensurePersisted();
+	// The create carried this snapshot; nothing left to write.
+	if (outcome === 'created') return undefined;
+	// The row already existed with content newer than this draft snapshot —
+	// writing it would clobber what the builder just produced.
+	if (outcome === 'conflict') return 'skipped';
+
 	const result = await updateConfig(snapshot.projectId, snapshot.agentId, snapshot.config);
 	// The write landed regardless of staleness below — tell other surfaces
 	// (e.g. canvas agent cards invalidate their capability-summary cache).

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -18,6 +18,7 @@ import {
 	MAX_AGENT_KNOWLEDGE_BASE_SIZE_GB,
 } from '@n8n/api-types';
 import type { AgentFileDto } from '@n8n/api-types';
+import { ResponseError } from '@n8n/rest-api-client';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
@@ -57,7 +58,12 @@ import { useAgentBuilderSession } from '../composables/useAgentBuilderSession';
 import { useAgentConfigAutosave } from '../composables/useAgentConfigAutosave';
 import { useAgentBuilderMainTabs } from '../composables/useAgentBuilderMainTabs';
 import { useAgentCapabilitiesActions } from '../composables/useAgentCapabilitiesActions';
-import { removeProjectAgentFromListCache } from '../composables/useProjectAgentsList';
+import {
+	removeProjectAgentFromListCache,
+	upsertProjectAgentsListCache,
+} from '../composables/useProjectAgentsList';
+import { useAgentEnsurePersisted } from '../composables/useAgentEnsurePersisted';
+import { provideAgentDraftContext } from '../composables/useAgentDraftContext';
 import { useInstanceAiAgentPreviewHandoff } from '@/features/ai/instanceAi/composables/useInstanceAiAgentPreviewHandoff';
 import { addMissingAgentPersonalisation } from '../utils/agentPersonalisation';
 import {
@@ -86,6 +92,8 @@ const props = withDefaults(
 		artifactMode?: boolean;
 		artifactProjectId?: string;
 		artifactAgentId?: string;
+		/** Name to show for an agent whose row does not exist yet (see `isPendingAgent`). */
+		artifactAgentName?: string;
 		/** True while the AI is actively building/mutating this agent in artifact mode — disables editing/publishing without hiding content. */
 		artifactEditingLocked?: boolean;
 	}>(),
@@ -93,6 +101,7 @@ const props = withDefaults(
 		artifactMode: false,
 		artifactProjectId: undefined,
 		artifactAgentId: undefined,
+		artifactAgentName: undefined,
 		artifactEditingLocked: false,
 	},
 );
@@ -188,6 +197,13 @@ const agentFilesLoading = ref(false);
 const agentFilesUploading = ref(false);
 const deletingAgentFileId = ref<string | null>(null);
 const lastKnowledgeSandboxWarmupKey = ref<string | null>(null);
+/**
+ * The agent id exists but its row does not — a draft opened from "New Agent"
+ * that nobody has written to yet. The panel renders the template config, and
+ * the first write of any kind creates the agent via `ensurePersisted`.
+ * Only reachable in artifact mode; the full-page route always opens a real agent.
+ */
+const isPendingAgent = ref(false);
 
 watch(agentName, (name) => {
 	documentTitle.set(name || locale.baseText('agents.heading'));
@@ -243,6 +259,22 @@ const builderTelemetry = useAgentBuilderTelemetry({
 	connectedTriggers,
 });
 const toolTelemetry = useAgentToolTelemetry(agentId);
+
+const { ensurePersisted } = useAgentEnsurePersisted({
+	projectId: () => projectId.value,
+	agentId: () => agentId.value,
+	isPending: isPendingAgent,
+	getConfig: () => localConfig.value,
+	getName: () => agentName.value || locale.baseText('agents.new.defaultName'),
+	onCreated: (created) => {
+		agent.value = created;
+		agentName.value = created.name;
+		upsertProjectAgentsListCache(projectId.value, created);
+		agentsEventBus.emit('agentUpdated', { agentId: created.id, source: 'agent-builder' });
+	},
+});
+
+provideAgentDraftContext({ isPending: isPendingAgent, ensurePersisted });
 
 /**
  * The backend owns runnable validation so the chat entry point either opens
@@ -324,6 +356,45 @@ async function fetchAgent(
 	agentName.value = data.name;
 }
 
+function isAgentNotFound(error: unknown): boolean {
+	return error instanceof ResponseError && error.httpStatusCode === 404;
+}
+
+/**
+ * Populate the panel from the template config for a draft — an agent id with no
+ * row behind it — so it renders and can be edited before anything is persisted.
+ */
+function seedPendingAgentDraft(targetProjectId: string, targetAgentId: string): void {
+	const name = props.artifactAgentName ?? locale.baseText('agents.new.defaultName');
+	const now = new Date().toISOString();
+	isPendingAgent.value = true;
+	agentName.value = name;
+	agent.value = {
+		resourceType: 'agent',
+		id: targetAgentId,
+		name,
+		projectId: targetProjectId,
+		isCompiled: false,
+		isRunnable: false,
+		hasPublishHistory: false,
+		availableInMCP: false,
+		versionId: null,
+		activeVersionId: null,
+		activeVersion: null,
+		tools: {},
+		skills: {},
+		createdAt: now,
+		updatedAt: now,
+	};
+	localConfig.value = {
+		name,
+		model: '',
+		instructions: '',
+		tools: [],
+		skills: [],
+	};
+}
+
 async function fetchAgentFiles(
 	targetProjectId: string = projectId.value,
 	targetAgentId: string = agentId.value,
@@ -392,6 +463,7 @@ async function onUploadAgentFiles(files: File[]) {
 	const targetAgentId = agentId.value;
 	agentFilesUploading.value = true;
 	try {
+		await ensurePersisted();
 		const uploadedFiles = await uploadAgentFiles(
 			rootStore.restApiContext,
 			targetProjectId,
@@ -569,6 +641,9 @@ function bindPreviewSession() {
 }
 
 function warmAgentKnowledgeSandboxForPage() {
+	// A draft has no row, so warming its sandbox would 404. It warms on the next
+	// initialize, once the first write has created the agent.
+	if (isPendingAgent.value) return;
 	if (!initialized.value || !isKnowledgeBaseEnabled.value || !agent.value) return;
 
 	const targetProjectId = projectId.value;
@@ -612,6 +687,12 @@ async function saveConfig(snapshot: ConfigAutosaveSnapshot): Promise<'skipped' |
 	// The AI may be mutating this agent right now — a save queued just before
 	// the lock engaged must not persist its now-stale full config over it.
 	if (props.artifactEditingLocked) return 'skipped';
+	// First save of a draft: the create carries the config, so there is no
+	// separate update to make afterwards.
+	if (isPendingAgent.value) {
+		await ensurePersisted();
+		return undefined;
+	}
 	const result = await updateConfig(snapshot.projectId, snapshot.agentId, snapshot.config);
 	// The write landed regardless of staleness below — tell other surfaces
 	// (e.g. canvas agent cards invalidate their capability-summary cache).
@@ -633,6 +714,7 @@ async function saveConfig(snapshot: ConfigAutosaveSnapshot): Promise<'skipped' |
 
 async function saveSkill(snapshot: SkillAutosaveSnapshot): Promise<'skipped' | undefined> {
 	if (props.artifactEditingLocked) return 'skipped';
+	await ensurePersisted();
 	const result = await updateAgentSkill(
 		rootStore.restApiContext,
 		snapshot.projectId,
@@ -699,6 +781,7 @@ const agentAvailableInMcp = computed(
 async function saveMcpAvailability(
 	snapshot: McpAvailabilitySnapshot,
 ): Promise<'skipped' | undefined> {
+	await ensurePersisted();
 	await mcpStore.toggleAgentMcpAccess(snapshot.agentId, snapshot.enabled);
 	if (snapshot.enabled) {
 		mcp.trackMcpAccessEnabledForAgent(snapshot.agentId);
@@ -1098,13 +1181,16 @@ async function onHeaderAction(action: string) {
 		skillAutosave.cancelPendingAutosave();
 		const capturedProjectId = projectId.value;
 
-		try {
-			await deleteAgent(rootStore.restApiContext, capturedProjectId, agentId.value);
-			removeProjectAgentFromListCache(capturedProjectId, agentId.value);
-			favoritesStore.removeFavoriteLocally(agentId.value, 'agent');
-		} catch (error) {
-			showError(error, 'Could not delete agent');
-			return;
+		// A draft has nothing to delete — discarding it is just navigating away.
+		if (!isPendingAgent.value) {
+			try {
+				await deleteAgent(rootStore.restApiContext, capturedProjectId, agentId.value);
+				removeProjectAgentFromListCache(capturedProjectId, agentId.value);
+				favoritesStore.removeFavoriteLocally(agentId.value, 'agent');
+			} catch (error) {
+				showError(error, 'Could not delete agent');
+				return;
+			}
 		}
 
 		// Clear local agent state before router.replace so the component teardown
@@ -1173,14 +1259,41 @@ async function initialize() {
 		agentFilesLoading.value = false;
 		agentFilesUploading.value = false;
 		deletingAgentFileId.value = null;
+		isPendingAgent.value = false;
 		repointConfigValidation(projectId.value, agentId.value);
 
-		await Promise.all([
+		// Kept in parallel: the agent and its config are the two loads the panel
+		// blocks on. `allSettled` so a draft's 404 lands here as a result instead
+		// of an unhandled rejection from the sibling call.
+		const targetProjectId = projectId.value;
+		const targetAgentId = agentId.value;
+		const [agentResult] = await Promise.allSettled([
 			fetchAgent(),
-			fetchConfig(projectId.value, agentId.value),
-			fetchAgentFiles(),
-			refreshConfigValidation(projectId.value, agentId.value),
+			fetchConfig(targetProjectId, targetAgentId),
 		]);
+
+		if (agentResult.status === 'rejected') {
+			if (!isArtifactMode.value || !isAgentNotFound(agentResult.reason)) {
+				throw agentResult.reason;
+			}
+			// A draft: no files, no sessions, nothing to validate. Everything below
+			// would only 404 against an agent that does not exist yet. Credentials
+			// and the integrations catalog are project-scoped, so those still load.
+			if (isStaleAgentTarget(targetProjectId, targetAgentId)) return;
+			seedPendingAgentDraft(targetProjectId, targetAgentId);
+			builderTelemetry.captureToolsBaseline();
+			builderTelemetry.captureSkillsBaseline();
+			builderTelemetry.captureTasksBaseline();
+			credentialsStore.setCredentials([]);
+			await Promise.all([
+				credentialsStore.fetchAllCredentialsForWorkflow({ projectId: targetProjectId }),
+				credentialsStore.fetchCredentialTypes(false),
+			]).catch(() => undefined);
+			void ensureIntegrationsCatalog(targetProjectId).catch(() => []);
+			return;
+		}
+
+		await Promise.all([fetchAgentFiles(), refreshConfigValidation(projectId.value, agentId.value)]);
 		persistMissingPersonalisationGradient();
 		builderTelemetry.captureToolsBaseline();
 		builderTelemetry.captureSkillsBaseline();

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -11,6 +11,7 @@ import type { ActionDropdownItem } from '@n8n/design-system/types/action-dropdow
 import type { PathItem } from '@n8n/design-system/components/N8nBreadcrumbs/Breadcrumbs.vue';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import {
+	blankAgentConfig,
 	MAX_AGENT_FILE_SIZE_BYTES,
 	MAX_AGENT_FILE_SIZE_MB,
 	MAX_AGENT_FILES_PER_UPLOAD,
@@ -266,11 +267,22 @@ const { ensurePersisted } = useAgentEnsurePersisted({
 	isPending: isPendingAgent,
 	getConfig: () => localConfig.value,
 	getName: () => agentName.value || locale.baseText('agents.new.defaultName'),
+	isStale: (p, a) => isStaleAgentTarget(p, a),
 	onCreated: (created) => {
 		agent.value = created;
 		agentName.value = created.name;
 		upsertProjectAgentsListCache(projectId.value, created);
 		agentsEventBus.emit('agentUpdated', { agentId: created.id, source: 'agent-builder' });
+
+		// The agent-scoped loads `initialize()` skipped for the draft never get a
+		// second chance: `initialize` only reruns when `agentId` changes, and the
+		// whole point of minting the id client-side is that it does not.
+		void runAgentScopedLoads();
+	},
+	onConflict: async () => {
+		const targetProjectId = projectId.value;
+		const targetAgentId = agentId.value;
+		await Promise.all([fetchAgent(), fetchConfig(targetProjectId, targetAgentId)]);
 	},
 });
 
@@ -353,6 +365,9 @@ async function fetchAgent(
 	const data = await getAgent(rootStore.restApiContext, targetProjectId, targetAgentId);
 	if (isStaleAgentTarget(targetProjectId, targetAgentId)) return;
 	agent.value = data;
+	// Successful fetch proves the row exists — even when the Instance AI builder
+	// (not this panel) created it — so later writes must not re-POST a create.
+	isPendingAgent.value = false;
 	agentName.value = data.name;
 }
 
@@ -386,13 +401,7 @@ function seedPendingAgentDraft(targetProjectId: string, targetAgentId: string): 
 		createdAt: now,
 		updatedAt: now,
 	};
-	localConfig.value = {
-		name,
-		model: '',
-		instructions: '',
-		tools: [],
-		skills: [],
-	};
+	localConfig.value = blankAgentConfig(name);
 }
 
 async function fetchAgentFiles(
@@ -641,8 +650,8 @@ function bindPreviewSession() {
 }
 
 function warmAgentKnowledgeSandboxForPage() {
-	// A draft has no row, so warming its sandbox would 404. It warms on the next
-	// initialize, once the first write has created the agent.
+	// A draft has no row, so warming its sandbox would 404. It warms once the
+	// agent is created, via `onCreated` → `runAgentScopedLoads`.
 	if (isPendingAgent.value) return;
 	if (!initialized.value || !isKnowledgeBaseEnabled.value || !agent.value) return;
 
@@ -690,8 +699,12 @@ async function saveConfig(snapshot: ConfigAutosaveSnapshot): Promise<'skipped' |
 	// First save of a draft: the create carries the config, so there is no
 	// separate update to make afterwards.
 	if (isPendingAgent.value) {
-		await ensurePersisted();
-		return undefined;
+		const outcome = await ensurePersisted();
+		// The create carried this snapshot; nothing left to write.
+		if (outcome === 'created') return undefined;
+		// The row already existed with content newer than this draft snapshot —
+		// writing it would clobber what the builder just produced.
+		if (outcome === 'conflict') return 'skipped';
 	}
 	const result = await updateConfig(snapshot.projectId, snapshot.agentId, snapshot.config);
 	// The write landed regardless of staleness below — tell other surfaces
@@ -968,6 +981,7 @@ const caps = useAgentCapabilitiesActions({
 			skill,
 		});
 	},
+	ensurePersisted,
 	telemetry: {
 		trackOpenedToolFromList: builderTelemetry.trackOpenedToolFromList,
 		trackOpenedSkillFromList: builderTelemetry.trackOpenedSkillFromList,
@@ -1226,6 +1240,46 @@ async function onHeaderAction(action: string) {
 	}
 }
 
+/**
+ * Agent-scoped work that `initialize()` skips for a draft. Shared with
+ * `onCreated` so materializing the row in place still warms files, sessions,
+ * triggers, and the knowledge sandbox — `initialize` itself will not rerun
+ * because the client-minted id stays stable.
+ */
+async function runAgentScopedLoads() {
+	const targetProjectId = projectId.value;
+	const targetAgentId = agentId.value;
+	try {
+		await Promise.all([
+			fetchAgentFiles(),
+			refreshConfigValidation(projectId.value, agentId.value),
+			fetchConfig(projectId.value, agentId.value),
+		]);
+		if (isStaleAgentTarget(targetProjectId, targetAgentId)) return;
+
+		persistMissingPersonalisationGradient();
+
+		sessionsStore.stopAutoRefresh();
+		void sessionsStore.fetchThreads(projectId.value, agentId.value).then(() => {
+			sessionsStore.startAutoRefresh();
+		});
+
+		void (async () => {
+			// Non-fatal — on failure, leave connectedTriggers empty; the sidebar emit
+			// will correct it once the user expands the Triggers section.
+			const integrations = await ensureIntegrationsCatalog(projectId.value).catch(() => []);
+			if (isStaleAgentTarget(targetProjectId, targetAgentId)) return;
+			const triggerTypes = integrations.map((i) => i.type);
+			const connected = await builderTelemetry.fetchInitialTriggersBaseline(triggerTypes);
+			if (connected) connectedTriggers.value = connected;
+		})();
+
+		warmAgentKnowledgeSandboxForPage();
+	} catch (error: unknown) {
+		showError(error, locale.baseText('agents.builder.loadError'));
+	}
+}
+
 async function initialize() {
 	clearTimeout(externalRefreshTimer);
 	// A refresh queued for the previous agent must not fire against this one.
@@ -1262,12 +1316,12 @@ async function initialize() {
 		isPendingAgent.value = false;
 		repointConfigValidation(projectId.value, agentId.value);
 
-		// Kept in parallel: the agent and its config are the two loads the panel
-		// blocks on. `allSettled` so a draft's 404 lands here as a result instead
-		// of an unhandled rejection from the sibling call.
+		// The agent and its config are the two loads the panel blocks on.
+		// `allSettled` so a draft's expected 404 arrives as a result rather than
+		// an unhandled rejection.
 		const targetProjectId = projectId.value;
 		const targetAgentId = agentId.value;
-		const [agentResult] = await Promise.allSettled([
+		const [agentResult, configResult] = await Promise.allSettled([
 			fetchAgent(),
 			fetchConfig(targetProjectId, targetAgentId),
 		]);
@@ -1276,28 +1330,22 @@ async function initialize() {
 			if (!isArtifactMode.value || !isAgentNotFound(agentResult.reason)) {
 				throw agentResult.reason;
 			}
-			// A draft: no files, no sessions, nothing to validate. Everything below
-			// would only 404 against an agent that does not exist yet. Credentials
-			// and the integrations catalog are project-scoped, so those still load.
 			if (isStaleAgentTarget(targetProjectId, targetAgentId)) return;
+			// A draft: no row, so everything agent-scoped below is skipped. The config
+			// fetch failed for the same reason, so its rejection is expected here.
 			seedPendingAgentDraft(targetProjectId, targetAgentId);
-			builderTelemetry.captureToolsBaseline();
-			builderTelemetry.captureSkillsBaseline();
-			builderTelemetry.captureTasksBaseline();
-			credentialsStore.setCredentials([]);
-			await Promise.all([
-				credentialsStore.fetchAllCredentialsForWorkflow({ projectId: targetProjectId }),
-				credentialsStore.fetchCredentialTypes(false),
-			]).catch(() => undefined);
-			void ensureIntegrationsCatalog(targetProjectId).catch(() => []);
-			return;
+		} else if (configResult.status === 'rejected') {
+			throw configResult.reason;
 		}
 
-		await Promise.all([fetchAgentFiles(), refreshConfigValidation(projectId.value, agentId.value)]);
-		persistMissingPersonalisationGradient();
+		if (!isPendingAgent.value) {
+			await runAgentScopedLoads();
+		}
+
 		builderTelemetry.captureToolsBaseline();
 		builderTelemetry.captureSkillsBaseline();
 		builderTelemetry.captureTasksBaseline();
+
 		// Keep agent credential pickers aligned with the workflow editor: load only
 		// credentials the current user can use in this project context.
 		credentialsStore.setCredentials([]);
@@ -1305,22 +1353,15 @@ async function initialize() {
 			credentialsStore.fetchAllCredentialsForWorkflow({ projectId: projectId.value }),
 			credentialsStore.fetchCredentialTypes(false),
 		]).catch(() => undefined);
+
 		// Stop any in-flight auto-refresh from the previous agent before kicking
 		// off a new fetch — keeps the store tied to the current project/agent.
-		sessionsStore.stopAutoRefresh();
-		void sessionsStore.fetchThreads(projectId.value, agentId.value).then(() => {
-			sessionsStore.startAutoRefresh();
-		});
-		void (async () => {
-			// Non-fatal — on failure, leave connectedTriggers empty; the sidebar emit
-			// will correct it once the user expands the Triggers section.
-			const integrations = await ensureIntegrationsCatalog(projectId.value).catch(() => []);
-			const triggerTypes = integrations.map((i) => i.type);
-			const connected = await builderTelemetry.fetchInitialTriggersBaseline(triggerTypes);
-			if (connected) connectedTriggers.value = connected;
-		})();
+		// Non-draft path already restarted refresh inside `runAgentScopedLoads`.
+		if (isPendingAgent.value) {
+			sessionsStore.stopAutoRefresh();
+		}
 
-		if (isPreviewMode.value) bindPreviewSession();
+		if (isPreviewMode.value && !isPendingAgent.value) bindPreviewSession();
 
 		if (!isArtifactMode.value && (route.query.prompt || route.query.expandBuildChat)) {
 			void router.replace({
@@ -1332,6 +1373,11 @@ async function initialize() {
 	} finally {
 		initialized.value = true;
 		void replayPendingExternalRefresh().catch(handleArtifactRefreshError);
+		// Warmup for a normal (non-draft) page load — `initialized` is true here, so
+		// the guard inside warmAgentKnowledgeSandboxForPage does not fire. The sibling
+		// call inside runAgentScopedLoads is inert during initialize (initialized is
+		// still false there) and only does work when that helper is reached from
+		// onCreated after a draft materializes.
 		warmAgentKnowledgeSandboxForPage();
 	}
 }

--- a/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
@@ -3,10 +3,8 @@ import { onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { v4 as uuidv4 } from 'uuid';
 import { useI18n } from '@n8n/i18n';
-import { useRootStore } from '@n8n/stores/useRootStore';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
+import { generateNanoId } from '@n8n/utils/generate-nano-id';
 
-import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { stashPendingAgentAttachment } from '@/features/ai/instanceAi/composables/useInstanceAiHandoff';
 import {
@@ -14,15 +12,11 @@ import {
 	INSTANCE_AI_THREAD_VIEW,
 } from '@/features/ai/instanceAi/constants';
 import { useInstanceAiStore } from '@/features/ai/instanceAi/instanceAi.store';
-import { createAgent } from '../composables/useAgentApi';
-import { upsertProjectAgentsListCache } from '../composables/useProjectAgentsList';
 import { AGENTS_LIST_VIEW, PROJECT_AGENTS } from '../constants';
 
 const route = useRoute();
 const router = useRouter();
 const i18n = useI18n();
-const rootStore = useRootStore();
-const telemetry = useTelemetry();
 const toast = useToast();
 const instanceAiStore = useInstanceAiStore();
 
@@ -35,34 +29,33 @@ onMounted(async () => {
 		return;
 	}
 
+	// The agent is minted here, not created: nothing is written until the first
+	// config edit or the builder's first `write_config`, so opening this page and
+	// walking away leaves no empty agent behind. Minting the final id up front
+	// keeps every reference taken before that first write — the thread binding,
+	// the artifact tab, the composer attachment — valid without a later rewrite.
+	const agentId = generateNanoId();
+	const name = i18n.baseText('agents.new.defaultName');
+
 	try {
-		const agent = await createAgent(
-			rootStore.restApiContext,
-			projectId,
-			i18n.baseText('agents.new.defaultName'),
-		);
-		upsertProjectAgentsListCache(projectId, agent);
-		telemetry.track(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
-			agent_id: agent.id,
-			source: 'create_blank',
-		});
 		const threadId = uuidv4();
 		await instanceAiStore.syncThread(threadId, projectId, {
 			source: 'agent_builder_page',
 			origin: 'internal',
-			sourceContext: { agentId: agent.id },
+			sourceContext: { agentId },
 		});
 		await instanceAiStore.updateThreadMetadata(threadId, {
 			[INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY]: {
-				agentId: agent.id,
+				agentId,
 				projectId,
-				name: agent.name,
+				name,
+				pending: true,
 			},
 		});
 		stashPendingAgentAttachment(threadId, {
 			type: 'agent',
-			id: agent.id,
-			name: agent.name,
+			id: agentId,
+			name,
 			projectId,
 		});
 		await router.replace({

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -1027,6 +1027,7 @@ async function dismissComposerContextChip() {
 								:class="$style.previewSlot"
 								:agent-id="preview.activeAgentId.value"
 								:project-id="preview.activeAgentProjectId.value"
+								:agent-name="preview.activeAgentName.value ?? undefined"
 							/>
 						</div>
 					</TabsRoot>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiAgentPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiAgentPreview.vue
@@ -7,6 +7,8 @@ import { useThread } from '../instanceAi.store';
 const props = defineProps<{
 	projectId: string;
 	agentId: string;
+	/** Tab label, used to name a draft the builder has not written to the DB yet. */
+	agentName?: string;
 }>();
 
 // === Editing lock ===
@@ -33,6 +35,7 @@ const isAgentBuilding = computed(() => {
 			artifact-mode
 			:artifact-project-id="props.projectId"
 			:artifact-agent-id="props.agentId"
+			:artifact-agent-name="props.agentName"
 			:artifact-editing-locked="isAgentBuilding"
 		/>
 	</div>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
@@ -83,6 +83,12 @@ export function useCanvasPreview({ thread }: UseCanvasPreviewOptions) {
 		return tab?.type === 'agent' ? (tab.projectId ?? null) : null;
 	});
 
+	/** Tab label for the active agent — the only name source for an agent the builder has not written yet. */
+	const activeAgentName = computed(() => {
+		const tab = allArtifactTabs.value.find((t) => t.id === activeTabId.value);
+		return tab?.type === 'agent' ? tab.name : null;
+	});
+
 	const executionResultsByWorkflow = computed(() => {
 		const results = new Map<string, ExecutionResult>();
 		for (const message of thread.messages) {
@@ -430,6 +436,7 @@ export function useCanvasPreview({ thread }: UseCanvasPreviewOptions) {
 		activeDataTableProjectId,
 		activeAgentId,
 		activeAgentProjectId,
+		activeAgentName,
 		activeWorkflowExecutionResult,
 		dataTableRefreshKey,
 		isPreviewVisible,


### PR DESCRIPTION
## Summary

Clicking **New Agent**, or asking Instance AI to build one, inserted an `agents` row before the user had said anything. Abandoned drafts piled up as empty agents: they showed in project lists, and every one of them counted towards `User created agent`.

The agent id is now minted client-side and the row is written by the **first write that carries real configuration** — whether that comes from the config panel or from the builder's first config-mutating tool. Open the page and walk away, and nothing is written.

Minting the *final* id up front (rather than a `__EMPTY__`-style sentinel) is what keeps this invisible: the thread binding, the artifact tab and the composer attachment all take the id at thread-open time and stay valid without a later rewrite. **Navigation and flow are unchanged.**

This also closes AGENT-508. Because a row can now only exist with content, "created" and "first real config" are the same moment, so `User created agent` is a plain emit at insert — no template-diff detection needed. It moves to `AgentsService.create` with `project_id` / `user_id` (dropping `source`), covering the editor, the Instance AI builder and MCP in one place.

### How it works

```mermaid
flowchart TD
    Click[User clicks New Agent] --> Mint[Mint nanoid, no POST]
    Mint --> Thread[Thread opens, artifact panel shows the draft]
    Thread --> Edit[User edits config]
    Thread --> Chat[User sends a build message]
    Edit --> PostA["POST /agents/v2 with id + name + config"]
    Chat --> Build[Builder's first config tool]
    Build --> PostB[materializeIfPending creates the row]
    PostA --> Row[(agents row exists)]
    PostB --> Row
    Abandon[User leaves] --> Nothing[No row ever written]
```

**Backend.** `CreateAgentDto` takes an optional `id` and `config`; `AgentsService.create` accepts a client-minted id, rejects one that is already taken, and emits the telemetry. The controller applies an initial config in the same request and deletes the agent again if that config is rejected, so a bad config cannot leave a husk behind — the same rollback MCP's `create_agent` already does.

**Builder.** `createBuilderAgent`'s existence check is relaxed for a pending target. That guard was the only thing standing in the way: nothing downstream reads the entity — the prompt takes a path string, and tools, memory and checkpoint storage all take the id. `read_config` returns the template for a pending target, and `materializeIfPending` creates the row at the top of `write_config`, `patch_config`, `build_custom_tool`, `create_skills` and `create_tasks`, re-checking existence so the config panel and the builder cannot both create it. Since the id may have been reserved by the UI rather than handed out by the delegate, `agent:create` is enforced there — the one place a builder run inserts an agent.

**Frontend.** `/new-agent` mints the id and skips the POST; thread sync, target binding, attachment stash and redirect are otherwise untouched. When the artifact panel opens an agent that 404s it seeds the template config instead of erroring. A single `useAgentEnsurePersisted` — deduped so racing callers produce one POST — creates the row on the first write, wired into config save, skill save, MCP toggle, knowledge upload, skill creation and the task modal. Deleting a draft just navigates away.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-508/emit-user-created-agent-telemetry-on-first-config-change-instead-of-on

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)