### PR TITLE
test(editor): Retire redundant `importOriginal` spreads and guard the telemetry boundary (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/composables/src/__tests__/packageBoundary.test.ts
+++ b/packages/frontend/@n8n/composables/src/__tests__/packageBoundary.test.ts
@@ -72,11 +72,18 @@ describe('telemetry registration surface', () => {
 			expect.arrayContaining(['setTelemetry', 'TelemetryKey', 'getRegisteredTelemetry']),
 		);
 
-		// Compared as runtime export names, so every re-export shape is caught —
-		// named, aliased, or `export *`. An intersection rather than a fixed
-		// denylist, so a registration symbol added later needs no edit here.
-		// Type-only re-exports are erased and harmless: the plugin needs values.
-		const reExported = Object.keys(useTelemetryModule).filter((name) => name in registry);
+		// Matched on name *and* value identity, because each half catches what the
+		// other misses: name catches a local re-implementation exported under a
+		// registration name, value catches an aliased re-export
+		// (`setTelemetry as registerTelemetry`), whose name the registry never
+		// holds. `export *` trips both. Neither half is a fixed denylist, so a
+		// registration symbol added later is covered without editing this test.
+		// Type-only re-exports stay uncaught by design — erased at runtime, and
+		// starving the plugin takes the value.
+		const registryValues = new Set<unknown>(Object.values(registry));
+		const reExported = Object.entries(useTelemetryModule)
+			.filter(([name, value]) => name in registry || registryValues.has(value))
+			.map(([name]) => name);
 
 		expect(reExported).toEqual([]);
 	});

--- a/packages/frontend/@n8n/composables/src/__tests__/packageBoundary.test.ts
+++ b/packages/frontend/@n8n/composables/src/__tests__/packageBoundary.test.ts
@@ -51,3 +51,33 @@ describe('package boundary', () => {
 		expect(offenders).toEqual([]);
 	});
 });
+
+/**
+ * `useTelemetry` is `vi.mock`ed in ~100 editor-ui test files, and a mock factory
+ * replaces the whole module. Re-exporting the registration surface from there
+ * puts it back behind those partial factories and starves the telemetry plugin's
+ * own bootstrap import of it — the failure this split fixed. Registration stays
+ * in `./registries/telemetryRegistry`, which nothing mocks.
+ */
+describe('telemetry registration surface', () => {
+	it('is not re-exported from the useTelemetry module', async () => {
+		const [useTelemetryModule, registry] = await Promise.all([
+			import('../useTelemetry'),
+			import('../registries/telemetryRegistry'),
+		]);
+
+		// Guards against a vacuous pass: were these renamed or moved, the
+		// intersection below would come back empty for the wrong reason.
+		expect(Object.keys(registry)).toEqual(
+			expect.arrayContaining(['setTelemetry', 'TelemetryKey', 'getRegisteredTelemetry']),
+		);
+
+		// Compared as runtime export names, so every re-export shape is caught —
+		// named, aliased, or `export *`. An intersection rather than a fixed
+		// denylist, so a registration symbol added later needs no edit here.
+		// Type-only re-exports are erased and harmless: the plugin needs values.
+		const reExported = Object.keys(useTelemetryModule).filter((name) => name in registry);
+
+		expect(reExported).toEqual([]);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/CompareCollectionView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/CompareCollectionView.test.ts
@@ -11,8 +11,7 @@ import type { EvaluationCollectionDetail } from '../evalCollections.types';
 import CompareCollectionView from './CompareCollectionView.vue';
 
 const track = vi.fn();
-vi.mock('@n8n/composables/useTelemetry', async (importOriginal) => ({
-	...(await importOriginal<typeof import('@n8n/composables/useTelemetry')>()),
+vi.mock('@n8n/composables/useTelemetry', () => ({
 	useTelemetry: () => ({ track }),
 }));
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -51,8 +51,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 	},
 });
 
-vi.mock('@n8n/composables/useTelemetry', async (importOriginal) => ({
-	...(await importOriginal<typeof import('@n8n/composables/useTelemetry')>()),
+vi.mock('@n8n/composables/useTelemetry', () => ({
 	useTelemetry: () => ({ track: telemetryTrackSpy }),
 }));
 

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts
@@ -42,10 +42,9 @@ vi.mock('vue-router', () => ({
 	},
 }));
 
-vi.mock('@n8n/composables/useTelemetry', async (importOriginal) => {
+vi.mock('@n8n/composables/useTelemetry', () => {
 	const track = vi.fn();
 	return {
-		...(await importOriginal<typeof import('@n8n/composables/useTelemetry')>()),
 		useTelemetry: () => {
 			return {
 				track,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.test.ts
@@ -30,8 +30,7 @@ vi.mock('@/features/ndv/shared/ndv.store', async (importOriginal) => {
 	};
 });
 
-vi.mock('@n8n/composables/useTelemetry', async (importOriginal) => ({
-	...(await importOriginal<typeof import('@n8n/composables/useTelemetry')>()),
+vi.mock('@n8n/composables/useTelemetry', () => ({
 	useTelemetry: () => ({
 		track: vi.fn(),
 	}),


### PR DESCRIPTION
## Summary

Tail cleanup for the telemetry registration split (#35350). Two changes, one surface.

**1. Four `importOriginal` spreads removed.** After the split, `@n8n/composables/useTelemetry` has exactly one runtime export — `useTelemetry`. Each of these four factories spread `importOriginal()` and then overrode that single export, so the spread contributed nothing:

- `ParameterInputExpanded.test.ts`
- `CompareCollectionView.test.ts`
- `InstanceAiThreadView.test.ts`
- `SourceControlPushModal.test.ts`

They were added when `setTelemetry` still lived in that module, to stop a partial mock starving the telemetry plugin's bootstrap import. The split made that unreachable — the plugin no longer imports the mocked module at all.

No factory needed its spread kept for an unrelated export, so no "load-bearing" comments were added. Checked by resolving every import statement targeting the module across `packages`: 251 statements, and the only named symbol any of them imports is `useTelemetry`. The four namespace imports (`import * as telemetryModule`) are in other test files and are unaffected.

**2. The registration surface is now self-enforcing.** Nothing stopped someone re-adding `export { setTelemetry } from './registries/telemetryRegistry'` and reopening the class behind ~100 partial mock factories; an in-file comment was the only guard. `packageBoundary.test.ts` now asserts it.

The assertion works on the two modules' **runtime exports** rather than source text, matching on both name and value identity. Each half is load-bearing:

| re-export shape | caught by |
| --- | --- |
| `export { setTelemetry }`, `export *` | either half |
| `export { setTelemetry as registerTelemetry }` — name the registry never holds | value identity |
| a local re-implementation exported as `setTelemetry` — distinct value object | name |

Because neither half is a fixed denylist, a registration symbol added to the registry later is covered without editing the test. An `arrayContaining` guard on the registry's own export names keeps a rename there from turning the check into a vacuous pass.

Type-only re-exports are deliberately not caught: they are erased at runtime, and starving the plugin takes the *value*.

## How to test

Behaviour-neutral — test-only change, no production code touched.

```bash
# The four de-spread suites, plus the partial-mock gate from #35350
cd packages/frontend/editor-ui
pnpm vitest run \
  src/features/ndv/parameters/components/ParameterInputExpanded.test.ts \
  src/features/ai/evaluation.ee/views/CompareCollectionView.test.ts \
  src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts \
  src/features/integrations/sourceControl.ee/components/SourceControlPushModal.test.ts \
  src/app/plugins/telemetry/telemetryRegistration.test.ts
# → 5 passed, 71 tests

cd ../@n8n/composables && pnpm vitest run src/__tests__/packageBoundary.test.ts src/useTelemetry.test.ts
# → 2 passed, 7 tests
```

Verified locally, all green, plus `typecheck` and `lint` on both packages (0 errors).

The partial-mock case was proven rather than inferred from the type error: `telemetryRegistration.test.ts` mocks the module with the bare partial factory and asserts both module-load and injection registration still resolve, and `SourceControlPushModal.test.ts` keeps asserting `telemetry.track` was called — so the de-spread factories are still binding, not silently letting the real implementation through.

The guard was checked against seven controls, each injected into `useTelemetry.ts`, run, then reverted:

| control | result |
| --- | --- |
| baseline, nothing injected | passes — no false positive |
| `export { setTelemetry }` | caught |
| `export *` | caught — all three symbols |
| `export { TelemetryKey }` | caught |
| `export { setTelemetry as registerTelemetry }` | caught — `expected [ 'registerTelemetry' ]` |
| `export { TelemetryKey as InjectTelemetry }` | caught — Symbol identity behaves the same |
| local `export function setTelemetry()` | caught by the name half |

The name half was confirmed necessary by running a value-only variant of the guard against that last control: it slips through, the union catches it.

The first pass of this guard matched on name only, so both alias shapes slipped through it while its comment claimed they were covered. Caught in review; the follow-up commit closes the gap and corrects the comment.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35350. 

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
