### PR TITLE
fix(editor): Focus Markdown editor input before toolbar

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.vue
@@ -134,15 +134,6 @@ defineExpose({
 		:style="maxHeightStyle"
 		data-test-id="n8n-markdown-editor"
 	>
-		<MarkdownEditorToolbar
-			v-if="shouldShowToolbar && editor"
-			:editor="editor"
-			:disabled="props.disabled || props.readonly"
-			:is-raw-mode="isRawMode"
-			:mode="toolbarMode"
-			:variant="props.variant"
-			@update:is-raw-mode="toggleRawMode"
-		/>
 		<div v-if="isRawMode" :class="[$style.content, shouldPadContentTop ? $style.padTop : '']">
 			<textarea
 				ref="rawEditor"
@@ -162,6 +153,15 @@ defineExpose({
 			v-else
 			:editor="editor"
 			:class="[$style.content, shouldPadContentTop ? $style.padTop : '']"
+		/>
+		<MarkdownEditorToolbar
+			v-if="shouldShowToolbar && editor"
+			:editor="editor"
+			:disabled="props.disabled || props.readonly"
+			:is-raw-mode="isRawMode"
+			:mode="toolbarMode"
+			:variant="props.variant"
+			@update:is-raw-mode="toggleRawMode"
 		/>
 	</div>
 </template>


### PR DESCRIPTION
## Summary

Moves the `N8nMarkdownEditor` toolbar after the editor content in the DOM so keyboard navigation focuses the markdown input before the toolbar controls.

https://github.com/user-attachments/assets/8b18742c-27a7-476f-92dd-112b9bde97c9

## How to test

1. Open a view containing an editable `N8nMarkdownEditor` with its toolbar visible.
2. Focus the element immediately before the editor.
3. Press Tab.
4. Verify focus enters the markdown input before moving through the toolbar controls.
5. Repeat in raw mode and verify focus enters the textarea first.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-605

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)