### PR TITLE
refactor(core): Tidy agent-eval runner and rating-persistence internals (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/agent-eval-rating.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/agent-eval-rating.repository.test.ts
@@ -1,4 +1,5 @@
 import { Container } from '@n8n/di';
+import { In } from '@n8n/typeorm';
 import type { Mock } from 'vitest';
 
 import { AgentEvalRating } from '../../entities/agent-eval-rating.ee';
@@ -101,7 +102,7 @@ describe('AgentEvalRatingRepository', () => {
 			expect(qb.where).toHaveBeenCalledWith('result.runId = :runId', { runId: 'run-1' });
 			// The superseded r-1 is never fetched, only the two winners.
 			expect(entityManager.find.mock.calls[0]?.[1]).toEqual({
-				where: { id: expect.objectContaining({ _value: ['r-2', 'r-3'] }) },
+				where: { id: In(['r-2', 'r-3']) },
 			});
 			expect(latest.map((rating) => rating.id)).toEqual(['r-2', 'r-3']);
 		});

--- a/packages/@n8n/db/src/repositories/agent-eval-rating.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-rating.repository.ee.ts
@@ -41,6 +41,13 @@ export class AgentEvalRatingRepository extends Repository<AgentEvalRating> {
 	/**
 	 * Newest rating per result in a run. Reduced here, not in SQL: `DISTINCT ON` is
 	 * Postgres-only and `MAX(createdAt)` returns both rows on a millisecond tie.
+	 *
+	 * The trailing `rating.id` tiebreak buys reproducibility, not recency: ids are
+	 * random nanoids, so on a same-millisecond tie the winner is arbitrary — but
+	 * without a final tiebreak it is also unstable, and two calls could disagree on
+	 * which rating is "latest". Resolving which one genuinely came last would need a
+	 * monotonic column, so a migration — only worth it if same-millisecond
+	 * double-submits prove real.
 	 */
 	async findLatestByRunId(runId: string): Promise<AgentEvalRating[]> {
 		// Ids only — whole rows would load every superseded `correction` just to drop it.

--- a/packages/@n8n/db/src/repositories/agent-eval-rating.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/agent-eval-rating.repository.ee.ts
@@ -43,11 +43,8 @@ export class AgentEvalRatingRepository extends Repository<AgentEvalRating> {
 	 * Postgres-only and `MAX(createdAt)` returns both rows on a millisecond tie.
 	 *
 	 * The trailing `rating.id` tiebreak buys reproducibility, not recency: ids are
-	 * random nanoids, so on a same-millisecond tie the winner is arbitrary — but
-	 * without a final tiebreak it is also unstable, and two calls could disagree on
-	 * which rating is "latest". Resolving which one genuinely came last would need a
-	 * monotonic column, so a migration — only worth it if same-millisecond
-	 * double-submits prove real.
+	 * random nanoids, so on a same-millisecond tie the winner is arbitrary but at
+	 * least stable across calls. Picking the later one needs a monotonic column.
 	 */
 	async findLatestByRunId(runId: string): Promise<AgentEvalRating[]> {
 		// Ids only — whole rows would load every superseded `correction` just to drop it.

--- a/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
+++ b/packages/cli/src/modules/agent-evals/__tests__/agent-eval-runner.service.test.ts
@@ -384,6 +384,29 @@ describe('AgentEvalRunnerService', () => {
 				'empty_input',
 				expect.anything(),
 			);
+			// Screened out before the queue: an unusable case must never hold a slot.
+			expect(concurrencyControl.throttle).not.toHaveBeenCalled();
+			expect(resultRepository.markAsRunning).not.toHaveBeenCalled();
+		});
+
+		it('still completes the run when recording an empty-input case fails', async () => {
+			seedFor(
+				[
+					{ id: 'row-1', question: '   ' },
+					{ id: 'row-2', question: 'Q2' },
+				],
+				{ success: 1, error: 1 },
+			);
+			// This write sits outside `runCase`'s catch, so left unguarded the rejection
+			// would settle as a dispatch failure and error an otherwise-successful run.
+			resultRepository.markAsError.mockRejectedValueOnce(new Error('db unavailable'));
+			evalAgentExecutionService.executeWithLlmMock.mockResolvedValue(successExec() as never);
+
+			const { finished } = await service.startRun('ds-1', 'proj-1', user);
+			await finished;
+
+			expect(runRepository.markAsCompleted).toHaveBeenCalled();
+			expect(runRepository.markAsError).not.toHaveBeenCalled();
 		});
 
 		it('pages through every row when the table exceeds one page', async () => {
@@ -682,8 +705,12 @@ describe('AgentEvalRunnerService', () => {
 			await finished;
 
 			expect(concurrencyControl.throttle).toHaveBeenCalledTimes(2);
+			// Prefixed so a throttled id is attributable to agent evals in log streaming.
 			expect(concurrencyControl.throttle).toHaveBeenCalledWith(
-				expect.objectContaining({ mode: 'evaluation' }),
+				expect.objectContaining({
+					mode: 'evaluation',
+					executionId: expect.stringMatching(/^agent-eval:/),
+				}),
 			);
 			expect(concurrencyControl.release).toHaveBeenCalledTimes(2);
 			expect(concurrencyControl.release).toHaveBeenCalledWith({ mode: 'evaluation' });

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -278,9 +278,29 @@ export class AgentEvalRunnerService {
 								return;
 							}
 
+							// An empty input can't produce an execution, so record the verdict
+							// here rather than letting the case hold a queue slot to reach it.
+							// Checked after the stop above, so a cancel still outranks it.
+							if (resolvedCase.input.trim().length === 0) {
+								// Self-contained like `runCase`: one unusable case must not fail
+								// the whole run just because recording its verdict failed.
+								try {
+									await this.resultRepository.markAsError(resultRow.id, 'empty_input', {
+										message: 'Case has no value in the mapped input column.',
+									});
+								} catch (error) {
+									this.logger.error(
+										`[AgentEvalRunner] Could not record empty input for case ${resultRow.id}`,
+										{ error: error instanceof Error ? error.message : String(error) },
+									);
+								}
+								return;
+							}
+
 							// The helper owns release/remove when the run stops while queued;
 							// the finally owns release once a slot is held.
-							const executionId = `${runId}-case-${index}`;
+							// Prefixed so the id is attributable in `n8n.execution.throttled`.
+							const executionId = `agent-eval:${runId}-case-${index}`;
 							if (!(await this.acquireEvaluationSlot(executionId, abort.signal))) {
 								await stopCase(resultRow);
 								return;
@@ -486,7 +506,8 @@ export class AgentEvalRunnerService {
 	 * Execute one case and persist its result. Returns the case's token usage.
 	 * Fully self-contained: a thrown execution or DB error is converted into a
 	 * per-case error so one case can never abort the batch or leave its result
-	 * stuck `running`.
+	 * stuck `running`. Assumes a non-empty input — the caller screens those out
+	 * before taking a queue slot.
 	 */
 	private async runCase(
 		resultRow: AgentEvalResult,
@@ -494,13 +515,6 @@ export class AgentEvalRunnerService {
 		ctx: { agentId: string; projectId: string; user: User; timeoutMs?: number },
 	): Promise<CaseUsage | undefined> {
 		try {
-			if (resolvedCase.input.trim().length === 0) {
-				await this.resultRepository.markAsError(resultRow.id, 'empty_input', {
-					message: 'Case has no value in the mapped input column.',
-				});
-				return undefined;
-			}
-
 			await this.resultRepository.markAsRunning(resultRow.id);
 
 			const execResult = await this.evalAgentExecutionService.executeWithLlmMock(
@@ -568,7 +582,7 @@ export class AgentEvalRunnerService {
 
 		// Validate the mapping against the live columns so a renamed/deleted column
 		// fails loudly here instead of silently turning every case into an
-		// "empty input" error at execution time.
+		// "empty input" error once the run starts.
 		const columnNames = new Set(
 			(await this.dataTableService.getColumns(dataTableId, tableProjectId)).map((c) => c.name),
 		);

--- a/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
+++ b/packages/cli/src/modules/agent-evals/agent-eval-runner.service.ts
@@ -263,6 +263,22 @@ export class AgentEvalRunnerService {
 				await this.resultRepository.markAsCancelled(resultRow.id);
 			};
 
+			// An empty input can't produce an execution, so its verdict is recorded
+			// without taking a queue slot. Self-contained like `runCase`: one unusable
+			// case must not fail the run just because recording it failed.
+			const markEmptyInput = async (resultRow: AgentEvalResult) => {
+				try {
+					await this.resultRepository.markAsError(resultRow.id, 'empty_input', {
+						message: 'Case has no value in the mapped input column.',
+					});
+				} catch (error) {
+					this.logger.error(
+						`[AgentEvalRunner] Could not record empty input for case ${resultRow.id}`,
+						{ error: error instanceof Error ? error.message : String(error) },
+					);
+				}
+			};
+
 			const deadline = this.startRunDeadline(abort);
 
 			// The stop reads/writes around `runCase` sit outside its safety net, so
@@ -278,22 +294,9 @@ export class AgentEvalRunnerService {
 								return;
 							}
 
-							// An empty input can't produce an execution, so record the verdict
-							// here rather than letting the case hold a queue slot to reach it.
-							// Checked after the stop above, so a cancel still outranks it.
+							// Screened before the slot, after the stop: a cancel still outranks it.
 							if (resolvedCase.input.trim().length === 0) {
-								// Self-contained like `runCase`: one unusable case must not fail
-								// the whole run just because recording its verdict failed.
-								try {
-									await this.resultRepository.markAsError(resultRow.id, 'empty_input', {
-										message: 'Case has no value in the mapped input column.',
-									});
-								} catch (error) {
-									this.logger.error(
-										`[AgentEvalRunner] Could not record empty input for case ${resultRow.id}`,
-										{ error: error instanceof Error ? error.message : String(error) },
-									);
-								}
+								await markEmptyInput(resultRow);
 								return;
 							}
 

--- a/packages/cli/vitest.config.integration.ts
+++ b/packages/cli/vitest.config.integration.ts
@@ -6,5 +6,9 @@ export default mergeConfig(baseConfig, {
 	test: {
 		include: ['test/integration/**/*.test.ts', 'src/**/*.integration.test.ts'],
 		testTimeout: 10_000,
+		// Loading modules and building the entity schema in `beforeAll` routinely
+		// runs past Vitest's 10s hook default, which reads as broken coverage
+		// (whole suite skipped) rather than a slow setup.
+		hookTimeout: 30_000,
 	},
 });


### PR DESCRIPTION
## Summary

Batch of non-blocking quality follow-ups raised in the reviews of #34904 (runner) and #35252 (rating persistence). No API surface is touched, and behaviour is unchanged apart from one narrow race called out below.

**Runner** (`agent-eval-runner.service.ts`)

- **Empty-input cases no longer take a queue slot.** The `input.trim()` check lived inside `runCase`, which only runs *after* `acquireEvaluationSlot` has been awaited — so an unusable case occupied a shared evaluation slot purely to reach a verdict it could have reached for free. The check now sits in the case pool ahead of slot acquisition, and the write itself moved into a `markEmptyInput` closure beside `stopCase`, matching how the pool already delegates its other side-effecting writes.

  It is deliberately placed *after* the existing stop check, so a cancel still outranks `empty_input`, and the result row is still persisted as `error`/`empty_input` — the bad dataset rows stay visible in the run's status tally. Filtering them out during `resolveCases` was considered and rejected for exactly that reason: it would silently drop those rows from the run.

  *One behaviour delta:* an empty-input case previously queued for a slot first, so a cancel landing during that wait marked it `cancelled`. It now short-circuits before queueing, so under that race it lands `empty_input` instead. Arguably more accurate — the case was never going to execute — but it is a real difference, not a pure no-op.

  `markEmptyInput` keeps its own `try`/`catch`. Without one, moving the write out of `runCase`'s safety net would let a single failed write settle as a `Promise.allSettled` rejection and mark an *entire* run `case_dispatch_failed` over one unusable case. That regression was caught in review and is now covered by a test.

- **Synthetic execution ids are prefixed with `agent-eval:`.** `run-x-case-3` surfaced in `n8n.execution.throttled` log streaming with no indication of where it came from. Confirmed opaque to every consumer — `ConcurrencyControlService`, the `execution-throttled` event, and `log-streaming.event-relay.ts` all treat `executionId` as an unparsed string, and these synthetic ids never enter the `activeExecutions` map.

**Rating persistence** (`agent-eval-rating.repository.ee.ts`)

- **Documented the `rating.id` tiebreak in `findLatestByRunId`.** `.addOrderBy('rating.id', 'DESC')` reads as though it picks the later rating, but ids are random nanoids, so on a same-millisecond tie the winner is arbitrary. What it actually buys is reproducibility across calls. Resolving which rating genuinely came last would need a monotonic column, so a migration — only worth it if same-millisecond double-submits prove real.

  Note for the reviewer who raised this: the committed rationale intentionally differs from the wording in TRUST-353. The ticket says the tiebreak stops the DB reordering equal-`createdAt` rows "between reads" so that "pass one's winner stays fixed", but pass two fetches by explicit id and the return order is rebuilt from `latestIds`, so the two passes cannot disagree. The instability the tiebreak actually prevents is between *separate calls*, which is what the docstring now says.

- **Stopped asserting on TypeORM internals** in the repository unit test. It matched `objectContaining({ _value: [...] })` against the `In()` operator's private backing field; it now compares against a constructed `In([...])`, so a TypeORM upgrade can't break it on an internal. The assertion stays where it is rather than moving to the integration test — it is the only guard that pass two fetches *just* the winners, and an outcome-only test still passes if someone collapses the query back to one pass and silently reintroduces the memory blow-up it was written to prevent.

### Unrelated change riding along

One commit raises `hookTimeout` to 30s in `packages/cli/vitest.config.integration.ts`. That config set `testTimeout` but left `hookTimeout` at Vitest's 10s default, while the heavy work in these suites is in `beforeAll` (loading modules, then building the entity schema) rather than the test bodies — so the one timeout that was raised was the one that didn't need it. Neither `vitest.config.base.ts` nor `@n8n/vitest-config` sets `hookTimeout`, so this value is the effective one.

`agent-eval-scoped-reads` measured 8.9s / 9.1s / 9.6s across three runs on an idle machine and has been observed at 10.3–12.0s elsewhere. To be explicit: every local run here came in *under* the old 10s limit, so these runs demonstrate no regression but do not themselves prove the fix — the case for it rests on the out-of-band 10.3–12.0s measurements. When it does tip over, every test in the file reports as *skipped*, so a slow setup reads as broken coverage. Every integration suite in the package shares that `beforeAll` shape, hence the config-level fix over a per-suite override.

It is pre-existing on master, not introduced here. It is included because this PR's own CI runs those suites, including the runner integration test that covers the code changed above — but it is genuinely out of scope for TRUST-353, so say the word and I'll split it into its own PR.

## How to test

The module is opt-in and flag-gated, so a default instance won't exercise any of this:

- `N8N_ENABLED_MODULES=agent-evals,agents,data-table` — `agents` and `data-table` are both required (`agent-evals-required-modules.ts`); without them the runner fails with a `BadRequestError` rather than a TypeORM metadata error.
- PostHog flag `101_agent_evals`, or the operator override `N8N_AGENT_EVALS_ENABLED=true`.

Automated coverage:

```bash
# unit — 201 tests
cd packages/cli && pnpm test src/modules/agent-evals

# integration, real sqlite — 15 tests, incl. the runner against a real DB
cd packages/cli && pnpm test:integration src/modules/agent-evals

# rating repository unit — 5 tests
cd packages/@n8n/db && pnpm test src/repositories/__tests__/agent-eval-rating.repository.test.ts
```

Both new guards were checked to actually fail without their fix, rather than just passing alongside it:

- Removing the `try`/`catch` from inside `markEmptyInput` makes *only* `still completes the run when recording an empty-input case fails` fail (1 failed / 35 passed).
- Regressing pass two to fetch all ids instead of the winners makes the `In([...])` assertion fail.

Manual check for the id prefix: start a run with the evaluation concurrency limit at 1 and more than one case, then confirm the queued case logs `agent-eval:<runId>-case-<n>` on the `execution-throttled` event.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-353

Follow-ups from the reviews of #34904 and #35252. Sibling ticket [TRUST-352](https://linear.app/n8n/issue/TRUST-352) owns every change to `agent-evals.controller.ts` and `agent-evals.schema.ts`; this PR touches neither, so the two can land in either order.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
