### PR TITLE
fix(cli): include homeProject in sharing-disabled workflow response

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
@@ -3,8 +3,8 @@ import type { ImportWorkflowFromUrlDto } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type { HttpRequestClient, OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { SsrfBlockedIpError } from '@n8n/backend-network';
-import type { SsrfProtectionConfig } from '@n8n/config';
-import type { AuthenticatedRequest, IExecutionResponse } from '@n8n/db';
+import type { GlobalConfig, SsrfProtectionConfig } from '@n8n/config';
+import type { AuthenticatedRequest, IExecutionResponse, WorkflowEntity } from '@n8n/db';
 import type { Response } from 'express';
 import { mock } from 'vitest-mock-extended';
 
@@ -13,7 +13,11 @@ import { WorkflowsController } from '../workflows.controller';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { ExecutionService } from '@/executions/execution.service';
+import type { License } from '@/license';
 import type { ProjectService } from '@/services/project.service.ee';
+import type { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import type { WorkflowService } from '@/workflows/workflow.service';
 
 describe('WorkflowsController', () => {
 	const controller = Object.create(WorkflowsController.prototype);
@@ -195,6 +199,53 @@ describe('WorkflowsController', () => {
 				await controller.getFromUrl(req, res, query);
 
 				expect(outboundHttp.requests).toHaveBeenCalledWith({ ssrf: 'disabled' });
+			});
+		});
+	});
+
+	describe('getWorkflow', () => {
+		describe('sharing disabled', () => {
+			it('should include homeProject in the response', async () => {
+				/**
+				 * Arrange
+				 */
+				const workflowId = 'wf-123';
+				const homeProject = { id: 'proj-abc', name: 'My Project', type: 'personal' };
+
+				const license = mock<License>({ isSharingEnabled: vi.fn().mockReturnValue(false) });
+				const globalConfig = mock<GlobalConfig>({ tags: { disabled: false } });
+				const workflowFinderService = mock<WorkflowFinderService>();
+				const enterpriseWorkflowService = mock<EnterpriseWorkflowService>();
+				const workflowService = mock<WorkflowService>();
+
+				const workflow = mock<WorkflowEntity>({ id: workflowId, nodes: [], connections: {} });
+				workflowFinderService.findWorkflowForUser.mockResolvedValue(workflow);
+
+				// addOwnerAndSharings enriches the workflow with homeProject
+				const workflowWithMeta = { ...workflow, homeProject };
+				enterpriseWorkflowService.addOwnerAndSharings.mockReturnValue(workflowWithMeta as any);
+
+				workflowService.getWorkflowScopes.mockResolvedValue(['workflow:read']);
+
+				controller.license = license;
+				controller.globalConfig = globalConfig;
+				controller.workflowFinderService = workflowFinderService;
+				controller.enterpriseWorkflowService = enterpriseWorkflowService;
+				controller.workflowService = workflowService;
+
+				const getReq = mock<AuthenticatedRequest>({ params: { workflowId } });
+
+				/**
+				 * Act
+				 */
+				const result = await controller.getWorkflow(getReq as any);
+
+				/**
+				 * Assert
+				 */
+				expect(enterpriseWorkflowService.addOwnerAndSharings).toHaveBeenCalledWith(workflow);
+				expect(result).toMatchObject({ homeProject });
+				expect(result).not.toHaveProperty('shared');
 			});
 		});
 	});

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -274,10 +274,16 @@ export class WorkflowsController {
 			);
 		}
 
+		const workflowWithMetaData = this.enterpriseWorkflowService.addOwnerAndSharings(workflow);
+
+		// @ts-expect-error: This is added as part of addOwnerAndSharings but
+		// shouldn't be returned to the frontend
+		delete workflowWithMetaData.shared;
+
 		const scopes = await this.workflowService.getWorkflowScopes(req.user, workflowId);
 		const checksum = await calculateWorkflowChecksum(workflow);
 
-		return { ...workflow, scopes, checksum };
+		return { ...workflowWithMetaData, scopes, checksum };
 	}
 
 	/**


### PR DESCRIPTION
## Summary

When `isSharingEnabled()` returns `false`, `WorkflowsController.getWorkflow` returns early without calling `enterpriseWorkflowService.addOwnerAndSharings(workflow)`. This causes `homeProject` to be missing from the response — breaking client code that reads it unconditionally.

The fix calls `addOwnerAndSharings` on the sharing-disabled path as well, so `homeProject` is populated regardless of the sharing setting.

Closes #36386

## Changes

- **`packages/cli/src/workflows/workflows.controller.ts`**: call `addOwnerAndSharings` before returning on the sharing-disabled branch
- **`packages/cli/src/workflows/__tests__/workflows.controller.test.ts`**: unit test asserting `homeProject` is present and `shared` is absent in the sharing-disabled response