### PR TITLE
feat(core): Create agents on first configuration instead of on click

### DIFF
--- a/packages/@n8n/api-types/src/agents/__tests__/agent-personalisation.test.ts
+++ b/packages/@n8n/api-types/src/agents/__tests__/agent-personalisation.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	addMissingAgentPersonalisation,
 	getRandomAgentPersonalisationGradient,
-} from '../agentPersonalisation';
+} from '../agent-personalisation';
 
 function sequenceRandom(values: number[]) {
 	let index = 0;

--- a/packages/@n8n/api-types/src/agents/agent-personalisation.ts
+++ b/packages/@n8n/api-types/src/agents/agent-personalisation.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_AGENT_PERSONALISATION, type AgentJsonConfig } from '@n8n/api-types';
+import { DEFAULT_AGENT_PERSONALISATION, type AgentJsonConfig } from './agent-json-config.schema';
 
 export type AgentPersonalisation = NonNullable<AgentJsonConfig['personalisation']>;
 type AgentPersonalisationGradient = AgentPersonalisation['gradient'];

--- a/packages/@n8n/api-types/src/agents/dto.ts
+++ b/packages/@n8n/api-types/src/agents/dto.ts
@@ -81,6 +81,15 @@ export class UpdateAgentsMcpAvailabilityDto extends Z.class({
 
 export class CreateAgentDto extends Z.class({
 	name: z.string().min(1),
+	/**
+	 * Client-minted agent id, so a surface can reference the agent (an artifact
+	 * tab, a thread binding) before it decides to persist it. Must match the
+	 * nanoid shape the entity would otherwise generate.
+	 */
+	id: z
+		.string()
+		.regex(/^[0-9A-Za-z]{16}$/)
+		.optional(),
 }) {}
 
 export class UpdateAgentConfigDto extends Z.class({

--- a/packages/@n8n/api-types/src/agents/index.ts
+++ b/packages/@n8n/api-types/src/agents/index.ts
@@ -5,6 +5,7 @@ export * from './agent-files.constants';
 export * from './agent-integration.schema';
 export * from './agent-json-config.schema';
 export * from './agent-node-tool-operations';
+export * from './agent-personalisation';
 export * from './agent-skill.schema';
 export * from './child-trace';
 export * from './inline-agent-config.schema';

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/agent-target-binding.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/agent-target-binding.test.ts
@@ -3,6 +3,7 @@ import type { InstanceAiContext } from '../../../types';
 import {
 	getSessionAgentByRef,
 	normalizeAgentRef,
+	PENDING_AGENT_METADATA_KEY,
 	resolveAgentBuilderTarget,
 	saveAgentBuilderTarget,
 } from '../agent-target-binding';
@@ -17,7 +18,7 @@ function createThreadMemory(initialMetadata: Record<string, unknown> = {}) {
 		updatedAt: new Date(),
 	};
 	return {
-		getThread: vi.fn().mockResolvedValue(thread),
+		getThread: vi.fn<() => Promise<ThreadRecord>>().mockResolvedValue(thread),
 		patchThread: vi.fn().mockImplementation(
 			async (args: {
 				update: (current: ThreadRecord) => { metadata?: Record<string, unknown> };
@@ -101,6 +102,19 @@ describe('agent-builder target binding', () => {
 
 		await expect(resolveAgentBuilderTarget(context)).rejects.toThrow('storage unavailable');
 		expect(context.agentBuilderTarget).toBeUndefined();
+	});
+
+	it('clears the pending new-agent marker once a real agent binds, keeping other metadata', async () => {
+		const threadMemory = createThreadMemory({
+			[PENDING_AGENT_METADATA_KEY]: { projectId: 'project-1' },
+			someOtherKey: 'keep me',
+		});
+
+		await saveAgentBuilderTarget(createContext({ threadMemory }), TARGET);
+
+		const thread: ThreadRecord = await threadMemory.getThread();
+		expect(thread.metadata).not.toHaveProperty(PENDING_AGENT_METADATA_KEY);
+		expect(thread.metadata?.someOtherKey).toBe('keep me');
 	});
 
 	it('propagates a metadata write failure instead of claiming success', async () => {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.target-registry.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.target-registry.test.ts
@@ -188,6 +188,40 @@ describe('build-agent target registry (real binding)', () => {
 		);
 	});
 
+	it('continues the persisted target when a later turn names a new agent without createNew', async () => {
+		const { memory } = createThreadMemory();
+		const first = makeContext(memory);
+		vi.mocked(first.delegate.createAgent).mockResolvedValue({
+			agentId: 'agent-1',
+			projectId: 'proj-1',
+		});
+		vi.mocked(first.delegate.resolveAgentName).mockResolvedValue('New agent');
+		vi.mocked(first.delegate.streamBuild).mockResolvedValue(completedStream('Created it.'));
+
+		await executeTool(createBuildAgentTool(first.context), {
+			message: 'Build it',
+			name: 'New agent',
+		});
+
+		// Fresh context: the binding has to come back from thread metadata, which
+		// is the path the real duplicate-agent regression went through.
+		const second = makeContext(memory);
+		vi.mocked(second.delegate.streamBuild).mockResolvedValue(completedStream('Extended it.'));
+
+		const result = await executeTool<{ agentId?: string }>(createBuildAgentTool(second.context), {
+			message: 'Make it triage support mail',
+			name: 'Support Triage',
+		});
+
+		expect(second.delegate.createAgent).not.toHaveBeenCalled();
+		expect(second.delegate.streamBuild).toHaveBeenCalledWith(
+			'agent-1',
+			'Make it triage support mail',
+			expect.objectContaining({ threadId: `ia-builder:${THREAD_ID}:agent-1` }),
+		);
+		expect(result).toMatchObject({ agentId: 'agent-1' });
+	});
+
 	it('creates a separate agent for a different name in the same thread', async () => {
 		const { memory } = createThreadMemory();
 		const first = makeContext(memory);
@@ -213,10 +247,10 @@ describe('build-agent target registry (real binding)', () => {
 
 		const result = await executeTool<{ agentId?: string; agentRef?: string }>(
 			createBuildAgentTool(second.context),
-			{ message: 'Build another', name: 'Docs Helper' },
+			{ message: 'Build another', name: 'Docs Helper', createNew: true },
 		);
 
-		expect(second.delegate.createAgent).toHaveBeenCalledWith('Docs Helper');
+		expect(second.delegate.createAgent).toHaveBeenCalledWith('Docs Helper', undefined);
 		expect(result).toMatchObject({ agentId: 'agent-2', agentRef: 'docs-helper' });
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
@@ -1081,6 +1081,11 @@ describe('build-agent tool', () => {
 				'Build a support triage agent',
 				expect.objectContaining({ threadId: 'ia-builder:thread-1:agent-1' }),
 			);
+			// The reported agentRef has to resolve on later calls.
+			expect(saveAgentBuilderTarget).toHaveBeenCalledWith(
+				context.domainContext,
+				expect.objectContaining({ agentId: 'agent-1', ref: 'support-triage' }),
+			);
 		});
 
 		it('switches back via registry ref instead of creating a duplicate', async () => {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
@@ -21,6 +21,7 @@ import type {
 import type * as AgentTargetBindingModule from '../agent-target-binding';
 import {
 	getSessionAgentByRef,
+	readPendingAgentTarget,
 	saveAgentBuilderTarget,
 	type AgentBuilderTarget,
 } from '../agent-target-binding';
@@ -35,6 +36,7 @@ vi.mock('../agent-target-binding', async () => {
 		),
 		saveAgentBuilderTarget: vi.fn(),
 		getSessionAgentByRef: vi.fn(async () => await Promise.resolve(undefined)),
+		readPendingAgentTarget: vi.fn(async () => await Promise.resolve(undefined)),
 	};
 });
 
@@ -286,7 +288,7 @@ describe('build-agent tool', () => {
 
 		await runTool(context, { message: 'Build me a support agent', name: 'Support Agent' });
 
-		expect(delegate.createAgent).toHaveBeenCalledWith('Support Agent');
+		expect(delegate.createAgent).toHaveBeenCalledWith('Support Agent', undefined);
 		expect(delegate.streamBuild).toHaveBeenCalledWith('agent-1', 'Build me a support agent', {
 			threadId: 'ia-builder:thread-1:agent-1',
 			hostThreadId: 'thread-1',
@@ -693,7 +695,7 @@ describe('build-agent tool', () => {
 
 			await runTool(context, { message: 'Build me a new one', name: 'Fresh Agent' });
 
-			expect(delegate.createAgent).toHaveBeenCalledWith('Fresh Agent');
+			expect(delegate.createAgent).toHaveBeenCalledWith('Fresh Agent', undefined);
 		});
 
 		it('persists the deferred agentId-path bind when the first turn suspends', async () => {
@@ -893,7 +895,7 @@ describe('build-agent tool', () => {
 				agentRef: 'support-triage',
 			});
 
-			expect(delegate.createAgent).toHaveBeenCalledWith('Support Triage');
+			expect(delegate.createAgent).toHaveBeenCalledWith('Support Triage', undefined);
 			expect(saveAgentBuilderTarget).toHaveBeenCalledWith(context.domainContext, {
 				agentId: 'agent-1',
 				projectId: 'proj-1',
@@ -995,7 +997,7 @@ describe('build-agent tool', () => {
 			expect(delegate.createAgent).not.toHaveBeenCalled();
 		});
 
-		it('creates a second agent under a different key while a target is bound', async () => {
+		it('creates a second agent under a different key when createNew is passed', async () => {
 			const { context, delegate } = makeContext();
 			context.domainContext!.agentBuilderTarget = {
 				agentId: 'agent-1',
@@ -1009,16 +1011,76 @@ describe('build-agent tool', () => {
 			});
 			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Created it.'));
 
-			await runTool(context, { message: 'Build me another agent', name: 'Second' });
+			await runTool(context, {
+				message: 'Build me another agent',
+				name: 'Second',
+				createNew: true,
+			});
 
 			expect(getSessionAgentByRef).toHaveBeenCalledWith(context.domainContext, 'second');
-			expect(delegate.createAgent).toHaveBeenCalledWith('Second');
+			expect(delegate.createAgent).toHaveBeenCalledWith('Second', undefined);
 			expect(saveAgentBuilderTarget).toHaveBeenCalledWith(context.domainContext, {
 				agentId: 'agent-2',
 				projectId: 'proj-1',
 				name: 'Second',
 				ref: 'second',
 			});
+		});
+
+		it('creates under the id the frontend minted for its unsaved artifact', async () => {
+			const { context, delegate } = makeContext();
+			vi.mocked(readPendingAgentTarget).mockResolvedValue({
+				projectId: 'proj-1',
+				agentId: 'aBcDeFgHiJkLmNoP',
+			});
+			vi.mocked(delegate.createAgent).mockResolvedValue({
+				agentId: 'aBcDeFgHiJkLmNoP',
+				projectId: 'proj-1',
+			});
+			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Created it.'));
+
+			await runTool(context, { message: 'Build it', name: 'Support Triage' });
+
+			expect(delegate.createAgent).toHaveBeenCalledWith('Support Triage', 'aBcDeFgHiJkLmNoP');
+		});
+
+		it('ignores a pending artifact belonging to another project', async () => {
+			const { context, delegate } = makeContext();
+			vi.mocked(readPendingAgentTarget).mockResolvedValue({
+				projectId: 'other-project',
+				agentId: 'aBcDeFgHiJkLmNoP',
+			});
+			vi.mocked(delegate.createAgent).mockResolvedValue({
+				agentId: 'agent-1',
+				projectId: 'proj-1',
+			});
+			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Created it.'));
+
+			await runTool(context, { message: 'Build it', name: 'Support Triage' });
+
+			expect(delegate.createAgent).toHaveBeenCalledWith('Support Triage', undefined);
+		});
+
+		it('continues the bound target when a fresh key arrives without createNew', async () => {
+			const { context, delegate } = makeContext();
+			context.domainContext!.agentBuilderTarget = {
+				agentId: 'agent-1',
+				projectId: 'proj-1',
+				name: 'New agent',
+			};
+			vi.mocked(delegate.streamBuild).mockResolvedValue(fakeStream([], 'Built it.'));
+
+			await runTool(context, {
+				message: 'Build a support triage agent',
+				name: 'Support Triage',
+			});
+
+			expect(delegate.createAgent).not.toHaveBeenCalled();
+			expect(delegate.streamBuild).toHaveBeenCalledWith(
+				'agent-1',
+				'Build a support triage agent',
+				expect.objectContaining({ threadId: 'ia-builder:thread-1:agent-1' }),
+			);
 		});
 
 		it('switches back via registry ref instead of creating a duplicate', async () => {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/agent-target-binding.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/agent-target-binding.ts
@@ -17,6 +17,14 @@ import type { InstanceAiContext } from '../../types';
 
 const METADATA_KEY = 'instanceAiAgentBuilderTarget';
 const REGISTRY_METADATA_KEY = 'instanceAiAgentBuilderTargets';
+/**
+ * Set by the frontend when the user opens a new-agent artifact that has no
+ * agent row behind it yet, so the artifact survives a reload before anything
+ * is persisted. Cleared here the moment a real agent binds to the thread —
+ * whether the chat created it or the user configured it by hand — so a reload
+ * doesn't show a phantom blank artifact beside the real one.
+ */
+export const PENDING_AGENT_METADATA_KEY = 'instanceAiPendingAgentTarget';
 
 const agentBuilderTargetSchema = z.object({
 	agentId: z.string(),
@@ -34,6 +42,33 @@ const agentBuilderTargetSchema = z.object({
 export type AgentBuilderTarget = z.infer<typeof agentBuilderTargetSchema>;
 
 const agentBuilderTargetRegistrySchema = z.record(z.string(), agentBuilderTargetSchema);
+
+const pendingAgentTargetSchema = z.object({ projectId: z.string(), agentId: z.string() });
+
+export type PendingAgentTarget = z.infer<typeof pendingAgentTargetSchema>;
+
+/**
+ * The id the frontend minted for an unsaved new-agent artifact, so a build
+ * creates the agent the user already has open instead of a second one.
+ * Best-effort: without a marker (or on a storage failure) the caller falls back
+ * to letting the backend mint an id, which is a worse artifact experience but
+ * never a failed build.
+ */
+export async function readPendingAgentTarget(
+	context: InstanceAiContext,
+): Promise<PendingAgentTarget | undefined> {
+	if (!context.threadMemory || !context.threadId) return undefined;
+
+	try {
+		const thread = await getThread(context.threadMemory, context.threadId);
+		const parsed = pendingAgentTargetSchema.safeParse(
+			thread?.metadata?.[PENDING_AGENT_METADATA_KEY],
+		);
+		return parsed.success ? parsed.data : undefined;
+	} catch {
+		return undefined;
+	}
+}
 
 /** Normalize an addressing key so "Support Triage", "support_triage" and
  *  "Support-Triage" all address the same agent. Unicode letters/digits are kept
@@ -107,6 +142,9 @@ export async function saveAgentBuilderTarget(
 	await patchThread(context.threadMemory, {
 		threadId: context.threadId,
 		update: ({ metadata = {} }) => {
+			// Omitted from the returned metadata, which `patchThread` writes
+			// wholesale — that is what deletes the pending marker.
+			const { [PENDING_AGENT_METADATA_KEY]: _pendingAgent, ...carriedMetadata } = metadata;
 			const existingRegistry = parseRegistry(metadata[REGISTRY_METADATA_KEY]);
 			const previousByAgentId = Object.values(existingRegistry).find(
 				(entry) => entry.agentId === target.agentId,
@@ -135,7 +173,7 @@ export async function saveAgentBuilderTarget(
 			}
 			return {
 				metadata: {
-					...metadata,
+					...carriedMetadata,
 					[METADATA_KEY]: entry,
 					[REGISTRY_METADATA_KEY]: registry,
 					...(options?.previewSession

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -839,10 +839,13 @@ async function resolveTargetForCall(
 			// explicitly. `name` is not applied here: the builder names the agent as
 			// part of the build, and overwriting would clobber a name the user chose.
 			if (boundTarget && !input.createNew) {
+				// Persisted after the turn so the key we hand back resolves on later
+				// calls — the tool reports this `agentRef`, and without registering it
+				// the model could not address the agent by it again.
 				return {
 					ok: true,
 					target: { ...boundTarget, ref: key },
-					bindAfterTurn: false,
+					bindAfterTurn: true,
 					mode: 'continued',
 				};
 			}

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -41,6 +41,7 @@ import { z } from 'zod';
 import {
 	getSessionAgentByRef,
 	normalizeAgentRef,
+	readPendingAgentTarget,
 	resolveAgentBuilderTarget,
 	saveAgentBuilderTarget,
 	type AgentBuilderTarget,
@@ -170,9 +171,9 @@ const buildAgentInputSchema = z.object({
 			'Short stable key you choose once for an agent in this conversation and repeat on ' +
 				'every later call for that same agent (like a workflow source filePath). Prefer a ' +
 				'slug of the display name. A repeated key continues that agent; a fresh key creates ' +
-				'a new one. Omit on follow-ups for the current agent when neither switching nor ' +
-				'creating — the active target is used. When omitted on a create/switch call, the ' +
-				'key is derived from `name`.',
+				'a new one only when no agent is bound yet, or alongside `createNew`. Omit on ' +
+				'follow-ups for the current agent when neither switching nor creating — the active ' +
+				'target is used. When omitted on a create/switch call, the key is derived from `name`.',
 		),
 	name: z
 		.string()
@@ -190,6 +191,15 @@ const buildAgentInputSchema = z.object({
 				'`agentRef`. NEVER pass for a request to build a NEW agent. Agents the request merely ' +
 				'references — as sub-agents, delegation targets, or examples — are not the build ' +
 				'target: mention them in `message` instead.',
+		),
+	createNew: z
+		.boolean()
+		.optional()
+		.describe(
+			'Set to true ONLY when the user explicitly wants an ADDITIONAL agent alongside the one ' +
+				'this conversation is already building. Leave unset otherwise: while a target is ' +
+				'bound, a fresh `agentRef`/`name` continues that agent instead of creating a second ' +
+				'one, so naming the agent for the first time cannot strand it behind a duplicate.',
 		),
 	workflowContext: z
 		.array(z.object({ id: z.string(), name: z.string(), description: z.string().optional() }))
@@ -676,7 +686,12 @@ async function handleResume(
 }
 
 type TargetResolution =
-	| { ok: true; target: AgentBuilderTarget; bindAfterTurn: boolean; mode: 'create' | 'edit' }
+	| {
+			ok: true;
+			target: AgentBuilderTarget;
+			bindAfterTurn: boolean;
+			mode: 'create' | 'edit' | 'continued';
+	  }
 	| { ok: false; error: string };
 
 const NO_TARGET_INPUT_ERROR =
@@ -699,6 +714,16 @@ async function resolveAgentNameSafely(
 	}
 }
 
+/**
+ * The id the frontend minted for an unsaved new-agent artifact on this thread,
+ * so the build persists the agent the user already has open rather than a
+ * second one beside it. Ignored when it belongs to a different project.
+ */
+async function pendingAgentIdFor(context: InstanceAiContext): Promise<string | undefined> {
+	const pending = await readPendingAgentTarget(context);
+	return pending && pending.projectId === context.projectId ? pending.agentId : undefined;
+}
+
 function agentRefConflictError(ref: string, boundAgentId: string, passedAgentId: string): string {
 	return (
 		`\`agentRef\` "${ref}" is already bound to agent ${boundAgentId} in this conversation, ` +
@@ -710,8 +735,11 @@ function agentRefConflictError(ref: string, boundAgentId: string, passedAgentId:
 /**
  * Resolve which agent this call should build/edit. Identity is keyed by
  * `slug(agentRef ?? name)` in the session registry — a repeated key continues,
- * an unknown key creates (with `name`) or adopts (with `agentId`). A bound
- * target stays active when neither key nor id is given.
+ * an unknown key adopts (with `agentId`) or, when no target is bound yet,
+ * creates (with `name`). A bound target stays active when neither key nor id
+ * is given, and also when an unknown key arrives without `createNew`: naming
+ * an agent is how the model addresses a new one, so treating that as a create
+ * would strand the agent the user already has open behind a duplicate.
  * agentId-path binds are always deferred (`bindAfterTurn: true`) — persisting
  * before the builder run settles would let a hallucinated/forbidden/missing
  * agentId permanently poison the thread (no unbind path exists). A create
@@ -804,7 +832,24 @@ async function resolveTargetForCall(
 		}
 
 		if (input.name) {
-			const created = await delegate.createAgent(input.name);
+			// Naming an agent is how the model addresses a new one, so on the first
+			// build request of a thread that already has a target — the artifact the
+			// user opened — an unrecognised key would strand that agent behind a
+			// duplicate. Continue the bound agent unless a second one was asked for
+			// explicitly. `name` is not applied here: the builder names the agent as
+			// part of the build, and overwriting would clobber a name the user chose.
+			if (boundTarget && !input.createNew) {
+				return {
+					ok: true,
+					target: { ...boundTarget, ref: key },
+					bindAfterTurn: false,
+					mode: 'continued',
+				};
+			}
+			const created = await delegate.createAgent(
+				input.name,
+				await pendingAgentIdFor(domainContext),
+			);
 			const target: AgentBuilderTarget = {
 				agentId: created.agentId,
 				projectId: created.projectId,
@@ -859,11 +904,13 @@ export function createBuildAgentTool(context: OrchestrationContext) {
 				'provide, ask the user or use a placeholder; do not route around that by calling ' +
 				'`build-agent`. ' +
 				'Address agents in this conversation with `agentRef` (a short stable key you choose, ' +
-				'like a workflow `filePath`). Pass `name` with a fresh key to create; repeat the same ' +
-				'key to continue. Calls with neither key nor `agentId` keep editing the current agent. ' +
-				'To build ANOTHER agent in the same conversation, use a different `agentRef` (and ' +
-				'`name`). To edit an agent that was not built here, pass `agentId` (optionally with ' +
-				'`agentRef`) once to adopt it. The builder can also publish or unpublish the target ' +
+				'like a workflow `filePath`). Pass `name` with a fresh key to create the first agent; ' +
+				'repeat the same key to continue. Calls with neither key nor `agentId` keep editing ' +
+				'the current agent, and so does a fresh key once an agent is bound — naming an agent ' +
+				'never silently creates a second one. To build ANOTHER agent in the same ' +
+				'conversation, pass `createNew: true` with a different `agentRef` and `name`. To edit ' +
+				'an agent that was not built here, pass `agentId` (optionally with `agentRef`) once ' +
+				'to adopt it. The builder can also publish or unpublish the target ' +
 				'agent when the user asks to publish, activate, make it live/usable, or unpublish — ' +
 				'forward that intent in `message`; never tell the user to open the agent editor and ' +
 				'click Publish. When the builder needs user input (a choice, a ' +

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -930,7 +930,9 @@ export interface BuilderOpenSuspension {
  * builder's questions survive a process restart.
  */
 export interface InstanceAiBuilderDelegate {
-	createAgent(name: string): Promise<{ agentId: string; projectId: string }>;
+	/** `id` creates the agent under an id the frontend already minted for its
+	 *  unsaved artifact, so the chat and the editor converge on one agent. */
+	createAgent(name: string, id?: string): Promise<{ agentId: string; projectId: string }>;
 	streamBuild(
 		agentId: string,
 		message: string,

--- a/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
@@ -68,6 +68,52 @@ describe('AgentsController route access scopes', () => {
 	});
 });
 
+describe('AgentsController create', () => {
+	const req = { params: { projectId: 'project-1' }, user: { id: 'user-1' } } as never;
+
+	function makeCreateController(createdId: string) {
+		const agentPublishService = mock<AgentPublishService>();
+		const agentValidationService = mock<AgentValidationService>();
+		const agentsService = mock<Pick<AgentsService, 'create'>>();
+		agentsService.create.mockResolvedValue({ id: createdId, projectId: 'project-1' } as never);
+		agentValidationService.validateLoadedAgentConfiguration.mockResolvedValue({
+			status: 'valid',
+			issues: [],
+		});
+		agentPublishService.hasPublishHistory.mockResolvedValue(false);
+
+		const { controller } = makeController({
+			agentsService: agentsService as never,
+			agentPublishService,
+			agentValidationService,
+		});
+		return { controller, agentsService };
+	}
+
+	it('creates the agent under the id the client minted', async () => {
+		const { controller, agentsService } = makeCreateController('aBcDeFgHiJkLmNoP');
+
+		await controller.create(req, mock<Response>(), {
+			name: 'Support Agent',
+			id: 'aBcDeFgHiJkLmNoP',
+		} as never);
+
+		expect(agentsService.create).toHaveBeenCalledWith('project-1', 'Support Agent', {
+			id: 'aBcDeFgHiJkLmNoP',
+		});
+	});
+
+	it('lets the backend mint the id when the client did not supply one', async () => {
+		const { controller, agentsService } = makeCreateController('server-minted');
+
+		await controller.create(req, mock<Response>(), { name: 'Support Agent' } as never);
+
+		expect(agentsService.create).toHaveBeenCalledWith('project-1', 'Support Agent', {
+			id: undefined,
+		});
+	});
+});
+
 describe('AgentsController list', () => {
 	const req = { params: { projectId: 'project-1' }, query: {}, user: { id: 'user-1' } } as never;
 

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/require-await, @typescript-eslint/unbound-method -- async mock stubs, unbound-method references and short `cb` names are acceptable test idioms */
 
+import { DEFAULT_AGENT_PERSONALISATION } from '@n8n/api-types';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { ProjectRelationRepository, User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { QueryFailedError } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -120,9 +122,74 @@ describe('AgentsService', () => {
 				instructions: '',
 				tools: [],
 				skills: [],
+				// A renderable icon name, not an emoji: the builder copies the idiom
+				// it reads, and the icon tile can only render registered icon names.
+				personalisation: {
+					icon: DEFAULT_AGENT_PERSONALISATION.icon,
+					gradient: expect.objectContaining({ angle: expect.any(Number) }),
+				},
 			},
 			versionId: expect.any(String),
 			availableInMCP: false,
+		});
+	});
+
+	describe('create with a client-minted id', () => {
+		const mintedId = 'aBcDeFgHiJkLmNoP';
+		const uniqueViolation = () =>
+			new QueryFailedError(
+				'insert',
+				undefined,
+				Object.assign(new Error('duplicate key'), { code: '23505' }),
+			);
+
+		it('persists the agent under the supplied id', async () => {
+			const { service, agentRepository } = makeService();
+			const saved = makeAgent({ id: mintedId });
+			agentRepository.create.mockReturnValue(saved);
+			agentRepository.save.mockResolvedValue(saved);
+
+			await service.create(projectId, 'Support Agent', { id: mintedId });
+
+			expect(agentRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({ id: mintedId }),
+			);
+		});
+
+		it('adopts the existing agent when the other creation path won the race', async () => {
+			const { service, agentRepository } = makeService();
+			const raced = makeAgent({ id: mintedId });
+			agentRepository.create.mockReturnValue(raced);
+			agentRepository.save.mockRejectedValue(uniqueViolation());
+			agentRepository.findByIdAndProjectId.mockResolvedValue(raced);
+
+			await expect(service.create(projectId, 'Support Agent', { id: mintedId })).resolves.toBe(
+				raced,
+			);
+		});
+
+		it('rethrows when the id collides with an agent outside this project', async () => {
+			const { service, agentRepository } = makeService();
+			const error = uniqueViolation();
+			agentRepository.create.mockReturnValue(makeAgent({ id: mintedId }));
+			agentRepository.save.mockRejectedValue(error);
+			agentRepository.findByIdAndProjectId.mockResolvedValue(null);
+
+			await expect(service.create(projectId, 'Support Agent', { id: mintedId })).rejects.toBe(
+				error,
+			);
+		});
+
+		it('rethrows a non-unique-violation failure instead of treating it as a race', async () => {
+			const { service, agentRepository } = makeService();
+			const error = new QueryFailedError('insert', undefined, new Error('connection lost'));
+			agentRepository.create.mockReturnValue(makeAgent({ id: mintedId }));
+			agentRepository.save.mockRejectedValue(error);
+
+			await expect(service.create(projectId, 'Support Agent', { id: mintedId })).rejects.toBe(
+				error,
+			);
+			expect(agentRepository.findByIdAndProjectId).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/instance-ai-builder-delegate.adapter.test.ts
@@ -361,8 +361,24 @@ describe('InstanceAiBuilderDelegateAdapterService', () => {
 
 			const result = await delegate.createAgent('New agent');
 
-			expect(agentsService.create).toHaveBeenCalledWith('project-1', 'New agent');
+			expect(agentsService.create).toHaveBeenCalledWith('project-1', 'New agent', {
+				id: undefined,
+			});
 			expect(result).toEqual({ agentId: 'agent-9', projectId: 'project-1' });
+		});
+
+		it('creates under the id the caller minted for its unsaved artifact', async () => {
+			const { delegate, agentsService } = setup();
+			vi.spyOn(checkAccess, 'userHasScopes').mockResolvedValue(true);
+			agentsService.create.mockResolvedValue(
+				mock<Agent>({ id: 'aBcDeFgHiJkLmNoP', name: 'New agent' }),
+			);
+
+			await delegate.createAgent('New agent', 'aBcDeFgHiJkLmNoP');
+
+			expect(agentsService.create).toHaveBeenCalledWith('project-1', 'New agent', {
+				id: 'aBcDeFgHiJkLmNoP',
+			});
 		});
 
 		it('rejects when the user lacks agent:create scope', async () => {

--- a/packages/cli/src/modules/agents/agent-knowledge.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge.service.ts
@@ -27,7 +27,7 @@ import { AgentRepository } from './repositories/agent.repository';
 
 const MAX_AGENT_FILE_METADATA_LENGTH = 255;
 
-function isUniqueConstraintError(error: unknown): boolean {
+export function isUniqueConstraintError(error: unknown): boolean {
 	if (!(error instanceof QueryFailedError)) return false;
 
 	const driverError = error.driverError;

--- a/packages/cli/src/modules/agents/agent-knowledge.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge.service.ts
@@ -27,7 +27,7 @@ import { AgentRepository } from './repositories/agent.repository';
 
 const MAX_AGENT_FILE_METADATA_LENGTH = 255;
 
-export function isUniqueConstraintError(error: unknown): boolean {
+function isUniqueConstraintError(error: unknown): boolean {
 	if (!(error instanceof QueryFailedError)) return false;
 
 	const driverError = error.driverError;

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -33,7 +33,7 @@ export class AgentsController {
 	) {
 		const { projectId } = req.params;
 
-		const agent = await this.agentsService.create(projectId, payload.name);
+		const agent = await this.agentsService.create(projectId, payload.name, { id: payload.id });
 		return await this.agentRunnableStateService.addRunnableState(agent, projectId, req.user);
 	}
 

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -1,5 +1,7 @@
 import { splitModelId } from '@n8n/ai-utilities/agent-config';
 import {
+	DEFAULT_AGENT_PERSONALISATION,
+	getRandomAgentPersonalisationGradient,
 	type AgentCapabilitySummary,
 	type AgentCapabilityTool,
 	type AgentJsonConfig,
@@ -14,7 +16,7 @@ import { v4 as uuid } from 'uuid';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentChatAttachmentService } from './agent-chat-attachment.service';
-import { AgentKnowledgeService } from './agent-knowledge.service';
+import { AgentKnowledgeService, isUniqueConstraintError } from './agent-knowledge.service';
 import { AgentExecutionService } from './agent-execution.service';
 import { AgentRuntimeCacheService } from './agent-runtime-cache.service';
 import { AgentTestChatService } from './agent-test-chat.service';
@@ -45,10 +47,16 @@ export class AgentsService {
 		private readonly agentExecutionService: AgentExecutionService,
 	) {}
 
+	/**
+	 * `id` lets the caller mint the agent id before deciding to persist it, so a
+	 * surface can reference the agent (an artifact tab, a thread binding) while
+	 * it is still unsaved. Both the REST and the builder path may then race to
+	 * create the same id; the loser adopts the winner's row rather than failing.
+	 */
 	async create(
 		projectId: string,
 		name: string,
-		{ availableInMCP = false }: { availableInMCP?: boolean } = {},
+		{ availableInMCP = false, id }: { availableInMCP?: boolean; id?: string } = {},
 	): Promise<Agent> {
 		const defaultConfig: AgentJsonConfig = {
 			name,
@@ -56,9 +64,17 @@ export class AgentsService {
 			instructions: '',
 			tools: [],
 			skills: [],
+			// Seeded at birth so every agent has a distinct tile, and so the builder
+			// sees an existing icon name when it reads the config — without one it
+			// invents its own, which the icon tile cannot render.
+			personalisation: {
+				icon: DEFAULT_AGENT_PERSONALISATION.icon,
+				gradient: getRandomAgentPersonalisationGradient(),
+			},
 		};
 
 		const agent = this.agentRepository.create({
+			...(id ? { id } : {}),
 			name,
 			projectId,
 			schema: defaultConfig,
@@ -66,7 +82,18 @@ export class AgentsService {
 			availableInMCP,
 		});
 
-		const saved = await this.agentRepository.save(agent);
+		let saved: Agent;
+		try {
+			saved = await this.agentRepository.save(agent);
+		} catch (error) {
+			if (!id || !isUniqueConstraintError(error)) throw error;
+			// Only adopt the existing row when it is the agent this caller asked
+			// for. An id taken in another project is a genuine collision.
+			const existing = await this.agentRepository.findByIdAndProjectId(id, projectId);
+			if (!existing) throw error;
+			this.logger.debug('Adopted concurrently created SDK agent', { agentId: id, projectId });
+			return existing;
+		}
 
 		this.logger.debug('Created SDK agent', { agentId: saved.id, projectId });
 

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -8,7 +8,7 @@ import {
 	type ListAgentsQueryDto,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import { In, ProjectRelationRepository, type User } from '@n8n/db';
+import { In, isUniqueConstraintError, ProjectRelationRepository, type User } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import { hasGlobalScope } from '@n8n/permissions';
 import { v4 as uuid } from 'uuid';
@@ -16,7 +16,7 @@ import { v4 as uuid } from 'uuid';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentChatAttachmentService } from './agent-chat-attachment.service';
-import { AgentKnowledgeService, isUniqueConstraintError } from './agent-knowledge.service';
+import { AgentKnowledgeService } from './agent-knowledge.service';
 import { AgentExecutionService } from './agent-execution.service';
 import { AgentRuntimeCacheService } from './agent-runtime-cache.service';
 import { AgentTestChatService } from './agent-test-chat.service';

--- a/packages/cli/src/modules/agents/builder/prompts/initial-build.prompt.ts
+++ b/packages/cli/src/modules/agents/builder/prompts/initial-build.prompt.ts
@@ -11,6 +11,9 @@ it is an addition to an existing agent or a follow-up turn.
 
 During an initial build:
 
+- Set \`name\` to something that describes what the agent does. A fresh agent
+  often arrives under a placeholder like "New agent" — replace it in your first
+  config write; never leave a placeholder as the agent's name.
 - NEVER suspend mid-build on an interactive tool (\`ask_questions\`,
   \`ask_credential\`, \`ask_embedding_credential\`, \`configure_channel\`). Build
   everything as a draft first; the only allowed suspends are the single

--- a/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
+++ b/packages/cli/src/modules/agents/instance-ai-builder-delegate.adapter.ts
@@ -110,9 +110,9 @@ export class InstanceAiBuilderDelegateAdapterService {
 		};
 
 		return {
-			createAgent: async (name) => {
+			createAgent: async (name, id) => {
 				await assertProjectScope('agent:create');
-				const agent = await this.agentsService.create(projectId, name);
+				const agent = await this.agentsService.create(projectId, name, { id });
 				return { agentId: agent.id, projectId };
 			},
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -3964,6 +3964,18 @@ describe('createContext — builder delegate telemetry', () => {
 		});
 	});
 
+	it('forwards the client-minted agent id through the telemetry wrapper', async () => {
+		const service = createAdapterWithGatewayMock(vi.fn(), { telemetry: { track: vi.fn() } });
+		const delegate = mock<InstanceAiBuilderDelegate>();
+		delegate.createAgent.mockResolvedValue({ agentId: 'aBcDeFgHiJkLmNoP', projectId: 'proj-1' });
+		mockBuilderModuleActive(delegate);
+
+		const context = service.createContext(mockUser, { threadId: 'thread-1', projectId: 'proj-1' });
+		await context.builderDelegate?.createAgent('New agent', 'aBcDeFgHiJkLmNoP');
+
+		expect(delegate.createAgent).toHaveBeenCalledWith('New agent', 'aBcDeFgHiJkLmNoP');
+	});
+
 	it('does not track when the context has no threadId', async () => {
 		const mockTelemetry = { track: vi.fn() };
 		const service = createAdapterWithGatewayMock(vi.fn(), { telemetry: mockTelemetry });

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -375,8 +375,11 @@ export class InstanceAiAdapterService {
 		if (!threadId) return delegate;
 		return {
 			...delegate,
-			createAgent: async (name) => {
-				const created = await delegate.createAgent(name);
+			// `id` must be forwarded: it carries the id the frontend minted for an
+			// unsaved new-agent artifact, and dropping it here silently creates a
+			// second agent beside the one the user already has open.
+			createAgent: async (name, id) => {
+				const created = await delegate.createAgent(name, id);
 				this.telemetry.track(TELEMETRY_EVENT.AGENTS.BUILDER_CREATED_AGENT, {
 					thread_id: threadId,
 					agent_id: created.agentId,

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -10,7 +10,7 @@ import type {
 	AgentJsonToolRef,
 	CustomToolEntry,
 } from '../types';
-import { getRandomAgentPersonalisationGradient } from '../utils/agentPersonalisation';
+import { getRandomAgentPersonalisationGradient } from '@n8n/api-types';
 import { agentsEventBus } from '../agents.eventBus';
 
 const routerPush = vi.fn();
@@ -117,6 +117,7 @@ const createAgentSkillMock = vi.fn();
 const getIntegrationStatusMock = vi.fn();
 const publishAgentMock = vi.fn();
 const getAgentMock = vi.fn();
+const createAgentMock = vi.fn();
 const updateConfigMock = vi.fn();
 const fetchConfigMock = vi.fn();
 const deleteAgentMock = vi.fn().mockResolvedValue(undefined);
@@ -128,6 +129,7 @@ const sessionThreads: Array<{ id: string; updatedAt: string }> = [];
 
 vi.mock('../composables/useAgentApi', () => ({
 	getAgent: getAgentMock,
+	createAgent: createAgentMock,
 	updateAgent: updateAgentMock,
 	updateAgentSkill: updateAgentSkillMock,
 	createAgentSkill: createAgentSkillMock,
@@ -278,6 +280,8 @@ vi.mock('../composables/useProjectAgentsList', () => ({
 		ensureLoaded: vi.fn().mockResolvedValue([]),
 		refresh: vi.fn(),
 	}),
+	upsertProjectAgentsListCache: vi.fn(),
+	removeProjectAgentFromListCache: vi.fn(),
 }));
 
 const instanceAiAvailableRef = ref(true);
@@ -524,6 +528,8 @@ function resetViewMocks() {
 	updateConfigMock.mockReset();
 	updateConfigMock.mockResolvedValue({ versionId: 'v1', stale: false });
 	getAgentMock.mockResolvedValue(makeAgentResponse());
+	createAgentMock.mockReset();
+	createAgentMock.mockResolvedValue(makeAgentResponse({ id: 'aBcDeFgHiJkLmNoP' }));
 	getIntegrationStatusMock.mockResolvedValue({ status: 'ok', integrations: [] });
 	getAgentConfigValidationMock.mockReset();
 	getAgentConfigValidationMock.mockResolvedValue({ status: 'valid', issues: [] });
@@ -1593,6 +1599,73 @@ describe('AgentBuilderView — three-column shell', () => {
 		await flushPromises();
 
 		expect(favoritesStoreMock.toggleFavorite).toHaveBeenCalledWith('a1', 'agent');
+	});
+
+	describe('unsaved (pending) artifact', () => {
+		const pendingProps = {
+			artifactMode: true,
+			artifactProjectId: 'p1',
+			artifactAgentId: 'aBcDeFgHiJkLmNoP',
+			artifactAgentPending: true,
+		};
+
+		it('renders without reading anything for an agent that does not exist yet', async () => {
+			await renderView({ props: pendingProps });
+
+			expect(getAgentMock).not.toHaveBeenCalled();
+			expect(fetchConfigMock).not.toHaveBeenCalled();
+			expect(createAgentMock).not.toHaveBeenCalled();
+		});
+
+		it('creates the agent once on the first edits, under the minted id', async () => {
+			const wrapper = await renderView({ props: pendingProps });
+			const editor = wrapper.findComponent({ name: 'AgentBuilderEditorColumn' });
+
+			editor.vm.$emit('update:config', { instructions: 'Answer support mail' });
+			editor.vm.$emit('update:config', { model: 'anthropic/claude-sonnet-4-5' });
+			await vi.waitFor(() => expect(updateConfigMock).toHaveBeenCalled());
+
+			expect(createAgentMock).toHaveBeenCalledTimes(1);
+			expect(createAgentMock).toHaveBeenCalledWith(expect.anything(), 'p1', expect.any(String), {
+				id: 'aBcDeFgHiJkLmNoP',
+			});
+			expect(updateConfigMock).toHaveBeenCalledWith(
+				'p1',
+				'aBcDeFgHiJkLmNoP',
+				expect.objectContaining({ instructions: 'Answer support mail' }),
+			);
+		});
+
+		it('persists the icon and gradient with the first save, so a new agent keeps them', async () => {
+			const wrapper = await renderView({ props: pendingProps });
+
+			wrapper
+				.findComponent({ name: 'AgentBuilderEditorColumn' })
+				.vm.$emit('update:config', { instructions: 'Answer support mail' });
+			await vi.waitFor(() => expect(updateConfigMock).toHaveBeenCalled());
+
+			expect(updateConfigMock).toHaveBeenCalledWith(
+				'p1',
+				'aBcDeFgHiJkLmNoP',
+				expect.objectContaining({
+					personalisation: expect.objectContaining({
+						icon: expect.any(String),
+						gradient: expect.objectContaining({ angle: expect.any(Number) }),
+					}),
+				}),
+			);
+		});
+
+		it('reports the agent so the host can stop treating the artifact as pending', async () => {
+			const wrapper = await renderView({ props: pendingProps });
+
+			wrapper
+				.findComponent({ name: 'AgentBuilderEditorColumn' })
+				.vm.$emit('update:config', { instructions: 'Answer support mail' });
+			await vi.waitFor(() => expect(updateConfigMock).toHaveBeenCalled());
+
+			expect(wrapper.emitted('persisted')).toHaveLength(1);
+		});
 	});
 
 	it('updates the favorite name in the sidebar when the agent is renamed', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
@@ -573,6 +573,14 @@ describe('AgentCapabilitiesSection', () => {
 		expect(wrapper.findAll('[data-testid="agent-capabilities-task-row"]').length).toBe(1);
 	});
 
+	it('does not load tasks for an agent that has not been saved yet', async () => {
+		const wrapper = mountSection([], {}, null, [], [], { agentUnsaved: true });
+		await flushPromises();
+
+		expect(getAgentTasksSpy).not.toHaveBeenCalled();
+		expect(wrapper.text()).not.toContain('not found');
+	});
+
 	it('reloads task bodies when switching agents', async () => {
 		getAgentTasksSpy.mockImplementation(
 			async (_context: unknown, _projectId: string, agentId: string) =>

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
@@ -1,37 +1,24 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
 
 import NewAgentView from '../views/NewAgentView.vue';
 import { INSTANCE_AI_THREAD_VIEW } from '@/features/ai/instanceAi/constants';
 import { AGENTS_LIST_VIEW, PROJECT_AGENTS } from '../constants';
-import type { AgentResource } from '../types';
 
 const mocks = vi.hoisted(() => ({
 	route: { query: { projectId: 'project-1' } as Record<string, string> },
 	replace: vi.fn(),
-	createAgent: vi.fn(),
-	upsertProjectAgentsListCache: vi.fn(),
-	track: vi.fn(),
 	showError: vi.fn(),
 	syncThread: vi.fn(),
 	updateThreadMetadata: vi.fn(),
-	getOrCreateRuntime: vi.fn(() => ({ sendMessage: vi.fn() })),
-	stashPendingAgentAttachment: vi.fn(),
 }));
 
 vi.mock('vue-router', () => ({
 	useRoute: () => mocks.route,
 	useRouter: () => ({ replace: mocks.replace }),
 }));
-vi.mock('@n8n/stores/useRootStore', () => ({
-	useRootStore: () => ({ restApiContext: { baseUrl: '/rest', pushRef: 'push-ref' } }),
-}));
 vi.mock('@n8n/i18n', () => ({
 	useI18n: () => ({ baseText: (key: string) => key }),
-}));
-vi.mock('@n8n/composables/useTelemetry', () => ({
-	useTelemetry: () => ({ track: mocks.track }),
 }));
 vi.mock('@n8n/composables/useToast', () => ({
 	useToast: () => ({ showError: mocks.showError }),
@@ -40,17 +27,10 @@ vi.mock('@/features/ai/instanceAi/instanceAi.store', () => ({
 	useInstanceAiStore: () => ({
 		syncThread: mocks.syncThread,
 		updateThreadMetadata: mocks.updateThreadMetadata,
-		getOrCreateRuntime: mocks.getOrCreateRuntime,
 	}),
 }));
-vi.mock('@/features/ai/instanceAi/composables/useInstanceAiHandoff', () => ({
-	stashPendingAgentAttachment: mocks.stashPendingAgentAttachment,
-}));
 vi.mock('uuid', () => ({ v4: () => 'thread-1' }));
-vi.mock('../composables/useAgentApi', () => ({ createAgent: mocks.createAgent }));
-vi.mock('../composables/useProjectAgentsList', () => ({
-	upsertProjectAgentsListCache: mocks.upsertProjectAgentsListCache,
-}));
+vi.mock('@n8n/utils/generate-nano-id', () => ({ generateNanoId: () => 'aBcDeFgHiJkLmNoP' }));
 
 describe('NewAgentView', () => {
 	beforeEach(() => {
@@ -58,43 +38,21 @@ describe('NewAgentView', () => {
 		mocks.route.query = { projectId: 'project-1' };
 	});
 
-	it('creates a blank agent and opens it in an empty Instance AI thread', async () => {
-		const agent = { id: 'agent-1', name: 'New agent' } as AgentResource;
-		mocks.createAgent.mockResolvedValue(agent);
-
+	it('opens an unsaved agent artifact without creating the agent', async () => {
 		mount(NewAgentView);
 		await flushPromises();
 
-		expect(mocks.createAgent).toHaveBeenCalledOnce();
-		expect(mocks.createAgent).toHaveBeenCalledWith(
-			{ baseUrl: '/rest', pushRef: 'push-ref' },
-			'project-1',
-			'agents.new.defaultName',
-		);
-		expect(mocks.upsertProjectAgentsListCache).toHaveBeenCalledWith('project-1', agent);
-		expect(mocks.track).toHaveBeenCalledWith(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
-			agent_id: 'agent-1',
-			source: 'create_blank',
-		});
 		expect(mocks.syncThread).toHaveBeenCalledWith('thread-1', 'project-1', {
 			source: 'agent_builder_page',
 			origin: 'internal',
-			sourceContext: { agentId: 'agent-1' },
+			sourceContext: { agentId: 'aBcDeFgHiJkLmNoP' },
 		});
 		expect(mocks.updateThreadMetadata).toHaveBeenCalledWith('thread-1', {
-			instanceAiAgentBuilderTarget: {
-				agentId: 'agent-1',
+			instanceAiPendingAgentTarget: {
 				projectId: 'project-1',
-				name: 'New agent',
+				agentId: 'aBcDeFgHiJkLmNoP',
 			},
 		});
-		expect(mocks.stashPendingAgentAttachment).toHaveBeenCalledWith('thread-1', {
-			type: 'agent',
-			id: 'agent-1',
-			name: 'New agent',
-			projectId: 'project-1',
-		});
-		expect(mocks.getOrCreateRuntime).not.toHaveBeenCalled();
 		expect(mocks.replace).toHaveBeenCalledWith({
 			name: INSTANCE_AI_THREAD_VIEW,
 			params: { threadId: 'thread-1' },
@@ -107,7 +65,7 @@ describe('NewAgentView', () => {
 		mount(NewAgentView);
 		await flushPromises();
 
-		expect(mocks.createAgent).not.toHaveBeenCalled();
+		expect(mocks.syncThread).not.toHaveBeenCalled();
 		expect(mocks.showError).toHaveBeenCalledWith(
 			expect.any(Error),
 			'agentSelector.createAgentFailed',
@@ -115,9 +73,9 @@ describe('NewAgentView', () => {
 		expect(mocks.replace).toHaveBeenCalledWith({ name: AGENTS_LIST_VIEW });
 	});
 
-	it('returns to the project agents list when creation fails', async () => {
-		const error = new Error('create failed');
-		mocks.createAgent.mockRejectedValue(error);
+	it('returns to the project agents list when the thread cannot be created', async () => {
+		const error = new Error('sync failed');
+		mocks.syncThread.mockRejectedValue(error);
 
 		mount(NewAgentView);
 		await flushPromises();

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentCapabilitiesActions.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/useAgentCapabilitiesActions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
 import { computed, ref } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
@@ -42,7 +43,9 @@ function makeConfig(overrides: Partial<AgentJsonConfig> = {}): AgentJsonConfig {
 	};
 }
 
-function setup(overrides: { supportsToolApproval?: boolean } = {}) {
+function setup(
+	overrides: { supportsToolApproval?: boolean; ensureAgentPersisted?: () => Promise<void> } = {},
+) {
 	setActivePinia(createTestingPinia({ stubActions: false }));
 	const uiStore = useUIStore();
 
@@ -180,6 +183,40 @@ describe('useAgentCapabilitiesActions — localSkills host seam', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+	});
+
+	it('waits for the unsaved agent to be persisted before creating the skill', async () => {
+		let releasePersist: () => void = () => {};
+		const persisted = new Promise<void>((resolve) => {
+			releasePersist = resolve;
+		});
+		const { uiStore, actions } = setup({ ensureAgentPersisted: async () => await persisted });
+
+		actions.onOpenAddSkillModal();
+		const modalData = uiStore.modalsById[AGENT_SKILL_MODAL_KEY].data as unknown as SkillModalData;
+		modalData.onConfirm({ skill: { ...triage, name: 'New Skill' } });
+		await flushPromises();
+
+		// The agent does not exist yet, so the skill endpoint would 404.
+		expect(createAgentSkill).not.toHaveBeenCalled();
+
+		releasePersist();
+		await flushPromises();
+
+		expect(createAgentSkill).toHaveBeenCalled();
+	});
+
+	it('does not create the skill when persisting the agent fails', async () => {
+		const { uiStore, actions } = setup({
+			ensureAgentPersisted: async () => await Promise.reject(new Error('create failed')),
+		});
+
+		actions.onOpenAddSkillModal();
+		const modalData = uiStore.modalsById[AGENT_SKILL_MODAL_KEY].data as unknown as SkillModalData;
+		modalData.onConfirm({ skill: { ...triage, name: 'New Skill' } });
+		await flushPromises();
+
+		expect(createAgentSkill).not.toHaveBeenCalled();
 	});
 
 	it('joins applied skills against the seam bodies instead of the agent entity', () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
@@ -45,6 +45,8 @@ const props = defineProps<{
 	executionsDescription: string;
 	tasksReloadKey?: number;
 	artifactMode?: boolean;
+	/** No agent row exists yet, so agent-scoped endpoints would 404. */
+	agentUnsaved?: boolean;
 	configValidationIssues?: AgentConfigValidationIssue[];
 }>();
 
@@ -117,6 +119,7 @@ const i18n = useI18n();
 						:is-published="Boolean(agent?.activeVersionId)"
 						:validation-issues="configValidationIssues ?? []"
 						:simple-channel-setup="artifactMode"
+						:agent-unsaved="agentUnsaved"
 						@update:connected-triggers="emit('update:connected-triggers', $event)"
 						@trigger-added="emit('trigger-added', $event)"
 						@agent-changed="emit('agent-changed')"
@@ -134,6 +137,7 @@ const i18n = useI18n();
 						:task-refs="localConfig?.tasks ?? []"
 						:reload-key="tasksReloadKey"
 						:validation-issues="configValidationIssues ?? []"
+						:agent-unsaved="agentUnsaved"
 						@open-tool="emit('open-tool', $event)"
 						@open-skill="emit('open-skill', $event)"
 						@add-tool="emit('add-tool')"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -35,6 +35,8 @@ const props = withDefaults(
 		isPublished: boolean;
 		taskRefs?: AgentJsonTaskConfig[];
 		reloadKey?: number;
+		/** No agent row exists yet — an unsaved agent has no tasks to load. */
+		agentUnsaved?: boolean;
 
 		/** Structured backend validation issues — drives the invalid state on capability chips. */
 		validationIssues?: AgentConfigValidationIssue[];
@@ -219,6 +221,10 @@ const subAgentIssueMessages = computed(() =>
 
 async function reloadTasks() {
 	taskErrorMessage.value = '';
+	if (props.agentUnsaved) {
+		taskBodies.value = [];
+		return;
+	}
 	try {
 		taskBodies.value = await getAgentTasks(
 			rootStore.restApiContext,

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelsSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelsSection.vue
@@ -18,6 +18,8 @@ const props = withDefaults(
 		isPublished: boolean;
 		validationIssues?: AgentConfigValidationIssue[];
 		simpleChannelSetup?: boolean;
+		/** No agent row exists yet — nothing can be connected to it. */
+		agentUnsaved?: boolean;
 	}>(),
 	{
 		connectedTriggers: () => [],
@@ -95,7 +97,12 @@ const channelRows = computed(() =>
 
 async function loadChannelDetails() {
 	const integrations = await ensureLoaded(props.projectId).catch(() => catalog.value ?? []);
-	await fetchStatus(integrations.map(({ type }) => type));
+	// Connection status is per agent, so there is nothing to ask for until one
+	// exists. The catalog and credential list below are project-scoped and still
+	// load, so the channel picker works on an unsaved agent.
+	if (!props.agentUnsaved) {
+		await fetchStatus(integrations.map(({ type }) => type));
+	}
 
 	try {
 		credentialsStore.setCredentials([]);

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentApi.ts
@@ -99,12 +99,15 @@ export const createAgent = async (
 	context: IRestApiContext,
 	projectId: string,
 	name: string,
+	/** Creates the agent under an already-minted id, so a surface that referenced
+	 *  it while unsaved keeps pointing at the same agent. */
+	options: { id?: string } = {},
 ): Promise<AgentResource> => {
 	return await makeRestApiRequest<AgentResource>(
 		context,
 		'POST',
 		`/projects/${projectId}/agents/v2`,
-		{ name },
+		{ name, ...(options.id ? { id: options.id } : {}) },
 	);
 };
 

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentCapabilitiesActions.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentCapabilitiesActions.ts
@@ -81,6 +81,12 @@ export interface UseAgentCapabilitiesActionsDeps {
 	 * don't support suspend/resume — the config modals hide the toggle.
 	 */
 	supportsToolApproval?: boolean;
+	/**
+	 * Creates the agent row if the host is still showing an unsaved agent, so a
+	 * handler that calls an agent-scoped API has something to call it against.
+	 * Hosts whose agent always exists omit it.
+	 */
+	ensureAgentPersisted?: () => Promise<void>;
 	telemetry?: AgentCapabilitiesTelemetry;
 }
 
@@ -101,6 +107,7 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 		scheduleSkillSave,
 		localSkills,
 		supportsToolApproval,
+		ensureAgentPersisted,
 		telemetry,
 	} = deps;
 
@@ -435,6 +442,7 @@ export function useAgentCapabilitiesActions(deps: UseAgentCapabilitiesActionsDep
 						let versionId: string | null;
 						let skillId: string;
 						try {
+							await ensureAgentPersisted?.();
 							const result = await createAgentSkill(
 								rootStore.restApiContext,
 								targetProjectId,

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -1349,7 +1349,11 @@ async function initialize() {
 	}
 }
 
-watch(agentId, initialize, { immediate: true });
+// Also re-initialize when the artifact stops being pending: the chat path
+// creates the agent under this same id, so the id never changes, but the view
+// must leave draft mode — otherwise it keeps skipping the agent-scoped fetches
+// and hiding the tabs for an agent that now exists.
+watch([agentId, () => props.artifactAgentPending], initialize, { immediate: true });
 
 onBeforeUnmount(() => {
 	agentsEventBus.off('agentUpdated', onExternalAgentUpdated);

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -32,6 +32,7 @@ import { MODAL_CONFIRM } from '@/app/constants';
 import { deepCopy } from 'n8n-workflow';
 import {
 	getAgent,
+	createAgent,
 	deleteAgent,
 	listAgentFiles,
 	uploadAgentFiles,
@@ -57,9 +58,12 @@ import { useAgentBuilderSession } from '../composables/useAgentBuilderSession';
 import { useAgentConfigAutosave } from '../composables/useAgentConfigAutosave';
 import { useAgentBuilderMainTabs } from '../composables/useAgentBuilderMainTabs';
 import { useAgentCapabilitiesActions } from '../composables/useAgentCapabilitiesActions';
-import { removeProjectAgentFromListCache } from '../composables/useProjectAgentsList';
+import {
+	removeProjectAgentFromListCache,
+	upsertProjectAgentsListCache,
+} from '../composables/useProjectAgentsList';
 import { useInstanceAiAgentPreviewHandoff } from '@/features/ai/instanceAi/composables/useInstanceAiAgentPreviewHandoff';
-import { addMissingAgentPersonalisation } from '../utils/agentPersonalisation';
+import { addMissingAgentPersonalisation } from '@n8n/api-types';
 import {
 	AGENT_BUILDER_VIEW,
 	AGENT_PREVIEW_VIEW,
@@ -88,14 +92,23 @@ const props = withDefaults(
 		artifactAgentId?: string;
 		/** True while the AI is actively building/mutating this agent in artifact mode — disables editing/publishing without hiding content. */
 		artifactEditingLocked?: boolean;
+		/** True when no agent row exists behind `artifactAgentId` yet — the builder
+		 *  renders a local default config and creates the agent on the first edit. */
+		artifactAgentPending?: boolean;
 	}>(),
 	{
 		artifactMode: false,
 		artifactProjectId: undefined,
 		artifactAgentId: undefined,
 		artifactEditingLocked: false,
+		artifactAgentPending: false,
 	},
 );
+
+const emit = defineEmits<{
+	/** The agent behind an unsaved artifact now exists. */
+	persisted: [agent: AgentResource];
+}>();
 
 const route = useRoute();
 const router = useRouter();
@@ -179,6 +192,13 @@ async function onSendPreviewToAssistant(executionId?: string) {
  *   - render the preview chat before the route/config/session state has settled.
  */
 const initialized = ref(false);
+/**
+ * No agent row exists behind `agentId` yet. The id was minted by whoever opened
+ * this artifact, so the config edits below can create the agent under it at the
+ * moment the user first configures something — and until then nothing is
+ * persisted. Cleared by `ensureAgentPersisted`.
+ */
+const isUnsaved = ref(false);
 /** Queues `agentUpdated` bus events that land mid-initialize for replay (see `onExternalAgentUpdated`). */
 const pendingExternalRefresh = ref(false);
 const agentName = ref('');
@@ -231,6 +251,15 @@ const { activeMainTab, mainTabOptions, executionsDescription } = useAgentBuilder
 	executionsCount,
 	routeBacked: computed(() => !isArtifactMode.value),
 });
+
+// Knowledge, Executions and Settings all read agent-scoped endpoints, so they
+// have nothing to show until the agent exists. Configuring the agent is what
+// creates it, so that is the only tab worth offering first.
+const visibleMainTabOptions = computed(() =>
+	isUnsaved.value
+		? mainTabOptions.value.filter((tab) => tab.value === 'agent')
+		: mainTabOptions.value,
+);
 
 const { ensureLoaded: ensureIntegrationsCatalog } = useAgentIntegrationsCatalog();
 
@@ -392,6 +421,7 @@ async function onUploadAgentFiles(files: File[]) {
 	const targetAgentId = agentId.value;
 	agentFilesUploading.value = true;
 	try {
+		await ensureAgentPersisted();
 		const uploadedFiles = await uploadAgentFiles(
 			rootStore.restApiContext,
 			targetProjectId,
@@ -570,6 +600,8 @@ function bindPreviewSession() {
 
 function warmAgentKnowledgeSandboxForPage() {
 	if (!initialized.value || !isKnowledgeBaseEnabled.value || !agent.value) return;
+	// No agent row to warm a sandbox for yet.
+	if (isUnsaved.value) return;
 
 	const targetProjectId = projectId.value;
 	const targetAgentId = agentId.value;
@@ -608,10 +640,50 @@ interface McpAvailabilitySnapshot {
 	enabled: boolean;
 }
 
+/**
+ * Create the agent the first time the user actually configures something, so an
+ * artifact that is only looked at never reaches the database. Every mutating
+ * path funnels through here; the cached promise keeps the independent autosave
+ * chains (config, skill, MCP) from racing into two agents.
+ *
+ * The agent is created under the already-minted `agentId`, so an agent-building
+ * chat request on the same thread converges on this agent rather than a second
+ * one (the backend adopts the existing row on an id collision).
+ */
+let persistPromise: Promise<void> | null = null;
+async function ensureAgentPersisted(): Promise<void> {
+	if (!isUnsaved.value) return;
+	persistPromise ??= (async () => {
+		const targetProjectId = projectId.value;
+		const targetAgentId = agentId.value;
+		const created = await createAgent(
+			rootStore.restApiContext,
+			targetProjectId,
+			localConfig.value?.name ?? locale.baseText('agents.new.defaultName'),
+			{ id: targetAgentId },
+		);
+		isUnsaved.value = false;
+		if (!isStaleAgentTarget(targetProjectId, targetAgentId)) {
+			agent.value = created;
+		}
+		upsertProjectAgentsListCache(targetProjectId, created);
+		// Lets the artifact host record that this agent is real now. Without it a
+		// reload would re-enter draft mode and overwrite the saved config with an
+		// empty one, since the pending marker itself cannot be deleted.
+		emit('persisted', created);
+	})().catch((error) => {
+		// Let the next edit retry rather than stranding the agent unsaved.
+		persistPromise = null;
+		throw error;
+	});
+	await persistPromise;
+}
+
 async function saveConfig(snapshot: ConfigAutosaveSnapshot): Promise<'skipped' | undefined> {
 	// The AI may be mutating this agent right now — a save queued just before
 	// the lock engaged must not persist its now-stale full config over it.
 	if (props.artifactEditingLocked) return 'skipped';
+	await ensureAgentPersisted();
 	const result = await updateConfig(snapshot.projectId, snapshot.agentId, snapshot.config);
 	// The write landed regardless of staleness below — tell other surfaces
 	// (e.g. canvas agent cards invalidate their capability-summary cache).
@@ -633,6 +705,7 @@ async function saveConfig(snapshot: ConfigAutosaveSnapshot): Promise<'skipped' |
 
 async function saveSkill(snapshot: SkillAutosaveSnapshot): Promise<'skipped' | undefined> {
 	if (props.artifactEditingLocked) return 'skipped';
+	await ensureAgentPersisted();
 	const result = await updateAgentSkill(
 		rootStore.restApiContext,
 		snapshot.projectId,
@@ -699,6 +772,7 @@ const agentAvailableInMcp = computed(
 async function saveMcpAvailability(
 	snapshot: McpAvailabilitySnapshot,
 ): Promise<'skipped' | undefined> {
+	await ensureAgentPersisted();
 	await mcpStore.toggleAgentMcpAccess(snapshot.agentId, snapshot.enabled);
 	if (snapshot.enabled) {
 		mcp.trackMcpAccessEnabledForAgent(snapshot.agentId);
@@ -872,6 +946,7 @@ const caps = useAgentCapabilitiesActions({
 	projectId,
 	agentId,
 	connectedTriggers,
+	ensureAgentPersisted,
 	scheduleConfigUpdate: onConfigFieldUpdate,
 	scheduleSkillSave: ({ skillId, skill }) => {
 		// The persisted validation result no longer reflects the working copy —
@@ -1140,6 +1215,33 @@ async function onHeaderAction(action: string) {
 	}
 }
 
+/**
+ * Stand-in for the resource the create endpoint would have returned, so the
+ * editor and its children can treat an unsaved agent like any other freshly
+ * created one instead of every consumer having to handle a null agent.
+ */
+function draftAgentResource(personalisation: AgentJsonConfig['personalisation']): AgentResource {
+	const now = new Date().toISOString();
+	return {
+		resourceType: 'agent',
+		id: agentId.value,
+		name: locale.baseText('agents.new.defaultName'),
+		projectId: projectId.value,
+		schema: personalisation ? { personalisation } : null,
+		availableInMCP: false,
+		isCompiled: false,
+		isRunnable: false,
+		hasPublishHistory: false,
+		createdAt: now,
+		updatedAt: now,
+		versionId: null,
+		activeVersionId: null,
+		tools: {},
+		skills: {},
+		activeVersion: null,
+	};
+}
+
 async function initialize() {
 	clearTimeout(externalRefreshTimer);
 	// A refresh queued for the previous agent must not fire against this one.
@@ -1175,13 +1277,35 @@ async function initialize() {
 		deletingAgentFileId.value = null;
 		repointConfigValidation(projectId.value, agentId.value);
 
-		await Promise.all([
-			fetchAgent(),
-			fetchConfig(projectId.value, agentId.value),
-			fetchAgentFiles(),
-			refreshConfigValidation(projectId.value, agentId.value),
-		]);
-		persistMissingPersonalisationGradient();
+		// An agent that does not exist yet has nothing to fetch: stand up the same
+		// blank config the backend would have written, and let the first edit
+		// create it (see `ensureAgentPersisted`). The personalisation backfill is
+		// skipped too — it schedules a save, which would persist on mount alone.
+		isUnsaved.value = props.artifactAgentPending;
+		if (isUnsaved.value) {
+			const draftConfig: AgentJsonConfig = {
+				name: locale.baseText('agents.new.defaultName'),
+				model: '',
+				instructions: '',
+				tools: [],
+				skills: [],
+			};
+			// Seed the icon and gradient the backfill would normally add, so the
+			// draft looks like any other new agent and the first save carries them.
+			// Seeded rather than backfilled because the backfill schedules a save,
+			// which would persist the agent on mount.
+			localConfig.value = addMissingAgentPersonalisation(draftConfig) ?? draftConfig;
+			agent.value = draftAgentResource(localConfig.value.personalisation);
+			agentName.value = agent.value.name;
+		} else {
+			await Promise.all([
+				fetchAgent(),
+				fetchConfig(projectId.value, agentId.value),
+				fetchAgentFiles(),
+				refreshConfigValidation(projectId.value, agentId.value),
+			]);
+			persistMissingPersonalisationGradient();
+		}
 		builderTelemetry.captureToolsBaseline();
 		builderTelemetry.captureSkillsBaseline();
 		builderTelemetry.captureTasksBaseline();
@@ -1195,9 +1319,11 @@ async function initialize() {
 		// Stop any in-flight auto-refresh from the previous agent before kicking
 		// off a new fetch — keeps the store tied to the current project/agent.
 		sessionsStore.stopAutoRefresh();
-		void sessionsStore.fetchThreads(projectId.value, agentId.value).then(() => {
-			sessionsStore.startAutoRefresh();
-		});
+		if (!isUnsaved.value) {
+			void sessionsStore.fetchThreads(projectId.value, agentId.value).then(() => {
+				sessionsStore.startAutoRefresh();
+			});
+		}
 		void (async () => {
 			// Non-fatal — on failure, leave connectedTriggers empty; the sidebar emit
 			// will correct it once the user expands the Triggers section.
@@ -1483,7 +1609,8 @@ function onPreviewBreadcrumbSelect(item: PathItem) {
 					:can-edit-agent="effectiveCanEditAgent"
 					:agent-available-in-mcp="agentAvailableInMcp"
 					:tasks-reload-key="tasksReloadKey"
-					:main-tab-options="mainTabOptions"
+					:main-tab-options="visibleMainTabOptions"
+					:agent-unsaved="isUnsaved"
 					:executions-description="executionsDescription"
 					:artifact-mode="isArtifactMode"
 					:config-validation-issues="configValidation?.issues ?? []"

--- a/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
@@ -3,29 +3,29 @@ import { onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { v4 as uuidv4 } from 'uuid';
 import { useI18n } from '@n8n/i18n';
-import { useRootStore } from '@n8n/stores/useRootStore';
-import { TELEMETRY_EVENT } from '@n8n/telemetry';
+import { generateNanoId } from '@n8n/utils/generate-nano-id';
 
-import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useToast } from '@n8n/composables/useToast';
-import { stashPendingAgentAttachment } from '@/features/ai/instanceAi/composables/useInstanceAiHandoff';
 import {
-	INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY,
+	INSTANCE_AI_PENDING_AGENT_METADATA_KEY,
 	INSTANCE_AI_THREAD_VIEW,
 } from '@/features/ai/instanceAi/constants';
 import { useInstanceAiStore } from '@/features/ai/instanceAi/instanceAi.store';
-import { createAgent } from '../composables/useAgentApi';
-import { upsertProjectAgentsListCache } from '../composables/useProjectAgentsList';
 import { AGENTS_LIST_VIEW, PROJECT_AGENTS } from '../constants';
 
 const route = useRoute();
 const router = useRouter();
 const i18n = useI18n();
-const rootStore = useRootStore();
-const telemetry = useTelemetry();
 const toast = useToast();
 const instanceAiStore = useInstanceAiStore();
 
+/**
+ * Opens a new-agent artifact without persisting anything. The agent id is
+ * minted here and carried on the thread so both paths that can create the
+ * agent — a config edit in the artifact, or an agent-building chat request —
+ * create it under the same id. Nothing reaches the database until one of them
+ * happens, so abandoning the thread leaves no empty agent behind.
+ */
 onMounted(async () => {
 	const projectId = route.query.projectId;
 	if (typeof projectId !== 'string' || !projectId) {
@@ -35,35 +35,16 @@ onMounted(async () => {
 		return;
 	}
 
+	const agentId = generateNanoId();
+	const threadId = uuidv4();
 	try {
-		const agent = await createAgent(
-			rootStore.restApiContext,
-			projectId,
-			i18n.baseText('agents.new.defaultName'),
-		);
-		upsertProjectAgentsListCache(projectId, agent);
-		telemetry.track(TELEMETRY_EVENT.AGENTS.USER_CREATED_AGENT, {
-			agent_id: agent.id,
-			source: 'create_blank',
-		});
-		const threadId = uuidv4();
 		await instanceAiStore.syncThread(threadId, projectId, {
 			source: 'agent_builder_page',
 			origin: 'internal',
-			sourceContext: { agentId: agent.id },
+			sourceContext: { agentId },
 		});
 		await instanceAiStore.updateThreadMetadata(threadId, {
-			[INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY]: {
-				agentId: agent.id,
-				projectId,
-				name: agent.name,
-			},
-		});
-		stashPendingAgentAttachment(threadId, {
-			type: 'agent',
-			id: agent.id,
-			name: agent.name,
-			projectId,
+			[INSTANCE_AI_PENDING_AGENT_METADATA_KEY]: { projectId, agentId },
 		});
 		await router.replace({
 			name: INSTANCE_AI_THREAD_VIEW,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -1027,6 +1027,7 @@ async function dismissComposerContextChip() {
 								:class="$style.previewSlot"
 								:agent-id="preview.activeAgentId.value"
 								:project-id="preview.activeAgentProjectId.value"
+								:pending="preview.activeAgentPending.value"
 							/>
 						</div>
 					</TabsRoot>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useCanvasPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useCanvasPreview.test.ts
@@ -1083,6 +1083,24 @@ describe('useCanvasPreview', () => {
 			expect(ctx.activeTabId.value).toBe('wf-1');
 		});
 
+		test('opens an unsaved new-agent artifact on arrival', async () => {
+			const ctx = setup();
+			const next = new Map<string, ResourceEntry>();
+			next.set('aBcDeFgHiJkLmNoP', {
+				type: 'agent',
+				id: 'aBcDeFgHiJkLmNoP',
+				name: 'New agent',
+				projectId: 'project-1',
+				pending: true,
+			});
+			ctx.thread.producedArtifacts = next;
+			await nextTick();
+
+			expect(ctx.activeTabId.value).toBe('aBcDeFgHiJkLmNoP');
+			expect(ctx.isPreviewVisible.value).toBe(true);
+			expect(ctx.activeAgentPending.value).toBe(true);
+		});
+
 		test('does not clear activeTabId when registry is empty (race condition)', async () => {
 			const ctx = setup();
 			registerWorkflow(ctx.thread, 'wf-1');

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
@@ -49,6 +49,7 @@ function makeMessage(overrides: Partial<InstanceAiMessage> = {}): InstanceAiMess
 function setup(
 	workflowNameLookup?: (id: string) => string | undefined,
 	agentBuilderTarget?: () => { agentId: string; projectId: string; name?: string } | undefined,
+	pendingAgentTarget?: () => { agentId: string; projectId: string; name: string } | undefined,
 ) {
 	const messages = ref<InstanceAiMessage[]>([]);
 	const { producedArtifacts, resourceNameIndex, linkableResourceNameIndex } = useResourceRegistry(
@@ -56,6 +57,7 @@ function setup(
 		workflowNameLookup,
 		undefined,
 		agentBuilderTarget,
+		pendingAgentTarget,
 	);
 	return { messages, producedArtifacts, resourceNameIndex, linkableResourceNameIndex };
 }
@@ -907,6 +909,37 @@ describe('useResourceRegistry', () => {
 			];
 			return result;
 		}
+
+		test('surfaces an unsaved new-agent artifact from the pending marker', async () => {
+			const { producedArtifacts } = setup(undefined, undefined, () => ({
+				agentId: 'aBcDeFgHiJkLmNoP',
+				projectId: 'project-1',
+				name: 'New agent',
+			}));
+			await nextTick();
+
+			expect(producedArtifacts.get('aBcDeFgHiJkLmNoP')).toEqual({
+				type: 'agent',
+				id: 'aBcDeFgHiJkLmNoP',
+				name: 'New agent',
+				projectId: 'project-1',
+				pending: true,
+			});
+		});
+
+		test('drops the pending flag once the agent is bound to the thread', async () => {
+			const { producedArtifacts } = setup(
+				undefined,
+				() => ({ agentId: 'aBcDeFgHiJkLmNoP', projectId: 'project-1', name: 'Support Triage' }),
+				() => ({ agentId: 'aBcDeFgHiJkLmNoP', projectId: 'project-1', name: 'New agent' }),
+			);
+			await nextTick();
+
+			const entry = producedArtifacts.get('aBcDeFgHiJkLmNoP');
+			expect(entry?.pending).toBeUndefined();
+			expect(entry?.name).toBe('Support Triage');
+			expect(producedArtifacts.size).toBe(1);
+		});
 
 		test('entry objects keep their identity across rebuilds', async () => {
 			const { messages, producedArtifacts } = setupWithArtifact();

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiAgentPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiAgentPreview.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import AgentBuilderView from '@/features/agents/views/AgentBuilderView.vue';
+import type { AgentResource } from '@/features/agents/types';
 import { isAgentEditingAgent } from '../canvasPreview.utils';
-import { useThread } from '../instanceAi.store';
+import { useThread, useInstanceAiStore } from '../instanceAi.store';
+import { INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY } from '../constants';
 
 const props = defineProps<{
 	projectId: string;
 	agentId: string;
+	/** No agent row exists yet — the builder renders a local draft and persists on first edit. */
+	pending?: boolean;
 }>();
 
 // === Editing lock ===
@@ -17,6 +21,7 @@ const props = defineProps<{
 // inspectable — only editing/publishing is disabled, via
 // `artifact-editing-locked` on `AgentBuilderView`.
 const thread = useThread();
+const instanceAiStore = useInstanceAiStore();
 
 const isAgentBuilding = computed(() => {
 	for (const message of thread.messages) {
@@ -25,6 +30,22 @@ const isAgentBuilding = computed(() => {
 	}
 	return false;
 });
+
+/**
+ * Bind the agent to the thread once the builder has actually created it. This
+ * is what stops a reload from treating the artifact as pending again: the
+ * pending marker cannot be removed (thread metadata merges rather than
+ * deletes), so a real binding is how the registry tells the two apart.
+ */
+async function onAgentPersisted(agent: AgentResource) {
+	await instanceAiStore.updateThreadMetadata(thread.id, {
+		[INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY]: {
+			agentId: agent.id,
+			projectId: props.projectId,
+			name: agent.name,
+		},
+	});
+}
 </script>
 
 <template>
@@ -33,7 +54,9 @@ const isAgentBuilding = computed(() => {
 			artifact-mode
 			:artifact-project-id="props.projectId"
 			:artifact-agent-id="props.agentId"
+			:artifact-agent-pending="props.pending"
 			:artifact-editing-locked="isAgentBuilding"
+			@persisted="onAgentPersisted"
 		/>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/constants.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/constants.ts
@@ -16,6 +16,13 @@ export const SANDBOX_PROVIDER_LABELS = {
 export type InstanceAiConnectionKind = 'model' | 'sandbox' | 'search';
 export const INSTANCE_AI_NEW_VIEW = 'InstanceAiNew';
 export const INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY = 'instanceAiAgentBuilderTarget';
+/**
+ * A new-agent artifact the user opened but has not configured yet, so no agent
+ * row exists. Carries the id minted for it, which whichever path persists the
+ * agent first creates it under. Mirrors `PENDING_AGENT_METADATA_KEY` in
+ * `@n8n/instance-ai`.
+ */
+export const INSTANCE_AI_PENDING_AGENT_METADATA_KEY = 'instanceAiPendingAgentTarget';
 export const NEW_CONVERSATION_TITLE = 'New conversation';
 export { AI_GATEWAY_MANAGED_TAG } from '@n8n/api-types';
 export const BROWSER_USE_CONNECTION_TYPE = 'browser-use';

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
@@ -23,6 +23,7 @@ import {
 } from '@n8n/api-types';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useToast } from '@n8n/composables/useToast';
+import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
@@ -42,7 +43,10 @@ import { handleEvent as reduceEvent, createRunStateFromTree } from './instanceAi
 import { getLatestBuildResult, type RememberedManualExecution } from './canvasPreview.utils';
 import { useResourceRegistry } from './useResourceRegistry';
 import { useResponseFeedback } from './useResponseFeedback';
-import { INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY } from './constants';
+import {
+	INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY,
+	INSTANCE_AI_PENDING_AGENT_METADATA_KEY,
+} from './constants';
 import {
 	findToolCallInTree,
 	isOrchestratorLive,
@@ -113,6 +117,16 @@ export function getAgentBuilderTargetFromThreadMetadata(
 		projectId: target.projectId,
 		...(typeof target.name === 'string' ? { name: target.name } : {}),
 	};
+}
+
+export function getPendingAgentTargetFromThreadMetadata(
+	metadata: Record<string, unknown> | undefined,
+) {
+	const raw = metadata?.[INSTANCE_AI_PENDING_AGENT_METADATA_KEY];
+	if (!raw || typeof raw !== 'object') return undefined;
+	const target = raw as Record<string, unknown>;
+	if (typeof target.agentId !== 'string' || typeof target.projectId !== 'string') return undefined;
+	return { agentId: target.agentId, projectId: target.projectId };
 }
 
 /** Walk an agent tree, collecting tool calls that have an active (pending) confirmation. */
@@ -304,6 +318,7 @@ export function createThreadRuntime(
 	const workflowsListStore = useWorkflowsListStore();
 	const toast = useToast();
 	const telemetry = useTelemetry();
+	const i18n = useI18n();
 
 	// --- Reactive state ---
 	const messages = ref<InstanceAiMessage[]>([]);
@@ -388,6 +403,10 @@ export function createThreadRuntime(
 		(id) => workflowsListStore.getWorkflowById(id)?.name,
 		() => archivedWorkflowIds.value,
 		() => getAgentBuilderTargetFromThreadMetadata(hooks.getThreadMetadata?.(threadId)),
+		() => {
+			const pending = getPendingAgentTargetFromThreadMetadata(hooks.getThreadMetadata?.(threadId));
+			return pending ? { ...pending, name: i18n.baseText('agents.new.defaultName') } : undefined;
+		},
 	);
 
 	const { feedbackByResponseId, rateableResponseId, submitFeedback, resetFeedback } =

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
@@ -21,6 +21,8 @@ export interface ArtifactTab {
 	name: string;
 	icon: IconName;
 	projectId?: string;
+	/** An agent artifact with no agent row behind it yet. */
+	pending?: boolean;
 }
 
 const ARTIFACT_ICON_MAP: Record<string, IconName> = {
@@ -50,6 +52,7 @@ export function useCanvasPreview({ thread }: UseCanvasPreviewOptions) {
 					name: entry.name,
 					icon: ARTIFACT_ICON_MAP[entry.type] ?? 'file',
 					projectId: entry.projectId,
+					pending: entry.pending,
 				});
 			}
 		}
@@ -81,6 +84,11 @@ export function useCanvasPreview({ thread }: UseCanvasPreviewOptions) {
 	const activeAgentProjectId = computed(() => {
 		const tab = allArtifactTabs.value.find((t) => t.id === activeTabId.value);
 		return tab?.type === 'agent' ? (tab.projectId ?? null) : null;
+	});
+
+	const activeAgentPending = computed(() => {
+		const tab = allArtifactTabs.value.find((t) => t.id === activeTabId.value);
+		return tab?.type === 'agent' && tab.pending === true;
 	});
 
 	const executionResultsByWorkflow = computed(() => {
@@ -116,10 +124,19 @@ export function useCanvasPreview({ thread }: UseCanvasPreviewOptions) {
 		return undefined;
 	});
 
-	// Open the attached resource on arrival. Only when nothing is open, so it
-	// never steals focus from an agent-driven open or a user selection.
+	// An unsaved new-agent artifact carries no attachment (there is no agent to
+	// attach yet), so it opens off the thread's pending marker instead — the user
+	// arrived here by asking for a new agent, so it should already be on screen.
+	const pendingAgentTabId = computed(() => allArtifactTabs.value.find((tab) => tab.pending)?.id);
+
+	const initialArtifactId = computed(
+		() => firstAttachedArtifactId.value ?? pendingAgentTabId.value,
+	);
+
+	// Open the arriving resource. Only when nothing is open, so it never steals
+	// focus from an agent-driven open or a user selection.
 	watch(
-		firstAttachedArtifactId,
+		initialArtifactId,
 		(id) => {
 			if (!id || activeTabId.value !== undefined) return;
 			activeTabId.value = id;
@@ -430,6 +447,7 @@ export function useCanvasPreview({ thread }: UseCanvasPreviewOptions) {
 		activeDataTableProjectId,
 		activeAgentId,
 		activeAgentProjectId,
+		activeAgentPending,
 		activeWorkflowExecutionResult,
 		dataTableRefreshKey,
 		isPreviewVisible,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
@@ -19,6 +19,11 @@ export type ResourceEntry = {
 	 * "Archived" label.
 	 */
 	archived?: boolean;
+	/**
+	 * A new-agent artifact with no agent row behind it yet. The builder renders
+	 * it from a local default config and persists on the first real edit.
+	 */
+	pending?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -46,6 +51,12 @@ type AgentBuilderTargetMetadata = {
 	agentId: string;
 	projectId: string;
 	name?: string;
+};
+
+type PendingAgentTargetMetadata = {
+	agentId: string;
+	projectId: string;
+	name: string;
 };
 
 /**
@@ -382,6 +393,38 @@ function enrichWorkflowNames(
 	}
 }
 
+/**
+ * Surface a new-agent artifact the user opened but has not configured yet, so
+ * the panel can show it before any agent row exists.
+ *
+ * Skipped once anything else knows this id — a bound target, or a builder event
+ * — because that means the agent was persisted and the marker is only still
+ * there because the thread-metadata API can merge keys but not delete them.
+ */
+function enrichAgentFromPendingTarget(
+	col: Collections,
+	pending: PendingAgentTargetMetadata | undefined,
+	boundTarget: AgentBuilderTargetMetadata | undefined,
+): void {
+	if (!pending) return;
+	if (boundTarget?.agentId === pending.agentId) return;
+	if (col.produced.has(pending.agentId)) return;
+
+	recordProduced(
+		col,
+		{
+			type: 'agent',
+			id: pending.agentId,
+			name: pending.name,
+			projectId: pending.projectId,
+			pending: true,
+		},
+		// The placeholder name is generic, so linking it would rewrite ordinary
+		// prose mentioning a new agent.
+		{ linkable: false },
+	);
+}
+
 // ---------------------------------------------------------------------------
 // Composable
 // ---------------------------------------------------------------------------
@@ -407,6 +450,7 @@ export function useResourceRegistry(
 	workflowNameLookup?: (id: string) => string | undefined,
 	archivedWorkflowIds?: () => ReadonlySet<string>,
 	agentBuilderTarget?: () => AgentBuilderTargetMetadata | undefined,
+	pendingAgentTarget?: () => PendingAgentTargetMetadata | undefined,
 ) {
 	// Long-lived reactive maps, reconciled in place: rebuilds that change
 	// nothing trigger nothing.
@@ -430,7 +474,9 @@ export function useResourceRegistry(
 				collectFromMessageAttachments(msg, col);
 				if (msg.agentTree) collectFromAgentNode(msg.agentTree, col);
 			}
-			enrichAgentFromBuilderTarget(col, agentBuilderTarget?.());
+			const boundTarget = agentBuilderTarget?.();
+			enrichAgentFromBuilderTarget(col, boundTarget);
+			enrichAgentFromPendingTarget(col, pendingAgentTarget?.(), boundTarget);
 
 			if (workflowNameLookup) {
 				enrichWorkflowNames(col, workflowNameLookup);


### PR DESCRIPTION
## Summary

Clicking "New agent" persisted a row immediately. Every abandoned click left an empty agent behind, and the "User created agent" event measured whether someone found the button rather than whether an agent came into existence.

The frontend now mints the agent id up front and records it on the thread as a pending marker, creating nothing. Whichever path first does real work creates the agent under that id:

- a configuration change in the artifact (model, instructions, a tool, a skill), or
- an agent-building request in the Instance AI chat.

Because both paths share the same id, the artifact keeps one identity from the moment it opens, and the backend adopts the existing row if the two ever race. Navigating away without touching anything leaves nothing behind.

Two related fixes fall out of this:

- **`build-agent` no longer creates a duplicate.** An unrecognised `agentRef`/`name` used to mean "create", which is exactly what the model sends when it names an agent for the first time — stranding the artifact the user already had open behind a second agent. While a target is bound it now continues that agent, and an explicit `createNew: true` requests an additional one.
- **Personalisation is seeded at creation** rather than backfilled by the editor on mount. The backfill schedules a save, which would have persisted the agent on mount and defeated the whole change. Seeding also means the builder reads an existing icon name instead of inventing one — it had started writing emoji, which the icon tile cannot render.

Telemetry is deliberately not part of this PR. `USER_CREATED_AGENT` fired at click time and now fires nowhere; folding it together with `BUILDER_CREATED_AGENT` into a single event with a `by` dimension (`user` / `builder` / `mcp`) is a follow-up.

## How to test

1. Open a project and click **New agent** from any entry point (agents list, project header, sidebar `+`, workflows empty state).
2. You land in an Instance AI thread with a "New agent" artifact already open on the right. **No `POST /rest/projects/:id/agents/v2` is sent** — the network tab shows only the thread sync and metadata write.
3. Navigate away without touching anything, then check the `agents` table: no new row.

Then verify each creation path:

- **Manual** — repeat step 1, set a model or add a tool. Exactly one create is sent, the id matches the artifact tab, and the config `PUT` follows it.
- **Chat** — repeat step 1, then ask the assistant to build an agent. It is created under the same id, so a single artifact tab stays open throughout rather than a second one appearing.
- **Mixed** — repeat step 1, tweak something by hand, then ask the chat to extend it. One agent, not two.

The new agent should show a distinct gradient tile with a rendered icon glyph in all cases.

## Related Linear tickets, Github issues, and Community forum posts

_To be linked._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

