### PR TITLE
fix(core): Use workflow timezone for Date local getters in expressions

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -217,6 +217,49 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		expect(result).toBe('09:00 +09:00');
 	});
 
+	it('should use workflow timezone for native Date local getters', async () => {
+		const data = {
+			// 2024-01-01T12:00:00.000Z
+			$json: { ts: 1704110400000 },
+		};
+
+		const nyHours = evaluator.evaluate('{{ new Date($json.ts).getHours() }}', data, caller, {
+			timezone: 'America/New_York',
+		});
+		const tokyoHours = evaluator.evaluate('{{ new Date($json.ts).getHours() }}', data, caller, {
+			timezone: 'Asia/Tokyo',
+		});
+
+		// 12:00 UTC → 07:00 EST, 21:00 JST
+		expect(nyHours).toBe(7);
+		expect(tokyoHours).toBe(21);
+	});
+
+	it('should format end time with native Date using workflow timezone (#35465)', async () => {
+		const data = {
+			$json: {
+				prefered_datetime: '2026-08-03T10:00:00-04:00',
+				slot_size: '60',
+			},
+		};
+
+		const result = evaluator.evaluate(
+			`{{ (() => {
+				const start = new Date($json.prefered_datetime);
+				const duration = (parseInt($json.slot_size) || 60) * 60000;
+				const end = new Date(start.getTime() + duration);
+				const offset = $json.prefered_datetime.slice(-6);
+				const pad = (n) => String(n).padStart(2, '0');
+				return end.getFullYear() + '-' + pad(end.getMonth() + 1) + '-' + pad(end.getDate()) + 'T' + pad(end.getHours()) + ':' + pad(end.getMinutes()) + ':' + pad(end.getSeconds()) + offset;
+			})() }}`,
+			data,
+			caller,
+			{ timezone: 'America/New_York' },
+		);
+
+		expect(result).toBe('2026-08-03T11:00:00-04:00');
+	});
+
 	describe('Luxon type serialization at boundary', () => {
 		it('should return DateTime as ISO string', () => {
 			const data = { $json: {} };

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -1,5 +1,7 @@
 import { DateTime, IANAZone, Settings } from 'luxon';
 
+import { createTimezoneAwareDateConstructor } from './workflow-timezone-date';
+
 import { extend, extendOptional } from '../extensions/extend';
 import { extendedFunctions } from '../extensions/function-extensions';
 
@@ -114,6 +116,11 @@ export function buildContext(
 	Settings.defaultZone = timezone ?? 'system';
 
 	const target: Record<string, unknown> = {};
+
+	// Local Date getters use the workflow timezone so expression preview and
+	// execution agree. Tournament resolves `Date` from this context (not the
+	// isolate global), matching Luxon's Settings.defaultZone behavior.
+	target.Date = createTimezoneAwareDateConstructor(timezone ?? 'system');
 
 	// __sanitize must be on the context because PrototypeSanitizer generates:
 	// obj[this.__sanitize(expr)] where 'this' is the context (via .call(ctx) wrapping)

--- a/packages/@n8n/expression-runtime/src/runtime/workflow-timezone-date.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/workflow-timezone-date.ts
@@ -1,0 +1,76 @@
+import { DateTime } from 'luxon';
+
+/** Native Date captured at module load — must not be replaced when we override globalThis.Date. */
+const NativeDate = Date;
+
+/**
+ * Local (non-UTC) Date getters that depend on the runtime timezone.
+ * Overridden so expression evaluation uses the workflow timezone instead of
+ * the isolate/OS timezone.
+ */
+function luxonParts(date: Date, timezone: string) {
+	// Use getTime() (UTC millis) — not fromJSDate — so luxon never calls
+	// overridden local getters like getTimezoneOffset (which would recurse).
+	return DateTime.fromMillis(date.getTime(), { zone: timezone });
+}
+
+function applyLocalGetters(instance: Date, timezone: string): void {
+	instance.getFullYear = () => luxonParts(instance, timezone).year;
+	instance.getMonth = () => luxonParts(instance, timezone).month - 1;
+	instance.getDate = () => luxonParts(instance, timezone).day;
+	// Luxon weekday: Mon=1 … Sun=7; JS getDay: Sun=0 … Sat=6
+	instance.getDay = () => luxonParts(instance, timezone).weekday % 7;
+	instance.getHours = () => luxonParts(instance, timezone).hour;
+	instance.getMinutes = () => luxonParts(instance, timezone).minute;
+	instance.getSeconds = () => luxonParts(instance, timezone).second;
+	instance.getMilliseconds = () => luxonParts(instance, timezone).millisecond;
+	instance.getTimezoneOffset = () => -luxonParts(instance, timezone).offset;
+}
+
+/**
+ * Returns a Date constructor whose instances use `timezone` for local getters
+ * (getHours, getDate, …) while preserving UTC methods and absolute time.
+ */
+export function createTimezoneAwareDateConstructor(timezone: string): DateConstructor {
+	function TimezoneAwareDate(
+		valueOrYear?: string | number | Date,
+		monthIndex?: number,
+		date?: number,
+		hours?: number,
+		minutes?: number,
+		seconds?: number,
+		ms?: number,
+	): Date {
+		let instance: Date;
+		if (arguments.length === 0) {
+			instance = new NativeDate();
+		} else if (arguments.length === 1) {
+			instance = new NativeDate(valueOrYear as string | number | Date);
+		} else {
+			// Multi-arg Date constructor uses local wall time — interpret in workflow TZ
+			instance = DateTime.fromObject(
+				{
+					year: valueOrYear as number,
+					month: (monthIndex as number) + 1,
+					day: date ?? 1,
+					hour: hours ?? 0,
+					minute: minutes ?? 0,
+					second: seconds ?? 0,
+					millisecond: ms ?? 0,
+				},
+				{ zone: timezone },
+			).toJSDate();
+		}
+
+		applyLocalGetters(instance, timezone);
+		// Returning an object from a constructor replaces the default `this`.
+		return instance;
+	}
+
+	TimezoneAwareDate.prototype = NativeDate.prototype;
+	TimezoneAwareDate.now = NativeDate.now.bind(NativeDate);
+	TimezoneAwareDate.parse = NativeDate.parse.bind(NativeDate);
+	TimezoneAwareDate.UTC = NativeDate.UTC.bind(NativeDate);
+
+	return TimezoneAwareDate as unknown as DateConstructor;
+}

--- a/packages/@n8n/tournament/src/Constants.ts
+++ b/packages/@n8n/tournament/src/Constants.ts
@@ -11,7 +11,8 @@ export const EXEMPT_IDENTIFIER_LIST = [
 	'isFinite',
 	'isNaN',
 	'NaN',
-	'Date',
+	// Date is NOT exempt: expressions resolve `Date` from the evaluation
+	// context so local getters use the workflow timezone (#35465).
 	'RegExp',
 	'Math',
 	'undefined',

--- a/packages/@n8n/tournament/test/utils.ts
+++ b/packages/@n8n/tournament/test/utils.ts
@@ -7,6 +7,7 @@ export const testExpressionsWithEvaluator = (Evaluator: ExpressionEvaluatorClass
 	const tourn = new Tournament(() => {}, undefined, Evaluator);
 	const builtins = {
 		String,
+		Date,
 		parseFloat,
 		parseInt,
 	};

--- a/packages/workflow/src/expression-timezone-date.ts
+++ b/packages/workflow/src/expression-timezone-date.ts
@@ -1,0 +1,79 @@
+import { DateTime } from 'luxon';
+
+/** Native Date captured at module load — must not be replaced when we override global Date. */
+const NativeDate = Date;
+
+/**
+ * Local (non-UTC) Date getters that depend on the runtime timezone.
+ * These are overridden so expression evaluation uses the workflow timezone
+ * instead of the browser/OS timezone (preview vs execution mismatch).
+ */
+function luxonParts(date: Date, timezone: string) {
+	// Use getTime() (UTC millis) — not fromJSDate — so luxon never calls
+	// overridden local getters like getTimezoneOffset (which would recurse).
+	return DateTime.fromMillis(date.getTime(), { zone: timezone });
+}
+
+function applyLocalGetters(instance: Date, timezone: string): void {
+	instance.getFullYear = () => luxonParts(instance, timezone).year;
+	instance.getMonth = () => luxonParts(instance, timezone).month - 1;
+	instance.getDate = () => luxonParts(instance, timezone).day;
+	// Luxon weekday: Mon=1 … Sun=7; JS getDay: Sun=0 … Sat=6
+	instance.getDay = () => luxonParts(instance, timezone).weekday % 7;
+	instance.getHours = () => luxonParts(instance, timezone).hour;
+	instance.getMinutes = () => luxonParts(instance, timezone).minute;
+	instance.getSeconds = () => luxonParts(instance, timezone).second;
+	instance.getMilliseconds = () => luxonParts(instance, timezone).millisecond;
+	instance.getTimezoneOffset = () => -luxonParts(instance, timezone).offset;
+}
+
+/**
+ * Returns a Date constructor whose instances use `timezone` for local getters
+ * (getHours, getDate, …) while preserving UTC methods and absolute time.
+ *
+ * Used so expression preview (browser) and workflow execution (server) agree
+ * when users format dates with native Date local getters (#35465).
+ */
+export function createTimezoneAwareDateConstructor(timezone: string): DateConstructor {
+	function TimezoneAwareDate(
+		valueOrYear?: string | number | Date,
+		monthIndex?: number,
+		date?: number,
+		hours?: number,
+		minutes?: number,
+		seconds?: number,
+		ms?: number,
+	): Date {
+		let instance: Date;
+		if (arguments.length === 0) {
+			instance = new NativeDate();
+		} else if (arguments.length === 1) {
+			instance = new NativeDate(valueOrYear as string | number | Date);
+		} else {
+			// Multi-arg Date constructor uses local wall time — interpret in workflow TZ
+			instance = DateTime.fromObject(
+				{
+					year: valueOrYear as number,
+					month: (monthIndex as number) + 1,
+					day: date ?? 1,
+					hour: hours ?? 0,
+					minute: minutes ?? 0,
+					second: seconds ?? 0,
+					millisecond: ms ?? 0,
+				},
+				{ zone: timezone },
+			).toJSDate();
+		}
+
+		applyLocalGetters(instance, timezone);
+		// Returning an object from a constructor replaces the default `this`.
+		return instance;
+	}
+
+	TimezoneAwareDate.prototype = NativeDate.prototype;
+	TimezoneAwareDate.now = NativeDate.now.bind(NativeDate);
+	TimezoneAwareDate.parse = NativeDate.parse.bind(NativeDate);
+	TimezoneAwareDate.UTC = NativeDate.UTC.bind(NativeDate);
+
+	return TimezoneAwareDate as unknown as DateConstructor;
+}

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -2,6 +2,8 @@ import type { IExpressionEvaluator, ObservabilityProvider } from '@n8n/expressio
 import { MemoryLimitError, SecurityViolationError, TimeoutError } from '@n8n/expression-runtime';
 import { DateTime, Duration, Interval } from 'luxon';
 
+import { createTimezoneAwareDateConstructor } from './expression-timezone-date';
+
 import { UnexpectedError, UserError } from './errors';
 import { ExpressionExtensionError } from './errors/expression-extension.error';
 import { ExpressionError } from './errors/expression.error';
@@ -416,8 +418,9 @@ export class Expression {
 		 * Allowlist
 		 */
 
-		// Dates
-		data.Date = Date;
+		// Dates — local getters use the workflow timezone so preview and
+		// execution agree (browser vs server OS timezone mismatch).
+		data.Date = createTimezoneAwareDateConstructor(this.timezone);
 		data.DateTime = DateTime;
 		data.Interval = Interval;
 		data.Duration = Duration;

--- a/packages/workflow/test/expression-timezone-date.test.ts
+++ b/packages/workflow/test/expression-timezone-date.test.ts
@@ -1,0 +1,146 @@
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+
+import { createTimezoneAwareDateConstructor } from '../src/expression-timezone-date';
+import { Workflow } from '../src/workflow';
+import * as Helpers from './helpers';
+
+describe('createTimezoneAwareDateConstructor', () => {
+	// 2024-01-01T12:00:00.000Z
+	const utcNoonMs = Date.UTC(2024, 0, 1, 12, 0, 0, 0);
+
+	it('uses workflow timezone for local getters (America/New_York)', () => {
+		const DateTz = createTimezoneAwareDateConstructor('America/New_York');
+		const date = new DateTz(utcNoonMs);
+
+		// 12:00 UTC → 07:00 EST
+		expect(date.getUTCHours()).toBe(12);
+		expect(date.getHours()).toBe(7);
+		expect(date.getFullYear()).toBe(2024);
+		expect(date.getMonth()).toBe(0);
+		expect(date.getDate()).toBe(1);
+	});
+
+	it('uses workflow timezone for local getters (Asia/Tokyo)', () => {
+		const DateTz = createTimezoneAwareDateConstructor('Asia/Tokyo');
+		const date = new DateTz(utcNoonMs);
+
+		// 12:00 UTC → 21:00 JST
+		expect(date.getHours()).toBe(21);
+		expect(date.getTimezoneOffset()).toBe(-540); // UTC+9
+	});
+
+	it('matches Luxon wall-clock parts for an offset datetime string', () => {
+		const iso = '2026-08-03T14:30:00-05:00';
+		const DateTz = createTimezoneAwareDateConstructor('America/Chicago');
+		const date = new DateTz(iso);
+		const luxon = DateTime.fromISO(iso, { setZone: true }).setZone('America/Chicago');
+
+		expect(date.getFullYear()).toBe(luxon.year);
+		expect(date.getMonth()).toBe(luxon.month - 1);
+		expect(date.getDate()).toBe(luxon.day);
+		expect(date.getHours()).toBe(luxon.hour);
+		expect(date.getMinutes()).toBe(luxon.minute);
+		expect(date.getSeconds()).toBe(luxon.second);
+	});
+
+	it('reproduces #35465-style arithmetic with consistent local formatting', () => {
+		const DateTz = createTimezoneAwareDateConstructor('America/New_York');
+		const prefered = '2026-08-03T10:00:00-04:00';
+		const slotSize = '60';
+
+		const start = new DateTz(prefered);
+		const duration = (parseInt(slotSize, 10) || 60) * 60000;
+		const end = new DateTz(start.getTime() + duration);
+		const offset = prefered.slice(-6);
+		const pad = (n: number) => String(n).padStart(2, '0');
+		const formatted = `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(end.getDate())}T${pad(end.getHours())}:${pad(end.getMinutes())}:${pad(end.getSeconds())}${offset}`;
+
+		// 10:00 EDT + 60m = 11:00 EDT, still on -04:00
+		expect(formatted).toBe('2026-08-03T11:00:00-04:00');
+	});
+});
+
+describe('Expression native Date uses workflow timezone (#35465)', () => {
+	const nodeTypes = Helpers.NodeTypes();
+
+	const makeWorkflow = (timezone: string) =>
+		new Workflow({
+			id: '1',
+			nodes: [
+				{
+					name: 'node',
+					typeVersion: 1,
+					type: 'test.set',
+					id: 'uuid-1234',
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+			connections: {},
+			active: false,
+			nodeTypes,
+			settings: { timezone },
+		});
+
+	it('formats Date local getters using workflow timezone, not OS timezone', async () => {
+		const workflow = makeWorkflow('America/New_York');
+		const expression = workflow.expression;
+		await expression.acquireIsolate();
+
+		const data: Array<{ json: Record<string, unknown> }> = [
+			{
+				json: {
+					prefered_datetime: '2026-08-03T10:00:00-04:00',
+					slot_size: '60',
+				},
+			},
+		];
+
+		const result = expression.getParameterValue(
+			`={{ (() => {
+				const start = new Date($json.prefered_datetime);
+				const duration = (parseInt($json.slot_size) || 60) * 60000;
+				const end = new Date(start.getTime() + duration);
+				const offset = $json.prefered_datetime.slice(-6);
+				const pad = (n) => String(n).padStart(2, '0');
+				return end.getFullYear() + '-' + pad(end.getMonth() + 1) + '-' + pad(end.getDate()) + 'T' + pad(end.getHours()) + ':' + pad(end.getMinutes()) + ':' + pad(end.getSeconds()) + offset;
+			})() }}`,
+			null,
+			0,
+			0,
+			'node',
+			data,
+			'manual',
+			{},
+		);
+
+		await expression.releaseIsolate();
+
+		expect(result).toBe('2026-08-03T11:00:00-04:00');
+	});
+
+	it('returns different local hours for the same instant across timezones', async () => {
+		const ms = 1704110400000; // 2024-01-01T12:00:00.000Z
+
+		const hoursFor = async (timezone: string) => {
+			const workflow = makeWorkflow(timezone);
+			await workflow.expression.acquireIsolate();
+			const result = workflow.expression.getParameterValue(
+				'={{ new Date($json.ts).getHours() }}',
+				null,
+				0,
+				0,
+				'node',
+				[{ json: { ts: ms } }],
+				'manual',
+				{},
+			);
+			await workflow.expression.releaseIsolate();
+			return result;
+		};
+
+		expect(await hoursFor('America/New_York')).toBe(7);
+		expect(await hoursFor('Asia/Tokyo')).toBe(21);
+	});
+});


### PR DESCRIPTION
## Summary

- Native `Date` local getters (`getHours`, `getDate`, `getMonth`, etc.) in expressions now use the **workflow timezone**, matching Luxon / `DateTime` behavior.
- Fixes the mismatch where Edit Fields (Set) expression **preview** (browser OS timezone) differed from **execution** (server OS timezone) for the same expression.
- Tournament no longer exempts `Date`, so `new Date(...)` resolves from the expression context (required for editor preview parity).
- Applies in both the legacy Expression engine and `@n8n/expression-runtime` (VM) path.

## How to test

1. Create a workflow and set its timezone to something different from the browser OS timezone (e.g. `America/New_York` while the machine is on UTC).
2. Add an Edit Fields (Set) node with input data like:
   - `prefered_datetime`: `2026-08-03T10:00:00-04:00`
   - `slot_size`: `60`
3. Use an expression similar to the issue repro:

```js
{{ (() => {
  const start = new Date($json.prefered_datetime);
  const duration = (parseInt($json.slot_size) || 60) * 60000;
  const end = new Date(start.getTime() + duration);
  const offset = $json.prefered_datetime.slice(-6);
  const pad = (n) => String(n).padStart(2, '0');
  return `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(end.getDate())}T${pad(end.getHours())}:${pad(end.getMinutes())}:${pad(end.getSeconds())}${offset}`;
})() }}

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

