### PR TITLE
fix(core): Attach user_id to backend Builder telemetry events (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2201,6 +2201,7 @@ describe('createWorkflowAdapter', () => {
 		await adapter.publish('wf-new');
 
 		expect(mockTelemetry.track).toHaveBeenCalledWith('Builder published workflow', {
+			user_id: 'user-1',
 			thread_id: 'thread-1',
 			workflow_id: 'wf-new',
 			executed_by: 'ai',
@@ -3259,6 +3260,7 @@ describe('createExecutionAdapter run()', () => {
 		await adapter.run('wf-1');
 
 		expect(mockTelemetry.track).toHaveBeenCalledWith('Builder executed workflow', {
+			user_id: 'user-1',
 			thread_id: 'thread-1',
 			workflow_id: 'wf-1',
 			executed_by: 'ai',

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
@@ -40,6 +40,7 @@ describe('InstanceAiService — "Builder asked for input" telemetry', () => {
 		planRequestsByThread: Map<string, number>;
 		telemetry: { track: Mock };
 		trackConfirmationRequest: (
+			userId: string,
 			threadId: string,
 			confirmationEvent: { payload: Record<string, unknown> },
 		) => void;
@@ -62,23 +63,28 @@ describe('InstanceAiService — "Builder asked for input" telemetry', () => {
 	it('marks the first plan review in a thread as first_plan and counts plan items', () => {
 		const service = makeService();
 
-		service.trackConfirmationRequest('thread-a', {
+		service.trackConfirmationRequest('user-1', 'thread-a', {
 			payload: { inputType: 'plan-review', planItems: [{}, {}, {}] },
 		});
 
 		expect(service.telemetry.track).toHaveBeenCalledWith(
 			'Builder asked for input',
-			expect.objectContaining({ thread_id: 'thread-a', type: 'first_plan', num_steps: 3 }),
+			expect.objectContaining({
+				user_id: 'user-1',
+				thread_id: 'thread-a',
+				type: 'first_plan',
+				num_steps: 3,
+			}),
 		);
 	});
 
 	it('marks later plan reviews in the same thread as revised_plan', () => {
 		const service = makeService();
 
-		service.trackConfirmationRequest('thread-a', {
+		service.trackConfirmationRequest('user-1', 'thread-a', {
 			payload: { inputType: 'plan-review', planItems: [{}] },
 		});
-		service.trackConfirmationRequest('thread-a', {
+		service.trackConfirmationRequest('user-1', 'thread-a', {
 			payload: { inputType: 'plan-review', planItems: [{}, {}] },
 		});
 
@@ -91,10 +97,10 @@ describe('InstanceAiService — "Builder asked for input" telemetry', () => {
 	it('counts plans per thread independently', () => {
 		const service = makeService();
 
-		service.trackConfirmationRequest('thread-a', {
+		service.trackConfirmationRequest('user-1', 'thread-a', {
 			payload: { inputType: 'plan-review', planItems: [{}] },
 		});
-		service.trackConfirmationRequest('thread-b', {
+		service.trackConfirmationRequest('user-1', 'thread-b', {
 			payload: { inputType: 'plan-review', planItems: [{}] },
 		});
 
@@ -106,7 +112,7 @@ describe('InstanceAiService — "Builder asked for input" telemetry', () => {
 	it('passes non-plan input types through unchanged and counts their steps', () => {
 		const service = makeService();
 
-		service.trackConfirmationRequest('thread-a', {
+		service.trackConfirmationRequest('user-1', 'thread-a', {
 			payload: { inputType: 'questions', questions: [{}, {}] },
 		});
 
@@ -120,7 +126,7 @@ describe('InstanceAiService — "Builder asked for input" telemetry', () => {
 	it('derives setup type from setupRequests when no inputType is present', () => {
 		const service = makeService();
 
-		service.trackConfirmationRequest('thread-a', {
+		service.trackConfirmationRequest('user-1', 'thread-a', {
 			payload: { setupRequests: [{}, {}, {}] },
 		});
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -668,6 +668,7 @@ export class InstanceAiAdapterService {
 
 				if (threadId) {
 					telemetry.track('Builder published workflow', {
+						user_id: user.id,
 						thread_id: threadId,
 						workflow_id: workflowId,
 						executed_by: 'ai',
@@ -847,6 +848,7 @@ export class InstanceAiAdapterService {
 
 				if (threadId) {
 					telemetry.track('Builder created workflow', {
+						user_id: user.id,
 						thread_id: threadId,
 						workflow_id: updated.id,
 					});
@@ -928,6 +930,7 @@ export class InstanceAiAdapterService {
 
 				if (threadId) {
 					telemetry.track('Builder modified workflow', {
+						user_id: user.id,
 						thread_id: threadId,
 						workflow_id: workflowId,
 					});
@@ -1258,6 +1261,7 @@ export class InstanceAiAdapterService {
 					if (!threadId) return;
 
 					telemetry.track('Builder executed workflow', {
+						user_id: user.id,
 						thread_id: threadId,
 						workflow_id: workflowId,
 						executed_by: 'ai',

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -3765,7 +3765,7 @@ export class InstanceAiService {
 				}
 
 				if (result.confirmationEvent) {
-					this.trackConfirmationRequest(threadId, result.confirmationEvent);
+					this.trackConfirmationRequest(user.id, threadId, result.confirmationEvent);
 					this.eventBus.publish(threadId, result.confirmationEvent);
 				}
 
@@ -5002,7 +5002,7 @@ export class InstanceAiService {
 				}
 
 				if (result.confirmationEvent) {
-					this.trackConfirmationRequest(opts.threadId, result.confirmationEvent);
+					this.trackConfirmationRequest(opts.user.id, opts.threadId, result.confirmationEvent);
 					this.eventBus.publish(opts.threadId, result.confirmationEvent);
 				}
 
@@ -5572,6 +5572,7 @@ export class InstanceAiService {
 	}
 
 	private trackConfirmationRequest(
+		userId: string,
 		threadId: string,
 		confirmationEvent: { payload: Record<string, unknown> },
 	): void {
@@ -5612,6 +5613,7 @@ export class InstanceAiService {
 		}
 
 		this.telemetry.track('Builder asked for input', {
+			user_id: userId,
 			thread_id: threadId,
 			input_thread_id: inputThreadId,
 			type,


### PR DESCRIPTION
## Summary

The backend `Builder …` telemetry events never reach PostHog. They only land in RudderStack.

The events split by where they are emitted:

- The frontend `User …` events (sent builder message, finished providing input, viewed new builder workflow, published version from canvas) show up in PostHog.
- The backend `Builder …` events (asked for input, created workflow, modified workflow, executed workflow, published workflow) do not.

Root cause is that the backend events are tracked without a `user_id`:

1. In `Telemetry.track()` the payload `userId` is built as `` `${instanceId}${user_id ? `#${user_id}` : ''}` ``, so with no `user_id` it collapses to the bare `instanceId`.
2. `PostHogClient.track()` starts with `if (!payload.userId || payload.userId === this.instanceSettings.instanceId) return;`, which drops any event whose userId is just the instance id.
3. RudderStack has no such guard, so the events still flow there and nowhere else.

## What this changes

Passes the acting user's id into each backend `Builder …` `track()` call. Once the payload userId is `instanceId#userId`, PostHog captures the events. The user is already in scope at every call site. `trackConfirmationRequest` gains a `userId` parameter threaded from its two callers.

RudderStack keeps receiving the events exactly as before, adding `user_id` does not remove them from there.

## Note for reviewer

The events have been emitted this way since #28116, so this is not a recent regression, they were never reaching PostHog. Worth a look from someone who knows the Builder analytics setup to confirm the instance-only identification wasn't intentional before we start attributing these to individual users.

## Test

- Updated the exact-match telemetry assertions in `instance-ai.adapter.service.test.ts` and threaded the new `userId` arg through `instance-ai.service.builderAskedForInput.test.ts`, plus an assertion that `user_id` is included.
- `pnpm vitest run` on both instance-ai test files: 176 passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

