### PR TITLE
ci: Replay 3.x onto master instead of merging into it (no-changelog)

### DIFF
--- a/.github/DEVELOPING_V3.md
+++ b/.github/DEVELOPING_V3.md
@@ -13,8 +13,8 @@ and this guide explains how to develop against them without friction.
 ## The branch model
 
 `3.x` is not a divergent fork — it is simply **"whatever is on `master`, plus the
-breaking-change commits"**. Their histories stay in lockstep via a daily sync, so
-merging `3.x` back into `master` at release time is painless.
+breaking-change commits"**. A daily sync keeps that literally true by replaying those
+commits on top of `master`, so merging `3.x` back into `master` at release time is painless.
 
 ```mermaid
 flowchart LR
@@ -27,7 +27,7 @@ flowchart LR
     end
     F --> master
     D --> master
-    master -- "daily sync (util-sync-master-to-3x.yml)" --> threex
+    master -- "daily sync: replay 3.x commits<br/>onto master (util-sync-master-to-3x.yml)" --> threex
     B --> threex
     threex -. "merged to master at v3 release" .-> master
 ```
@@ -107,9 +107,11 @@ Override flags locally without touching PostHog:
 
 ## Introducing a breaking change (on `3.x`)
 
-Breaking changes go **only on `3.x`**, via a PR that targets `3.x` directly
-(branch off the latest `3.x`, open the PR against `3.x`). Do not land breaking
-changes on `master` — the sync guarantees `master` stays releasable as v2.
+Breaking changes go **only on `3.x`**, via a PR that targets `3.x` directly. Branch off
+**latest `master`** and open the PR against `3.x` — since `3.x` is `master` plus the breaking
+commits, such a PR merges cleanly and is immune to the daily force-push (see
+[How the daily sync works](#how-the-daily-sync-works)). Do not land breaking changes on
+`master` — the sync guarantees `master` stays releasable as v2.
 
 - Track the change in the [v3 breaking-changes tracker](https://www.notion.so/n8n/1a75b6e0c94f802caca3ce378d0d8046)
   and the [Release v3 Linear project](https://linear.app/n8n/project/release-v3-7d7032bebbec/activity).
@@ -122,24 +124,59 @@ of the breaking removal on `3.x`.
 
 ## How the daily sync works
 
-[`util-sync-master-to-3x.yml`](./workflows/util-sync-master-to-3x.yml) runs daily
-and merges `master` into `3.x`:
+[`util-sync-master-to-3x.yml`](./workflows/util-sync-master-to-3x.yml) runs daily and
+**replays the `3.x`-only commits on top of `master`** (a rebase), then force-pushes `3.x`:
 
-1. **Fast-forward** when `3.x` hasn't diverged.
-2. **Three-way merge** when it has.
-3. On a **merge conflict** it opens a **draft conflict PR** (labeled
-   `automation:v3-sync`) and posts to the **`#alerts-v3-sync`** Slack channel.
-   **Syncs pause until that PR is resolved and merged** — so conflicts never pile
-   up silently.
+1. **Nothing to do** when `3.x` already contains `master`.
+2. **Replay + force-push** otherwise. A clean sync adds **no commit of its own** — `3.x`
+   stays literally "master + the breaking commits", every replayed commit kept as-is with its
+   original message and author. Nothing is ever squashed. Merge commits in the range (breaking
+   PRs merged into `3.x`) are flattened away, and a breaking commit that also landed on
+   `master` is dropped as empty.
+3. On a **conflict**, `3.x` is left **untouched** and a **draft conflict PR** (labeled
+   `automation:v3-sync`) carrying the conflict markers is opened on `sync/master-to-3x`, plus a
+   post to the **`#alerts-v3-sync`** Slack channel. **Syncs pause until that PR is merged** —
+   so conflicts never pile up silently.
 
-**Who gets pinged.** The conflict is attributed to the authors of the `3.x`
-breaking commits touching the conflicted files (computed by
-`.github/scripts/sync-conflict-owners.mjs`: the `master..HEAD` commits per
-conflicted file, mapped to GitHub accounts). Those authors are **requested as
-reviewers** on the conflict PR and listed in the `#alerts-v3-sync` message. So if you
-authored the breaking commit that caused a conflict, you'll be nudged to resolve
-it: fix the conflict markers on the `sync/master-to-3x` branch and merge the PR;
-the next daily run then resumes normally.
+Whatever route it takes, the sync verifies that the content it is about to push is **exactly
+the tree a merge of `3.x` and `master` produces** (`git merge-tree`), and that no conflict
+markers are present. Either check failing fails the run instead of rewriting `3.x`.
+
+> **`3.x` is force-pushed daily.** Branch breaking-change PRs off **`master`** and target
+> `3.x` — then your merge-base is a `master` commit that survives every rewrite and your
+> diff stays clean. If you branch off `3.x` itself, re-base after a sync
+> (`git rebase --onto origin/3.x <old-3.x-tip> <your-branch>`). Commit links on
+> already-merged `3.x` PRs keep working but point at commits no longer on any branch.
+
+### Resolving a conflict PR
+
+The conflict branch is `master` merged into `3.x` with the **conflict markers committed**, so
+you see exactly what clashed — and the required checks stay red until they're gone, so the PR
+can't be merged half-resolved:
+
+```bash
+git fetch origin sync/master-to-3x && git switch sync/master-to-3x
+# fix the conflict markers, then commit them in ONE commit of your own
+git push origin sync/master-to-3x
+```
+
+Then **merge the PR with the normal merge button.** `master`'s commits arrive as-is and your
+fix stays its own commit.
+
+`3.x` never holds markers at its tip, so nightly images keep building; the merge commit that
+carries them drops out of `3.x`'s history at the next sync (the replay takes the queue's
+commits only).
+
+The next sync then makes `3.x` linear again. The plain replay stalls at that point (a fix
+recorded around a merge commit leaves no patch to replay), so it replays a second time with
+`3.x`'s side favoured, and your fix commit — which is in the queue — does the real work.
+Nothing is squashed, and the tree guard proves the result is exactly the merge of `3.x` and
+`master`.
+
+**Who gets pinged.** The conflict is attributed to the authors of the `3.x` commits behind the
+conflicted files (`.github/scripts/sync-conflict-owners.mjs`, mapped to GitHub accounts).
+Those authors are **requested as reviewers** on the conflict PR and listed in the
+`#alerts-v3-sync` message.
 
 ## Trialing v3
 

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -413,7 +413,7 @@ Push to master/1.x
 | Daily 01:30, 02:30, 03:30 | `test-benchmark-nightly.yml`      | Performance benchmarks   |
 | Daily 04:00               | `test-e2e-vm-expressions-nightly.yml`| VM expression E2E     |
 | Daily 05:00               | `test-benchmark-destroy-nightly.yml`| Cleanup benchmark env  |
-| Daily 06:00               | `util-sync-master-to-3x.yml`      | Sync master → 3.x (v3)   |
+| Daily 06:00               | `util-sync-master-to-3x.yml`      | Replay 3.x onto master (v3) |
 | Daily 08:00               | `build-v3-nightly.yml`            | Nightly v3 Docker images |
 | Monday 00:00              | `util-update-node-popularity.yml` | Node usage stats         |
 | Monday 02:00              | `test-e2e-coverage-weekly.yml`    | Weekly E2E coverage      |
@@ -424,10 +424,14 @@ Push to master/1.x
 ## v3 development (master + 3.x)
 
 During the v3 release window, `master` carries normal feature work (behind opt-in
-flags) and the long-lived `3.x` branch carries breaking changes. `master` is
-synced into `3.x` daily by `util-sync-master-to-3x.yml` (conflicts open a draft PR
-labeled `automation:v3-sync`, request the breaking-commit authors as reviewers via
-`sync-conflict-owners.mjs`, post to `#alerts-v3-sync`, and pause further syncs).
+flags) and the long-lived `3.x` branch carries breaking changes. `util-sync-master-to-3x.yml`
+syncs daily by **replaying the `3.x`-only commits onto `master` and force-pushing `3.x`**, so a
+clean sync adds no commit and nothing is squashed. What it pushes is always verified to be
+exactly the tree a merge of `3.x` and `master` produces, and marker-free. On a real conflict
+`3.x` is left untouched and a draft PR carrying the conflict markers (labeled
+`automation:v3-sync`) is opened on `sync/master-to-3x`, requesting the breaking-commit authors
+as reviewers via `sync-conflict-owners.mjs`, posting to `#alerts-v3-sync` and pausing further
+syncs until it is resolved and merged normally.
 `build-v3-nightly.yml` publishes `n8nio/n8n:v3-nightly[-<date>]` images from `3.x`
 by calling `docker-build-push.yml` with `ref: 3.x` + `date_tag`.
 

--- a/.github/scripts/sync-conflict-owners.mjs
+++ b/.github/scripts/sync-conflict-owners.mjs
@@ -3,10 +3,10 @@
  * Attributes a master→3.x sync conflict to the authors of the breaking commits.
  *
  * Since 3.x = master + breaking commits, the commits that diverged 3.x are exactly
- * `<base>..HEAD` (where <base> is the fetched master SHA). Scoped to the conflicted
- * files, those are the commits responsible for the conflict; their GitHub authors are
- * who to nudge. Must run while the merge is unresolved — HEAD still at the pre-merge
- * 3.x tip and unmerged paths present in the index.
+ * `<base>..<tip>` (where <base> is the fetched master SHA and <tip> the pre-rebase 3.x
+ * tip). Scoped to the conflicted files, those are the commits responsible for the
+ * conflict; their GitHub authors are who to nudge. `conflictedFiles` must run while the
+ * rebase is stopped, i.e. with unmerged paths present in the index.
  *
  * git log gives only the author name/email, and ~2/3 of n8n authors commit with a
  * non-noreply email that carries no GitHub username. So the conflicted files → breaking
@@ -29,17 +29,19 @@ export function runGit(args) {
 	return execFileSync('git', args, { encoding: 'utf8' }).trim();
 }
 
-// Files with unresolved conflicts in the current (in-progress) merge.
+// Files with unresolved conflicts at the current (stopped) rebase step.
 export function conflictedFiles(git = runGit) {
 	const out = git(['diff', '--name-only', '--diff-filter=U']);
 	return out ? out.split('\n').filter(Boolean) : [];
 }
 
-// Unique SHAs of the 3.x-only (breaking) commits that touched the given files.
-export function breakingShas(base, files, git = runGit) {
+// Unique SHAs of the 3.x-only (breaking) commits that touched the given files. `tip`
+// defaults to HEAD but must be the PRE-rebase tip when called after a rebase, since HEAD
+// is by then a replay whose commits carry different SHAs.
+export function breakingShas(base, files, git = runGit, tip = 'HEAD') {
 	const shas = new Set();
 	for (const file of files) {
-		const out = git(['log', `${base}..HEAD`, '--format=%H', '--', file]);
+		const out = git(['log', `${base}..${tip}`, '--format=%H', '--', file]);
 		for (const sha of out.split('\n').filter(Boolean)) shas.add(sha);
 	}
 	return [...shas];
@@ -78,7 +80,7 @@ export async function resolveLogins(repo, shas, token, fetchFn = fetch) {
 }
 
 // Build the conflict-PR body, reviewer CSV, and Slack owner line.
-export function buildOutputs({ syncBranch, files, owners }) {
+export function buildOutputs({ syncBranch, targetBranch = '3.x', files, owners }) {
 	const filesMd = files.map((f) => `- \`${f}\``).join('\n') || '_none detected_';
 	const ownersMd = owners.length
 		? owners.map((o) => `- @${o}`).join('\n')
@@ -87,13 +89,23 @@ export function buildOutputs({ syncBranch, files, owners }) {
 		? `Likely owners (GitHub): ${owners.map((o) => `@${o}`).join(' ')}`
 		: 'Could not auto-attribute owners.';
 	const body = [
-		`Automated \`master\`→\`3.x\` sync hit a merge conflict. Resolve the conflict markers on \`${syncBranch}\`, then merge this PR. **Daily syncs are paused until it is merged.**`,
+		`Automated \`master\`→\`${targetBranch}\` sync hit a conflict.`,
+		'',
+		`**\`${targetBranch}\` was not touched.** This branch is \`master\` merged into \`${targetBranch}\` with the **conflict markers committed**, so you can see exactly what clashed. The required checks stay red until they are resolved, so this PR cannot be merged half-done.`,
+		'',
+		'### How to resolve',
+		`1. \`git fetch origin ${syncBranch} && git switch ${syncBranch}\``,
+		'2. Fix the conflict markers and commit them **in one commit of your own** (rather than amending the merge).',
+		`3. \`git push origin ${syncBranch}\``,
+		`4. **Merge this PR with the normal merge button.** \`master\`'s commits come in as-is and your fix stays its own commit — nothing is squashed.`,
+		'',
+		`**Daily syncs are paused until this PR is merged.** The next sync then replays \`${targetBranch}\` onto master linearly again — which also drops this merge commit and its markers out of \`${targetBranch}\`'s history — and verifies the result is exactly what a merge would produce.`,
 		'',
 		'### Conflicted files',
 		filesMd,
 		'',
 		'### Likely owners',
-		'Authors of the 3.x commits touching the conflicted files, requested as reviewers:',
+		`Authors of the ${targetBranch} commits behind the conflicted files, requested as reviewers:`,
 		ownersMd,
 	].join('\n');
 	return { ownersCsv: owners.join(','), slack, body };
@@ -104,6 +116,7 @@ async function main() {
 		options: {
 			base: { type: 'string' },
 			'sync-branch': { type: 'string', default: 'sync/master-to-3x' },
+			'target-branch': { type: 'string', default: '3.x' },
 		},
 	});
 
@@ -128,7 +141,16 @@ async function main() {
 		console.error(`warning: could not resolve owners: ${error.message}`);
 	}
 
-	process.stdout.write(JSON.stringify(buildOutputs({ syncBranch, files, owners })));
+	process.stdout.write(
+		JSON.stringify(
+			buildOutputs({
+				syncBranch,
+				targetBranch: values['target-branch'],
+				files,
+				owners,
+			}),
+		),
+	);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/.github/scripts/sync-conflict-owners.test.mjs
+++ b/.github/scripts/sync-conflict-owners.test.mjs
@@ -19,6 +19,16 @@ test('breakingShas collects unique SHAs across the conflicted files only', () =>
 	assert.deepEqual(calls[0], ['log', 'BASE..HEAD', '--format=%H', '--', 'a.ts']);
 });
 
+test('breakingShas can be scoped to an explicit tip (the pre-rebase 3.x tip)', () => {
+	const calls = [];
+	const git = (args) => {
+		calls.push(args);
+		return 'sha1';
+	};
+	breakingShas('BASE', ['a.ts'], git, 'PREHEAD');
+	assert.deepEqual(calls[0], ['log', 'BASE..PREHEAD', '--format=%H', '--', 'a.ts']);
+});
+
 test('resolveLogins maps SHAs to logins in one call, dropping unlinked/bot authors', async () => {
 	let calls = 0;
 	const fetchFn = async (url, opts) => {
@@ -63,18 +73,27 @@ test('resolveLogins throws on API/GraphQL errors (caller degrades gracefully)', 
 });
 
 test('buildOutputs formats reviewers, slack line, and PR body with owners', () => {
-	const out = buildOutputs({ syncBranch: 'sync/master-to-3x', files: ['packages/cli/x.ts'], owners: ['alice', 'bob'] });
+	const out = buildOutputs({
+		syncBranch: 'sync/master-to-3x',
+		files: ['packages/cli/x.ts'],
+		owners: ['alice', 'bob'],
+	});
 	assert.equal(out.ownersCsv, 'alice,bob');
 	assert.equal(out.slack, 'Likely owners (GitHub): @alice @bob');
 	assert.match(out.body, /### Conflicted files/);
 	assert.match(out.body, /- `packages\/cli\/x\.ts`/);
 	assert.match(out.body, /- @alice/);
 	assert.match(out.body, /- @bob/);
-	assert.match(out.body, /Daily syncs are paused until it is merged/);
+	assert.match(out.body, /Daily syncs are paused until this PR is merged/);
+	// Markers are the review surface; the fix goes in the resolver's own commit.
+	assert.match(out.body, /conflict markers committed/);
+	assert.match(out.body, /in one commit of your own/);
+	assert.match(out.body, /Merge this PR with the normal merge button/);
+	assert.match(out.body, /`3\.x` was not touched/);
 });
 
 test('buildOutputs degrades gracefully when nothing could be attributed', () => {
-	const out = buildOutputs({ syncBranch: 'sync/master-to-3x', files: ['x.ts'], owners: [] });
+	const out = buildOutputs({ syncBranch: 'sync/master-to-3x', syncBase: 'abc1234', files: ['x.ts'], owners: [] });
 	assert.equal(out.ownersCsv, '');
 	assert.equal(out.slack, 'Could not auto-attribute owners.');
 	assert.match(out.body, /Could not auto-attribute/);

--- a/.github/scripts/sync-master-to-3x.mjs
+++ b/.github/scripts/sync-master-to-3x.mjs
@@ -1,23 +1,45 @@
 #!/usr/bin/env node
 /**
- * Syncs the master branch into the long-lived 3.x branch.
+ * Syncs the master branch into the long-lived 3.x branch by REPLAYING (rebasing) the
+ * 3.x-only commits on top of master.
  *
- * During the v3 development window, master carries normal feature work (behind
- * opt-in flags) and 3.x is "master + breaking-change commits". This script
- * fast-forwards 3.x when possible, falls back to a three-way merge when 3.x has
- * diverged, and — when a merge conflict occurs — opens a draft conflict PR,
- * attributing it to the authors of the breaking commits. No further syncs run
- * until that PR is resolved and merged (see the halt gate below).
+ * During the v3 development window, master carries normal feature work (behind opt-in
+ * flags) and 3.x is "master + breaking-change commits". Keeping that literally true means
+ * replaying, not merging: a merge would add a merge commit on every single run now that 3.x
+ * has permanently diverged. So a clean sync force-pushes 3.x and adds NO commit of its own,
+ * keeping every replayed commit intact — nothing is ever squashed, and authors are kept.
  *
- * Runs from a checkout of the 3.x branch (fetch-depth 0). Assumes credentials
- * are NOT persisted by checkout — pushes go through an explicit token URL.
+ * Whatever route it takes, the content 3.x receives is verified to be exactly the tree that
+ * merging 3.x with master produces (`git merge-tree`); a mismatch fails the run instead of
+ * pushing. That invariant is what makes the rewrite safe.
  *
- * On conflict, emits `conflict_pr` and `conflict_owners` to $GITHUB_OUTPUT so a
- * downstream job can post to Slack.
+ * Three cases:
+ *   1. The replay is clean            → force-push. No commit.
+ *   2. The replay stalls, but 3.x's content still reconciles with master → an earlier
+ *      conflict was resolved in a merge, which leaves no patch to replay. Replay again
+ *      favouring the 3.x side (`-X theirs`), mirroring the side the resolved merge kept;
+ *      the human's fix commit is in the queue and does the real work. Tree is then proven.
+ *   3. The content does NOT reconcile → a genuinely new conflict. 3.x is left UNTOUCHED and a
+ *      draft PR is opened on the sync branch carrying the conflict markers, attributed to the
+ *      authors of the breaking commits behind the conflicted files. Syncs pause until it is
+ *      merged.
+ *
+ * The conflict branch carries the conflict markers, so the resolver sees exactly what clashed
+ * and the required checks stay red until they fix it in a commit of their own. That PR is
+ * merged with the normal GitHub merge button — master's commits arrive as-is and the fix stays
+ * its own commit. 3.x itself never has markers at its tip (nightly images build from it), and
+ * the merge commit holding them is dropped from its history by the next replay.
+ *
+ * Runs from a checkout of the target branch (fetch-depth 0). Assumes credentials are NOT
+ * persisted by checkout — pushes go through an explicit token URL.
+ *
+ * On conflict, emits `conflict_pr` and `conflict_owners` to $GITHUB_OUTPUT so a downstream
+ * job can post to Slack.
  *
  * Env: GH_TOKEN (installation token with contents/pull-requests/issues write),
- *      GITHUB_REPOSITORY (owner/repo, auto-provided by Actions).
- * Requires Node 18+ (global fetch) and the `gh` CLI on PATH.
+ *      GITHUB_REPOSITORY (owner/repo, auto-provided by Actions),
+ *      SYNC_TARGET_BRANCH (optional — override 3.x to rehearse against a scratch branch).
+ * Requires Node 18+ (global fetch), git 2.38+ (`merge-tree --write-tree`) and `gh` on PATH.
  *
  * See .github/DEVELOPING_V3.md for the full v3 development model.
  */
@@ -39,23 +61,70 @@ const BOT_EMAIL = 'n8n-assistant[bot]@users.noreply.github.com';
 const runGit = (args, opts = {}) => execFileSync('git', args, { encoding: 'utf8', ...opts }).trim();
 const runGh = (args, opts = {}) => execFileSync('gh', args, { encoding: 'utf8', ...opts }).trim();
 
+// The branch to sync into. Overridable so the whole flow can be rehearsed end-to-end
+// against a throwaway branch before it is pointed at the real 3.x.
+export function targetBranch(env = process.env) {
+	return env.SYNC_TARGET_BRANCH || TARGET_BRANCH;
+}
+
+// Run a command for its exit status: `{ ok, out }` instead of a throw. Used for the git
+// commands whose non-zero exit is an expected answer, not a failure. stderr is captured
+// rather than inherited, so an expected-to-fail probe doesn't spill into the run log.
+export function attempt(run, args, opts = {}) {
+	try {
+		return { ok: true, out: run(args, { stdio: ['ignore', 'pipe', 'pipe'], ...opts }) ?? '' };
+	} catch (error) {
+		const out = `${error.stdout ?? ''}\n${error.stderr ?? ''}`.trim();
+		return { ok: false, out };
+	}
+}
+
 // True when a previous conflict PR is still open — the halt gate.
 export function hasOpenConflictPr(gh, label = CONFLICT_LABEL) {
 	const out = gh(['pr', 'list', '--state', 'open', '--label', label, '--json', 'number']);
 	return JSON.parse(out || '[]').length > 0;
 }
 
-// Attempt the merge. `git merge` fast-forwards when 3.x has not diverged and
-// does a three-way merge otherwise; a non-zero exit means a conflict.
-export function tryMerge(git, masterSha, log = console.log) {
-	try {
-		git(['merge', '--no-edit', masterSha]);
-		return true;
-	} catch (error) {
-		// Surface the merge output (conflict summary) before falling back.
-		if (error.stdout) log(String(error.stdout).trim());
-		return false;
+export function isAncestor(git, maybeAncestor, descendant) {
+	return attempt(git, ['merge-base', '--is-ancestor', maybeAncestor, descendant]).ok;
+}
+
+/**
+ * The tree a merge of the two commits would produce — the definition of the content 3.x
+ * should end up with, computed without touching the working tree.
+ *
+ * `ok: false` means the two sides genuinely conflict: there is a new conflict that no
+ * existing commit on 3.x resolves.
+ */
+export function mergeTree(git, a, b) {
+	const res = attempt(git, ['merge-tree', '--write-tree', a, b]);
+	return { ok: res.ok, tree: res.ok ? res.out.split('\n')[0].trim() : '', out: res.out };
+}
+
+// Replay the 3.x-only commits onto master. Merge commits in the range (breaking PR merges,
+// past sync merges) are flattened; commits already applied to master are dropped as empty.
+// Individual commits, messages and authors are preserved — nothing is squashed.
+export function tryRebase(git, masterSha, log = console.log, extraArgs = []) {
+	const { ok, out } = attempt(git, ['rebase', ...extraArgs, masterSha]);
+	if (!ok && out) log(out);
+	return ok;
+}
+
+// The content guard for every push: whichever route produced HEAD, its tree must be exactly
+// what merging 3.x with master yields.
+export function assertTree(git, expectedTree) {
+	const actual = git(['rev-parse', 'HEAD^{tree}']);
+	if (actual !== expectedTree) {
+		throw new Error(`Replayed tree ${actual} does not match the merge tree ${expectedTree}; refusing to push.`);
 	}
+}
+
+// Conflict markers must never reach 3.x — nightly images build from it. git grep exits 0
+// with matches, 1 with none and >1 on error, so an error must not be read as "clean".
+export function assertNoMarkers(git, rev = 'HEAD') {
+	const found = attempt(git, ['grep', '-I', '-l', '-e', '^<<<<<<< ', '-e', '^>>>>>>> ', rev]);
+	if (found.ok) throw new Error(`Refusing to continue: conflict markers present in ${rev}:\n${found.out}`);
+	if (found.out.includes('fatal:')) throw new Error(`Could not scan ${rev} for conflict markers:\n${found.out}`);
 }
 
 // Append key=value lines to $GITHUB_OUTPUT (no-op when running outside Actions).
@@ -69,16 +138,51 @@ export function writeGithubOutput(obj, env = process.env) {
 }
 
 /**
- * Record the conflicted state on the sync branch and open a draft PR, attributing
- * it to the authors of the 3.x breaking commits touching the conflicted files.
- * Runs while the merge is unresolved (HEAD still at the pre-merge 3.x tip,
- * unmerged paths present) — before committing below.
+ * Build the conflict branch: master merged into 3.x with the conflict markers committed as
+ * they are. The markers are the review surface — the resolver sees exactly what clashed, and
+ * the required checks stay red until they fix it, so the PR cannot be merged half-resolved
+ * (an auto-resolved branch would be green with master's change silently dropped).
+ *
+ * 3.x never carries them at its tip, and not for long in its history either: this merge
+ * commit is dropped by the next replay, which takes the queue's commits only.
+ *
+ * @returns {string[]} the conflicted files
+ */
+export function buildConflictBranch({ git, masterSha, log = console.log }) {
+	const merge = attempt(git, ['merge', '--no-edit', masterSha]);
+	if (merge.ok) {
+		// merge-tree said these conflict; if a real merge disagrees, don't guess.
+		throw new Error('Expected a merge conflict but the merge succeeded; aborting to avoid guessing.');
+	}
+	if (merge.out) log(merge.out);
+
+	const files = conflictedFiles(git);
+	git(['add', '-A']);
+	git(['commit', '--no-edit', '--no-verify']);
+	return files;
+}
+
+/**
+ * Push the marker-free conflict branch and open a draft PR, attributing it to the authors of
+ * the breaking commits behind the conflicted files. 3.x is left untouched.
  *
  * @returns {Promise<{ prUrl: string, ownersSlack: string }>}
  */
-export async function openConflictPr({ git, gh, repo, token, masterSha, pushUrl, fetchFn = fetch, log = console.log }) {
-	const files = conflictedFiles(git);
-	const shas = breakingShas(masterSha, files, git);
+export async function openConflictPr({
+	git,
+	gh,
+	repo,
+	token,
+	masterSha,
+	preHead,
+	pushUrl,
+	target = TARGET_BRANCH,
+	files = [],
+	fetchFn = fetch,
+	log = console.log,
+}) {
+	// Attribute against the pre-merge tip: HEAD is the merge commit by now.
+	const shas = breakingShas(masterSha, files, git, preHead);
 
 	// Degrade gracefully: a transient API failure should still open the PR
 	// (unattributed) rather than fail the whole sync.
@@ -89,19 +193,20 @@ export async function openConflictPr({ git, gh, repo, token, masterSha, pushUrl,
 		log(`warning: could not resolve owners: ${error.message}`);
 	}
 
-	const { ownersCsv, slack, body } = buildOutputs({ syncBranch: SYNC_BRANCH, files, owners });
+	const { ownersCsv, slack, body } = buildOutputs({
+		syncBranch: SYNC_BRANCH,
+		targetBranch: target,
+		files,
+		owners,
+	});
 
-	// Record the conflicted state (with markers) on the PR branch so it can be
-	// resolved in review, mirroring the backport conflict convention.
-	git(['add', '-A']);
-	git(['commit', '--no-edit']);
 	git(['push', '--force', pushUrl, `HEAD:refs/heads/${SYNC_BRANCH}`]);
 
 	// Ensure the label exists (idempotent), then open the draft conflict PR.
 	gh(['label', 'create', CONFLICT_LABEL, '--color', 'B60205', '--description', 'master→3.x sync conflict', '--force']);
 	const prUrl = gh([
 		'pr', 'create', '--draft',
-		'--base', TARGET_BRANCH,
+		'--base', target,
 		'--head', SYNC_BRANCH,
 		'--label', CONFLICT_LABEL,
 		'--title', 'chore: Resolve master→3.x sync conflict',
@@ -133,13 +238,17 @@ export async function sync({
 	if (!token) throw new Error('GH_TOKEN / GITHUB_TOKEN env var is required');
 	if (!repo) throw new Error('GITHUB_REPOSITORY env var is required');
 
+	const target = targetBranch(env);
+
 	// Authenticated push URL (credentials are not persisted by checkout).
 	const pushUrl = `https://x-access-token:${token}@github.com/${repo}.git`;
+	// The lease pins the tip we replayed from, so a concurrent push is never overwritten.
+	const pushReplay = (from) =>
+		git(['push', `--force-with-lease=refs/heads/${target}:${from}`, pushUrl, `HEAD:refs/heads/${target}`]);
 
-	// Halt gate: if a previous conflict PR is still open, do nothing until it is
-	// resolved and merged.
+	// Halt gate: if a previous conflict PR is still open, do nothing until it is merged.
 	if (hasOpenConflictPr(gh)) {
-		log(`An open '${CONFLICT_LABEL}' conflict PR exists; skipping sync until it is resolved and merged.`);
+		log(`An open '${CONFLICT_LABEL}' conflict PR exists; skipping sync until it is merged.`);
 		return;
 	}
 
@@ -150,16 +259,53 @@ export async function sync({
 	// Pin to the fetched SHA — a command-line refspec doesn't reliably update the
 	// origin/master tracking ref, so FETCH_HEAD is the unambiguous target.
 	const masterSha = git(['rev-parse', 'FETCH_HEAD']);
+	const preHead = git(['rev-parse', 'HEAD']);
 
-	if (tryMerge(git, masterSha, log)) {
-		git(['push', pushUrl, `HEAD:${TARGET_BRANCH}`]);
-		log('Synced master into 3.x.');
+	if (isAncestor(git, masterSha, preHead)) {
+		log(`${target} already contains master (${masterSha}); nothing to sync.`);
 		return;
 	}
 
-	log('Merge conflict encountered — attributing owners and opening a conflict PR.');
-	const { prUrl, ownersSlack } = await openConflictPr({ git, gh, repo, token, masterSha, pushUrl, fetchFn, log });
-	writeGithubOutput({ conflict_pr: prUrl, conflict_owners: ownersSlack }, env);
+	const queue = git(['log', '--no-merges', '--reverse', '--format=%h %s', `${masterSha}..${preHead}`]);
+	log(`Replaying onto master ${masterSha}:\n${queue || '(none)'}`);
+
+	// What the content must end up as, and whether a new conflict exists at all.
+	const merged = mergeTree(git, preHead, masterSha);
+
+	if (!merged.ok) {
+		log(`master conflicts with ${target} — leaving ${target} untouched and opening a conflict PR.`);
+		const files = buildConflictBranch({ git, masterSha, log });
+		const { prUrl, ownersSlack } = await openConflictPr({
+			git, gh, repo, token, masterSha, preHead, pushUrl, target, files, fetchFn, log,
+		});
+		writeGithubOutput({ conflict_pr: prUrl, conflict_owners: ownersSlack }, env);
+		return;
+	}
+
+	if (tryRebase(git, masterSha, log)) {
+		assertTree(git, merged.tree);
+		assertNoMarkers(git);
+		pushReplay(preHead);
+		log(`Replayed ${target} onto master — no sync commit created.`);
+		return;
+	}
+
+	// The content reconciles but the patches no longer apply on their own: an earlier
+	// conflict was resolved in a merge, and a merge resolution leaves no patch to replay.
+	// Replay favouring the 3.x side — the same side that resolved merge kept — and let the
+	// resolver's own fix commit, which is in the queue, do the real work. Nothing is
+	// squashed; the tree guard below proves the outcome.
+	git(['rebase', '--abort']);
+	log(`Patches no longer apply individually; replaying with ${target}'s side favoured.`);
+	if (!tryRebase(git, masterSha, log, ['-X', 'theirs'])) {
+		git(['rebase', '--abort']);
+		throw new Error(`Could not replay ${target} onto master even with its own side favoured; needs a human.`);
+	}
+
+	assertTree(git, merged.tree);
+	assertNoMarkers(git);
+	pushReplay(preHead);
+	log(`Replayed ${target} onto master — no sync commit created.`);
 }
 
 // Only run when executed directly, not when imported by tests.

--- a/.github/scripts/sync-master-to-3x.test.mjs
+++ b/.github/scripts/sync-master-to-3x.test.mjs
@@ -3,9 +3,14 @@ import { test } from 'node:test';
 
 import {
 	hasOpenConflictPr,
-	tryMerge,
+	mergeTree,
+	tryRebase,
+	assertTree,
+	assertNoMarkers,
+	buildConflictBranch,
 	openConflictPr,
 	sync,
+	targetBranch,
 	CONFLICT_LABEL,
 	SYNC_BRANCH,
 	TARGET_BRANCH,
@@ -25,9 +30,42 @@ function makeStub(routes = []) {
 	return fn;
 }
 
+const fail = (stdout = '') => () => {
+	const err = new Error('command failed');
+	err.status = 1;
+	err.stdout = stdout;
+	throw err;
+};
+
 const okFetch = (logins) => async () => ({
 	ok: true,
 	json: async () => ({ data: { repository: Object.fromEntries(logins.map((l, i) => [`c${i}`, { author: { user: { login: l } } }])) } }),
+});
+
+const PRE_HEAD = 'PREHEAD';
+const MASTER = 'MASTERSHA';
+const MERGE_TREE = 'MERGETREEOID';
+
+const isRebase = (a) => a[0] === 'rebase' && a[1] !== '--abort';
+const favouringOwnSide = (a) => a[0] === 'rebase' && a.includes('-X') && a.includes('theirs');
+
+// Routes shared by every sync path: master fetched, 3.x hasn't absorbed it yet, and the
+// merge tree is computable (no new conflict). git grep exits non-zero => no markers.
+const baseGitRoutes = [
+	[(a) => a[0] === 'rev-parse' && a[1] === 'FETCH_HEAD', MASTER],
+	[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD', PRE_HEAD],
+	[(a) => a[0] === 'merge-base', fail()],
+	[(a) => a[0] === 'merge-tree', MERGE_TREE],
+	[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', MERGE_TREE],
+	[(a) => a[0] === 'grep', fail()],
+];
+
+const env = { GH_TOKEN: 'tok', GITHUB_REPOSITORY: 'n8n-io/n8n' };
+const noOpenPr = [[(a) => a[0] === 'pr' && a[1] === 'list', '[]']];
+
+test('targetBranch defaults to 3.x and honours the rehearsal override', () => {
+	assert.equal(targetBranch({}), TARGET_BRANCH);
+	assert.equal(targetBranch({ SYNC_TARGET_BRANCH: '3x-sync-test' }), '3x-sync-test');
 });
 
 test('hasOpenConflictPr reflects the open-PR count from gh', () => {
@@ -39,88 +77,187 @@ test('hasOpenConflictPr reflects the open-PR count from gh', () => {
 	assert.equal(hasOpenConflictPr(one), true);
 });
 
-test('tryMerge returns true when the merge succeeds', () => {
-	const git = makeStub([[(a) => a[0] === 'merge', '']]);
-	assert.equal(tryMerge(git, 'MASTER', () => {}), true);
-	assert.deepEqual(git.calls[0], ['merge', '--no-edit', 'MASTER']);
+test('mergeTree reports the tree when clean and not-ok when the sides conflict', () => {
+	const clean = makeStub([[() => true, `${MERGE_TREE}\nsome extra output`]]);
+	assert.deepEqual(mergeTree(clean, 'A', 'B'), { ok: true, tree: MERGE_TREE, out: `${MERGE_TREE}\nsome extra output` });
+	assert.deepEqual(clean.calls[0], ['merge-tree', '--write-tree', 'A', 'B']);
+
+	const conflicting = makeStub([[() => true, fail('CONFLICT (content): x.ts')]]);
+	assert.equal(mergeTree(conflicting, 'A', 'B').ok, false);
 });
 
-test('tryMerge returns false and logs merge output on conflict', () => {
-	const logged = [];
-	const git = () => {
-		const err = new Error('merge failed');
-		err.stdout = 'CONFLICT (content): x.ts\n';
-		throw err;
-	};
-	assert.equal(tryMerge(git, 'MASTER', (m) => logged.push(m)), false);
-	assert.match(logged.join('\n'), /CONFLICT/);
+test('tryRebase replays onto master and can favour a side', () => {
+	const git = makeStub([[(a) => a[0] === 'rebase', '']]);
+	assert.equal(tryRebase(git, MASTER, () => {}), true);
+	assert.deepEqual(git.calls[0], ['rebase', MASTER]);
+
+	assert.equal(tryRebase(git, MASTER, () => {}, ['-X', 'theirs']), true);
+	assert.deepEqual(git.calls[1], ['rebase', '-X', 'theirs', MASTER]);
 });
 
-test('sync fast-forwards and pushes to 3.x on a clean merge', async () => {
-	const git = makeStub([
-		[(a) => a[0] === 'rev-parse', 'MASTERSHA'],
-		[(a) => a[0] === 'merge', ''],
-	]);
-	const gh = makeStub([[(a) => a[0] === 'pr' && a[1] === 'list', '[]']]);
-	const env = { GH_TOKEN: 'tok', GITHUB_REPOSITORY: 'n8n-io/n8n' };
+test('assertTree and assertNoMarkers are the push guards', () => {
+	assert.doesNotThrow(() => assertTree(makeStub([[() => true, MERGE_TREE]]), MERGE_TREE));
+	assert.throws(() => assertTree(makeStub([[() => true, 'OTHER']]), MERGE_TREE), /does not match the merge tree/);
+
+	assert.doesNotThrow(() => assertNoMarkers(makeStub([[() => true, fail()]])));
+	assert.throws(() => assertNoMarkers(makeStub([[() => true, 'packages/cli/x.ts']])), /conflict markers present/);
+	// git grep failing for any other reason must not read as "clean".
+	assert.throws(() => assertNoMarkers(makeStub([[() => true, fail('fatal: bad object')]])), /Could not scan/);
+});
+
+test('sync replays and force-pushes with a lease, creating no commit', async () => {
+	const git = makeStub([...baseGitRoutes, [isRebase, '']]);
+	const gh = makeStub(noOpenPr);
 
 	await sync({ git, gh, env, log: () => {} });
 
 	const push = git.calls.find((a) => a[0] === 'push');
-	assert.ok(push, 'expected a push');
-	assert.equal(push[1], 'https://x-access-token:tok@github.com/n8n-io/n8n.git');
-	assert.equal(push[2], `HEAD:${TARGET_BRANCH}`);
-	// No PR created on a clean merge.
+	assert.deepEqual(push, [
+		'push',
+		`--force-with-lease=refs/heads/${TARGET_BRANCH}:${PRE_HEAD}`,
+		'https://x-access-token:tok@github.com/n8n-io/n8n.git',
+		`HEAD:refs/heads/${TARGET_BRANCH}`,
+	]);
+	// The point of the change: no merge, no squash, no PR on the clean path.
+	assert.equal(git.calls.some((a) => a[0] === 'merge'), false);
+	assert.equal(git.calls.some((a) => a[0] === 'commit'), false);
 	assert.equal(gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'), false);
 });
 
-test('sync halts (no fetch/merge) when a conflict PR is already open', async () => {
+test('sync targets the rehearsal branch when SYNC_TARGET_BRANCH is set', async () => {
+	const git = makeStub([...baseGitRoutes, [isRebase, '']]);
+	const gh = makeStub(noOpenPr);
+
+	await sync({ git, gh, env: { ...env, SYNC_TARGET_BRANCH: '3x-sync-test' }, log: () => {} });
+
+	assert.equal(git.calls.find((a) => a[0] === 'push').at(-1), 'HEAD:refs/heads/3x-sync-test');
+});
+
+test('sync does nothing when 3.x already contains master', async () => {
+	const git = makeStub([
+		[(a) => a[0] === 'rev-parse' && a[1] === 'FETCH_HEAD', MASTER],
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD', PRE_HEAD],
+		[(a) => a[0] === 'merge-base', ''], // --is-ancestor succeeds
+	]);
+	const gh = makeStub(noOpenPr);
+
+	await sync({ git, gh, env, log: () => {} });
+
+	assert.equal(git.calls.some((a) => a[0] === 'rebase'), false, 'must not rebase');
+	assert.equal(git.calls.some((a) => a[0] === 'push'), false, 'must not push');
+});
+
+test('sync refuses to push when the replayed tree is not the merge tree', async () => {
+	const git = makeStub([
+		...baseGitRoutes.filter((r) => !r[0](['rev-parse', 'HEAD^{tree}'])),
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', 'OTHERTREE'],
+		[isRebase, ''],
+	]);
+	const gh = makeStub(noOpenPr);
+
+	await assert.rejects(() => sync({ git, gh, env, log: () => {} }), /does not match the merge tree/);
+	assert.equal(git.calls.some((a) => a[0] === 'push'), false, 'must not push a suspect rewrite');
+});
+
+test('sync halts (no fetch/rebase) when a conflict PR is already open', async () => {
 	const git = makeStub();
 	const gh = makeStub([[(a) => a[0] === 'pr' && a[1] === 'list', JSON.stringify([{ number: 7 }])]]);
 
-	await sync({ git, gh, env: { GH_TOKEN: 't', GITHUB_REPOSITORY: 'n8n-io/n8n' }, log: () => {} });
+	await sync({ git, gh, env, log: () => {} });
 
 	assert.equal(git.calls.length, 0, 'must not touch git while halted');
 });
 
-test('sync opens a conflict PR and writes outputs on merge conflict', async () => {
+test('sync replays favouring 3.x when the patches no longer apply on their own', async () => {
+	// A previous conflict was resolved in a merge: content reconciles (merge-tree is clean)
+	// but the plain replay stalls.
 	const git = makeStub([
-		[(a) => a[0] === 'rev-parse', 'MASTERSHA'],
-		[(a) => a[0] === 'merge', () => { const e = new Error('conflict'); e.status = 1; throw e; }],
+		...baseGitRoutes,
+		[favouringOwnSide, ''],
+		[isRebase, fail('CONFLICT (content): packages/cli/x.ts')],
+	]);
+	const gh = makeStub(noOpenPr);
+
+	await sync({ git, gh, env, log: () => {} });
+
+	assert.ok(git.calls.some((a) => a[0] === 'rebase' && a[1] === '--abort'), 'stalled rebase must be aborted');
+	assert.ok(git.calls.some(favouringOwnSide), 'expected the second replay to favour 3.x');
+	assert.ok(git.calls.some((a) => a[0] === 'push'), 'expected the replay to be pushed');
+	// Still no new commit and no PR: the resolver's own fix commit is already in the queue.
+	assert.equal(git.calls.some((a) => a[0] === 'commit'), false);
+	assert.equal(gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'), false);
+});
+
+test('sync fails without pushing when even the favoured replay cannot finish', async () => {
+	const git = makeStub([...baseGitRoutes, [isRebase, fail('CONFLICT')]]);
+	const gh = makeStub(noOpenPr);
+
+	await assert.rejects(() => sync({ git, gh, env, log: () => {} }), /needs a human/);
+	assert.equal(git.calls.some((a) => a[0] === 'push'), false);
+	assert.equal(git.calls.filter((a) => a[0] === 'rebase' && a[1] === '--abort').length, 2);
+});
+
+test('buildConflictBranch commits the conflicted state, markers and all', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge', fail('CONFLICT (content): packages/cli/x.ts')],
 		[(a) => a[0] === 'diff', 'packages/cli/x.ts'],
-		[(a) => a[0] === 'log', 'sha1'],
+	]);
+
+	const files = buildConflictBranch({ git, masterSha: MASTER, log: () => {} });
+
+	assert.deepEqual(files, ['packages/cli/x.ts']);
+	assert.deepEqual(git.calls[0], ['merge', '--no-edit', MASTER]);
+	assert.ok(git.calls.some((a) => a[0] === 'add' && a[1] === '-A'));
+	assert.ok(git.calls.some((a) => a[0] === 'commit' && a.includes('--no-edit')));
+	// The markers ARE the review surface here, so nothing may auto-resolve them.
+	assert.equal(git.calls.some((a) => a.includes('-X')), false);
+	assert.equal(git.calls.some((a) => a[0] === 'merge' && a[1] === '--abort'), false);
+});
+
+test('buildConflictBranch refuses to guess when the merge unexpectedly succeeds', () => {
+	const git = makeStub([[(a) => a[0] === 'merge', '']]);
+
+	assert.throws(() => buildConflictBranch({ git, masterSha: MASTER, log: () => {} }), /Expected a merge conflict/);
+	assert.equal(git.calls.some((a) => a[0] === 'commit'), false);
+});
+
+test('sync opens a draft conflict PR and leaves 3.x untouched on a real conflict', async () => {
+	const git = makeStub([
+		...baseGitRoutes.filter((r) => !r[0](['merge-tree'])),
+		[(a) => a[0] === 'merge-tree', fail('CONFLICT (content): packages/cli/x.ts')],
+		[(a) => a[0] === 'merge', fail('CONFLICT (content): packages/cli/x.ts')],
+		[(a) => a[0] === 'diff', 'packages/cli/x.ts'],
+		[(a) => a[0] === 'log', 'breaking-sha'],
 	]);
 	const gh = makeStub([
-		[(a) => a[0] === 'pr' && a[1] === 'list', '[]'],
+		...noOpenPr,
 		[(a) => a[0] === 'pr' && a[1] === 'create', 'https://github.com/n8n-io/n8n/pull/99'],
 	]);
-	// No GITHUB_OUTPUT set → writeGithubOutput no-ops; assert on the gh/git calls instead.
-	const env = { GH_TOKEN: 'tok', GITHUB_REPOSITORY: 'n8n-io/n8n' };
 
 	await sync({ git, gh, env, fetchFn: okFetch(['alice']), log: () => {} });
 
 	const create = gh.calls.find((a) => a[0] === 'pr' && a[1] === 'create');
-	assert.ok(create, 'expected a PR to be created');
 	assert.ok(create.includes('--draft'));
 	assert.equal(create[create.indexOf('--base') + 1], TARGET_BRANCH);
 	assert.equal(create[create.indexOf('--head') + 1], SYNC_BRANCH);
+	const body = create[create.indexOf('--body') + 1];
+	assert.match(body, /Merge this PR with the normal merge button/);
+	assert.match(body, /nothing is squashed/);
+	assert.match(body, /conflict markers committed/);
 
 	// Owner requested as reviewer.
 	const edit = gh.calls.find((a) => a[0] === 'pr' && a[1] === 'edit');
-	assert.ok(edit, 'expected reviewers to be requested');
 	assert.equal(edit[edit.indexOf('--add-reviewer') + 1], 'alice');
 
-	// Conflicted state force-pushed to the sync branch.
-	const push = git.calls.find((a) => a[0] === 'push' && a.includes('--force'));
-	assert.ok(push, 'expected a force push to the sync branch');
-	assert.equal(push.at(-1), `HEAD:refs/heads/${SYNC_BRANCH}`);
+	// Only the sync branch is pushed — 3.x must not move.
+	const pushes = git.calls.filter((a) => a[0] === 'push');
+	assert.equal(pushes.length, 1);
+	assert.equal(pushes[0].at(-1), `HEAD:refs/heads/${SYNC_BRANCH}`);
+	assert.equal(git.calls.some((a) => a[0] === 'rebase'), false, 'no replay attempt while a conflict is unresolved');
 });
 
 test('openConflictPr degrades gracefully when owner resolution fails', async () => {
-	const git = makeStub([
-		[(a) => a[0] === 'diff', 'x.ts'],
-		[(a) => a[0] === 'log', 'sha1'],
-	]);
+	const git = makeStub([[(a) => a[0] === 'log', 'sha1']]);
 	const gh = makeStub([[(a) => a[0] === 'pr' && a[1] === 'create', 'https://github.com/n8n-io/n8n/pull/1']]);
 	const failingFetch = async () => ({ ok: false, status: 500, json: async () => ({}) });
 
@@ -129,8 +266,10 @@ test('openConflictPr degrades gracefully when owner resolution fails', async () 
 		gh,
 		repo: 'n8n-io/n8n',
 		token: 't',
-		masterSha: 'MASTER',
+		masterSha: MASTER,
+		preHead: PRE_HEAD,
 		pushUrl: 'https://push',
+		files: ['x.ts'],
 		fetchFn: failingFetch,
 		log: () => {},
 	});

--- a/.github/workflows/util-sync-master-to-3x.yml
+++ b/.github/workflows/util-sync-master-to-3x.yml
@@ -1,10 +1,18 @@
 # Syncs the master branch into the long-lived 3.x branch daily.
 #
-# During the v3 development window, master carries normal feature work (behind
-# opt-in flags) and 3.x is "master + breaking-change commits". This workflow
-# fast-forwards 3.x when possible, falls back to a three-way merge when 3.x has
-# diverged, and — when a merge conflict occurs — opens a draft conflict PR and
-# posts to #alerts-v3-sync. No further syncs run until that PR is resolved and merged.
+# During the v3 development window, master carries normal feature work (behind opt-in
+# flags) and 3.x is "master + breaking-change commits". This workflow keeps that literally
+# true by REPLAYING the 3.x-only commits onto master and force-pushing 3.x — so a clean
+# sync adds no commit at all, and every replayed commit is kept as-is (nothing squashed,
+# authors preserved). The content pushed is always verified to be exactly what a merge of
+# 3.x and master would produce.
+#
+# When master genuinely conflicts with 3.x, 3.x is left untouched: a draft conflict PR
+# carrying the conflict markers is opened on the sync branch and #alerts-v3-sync is notified.
+# The resolver fixes the markers in a commit of their own and merges that PR with the normal
+# merge button. No further syncs run until it is merged. 3.x itself never has markers at its
+# tip (nightly images build from it) and the merge commit holding them drops out of its
+# history at the next replay.
 #
 # See .github/DEVELOPING_V3.md for the full v3 development model.
 
@@ -42,7 +50,7 @@ jobs:
           app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
           private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
           # Scope the installation token to only what the sync needs.
-          permission-contents: write # push to 3.x / the conflict branch
+          permission-contents: write # force-push 3.x / push the conflict branch
           permission-pull-requests: write # open the conflict PR
           permission-issues: write # create the conflict label
 
@@ -80,7 +88,7 @@ jobs:
         run: |
           node .github/scripts/slack/notify.mjs \
             --channel '#alerts-v3-sync' \
-            --text "<${PR_URL}|master→3.x sync hit a conflict — resolve this PR>. Daily syncs are paused until it is merged. ${OWNERS_TEXT}"
+            --text "<${PR_URL}|master→3.x sync hit a conflict — resolve and merge this PR>. 3.x is untouched and daily syncs are paused until it is merged. ${OWNERS_TEXT}"
 
   notify-on-failure:
     name: Notify Slack on failure


### PR DESCRIPTION
## Summary

The daily master→3.x sync ran `git merge`, which added a merge commit on every run now that 3.x carries breaking commits. It now replays the 3.x-only commits onto master and force-pushes, so a clean sync adds no commit at all and keeps every replayed commit as-is — nothing squashed, messages and authors preserved.

Whatever route a run takes, the content pushed is verified to be exactly the tree that merging 3.x with master produces, and to carry no conflict markers; either check failing fails the run instead of rewriting 3.x.

On a real conflict, 3.x is left untouched and the draft conflict PR is opened as before, carrying the conflict markers: they are the review surface, and the required checks stay red until they are fixed, so the PR cannot be merged half-resolved. The resolver fixes them in a commit of their own and merges with the normal merge button, so master's commits arrive as-is. 3.x never has markers at its tip — nightly images build from it — and the merge commit holding them drops out of its history at the next replay.

That next replay is what makes 3.x linear again: the plain replay stalls, because a fix recorded around a merge commit leaves no patch to replay, so it replays once more with 3.x's side favoured and the resolver's fix commit does the real work. The halt gate, owner attribution and the Slack alert are unchanged.


## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

