### PR TITLE
docs: Fix Instance AI eval skill env recipe and add build-recovery step

### DIFF
--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -263,6 +263,13 @@ switch. Two shapes to know:
   rewrites `@/` path aliases to relative requires) didn't complete, so the dist is
   internally inconsistent.
 
+- **Out-of-sync `node_modules`** — `pnpm build` itself dies early with `Cannot find
+  module '@n8n/<pkg>'` even though that package is a declared `workspace:*`
+  dependency *and* has a `dist/`. The workspace symlink is missing from the
+  consumer's `node_modules` (typical after a branch or worktree switch). Confirm
+  with `ls -d packages/<consumer>/node_modules/@n8n/<pkg>`; fix with a plain
+  `pnpm install` — no need for the heavier `pnpm reset --full`.
+
 Fix it, don't calibrate around it: run a full ordered `pnpm build` (a targeted
 `--filter` build can fail on unrelated stale-dep type errors; for the instance-ai
 shape, `cd packages/@n8n/instance-ai && pnpm build` runs `tsc && tsc-alias`), then

--- a/.agents/skills/create-instance-ai-eval/running-evals.md
+++ b/.agents/skills/create-instance-ai-eval/running-evals.md
@@ -123,15 +123,18 @@ second instance its own everything:
 # N8N_AI_ANTHROPIC_KEY. Skip .env.local: its staging base-url / port-5678
 # defaults fight the settings below.
 N8N_PORT=5680 N8N_RUNNERS_BROKER_PORT=5681 N8N_USER_FOLDER=/tmp/n8n-eval-run \
-E2E_TESTS=true N8N_AI_ASSISTANT_BASE_URL= DB_SQLITE_POOL_SIZE=0 \
+E2E_TESTS=true N8N_AI_ASSISTANT_BASE_URL= \
   npx dotenvx run -f .env.eval -- \
   sh -c 'ANTHROPIC_API_KEY="$N8N_AI_ANTHROPIC_KEY" exec pnpm start'
 # then seed the owner (above), and run the eval with: --base-url http://localhost:5680
 ```
 
-`DB_SQLITE_POOL_SIZE=0` selects the classic non-pooled driver — under the pooled
-one `POST /rest/e2e/reset` fails with a `SQLITE_CONSTRAINT` FK error ("Dropping
-Table role for E2E Reset error") and you can never seed the owner.
+**Don't reach for `DB_SQLITE_POOL_SIZE=0`** if you find it in an older note. It
+can't disable pooling: the schema is `.int().gte(1)`, so `0` is rejected and
+`@Env` warns (`Invalid value for DB_SQLITE_POOL_SIZE … Falling back to default
+value.`) and keeps the default of 3. There is no non-pooled path to select
+anyway — `getSqliteConnectionOptions()` always returns `type: 'sqlite-pooled'`.
+`POST /rest/e2e/reset` seeds the owner fine under the pooled driver.
 
 `pnpm start` (built dist) is enough — no need for `pnpm dev:ai`. Case JSON is read
 from source at run time, so new/edited cases need no rebuild.

--- a/.agents/skills/create-instance-ai-eval/running-evals.md
+++ b/.agents/skills/create-instance-ai-eval/running-evals.md
@@ -96,7 +96,12 @@ flag wins — use it.
   getAuthToken`.
 - `ANTHROPIC_API_KEY` — the non-proxy orchestrator reads this (not just
   `N8N_AI_ANTHROPIC_KEY`); the eval helper (mock-gen / verify / judge) reads
-  either.
+  either. **You usually don't need a separate key: `.env.eval` already carries
+  `N8N_AI_ANTHROPIC_KEY`** — mirror it rather than hunting for another one
+  (`ANTHROPIC_API_KEY="$(grep '^N8N_AI_ANTHROPIC_KEY=' .env.eval | cut -d= -f2-)"`,
+  or just export it inside the `dotenvx` child). Check the file before concluding
+  a key is missing — and grep its names with `^[A-Za-z0-9_]+=`, since a
+  `^[A-Z_]*=` pattern silently drops every `N8N_*` var (the digit).
 - `E2E_TESTS=true` — exposes `POST /rest/e2e/reset` so you can seed a known owner.
 
 **Seed an owner** (a fresh instance has none → login 401s). Full payload shape in
@@ -114,11 +119,19 @@ it): a running instance holds both its main port *and* the task-broker port
 second instance its own everything:
 
 ```bash
+# .env.eval alone is enough — it carries N8N_AI_*, the sandbox/Daytona keys and
+# N8N_AI_ANTHROPIC_KEY. Skip .env.local: its staging base-url / port-5678
+# defaults fight the settings below.
 N8N_PORT=5680 N8N_RUNNERS_BROKER_PORT=5681 N8N_USER_FOLDER=/tmp/n8n-eval-run \
-E2E_TESTS=true N8N_AI_ASSISTANT_BASE_URL= ANTHROPIC_API_KEY=… \
-  npx dotenvx run -f .env.local -f .env.eval -- pnpm start
+E2E_TESTS=true N8N_AI_ASSISTANT_BASE_URL= DB_SQLITE_POOL_SIZE=0 \
+  npx dotenvx run -f .env.eval -- \
+  sh -c 'ANTHROPIC_API_KEY="$N8N_AI_ANTHROPIC_KEY" exec pnpm start'
 # then seed the owner (above), and run the eval with: --base-url http://localhost:5680
 ```
+
+`DB_SQLITE_POOL_SIZE=0` selects the classic non-pooled driver — under the pooled
+one `POST /rest/e2e/reset` fails with a `SQLITE_CONSTRAINT` FK error ("Dropping
+Table role for E2E Reset error") and you can never seed the owner.
 
 `pnpm start` (built dist) is enough — no need for `pnpm dev:ai`. Case JSON is read
 from source at run time, so new/edited cases need no rebuild.


### PR DESCRIPTION
## Summary

Two corrections to the `create-instance-ai-eval` skill, both found the hard way while running the workflow evals locally. Docs only — no code changes.

**`running-evals.md` — the direct-mode env recipe**

- `.env.eval` already carries `N8N_AI_ANTHROPIC_KEY`. The recipe previously sent readers hunting for a separate `ANTHROPIC_API_KEY`; it now mirrors the one that's already there.
- Added a warning that listing the file's var names with a `^[A-Z_]*=` pattern silently drops every `N8N_*` var (the digit doesn't match). That's an easy way to conclude a key is missing when it's sitting right there — which is exactly what happened here.
- The boot recipe now uses `-f .env.eval` alone. `.env.local`'s staging base-url and port-5678 defaults fight the flags set around it.
- Adds a note warning readers **off** `DB_SQLITE_POOL_SIZE=0`, which circulates in older local notes and does not do what it claims (see below).

**`SKILL.md` — environment-check list**

Added out-of-sync `node_modules` as a failure mode. `pnpm build` can die with `Cannot find module '@n8n/<pkg>'` even though that package is a declared `workspace:*` dependency *and* has a built `dist/` — the workspace symlink is just missing from the consumer's `node_modules`, which is typical after a branch or worktree switch. Confirm with `ls -d packages/<consumer>/node_modules/@n8n/<pkg>`; a plain `pnpm install` fixes it, no need for the heavier `pnpm reset --full`.

This sits next to the existing stale-dist entries because it presents the same way — a uniform failure that looks like it might be your case when it isn't.

### Correction in review (commit 2)

The first version of this PR recommended `DB_SQLITE_POOL_SIZE=0` to "select the classic non-pooled driver" and avoid a `SQLITE_CONSTRAINT` FK failure in `POST /rest/e2e/reset`. **That was wrong on two counts** and has been removed:

1. `sqlitePoolSizeSchema` is `z.coerce.number().int().gte(1)`, so `0` fails validation. The `@Env` decorator warns and keeps the class default of `3`. The very run that produced this recipe logged `Invalid value for DB_SQLITE_POOL_SIZE - Number must be greater than or equal to 1. Falling back to default value.` — so the pooled driver was active throughout and the reset returned 200 anyway. The FK failure did not reproduce.
2. There is no non-pooled path to select regardless: `getSqliteConnectionOptions()` unconditionally returns `type: 'sqlite-pooled'`. The variable only ever sizes the pool.

Replaced with a short note steering readers away from the setting, since it appears in older notes.

## How to test

Docs only; nothing to execute. The `skill_links_check` pre-commit hook passes.

The recipe was verified end-to-end on the way to #35421: booted an isolated instance on 5680 with these settings, seeded the owner, and ran a calibration build to completion — with the pooled driver, as the correction above notes.

## Related Linear tickets, Github issues, and Community forum posts

No ticket — incidental fixes found while working on https://linear.app/n8n/issue/TRUST-228 (code PR: #35421). Independent of that PR; can merge in either order.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- N/A — documentation only -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI