### PR TITLE
docs: Correct SearXNG JSON-format setup for Instance AI (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -254,6 +254,10 @@ Add `N8N_INSTANCE_AI_SEARXNG_URL` pointing to your SearXNG service:
 services:
   searxng:
     image: searxng/searxng:latest
+    environment:
+      SEARXNG_SECRET: replace-with-a-random-string
+    volumes:
+      - ./searxng-settings.yml:/etc/searxng/settings.yml:ro
     ports:
       - "8888:8080"  # optional: expose to host
   n8n:
@@ -262,13 +266,15 @@ services:
       N8N_INSTANCE_AI_SEARXNG_URL: http://searxng:8080
 ```
 
-SearXNG must have JSON format enabled in its `settings.yml`:
+The stock `searxng/searxng` image serves HTML only — `format=json` requests
+return `403 Forbidden` — so Instance AI's web search needs a mounted
+`settings.yml` that enables the JSON API:
 
 ```yaml
+# searxng-settings.yml
+use_default_settings: true
 search:
   formats:
     - html
     - json   # required for Instance AI
 ```
-
-Most SearXNG Docker images enable JSON format by default.


### PR DESCRIPTION
## Summary

The Instance AI configuration doc claimed "Most SearXNG Docker images enable JSON format by default." Empirically false: the stock `searxng/searxng` image returns **403 Forbidden** for `format=json` requests, so anyone following the doc's compose example gets a broken web search.

Fixes verified while bundling SearXNG into the get.n8n.io installer (#34711):

- Compose example now mounts a `settings.yml` that enables the JSON API and sets `SEARXNG_SECRET` (required when the settings file is mounted read-only).
- The settings snippet gains `use_default_settings: true` — without it, a mounted `settings.yml` **replaces** SearXNG's entire config instead of extending it.
- Replaced the false default-enabled claim with the actual symptom (403) so it's searchable.

The exact shape shown here is what #34711's e2e boots and asserts against in CI.

## How to test

Docs-only. To verify the claim: `docker run --rm -p 8888:8080 searxng/searxng:latest` then `curl 'http://localhost:8888/search?q=test&format=json'` → 403; with the mounted settings.yml from the doc → JSON results.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-661

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

