### PR TITLE
feat(ai-builder): Trace the resources the editor attaches to a message (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3914,6 +3914,15 @@ describe('InstanceAiService — editor handoff context resources', () => {
 		expect(source).toContain('buildContextResourcesBlock(contextAttachments)');
 		expect(source).not.toContain('buildContextResourcesBlock(workflowAttachments)');
 	});
+
+	it('traces the attached resources, which the raw message no longer shows', () => {
+		const source = InstanceAiService.toString();
+
+		// `traceInput.message` is the user's text before enrichment, so the
+		// context block never reaches the trace — this is the only record that
+		// the editor handed over a resource.
+		expect(source).toContain('resourceAttachments: contextAttachments.map');
+	});
 });
 
 describe('InstanceAiService — workflow verification follow-up gate', () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3918,7 +3918,9 @@ describe('InstanceAiService — editor handoff context resources', () => {
 	it('traces the attached resources, which the raw message no longer shows', () => {
 		const source = InstanceAiService.toString();
 
-		expect(source).toContain('resourceAttachments: contextAttachments.map');
+		// Assignment-form tolerant: the wiring is what matters, not whether the
+		// field is spread into the literal or set on it afterwards.
+		expect(source).toMatch(/resourceAttachments\s*[:=]\s*contextAttachments\.map/);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3918,7 +3918,6 @@ describe('InstanceAiService — editor handoff context resources', () => {
 	it('traces the attached resources, which the raw message no longer shows', () => {
 		const source = InstanceAiService.toString();
 
-		// The context block never reaches the trace, so this is the only record.
 		expect(source).toContain('resourceAttachments: contextAttachments.map');
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3918,9 +3918,7 @@ describe('InstanceAiService — editor handoff context resources', () => {
 	it('traces the attached resources, which the raw message no longer shows', () => {
 		const source = InstanceAiService.toString();
 
-		// `traceInput.message` is the user's text before enrichment, so the
-		// context block never reaches the trace — this is the only record that
-		// the editor handed over a resource.
+		// The context block never reaches the trace, so this is the only record.
 		expect(source).toContain('resourceAttachments: contextAttachments.map');
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -200,6 +200,14 @@ function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+/** A resource attachment as the trace records it: the reference, not its contents. */
+type TracedResourceAttachment = {
+	type: InstanceAiResourceAttachment['type'];
+	id: string;
+	projectId?: string;
+	executionId?: string;
+};
+
 /** Root-run outputs for a suspended segment — keep the LangSmith turn readable (AGENT-371). */
 function buildSuspensionTraceOutputs(runId: string, suspension: SuspensionInfo | undefined) {
 	const rawMessage = suspension?.suspendPayload.message;
@@ -3295,32 +3303,33 @@ export class InstanceAiService {
 			errorReporterExecutionToken = this.instanceAiErrorReporter.beginRun(runId);
 
 			messageId = nanoid();
-			const traceInput: Record<string, unknown> = {
-				message,
-				...(fileAttachments.length
-					? {
-							attachments: fileAttachments.map((attachment) => ({
-								mimeType: attachment.mimeType,
-								size: attachment.data.length,
-							})),
-						}
-					: {}),
-				// `message` is the user's raw text, so without this the trace has no
-				// record that the editor handed the agent a resource.
-				...(contextAttachments.length
-					? {
-							resourceAttachments: contextAttachments.map((attachment) => ({
-								type: attachment.type,
-								id: attachment.id,
-								...(attachment.type === 'agent' ? { projectId: attachment.projectId } : {}),
-								...(attachment.type === 'workflow' && attachment.executionId
-									? { executionId: attachment.executionId }
-									: {}),
-							})),
-						}
-					: {}),
-				...(messageGroupId ? { messageGroupId } : {}),
-			};
+			const traceInput: Record<string, unknown> = { message };
+			if (fileAttachments.length) {
+				traceInput.attachments = fileAttachments.map((attachment) => ({
+					mimeType: attachment.mimeType,
+					size: attachment.data.length,
+				}));
+			}
+			// `message` is the user's raw text, so without this the trace has no
+			// record that the editor handed the agent a resource.
+			if (contextAttachments.length) {
+				traceInput.resourceAttachments = contextAttachments.map((attachment) => {
+					const resource: TracedResourceAttachment = {
+						type: attachment.type,
+						id: attachment.id,
+					};
+					if (attachment.type === 'agent') {
+						resource.projectId = attachment.projectId;
+					}
+					if (attachment.type === 'workflow' && attachment.executionId) {
+						resource.executionId = attachment.executionId;
+					}
+					return resource;
+				});
+			}
+			if (messageGroupId) {
+				traceInput.messageGroupId = messageGroupId;
+			}
 
 			// Shared with createExecutionEnvironment so one ProxyTokenManager backs tracing + the run.
 			const proxyRunConfig = await this.createProxyRunConfig(user);

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -3305,8 +3305,8 @@ export class InstanceAiService {
 							})),
 						}
 					: {}),
-				// Kind + id only: `message` here is the user's raw text, so without this the
-				// trace has no record that the editor handed the agent a resource to work on.
+				// `message` is the user's raw text, so without this the trace has no
+				// record that the editor handed the agent a resource.
 				...(contextAttachments.length
 					? {
 							resourceAttachments: contextAttachments.map((attachment) => ({

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -3305,6 +3305,20 @@ export class InstanceAiService {
 							})),
 						}
 					: {}),
+				// Kind + id only: `message` here is the user's raw text, so without this the
+				// trace has no record that the editor handed the agent a resource to work on.
+				...(contextAttachments.length
+					? {
+							resourceAttachments: contextAttachments.map((attachment) => ({
+								type: attachment.type,
+								id: attachment.id,
+								...(attachment.type === 'agent' ? { projectId: attachment.projectId } : {}),
+								...(attachment.type === 'workflow' && attachment.executionId
+									? { executionId: attachment.executionId }
+									: {}),
+							})),
+						}
+					: {}),
 				...(messageGroupId ? { messageGroupId } : {}),
 			};
 


### PR DESCRIPTION
## Summary

A message's traced inputs carried its **file** attachments but not its **resource** attachments, so nothing in the trace recorded that the editor handed the agent a workflow.

Not deliberate. Before #32398, `traceInput.attachments` covered every attachment. That PR introduced workflow/agent attachments and narrowed the same line to files — `attachment.data.length` only exists on the file variant, so it wouldn't compile against the union — and the new kind fell out:

```diff
-      ...(attachments?.length
+      ...(fileAttachments.length
```

It went unnoticed because it was never observable: `traceInput.message` is the user's raw text (the `<editor-context>` block is added later), so no trace recorded the hand-off. A marker appended to **every** user message appears in **0 of 122,413** imported turns, confirming no enrichment reaches the trace.

Adds kind + ids. No display name — the id identifies the resource, the name is user data.

## Why

An author turning a real conversation into an eval case can't tell whether the opening had a workflow attached. Guess wrong and the case is harder than reality: the real agent was handed the workflow, the eval agent must infer it from prose naming nothing, and asking "which workflow?" scores as a clarification failure the user never hit.

Consumed by n8n-io/lang-tracer#119. https://linear.app/n8n/issue/TRUST-377

## Validated on a real UI hand-off

A conversation started from the workflow canvas on a local instance produced this `message_turn` root in LangSmith:

```json
"inputs": {
  "message": "",
  "messageGroupId": "mg_k33cx0CbNcFsJWQqwVIWr",
  "resourceAttachments": [{"id": "Mn0cpcexbrYps1si", "type": "workflow"}]
}
```

The UI sent a `name` alongside the id; the trace carries only `id` + `type`. `message` is empty, so without this field the opening turn traced as a blank record. The follow-up turn in the same thread carries no attachment, as expected.

## Notes

- Additive to a trace payload — no behaviour change, no new request/response field.
- `contextAttachments` was already computed two lines above for the context block.

`pnpm --filter n8n test src/modules/instance-ai/__tests__/instance-ai.service.test.ts -t "editor handoff context resources"`

#### Responsibility
- [x] I have tested this code to the best of my abilities

