### PR TITLE
refactor(editor): Remove the dead `NotificationOptions` re-export chain (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/stores/src/notifications.store.ts
+++ b/packages/frontend/@n8n/stores/src/notifications.store.ts
@@ -4,13 +4,6 @@ import { ref, type Ref } from 'vue';
 import { STORES } from './constants';
 
 /**
- * `NotificationOptions` now lives in `@n8n/composables`, alongside the toast
- * layer that owns the contract, since that package sits below this one
- * (N8N-100). Re-exported here so existing importers stay unchanged.
- */
-export type { NotificationOptions } from '@n8n/composables/types/notification';
-
-/**
  * Public surface of the notifications store. Declared explicitly so the emitted
  * type declarations reference these named types instead of inlining the
  * structural Vue ref types, keeping the declarations portable across the package

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -697,10 +697,6 @@ export type TargetNodeParameterContext = {
 	parameterPath: string;
 };
 
-// Relocated to `@n8n/stores/notifications.store` alongside the notifications
-// store; re-exported here for existing importers.
-export type { NotificationOptions } from '@n8n/stores/notifications.store';
-
 export type NodeFilterType =
 	| typeof REGULAR_NODE_CREATOR_VIEW
 	| typeof TRIGGER_NODE_CREATOR_VIEW


### PR DESCRIPTION
## Summary

The third dead-surface finding flagged in #35345's description and deliberately
left out of it. 11 lines, all deletions, no behaviour change.

Two **chained** type re-export hops, each carrying a comment that promises
importers which do not exist:

| File | Claimed |
| --- | --- |
| `packages/frontend/editor-ui/src/Interface.ts` | `NotificationOptions` *"re-exported here for existing importers"* — from `@n8n/stores/notifications.store` |
| `packages/frontend/@n8n/stores/src/notifications.store.ts` | the same type *"Re-exported here so existing importers stay unchanged"* — from `@n8n/composables/types/notification`, the real home |

A repo-wide search for the symbol returns **11 hits, and none of them is an
importer through either hop:**

- `@n8n/composables/src/types/notification.ts` — the declaration.
- `@n8n/composables/src/useToast.ts` (5 hits) — imports it from `./types/notification`, i.e. straight from the declaration, bypassing both hops.
- `useBrowserNotifications.ts` and its test (2 hits) — the **DOM lib global**, not this symbol. The composable passes `notificationOptions` to `new Notification(title, notificationOptions)`; the test types a `MockNotification` constructor arg the same way. Neither file imports the type — same family as the `NotificationPermission` global two lines up.
- The two re-export lines themselves, plus the sentence in `notifications.store.ts`'s doc comment.

Every importer of `@n8n/stores/notifications.store` — `toastNotifier.ts`,
`usePostMessageHandler.ts`, and both of their tests — takes
`useNotificationsStore`, never the type.

Rewriting the comments truthfully would leave 9 lines reading "re-exported for
no one", so the lines go instead. Two-way door: a revert restores them.

### What is deliberately left standing

`ModalState`'s near-identical comment in the same file is **true** — it is
re-exported from `@n8n/frontend-module-sdk` and `Modals` / `NewCredentialsModal`
build on it in place. Untouched, as is the live declaration in
`@n8n/composables`. The phrasing is not word-for-word across the three sites and
the pattern is not uniformly false, so the check here was the consumer set, not
the comment wording.

`@n8n/composables` stays a dependency of `@n8n/stores` on its own merits
(`versions.store.ts`, `composables/useBasePageRedirectionHelper.ts`), so
removing this import leaves no orphaned dependency.

## How to test

Verified at head `8fb0ed5f`, branched off master `c6917a19`, which contains
`9616f874` (the merge commit of #35345). `notifications.store.ts` has a **zero
diff** since the finding was first measured, and #35345 is the only commit that
touched `Interface.ts` in that window — so the consumer set above was
re-derived against current master, not carried over.

| Check | Result |
| --- | --- |
| `editor-ui` typecheck (`vue-tsc --noEmit`) | exit 0, **0 TS errors** |
| `@n8n/stores` typecheck (`vue-tsc --noEmit`) | exit 0, **0 TS errors** |
| `@n8n/stores` + `editor-ui` lint | exit 0, **0 errors** (both cache-missed; editor-ui's 1918 warnings are its pre-existing baseline, and `Interface.ts`'s 2 are unused-eslint-disable directives at line 332, far from this diff) |
| `@n8n/stores` full suite | **11 files / 173 passed** |
| The three `editor-ui` suites covering this surface — `useBrowserNotifications`, `toastNotifier`, `usePostMessageHandler` | **3 files / 64 passed** |

Typecheck alone is not a sufficient oracle here: `vue-tsc` cannot see a module
specifier inside a `vi.mock` string. So the symbol was grepped across mock
factories too — there is no `vi.mock` of `@/Interface` or of
`@n8n/stores/notifications.store` anywhere in the repo, and no mock factory
mentions the type. Both deleted lines are `export type`, which is erased at
build time and cannot be reached at runtime regardless.

```bash
# from packages/frontend/@n8n/stores
pnpm test && pnpm typecheck && pnpm lint

# from the repo root
pnpm turbo typecheck lint --filter=@n8n/stores --filter=n8n-editor-ui
```

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35345, which found this while under review, scoped it out (it sits
outside that PR's 9-line diff), and gated it on its own merge because both PRs
edit `Interface.ts`. That gate is now satisfied.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- N/A: no user-facing or documented surface changes -->
- [x] Tests included. <!-- Deletions only. No regression test applies to removing dead surface; the existing suites are the guard and are green. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

