### PR TITLE
test: Repair `vi.mock` specifiers that no longer resolve (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -170,16 +170,6 @@ vi.mock('@/app/stores/workflowsList.store', () => {
 	};
 });
 
-vi.mock('@/app/stores/parameterOverrides.store', () => {
-	const storeState: Partial<ReturnType<typeof useAgentRequestStore>> & {} = {
-		agentRequests: {},
-		getAgentRequest: vi.fn(),
-	};
-	return {
-		useAgentRequestStore: vi.fn().mockReturnValue(storeState),
-	};
-});
-
 vi.mock('@/app/stores/pushConnection.store', () => ({
 	usePushConnectionStore: vi.fn().mockReturnValue({
 		isConnected: true,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiConfirmationPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiConfirmationPanel.test.ts
@@ -79,7 +79,7 @@ vi.mock('../components/InstanceAiCredentialSetup.vue', () => ({
 		props: ['requestId', 'credentialRequests', 'message', 'projectId', 'credentialFlow'],
 	},
 }));
-vi.mock('../components/InstanceAiWorkflowSetup.vue', () => ({
+vi.mock('../workflowSetup/InstanceAiWorkflowSetup.vue', () => ({
 	default: {
 		template: '<div />',
 		props: ['requestId', 'setupRequests', 'workflowId', 'message', 'projectId', 'credentialFlow'],

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.test.ts
@@ -42,10 +42,6 @@ vi.mock('@/app/composables/usePageRedirectionHelper', () => {
 	};
 });
 
-vi.mock('is-emoji-supported', () => ({
-	isEmojiSupported: () => true,
-}));
-
 const renderComponent = createComponentRenderer(ProjectsNavigation, {
 	global: {
 		plugins: [

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/dataGrid/DataTableTable.test.ts
@@ -61,17 +61,6 @@ vi.mock('@/features/core/dataTable/components/dataGrid/n8nTheme', () => ({
 	n8nTheme: 'n8n-theme',
 }));
 
-// Mock AddColumnPopover
-vi.mock('@/features/core/dataTable/components/dataGrid/AddColumnPopover.vue', () => ({
-	default: {
-		name: 'AddColumnPopover',
-		template:
-			'<div data-test-id="add-column-popover"><button data-test-id="data-table-add-column-button" @click="$emit(\'add-column\', { column: { name: \'newColumn\', type: \'string\' } })">Add Column</button></div>',
-		props: ['dataTable'],
-		emits: ['add-column'],
-	},
-}));
-
 // Mock composables
 vi.mock('@n8n/composables/useToast', () => ({
 	useToast: () => ({

--- a/packages/frontend/editor-ui/src/features/core/folders/folders.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/folders.store.test.ts
@@ -8,10 +8,6 @@ import type { IUsedCredential } from '@/features/credentials/credentials.types';
 import type { ChangeLocationSearchResponseItem } from './folders.types';
 import { useRootStore } from '@n8n/stores/useRootStore';
 
-vi.mock('@/app/utils/apiUtils', () => ({
-	makeRestApiRequest: vi.fn(),
-}));
-
 const createFolder = (
 	overrides: Partial<ChangeLocationSearchResponseItem> = {},
 ): ChangeLocationSearchResponseItem => ({

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -65,7 +65,7 @@ vi.mock('@vueuse/core', async () => {
 	};
 });
 
-vi.mock('@/stores/pushConnection.store', () => ({
+vi.mock('@/app/stores/pushConnection.store', () => ({
 	usePushConnectionStore: vi.fn().mockReturnValue({
 		isConnected: true,
 	}),

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.test.ts
@@ -6,17 +6,6 @@ import type { AskAiRequest } from '@/features/ai/assistant/assistant.types';
 import type { Schema } from '@/Interface';
 import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 
-vi.mock('./utils', async () => {
-	const actual = await vi.importActual('./utils');
-	return {
-		...actual,
-		getSchemas: vi.fn(() => ({
-			parentNodesSchemas: { test: 'parentSchema' },
-			inputSchema: { test: 'inputSchema' },
-		})),
-	};
-});
-
 vi.mock('@n8n/stores/useRootStore', () => ({
 	useRootStore: () => ({
 		pushRef: 'mockRootPushRef',

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts
@@ -8,10 +8,6 @@ import { type ComputedRef, ref } from 'vue';
 import type { CommunityNodeDetails } from '@/features/shared/nodeCreator/composables/useViewStacks';
 import CommunityNodeInfo from './CommunityNodeInfo.vue';
 
-vi.mock('./utils', () => ({
-	fetchInstalledPackageInfo: vi.fn(),
-}));
-
 // const mockInstalledPackage = ref<ExtendedPublicInstalledPackage | undefined>(undefined);
 // const isUpdateCheckAvailable = ref(false);
 


### PR DESCRIPTION
## Summary

An unresolvable `vi.mock` specifier does not raise in this repo's Vitest config. The factory is simply never invoked, so the whole block is inert and the real module keeps loading in a test written expecting a mock. `vue-tsc` cannot see a specifier inside a `vi.mock` string, so a path that drifts during an import repoint typechecks clean and fails nothing.

Verified mechanism, on `folders.store.test.ts`: putting `vi.mock('@/app/utils/apiUtils', () => { throw new Error(...) })` in the file leaves the suite green at 5/5. A factory that unconditionally throws never runs.

I audited all **2250** `vi.mock` call sites (520 distinct specifiers) under `packages/frontend/editor-ui/src`, resolving each against the alias table in `vite.config.mts` plus the test-only alias from `@n8n/vitest-config/frontend`. **Eight** specifiers resolved to nothing. Two were mocks the test genuinely wanted — those are repointed and now load-bearing. Six were unreachable — those are deleted.

### Repointed — mock was intended, now actually intercepts

| Site | Was | Now |
|---|---|---|
| `LogsPanel.test.ts:68` | `@/stores/pushConnection.store` | `@/app/stores/pushConnection.store` |
| `InstanceAiConfirmationPanel.test.ts:82` | `../components/InstanceAiWorkflowSetup.vue` | `../workflowSetup/InstanceAiWorkflowSetup.vue` |

Both were silently not mocking. `useChatState.ts:54` reads `pushConnectionStore.isConnected`, and `InstanceAiConfirmationPanel.vue:18` renders the real `InstanceAiWorkflowSetup`. Liveness proven by temporarily making each factory throw: with the repointed specifier the suite fails at `useRunWorkflow.ts:59` and `InstanceAiConfirmationPanel.vue:18` respectively, i.e. the mock now sits on a real import edge. Probes reverted.

### Deleted — target module is gone and the mock is unreachable

- `useRunWorkflow.test.ts` — `@/app/stores/parameterOverrides.store`. The store moved to `@n8n/stores/useAgentRequestStore`; the suite already imports it from there and drives `getAgentRequest` through the `createTestingPinia` action spy, so the module mock adds nothing.
- `folders.store.test.ts` — `@/app/utils/apiUtils`. `makeRestApiRequest` now lives in `@n8n/rest-api-client`, and the suite spies `foldersApi.*` directly, so it is never reached.
- `DataTableTable.test.ts` — `AddColumnPopover.vue`. Renamed to `AddColumnButton.vue`, and it is rendered by `DataTableDetailsView.vue`, not by `DataTableTable.vue`. No assertion referenced the stub.
- `buttonParameter.utils.test.ts` — `./utils`. `getSchemas` now lives in the module under test (`buttonParameter.utils.ts:35`) and is called intra-module at line 192, so no module mock can intercept it. Not repointable.
- `CommunityNodeInfo.test.ts` — `./utils`. The only consumer of `fetchInstalledPackageInfo` is `useInstalledCommunityPackage`, which the same file already mocks.
- `ProjectNavigation.test.ts` — `is-emoji-supported`. Declared by `@n8n/design-system`, not by `editor-ui`, so the specifier cannot resolve from an editor-ui test; the component renders nothing that uses it.

Each delete is provably a no-op: the specifier resolves to nothing today, so there is no import edge for the block to sit on.

No product code is touched — this is test hygiene only. Zero unresolved specifiers remain.

## How to test

```bash
cd packages/frontend/editor-ui
pnpm vitest run \
  src/app/composables/useRunWorkflow.test.ts \
  src/features/ai/instanceAi/__tests__/InstanceAiConfirmationPanel.test.ts \
  src/features/core/dataTable/components/dataGrid/DataTableTable.test.ts \
  src/features/core/folders/folders.store.test.ts \
  src/features/execution/logs/components/LogsPanel.test.ts \
  src/features/ndv/parameters/utils/buttonParameter.utils.test.ts \
  src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.test.ts \
  src/features/collaboration/projects/components/ProjectNavigation.test.ts
```

132/132 passing on the merge base and 132/132 after — the two repoints do not change any assertion outcome. `pnpm lint` and `pnpm typecheck` clean in `editor-ui`.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to the dead-specifier instance fixed in #35438.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

