### PR TITLE
feat(core): Enforce application_type and gate loopback redirect matching (SEP-837)

### DIFF
--- a/docs/generated/postgres-schema/README.md
+++ b/docs/generated/postgres-schema/README.md
@@ -88,7 +88,7 @@ Auto-generated from the PostgreSQL migrations in @n8n/db. Do not edit by hand.
 | [public.mcp_registry_server](public.mcp_registry_server.md) | 7 |  | BASE TABLE |
 | [public.oauth_access_tokens](public.oauth_access_tokens.md) | 3 |  | BASE TABLE |
 | [public.oauth_authorization_codes](public.oauth_authorization_codes.md) | 13 |  | BASE TABLE |
-| [public.oauth_clients](public.oauth_clients.md) | 11 |  | BASE TABLE |
+| [public.oauth_clients](public.oauth_clients.md) | 12 |  | BASE TABLE |
 | [public.oauth_refresh_tokens](public.oauth_refresh_tokens.md) | 7 |  | BASE TABLE |
 | [public.oauth_user_consents](public.oauth_user_consents.md) | 5 |  | BASE TABLE |
 | [public.processed_data](public.processed_data.md) | 5 |  | BASE TABLE |
@@ -1137,6 +1137,7 @@ erDiagram
   uuid userId FK
 }
 "public.oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   timestamp_3__with_time_zone createdAt

--- a/docs/generated/postgres-schema/public.oauth_access_tokens.md
+++ b/docs/generated/postgres-schema/public.oauth_access_tokens.md
@@ -39,6 +39,7 @@ erDiagram
   uuid userId FK
 }
 "public.oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   timestamp_3__with_time_zone createdAt

--- a/docs/generated/postgres-schema/public.oauth_authorization_codes.md
+++ b/docs/generated/postgres-schema/public.oauth_authorization_codes.md
@@ -67,6 +67,7 @@ erDiagram
   uuid userId FK
 }
 "public.oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   timestamp_3__with_time_zone createdAt

--- a/docs/generated/postgres-schema/public.oauth_clients.md
+++ b/docs/generated/postgres-schema/public.oauth_clients.md
@@ -4,6 +4,7 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
+| applicationType | varchar(255) | 'native'::character varying | false |  |  |  |
 | clientSecret | varchar(255) |  | true |  |  |  |
 | clientSecretExpiresAt | bigint |  | true |  |  |  |
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
@@ -21,6 +22,7 @@
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
 | PK_c4759172d3431bae6f04e678e0d | PRIMARY KEY | PRIMARY KEY (id) |
+| oauth_clients_applicationType_not_null | n | NOT NULL "applicationType" |
 | oauth_clients_createdAt_not_null | n | NOT NULL "createdAt" |
 | oauth_clients_grantTypes_not_null | n | NOT NULL "grantTypes" |
 | oauth_clients_id_not_null | n | NOT NULL id |
@@ -48,6 +50,7 @@ erDiagram
 "public.oauth_user_consents" }o--|| "public.oauth_clients" : "FOREIGN KEY (#quot;clientId#quot;) REFERENCES oauth_clients(id) ON DELETE CASCADE"
 
 "public.oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   timestamp_3__with_time_zone createdAt

--- a/docs/generated/postgres-schema/public.oauth_refresh_tokens.md
+++ b/docs/generated/postgres-schema/public.oauth_refresh_tokens.md
@@ -51,6 +51,7 @@ erDiagram
   uuid userId FK
 }
 "public.oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   timestamp_3__with_time_zone createdAt

--- a/docs/generated/postgres-schema/public.oauth_user_consents.md
+++ b/docs/generated/postgres-schema/public.oauth_user_consents.md
@@ -47,6 +47,7 @@ erDiagram
   uuid userId FK
 }
 "public.oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   timestamp_3__with_time_zone createdAt

--- a/docs/generated/sqlite-schema/README.md
+++ b/docs/generated/sqlite-schema/README.md
@@ -88,7 +88,7 @@ Auto-generated from the SQLite migrations in @n8n/db. Do not edit by hand.
 | [mcp_registry_server](mcp_registry_server.md) | 7 |  | table |
 | [oauth_access_tokens](oauth_access_tokens.md) | 3 |  | table |
 | [oauth_authorization_codes](oauth_authorization_codes.md) | 13 |  | table |
-| [oauth_clients](oauth_clients.md) | 11 |  | table |
+| [oauth_clients](oauth_clients.md) | 12 |  | table |
 | [oauth_refresh_tokens](oauth_refresh_tokens.md) | 7 |  | table |
 | [oauth_user_consents](oauth_user_consents.md) | 5 |  | table |
 | [processed_data](processed_data.md) | 5 |  | table |
@@ -1124,6 +1124,7 @@ erDiagram
   varchar userId FK
 }
 "oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   datetime_3_ createdAt

--- a/docs/generated/sqlite-schema/oauth_access_tokens.md
+++ b/docs/generated/sqlite-schema/oauth_access_tokens.md
@@ -48,6 +48,7 @@ erDiagram
   varchar userId FK
 }
 "oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   datetime_3_ createdAt

--- a/docs/generated/sqlite-schema/oauth_authorization_codes.md
+++ b/docs/generated/sqlite-schema/oauth_authorization_codes.md
@@ -68,6 +68,7 @@ erDiagram
   varchar userId FK
 }
 "oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   datetime_3_ createdAt

--- a/docs/generated/sqlite-schema/oauth_clients.md
+++ b/docs/generated/sqlite-schema/oauth_clients.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "oauth_clients" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar(255) NOT NULL, "redirectUris" text NOT NULL, "grantTypes" text NOT NULL, "clientSecret" varchar(255), "clientSecretExpiresAt" bigint, "tokenEndpointAuthMethod" varchar(255) NOT NULL DEFAULT ('none'), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "isFirstParty" boolean NOT NULL DEFAULT (false), "isCimd" boolean NOT NULL DEFAULT (false))
+CREATE TABLE "oauth_clients" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar(255) NOT NULL, "redirectUris" text NOT NULL, "grantTypes" text NOT NULL, "clientSecret" varchar(255), "clientSecretExpiresAt" bigint, "tokenEndpointAuthMethod" varchar(255) NOT NULL DEFAULT ('none'), "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "isFirstParty" boolean NOT NULL DEFAULT (false), "isCimd" boolean NOT NULL DEFAULT (false), "applicationType" varchar(255) NOT NULL DEFAULT ('native'))
 ```
 
 </details>
@@ -15,6 +15,7 @@ CREATE TABLE "oauth_clients" ("id" varchar PRIMARY KEY NOT NULL, "name" varchar(
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
+| applicationType | varchar(255) | 'native' | false |  |  |  |
 | clientSecret | varchar(255) |  | true |  |  |  |
 | clientSecretExpiresAt | bigint |  | true |  |  |  |
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
@@ -51,6 +52,7 @@ erDiagram
 "oauth_user_consents" }o--|| "oauth_clients" : "FOREIGN KEY (clientId) REFERENCES oauth_clients (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE"
 
 "oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   datetime_3_ createdAt

--- a/docs/generated/sqlite-schema/oauth_refresh_tokens.md
+++ b/docs/generated/sqlite-schema/oauth_refresh_tokens.md
@@ -56,6 +56,7 @@ erDiagram
   varchar userId FK
 }
 "oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   datetime_3_ createdAt

--- a/docs/generated/sqlite-schema/oauth_user_consents.md
+++ b/docs/generated/sqlite-schema/oauth_user_consents.md
@@ -52,6 +52,7 @@ erDiagram
   varchar userId FK
 }
 "oauth_clients" {
+  varchar_255_ applicationType
   varchar_255_ clientSecret
   bigint clientSecretExpiresAt
   datetime_3_ createdAt

--- a/packages/@n8n/db/src/migrations/common/1785500900001-AddApplicationTypeToOAuthClients.ts
+++ b/packages/@n8n/db/src/migrations/common/1785500900001-AddApplicationTypeToOAuthClients.ts
@@ -1,0 +1,22 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const OAUTH_CLIENTS_TABLE = 'oauth_clients';
+const APPLICATION_TYPE_COLUMN = 'applicationType';
+
+export class AddApplicationTypeToOAuthClients1785500900001 implements ReversibleMigration {
+	// Existing rows default to `native`: before this column, every client got
+	// RFC 8252 port-agnostic loopback matching, so `native` preserves that.
+	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
+		await addColumns(
+			OAUTH_CLIENTS_TABLE,
+			[column(APPLICATION_TYPE_COLUMN).varchar(255).notNull.default("'native'")],
+			{ recreatesOnSqlite: true },
+		);
+	}
+
+	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns(OAUTH_CLIENTS_TABLE, [APPLICATION_TYPE_COLUMN], {
+			recreatesOnSqlite: true,
+		});
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -238,6 +238,7 @@ import { AddMisfirePolicyToScheduler1785247194307 } from '../common/178524719430
 import { CreateAgentChatAttachmentsTable1785255306000 } from '../common/1785255306000-CreateAgentChatAttachmentsTable';
 import { AddSetupCompletedAtToAgents1785500832626 } from '../common/1785500832626-AddSetupCompletedAtToAgents';
 import { AddIsCimdToOAuthClients1785500900000 } from '../common/1785500900000-AddIsCimdToOAuthClients';
+import { AddApplicationTypeToOAuthClients1785500900001 } from '../common/1785500900001-AddApplicationTypeToOAuthClients';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -481,4 +482,5 @@ export const postgresMigrations: Migration[] = [
 	CreateAgentChatAttachmentsTable1785255306000,
 	AddSetupCompletedAtToAgents1785500832626,
 	AddIsCimdToOAuthClients1785500900000,
+	AddApplicationTypeToOAuthClients1785500900001,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/1785500900001-AddApplicationTypeToOAuthClients.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1785500900001-AddApplicationTypeToOAuthClients.ts
@@ -1,0 +1,27 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const OAUTH_CLIENTS_TABLE = 'oauth_clients';
+const APPLICATION_TYPE_COLUMN = 'applicationType';
+
+export class AddApplicationTypeToOAuthClients1785500900001 implements ReversibleMigration {
+	// oauth_clients has inbound ON DELETE CASCADE FKs (access/refresh tokens,
+	// authorization codes, user consents). Recreating the table on SQLite would
+	// fire those cascades and wipe the referencing rows, so disable FKs.
+	withFKsDisabled = true as const;
+
+	// Existing rows default to `native`: before this column, every client got
+	// RFC 8252 port-agnostic loopback matching, so `native` preserves that.
+	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
+		await addColumns(
+			OAUTH_CLIENTS_TABLE,
+			[column(APPLICATION_TYPE_COLUMN).varchar(255).notNull.default("'native'")],
+			{ recreatesOnSqlite: true },
+		);
+	}
+
+	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns(OAUTH_CLIENTS_TABLE, [APPLICATION_TYPE_COLUMN], {
+			recreatesOnSqlite: true,
+		});
+	}
+}

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -64,6 +64,7 @@ import { AddIsFirstPartyToOAuthClients1785162364001 } from './1785162364001-AddI
 import { AddMisfirePolicyToScheduler1785247194307 } from './1785247194307-AddMisfirePolicyToScheduler';
 import { AddSetupCompletedAtToAgents1785500832626 } from './1785500832626-AddSetupCompletedAtToAgents';
 import { AddIsCimdToOAuthClients1785500900000 } from './1785500900000-AddIsCimdToOAuthClients';
+import { AddApplicationTypeToOAuthClients1785500900001 } from './1785500900001-AddApplicationTypeToOAuthClients';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';
@@ -463,6 +464,7 @@ const sqliteMigrations: Migration[] = [
 	CreateAgentChatAttachmentsTable1785255306000,
 	AddSetupCompletedAtToAgents1785500832626,
 	AddIsCimdToOAuthClients1785500900000,
+	AddApplicationTypeToOAuthClients1785500900001,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
@@ -1,3 +1,4 @@
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/server';
 import { InvalidGrantError, InvalidTargetError } from '@modelcontextprotocol/server-legacy/auth';
 import { Logger, type ModuleRegistry } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
@@ -191,6 +192,75 @@ describe('OAuthServerService', () => {
 
 			expect(res.redirect).toHaveBeenCalledWith('/oauth/consent');
 			expect(res.status).not.toHaveBeenCalledWith(400);
+		});
+	});
+
+	describe('application_type (SEP-837)', () => {
+		const baseClient = {
+			client_id: 'app-type-client',
+			client_name: 'App Type Client',
+			redirect_uris: ['http://127.0.0.1/callback'],
+			grant_types: ['authorization_code'],
+			token_endpoint_auth_method: 'none',
+			response_types: ['code'],
+			logo_uri: undefined,
+			tos_uri: undefined,
+		};
+		const loopbackParams = {
+			redirectUri: 'http://127.0.0.1:53123/callback',
+			codeChallenge: 'challenge',
+			state: 'state-xyz',
+			resource: new URL(TEST_RESOURCE_URL),
+		};
+
+		it('stores application_type=web when the client declares it', async () => {
+			oauthClientRepository.insert.mockResolvedValue({} as never);
+
+			await service.clientsStore.registerClient!({
+				...baseClient,
+				client_id: 'web-client',
+				redirect_uris: ['https://web.example.com/callback'],
+				application_type: 'web',
+			} as OAuthClientInformationFull);
+
+			expect(oauthClientRepository.insert).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'web-client', applicationType: 'web' }),
+			);
+		});
+
+		it('defaults application_type to native when the client omits it', async () => {
+			oauthClientRepository.insert.mockResolvedValue({} as never);
+
+			await service.clientsStore.registerClient!(baseClient);
+
+			expect(oauthClientRepository.insert).toHaveBeenCalledWith(
+				expect.objectContaining({ applicationType: 'native' }),
+			);
+		});
+
+		it('gives native clients port-agnostic loopback redirect matching', async () => {
+			getAllowedRedirectUris.mockResolvedValue(['http://127.0.0.1/callback']);
+			oauthClientRepository.findOneBy.mockResolvedValue({
+				applicationType: 'native',
+			} as OAuthClient);
+			const res = mock<Response>();
+
+			await service.authorize(baseClient, loopbackParams, res);
+
+			expect(res.redirect).toHaveBeenCalledWith('/oauth/consent');
+			expect(res.status).not.toHaveBeenCalledWith(400);
+		});
+
+		it('denies a web client a loopback redirect on a non-registered port', async () => {
+			getAllowedRedirectUris.mockResolvedValue(['http://127.0.0.1/callback']);
+			oauthClientRepository.findOneBy.mockResolvedValue({ applicationType: 'web' } as OAuthClient);
+			const res = mock<Response>();
+			res.status.mockReturnThis();
+
+			await service.authorize(baseClient, loopbackParams, res);
+
+			expect(res.status).toHaveBeenCalledWith(400);
+			expect(res.redirect).not.toHaveBeenCalledWith('/oauth/consent');
 		});
 	});
 
@@ -424,6 +494,7 @@ describe('OAuthServerService', () => {
 					clientSecret: null,
 					clientSecretExpiresAt: null,
 					tokenEndpointAuthMethod: 'none',
+					applicationType: 'native',
 					isFirstParty: false,
 				});
 				expect(result).toEqual(clientInfo);
@@ -456,6 +527,7 @@ describe('OAuthServerService', () => {
 					clientSecret: 'secret-123',
 					clientSecretExpiresAt: 1234567890,
 					tokenEndpointAuthMethod: 'client_secret_post',
+					applicationType: 'native',
 					isFirstParty: false,
 				});
 			});

--- a/packages/cli/src/modules/oauth-server/database/entities/oauth-client.entity.ts
+++ b/packages/cli/src/modules/oauth-server/database/entities/oauth-client.entity.ts
@@ -35,6 +35,16 @@ export class OAuthClient extends WithTimestamps {
 	@Column({ type: Boolean, default: false })
 	isCimd: boolean;
 
+	/**
+	 * RFC 7591 / SEP-837 `application_type`. Only `native` clients get RFC 8252
+	 * port-agnostic loopback redirect matching; `web` clients are matched
+	 * exactly, so a web client can't claim an arbitrary localhost port. Defaults
+	 * to `native` for rows registered before this field existed, preserving their
+	 * prior matching behavior.
+	 */
+	@Column({ type: String, default: 'native' })
+	applicationType: 'web' | 'native';
+
 	@OneToMany('AuthorizationCode', 'client')
 	authorizationCodes: AuthorizationCode[];
 

--- a/packages/cli/src/modules/oauth-server/oauth-server.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-server.service.ts
@@ -89,6 +89,17 @@ function sortOwners(owners: ConnectedOAuthClientOwner[]): ConnectedOAuthClientOw
 const MAX_REDIRECT_URI_LENGTH = 2048;
 
 /**
+ * SEP-837 `application_type` off a DCR registration payload. The v2 SDK keeps
+ * the field on the request but doesn't surface it on the typed client shape, so
+ * read it defensively. Only an explicit `web` narrows redirect matching to exact;
+ * every other value (including omitted) stays `native`, preserving the prior
+ * port-agnostic loopback behavior.
+ */
+function readApplicationType(client: OAuthClientInformationFull): 'web' | 'native' {
+	return Reflect.get(client, 'application_type') === 'web' ? 'web' : 'native';
+}
+
+/**
  * OAuth 2.1 server implementation shared by all registered protected resources.
  * Implements MCP SDK OAuthServerProvider interface for client registration, authorization, and token management
  */
@@ -159,6 +170,7 @@ export class OAuthServerService implements OAuthServerProvider {
 					clientSecret: client.client_secret ?? null,
 					clientSecretExpiresAt: client.client_secret_expires_at ?? null,
 					tokenEndpointAuthMethod: client.token_endpoint_auth_method ?? 'none',
+					applicationType: readApplicationType(client),
 					isFirstParty: false,
 				});
 
@@ -381,13 +393,22 @@ export class OAuthServerService implements OAuthServerProvider {
 	 *
 	 * Non-loopback URIs must match an allowlist entry exactly. Loopback URIs
 	 * (localhost / 127.0.0.1 / [::1]) match a loopback allowlist entry that
-	 * shares the same scheme, host and path regardless of port: native clients
-	 * bind an ephemeral port at request time, so the port cannot be known in
-	 * advance (RFC 8252 §7.3).
+	 * shares the same scheme, host and path regardless of port, but only for
+	 * `native` clients: they bind an ephemeral port at request time, so the port
+	 * can't be known in advance (RFC 8252 §7.3). `web` clients get exact matching
+	 * (SEP-837), so a web client can't claim an arbitrary localhost port.
 	 */
-	private isRedirectUriAllowed(allowedUris: string[], redirectUri: string): boolean {
+	private isRedirectUriAllowed(
+		allowedUris: string[],
+		redirectUri: string,
+		applicationType: 'web' | 'native',
+	): boolean {
 		if (allowedUris.includes(redirectUri)) {
 			return true;
+		}
+
+		if (applicationType !== 'native') {
+			return false;
 		}
 
 		let requested: URL;
@@ -422,6 +443,15 @@ export class OAuthServerService implements OAuthServerProvider {
 		return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
 	}
 
+	/**
+	 * The stored SEP-837 `application_type` for a client, defaulting to `native`
+	 * for unknown clients so the redirect check keeps its pre-SEP-837 behavior.
+	 */
+	private async getClientApplicationType(clientId: string): Promise<'web' | 'native'> {
+		const client = await this.oauthClientRepository.findOneBy({ id: clientId });
+		return client?.applicationType === 'web' ? 'web' : 'native';
+	}
+
 	async authorize(
 		client: OAuthClientInformationFull,
 		params: AuthorizationParams,
@@ -442,7 +472,12 @@ export class OAuthServerService implements OAuthServerProvider {
 			const allowedUris = this.isCimdClientId(client.client_id)
 				? []
 				: ((await targetResource?.getAllowedRedirectUris?.()) ?? []);
-			if (allowedUris.length > 0 && !this.isRedirectUriAllowed(allowedUris, params.redirectUri)) {
+			const applicationType =
+				allowedUris.length > 0 ? await this.getClientApplicationType(client.client_id) : 'native';
+			if (
+				allowedUris.length > 0 &&
+				!this.isRedirectUriAllowed(allowedUris, params.redirectUri, applicationType)
+			) {
 				this.logger.warn(
 					'MCP OAuth authorization rejected: requested redirect URI is not in the configured allowlist',
 					{


### PR DESCRIPTION
## Summary

Milestone 2 (Authorization: CIMD and DCR hardening), ticket 3 of 3. Persists the RFC 7591 / SEP-837 `application_type` on registered OAuth clients and uses it to decide redirect-URI matching. RFC 8252 port-agnostic loopback matching (which lets an ephemeral-port `http://127.0.0.1:PORT/cb` match a portless allowlist entry) now applies **only to clients registered as `native`**. A client registered as `web` gets exact matching, so it can't claim an arbitrary localhost port.

https://linear.app/n8n/issue/ADO-5687

## Changes

- New `applicationType` column on `oauth_clients` (migration, common + SQLite variants). Existing rows default to `native`, preserving their prior port-agnostic behavior on upgrade.
- Registration captures `application_type` from the DCR request (the v2 SDK keeps the field on the payload though it isn't on the typed client shape, so it's read defensively).
- `isRedirectUriAllowed` reads the client's stored `applicationType` and skips the port-agnostic loopback branch for `web` clients.

## The omitted-default decision (worth a look)

The ticket asks to "decide the default so nothing breaks on upgrade; existing clients with loopback redirect URIs are presumably native." I extended that reasoning: **only an explicit `application_type: web` narrows matching to exact; every other value — including omitted — stays `native`**. This is the no-regression reading (every client got port-agnostic matching before, and native clients that haven't adopted SEP-837 yet keep working), and it honors n8n's "security must not degrade the building experience" principle. SEP-837 is still enforced for clients that declare themselves `web`.

The stricter alternative — treat omitted as `web` (OIDC default) and require native clients to declare `application_type: native` — is more aggressive but risks breaking native MCP clients that don't send the field yet. Happy to switch to that if we'd rather be strict; it's a one-line change in `readApplicationType`.

## Testing

- `pnpm test src/modules/oauth-server` — green (adds a `application_type (SEP-837)` suite: registration captures web / defaults to native; native gets port-agnostic loopback, web is denied a non-registered loopback port; existing register-insert and cap assertions updated).
- `pnpm typecheck` — clean (cli, `@n8n/db`).
- DB schema docs regenerated; pre-commit schema check passes.

Stacked on #35478 (ADO-5686). Review/merge the milestone-2 stack in order: #35476 → #35478 → this.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

