### PR TITLE
fix(editor): Clarify Slack HITL "Capture Who Responded" helper text

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -222,8 +222,9 @@ export const captureResponderField: INodeProperties = {
 			responseType: ['approval'],
 		},
 	},
+	// eslint-disable-next-line n8n-nodes-base/node-param-description-miscased-id
 	description:
-		"Whether to use Slack interactive buttons so the responder's identity (ID, name, email) is captured and returned with the response. Requires the Slack app to have Interactivity enabled (Request URL pointed at this n8n instance), a signing secret on the credential, and the users:read and users:read.email scopes.",
+		'Whether to return the responder\'s identity with the Slack response. Requires additional setup on the Slack app — <a href="https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.slack/approvals#id-1.-create-a-slack-app-and-credential" target="_blank">see docs</a>.',
 };
 
 export const approversField: INodeProperties = {


### PR DESCRIPTION
## Summary

- Shortened the helper text and linked to the docs section that documents the exact Request URL setup.

<img width="519" height="216" alt="Screenshot 2026-08-03 at 14 54 06" src="https://github.com/user-attachments/assets/bd7f569f-a5fb-4d8b-8130-55967a28605c" />


## Test plan
- [x] `pnpm typecheck` passes in `packages/nodes-base`
- [x] Visually confirm the new helper text and doc link render correctly for the "Capture Who Responded" toggle on the Slack node (Approval response type)

Linear: https://linear.app/n8n/issue/ENT-310