### PR TITLE
fix(core): Exclude non-referenceable credentials from MCP workflow reads (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
@@ -110,7 +110,7 @@ describe('get-workflow-details MCP tool', () => {
 			expect(payload.workflow.canExecute).toBe(true);
 		});
 
-		test('drops internal credential fields, keeping only id and name', async () => {
+		test('keeps only id and name for real credentials and drops AI Gateway (null-id) slots', async () => {
 			const workflow = createWorkflow({
 				nodes: [
 					{
@@ -123,6 +123,18 @@ describe('get-workflow-details MCP tool', () => {
 						parameters: {},
 						credentials: {
 							openAiApi: { id: null, name: 'n8n credits', __aiGatewayManaged: true },
+						},
+					},
+					{
+						id: 'node-2',
+						name: 'HTTP Request',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 1,
+						position: [0, 0],
+						disabled: false,
+						parameters: {},
+						credentials: {
+							httpHeaderAuth: { id: 'cred-1', name: 'HeaderAuth', extra: 'internal' },
 						},
 					},
 				] as INode[],
@@ -145,8 +157,11 @@ describe('get-workflow-details MCP tool', () => {
 				{ workflowId: 'wf-1' },
 			);
 
-			expect(payload.workflow.nodes[0].credentials).toEqual({
-				openAiApi: { id: null, name: 'n8n credits' },
+			// Null-id managed slot is dropped entirely (nothing to reference)
+			expect(payload.workflow.nodes[0]).not.toHaveProperty('credentials');
+			// Real credential is reduced to id and name, internal fields removed
+			expect(payload.workflow.nodes[1].credentials).toEqual({
+				httpHeaderAuth: { id: 'cred-1', name: 'HeaderAuth' },
 			});
 		});
 

--- a/packages/cli/src/modules/mcp/tools/schemas.ts
+++ b/packages/cli/src/modules/mcp/tools/schemas.ts
@@ -9,7 +9,9 @@ import z from 'zod';
 
 export const nodeCredentialSummarySchema = z
 	.object({
-		id: z.string().nullable().describe('The credential ID; null for n8n-managed credentials'),
+		id: z
+			.string()
+			.describe('The credential ID, used to reference this credential in write operations'),
 		name: z.string().describe('The credential name'),
 	})
 	.describe('The credential assigned to this slot (id and name only, never secret data)');
@@ -29,17 +31,21 @@ export const nodeSchema = z
 
 /**
  * Reduces a node's credentials to `{ id, name }` per slot for the read path,
- * dropping internal fields (e.g. n8n Connect markers) while keeping enough for
- * clients to reuse the workflow's existing credentials in write operations.
+ * keeping only slots a client can reference by id when reusing them. Any slot
+ * with no id is dropped; in practice those are AI Gateway synthetic sentinels
+ * (`__aiGatewayManaged`, always `id: null`), which have no id to reference and
+ * whose marker is stripped here, leaving them indistinguishable from a real
+ * credential. DB-backed managed credentials (`isManaged`) keep a real id and
+ * are retained.
  */
 export const sanitizeNodeCredentials = ({ credentials, ...node }: INode) => {
-	if (!credentials || Object.keys(credentials).length === 0) return node;
-	return {
-		...node,
-		credentials: Object.fromEntries(
-			Object.entries(credentials).map(([type, { id, name }]) => [type, { id, name }]),
-		),
-	};
+	const referenceable: Array<[string, { id: string; name: string }]> = [];
+	for (const [type, cred] of Object.entries(credentials ?? {})) {
+		if (!cred || cred.id == null) continue;
+		referenceable.push([type, { id: cred.id, name: cred.name }]);
+	}
+	if (referenceable.length === 0) return node;
+	return { ...node, credentials: Object.fromEntries(referenceable) };
 };
 
 export const connectionsSchema = z


### PR DESCRIPTION
## Summary

Follow-up to #35173, which started returning node credentials as `{ id, name }` so agents can reuse them. This narrows it to only surface credentials an agent can actually reference by id.

`sanitizeNodeCredentials` now drops null-id slots. In practice those are AI Gateway synthetic sentinels (`__aiGatewayManaged`, e.g. `{ id: null, name: 'n8n credits' }`, no DB record). They don't belong in a reuse hint: there's no id to reference, and the read path strips the `__aiGatewayManaged` marker, so the slot is indistinguishable from a real credential. DB-backed managed credentials (`isManaged`, e.g. cloud OpenAI free credits) have real ids and are retained.

Also tightens `nodeCredentialSummarySchema.id` from `string | null` to `string`, since a null id is no longer emitted.

## How to test

1. `get_workflow_details` on a workflow whose node uses n8n credits (AI Gateway) -> that node has no `credentials` in the output.
2. `get_workflow_details` on a workflow with a normal saved credential -> node shows `{ credType: { id, name } }`, internal fields removed.

## Review / merge checklist

- [x] Tests updated (`get-workflow-details.tool.test.ts`); 13 tests pass, cli typecheck passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

