### PR TITLE
fix(core): Derive OAuth resource URL from the served endpoint (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpTrigger.node.test.ts
@@ -399,7 +399,7 @@ describe('McpTrigger', () => {
 			const node = mock<INode>({ typeVersion: opts.typeVersion, name: 'MCP Server Trigger' });
 
 			mockContext.getNodeParameter.mockReturnValue('n8nOAuth2');
-			mockContext.getNodeWebhookUrl.mockReturnValue(resourceUrl);
+			mockContext.getWebhookResourceUrl.mockReturnValue(resourceUrl);
 			mockContext.getWebhookName.mockReturnValue('setup');
 			mockContext.getRequestObject.mockReturnValue(req as never);
 			mockContext.getResponseObject.mockReturnValue(resp as never);

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/webhook-context.test.ts
@@ -187,7 +187,13 @@ describe('WebhookContext', () => {
 		});
 	});
 
-	describe('getNodeWebhookUrl', () => {
+	describe('webhook URLs', () => {
+		const WEBHOOK_KINDS = [
+			['a generic webhook', undefined],
+			['a form webhook', 'form'],
+			['an MCP webhook', 'mcp'],
+		] as const;
+
 		const buildUrlContext = (webhookNodeType: 'form' | 'mcp' | undefined, isTest: boolean) => {
 			const urlNodeType = mock<INodeType>({
 				description: {
@@ -202,6 +208,8 @@ describe('WebhookContext', () => {
 			const urlAdditionalData = mock<IWorkflowExecuteAdditionalData>({
 				formBaseUrl: 'http://localhost/prod-webhook',
 				formTestBaseUrl: 'http://localhost/test-webhook',
+				mcpBaseUrl: 'http://localhost/prod-webhook',
+				mcpTestBaseUrl: 'http://localhost/test-webhook',
 				webhookBaseUrl: 'http://localhost/prod-webhook',
 				webhookTestBaseUrl: 'http://localhost/test-webhook',
 			});
@@ -221,19 +229,32 @@ describe('WebhookContext', () => {
 			);
 		};
 
-		it('should use the test base URL for a form webhook running as a test', () => {
-			const context = buildUrlContext('form', true);
-			expect(context.getNodeWebhookUrl('default')).toContain('test-webhook');
+		describe('getNodeWebhookUrl', () => {
+			it.each(WEBHOOK_KINDS)(
+				'should use the production base URL for %s running as a test',
+				(_label, nodeType) => {
+					const context = buildUrlContext(nodeType, true);
+					expect(context.getNodeWebhookUrl('default')).toContain('prod-webhook');
+				},
+			);
 		});
 
-		it('should use the production base URL for a form webhook running in production', () => {
-			const context = buildUrlContext('form', false);
-			expect(context.getNodeWebhookUrl('default')).toContain('prod-webhook');
-		});
+		describe('getWebhookResourceUrl', () => {
+			it.each(WEBHOOK_KINDS)(
+				'should use the test base URL for %s running as a test',
+				(_label, nodeType) => {
+					const context = buildUrlContext(nodeType, true);
+					expect(context.getWebhookResourceUrl('default')).toContain('test-webhook');
+				},
+			);
 
-		it('should ignore isTest for non-form/non-mcp webhooks (production base)', () => {
-			const context = buildUrlContext(undefined, true);
-			expect(context.getNodeWebhookUrl('default')).toContain('prod-webhook');
+			it.each(WEBHOOK_KINDS)(
+				'should use the production base URL for %s running in production',
+				(_label, nodeType) => {
+					const context = buildUrlContext(nodeType, false);
+					expect(context.getWebhookResourceUrl('default')).toContain('prod-webhook');
+				},
+			);
 		});
 	});
 

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -137,13 +137,6 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 	}
 
 	getNodeWebhookUrl(name: WebhookType): string | undefined {
-		// MCP and form webhooks are served under dedicated /mcp(+/mcp-test) and
-		// /form(+/form-test) endpoints; the OAuth resource URL must match the endpoint the
-		// request actually arrived on. Other webhook types keep their existing behaviour
-		// (production base) here.
-		const { nodeType } = this.webhookData.webhookDescription;
-		const isTest = nodeType === 'mcp' || nodeType === 'form' ? this.webhookData.isTest : undefined;
-
 		return getNodeWebhookUrl(
 			name,
 			this.workflow,
@@ -151,7 +144,20 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 			this.additionalData,
 			this.mode,
 			this.additionalKeys,
-			isTest,
+		);
+	}
+
+	getWebhookResourceUrl(name: WebhookType): string | undefined {
+		// Unlike `getNodeWebhookUrl`, names the endpoint actually being served, since token
+		// minting and verification must agree on it (see `IWebhookFunctions`).
+		return getNodeWebhookUrl(
+			name,
+			this.workflow,
+			this.node,
+			this.additionalData,
+			this.mode,
+			this.additionalKeys,
+			this.webhookData.isTest,
 		);
 	}
 

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -1072,7 +1072,7 @@ describe('FormTrigger, formWebhook', () => {
 			ctx.getNodeParameter.calledWith('responseMode').mockReturnValue('onReceived');
 			ctx.getNodeParameter.calledWith('authentication', 'none').mockReturnValue('n8nUserAuth');
 			ctx.getNodeParameter.calledWith('formFields.values').mockReturnValue(formFields);
-			ctx.getNodeWebhookUrl.mockReturnValue(resourceUrl);
+			ctx.getWebhookResourceUrl.mockReturnValue(resourceUrl);
 			ctx.getRequestObject.mockReturnValue(request as any);
 			ctx.getHeaderData.mockReturnValue(request.headers);
 			ctx.getResponseObject.mockReturnValue({

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -769,7 +769,7 @@ async function authenticateFormUserOrRespond(
 
 	if (oauth2Enabled) {
 		const res = context.getResponseObject();
-		const url = context.getNodeWebhookUrl('default');
+		const url = context.getWebhookResourceUrl('default');
 		if (!url) {
 			throw new UnexpectedError('Webhook URL not found for the node');
 		}

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -208,6 +208,7 @@ describe('Test Webhook Node', () => {
 				name: 'Webhook',
 			} as any);
 			context.getNodeWebhookUrl.calledWith('default').mockReturnValue(WEBHOOK_URL);
+			context.getWebhookResourceUrl.calledWith('default').mockReturnValue(WEBHOOK_URL);
 			context.getNodeParameter.mockImplementation((paramName: string) => {
 				if (paramName === 'options') return {};
 				if (paramName === 'responseMode') return 'onReceived';

--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -244,6 +244,7 @@ export async function testWebhookTriggerNode(
 		getHeaderData: () => options.headerData ?? request.headers ?? {},
 		getInputConnectionData: async () => ({}),
 		getNodeWebhookUrl: (name) => `/test-webhook-url/${name}`,
+		getWebhookResourceUrl: (name) => `/test-webhook-url/${name}`,
 		getParamsData: () => ({}),
 		getQueryData: () => ({}),
 		getRequestObject: () => request,

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1531,7 +1531,14 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 		fallbackValue?: any,
 		options?: IGetNodeParameterOptions,
 	): NodeParameterValueType | object;
+	/** Always the production endpoint, whichever endpoint the request arrived on. */
 	getNodeWebhookUrl: (name: WebhookType) => string | undefined;
+	/**
+	 * The endpoint actually being served (`/webhook-test/…` on a test run), which
+	 * identifies the webhook as an OAuth protected resource. Minting and verifying a
+	 * token both derive the resource from it, so it must track the endpoint served.
+	 */
+	getWebhookResourceUrl: (name: WebhookType) => string | undefined;
 	evaluateExpression(expression: string, itemIndex?: number): NodeParameterValueType;
 	getParamsData(): object;
 	getQueryData(): object;

--- a/packages/workflow/src/n8n-oauth2-auth.ts
+++ b/packages/workflow/src/n8n-oauth2-auth.ts
@@ -56,7 +56,7 @@ export const n8nOAuth2Auth = async (
 	  }
 	| 'handled'
 > => {
-	const webhookUrl = context.getNodeWebhookUrl('default');
+	const webhookUrl = context.getWebhookResourceUrl('default');
 	if (!webhookUrl) {
 		throw new UnexpectedError('Webhook URL is not available');
 	}

--- a/packages/workflow/test/n8n-oauth2-auth.test.ts
+++ b/packages/workflow/test/n8n-oauth2-auth.test.ts
@@ -18,7 +18,9 @@ const buildContext = (opts: {
 	response.send.mockReturnValue(response);
 
 	const context = mock<IWebhookFunctions>();
-	context.getNodeWebhookUrl.mockReturnValue('webhookUrl' in opts ? opts.webhookUrl : WEBHOOK_URL);
+	context.getWebhookResourceUrl.mockReturnValue(
+		'webhookUrl' in opts ? opts.webhookUrl : WEBHOOK_URL,
+	);
 	context.getResponseObject.mockReturnValue(response);
 	context.getRequestObject.mockReturnValue({
 		headers: opts.authorization ? { authorization: opts.authorization } : {},


### PR DESCRIPTION
## Summary

A Webhook node using `n8nOAuth2` could never be called on `/webhook-test/*`: `WebhookContext.getNodeWebhookUrl` only tracked the test endpoint for `mcp` and `form` webhooks, so the node identified itself by its **production** URL while the token had been minted for the **test** URL, and the audience check rejected every call with `invalid_token`. This splits the two meanings instead of widening the existing exception — `getNodeWebhookUrl` always names the production endpoint, and the new `IWebhookFunctions.getWebhookResourceUrl` names the endpoint actually being served. Only the three OAuth resource derivations use the new accessor (`n8nOAuth2Auth` for the Webhook node and the MCP trigger, plus the Form OAuth path), which were also the only callers of the old `mcp`/`form` exception, so no other node changes behaviour.

## How to test

Requires `N8N_ENV_FEAT_WEBHOOK_PRIVATE_CREDENTIALS=true` and the `dynamic-credentials` module active.

1. Add a Webhook node with `Authentication: n8n user OAuth`, then hit **Listen for test event**.
2. Register an OAuth client against the n8n OAuth server and run the consent flow for `http://localhost:5678/webhook-test/<path>`.
3. `curl http://localhost:5678/webhook-test/<path> -H 'Authorization: Bearer <token>'` — the workflow now runs. On `master` this returns `Bearer realm="n8n Webhook", …, error="invalid_token"`, and the advertised `resource_metadata` wrongly points at `/oauth-protected-resource/webhook/<path>`.
4. Production mode (`/webhook/<path>` on an active workflow) and the MCP/Form OAuth flows are unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1155

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


