### PR TITLE
test: Point the global-credential HTTP node at an in-network n8n URL

### DIFF
--- a/packages/testing/containers/stack.ts
+++ b/packages/testing/containers/stack.ts
@@ -39,6 +39,12 @@ export interface N8NStack {
 	stopContainer: (namePattern: string | RegExp) => Promise<StoppedTestContainer | null>;
 	/** Direct URLs to each main instance (bypasses load balancer). Index 0 = main-1, etc. */
 	mainUrls: string[];
+	/**
+	 * Same mains addressed by their network alias, for callers running *inside* the
+	 * stack's network — e.g. an HTTP Request node executed by a worker container,
+	 * which cannot reach the host-mapped ports in `baseUrl`/`mainUrls`.
+	 */
+	internalMainUrls: string[];
 	startupDiagnostics: N8NStartupDiagnostics;
 }
 
@@ -245,14 +251,18 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 
 		ctx.baseUrl = baseUrl;
 
-		// Build direct main URLs (bypassing load balancer)
+		// Build direct main URLs (bypassing load balancer). `mainUrls` are host-mapped
+		// and only reachable from the test process; `internalMainUrls` use the network
+		// alias and are what other containers (workers running a node) must dial.
 		const mainUrls: string[] = [];
+		const internalMainUrls: string[] = [];
 		for (let i = 1; i <= mains; i++) {
-			const mainNamePattern = mains > 1 ? `-n8n-main-${i}` : '-n8n';
-			const mainContainer = containers.find((c) => c.getName().endsWith(mainNamePattern));
+			const mainNameSuffix = mains > 1 ? `-n8n-main-${i}` : '-n8n';
+			const mainContainer = containers.find((c) => c.getName().endsWith(mainNameSuffix));
 			if (mainContainer) {
 				const mainPort = mainContainer.getMappedPort(5678);
 				mainUrls.push(`http://localhost:${mainPort}`);
+				internalMainUrls.push(`http://${uniqueProjectName}${mainNameSuffix}:5678`);
 			}
 		}
 		log(`Direct main URLs: ${mainUrls.join(', ')}`);
@@ -339,6 +349,7 @@ export async function createN8NStack(config: N8NConfig = {}): Promise<N8NStack> 
 				return container ? await container.stop() : null;
 			},
 			mainUrls,
+			internalMainUrls,
 			startupDiagnostics: n8nResult.diagnostics,
 		};
 	} catch (error) {

--- a/packages/testing/playwright/fixtures/base.ts
+++ b/packages/testing/playwright/fixtures/base.ts
@@ -51,6 +51,7 @@ type WorkerFixtures = {
 	n8nUrl: string;
 	backendUrl: string;
 	frontendUrl: string;
+	internalUrl: string;
 	dbSetup: undefined;
 	n8nStackConfig: N8NConfig;
 	n8nContainer: N8NStack;
@@ -171,6 +172,18 @@ export const test = base.extend<
 		async ({ n8nContainer }, use) => {
 			const envFrontendURL = getFrontendUrl() ?? n8nContainer?.baseUrl;
 			await use(envFrontendURL);
+		},
+		{ scope: 'worker' },
+	],
+
+	// The n8n URL as seen from *inside* the stack, for specs that make n8n itself
+	// call it (an HTTP Request node, a webhook destination). Under container
+	// projects the node runs in a main or worker container, where the host-mapped
+	// `backendUrl` port does not exist - use the network alias instead. Locally
+	// there are no containers and n8n shares the host's loopback, so they match.
+	internalUrl: [
+		async ({ n8nContainer, backendUrl }, use) => {
+			await use(n8nContainer?.internalMainUrls[0] ?? backendUrl);
 		},
 		{ scope: 'worker' },
 	],

--- a/packages/testing/playwright/tests/e2e/credentials/global.spec.ts
+++ b/packages/testing/playwright/tests/e2e/credentials/global.spec.ts
@@ -66,7 +66,7 @@ test.describe(
 
 		test('member should execute workflow with HTTP node using global credential', async ({
 			n8n,
-			baseURL,
+			internalUrl,
 		}) => {
 			await n8n.api.signin('member', 0);
 
@@ -78,7 +78,9 @@ test.describe(
 			await n8n.canvas.addNode('Manual Trigger');
 			await n8n.canvas.addNode('HTTP Request');
 
-			await n8n.ndv.fillParameterInput('URL', `${baseURL}/rest/settings`);
+			// n8n calls this URL, not the browser, so it must resolve from inside the
+			// stack - under container projects the request leaves a worker container.
+			await n8n.ndv.fillParameterInput('URL', `${internalUrl}/rest/settings`);
 			await n8n.ndv.selectOptionInParameterDropdown('authentication', 'Generic Credential Type');
 			await n8n.ndv.selectOptionInParameterDropdown('genericAuthType', 'Header Auth');
 


### PR DESCRIPTION
## Summary

`[multi-main:e2e] › tests/e2e/credentials/global.spec.ts:67` has been red on every branch that runs it. It is not a timeout problem and not a multi-main push regression — the workflow the spec executes genuinely **fails**, so the `Workflow executed successfully` toast never arrives.

`global.spec.ts:81` fed the test context's `baseURL` into an HTTP Request node parameter. `baseURL` is the host-mapped load balancer port (`http://localhost:35099` in the run below), but the node's request is issued by **n8n**, not the browser. Under container projects `multi-main` sets `workers: 1` → `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true`, so the request leaves a worker container where that host port does not exist:

> **Problem in node ‘HTTP Request’** — The service refused the connection - perhaps it is offline

This is the only place in the e2e suite that passes `baseURL` into a node parameter. It works locally (`test:local`) because n8n runs on the host and shares the browser's loopback — the failure is container-only.

### Why it surfaced on 2026-08-04

It didn't start failing; it *stopped passing silently*. Before #35325 (`cdd6a737f`, 08:03 UTC) `waitForNotificationAndClose` returned `false` on timeout, and `WorkflowComposer.executeWorkflowAndWaitForNotification` discarded the return value — so the assertion could not fail. Same branch, same spec, same `[multi-main:e2e]` project:

| run | commit | contains `cdd6a737f` | result |
|---|---|---|---|
| [30887121143](https://github.com/n8n-io/n8n/actions/runs/30887121143) 07:28 UTC | `7d3a2b5` | no (11 behind) | ✅ **passed, 11.4s** |
| [30894053150](https://github.com/n8n-io/n8n/actions/runs/30894053150) 09:41 UTC | `f11fc00` | yes | ❌ **failed, 11.3s** |

Identical duration, identical product behaviour. #35325 was right; it just uncovered a spec that had been asserting nothing.

The `timeout = 3000` default at `WorkflowComposer.ts:19` (which silently overrides `NotificationsPage`'s own `5000` across ~40 call sites) is a real harness wart, but it is **not** the cause here and is deliberately left alone so this PR's CI result is unambiguous.

## Changes

- `N8NStack.internalMainUrls` — the mains addressed by their network alias (`http://<project>-n8n-main-1:5678`), alongside the existing host-mapped `mainUrls`.
- `internalUrl` worker fixture — resolves to that in-network URL under container projects, and falls back to `backendUrl` when no containers are involved, so local runs are unchanged.
- `global.spec.ts` uses it.

## How to test

```bash
pnpm --filter=n8n-playwright test:container:multi-main:e2e tests/e2e/credentials/global.spec.ts
```

Expected: `member should execute workflow with HTTP node using global credential` passes, with the HTTP Request node reaching `/rest/settings` instead of erroring.

⚠️ **Not verified locally — no Docker daemon in the authoring environment.** Everything runnable without containers is green: playwright unit tests (39/39), `eslint` and `biome ci` on all three files, `janitor` (0 new violations), and `tsc --noEmit` with zero new errors. **This PR's own `multi-main:e2e` run is the verification** — please read it before merging.

## Related

Filed from N8N-171. Verified against runs [30894053150](https://github.com/n8n-io/n8n/actions/runs/30894053150) and [30897310336](https://github.com/n8n-io/n8n/actions/runs/30897310336).

Not fixed here — the other `[multi-main:e2e]` failure in the same window, `tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts:81`, is a different mechanism (`expect(getPreviewRunWorkflowButton()).toBeVisible()` → *element(s) not found*, `@capability:proxy`, 36.8s). It needs its own issue; it does not share a root cause with this one.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. <!-- This PR repairs the test that was asserting nothing. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

