### PR TITLE
feat(editor): Add ChatMessage to @n8n/design-system

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/ChatMessage.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/ChatMessage.stories.ts
@@ -1,0 +1,46 @@
+import type { StoryFn } from '@storybook/vue3-vite';
+
+import '../../css/_tokens.scss';
+
+import N8nChatMessage from './ChatMessage.vue';
+import N8nIconButton from '../N8nIconButton';
+
+export default {
+	title: 'AI/ChatMessage',
+	component: N8nChatMessage,
+	argTypes: {
+		role: {
+			control: 'select',
+			options: ['assistant', 'user'],
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A presentational shell for role-based chat message alignment, user bubbles, and optional assistant actions.',
+			},
+		},
+	},
+};
+
+const Template: StoryFn = (args) => ({
+	components: { N8nChatMessage, N8nIconButton },
+	setup: () => ({ args }),
+	template: `
+		<div style="width: 500px; max-width: 100%;">
+			<N8nChatMessage v-bind="args">
+				<p style="margin: 0;">Build a workflow that summarizes new support tickets.</p>
+				<template v-if="args.role === 'assistant'" #actions>
+					<N8nIconButton icon="copy" variant="ghost" size="xsmall" aria-label="Copy message" />
+				</template>
+			</N8nChatMessage>
+		</div>
+	`,
+});
+
+export const User = Template.bind({});
+User.args = { role: 'user' };
+
+export const Assistant = Template.bind({});
+Assistant.args = { role: 'assistant' };

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/ChatMessage.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/ChatMessage.test.ts
@@ -1,0 +1,104 @@
+import { render } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
+import { vi } from 'vitest';
+import { h, nextTick, ref } from 'vue';
+
+import ChatMessage from './ChatMessage.vue';
+
+function mockRange(width?: number) {
+	const selectNodeContents = vi.fn();
+	const getBoundingClientRect = vi.fn(() =>
+		width === undefined ? undefined : ({ width } as DOMRect),
+	);
+
+	vi.spyOn(document, 'createRange').mockReturnValue({
+		selectNodeContents,
+		getBoundingClientRect,
+	} as unknown as Range);
+
+	return { selectNodeContents, getBoundingClientRect };
+}
+
+describe('N8nChatMessage', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should render and shrink-wrap a user message', () => {
+		const range = mockRange(120);
+		const { container, getByText } = render(ChatMessage, {
+			props: { role: 'user' },
+			slots: { default: 'Build a workflow' },
+		});
+
+		const message = container.firstElementChild;
+		const bubble = container.querySelector<HTMLElement>('.userBubble');
+
+		expect(getByText('Build a workflow')).toBeInTheDocument();
+		expect(message).toHaveClass('userMessage');
+		expect(bubble).toHaveStyle({ width: '120px', boxSizing: 'content-box' });
+		expect(range.selectNodeContents).toHaveBeenCalledWith(bubble);
+	});
+
+	it('should render an assistant message without measuring it', () => {
+		const range = mockRange(120);
+		const { container, getByText } = render(ChatMessage, {
+			props: { role: 'assistant' },
+			slots: { default: 'How can I help?' },
+		});
+
+		expect(getByText('How can I help?')).toBeInTheDocument();
+		expect(container.firstElementChild).toHaveClass('assistantMessage');
+		expect(container.querySelector('.assistantContent')).toBeInTheDocument();
+		expect(range.getBoundingClientRect).not.toHaveBeenCalled();
+	});
+
+	it('should update the user bubble width when its content changes', async () => {
+		const widths = [80, 160];
+		const getBoundingClientRect = vi.fn(() => ({ width: widths.shift() }) as DOMRect);
+		vi.spyOn(document, 'createRange').mockReturnValue({
+			selectNodeContents: vi.fn(),
+			getBoundingClientRect,
+		} as unknown as Range);
+		const content = ref('Short message');
+		const wrapper = mount(ChatMessage, {
+			props: { role: 'user' },
+			slots: { default: () => h('span', content.value) },
+		});
+
+		expect(wrapper.get('.userBubble').attributes('style')).toContain('width: 80px');
+
+		content.value = 'A longer message';
+		await nextTick();
+
+		expect(wrapper.get('.userBubble').attributes('style')).toContain('width: 160px');
+		expect(getBoundingClientRect).toHaveBeenCalledTimes(2);
+	});
+
+	it('should render actions only when the actions slot is provided', () => {
+		const withoutActions = render(ChatMessage, {
+			props: { role: 'assistant' },
+			slots: { default: 'Message' },
+		});
+
+		expect(withoutActions.queryByRole('button')).not.toBeInTheDocument();
+
+		const withActions = render(ChatMessage, {
+			props: { role: 'assistant' },
+			slots: { default: 'Message', actions: '<button>Copy</button>' },
+		});
+
+		expect(withActions.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+	});
+
+	it('should render when layout bounds are unavailable', () => {
+		mockRange();
+
+		expect(() =>
+			render(ChatMessage, {
+				props: { role: 'user' },
+				slots: { default: 'Message' },
+			}),
+		).not.toThrow();
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/ChatMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/ChatMessage.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { onMounted, onUpdated, ref } from 'vue';
+
+interface Props {
+	role: 'assistant' | 'user';
+}
+
+const props = defineProps<Props>();
+
+const userBubble = ref<HTMLElement | null>(null);
+
+function shrinkWrapUserMessage() {
+	if (props.role !== 'user' || !userBubble.value) return;
+
+	userBubble.value.style.removeProperty('width');
+
+	const range = document.createRange();
+	range.selectNodeContents(userBubble.value);
+
+	const bounds = range.getBoundingClientRect();
+	if (!bounds) return;
+
+	userBubble.value.style.width = `${bounds.width}px`;
+	userBubble.value.style.boxSizing = 'content-box';
+}
+
+onMounted(shrinkWrapUserMessage);
+onUpdated(shrinkWrapUserMessage);
+
+defineSlots<{
+	default(): unknown;
+	actions?(): unknown;
+}>();
+</script>
+
+<template>
+	<div :class="[$style.message, role === 'user' ? $style.userMessage : $style.assistantMessage]">
+		<div ref="userBubble" :class="role === 'user' ? $style.userBubble : $style.assistantContent">
+			<slot />
+			<div v-if="$slots.actions" :class="$style.actions">
+				<slot name="actions" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<style lang="scss" module>
+.message {
+	width: 100%;
+}
+
+.userMessage {
+	display: flex;
+	justify-content: flex-end;
+	margin-block: var(--spacing--md);
+}
+
+.userBubble {
+	max-width: 90%;
+	padding: var(--spacing--xs) var(--spacing--sm);
+	border-radius: var(--radius--xl);
+	background: var(--assistant--color--background--user-bubble);
+	color: var(--assistant--color--text--user-bubble);
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.assistantMessage {
+	position: relative;
+}
+
+.assistantContent {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--xs);
+
+	&:hover .actions,
+	&:focus-within .actions {
+		opacity: 1;
+	}
+}
+
+.actions {
+	position: absolute;
+	top: 0;
+	right: 0;
+	opacity: 0;
+	transition: opacity var(--duration--snappy) var(--easing--ease-out);
+
+	@media (hover: none) {
+		opacity: 1;
+	}
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/ChatMessage.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/ChatMessage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useResizeObserver } from '@vueuse/core';
 import { onMounted, onUpdated, ref } from 'vue';
 
 interface Props {
@@ -7,6 +8,7 @@ interface Props {
 
 const props = defineProps<Props>();
 
+const message = ref<HTMLElement | null>(null);
 const userBubble = ref<HTMLElement | null>(null);
 
 function shrinkWrapUserMessage() {
@@ -26,6 +28,7 @@ function shrinkWrapUserMessage() {
 
 onMounted(shrinkWrapUserMessage);
 onUpdated(shrinkWrapUserMessage);
+useResizeObserver(message, shrinkWrapUserMessage);
 
 defineSlots<{
 	default(): unknown;
@@ -34,7 +37,10 @@ defineSlots<{
 </script>
 
 <template>
-	<div :class="[$style.message, role === 'user' ? $style.userMessage : $style.assistantMessage]">
+	<div
+		ref="message"
+		:class="[$style.message, role === 'user' ? $style.userMessage : $style.assistantMessage]"
+	>
 		<div ref="userBubble" :class="role === 'user' ? $style.userBubble : $style.assistantContent">
 			<slot />
 			<div v-if="$slots.actions" :class="$style.actions">

--- a/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nChatMessage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChatMessage.vue';

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -104,6 +104,7 @@ export {
 	type ChatInputAutoFocusOptions,
 	type ChatInputAutoFocusTarget,
 } from './N8nChatInput';
+export { default as N8nChatMessage } from './N8nChatMessage';
 export { default as N8nPulse } from './N8nPulse';
 export { default as N8nSendStopButton } from './N8nSendStopButton';
 export { default as N8nRadioButtons } from './N8nRadioButtons';

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
@@ -4,6 +4,7 @@ import type { RatingFeedback } from '@n8n/design-system';
 import {
 	N8nButton,
 	N8nCallout,
+	N8nChatMessage,
 	N8nIcon,
 	N8nIconButton,
 	N8nMessageRating,
@@ -117,9 +118,12 @@ function formatJson(value: unknown): string {
 </script>
 
 <template>
-	<div :class="[isUser ? $style.userMessage : '']">
+	<N8nChatMessage
+		:role="props.message.role"
+		:data-test-id="isUser ? 'instance-ai-user-message' : 'instance-ai-assistant-message'"
+	>
 		<!-- User message -->
-		<div v-if="isUser" :class="$style.userBubble" data-test-id="instance-ai-user-message">
+		<div v-if="isUser">
 			<div v-if="attachments.length > 0" :class="$style.userAttachments">
 				<AttachmentPreview
 					v-for="(attachment, index) in attachments"
@@ -132,7 +136,7 @@ function formatJson(value: unknown): string {
 		</div>
 
 		<!-- Assistant message -->
-		<div v-else :class="$style.assistantWrapper" data-test-id="instance-ai-assistant-message">
+		<template v-else>
 			<!-- Agent activity tree (handles reasoning, tool calls, sub-agents) -->
 			<AgentActivityTree v-if="props.message.agentTree" :agent-node="props.message.agentTree" />
 
@@ -211,67 +215,28 @@ function formatJson(value: unknown): string {
 				{{ i18n.baseText('instanceAi.feedback.success') }}
 			</p>
 
+			<pre v-if="showDebugInfo" :class="$style.debugJson">{{ formatJson(props.message) }}</pre>
+		</template>
+
+		<template v-if="store.debugMode && !isUser" #actions>
 			<N8nIconButton
-				v-if="store.debugMode && !isUser"
 				icon="code"
 				variant="ghost"
 				size="xsmall"
-				:class="$style.actionBtn"
 				@click="showDebugInfo = !showDebugInfo"
 			/>
-			<pre v-if="showDebugInfo" :class="$style.debugJson">{{ formatJson(props.message) }}</pre>
-		</div>
-	</div>
+		</template>
+	</N8nChatMessage>
 </template>
 
 <style lang="scss" module>
 @use '@n8n/design-system/css/mixins/motion';
-
-.userMessage {
-	align-self: flex-end;
-	display: flex;
-	justify-content: flex-end;
-	width: 100%;
-	margin-block: var(--spacing--md);
-}
 
 .userAttachments {
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--spacing--2xs);
 	margin-bottom: var(--spacing--2xs);
-}
-
-.userBubble {
-	background: var(--assistant--color--background--user-bubble);
-	padding: var(--spacing--xs) var(--spacing--sm);
-	border-radius: var(--radius--xl);
-	white-space: pre-wrap;
-	word-break: break-word;
-	max-width: 90%;
-}
-
-.assistantWrapper {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--xs);
-
-	&:hover .actionBtn {
-		opacity: 1;
-	}
-}
-
-.actionBtn {
-	opacity: 0;
-	transition: opacity 0.15s ease;
-	position: absolute;
-	top: 0;
-	right: 0;
-
-	@media (hover: none) {
-		opacity: 1;
-	}
 }
 
 .statusIndicator {


### PR DESCRIPTION
## Summary

Adds a reusable `N8nChatMessage` design-system component for role-based chat message layout, user message bubbles, and assistant actions.

Updates Instance AI messages to use the shared component and adds Storybook stories and component tests.

<img width="2050" height="866" alt="CleanShot 2026-08-03 at 18 35 28@2x" src="https://github.com/user-attachments/assets/aa041880-3b86-4379-a9f7-e57066f7d476" />


## How to test

1. From `packages/frontend/@n8n/design-system`, run the `ChatMessage.test.ts` component tests.
2. Open Storybook and verify the `AI/ChatMessage` user and assistant stories.
3. Open Instance AI and confirm:
   - User messages are right-aligned and shrink-wrap their content.
   - Assistant messages render normally.
   - In debug mode, the code action appears on hover/focus and toggles the debug payload.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-552

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)