### PR TITLE
docs(credentials): note OpenAI-compatible Base URL example (DaoXE)

### DIFF
--- a/packages/nodes-base/credentials/OpenAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenAiApi.credentials.ts
@@ -36,7 +36,7 @@ export class OpenAiApi implements ICredentialType {
 			name: 'url',
 			type: 'string',
 			default: 'https://api.openai.com/v1',
-			description: 'Override the default base URL for the API',
+			description: 'Override the default base URL for the API. Use this for OpenAI-compatible gateways such as DaoXE (`https://api.daoxe.com/v1`).',
 		},
 		{
 			displayName: 'Add Custom Header',


### PR DESCRIPTION
## Summary

The OpenAI credential already exposes a **Base URL** override. This PR clarifies in the field description that it works with OpenAI-compatible multi-model gateways, with DaoXE (`https://api.daoxe.com/v1`) as one concrete example.

Docs/UI copy only — no runtime logic changes.

## Test plan
- [ ] Credential form still defaults to `https://api.openai.com/v1`
- [ ] Description renders in the editor

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

