### PR TITLE
ci: Show workflow_dispatch inputs in workflow run names

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,4 +1,5 @@
 name: 'Build: Base Image'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Build: Base Image (push={0})', inputs.push) || '' }}"
 
 on:
   push:

--- a/.github/workflows/ci-cla-check.yml
+++ b/.github/workflows/ci-cla-check.yml
@@ -1,4 +1,5 @@
 name: 'CI: CLA Check'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('CI: CLA Check (PR #{0})', inputs.pr_number) || '' }}"
 
 # In-house replacement for the GitHub App "CLA Bot".
 #

--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -1,4 +1,5 @@
 name: 'Instance AI Evals: PR Gate'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Instance AI Evals: PR #{0} (tier={1})', inputs.pr, inputs.tier || 'pr') || '' }}"
 
 # The PR gate for Instance AI workflow evals. Auto-runs on PR open/reopen/ready
 # (non-draft, non-fork, path-filtered); manual dispatch re-runs a specific PR

--- a/.github/workflows/ci-mcp-evals.yml
+++ b/.github/workflows/ci-mcp-evals.yml
@@ -1,4 +1,5 @@
 name: 'CI: MCP Workflow Evals'
+run-name: "CI: MCP Workflow Evals (tier=${{ inputs.tier }}, iterations=${{ inputs.iterations }}, model=${{ inputs['build-model'] }}, filter=${{ inputs.filter || 'all' }})"
 
 # Runs the MCP workflow evals: builds workflows through the instance MCP server
 # with Claude, then scores them. Manual only (Actions tab → "Run workflow"),

--- a/.github/workflows/clean-stale-branches.yml
+++ b/.github/workflows/clean-stale-branches.yml
@@ -1,4 +1,5 @@
 name: 'Util: Clean Stale Branches'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Util: Clean Stale Branches (dry-run={0}, days={1}, exclude={2})', inputs['dry-run'], inputs.days, inputs.exclude) || '' }}"
 
 on:
   schedule:

--- a/.github/workflows/community-pr-close-stale.yml
+++ b/.github/workflows/community-pr-close-stale.yml
@@ -1,4 +1,5 @@
 name: 'Community: Close Stale PRs'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Community: Close Stale PRs (dry-run={0})', inputs['dry-run']) || '' }}"
 
 # Closes community PRs that were sent back to the contributor
 # (triage:needs-info / triage:tests-needed / Needs Feedback) and have been

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,6 +4,7 @@
 # - Uses docker-tags.mjs for tag generation, this generates the tags for the images
 
 name: 'Docker: Build and Push'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Docker: Build and Push {0} (push={1}, arm64={2})', github.ref_name, inputs.push_enabled, inputs.include_arm64) || '' }}"
 
 env:
   NODE_OPTIONS: '--max-old-space-size=7168'

--- a/.github/workflows/mutation-health-nightly.yml
+++ b/.github/workflows/mutation-health-nightly.yml
@@ -1,4 +1,5 @@
 name: 'Mutation Health (nightly)'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Mutation Health (mode={0}, top_n={1}, source_file={2})', inputs.mode, inputs.top_n, inputs.source_file) || '' }}"
 
 on:
   schedule:

--- a/.github/workflows/release-build-daytona-snapshot.yml
+++ b/.github/workflows/release-build-daytona-snapshot.yml
@@ -1,4 +1,5 @@
 name: 'Release: Build Daytona snapshot'
+run-name: 'Build Daytona snapshot for n8n@${{ inputs.n8n_version }}'
 
 on:
   workflow_call:

--- a/.github/workflows/release-create-experiment.yml
+++ b/.github/workflows/release-create-experiment.yml
@@ -1,5 +1,5 @@
 name: 'Release: Create Experiment PR'
-run-name: 'Release: Create Experiment Release PR'
+run-name: 'Release: Create Experiment Release PR (${{ inputs.commits }})'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-create-minor-pr.yml
+++ b/.github/workflows/release-create-minor-pr.yml
@@ -1,4 +1,5 @@
 name: 'Release: Create Minor Release PR'
+run-name: 'Release: Create Minor Release PR (force=${{ inputs.force }})'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -1,4 +1,5 @@
 name: 'Release: Create Pull Request'
+run-name: "Release: Create ${{ inputs['release-type'] }} PR from ${{ inputs['base-branch'] }}"
 
 on:
   workflow_call:

--- a/.github/workflows/release-publish-new-package.yml
+++ b/.github/workflows/release-publish-new-package.yml
@@ -1,4 +1,5 @@
 name: 'Release: Publish New Package'
+run-name: "Release: Publish New Package (${{ inputs['package-path'] }})"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -1,4 +1,5 @@
 name: 'Release: Push to Channel'
+run-name: "Release: Push n8n@${{ inputs.version }} to ${{ inputs['release-channel'] }}"
 
 on:
   workflow_call:

--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -1,4 +1,5 @@
 name: 'Release: Standalone Package'
+run-name: 'Release: ${{ inputs.package }} (${{ inputs.bump }})'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/sbom-generation-callable.yml
+++ b/.github/workflows/sbom-generation-callable.yml
@@ -1,4 +1,5 @@
 name: 'Release: Attach SBOM'
+run-name: 'Release: Attach SBOM for n8n@${{ inputs.n8n_version }}'
 
 on:
   workflow_call:

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -7,6 +7,7 @@
 # Manual runs always sync (for conflict recovery after failed cherry-pick).
 
 name: 'Security: Sync from Public'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Security: Sync from Public (force={0})', inputs.force) || '' }}"
 
 on:
   schedule:

--- a/.github/workflows/security-trivy-scan-callable.yml
+++ b/.github/workflows/security-trivy-scan-callable.yml
@@ -1,4 +1,5 @@
 name: Security - Scan Docker Image With Trivy
+run-name: 'Trivy scan of ${{ inputs.image_ref }}'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-bench-reusable.yml
+++ b/.github/workflows/test-bench-reusable.yml
@@ -1,4 +1,5 @@
 name: 'Test: Benchmarks'
+run-name: "Test: Benchmarks (${{ inputs.ref || github.ref_name }})"
 
 on:
   workflow_call:

--- a/.github/workflows/test-e2e-helm.yml
+++ b/.github/workflows/test-e2e-helm.yml
@@ -1,4 +1,5 @@
 name: 'Test: E2E Helm Chart'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Test: E2E Helm Chart (mode={0}, branch={1}, chart={2})', inputs.mode, inputs.branch || 'default', inputs['helm-chart-ref']) || '' }}"
 
 on:
   pull_request:

--- a/.github/workflows/test-e2e-helm.yml
+++ b/.github/workflows/test-e2e-helm.yml
@@ -95,7 +95,10 @@ jobs:
         env:
           TESTCONTAINERS_RYUK_DISABLED: 'true'
         run: |
-          npx tsx packages/testing/containers/helm-start-stack.ts \
+          # tsx is a devDependency of n8n-containers, not the repo root, so it
+          # must run via that package (root `npx tsx` stopped resolving when
+          # shamefully-hoist was removed).
+          pnpm --filter n8n-containers exec tsx helm-start-stack.ts \
             --env E2E_TESTS=true --env NODE_ENV=development \
             --mode "${{ inputs.mode || 'queue' }}" \
             --image "${{ env.DOCKER_IMAGE }}" \

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Pre-pull Test Container Images
         if: ${{ !contains(inputs.test-command, 'test:local') }}
-        run: npx tsx packages/testing/containers/pull-test-images.ts ${{ matrix.images }} || true
+        run: pnpm --filter n8n-containers exec tsx pull-test-images.ts ${{ matrix.images }} || true
 
       - name: Filter specs to previous-attempt failures
         if: github.run_attempt > 1 && matrix.specs != ''

--- a/.github/workflows/test-e2e-vm-expressions-nightly.yml
+++ b/.github/workflows/test-e2e-vm-expressions-nightly.yml
@@ -1,4 +1,5 @@
 name: 'Test: E2E VM Expressions Nightly'
+run-name: "Test: E2E VM Expressions (${{ inputs.branch || 'nightly' }})"
 
 on:
   schedule:

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -1,4 +1,5 @@
 name: 'Test: Evals AI'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Test: Evals AI on {0} (eval_type={1}, spec_repetitions={2}, spec_judges={3})', inputs.branch, inputs.eval_type, inputs.spec_repetitions, inputs.spec_judges) || '' }}"
 
 on:
   push:

--- a/.github/workflows/test-evals-discovery.yml
+++ b/.github/workflows/test-evals-discovery.yml
@@ -1,4 +1,5 @@
 name: 'Test: Instance AI Discovery Evals'
+run-name: "Test: Instance AI Discovery Evals (branch=${{ inputs.branch || 'master' }}, filter=${{ inputs.filter || 'all' }}, trials=${{ inputs.trials }})"
 
 on:
   workflow_call:

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -1,4 +1,5 @@
 name: 'Instance AI Evals: Experiments'
+run-name: "Instance AI Evals: ${{ inputs.branch || 'master' }} (tier=${{ inputs.tier || 'all' }}, iterations=${{ inputs.iterations }}, model=${{ inputs.model || 'default' }}, experiment=${{ inputs['experiment-name'] || '-' }})"
 
 on:
   workflow_call:

--- a/.github/workflows/test-evals-mcp.yml
+++ b/.github/workflows/test-evals-mcp.yml
@@ -1,4 +1,5 @@
 name: 'Test: MCP Workflow Evals'
+run-name: "Test: MCP Workflow Evals (branch=${{ inputs.branch || github.ref_name }}, tier=${{ inputs.tier }}, iterations=${{ inputs.iterations }}, model=${{ inputs['build-model'] }})"
 
 # Scores workflows built through the instance MCP server (packages/cli/src/modules/mcp)
 # with the Instance AI verifier, using the fused `--build-via-mcp` lane model:

--- a/.github/workflows/test-workflows-nightly.yml
+++ b/.github/workflows/test-workflows-nightly.yml
@@ -1,4 +1,5 @@
 name: 'Test: Workflows Nightly'
+run-name: 'Test: Workflows Nightly (${{ inputs.git_ref_to_test }})'
 
 # Nightly schedule disabled (DEVP-544): the "Run Workflow Tests with Snapshots"
 # job fails the majority of its runs due to host-level port contention on shared

--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -1,4 +1,8 @@
 name: 'Util: Claude Task Runner'
+# The `task` input is deliberately not in the run name: dispatchers pass large
+# multiline payloads (e.g. a full Linear issue as JSON) that must not appear in
+# the publicly visible run list.
+run-name: 'Util: Claude Task Runner (model=${{ inputs.model }}, ref=${{ inputs.ref }})'
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Adds `run-name` to every workflow that has `workflow_dispatch` inputs (26 workflows, plus one existing static `run-name` updated), so the Actions run list shows which inputs a run was dispatched with — e.g. `Release: Push n8n@1.2.3 to stable` instead of a bare workflow name.

- Workflows that also run on schedule/push/PR guard the name with `github.event_name == 'workflow_dispatch'` so non-dispatch runs keep their default title instead of showing empty `key=` noise.
- `util-claude-task.yml` deliberately excludes its `task` input: dispatchers pass large multiline payloads (e.g. a full Linear issue as JSON) that must not appear in the publicly visible run list — only `model` and `ref` are shown.
- Workflows whose only dispatch input is uninformative (`build-windows.yml`'s notify flag) or that already had input-bearing run-names were left unchanged.

Also fixes a latent CI break this PR surfaced: `npx tsx packages/testing/containers/...` at the repo root stopped resolving when `shamefully-hoist` was removed from `.npmrc` (#32569) — `tsx` is only a devDependency of `n8n-containers`. The Helm E2E stack start (hard failure, workflow only runs when its own paths change so it went unnoticed since June) and the e2e test-image pre-pull (silently no-opped via `|| true`) now run tsx via `pnpm --filter n8n-containers exec`.

## How to test

`actionlint` passes on all workflows. The Helm E2E check on this PR exercises the tsx fix. After merge, dispatch any affected workflow (e.g. Release: Push to Channel) from the Actions tab and confirm the run title shows the chosen inputs; a scheduled run of a guarded workflow (e.g. Clean Stale Branches) keeps its default title.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)