### PR TITLE
docs: Add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ docker run -it --rm --name n8n -p 5678:5678 -v n8n_data:/home/node/.n8n docker.n
 
 Access the editor at http://localhost:5678
 
+Or skip the server entirely and have an instance deployed and managed for you, with storage, backups, email and a subdomain included:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/n8n)
+
 ## Resources
 
 - 📚 [Documentation](https://docs.n8n.io)


### PR DESCRIPTION
## Summary

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added n8n to our marketplace, so this PR adds a small "Deploy with Zenith" badge under "Quick Start" in the README (links to https://zenith.hosting/host/n8n).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

it is one file, README.md, four added lines, and it sits after the npx and Docker options so nothing above it moves.

happy to close this if the Sustainable Use License means you would rather not point at third-party managed hosting at all. just say the word and tell us what you would need from us, we would rather sort that out with you than around you.

## How to test

Open `README.md`. The badge renders after "Access the editor at http://localhost:5678" and links to https://zenith.hosting/host/n8n.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (N/A, this is a README change; happy to mirror it in n8n-docs if you want it there too)
- [ ] Tests included. (N/A, docs-only)
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (N/A, not an urgent fix)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

