### PR TITLE
feat: Add task-runners sidecar to the get.n8n.io stack

### DIFF
--- a/docker/get-n8n.sh
+++ b/docker/get-n8n.sh
@@ -187,6 +187,13 @@ N8N_VERSION=${INSTALL_VERSION}
 
 N8N_ENABLED_MODULES=instance-ai
 
+# Code-node user code (JavaScript and Python) runs in the separate 'runners'
+# container. The broker binds 0.0.0.0 so that container can reach it — its
+# port (5679) stays private to the compose network.
+N8N_RUNNERS_MODE=external
+N8N_RUNNERS_BROKER_LISTEN_ADDRESS=0.0.0.0
+N8N_RUNNERS_AUTH_TOKEN=$(gen_secret)
+
 # Instance AI (optional): fill this in to enable the AI assistant in n8n.
 # n8n works fine without it. Setup guide:
 # https://docs.n8n.io/deploy/host-n8n/configure-n8n/set-up-ai-assistant
@@ -303,6 +310,17 @@ services:
     env_file: .env
     volumes:
       - n8n-data:/home/node/.n8n
+
+  runners:
+    image: ghcr.io/n8n-io/runners:${N8N_VERSION}
+    depends_on:
+      - n8n
+    environment:
+      N8N_RUNNERS_AUTH_TOKEN: ${N8N_RUNNERS_AUTH_TOKEN}
+      N8N_RUNNERS_TASK_BROKER_URI: http://n8n:5679
+      # Idle runners exit and are relaunched on demand (per the task-runners docs)
+      N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT: '15'
+    # Runs user code from Code nodes. Never publish this container's ports.
 
   searxng:
     image: ghcr.io/searxng/searxng:latest

--- a/docker/test-get-n8n.sh
+++ b/docker/test-get-n8n.sh
@@ -182,6 +182,7 @@ if [ "$E2E" -eq 1 ]; then
 	echo "$ps_out" | grep -q '^sandbox-runner-1 running' && pass "sandbox-runner running" || fail "sandbox-runner running"
 	echo "$ps_out" | grep -q '^n8n running' && pass "n8n running" || fail "n8n running"
 	echo "$ps_out" | grep -q '^searxng running' && pass "searxng running" || fail "searxng running"
+	echo "$ps_out" | grep -q '^runners running' && pass "task runners running" || fail "task runners running"
 
 	check "n8n reaches sandbox-api" \
 		docker compose -f "$E2E_DIR/compose.yml" exec -T n8n wget -qO- http://sandbox-api:8080/healthz


### PR DESCRIPTION
## Summary

Follow-up to #34711 (merged); rebased onto master so the diff is now just the task-runners sidecar.

Python code nodes fail on the installer stack with "Python runner unavailable: Python 3 is missing from this system". Verified empirically in `ghcr.io/n8n-io/n8n:2.32.0` that bundling Python internally is a dead end: no `python3`, no package manager (Docker Hardened Images base — `apk` itself is absent), and `@n8n/task-runner-python` isn't shipped in the image (only the JS runner is). Internal mode is also labeled debug-only by the product.

This adds n8n's supported answer: the `ghcr.io/n8n-io/runners:${N8N_VERSION}` sidecar in external mode.

- `.env` gains `N8N_RUNNERS_MODE=external`, `N8N_RUNNERS_BROKER_LISTEN_ADDRESS=0.0.0.0` (default binds 127.0.0.1, unreachable from the sidecar), and a per-install generated `N8N_RUNNERS_AUTH_TOKEN`.
- The `runners` service gets only the two env vars it needs via interpolation — **not** `env_file: .env` — so sandbox/API secrets never enter the container that executes user code.
- Image tag tracks `${N8N_VERSION}`: `--upgrade` moves n8n and runners in lockstep.
- Broker port 5679 and the runner stay unpublished (compose-network only).
- e2e asserts the runners container is running.

## How to test

See `.context` handover in the workspace / #34711's harness: `sh docker/test-get-n8n.sh --e2e`, then run a Python Code node against the booted instance.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-661

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


