### PR TITLE
feat(core): Warn on startup when Postgres is below the supported range

### DIFF
--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -125,7 +125,7 @@ describe('DbConnection', () => {
 
 			await dbConnection.init();
 
-			expect(logger.warn).not.toHaveBeenCalled();
+			expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Postgres'));
 		});
 
 		it('should complete startup even when the version check throws', async () => {
@@ -157,7 +157,7 @@ describe('DbConnection', () => {
 			await sqliteConnection.init();
 
 			expect(dataSource.query).not.toHaveBeenCalled();
-			expect(logger.warn).not.toHaveBeenCalled();
+			expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Postgres'));
 		});
 
 		it('should not reinitialize if already connected', async () => {

--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -128,6 +128,18 @@ describe('DbConnection', () => {
 			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
+		it('should complete startup even when the version check throws', async () => {
+			dataSource.initialize.mockResolvedValue(dataSource);
+			// getDbVersion never rejects today; pin that a future regression cannot abort startup
+			vi.spyOn(dbConnection, 'getDbVersion').mockRejectedValue(new Error('boom'));
+
+			await dbConnection.init();
+
+			expect(dbConnection.connectionState.connected).toBe(true);
+			expect(monitor.start).toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalledWith('Could not check database version: boom');
+		});
+
 		it('should not warn about the version on sqlite', async () => {
 			connectionOptions.getOptions.mockReturnValue({ type: 'sqlite', database: ':memory:' });
 			// options are @Memoized and read in the constructor — re-instantiate

--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -65,6 +65,9 @@ describe('DbConnection', () => {
 		vi.resetAllMocks();
 
 		connectionOptions.getOptions.mockReturnValue(postgresOptions);
+		// resetAllMocks leaves deep-mock properties in place, so clear the one
+		// the version check reads or it leaks a proxy into unrelated tests
+		dataSource.driver.version = undefined;
 		// Default to legacy single-attempt behavior; retry tests override startupConnectMaxRetries.
 		databaseConfig.startupConnectMaxRetries = 0;
 		databaseConfig.minRecoveryBackoffMs = 1;
@@ -101,6 +104,48 @@ describe('DbConnection', () => {
 			await dbConnection.init();
 
 			expect(monitor.start).toHaveBeenCalled();
+		});
+
+		it('should warn when the postgres server is below the supported range', async () => {
+			dataSource.initialize.mockResolvedValue(dataSource);
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = true;
+			dataSource.driver.version = '14.22';
+
+			await dbConnection.init();
+
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Postgres 14'));
+		});
+
+		it('should not warn when the postgres server is supported', async () => {
+			dataSource.initialize.mockResolvedValue(dataSource);
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = true;
+			dataSource.driver.version = '17.6';
+
+			await dbConnection.init();
+
+			expect(logger.warn).not.toHaveBeenCalled();
+		});
+
+		it('should not warn about the version on sqlite', async () => {
+			connectionOptions.getOptions.mockReturnValue({ type: 'sqlite', database: ':memory:' });
+			// options are @Memoized and read in the constructor — re-instantiate
+			const sqliteConnection = new DbConnection(
+				errorReporter,
+				connectionOptions,
+				databaseConfig,
+				logger,
+				dbConnectionMetrics,
+			);
+			dataSource.initialize.mockResolvedValue(dataSource);
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = true;
+
+			await sqliteConnection.init();
+
+			expect(dataSource.query).not.toHaveBeenCalled();
+			expect(logger.warn).not.toHaveBeenCalled();
 		});
 
 		it('should not reinitialize if already connected', async () => {

--- a/packages/@n8n/db/src/connection/__tests__/postgres-version-policy.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/postgres-version-policy.test.ts
@@ -1,0 +1,38 @@
+import {
+	getPostgresVersionWarning,
+	OLDEST_COMPATIBILITY_POSTGRES_MAJOR,
+	OLDEST_SUPPORTED_POSTGRES_MAJOR,
+} from '../postgres-version-policy';
+
+describe('getPostgresVersionWarning', () => {
+	it('should not warn for the oldest supported major', () => {
+		expect(getPostgresVersionWarning(`${OLDEST_SUPPORTED_POSTGRES_MAJOR}.6`)).toBeNull();
+	});
+
+	it('should not warn for a major newer than the supported range', () => {
+		expect(getPostgresVersionWarning(`${OLDEST_SUPPORTED_POSTGRES_MAJOR + 5}.0`)).toBeNull();
+	});
+
+	it('should warn about compatibility support for the compatibility major', () => {
+		const warning = getPostgresVersionWarning(`${OLDEST_COMPATIBILITY_POSTGRES_MAJOR}.11`);
+
+		expect(warning).toContain('compatibility support only');
+		expect(warning).toContain(`Postgres ${OLDEST_COMPATIBILITY_POSTGRES_MAJOR}`);
+	});
+
+	it('should warn more sharply below the compatibility major', () => {
+		const warning = getPostgresVersionWarning(`${OLDEST_COMPATIBILITY_POSTGRES_MAJOR - 1}.4`);
+
+		expect(warning).toContain('is not supported');
+		expect(warning).not.toContain('compatibility support only');
+	});
+
+	it('should treat pre-10 versions as unsupported', () => {
+		expect(getPostgresVersionWarning('9.6')).toContain('is not supported');
+	});
+
+	it('should stay silent when the version cannot be parsed', () => {
+		expect(getPostgresVersionWarning('CockroachDB CCL v23.1.11')).toBeNull();
+		expect(getPostgresVersionWarning('')).toBeNull();
+	});
+});

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -105,7 +105,7 @@ export class DbConnection {
 		await this.connectWithRetry();
 
 		connectionState.connected = true;
-		await this.warnOnUnsupportedDbVersion();
+		await this.warnOnUnsupportedPostgresVersion();
 		this.monitor = new DbConnectionMonitor(
 			this.dataSource,
 			(connected) => (this.connectionState.connected = connected),
@@ -118,7 +118,12 @@ export class DbConnection {
 		this.monitor.start();
 	}
 
-	private async warnOnUnsupportedDbVersion() {
+	/**
+	 * Warns when the Postgres server is below the version policy range. Only
+	 * Postgres has a version policy: SQLite ships bundled with n8n, so users
+	 * never pick its version.
+	 */
+	private async warnOnUnsupportedPostgresVersion() {
 		if (this.options.type !== 'postgres') return;
 
 		try {

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -14,6 +14,7 @@ import { DbConnectionMetrics } from './db-connection-metrics';
 import { DbConnectionMonitor } from './db-connection-monitor';
 import { DbConnectionOptions } from './db-connection-options';
 import { readPoolStats, type DbPoolStats } from './db-pool-stats';
+import { getPostgresVersionWarning } from './postgres-version-policy';
 import { wrapMigration } from '../migrations/migration-helpers';
 import type { Migration } from '../migrations/migration-types';
 import { DbLock, DbLockService } from '../services/db-lock.service';
@@ -104,6 +105,7 @@ export class DbConnection {
 		await this.connectWithRetry();
 
 		connectionState.connected = true;
+		await this.warnOnUnsupportedDbVersion();
 		this.monitor = new DbConnectionMonitor(
 			this.dataSource,
 			(connected) => (this.connectionState.connected = connected),
@@ -114,6 +116,20 @@ export class DbConnection {
 			connectionState.connected,
 		);
 		this.monitor.start();
+	}
+
+	private async warnOnUnsupportedDbVersion() {
+		if (this.options.type !== 'postgres') return;
+
+		try {
+			const version = await this.getDbVersion();
+			if (typeof version !== 'string') return;
+
+			const warning = getPostgresVersionWarning(version);
+			if (warning) this.logger.warn(warning);
+		} catch (e) {
+			this.logger.warn(`Could not check database version: ${ensureError(e).message}`);
+		}
 	}
 
 	async migrate() {

--- a/packages/@n8n/db/src/connection/postgres-version-policy.ts
+++ b/packages/@n8n/db/src/connection/postgres-version-policy.ts
@@ -1,3 +1,6 @@
+// n8n's database version policy covers Postgres only. SQLite has no policy:
+// the library ships bundled with n8n, so users never pick its version.
+
 /**
  * Oldest Postgres major inside the supported range. The range is the two
  * newest actively maintained majors, so anything newer than this is fine too.

--- a/packages/@n8n/db/src/connection/postgres-version-policy.ts
+++ b/packages/@n8n/db/src/connection/postgres-version-policy.ts
@@ -23,12 +23,15 @@ function parsePostgresMajor(version: string): number | null {
  */
 export function getPostgresVersionWarning(version: string): string | null {
 	const major = parsePostgresMajor(version);
+	if (major === null) return null;
 
-	if (major === null || major >= OLDEST_SUPPORTED_POSTGRES_MAJOR) return null;
+	if (major < OLDEST_COMPATIBILITY_POSTGRES_MAJOR) {
+		return `Postgres ${major} is not supported. n8n supports Postgres ${OLDEST_SUPPORTED_POSTGRES_MAJOR} and newer, with ${OLDEST_COMPATIBILITY_POSTGRES_MAJOR} on compatibility support. Upgrade to Postgres ${OLDEST_SUPPORTED_POSTGRES_MAJOR} or newer.`;
+	}
 
-	if (major >= OLDEST_COMPATIBILITY_POSTGRES_MAJOR) {
+	if (major < OLDEST_SUPPORTED_POSTGRES_MAJOR) {
 		return `Postgres ${major} is outside the supported range and receives compatibility support only. Upgrade to Postgres ${OLDEST_SUPPORTED_POSTGRES_MAJOR} or newer.`;
 	}
 
-	return `Postgres ${major} is not supported. n8n supports Postgres ${OLDEST_SUPPORTED_POSTGRES_MAJOR} and newer, with ${OLDEST_COMPATIBILITY_POSTGRES_MAJOR} on compatibility support. Upgrade to Postgres ${OLDEST_SUPPORTED_POSTGRES_MAJOR} or newer.`;
+	return null;
 }

--- a/packages/@n8n/db/src/connection/postgres-version-policy.ts
+++ b/packages/@n8n/db/src/connection/postgres-version-policy.ts
@@ -1,0 +1,34 @@
+/**
+ * Oldest Postgres major inside the supported range. The range is the two
+ * newest actively maintained majors, so anything newer than this is fine too.
+ */
+export const OLDEST_SUPPORTED_POSTGRES_MAJOR = 17;
+
+/**
+ * Oldest Postgres major that still gets compatibility support. Below this,
+ * n8n is _not_ tested against the server at all.
+ */
+export const OLDEST_COMPATIBILITY_POSTGRES_MAJOR = 16;
+
+/** Parses the major out of a Postgres server version like `17.6`. */
+function parsePostgresMajor(version: string): number | null {
+	const major = Number.parseInt(version.split('.')[0], 10);
+
+	return Number.isInteger(major) ? major : null;
+}
+
+/**
+ * Warning to log for a Postgres server version outside the supported range,
+ * or `null` when the version is supported or could not be parsed.
+ */
+export function getPostgresVersionWarning(version: string): string | null {
+	const major = parsePostgresMajor(version);
+
+	if (major === null || major >= OLDEST_SUPPORTED_POSTGRES_MAJOR) return null;
+
+	if (major >= OLDEST_COMPATIBILITY_POSTGRES_MAJOR) {
+		return `Postgres ${major} is outside the supported range and receives compatibility support only. Upgrade to Postgres ${OLDEST_SUPPORTED_POSTGRES_MAJOR} or newer.`;
+	}
+
+	return `Postgres ${major} is not supported. n8n supports Postgres ${OLDEST_SUPPORTED_POSTGRES_MAJOR} and newer, with ${OLDEST_COMPATIBILITY_POSTGRES_MAJOR} on compatibility support. Upgrade to Postgres ${OLDEST_SUPPORTED_POSTGRES_MAJOR} or newer.`;
+}


### PR DESCRIPTION
## Summary

On PG connect, we now log a warning when the server is older than the [version policy](https://app.notion.com/p/n8n/Settling-on-a-Postgres-version-policy-3975b6e0c94f806e9354d3d1511bc872) allows. 

Refusing to start is out of scope.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3912

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
