### PR TITLE
test(editor): Add the missing setNotify stub to the app init useToast mock (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/init/index.test.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.test.ts
@@ -28,6 +28,12 @@ const showToast = vi.fn();
 
 vi.mock('@n8n/composables/useToast', () => ({
 	useToast: () => ({ showMessage, showToast }),
+	// The factory replaces the whole module, so it has to name every export the
+	// real one has. Nothing here asserts on `setNotify` — its only caller,
+	// `toastNotifier`, is kept out of this graph by the mock below — so dropping
+	// this line looks safe and stays green. Loosen that mock and it is not:
+	// vitest fails every test with `No "setNotify" export is defined`.
+	setNotify: vi.fn(),
 }));
 
 vi.mock('@/app/init/toastNotifier', () => ({


### PR DESCRIPTION
## Summary

Adds the one export a `vi.mock` factory was missing after a specifier swap. Test-only, no runtime change.

A `vi.mock` factory replaces the **whole** module, so it has to name every export the real one has. The factory in `packages/frontend/editor-ui/src/app/init/index.test.ts` was complete when it targeted the `@/app` shim, which re-exported exactly one symbol (`useToast`). #35348 retargeted it at `@n8n/composables/useToast`, which exports **two** — `useToast` and `setNotify` — so `setNotify` has been shadowed to `undefined` for that suite's module graph ever since.

Nothing walks that path today: `setNotify`'s only caller in the app is `app/init/toastNotifier`, and the same test file mocks `@/app/init/toastNotifier` four lines below the factory. Two unrelated mocks cover each other, which is why the factory reads complete and the suite is green. Loosen or remove the `toastNotifier` mock and it isn't.

Deliberately left out of #35348: it was a line beyond re-anchoring, and adding it would have invalidated a review signature on a 374-file mechanical codemod to close a path nothing currently walks.

## How to test

No app-facing behaviour to exercise — the evidence is that the stub is load-bearing rather than decorative.

```bash
cd packages/frontend/editor-ui
pnpm test src/app/init/
```

`24 passed (24)` — `index.test.ts` (19) and `toastNotifier.test.ts` (5).

To confirm the stub actually holds something up, make the hidden consumer load by spy-throughing the `toastNotifier` mock in `index.test.ts` — this keeps it a `vi.fn`, so the call-ordering assertions still work, but runs the real registration:

```ts
vi.mock('@/app/init/toastNotifier', async (importOriginal) => {
	const actual = await importOriginal();
	return { registerToastNotifier: vi.fn(actual.registerToastNotifier) };
});
```

- **Without** the `setNotify` stub (i.e. this PR reverted): all 8 `initializeCore()` tests fail with
  `Error: [vitest] No "setNotify" export is defined on the "@n8n/composables/useToast" mock. Did you forget to return it from "vi.mock"?`
- **With** it: `19 passed (19)`.

Also verified: `pnpm lint` 0 errors, `pnpm typecheck` clean, full `pnpm build` green.

Worth noting for anyone auditing the wider class — roughly 150 test files mock `@n8n/composables/useToast` with a factory and every one of them omits `setNotify`, but `index.test.ts` is the only one where a `setNotify` consumer is reachable in the same module graph. The other files that load `@/app/init` (`router.test.ts`, `toastNotifier.test.ts`, `WorkflowHistory.test.ts`, `BannersStack.test.ts`, `SettingsSourceControl.test.ts`, `ChatView.test.ts`) don't mock `useToast`, so a one-line fix here is the correct scope, not a sweep.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35348. no Linear ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

