### PR TITLE
fix(ai-builder): Bind the eval credential-test bypass to the thread allowlist (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/eval/__tests__/thread-credential-allowlist.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/thread-credential-allowlist.service.test.ts
@@ -1,13 +1,7 @@
 import { EvalThreadCredentialAllowlistService } from '../thread-credential-allowlist.service';
 
-/**
- * The allowlist ONLY NARROWS — that is what makes it safe for an
- * `instanceAi:eval` caller to set. The test bypass has to inherit that
- * property: synthesizing a successful connection test for a credential the
- * thread cannot even see would let an eval-scoped caller assert something about
- * a credential outside its reach. A bypass id is therefore only honoured when
- * it is also in the thread's allowlist.
- */
+/** A bypass is honoured only for a credential the thread is already allowed to
+ *  see, so an eval-scoped caller can't reach one outside that set. */
 describe('EvalThreadCredentialAllowlistService', () => {
 	let service: EvalThreadCredentialAllowlistService;
 
@@ -27,9 +21,6 @@ describe('EvalThreadCredentialAllowlistService', () => {
 		expect(service.shouldBypassTest('thread-1', 'cred-b')).toBe(false);
 	});
 
-	// The gap: a bypass id outside the allowlist was honoured verbatim, so an
-	// eval-scoped caller could name ANY credential id — including one belonging
-	// to someone else — and have its connection test report success.
 	it('ignores a bypass id that is not in the thread allowlist', () => {
 		service.set('thread-1', ['cred-a'], ['someone-elses-cred']);
 
@@ -47,8 +38,7 @@ describe('EvalThreadCredentialAllowlistService', () => {
 		expect(service.shouldBypassTest('unknown-thread', 'cred-a')).toBe(false);
 	});
 
-	// The harness re-sends the whole list when it appends a mid-run credential,
-	// so a bypass dropped from a later call must not survive.
+	// The harness re-sends the whole list as it appends mid-run credentials.
 	it('overwrites rather than merges across calls', () => {
 		service.set('thread-1', ['cred-a', 'cred-b'], ['cred-a', 'cred-b']);
 		service.set('thread-1', ['cred-a', 'cred-b'], ['cred-b']);

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/thread-credential-allowlist.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/thread-credential-allowlist.service.test.ts
@@ -1,0 +1,67 @@
+import { EvalThreadCredentialAllowlistService } from '../thread-credential-allowlist.service';
+
+/**
+ * The allowlist ONLY NARROWS — that is what makes it safe for an
+ * `instanceAi:eval` caller to set. The test bypass has to inherit that
+ * property: synthesizing a successful connection test for a credential the
+ * thread cannot even see would let an eval-scoped caller assert something about
+ * a credential outside its reach. A bypass id is therefore only honoured when
+ * it is also in the thread's allowlist.
+ */
+describe('EvalThreadCredentialAllowlistService', () => {
+	let service: EvalThreadCredentialAllowlistService;
+
+	beforeEach(() => {
+		service = new EvalThreadCredentialAllowlistService();
+	});
+
+	it('bypasses the test for an allowlisted credential', () => {
+		service.set('thread-1', ['cred-a', 'cred-b'], ['cred-a']);
+
+		expect(service.shouldBypassTest('thread-1', 'cred-a')).toBe(true);
+	});
+
+	it('does not bypass a credential the case never declared', () => {
+		service.set('thread-1', ['cred-a'], ['cred-a']);
+
+		expect(service.shouldBypassTest('thread-1', 'cred-b')).toBe(false);
+	});
+
+	// The gap: a bypass id outside the allowlist was honoured verbatim, so an
+	// eval-scoped caller could name ANY credential id — including one belonging
+	// to someone else — and have its connection test report success.
+	it('ignores a bypass id that is not in the thread allowlist', () => {
+		service.set('thread-1', ['cred-a'], ['someone-elses-cred']);
+
+		expect(service.shouldBypassTest('thread-1', 'someone-elses-cred')).toBe(false);
+	});
+
+	it('keeps only the allowlisted subset when the two lists overlap partially', () => {
+		service.set('thread-1', ['cred-a'], ['cred-a', 'someone-elses-cred']);
+
+		expect(service.shouldBypassTest('thread-1', 'cred-a')).toBe(true);
+		expect(service.shouldBypassTest('thread-1', 'someone-elses-cred')).toBe(false);
+	});
+
+	it('bypasses nothing for a thread that was never set', () => {
+		expect(service.shouldBypassTest('unknown-thread', 'cred-a')).toBe(false);
+	});
+
+	// The harness re-sends the whole list when it appends a mid-run credential,
+	// so a bypass dropped from a later call must not survive.
+	it('overwrites rather than merges across calls', () => {
+		service.set('thread-1', ['cred-a', 'cred-b'], ['cred-a', 'cred-b']);
+		service.set('thread-1', ['cred-a', 'cred-b'], ['cred-b']);
+
+		expect(service.shouldBypassTest('thread-1', 'cred-a')).toBe(false);
+		expect(service.shouldBypassTest('thread-1', 'cred-b')).toBe(true);
+	});
+
+	it('forgets the bypass when the thread is cleared', () => {
+		service.set('thread-1', ['cred-a'], ['cred-a']);
+		service.clearThread('thread-1');
+
+		expect(service.shouldBypassTest('thread-1', 'cred-a')).toBe(false);
+		expect(service.get('thread-1')).toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/instance-ai/eval/thread-credential-allowlist.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/thread-credential-allowlist.service.ts
@@ -16,9 +16,21 @@ export class EvalThreadCredentialAllowlistService {
 
 	set(threadId: string, credentialIds: string[], bypassCredentialTest?: string[]): void {
 		this.byThread.set(threadId, [...credentialIds]);
+		// Bound to the allowlist, which is the property that makes this endpoint
+		// safe for an `instanceAi:eval` caller: the allowlist only ever NARROWS
+		// what a thread can see, so a bypass outside it would be the one part that
+		// widens — synthesizing a passing connection test for a credential the
+		// thread cannot even reach, including one owned by somebody else. An id
+		// that isn't allowlisted is dropped rather than rejected: the harness
+		// re-sends the whole list as it appends mid-run credentials, and ordering
+		// there shouldn't fail a run.
+		const allowed = new Set(credentialIds);
 		// Always overwrite rather than merge: the harness re-sends the whole list
 		// when it appends a mid-run credential, so a stale bypass must not survive.
-		this.testBypassByThread.set(threadId, [...(bypassCredentialTest ?? [])]);
+		this.testBypassByThread.set(
+			threadId,
+			(bypassCredentialTest ?? []).filter((id) => allowed.has(id)),
+		);
 	}
 
 	get(threadId: string): string[] | undefined {

--- a/packages/cli/src/modules/instance-ai/eval/thread-credential-allowlist.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/thread-credential-allowlist.service.ts
@@ -16,17 +16,10 @@ export class EvalThreadCredentialAllowlistService {
 
 	set(threadId: string, credentialIds: string[], bypassCredentialTest?: string[]): void {
 		this.byThread.set(threadId, [...credentialIds]);
-		// Bound to the allowlist, which is the property that makes this endpoint
-		// safe for an `instanceAi:eval` caller: the allowlist only ever NARROWS
-		// what a thread can see, so a bypass outside it would be the one part that
-		// widens — synthesizing a passing connection test for a credential the
-		// thread cannot even reach, including one owned by somebody else. An id
-		// that isn't allowlisted is dropped rather than rejected: the harness
-		// re-sends the whole list as it appends mid-run credentials, and ordering
-		// there shouldn't fail a run.
+		// Bypass only what the thread can already see: the allowlist narrows, and a
+		// bypass must not be the thing that widens. Overwrite rather than merge —
+		// the harness re-sends the whole list as it appends mid-run credentials.
 		const allowed = new Set(credentialIds);
-		// Always overwrite rather than merge: the harness re-sends the whole list
-		// when it appends a mid-run credential, so a stale bypass must not survive.
 		this.testBypassByThread.set(
 			threadId,
 			(bypassCredentialTest ?? []).filter((id) => allowed.has(id)),


### PR DESCRIPTION
## Summary

Follow-up to #35410, which merged before its last review finding was addressed. The finding is now on `master`.

**The gap.** The thread credential allowlist is safe for an `instanceAi:eval` caller precisely because it only ever **narrows**: `list()` is intersected with it, so a caller can never reach a credential they couldn't already. The test bypass added in #35410 was the one part that widened — `bypassCredentialTest` ids were stored verbatim, with no requirement that they appear in the thread's own allowlist. A caller could therefore name **any** credential id, including one outside the thread's view, and have its connection test resolve as successful without contacting the provider.

**The change.** Intersect the bypass with the allowlist. That is what #35410's own description always promised ("only for credentials a case created") — this makes it structural instead of conventional.

Dropped rather than rejected: the harness re-sends the whole list as it appends mid-run credentials, and an ordering quirk there shouldn't fail a run.

Nothing else changes — the stored token is still untouched, and only the test *result* is synthesized.

## Testing

New unit test for `EvalThreadCredentialAllowlistService`, covering the allowlisted case, the out-of-allowlist case, partial overlap, overwrite-not-merge, and thread clearing. Verified the two binding assertions fail against the pre-fix implementation.

`packages/cli` instance-ai eval suite: 674 passing.

## Related

- #35410 — the PR this completes
- Finding: https://github.com/n8n-io/n8n/pull/35410#discussion_r3703186745

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

