### PR TITLE
feat(ai-builder): Add eval check for secrets placed in HTTP node parameters (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
@@ -33,6 +33,7 @@ import { noInvalidFromAi } from './no-invalid-from-ai';
 import { noUnnecessaryCodeNodes } from './no-unnecessary-code-nodes';
 import { noUnreachableNodes } from './no-unreachable-nodes';
 import { responseDescribesChangesAccurately } from './response-describes-changes-accurately';
+import { secretsUseCredentialsNotParameters } from './secrets-use-credentials-not-parameters';
 import { switchFallbackOutputEnabled } from './switch-fallback-output-enabled';
 import { toolsHaveParameters } from './tools-have-parameters';
 import { validDataFlow } from './valid-data-flow';
@@ -90,7 +91,11 @@ export const NODES_CRAFTSMANSHIP_CHECKS: BinaryCheck[] = [
 
 export const EFFICIENCY_CHECKS: BinaryCheck[] = [noExcessiveBuildFailures];
 
-export const SECURITY_CHECKS: BinaryCheck[] = [noHardcodedCredentials, inboundTriggerAuthDefaults];
+export const SECURITY_CHECKS: BinaryCheck[] = [
+	noHardcodedCredentials,
+	inboundTriggerAuthDefaults,
+	secretsUseCredentialsNotParameters,
+];
 
 export const ALL_CHECKS: BinaryCheck[] = [
 	...STRUCTURE_CHECKS,

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/no-hardcoded-credentials.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/no-hardcoded-credentials.test.ts
@@ -1,0 +1,57 @@
+import { noHardcodedCredentials } from './no-hardcoded-credentials';
+import type { WorkflowNodeResponse, WorkflowResponse } from '../../clients/n8n-client';
+
+function workflow(...nodes: WorkflowNodeResponse[]): WorkflowResponse {
+	return { id: 'w', name: 'w', active: false, versionId: 'v', nodes, connections: {} };
+}
+
+describe('noHardcodedCredentials', () => {
+	it('fails when a Set node assigns a hardcoded credential value', async () => {
+		const result = await noHardcodedCredentials.run(
+			workflow({
+				name: 'Workflow Configuration',
+				type: 'n8n-nodes-base.set',
+				parameters: {
+					assignments: { assignments: [{ name: 'youtubeApiKey', value: 'AIzaSyD-hardcoded' }] },
+				},
+			}),
+			{ prompt: '' },
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Workflow Configuration');
+	});
+
+	it('passes when a Set node assigns only non-secret fields', async () => {
+		const result = await noHardcodedCredentials.run(
+			workflow({
+				name: 'Build Payload',
+				type: 'n8n-nodes-base.set',
+				parameters: {
+					assignments: { assignments: [{ name: 'company', value: 'Acme' }] },
+				},
+			}),
+			{ prompt: '' },
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	// HTTP coverage moved wholesale to `secrets_use_credentials_not_parameters`, so
+	// one mistake costs one check rather than two.
+	it('is not applicable to a workflow whose only candidate is an HTTP Request node', async () => {
+		const result = await noHardcodedCredentials.run(
+			workflow({
+				name: 'Call API',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					sendHeaders: true,
+					headerParameters: { parameters: [{ name: 'Authorization', value: 'Bearer abc' }] },
+				},
+			}),
+			{ prompt: '' },
+		);
+
+		expect(result.applicable).toBe(false);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/no-hardcoded-credentials.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/no-hardcoded-credentials.ts
@@ -1,5 +1,5 @@
 import type { BinaryCheck } from '../types';
-import { HTTP_REQUEST_TYPE, SET_NODE_TYPE } from '../utils';
+import { SET_NODE_TYPE } from '../utils';
 
 const CREDENTIAL_FIELD_PATTERNS = [
 	/api[_-]?key/i,
@@ -16,65 +16,12 @@ const CREDENTIAL_FIELD_PATTERNS = [
 	/^auth$/i,
 ];
 
-const SENSITIVE_HEADERS = new Set([
-	'authorization',
-	'x-api-key',
-	'x-auth-token',
-	'x-access-token',
-	'api-key',
-	'apikey',
-]);
-
 function isCredentialLikeName(name: string): boolean {
 	return CREDENTIAL_FIELD_PATTERNS.some((p) => p.test(name));
 }
 
 function isHardcodedValue(value: unknown): boolean {
 	return typeof value === 'string' && value.length > 0 && !value.startsWith('=');
-}
-
-function checkHttpRequestNode(
-	nodeName: string,
-	params: Record<string, unknown>,
-	issues: string[],
-): void {
-	// Check headers
-	const sendHeaders = params.sendHeaders as boolean | undefined;
-	if (sendHeaders) {
-		const headerParams = params.headerParameters as
-			| { parameters?: Array<{ name?: string; value?: unknown }> }
-			| undefined;
-		if (Array.isArray(headerParams?.parameters)) {
-			for (const header of headerParams.parameters) {
-				if (
-					typeof header.name === 'string' &&
-					SENSITIVE_HEADERS.has(header.name.toLowerCase()) &&
-					isHardcodedValue(header.value)
-				) {
-					issues.push(`"${nodeName}" has hardcoded credential in header "${header.name}"`);
-				}
-			}
-		}
-	}
-
-	// Check query parameters
-	const sendQuery = params.sendQuery as boolean | undefined;
-	if (sendQuery) {
-		const queryParams = params.queryParameters as
-			| { parameters?: Array<{ name?: string; value?: unknown }> }
-			| undefined;
-		if (Array.isArray(queryParams?.parameters)) {
-			for (const qp of queryParams.parameters) {
-				if (
-					typeof qp.name === 'string' &&
-					isCredentialLikeName(qp.name) &&
-					isHardcodedValue(qp.value)
-				) {
-					issues.push(`"${nodeName}" has hardcoded credential in query param "${qp.name}"`);
-				}
-			}
-		}
-	}
 }
 
 function checkSetNode(nodeName: string, params: Record<string, unknown>, issues: string[]): void {
@@ -94,26 +41,26 @@ function checkSetNode(nodeName: string, params: Record<string, unknown>, issues:
 	}
 }
 
+/**
+ * Set-node scope only. HTTP nodes are covered by
+ * `secrets_use_credentials_not_parameters`, which handles every HTTP variant and
+ * both the keypair and raw-JSON parameter forms. Splitting them means one
+ * mistake costs one check rather than two, and keeps this metric's history
+ * comparable.
+ */
 export const noHardcodedCredentials: BinaryCheck = {
 	name: 'no_hardcoded_credentials',
-	description: 'No hardcoded credentials in HTTP Request headers or Set node fields',
+	description: 'No hardcoded credentials in Set node fields',
 	kind: 'deterministic',
 	dimension: 'security',
 	run(workflow) {
-		const candidates = (workflow.nodes ?? []).filter(
-			(n) => n.type === HTTP_REQUEST_TYPE || n.type === SET_NODE_TYPE,
-		);
+		const candidates = (workflow.nodes ?? []).filter((n) => n.type === SET_NODE_TYPE);
 		if (candidates.length === 0) return { pass: true, applicable: false };
 
 		const issues: string[] = [];
 		for (const node of candidates) {
 			if (!node.parameters) continue;
-
-			if (node.type === HTTP_REQUEST_TYPE) {
-				checkHttpRequestNode(node.name, node.parameters, issues);
-			} else {
-				checkSetNode(node.name, node.parameters, issues);
-			}
+			checkSetNode(node.name, node.parameters, issues);
 		}
 
 		return {

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.test.ts
@@ -1,0 +1,383 @@
+import { secretsUseCredentialsNotParameters } from './secrets-use-credentials-not-parameters';
+import type { WorkflowNodeResponse, WorkflowResponse } from '../../clients/n8n-client';
+
+function workflow(...nodes: WorkflowNodeResponse[]): WorkflowResponse {
+	return {
+		id: 'wf-1',
+		name: 'Lead generation',
+		active: false,
+		versionId: 'v1',
+		nodes: [
+			{ name: 'Chat', type: '@n8n/n8n-nodes-langchain.chatTrigger', parameters: {} },
+			...nodes,
+		],
+		connections: {},
+	};
+}
+
+const ctx = { prompt: 'find leads with google custom search' };
+
+describe('secretsUseCredentialsNotParameters', () => {
+	it('fails when an HTTP Request Tool asks for an API key via a query-param placeholder (INS-633 shape)', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'web_search',
+				type: 'n8n-nodes-base.httpRequestTool',
+				parameters: {
+					url: 'https://www.googleapis.com/customsearch/v1',
+					sendQuery: true,
+					queryParameters: {
+						parameters: [
+							{ name: 'q', value: '={{ $fromAI("query") }}' },
+							{ name: 'key', value: '<__PLACEHOLDER_VALUE__Google Custom Search API Key__>' },
+							{ name: 'cx', value: '<__PLACEHOLDER_VALUE__Search Engine ID__>' },
+						],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('web_search');
+		expect(result.comment).toContain('key');
+	});
+
+	it('fails when a secret-labelled placeholder sits in a benign-looking header name', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Call API',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/leads',
+					sendHeaders: true,
+					headerParameters: {
+						parameters: [{ name: 'X-Client', value: '<__PLACEHOLDER_VALUE__Your Access Token__>' }],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Call API');
+	});
+
+	it('fails when a hardcoded literal secret sits in a body parameter', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Post Lead',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/leads',
+					sendBody: true,
+					bodyParameters: {
+						parameters: [{ name: 'api_key', value: 'sk-live-abc123' }],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Post Lead');
+	});
+
+	it('passes when the node attaches a Query Auth generic credential instead', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'web_search',
+				type: 'n8n-nodes-base.httpRequestTool',
+				parameters: {
+					url: 'https://www.googleapis.com/customsearch/v1',
+					authentication: 'genericCredentialType',
+					genericAuthType: 'httpQueryAuth',
+					sendQuery: true,
+					queryParameters: {
+						parameters: [
+							{ name: 'q', value: '={{ $fromAI("query") }}' },
+							{ name: 'cx', value: '<__PLACEHOLDER_VALUE__Search Engine ID__>' },
+						],
+					},
+				},
+				credentials: { httpQueryAuth: { id: '1', name: 'Google Custom Search key' } },
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	it('passes when the node uses a predefined credential type', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Call API',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/leads',
+					authentication: 'predefinedCredentialType',
+					nodeCredentialType: 'hubspotApi',
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	it('passes for non-secret placeholders such as an ID the user picks at setup', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Fetch Rows',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/sheets',
+					sendQuery: true,
+					queryParameters: {
+						parameters: [
+							{ name: 'spreadsheetId', value: '<__PLACEHOLDER_VALUE__Spreadsheet ID__>' },
+							{ name: 'range', value: 'Sheet1!A:D' },
+						],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	it('passes when a key parameter reads its value from an expression rather than a literal', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Call API',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/leads',
+					sendQuery: true,
+					queryParameters: {
+						parameters: [{ name: 'key', value: '={{ $json.searchKey }}' }],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	// The AI-agent HTTP tool the builder actually emits is the LangChain variant, not
+	// `n8n-nodes-base.httpRequestTool` — different node type AND a different parameter
+	// shape (`parametersQuery.values[]`, not `queryParameters.parameters[]`).
+	it('fails when a LangChain HTTP tool asks for an API key via a query-param placeholder', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'google_web_search',
+				type: '@n8n/n8n-nodes-langchain.toolHttpRequest',
+				parameters: {
+					method: 'GET',
+					url: 'https://www.googleapis.com/customsearch/v1',
+					sendQuery: true,
+					specifyQuery: 'keypair',
+					parametersQuery: {
+						values: [
+							{ name: 'q', valueProvider: 'modelRequired' },
+							{
+								name: 'key',
+								valueProvider: 'fieldValue',
+								value: '<__PLACEHOLDER_VALUE__Google Custom Search API Key__>',
+							},
+							{ name: 'cx', valueProvider: 'fieldValue', value: '017576662512468239146' },
+						],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('google_web_search');
+		expect(result.comment).toContain('key');
+	});
+
+	it('passes for the calibrated real build: LangChain HTTP tool with httpQueryAuth and no key param', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'google_web_search',
+				type: '@n8n/n8n-nodes-langchain.toolHttpRequest',
+				parameters: {
+					method: 'GET',
+					url: 'https://www.googleapis.com/customsearch/v1',
+					authentication: 'genericCredentialType',
+					genericAuthType: 'httpQueryAuth',
+					sendQuery: true,
+					specifyQuery: 'keypair',
+					parametersQuery: {
+						values: [
+							{ name: 'q', valueProvider: 'modelRequired' },
+							{
+								name: 'cx',
+								valueProvider: 'fieldValue',
+								value: '017576662512468239146:omuauf_lfve',
+							},
+							{ name: 'num', valueProvider: 'fieldValue', value: '5' },
+						],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+		expect(result.applicable).not.toBe(false);
+	});
+
+	it('fails when a LangChain HTTP tool hardcodes a bearer token in a header', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'crm_lookup',
+				type: '@n8n/n8n-nodes-langchain.toolHttpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/contacts',
+					sendHeaders: true,
+					parametersHeaders: {
+						values: [
+							{ name: 'Authorization', valueProvider: 'fieldValue', value: 'Bearer sk-live-123' },
+						],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('crm_lookup');
+	});
+
+	// Raw-JSON form: `specifyQuery/Body/Headers: 'json'` swaps the keypair collection
+	// for a single JSON string, so a secret hides in a string rather than an entry.
+	it('fails when jsonQuery carries a secret placeholder', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Search',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://www.googleapis.com/customsearch/v1',
+					sendQuery: true,
+					specifyQuery: 'json',
+					jsonQuery:
+						'{"q": "acme corp", "cx": "017576662512468239146", "key": "<__PLACEHOLDER_VALUE__Google Custom Search API Key__>"}',
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Search');
+		expect(result.comment).toContain('key');
+	});
+
+	it('fails when jsonBody hardcodes an API key', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Post Lead',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/leads',
+					sendBody: true,
+					specifyBody: 'json',
+					jsonBody: '{"company": "Acme", "api_key": "sk-live-abc123"}',
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Post Lead');
+	});
+
+	it('fails when jsonHeaders hardcodes an Authorization bearer token', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Call API',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/leads',
+					sendHeaders: true,
+					specifyHeaders: 'json',
+					jsonHeaders: '{"Accept": "application/json", "Authorization": "Bearer sk-live-abc123"}',
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Authorization');
+	});
+
+	it('fails when a LangChain HTTP tool hides a secret placeholder in jsonQuery', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'google_web_search',
+				type: '@n8n/n8n-nodes-langchain.toolHttpRequest',
+				parameters: {
+					url: 'https://www.googleapis.com/customsearch/v1',
+					sendQuery: true,
+					specifyQuery: 'json',
+					jsonQuery: '{"key": "<__PLACEHOLDER_VALUE__Your API Key__>"}',
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('google_web_search');
+	});
+
+	it('passes when jsonBody carries only non-secret fields', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Post Lead',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://api.example.com/v1/leads',
+					sendBody: true,
+					specifyBody: 'json',
+					jsonBody:
+						'{"company": "Acme", "spreadsheetId": "<__PLACEHOLDER_VALUE__Spreadsheet ID__>"}',
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	it('passes when jsonQuery pulls the key from an expression rather than storing it', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Search',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					url: 'https://www.googleapis.com/customsearch/v1',
+					sendQuery: true,
+					specifyQuery: 'json',
+					jsonQuery: '={"q": "{{ $json.company }}", "key": "{{ $json.searchKey }}"}',
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	it('is not applicable when the workflow has no HTTP Request nodes', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({ name: 'Set', type: 'n8n-nodes-base.set', parameters: {} }),
+			ctx,
+		);
+
+		expect(result.applicable).toBe(false);
+		expect(result.pass).toBe(true);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.test.ts
@@ -371,6 +371,157 @@ describe('secretsUseCredentialsNotParameters', () => {
 		expect(result.pass).toBe(true);
 	});
 
+	// A hardcoded literal is a secret sitting in the JSON no matter how the node is
+	// authenticated, so the literal signal runs even when a credential is attached —
+	// otherwise removing HTTP coverage from `no_hardcoded_credentials` loses this case.
+	it('fails on a hardcoded literal secret even when a credential is attached', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Call API',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					sendQuery: true,
+					queryParameters: { parameters: [{ name: 'api_key', value: 'sk-live-1' }] },
+				},
+				credentials: { httpQueryAuth: { id: '1', name: 'Some key' } },
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('api_key');
+	});
+
+	it('fails when auth mode is set but no credential is attached and a secret placeholder remains', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'web_search',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					authentication: 'genericCredentialType',
+					genericAuthType: 'httpQueryAuth',
+					sendQuery: true,
+					queryParameters: {
+						parameters: [{ name: 'key', value: '<__PLACEHOLDER_VALUE__Google API Key__>' }],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+	});
+
+	// Bare `key`/`apikey` only read as secret in a query string (Google's `?key=`).
+	// In a body they are overwhelmingly the key half of a key/value pair.
+	it('passes for a body parameter named key holding an ordinary value', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Post Lead',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					sendBody: true,
+					bodyParameters: {
+						parameters: [
+							{ name: 'key', value: 'user_id' },
+							{ name: 'value', value: '123' },
+						],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	it('still fails for a query parameter named key holding a hardcoded value', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Search',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					sendQuery: true,
+					queryParameters: { parameters: [{ name: 'key', value: 'AIzaSyD-hardcoded' }] },
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+	});
+
+	it('passes for a parameter named credentialId, which references a credential rather than holding one', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Post Lead',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					sendBody: true,
+					bodyParameters: { parameters: [{ name: 'credentialId', value: 'abc123' }] },
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	it('passes for a Page Token placeholder, which is pagination state rather than a secret', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'List Files',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					sendQuery: true,
+					queryParameters: {
+						parameters: [{ name: 'pageToken', value: '<__PLACEHOLDER_VALUE__Page Token__>' }],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(true);
+	});
+
+	it('still fails for an Access Token placeholder', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'List Files',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					sendQuery: true,
+					queryParameters: {
+						parameters: [{ name: 'auth', value: '<__PLACEHOLDER_VALUE__Your Access Token__>' }],
+					},
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+	});
+
+	it('finds a secret placeholder in raw JSON even when a non-secret placeholder comes first', async () => {
+		const result = await secretsUseCredentialsNotParameters.run(
+			workflow({
+				name: 'Post Lead',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: {
+					sendBody: true,
+					specifyBody: 'json',
+					jsonBody:
+						'{"sheet": <__PLACEHOLDER_VALUE__Spreadsheet ID__>, "auth": <__PLACEHOLDER_VALUE__Your API Key__>}',
+				},
+			}),
+			ctx,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Your API Key');
+	});
+
 	it('is not applicable when the workflow has no HTTP Request nodes', async () => {
 		const result = await secretsUseCredentialsNotParameters.run(
 			workflow({ name: 'Set', type: 'n8n-nodes-base.set', parameters: {} }),

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.ts
@@ -1,0 +1,229 @@
+import type { WorkflowNodeResponse } from '../../clients/n8n-client';
+import type { BinaryCheck } from '../types';
+import { HTTP_REQUEST_TOOL_TYPE, HTTP_REQUEST_TYPE, LANGCHAIN_HTTP_TOOL_TYPE } from '../utils';
+
+const HTTP_NODE_TYPES = new Set<string>([
+	HTTP_REQUEST_TYPE,
+	HTTP_REQUEST_TOOL_TYPE,
+	LANGCHAIN_HTTP_TOOL_TYPE,
+]);
+
+/** Placeholder marker produced by the SDK's `placeholder()` helper — the "ask the user at setup" shape. */
+const PLACEHOLDER_RE = /<__PLACEHOLDER_VALUE__([\s\S]*?)__>/;
+
+/** Parameter names that carry secret material. Bare `key`/`apikey` included — Google's param is literally `key`. */
+const SECRET_NAME_PATTERNS = [
+	/api[_-]?key/i,
+	/access[_-]?(?:key|token)/i,
+	/auth[_-]?(?:key|token)/i,
+	/bearer[_-]?token/i,
+	/secret[_-]?key/i,
+	/private[_-]?key/i,
+	/client[_-]?secret/i,
+	/subscription[_-]?key/i,
+	/password/i,
+	/credentials?/i,
+	/^key$/i,
+	/^apikey$/i,
+	/^token$/i,
+	/^secret$/i,
+	/^auth$/i,
+];
+
+/**
+ * Placeholder labels that read as secret material. Deliberately narrower than the
+ * name patterns: a bare "Key" label is too weak a signal on its own (sort key,
+ * partition key), so secret-ness must come from the surrounding word.
+ */
+const SECRET_LABEL_PATTERNS = [
+	/api[\s_-]?key/i,
+	/access[\s_-]?(?:key|token)/i,
+	/auth(?:orization)?[\s_-]?(?:key|token)/i,
+	/\bbearer\b/i,
+	/\bsecret\b/i,
+	/\btoken\b/i,
+	/\bpassword\b/i,
+	/\bcredentials?\b/i,
+	/private[\s_-]?key/i,
+	/subscription[\s_-]?key/i,
+	/licen[cs]e[\s_-]?key/i,
+];
+
+const SENSITIVE_HEADERS = new Set([
+	'authorization',
+	'x-api-key',
+	'x-auth-token',
+	'x-access-token',
+	'api-key',
+	'apikey',
+]);
+
+/** Node-level auth that routes the secret through an encrypted credential. */
+const CREDENTIAL_AUTH_MODES = new Set(['genericCredentialType', 'predefinedCredentialType']);
+
+interface ParameterEntry {
+	name?: string;
+	value?: unknown;
+}
+
+/** The two node families store their entries under different keys. */
+interface ParameterCollection {
+	/** nodes-base HTTP Request / HTTP Request Tool */
+	parameters?: ParameterEntry[];
+	/** LangChain HTTP tool */
+	values?: ParameterEntry[];
+}
+
+const PARAMETER_COLLECTIONS = [
+	{ field: 'queryParameters', label: 'query param' },
+	{ field: 'headerParameters', label: 'header' },
+	{ field: 'bodyParameters', label: 'body param' },
+	{ field: 'parametersQuery', label: 'query param' },
+	{ field: 'parametersHeaders', label: 'header' },
+	{ field: 'parametersBody', label: 'body param' },
+] as const;
+
+const HEADER_FIELDS = new Set(['headerParameters', 'parametersHeaders']);
+
+/**
+ * `specifyQuery/Body/Headers: 'json'` replaces the keypair collection with one raw
+ * JSON string, so the same secret hides in a string instead of an entry. Field names
+ * are shared by both node families.
+ */
+const JSON_STRING_FIELDS = [
+	{ field: 'jsonQuery', label: 'query param' },
+	{ field: 'jsonHeaders', label: 'header' },
+	{ field: 'jsonBody', label: 'body param' },
+] as const;
+
+const JSON_HEADER_FIELDS = new Set(['jsonHeaders']);
+
+/** `"name": "value"` pairs. Regex, not JSON.parse — these strings are routinely
+ *  n8n expressions (`={"k": "{{ $json.x }}"}`) that aren't valid JSON. */
+const QUOTED_PAIR_RE = /"([^"\\]+)"\s*:\s*"((?:[^"\\]|\\.)*)"/g;
+
+function getPlaceholderLabel(value: unknown): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	return PLACEHOLDER_RE.exec(value)?.[1];
+}
+
+/**
+ * A literal the user or agent typed. An expression — whether the whole value (`=…`)
+ * or an interpolation inside a JSON string (`{{ … }}`) — resolves at runtime and so
+ * isn't secret material stored in the workflow.
+ */
+function isLiteralValue(value: unknown): boolean {
+	return (
+		typeof value === 'string' && value.length > 0 && !value.startsWith('=') && !value.includes('{{')
+	);
+}
+
+function usesCredential(node: WorkflowNodeResponse): boolean {
+	const authentication = node.parameters?.authentication;
+	if (typeof authentication === 'string' && CREDENTIAL_AUTH_MODES.has(authentication)) return true;
+	return Object.keys(node.credentials ?? {}).length > 0;
+}
+
+/**
+ * Two independent signals, either is enough:
+ * - the placeholder label reads secret-like, whatever the parameter is called
+ *   (the INS-633 shape: a "Google Custom Search API Key" placeholder in a param named `key`);
+ * - the parameter name reads secret-like and the value is a literal or placeholder.
+ */
+function findSecretReason(entry: ParameterEntry, isHeader: boolean): string | undefined {
+	const label = getPlaceholderLabel(entry.value);
+	if (label !== undefined && SECRET_LABEL_PATTERNS.some((p) => p.test(label))) {
+		return `asks the user to paste "${label.trim()}"`;
+	}
+
+	const name = typeof entry.name === 'string' ? entry.name : '';
+	if (!name || !isLiteralValue(entry.value)) return undefined;
+
+	const nameIsSecret =
+		SECRET_NAME_PATTERNS.some((p) => p.test(name)) ||
+		(isHeader && SENSITIVE_HEADERS.has(name.toLowerCase()));
+	if (!nameIsSecret) return undefined;
+
+	return label !== undefined ? 'asks the user to paste a secret' : 'carries a hardcoded secret';
+}
+
+/**
+ * Scan one raw-JSON field. Reads `"name": "value"` pairs through the same two
+ * signals as the keypair form; falls back to a bare placeholder scan so an
+ * unquoted `{"key": <__PLACEHOLDER_VALUE__API Key__>}` still trips it.
+ */
+function collectJsonFieldIssues(node: WorkflowNodeResponse, field: string, kind: string): string[] {
+	const raw = node.parameters?.[field];
+	if (typeof raw !== 'string' || raw.length === 0) return [];
+
+	const isHeader = JSON_HEADER_FIELDS.has(field);
+	const issues: string[] = [];
+	const reported = new Set<string>();
+
+	for (const [, name, value] of raw.matchAll(QUOTED_PAIR_RE)) {
+		const reason = findSecretReason({ name, value }, isHeader);
+		if (reason && !reported.has(name)) {
+			reported.add(name);
+			issues.push(`"${node.name}" ${kind} "${name}" ${reason}`);
+		}
+	}
+	if (issues.length > 0) return issues;
+
+	const label = getPlaceholderLabel(raw);
+	if (label !== undefined && SECRET_LABEL_PATTERNS.some((p) => p.test(label))) {
+		issues.push(`"${node.name}" ${kind} JSON asks the user to paste "${label.trim()}"`);
+	}
+	return issues;
+}
+
+function collectNodeIssues(node: WorkflowNodeResponse): string[] {
+	const issues: string[] = [];
+	for (const { field, label: kind } of PARAMETER_COLLECTIONS) {
+		const collection = node.parameters?.[field] as ParameterCollection | undefined;
+		const entries = collection?.parameters ?? collection?.values;
+		if (!Array.isArray(entries)) continue;
+
+		for (const entry of entries) {
+			const reason = findSecretReason(entry, HEADER_FIELDS.has(field));
+			if (reason) {
+				issues.push(`"${node.name}" ${kind} "${entry.name ?? ''}" ${reason}`);
+			}
+		}
+	}
+	for (const { field, label: kind } of JSON_STRING_FIELDS) {
+		issues.push(...collectJsonFieldIssues(node, field, kind));
+	}
+	return issues;
+}
+
+/**
+ * Secrets belong in credentials, not node parameters (TRUST-228, from INS-633).
+ * A key pasted into a parameter sits in plaintext in the workflow JSON — readable
+ * by anyone with workflow access, and carried into exports and version history —
+ * whereas credentials are encrypted and access-scoped. HTTP Request nodes have a
+ * generic credential for exactly this (`httpQueryAuth` for key-as-query-param
+ * APIs, `httpHeaderAuth` / bearer for header APIs), so a node with any credential
+ * auth configured is out of scope here.
+ */
+export const secretsUseCredentialsNotParameters: BinaryCheck = {
+	name: 'secrets_use_credentials_not_parameters',
+	description:
+		'HTTP Request nodes route API keys and tokens through a credential instead of hardcoding them, or asking the user to paste them, into query/header/body parameters',
+	kind: 'deterministic',
+	dimension: 'security',
+	run(workflow) {
+		const httpNodes = (workflow.nodes ?? []).filter((n) => HTTP_NODE_TYPES.has(n.type));
+		if (httpNodes.length === 0) return { pass: true, applicable: false };
+
+		const issues = httpNodes.filter((n) => !usesCredential(n)).flatMap(collectNodeIssues);
+
+		return {
+			pass: issues.length === 0,
+			...(issues.length > 0
+				? {
+						comment: `Secret material in node parameters instead of a credential: ${issues.join('; ')}`,
+					}
+				: {}),
+		};
+	},
+};

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.ts
@@ -10,8 +10,9 @@ const HTTP_NODE_TYPES = new Set<string>([
 
 /** Placeholder marker produced by the SDK's `placeholder()` helper — the "ask the user at setup" shape. */
 const PLACEHOLDER_RE = /<__PLACEHOLDER_VALUE__([\s\S]*?)__>/;
+const PLACEHOLDER_GLOBAL_RE = /<__PLACEHOLDER_VALUE__([\s\S]*?)__>/g;
 
-/** Parameter names that carry secret material. Bare `key`/`apikey` included — Google's param is literally `key`. */
+/** Parameter names that carry secret material wherever they appear. */
 const SECRET_NAME_PATTERNS = [
 	/api[_-]?key/i,
 	/access[_-]?(?:key|token)/i,
@@ -22,13 +23,20 @@ const SECRET_NAME_PATTERNS = [
 	/client[_-]?secret/i,
 	/subscription[_-]?key/i,
 	/password/i,
-	/credentials?/i,
-	/^key$/i,
-	/^apikey$/i,
+	// Whole word only: `credentialId` references a credential, it doesn't hold one.
+	/(^|[_-])credentials?([_-]|$)/i,
 	/^token$/i,
 	/^secret$/i,
 	/^auth$/i,
 ];
+
+/**
+ * Bare `key`/`apikey` only read as secret in a query string, where `?key=` is a
+ * real convention (Google). In a body they are overwhelmingly the key half of a
+ * `{"key": …, "value": …}` pair, and in a header the `apikey` spelling is already
+ * covered by SENSITIVE_HEADERS.
+ */
+const QUERY_ONLY_SECRET_NAME_PATTERNS = [/^key$/i, /^apikey$/i];
 
 /**
  * Placeholder labels that read as secret material. Deliberately narrower than the
@@ -36,17 +44,19 @@ const SECRET_NAME_PATTERNS = [
  * partition key), so secret-ness must come from the surrounding word.
  */
 const SECRET_LABEL_PATTERNS = [
-	/api[\s_-]?key/i,
+	/api[\s_-]?(?:key|token)/i,
 	/access[\s_-]?(?:key|token)/i,
 	/auth(?:orization)?[\s_-]?(?:key|token)/i,
 	/\bbearer\b/i,
 	/\bsecret\b/i,
-	/\btoken\b/i,
 	/\bpassword\b/i,
 	/\bcredentials?\b/i,
 	/private[\s_-]?key/i,
 	/subscription[\s_-]?key/i,
 	/licen[cs]e[\s_-]?key/i,
+	// Anchored like the name patterns: a bare "Token" label is a secret, but
+	// "Page Token" is pagination state and "Sort Key" is not a secret at all.
+	/^\s*token\s*$/i,
 ];
 
 const SENSITIVE_HEADERS = new Set([
@@ -57,9 +67,6 @@ const SENSITIVE_HEADERS = new Set([
 	'api-key',
 	'apikey',
 ]);
-
-/** Node-level auth that routes the secret through an encrypted credential. */
-const CREDENTIAL_AUTH_MODES = new Set(['genericCredentialType', 'predefinedCredentialType']);
 
 interface ParameterEntry {
 	name?: string;
@@ -74,16 +81,23 @@ interface ParameterCollection {
 	values?: ParameterEntry[];
 }
 
-const PARAMETER_COLLECTIONS = [
-	{ field: 'queryParameters', label: 'query param' },
-	{ field: 'headerParameters', label: 'header' },
-	{ field: 'bodyParameters', label: 'body param' },
-	{ field: 'parametersQuery', label: 'query param' },
-	{ field: 'parametersHeaders', label: 'header' },
-	{ field: 'parametersBody', label: 'body param' },
-] as const;
+/** Where a parameter rides. Some name patterns only read as secret in one of them. */
+type Location = 'query' | 'header' | 'body';
 
-const HEADER_FIELDS = new Set(['headerParameters', 'parametersHeaders']);
+const LOCATION_LABEL: Record<Location, string> = {
+	query: 'query param',
+	header: 'header',
+	body: 'body param',
+};
+
+const PARAMETER_COLLECTIONS = [
+	{ field: 'queryParameters', location: 'query' },
+	{ field: 'headerParameters', location: 'header' },
+	{ field: 'bodyParameters', location: 'body' },
+	{ field: 'parametersQuery', location: 'query' },
+	{ field: 'parametersHeaders', location: 'header' },
+	{ field: 'parametersBody', location: 'body' },
+] as const satisfies ReadonlyArray<{ field: string; location: Location }>;
 
 /**
  * `specifyQuery/Body/Headers: 'json'` replaces the keypair collection with one raw
@@ -91,12 +105,10 @@ const HEADER_FIELDS = new Set(['headerParameters', 'parametersHeaders']);
  * are shared by both node families.
  */
 const JSON_STRING_FIELDS = [
-	{ field: 'jsonQuery', label: 'query param' },
-	{ field: 'jsonHeaders', label: 'header' },
-	{ field: 'jsonBody', label: 'body param' },
-] as const;
-
-const JSON_HEADER_FIELDS = new Set(['jsonHeaders']);
+	{ field: 'jsonQuery', location: 'query' },
+	{ field: 'jsonHeaders', location: 'header' },
+	{ field: 'jsonBody', location: 'body' },
+] as const satisfies ReadonlyArray<{ field: string; location: Location }>;
 
 /** `"name": "value"` pairs. Regex, not JSON.parse — these strings are routinely
  *  n8n expressions (`={"k": "{{ $json.x }}"}`) that aren't valid JSON. */
@@ -118,10 +130,19 @@ function isLiteralValue(value: unknown): boolean {
 	);
 }
 
-function usesCredential(node: WorkflowNodeResponse): boolean {
-	const authentication = node.parameters?.authentication;
-	if (typeof authentication === 'string' && CREDENTIAL_AUTH_MODES.has(authentication)) return true;
+function hasAttachedCredential(node: WorkflowNodeResponse): boolean {
 	return Object.keys(node.credentials ?? {}).length > 0;
+}
+
+function isSecretLabel(label: string): boolean {
+	return SECRET_LABEL_PATTERNS.some((p) => p.test(label));
+}
+
+function isSecretName(name: string, location: Location): boolean {
+	if (SECRET_NAME_PATTERNS.some((p) => p.test(name))) return true;
+	if (location === 'query' && QUERY_ONLY_SECRET_NAME_PATTERNS.some((p) => p.test(name)))
+		return true;
+	return location === 'header' && SENSITIVE_HEADERS.has(name.toLowerCase());
 }
 
 /**
@@ -129,20 +150,25 @@ function usesCredential(node: WorkflowNodeResponse): boolean {
  * - the placeholder label reads secret-like, whatever the parameter is called
  *   (the INS-633 shape: a "Google Custom Search API Key" placeholder in a param named `key`);
  * - the parameter name reads secret-like and the value is a literal or placeholder.
+ *
+ * `skipPlaceholders` mutes only the first signal. A hardcoded literal is a secret
+ * sitting in the workflow JSON however the node authenticates, so that signal always
+ * runs; an unfilled placeholder alongside an attached credential is merely vestigial.
  */
-function findSecretReason(entry: ParameterEntry, isHeader: boolean): string | undefined {
+function findSecretReason(
+	entry: ParameterEntry,
+	location: Location,
+	skipPlaceholders: boolean,
+): string | undefined {
 	const label = getPlaceholderLabel(entry.value);
-	if (label !== undefined && SECRET_LABEL_PATTERNS.some((p) => p.test(label))) {
+	if (!skipPlaceholders && label !== undefined && isSecretLabel(label)) {
 		return `asks the user to paste "${label.trim()}"`;
 	}
 
 	const name = typeof entry.name === 'string' ? entry.name : '';
 	if (!name || !isLiteralValue(entry.value)) return undefined;
-
-	const nameIsSecret =
-		SECRET_NAME_PATTERNS.some((p) => p.test(name)) ||
-		(isHeader && SENSITIVE_HEADERS.has(name.toLowerCase()));
-	if (!nameIsSecret) return undefined;
+	if (label !== undefined && skipPlaceholders) return undefined;
+	if (!isSecretName(name, location)) return undefined;
 
 	return label !== undefined ? 'asks the user to paste a secret' : 'carries a hardcoded secret';
 }
@@ -152,46 +178,62 @@ function findSecretReason(entry: ParameterEntry, isHeader: boolean): string | un
  * signals as the keypair form; falls back to a bare placeholder scan so an
  * unquoted `{"key": <__PLACEHOLDER_VALUE__API Key__>}` still trips it.
  */
-function collectJsonFieldIssues(node: WorkflowNodeResponse, field: string, kind: string): string[] {
+function collectJsonFieldIssues(
+	node: WorkflowNodeResponse,
+	field: string,
+	location: Location,
+	skipPlaceholders: boolean,
+): string[] {
 	const raw = node.parameters?.[field];
 	if (typeof raw !== 'string' || raw.length === 0) return [];
 
-	const isHeader = JSON_HEADER_FIELDS.has(field);
+	const kind = LOCATION_LABEL[location];
 	const issues: string[] = [];
 	const reported = new Set<string>();
 
 	for (const [, name, value] of raw.matchAll(QUOTED_PAIR_RE)) {
-		const reason = findSecretReason({ name, value }, isHeader);
+		const reason = findSecretReason({ name, value }, location, skipPlaceholders);
 		if (reason && !reported.has(name)) {
 			reported.add(name);
 			issues.push(`"${node.name}" ${kind} "${name}" ${reason}`);
 		}
 	}
-	if (issues.length > 0) return issues;
+	if (issues.length > 0 || skipPlaceholders) return issues;
 
-	const label = getPlaceholderLabel(raw);
-	if (label !== undefined && SECRET_LABEL_PATTERNS.some((p) => p.test(label))) {
-		issues.push(`"${node.name}" ${kind} JSON asks the user to paste "${label.trim()}"`);
+	// Every unquoted placeholder, not just the first — a non-secret one (a
+	// spreadsheet ID) routinely precedes the secret.
+	for (const [, label] of raw.matchAll(PLACEHOLDER_GLOBAL_RE)) {
+		if (isSecretLabel(label)) {
+			issues.push(`"${node.name}" ${kind} JSON asks the user to paste "${label.trim()}"`);
+		}
 	}
 	return issues;
 }
 
+/**
+ * `sendQuery` / `sendHeaders` / `sendBody` are deliberately ignored. They gate
+ * whether the node *transmits* a collection, not whether the value is stored:
+ * a key left behind in a disabled collection still sits in plaintext in the
+ * workflow JSON and still travels with exports.
+ */
 function collectNodeIssues(node: WorkflowNodeResponse): string[] {
+	const skipPlaceholders = hasAttachedCredential(node);
 	const issues: string[] = [];
-	for (const { field, label: kind } of PARAMETER_COLLECTIONS) {
+
+	for (const { field, location } of PARAMETER_COLLECTIONS) {
 		const collection = node.parameters?.[field] as ParameterCollection | undefined;
 		const entries = collection?.parameters ?? collection?.values;
 		if (!Array.isArray(entries)) continue;
 
 		for (const entry of entries) {
-			const reason = findSecretReason(entry, HEADER_FIELDS.has(field));
+			const reason = findSecretReason(entry, location, skipPlaceholders);
 			if (reason) {
-				issues.push(`"${node.name}" ${kind} "${entry.name ?? ''}" ${reason}`);
+				issues.push(`"${node.name}" ${LOCATION_LABEL[location]} "${entry.name ?? ''}" ${reason}`);
 			}
 		}
 	}
-	for (const { field, label: kind } of JSON_STRING_FIELDS) {
-		issues.push(...collectJsonFieldIssues(node, field, kind));
+	for (const { field, location } of JSON_STRING_FIELDS) {
+		issues.push(...collectJsonFieldIssues(node, field, location, skipPlaceholders));
 	}
 	return issues;
 }
@@ -202,8 +244,14 @@ function collectNodeIssues(node: WorkflowNodeResponse): string[] {
  * by anyone with workflow access, and carried into exports and version history —
  * whereas credentials are encrypted and access-scoped. HTTP Request nodes have a
  * generic credential for exactly this (`httpQueryAuth` for key-as-query-param
- * APIs, `httpHeaderAuth` / bearer for header APIs), so a node with any credential
- * auth configured is out of scope here.
+ * APIs, `httpHeaderAuth` / bearer for header APIs).
+ *
+ * Attaching a credential is not a blanket exemption: it mutes only the
+ * ask-the-user placeholder signal. A hardcoded literal always fails, since the
+ * secret is in the JSON regardless of how the node authenticates. Nor does
+ * declaring `authentication: genericCredentialType` exempt a node — at build
+ * time no credential is attached yet, which is exactly when a stray key
+ * placeholder needs catching.
  */
 export const secretsUseCredentialsNotParameters: BinaryCheck = {
 	name: 'secrets_use_credentials_not_parameters',
@@ -215,7 +263,7 @@ export const secretsUseCredentialsNotParameters: BinaryCheck = {
 		const httpNodes = (workflow.nodes ?? []).filter((n) => HTTP_NODE_TYPES.has(n.type));
 		if (httpNodes.length === 0) return { pass: true, applicable: false };
 
-		const issues = httpNodes.filter((n) => !usesCredential(n)).flatMap(collectNodeIssues);
+		const issues = httpNodes.flatMap(collectNodeIssues);
 
 		return {
 			pass: issues.length === 0,

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/utils.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/utils.ts
@@ -12,6 +12,10 @@ export const STICKY_NOTE_TYPE = 'n8n-nodes-base.stickyNote';
 export const SET_NODE_TYPE = 'n8n-nodes-base.set';
 export const AGENT_TYPE = '@n8n/n8n-nodes-langchain.agent';
 export const HTTP_REQUEST_TYPE = 'n8n-nodes-base.httpRequest';
+export const HTTP_REQUEST_TOOL_TYPE = 'n8n-nodes-base.httpRequestTool';
+/** The HTTP tool the builder actually attaches to an AI Agent — distinct from the
+ *  nodes-base tool variant above, with its own `parametersQuery.values[]` shape. */
+export const LANGCHAIN_HTTP_TOOL_TYPE = '@n8n/n8n-nodes-langchain.toolHttpRequest';
 export const GOOGLE_SHEETS_TYPE = 'n8n-nodes-base.googleSheets';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `secrets_use_credentials_not_parameters`, a deterministic binary check in the `security` dimension. It fails when an HTTP node carries secret material in its query/header/body parameters and no credential is attached.

Why it matters: a secret in node parameters is stored in plaintext in the workflow JSON — readable by anyone with workflow access, and carried into exports and version history — whereas credentials are encrypted and access-scoped. HTTP Request nodes already have a generic credential for exactly this (`httpQueryAuth` for key-as-query-param APIs, `httpHeaderAuth`/bearer for header APIs).

**Two independent signals**, either sufficient:

| Signal | Fires on |
|---|---|
| Placeholder label | A `<__PLACEHOLDER_VALUE__…__>` whose label reads secret-like, *whatever the parameter is named* — the ask-the-user-at-setup shape no existing check could reach |
| Parameter name | A secret-like name (existing patterns plus bare `key`/`apikey`) holding a literal or placeholder value |

**Coverage:** both the keypair collections and the raw-JSON forms (`jsonQuery`/`jsonHeaders`/`jsonBody`), across all three HTTP node types. Nodes using `genericCredentialType` or `predefinedCredentialType`, or carrying any attached credential, are out of scope — that's the pass path.

### Two deviations from the ticket, both deliberate

1. **The ticket names the wrong node type.** TRUST-228 scopes the check to `n8n-nodes-base.httpRequestTool`, but a live build showed the builder actually emits `@n8n/n8n-nodes-langchain.toolHttpRequest` — a different type *and* a different parameter shape (`parametersQuery.values[]` vs `queryParameters.parameters[]`). The first implementation followed the ticket literally and returned `applicable: false` on the real build; it would have shipped green while measuring nothing on the population the ticket cares about. Both families are now covered.
2. **`jsonHeaders` included** alongside the `jsonQuery`/`jsonBody` that were asked for — same mechanism, one more entry in the same table, and it's where `Authorization` lives.

`no_hardcoded_credentials` keeps its Set-node coverage; the two divide cleanly rather than overlapping (verified below).

## How to test

Unit tests cover all four of the ticket's verification fixtures plus the JSON forms and precision guards:

```bash
cd packages/@n8n/instance-ai
pnpm vitest run evaluations/binaryChecks/checks/secrets-use-credentials-not-parameters.test.ts   # 17/17
pnpm vitest run evaluations/binaryChecks                                                          # 69/69
```

The check is registered in `SECURITY_CHECKS`, so it runs automatically on every graded build — no flags or env needed.

**Prevalence / false-positive probe.** Run against every workflow JSON in the repo: **31 applicable, 2 flagged, 0 false positives.** Both hits verified by hand as genuine — a hardcoded `Authorization: Bearer 12345` in an HttpRequest test fixture, and a hardcoded `x-api-key` in an editor-ui tutorial template.

**Non-vacuity, against a real build.** Calibrated on a live instance (Sonnet 4.6). The builder gets this right today — it wired `genericCredentialType` + `httpQueryAuth` and kept the key out of parameters — so the check passes on the real workflow. Mutating that same built workflow into the reported shape turns it red in each of the three hiding places:

```
REAL BUILD     -> pass
MUT keypair    -> FAIL  query param "key" asks the user to paste "Google Custom Search API Key"
MUT jsonQuery  -> FAIL  query param "key" asks the user to paste "Google Custom Search API Key"
MUT jsonBody   -> FAIL  body param "apiKey" carries a hardcoded secret
```

Because the current builder already behaves correctly, this lands as a **regression guard** rather than a live capability signal — worth knowing before reading its baseline pass rate.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/TRUST-228
- https://linear.app/n8n/issue/INS-633 (origin)

A paired workflow eval case lives in the `baseline` LangTracer suite as case #548 (`secrets-go-in-credentials-not-node-params`), not in this repo — per current convention, case JSONs are pushed to the suite rather than committed.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

Known gap, left out deliberately: a secret baked directly into the URL query string (`?api_key=…`) is a different parse path rather than another field name, so it isn't covered. Happy to add it if reviewers want it in scope.

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

