### PR TITLE
test(core): Audit and lock MCP error-code and no-logging compliance

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -672,6 +672,44 @@ describe('McpService', () => {
 				expect(result.protocolVersion).toBe('2025-06-18');
 				expect(result.serverInfo).toMatchObject({ name: 'n8n MCP Server' });
 			});
+
+			// Logging is deprecated in 2026-07-28, and a server must not emit
+			// notifications/message unless the client opted in via _meta logLevel. We
+			// never register the capability or emit those notifications; this locks
+			// server/discover to keep advertising no logging capability.
+			it('never advertises the deprecated logging capability', async () => {
+				const handler = await buildHandler();
+
+				const res = await handler.fetch(
+					new Request('http://n8n.local/mcp-server/http', {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json',
+							accept: 'application/json, text/event-stream',
+							'mcp-method': 'server/discover',
+						},
+						body: JSON.stringify({
+							jsonrpc: '2.0',
+							id: 1,
+							method: 'server/discover',
+							params: {
+								_meta: {
+									'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+									'io.modelcontextprotocol/clientCapabilities': {},
+									'io.modelcontextprotocol/clientInfo': { name: 'vitest', version: '1.0.0' },
+								},
+							},
+						}),
+					}),
+				);
+
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					result: { capabilities: Record<string, unknown> };
+				};
+				expect(body.result.capabilities).toHaveProperty('tools');
+				expect(body.result.capabilities).not.toHaveProperty('logging');
+			});
 		});
 
 		const mcpUser = () =>
@@ -1171,6 +1209,48 @@ describe('McpService', () => {
 				await buildService({ builderEnabled: false }).getServer(user, appsEnabled);
 
 				expect(registerWorkflowPreviewApp).not.toHaveBeenCalled();
+			});
+
+			// 2026-07-28 renumbered resource-not-found from -32002 to -32602 (Invalid
+			// Params). We never build the code by hand; this confirms a client reading
+			// an unknown resource sees the renumbered code, not the retired -32002.
+			// Builder is on so the server advertises the resources capability (it
+			// registers the SDK reference resource); the read targets a different URI.
+			it('returns -32602 for an unknown resource, not the retired -32002', async () => {
+				const user = Object.assign(new User(), { id: 'user-1' });
+				const handler = createMcpHandler(
+					async () => await buildService().getServer(user, mcpFeatureFlags()),
+					{ legacy: 'stateless' },
+				);
+
+				const res = await handler.fetch(
+					new Request('http://n8n.local/mcp-server/http', {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json',
+							accept: 'application/json, text/event-stream',
+							'mcp-method': 'resources/read',
+							// SEP-2243: for resources/read the Mcp-Name header carries the URI.
+							'mcp-name': 'n8n://does-not-exist',
+						},
+						body: JSON.stringify({
+							jsonrpc: '2.0',
+							id: 1,
+							method: 'resources/read',
+							params: {
+								uri: 'n8n://does-not-exist',
+								_meta: {
+									'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+									'io.modelcontextprotocol/clientCapabilities': {},
+									'io.modelcontextprotocol/clientInfo': { name: 'vitest', version: '1.0.0' },
+								},
+							},
+						}),
+					}),
+				);
+
+				const body = (await res.json()) as { error?: { code: number } };
+				expect(body.error?.code).toBe(-32602);
 			});
 		});
 	});


### PR DESCRIPTION
> Stacked on #35472 (cache metadata) → #35471 (headers) → #35470 (discovery) → #35467 (v2 migration). Review those first; this PR's base is #35472's branch, so the diff here is just the one commit.

https://linear.app/n8n/issue/ADO-5685

## Summary

An audit pass for the 2026-07-28 error-code and `resultType` changes. The instance server turned out to be compliant already, so this adds regression guards rather than fixes.

Findings:

- **`resultType`** — the SDK stamps it on every result; the existing tools/list test already asserts `'complete'`. No result envelopes are built by hand (tool handlers return content/structured output, which the SDK wraps).
- **Resource not found (-32002 → -32602)** — we never emit -32002 anywhere. Reading an unknown resource returns -32602 from the SDK.
- **Reserved error range (-32020..-32099)** — the only error code we build by hand is -32000 (the GET 405 rejection and the per-tool rate-limit message), which stays in the implementation-defined -32000..-32019 range. Nothing we emit lands in the reserved range.
- **Logging (deprecated)** — we never register the logging capability or emit `notifications/message`, and the revision forbids emitting them unless the client opts in via `_meta` logLevel.

## What this adds

Two regression guards in the service test, driven through the real `createMcpHandler` + `getServer` (wire-level, not mocks):

- `server/discover` advertises `tools` but never `logging`.
- Reading an unknown resource returns -32602, not the retired -32002.

No production code change — the audit found nothing to fix.

## Testing

Full MCP suite green (1194), typecheck clean, lint clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

