### PR TITLE
fix(editor): Align node status border widths (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/_canvasNodeStyles.scss
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/_canvasNodeStyles.scss
@@ -28,16 +28,17 @@
 }
 
 @mixin status-success {
-	--canvas-node--border-width: 2px;
+	--canvas-node--border-width: var(--spacing--5xs);
 	--canvas-node--border-color: var(--color-canvas-node-success-border-color, var(--color--success));
 }
 
 @mixin status-error {
+	--canvas-node--border-width: var(--spacing--5xs);
 	--canvas-node--border-color: var(--canvas-node--border-color--error, var(--color--danger));
 }
 
 @mixin status-warning {
-	--canvas-node--border-width: 2px;
+	--canvas-node--border-width: var(--spacing--5xs);
 	--canvas-node--border-color: var(--color--warning);
 }
 


### PR DESCRIPTION
## Summary

The error state variant for `CanvasNode` wasn't set to `2px` like the others. Also moves node outlines to use the same design-system border width token.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/e3c974bc-7fa4-42ee-b664-c9717751c8f1" width="960" /> | <img src="https://github.com/user-attachments/assets/5b8e7bec-fc46-4f91-b3d6-9a3301456c6b" width="960" /> |

## How to test

1. Open a workflow in the editor.
2. Compare nodes in success, error, and warning states.
3. Confirm each status outline uses a consistent border width and retains its expected color.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-536

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

