### PR TITLE
fix(core): Resolve External Secrets in log streaming webhook auth

### DIFF
--- a/packages/cli/src/modules/log-streaming.ee/destinations/__tests__/message-event-bus-destination-webhook.ee.test.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/__tests__/message-event-bus-destination-webhook.ee.test.ts
@@ -169,6 +169,133 @@ describe('MessageEventBusDestinationWebhook', () => {
 			);
 		});
 
+		it('should decrypt Header Auth credentials with expression resolution enabled', async () => {
+			const { outboundHttp, request } = mockOutboundHttp();
+			const credentialDetails = { id: 'header-cred-id', name: 'Header Auth' };
+			const destination = new MessageEventBusDestinationWebhook(
+				mockEventBus,
+				{
+					__type: MessageEventBusDestinationTypeNames.webhook,
+					url: 'https://example.com/webhook',
+					authentication: 'genericCredentialType',
+					genericAuthType: 'httpHeaderAuth',
+					credentials: { httpHeaderAuth: credentialDetails },
+				},
+				outboundHttp,
+			);
+			const credentialsHelper = mock<CredentialsHelper>();
+			// Resolved External Secrets expression ({{ $secrets... }}) → concrete token
+			credentialsHelper.getDecrypted.mockResolvedValue({
+				name: 'X-Auth-Token',
+				value: 'resolved-secret-token',
+			});
+			destination.credentialsHelper = credentialsHelper;
+
+			await destination.receiveFromEventBus({
+				msg: createMessage(),
+				confirmCallback: vi.fn(),
+			} as any);
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+				expect.anything(),
+				credentialDetails,
+				'httpHeaderAuth',
+				'internal',
+				undefined,
+				false,
+			);
+			expect(request).toHaveBeenCalledWith(
+				expect.objectContaining({
+					headers: expect.objectContaining({ 'X-Auth-Token': 'resolved-secret-token' }),
+				}),
+			);
+		});
+
+		it('should decrypt Basic Auth credentials with expression resolution enabled', async () => {
+			const { outboundHttp, request } = mockOutboundHttp();
+			const credentialDetails = { id: 'basic-cred-id', name: 'Basic Auth' };
+			const destination = new MessageEventBusDestinationWebhook(
+				mockEventBus,
+				{
+					__type: MessageEventBusDestinationTypeNames.webhook,
+					url: 'https://example.com/webhook',
+					authentication: 'genericCredentialType',
+					genericAuthType: 'httpBasicAuth',
+					credentials: { httpBasicAuth: credentialDetails },
+				},
+				outboundHttp,
+			);
+			const credentialsHelper = mock<CredentialsHelper>();
+			credentialsHelper.getDecrypted.mockResolvedValue({
+				user: 'webhook-user',
+				password: 'resolved-secret-password',
+			});
+			destination.credentialsHelper = credentialsHelper;
+
+			await destination.receiveFromEventBus({
+				msg: createMessage(),
+				confirmCallback: vi.fn(),
+			} as any);
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+				expect.anything(),
+				credentialDetails,
+				'httpBasicAuth',
+				'internal',
+				undefined,
+				false,
+			);
+			expect(request).toHaveBeenCalledWith(
+				expect.objectContaining({
+					auth: {
+						username: 'webhook-user',
+						password: 'resolved-secret-password',
+					},
+				}),
+			);
+		});
+
+		it('should decrypt Query Auth credentials with expression resolution enabled', async () => {
+			const { outboundHttp, request } = mockOutboundHttp();
+			const credentialDetails = { id: 'query-cred-id', name: 'Query Auth' };
+			const destination = new MessageEventBusDestinationWebhook(
+				mockEventBus,
+				{
+					__type: MessageEventBusDestinationTypeNames.webhook,
+					url: 'https://example.com/webhook',
+					authentication: 'genericCredentialType',
+					genericAuthType: 'httpQueryAuth',
+					credentials: { httpQueryAuth: credentialDetails },
+				},
+				outboundHttp,
+			);
+			const credentialsHelper = mock<CredentialsHelper>();
+			credentialsHelper.getDecrypted.mockResolvedValue({
+				name: 'api_key',
+				value: 'resolved-query-secret',
+			});
+			destination.credentialsHelper = credentialsHelper;
+
+			await destination.receiveFromEventBus({
+				msg: createMessage(),
+				confirmCallback: vi.fn(),
+			} as any);
+
+			expect(credentialsHelper.getDecrypted).toHaveBeenCalledWith(
+				expect.anything(),
+				credentialDetails,
+				'httpQueryAuth',
+				'internal',
+				undefined,
+				false,
+			);
+			expect(request).toHaveBeenCalledWith(
+				expect.objectContaining({
+					qs: expect.objectContaining({ api_key: 'resolved-query-secret' }),
+				}),
+			);
+		});
+
 		it('should not send when Simplified Custom Auth credentials cannot be resolved', async () => {
 			const { outboundHttp, request } = mockOutboundHttp();
 			const destination = new MessageEventBusDestinationWebhook(

--- a/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
@@ -167,7 +167,12 @@ export class MessageEventBusDestinationWebhook
 		return requestOptions;
 	}
 
-	async matchDecryptedCredentialType(credentialType: string, raw = true) {
+	/**
+	 * Decrypt destination credentials with expression resolution enabled by default
+	 * (`raw = false`) so External Secrets expressions (e.g. `{{ $secrets... }}`)
+	 * are resolved before the request is sent.
+	 */
+	async matchDecryptedCredentialType(credentialType: string, raw = false) {
 		const foundCredential = Object.entries(this.credentials).find((e) => e[0] === credentialType);
 		if (foundCredential) {
 			const credentialsDecrypted = await this.credentialsHelper?.getDecrypted(
@@ -373,10 +378,8 @@ export class MessageEventBusDestinationWebhook
 					httpQueryAuth = await this.matchDecryptedCredentialType('httpQueryAuth');
 				} catch {}
 			} else if (this.genericAuthType === 'httpTemplatedCustomAuth') {
-				httpTemplatedCustomAuth = await this.matchDecryptedCredentialType(
-					'httpTemplatedCustomAuth',
-					false,
-				);
+				httpTemplatedCustomAuth =
+					await this.matchDecryptedCredentialType('httpTemplatedCustomAuth');
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Decrypt log streaming webhook credentials with expression resolution enabled (`raw = false`) so External Secrets expressions like `{{ $secrets... }}` are resolved before the request is sent.
- Applies to Header Auth, Basic Auth, Query Auth, Digest Auth, and Simplified Custom Auth.
- Add regression tests covering Header, Basic, and Query Auth decryption with `raw = false`.

## How to test

1. Configure External Secrets (e.g. AWS Secrets Manager).
2. Create a Header Auth credential whose Value is an External Secrets expression, e.g. `{{ $secrets.<vault>['...'] }}`.
3. Attach that credential to a Log Streaming webhook destination (`authentication: genericCredentialType`, `genericAuthType: httpHeaderAuth`).
4. Keep destination `sendHeaders` off (auth via credential only).
5. Send a Test Event to a receiver that validates the custom header token.
6. Confirm the receiver accepts the request (header contains the resolved secret, not the unresolved expression).
7. From `packages/cli` run:
   ```bash
   pnpm test:win src/modules/log-streaming.ee/destinations/__tests__/message-event-bus-destination-webhook.ee.test.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

