### PR TITLE
fix(GitlabTrigger): use NodeApiError.httpCode and safe description access in webhook checkExists

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -196,7 +196,7 @@ export class GitlabTrigger implements INodeType {
 				try {
 					await gitlabApiRequest.call(this, 'GET', endpoint, {});
 				} catch (error) {
-					if (error.cause.httpCode === '404' || error.description.includes('404')) {
+					if (error.httpCode === '404' || error.description?.includes('404')) {
 						// Webhook does not exist
 						delete webhookData.webhookId;
 						delete webhookData.webhookEvents;
@@ -205,7 +205,7 @@ export class GitlabTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 

--- a/packages/nodes-base/nodes/Gitlab/__tests__/GitlabTrigger.test.ts
+++ b/packages/nodes-base/nodes/Gitlab/__tests__/GitlabTrigger.test.ts
@@ -7,7 +7,13 @@ vi.mock('../GitlabTriggerHelpers', () => ({
 	verifySignature: vi.fn(),
 }));
 
+vi.mock('../GenericFunctions', () => ({
+	gitlabApiRequest: vi.fn(),
+}));
+
+import { gitlabApiRequest } from '../GenericFunctions';
 import { verifySignature } from '../GitlabTriggerHelpers';
+import { NodeApiError } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 
 describe('GitlabTrigger', () => {
@@ -82,6 +88,87 @@ describe('GitlabTrigger', () => {
 
 			expect(result.workflowData).toBeDefined();
 			expect(mockResponse.status).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('webhookMethods.default.checkExists', () => {
+		let mockHookFunctions: Partial<IWebhookFunctions>;
+
+		const staticData = (webhookId: unknown) => ({
+			getWorkflowStaticData: vi.fn().mockReturnValue({ webhookId }),
+			getNodeParameter: vi.fn((name: string) => (name === 'owner' ? 'some-owner' : 'some-repo')),
+		});
+
+		beforeEach(() => {
+			(gitlabApiRequest as Mock).mockReset();
+		});
+
+		it('should return false when no webhook id is stored', async () => {
+			mockHookFunctions = staticData(undefined) as unknown as Partial<IWebhookFunctions>;
+
+			const result = await trigger.webhookMethods!.default.checkExists.call(
+				mockHookFunctions as never,
+			);
+
+			expect(result).toBe(false);
+			expect(gitlabApiRequest).not.toHaveBeenCalled();
+		});
+
+		it('should return true when the API confirms the webhook', async () => {
+			mockHookFunctions = staticData(42) as unknown as Partial<IWebhookFunctions>;
+			(gitlabApiRequest as Mock).mockResolvedValue({ id: 42 });
+
+			const result = await trigger.webhookMethods!.default.checkExists.call(
+				mockHookFunctions as never,
+			);
+
+			expect(result).toBe(true);
+			expect(gitlabApiRequest).toHaveBeenCalledWith(
+				'GET',
+				'/projects/some-owner%2Fsome-repo/hooks/42',
+				{},
+			);
+		});
+
+		it('should return false and clear static data when the webhook is gone (404 via httpCode)', async () => {
+			mockHookFunctions = staticData(42) as unknown as Partial<IWebhookFunctions>;
+			const error = new NodeApiError({} as never, {}, { httpCode: '404' });
+			(gitlabApiRequest as Mock).mockRejectedValue(error);
+
+			const result = await trigger.webhookMethods!.default.checkExists.call(
+				mockHookFunctions as never,
+			);
+
+			expect(result).toBe(false);
+			const data = mockHookFunctions.getWorkflowStaticData!('node') as IDataObject;
+			expect(data.webhookId).toBeUndefined();
+			expect(data.webhookEvents).toBeUndefined();
+			expect(data.webhookSecret).toBeUndefined();
+		});
+
+		it('should not crash when a 404-shaped error has no description', async () => {
+			// Regression: the old code read error.cause.httpCode and called
+			// error.description.includes('404') unconditionally, which threw
+			// TypeError on errors without a description.
+			mockHookFunctions = staticData(42) as unknown as Partial<IWebhookFunctions>;
+			const error = new NodeApiError({} as never, {}, { httpCode: '404', description: '' });
+			(gitlabApiRequest as Mock).mockRejectedValue(error);
+
+			const result = await trigger.webhookMethods!.default.checkExists.call(
+				mockHookFunctions as never,
+			);
+
+			expect(result).toBe(false);
+		});
+
+		it('should rethrow non-404 errors', async () => {
+			mockHookFunctions = staticData(42) as unknown as Partial<IWebhookFunctions>;
+			const error = new NodeApiError({} as never, {}, { httpCode: '500' });
+			(gitlabApiRequest as Mock).mockRejectedValue(error);
+
+			await expect(
+				trigger.webhookMethods!.default.checkExists.call(mockHookFunctions as never),
+			).rejects.toThrow(error);
 		});
 	});
 


### PR DESCRIPTION
The webhook checkExists handler in GitlabTrigger catches errors thrown by gitlabApiRequest, which wraps them in a NodeApiError. The 404 detection was checking error.cause.httpCode — the raw underlying request error — instead of error.httpCode, the property NodeApiError populates by recursively extracting the HTTP status from the response. As a result the first condition rarely matched, and the fallback error.description.includes('404') would throw a TypeError whenever description was undefined (e.g. on network errors with no response body), crashing the webhook lifecycle check instead of cleanly returning false.

Changed to check error.httpCode directly and use optional chaining on description. Also fixed the 'occured' typo in the adjacent comment while in the file.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

