### PR TITLE
feat(core): Report database version in telemetry (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -251,6 +251,72 @@ describe('DbConnection', () => {
 		});
 	});
 
+	describe('getDbVersion', () => {
+		const newSqliteConnection = () => {
+			connectionOptions.getOptions.mockReturnValue({
+				type: 'sqlite',
+				database: ':memory:',
+				migrations,
+			});
+			// options are @Memoized and read in the constructor — re-instantiate
+			return new DbConnection(
+				errorReporter,
+				connectionOptions,
+				databaseConfig,
+				logger,
+				dbConnectionMetrics,
+			);
+		};
+
+		beforeEach(() => {
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = true;
+		});
+
+		it('should return the version the postgres driver resolved on connect', async () => {
+			dataSource.driver.version = '16.11';
+
+			await expect(dbConnection.getDbVersion()).resolves.toBe('16.11');
+			expect(dataSource.query).not.toHaveBeenCalled();
+		});
+
+		it('should return null when the postgres driver has no version', async () => {
+			dataSource.driver.version = undefined;
+
+			await expect(dbConnection.getDbVersion()).resolves.toBeNull();
+		});
+
+		it('should query the sqlite library version', async () => {
+			dataSource.query.mockResolvedValue([{ version: '3.45.0' }]);
+
+			await expect(newSqliteConnection().getDbVersion()).resolves.toBe('3.45.0');
+			expect(dataSource.query).toHaveBeenCalledWith('SELECT sqlite_version() AS version');
+		});
+
+		it('should return null when the sqlite query returns no rows', async () => {
+			dataSource.query.mockResolvedValue([]);
+
+			await expect(newSqliteConnection().getDbVersion()).resolves.toBeNull();
+		});
+
+		it('should return null when the query fails', async () => {
+			dataSource.query.mockRejectedValue(new Error('no such function: sqlite_version'));
+
+			await expect(newSqliteConnection().getDbVersion()).resolves.toBeNull();
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Could not determine database version: no such function: sqlite_version',
+			);
+		});
+
+		it('should return null when the data source is not initialized', async () => {
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = false;
+			dataSource.driver.version = '16.11';
+
+			await expect(dbConnection.getDbVersion()).resolves.toBeNull();
+		});
+	});
+
 	describe('close', () => {
 		it('should stop the monitor', async () => {
 			dataSource.initialize.mockResolvedValue(dataSource);

--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -252,12 +252,12 @@ describe('DbConnection', () => {
 	});
 
 	describe('getDbVersion', () => {
-		const newSqliteConnection = () => {
+		const newConnection = (type: 'sqlite' | 'sqlite-pooled' | 'mysql') => {
 			connectionOptions.getOptions.mockReturnValue({
-				type: 'sqlite',
+				type,
 				database: ':memory:',
 				migrations,
-			});
+			} as DataSourceOptions);
 			// options are @Memoized and read in the constructor — re-instantiate
 			return new DbConnection(
 				errorReporter,
@@ -286,26 +286,34 @@ describe('DbConnection', () => {
 			await expect(dbConnection.getDbVersion()).resolves.toBeNull();
 		});
 
-		it('should query the sqlite library version', async () => {
-			dataSource.query.mockResolvedValue([{ version: '3.45.0' }]);
+		it.each(['sqlite', 'sqlite-pooled'] as const)(
+			'should query the sqlite library version on %s',
+			async (type) => {
+				dataSource.query.mockResolvedValue([{ version: '3.45.0' }]);
 
-			await expect(newSqliteConnection().getDbVersion()).resolves.toBe('3.45.0');
-			expect(dataSource.query).toHaveBeenCalledWith('SELECT sqlite_version() AS version');
-		});
+				await expect(newConnection(type).getDbVersion()).resolves.toBe('3.45.0');
+				expect(dataSource.query).toHaveBeenCalledWith('SELECT sqlite_version() AS version');
+			},
+		);
 
 		it('should return null when the sqlite query returns no rows', async () => {
 			dataSource.query.mockResolvedValue([]);
 
-			await expect(newSqliteConnection().getDbVersion()).resolves.toBeNull();
+			await expect(newConnection('sqlite-pooled').getDbVersion()).resolves.toBeNull();
 		});
 
 		it('should return null when the query fails', async () => {
 			dataSource.query.mockRejectedValue(new Error('no such function: sqlite_version'));
 
-			await expect(newSqliteConnection().getDbVersion()).resolves.toBeNull();
+			await expect(newConnection('sqlite-pooled').getDbVersion()).resolves.toBeNull();
 			expect(logger.warn).toHaveBeenCalledWith(
 				'Could not determine database version: no such function: sqlite_version',
 			);
+		});
+
+		it('should return null for a database type n8n does not configure', async () => {
+			await expect(newConnection('mysql').getDbVersion()).resolves.toBeNull();
+			expect(dataSource.query).not.toHaveBeenCalled();
 		});
 
 		it('should return null when the data source is not initialized', async () => {

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -59,6 +59,24 @@ export class DbConnection {
 		return readPoolStats(this.dataSource);
 	}
 
+	async getDbVersion(): Promise<string | null> {
+		if (!this.dataSource.isInitialized) return null;
+
+		try {
+			if (this.options.type === 'postgres') return this.dataSource.driver.version ?? null;
+
+			const rows = await this.dataSource.query<Array<{ version: string }>>(
+				'SELECT sqlite_version() AS version',
+			);
+
+			return rows[0]?.version ?? null;
+		} catch (e) {
+			const error = ensureError(e);
+			this.logger.warn(`Could not determine database version: ${error.message}`);
+			return null;
+		}
+	}
+
 	async init(): Promise<void> {
 		const { connectionState } = this;
 		if (connectionState.connected) return;

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -59,17 +59,30 @@ export class DbConnection {
 		return readPoolStats(this.dataSource);
 	}
 
+	/**
+	 * Version of the database backing this connection, as a dotted version
+	 * string: the Postgres server version (e.g. `17.6`, not the full
+	 * `version()` banner) or the SQLite library version (e.g. `3.44.2`).
+	 * `null` when it cannot be determined, e.g. the connection is not up.
+	 */
 	async getDbVersion(): Promise<string | null> {
 		if (!this.dataSource.isInitialized) return null;
 
 		try {
-			if (this.options.type === 'postgres') return this.dataSource.driver.version ?? null;
+			switch (this.options.type) {
+				case 'postgres':
+					return this.dataSource.driver.version ?? null;
+				case 'sqlite':
+				case 'sqlite-pooled': {
+					const rows = await this.dataSource.query<Array<{ version: string }>>(
+						'SELECT sqlite_version() AS version',
+					);
 
-			const rows = await this.dataSource.query<Array<{ version: string }>>(
-				'SELECT sqlite_version() AS version',
-			);
-
-			return rows[0]?.version ?? null;
+					return rows[0]?.version ?? null;
+				}
+				default:
+					return null;
+			}
 		} catch (e) {
 			const error = ensureError(e);
 			this.logger.warn(`Could not determine database version: ${error.message}`);

--- a/packages/@n8n/telemetry/src/events/instance.ts
+++ b/packages/@n8n/telemetry/src/events/instance.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod/v4';
+
+import { defineTelemetryEvents } from '../define';
+
+export const INSTANCE_TELEMETRY = defineTelemetryEvents({
+	STARTED: {
+		name: 'Instance started',
+		description:
+			'Instance finished booting, reported once per main process start with a snapshot of its configuration.',
+		properties: z.object({
+			version_cli: z.string(),
+			db_type: z.enum(['sqlite', 'postgresdb']),
+			db_version: z
+				.string()
+				.nullable()
+				.describe(
+					'Postgres server version, or SQLite library version. Null when it could not be determined, which for `postgresdb` means the query failed rather than that the instance runs SQLite.',
+				),
+			n8n_version_notifications_enabled: z.boolean(),
+			n8n_disable_production_main_process: z.boolean(),
+			system_info: z.object({
+				os: z.object({
+					type: z.string(),
+					version: z.string(),
+				}),
+				memory: z.number().describe('Total system memory in KiB'),
+				cpus: z.object({
+					count: z.number(),
+					model: z.string(),
+					speed: z.number().describe('Clock speed in MHz'),
+				}),
+				is_docker: z.boolean(),
+			}),
+			execution_variables: z.object({
+				executions_mode: z.enum(['regular', 'queue']),
+				executions_timeout: z.number().describe('Seconds, -1 for unlimited'),
+				executions_timeout_max: z.number().describe('Seconds'),
+				executions_data_save_on_error: z.enum(['all', 'none']),
+				executions_data_save_on_success: z.enum(['all', 'none']),
+				executions_data_save_on_progress: z.boolean(),
+				executions_data_save_manual_executions: z.boolean(),
+				executions_data_prune: z.boolean(),
+				executions_data_max_age: z.number().describe('Hours'),
+			}),
+			workflow_history: z.object({
+				compaction_optimizing_time_window_hours: z.number(),
+				compaction_trim_on_start_up: z.boolean(),
+				compaction_trimming_time_window_days: z.number(),
+			}),
+			n8n_deployment_type: z.string(),
+			n8n_binary_data_mode: z.enum(['default', 'filesystem', 's3', 'azure', 'database']),
+			smtp_set_up: z.boolean(),
+			ldap_allowed: z.boolean(),
+			saml_enabled: z.boolean(),
+			license_plan_name: z.string(),
+			license_tenant_id: z.number(),
+			binary_data_s3: z
+				.boolean()
+				.describe('S3 binary data is selected, available and licensed, all three'),
+			multi_main_setup_enabled: z.boolean(),
+			instance_ai: z
+				.object({
+					sandbox_enabled: z.boolean(),
+					sandbox_provider: z.string(),
+					search_brave_set: z.boolean(),
+					search_searxng_set: z.boolean(),
+				})
+				.describe('Which sandbox and search providers are configured, never key values'),
+			metrics: z.object({
+				metrics_enabled: z.boolean(),
+				metrics_category_default: z.boolean(),
+				metrics_category_routes: z.boolean(),
+				metrics_category_cache: z.boolean(),
+				metrics_category_logs: z.boolean(),
+				metrics_category_queue: z.boolean(),
+				metrics_category_execution_data: z.boolean(),
+				metrics_category_webhooks: z.boolean(),
+				metrics_category_forms: z.boolean(),
+				metrics_category_workflow_info: z.boolean(),
+			}),
+			earliest_workflow_created: z
+				// `unknown` because this is emitted as a Date, which zod cannot represent in
+				// JSON Schema. It reaches the warehouse as an ISO timestamp via JSON.stringify.
+				.unknown()
+				.describe('Date of the oldest workflow, absent when the instance has none'),
+			otel: z.object({
+				enabled: z.boolean(),
+				include_node_spans: z.boolean(),
+			}),
+			settings_managed_by_env_vars: z.object({
+				owner_managed_by_env: z.boolean(),
+				sso_managed_by_env: z.boolean(),
+				security_policy_managed_by_env: z.boolean(),
+				log_streaming_managed_by_env: z.boolean(),
+				mcp_managed_by_env: z.boolean(),
+				community_packages_managed_by_env: z.boolean(),
+			}),
+		}),
+	},
+});

--- a/packages/@n8n/telemetry/src/events/instance.ts
+++ b/packages/@n8n/telemetry/src/events/instance.ts
@@ -3,7 +3,7 @@ import { z } from 'zod/v4';
 import { defineTelemetryEvents } from '../define';
 
 export const INSTANCE_TELEMETRY = defineTelemetryEvents({
-	STARTED: {
+	INSTANCE_STARTED: {
 		name: 'Instance started',
 		description:
 			'Instance finished booting, reported once per main process start with a snapshot of its configuration.',

--- a/packages/@n8n/telemetry/src/telemetry-events.ts
+++ b/packages/@n8n/telemetry/src/telemetry-events.ts
@@ -1,8 +1,10 @@
 import type { TelemetryEventRegistry } from './define';
 import { AGENTS_TELEMETRY } from './events/agents';
+import { INSTANCE_TELEMETRY } from './events/instance';
 import { PLATFORM_TELEMETRY } from './events/platform';
 
 export const TELEMETRY_EVENT = {
 	PLATFORM: PLATFORM_TELEMETRY,
 	AGENTS: AGENTS_TELEMETRY,
+	INSTANCE: INSTANCE_TELEMETRY,
 } satisfies TelemetryEventRegistry;

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -4,6 +4,7 @@ import type { GlobalConfig } from '@n8n/config';
 import {
 	type CredentialsEntity,
 	type CredentialsRepository,
+	type DbConnection,
 	type IWorkflowDb,
 	type ProjectRelationRepository,
 	type SharedWorkflowRepository,
@@ -13,6 +14,7 @@ import {
 	In,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { type BinaryDataConfig, InstanceSettings } from 'n8n-core';
 import {
 	createErrorExecutionData,
@@ -64,7 +66,22 @@ describe('TelemetryEventRelay', () => {
 		diagnostics: {
 			enabled: true,
 		},
+		versionNotifications: {
+			enabled: true,
+		},
+		executions: {
+			mode: 'regular',
+			timeout: -1,
+			maxTimeout: 3600,
+			saveDataOnError: 'all',
+			saveDataOnSuccess: 'all',
+			saveExecutionProgress: false,
+			saveDataManualExecutions: true,
+			pruneData: true,
+			pruneDataMaxAge: 336,
+		},
 		endpoints: {
+			disableProductionWebhooksOnMainProcess: false,
 			metrics: {
 				enable: true,
 				includeDefaultMetrics: true,
@@ -87,6 +104,7 @@ describe('TelemetryEventRelay', () => {
 			batchSize: 234,
 			optimizingTimeWindowHours: 400,
 			trimmingTimeWindowDays: 600,
+			trimOnStartUp: false,
 		},
 		host: 'localhost',
 		generic: {
@@ -136,6 +154,7 @@ describe('TelemetryEventRelay', () => {
 	const projectRelationRepository = mock<ProjectRelationRepository>();
 	const credentialsRepository = mock<CredentialsRepository>();
 	const dynamicCredentialsProxy = mock<DynamicCredentialsProxy>();
+	const dbConnection = mock<DbConnection>();
 	const eventService = new EventService();
 
 	let telemetryEventRelay: TelemetryEventRelay;
@@ -155,6 +174,7 @@ describe('TelemetryEventRelay', () => {
 			projectRelationRepository,
 			credentialsRepository,
 			dynamicCredentialsProxy,
+			dbConnection,
 		);
 
 		await telemetryEventRelay.init();
@@ -186,6 +206,7 @@ describe('TelemetryEventRelay', () => {
 				projectRelationRepository,
 				credentialsRepository,
 				dynamicCredentialsProxy,
+				dbConnection,
 			);
 			// @ts-expect-error Private method
 			const setupListenersSpy = vi.spyOn(telemetryEventRelay, 'setupListeners');
@@ -212,6 +233,7 @@ describe('TelemetryEventRelay', () => {
 				projectRelationRepository,
 				credentialsRepository,
 				dynamicCredentialsProxy,
+				dbConnection,
 			);
 			// @ts-expect-error Private method
 			const setupListenersSpy = vi.spyOn(telemetryEventRelay, 'setupListeners');
@@ -2577,6 +2599,11 @@ describe('TelemetryEventRelay', () => {
 	});
 
 	describe('lifecycle events', () => {
+		beforeEach(() => {
+			dbConnection.getDbVersion.mockResolvedValue(null);
+			license.getPlanName.mockReturnValue('Community');
+		});
+
 		it('should track on `server-started` event', async () => {
 			const firstWorkflow = mock<WorkflowEntity>({ createdAt: new Date() });
 			workflowRepository.findOne.mockResolvedValue(firstWorkflow);
@@ -2647,7 +2674,7 @@ describe('TelemetryEventRelay', () => {
 				}),
 			);
 			expect(telemetry.track).toHaveBeenCalledWith(
-				'Instance started',
+				TELEMETRY_EVENT.INSTANCE.STARTED,
 				expect.objectContaining({
 					earliest_workflow_created: firstWorkflow.createdAt,
 					settings_managed_by_env_vars: {
@@ -2678,6 +2705,56 @@ describe('TelemetryEventRelay', () => {
 			);
 		});
 
+		it('should report the database version on `server-started` event', async () => {
+			workflowRepository.findOne.mockResolvedValue(null);
+			dbConnection.getDbVersion.mockResolvedValue('16.11');
+
+			eventService.emit('server-started');
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				TELEMETRY_EVENT.INSTANCE.STARTED,
+				expect.objectContaining({ db_type: 'sqlite', db_version: '16.11' }),
+			);
+			expect(telemetry.identify).toHaveBeenCalledWith(
+				expect.objectContaining({ db_type: 'sqlite', db_version: '16.11' }),
+			);
+			expect(telemetry.groupIdentify).toHaveBeenCalledWith(
+				expect.objectContaining({
+					traits: expect.objectContaining({ db_type: 'sqlite', db_version: '16.11' }),
+				}),
+			);
+		});
+
+		it('should emit a payload that satisfies the registry schema', async () => {
+			workflowRepository.findOne.mockResolvedValue(mock<WorkflowEntity>({ createdAt: new Date() }));
+			dbConnection.getDbVersion.mockResolvedValue('17.6');
+
+			eventService.emit('server-started');
+
+			await flushPromises();
+
+			const startupEvent = telemetry.track.mock.calls.find(
+				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.STARTED,
+			);
+			expect(TELEMETRY_EVENT.INSTANCE.STARTED.getValidationError(startupEvent?.[1])).toBeNull();
+		});
+
+		it('should report a `null` database version when it cannot be determined', async () => {
+			workflowRepository.findOne.mockResolvedValue(null);
+			dbConnection.getDbVersion.mockResolvedValue(null);
+
+			eventService.emit('server-started');
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				TELEMETRY_EVENT.INSTANCE.STARTED,
+				expect.objectContaining({ db_type: 'sqlite', db_version: null }),
+			);
+		});
+
 		it('should track instance settings env management on `server-started` event', async () => {
 			workflowRepository.findOne.mockResolvedValue(null);
 			Object.assign(globalConfig.instanceSettingsLoader, {
@@ -2694,7 +2771,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			expect(telemetry.track).toHaveBeenCalledWith(
-				'Instance started',
+				TELEMETRY_EVENT.INSTANCE.STARTED,
 				expect.objectContaining({
 					settings_managed_by_env_vars: {
 						owner_managed_by_env: true,
@@ -2745,7 +2822,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			const startupEvent = telemetry.track.mock.calls.find(
-				([eventName]) => eventName === 'Instance started',
+				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.STARTED,
 			);
 			expect(startupEvent).toBeDefined();
 			if (!startupEvent) throw new Error('Expected Instance started telemetry event');
@@ -2773,7 +2850,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			expect(telemetry.track).toHaveBeenCalledWith(
-				'Instance started',
+				TELEMETRY_EVENT.INSTANCE.STARTED,
 				expect.objectContaining({
 					otel: {
 						enabled: true,
@@ -2804,7 +2881,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			const startupEvent = telemetry.track.mock.calls.find(
-				([eventName]) => eventName === 'Instance started',
+				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.STARTED,
 			);
 			expect(startupEvent).toBeDefined();
 			expect(startupEvent?.[1]).toEqual(

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2674,7 +2674,7 @@ describe('TelemetryEventRelay', () => {
 				}),
 			);
 			expect(telemetry.track).toHaveBeenCalledWith(
-				TELEMETRY_EVENT.INSTANCE.STARTED,
+				TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED,
 				expect.objectContaining({
 					earliest_workflow_created: firstWorkflow.createdAt,
 					settings_managed_by_env_vars: {
@@ -2714,7 +2714,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			expect(telemetry.track).toHaveBeenCalledWith(
-				TELEMETRY_EVENT.INSTANCE.STARTED,
+				TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED,
 				expect.objectContaining({ db_type: 'sqlite', db_version: '16.11' }),
 			);
 			expect(telemetry.identify).toHaveBeenCalledWith(
@@ -2736,9 +2736,11 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			const startupEvent = telemetry.track.mock.calls.find(
-				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.STARTED,
+				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED,
 			);
-			expect(TELEMETRY_EVENT.INSTANCE.STARTED.getValidationError(startupEvent?.[1])).toBeNull();
+			expect(
+				TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED.getValidationError(startupEvent?.[1]),
+			).toBeNull();
 		});
 
 		it('should report a `null` database version when it cannot be determined', async () => {
@@ -2750,7 +2752,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			expect(telemetry.track).toHaveBeenCalledWith(
-				TELEMETRY_EVENT.INSTANCE.STARTED,
+				TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED,
 				expect.objectContaining({ db_type: 'sqlite', db_version: null }),
 			);
 		});
@@ -2771,7 +2773,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			expect(telemetry.track).toHaveBeenCalledWith(
-				TELEMETRY_EVENT.INSTANCE.STARTED,
+				TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED,
 				expect.objectContaining({
 					settings_managed_by_env_vars: {
 						owner_managed_by_env: true,
@@ -2822,7 +2824,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			const startupEvent = telemetry.track.mock.calls.find(
-				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.STARTED,
+				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED,
 			);
 			expect(startupEvent).toBeDefined();
 			if (!startupEvent) throw new Error('Expected Instance started telemetry event');
@@ -2850,7 +2852,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			expect(telemetry.track).toHaveBeenCalledWith(
-				TELEMETRY_EVENT.INSTANCE.STARTED,
+				TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED,
 				expect.objectContaining({
 					otel: {
 						enabled: true,
@@ -2881,7 +2883,7 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			const startupEvent = telemetry.track.mock.calls.find(
-				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.STARTED,
+				([event]) => (event as unknown) === TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED,
 			);
 			expect(startupEvent).toBeDefined();
 			expect(startupEvent?.[1]).toEqual(

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -2,6 +2,7 @@ import { LicenseState } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import {
 	CredentialsRepository,
+	DbConnection,
 	In,
 	ProjectRelationRepository,
 	SharedWorkflowRepository,
@@ -10,6 +11,7 @@ import {
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { snakeCase } from 'change-case';
 import { BinaryDataConfig, InstanceSettings } from 'n8n-core';
 import type {
@@ -95,6 +97,7 @@ export class TelemetryEventRelay extends EventRelay {
 		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly credentialsRepository: CredentialsRepository,
 		private readonly dynamicCredentialsProxy: DynamicCredentialsProxy,
+		private readonly dbConnection: DbConnection,
 	) {
 		super(eventService);
 	}
@@ -1457,10 +1460,12 @@ export class TelemetryEventRelay extends EventRelay {
 		const isS3Available = this.binaryDataConfig.availableModes.includes('s3');
 		const isS3Licensed = this.license.isBinaryDataS3Licensed();
 		const authenticationMethod = config.getEnv('userManagement.authenticationMethod');
+		const dbVersion = await this.dbConnection.getDbVersion();
 
 		const info = {
 			version_cli: N8N_VERSION,
 			db_type: this.globalConfig.database.type,
+			db_version: dbVersion,
 			n8n_version_notifications_enabled: this.globalConfig.versionNotifications.enabled,
 			n8n_disable_production_main_process:
 				this.globalConfig.endpoints.disableProductionWebhooksOnMainProcess,
@@ -1542,6 +1547,7 @@ export class TelemetryEventRelay extends EventRelay {
 			executions_mode: this.globalConfig.executions.mode,
 			n8n_deployment_type: this.globalConfig.deployment.type,
 			db_type: this.globalConfig.database.type,
+			db_version: dbVersion,
 
 			// Location settings
 			timezone: this.globalConfig.generic.timezone,
@@ -1585,7 +1591,7 @@ export class TelemetryEventRelay extends EventRelay {
 		});
 
 		this.telemetry.identify(info);
-		this.telemetry.track('Instance started', {
+		this.telemetry.track(TELEMETRY_EVENT.INSTANCE.STARTED, {
 			...info,
 			earliest_workflow_created: firstWorkflow?.createdAt,
 			otel,

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1591,7 +1591,7 @@ export class TelemetryEventRelay extends EventRelay {
 		});
 
 		this.telemetry.identify(info);
-		this.telemetry.track(TELEMETRY_EVENT.INSTANCE.STARTED, {
+		this.telemetry.track(TELEMETRY_EVENT.INSTANCE.INSTANCE_STARTED, {
 			...info,
 			earliest_workflow_created: firstWorkflow?.createdAt,
 			otel,


### PR DESCRIPTION
## Summary

`Instance started` now reports `db_version` next to the existing `db_type`: the Postgres server version, or the SQLite library version. Paired with `db_type`, a `postgresdb` instance reporting a null version is distinguishable from a SQLite one. It also goes into the instance group traits, so it is queryable as current state and not just per startup event.

For Postgres this costs no extra round trip, since TypeORM already resolves the version from `SELECT version()` on connect.

Registering `Instance started` in the `@n8n/telemetry` registry is what types the new property. That is most of the diff.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3913

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

