### PR TITLE
feat(core): Support branching in @n8n/engine (no-changelog)

### DIFF
--- a/packages/@n8n/engine/src/common/errors.ts
+++ b/packages/@n8n/engine/src/common/errors.ts
@@ -10,3 +10,14 @@ export class UnimplementedError extends Error {
 		this.name = 'UnimplementedError';
 	}
 }
+
+/**
+ * Thrown when the engine hits state that shouldn't be reachable — a bug rather
+ * than bad input or an unbuilt path.
+ */
+export class UnexpectedError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'UnexpectedError';
+	}
+}

--- a/packages/@n8n/engine/src/common/index.ts
+++ b/packages/@n8n/engine/src/common/index.ts
@@ -1,2 +1,2 @@
 export type { JsonObject, JsonValue } from './json';
-export { UnimplementedError } from './errors';
+export { UnexpectedError, UnimplementedError } from './errors';

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -227,11 +227,62 @@ describe('workflow_step_execution table (integration)', () => {
 		});
 	});
 
+	it('TypeOrmStepStore.loadCompletedNodeIds returns only the completed ones', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		// completed with null outputs — indistinguishable from not-completed via
+		// loadStepOutputs, which is why readiness has its own method
+		await store.completeStep(aId, null);
+		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
+		const { id: cId } = await createStep(store, { executionId, nodeId: 'c', status: 'running' });
+		await store.failStep(cId, { name: 'Error', message: 'node blew up' });
+
+		const completed = await store.loadCompletedNodeIds(executionId, ['a', 'b', 'c', 'd']);
+
+		// b queued, c failed, d has no row at all
+		expect(completed).toEqual(new Set(['a']));
+	});
+
 	it('rejects an invalid status (check constraint)', async () => {
 		const executionId = await createExecution();
 		const repo = dataSource.getRepository(WorkflowStepExecution);
 		await expect(
 			repo.save(repo.create({ executionId, nodeId: 'a', status: 'bogus' as StepStatus })),
 		).rejects.toThrow();
+	});
+
+	// Planning leans on this: two workers that concurrently decide the same step is
+	// ready both insert, and the loser is skipped rather than duplicating the node.
+	it('TypeOrmStepStore.createSteps skips a node already planned, keeping the rest', async () => {
+		const executionId = await createExecution();
+		const repo = dataSource.getRepository(WorkflowStepExecution);
+		const store = new TypeOrmStepStore(repo);
+		await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
+
+		// 'a' is taken; 'b' is not, and must still land — the whole point of skipping
+		// the conflict rather than failing the statement
+		const created = await store.createSteps([
+			{ executionId, nodeId: 'a', status: 'queued' },
+			{ executionId, nodeId: 'b', status: 'queued' },
+		]);
+
+		expect(created).toEqual([{ id: expect.any(String) as string, nodeId: 'b' }]);
+		// `count({ where })`, not `countBy`, for the reason given in `loadStep`
+		expect(await repo.count({ where: { executionId, nodeId: 'a' } })).toBe(1);
+		expect(await repo.count({ where: { executionId, nodeId: 'b' } })).toBe(1);
+	});
+
+	it('scopes the one-step-per-node key to a single execution', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const executionId = await createExecution();
+		const otherExecutionId = await createExecution();
+		await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
+
+		const created = await store.createSteps([
+			{ executionId: otherExecutionId, nodeId: 'a', status: 'queued' },
+		]);
+
+		expect(created).toEqual([{ id: expect.any(String) as string, nodeId: 'a' }]);
 	});
 });

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -227,21 +227,42 @@ describe('workflow_step_execution table (integration)', () => {
 		});
 	});
 
-	it('TypeOrmStepStore.loadCompletedNodeIds returns only the completed ones', async () => {
+	it('TypeOrmStepStore.loadSettledSteps returns settled steps with their filled output slots', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
-		// completed having produced nothing: still completed, which is the case a
-		// readiness question must get right
-		await store.completeStep(aId, []);
-		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
-		const { id: cId } = await createStep(store, { executionId, nodeId: 'c', status: 'running' });
-		await store.failStep(cId, { name: 'Error', message: 'node blew up' });
+		// a Switch-like outcome: slots 0 and 2 filled, slot 1 not taken
+		await store.completeStep(aId, [[{ json: { from: 'a' } }], null, [{ json: { alt: true } }]]);
+		const { id: bId } = await createStep(store, { executionId, nodeId: 'b', status: 'running' });
+		await store.failStep(bId, { name: 'Error', message: 'node blew up' });
+		await createStep(store, { executionId, nodeId: 'c', status: 'skipped' });
+		await createStep(store, { executionId, nodeId: 'd', status: 'queued' });
 
-		const completed = await store.loadCompletedNodeIds(executionId, ['a', 'b', 'c', 'd']);
+		const settled = await store.loadSettledSteps(executionId, ['a', 'b', 'c', 'd', 'e']);
 
-		// b queued, c failed, d has no row at all
-		expect(completed).toEqual(new Set(['a']));
+		// d is queued and e has no row — both read as "not yet", so they're absent
+		expect(settled.sort((x, y) => x.nodeId.localeCompare(y.nodeId))).toEqual([
+			{ nodeId: 'a', status: 'completed', filledOutputSlots: [0, 2] },
+			{ nodeId: 'b', status: 'failed', filledOutputSlots: [] },
+			{ nodeId: 'c', status: 'skipped', filledOutputSlots: [] },
+		]);
+	});
+
+	it('TypeOrmStepStore.loadSettledSteps reads a completed step with no filled slots as settled', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		// completed having produced nothing: settled, with every edge out of it dead
+		await store.completeStep(id, []);
+
+		const settled = await store.loadSettledSteps(executionId, ['a']);
+
+		expect(settled).toEqual([{ nodeId: 'a', status: 'completed', filledOutputSlots: [] }]);
+	});
+
+	it('TypeOrmStepStore.loadSettledSteps is a no-op for an empty node list', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		expect(await store.loadSettledSteps('00000000-0000-7000-8000-000000000000', [])).toEqual([]);
 	});
 
 	it('rejects an invalid status (check constraint)', async () => {

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -231,9 +231,9 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
-		// completed with null outputs — indistinguishable from not-completed via
-		// loadStepOutputs, which is why readiness has its own method
-		await store.completeStep(aId, null);
+		// completed having produced nothing: still completed, which is the case a
+		// readiness question must get right
+		await store.completeStep(aId, []);
 		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
 		const { id: cId } = await createStep(store, { executionId, nodeId: 'c', status: 'running' });
 		await store.failStep(cId, { name: 'Error', message: 'node blew up' });

--- a/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
+++ b/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
@@ -14,7 +14,9 @@ import type { StepError } from '../../execution/step-store';
 import { generateId } from '../generate-id';
 
 @Entity('workflow_step_execution')
-@Index('idx_workflow_step_execution_execution_id_node_id', ['executionId', 'nodeId'])
+@Index('uniq_workflow_step_execution_execution_id_node_id', ['executionId', 'nodeId'], {
+	unique: true,
+})
 export class WorkflowStepExecution {
 	@PrimaryColumn('uuid')
 	id!: string;

--- a/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
+++ b/packages/@n8n/engine/src/database/entities/workflow-step-execution.entity.ts
@@ -8,8 +8,7 @@ import {
 	UpdateDateColumn,
 } from '@n8n/typeorm';
 
-import type { JsonValue } from '../../common';
-import type { StepStatus } from '../../execution/execution.types';
+import type { StepSlots, StepStatus } from '../../execution/execution.types';
 import type { StepError } from '../../execution/step-store';
 import { generateId } from '../generate-id';
 
@@ -31,7 +30,7 @@ export class WorkflowStepExecution {
 	status!: StepStatus;
 
 	@Column('jsonb', { nullable: true })
-	outputs!: JsonValue | null;
+	outputs!: StepSlots | null;
 
 	@Column('jsonb', { nullable: true })
 	error!: StepError | null;

--- a/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
+++ b/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
@@ -40,12 +40,13 @@ export class CreateWorkflowStepExecution1784890100000 implements MigrationInterf
 					},
 				],
 				indices: [
-					// Composite: steps are looked up per execution, usually narrowed to
-					// specific nodes. The leading column also serves execution-only
-					// lookups and the FK's cascading delete.
+					// Index execution and node id to look up inputs on the hot path. Unique
+					// to prevent double writes on failure recovery.
+					// TODO(CAT-2875): looping adds an iteration to this key.
 					{
-						name: 'idx_workflow_step_execution_execution_id_node_id',
+						name: 'uniq_workflow_step_execution_execution_id_node_id',
 						columnNames: ['execution_id', 'node_id'],
+						isUnique: true,
 					},
 				],
 				foreignKeys: [

--- a/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
+++ b/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
@@ -60,7 +60,8 @@ export class CreateWorkflowStepExecution1784890100000 implements MigrationInterf
 				checks: [
 					{
 						name: 'chk_workflow_step_execution_status',
-						expression: "status IN ('queued', 'running', 'completed', 'failed', 'cancelled')",
+						expression:
+							"status IN ('queued', 'running', 'completed', 'failed', 'skipped', 'cancelled')",
 					},
 				],
 			}),

--- a/packages/@n8n/engine/src/database/typeorm-execution-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-execution-store.ts
@@ -38,4 +38,12 @@ export class TypeOrmExecutionStore implements ExecutionStore {
 		const result = await this.repo.update({ id, status: from }, { status: to });
 		return result.affected === 1;
 	}
+
+	async finishExecution(id: string, status: 'completed' | 'failed'): Promise<boolean> {
+		const result = await this.repo.update(
+			{ id, status: 'running' },
+			{ status, finishedAt: new Date() },
+		);
+		return result.affected === 1;
+	}
 }

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -2,8 +2,7 @@ import { In, type Repository } from '@n8n/typeorm';
 
 import type { WorkflowStepExecution } from './entities';
 import { generateId } from './generate-id';
-import type { JsonValue } from '../common';
-import type { StepStatus } from '../execution/execution.types';
+import type { StepSlots, StepStatus } from '../execution/execution.types';
 import {
 	StepNotFoundError,
 	type NewStepRecord,
@@ -53,7 +52,7 @@ export class TypeOrmStepStore implements StepStore {
 		return await this.transition(id, 'queued', 'running');
 	}
 
-	async completeStep(id: string, outputs: JsonValue): Promise<boolean> {
+	async completeStep(id: string, outputs: StepSlots): Promise<boolean> {
 		return await this.transition(id, 'running', 'completed', { outputs });
 	}
 
@@ -69,7 +68,7 @@ export class TypeOrmStepStore implements StepStore {
 		id: string,
 		from: StepStatus,
 		to: StepStatus,
-		fields: { outputs?: JsonValue; error?: StepError } = {},
+		fields: { outputs?: StepSlots; error?: StepError } = {},
 	): Promise<boolean> {
 		const result = await this.repo.update({ id, status: from }, { ...fields, status: to });
 		return result.affected === 1;
@@ -78,8 +77,8 @@ export class TypeOrmStepStore implements StepStore {
 	async loadStepOutputs(
 		executionId: string,
 		nodeIds: string[],
-	): Promise<Record<string, JsonValue | null>> {
-		const outputsByNodeId: Record<string, JsonValue | null> = {};
+	): Promise<Record<string, StepSlots | null>> {
+		const outputsByNodeId: Record<string, StepSlots | null> = {};
 		for (const nodeId of nodeIds) outputsByNodeId[nodeId] = null;
 		if (nodeIds.length === 0) return outputsByNodeId;
 

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -1,6 +1,7 @@
 import { In, type Repository } from '@n8n/typeorm';
 
 import type { WorkflowStepExecution } from './entities';
+import { generateId } from './generate-id';
 import type { JsonValue } from '../common';
 import type { StepStatus } from '../execution/execution.types';
 import {
@@ -15,11 +16,29 @@ import {
 export class TypeOrmStepStore implements StepStore {
 	constructor(private readonly repo: Repository<WorkflowStepExecution>) {}
 
-	async createSteps(records: NewStepRecord[]): Promise<Array<{ id: string }>> {
-		const steps = records.map((record) => this.repo.create(record));
-		// NOTE: prefer insert to save for performance reasons.
-		await this.repo.insert(steps);
-		return steps.map(({ id }) => ({ id }));
+	async createSteps(records: NewStepRecord[]): Promise<Array<{ id: string; nodeId: string }>> {
+		if (records.length === 0) return [];
+
+		// Ids are assigned here, not by the entity's insert hook, so the rows that
+		// survived the insert can be picked out of what RETURNING gives back.
+		const rows = records.map((record) => ({ ...record, id: generateId() }));
+
+		// `orIgnore` is the unique key doing its job: a node another planner already
+		// queued is skipped, leaving the rest of the batch to land.
+		const result = await this.repo
+			.createQueryBuilder()
+			.insert()
+			// Copies, because TypeORM writes the RETURNING values back onto whatever
+			// it is given — which would overwrite the ids we are about to match on.
+			.values(rows.map((row) => ({ ...row })))
+			.orIgnore()
+			.returning(['id'])
+			.execute();
+
+		// `raw` is the driver's untyped result; RETURNING was asked for `id` alone.
+		const inserted = new Set((result.raw as Array<{ id: string }>).map(({ id }) => id));
+
+		return rows.filter(({ id }) => inserted.has(id)).map(({ id, nodeId }) => ({ id, nodeId }));
 	}
 
 	async loadStep(id: string): Promise<StepRecord> {
@@ -73,5 +92,29 @@ export class TypeOrmStepStore implements StepStore {
 		for (const row of rows) outputsByNodeId[row.nodeId] = row.outputs;
 
 		return outputsByNodeId;
+	}
+
+	async loadCompletedNodeIds(executionId: string, nodeIds: string[]): Promise<Set<string>> {
+		if (nodeIds.length === 0) return new Set();
+
+		const rows = await this.repo.find({
+			where: { executionId, nodeId: In(nodeIds), status: 'completed' },
+			select: ['nodeId'],
+		});
+
+		return new Set(rows.map((row) => row.nodeId));
+	}
+
+	async hasActiveSteps(executionId: string): Promise<boolean> {
+		// `count({ where })`, not `countBy`, for the reason given in `loadStep`.
+		const active = await this.repo.count({
+			where: { executionId, status: In<StepStatus>(['queued', 'running']) },
+		});
+		return active > 0;
+	}
+
+	async hasFailedSteps(executionId: string): Promise<boolean> {
+		const failed = await this.repo.count({ where: { executionId, status: 'failed' } });
+		return failed > 0;
 	}
 }

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -6,6 +6,7 @@ import type { StepSlots, StepStatus } from '../execution/execution.types';
 import {
 	StepNotFoundError,
 	type NewStepRecord,
+	type SettledStep,
 	type StepError,
 	type StepRecord,
 	type StepStore,
@@ -93,15 +94,27 @@ export class TypeOrmStepStore implements StepStore {
 		return outputsByNodeId;
 	}
 
-	async loadCompletedNodeIds(executionId: string, nodeIds: string[]): Promise<Set<string>> {
-		if (nodeIds.length === 0) return new Set();
+	async loadSettledSteps(executionId: string, nodeIds: string[]): Promise<SettledStep[]> {
+		if (nodeIds.length === 0) return [];
 
-		const rows = await this.repo.find({
-			where: { executionId, nodeId: In(nodeIds), status: 'completed' },
-			select: ['nodeId'],
-		});
-
-		return new Set(rows.map((row) => row.nodeId));
+		// The filled slots are projected out of the jsonb in SQL — a slot is filled
+		// when its element is not json null — so payloads never leave the database.
+		return await this.repo
+			.createQueryBuilder('step')
+			.select('step.node_id', 'nodeId')
+			.addSelect('step.status', 'status')
+			.addSelect(
+				`COALESCE(
+					(SELECT array_agg((slot.ord - 1)::int ORDER BY slot.ord)
+						FROM jsonb_array_elements(step.outputs) WITH ORDINALITY AS slot(value, ord)
+						WHERE slot.value <> 'null'::jsonb),
+					'{}')`,
+				'filledOutputSlots',
+			)
+			.where('step.execution_id = :executionId', { executionId })
+			.andWhere('step.node_id IN (:...nodeIds)', { nodeIds })
+			.andWhere('step.status NOT IN (:...active)', { active: ['queued', 'running'] })
+			.getRawMany<SettledStep>();
 	}
 
 	async hasActiveSteps(executionId: string): Promise<boolean> {

--- a/packages/@n8n/engine/src/dependencies/external-dependencies.ts
+++ b/packages/@n8n/engine/src/dependencies/external-dependencies.ts
@@ -1,5 +1,4 @@
-import type { JsonValue } from '../common';
-import type { ExecutionMode } from '../execution';
+import type { ExecutionMode, StepSlots } from '../execution';
 import type { GraphNode } from '../graph';
 
 /**
@@ -36,14 +35,15 @@ export interface StepExecutionContext {
 export interface StepExecutionRequest {
 	/** The graph node to run; `node.config` is the step-type-specific payload. */
 	node: GraphNode;
-	/** Inputs gathered from predecessor steps; opaque to the engine but serializable. */
-	inputs: JsonValue;
+	/** Inputs by input slot, gathered from predecessor steps. Slot contents are
+	 * opaque to the engine but must be serializable. */
+	inputs: StepSlots;
 	context: StepExecutionContext;
 }
 
 export interface StepExecutionResult {
-	/** Step outputs; persisted by the engine without inspection. */
-	outputs: JsonValue;
+	/** Outputs by output slot; persisted by the engine without inspection. */
+	outputs: StepSlots;
 }
 
 /**

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -11,6 +11,7 @@ function makeExecutionStore(overrides: Partial<ExecutionStore> = {}): ExecutionS
 		createExecution: vi.fn(),
 		loadExecution: vi.fn(),
 		transitionStatus: vi.fn().mockResolvedValue(true),
+		finishExecution: vi.fn().mockResolvedValue(true),
 		...overrides,
 	};
 }
@@ -28,6 +29,9 @@ function makeStepStore(createSteps = vi.fn()): StepStore {
 		completeStep: vi.fn(),
 		failStep: vi.fn(),
 		loadStepOutputs: vi.fn(),
+		loadCompletedNodeIds: vi.fn(),
+		hasActiveSteps: vi.fn().mockResolvedValue(false),
+		hasFailedSteps: vi.fn().mockResolvedValue(false),
 	};
 }
 
@@ -58,9 +62,11 @@ describe('ExecutionStartHandler', () => {
 		const executionStore = makeExecutionStore({
 			loadExecution: vi.fn().mockResolvedValue(record(graph)),
 		});
-		const createSteps = vi
-			.fn()
-			.mockResolvedValue([{ id: 'step-trigger' }, { id: 'step-a' }, { id: 'step-b' }]);
+		const createSteps = vi.fn().mockResolvedValue([
+			{ id: 'step-trigger', nodeId: 'trigger' },
+			{ id: 'step-a', nodeId: 'a' },
+			{ id: 'step-b', nodeId: 'b' },
+		]);
 		const stepStore = makeStepStore(createSteps);
 		const stepQueue = makeStepQueue();
 		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
@@ -127,7 +133,7 @@ describe('ExecutionStartHandler', () => {
 		const executionStore = makeExecutionStore({
 			loadExecution: vi.fn().mockResolvedValue(record(graph)),
 		});
-		const createSteps = vi.fn().mockResolvedValue([{ id: 'step-trigger' }]);
+		const createSteps = vi.fn().mockResolvedValue([{ id: 'step-trigger', nodeId: 'trigger' }]);
 		const stepStore = makeStepStore(createSteps);
 		const stepQueue = makeStepQueue();
 		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -77,7 +77,7 @@ describe('ExecutionStartHandler', () => {
 		// one batch: the trigger completed, then each successor queued
 		expect(createSteps).toHaveBeenCalledTimes(1);
 		expect(createSteps).toHaveBeenCalledWith([
-			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed' },
+			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed', outputs: [null] },
 			{ executionId: 'exec-1', nodeId: 'a', status: 'queued' },
 			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
 		]);
@@ -124,7 +124,7 @@ describe('ExecutionStartHandler', () => {
 		await handler.handle({ type: 'execution:enqueued', executionId: 'exec-1' });
 
 		expect(createSteps).toHaveBeenCalledWith([
-			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed' },
+			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed', outputs: [null] },
 			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
 		]);
 		expect(stepQueue.publish).toHaveBeenCalledExactlyOnceWith({
@@ -185,7 +185,7 @@ describe('ExecutionStartHandler', () => {
 		expect(executionStore.transitionStatus).not.toHaveBeenCalledWith('exec-1', 'running', 'failed');
 		expect(createSteps).toHaveBeenCalledTimes(1);
 		expect(createSteps).toHaveBeenCalledWith([
-			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed' },
+			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed', outputs: [null] },
 		]);
 		expect(stepQueue.publish).not.toHaveBeenCalled();
 		// nothing will ever report completion, so the execution has to finish here or

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -92,6 +92,8 @@ describe('ExecutionStartHandler', () => {
 			executionId: 'exec-1',
 			stepId: 'step-b',
 		});
+		// work is outstanding, so the execution is provably unfinished
+		expect(executionStore.finishExecution).not.toHaveBeenCalled();
 	});
 
 	it('skips a trigger successor that also sits behind another node', async () => {
@@ -186,5 +188,36 @@ describe('ExecutionStartHandler', () => {
 			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed' },
 		]);
 		expect(stepQueue.publish).not.toHaveBeenCalled();
+		// nothing will ever report completion, so the execution has to finish here or
+		// it stays `running` forever
+		expect(executionStore.finishExecution).toHaveBeenCalledWith('exec-1', 'completed');
+	});
+
+	it('finishes the execution when no first step is ready to plan', async () => {
+		// a cycle: 'a' waits on 'b', which waits on 'a', so neither can start
+		const graph: WorkflowGraph = {
+			nodes: [
+				{ id: 'trigger', name: 'T', type: 'trigger' },
+				{ id: 'a', name: 'A', type: 'v1-node' },
+				{ id: 'b', name: 'B', type: 'v1-node' },
+			],
+			edges: [
+				{ from: 'trigger', to: 'a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'a', to: 'b', outputIndex: 0, inputIndex: 0 },
+				{ from: 'b', to: 'a', outputIndex: 0, inputIndex: 1, isBackEdge: true },
+			],
+		};
+		const executionStore = makeExecutionStore({
+			loadExecution: vi.fn().mockResolvedValue(record(graph)),
+		});
+		const createSteps = vi.fn().mockResolvedValue([{ id: 'step-trigger', nodeId: 'trigger' }]);
+		const stepStore = makeStepStore(createSteps);
+		const stepQueue = makeStepQueue();
+		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
+
+		await handler.handle({ type: 'execution:enqueued', executionId: 'exec-1' });
+
+		expect(stepQueue.publish).not.toHaveBeenCalled();
+		expect(executionStore.finishExecution).toHaveBeenCalledWith('exec-1', 'completed');
 	});
 });

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -94,6 +94,44 @@ describe('ExecutionStartHandler', () => {
 		});
 	});
 
+	it('skips a trigger successor that also sits behind another node', async () => {
+		// trigger feeds both a and b, but a also waits on b, so only b can start
+		const graph: WorkflowGraph = {
+			nodes: [
+				{ id: 'trigger', name: 'T', type: 'trigger' },
+				{ id: 'a', name: 'A', type: 'v1-node' },
+				{ id: 'b', name: 'B', type: 'v1-node' },
+			],
+			edges: [
+				{ from: 'trigger', to: 'a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 0 },
+				{ from: 'b', to: 'a', outputIndex: 0, inputIndex: 1 },
+			],
+		};
+		const executionStore = makeExecutionStore({
+			loadExecution: vi.fn().mockResolvedValue(record(graph)),
+		});
+		const createSteps = vi.fn().mockResolvedValue([
+			{ id: 'step-trigger', nodeId: 'trigger' },
+			{ id: 'step-b', nodeId: 'b' },
+		]);
+		const stepStore = makeStepStore(createSteps);
+		const stepQueue = makeStepQueue();
+		const handler = new ExecutionStartHandler(executionStore, stepStore, stepQueue);
+
+		await handler.handle({ type: 'execution:enqueued', executionId: 'exec-1' });
+
+		expect(createSteps).toHaveBeenCalledWith([
+			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed' },
+			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
+		]);
+		expect(stepQueue.publish).toHaveBeenCalledExactlyOnceWith({
+			type: 'step:ready',
+			executionId: 'exec-1',
+			stepId: 'step-b',
+		});
+	});
+
 	it('is a no-op when the execution cannot be claimed (duplicate delivery)', async () => {
 		const executionStore = makeExecutionStore({
 			transitionStatus: vi.fn().mockResolvedValue(false),

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -29,7 +29,7 @@ function makeStepStore(createSteps = vi.fn()): StepStore {
 		completeStep: vi.fn(),
 		failStep: vi.fn(),
 		loadStepOutputs: vi.fn(),
-		loadCompletedNodeIds: vi.fn(),
+		loadSettledSteps: vi.fn().mockResolvedValue([]),
 		hasActiveSteps: vi.fn().mockResolvedValue(false),
 		hasFailedSteps: vi.fn().mockResolvedValue(false),
 	};

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
@@ -67,8 +67,8 @@ describe('execution start (integration)', () => {
 			orchestrationQueue,
 		);
 
-		// Stand in for the (not yet built) step worker: consuming the step queue is
-		// both the assertion target and the signal that orchestration finished.
+		// Stand in for the step worker: consuming the step queue is both the
+		// assertion target and the signal that orchestration finished.
 		const readySteps: StepMessage[] = [];
 		let firstReady!: () => void;
 		const ready = new Promise<void>((resolve) => (firstReady = resolve));

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
@@ -20,6 +20,7 @@ import {
 import { ExecutionStartHandler } from '../execution-start-handler';
 import { OrchestrationWorker } from '../orchestration-worker';
 import { StartExecutionService } from '../start-execution.service';
+import { StepCompletedHandler } from '../step-completed-handler';
 
 const graph: WorkflowGraph = {
 	nodes: [
@@ -59,6 +60,7 @@ describe('execution start (integration)', () => {
 		const worker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, stepQueue),
+			new StepCompletedHandler(executionStore, stepStore, stepQueue),
 		);
 		worker.start();
 		const startExecution = new StartExecutionService(

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
@@ -83,7 +83,7 @@ describe('execution start (integration)', () => {
 		const { executionId } = await startExecution.start({
 			workflowId: 'wf-1',
 			graph,
-			triggerPayload: null,
+			triggerPayload: { body: { name: 'ada' } },
 		});
 		await ready;
 
@@ -98,6 +98,8 @@ describe('execution start (integration)', () => {
 		const triggerStep = steps.find((s) => s.nodeId === 'trigger');
 		const firstStep = steps.find((s) => s.nodeId === 'step-a');
 		expect(triggerStep?.status).toBe('completed');
+		// the payload is the trigger step's output slot 0, read like any other predecessor's
+		expect(triggerStep?.outputs).toEqual([{ body: { name: 'ada' } }]);
 		expect(firstStep?.status).toBe('queued');
 
 		// step:ready references the durable step-record id, not the node id.

--- a/packages/@n8n/engine/src/execution/__tests__/start-execution.service.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/start-execution.service.test.ts
@@ -20,6 +20,7 @@ function makeStore(overrides: Partial<ExecutionStore> = {}): ExecutionStore {
 		createExecution: vi.fn().mockResolvedValue({ id: 'exec-id-1' }),
 		loadExecution: vi.fn(),
 		transitionStatus: vi.fn().mockResolvedValue(true),
+		finishExecution: vi.fn().mockResolvedValue(true),
 		...overrides,
 	};
 }

--- a/packages/@n8n/engine/src/execution/__tests__/step-completed-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-completed-handler.test.ts
@@ -3,12 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 import type { WorkflowGraph } from '../../graph';
 import type { StepMessage, WorkQueue } from '../../queue';
 import type { ExecutionRecord, ExecutionStore } from '../execution-store';
+import type { SettledStepStatus } from '../execution.types';
 import { StepCompletedHandler } from '../step-completed-handler';
 import type { NewStepRecord, StepRecord, StepStore } from '../step-store';
 
 /**
- * trigger → a → {b, c} → m. So `a` fans out, `m` fans in behind both `b` and
- * `c`, and `m` is terminal.
+ * trigger → a → {b, c} → m. So `a` fans out (`b` off slot 0, `c` off slot 1),
+ * `m` fans in behind both `b` and `c`, and `m` is terminal.
  */
 const graph: WorkflowGraph = {
 	nodes: [
@@ -45,7 +46,13 @@ function makeExecutionStore(overrides: Partial<ExecutionRecord> = {}): Execution
 	};
 }
 
-function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepStore> = {}) {
+/** What each node's step has settled to; a node absent here hasn't settled. */
+type SettledSeed = Record<string, { status: SettledStepStatus; filledOutputSlots: number[] }>;
+
+function makeStepStore(
+	step: Partial<StepRecord> = {},
+	{ settled = {}, overrides = {} }: { settled?: SettledSeed; overrides?: Partial<StepStore> } = {},
+) {
 	const record: StepRecord = {
 		id: 'step-a',
 		executionId: 'exec-1',
@@ -55,10 +62,18 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		error: null,
 		...step,
 	};
+	const settledByNodeId = new Map(Object.entries(settled));
 	return {
-		// ids derived from the node, so assertions can name the step they expect
+		// ids derived from the node, so assertions can name the step they expect.
+		// A row written as skipped settles its node, so the next planning round
+		// sees it — the cascade behaves as it would against the real store.
 		createSteps: vi.fn().mockImplementation(async (records: NewStepRecord[]) => {
 			await Promise.resolve();
+			for (const { nodeId, status } of records) {
+				if (status === 'skipped') {
+					settledByNodeId.set(nodeId, { status: 'skipped', filledOutputSlots: [] });
+				}
+			}
 			return records.map(({ nodeId }) => ({ id: `step-${nodeId}`, nodeId }));
 		}),
 		loadStep: vi.fn().mockResolvedValue(record),
@@ -66,8 +81,15 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		completeStep: vi.fn(),
 		failStep: vi.fn(),
 		loadStepOutputs: vi.fn(),
-		// every node completed, so a case has to opt out to be unready
-		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set(graph.nodes.map(({ id }) => id))),
+		loadSettledSteps: vi
+			.fn()
+			.mockImplementation(async (_executionId: string, nodeIds: string[]) => {
+				await Promise.resolve();
+				return nodeIds.flatMap((nodeId) => {
+					const settledStep = settledByNodeId.get(nodeId);
+					return settledStep ? [{ nodeId, ...settledStep }] : [];
+				});
+			}),
 		hasActiveSteps: vi.fn().mockResolvedValue(false),
 		hasFailedSteps: vi.fn().mockResolvedValue(false),
 		...overrides,
@@ -81,14 +103,17 @@ function makeQueue(): WorkQueue<StepMessage> {
 const event = { type: 'step:completed', executionId: 'exec-1', stepId: 'step-a' } as const;
 
 describe('StepCompletedHandler', () => {
-	it('plans every ready successor in one batch and publishes step:ready for each', async () => {
-		const stepStore = makeStepStore();
+	it('plans every live successor in one batch and publishes step:ready for each', async () => {
+		const stepStore = makeStepStore(
+			{},
+			{ settled: { a: { status: 'completed', filledOutputSlots: [0, 1] } } },
+		);
 		const queue = makeQueue();
 		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
 
 		await handler.handle(event);
 
-		expect(stepStore.createSteps).toHaveBeenCalledWith([
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
 			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
 			{ executionId: 'exec-1', nodeId: 'c', status: 'queued' },
 		]);
@@ -106,44 +131,149 @@ describe('StepCompletedHandler', () => {
 	});
 
 	it("asks readiness in one query, for the successors' own predecessors", async () => {
-		const stepStore = makeStepStore({ id: 'step-b', nodeId: 'b' });
+		const stepStore = makeStepStore(
+			{ id: 'step-b', nodeId: 'b' },
+			{
+				settled: {
+					a: { status: 'completed', filledOutputSlots: [0, 1] },
+					b: { status: 'completed', filledOutputSlots: [0] },
+					c: { status: 'completed', filledOutputSlots: [0] },
+				},
+			},
+		);
 		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, makeQueue());
 
 		await handler.handle({ ...event, stepId: 'step-b' });
 
 		// b's only successor is m, which sits behind both b and c
-		expect(stepStore.loadCompletedNodeIds).toHaveBeenCalledExactlyOnceWith('exec-1', ['b', 'c']);
+		expect(stepStore.loadSettledSteps).toHaveBeenCalledExactlyOnceWith('exec-1', ['b', 'c']);
+	});
+
+	it('skips a successor whose only edge leaves a slot the step did not fill', async () => {
+		// 'a' filled slot 0 but not slot 1, so 'c' is behind a branch not taken
+		const stepStore = makeStepStore(
+			{},
+			{ settled: { a: { status: 'completed', filledOutputSlots: [0] } } },
+		);
+		const queue = makeQueue();
+		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
+
+		await handler.handle(event);
+
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
+			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
+			{ executionId: 'exec-1', nodeId: 'c', status: 'skipped' },
+		]);
+		// m stays undecided: its other predecessor, b, was queued, not settled
+		expect(queue.publish).toHaveBeenCalledExactlyOnceWith({
+			type: 'step:ready',
+			executionId: 'exec-1',
+			stepId: 'step-b',
+		});
+	});
+
+	it('runs a join on its one live edge once the dead branch has settled', async () => {
+		// the second half of the diamond: c was skipped earlier, b completes now
+		const stepStore = makeStepStore(
+			{ id: 'step-b', nodeId: 'b' },
+			{
+				settled: {
+					a: { status: 'completed', filledOutputSlots: [0] },
+					b: { status: 'completed', filledOutputSlots: [0] },
+					c: { status: 'skipped', filledOutputSlots: [] },
+				},
+			},
+		);
+		const queue = makeQueue();
+		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
+
+		await handler.handle({ ...event, stepId: 'step-b' });
+
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
+			{ executionId: 'exec-1', nodeId: 'm', status: 'queued' },
+		]);
+		expect(queue.publish).toHaveBeenCalledExactlyOnceWith({
+			type: 'step:ready',
+			executionId: 'exec-1',
+			stepId: 'step-m',
+		});
+	});
+
+	it('cascades skips to the end and completes the execution when nothing ran', async () => {
+		// 'a' completed but filled nothing, so its whole downstream is dead
+		const stepStore = makeStepStore(
+			{},
+			{ settled: { a: { status: 'completed', filledOutputSlots: [] } } },
+		);
+		const queue = makeQueue();
+		const executionStore = makeExecutionStore();
+		const handler = new StepCompletedHandler(executionStore, stepStore, queue);
+
+		await handler.handle(event);
+
+		// round one skips the fan-out, round two the join behind it
+		expect(stepStore.createSteps).toHaveBeenNthCalledWith(1, [
+			{ executionId: 'exec-1', nodeId: 'b', status: 'skipped' },
+			{ executionId: 'exec-1', nodeId: 'c', status: 'skipped' },
+		]);
+		expect(stepStore.createSteps).toHaveBeenNthCalledWith(2, [
+			{ executionId: 'exec-1', nodeId: 'm', status: 'skipped' },
+		]);
+		expect(queue.publish).not.toHaveBeenCalled();
+		expect(executionStore.finishExecution).toHaveBeenCalledWith('exec-1', 'completed');
+	});
+
+	it('skips the successors of a failed step and fails the execution', async () => {
+		const stepStore = makeStepStore(
+			{ status: 'failed' },
+			{
+				settled: { a: { status: 'failed', filledOutputSlots: [] } },
+				overrides: { hasFailedSteps: vi.fn().mockResolvedValue(true) },
+			},
+		);
+		const queue = makeQueue();
+		const executionStore = makeExecutionStore();
+		const handler = new StepCompletedHandler(executionStore, stepStore, queue);
+
+		await handler.handle(event);
+
+		expect(stepStore.createSteps).toHaveBeenNthCalledWith(1, [
+			{ executionId: 'exec-1', nodeId: 'b', status: 'skipped' },
+			{ executionId: 'exec-1', nodeId: 'c', status: 'skipped' },
+		]);
+		expect(stepStore.createSteps).toHaveBeenNthCalledWith(2, [
+			{ executionId: 'exec-1', nodeId: 'm', status: 'skipped' },
+		]);
+		expect(queue.publish).not.toHaveBeenCalled();
+		expect(executionStore.finishExecution).toHaveBeenCalledWith('exec-1', 'failed');
 	});
 
 	const notPlanned: Array<{
 		reason: string;
 		stepId: string;
 		step: Partial<StepRecord>;
-		overrides: Partial<StepStore>;
+		settled: SettledSeed;
 	}> = [
 		{
-			reason: 'the step did not complete',
-			stepId: 'step-a',
-			step: { status: 'failed' },
-			overrides: {},
-		},
-		{
-			reason: 'a successor still has an incomplete predecessor',
+			reason: 'a successor still has an unsettled predecessor',
 			stepId: 'step-b',
 			step: { id: 'step-b', nodeId: 'b' },
-			// m sits behind b and c; c hasn't completed
-			overrides: { loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set(['b'])) },
+			// m sits behind b and c; c hasn't settled
+			settled: {
+				a: { status: 'completed', filledOutputSlots: [0, 1] },
+				b: { status: 'completed', filledOutputSlots: [0] },
+			},
 		},
 		{
 			reason: 'the completed node has no successors',
 			stepId: 'step-m',
 			step: { id: 'step-m', nodeId: 'm' },
-			overrides: {},
+			settled: { m: { status: 'completed', filledOutputSlots: [0] } },
 		},
 	];
 
-	it.each(notPlanned)('plans nothing when $reason', async ({ stepId, step, overrides }) => {
-		const stepStore = makeStepStore(step, overrides);
+	it.each(notPlanned)('plans nothing when $reason', async ({ stepId, step, settled }) => {
+		const stepStore = makeStepStore(step, { settled });
 		const queue = makeQueue();
 		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
 
@@ -155,7 +285,10 @@ describe('StepCompletedHandler', () => {
 
 	it('finishes the execution once the last step is done', async () => {
 		// 'm' is terminal, and nothing else is left running
-		const stepStore = makeStepStore({ id: 'step-m', nodeId: 'm' });
+		const stepStore = makeStepStore(
+			{ id: 'step-m', nodeId: 'm' },
+			{ settled: { m: { status: 'completed', filledOutputSlots: [0] } } },
+		);
 		const executionStore = makeExecutionStore();
 		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
 
@@ -167,7 +300,10 @@ describe('StepCompletedHandler', () => {
 	it('finishes the execution as failed when any step failed', async () => {
 		const stepStore = makeStepStore(
 			{ id: 'step-m', nodeId: 'm' },
-			{ hasFailedSteps: vi.fn().mockResolvedValue(true) },
+			{
+				settled: { m: { status: 'completed', filledOutputSlots: [0] } },
+				overrides: { hasFailedSteps: vi.fn().mockResolvedValue(true) },
+			},
 		);
 		const executionStore = makeExecutionStore();
 		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
@@ -178,10 +314,16 @@ describe('StepCompletedHandler', () => {
 	});
 
 	it('leaves the execution running while another step is still outstanding', async () => {
-		// 'b' failed, so nothing downstream is planned, but 'c' is still going
+		// 'b' failed, its downstream skips are held up by c — but c is still going
 		const stepStore = makeStepStore(
 			{ id: 'step-b', nodeId: 'b', status: 'failed' },
-			{ hasActiveSteps: vi.fn().mockResolvedValue(true) },
+			{
+				settled: {
+					a: { status: 'completed', filledOutputSlots: [0, 1] },
+					b: { status: 'failed', filledOutputSlots: [] },
+				},
+				overrides: { hasActiveSteps: vi.fn().mockResolvedValue(true) },
+			},
 		);
 		const executionStore = makeExecutionStore();
 		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
@@ -192,7 +334,10 @@ describe('StepCompletedHandler', () => {
 	});
 
 	it('does not test for completion when it just queued work', async () => {
-		const stepStore = makeStepStore();
+		const stepStore = makeStepStore(
+			{},
+			{ settled: { a: { status: 'completed', filledOutputSlots: [0, 1] } } },
+		);
 		const executionStore = makeExecutionStore();
 		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
 

--- a/packages/@n8n/engine/src/execution/__tests__/step-completed-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-completed-handler.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkflowGraph } from '../../graph';
+import type { StepMessage, WorkQueue } from '../../queue';
+import type { ExecutionRecord, ExecutionStore } from '../execution-store';
+import { StepCompletedHandler } from '../step-completed-handler';
+import type { NewStepRecord, StepRecord, StepStore } from '../step-store';
+
+/**
+ * trigger → a → {b, c} → m. So `a` fans out, `m` fans in behind both `b` and
+ * `c`, and `m` is terminal.
+ */
+const graph: WorkflowGraph = {
+	nodes: [
+		{ id: 'trigger', name: 'T', type: 'trigger' },
+		{ id: 'a', name: 'A', type: 'v1-node' },
+		{ id: 'b', name: 'B', type: 'v1-node' },
+		{ id: 'c', name: 'C', type: 'v1-node' },
+		{ id: 'm', name: 'M', type: 'v1-node' },
+	],
+	edges: [
+		{ from: 'trigger', to: 'a', outputIndex: 0, inputIndex: 0 },
+		{ from: 'a', to: 'b', outputIndex: 0, inputIndex: 0 },
+		{ from: 'a', to: 'c', outputIndex: 1, inputIndex: 0 },
+		{ from: 'b', to: 'm', outputIndex: 0, inputIndex: 0 },
+		{ from: 'c', to: 'm', outputIndex: 0, inputIndex: 1 },
+	],
+};
+
+function makeExecutionStore(overrides: Partial<ExecutionRecord> = {}): ExecutionStore {
+	const execution: ExecutionRecord = {
+		id: 'exec-1',
+		workflowId: 'wf-1',
+		status: 'running',
+		mode: 'production',
+		graph,
+		triggerPayload: null,
+		...overrides,
+	};
+	return {
+		createExecution: vi.fn(),
+		loadExecution: vi.fn().mockResolvedValue(execution),
+		transitionStatus: vi.fn().mockResolvedValue(true),
+		finishExecution: vi.fn().mockResolvedValue(true),
+	};
+}
+
+function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepStore> = {}) {
+	const record: StepRecord = {
+		id: 'step-a',
+		executionId: 'exec-1',
+		nodeId: 'a',
+		status: 'completed',
+		outputs: null,
+		error: null,
+		...step,
+	};
+	return {
+		// ids derived from the node, so assertions can name the step they expect
+		createSteps: vi.fn().mockImplementation(async (records: NewStepRecord[]) => {
+			await Promise.resolve();
+			return records.map(({ nodeId }) => ({ id: `step-${nodeId}`, nodeId }));
+		}),
+		loadStep: vi.fn().mockResolvedValue(record),
+		claimStep: vi.fn(),
+		completeStep: vi.fn(),
+		failStep: vi.fn(),
+		loadStepOutputs: vi.fn(),
+		// every node completed, so a case has to opt out to be unready
+		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set(graph.nodes.map(({ id }) => id))),
+		hasActiveSteps: vi.fn().mockResolvedValue(false),
+		hasFailedSteps: vi.fn().mockResolvedValue(false),
+		...overrides,
+	} satisfies StepStore;
+}
+
+function makeQueue(): WorkQueue<StepMessage> {
+	return { publish: vi.fn(), start: vi.fn(), stop: vi.fn() };
+}
+
+const event = { type: 'step:completed', executionId: 'exec-1', stepId: 'step-a' } as const;
+
+describe('StepCompletedHandler', () => {
+	it('plans every ready successor in one batch and publishes step:ready for each', async () => {
+		const stepStore = makeStepStore();
+		const queue = makeQueue();
+		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
+
+		await handler.handle(event);
+
+		expect(stepStore.createSteps).toHaveBeenCalledWith([
+			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
+			{ executionId: 'exec-1', nodeId: 'c', status: 'queued' },
+		]);
+		expect(queue.publish).toHaveBeenCalledTimes(2);
+		expect(queue.publish).toHaveBeenCalledWith({
+			type: 'step:ready',
+			executionId: 'exec-1',
+			stepId: 'step-b',
+		});
+		expect(queue.publish).toHaveBeenCalledWith({
+			type: 'step:ready',
+			executionId: 'exec-1',
+			stepId: 'step-c',
+		});
+	});
+
+	it("asks readiness in one query, for the successors' own predecessors", async () => {
+		const stepStore = makeStepStore({ id: 'step-b', nodeId: 'b' });
+		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, makeQueue());
+
+		await handler.handle({ ...event, stepId: 'step-b' });
+
+		// b's only successor is m, which sits behind both b and c
+		expect(stepStore.loadCompletedNodeIds).toHaveBeenCalledExactlyOnceWith('exec-1', ['b', 'c']);
+	});
+
+	const notPlanned: Array<{
+		reason: string;
+		stepId: string;
+		step: Partial<StepRecord>;
+		overrides: Partial<StepStore>;
+	}> = [
+		{
+			reason: 'the step did not complete',
+			stepId: 'step-a',
+			step: { status: 'failed' },
+			overrides: {},
+		},
+		{
+			reason: 'a successor still has an incomplete predecessor',
+			stepId: 'step-b',
+			step: { id: 'step-b', nodeId: 'b' },
+			// m sits behind b and c; c hasn't completed
+			overrides: { loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set(['b'])) },
+		},
+		{
+			reason: 'the completed node has no successors',
+			stepId: 'step-m',
+			step: { id: 'step-m', nodeId: 'm' },
+			overrides: {},
+		},
+	];
+
+	it.each(notPlanned)('plans nothing when $reason', async ({ stepId, step, overrides }) => {
+		const stepStore = makeStepStore(step, overrides);
+		const queue = makeQueue();
+		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
+
+		await handler.handle({ ...event, stepId });
+
+		expect(stepStore.createSteps).not.toHaveBeenCalled();
+		expect(queue.publish).not.toHaveBeenCalled();
+	});
+
+	it('finishes the execution once the last step is done', async () => {
+		// 'm' is terminal, and nothing else is left running
+		const stepStore = makeStepStore({ id: 'step-m', nodeId: 'm' });
+		const executionStore = makeExecutionStore();
+		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+
+		await handler.handle({ ...event, stepId: 'step-m' });
+
+		expect(executionStore.finishExecution).toHaveBeenCalledWith('exec-1', 'completed');
+	});
+
+	it('finishes the execution as failed when any step failed', async () => {
+		const stepStore = makeStepStore(
+			{ id: 'step-m', nodeId: 'm' },
+			{ hasFailedSteps: vi.fn().mockResolvedValue(true) },
+		);
+		const executionStore = makeExecutionStore();
+		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+
+		await handler.handle({ ...event, stepId: 'step-m' });
+
+		expect(executionStore.finishExecution).toHaveBeenCalledWith('exec-1', 'failed');
+	});
+
+	it('leaves the execution running while another step is still outstanding', async () => {
+		// 'b' failed, so nothing downstream is planned, but 'c' is still going
+		const stepStore = makeStepStore(
+			{ id: 'step-b', nodeId: 'b', status: 'failed' },
+			{ hasActiveSteps: vi.fn().mockResolvedValue(true) },
+		);
+		const executionStore = makeExecutionStore();
+		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+
+		await handler.handle({ ...event, stepId: 'step-b' });
+
+		expect(executionStore.finishExecution).not.toHaveBeenCalled();
+	});
+
+	it('does not test for completion when it just queued work', async () => {
+		const stepStore = makeStepStore();
+		const executionStore = makeExecutionStore();
+		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+
+		await handler.handle(event);
+
+		// 'a' fanned out to b and c, so the execution is provably unfinished
+		expect(stepStore.hasActiveSteps).not.toHaveBeenCalled();
+		expect(executionStore.finishExecution).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -17,6 +17,7 @@ import { InMemoryWorkQueue, type OrchestrationMessage, type StepMessage } from '
 import { ExecutionStartHandler } from '../execution-start-handler';
 import { OrchestrationWorker } from '../orchestration-worker';
 import { StartExecutionService } from '../start-execution.service';
+import { StepCompletedHandler } from '../step-completed-handler';
 import { StepReadyHandler } from '../step-ready-handler';
 import { StepWorker } from '../step-worker';
 
@@ -72,6 +73,7 @@ describe('step execution (integration)', () => {
 		const orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, stepQueue),
+			new StepCompletedHandler(executionStore, stepStore, stepQueue),
 		);
 		const stepWorker = new StepWorker(
 			stepQueue,
@@ -144,6 +146,82 @@ describe('step execution (integration)', () => {
 			stack: expect.stringContaining('TypeError: credentials missing') as string,
 		});
 		expect(step?.outputs).toBeNull();
+	});
+
+	it('runs a chain of steps, feeding each output forward, and finishes the execution', async () => {
+		const chainGraph: WorkflowGraph = {
+			nodes: [
+				{ id: 'trigger', name: 'Webhook', type: 'trigger' },
+				{ id: 'node-a', name: 'A', type: 'v1-node' },
+				{ id: 'node-b', name: 'B', type: 'v1-node' },
+			],
+			edges: [
+				{ from: 'trigger', to: 'node-a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-a', to: 'node-b', outputIndex: 0, inputIndex: 0 },
+			],
+		};
+		const { executionStore, stepStore } = stores();
+		const orchestrationQueue = new InMemoryWorkQueue<OrchestrationMessage>();
+		const stepQueue = new InMemoryWorkQueue<StepMessage>();
+
+		// The run is over when the execution is recorded finished, not when the first
+		// step completes — there are two hops here.
+		let done!: () => void;
+		const finished = new Promise<void>((resolve) => (done = resolve));
+		const finishExecution = executionStore.finishExecution.bind(executionStore);
+		vi.spyOn(executionStore, 'finishExecution').mockImplementation(async (id, status) => {
+			const recorded = await finishExecution(id, status);
+			done();
+			return recorded;
+		});
+
+		const requests: StepExecutionRequest[] = [];
+		const executor: IStepExecutor = {
+			execute: async (request) => {
+				requests.push(request);
+				await Promise.resolve();
+				return { outputs: [[{ json: { ran: request.node.id } }]] };
+			},
+		};
+
+		const orchestrationWorker = new OrchestrationWorker(
+			orchestrationQueue,
+			new ExecutionStartHandler(executionStore, stepStore, stepQueue),
+			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+		);
+		const stepWorker = new StepWorker(
+			stepQueue,
+			new StepReadyHandler(executionStore, stepStore, orchestrationQueue, {
+				v1StepExecutor: executor,
+			}),
+		);
+		orchestrationWorker.start();
+		stepWorker.start();
+
+		const { executionId } = await new StartExecutionService(
+			new AllowAllAdmittance(),
+			executionStore,
+			orchestrationQueue,
+		).start({
+			workflowId: 'wf-chain',
+			graph: chainGraph,
+			triggerPayload: { body: { name: 'ada' } },
+		});
+		await finished;
+
+		await stepWorker.stop();
+		await orchestrationWorker.stop();
+
+		// both nodes ran, in order, each on what came before it
+		expect(requests.map(({ node }) => node.id)).toEqual(['node-a', 'node-b']);
+		expect(requests[0].inputs).toEqual({ body: { name: 'ada' } });
+		expect(requests[1].inputs).toEqual([[{ json: { ran: 'node-a' } }]]);
+
+		const execution = await dataSource
+			.getRepository(WorkflowExecution)
+			.findOneOrFail({ where: { id: executionId } });
+		expect(execution.status).toBe('completed');
+		expect(execution.finishedAt).toBeInstanceOf(Date);
 	});
 
 	it('is idempotent across duplicate step:ready deliveries', async () => {

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -116,9 +116,9 @@ describe('step execution (integration)', () => {
 		expect(step?.outputs).toEqual([[{ json: { greeting: 'hi' } }]]);
 		expect(step?.error).toBeNull();
 
-		// the trigger payload reaches the executor as the step's inputs
+		// the trigger payload reaches the executor on input slot 0
 		expect(requests).toHaveLength(1);
-		expect(requests[0].inputs).toEqual({ body: { name: 'ada' } });
+		expect(requests[0].inputs).toEqual([{ body: { name: 'ada' } }]);
 		expect(requests[0].node.id).toBe('node-a');
 		expect(requests[0].context).toEqual({
 			executionId,
@@ -214,7 +214,8 @@ describe('step execution (integration)', () => {
 
 		// both nodes ran, in order, each on what came before it
 		expect(requests.map(({ node }) => node.id)).toEqual(['node-a', 'node-b']);
-		expect(requests[0].inputs).toEqual({ body: { name: 'ada' } });
+		expect(requests[0].inputs).toEqual([{ body: { name: 'ada' } }]);
+		// node-a's output slot 0 arrives on node-b's input slot 0
 		expect(requests[1].inputs).toEqual([[{ json: { ran: 'node-a' } }]]);
 
 		const execution = await dataSource

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -1,0 +1,177 @@
+import type { DataSource } from '@n8n/typeorm';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { AllowAllAdmittance } from '../../admittance';
+import type { JsonObject } from '../../common';
+import {
+	createDataSource,
+	TypeOrmExecutionStore,
+	TypeOrmStepStore,
+	WorkflowExecution,
+	WorkflowStepExecution,
+} from '../../database';
+import type { IStepExecutor, StepExecutionRequest } from '../../dependencies';
+import type { WorkflowGraph } from '../../graph';
+import { InMemoryWorkQueue, type OrchestrationMessage, type StepMessage } from '../../queue';
+import { ExecutionStartHandler } from '../execution-start-handler';
+import { OrchestrationWorker } from '../orchestration-worker';
+import { StartExecutionService } from '../start-execution.service';
+import { StepReadyHandler } from '../step-ready-handler';
+import { StepWorker } from '../step-worker';
+
+const graph: WorkflowGraph = {
+	nodes: [
+		{ id: 'trigger', name: 'Webhook', type: 'trigger' },
+		{ id: 'node-a', name: 'A', type: 'v1-node' },
+	],
+	edges: [{ from: 'trigger', to: 'node-a', outputIndex: 0, inputIndex: 0 }],
+};
+
+describe('step execution (integration)', () => {
+	let container: StartedPostgreSqlContainer;
+	let dataSource: DataSource;
+
+	beforeAll(async () => {
+		container = await new PostgreSqlContainer('postgres:18-alpine').start();
+		dataSource = createDataSource(container.getConnectionUri());
+		await dataSource.initialize();
+		await dataSource.runMigrations();
+	}, 120_000);
+
+	afterAll(async () => {
+		if (dataSource?.isInitialized) await dataSource.destroy();
+		if (container) await container.stop();
+	});
+
+	function stores() {
+		return {
+			executionStore: new TypeOrmExecutionStore(dataSource.getRepository(WorkflowExecution)),
+			stepStore: new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution)),
+		};
+	}
+
+	/**
+	 * Wires both workers over shared queues and runs a workflow through them.
+	 * Resolves once a `step:completed` has been published, which is the point at
+	 * which the step's outcome is durable.
+	 */
+	async function runWorkflow(executor: IStepExecutor, triggerPayload: JsonObject) {
+		const { executionStore, stepStore } = stores();
+		const orchestrationQueue = new InMemoryWorkQueue<OrchestrationMessage>();
+		const stepQueue = new InMemoryWorkQueue<StepMessage>();
+
+		let stepDone!: () => void;
+		const completed = new Promise<void>((resolve) => (stepDone = resolve));
+		const publish = orchestrationQueue.publish.bind(orchestrationQueue);
+		vi.spyOn(orchestrationQueue, 'publish').mockImplementation(async (message) => {
+			await publish(message);
+			if (message.type === 'step:completed') stepDone();
+		});
+
+		const orchestrationWorker = new OrchestrationWorker(
+			orchestrationQueue,
+			new ExecutionStartHandler(executionStore, stepStore, stepQueue),
+		);
+		const stepWorker = new StepWorker(
+			stepQueue,
+			new StepReadyHandler(executionStore, stepStore, orchestrationQueue, {
+				v1StepExecutor: executor,
+			}),
+		);
+		orchestrationWorker.start();
+		stepWorker.start();
+
+		const { executionId } = await new StartExecutionService(
+			new AllowAllAdmittance(),
+			executionStore,
+			orchestrationQueue,
+		).start({ workflowId: 'wf-1', graph, triggerPayload });
+		await completed;
+
+		await stepWorker.stop();
+		await orchestrationWorker.stop();
+
+		const steps = await dataSource
+			.getRepository(WorkflowStepExecution)
+			.find({ where: { executionId } });
+		return { executionId, step: steps.find((candidate) => candidate.nodeId === 'node-a') };
+	}
+
+	it('runs a queued step and persists its outputs', async () => {
+		const requests: StepExecutionRequest[] = [];
+		const executor: IStepExecutor = {
+			execute: async (request) => {
+				requests.push(request);
+				await Promise.resolve();
+				return { outputs: [[{ json: { greeting: 'hi' } }]] };
+			},
+		};
+
+		const { executionId, step } = await runWorkflow(executor, { body: { name: 'ada' } });
+
+		expect(step?.status).toBe('completed');
+		expect(step?.outputs).toEqual([[{ json: { greeting: 'hi' } }]]);
+		expect(step?.error).toBeNull();
+
+		// the trigger payload reaches the executor as the step's inputs
+		expect(requests).toHaveLength(1);
+		expect(requests[0].inputs).toEqual({ body: { name: 'ada' } });
+		expect(requests[0].node.id).toBe('node-a');
+		expect(requests[0].context).toEqual({
+			executionId,
+			stepId: step?.id,
+			workflowId: 'wf-1',
+			mode: 'production',
+		});
+	});
+
+	it('records the error when a step throws', async () => {
+		const executor: IStepExecutor = {
+			execute: async () => {
+				await Promise.resolve();
+				throw new TypeError('credentials missing');
+			},
+		};
+
+		const { step } = await runWorkflow(executor, {});
+
+		expect(step?.status).toBe('failed');
+		expect(step?.error).toEqual({ name: 'TypeError', message: 'credentials missing' });
+		expect(step?.outputs).toBeNull();
+	});
+
+	it('is idempotent across duplicate step:ready deliveries', async () => {
+		const { executionStore, stepStore } = stores();
+		const execute = vi.fn().mockResolvedValue({ outputs: [[{ json: { n: 1 } }]] });
+		const orchestrationQueue = new InMemoryWorkQueue<OrchestrationMessage>();
+		const handler = new StepReadyHandler(executionStore, stepStore, orchestrationQueue, {
+			v1StepExecutor: { execute },
+		});
+
+		const { id: executionId } = await executionStore.createExecution({
+			workflowId: 'wf-2',
+			status: 'running',
+			mode: 'production',
+			graph,
+			triggerPayload: null,
+		});
+		await stepStore.createStep({ executionId, nodeId: 'trigger', status: 'completed' });
+		const { id: stepId } = await stepStore.createStep({
+			executionId,
+			nodeId: 'node-a',
+			status: 'queued',
+		});
+
+		// Delivered twice, both awaited — the CAS is what makes the second a no-op.
+		const event = { type: 'step:ready', executionId, stepId } as const;
+		await handler.handle(event);
+		await handler.handle(event);
+
+		expect(execute).toHaveBeenCalledTimes(1);
+		const step = await dataSource
+			.getRepository(WorkflowStepExecution)
+			.findOneOrFail({ where: { id: stepId } });
+		expect(step.status).toBe('completed');
+	});
+});

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -137,7 +137,12 @@ describe('step execution (integration)', () => {
 		const { step } = await runWorkflow(executor, {});
 
 		expect(step?.status).toBe('failed');
-		expect(step?.error).toEqual({ name: 'TypeError', message: 'credentials missing' });
+		expect(step?.error).toEqual({
+			name: 'TypeError',
+			message: 'credentials missing',
+			// the stack survives the round trip through jsonb
+			stack: expect.stringContaining('TypeError: credentials missing') as string,
+		});
 		expect(step?.outputs).toBeNull();
 	});
 
@@ -156,12 +161,10 @@ describe('step execution (integration)', () => {
 			graph,
 			triggerPayload: null,
 		});
-		await stepStore.createStep({ executionId, nodeId: 'trigger', status: 'completed' });
-		const { id: stepId } = await stepStore.createStep({
-			executionId,
-			nodeId: 'node-a',
-			status: 'queued',
-		});
+		const [, { id: stepId }] = await stepStore.createSteps([
+			{ executionId, nodeId: 'trigger', status: 'completed' },
+			{ executionId, nodeId: 'node-a', status: 'queued' },
+		]);
 
 		// Delivered twice, both awaited — the CAS is what makes the second a no-op.
 		const event = { type: 'step:ready', executionId, stepId } as const;

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -34,6 +34,7 @@ function makeExecutionStore(overrides: Partial<ExecutionRecord> = {}): Execution
 		createExecution: vi.fn(),
 		loadExecution: vi.fn().mockResolvedValue(execution),
 		transitionStatus: vi.fn().mockResolvedValue(true),
+		finishExecution: vi.fn().mockResolvedValue(true),
 	};
 }
 
@@ -54,6 +55,9 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		completeStep: vi.fn().mockResolvedValue(true),
 		failStep: vi.fn().mockResolvedValue(true),
 		loadStepOutputs: vi.fn().mockResolvedValue({}),
+		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set()),
+		hasActiveSteps: vi.fn().mockResolvedValue(false),
+		hasFailedSteps: vi.fn().mockResolvedValue(false),
 		...overrides,
 	} satisfies StepStore;
 }

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -74,21 +74,26 @@ const event = { type: 'step:ready', executionId: 'exec-1', stepId: 'step-a' } as
 
 describe('StepReadyHandler', () => {
 	it('claims the step, runs it through the executor, records its outputs and reports completion', async () => {
-		const stepStore = makeStepStore();
+		// the trigger is an ordinary completed predecessor: its payload is its outputs
+		const stepStore = makeStepStore(
+			{},
+			{
+				loadStepOutputs: vi.fn().mockResolvedValue({ trigger: [{ body: { hello: 'world' } }] }),
+			},
+		);
 		const queue = makeQueue();
 		const executor = makeExecutor({ outputs: [[{ json: { ok: true } }]] });
-		const executionStore = makeExecutionStore({ triggerPayload: { body: { hello: 'world' } } });
-		const handler = new StepReadyHandler(executionStore, stepStore, queue, {
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
 			v1StepExecutor: executor,
 		});
 
 		await handler.handle(event);
 
 		expect(stepStore.claimStep).toHaveBeenCalledWith('step-a');
-		// 'a' sits directly behind the trigger, so its inputs are the trigger payload
+		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['trigger']);
 		expect(executor.execute).toHaveBeenCalledWith({
 			node: { id: 'a', name: 'A', type: 'v1-node', config: { some: 'config' } },
-			inputs: { body: { hello: 'world' } },
+			inputs: [{ body: { hello: 'world' } }],
 			context: {
 				executionId: 'exec-1',
 				stepId: 'step-a',
@@ -121,6 +126,76 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['a']);
 		expect(executor.execute).toHaveBeenCalledWith(
 			expect.objectContaining({ inputs: [[{ json: { from: 'a' } }]] }),
+		);
+	});
+
+	/** trigger -> a -> m and trigger -> c -> m, so `m` fans in on two input slots. */
+	const fanInGraph: WorkflowGraph = {
+		nodes: [
+			...graph.nodes,
+			{ id: 'c', name: 'C', type: 'v1-node' },
+			{ id: 'm', name: 'M', type: 'v1-node' },
+		],
+		edges: [
+			...graph.edges,
+			{ from: 'trigger', to: 'c', outputIndex: 0, inputIndex: 0 },
+			// a's *second* output feeds m's first input; c's first feeds m's second
+			{ from: 'a', to: 'm', outputIndex: 1, inputIndex: 0 },
+			{ from: 'c', to: 'm', outputIndex: 0, inputIndex: 1 },
+		],
+	};
+
+	it('routes each incoming edge from its output slot into its input slot', async () => {
+		const executor = makeExecutor();
+		const stepStore = makeStepStore(
+			{ id: 'step-m', nodeId: 'm' },
+			{
+				loadStepOutputs: vi.fn().mockResolvedValue({
+					a: [[{ json: { slot: 'a0' } }], [{ json: { slot: 'a1' } }]],
+					c: [[{ json: { slot: 'c0' } }]],
+				}),
+			},
+		);
+		const handler = new StepReadyHandler(
+			makeExecutionStore({ graph: fanInGraph }),
+			stepStore,
+			makeQueue(),
+			{ v1StepExecutor: executor },
+		);
+
+		await handler.handle({ ...event, stepId: 'step-m' });
+
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({
+				// a's slot 1, not its slot 0, and c's slot 0 second
+				inputs: [[{ json: { slot: 'a1' } }], [{ json: { slot: 'c0' } }]],
+			}),
+		);
+	});
+
+	it('reads an output slot the predecessor never took as null', async () => {
+		const executor = makeExecutor();
+		const stepStore = makeStepStore(
+			// m reads a's output 1, but a only took output 0
+			{ id: 'step-m', nodeId: 'm' },
+			{
+				loadStepOutputs: vi.fn().mockResolvedValue({
+					a: [[{ json: { slot: 'a0' } }]],
+					c: [[{ json: { slot: 'c0' } }]],
+				}),
+			},
+		);
+		const handler = new StepReadyHandler(
+			makeExecutionStore({ graph: fanInGraph }),
+			stepStore,
+			makeQueue(),
+			{ v1StepExecutor: executor },
+		);
+
+		await handler.handle({ ...event, stepId: 'step-m' });
+
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({ inputs: [null, [{ json: { slot: 'c0' } }]] }),
 		);
 	});
 
@@ -255,52 +330,19 @@ describe('StepReadyHandler', () => {
 			expected: { name: 'UnimplementedError', message: 'v1-node' },
 		},
 		{
-			reason: 'more than one edge feeds it (fan-in)',
+			reason: 'two edges arrive at the same input slot',
 			stepId: 'step-b',
 			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
 			execution: () =>
 				makeExecutionStore({
 					graph: {
 						nodes: graph.nodes,
-						// second input into b makes it a fan-in
-						edges: [...graph.edges, { from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 1 }],
+						// the trigger joins 'a' on input 0, which v1 would run 'b' twice for
+						edges: [...graph.edges, { from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 0 }],
 					},
 				}),
 			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
-			expected: { name: 'UnimplementedError', message: 'connection slots' },
-		},
-		{
-			reason: 'one node feeds it through two edges',
-			stepId: 'step-b',
-			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
-			execution: () =>
-				makeExecutionStore({
-					graph: {
-						nodes: graph.nodes,
-						// 'a' connected to b twice still counts per edge, not per node
-						edges: [...graph.edges, { from: 'a', to: 'b', outputIndex: 1, inputIndex: 1 }],
-					},
-				}),
-			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
-			expected: { name: 'UnimplementedError', message: 'connection slots' },
-		},
-		{
-			reason: "its edge leaves the predecessor's second output",
-			stepId: 'step-b',
-			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
-			execution: () =>
-				makeExecutionStore({
-					graph: {
-						nodes: graph.nodes,
-						edges: [
-							graph.edges[0],
-							// the pass-through would hand b all of a's outputs, not slot 1
-							{ from: 'a', to: 'b', outputIndex: 1, inputIndex: 0 },
-						],
-					},
-				}),
-			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
-			expected: { name: 'UnimplementedError', message: 'connection slots' },
+			expected: { name: 'UnimplementedError', message: 'more than one edge into input 0' },
 		},
 		{
 			reason: 'its node has no predecessor in the graph',

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -44,12 +44,13 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		nodeId: 'a',
 		status: 'running',
 		outputs: null,
+		error: null,
 		...step,
 	};
 	return {
-		createStep: vi.fn(),
+		createSteps: vi.fn(),
 		loadStep: vi.fn().mockResolvedValue(record),
-		transitionStepStatus: vi.fn().mockResolvedValue(true),
+		claimStep: vi.fn().mockResolvedValue(true),
 		completeStep: vi.fn().mockResolvedValue(true),
 		failStep: vi.fn().mockResolvedValue(true),
 		loadStepOutputs: vi.fn().mockResolvedValue({}),
@@ -78,7 +79,7 @@ describe('StepReadyHandler', () => {
 
 		await handler.handle(event);
 
-		expect(stepStore.transitionStepStatus).toHaveBeenCalledWith('step-a', 'queued', 'running');
+		expect(stepStore.claimStep).toHaveBeenCalledWith('step-a');
 		expect(stepStore.completeStep).toHaveBeenCalledWith('step-a', [[{ json: { ok: true } }]]);
 		expect(stepStore.failStep).not.toHaveBeenCalled();
 		expect(queue.publish).toHaveBeenCalledWith({
@@ -142,7 +143,7 @@ describe('StepReadyHandler', () => {
 	});
 
 	it('is a no-op when the step cannot be claimed (duplicate delivery)', async () => {
-		const stepStore = makeStepStore({}, { transitionStepStatus: vi.fn().mockResolvedValue(false) });
+		const stepStore = makeStepStore({}, { claimStep: vi.fn().mockResolvedValue(false) });
 		const queue = makeQueue();
 		const executor = makeExecutor();
 		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
@@ -200,6 +201,8 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
 			name: 'TypeError',
 			message: 'node blew up',
+			// the stack is what makes a failed step debuggable
+			stack: expect.stringContaining('TypeError: node blew up') as string,
 		});
 		expect(stepStore.completeStep).not.toHaveBeenCalled();
 		// the orchestrator still has to hear about it
@@ -221,6 +224,7 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
 			name: 'UnimplementedError',
 			message: expect.stringContaining('v1-node') as string,
+			stack: expect.any(String) as string,
 		});
 		expect(queue.publish).toHaveBeenCalledWith({
 			type: 'step:completed',
@@ -252,6 +256,7 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.failStep).toHaveBeenCalledWith('step-b', {
 			name: 'UnimplementedError',
 			message: expect.stringContaining('more than one') as string,
+			stack: expect.any(String) as string,
 		});
 	});
 
@@ -268,6 +273,7 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
 			name: 'UnexpectedError',
 			message: expect.stringContaining('ghost') as string,
+			stack: expect.any(String) as string,
 		});
 	});
 });

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -137,8 +137,7 @@ describe('StepReadyHandler', () => {
 		expect(queue.publish).not.toHaveBeenCalled();
 	});
 
-	// The failure path shares the same `if (!recorded) return`, so one case covers both.
-	it('does not report completion when the step was taken over while it ran', async () => {
+	it('does not report completion when the status update is not recorded', async () => {
 		const stepStore = makeStepStore({}, { completeStep: vi.fn().mockResolvedValue(false) });
 		const queue = makeQueue();
 		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -177,6 +177,30 @@ describe('StepReadyHandler', () => {
 		});
 	});
 
+	// A v1 node runs user code, which can reject with anything — a non-Error still
+	// has to land as a recorded failure rather than escaping the handler.
+	it('records a non-Error rejection as a failure', async () => {
+		const stepStore = makeStepStore();
+		const queue = makeQueue();
+		const executor: IStepExecutor = { execute: vi.fn().mockRejectedValue('just a string') };
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle(event);
+
+		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
+			name: 'Error',
+			message: 'just a string',
+		});
+		expect(stepStore.completeStep).not.toHaveBeenCalled();
+		expect(queue.publish).toHaveBeenCalledWith({
+			type: 'step:completed',
+			executionId: 'exec-1',
+			stepId: 'step-a',
+		});
+	});
+
 	/**
 	 * Every way a step can fail before it runs has to land the same way: the error
 	 * on the step row and a `step:completed`, so the execution gets an outcome

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -260,6 +260,29 @@ describe('StepReadyHandler', () => {
 		});
 	});
 
+	it('fails the step when its node has no predecessor in the graph', async () => {
+		const stepStore = makeStepStore({ id: 'step-orphan', nodeId: 'orphan' });
+		const executionStore = makeExecutionStore({
+			graph: {
+				nodes: [...graph.nodes, { id: 'orphan', name: 'Orphan', type: 'v1-node' }],
+				edges: graph.edges,
+			},
+		});
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(executionStore, stepStore, makeQueue(), {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle({ ...event, stepId: 'step-orphan' });
+
+		expect(executor.execute).not.toHaveBeenCalled();
+		expect(stepStore.failStep).toHaveBeenCalledWith('step-orphan', {
+			name: 'UnexpectedError',
+			message: expect.stringContaining('no predecessor') as string,
+			stack: expect.any(String) as string,
+		});
+	});
+
 	it('fails the step when its node is absent from the execution graph', async () => {
 		const stepStore = makeStepStore({ nodeId: 'ghost' });
 		const executor = makeExecutor();

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -159,6 +159,7 @@ describe('StepReadyHandler', () => {
 		expect(queue.publish).not.toHaveBeenCalled();
 	});
 
+	// The failure path shares the same `if (!recorded) return`, so one case covers both.
 	it('does not report completion when the step was taken over while it ran', async () => {
 		const stepStore = makeStepStore({}, { completeStep: vi.fn().mockResolvedValue(false) });
 		const queue = makeQueue();
@@ -169,20 +170,6 @@ describe('StepReadyHandler', () => {
 		await handler.handle(event);
 
 		expect(stepStore.completeStep).toHaveBeenCalled();
-		expect(queue.publish).not.toHaveBeenCalled();
-	});
-
-	it('does not report completion when the failure could not be recorded', async () => {
-		const stepStore = makeStepStore({}, { failStep: vi.fn().mockResolvedValue(false) });
-		const queue = makeQueue();
-		const executor: IStepExecutor = { execute: vi.fn().mockRejectedValue(new Error('boom')) };
-		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
-			v1StepExecutor: executor,
-		});
-
-		await handler.handle(event);
-
-		expect(stepStore.failStep).toHaveBeenCalled();
 		expect(queue.publish).not.toHaveBeenCalled();
 	});
 
@@ -213,90 +200,79 @@ describe('StepReadyHandler', () => {
 		});
 	});
 
-	it('fails the step when no executor is configured for its step type', async () => {
-		const stepStore = makeStepStore();
-		const queue = makeQueue();
-		const deps: ExternalDependencies = {};
-		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, deps);
-
-		await handler.handle(event);
-
-		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
-			name: 'UnimplementedError',
-			message: expect.stringContaining('v1-node') as string,
-			stack: expect.any(String) as string,
-		});
-		expect(queue.publish).toHaveBeenCalledWith({
-			type: 'step:completed',
-			executionId: 'exec-1',
+	/**
+	 * Every way a step can fail before it runs has to land the same way: the error
+	 * on the step row and a `step:completed`, so the execution gets an outcome
+	 * instead of stalling on a step stuck in `running`.
+	 */
+	it.each([
+		{
+			reason: 'no executor is configured for its step type',
 			stepId: 'step-a',
-		});
-	});
+			steps: () => makeStepStore(),
+			execution: () => makeExecutionStore(),
+			deps: (): ExternalDependencies => ({}),
+			expected: { name: 'UnimplementedError', message: 'v1-node' },
+		},
+		{
+			reason: 'it has more than one predecessor',
+			stepId: 'step-b',
+			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
+			execution: () =>
+				makeExecutionStore({
+					graph: {
+						nodes: graph.nodes,
+						// second input into b makes it a fan-in
+						edges: [...graph.edges, { from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 1 }],
+					},
+				}),
+			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
+			expected: { name: 'UnimplementedError', message: 'more than one' },
+		},
+		{
+			reason: 'its node has no predecessor in the graph',
+			stepId: 'step-orphan',
+			steps: () => makeStepStore({ id: 'step-orphan', nodeId: 'orphan' }),
+			execution: () =>
+				makeExecutionStore({
+					graph: {
+						nodes: [...graph.nodes, { id: 'orphan', name: 'Orphan', type: 'v1-node' }],
+						edges: graph.edges,
+					},
+				}),
+			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
+			expected: { name: 'UnexpectedError', message: 'no predecessor' },
+		},
+		{
+			reason: 'its node is absent from the execution graph',
+			stepId: 'step-a',
+			steps: () => makeStepStore({ nodeId: 'ghost' }),
+			execution: () => makeExecutionStore(),
+			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
+			expected: { name: 'UnexpectedError', message: 'ghost' },
+		},
+	])(
+		'fails the step without running it, and reports completion, when $reason',
+		async ({ stepId, steps, execution, deps, expected }) => {
+			const stepStore = steps();
+			const queue = makeQueue();
+			const executor = makeExecutor();
+			const handler = new StepReadyHandler(execution(), stepStore, queue, deps(executor));
 
-	it('fails the step when it has more than one predecessor', async () => {
-		const stepStore = makeStepStore({ id: 'step-b', nodeId: 'b' });
-		const executionStore = makeExecutionStore({
-			graph: {
-				nodes: graph.nodes,
-				edges: [
-					...graph.edges,
-					// second input into b makes it a fan-in
-					{ from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 1 },
-				],
-			},
-		});
-		const executor = makeExecutor();
-		const handler = new StepReadyHandler(executionStore, stepStore, makeQueue(), {
-			v1StepExecutor: executor,
-		});
+			await handler.handle({ ...event, stepId });
 
-		await handler.handle({ ...event, stepId: 'step-b' });
-
-		expect(executor.execute).not.toHaveBeenCalled();
-		expect(stepStore.failStep).toHaveBeenCalledWith('step-b', {
-			name: 'UnimplementedError',
-			message: expect.stringContaining('more than one') as string,
-			stack: expect.any(String) as string,
-		});
-	});
-
-	it('fails the step when its node has no predecessor in the graph', async () => {
-		const stepStore = makeStepStore({ id: 'step-orphan', nodeId: 'orphan' });
-		const executionStore = makeExecutionStore({
-			graph: {
-				nodes: [...graph.nodes, { id: 'orphan', name: 'Orphan', type: 'v1-node' }],
-				edges: graph.edges,
-			},
-		});
-		const executor = makeExecutor();
-		const handler = new StepReadyHandler(executionStore, stepStore, makeQueue(), {
-			v1StepExecutor: executor,
-		});
-
-		await handler.handle({ ...event, stepId: 'step-orphan' });
-
-		expect(executor.execute).not.toHaveBeenCalled();
-		expect(stepStore.failStep).toHaveBeenCalledWith('step-orphan', {
-			name: 'UnexpectedError',
-			message: expect.stringContaining('no predecessor') as string,
-			stack: expect.any(String) as string,
-		});
-	});
-
-	it('fails the step when its node is absent from the execution graph', async () => {
-		const stepStore = makeStepStore({ nodeId: 'ghost' });
-		const executor = makeExecutor();
-		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
-			v1StepExecutor: executor,
-		});
-
-		await handler.handle(event);
-
-		expect(executor.execute).not.toHaveBeenCalled();
-		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
-			name: 'UnexpectedError',
-			message: expect.stringContaining('ghost') as string,
-			stack: expect.any(String) as string,
-		});
-	});
+			expect(executor.execute).not.toHaveBeenCalled();
+			expect(stepStore.failStep).toHaveBeenCalledWith(stepId, {
+				name: expected.name,
+				message: expect.stringContaining(expected.message) as string,
+				stack: expect.any(String) as string,
+			});
+			expect(stepStore.completeStep).not.toHaveBeenCalled();
+			expect(queue.publish).toHaveBeenCalledWith({
+				type: 'step:completed',
+				executionId: 'exec-1',
+				stepId,
+			});
+		},
+	);
 });

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ExternalDependencies, IStepExecutor } from '../../dependencies';
+import type { WorkflowGraph } from '../../graph';
+import type { OrchestrationMessage, WorkQueue } from '../../queue';
+import type { ExecutionRecord, ExecutionStore } from '../execution-store';
+import { StepReadyHandler } from '../step-ready-handler';
+import type { StepRecord, StepStore } from '../step-store';
+
+/** trigger -> a -> b, so `a` has the trigger as its only predecessor. */
+const graph: WorkflowGraph = {
+	nodes: [
+		{ id: 'trigger', name: 'T', type: 'trigger' },
+		{ id: 'a', name: 'A', type: 'v1-node', config: { some: 'config' } },
+		{ id: 'b', name: 'B', type: 'v1-node' },
+	],
+	edges: [
+		{ from: 'trigger', to: 'a', outputIndex: 0, inputIndex: 0 },
+		{ from: 'a', to: 'b', outputIndex: 0, inputIndex: 0 },
+	],
+};
+
+function makeExecutionStore(overrides: Partial<ExecutionRecord> = {}): ExecutionStore {
+	const execution: ExecutionRecord = {
+		id: 'exec-1',
+		workflowId: 'wf-1',
+		status: 'running',
+		mode: 'production',
+		graph,
+		triggerPayload: null,
+		...overrides,
+	};
+	return {
+		createExecution: vi.fn(),
+		loadExecution: vi.fn().mockResolvedValue(execution),
+		transitionStatus: vi.fn().mockResolvedValue(true),
+	};
+}
+
+function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepStore> = {}) {
+	const record: StepRecord = {
+		id: 'step-a',
+		executionId: 'exec-1',
+		nodeId: 'a',
+		status: 'running',
+		outputs: null,
+		...step,
+	};
+	return {
+		createStep: vi.fn(),
+		loadStep: vi.fn().mockResolvedValue(record),
+		transitionStepStatus: vi.fn().mockResolvedValue(true),
+		completeStep: vi.fn().mockResolvedValue(true),
+		failStep: vi.fn().mockResolvedValue(true),
+		loadStepOutputs: vi.fn().mockResolvedValue({}),
+		...overrides,
+	} satisfies StepStore;
+}
+
+function makeQueue(): WorkQueue<OrchestrationMessage> {
+	return { publish: vi.fn(), start: vi.fn(), stop: vi.fn() };
+}
+
+function makeExecutor(result: unknown = { outputs: [[{ json: { ok: true } }]] }): IStepExecutor {
+	return { execute: vi.fn().mockResolvedValue(result) };
+}
+
+const event = { type: 'step:ready', executionId: 'exec-1', stepId: 'step-a' } as const;
+
+describe('StepReadyHandler', () => {
+	it('runs the step through the executor, records its outputs and reports completion', async () => {
+		const stepStore = makeStepStore();
+		const queue = makeQueue();
+		const executor = makeExecutor({ outputs: [[{ json: { ok: true } }]] });
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle(event);
+
+		expect(stepStore.transitionStepStatus).toHaveBeenCalledWith('step-a', 'queued', 'running');
+		expect(stepStore.completeStep).toHaveBeenCalledWith('step-a', [[{ json: { ok: true } }]]);
+		expect(stepStore.failStep).not.toHaveBeenCalled();
+		expect(queue.publish).toHaveBeenCalledWith({
+			type: 'step:completed',
+			executionId: 'exec-1',
+			stepId: 'step-a',
+		});
+	});
+
+	it('hands the executor the graph node and a context describing the execution', async () => {
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(makeExecutionStore(), makeStepStore(), makeQueue(), {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle(event);
+
+		expect(executor.execute).toHaveBeenCalledWith({
+			node: { id: 'a', name: 'A', type: 'v1-node', config: { some: 'config' } },
+			inputs: null,
+			context: {
+				executionId: 'exec-1',
+				stepId: 'step-a',
+				workflowId: 'wf-1',
+				mode: 'production',
+			},
+		});
+	});
+
+	it('passes the trigger payload as inputs when the predecessor is the trigger', async () => {
+		const executor = makeExecutor();
+		const executionStore = makeExecutionStore({ triggerPayload: { body: { hello: 'world' } } });
+		const handler = new StepReadyHandler(executionStore, makeStepStore(), makeQueue(), {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle(event);
+
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({ inputs: { body: { hello: 'world' } } }),
+		);
+	});
+
+	it('passes the predecessor step outputs as inputs for a non-trigger predecessor', async () => {
+		const executor = makeExecutor();
+		// step 'b', whose only predecessor is 'a'
+		const stepStore = makeStepStore(
+			{ id: 'step-b', nodeId: 'b' },
+			{ loadStepOutputs: vi.fn().mockResolvedValue({ a: [[{ json: { from: 'a' } }]] }) },
+		);
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle({ ...event, stepId: 'step-b' });
+
+		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['a']);
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({ inputs: [[{ json: { from: 'a' } }]] }),
+		);
+	});
+
+	it('is a no-op when the step cannot be claimed (duplicate delivery)', async () => {
+		const stepStore = makeStepStore({}, { transitionStepStatus: vi.fn().mockResolvedValue(false) });
+		const queue = makeQueue();
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle(event);
+
+		expect(stepStore.loadStep).not.toHaveBeenCalled();
+		expect(executor.execute).not.toHaveBeenCalled();
+		expect(stepStore.completeStep).not.toHaveBeenCalled();
+		expect(stepStore.failStep).not.toHaveBeenCalled();
+		expect(queue.publish).not.toHaveBeenCalled();
+	});
+
+	it('does not report completion when the step was taken over while it ran', async () => {
+		const stepStore = makeStepStore({}, { completeStep: vi.fn().mockResolvedValue(false) });
+		const queue = makeQueue();
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+			v1StepExecutor: makeExecutor(),
+		});
+
+		await handler.handle(event);
+
+		expect(stepStore.completeStep).toHaveBeenCalled();
+		expect(queue.publish).not.toHaveBeenCalled();
+	});
+
+	it('does not report completion when the failure could not be recorded', async () => {
+		const stepStore = makeStepStore({}, { failStep: vi.fn().mockResolvedValue(false) });
+		const queue = makeQueue();
+		const executor: IStepExecutor = { execute: vi.fn().mockRejectedValue(new Error('boom')) };
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle(event);
+
+		expect(stepStore.failStep).toHaveBeenCalled();
+		expect(queue.publish).not.toHaveBeenCalled();
+	});
+
+	it('records the error and reports completion when the executor throws', async () => {
+		const stepStore = makeStepStore();
+		const queue = makeQueue();
+		const executor: IStepExecutor = {
+			execute: vi.fn().mockRejectedValue(new TypeError('node blew up')),
+		};
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle(event);
+
+		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
+			name: 'TypeError',
+			message: 'node blew up',
+		});
+		expect(stepStore.completeStep).not.toHaveBeenCalled();
+		// the orchestrator still has to hear about it
+		expect(queue.publish).toHaveBeenCalledWith({
+			type: 'step:completed',
+			executionId: 'exec-1',
+			stepId: 'step-a',
+		});
+	});
+
+	it('fails the step when no executor is configured for its step type', async () => {
+		const stepStore = makeStepStore();
+		const queue = makeQueue();
+		const deps: ExternalDependencies = {};
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, deps);
+
+		await handler.handle(event);
+
+		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
+			name: 'UnimplementedError',
+			message: expect.stringContaining('v1-node') as string,
+		});
+		expect(queue.publish).toHaveBeenCalledWith({
+			type: 'step:completed',
+			executionId: 'exec-1',
+			stepId: 'step-a',
+		});
+	});
+
+	it('fails the step when it has more than one predecessor', async () => {
+		const stepStore = makeStepStore({ id: 'step-b', nodeId: 'b' });
+		const executionStore = makeExecutionStore({
+			graph: {
+				nodes: graph.nodes,
+				edges: [
+					...graph.edges,
+					// second input into b makes it a fan-in
+					{ from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 1 },
+				],
+			},
+		});
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(executionStore, stepStore, makeQueue(), {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle({ ...event, stepId: 'step-b' });
+
+		expect(executor.execute).not.toHaveBeenCalled();
+		expect(stepStore.failStep).toHaveBeenCalledWith('step-b', {
+			name: 'UnimplementedError',
+			message: expect.stringContaining('more than one') as string,
+		});
+	});
+
+	it('fails the step when its node is absent from the execution graph', async () => {
+		const stepStore = makeStepStore({ nodeId: 'ghost' });
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
+			v1StepExecutor: executor,
+		});
+
+		await handler.handle(event);
+
+		expect(executor.execute).not.toHaveBeenCalled();
+		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
+			name: 'UnexpectedError',
+			message: expect.stringContaining('ghost') as string,
+		});
+	});
+});

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -69,17 +69,29 @@ function makeExecutor(result: unknown = { outputs: [[{ json: { ok: true } }]] })
 const event = { type: 'step:ready', executionId: 'exec-1', stepId: 'step-a' } as const;
 
 describe('StepReadyHandler', () => {
-	it('runs the step through the executor, records its outputs and reports completion', async () => {
+	it('claims the step, runs it through the executor, records its outputs and reports completion', async () => {
 		const stepStore = makeStepStore();
 		const queue = makeQueue();
 		const executor = makeExecutor({ outputs: [[{ json: { ok: true } }]] });
-		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+		const executionStore = makeExecutionStore({ triggerPayload: { body: { hello: 'world' } } });
+		const handler = new StepReadyHandler(executionStore, stepStore, queue, {
 			v1StepExecutor: executor,
 		});
 
 		await handler.handle(event);
 
 		expect(stepStore.claimStep).toHaveBeenCalledWith('step-a');
+		// 'a' sits directly behind the trigger, so its inputs are the trigger payload
+		expect(executor.execute).toHaveBeenCalledWith({
+			node: { id: 'a', name: 'A', type: 'v1-node', config: { some: 'config' } },
+			inputs: { body: { hello: 'world' } },
+			context: {
+				executionId: 'exec-1',
+				stepId: 'step-a',
+				workflowId: 'wf-1',
+				mode: 'production',
+			},
+		});
 		expect(stepStore.completeStep).toHaveBeenCalledWith('step-a', [[{ json: { ok: true } }]]);
 		expect(stepStore.failStep).not.toHaveBeenCalled();
 		expect(queue.publish).toHaveBeenCalledWith({
@@ -89,41 +101,7 @@ describe('StepReadyHandler', () => {
 		});
 	});
 
-	it('hands the executor the graph node and a context describing the execution', async () => {
-		const executor = makeExecutor();
-		const handler = new StepReadyHandler(makeExecutionStore(), makeStepStore(), makeQueue(), {
-			v1StepExecutor: executor,
-		});
-
-		await handler.handle(event);
-
-		expect(executor.execute).toHaveBeenCalledWith({
-			node: { id: 'a', name: 'A', type: 'v1-node', config: { some: 'config' } },
-			inputs: null,
-			context: {
-				executionId: 'exec-1',
-				stepId: 'step-a',
-				workflowId: 'wf-1',
-				mode: 'production',
-			},
-		});
-	});
-
-	it('passes the trigger payload as inputs when the predecessor is the trigger', async () => {
-		const executor = makeExecutor();
-		const executionStore = makeExecutionStore({ triggerPayload: { body: { hello: 'world' } } });
-		const handler = new StepReadyHandler(executionStore, makeStepStore(), makeQueue(), {
-			v1StepExecutor: executor,
-		});
-
-		await handler.handle(event);
-
-		expect(executor.execute).toHaveBeenCalledWith(
-			expect.objectContaining({ inputs: { body: { hello: 'world' } } }),
-		);
-	});
-
-	it('passes the predecessor step outputs as inputs for a non-trigger predecessor', async () => {
+	it('reads inputs from the predecessor step outputs when the predecessor is not the trigger', async () => {
 		const executor = makeExecutor();
 		// step 'b', whose only predecessor is 'a'
 		const stepStore = makeStepStore(

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -55,7 +55,7 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		completeStep: vi.fn().mockResolvedValue(true),
 		failStep: vi.fn().mockResolvedValue(true),
 		loadStepOutputs: vi.fn().mockResolvedValue({}),
-		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set()),
+		loadSettledSteps: vi.fn().mockResolvedValue([]),
 		hasActiveSteps: vi.fn().mockResolvedValue(false),
 		hasFailedSteps: vi.fn().mockResolvedValue(false),
 		...overrides,

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -150,6 +150,41 @@ describe('StepReadyHandler', () => {
 		expect(queue.publish).not.toHaveBeenCalled();
 	});
 
+	it('throws, recording nothing, when the event names an execution the step is not part of', async () => {
+		const stepStore = makeStepStore({ executionId: 'exec-other' });
+		const queue = makeQueue();
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+			v1StepExecutor: executor,
+		});
+
+		await expect(handler.handle(event)).rejects.toThrow(
+			'step step-a belongs to execution exec-other, but the event claims exec-1',
+		);
+
+		expect(executor.execute).not.toHaveBeenCalled();
+		expect(stepStore.completeStep).not.toHaveBeenCalled();
+		expect(stepStore.failStep).not.toHaveBeenCalled();
+		expect(queue.publish).not.toHaveBeenCalled();
+	});
+
+	it('propagates a failure to record a completed step rather than failing the step', async () => {
+		// the step ran; a write blip must not record it as if the node failed
+		const stepStore = makeStepStore(
+			{},
+			{ completeStep: vi.fn().mockRejectedValue(new Error('connection reset')) },
+		);
+		const queue = makeQueue();
+		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
+			v1StepExecutor: makeExecutor(),
+		});
+
+		await expect(handler.handle(event)).rejects.toThrow('connection reset');
+
+		expect(stepStore.failStep).not.toHaveBeenCalled();
+		expect(queue.publish).not.toHaveBeenCalled();
+	});
+
 	it('records the error and reports completion when the executor throws', async () => {
 		const stepStore = makeStepStore();
 		const queue = makeQueue();
@@ -216,7 +251,7 @@ describe('StepReadyHandler', () => {
 			expected: { name: 'UnimplementedError', message: 'v1-node' },
 		},
 		{
-			reason: 'it has more than one predecessor',
+			reason: 'more than one edge feeds it (fan-in)',
 			stepId: 'step-b',
 			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
 			execution: () =>
@@ -228,7 +263,40 @@ describe('StepReadyHandler', () => {
 					},
 				}),
 			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
-			expected: { name: 'UnimplementedError', message: 'more than one' },
+			expected: { name: 'UnimplementedError', message: 'connection slots' },
+		},
+		{
+			reason: 'one node feeds it through two edges',
+			stepId: 'step-b',
+			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
+			execution: () =>
+				makeExecutionStore({
+					graph: {
+						nodes: graph.nodes,
+						// 'a' connected to b twice still counts per edge, not per node
+						edges: [...graph.edges, { from: 'a', to: 'b', outputIndex: 1, inputIndex: 1 }],
+					},
+				}),
+			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
+			expected: { name: 'UnimplementedError', message: 'connection slots' },
+		},
+		{
+			reason: "its edge leaves the predecessor's second output",
+			stepId: 'step-b',
+			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
+			execution: () =>
+				makeExecutionStore({
+					graph: {
+						nodes: graph.nodes,
+						edges: [
+							graph.edges[0],
+							// the pass-through would hand b all of a's outputs, not slot 1
+							{ from: 'a', to: 'b', outputIndex: 1, inputIndex: 0 },
+						],
+					},
+				}),
+			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
+			expected: { name: 'UnimplementedError', message: 'connection slots' },
 		},
 		{
 			reason: 'its node has no predecessor in the graph',

--- a/packages/@n8n/engine/src/execution/__tests__/step-worker.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-worker.test.ts
@@ -27,29 +27,4 @@ describe('StepWorker', () => {
 
 		expect(handle).toHaveBeenCalledWith(event);
 	});
-
-	it('stops consuming when stopped', async () => {
-		const queue = new InMemoryWorkQueue<StepMessage>();
-		const stop = vi.spyOn(queue, 'stop');
-		const { handler } = makeReadyHandler();
-		const worker = new StepWorker(queue, handler);
-		worker.start();
-
-		await worker.stop();
-
-		expect(stop).toHaveBeenCalled();
-	});
-
-	it('rejects a message type it has no handler for', async () => {
-		const queue = new InMemoryWorkQueue<StepMessage>();
-		const { handler, handle } = makeReadyHandler();
-		const consume = vi.spyOn(queue, 'start');
-		new StepWorker(queue, handler).start();
-		const dispatch = consume.mock.calls[0][0];
-
-		await expect(dispatch({ type: 'step:unknown' } as unknown as StepMessage)).rejects.toThrowError(
-			/unimplemented message type/,
-		);
-		expect(handle).not.toHaveBeenCalled();
-	});
 });

--- a/packages/@n8n/engine/src/execution/__tests__/step-worker.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-worker.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { InMemoryWorkQueue, type StepMessage } from '../../queue';
+import type { StepReadyHandler } from '../step-ready-handler';
+import { StepWorker } from '../step-worker';
+
+/** Resolves once the handler has been called, since dispatch is asynchronous. */
+function makeReadyHandler() {
+	let called!: () => void;
+	const complete = new Promise<void>((resolve) => (called = resolve));
+	const handle = vi.fn().mockImplementation(async () => {
+		called();
+		await Promise.resolve();
+	});
+	return { handler: { handle } as unknown as StepReadyHandler, handle, complete };
+}
+
+describe('StepWorker', () => {
+	it('routes step:ready to the ready handler', async () => {
+		const queue = new InMemoryWorkQueue<StepMessage>();
+		const { handler, handle, complete } = makeReadyHandler();
+		new StepWorker(queue, handler).start();
+
+		const event = { type: 'step:ready', executionId: 'exec-1', stepId: 'step-a' } as const;
+		await queue.publish(event);
+		await complete;
+
+		expect(handle).toHaveBeenCalledWith(event);
+	});
+
+	it('stops consuming when stopped', async () => {
+		const queue = new InMemoryWorkQueue<StepMessage>();
+		const stop = vi.spyOn(queue, 'stop');
+		const { handler } = makeReadyHandler();
+		const worker = new StepWorker(queue, handler);
+		worker.start();
+
+		await worker.stop();
+
+		expect(stop).toHaveBeenCalled();
+	});
+
+	it('rejects a message type it has no handler for', async () => {
+		const queue = new InMemoryWorkQueue<StepMessage>();
+		const { handler, handle } = makeReadyHandler();
+		const consume = vi.spyOn(queue, 'start');
+		new StepWorker(queue, handler).start();
+		const dispatch = consume.mock.calls[0][0];
+
+		await expect(dispatch({ type: 'step:unknown' } as unknown as StepMessage)).rejects.toThrowError(
+			/unimplemented message type/,
+		);
+		expect(handle).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@n8n/engine/src/execution/execution-start-handler.ts
+++ b/packages/@n8n/engine/src/execution/execution-start-handler.ts
@@ -34,8 +34,9 @@ export class ExecutionStartHandler {
 			return;
 		}
 
-		// The trigger's output was captured at execution start; record it as
-		// already completed so successors can treat it as a satisfied predecessor.
+		// The trigger ran before the execution was enqueued, so its step is recorded
+		// already completed, carrying the captured payload as its outputs — that way
+		// successors read it exactly as they read any other predecessor's.
 		// Planned together with the successors so a fan-out is one round trip.
 		// The trigger is the only node that has completed, so a successor sitting
 		// behind anything else isn't ready yet — `StepCompletedHandler` plans it once
@@ -44,7 +45,13 @@ export class ExecutionStartHandler {
 			getPredecessorNodeIds(execution.graph, nodeId).every((id) => id === trigger.id),
 		);
 		const created = await this.stepStore.createSteps([
-			{ executionId: event.executionId, nodeId: trigger.id, status: 'completed' },
+			{
+				executionId: event.executionId,
+				nodeId: trigger.id,
+				status: 'completed',
+				// slot 0, so a successor edge from output 0 picks it up like any other
+				outputs: [execution.triggerPayload],
+			},
 			...successorNodeIds.map((nodeId) => ({
 				executionId: event.executionId,
 				nodeId,

--- a/packages/@n8n/engine/src/execution/execution-start-handler.ts
+++ b/packages/@n8n/engine/src/execution/execution-start-handler.ts
@@ -1,4 +1,4 @@
-import { findTriggerNode, getSuccessorNodeIds } from '../graph';
+import { findTriggerNode, getPredecessorNodeIds, getSuccessorNodeIds } from '../graph';
 import type { ExecutionEnqueuedEvent, StepMessage, WorkQueue } from '../queue';
 import type { ExecutionStore } from './execution-store';
 import type { StepStore } from './step-store';
@@ -36,8 +36,13 @@ export class ExecutionStartHandler {
 		// The trigger's output was captured at execution start; record it as
 		// already completed so successors can treat it as a satisfied predecessor.
 		// Planned together with the successors so a fan-out is one round trip.
-		const successorNodeIds = getSuccessorNodeIds(execution.graph, trigger.id);
-		const [, ...successorSteps] = await this.stepStore.createSteps([
+		// The trigger is the only node that has completed, so a successor sitting
+		// behind anything else isn't ready yet — `StepCompletedHandler` plans it once
+		// that predecessor finishes.
+		const successorNodeIds = getSuccessorNodeIds(execution.graph, trigger.id).filter((nodeId) =>
+			getPredecessorNodeIds(execution.graph, nodeId).every((id) => id === trigger.id),
+		);
+		const created = await this.stepStore.createSteps([
 			{ executionId: event.executionId, nodeId: trigger.id, status: 'completed' },
 			...successorNodeIds.map((nodeId) => ({
 				executionId: event.executionId,
@@ -46,7 +51,9 @@ export class ExecutionStartHandler {
 			})),
 		]);
 
-		// Published only after the rows exist, so a consumer can always load the step.
+		// Published only after the rows exist, so a consumer can always load the
+		// step. The trigger's row is already completed, so it isn't announced.
+		const successorSteps = created.filter(({ nodeId }) => nodeId !== trigger.id);
 		for (const { id: stepId } of successorSteps) {
 			await this.stepQueue.publish({
 				type: 'step:ready',

--- a/packages/@n8n/engine/src/execution/execution-start-handler.ts
+++ b/packages/@n8n/engine/src/execution/execution-start-handler.ts
@@ -1,6 +1,7 @@
 import { findTriggerNode, getPredecessorNodeIds, getSuccessorNodeIds } from '../graph';
 import type { ExecutionEnqueuedEvent, StepMessage, WorkQueue } from '../queue';
 import type { ExecutionStore } from './execution-store';
+import { finishExecutionIfDone } from './finish-execution';
 import type { StepStore } from './step-store';
 
 /**
@@ -54,6 +55,13 @@ export class ExecutionStartHandler {
 		// Published only after the rows exist, so a consumer can always load the
 		// step. The trigger's row is already completed, so it isn't announced.
 		const successorSteps = created.filter(({ nodeId }) => nodeId !== trigger.id);
+		if (successorSteps.length === 0) {
+			// Nothing to run, so no step will ever report completion — this is the only
+			// chance to notice the execution is already over.
+			await finishExecutionIfDone(this.executionStore, this.stepStore, event.executionId);
+			return;
+		}
+
 		for (const { id: stepId } of successorSteps) {
 			await this.stepQueue.publish({
 				type: 'step:ready',

--- a/packages/@n8n/engine/src/execution/execution-store.ts
+++ b/packages/@n8n/engine/src/execution/execution-store.ts
@@ -42,4 +42,10 @@ export interface ExecutionStore {
 	 * the transition, so duplicate/redelivered events are handled idempotently.
 	 */
 	transitionStatus(id: string, from: ExecutionStatus, to: ExecutionStatus): Promise<boolean>;
+
+	/**
+	 * Record an execution's outcome: writes the final status and the finish time
+	 * together, as a compare-and-set on `running`, so they can't be observed apart.
+	 */
+	finishExecution(id: string, status: 'completed' | 'failed'): Promise<boolean>;
 }

--- a/packages/@n8n/engine/src/execution/execution.types.ts
+++ b/packages/@n8n/engine/src/execution/execution.types.ts
@@ -6,15 +6,29 @@ export type ExecutionStatus = 'queued' | 'running' | 'completed' | 'failed' | 'c
 /** How an execution was initiated. */
 export type ExecutionMode = 'production' | 'manual';
 
-/** Lifecycle status of a single step within an execution. */
-export type StepStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+/**
+ * Lifecycle status of a single step within an execution. `skipped` marks a
+ * node whose every incoming edge was dead — the explicit record that a branch
+ * was not taken, written at planning time without the step ever running.
+ */
+export type StepStatus = 'queued' | 'running' | 'completed' | 'failed' | 'skipped' | 'cancelled';
+
+/**
+ * Status of a step that has settled: reached a terminal state, never to
+ * produce more data. Every node an execution considers eventually settles, so
+ * "predecessor not settled" always means "not yet", never "never" — which is
+ * what lets a successor's readiness be decided locally.
+ */
+export type SettledStepStatus = Exclude<StepStatus, 'queued' | 'running'>;
 
 /**
  * A step's data on one side of a connection, indexed by slot: outputs by output
  * index, inputs by input index. An edge copies one slot to another, so this is
  * the only structure the engine understands — a slot's contents are opaque.
  *
- * `null` at a slot means that branch was not taken. A slot that was taken but
- * produced nothing is empty rather than `null`.
+ * `null` marks a slot with no data, and means something slightly different on
+ * each side. On outputs the producer did not fire that slot, so the planner does
+ * not follow the edges leaving it. On inputs nothing arrived — either no edge
+ * feeds that slot, or the edge's source slot was never filled.
  */
 export type StepSlots = JsonValue[];

--- a/packages/@n8n/engine/src/execution/execution.types.ts
+++ b/packages/@n8n/engine/src/execution/execution.types.ts
@@ -1,3 +1,5 @@
+import type { JsonValue } from '../common';
+
 /** Lifecycle status of an execution. */
 export type ExecutionStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
 
@@ -6,3 +8,13 @@ export type ExecutionMode = 'production' | 'manual';
 
 /** Lifecycle status of a single step within an execution. */
 export type StepStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+/**
+ * A step's data on one side of a connection, indexed by slot: outputs by output
+ * index, inputs by input index. An edge copies one slot to another, so this is
+ * the only structure the engine understands — a slot's contents are opaque.
+ *
+ * `null` at a slot means that branch was not taken. A slot that was taken but
+ * produced nothing is empty rather than `null`.
+ */
+export type StepSlots = JsonValue[];

--- a/packages/@n8n/engine/src/execution/finish-execution.ts
+++ b/packages/@n8n/engine/src/execution/finish-execution.ts
@@ -1,0 +1,26 @@
+import type { ExecutionStore } from './execution-store';
+import type { StepStore } from './step-store';
+
+/**
+ * Records the execution's outcome once no step is left to run: `failed` if any
+ * step failed, `completed` otherwise. A no-op while work is still outstanding.
+ *
+ * Shared by every handler that can leave an execution with nothing planned —
+ * both the one that plans the first steps and the one that plans the rest — since
+ * whichever of them runs last is the one that has to notice.
+ *
+ * TODO(CAT-3910): "nothing queued or running" has a false-empty window — a step
+ * can be completed while its successors are not yet planned — so a concurrent
+ * handler can finish the execution early. Unreachable while the queue dispatches
+ * sequentially.
+ */
+export async function finishExecutionIfDone(
+	executionStore: ExecutionStore,
+	stepStore: StepStore,
+	executionId: string,
+): Promise<void> {
+	if (await stepStore.hasActiveSteps(executionId)) return;
+
+	const failed = await stepStore.hasFailedSteps(executionId);
+	await executionStore.finishExecution(executionId, failed ? 'failed' : 'completed');
+}

--- a/packages/@n8n/engine/src/execution/index.ts
+++ b/packages/@n8n/engine/src/execution/index.ts
@@ -10,5 +10,6 @@ export { StepNotFoundError } from './step-store';
 export type { NewStepRecord, StepError, StepRecord, StepStore } from './step-store';
 export { ExecutionStartHandler } from './execution-start-handler';
 export { OrchestrationWorker } from './orchestration-worker';
+export { StepCompletedHandler } from './step-completed-handler';
 export { StepReadyHandler } from './step-ready-handler';
 export { StepWorker } from './step-worker';

--- a/packages/@n8n/engine/src/execution/index.ts
+++ b/packages/@n8n/engine/src/execution/index.ts
@@ -3,7 +3,7 @@ export type {
 	StartExecutionRequest,
 	StartExecutionResult,
 } from './start-execution.service';
-export type { ExecutionMode, ExecutionStatus, StepStatus } from './execution.types';
+export type { ExecutionMode, ExecutionStatus, StepSlots, StepStatus } from './execution.types';
 export { ExecutionNotFoundError } from './execution-store';
 export type { ExecutionRecord, ExecutionStore, NewExecutionRecord } from './execution-store';
 export { StepNotFoundError } from './step-store';

--- a/packages/@n8n/engine/src/execution/index.ts
+++ b/packages/@n8n/engine/src/execution/index.ts
@@ -10,3 +10,5 @@ export { StepNotFoundError } from './step-store';
 export type { NewStepRecord, StepError, StepRecord, StepStore } from './step-store';
 export { ExecutionStartHandler } from './execution-start-handler';
 export { OrchestrationWorker } from './orchestration-worker';
+export { StepReadyHandler } from './step-ready-handler';
+export { StepWorker } from './step-worker';

--- a/packages/@n8n/engine/src/execution/index.ts
+++ b/packages/@n8n/engine/src/execution/index.ts
@@ -3,11 +3,17 @@ export type {
 	StartExecutionRequest,
 	StartExecutionResult,
 } from './start-execution.service';
-export type { ExecutionMode, ExecutionStatus, StepSlots, StepStatus } from './execution.types';
+export type {
+	ExecutionMode,
+	ExecutionStatus,
+	SettledStepStatus,
+	StepSlots,
+	StepStatus,
+} from './execution.types';
 export { ExecutionNotFoundError } from './execution-store';
 export type { ExecutionRecord, ExecutionStore, NewExecutionRecord } from './execution-store';
 export { StepNotFoundError } from './step-store';
-export type { NewStepRecord, StepError, StepRecord, StepStore } from './step-store';
+export type { NewStepRecord, SettledStep, StepError, StepRecord, StepStore } from './step-store';
 export { ExecutionStartHandler } from './execution-start-handler';
 export { OrchestrationWorker } from './orchestration-worker';
 export { StepCompletedHandler } from './step-completed-handler';

--- a/packages/@n8n/engine/src/execution/orchestration-worker.ts
+++ b/packages/@n8n/engine/src/execution/orchestration-worker.ts
@@ -17,10 +17,16 @@ export class OrchestrationWorker {
 				case 'execution:enqueued':
 					await this.startHandler.handle(message);
 					break;
-				default:
+				case 'step:completed':
+					// TODO(CAT-2871): advance the execution and plan the next steps.
+					break;
+				default: {
+					// Exhaustive today; the throw guards an off-contract message at runtime.
+					const unhandled: never = message;
 					throw new UnimplementedError(
-						`orchestration worker received an unimplemented message type: ${String(message.type)}`,
+						`orchestration worker received an unimplemented message type: ${JSON.stringify(unhandled)}`,
 					);
+				}
 			}
 		});
 	}

--- a/packages/@n8n/engine/src/execution/orchestration-worker.ts
+++ b/packages/@n8n/engine/src/execution/orchestration-worker.ts
@@ -1,6 +1,7 @@
 import { UnimplementedError } from '../common';
 import type { OrchestrationMessage, WorkQueue } from '../queue';
 import type { ExecutionStartHandler } from './execution-start-handler';
+import type { StepCompletedHandler } from './step-completed-handler';
 
 /**
  * Consumes the orchestration queue and routes each message to its handler.
@@ -9,6 +10,7 @@ export class OrchestrationWorker {
 	constructor(
 		private readonly orchestrationQueue: WorkQueue<OrchestrationMessage>,
 		private readonly startHandler: ExecutionStartHandler,
+		private readonly completedHandler: StepCompletedHandler,
 	) {}
 
 	start(): void {
@@ -18,7 +20,7 @@ export class OrchestrationWorker {
 					await this.startHandler.handle(message);
 					break;
 				case 'step:completed':
-					// TODO(CAT-2871): advance the execution and plan the next steps.
+					await this.completedHandler.handle(message);
 					break;
 				default: {
 					// Exhaustive today; the throw guards an off-contract message at runtime.

--- a/packages/@n8n/engine/src/execution/step-completed-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-completed-handler.ts
@@ -1,6 +1,7 @@
 import { getPredecessorNodeIds, getSuccessorNodeIds } from '../graph';
 import type { StepCompletedEvent, StepMessage, WorkQueue } from '../queue';
 import type { ExecutionRecord, ExecutionStore } from './execution-store';
+import { finishExecutionIfDone } from './finish-execution';
 import type { StepStore } from './step-store';
 
 /**
@@ -34,7 +35,7 @@ export class StepCompletedHandler {
 		// and the execution gets tested for completion then.
 		if (planned > 0) return;
 
-		await this.finishIfDone(execution.id);
+		await finishExecutionIfDone(this.executionStore, this.stepStore, execution.id);
 	}
 
 	/** Plans the ready successors of `nodeId`, returning how many were queued. */
@@ -62,22 +63,6 @@ export class StepCompletedHandler {
 		}
 
 		return created.length;
-	}
-
-	/**
-	 * Records the execution's outcome once no step is left to run: `failed` if any
-	 * step failed, `completed` otherwise.
-	 *
-	 * TODO(CAT-3910): "nothing queued or running" has a false-empty window — a step
-	 * can be completed while its successors are not yet planned — so a concurrent
-	 * handler can finish the execution early. Unreachable while the queue dispatches
-	 * sequentially.
-	 */
-	private async finishIfDone(executionId: string): Promise<void> {
-		if (await this.stepStore.hasActiveSteps(executionId)) return;
-
-		const failed = await this.stepStore.hasFailedSteps(executionId);
-		await this.executionStore.finishExecution(executionId, failed ? 'failed' : 'completed');
 	}
 
 	/** Successors of `nodeId` whose every predecessor has completed. */

--- a/packages/@n8n/engine/src/execution/step-completed-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-completed-handler.ts
@@ -1,24 +1,24 @@
-import { getPredecessorNodeIds, getSuccessorNodeIds } from '../graph';
 import type { StepCompletedEvent, StepMessage, WorkQueue } from '../queue';
-import type { ExecutionRecord, ExecutionStore } from './execution-store';
+import type { ExecutionStore } from './execution-store';
 import { finishExecutionIfDone } from './finish-execution';
+import { StepPlanner } from './step-planner';
 import type { StepStore } from './step-store';
 
 /**
- * Handles the `step:completed` orchestration event: plans the successors of the
- * finished step and publishes `step:ready` for each, or records the execution's
- * outcome when there is nothing left to run.
- *
- * A successor is planned once, when every predecessor has completed — never
- * planned early and held back at run time — so a step row exists only for work
- * whose inputs are all available.
+ * Handles the `step:completed` orchestration event: settles what the outcome
+ * decides downstream — successors run or skip, per the planner — or records
+ * the execution's outcome when there is nothing left to run.
  */
 export class StepCompletedHandler {
+	private readonly planner: StepPlanner;
+
 	constructor(
 		private readonly executionStore: ExecutionStore,
 		private readonly stepStore: StepStore,
-		private readonly stepQueue: WorkQueue<StepMessage>,
-	) {}
+		stepQueue: WorkQueue<StepMessage>,
+	) {
+		this.planner = new StepPlanner(stepStore, stepQueue);
+	}
 
 	async handle(event: StepCompletedEvent): Promise<void> {
 		const [step, execution] = await Promise.all([
@@ -26,64 +26,14 @@ export class StepCompletedHandler {
 			this.executionStore.loadExecution(event.executionId),
 		]);
 
-		// A step that didn't complete ends its branch: no successor of it can have
-		// all of its inputs.
-		const planned =
-			step.status === 'completed' ? await this.planSuccessors(execution, step.nodeId) : 0;
+		// A failed step settles its successors too: every edge out of it is dead,
+		// so downstream nodes are recorded skipped rather than left dangling.
+		const planned = await this.planner.settleSuccessors(execution, step.nodeId);
 
 		// A planned step always runs eventually, so it will report its own completion
 		// and the execution gets tested for completion then.
 		if (planned > 0) return;
 
 		await finishExecutionIfDone(this.executionStore, this.stepStore, execution.id);
-	}
-
-	/** Plans the ready successors of `nodeId`, returning how many were queued. */
-	private async planSuccessors(execution: ExecutionRecord, nodeId: string): Promise<number> {
-		const readyNodeIds = await this.readySuccessorNodeIds(execution, nodeId);
-		if (readyNodeIds.length === 0) return 0;
-
-		// Planned together so a fan-out is one round trip, and published only after
-		// the rows exist, so a consumer can always load the step. A step another
-		// planner got to first isn't returned, so it isn't announced twice either.
-		const created = await this.stepStore.createSteps(
-			readyNodeIds.map((readyNodeId) => ({
-				executionId: execution.id,
-				nodeId: readyNodeId,
-				status: 'queued' as const,
-			})),
-		);
-
-		for (const { id: stepId } of created) {
-			await this.stepQueue.publish({
-				type: 'step:ready',
-				executionId: execution.id,
-				stepId,
-			});
-		}
-
-		return created.length;
-	}
-
-	/** Successors of `nodeId` whose every predecessor has completed. */
-	private async readySuccessorNodeIds(
-		execution: ExecutionRecord,
-		nodeId: string,
-	): Promise<string[]> {
-		const successors = getSuccessorNodeIds(execution.graph, nodeId).map((id) => ({
-			id,
-			predecessorIds: getPredecessorNodeIds(execution.graph, id),
-		}));
-
-		// One query covering every predecessor in play; readiness is then set
-		// membership, so a fan-out costs a single round trip.
-		const completed = await this.stepStore.loadCompletedNodeIds(
-			execution.id,
-			successors.flatMap(({ predecessorIds }) => predecessorIds),
-		);
-
-		return successors
-			.filter(({ predecessorIds }) => predecessorIds.every((id) => completed.has(id)))
-			.map(({ id }) => id);
 	}
 }

--- a/packages/@n8n/engine/src/execution/step-completed-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-completed-handler.ts
@@ -1,0 +1,104 @@
+import { getPredecessorNodeIds, getSuccessorNodeIds } from '../graph';
+import type { StepCompletedEvent, StepMessage, WorkQueue } from '../queue';
+import type { ExecutionRecord, ExecutionStore } from './execution-store';
+import type { StepStore } from './step-store';
+
+/**
+ * Handles the `step:completed` orchestration event: plans the successors of the
+ * finished step and publishes `step:ready` for each, or records the execution's
+ * outcome when there is nothing left to run.
+ *
+ * A successor is planned once, when every predecessor has completed — never
+ * planned early and held back at run time — so a step row exists only for work
+ * whose inputs are all available.
+ */
+export class StepCompletedHandler {
+	constructor(
+		private readonly executionStore: ExecutionStore,
+		private readonly stepStore: StepStore,
+		private readonly stepQueue: WorkQueue<StepMessage>,
+	) {}
+
+	async handle(event: StepCompletedEvent): Promise<void> {
+		const [step, execution] = await Promise.all([
+			this.stepStore.loadStep(event.stepId),
+			this.executionStore.loadExecution(event.executionId),
+		]);
+
+		// A step that didn't complete ends its branch: no successor of it can have
+		// all of its inputs.
+		const planned =
+			step.status === 'completed' ? await this.planSuccessors(execution, step.nodeId) : 0;
+
+		// A planned step always runs eventually, so it will report its own completion
+		// and the execution gets tested for completion then.
+		if (planned > 0) return;
+
+		await this.finishIfDone(execution.id);
+	}
+
+	/** Plans the ready successors of `nodeId`, returning how many were queued. */
+	private async planSuccessors(execution: ExecutionRecord, nodeId: string): Promise<number> {
+		const readyNodeIds = await this.readySuccessorNodeIds(execution, nodeId);
+		if (readyNodeIds.length === 0) return 0;
+
+		// Planned together so a fan-out is one round trip, and published only after
+		// the rows exist, so a consumer can always load the step. A step another
+		// planner got to first isn't returned, so it isn't announced twice either.
+		const created = await this.stepStore.createSteps(
+			readyNodeIds.map((readyNodeId) => ({
+				executionId: execution.id,
+				nodeId: readyNodeId,
+				status: 'queued' as const,
+			})),
+		);
+
+		for (const { id: stepId } of created) {
+			await this.stepQueue.publish({
+				type: 'step:ready',
+				executionId: execution.id,
+				stepId,
+			});
+		}
+
+		return created.length;
+	}
+
+	/**
+	 * Records the execution's outcome once no step is left to run: `failed` if any
+	 * step failed, `completed` otherwise.
+	 *
+	 * TODO(CAT-3910): "nothing queued or running" has a false-empty window — a step
+	 * can be completed while its successors are not yet planned — so a concurrent
+	 * handler can finish the execution early. Unreachable while the queue dispatches
+	 * sequentially.
+	 */
+	private async finishIfDone(executionId: string): Promise<void> {
+		if (await this.stepStore.hasActiveSteps(executionId)) return;
+
+		const failed = await this.stepStore.hasFailedSteps(executionId);
+		await this.executionStore.finishExecution(executionId, failed ? 'failed' : 'completed');
+	}
+
+	/** Successors of `nodeId` whose every predecessor has completed. */
+	private async readySuccessorNodeIds(
+		execution: ExecutionRecord,
+		nodeId: string,
+	): Promise<string[]> {
+		const successors = getSuccessorNodeIds(execution.graph, nodeId).map((id) => ({
+			id,
+			predecessorIds: getPredecessorNodeIds(execution.graph, id),
+		}));
+
+		// One query covering every predecessor in play; readiness is then set
+		// membership, so a fan-out costs a single round trip.
+		const completed = await this.stepStore.loadCompletedNodeIds(
+			execution.id,
+			successors.flatMap(({ predecessorIds }) => predecessorIds),
+		);
+
+		return successors
+			.filter(({ predecessorIds }) => predecessorIds.every((id) => completed.has(id)))
+			.map(({ id }) => id);
+	}
+}

--- a/packages/@n8n/engine/src/execution/step-planner.ts
+++ b/packages/@n8n/engine/src/execution/step-planner.ts
@@ -1,0 +1,111 @@
+import type { GraphEdge } from '../graph';
+import type { StepMessage, WorkQueue } from '../queue';
+import type { ExecutionRecord } from './execution-store';
+import type { SettledStep, StepStore } from './step-store';
+
+/**
+ * Plans the consequences of a node settling: follows every edge leaving it —
+ * live or dead — queues the successors that have data, and records the ones
+ * that don't as `skipped`.
+ *
+ * Deadness is explicit rather than inferred: a successor is decided only once
+ * every predecessor has settled, so an absent step row always means "not yet",
+ * never "never", and readiness stays decidable from the step rows alone.
+ */
+export class StepPlanner {
+	constructor(
+		private readonly stepStore: StepStore,
+		private readonly stepQueue: WorkQueue<StepMessage>,
+	) {}
+
+	/**
+	 * Settles everything downstream of `settledNodeId` that is decidable now,
+	 * returning how many steps were queued. A skipped step never runs, so no
+	 * event will follow it — its successors are decided here too, transitively.
+	 */
+	async settleSuccessors(execution: ExecutionRecord, settledNodeId: string): Promise<number> {
+		let queued = 0;
+
+		// Worklist of nodes settled without running. Only rows this planner
+		// created are followed — a row lost to the unique key belongs to whichever
+		// planner created it, announcement and propagation included.
+		let settled = [settledNodeId];
+		while (settled.length > 0) {
+			const round = await this.settleRound(execution, settled);
+			queued += round.queued;
+			settled = round.skippedNodeIds;
+		}
+
+		return queued;
+	}
+
+	private async settleRound(
+		execution: ExecutionRecord,
+		settledNodeIds: string[],
+	): Promise<{ queued: number; skippedNodeIds: string[] }> {
+		const decidable = await this.decidableSuccessors(execution, settledNodeIds);
+		if (decidable.length === 0) return { queued: 0, skippedNodeIds: [] };
+
+		// One insert for the round, published only after the rows exist, so a
+		// consumer can always load the step.
+		const created = await this.stepStore.createSteps(
+			decidable.map(({ nodeId, live }) => ({
+				executionId: execution.id,
+				nodeId,
+				status: live ? ('queued' as const) : ('skipped' as const),
+			})),
+		);
+
+		const liveNodeIds = new Set(decidable.filter(({ live }) => live).map(({ nodeId }) => nodeId));
+		const queuedSteps = created.filter(({ nodeId }) => liveNodeIds.has(nodeId));
+		for (const { id: stepId } of queuedSteps) {
+			await this.stepQueue.publish({ type: 'step:ready', executionId: execution.id, stepId });
+		}
+
+		return {
+			queued: queuedSteps.length,
+			skippedNodeIds: created
+				.filter(({ nodeId }) => !liveNodeIds.has(nodeId))
+				.map(({ nodeId }) => nodeId),
+		};
+	}
+
+	/**
+	 * Successors of the given nodes whose every predecessor has settled, each
+	 * marked live — at least one incoming edge carries data — or not. An `if` or
+	 * `switch` selects by what it leaves dead: an unfilled output slot kills the
+	 * edges leaving it, and a successor with nothing live left is skipped.
+	 */
+	private async decidableSuccessors(
+		execution: ExecutionRecord,
+		settledNodeIds: string[],
+	): Promise<Array<{ nodeId: string; live: boolean }>> {
+		const settledSet = new Set(settledNodeIds);
+		// TODO(CAT-2875): a back-edge closes a loop, so it must not hold its
+		// target's readiness hostage to a node that runs after it.
+		const edges = execution.graph.edges.filter((edge) => !edge.isBackEdge);
+
+		const candidates = [
+			...new Set(edges.filter((edge) => settledSet.has(edge.from)).map((edge) => edge.to)),
+		].map((nodeId) => ({ nodeId, incoming: edges.filter((edge) => edge.to === nodeId) }));
+
+		// One query covering every predecessor in play; readiness and liveness are
+		// then set membership, so a fan-out costs a single round trip.
+		const settled = await this.stepStore.loadSettledSteps(execution.id, [
+			...new Set(candidates.flatMap(({ incoming }) => incoming.map(({ from }) => from))),
+		]);
+		const byNodeId = new Map(settled.map((step) => [step.nodeId, step]));
+
+		return candidates
+			.filter(({ incoming }) => incoming.every(({ from }) => byNodeId.has(from)))
+			.map(({ nodeId, incoming }) => ({
+				nodeId,
+				live: incoming.some((edge) => carriesData(byNodeId.get(edge.from), edge)),
+			}));
+	}
+}
+
+/** Whether data flows along `edge`: its source completed, filling the slot the edge leaves. */
+function carriesData(source: SettledStep | undefined, edge: GraphEdge): boolean {
+	return source?.status === 'completed' && source.filledOutputSlots.includes(edge.outputIndex);
+}

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -1,9 +1,9 @@
 import { UnexpectedError, UnimplementedError, type JsonValue } from '../common';
 import type { ExternalDependencies, IStepExecutor } from '../dependencies';
-import { getPredecessorNodeIds, type GraphNode, type WorkflowGraph } from '../graph';
+import type { GraphNode, WorkflowGraph } from '../graph';
 import type { OrchestrationMessage, StepReadyEvent, WorkQueue } from '../queue';
 import type { ExecutionRecord, ExecutionStore } from './execution-store';
-import type { StepError, StepStore } from './step-store';
+import type { StepError, StepRecord, StepStore } from './step-store';
 
 /**
  * Handles the `step:ready` step event: claims the step (`queued → running`),
@@ -27,13 +27,28 @@ export class StepReadyHandler {
 		const claimed = await this.stepStore.claimStep(event.stepId);
 		if (!claimed) return;
 
-		let recorded: boolean;
-		try {
-			const outputs = await this.runStep(event);
-			recorded = await this.stepStore.completeStep(event.stepId, outputs);
-		} catch (error) {
-			recorded = await this.stepStore.failStep(event.stepId, toStepError(error));
+		const [step, execution] = await Promise.all([
+			this.stepStore.loadStep(event.stepId),
+			this.executionStore.loadExecution(event.executionId),
+		]);
+		if (step.executionId !== event.executionId) {
+			throw new UnexpectedError(
+				`step ${step.id} belongs to execution ${step.executionId}, but the event claims ${event.executionId}`,
+			);
 		}
+
+		// Only a failure to run the step fails it. A store error propagates instead —
+		// recording `failed` on a step whose side effects happened would be a lie.
+		let run: { ok: true; outputs: JsonValue } | { ok: false; error: unknown };
+		try {
+			run = { ok: true, outputs: await this.runStep(step, execution) };
+		} catch (error) {
+			run = { ok: false, error };
+		}
+
+		const recorded = run.ok
+			? await this.stepStore.completeStep(event.stepId, run.outputs)
+			: await this.stepStore.failStep(event.stepId, toStepError(run.error));
 
 		// Recording is a CAS on `running`, so losing it means something else took the
 		// step over while we ran — announce only outcomes we actually wrote, and let
@@ -48,12 +63,7 @@ export class StepReadyHandler {
 		});
 	}
 
-	private async runStep(event: StepReadyEvent): Promise<JsonValue> {
-		const [step, execution] = await Promise.all([
-			this.stepStore.loadStep(event.stepId),
-			this.executionStore.loadExecution(event.executionId),
-		]);
-
+	private async runStep(step: StepRecord, execution: ExecutionRecord): Promise<JsonValue> {
 		const node = execution.graph.nodes.find((candidate) => candidate.id === step.nodeId);
 		if (!node) {
 			throw new UnexpectedError(
@@ -86,28 +96,32 @@ export class StepReadyHandler {
 		node: GraphNode,
 		stepId: string,
 	): Promise<JsonValue> {
-		const predecessorIds = getPredecessorNodeIds(execution.graph, node.id);
-		if (predecessorIds.length === 0) {
+		const incoming = execution.graph.edges.filter((edge) => edge.to === node.id);
+		if (incoming.length === 0) {
 			// Steps are planned only for a completed step's successors, so a step
 			// without a predecessor means the graph and the step rows disagree.
 			throw new UnexpectedError(
 				`step ${stepId} runs node ${node.id}, which has no predecessor in the execution graph`,
 			);
 		}
-		if (predecessorIds.length > 1) {
+		// The pass-through below hands over the whole output, so anything but a
+		// single first-output-to-first-input edge would misroute data.
+		// TODO(CAT-2874): route inputs by connection slot.
+		const [edge] = incoming;
+		if (incoming.length > 1 || edge.outputIndex !== 0 || edge.inputIndex !== 0) {
 			throw new UnimplementedError(
-				`step ${stepId} runs node ${node.id}, which has more than one predecessor; combining inputs from several steps is not supported yet`,
+				`step ${stepId} runs node ${node.id}, whose inputs use connection slots; routing by slot is not supported yet`,
 			);
 		}
 
-		const [predecessorId] = predecessorIds;
+		const predecessorId = edge.from;
 		// The trigger's step row is recorded already-completed and carries no
 		// outputs, so its payload comes off the execution instead.
 		// NOTE: proper trigger handling has not been built yet. We'll clean this up
 		// when we get there.
 		if (isTrigger(execution.graph, predecessorId)) return execution.triggerPayload;
 
-		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, predecessorIds);
+		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, [predecessorId]);
 		return outputsByNodeId[predecessorId] ?? null;
 	}
 

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -1,8 +1,9 @@
-import { UnexpectedError, UnimplementedError, type JsonValue } from '../common';
+import { UnexpectedError, UnimplementedError } from '../common';
 import type { ExternalDependencies, IStepExecutor } from '../dependencies';
-import type { GraphNode, WorkflowGraph } from '../graph';
+import type { GraphNode } from '../graph';
 import type { OrchestrationMessage, StepReadyEvent, WorkQueue } from '../queue';
 import type { ExecutionRecord, ExecutionStore } from './execution-store';
+import type { StepSlots } from './execution.types';
 import type { StepError, StepRecord, StepStore } from './step-store';
 
 /**
@@ -39,7 +40,7 @@ export class StepReadyHandler {
 
 		// Only a failure to run the step fails it. A store error propagates instead —
 		// recording `failed` on a step whose side effects happened would be a lie.
-		let run: { ok: true; outputs: JsonValue } | { ok: false; error: unknown };
+		let run: { ok: true; outputs: StepSlots } | { ok: false; error: unknown };
 		try {
 			run = { ok: true, outputs: await this.runStep(step, execution) };
 		} catch (error) {
@@ -63,7 +64,7 @@ export class StepReadyHandler {
 		});
 	}
 
-	private async runStep(step: StepRecord, execution: ExecutionRecord): Promise<JsonValue> {
+	private async runStep(step: StepRecord, execution: ExecutionRecord): Promise<StepSlots> {
 		const node = execution.graph.nodes.find((candidate) => candidate.id === step.nodeId);
 		if (!node) {
 			throw new UnexpectedError(
@@ -88,14 +89,14 @@ export class StepReadyHandler {
 	}
 
 	/**
-	 * Inputs for `node`, taken from its predecessor's output. The trigger's output
-	 * is the payload captured on the execution rather than a step output.
+	 * Inputs for `node`, routed slot to slot: each incoming edge copies the output
+	 * slot it leaves from into the input slot it arrives at.
 	 */
 	private async gatherInputs(
 		execution: ExecutionRecord,
 		node: GraphNode,
 		stepId: string,
-	): Promise<JsonValue> {
+	): Promise<StepSlots> {
 		const incoming = execution.graph.edges.filter((edge) => edge.to === node.id);
 		if (incoming.length === 0) {
 			// Steps are planned only for a completed step's successors, so a step
@@ -104,25 +105,27 @@ export class StepReadyHandler {
 				`step ${stepId} runs node ${node.id}, which has no predecessor in the execution graph`,
 			);
 		}
-		// The pass-through below hands over the whole output, so anything but a
-		// single first-output-to-first-input edge would misroute data.
-		// TODO(CAT-2874): route inputs by connection slot.
-		const [edge] = incoming;
-		if (incoming.length > 1 || edge.outputIndex !== 0 || edge.inputIndex !== 0) {
-			throw new UnimplementedError(
-				`step ${stepId} runs node ${node.id}, whose inputs use connection slots; routing by slot is not supported yet`,
-			);
+
+		const predecessorIds = [...new Set(incoming.map((edge) => edge.from))];
+		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, predecessorIds);
+
+		const inputs: StepSlots = [];
+		for (const edge of incoming) {
+			if (inputs[edge.inputIndex] !== undefined) {
+				// v1 runs the node once per incoming branch rather than combining them,
+				// which needs several step rows for one node — the unique step key
+				// forbids that until it gains a run dimension.
+				throw new UnimplementedError(
+					`step ${stepId} runs node ${node.id}, which has more than one edge into input ${edge.inputIndex}; running a node once per incoming branch is not supported yet`,
+				);
+			}
+			inputs[edge.inputIndex] = outputsByNodeId[edge.from]?.[edge.outputIndex] ?? null;
 		}
 
-		const predecessorId = edge.from;
-		// The trigger's step row is recorded already-completed and carries no
-		// outputs, so its payload comes off the execution instead.
-		// NOTE: proper trigger handling has not been built yet. We'll clean this up
-		// when we get there.
-		if (isTrigger(execution.graph, predecessorId)) return execution.triggerPayload;
+		// An input slot nothing connects to reads as not taken, not as a hole.
+		for (let slot = 0; slot < inputs.length; slot++) inputs[slot] ??= null;
 
-		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, [predecessorId]);
-		return outputsByNodeId[predecessorId] ?? null;
+		return inputs;
 	}
 
 	/**
@@ -142,10 +145,6 @@ export class StepReadyHandler {
 
 		throw new UnimplementedError(`step ${stepId}: no executor for step type ${node.type}`);
 	}
-}
-
-function isTrigger(graph: WorkflowGraph, nodeId: string): boolean {
-	return graph.nodes.find((node) => node.id === nodeId)?.type === 'trigger';
 }
 
 function toStepError(error: unknown): StepError {

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -103,6 +103,8 @@ export class StepReadyHandler {
 		const [predecessorId] = predecessorIds;
 		// The trigger's step row is recorded already-completed and carries no
 		// outputs, so its payload comes off the execution instead.
+		// NOTE: proper trigger handling has not been built yet. We'll clean this up
+		// when we get there.
 		if (isTrigger(execution.graph, predecessorId)) return execution.triggerPayload;
 
 		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, predecessorIds);

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -24,7 +24,7 @@ export class StepReadyHandler {
 
 	async handle(event: StepReadyEvent): Promise<void> {
 		// Claim via CAS so a duplicate/redelivered event is a no-op.
-		const claimed = await this.stepStore.transitionStepStatus(event.stepId, 'queued', 'running');
+		const claimed = await this.stepStore.claimStep(event.stepId);
 		if (!claimed) return;
 
 		let recorded: boolean;
@@ -119,6 +119,8 @@ function isTrigger(graph: WorkflowGraph, nodeId: string): boolean {
 }
 
 function toStepError(error: unknown): StepError {
-	if (error instanceof Error) return { name: error.name, message: error.message };
+	if (error instanceof Error) {
+		return { name: error.name, message: error.message, stack: error.stack };
+	}
 	return { name: 'Error', message: String(error) };
 }

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -49,8 +49,10 @@ export class StepReadyHandler {
 	}
 
 	private async runStep(event: StepReadyEvent): Promise<JsonValue> {
-		const step = await this.stepStore.loadStep(event.stepId);
-		const execution = await this.executionStore.loadExecution(event.executionId);
+		const [step, execution] = await Promise.all([
+			this.stepStore.loadStep(event.stepId),
+			this.executionStore.loadExecution(event.executionId),
+		]);
 
 		const node = execution.graph.nodes.find((candidate) => candidate.id === step.nodeId);
 		if (!node) {
@@ -59,8 +61,8 @@ export class StepReadyHandler {
 			);
 		}
 
-		const inputs = await this.gatherInputs(execution, node);
-		const executor = this.executorFor(node);
+		const inputs = await this.gatherInputs(execution, node, step.id);
+		const executor = this.executorFor(node, step.id);
 		const { outputs } = await executor.execute({
 			node,
 			inputs,
@@ -79,19 +81,31 @@ export class StepReadyHandler {
 	 * Inputs for `node`, taken from its predecessor's output. The trigger's output
 	 * is the payload captured on the execution rather than a step output.
 	 */
-	private async gatherInputs(execution: ExecutionRecord, node: GraphNode): Promise<JsonValue> {
+	private async gatherInputs(
+		execution: ExecutionRecord,
+		node: GraphNode,
+		stepId: string,
+	): Promise<JsonValue> {
 		const predecessorIds = getPredecessorNodeIds(execution.graph, node.id);
-		if (predecessorIds.length === 0) return null;
+		if (predecessorIds.length === 0) {
+			// Steps are planned only for a completed step's successors, so a step
+			// without a predecessor means the graph and the step rows disagree.
+			throw new UnexpectedError(
+				`step ${stepId} runs node ${node.id}, which has no predecessor in the execution graph`,
+			);
+		}
 		if (predecessorIds.length > 1) {
 			throw new UnimplementedError(
-				`step ${node.id} has more than one predecessor; combining inputs from several steps is not supported yet`,
+				`step ${stepId} runs node ${node.id}, which has more than one predecessor; combining inputs from several steps is not supported yet`,
 			);
 		}
 
 		const [predecessorId] = predecessorIds;
+		// The trigger's step row is recorded already-completed and carries no
+		// outputs, so its payload comes off the execution instead.
 		if (isTrigger(execution.graph, predecessorId)) return execution.triggerPayload;
 
-		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, [predecessorId]);
+		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, predecessorIds);
 		return outputsByNodeId[predecessorId] ?? null;
 	}
 
@@ -99,18 +113,18 @@ export class StepReadyHandler {
 	 * The executor for `node`'s step type. Step types the engine runs itself
 	 * (`wait`, `subworkflow`, `batch`) don't reach this seam, and aren't built yet.
 	 */
-	private executorFor(node: GraphNode): IStepExecutor {
+	private executorFor(node: GraphNode, stepId: string): IStepExecutor {
 		if (node.type === 'v1-node') {
 			const executor = this.dependencies.v1StepExecutor;
 			if (!executor) {
 				throw new UnimplementedError(
-					'no executor configured for v1-node steps; the host must supply one in integrated mode',
+					`step ${stepId}: no executor configured for v1-node steps; the host must supply one in integrated mode`,
 				);
 			}
 			return executor;
 		}
 
-		throw new UnimplementedError(`no executor for step type ${node.type}`);
+		throw new UnimplementedError(`step ${stepId}: no executor for step type ${node.type}`);
 	}
 }
 

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -1,0 +1,124 @@
+import { UnexpectedError, UnimplementedError, type JsonValue } from '../common';
+import type { ExternalDependencies, IStepExecutor } from '../dependencies';
+import { getPredecessorNodeIds, type GraphNode, type WorkflowGraph } from '../graph';
+import type { OrchestrationMessage, StepReadyEvent, WorkQueue } from '../queue';
+import type { ExecutionRecord, ExecutionStore } from './execution-store';
+import type { StepError, StepStore } from './step-store';
+
+/**
+ * Handles the `step:ready` step event: claims the step (`queued → running`),
+ * runs it through the executor for its step type, records the outcome, and
+ * reports back to the orchestration worker with `step:completed`.
+ *
+ * A step that cannot run — no executor, an input shape we don't support yet —
+ * is recorded as `failed` rather than left `running`, so the execution has a
+ * legible outcome instead of stalling.
+ */
+export class StepReadyHandler {
+	constructor(
+		private readonly executionStore: ExecutionStore,
+		private readonly stepStore: StepStore,
+		private readonly orchestrationQueue: WorkQueue<OrchestrationMessage>,
+		private readonly dependencies: ExternalDependencies,
+	) {}
+
+	async handle(event: StepReadyEvent): Promise<void> {
+		// Claim via CAS so a duplicate/redelivered event is a no-op.
+		const claimed = await this.stepStore.transitionStepStatus(event.stepId, 'queued', 'running');
+		if (!claimed) return;
+
+		let recorded: boolean;
+		try {
+			const outputs = await this.runStep(event);
+			recorded = await this.stepStore.completeStep(event.stepId, outputs);
+		} catch (error) {
+			recorded = await this.stepStore.failStep(event.stepId, toStepError(error));
+		}
+
+		// Recording is a CAS on `running`, so losing it means something else took the
+		// step over while we ran — announce only outcomes we actually wrote, and let
+		// whoever holds it now announce theirs. TODO(CAT-2938): reconciliation is the
+		// only thing that can take a step over, and it doesn't exist yet.
+		if (!recorded) return;
+
+		await this.orchestrationQueue.publish({
+			type: 'step:completed',
+			executionId: event.executionId,
+			stepId: event.stepId,
+		});
+	}
+
+	private async runStep(event: StepReadyEvent): Promise<JsonValue> {
+		const step = await this.stepStore.loadStep(event.stepId);
+		const execution = await this.executionStore.loadExecution(event.executionId);
+
+		const node = execution.graph.nodes.find((candidate) => candidate.id === step.nodeId);
+		if (!node) {
+			throw new UnexpectedError(
+				`step ${step.id} references node ${step.nodeId}, which is absent from the execution graph`,
+			);
+		}
+
+		const inputs = await this.gatherInputs(execution, node);
+		const executor = this.executorFor(node);
+		const { outputs } = await executor.execute({
+			node,
+			inputs,
+			context: {
+				executionId: execution.id,
+				stepId: step.id,
+				workflowId: execution.workflowId,
+				mode: execution.mode,
+			},
+		});
+
+		return outputs;
+	}
+
+	/**
+	 * Inputs for `node`, taken from its predecessor's output. The trigger's output
+	 * is the payload captured on the execution rather than a step output.
+	 */
+	private async gatherInputs(execution: ExecutionRecord, node: GraphNode): Promise<JsonValue> {
+		const predecessorIds = getPredecessorNodeIds(execution.graph, node.id);
+		if (predecessorIds.length === 0) return null;
+		if (predecessorIds.length > 1) {
+			throw new UnimplementedError(
+				`step ${node.id} has more than one predecessor; combining inputs from several steps is not supported yet`,
+			);
+		}
+
+		const [predecessorId] = predecessorIds;
+		if (isTrigger(execution.graph, predecessorId)) return execution.triggerPayload;
+
+		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, [predecessorId]);
+		return outputsByNodeId[predecessorId] ?? null;
+	}
+
+	/**
+	 * The executor for `node`'s step type. Step types the engine runs itself
+	 * (`wait`, `subworkflow`, `batch`) don't reach this seam, and aren't built yet.
+	 */
+	private executorFor(node: GraphNode): IStepExecutor {
+		if (node.type === 'v1-node') {
+			const executor = this.dependencies.v1StepExecutor;
+			if (!executor) {
+				throw new UnimplementedError(
+					'no executor configured for v1-node steps; the host must supply one in integrated mode',
+				);
+			}
+			return executor;
+		}
+
+		throw new UnimplementedError(`no executor for step type ${node.type}`);
+	}
+}
+
+function isTrigger(graph: WorkflowGraph, nodeId: string): boolean {
+	return graph.nodes.find((node) => node.id === nodeId)?.type === 'trigger';
+}
+
+function toStepError(error: unknown): StepError {
+	if (error instanceof Error) return { name: error.name, message: error.message };
+	return { name: 'Error', message: String(error) };
+}

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -1,11 +1,13 @@
 import type { JsonValue } from '../common';
-import type { StepStatus } from './execution.types';
+import type { StepSlots, StepStatus } from './execution.types';
 
 /** A new step to persist. `id` and timestamps are assigned by the store. */
 export interface NewStepRecord {
 	executionId: string;
 	nodeId: string;
 	status: StepStatus;
+	/** Only for a step recorded already-completed, such as the trigger. */
+	outputs?: StepSlots;
 }
 
 /** The error that failed a step, as persisted on its row. */
@@ -28,7 +30,7 @@ export interface StepRecord {
 	nodeId: string;
 	status: StepStatus;
 	/** Outputs of a completed step; `null` until it completes. */
-	outputs: JsonValue | null;
+	outputs: StepSlots | null;
 	/** The error that failed the step; `null` unless it failed. */
 	error: StepError | null;
 }
@@ -73,7 +75,7 @@ export interface StepStore {
 	 * longer holds the claim — the outcome and the status are written together,
 	 * so they can't be observed apart.
 	 */
-	completeStep(id: string, outputs: JsonValue): Promise<boolean>;
+	completeStep(id: string, outputs: StepSlots): Promise<boolean>;
 
 	/** Record a failed run: persist `error` and mark the step failed. As `completeStep`. */
 	failStep(id: string, error: StepError): Promise<boolean>;
@@ -89,7 +91,7 @@ export interface StepStore {
 	loadStepOutputs(
 		executionId: string,
 		nodeIds: string[],
-	): Promise<Record<string, JsonValue | null>>;
+	): Promise<Record<string, StepSlots | null>>;
 
 	/**
 	 * Which of `nodeIds` have a completed step in the execution. Returns the

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -44,11 +44,14 @@ export class StepNotFoundError extends Error {
 /** Persistence interface for step records. */
 export interface StepStore {
 	/**
-	 * Persist new step records; returns their generated ids, in input order.
-	 * Batched rather than one-per-call so planning a fan-out costs a single
-	 * round trip and cannot half-persist.
+	 * Persist new step records, batched so planning a fan-out costs a single round
+	 * trip. Returns the rows actually created, in input order.
+	 *
+	 * A node already planned for the execution is skipped rather than fatal, so a
+	 * concurrent planner that reached it first doesn't cost the caller its other
+	 * rows. The caller owns — and so announces — only what it gets back.
 	 */
-	createSteps(records: NewStepRecord[]): Promise<Array<{ id: string }>>;
+	createSteps(records: NewStepRecord[]): Promise<Array<{ id: string; nodeId: string }>>;
 
 	/** Load a single step by id. Throws `StepNotFoundError` if absent. */
 	loadStep(id: string): Promise<StepRecord>;
@@ -81,11 +84,23 @@ export interface StepStore {
 	 *
 	 * This is for gathering a step's inputs, so it deliberately can't answer
 	 * "have all predecessors completed?" — the two are indistinguishable from a
-	 * `null` here. Readiness belongs to whoever plans the next step
-	 * (TODO(CAT-2871)), and will need its own method.
+	 * `null` here. Use `loadCompletedNodeIds` for that.
 	 */
 	loadStepOutputs(
 		executionId: string,
 		nodeIds: string[],
 	): Promise<Record<string, JsonValue | null>>;
+
+	/**
+	 * Which of `nodeIds` have a completed step in the execution. Returns the
+	 * subset rather than a yes/no so one query can answer readiness for several
+	 * candidate steps at once.
+	 */
+	loadCompletedNodeIds(executionId: string, nodeIds: string[]): Promise<Set<string>>;
+
+	/** Whether the execution has any step still `queued` or `running`. */
+	hasActiveSteps(executionId: string): Promise<boolean>;
+
+	/** Whether any of the execution's steps failed. */
+	hasFailedSteps(executionId: string): Promise<boolean>;
 }

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -1,5 +1,5 @@
 import type { JsonValue } from '../common';
-import type { StepSlots, StepStatus } from './execution.types';
+import type { SettledStepStatus, StepSlots, StepStatus } from './execution.types';
 
 /** A new step to persist. `id` and timestamps are assigned by the store. */
 export interface NewStepRecord {
@@ -33,6 +33,18 @@ export interface StepRecord {
 	outputs: StepSlots | null;
 	/** The error that failed the step; `null` unless it failed. */
 	error: StepError | null;
+}
+
+/**
+ * A settled step, as read for planning decisions: whether a successor's
+ * predecessors have all settled, and which edges leaving them carry data.
+ * `filledOutputSlots` lists the output slots holding data — empty unless the
+ * step completed — so planning never loads the outputs themselves.
+ */
+export interface SettledStep {
+	nodeId: string;
+	status: SettledStepStatus;
+	filledOutputSlots: number[];
 }
 
 /** Thrown by `loadStep` when no step exists for the given id. */
@@ -85,8 +97,8 @@ export interface StepStore {
 	 * node id. A node whose step is absent or hasn't completed maps to `null`.
 	 *
 	 * This is for gathering a step's inputs, so it deliberately can't answer
-	 * "have all predecessors completed?" — the two are indistinguishable from a
-	 * `null` here. Use `loadCompletedNodeIds` for that.
+	 * "have all predecessors settled?" — the two are indistinguishable from a
+	 * `null` here. Use `loadSettledSteps` for that.
 	 */
 	loadStepOutputs(
 		executionId: string,
@@ -94,11 +106,11 @@ export interface StepStore {
 	): Promise<Record<string, StepSlots | null>>;
 
 	/**
-	 * Which of `nodeIds` have a completed step in the execution. Returns the
-	 * subset rather than a yes/no so one query can answer readiness for several
-	 * candidate steps at once.
+	 * Which of `nodeIds` have settled in the execution, and which output slots
+	 * each filled. Returns the subset rather than a yes/no so one query can
+	 * answer readiness and edge liveness for several candidate steps at once.
 	 */
-	loadCompletedNodeIds(executionId: string, nodeIds: string[]): Promise<Set<string>>;
+	loadSettledSteps(executionId: string, nodeIds: string[]): Promise<SettledStep[]>;
 
 	/** Whether the execution has any step still `queued` or `running`. */
 	hasActiveSteps(executionId: string): Promise<boolean>;

--- a/packages/@n8n/engine/src/execution/step-worker.ts
+++ b/packages/@n8n/engine/src/execution/step-worker.ts
@@ -18,10 +18,14 @@ export class StepWorker {
 				case 'step:ready':
 					await this.readyHandler.handle(message);
 					break;
-				default:
+				default: {
+					// Exhaustive today; the throw guards an off-contract message at runtime.
+					// `message.type`, not `message`: a non-union doesn't narrow to `never`.
+					const unhandled: never = message.type;
 					throw new UnimplementedError(
-						`step worker received an unimplemented message type: ${String(message.type)}`,
+						`step worker received an unimplemented message type: ${String(unhandled)}`,
 					);
+				}
 			}
 		});
 	}

--- a/packages/@n8n/engine/src/execution/step-worker.ts
+++ b/packages/@n8n/engine/src/execution/step-worker.ts
@@ -1,0 +1,32 @@
+import { UnimplementedError } from '../common';
+import type { StepMessage, WorkQueue } from '../queue';
+import type { StepReadyHandler } from './step-ready-handler';
+
+/**
+ * Consumes the step queue and routes each message to its handler. Kept separate
+ * from the orchestration worker so a flood of step work can't starve planning.
+ */
+export class StepWorker {
+	constructor(
+		private readonly stepQueue: WorkQueue<StepMessage>,
+		private readonly readyHandler: StepReadyHandler,
+	) {}
+
+	start(): void {
+		this.stepQueue.start(async (message) => {
+			switch (message.type) {
+				case 'step:ready':
+					await this.readyHandler.handle(message);
+					break;
+				default:
+					throw new UnimplementedError(
+						`step worker received an unimplemented message type: ${String(message.type)}`,
+					);
+			}
+		});
+	}
+
+	async stop(): Promise<void> {
+		await this.stepQueue.stop();
+	}
+}

--- a/packages/@n8n/engine/src/graph/__tests__/workflow-graph-queries.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/workflow-graph-queries.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import type { WorkflowGraph } from '../workflow-graph';
-import { findTriggerNode, getSuccessorNodeIds } from '../workflow-graph-queries';
+import {
+	findTriggerNode,
+	getPredecessorNodeIds,
+	getSuccessorNodeIds,
+} from '../workflow-graph-queries';
 
 const graph: WorkflowGraph = {
 	nodes: [
@@ -41,5 +45,37 @@ describe('getSuccessorNodeIds', () => {
 
 	it('returns an empty array for an unknown node', () => {
 		expect(getSuccessorNodeIds(graph, 'nope')).toEqual([]);
+	});
+});
+
+describe('getPredecessorNodeIds', () => {
+	it('returns predecessors in edge order, de-duplicated', () => {
+		expect(getPredecessorNodeIds(graph, 'b')).toEqual(['trigger', 'a']);
+	});
+
+	it('de-duplicates a predecessor reaching the same target from two output slots', () => {
+		expect(getPredecessorNodeIds(graph, 'a')).toEqual(['trigger']);
+	});
+
+	it('returns an empty array for the trigger node', () => {
+		expect(getPredecessorNodeIds(graph, 'trigger')).toEqual([]);
+	});
+
+	it('returns an empty array for an unknown node', () => {
+		expect(getPredecessorNodeIds(graph, 'nope')).toEqual([]);
+	});
+
+	it('includes back-edges, matching getSuccessorNodeIds', () => {
+		const looping: WorkflowGraph = {
+			nodes: [
+				{ id: 'a', name: 'A', type: 'v1-node' },
+				{ id: 'b', name: 'B', type: 'v1-node' },
+			],
+			edges: [
+				{ from: 'a', to: 'b', outputIndex: 0, inputIndex: 0 },
+				{ from: 'b', to: 'a', outputIndex: 0, inputIndex: 0, isBackEdge: true },
+			],
+		};
+		expect(getPredecessorNodeIds(looping, 'a')).toEqual(['b']);
 	});
 });

--- a/packages/@n8n/engine/src/graph/index.ts
+++ b/packages/@n8n/engine/src/graph/index.ts
@@ -5,4 +5,8 @@ export type {
 	StepType,
 	WorkflowGraph,
 } from './workflow-graph';
-export { findTriggerNode, getSuccessorNodeIds } from './workflow-graph-queries';
+export {
+	findTriggerNode,
+	getPredecessorNodeIds,
+	getSuccessorNodeIds,
+} from './workflow-graph-queries';

--- a/packages/@n8n/engine/src/graph/workflow-graph-queries.ts
+++ b/packages/@n8n/engine/src/graph/workflow-graph-queries.ts
@@ -19,3 +19,18 @@ export function getSuccessorNodeIds(graph: WorkflowGraph, nodeId: string): strin
 	}
 	return successors;
 }
+
+/**
+ * Ids of the nodes directly upstream of `nodeId`, de-duplicated, in edge order.
+ *
+ * TODO(CAT-3854): validate edge endpoints against `nodes`.
+ */
+export function getPredecessorNodeIds(graph: WorkflowGraph, nodeId: string): string[] {
+	const predecessors: string[] = [];
+	for (const edge of graph.edges) {
+		if (edge.to === nodeId && !predecessors.includes(edge.from)) {
+			predecessors.push(edge.from);
+		}
+	}
+	return predecessors;
+}

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -54,6 +54,7 @@ export type {
 	NewStepRecord,
 	StepError,
 	StepRecord,
+	StepSlots,
 	StepStatus,
 	StepStore,
 } from './execution';

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -40,6 +40,7 @@ export {
 	ExecutionNotFoundError,
 	ExecutionStartHandler,
 	OrchestrationWorker,
+	StepCompletedHandler,
 	StepNotFoundError,
 	StepReadyHandler,
 	StepWorker,

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -30,6 +30,7 @@ export { InMemoryWorkQueue } from './queue';
 export type {
 	ExecutionEnqueuedEvent,
 	OrchestrationMessage,
+	StepCompletedEvent,
 	StepMessage,
 	StepReadyEvent,
 	WorkQueue,
@@ -40,6 +41,8 @@ export {
 	ExecutionStartHandler,
 	OrchestrationWorker,
 	StepNotFoundError,
+	StepReadyHandler,
+	StepWorker,
 } from './execution';
 export type {
 	ExecutionMode,

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -52,6 +52,8 @@ export type {
 	ExecutionStore,
 	NewExecutionRecord,
 	NewStepRecord,
+	SettledStep,
+	SettledStepStatus,
 	StepError,
 	StepRecord,
 	StepSlots,

--- a/packages/@n8n/engine/src/queue/index.ts
+++ b/packages/@n8n/engine/src/queue/index.ts
@@ -1,6 +1,7 @@
 export type {
 	ExecutionEnqueuedEvent,
 	OrchestrationMessage,
+	StepCompletedEvent,
 	StepMessage,
 	StepReadyEvent,
 	WorkQueue,

--- a/packages/@n8n/engine/src/queue/work-queue.types.ts
+++ b/packages/@n8n/engine/src/queue/work-queue.types.ts
@@ -12,8 +12,18 @@ export interface ExecutionEnqueuedEvent {
 	executionId: string;
 }
 
+/**
+ * A step has finished, successfully or not. Carries ids only, like
+ * `step:ready` — the consumer reads the step row for the outcome.
+ */
+export interface StepCompletedEvent {
+	type: 'step:completed';
+	executionId: string;
+	stepId: string;
+}
+
 /** Messages consumed by the orchestration worker. */
-export type OrchestrationMessage = ExecutionEnqueuedEvent;
+export type OrchestrationMessage = ExecutionEnqueuedEvent | StepCompletedEvent;
 
 export interface StepReadyEvent {
 	type: 'step:ready';
@@ -21,7 +31,7 @@ export interface StepReadyEvent {
 	stepId: string;
 }
 
-/** Messages consumed by the step worker (CAT-2870). */
+/** Messages consumed by the step worker. */
 export type StepMessage = StepReadyEvent;
 
 export interface WorkQueue<TMessage> {

--- a/packages/@n8n/engine/src/serve.ts
+++ b/packages/@n8n/engine/src/serve.ts
@@ -10,7 +10,12 @@ import {
 	WorkflowExecution,
 	WorkflowStepExecution,
 } from './database';
-import { ExecutionStartHandler, OrchestrationWorker } from './execution';
+import {
+	ExecutionStartHandler,
+	OrchestrationWorker,
+	StepReadyHandler,
+	StepWorker,
+} from './execution';
 import { InMemoryWorkQueue } from './queue';
 import type { OrchestrationMessage, StepMessage } from './queue';
 import { createEngineServer } from './server';
@@ -30,19 +35,26 @@ async function main(): Promise<void> {
 	}
 
 	const orchestrationQueue = new InMemoryWorkQueue<OrchestrationMessage>();
-	// Published to but not yet consumed — the step worker is CAT-2870. Queued
-	// messages dispatch as soon as it registers.
 	const stepQueue = new InMemoryWorkQueue<StepMessage>();
 
-	let worker: OrchestrationWorker | undefined;
+	let orchestrationWorker: OrchestrationWorker | undefined;
+	let stepWorker: StepWorker | undefined;
 	if (dataSource) {
 		const executionStore = new TypeOrmExecutionStore(dataSource.getRepository(WorkflowExecution));
 		const stepStore = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		worker = new OrchestrationWorker(
+		orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, stepQueue),
 		);
-		worker.start();
+		// No executors here: the v1 one lives in `@n8n/node-engine-compatibility`,
+		// which depends on this package, so only an integrated host can supply it.
+		// `v1-node` steps therefore fail as unimplemented in standalone mode.
+		stepWorker = new StepWorker(
+			stepQueue,
+			new StepReadyHandler(executionStore, stepStore, orchestrationQueue, {}),
+		);
+		orchestrationWorker.start();
+		stepWorker.start();
 	}
 
 	const { app } = createEngineServer(
@@ -63,7 +75,11 @@ async function main(): Promise<void> {
 		await new Promise<void>((resolve, reject) => {
 			server.close((error) => (error ? reject(error) : resolve()));
 		});
-		if (worker) await worker.stop();
+		// TODO(CAT-3882): drain in-flight work instead. Stopping the workers waits
+		// only for whatever each is mid-handling; anything queued behind it is
+		// dropped, since the in-memory queues die with the process.
+		if (orchestrationWorker) await orchestrationWorker.stop();
+		if (stepWorker) await stepWorker.stop();
 		if (dataSource?.isInitialized) await dataSource.destroy();
 		process.exit(0);
 	};

--- a/packages/@n8n/engine/src/serve.ts
+++ b/packages/@n8n/engine/src/serve.ts
@@ -13,6 +13,7 @@ import {
 import {
 	ExecutionStartHandler,
 	OrchestrationWorker,
+	StepCompletedHandler,
 	StepReadyHandler,
 	StepWorker,
 } from './execution';
@@ -45,6 +46,7 @@ async function main(): Promise<void> {
 		orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, stepQueue),
+			new StepCompletedHandler(executionStore, stepStore, stepQueue),
 		);
 		// No executors here: the v1 one lives in `@n8n/node-engine-compatibility`,
 		// which depends on this package, so only an integrated host can supply it.

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/fixtures.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, JsonValue, StepExecutionRequest, WorkflowGraph } from '@n8n/engine';
+import type { JsonObject, StepExecutionRequest, StepSlots, WorkflowGraph } from '@n8n/engine';
 import type { ExecuteContext } from 'n8n-core';
 import { NoOp } from 'n8n-nodes-base/nodes/NoOp/NoOp.node';
 import type {
@@ -235,11 +235,12 @@ export const v1Workflow = (
 export const stepRequest = (
 	graph: WorkflowGraph,
 	nodeId: string,
-	inputs: JsonValue,
+	inputs: StepSlots,
 ): StepExecutionRequest => ({
 	node: graph.nodes.find((n) => n.id === nodeId)!,
 	inputs,
 	context: { executionId: 'exec-1', stepId: 'step-1', workflowId: 'wf-1', mode: 'manual' },
 });
 
-export const items = (...objects: JsonObject[]): JsonValue => [objects.map((json) => ({ json }))];
+/** One output/input slot holding the given objects as items. */
+export const items = (...objects: JsonObject[]): StepSlots => [objects.map((json) => ({ json }))];

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
@@ -41,8 +41,21 @@ describe('fromStepInputs', () => {
 });
 
 describe('toStepOutputs', () => {
+	// v1 stops a branch that produced no items, and the engine reads null as
+	// "not taken", so the collapse is what carries that behaviour across
+	it('collapses an empty slot to null', () => {
+		expect(toStepOutputs([[{ json: { a: 1 } }], []])).toEqual([[{ json: { a: 1 } }], null]);
+	});
+
+	it('collapses a slot the node left unfilled', () => {
+		const sparse: INodeExecutionData[][] = [];
+		sparse[1] = [{ json: { b: 2 } }];
+		expect(toStepOutputs(sparse)).toEqual([null, [{ json: { b: 2 } }]]);
+	});
+
 	it('survives a JSON round-trip', () => {
-		const outputs: INodeExecutionData[][] = [[{ json: { x: 1 } }], []];
+		// both slots filled: an empty one would collapse to null, which is covered above
+		const outputs: INodeExecutionData[][] = [[{ json: { x: 1 } }], [{ json: { y: 2 } }]];
 		const payload = toStepOutputs(outputs);
 		expect(payload).toEqual(outputs);
 

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
@@ -31,12 +31,11 @@ describe('fromStepInputs', () => {
 		expect(fromStepInputs([[{ json }]])).toEqual([[{ json: { json } }]]);
 	});
 
-	it('yields a single empty item list for non-array payloads', () => {
-		expect(fromStepInputs({})).toEqual([[]]);
-		expect(fromStepInputs(null)).toEqual([[]]);
+	it('yields an empty item list for a slot that was not taken', () => {
+		expect(fromStepInputs([null, [{ json: { a: 1 } }]])).toEqual([[], [{ json: { a: 1 } }]]);
 	});
 
-	it('yields an empty item list for non-array elements', () => {
+	it('yields an empty item list for a slot that is not a list of items', () => {
 		expect(fromStepInputs(['nope'])).toEqual([[]]);
 	});
 });

--- a/packages/@n8n/node-engine-compatibility/src/io.ts
+++ b/packages/@n8n/node-engine-compatibility/src/io.ts
@@ -1,4 +1,4 @@
-import type { StepSlots } from '@n8n/engine';
+import type { JsonValue, StepSlots } from '@n8n/engine';
 import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
 
 import { isRecord } from './guards';
@@ -16,6 +16,15 @@ export function fromStepInputs(value: StepSlots): INodeExecutionData[][] {
 	});
 }
 
+/**
+ * v1's `INodeExecutionData[][]` to slot-indexed outputs.
+ *
+ * An empty slot becomes `null`, because v1 treats "produced no items" as "branch
+ * not taken" and stops there. `alwaysOutputData` is how a v1 node opts out: it
+ * substitutes a single empty item, so the slot is no longer empty by the time it
+ * reaches here. `Array.from` rather than `map`, to visit the holes a node leaves
+ * when it fills only some of its slots.
+ */
 export function toStepOutputs(outputs: INodeExecutionData[][]): StepSlots {
-	return outputs as unknown as StepSlots;
+	return Array.from(outputs, (slot) => (slot?.length ? (slot as unknown as JsonValue) : null));
 }

--- a/packages/@n8n/node-engine-compatibility/src/io.ts
+++ b/packages/@n8n/node-engine-compatibility/src/io.ts
@@ -1,12 +1,12 @@
-import type { JsonValue } from '@n8n/engine';
+import type { StepSlots } from '@n8n/engine';
 import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
 
 import { isRecord } from './guards';
 
-export function fromStepInputs(value: JsonValue): INodeExecutionData[][] {
-	if (!Array.isArray(value)) return [[]];
-
+/** Slot-indexed inputs to v1's `INodeExecutionData[][]`, which is also slot-indexed. */
+export function fromStepInputs(value: StepSlots): INodeExecutionData[][] {
 	return value.map((items) => {
+		// a slot the engine reports as not taken carries no items
 		if (!Array.isArray(items)) return [];
 		return items.map((item): INodeExecutionData => {
 			if (isRecord(item) && isRecord(item.json)) return item as unknown as INodeExecutionData;
@@ -16,6 +16,6 @@ export function fromStepInputs(value: JsonValue): INodeExecutionData[][] {
 	});
 }
 
-export function toStepOutputs(outputs: INodeExecutionData[][]): JsonValue {
-	return outputs as unknown as JsonValue;
+export function toStepOutputs(outputs: INodeExecutionData[][]): StepSlots {
+	return outputs as unknown as StepSlots;
 }


### PR DESCRIPTION
## Summary

Adds branching support to the engine, stacked on #35387 (step:completed handler → #35184 → master). Two pieces:

- Route step inputs and outputs by connection slot, so multi-output nodes (IF, Switch) hand each successor the data from its branch instead of the whole output.
- Introduce a `StepPlanner` that plans the consequences of a node settling: successors whose inputs are ready are queued, and branches that can never run are recorded as `skipped` step rows. Deadness is explicit rather than inferred, so an absent step row always means "not yet", never "never", and readiness stays decidable from the step rows alone. Skipped steps settle their successors transitively.

> [!NOTE]
> The dead-branch settling commit is still WIP — opening as draft to get the branch backed up and visible.

## How to test

Unit and integration tests cover the planner, slot routing, and the reworked step:completed handler:

```bash
pushd packages/@n8n/engine && pnpm test
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2874

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

