### PR TITLE
fix(editor): Redirect to sign-in when the user's session expires

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -239,6 +239,8 @@
 	"auth.setup.setupOwner": "Set up owner account",
 	"auth.signin": "Sign in",
 	"auth.signin.error": "Problem logging in",
+	"auth.signin.sessionExpired.title": "Session expired",
+	"auth.signin.sessionExpired": "Your session has expired. Please log in again to continue using n8n.",
 	"auth.signout": "Sign out",
 	"auth.signout.error": "Could not sign out",
 	"auth.signup.finishAccountSetup": "Finish account setup",

--- a/packages/frontend/@n8n/rest-api-client/src/utils.test.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/utils.test.ts
@@ -1,4 +1,68 @@
-import { ResponseError, STREAM_SEPARATOR, streamRequest } from './utils';
+import {
+	MfaRequiredError,
+	ResponseError,
+	STREAM_SEPARATOR,
+	request,
+	setUnauthorizedHandler,
+	streamRequest,
+} from './utils';
+
+const { axiosRequest } = vi.hoisted(() => ({ axiosRequest: vi.fn() }));
+
+vi.mock('axios', () => ({
+	default: { request: axiosRequest },
+}));
+
+describe('request', () => {
+	afterEach(() => {
+		setUnauthorizedHandler(() => {});
+	});
+
+	const baseConfig = {
+		method: 'GET' as const,
+		baseURL: 'https://api.example.com',
+		endpoint: '/workflows',
+	};
+
+	it('calls the registered unauthorized handler with the request baseURL on a 401 response', async () => {
+		axiosRequest.mockRejectedValueOnce({
+			response: { status: 401, data: { message: 'Unauthorized' } },
+		});
+
+		const handler = vi.fn();
+		setUnauthorizedHandler(handler);
+
+		await expect(request(baseConfig)).rejects.toThrow('Unauthorized');
+
+		expect(handler).toHaveBeenCalledExactlyOnceWith(baseConfig.baseURL);
+	});
+
+	it('does not call the unauthorized handler on a non-401 error response', async () => {
+		axiosRequest.mockRejectedValueOnce({
+			response: { status: 500, data: { message: 'Internal Server Error' } },
+		});
+
+		const handler = vi.fn();
+		setUnauthorizedHandler(handler);
+
+		await expect(request(baseConfig)).rejects.toThrow('Internal Server Error');
+
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it('does not call the unauthorized handler on a 401 that is actually an MFA-required response', async () => {
+		axiosRequest.mockRejectedValueOnce({
+			response: { status: 401, data: { message: 'Unauthorized', mfaRequired: true } },
+		});
+
+		const handler = vi.fn();
+		setUnauthorizedHandler(handler);
+
+		await expect(request(baseConfig)).rejects.toThrow(MfaRequiredError);
+
+		expect(handler).not.toHaveBeenCalled();
+	});
+});
 
 describe('streamRequest', () => {
 	it('should stream data from the API endpoint', async () => {

--- a/packages/frontend/@n8n/rest-api-client/src/utils.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/utils.ts
@@ -83,6 +83,14 @@ export class ResponseError extends Error {
 	}
 }
 
+export type UnauthorizedHandler = (baseURL: string) => void;
+let unauthorizedHandler: UnauthorizedHandler | undefined;
+
+// Called on every 401 from request() below, with its baseURL, so non-n8n hosts can be ignored.
+export function setUnauthorizedHandler(handler: UnauthorizedHandler): void {
+	unauthorizedHandler = handler;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const legacyParamSerializer = (params: Record<string, any>) =>
 	Object.keys(params)
@@ -144,6 +152,12 @@ export async function request(config: {
 		if (errorResponseData?.mfaRequired === true) {
 			throw new MfaRequiredError();
 		}
+
+		// After mfaRequired: that 401 means valid-but-unenrolled, not expired.
+		if (error.response?.status === 401) {
+			unauthorizedHandler?.(baseURL);
+		}
+
 		if (errorResponseData?.message !== undefined) {
 			if (errorResponseData.name === 'NodeApiError') {
 				errorResponseData.httpStatusCode = error.response.status;

--- a/packages/frontend/@n8n/stores/src/users.store.test.ts
+++ b/packages/frontend/@n8n/stores/src/users.store.test.ts
@@ -1,4 +1,5 @@
 import type { FrontendSettings } from '@n8n/api-types';
+import { ResponseError } from '@n8n/rest-api-client';
 import type { CurrentUserResponse } from '@n8n/rest-api-client/api/users';
 import { createPinia, setActivePinia } from 'pinia';
 
@@ -333,6 +334,58 @@ describe('users.store', () => {
 
 			expect(usersStore.currentUser).toBeNull();
 			expect(hook).toHaveBeenCalled();
+		});
+
+		it('should clear the current user and still run logout hooks when the session was already invalid server-side', async () => {
+			const usersStore = useUsersStore();
+			usersStore.usersById['1'] = {
+				...mockUser,
+				isDefaultUser: false,
+				isPendingUser: false,
+				mfaEnabled: false,
+			};
+			usersStore.currentUserId = '1';
+			logout.mockRejectedValueOnce(new ResponseError('Unauthorized', { httpStatusCode: 401 }));
+
+			const hook = vi.fn();
+			usersStore.registerLogoutHook(hook);
+
+			await usersStore.logout();
+
+			expect(usersStore.currentUser).toBeNull();
+			expect(hook).toHaveBeenCalled();
+		});
+
+		it('should propagate a genuine logout failure instead of silently completing', async () => {
+			const usersStore = useUsersStore();
+			logout.mockRejectedValueOnce(new Error('Network Error'));
+
+			await expect(usersStore.logout()).rejects.toThrow('Network Error');
+		});
+
+		it('should propagate a genuine failure from the OIDC fallback logout call', async () => {
+			const usersStore = useUsersStore();
+			oidcLogout.mockRejectedValueOnce(new Error('license expired'));
+			logout.mockRejectedValueOnce(new Error('Network Error'));
+
+			await expect(usersStore.logout({ viaOidc: true })).rejects.toThrow('Network Error');
+		});
+
+		it('should clear the current user when the OIDC fallback logout call fails because the session was already invalid', async () => {
+			const usersStore = useUsersStore();
+			usersStore.usersById['1'] = {
+				...mockUser,
+				isDefaultUser: false,
+				isPendingUser: false,
+				mfaEnabled: false,
+			};
+			usersStore.currentUserId = '1';
+			oidcLogout.mockRejectedValueOnce(new Error('license expired'));
+			logout.mockRejectedValueOnce(new ResponseError('Unauthorized', { httpStatusCode: 401 }));
+
+			await usersStore.logout({ viaOidc: true });
+
+			expect(usersStore.currentUser).toBeNull();
 		});
 	});
 

--- a/packages/frontend/@n8n/stores/src/users.store.ts
+++ b/packages/frontend/@n8n/stores/src/users.store.ts
@@ -11,6 +11,7 @@ import {
 import { BROWSER_ID_STORAGE_KEY } from '@n8n/constants';
 import { PERSONALIZATION_MODAL_KEY } from '@n8n/frontend-constants/users';
 import type { AssignableGlobalRole } from '@n8n/permissions';
+import { ResponseError } from '@n8n/rest-api-client';
 import * as cloudApi from '@n8n/rest-api-client/api/cloudPlans';
 import * as mfaApi from '@n8n/rest-api-client/api/mfa';
 import * as ssoApi from '@n8n/rest-api-client/api/sso';
@@ -38,6 +39,10 @@ const _isInstanceOwner = (user: IUserResponse | null) => user?.role === ROLE.Own
 const _isDefaultUser = (user: IUserResponse | null) =>
 	_isInstanceOwner(user) && _isPendingUser(user);
 const _isAdmin = (user: IUserResponse | null) => user?.role === ROLE.Admin;
+
+// A 401 means the session was already dead server-side; any other error must still propagate.
+const _isSessionAlreadyInvalid = (error: unknown) =>
+	error instanceof ResponseError && error.httpStatusCode === 401;
 
 export type LoginHook = (user: CurrentUserResponse) => void | Promise<void>;
 type LogoutHook = () => void | Promise<void>;
@@ -240,6 +245,14 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		logoutHooks.value.push(hook);
 	};
 
+	const standardLogout = async () => {
+		try {
+			await usersApi.logout(rootStore.restApiContext);
+		} catch (error) {
+			if (!_isSessionAlreadyInvalid(error)) throw error;
+		}
+	};
+
 	const logout = async (options?: { viaOidc?: boolean }) => {
 		let redirectUrl: string | null = null;
 
@@ -250,10 +263,10 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 				// The OIDC logout endpoint may be unavailable (e.g. the license
 				// lapsed since login). Fall back to the standard logout so the
 				// n8n session is terminated in any case.
-				await usersApi.logout(rootStore.restApiContext);
+				await standardLogout();
 			}
 		} else {
-			await usersApi.logout(rootStore.restApiContext);
+			await standardLogout();
 		}
 
 		unsetCurrentUser();

--- a/packages/frontend/editor-ui/src/app/init/index.test.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.test.ts
@@ -285,6 +285,26 @@ describe('Init', () => {
 			expect(cloudStoreSpy).toHaveBeenCalledTimes(1);
 		});
 
+		it('re-initializes authenticated features for the next login after the registered logout hook runs', async () => {
+			// Force registerAuthenticationHooks() (only runs once) to run again.
+			state.initialized = false;
+			const registerLogoutHookSpy = vi.spyOn(usersStore, 'registerLogoutHook');
+			await initializeCore();
+			const registeredLogoutHook = registerLogoutHookSpy.mock.calls[0][0];
+
+			const cloudStoreSpy = vi.spyOn(cloudPlanStore, 'initialize').mockResolvedValue();
+			usersStore.currentUser = mock<IUser>({ id: '123', globalScopes: ['user:list'] });
+
+			await initializeAuthenticatedFeatures(false);
+			expect(cloudStoreSpy).toHaveBeenCalledTimes(1);
+
+			// Simulates a session-expiry logout resetting the module-level flag.
+			await registeredLogoutHook();
+
+			await initializeAuthenticatedFeatures();
+			expect(cloudStoreSpy).toHaveBeenCalledTimes(2);
+		});
+
 		it('should handle cloud plan initialization error', async () => {
 			const cloudStoreSpy = vi
 				.spyOn(cloudPlanStore, 'initialize')

--- a/packages/frontend/editor-ui/src/app/init/index.test.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.test.ts
@@ -23,14 +23,6 @@ import { mock } from 'vitest-mock-extended';
 import { telemetry } from '@/app/plugins/telemetry';
 import { registerToastNotifier } from '@/app/init/toastNotifier';
 
-const { resetSessionExpiredHandledFlag } = vi.hoisted(() => ({
-	resetSessionExpiredHandledFlag: vi.fn(),
-}));
-
-vi.mock('@/app/utils/handleSessionExpired', () => ({
-	resetSessionExpiredHandledFlag,
-}));
-
 const showMessage = vi.fn();
 const showToast = vi.fn();
 
@@ -226,16 +218,6 @@ describe('Init', () => {
 					oidc: false,
 				},
 			});
-		});
-
-		it('should reset the session-expiry handled flag in the login hook, so any login path catches a future expiry', async () => {
-			usersStore.registerLoginHook.mockImplementation(async (hook) => {
-				await hook(mock<CurrentUserResponse>({ id: 'userId', role: 'global:member' }));
-			});
-
-			await initializeCore();
-
-			expect(resetSessionExpiredHandledFlag).toHaveBeenCalled();
 		});
 
 		it('should still call getModuleSettings if postHogStore.init throws', async () => {

--- a/packages/frontend/editor-ui/src/app/init/index.test.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.test.ts
@@ -23,6 +23,14 @@ import { mock } from 'vitest-mock-extended';
 import { telemetry } from '@/app/plugins/telemetry';
 import { registerToastNotifier } from '@/app/init/toastNotifier';
 
+const { resetSessionExpiredHandledFlag } = vi.hoisted(() => ({
+	resetSessionExpiredHandledFlag: vi.fn(),
+}));
+
+vi.mock('@/app/utils/handleSessionExpired', () => ({
+	resetSessionExpiredHandledFlag,
+}));
+
 const showMessage = vi.fn();
 const showToast = vi.fn();
 
@@ -218,6 +226,16 @@ describe('Init', () => {
 					oidc: false,
 				},
 			});
+		});
+
+		it('should reset the session-expiry handled flag in the login hook, so any login path catches a future expiry', async () => {
+			usersStore.registerLoginHook.mockImplementation(async (hook) => {
+				await hook(mock<CurrentUserResponse>({ id: 'userId', role: 'global:member' }));
+			});
+
+			await initializeCore();
+
+			expect(resetSessionExpiredHandledFlag).toHaveBeenCalled();
 		});
 
 		it('should still call getModuleSettings if postHogStore.init throws', async () => {

--- a/packages/frontend/editor-ui/src/app/init/index.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.ts
@@ -305,5 +305,7 @@ function registerAuthenticationHooks() {
 		telemetry.reset();
 		RBACStore.setGlobalScopes([]);
 		favoritesStore.reset();
+		// So a soft-redirect re-login (no page reload) re-fetches per-user data.
+		authenticatedFeaturesInitialized = false;
 	});
 }

--- a/packages/frontend/editor-ui/src/app/init/index.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.ts
@@ -34,7 +34,6 @@ import { useRolesStore } from '@n8n/stores/roles.store';
 import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 import { useFavoritesStore } from '@/app/stores/favorites.store';
 import { hasPermission } from '@/app/utils/rbac/permissions';
-import { resetSessionExpiredHandledFlag } from '@/app/utils/handleSessionExpired';
 
 export const state = {
 	initialized: false,
@@ -263,8 +262,6 @@ function registerAuthenticationHooks() {
 	const favoritesStore = useFavoritesStore();
 
 	usersStore.registerLoginHook(async (user) => {
-		resetSessionExpiredHandledFlag();
-
 		await settingsStore.getSettings();
 
 		// Re-initialize SSO store with authenticated settings.

--- a/packages/frontend/editor-ui/src/app/init/index.ts
+++ b/packages/frontend/editor-ui/src/app/init/index.ts
@@ -34,6 +34,7 @@ import { useRolesStore } from '@n8n/stores/roles.store';
 import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 import { useFavoritesStore } from '@/app/stores/favorites.store';
 import { hasPermission } from '@/app/utils/rbac/permissions';
+import { resetSessionExpiredHandledFlag } from '@/app/utils/handleSessionExpired';
 
 export const state = {
 	initialized: false,
@@ -262,6 +263,8 @@ function registerAuthenticationHooks() {
 	const favoritesStore = useFavoritesStore();
 
 	usersStore.registerLoginHook(async (user) => {
+		resetSessionExpiredHandledFlag();
+
 		await settingsStore.getSettings();
 
 		// Re-initialize SSO store with authenticated settings.

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -13,7 +13,7 @@ import { useNotificationsStore } from '@n8n/stores/notifications.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUsersStore } from '@n8n/stores/users.store';
 import { get } from '@n8n/rest-api-client';
-import { resetSessionExpiredHandledFlag } from '@/app/utils/handleSessionExpired';
+import { useSessionExpiryStore } from '@/app/stores/sessionExpiry.store';
 import type { Scope } from '@n8n/permissions';
 import type { RouteRecordName } from 'vue-router';
 import type { MockInstance } from 'vitest';
@@ -377,22 +377,31 @@ describe('router', () => {
 	// `afterEach` rather than depending on file/test order.
 	describe('session-expiry redirect (registered on rest-api-client, see router.ts)', () => {
 		afterEach(async () => {
-			resetSessionExpiredHandledFlag();
+			useSessionExpiryStore().handled = false;
 			useNotificationsStore().setNotificationsSuppressed(false);
 			await useUsersStore().initialize();
 			await router.replace('/workflow/router-test-reset');
 		});
 
-		test('redirects to sign-in when a REST call to the app backend comes back 401', async () => {
+		test('reloads to sign-in when a REST call to the app backend comes back 401', async () => {
 			const rootStore = useRootStore();
 			server.get('/rest/__test_401__', () => new Response(401, {}, { message: 'Unauthorized' }));
+
+			Object.defineProperty(window, 'location', {
+				value: { href: '' },
+				writable: true,
+			});
+			const hrefSpy = vi.spyOn(window.location, 'href', 'set');
 
 			await expect(get(rootStore.restApiContext.baseUrl, '/__test_401__')).rejects.toThrow();
 
 			await vi.waitFor(() => {
-				expect(router.currentRoute.value.name).toBe(VIEWS.SIGNIN);
+				expect(hrefSpy).toHaveBeenCalled();
 			});
-			expect(router.currentRoute.value.query.sessionExpired).toBe('true');
+
+			const [href] = hrefSpy.mock.calls[0];
+			expect(href).toContain(router.resolve({ name: VIEWS.SIGNIN }).path);
+			expect(href).toContain('sessionExpired=true');
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -1,4 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia';
+import { Response } from 'miragejs';
 import { createComponentRenderer } from '@/__tests__/render';
 import router, { routes } from '@/app/router';
 import { VIEWS } from '@/app/constants';
@@ -8,7 +9,11 @@ import { setupServer } from '@/__tests__/server';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { useRBACStore } from '@n8n/stores/rbac.store';
+import { useNotificationsStore } from '@n8n/stores/notifications.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUsersStore } from '@n8n/stores/users.store';
+import { get } from '@n8n/rest-api-client';
+import { resetSessionExpiredHandledFlag } from '@/app/utils/handleSessionExpired';
 import type { Scope } from '@n8n/permissions';
 import type { RouteRecordName } from 'vue-router';
 import type { MockInstance } from 'vitest';
@@ -364,5 +369,30 @@ describe('router', () => {
 		);
 		expect(editRoleRoute?.props).toBe(true);
 		expect(editRoleRoute?.path).toBe('edit/:roleSlug');
+	});
+
+	// Kept last and self-contained: it logs the shared `currentUser` out for real
+	// and flips module-level state in handleSessionExpired.ts that every other
+	// test in this file implicitly relies on staying logged in, so it restores
+	// both in its own `afterEach` rather than depending on file/test order.
+	describe('session-expiry redirect (registered on rest-api-client, see router.ts)', () => {
+		afterEach(async () => {
+			resetSessionExpiredHandledFlag();
+			useNotificationsStore().setNotificationsSuppressed(false);
+			await useUsersStore().initialize();
+			await router.replace('/workflow/router-test-reset');
+		});
+
+		test('redirects to sign-in when a REST call to the app backend comes back 401', async () => {
+			const rootStore = useRootStore();
+			server.get('/rest/__test_401__', () => new Response(401, {}, { message: 'Unauthorized' }));
+
+			await expect(get(rootStore.restApiContext.baseUrl, '/__test_401__')).rejects.toThrow();
+
+			await vi.waitFor(() => {
+				expect(router.currentRoute.value.name).toBe(VIEWS.SIGNIN);
+			});
+			expect(router.currentRoute.value.query.sessionExpired).toBe('true');
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -379,29 +379,35 @@ describe('router', () => {
 		afterEach(async () => {
 			useSessionExpiryStore().handled = false;
 			useNotificationsStore().setNotificationsSuppressed(false);
+			window.preventNodeViewBeforeUnload = undefined;
 			await useUsersStore().initialize();
 			await router.replace('/workflow/router-test-reset');
 		});
 
+		// The actual `window.location.href` assignment isn't asserted on here: jsdom doesn't
+		// implement real navigation, and swapping out `window.location` to spy on it breaks the
+		// (also real, jsdom-hosted) HTTP request this test drives, since the mocked object lacks
+		// the properties the request layer needs to resolve a relative baseURL. Asserting on
+		// `router.resolve` (the same call the redirect makes to build its href) and on
+		// `preventNodeViewBeforeUnload` (set immediately before the redirect) verifies the same
+		// behavior without touching the real `window.location`.
 		test('reloads to sign-in when a REST call to the app backend comes back 401', async () => {
 			const rootStore = useRootStore();
 			server.get('/rest/__test_401__', () => new Response(401, {}, { message: 'Unauthorized' }));
-
-			Object.defineProperty(window, 'location', {
-				value: { href: '' },
-				writable: true,
-			});
-			const hrefSpy = vi.spyOn(window.location, 'href', 'set');
+			const resolveSpy = vi.spyOn(router, 'resolve');
 
 			await expect(get(rootStore.restApiContext.baseUrl, '/__test_401__')).rejects.toThrow();
 
 			await vi.waitFor(() => {
-				expect(hrefSpy).toHaveBeenCalled();
+				expect(window.preventNodeViewBeforeUnload).toBe(true);
 			});
 
-			const [href] = hrefSpy.mock.calls[0];
-			expect(href).toContain(router.resolve({ name: VIEWS.SIGNIN }).path);
-			expect(href).toContain('sessionExpired=true');
+			expect(resolveSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: VIEWS.SIGNIN,
+					query: expect.objectContaining({ sessionExpired: 'true' }),
+				}),
+			);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -372,9 +372,9 @@ describe('router', () => {
 	});
 
 	// Kept last and self-contained: it logs the shared `currentUser` out for real
-	// and flips module-level state in handleSessionExpired.ts that every other
-	// test in this file implicitly relies on staying logged in, so it restores
-	// both in its own `afterEach` rather than depending on file/test order.
+	// and flips session-expiry store state that every other test in this file
+	// implicitly relies on staying logged in, so it restores both in its own
+	// `afterEach` rather than depending on file/test order.
 	describe('session-expiry redirect (registered on rest-api-client, see router.ts)', () => {
 		afterEach(async () => {
 			resetSessionExpiredHandledFlag();

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -19,7 +19,8 @@ import type { RouterMiddleware } from '@/app/types/router';
 import { initializeAuthenticatedFeatures, initializeCore } from '@/app/init';
 import { tryToParseNumber } from '@/app/utils/typesUtils';
 import { projectsRoutes } from '@/features/collaboration/projects/projects.routes';
-import { MfaRequiredError } from '@n8n/rest-api-client';
+import { MfaRequiredError, setUnauthorizedHandler } from '@n8n/rest-api-client';
+import { handleSessionExpired } from '@/app/utils/handleSessionExpired';
 import { useRecentResources } from '@/features/shared/commandBar/composables/useRecentResources';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { RESOURCE_CENTER_EXPERIMENT, TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants/experiments';
@@ -1181,6 +1182,10 @@ const router = createRouter({
 		}
 	},
 	routes: routes.map(withCanvasReadOnlyMeta),
+});
+
+setUnauthorizedHandler((baseURL) => {
+	void handleSessionExpired(router, baseURL);
 });
 
 router.beforeEach(async (to: RouteLocationNormalized, from, next) => {

--- a/packages/frontend/editor-ui/src/app/stores/sessionExpiry.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/sessionExpiry.store.ts
@@ -1,33 +1,16 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
-interface NotificationSuppressionState {
-	suppressed: boolean;
-	allowErrors: boolean;
-}
-
-// Whether the current session expiry has been handled, and notification-suppression state to restore afterwards.
+// Dedupes concurrent 401s so only the first one redirects to sign-in.
 export const useSessionExpiryStore = defineStore('sessionExpiry', () => {
 	const handled = ref(false);
-	const priorSuppression = ref<NotificationSuppressionState | undefined>(undefined);
 
 	function markHandled() {
 		handled.value = true;
 	}
 
-	function resetHandled() {
-		handled.value = false;
-	}
-
-	function setPriorSuppression(value: NotificationSuppressionState) {
-		priorSuppression.value = value;
-	}
-
 	return {
 		handled,
-		priorSuppression,
 		markHandled,
-		resetHandled,
-		setPriorSuppression,
 	};
 });

--- a/packages/frontend/editor-ui/src/app/stores/sessionExpiry.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/sessionExpiry.store.ts
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+interface NotificationSuppressionState {
+	suppressed: boolean;
+	allowErrors: boolean;
+}
+
+// Whether the current session expiry has been handled, and notification-suppression state to restore afterwards.
+export const useSessionExpiryStore = defineStore('sessionExpiry', () => {
+	const handled = ref(false);
+	const priorSuppression = ref<NotificationSuppressionState | undefined>(undefined);
+
+	function markHandled() {
+		handled.value = true;
+	}
+
+	function resetHandled() {
+		handled.value = false;
+	}
+
+	function setPriorSuppression(value: NotificationSuppressionState) {
+		priorSuppression.value = value;
+	}
+
+	return {
+		handled,
+		priorSuppression,
+		markHandled,
+		resetHandled,
+		setPriorSuppression,
+	};
+});

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -526,6 +526,16 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		modalStack.value = modalStack.value.filter((openModalName) => name !== openModalName);
 	};
 
+	const closeAllModals = () => {
+		for (const name of modalStack.value) {
+			modalsById.value[name] = {
+				...modalsById.value[name],
+				open: false,
+			};
+		}
+		modalStack.value = [];
+	};
+
 	const openDeleteUserModal = (id: string) => {
 		setActiveId(DELETE_USER_MODAL_KEY, id);
 		openModal(DELETE_USER_MODAL_KEY);
@@ -778,6 +788,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		openModalWithData,
 		openModal,
 		closeModal,
+		closeAllModals,
 		openDeleteUserModal,
 		openExistingCredential,
 		openNewCredential,

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
@@ -6,8 +6,6 @@ import type { Router } from 'vue-router';
 import { VIEWS } from '@/app/constants';
 import {
 	handleSessionExpired,
-	resetPriorSuppressionForTests,
-	resetSessionExpiredHandledFlag,
 	restoreNotificationSuppression,
 } from '@/app/utils/handleSessionExpired';
 import { useUsersStore } from '@n8n/stores/users.store';
@@ -21,8 +19,6 @@ describe('handleSessionExpired', () => {
 
 	beforeEach(() => {
 		setActivePinia(createPinia());
-		resetSessionExpiredHandledFlag();
-		resetPriorSuppressionForTests();
 		ownBackendURL = useRootStore().restApiContext.baseUrl;
 	});
 

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
@@ -5,22 +5,23 @@ import type { Router, RouteLocationNormalizedLoaded } from 'vue-router';
 
 import { VIEWS } from '@/app/constants';
 import { useUIStore } from '@/app/stores/ui.store';
-import {
-	handleSessionExpired,
-	restoreNotificationSuppression,
-} from '@/app/utils/handleSessionExpired';
+import { handleSessionExpired } from '@/app/utils/handleSessionExpired';
 import { useUsersStore } from '@n8n/stores/users.store';
 
 vi.mock('@n8n/stores/users.store', () => ({
 	useUsersStore: vi.fn(),
 }));
 
+const SIGNIN_HREF = '/signin';
+
 function createRouterMock(
-	push = vi.fn(),
 	currentRoute: Partial<RouteLocationNormalizedLoaded> = { fullPath: '/' },
-	resolve = vi.fn(),
+	resolveWorkflowRoute: (to: unknown) => unknown = vi.fn(),
 ): Router {
-	return { push, resolve, currentRoute: { value: currentRoute } } as unknown as Router;
+	const resolve = vi.fn((to: { name?: unknown }) =>
+		to.name === VIEWS.SIGNIN ? { href: SIGNIN_HREF } : resolveWorkflowRoute(to),
+	);
+	return { resolve, currentRoute: { value: currentRoute } } as unknown as Router;
 }
 
 describe('handleSessionExpired', () => {
@@ -29,6 +30,12 @@ describe('handleSessionExpired', () => {
 	beforeEach(() => {
 		setActivePinia(createPinia());
 		ownBackendURL = useRootStore().restApiContext.baseUrl;
+		window.preventNodeViewBeforeUnload = undefined;
+
+		Object.defineProperty(window, 'location', {
+			value: { href: '' },
+			writable: true,
+		});
 	});
 
 	it('does nothing when there is no current user', async () => {
@@ -36,13 +43,13 @@ describe('handleSessionExpired', () => {
 		vi.mocked(useUsersStore).mockReturnValue({ currentUser: null, logout } as unknown as ReturnType<
 			typeof useUsersStore
 		>);
-		const push = vi.fn();
-		const router = createRouterMock(push);
+		const router = createRouterMock();
+		const hrefSpy = vi.spyOn(window.location, 'href', 'set');
 
 		await handleSessionExpired(router, ownBackendURL);
 
 		expect(logout).not.toHaveBeenCalled();
-		expect(push).not.toHaveBeenCalled();
+		expect(hrefSpy).not.toHaveBeenCalled();
 		expect(useNotificationsStore().areNotificationsSuppressed).toBe(false);
 	});
 
@@ -52,31 +59,33 @@ describe('handleSessionExpired', () => {
 			currentUser: { id: '123' },
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
-		const push = vi.fn();
-		const router = createRouterMock(push);
+		const router = createRouterMock();
+		const hrefSpy = vi.spyOn(window.location, 'href', 'set');
 
 		await handleSessionExpired(router, 'https://thirdparty.example.com');
 
 		expect(logout).not.toHaveBeenCalled();
-		expect(push).not.toHaveBeenCalled();
+		expect(hrefSpy).not.toHaveBeenCalled();
 	});
 
-	it('logs out and redirects to signin with the current path when a current user is present', async () => {
+	it('logs out, skips the unsaved-changes prompt, and reloads to signin with the current path when a current user is present', async () => {
 		const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
 		vi.mocked(useUsersStore).mockReturnValue({
 			currentUser: { id: '123' },
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
-		const push = vi.fn();
-		const router = createRouterMock(push, { fullPath: '/workflow/1' });
+		const router = createRouterMock({ fullPath: '/workflow/1' });
+		const hrefSpy = vi.spyOn(window.location, 'href', 'set');
 
 		await handleSessionExpired(router, ownBackendURL);
 
 		expect(logout).toHaveBeenCalledTimes(1);
-		expect(push).toHaveBeenCalledWith({
+		expect(window.preventNodeViewBeforeUnload).toBe(true);
+		expect(router.resolve).toHaveBeenCalledWith({
 			name: VIEWS.SIGNIN,
 			query: { redirect: encodeURIComponent('/workflow/1'), sessionExpired: 'true' },
 		});
+		expect(hrefSpy).toHaveBeenCalledWith(SIGNIN_HREF);
 	});
 
 	it('drops the open node id from the redirect path when there are unsaved changes', async () => {
@@ -87,30 +96,30 @@ describe('handleSessionExpired', () => {
 		} as unknown as ReturnType<typeof useUsersStore>);
 		useUIStore().markStateDirty();
 
-		const push = vi.fn();
-		const resolve = vi.fn().mockReturnValue({ fullPath: '/workflow/1' });
+		const resolveWorkflowRoute = vi.fn().mockReturnValue({ fullPath: '/workflow/1' });
 		const router = createRouterMock(
-			push,
 			{
 				fullPath: '/workflow/1/abc123',
 				name: VIEWS.WORKFLOW,
 				params: { workflowId: '1', nodeId: 'abc123' },
 				query: {},
 			},
-			resolve,
+			resolveWorkflowRoute,
 		);
+		const hrefSpy = vi.spyOn(window.location, 'href', 'set');
 
 		await handleSessionExpired(router, ownBackendURL);
 
-		expect(resolve).toHaveBeenCalledWith({
+		expect(resolveWorkflowRoute).toHaveBeenCalledWith({
 			name: VIEWS.WORKFLOW,
 			params: { workflowId: '1', nodeId: undefined },
 			query: {},
 		});
-		expect(push).toHaveBeenCalledWith({
+		expect(router.resolve).toHaveBeenCalledWith({
 			name: VIEWS.SIGNIN,
 			query: { redirect: encodeURIComponent('/workflow/1'), sessionExpired: 'true' },
 		});
+		expect(hrefSpy).toHaveBeenCalledWith(SIGNIN_HREF);
 	});
 
 	it('keeps the open node id in the redirect path when there are no unsaved changes', async () => {
@@ -120,26 +129,26 @@ describe('handleSessionExpired', () => {
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
 
-		const push = vi.fn();
-		const resolve = vi.fn();
+		const resolveWorkflowRoute = vi.fn();
 		const router = createRouterMock(
-			push,
 			{
 				fullPath: '/workflow/1/abc123',
 				name: VIEWS.WORKFLOW,
 				params: { workflowId: '1', nodeId: 'abc123' },
 				query: {},
 			},
-			resolve,
+			resolveWorkflowRoute,
 		);
+		const hrefSpy = vi.spyOn(window.location, 'href', 'set');
 
 		await handleSessionExpired(router, ownBackendURL);
 
-		expect(resolve).not.toHaveBeenCalled();
-		expect(push).toHaveBeenCalledWith({
+		expect(resolveWorkflowRoute).not.toHaveBeenCalled();
+		expect(router.resolve).toHaveBeenCalledWith({
 			name: VIEWS.SIGNIN,
 			query: { redirect: encodeURIComponent('/workflow/1/abc123'), sessionExpired: 'true' },
 		});
+		expect(hrefSpy).toHaveBeenCalledWith(SIGNIN_HREF);
 	});
 
 	it('suppresses notifications synchronously, before logout is awaited', () => {
@@ -162,12 +171,12 @@ describe('handleSessionExpired', () => {
 			currentUser: { id: '123' },
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
-		const push = vi.fn();
-		const router = createRouterMock(push);
+		const router = createRouterMock();
+		const hrefSpy = vi.spyOn(window.location, 'href', 'set');
 
 		await handleSessionExpired(router, ownBackendURL);
 
-		expect(push).toHaveBeenCalledWith(expect.objectContaining({ name: VIEWS.SIGNIN }));
+		expect(hrefSpy).toHaveBeenCalledWith(SIGNIN_HREF);
 	});
 
 	it('only handles the first of several concurrent calls', async () => {
@@ -176,8 +185,8 @@ describe('handleSessionExpired', () => {
 			currentUser: { id: '123' },
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
-		const push = vi.fn();
-		const router = createRouterMock(push);
+		const router = createRouterMock();
+		const hrefSpy = vi.spyOn(window.location, 'href', 'set');
 
 		await Promise.all([
 			handleSessionExpired(router, ownBackendURL),
@@ -185,46 +194,6 @@ describe('handleSessionExpired', () => {
 		]);
 
 		expect(logout).toHaveBeenCalledTimes(1);
-		expect(push).toHaveBeenCalledTimes(1);
-	});
-
-	describe('restoreNotificationSuppression', () => {
-		it('no-ops to false when called without a session expiry ever having happened', () => {
-			restoreNotificationSuppression();
-
-			expect(useNotificationsStore().areNotificationsSuppressed).toBe(false);
-		});
-
-		it('restores suppression to false when nothing suppressed it before the expiry', async () => {
-			const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
-			vi.mocked(useUsersStore).mockReturnValue({
-				currentUser: { id: '123' },
-				logout,
-			} as unknown as ReturnType<typeof useUsersStore>);
-			const router = createRouterMock();
-
-			await handleSessionExpired(router, ownBackendURL);
-			restoreNotificationSuppression();
-
-			expect(useNotificationsStore().areNotificationsSuppressed).toBe(false);
-		});
-
-		it("restores an embed's prior suppression setting instead of hardcoding it off", async () => {
-			useNotificationsStore().setNotificationsSuppressed(true, { allowErrors: true });
-
-			const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
-			vi.mocked(useUsersStore).mockReturnValue({
-				currentUser: { id: '123' },
-				logout,
-			} as unknown as ReturnType<typeof useUsersStore>);
-			const router = createRouterMock();
-
-			await handleSessionExpired(router, ownBackendURL);
-			restoreNotificationSuppression();
-
-			const notificationsStore = useNotificationsStore();
-			expect(notificationsStore.areNotificationsSuppressed).toBe(true);
-			expect(notificationsStore.allowErrorNotificationsWhenSuppressed).toBe(true);
-		});
+		expect(hrefSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
@@ -14,6 +14,10 @@ vi.mock('@n8n/stores/users.store', () => ({
 	useUsersStore: vi.fn(),
 }));
 
+function createRouterMock(push = vi.fn(), fullPath = '/'): Router {
+	return { push, currentRoute: { value: { fullPath } } } as unknown as Router;
+}
+
 describe('handleSessionExpired', () => {
 	let ownBackendURL: string;
 
@@ -28,7 +32,7 @@ describe('handleSessionExpired', () => {
 			typeof useUsersStore
 		>);
 		const push = vi.fn();
-		const router = { push } as unknown as Router;
+		const router = createRouterMock(push);
 
 		await handleSessionExpired(router, ownBackendURL);
 
@@ -44,7 +48,7 @@ describe('handleSessionExpired', () => {
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
 		const push = vi.fn();
-		const router = { push } as unknown as Router;
+		const router = createRouterMock(push);
 
 		await handleSessionExpired(router, 'https://thirdparty.example.com');
 
@@ -59,9 +63,7 @@ describe('handleSessionExpired', () => {
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
 		const push = vi.fn();
-		const router = { push } as unknown as Router;
-
-		window.history.pushState({}, '', '/workflow/1');
+		const router = createRouterMock(push, '/workflow/1');
 
 		await handleSessionExpired(router, ownBackendURL);
 
@@ -78,7 +80,7 @@ describe('handleSessionExpired', () => {
 			currentUser: { id: '123' },
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
-		const router = { push: vi.fn() } as unknown as Router;
+		const router = createRouterMock();
 
 		void handleSessionExpired(router, ownBackendURL);
 
@@ -93,7 +95,7 @@ describe('handleSessionExpired', () => {
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
 		const push = vi.fn();
-		const router = { push } as unknown as Router;
+		const router = createRouterMock(push);
 
 		await handleSessionExpired(router, ownBackendURL);
 
@@ -107,7 +109,7 @@ describe('handleSessionExpired', () => {
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
 		const push = vi.fn();
-		const router = { push } as unknown as Router;
+		const router = createRouterMock(push);
 
 		await Promise.all([
 			handleSessionExpired(router, ownBackendURL),
@@ -131,7 +133,7 @@ describe('handleSessionExpired', () => {
 				currentUser: { id: '123' },
 				logout,
 			} as unknown as ReturnType<typeof useUsersStore>);
-			const router = { push: vi.fn() } as unknown as Router;
+			const router = createRouterMock();
 
 			await handleSessionExpired(router, ownBackendURL);
 			restoreNotificationSuppression();
@@ -147,7 +149,7 @@ describe('handleSessionExpired', () => {
 				currentUser: { id: '123' },
 				logout,
 			} as unknown as ReturnType<typeof useUsersStore>);
-			const router = { push: vi.fn() } as unknown as Router;
+			const router = createRouterMock();
 
 			await handleSessionExpired(router, ownBackendURL);
 			restoreNotificationSuppression();

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
@@ -1,0 +1,156 @@
+import { useNotificationsStore } from '@n8n/stores/notifications.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import { createPinia, setActivePinia } from 'pinia';
+import type { Router } from 'vue-router';
+
+import { VIEWS } from '@/app/constants';
+import {
+	handleSessionExpired,
+	resetSessionExpiredHandledFlag,
+	restoreNotificationSuppression,
+} from '@/app/utils/handleSessionExpired';
+import { useUsersStore } from '@/features/settings/users/users.store';
+
+vi.mock('@/features/settings/users/users.store', () => ({
+	useUsersStore: vi.fn(),
+}));
+
+describe('handleSessionExpired', () => {
+	let ownBackendURL: string;
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		resetSessionExpiredHandledFlag();
+		ownBackendURL = useRootStore().restApiContext.baseUrl;
+	});
+
+	it('does nothing when there is no current user', async () => {
+		const logout = vi.fn();
+		vi.mocked(useUsersStore).mockReturnValue({ currentUser: null, logout } as unknown as ReturnType<
+			typeof useUsersStore
+		>);
+		const push = vi.fn();
+		const router = { push } as unknown as Router;
+
+		await handleSessionExpired(router, ownBackendURL);
+
+		expect(logout).not.toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalled();
+		expect(useNotificationsStore().areNotificationsSuppressed).toBe(false);
+	});
+
+	it('does nothing when the 401 came from a different host than the app backend', async () => {
+		const logout = vi.fn();
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { id: '123' },
+			logout,
+		} as unknown as ReturnType<typeof useUsersStore>);
+		const push = vi.fn();
+		const router = { push } as unknown as Router;
+
+		await handleSessionExpired(router, 'https://thirdparty.example.com');
+
+		expect(logout).not.toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it('logs out and redirects to signin with the current path when a current user is present', async () => {
+		const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { id: '123' },
+			logout,
+		} as unknown as ReturnType<typeof useUsersStore>);
+		const push = vi.fn();
+		const router = { push } as unknown as Router;
+
+		window.history.pushState({}, '', '/workflow/1');
+
+		await handleSessionExpired(router, ownBackendURL);
+
+		expect(logout).toHaveBeenCalledTimes(1);
+		expect(push).toHaveBeenCalledWith({
+			name: VIEWS.SIGNIN,
+			query: { redirect: encodeURIComponent('/workflow/1'), sessionExpired: 'true' },
+		});
+	});
+
+	it('suppresses notifications synchronously, before logout is awaited', () => {
+		const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { id: '123' },
+			logout,
+		} as unknown as ReturnType<typeof useUsersStore>);
+		const router = { push: vi.fn() } as unknown as Router;
+
+		void handleSessionExpired(router, ownBackendURL);
+
+		// Asserted before awaiting: suppression must be set synchronously.
+		expect(useNotificationsStore().areNotificationsSuppressed).toBe(true);
+	});
+
+	it('still redirects even if logout rejects', async () => {
+		const logout = vi.fn().mockRejectedValue(new Error('Unauthorized'));
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { id: '123' },
+			logout,
+		} as unknown as ReturnType<typeof useUsersStore>);
+		const push = vi.fn();
+		const router = { push } as unknown as Router;
+
+		await handleSessionExpired(router, ownBackendURL);
+
+		expect(push).toHaveBeenCalledWith(expect.objectContaining({ name: VIEWS.SIGNIN }));
+	});
+
+	it('only handles the first of several concurrent calls', async () => {
+		const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { id: '123' },
+			logout,
+		} as unknown as ReturnType<typeof useUsersStore>);
+		const push = vi.fn();
+		const router = { push } as unknown as Router;
+
+		await Promise.all([
+			handleSessionExpired(router, ownBackendURL),
+			handleSessionExpired(router, ownBackendURL),
+		]);
+
+		expect(logout).toHaveBeenCalledTimes(1);
+		expect(push).toHaveBeenCalledTimes(1);
+	});
+
+	describe('restoreNotificationSuppression', () => {
+		it('restores suppression to false when nothing suppressed it before the expiry', async () => {
+			const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
+			vi.mocked(useUsersStore).mockReturnValue({
+				currentUser: { id: '123' },
+				logout,
+			} as unknown as ReturnType<typeof useUsersStore>);
+			const router = { push: vi.fn() } as unknown as Router;
+
+			await handleSessionExpired(router, ownBackendURL);
+			restoreNotificationSuppression();
+
+			expect(useNotificationsStore().areNotificationsSuppressed).toBe(false);
+		});
+
+		it("restores an embed's prior suppression setting instead of hardcoding it off", async () => {
+			useNotificationsStore().setNotificationsSuppressed(true, { allowErrors: true });
+
+			const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
+			vi.mocked(useUsersStore).mockReturnValue({
+				currentUser: { id: '123' },
+				logout,
+			} as unknown as ReturnType<typeof useUsersStore>);
+			const router = { push: vi.fn() } as unknown as Router;
+
+			await handleSessionExpired(router, ownBackendURL);
+			restoreNotificationSuppression();
+
+			const notificationsStore = useNotificationsStore();
+			expect(notificationsStore.areNotificationsSuppressed).toBe(true);
+			expect(notificationsStore.allowErrorNotificationsWhenSuppressed).toBe(true);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
@@ -1,9 +1,10 @@
 import { useNotificationsStore } from '@n8n/stores/notifications.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { createPinia, setActivePinia } from 'pinia';
-import type { Router } from 'vue-router';
+import type { Router, RouteLocationNormalizedLoaded } from 'vue-router';
 
 import { VIEWS } from '@/app/constants';
+import { useUIStore } from '@/app/stores/ui.store';
 import {
 	handleSessionExpired,
 	restoreNotificationSuppression,
@@ -14,8 +15,12 @@ vi.mock('@n8n/stores/users.store', () => ({
 	useUsersStore: vi.fn(),
 }));
 
-function createRouterMock(push = vi.fn(), fullPath = '/'): Router {
-	return { push, currentRoute: { value: { fullPath } } } as unknown as Router;
+function createRouterMock(
+	push = vi.fn(),
+	currentRoute: Partial<RouteLocationNormalizedLoaded> = { fullPath: '/' },
+	resolve = vi.fn(),
+): Router {
+	return { push, resolve, currentRoute: { value: currentRoute } } as unknown as Router;
 }
 
 describe('handleSessionExpired', () => {
@@ -63,7 +68,7 @@ describe('handleSessionExpired', () => {
 			logout,
 		} as unknown as ReturnType<typeof useUsersStore>);
 		const push = vi.fn();
-		const router = createRouterMock(push, '/workflow/1');
+		const router = createRouterMock(push, { fullPath: '/workflow/1' });
 
 		await handleSessionExpired(router, ownBackendURL);
 
@@ -71,6 +76,69 @@ describe('handleSessionExpired', () => {
 		expect(push).toHaveBeenCalledWith({
 			name: VIEWS.SIGNIN,
 			query: { redirect: encodeURIComponent('/workflow/1'), sessionExpired: 'true' },
+		});
+	});
+
+	it('drops the open node id from the redirect path when there are unsaved changes', async () => {
+		const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { id: '123' },
+			logout,
+		} as unknown as ReturnType<typeof useUsersStore>);
+		useUIStore().markStateDirty();
+
+		const push = vi.fn();
+		const resolve = vi.fn().mockReturnValue({ fullPath: '/workflow/1' });
+		const router = createRouterMock(
+			push,
+			{
+				fullPath: '/workflow/1/abc123',
+				name: VIEWS.WORKFLOW,
+				params: { workflowId: '1', nodeId: 'abc123' },
+				query: {},
+			},
+			resolve,
+		);
+
+		await handleSessionExpired(router, ownBackendURL);
+
+		expect(resolve).toHaveBeenCalledWith({
+			name: VIEWS.WORKFLOW,
+			params: { workflowId: '1', nodeId: undefined },
+			query: {},
+		});
+		expect(push).toHaveBeenCalledWith({
+			name: VIEWS.SIGNIN,
+			query: { redirect: encodeURIComponent('/workflow/1'), sessionExpired: 'true' },
+		});
+	});
+
+	it('keeps the open node id in the redirect path when there are no unsaved changes', async () => {
+		const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
+		vi.mocked(useUsersStore).mockReturnValue({
+			currentUser: { id: '123' },
+			logout,
+		} as unknown as ReturnType<typeof useUsersStore>);
+
+		const push = vi.fn();
+		const resolve = vi.fn();
+		const router = createRouterMock(
+			push,
+			{
+				fullPath: '/workflow/1/abc123',
+				name: VIEWS.WORKFLOW,
+				params: { workflowId: '1', nodeId: 'abc123' },
+				query: {},
+			},
+			resolve,
+		);
+
+		await handleSessionExpired(router, ownBackendURL);
+
+		expect(resolve).not.toHaveBeenCalled();
+		expect(push).toHaveBeenCalledWith({
+			name: VIEWS.SIGNIN,
+			query: { redirect: encodeURIComponent('/workflow/1/abc123'), sessionExpired: 'true' },
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
@@ -9,9 +9,9 @@ import {
 	resetSessionExpiredHandledFlag,
 	restoreNotificationSuppression,
 } from '@/app/utils/handleSessionExpired';
-import { useUsersStore } from '@/features/settings/users/users.store';
+import { useUsersStore } from '@n8n/stores/users.store';
 
-vi.mock('@/features/settings/users/users.store', () => ({
+vi.mock('@n8n/stores/users.store', () => ({
 	useUsersStore: vi.fn(),
 }));
 

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.test.ts
@@ -6,6 +6,7 @@ import type { Router } from 'vue-router';
 import { VIEWS } from '@/app/constants';
 import {
 	handleSessionExpired,
+	resetPriorSuppressionForTests,
 	resetSessionExpiredHandledFlag,
 	restoreNotificationSuppression,
 } from '@/app/utils/handleSessionExpired';
@@ -21,6 +22,7 @@ describe('handleSessionExpired', () => {
 	beforeEach(() => {
 		setActivePinia(createPinia());
 		resetSessionExpiredHandledFlag();
+		resetPriorSuppressionForTests();
 		ownBackendURL = useRootStore().restApiContext.baseUrl;
 	});
 
@@ -121,6 +123,12 @@ describe('handleSessionExpired', () => {
 	});
 
 	describe('restoreNotificationSuppression', () => {
+		it('no-ops to false when called without a session expiry ever having happened', () => {
+			restoreNotificationSuppression();
+
+			expect(useNotificationsStore().areNotificationsSuppressed).toBe(false);
+		});
+
 		it('restores suppression to false when nothing suppressed it before the expiry', async () => {
 			const logout = vi.fn().mockResolvedValue({ redirectUrl: null });
 			vi.mocked(useUsersStore).mockReturnValue({

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
@@ -40,7 +40,8 @@ export async function handleSessionExpired(router: Router, baseURL: string): Pro
 	}
 	sessionExpiryStore.markHandled();
 
-	useUIStore().closeAllModals();
+	const uiStore = useUIStore();
+	uiStore.closeAllModals();
 
 	// Set before any `await` so the triggering request's own toast is suppressed too.
 	const notificationsStore = useNotificationsStore();
@@ -50,7 +51,20 @@ export async function handleSessionExpired(router: Router, baseURL: string): Pro
 	});
 	notificationsStore.setNotificationsSuppressed(true);
 
-	const redirectPath = getSanitizedCurrentPath(router.currentRoute.value);
+	const currentRoute = router.currentRoute.value;
+
+	// Unsaved changes won't survive the redirect (the unsaved-changes prompt is skipped below via
+	// sessionExpiryStore.handled), so drop any open node id rather than restore a URL pointing at
+	// a node a fresh fetch of the workflow won't find.
+	const redirectRoute = uiStore.stateIsDirty
+		? router.resolve({
+				name: currentRoute.name,
+				params: { ...currentRoute.params, nodeId: undefined },
+				query: currentRoute.query,
+			})
+		: currentRoute;
+
+	const redirectPath = getSanitizedCurrentPath(redirectRoute);
 
 	try {
 		await usersStore.logout();

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
@@ -1,10 +1,10 @@
 import { useNotificationsStore } from '@n8n/stores/notifications.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
+import { useUsersStore } from '@n8n/stores/users.store';
 import type { Router } from 'vue-router';
 
 import { VIEWS } from '@/app/constants';
 import { getSanitizedCurrentPath } from '@/app/utils/urlUtils';
-import { useUsersStore } from '@/features/settings/users/users.store';
 
 let handled = false;
 

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
@@ -5,6 +5,7 @@ import type { Router } from 'vue-router';
 
 import { VIEWS } from '@/app/constants';
 import { useSessionExpiryStore } from '@/app/stores/sessionExpiry.store';
+import { useUIStore } from '@/app/stores/ui.store';
 import { getSanitizedCurrentPath } from '@/app/utils/urlUtils';
 
 // Called on successful login so a future expiry is handled again.
@@ -38,6 +39,8 @@ export async function handleSessionExpired(router: Router, baseURL: string): Pro
 		return;
 	}
 	sessionExpiryStore.markHandled();
+
+	useUIStore().closeAllModals();
 
 	// Set before any `await` so the triggering request's own toast is suppressed too.
 	const notificationsStore = useNotificationsStore();

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
@@ -47,7 +47,7 @@ export async function handleSessionExpired(router: Router, baseURL: string): Pro
 	});
 	notificationsStore.setNotificationsSuppressed(true);
 
-	const redirectPath = getSanitizedCurrentPath();
+	const redirectPath = getSanitizedCurrentPath(router.currentRoute.value);
 
 	try {
 		await usersStore.logout();

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
@@ -1,0 +1,60 @@
+import { useNotificationsStore } from '@n8n/stores/notifications.store';
+import { useRootStore } from '@n8n/stores/useRootStore';
+import type { Router } from 'vue-router';
+
+import { VIEWS } from '@/app/constants';
+import { getSanitizedCurrentPath } from '@/app/utils/urlUtils';
+import { useUsersStore } from '@/features/settings/users/users.store';
+
+let handled = false;
+
+// Captured pre-suppress so restoreNotificationSuppression() can restore it, not hardcode false.
+let priorSuppression: { suppressed: boolean; allowErrors: boolean } | undefined;
+
+// Called on successful login so a future expiry is handled again; also used by tests.
+export function resetSessionExpiredHandledFlag(): void {
+	handled = false;
+}
+
+// Called from SigninView.vue on a login attempt or on unmount; safe to call more than once.
+export function restoreNotificationSuppression(): void {
+	const notificationsStore = useNotificationsStore();
+	if (priorSuppression) {
+		notificationsStore.setNotificationsSuppressed(priorSuppression.suppressed, {
+			allowErrors: priorSuppression.allowErrors,
+		});
+	} else {
+		notificationsStore.setNotificationsSuppressed(false);
+	}
+}
+
+// currentUser excludes failed-login 401s; handled dedupes concurrent ones; baseURL excludes non-n8n hosts.
+export async function handleSessionExpired(router: Router, baseURL: string): Promise<void> {
+	const usersStore = useUsersStore();
+
+	if (handled || !usersStore.currentUser || baseURL !== useRootStore().restApiContext.baseUrl) {
+		return;
+	}
+	handled = true;
+
+	// Set before any `await` so the triggering request's own toast is suppressed too.
+	const notificationsStore = useNotificationsStore();
+	priorSuppression = {
+		suppressed: notificationsStore.areNotificationsSuppressed,
+		allowErrors: notificationsStore.allowErrorNotificationsWhenSuppressed,
+	};
+	notificationsStore.setNotificationsSuppressed(true);
+
+	const redirectPath = getSanitizedCurrentPath();
+
+	try {
+		await usersStore.logout();
+	} catch {
+		// Session is already invalid server-side; local cleanup still happens inside logout().
+	}
+
+	await router.push({
+		name: VIEWS.SIGNIN,
+		query: { redirect: encodeURIComponent(redirectPath), sessionExpired: 'true' },
+	});
+}

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
@@ -8,24 +8,6 @@ import { useSessionExpiryStore } from '@/app/stores/sessionExpiry.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { getSanitizedCurrentPath } from '@/app/utils/urlUtils';
 
-// Called on successful login so a future expiry is handled again.
-export function resetSessionExpiredHandledFlag(): void {
-	useSessionExpiryStore().resetHandled();
-}
-
-// Called from SigninView.vue on a login attempt or on unmount; safe to call more than once.
-export function restoreNotificationSuppression(): void {
-	const notificationsStore = useNotificationsStore();
-	const { priorSuppression } = useSessionExpiryStore();
-	if (priorSuppression) {
-		notificationsStore.setNotificationsSuppressed(priorSuppression.suppressed, {
-			allowErrors: priorSuppression.allowErrors,
-		});
-	} else {
-		notificationsStore.setNotificationsSuppressed(false);
-	}
-}
-
 // currentUser excludes failed-login 401s; handled dedupes concurrent ones; baseURL excludes non-n8n hosts.
 export async function handleSessionExpired(router: Router, baseURL: string): Promise<void> {
 	const usersStore = useUsersStore();
@@ -43,19 +25,14 @@ export async function handleSessionExpired(router: Router, baseURL: string): Pro
 	const uiStore = useUIStore();
 	uiStore.closeAllModals();
 
-	// Set before any `await` so the triggering request's own toast is suppressed too.
-	const notificationsStore = useNotificationsStore();
-	sessionExpiryStore.setPriorSuppression({
-		suppressed: notificationsStore.areNotificationsSuppressed,
-		allowErrors: notificationsStore.allowErrorNotificationsWhenSuppressed,
-	});
-	notificationsStore.setNotificationsSuppressed(true);
+	// Set before any `await` so the triggering request's own toast is suppressed too. The
+	// redirect below reloads the page, so there's nothing to restore this to afterwards.
+	useNotificationsStore().setNotificationsSuppressed(true);
 
 	const currentRoute = router.currentRoute.value;
 
-	// Unsaved changes won't survive the redirect (the unsaved-changes prompt is skipped below via
-	// sessionExpiryStore.handled), so drop any open node id rather than restore a URL pointing at
-	// a node a fresh fetch of the workflow won't find.
+	// Unsaved changes won't survive the redirect, so drop any open node id rather than restore a
+	// URL pointing at a node a fresh fetch of the workflow won't find.
 	const redirectRoute = uiStore.stateIsDirty
 		? router.resolve({
 				name: currentRoute.name,
@@ -72,8 +49,12 @@ export async function handleSessionExpired(router: Router, baseURL: string): Pro
 		// Session is already invalid server-side; local cleanup still happens inside logout().
 	}
 
-	await router.push({
+	// The session is already invalid server-side, so saving would fail anyway; skip the
+	// unsaved-changes confirmation and reload straight to sign-in, matching the explicit
+	// sign-out flow (SignoutView.vue).
+	window.preventNodeViewBeforeUnload = true;
+	window.location.href = router.resolve({
 		name: VIEWS.SIGNIN,
 		query: { redirect: encodeURIComponent(redirectPath), sessionExpired: 'true' },
-	});
+	}).href;
 }

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
@@ -4,25 +4,18 @@ import { useUsersStore } from '@n8n/stores/users.store';
 import type { Router } from 'vue-router';
 
 import { VIEWS } from '@/app/constants';
+import { useSessionExpiryStore } from '@/app/stores/sessionExpiry.store';
 import { getSanitizedCurrentPath } from '@/app/utils/urlUtils';
 
-let handled = false;
-
-// Captured pre-suppress so restoreNotificationSuppression() can restore it, not hardcode false.
-let priorSuppression: { suppressed: boolean; allowErrors: boolean } | undefined;
-
-// Called on successful login so a future expiry is handled again; also used by tests.
+// Called on successful login so a future expiry is handled again.
 export function resetSessionExpiredHandledFlag(): void {
-	handled = false;
-}
-
-export function resetPriorSuppressionForTests(): void {
-	priorSuppression = undefined;
+	useSessionExpiryStore().resetHandled();
 }
 
 // Called from SigninView.vue on a login attempt or on unmount; safe to call more than once.
 export function restoreNotificationSuppression(): void {
 	const notificationsStore = useNotificationsStore();
+	const { priorSuppression } = useSessionExpiryStore();
 	if (priorSuppression) {
 		notificationsStore.setNotificationsSuppressed(priorSuppression.suppressed, {
 			allowErrors: priorSuppression.allowErrors,
@@ -35,18 +28,23 @@ export function restoreNotificationSuppression(): void {
 // currentUser excludes failed-login 401s; handled dedupes concurrent ones; baseURL excludes non-n8n hosts.
 export async function handleSessionExpired(router: Router, baseURL: string): Promise<void> {
 	const usersStore = useUsersStore();
+	const sessionExpiryStore = useSessionExpiryStore();
 
-	if (handled || !usersStore.currentUser || baseURL !== useRootStore().restApiContext.baseUrl) {
+	if (
+		sessionExpiryStore.handled ||
+		!usersStore.currentUser ||
+		baseURL !== useRootStore().restApiContext.baseUrl
+	) {
 		return;
 	}
-	handled = true;
+	sessionExpiryStore.markHandled();
 
 	// Set before any `await` so the triggering request's own toast is suppressed too.
 	const notificationsStore = useNotificationsStore();
-	priorSuppression = {
+	sessionExpiryStore.setPriorSuppression({
 		suppressed: notificationsStore.areNotificationsSuppressed,
 		allowErrors: notificationsStore.allowErrorNotificationsWhenSuppressed,
-	};
+	});
 	notificationsStore.setNotificationsSuppressed(true);
 
 	const redirectPath = getSanitizedCurrentPath();

--- a/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
+++ b/packages/frontend/editor-ui/src/app/utils/handleSessionExpired.ts
@@ -16,6 +16,10 @@ export function resetSessionExpiredHandledFlag(): void {
 	handled = false;
 }
 
+export function resetPriorSuppressionForTests(): void {
+	priorSuppression = undefined;
+}
+
 // Called from SigninView.vue on a login attempt or on unmount; safe to call more than once.
 export function restoreNotificationSuppression(): void {
 	const notificationsStore = useNotificationsStore();

--- a/packages/frontend/editor-ui/src/app/utils/rbac/middleware/authenticated.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/rbac/middleware/authenticated.test.ts
@@ -20,7 +20,7 @@ describe('Middleware', () => {
 			>);
 
 			const nextMock = vi.fn();
-			const toMock = { query: {} } as RouteLocationNormalized;
+			const toMock = { query: {}, fullPath: '/' } as RouteLocationNormalized;
 			const fromMock = {} as RouteLocationNormalized;
 
 			await authenticatedMiddleware(toMock, fromMock, nextMock, {});
@@ -54,7 +54,7 @@ describe('Middleware', () => {
 			>);
 
 			const nextMock = vi.fn();
-			const toMock = { query: {} } as RouteLocationNormalized;
+			const toMock = { query: {}, fullPath: '/' } as RouteLocationNormalized;
 			const fromMock = {} as RouteLocationNormalized;
 
 			await authenticatedMiddleware(toMock, fromMock, nextMock, {});

--- a/packages/frontend/editor-ui/src/app/utils/rbac/middleware/authenticated.ts
+++ b/packages/frontend/editor-ui/src/app/utils/rbac/middleware/authenticated.ts
@@ -2,6 +2,7 @@ import type { RouterMiddleware } from '@/app/types/router';
 import { VIEWS } from '@/app/constants';
 import type { AuthenticatedPermissionOptions } from '@/app/types/rbac';
 import { isAuthenticated, shouldEnableMfa } from '@/app/utils/rbac/checks';
+import { getSanitizedCurrentPath } from '@/app/utils/urlUtils';
 
 export const authenticatedMiddleware: RouterMiddleware<AuthenticatedPermissionOptions> = async (
 	to,
@@ -9,11 +10,7 @@ export const authenticatedMiddleware: RouterMiddleware<AuthenticatedPermissionOp
 	next,
 	options,
 ) => {
-	// ensure that we are removing the already existing redirect query parameter
-	// to avoid infinite redirect loops
-	const url = new URL(window.location.href);
-	url.searchParams.delete('redirect');
-	const redirect = to.query.redirect ?? encodeURIComponent(`${url.pathname}${url.search}`);
+	const redirect = to.query.redirect ?? encodeURIComponent(getSanitizedCurrentPath());
 
 	const valid = isAuthenticated(options);
 	if (!valid) {

--- a/packages/frontend/editor-ui/src/app/utils/rbac/middleware/authenticated.ts
+++ b/packages/frontend/editor-ui/src/app/utils/rbac/middleware/authenticated.ts
@@ -10,7 +10,7 @@ export const authenticatedMiddleware: RouterMiddleware<AuthenticatedPermissionOp
 	next,
 	options,
 ) => {
-	const redirect = to.query.redirect ?? encodeURIComponent(getSanitizedCurrentPath());
+	const redirect = to.query.redirect ?? encodeURIComponent(getSanitizedCurrentPath(to));
 
 	const valid = isAuthenticated(options);
 	if (!valid) {

--- a/packages/frontend/editor-ui/src/app/utils/urlUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/urlUtils.test.ts
@@ -1,0 +1,21 @@
+import { getSanitizedCurrentPath } from '@/app/utils/urlUtils';
+
+describe('getSanitizedCurrentPath', () => {
+	it('returns the path and query as-is when there is no redirect param', () => {
+		expect(getSanitizedCurrentPath({ fullPath: '/workflow/1?tab=settings' })).toBe(
+			'/workflow/1?tab=settings',
+		);
+	});
+
+	it('strips an existing redirect param to avoid infinite-redirect nesting', () => {
+		expect(
+			getSanitizedCurrentPath({
+				fullPath: '/signin?redirect=%2Fworkflow%2F1&sessionExpired=true',
+			}),
+		).toBe('/signin?sessionExpired=true');
+	});
+
+	it('returns just the path when there is no query string', () => {
+		expect(getSanitizedCurrentPath({ fullPath: '/workflow/1' })).toBe('/workflow/1');
+	});
+});

--- a/packages/frontend/editor-ui/src/app/utils/urlUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/urlUtils.ts
@@ -1,6 +1,6 @@
 // Strips an existing `redirect` query param to avoid infinite-redirect nesting.
-export function getSanitizedCurrentPath(): string {
-	const url = new URL(window.location.href);
+export function getSanitizedCurrentPath(route: { fullPath: string }): string {
+	const url = new URL(route.fullPath, 'http://placeholder');
 	url.searchParams.delete('redirect');
 	return `${url.pathname}${url.search}`;
 }

--- a/packages/frontend/editor-ui/src/app/utils/urlUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/urlUtils.ts
@@ -1,0 +1,6 @@
+// Strips an existing `redirect` query param to avoid infinite-redirect nesting.
+export function getSanitizedCurrentPath(): string {
+	const url = new URL(window.location.href);
+	url.searchParams.delete('redirect');
+	return `${url.pathname}${url.search}`;
+}

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -130,6 +130,7 @@ import { useLogsStore } from '@/app/stores/logs.store';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import CanvasChatButton from '@/features/workflows/canvas/components/elements/buttons/CanvasChatButton.vue';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
+import { useSessionExpiryStore } from '@/app/stores/sessionExpiry.store';
 import { useEvaluationsWizardSidepanelStore } from '@/features/ai/evaluation.ee/wizardSidepanel.store';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
 import EvaluationsCanvasInfoCard from '@/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.vue';
@@ -205,6 +206,7 @@ const tagsStore = useTagsStore();
 
 const ndvStore = injectNDVStore();
 const focusPanelStore = useFocusPanelStore();
+const sessionExpiryStore = useSessionExpiryStore();
 const evaluationsWizardSidepanelStore = useEvaluationsWizardSidepanelStore();
 const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
@@ -1889,6 +1891,12 @@ onBeforeRouteLeave(async (to, from, next) => {
 	}
 
 	if (isReadOnlyEnvironment.value) {
+		next();
+		return;
+	}
+
+	// The session is already invalid server-side, so saving would fail anyway; let the redirect to sign-in through.
+	if (sessionExpiryStore.handled) {
 		next();
 		return;
 	}

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -130,7 +130,6 @@ import { useLogsStore } from '@/app/stores/logs.store';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import CanvasChatButton from '@/features/workflows/canvas/components/elements/buttons/CanvasChatButton.vue';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
-import { useSessionExpiryStore } from '@/app/stores/sessionExpiry.store';
 import { useEvaluationsWizardSidepanelStore } from '@/features/ai/evaluation.ee/wizardSidepanel.store';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
 import EvaluationsCanvasInfoCard from '@/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.vue';
@@ -206,7 +205,6 @@ const tagsStore = useTagsStore();
 
 const ndvStore = injectNDVStore();
 const focusPanelStore = useFocusPanelStore();
-const sessionExpiryStore = useSessionExpiryStore();
 const evaluationsWizardSidepanelStore = useEvaluationsWizardSidepanelStore();
 const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
@@ -1891,12 +1889,6 @@ onBeforeRouteLeave(async (to, from, next) => {
 	}
 
 	if (isReadOnlyEnvironment.value) {
-		next();
-		return;
-	}
-
-	// The session is already invalid server-side, so saving would fail anyway; let the redirect to sign-in through.
-	if (sessionExpiryStore.handled) {
 		next();
 		return;
 	}

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
@@ -44,13 +44,11 @@ vi.mock('@n8n/composables/useToast', () => ({
 	useToast: () => ({ showMessage, showError, clearAllStickyNotifications }),
 }));
 
-const { resetSessionExpiredHandledFlag, restoreNotificationSuppression } = vi.hoisted(() => ({
-	resetSessionExpiredHandledFlag: vi.fn(),
+const { restoreNotificationSuppression } = vi.hoisted(() => ({
 	restoreNotificationSuppression: vi.fn(),
 }));
 
 vi.mock('@/app/utils/handleSessionExpired', () => ({
-	resetSessionExpiredHandledFlag,
 	restoreNotificationSuppression,
 }));
 
@@ -157,12 +155,6 @@ describe('SigninView', () => {
 		await signInWithValidUser();
 
 		expect(restoreNotificationSuppression).toHaveBeenCalled();
-	});
-
-	it('should reset the session-expiry handled flag on successful login, so a future expiry can be handled again', async () => {
-		await signInWithValidUser();
-
-		expect(resetSessionExpiredHandledFlag).toHaveBeenCalled();
 	});
 
 	it('should restore notification suppression when leaving via a route other than a login attempt', () => {

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
@@ -7,6 +7,7 @@ import SigninView from './SigninView.vue';
 import { useUsersStore } from '@n8n/stores/users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
+import { useNotificationsStore } from '@n8n/stores/notifications.store';
 import { VIEWS } from '@/app/constants';
 
 vi.mock('vue-router', () => {
@@ -35,10 +36,29 @@ vi.mock('@n8n/composables/useTelemetry', () => {
 	};
 });
 
+const showMessage = vi.fn();
+const showError = vi.fn();
+const clearAllStickyNotifications = vi.fn();
+
+vi.mock('@n8n/composables/useToast', () => ({
+	useToast: () => ({ showMessage, showError, clearAllStickyNotifications }),
+}));
+
+const { resetSessionExpiredHandledFlag, restoreNotificationSuppression } = vi.hoisted(() => ({
+	resetSessionExpiredHandledFlag: vi.fn(),
+	restoreNotificationSuppression: vi.fn(),
+}));
+
+vi.mock('@/app/utils/handleSessionExpired', () => ({
+	resetSessionExpiredHandledFlag,
+	restoreNotificationSuppression,
+}));
+
 const renderComponent = createComponentRenderer(SigninView);
 
 let usersStore: ReturnType<typeof mockedStore<typeof useUsersStore>>;
 let settingsStore: ReturnType<typeof mockedStore<typeof useSettingsStore>>;
+let notificationsStore: ReturnType<typeof mockedStore<typeof useNotificationsStore>>;
 
 let router: ReturnType<typeof useRouter>;
 let telemetry: ReturnType<typeof useTelemetry>;
@@ -78,6 +98,7 @@ describe('SigninView', () => {
 		createTestingPinia();
 		usersStore = mockedStore(useUsersStore);
 		settingsStore = mockedStore(useSettingsStore);
+		notificationsStore = mockedStore(useNotificationsStore);
 
 		router = useRouter();
 		telemetry = useTelemetry();
@@ -89,6 +110,30 @@ describe('SigninView', () => {
 
 	it('should not throw error when opened', () => {
 		expect(() => renderComponent()).not.toThrow();
+	});
+
+	it('should show a session expired toast when the sessionExpired query parameter is set', () => {
+		const route = useRoute();
+		vi.spyOn(route, 'query', 'get').mockReturnValue({
+			redirect: '/home/workflows',
+			sessionExpired: 'true',
+		});
+
+		renderComponent();
+
+		expect(showMessage).toHaveBeenCalledWith({
+			title: 'Session expired',
+			message: 'Your session has expired. Please log in again to continue using n8n.',
+			type: 'info',
+		});
+		// Stepped around suppression to show this toast, then put it right back.
+		expect(notificationsStore.setNotificationsSuppressed.mock.calls).toEqual([[false], [true]]);
+	});
+
+	it('should not show a session expired toast when the sessionExpired query parameter is absent', () => {
+		renderComponent();
+
+		expect(showMessage).not.toHaveBeenCalled();
 	});
 
 	it('should show and submit email/password form (happy path)', async () => {
@@ -106,6 +151,26 @@ describe('SigninView', () => {
 		});
 
 		expect(router.push).toHaveBeenCalledWith('/home/workflows');
+	});
+
+	it('should restore notification suppression as soon as a login attempt is submitted', async () => {
+		await signInWithValidUser();
+
+		expect(restoreNotificationSuppression).toHaveBeenCalled();
+	});
+
+	it('should reset the session-expiry handled flag on successful login, so a future expiry can be handled again', async () => {
+		await signInWithValidUser();
+
+		expect(resetSessionExpiredHandledFlag).toHaveBeenCalled();
+	});
+
+	it('should restore notification suppression when leaving via a route other than a login attempt', () => {
+		const { unmount } = renderComponent();
+
+		unmount();
+
+		expect(restoreNotificationSuppression).toHaveBeenCalled();
 	});
 
 	describe('when redirect query parameter is set', () => {

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.test.ts
@@ -44,14 +44,6 @@ vi.mock('@n8n/composables/useToast', () => ({
 	useToast: () => ({ showMessage, showError, clearAllStickyNotifications }),
 }));
 
-const { restoreNotificationSuppression } = vi.hoisted(() => ({
-	restoreNotificationSuppression: vi.fn(),
-}));
-
-vi.mock('@/app/utils/handleSessionExpired', () => ({
-	restoreNotificationSuppression,
-}));
-
 const renderComponent = createComponentRenderer(SigninView);
 
 let usersStore: ReturnType<typeof mockedStore<typeof useUsersStore>>;
@@ -151,18 +143,18 @@ describe('SigninView', () => {
 		expect(router.push).toHaveBeenCalledWith('/home/workflows');
 	});
 
-	it('should restore notification suppression as soon as a login attempt is submitted', async () => {
+	it('should unsuppress notifications as soon as a login attempt is submitted', async () => {
 		await signInWithValidUser();
 
-		expect(restoreNotificationSuppression).toHaveBeenCalled();
+		expect(notificationsStore.setNotificationsSuppressed).toHaveBeenCalledWith(false);
 	});
 
-	it('should restore notification suppression when leaving via a route other than a login attempt', () => {
+	it('should unsuppress notifications when leaving via a route other than a login attempt', () => {
 		const { unmount } = renderComponent();
 
 		unmount();
 
-		expect(restoreNotificationSuppression).toHaveBeenCalled();
+		expect(notificationsStore.setNotificationsSuppressed).toHaveBeenCalledWith(false);
 	});
 
 	describe('when redirect query parameter is set', () => {

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
+import { computed, onMounted, onUnmounted, reactive, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 import AuthView from './AuthView.vue';
@@ -8,10 +8,15 @@ import MfaView from './MfaView.vue';
 import { useToast } from '@n8n/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
+import { useNotificationsStore } from '@n8n/stores/notifications.store';
 
 import { useUsersStore } from '@n8n/stores/users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSSOStore } from '@/features/settings/sso/sso.store';
+import {
+	resetSessionExpiredHandledFlag,
+	restoreNotificationSuppression,
+} from '@/app/utils/handleSessionExpired';
 
 import type { IFormBoxConfig } from '@/Interface';
 import { MFA_AUTHENTICATION_REQUIRED_ERROR_CODE, VIEWS, MFA_FORM } from '@/app/constants';
@@ -40,6 +45,26 @@ const showMfaView = ref(false);
 const emailOrLdapLoginId = ref('');
 const password = ref('');
 const reportError = ref(false);
+
+onMounted(() => {
+	if (route.query.sessionExpired !== 'true') {
+		return;
+	}
+
+	const notificationsStore = useNotificationsStore();
+	notificationsStore.setNotificationsSuppressed(false);
+	toast.showMessage({
+		title: locale.baseText('auth.signin.sessionExpired.title'),
+		message: locale.baseText('auth.signin.sessionExpired'),
+		type: 'info',
+	});
+	notificationsStore.setNotificationsSuppressed(true);
+});
+
+// Covers leaving via e.g. "Forgot password", which login() below never sees.
+onUnmounted(() => {
+	restoreNotificationSuppression();
+});
 
 const ldapLoginLabel = computed(() => ssoStore.ldapLoginLabel);
 const isLdapLoginEnabled = computed(() => ssoStore.isLdapLoginEnabled);
@@ -125,6 +150,7 @@ const getRedirectQueryParameter = () => {
 };
 
 const login = async (form: LoginRequestDto) => {
+	restoreNotificationSuppression();
 	try {
 		loading.value = true;
 		await usersStore.loginWithCreds({
@@ -134,6 +160,8 @@ const login = async (form: LoginRequestDto) => {
 			mfaRecoveryCode: form.mfaRecoveryCode,
 		});
 		loading.value = false;
+		// Before getSettings(), which can independently fail with correct credentials.
+		resetSessionExpiredHandledFlag();
 		await settingsStore.getSettings();
 
 		toast.clearAllStickyNotifications();

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
@@ -13,7 +13,6 @@ import { useNotificationsStore } from '@n8n/stores/notifications.store';
 import { useUsersStore } from '@n8n/stores/users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSSOStore } from '@/features/settings/sso/sso.store';
-import { restoreNotificationSuppression } from '@/app/utils/handleSessionExpired';
 
 import type { IFormBoxConfig } from '@/Interface';
 import { MFA_AUTHENTICATION_REQUIRED_ERROR_CODE, VIEWS, MFA_FORM } from '@/app/constants';
@@ -43,12 +42,13 @@ const emailOrLdapLoginId = ref('');
 const password = ref('');
 const reportError = ref(false);
 
+const notificationsStore = useNotificationsStore();
+
 onMounted(() => {
 	if (route.query.sessionExpired !== 'true') {
 		return;
 	}
 
-	const notificationsStore = useNotificationsStore();
 	notificationsStore.setNotificationsSuppressed(false);
 	toast.showMessage({
 		title: locale.baseText('auth.signin.sessionExpired.title'),
@@ -60,7 +60,7 @@ onMounted(() => {
 
 // Covers leaving via e.g. "Forgot password", which login() below never sees.
 onUnmounted(() => {
-	restoreNotificationSuppression();
+	notificationsStore.setNotificationsSuppressed(false);
 });
 
 const ldapLoginLabel = computed(() => ssoStore.ldapLoginLabel);
@@ -147,7 +147,7 @@ const getRedirectQueryParameter = () => {
 };
 
 const login = async (form: LoginRequestDto) => {
-	restoreNotificationSuppression();
+	notificationsStore.setNotificationsSuppressed(false);
 	try {
 		loading.value = true;
 		await usersStore.loginWithCreds({

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SigninView.vue
@@ -13,10 +13,7 @@ import { useNotificationsStore } from '@n8n/stores/notifications.store';
 import { useUsersStore } from '@n8n/stores/users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSSOStore } from '@/features/settings/sso/sso.store';
-import {
-	resetSessionExpiredHandledFlag,
-	restoreNotificationSuppression,
-} from '@/app/utils/handleSessionExpired';
+import { restoreNotificationSuppression } from '@/app/utils/handleSessionExpired';
 
 import type { IFormBoxConfig } from '@/Interface';
 import { MFA_AUTHENTICATION_REQUIRED_ERROR_CODE, VIEWS, MFA_FORM } from '@/app/constants';
@@ -160,8 +157,6 @@ const login = async (form: LoginRequestDto) => {
 			mfaRecoveryCode: form.mfaRecoveryCode,
 		});
 		loading.value = false;
-		// Before getSettings(), which can independently fail with correct credentials.
-		resetSessionExpiredHandledFlag();
 		await settingsStore.getSettings();
 
 		toast.clearAllStickyNotifications();


### PR DESCRIPTION
## Summary

When a user's session expires (auth cookie/token invalidated) while they're already on a page, n8n never detected it. The UI kept showing stale, previously loaded content, and any further interaction just produced a raw, ambiguous "Unauthorized" toast instead of prompting re-authentication.

Adds a global 401 handler: The app logs the user out, redirects to the sign-in screen with a friendly "Your session has expired. Please log in again to continue using n8n." message.

Also fixes two related issues found along the way:
- logout() now only silently treats a 401 from the logout call itself as "already signed out"; a genuine network/server error during sign-out still surfaces its error toast instead of being swallowed.
- Per-user data (projects, roles) is now correctly re-fetched on the next login in the same tab, since this is the first logout path that doesn't do a full page reload.

## How to test

Main flow:
1. Log in, navigate to a workflow or the workflows list.
2. Open DevTools → Application → Cookies → delete the n8n-auth cookie (simulates the session dying server-side, without reloading the page).
3. Trigger any request, click a workflow, save, or wait for autosave/polling.
4. Expect: redirect to /signin, a "Session expired" toast, and no raw "Error fetching workflows: Unauthorized"-style toast.
5. Log back in → should land back on the same page you were on.

Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-691

Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. (conventions)
- [ ] Docs updated or follow-up ticket created.
- [X] Tests included.
- [X] PR Labeled with Backport to Beta, Backport to Stable, or Backport to v1 (if the PR is an urgent fix that needs to be backported)