### PR TITLE
fix(editor): Realign SchemaItem text to optical baseline (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchemaItem.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchemaItem.vue
@@ -247,6 +247,8 @@ const emit = defineEmits<{
 	font-size: var(--font-size--2xs);
 	margin-left: var(--spacing--2xs);
 	word-break: break-word;
+	/** Fixes DS-538 where text was optically un-aligned from baseline **/
+	transform: translateY(-1px);
 }
 
 .collapse-icon {


### PR DESCRIPTION
## Summary

Realign schema item value text with the surrounding content by applying a small vertical offset.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/226c670d-b45a-4945-9d79-3e3c32ccf95b" width="960" /> | <img src="https://github.com/user-attachments/assets/63d2a58d-3c6a-4389-a12e-43a3c621f6d4" width="960" /> |


## How to test

1. Open a workflow with execution data in the editor.
2. Open the schema view in the node details panel.
3. Verify schema item values align visually with their labels and controls.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-538

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)