### PR TITLE
fix: Enumerate the `@n8n/composables` export map so internal chunks stay private (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/composables/package.json
+++ b/packages/frontend/@n8n/composables/package.json
@@ -6,10 +6,80 @@
     "dist"
   ],
   "exports": {
-    "./*": {
-      "types": "./dist/*.d.mts",
-      "import": "./dist/*.mjs",
-      "require": "./dist/*.cjs"
+    "./injectionKeys": {
+      "types": "./dist/injectionKeys.d.mts",
+      "import": "./dist/injectionKeys.mjs",
+      "require": "./dist/injectionKeys.cjs"
+    },
+    "./registries/telemetryRegistry": {
+      "types": "./dist/registries/telemetryRegistry.d.mts",
+      "import": "./dist/registries/telemetryRegistry.mjs",
+      "require": "./dist/registries/telemetryRegistry.cjs"
+    },
+    "./structuralComputed": {
+      "types": "./dist/structuralComputed.d.mts",
+      "import": "./dist/structuralComputed.mjs",
+      "require": "./dist/structuralComputed.cjs"
+    },
+    "./types/notification": {
+      "types": "./dist/types/notification.d.mts",
+      "import": "./dist/types/notification.mjs",
+      "require": "./dist/types/notification.cjs"
+    },
+    "./useClipboard": {
+      "types": "./dist/useClipboard.d.mts",
+      "import": "./dist/useClipboard.mjs",
+      "require": "./dist/useClipboard.cjs"
+    },
+    "./useDebounce": {
+      "types": "./dist/useDebounce.d.mts",
+      "import": "./dist/useDebounce.mjs",
+      "require": "./dist/useDebounce.cjs"
+    },
+    "./useDeviceSupport": {
+      "types": "./dist/useDeviceSupport.d.mts",
+      "import": "./dist/useDeviceSupport.mjs",
+      "require": "./dist/useDeviceSupport.cjs"
+    },
+    "./useDocumentTitle": {
+      "types": "./dist/useDocumentTitle.d.mts",
+      "import": "./dist/useDocumentTitle.mjs",
+      "require": "./dist/useDocumentTitle.cjs"
+    },
+    "./useExternalHooks": {
+      "types": "./dist/useExternalHooks.d.mts",
+      "import": "./dist/useExternalHooks.mjs",
+      "require": "./dist/useExternalHooks.cjs"
+    },
+    "./useShortKeyPress": {
+      "types": "./dist/useShortKeyPress.d.mts",
+      "import": "./dist/useShortKeyPress.mjs",
+      "require": "./dist/useShortKeyPress.cjs"
+    },
+    "./useStorage": {
+      "types": "./dist/useStorage.d.mts",
+      "import": "./dist/useStorage.mjs",
+      "require": "./dist/useStorage.cjs"
+    },
+    "./useStyles": {
+      "types": "./dist/useStyles.d.mts",
+      "import": "./dist/useStyles.mjs",
+      "require": "./dist/useStyles.cjs"
+    },
+    "./useTelemetry": {
+      "types": "./dist/useTelemetry.d.mts",
+      "import": "./dist/useTelemetry.mjs",
+      "require": "./dist/useTelemetry.cjs"
+    },
+    "./useThrottleWithReactiveDelay": {
+      "types": "./dist/useThrottleWithReactiveDelay.d.mts",
+      "import": "./dist/useThrottleWithReactiveDelay.mjs",
+      "require": "./dist/useThrottleWithReactiveDelay.cjs"
+    },
+    "./useToast": {
+      "types": "./dist/useToast.d.mts",
+      "import": "./dist/useToast.mjs",
+      "require": "./dist/useToast.cjs"
     }
   },
   "scripts": {

--- a/packages/frontend/@n8n/composables/src/__tests__/exportMap.test.ts
+++ b/packages/frontend/@n8n/composables/src/__tests__/exportMap.test.ts
@@ -1,0 +1,90 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+/**
+ * The export map must list every entry point explicitly and nothing else.
+ *
+ * A `./*` pattern is not equivalent: Node subpath patterns are greedy (`*` spans
+ * `/`), so a wildcard publishes every file tsdown emits under `dist/` — including
+ * the shared chunks it hoists out of multiple entries. Those chunks export only
+ * mangled aliases, and the aliases disagree between runtime and declarations
+ * (the same letter was `setTelemetry` in one and `TelemetryKey` in the other),
+ * so a wildcard hands consumers a type-unsound public surface nobody meant to
+ * ship. Enumerating costs one manifest edit per new module; this test is what
+ * makes that edit impossible to forget.
+ */
+describe('export map', () => {
+	// `process.cwd()` rather than `import.meta.url`: the jsdom environment does
+	// not give test modules a `file:` URL. Vitest runs with the package as cwd.
+	const packageRoot = process.cwd();
+
+	// `JSON.parse` in a try/catch rather than `jsonParse` from `n8n-workflow` as
+	// its neighbour in `packageBoundary.test.ts` does — both satisfy
+	// `no-uncaught-json-parse`, and this guard exists to fail fast for whoever
+	// adds the next composable, so it must run without the backend chain built.
+	const manifest = ((): { exports: Record<string, Record<string, string>> } => {
+		const raw = readFileSync(join(packageRoot, 'package.json'), 'utf8');
+		try {
+			return JSON.parse(raw) as { exports: Record<string, Record<string, string>> };
+		} catch (error) {
+			throw new Error(`package.json is not valid JSON: ${(error as Error).message}`);
+		}
+	})();
+
+	/**
+	 * The entry points tsdown builds, derived from the same globs as
+	 * `tsdown.config.ts` — keep the two in step.
+	 */
+	const entryPoints = (() => {
+		const srcDir = join(packageRoot, 'src');
+
+		const walk = (dir: string): string[] =>
+			readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+				const path = join(dir, entry.name);
+				return entry.isDirectory() ? walk(path) : [path];
+			});
+
+		return walk(srcDir)
+			.map((file) => relative(srcDir, file).split(sep).join('/'))
+			.filter(
+				(file) =>
+					file.endsWith('.ts') &&
+					!file.endsWith('.test.ts') &&
+					!file.endsWith('.d.ts') &&
+					!file.startsWith('__tests__/'),
+			)
+			.map((file) => file.replace(/\.ts$/, ''))
+			.sort();
+	})();
+
+	it('has an entry point to check', () => {
+		expect(entryPoints.length).toBeGreaterThan(0);
+	});
+
+	it('exports exactly the built entry points', () => {
+		// Failure here names the fix: a listed-but-absent key is a stale entry to
+		// delete, a missing one is a new module to add to `exports`.
+		expect(Object.keys(manifest.exports).sort()).toEqual(entryPoints.map((e) => `./${e}`));
+	});
+
+	it('declares no subpath pattern', () => {
+		// The regression guard: a `*` anywhere re-publishes the hoisted chunks.
+		expect(Object.keys(manifest.exports).filter((key) => key.includes('*'))).toEqual([]);
+	});
+
+	it('points every subpath at its own emitted files', () => {
+		// Catches a copy-paste target, which set equality above cannot see.
+		const expected = Object.fromEntries(
+			entryPoints.map((entry) => [
+				`./${entry}`,
+				{
+					types: `./dist/${entry}.d.mts`,
+					import: `./dist/${entry}.mjs`,
+					require: `./dist/${entry}.cjs`,
+				},
+			]),
+		);
+
+		expect(manifest.exports).toEqual(expected);
+	});
+});


### PR DESCRIPTION
## Summary

`@n8n/composables` declared a single `./*` subpath pattern. Node subpath patterns are greedy — `*` spans `/` — so every file tsdown emits under `dist/` became a public subpath, including the chunks rolldown hoists out of shared imports. Five were reachable:

| chunk | conditions | exports |
|---|---|---|
| `injectionKeys2` | import, require | `["t"]` |
| `useExternalHooks2` | import, require | `["n","r","t"]` |
| `useTelemetry2` | import, require | `["t"]` |
| `telemetryRegistry` | import, require, types | runtime `["n","r","t"]` / dts `["a","i","n","o","r","t"]` |
| `notification` | types only | dts `["n","r","t"]`, **no runtime sibling** |

That surface is type-unsound rather than merely useless: the mangled letters disagree between runtime and declarations, so `t` is the `TelemetryKey` value in `telemetryRegistry.mjs` but the `Telemetry` interface in `telemetryRegistry.d.mts`. Nobody imports single letters deliberately, which is why this is an argument for tightening the map rather than an incident.

This PR enumerates the 15 entry points instead.

**Why enumerate rather than keep the wildcard and relocate chunks.** I probed the alternative — `outputOptions.chunkFileNames` does move both JS *and* dts chunks under an unexported directory, so it works mechanically. I did not take it: it pins the package's public API to two 0.x tools' chunk-placement behaviour, still needs an exports override (`"./internal/*": null`) so the map grows anyway, and its failure mode is silently re-widening the surface instead of a red test. Enumerating states the intended surface in the place consumers and reviewers actually read, with no coupling to bundler internals.

**The friction that buys.** One manifest edit per new module — the cost PR #35350 was pleased to avoid. So `src/__tests__/exportMap.test.ts` asserts the map matches the tsdown entry globs exactly, rejects any `*` key, and checks each subpath points at its own emitted files. Forgetting the edit is now a named test failure, not a resolution error downstream. Negative-tested against three regressions: reintroduced wildcard (3 assertions fail), a module missing from `exports` (2 fail), and a copy-paste target typo (caught only by the per-target assertion).

## How to test

Verified against **built** output, not config — `editor-ui`, `design-system` and `storybook` all alias `@n8n/composables` to `src` (e.g. `packages/frontend/editor-ui/vite.config.mts:51-52`), so no test there exercises the emitted export map. `@n8n/stores` is the one in-repo consumer that resolves the package for real, so probing runs from there through Node's own resolver.

```bash
pnpm --filter @n8n/composables build
pnpm --filter @n8n/composables test    # 4 new export-map assertions
```

To reproduce the probe, from `packages/frontend/@n8n/stores`:

```js
// each of the 15 subpaths in use today still resolves
import.meta.resolve('@n8n/composables/useToast');
import.meta.resolve('@n8n/composables/useStorage');
import.meta.resolve('@n8n/composables/registries/telemetryRegistry');

// each of the 5 internal chunks is now blocked
import.meta.resolve('@n8n/composables/useTelemetry2');  // ERR_PACKAGE_PATH_NOT_EXPORTED
import.meta.resolve('@n8n/composables/notification');   // ERR_PACKAGE_PATH_NOT_EXPORTED
```

Results, before → after:

| check | before | after |
|---|---|---|
| subpaths exposed but not an intended entry | 5 | 0 |
| source modules resolving to a shadowed entry | 0 | 0 |
| subpaths in use today that resolve | 15 / 15 | 15 / 15 |
| internal chunks reachable | 5 | 0 |

No consumer breakage: all 15 subpaths any in-repo importer uses today still resolve, including `useStorage` and `registries/telemetryRegistry`. Package tests go from 10 to 11 files passing and 64 to 68 tests; the 3 files failing locally (`useToast`, `useStyles`, `packageBoundary`) fail identically on a stashed tree — they need `n8n-workflow` built, which my filtered install did not cover.

## Related Linear tickets, Github issues, and Community forum posts

Found by Filter while reviewing #35350; pre-existing, three of the four chunks named there predate that PR.

Two follow-ups deliberately left out of scope:

- Sibling packages (`@n8n/frontend-utils`, `@n8n/frontend-constants`, `@n8n/i18n`, `@n8n/rest-api-client`, `@n8n/stores`) all declare the same `./*` pattern. Whether they emit chunks is unmeasured — worth a look, not assumed.
- `packages/frontend/@n8n/storybook/vite.config.ts:73-74` aliases bare `@n8n/composables` to `../composables/src/index.ts`, which does not exist. Dead alias; nothing imports the bare specifier.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- no user-facing docs surface; packaging change only -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

