### PR TITLE
test(design-system): Guard ConditionalRouterLink prop declarations (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/ConditionalRouterLink/ConditionalRouterLink.props.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/ConditionalRouterLink/ConditionalRouterLink.props.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { RouterLink } from 'vue-router';
+
+import ConditionalRouterLink from './CondtionalRouterLink.vue';
+
+/**
+ * These props used to be spread from `RouterLink.props`, which kept them in sync
+ * automatically. They are declared by hand now, so the mirror needs a guard:
+ * both failure modes below are silent — typecheck, lint and the render tests all
+ * stay green while prop validation quietly disappears.
+ */
+describe('ConditionalRouterLink prop declarations', () => {
+	const props = (ConditionalRouterLink as unknown as { props: Record<string, unknown> }).props;
+	// `RouterLink`'s public type does not expose `props`, hence the cast.
+	const routerLinkProps = (
+		RouterLink as unknown as { props: Record<string, { required?: boolean }> }
+	).props;
+
+	it('declares every prop RouterLink declares', () => {
+		expect(Object.keys(props).sort()).toEqual(Object.keys(routerLinkProps).sort());
+	});
+
+	it('gives `to` a runtime type', () => {
+		// `RouteLocationRaw` is a conditional type, which Vue's compile-time resolver
+		// cannot evaluate — writing `to?: RouterLinkProps['to']` emits no type at all.
+		expect((props.to as { type: unknown[] }).type).toEqual([String, Object]);
+	});
+
+	it('keeps `to` optional, unlike RouterLink', () => {
+		expect((props.to as { required?: boolean }).required).not.toBe(true);
+		expect(routerLinkProps.to.required).toBe(true);
+	});
+});


### PR DESCRIPTION
> **Closed as superseded — not abandoned.** This guard is already on `master`
> as `ConditionalRouterLink.test.ts`, landed via #35447 (merged 2026-08-04), and
> it is load-bearing there: re-applying the `to?: RouterLinkProps['to']`
> translation on top of #35604 fails this guard while three render tests, the
> snapshot and `vue-tsc` all stay green. It is the only check in the repo that
> catches that silent prop loss.
>
> This PR also targeted #35148's branch (`agent/palette/5625149b`), which is
> itself closed as superseded, so it is orphaned regardless. Branch retained;
> nothing here is lost.

---

## Summary

Adds the regression guard missing from #35148, which this PR targets.

#35148 replaces `ConditionalRouterLink`'s `...RouterLink.props` spread with a
hand-written `Props` type. The prop declarations it produces are exactly
master's (verified: 6/6 keys, same types, defaults and `required` flags), but
two ways of losing them are completely silent:

1. **The conditional-type trap.** The obvious translation
   `to?: RouterLinkProps['to']` emits *no* runtime type for `to`
   (`[String, Object]` → nothing), because `RouteLocationRaw` is a conditional
   type that Vue's compile-time resolver cannot evaluate. #35148 works around
   this by expanding the union by hand; anyone "simplifying" it back
   re-introduces the bug.
2. **vue-router drift.** The spread stayed in sync automatically; the hand-written
   list does not. Since the template is `v-bind="props"` with
   `inheritAttrs: false`, a prop added by a future vue-router would be silently
   dropped in the `RouterLink` branch.

Measured on #35148's head with the "simplification" applied: `to`'s runtime type
is gone, and `vue-tsc --noEmit` reports **0 errors**, `eslint` is **clean**, and
all **1385** design-system tests **pass**. Nothing in the repo notices.

These three assertions do.

## How to test

```bash
cd packages/frontend/@n8n/design-system
pnpm vitest run src/components/ConditionalRouterLink/
```

To see the guard earn its keep, change `to` in
`CondtionalRouterLink.vue` to `to?: RouterLinkProps['to']` and re-run — the
`gives \`to\` a runtime type` assertion fails, while typecheck and lint stay green.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35148.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


