### PR TITLE
fix(Form Node): Skip unexecuted branch parents when returning binary …

### DIFF
--- a/packages/nodes-base/nodes/Form/test/Form.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/Form.node.test.ts
@@ -700,6 +700,224 @@ describe('Form Node', () => {
 		});
 	});
 
+	// Reproduces #35380: Form completion with returnBinary after Switch/If
+	// where an unexecuted branch parent (Code1) is still listed in getParentNodes.
+	describe('webhook completion with unexecuted conditional branch parents (#35380)', () => {
+		const triggerName = 'Form Trigger';
+		const code1Name = 'Code1';
+		const convertName = 'Convert to File';
+		const formName = 'Form';
+
+		const triggerNode = {
+			id: 'trigger-id',
+			name: triggerName,
+			type: FORM_TRIGGER_NODE_TYPE,
+			typeVersion: 2.6,
+			disabled: false,
+			position: [0, 0],
+			parameters: {
+				formTitle: 'Contact',
+				authentication: 'none',
+				options: { appendAttribution: false },
+			},
+		} satisfies INode & NodeTypeAndVersion;
+
+		const code1Node: INode = {
+			id: 'code1-id',
+			name: code1Name,
+			type: 'n8n-nodes-base.code',
+			typeVersion: 2,
+			position: [200, -100],
+			parameters: {},
+		};
+
+		const convertNode: INode = {
+			id: 'convert-id',
+			name: convertName,
+			type: 'n8n-nodes-base.convertToFile',
+			typeVersion: 1,
+			position: [400, 0],
+			parameters: {},
+		};
+
+		const formNode: INode = {
+			id: 'form-id',
+			name: formName,
+			type: FORM_NODE_TYPE,
+			typeVersion: 2.5,
+			position: [600, 0],
+			parameters: {},
+		};
+
+		const triggerOutput: INodeExecutionData = {
+			json: { formMode: 'test' },
+		};
+
+		const convertOutput: INodeExecutionData = {
+			json: {},
+			binary: {
+				data: {
+					data: 'ZmlsZSBjb250ZW50',
+					fileName: 'file.txt',
+					mimeType: 'text/plain',
+				},
+			},
+		};
+
+		const workflow = new Workflow({
+			id: 'workflow-id',
+			name: 'Conditional Form workflow',
+			nodes: [triggerNode, code1Node, convertNode, formNode],
+			connections: {
+				[triggerName]: {
+					main: [
+						[
+							{ node: code1Name, type: 'main', index: 0 },
+							{ node: convertName, type: 'main', index: 0 },
+						],
+					],
+				},
+				[code1Name]: {
+					main: [[{ node: convertName, type: 'main', index: 0 }]],
+				},
+				[convertName]: {
+					main: [[{ node: formName, type: 'main', index: 0 }]],
+				},
+			},
+			active: false,
+			nodeTypes: mock<INodeTypes>(),
+		});
+
+		// Path B taken: Code1 never ran; Convert to File has binary.
+		const runExecutionData = createRunExecutionData({
+			resultData: {
+				runData: {
+					[triggerName]: [
+						{
+							startTime: 1,
+							executionTime: 1,
+							executionIndex: 0,
+							source: [],
+							data: { main: [[triggerOutput]] },
+						},
+					],
+					[convertName]: [
+						{
+							startTime: 2,
+							executionTime: 1,
+							executionIndex: 1,
+							source: [],
+							data: { main: [[convertOutput]] },
+						},
+					],
+				},
+			},
+		});
+
+		beforeAll(async () => await workflow.expression.acquireIsolate());
+		afterAll(async () => await workflow.expression.releaseIsolate());
+
+		it('should complete returnBinary when an unexecuted branch parent is among parents', async () => {
+			const context = mock<IWebhookFunctions>();
+			context.getNode.mockReturnValue(formNode);
+			// All ancestors including unexecuted Code1 (as getParentNodes returns)
+			context.getParentNodes.mockReturnValue([triggerNode, code1Node, convertNode]);
+			context.getWorkflowSettings.mockReturnValue({});
+			context.evaluateExpression.mockImplementation((expression) =>
+				workflow.expression.resolveSimpleParameterValue(
+					`=${expression}`,
+					{},
+					runExecutionData,
+					0,
+					0,
+					formNode.name,
+					[convertOutput],
+					'manual',
+					{},
+				),
+			);
+
+			const response = mock<Response>();
+			context.getResponseObject.mockReturnValue(response);
+			context.getRequestObject.mockReturnValue({ method: 'GET' } as Request);
+			context.getNodeParameter.mockImplementation((name) => {
+				if (name === 'operation') return 'completion';
+				if (name === 'defineForm') return 'fields';
+				if (name === 'formFields.values') return [];
+				if (name === 'options') return { formTitle: '' };
+				if (name === 'respondWith') return 'returnBinary';
+				if (name === 'inputDataFieldName') return 'data';
+				if (name === 'completionTitle') return 'Done';
+				if (name === 'completionMessage') return 'Thanks';
+				return undefined;
+			});
+
+			await form.webhook(context);
+
+			expect(response.render).toHaveBeenCalledWith(
+				'form-trigger-completion',
+				expect.objectContaining({
+					formTitle: 'Contact',
+					responseBinary: encodeURIComponent(
+						JSON.stringify([
+							{
+								data: 'file content',
+								fileName: 'file.txt',
+								type: 'text/plain',
+							},
+						]),
+					),
+				}),
+			);
+		});
+
+		it('should complete completionMessage when an unexecuted branch parent is among parents', async () => {
+			const context = mock<IWebhookFunctions>();
+			context.getNode.mockReturnValue(formNode);
+			context.getParentNodes.mockReturnValue([triggerNode, code1Node, convertNode]);
+			context.getWorkflowSettings.mockReturnValue({});
+			context.evaluateExpression.mockImplementation((expression) =>
+				workflow.expression.resolveSimpleParameterValue(
+					`=${expression}`,
+					{},
+					runExecutionData,
+					0,
+					0,
+					formNode.name,
+					[convertOutput],
+					'manual',
+					{},
+				),
+			);
+
+			const response = mock<Response>();
+			context.getResponseObject.mockReturnValue(response);
+			context.getRequestObject.mockReturnValue({ method: 'GET' } as Request);
+			context.getNodeParameter.mockImplementation((name) => {
+				if (name === 'operation') return 'completion';
+				if (name === 'defineForm') return 'fields';
+				if (name === 'formFields.values') return [];
+				if (name === 'options') return { formTitle: '' };
+				if (name === 'respondWith') return 'text';
+				if (name === 'completionTitle') return 'Done';
+				if (name === 'completionMessage') return 'Thanks';
+				if (name === 'responseText') return '';
+				return undefined;
+			});
+
+			await form.webhook(context);
+
+			expect(response.render).toHaveBeenCalledWith(
+				'form-trigger-completion',
+				expect.objectContaining({
+					formTitle: 'Contact',
+					title: 'Done',
+					message: 'Thanks',
+				}),
+			);
+		});
+	});
+
 	describe('webhook method - n8nUserAuth propagation', () => {
 		const authedUser = {
 			id: 'user-1',

--- a/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
@@ -295,6 +295,9 @@ describe('formCompletionUtils', () => {
 			for (const parentNodes of parentNodesTestCases) {
 				mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodes);
 				mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
+					if (typeof arg === 'string' && arg.includes('.isExecuted')) {
+						return true;
+					}
 					if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 						return expectedBinaryResponse;
 					} else if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
@@ -359,6 +362,9 @@ describe('formCompletionUtils', () => {
 			for (const parentNodes of parentNodesTestCases) {
 				mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodes);
 				mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
+					if (typeof arg === 'string' && arg.includes('.isExecuted')) {
+						return true;
+					}
 					if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 						return expectedBinaryResponse;
 					} else if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
@@ -519,6 +525,9 @@ describe('formCompletionUtils', () => {
 
 			mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodesWithMultipleBinaryFiles);
 			mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
+				if (typeof arg === 'string' && arg.includes('.isExecuted')) {
+					return true;
+				}
 				if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
 					return expectedBinaryResponse;
 				} else {
@@ -554,6 +563,12 @@ describe('formCompletionUtils', () => {
 			});
 			mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodesWithMultipleBinaryFiles);
 			mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
+				if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).isExecuted }}`) {
+					return true;
+				}
+				if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).isExecuted }}`) {
+					return false;
+				}
 				if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 					return expectedBinaryResponse;
 				}
@@ -595,6 +610,9 @@ describe('formCompletionUtils', () => {
 			});
 			mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodesWithSingleNodeFile);
 			mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
+				if (typeof arg === 'string' && arg.includes('.isExecuted')) {
+					return true;
+				}
 				if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 					return expectedBinaryResponse;
 				}
@@ -640,6 +658,9 @@ describe('formCompletionUtils', () => {
 			});
 			mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodesWithSingleNodeFile);
 			mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
+				if (typeof arg === 'string' && arg.includes('.isExecuted')) {
+					return true;
+				}
 				if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 					return expectedBinaryResponse;
 				}

--- a/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
@@ -27,13 +27,17 @@ const getBinaryDataFromNode = (
 	nodeName: string,
 ): IDataObject | undefined => {
 	try {
-		return context.evaluateExpression(`{{ ${getNodeReference(nodeName)}.first().binary }}`) as
-			| IDataObject
-			| undefined;
+		const nodeRef = getNodeReference(nodeName);
+		// Skip parents on inactive Switch/If branches (and other unexecuted ancestors).
+		// `.first()` throws ExpressionError when the node has no run data.
+		const isExecuted = context.evaluateExpression(`{{ ${nodeRef}.isExecuted }}`) as boolean;
+		if (!isExecuted) {
+			return undefined;
+		}
+		return context.evaluateExpression(`{{ ${nodeRef}.first().binary }}`) as IDataObject | undefined;
 	} catch {
-		// Parent nodes without run data (e.g. branches of another Form Trigger,
-		// or nodes that ran before a resumed waiting form in queue mode) throw
-		// an ExpressionError — treat them as having no binary data.
+		// Safety net for unexpected expression failures (e.g. other Form Trigger
+		// branches, or nodes that ran before a resumed waiting form in queue mode).
 		return undefined;
 	}
 };


### PR DESCRIPTION
## Summary

- Skip unexecuted parent nodes (e.g. inactive Switch/If branches) when Form completion returns binary, by checking `.isExecuted` before `.first().binary`.
- Keep try/catch as a safety net for unexpected expression failures.
- Add regression tests for GitHub issue #35380.

## How to test

1. Create a workflow: Form Trigger → Switch/If → Path A (`Code1`) and Path B → merge into Convert to File → Form completion with **Respond With = Return Binary**.
2. Submit the form so Path B runs and `Code1` is skipped.
3. Confirm the completion page succeeds with no `ExpressionError: Node 'Code1' hasn't been executed`.
4. From `packages/nodes-base` run:
   ```bash
   pnpm test Form.node.test.ts formCompletionUtils.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

