### PR TITLE
ci: Re-add triage:pending label when stale community PRs become active again

### DIFF
--- a/.github/workflows/community-pr-close-stale.yml
+++ b/.github/workflows/community-pr-close-stale.yml
@@ -37,6 +37,8 @@ jobs:
           days-before-pr-close: 14
           stale-pr-label: 'Stale'
           close-pr-label: 'status:internal-closed'
+          labels-to-add-when-unstale: 'triage:pending'
+          labels-to-remove-when-unstale: 'Stale'
           operations-per-run: 1000 # default 30 exhausts on page fetches before reaching recent PRs
           # contributor activity resets the clock (remove-stale-when-updated defaults to true)
           ascending: true # oldest first


### PR DESCRIPTION
## Summary

When a community PR is marked `Stale` and then becomes active again (e.g. the contributor pushes a new commit), the stale-close workflow already removes the `Stale` label via its default `remove-stale-when-updated` behavior, but the PR was left without any triage label. This adds explicit `labels-to-add-when-unstale`/`labels-to-remove-when-unstale` config so the PR gets re-labeled `triage:pending` (and has `Stale` removed) when it comes back out of staleness, ensuring it re-enters the normal triage flow instead of sitting unlabeled.

## How to test

This only affects the `community-pr-close-stale` GitHub Actions workflow config (uses `actions/stale`). To verify:
- Confirm the workflow YAML is valid (`actionlint` passes via the pre-commit hook).
- Optionally dry-run the `actions/stale` action against a test repo/PR marked `Stale`, push a commit to it, and confirm the label swap (`Stale` removed, `triage:pending` added) happens on the next scheduled run.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-1857/first-strike-for-older-prs

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI