### PR TITLE
fix: Fixes see all button tracking on aia template examples

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewSuggestions.test.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewSuggestions.test.ts
@@ -60,4 +60,16 @@ describe('WorkflowPreviewSuggestions', () => {
 		const link = container.querySelector('a');
 		expect(link).toHaveAttribute('href', websiteTemplateRepositoryURL);
 	});
+
+	it('tracks a telemetry event when "see all" is clicked', async () => {
+		const { container } = renderComponent();
+
+		const link = container.querySelector('a');
+		expect(link).not.toBeNull();
+		if (!link) throw new Error('Missing see-all link');
+
+		await fireEvent.click(link);
+
+		expect(telemetryTrack).toHaveBeenCalledWith('AI Assistant examples see all button clicked');
+	});
 });

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewSuggestions.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewSuggestions.vue
@@ -98,6 +98,10 @@ function handleSuggestionClick(suggestion: WorkflowPreviewSuggestion) {
 	});
 }
 
+function handleSeeAllClick() {
+	telemetry.track('AI Assistant examples see all button clicked');
+}
+
 onUnmounted(clearPreview);
 </script>
 
@@ -129,6 +133,7 @@ onUnmounted(clearPreview);
 				target="_blank"
 				rel="noopener noreferrer"
 				:class="$style.seeAllLink"
+				@click="handleSeeAllClick"
 			>
 				<span>{{
 					i18n.baseText(


### PR DESCRIPTION
## Summary
Addresses : https://linear.app/n8n/issue/GRO-375/add-telemetry-to-the-see-all-button-right-now-when-a-user-clicks-we#comment-71aa7951

Fixes AI Assistant "See all" button on suggestions bar not having a telemetry event. Added `AI Assistant examples see all button clicked` event + whitelisted on PostHog

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/GRO-375/add-telemetry-to-the-see-all-button-right-now-when-a-user-clicks-we#comment-71aa7951

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

