### PR TITLE
feat(editor): Restore one-click connector for ChatGPT MCP client

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/McpConnectClientDialog.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/McpConnectClientDialog.test.ts
@@ -70,7 +70,7 @@ describe('McpConnectClientDialog', () => {
 		expect(body().queryByText('Authenticate')).not.toBeInTheDocument();
 	});
 
-	it('should show only the server URL (no one-click) for web clients without a connector URL', async () => {
+	it('should show the one-click connector, server URL, and no token setup for web clients', async () => {
 		renderComponent({ pinia });
 
 		await waitFor(() => {
@@ -82,11 +82,15 @@ describe('McpConnectClientDialog', () => {
 		});
 		await userEvent.click(body().getByText('ChatGPT'));
 
-		// ChatGPT has no one-click connector, so only the mandatory server URL shows.
 		await waitFor(() => {
-			expect(body().getByText('Server URL')).toBeInTheDocument();
+			expect(body().getByTestId('mcp-connect-one-click')).toBeInTheDocument();
 		});
-		expect(body().queryByTestId('mcp-connect-one-click')).not.toBeInTheDocument();
+		expect(body().getByTestId('mcp-connect-one-click')).toHaveAttribute(
+			'href',
+			'https://chatgpt.com/plugins#settings/Connectors?create-connector=true&redirectAfter=%2Fplugins',
+		);
+		// Server URL is mandatory for web clients.
+		expect(body().getByText('Server URL')).toBeInTheDocument();
 	});
 
 	it('should show the OAuth client setup by default and switch to the API key tab', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.clients.catalog.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.clients.catalog.test.ts
@@ -40,12 +40,9 @@ describe('getMcpClientCatalog', () => {
 		});
 	});
 
-	it('should give web connector URLs as https and every CLI an install command', () => {
+	it('should give every web client a connector URL and every CLI an install command', () => {
 		const web = catalog.find((group) => group.id === 'web')!;
-		// A one-click connector URL is optional per web client, but when present it must be https.
-		for (const client of web.clients) {
-			if (client.addUrl) expect(client.addUrl).toMatch(/^https:\/\//);
-		}
+		for (const client of web.clients) expect(client.addUrl).toMatch(/^https:\/\//);
 
 		const cli = catalog.find((group) => group.id === 'cli')!;
 		for (const client of cli.clients) {

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.clients.catalog.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.clients.catalog.ts
@@ -136,6 +136,10 @@ url = "${serverUrl}"`;
 					name: 'ChatGPT',
 					category: 'web',
 					icon: OpenAiIcon,
+					// Opens ChatGPT's "create connector" form directly, prefilled to just take the
+					// server URL, rather than dropping the user on the connectors settings page.
+					addUrl:
+						'https://chatgpt.com/plugins#settings/Connectors?create-connector=true&redirectAfter=%2Fplugins',
 				},
 			],
 		},


### PR DESCRIPTION
## Summary

Restores the one-click connector button for the **ChatGPT** MCP client in the "Connect a client" dialog.

Rather than the old link that just dropped users on ChatGPT's connectors settings page (confusing, and only works with developer mode on), this points at the **create-connector form directly** so the user only has to paste the server URL:

`https://chatgpt.com/plugins#settings/Connectors?create-connector=true&redirectAfter=%2Fplugins`

The dialog already renders the one-click row behind `v-if="activeClient.addUrl"`, so no component logic changed — only the catalog entry and the two tests that asserted its absence.

## How to test

1. Open **Settings → MCP** and click **Connect a client**.
2. Pick **ChatGPT** from the client picker.
3. The **One-click setup** row now appears with an **Add to ChatGPT** button, above the mandatory Server URL field.
4. Clicking it opens ChatGPT's create-connector form; paste the server URL to finish.

## Related tickets

https://linear.app/n8n/issue/ADO-5660

## Review / merge checklist

- [ ] PR title follows [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md).
- [ ] Tests included.

🤖 PR Summary generated by AI