### PR TITLE
fix(editor): Fix janky spacing between agent capability chips with long labels

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -841,9 +841,7 @@ function openExistingSubAgentModal(subAgent: {
 	align-items: center;
 	flex-wrap: nowrap;
 	gap: var(--spacing--3xs);
-	max-width: 100%;
 	min-width: 0;
-
 	/** Truncates chip to stop overly-long labels **/
 	max-width: min(var(--spacing--5xl), 100%);
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -843,16 +843,19 @@ function openExistingSubAgentModal(subAgent: {
 	gap: var(--spacing--3xs);
 	max-width: 100%;
 	min-width: 0;
+
+	/** Truncates chip to stop overly-long labels **/
+	max-width: min(var(--spacing--5xl), 100%);
+
+	> .capabilityChip {
+		width: 100%;
+	}
 }
 
 .addButtonEmpty {
 	--button--color: var(--text-color--subtler);
 	margin-left: calc(-1 * var(--spacing--xs));
 	margin-top: calc(-1 * var(--spacing--4xs));
-}
-
-.capabilityChip {
-	max-width: min(12rem, 100%);
 }
 
 .groupChipLabel {


### PR DESCRIPTION
## Summary

Fixes [AGENT-559](https://linear.app/n8n/issue/AGENT-559)

Keeps agent capability tag chips within the available container width and applies the width constraint consistently to nested capability chips. This prevents long labels from disrupting chip spacing and layout.

On L860 of `packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue` we were constraining the width of the chip, presumably to prevent overly-long chips breaking the layout. However these chips are wrapped in a containing div on mount, to ensure they they are never orphaned on one line, which causing the large gaps.

Simple fix is to constrain the group rather than the chip itself.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/a2d7ba0c-6421-4bb9-b0f1-293953c5d9b3" width="960" /> | <img src="https://github.com/user-attachments/assets/e486bdef-6b04-4eac-8028-23436a377abf" width="960" /> |

## How to test

1. Open an agent's capabilities section.
2. Add multiple capabilities, each with a long label.
3. Verify the chip stays within its container and the label truncates without affecting surrounding chip spacing.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-559

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

