### PR TITLE
fix(core): Disable Slack app Home tab

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/slack-app-setup.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/slack-app-setup.service.test.ts
@@ -170,7 +170,7 @@ describe('SlackAppSetupService', () => {
 			'https://hooks.example/rest/projects/project-1/agents/v2/agent-1/integrations/slack/oauth/callback';
 		expect(manifest.oauth_config.redirect_urls).toEqual([callbackUrl]);
 		expect(manifest.features.app_home).toEqual({
-			home_tab_enabled: true,
+			home_tab_enabled: false,
 			messages_tab_enabled: true,
 			messages_tab_read_only_enabled: false,
 		});
@@ -271,7 +271,7 @@ describe('SlackAppSetupService', () => {
 
 		expect(result.manifest.display_information.name).toBe('Support Agent');
 		expect(result.manifest.features.app_home).toEqual({
-			home_tab_enabled: true,
+			home_tab_enabled: false,
 			messages_tab_enabled: true,
 			messages_tab_read_only_enabled: false,
 		});

--- a/packages/cli/src/modules/agents/integrations/slack-app-setup.service.ts
+++ b/packages/cli/src/modules/agents/integrations/slack-app-setup.service.ts
@@ -299,7 +299,7 @@ export class SlackAppSetupService {
 			},
 			features: {
 				app_home: {
-					home_tab_enabled: true,
+					home_tab_enabled: false,
 					messages_tab_enabled: true,
 					messages_tab_read_only_enabled: false,
 				},


### PR DESCRIPTION
## Summary

Disable the unused Home tab for newly generated Slack agent apps while keeping Messages enabled and writable.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

