### PR TITLE
test(editor): Remove a dead `vi.mock` of an unresolvable path in `ReadyToRunButton` test (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/readyToRun/components/ReadyToRunButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/readyToRun/components/ReadyToRunButton.test.ts
@@ -8,12 +8,6 @@ import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/
 import { useFoldersStore } from '@/features/core/folders/folders.store';
 import type { Project } from '@/features/collaboration/projects/projects.types';
 
-vi.mock('@/composables/useToast', () => ({
-	useToast: () => ({
-		showError: vi.fn(),
-	}),
-}));
-
 vi.mock('@/features/collaboration/projects/composables/useProjectPages', () => ({
 	useProjectPages: () => ({
 		isOverviewSubPage: false,


### PR DESCRIPTION
## Summary

Deletes a six-line `vi.mock` block in `ReadyToRunButton.test.ts` that mocked a module path which resolves to nothing.

```ts
vi.mock('@/composables/useToast', () => ({ useToast: () => ({ showError: vi.fn() }) }));
```

`@/*` maps to `editor-ui/src/*` (`tsconfig.json:23`), and `src/composables/` does not exist — so the specifier never resolved and the factory never ran.

**The mock's intent was live, but it never took effect.** `ReadyToRunButton.vue` uses `useReadyToRunStore`, and `readyToRun.store.ts:13` imports the real `useToast` from `@n8n/composables/useToast` — the specifier the sibling `readyToRun.store.test.ts` already mocks correctly. Because this one pointed at the wrong path, the real composable has been loading unmocked in this suite all along. Nothing exercises it: the only test that reaches the store's error path stubs `claimCreditsAndOpenWorkflow` with `mockResolvedValue`, so `toast.showError` is never called.

Deleting an unused mock registration cannot change the module graph — the real `useToast` was already loading unmocked and still is. Behaviour-neutral, no assertion touched.

One note for whoever extends this suite next: a future test that lets the store's error path run needs `vi.mock('@n8n/composables/useToast', …)`. This is not the "missing `app/` segment" it looks like — `@/app/composables/useToast.ts` does not exist either; the module lives in the `@n8n/composables` workspace package.

This was the last `@/composables/*` reference in `editor-ui/src` (now zero).

## How to test

`vue-tsc` is not the oracle here — a specifier inside a `vi.mock` string is invisible to typecheck, so the suite is the only thing that can confirm this. From `packages/frontend/editor-ui`:

```bash
pnpm test src/features/workflows/readyToRun/
```

Verified before and after the deletion on this branch's base:

| run | result |
| --- | --- |
| `ReadyToRunButton.test.ts` before | 8/8 passed |
| `ReadyToRunButton.test.ts` after | 8/8 passed |
| whole `readyToRun/` feature after | 67/67 passed (3 files) |

## Related Linear tickets, Github issues, and Community forum posts

Surfaced during the `useToast` shim retirement and deliberately left out of that PR to keep an otherwise mechanical 374-file diff purely mechanical.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — n/a, no user-facing or documented behaviour changes.
- [x] Tests included. — no new test; this deletes dead test scaffolding, and the existing suite is the regression guard (67/67 green).
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

