### PR TITLE
test: Assert debug mode pinned data with a retrying check

### DIFF
--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -956,6 +956,10 @@ export class CanvasPage extends BasePage {
 		return this.nodeByName(nodeName).getByTestId('canvas-node-status-warning');
 	}
 
+	getNodePinnedStatusIndicator(nodeName: string): Locator {
+		return this.nodeByName(nodeName).getByTestId('canvas-node-status-pinned');
+	}
+
 	getNodeRunningStatusIndicator(nodeName: string): Locator {
 		return this.page.locator(
 			`[data-test-id="canvas-node"][data-node-name="${nodeName}"].running, [data-test-id="canvas-node"][data-node-name="${nodeName}"].waiting`,

--- a/packages/testing/playwright/tests/e2e/workflows/editor/execution/debug.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/execution/debug.spec.ts
@@ -51,7 +51,12 @@ test.describe(
 			// import pins the trigger's data, and the autosave that follows ~1.5s after
 			// routes straight back out of /debug.
 			await n8n.page.waitForURL(/\/debug/);
-			await n8n.notifications.waitForNotificationAndClose(NOTIFICATIONS.EXECUTION_IMPORTED);
+			// The route change lands before the import fetches the execution, so give the
+			// toast the same headroom the runs get: CI runs one n8n instance for as many
+			// workers as there are cores.
+			await n8n.notifications.waitForNotificationAndClose(NOTIFICATIONS.EXECUTION_IMPORTED, {
+				timeout: 10_000,
+			});
 		}
 
 		test('should enter debug mode for failed executions', async ({ n8n }) => {
@@ -64,8 +69,11 @@ test.describe(
 				{ timeout: 10_000 },
 			);
 			await importLastExecutionForDebugging(n8n);
-			// The execution's data is now pinned onto the editor's canvas
-			expect(await n8n.canvas.getPinnedNodeNames()).toContain(FAILING_WORKFLOW_TRIGGER);
+			// The execution's data is now pinned onto the editor's canvas. Asserted on the
+			// badge rather than a one-shot read of every pinned name: the autosave that
+			// follows the import re-renders the canvas, so a snapshot taken mid-render can
+			// miss the node that was just pinned.
+			await expect(n8n.canvas.getNodePinnedStatusIndicator(FAILING_WORKFLOW_TRIGGER)).toBeVisible();
 		});
 
 		test('should exit debug mode after successful execution', async ({ n8n }) => {


### PR DESCRIPTION
## Summary

`Debug mode > should enter debug mode for failed executions` was quarantined in Currents (CAT-3931). The main causes were already addressed by #35203, which landed shortly after the quarantine ticket was filed. On top of that fix, two latent races remained in the spec:

- **The final assertion was not retrying.** `expect(await n8n.canvas.getPinnedNodeNames()).toContain(...)` reads every pinned node name once. Importing an execution pins the trigger's data and marks the state dirty, so the autosave that follows re-renders the canvas; a snapshot taken mid-render can miss the node that was just pinned. It now asserts on that node's pinned badge via a new `getNodePinnedStatusIndicator()` locator on `CanvasPage`, so Playwright retries.
- **The import toast had the default 5s budget.** The `/debug` route change lands before `applyExecutionData()` fetches the execution, so that wait covers a REST round trip. The two workflow runs in the same test already get 10s; the toast now gets the same headroom.

I could not reproduce a failure on current master, so this is hardening rather than a confirmed root-cause fix.

Note: lifting the quarantine is a Currents-side action (action `6a71b3ecd36c55cb6a6526fc`, expires 2026-08-11). The test stays skipped on forks via the quarantine webhook list until someone with Currents access unquarantines it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3931

Follows up on #35203.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

🤖 PR Summary generated by AI