### PR TITLE
fix: Skip redundant workflow edit approval in AI Assistant

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -487,6 +487,89 @@ describe('createBuildWorkflowTool', () => {
 		);
 	});
 
+	it('updates a workflow created earlier in the run without requesting approval', async () => {
+		const { context, filePath } = makeContext({
+			source: 'workflow source',
+			overrides: {
+				permissions: {
+					createWorkflow: 'always_allow',
+					updateWorkflow: 'require_approval',
+				} as InstanceAiContext['permissions'],
+			},
+		});
+		const tool = createBuildWorkflowTool(context);
+		const suspend = vi.fn();
+
+		const created = await executeTool<BuildToolOutput>(tool, { filePath });
+		// INS-1044: follow-up builds reuse the workflow created by the first build.
+		const updated = await executeTool<BuildToolOutput>(tool, { filePath }, { suspend });
+
+		expect(created).toMatchObject({ success: true, workflowId: 'wf-1' });
+		expect(updated).toMatchObject({ success: true, workflowId: 'wf-1' });
+		expect(context.aiCreatedWorkflowIds).toEqual(new Set(['wf-1']));
+		expect(suspend).not.toHaveBeenCalled();
+		expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenCalledTimes(1);
+	});
+
+	it('requests approval before updating a pre-existing workflow', async () => {
+		const { context, filePath } = makeContext({
+			source: 'workflow source',
+			overrides: {
+				permissions: {
+					createWorkflow: 'always_allow',
+					updateWorkflow: 'require_approval',
+				} as InstanceAiContext['permissions'],
+			},
+		});
+		const suspend = vi.fn();
+
+		await executeTool(
+			createBuildWorkflowTool(context),
+			{ filePath, workflowId: 'wf-existing' },
+			{ suspend },
+		);
+
+		expect(suspend).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: 'Target workflow (ID: wf-existing)',
+				severity: 'warning',
+			}),
+		);
+		expect(compileWorkflowSource).not.toHaveBeenCalled();
+		expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+	});
+
+	it('blocks updates to workflows created earlier in the run when admin policy denies them', async () => {
+		const { context, filePath } = makeContext({
+			source: 'workflow source',
+			overrides: {
+				aiCreatedWorkflowIds: new Set(['wf-created']),
+				permissions: {
+					createWorkflow: 'always_allow',
+					updateWorkflow: 'blocked',
+				} as InstanceAiContext['permissions'],
+			},
+		});
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+			workflowId: 'wf-created',
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			workflowId: 'wf-created',
+			remediation: {
+				category: 'blocked',
+				shouldEdit: false,
+				reason: 'permission_blocked',
+			},
+			errors: ['Action blocked by admin'],
+		});
+		expect(compileWorkflowSource).not.toHaveBeenCalled();
+		expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+	});
+
 	it('returns conflict remediation when the workflow changed outside the conversation', async () => {
 		const { context, filePath, trackTelemetry } = makeContext({ source: 'workflow source' });
 		const tool = createBuildWorkflowTool(context);

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -531,7 +531,7 @@ describe('createBuildWorkflowTool', () => {
 
 		expect(suspend).toHaveBeenCalledWith(
 			expect.objectContaining({
-				message: 'Target workflow (ID: wf-existing)',
+				message: 'Edit Target workflow (ID: wf-existing)?',
 				severity: 'warning',
 			}),
 		);

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -453,7 +453,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					});
 					return await ctx.suspend({
 						requestId: nanoid(),
-						message: `${workflowName} (ID: ${targetWorkflowId})`,
+						message: `Edit ${workflowName} (ID: ${targetWorkflowId})?`,
 						severity: 'warning',
 					});
 				}

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -382,8 +382,13 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				};
 			}
 
+			const isOwnInFlightWorkflow =
+				targetWorkflowId !== undefined &&
+				(context.aiCreatedWorkflowIds?.has(targetWorkflowId) ?? false);
+
 			if (
 				targetWorkflowId &&
+				!isOwnInFlightWorkflow &&
 				!isApprovedBuildContext(context) &&
 				context.permissions?.updateWorkflow !== 'always_allow'
 			) {
@@ -448,7 +453,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					});
 					return await ctx.suspend({
 						requestId: nanoid(),
-						message: `Edit ${workflowName} (ID: ${targetWorkflowId})?`,
+						message: `${workflowName} (ID: ${targetWorkflowId})`,
 						severity: 'warning',
 					});
 				}

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -7031,6 +7031,7 @@
 	"instanceAi.tools.list-nodes": "Listing available nodes",
 	"instanceAi.tools.get-workflow-as-code": "Reading workflow code",
 	"instanceAi.tools.build-workflow": "Generating workflow",
+	"instanceAi.tools.build-workflow.imperative": "edit workflow",
 	"instanceAi.tools.read_config": "Reading agent config",
 	"instanceAi.tools.write_config": "Writing agent config",
 	"instanceAi.tools.patch_config": "Updating agent config",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
@@ -625,8 +625,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 .approvalRow {
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--2xs);
-	padding: var(--spacing--sm);
 	font-size: var(--font-size--2xs);
 }
 
@@ -634,6 +632,7 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--2xs);
+	padding: var(--spacing--sm) var(--spacing--sm) 0;
 }
 
 .textInputRow {


### PR DESCRIPTION
## Summary

- Skip human approval when AI Assistant updates a workflow it created earlier in the same run.
- Preserve administrator blocks and approval requirements for pre-existing workflows.
- Clarify legitimate edit approvals with an imperative title and resource-only subtitle.
- Remove duplicate padding from generic approval cards without changing domain-access approvals.

## How to test

1. In an AI Assistant-enabled instance, ask it in one message to create a workflow and then edit it. Confirm the same-run update completes without an approval prompt.
2. Ask it to edit a pre-existing workflow or edit the created workflow in a later user turn. Confirm the approval displays:
   - `Allow AI Assistant to edit workflow?`
   - `<workflow name> (ID: <workflow ID>)`
3. Confirm the generic approval card spacing is compact and domain-access approval layout is unchanged.

Automated checks completed:

- `@n8n/instance-ai`: targeted build-workflow tests (38/38), lint, and typecheck
- `n8n-editor-ui`: InstanceAiConfirmationPanel tests (16/16), lint, and typecheck
- `@n8n/i18n`: lint and typecheck

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1044

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## 🤖 PR Summary generated by AI

This PR removes a redundant same-run workflow edit approval while retaining existing permission boundaries and improving legitimate approval copy and spacing.

<img width="803" height="282" alt="image" src="https://github.com/user-attachments/assets/6fb14dfa-8888-48b2-99ba-001202b30308" />