### PR TITLE
docs(ai-builder): Add the scrub recipe for seeded eval cases (no-changelog)

### DIFF
--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -104,7 +104,7 @@ case can still assert outcome), but the primary shape drives the work.
 | **Build** (default) | Does the workflow the agent builds actually *work*? | `outcomeExpectations` + `executionScenarios` |
 | **Behaviour / process** | Does the agent *converse* correctly (ask the right clarifying question, not re-ask, honour a correction, respect plan approval)? | `processExpectations` + multi-turn director script; often **build-only** |
 | **Credential** | Does the build behave correctly given a specific credential view? | `credentials[]` |
-| **Seeded** | Reproduce a conversation mid-thread and drive the turn under test | `seed` (`mode: "inline"` or `"replay"`) |
+| **Seeded** | Start mid-thread, with prior work already in place, and drive the turn under test | `seed` (authored `mode: "inline"`; `"replay"` for a local check) |
 
 **Build** is documented in full below. The other three, the director-script
 vocabulary, and the seeding modes are in [`case-shapes.md`](case-shapes.md).

--- a/.agents/skills/create-instance-ai-eval/case-shapes.md
+++ b/.agents/skills/create-instance-ai-eval/case-shapes.md
@@ -394,8 +394,10 @@ costs keep it a last resort, not a default:
   instance. The most sensitive parts are removed first — data-table row values are
   kept out and redacted from the history, node credentials stripped — but that pass
   can't be assumed exhaustive, so treat what comes back as potentially personal data
-  and follow your team's data-handling policy. Scrubbing it into an `inline` seed is
-  how that concern goes away for good.
+  and follow your team's data-handling policy. Cleanup deletes the thread, workflows
+  and tables when the build finishes, though it is best-effort: a crashed run can
+  leave them on the instance. Scrubbing the workflow into an `inline` seed is how the
+  whole concern goes away for good.
 - **Transience.** It depends on LangSmith trace retention (~14 days); the case
   stops running once the source trace ages out (tag it `seeded`, keep it out of
   `full`/`pr`).

--- a/.agents/skills/create-instance-ai-eval/case-shapes.md
+++ b/.agents/skills/create-instance-ai-eval/case-shapes.md
@@ -345,19 +345,19 @@ assertion: two credentials with one scripted invalid should show exactly `1`.
 
 ## Seeded cases (start mid-conversation)
 
-A seeded case restores prior history into the build thread *before* the live
-turn, so the eval drives only the turn under test. Use it to reproduce a real
-situation — a conversation up to some point, then a message that should trigger
-(or correct) a behaviour.
+A seeded case puts prior history into the build thread *before* the live turn, so
+the eval drives only the turn under test. Use it to set up the situation you want
+to test — history up to some point, then a message that should trigger (or
+correct) a behaviour.
 
 Pick the lightest mode that fits:
 
 | Situation | Mode | Pairs with |
 |---|---|---|
-| Reproduce a real conversation (common case) | `seed.mode: "replay"` — fetch + reconstruct its LangSmith trace at run time; nothing committed | supplies its own live turn (omit `conversation`) |
 | Prior work already exists (a workflow to repair) | `seed.mode: "inline"` — prior messages + the workflows they reference, in the case body | a normal `conversation` for the live turn |
 | Prelude is just "what was discussed" (no tool calls, no workflows) | `seed.mode: "inline"` with `{role, text}` shorthand messages | a normal `conversation` for the live turn |
 | Shallow 2–3 turn prelude where the agent's live replies matter | none — a plain multi-turn `conversation` re-drives it live | — |
+| Confirming a real failure locally, before authoring the case | `seed.mode: "replay"` — rebuilds a thread from its LangSmith trace at run time; nothing committed, expires with the trace | supplies its own live turn (omit `conversation`) |
 
 Both modes are implemented and wired (`harness/conversation-seed.ts` +
 `harness/langsmith-seed.ts`, threaded through the runner). The literals match
@@ -365,13 +365,12 @@ lang-tracer's `metadata.seed` verbatim, so nothing translates between the repos.
 
 ### What the seed does — and does not — exercise
 
-**The seeded portion is restored, not re-run.** The message log is written into
-the thread verbatim (marked `seeded: true` so the judge and checks can tell it
-apart), and the workflows and data tables the history references are **recreated
-on the instance** — so when the live turn runs, the agent sees the same
-workspace the original conversation left behind. Data tables are recreated
-**schema-only, no rows** (row values are the most sensitive part of a trace and
-are kept out of the eval instance).
+**The seeded portion is replayed, not re-run.** The prior messages are written into
+the thread as they stand (marked `seeded: true` so the judge and checks can tell
+them apart), and the workflows and data tables they reference are **created on the
+instance** — so when the live turn runs, the agent sees the workspace the case says
+it should. Data tables are created **schema-only, no rows**: row values are the most
+sensitive thing a table holds, and they stay off the eval instance.
 
 The consequence to internalise: **nothing you assert can change what already
 happened in the seeded turns** — the agent didn't produce them, it's only
@@ -391,18 +390,19 @@ the issue is in a *later* turn. (A turn-0 issue can't be isolated by seeding: it
 lands inside the seed, so you'd bake the bug into the prelude.) Two standing
 costs keep it a last resort, not a default:
 
-- **Data handling.** It recreates a real conversation on the eval instance. The
-  most sensitive content is scrubbed first — data-table row values are kept out
-  and redacted from the restored history, node credentials stripped — but that
-  isn't guaranteed exhaustive, so treat reproduced content as if it may carry
-  user data and follow your team's data-handling policy.
+- **Data handling.** A replay stands someone's own conversation up on the eval
+  instance. The most sensitive parts are removed first — data-table row values are
+  kept out and redacted from the history, node credentials stripped — but that pass
+  can't be assumed exhaustive, so treat what comes back as potentially personal data
+  and follow your team's data-handling policy. Scrubbing it into an `inline` seed is
+  how that concern goes away for good.
 - **Transience.** It depends on LangSmith trace retention (~14 days); the case
   stops running once the source trace ages out (tag it `seeded`, keep it out of
   `full`/`pr`).
 
 If a plain prompt + director script can reproduce the situation, prefer that.
 
-### `mode: "replay"` — reproduce a real conversation
+### `mode: "replay"` — rebuild a thread for a local run
 
 ```json
 "seed": { "mode": "replay", "threadId": "<thread-id>", "project": "instance-ai" }
@@ -416,13 +416,11 @@ sent live. `project` defaults to `instance-ai`. Optional `endpoint` pins a
 US-tenant source host during the US→EU migration; optional `liveTurnRunId` pins
 which user turn goes live.
 
-- **Cross-workspace, zero config.** A prod thread can be reproduced in a staging
+- **Cross-workspace, zero config.** A production thread can be replayed in a staging
   eval — the harness enumerates the workspaces your `LANGSMITH_API_KEY` can reach
   and finds the one holding the thread. It only *reads* the source; the eval
-  writes its own traces/datasets to its own workspace. Reproducing a real thread
-  recreates its conversation on the eval instance; the most sensitive content is
-  scrubbed first (see the data-handling note above), and it's still worth
-  handling per your team's data policy.
+  writes its own traces/datasets to its own workspace. What it rebuilds still lands
+  on the eval instance, so the data-handling note above applies.
 - **Continue past the live turn.** Add a `conversation` to keep driving after the
   trace's last message replays (first authored turn = expected assistant reply as
   proxy reference; subsequent `user` turns become follow-ups). Omit it to replay

--- a/.agents/skills/create-instance-ai-eval/sourcing-cases.md
+++ b/.agents/skills/create-instance-ai-eval/sourcing-cases.md
@@ -93,9 +93,13 @@ Identifying data hides in more places than the obvious ones:
   `Acme Corp`.
 - **The earlier messages you seed alongside it** — someone's own wording, their name,
   their employer, links they pasted. Write those turns yourself, in a user's voice.
-- **Recorded tool calls, if you keep any** — the builder's own code and the results it
-  got back contain everything above. Keep only the calls the story needs, and only the
-  parts of their output that matter.
+- **Recorded tool calls, if you keep any.** Measured on a real thread, this is where
+  the leaks actually were — the workflow was clean, while the outputs of
+  `workflows[list]` / `get` / `get-as-code` and `data-tables[list]` carried a live
+  credential id, the project id, the person's entire workflow inventory, table schemas
+  down to every column name, and a webhook id. Each `toolCallId` also carries the
+  source run id. Read the messages: a regex pass over that seed caught one category out
+  of about eight.
 
 Provenance is the one thing worth keeping: note the source thread id in the case's
 `description` so anyone can find the original later. An id points at the conversation
@@ -163,10 +167,13 @@ the reference to another node and the parameter names don't.
 "headerParameters": { "parameters": [{ "name": "X-Api-Key", "value": "sk_test_placeholder" }] }
 ```
 
-**Trim as you go.** The seed is one field on the case, with a 256KB ceiling: drop
-`load_skill` bodies and any tool output the story doesn't need. If you keep a
-build-workflow call, its `output.workflowId` has to match a workflow the seed
-declares — see [`case-shapes.md`](case-shapes.md).
+**Trim as you go.** The seed is one field on the case, with a 256KB ceiling —
+`load_skill` bodies alone can account for most of it. Trimming has a rule of its own:
+**keep the shape here too.** Filtering a list output changes what the agent believes
+exists, and a `{ "note": "…" }` where a result belongs invents a shape no tool ever
+returns. Shortening the text inside a block is fine; to get rid of a call, drop the
+whole tool-call block. If you keep a build-workflow call, its `output.workflowId` has
+to match a workflow the seed declares — see [`case-shapes.md`](case-shapes.md).
 
 ### Three easy mistakes
 

--- a/.agents/skills/create-instance-ai-eval/sourcing-cases.md
+++ b/.agents/skills/create-instance-ai-eval/sourcing-cases.md
@@ -87,11 +87,19 @@ Identifying data hides in more places than the obvious ones:
   credential, so nothing strips it for you.
 - **Free text inside the workflow** — sticky notes and node notes, string literals in
   a Code node, sample rows in a Set node. Sample rows are often real records.
+- **The workflow's own name**, which often carries a company or a person
+  ("Acme lead sync", "Chase invoices — Dana"). This repo is public, so a real
+  customer's name must not appear anywhere in a case; use a placeholder like
+  `Acme Corp`.
 - **The earlier messages you seed alongside it** — someone's own wording, their name,
   their employer, links they pasted. Write those turns yourself, in a user's voice.
 - **Recorded tool calls, if you keep any** — the builder's own code and the results it
   got back contain everything above. Keep only the calls the story needs, and only the
   parts of their output that matter.
+
+Provenance is the one thing worth keeping: note the source thread id in the case's
+`description` so anyone can find the original later. An id points at the conversation
+without carrying any of it.
 
 ### Which version of the workflow to start from
 
@@ -113,9 +121,11 @@ ended the thread in.
   `workflows[get]` call whose input mentions that id.
 - **Nothing was stored.** Older threads pre-date this being kept at all, and the read
   says so in a `note` rather than returning an empty list. An empty answer never means
-  "there was no workflow". Write the stand-in yourself: the simplest set of nodes that
-  can still show the problem. There's then no original to compare against, so the
-  before-you-ship checks are the only safety net left.
+  "there was no workflow". Two ways out: replay the thread locally and take the
+  workflow the harness rebuilds from the trace (see below), or write the stand-in
+  yourself — the simplest set of nodes that can still show the problem. Hand-authored,
+  there's no original to compare against, so the before-you-ship checks are the only
+  safety net left.
 
 ### What to keep, and what to replace
 
@@ -139,6 +149,19 @@ That's not only about readability:
   Anything under 8 characters is rejected outright, and a short id that squeaks
   through is exactly how you end up rewriting unrelated text that happens to contain
   it.
+
+On one node that comes out as: the host, the id and the key change; the expression,
+the reference to another node and the parameter names don't.
+
+```jsonc
+// before
+"url": "=https://acme-internal.example/v2/orders/{{ $('Get order').item.json.orderId }}",
+"headerParameters": { "parameters": [{ "name": "X-Api-Key", "value": "sk_live_9f2c8b…" }] }
+
+// after
+"url": "=https://api.example.com/v2/orders/{{ $('Get order').item.json.orderId }}",
+"headerParameters": { "parameters": [{ "name": "X-Api-Key", "value": "sk_test_placeholder" }] }
+```
 
 **Trim as you go.** The seed is one field on the case, with a 256KB ceiling: drop
 `load_skill` bodies and any tool output the story doesn't need. If you keep a

--- a/.agents/skills/create-instance-ai-eval/sourcing-cases.md
+++ b/.agents/skills/create-instance-ai-eval/sourcing-cases.md
@@ -1,17 +1,24 @@
-# Sourcing cases from real failures (LangTracer + LangSmith)
+# Sourcing cases from real conversations (LangTracer + LangSmith)
 
-The strongest cases encode a **real** failure, not an invented premise. Two
-connections help you find one and confirm it — and neither is usually the
-durable artifact. You author a synthetic case from what you learn (reach for
-`seed.mode: "replay"` only per [`case-shapes.md`](case-shapes.md)).
+The strongest cases encode a **real** failure, not an invented premise. But the
+case you keep is always one you **wrote**: a real thread tells you what to test,
+and you author the case — prompt, workflow, seed and all — from what you learned.
+That is what makes the committed fixture durable and free of anyone's personal
+data. The [scrub recipe](#scrubbing-a-real-workflow-into-a-synthetic-seed) below is
+that path, and it's the default.
 
-- **LangTracer — discover.** It ingests real Instance AI conversations and
-  clusters them into **capability-gap themes** ("what fails, at scale"), and
-  stores each analysed conversation. Use it to find high-frequency real failures
-  worth encoding, instead of guessing a failure mode.
-- **LangSmith — verify.** Eval runs and prod conversations land in LangSmith as
-  raw traces. When a finding or a flaky result is ambiguous, read the raw trace
-  to confirm exactly what happened — which tool calls fired, and their payloads.
+Replaying a thread at run time (`seed.mode: "replay"`) is a **secondary mode**: a
+local check that the failure is real, not something to commit. See
+[Replaying a thread first](#replaying-a-thread-first-the-secondary-mode).
+
+Two connections make either possible:
+
+- **LangTracer — discover.** It analyses Instance AI conversations and clusters
+  them into **capability-gap themes** ("what fails, at scale"). Use it to find
+  high-frequency real failures worth encoding, instead of guessing a failure mode.
+- **LangSmith — verify.** Eval runs and production conversations land in LangSmith
+  as traces. When a finding or a flaky result is ambiguous, read the trace to
+  confirm what happened — which tool calls fired, and their payloads.
 
 ## Connect the LangTracer MCP
 
@@ -204,6 +211,21 @@ You don't need to do these by hand:
   node definitions or recorded tool calls.
 
 Everything else in the seed is yours to check.
+
+### Replaying a thread first (the secondary mode)
+
+Scrubbing takes work, and sometimes you want to know the failure is real before you
+put that work in. That's what `seed.mode: "replay"` is for: give it a thread id and
+the harness rebuilds the conversation from its trace at run time, then drives the
+turn you care about. Nothing about the thread lands in the repo — the case holds only
+the id.
+
+Treat it as a local check, not a case. The trace it depends on ages out in about two
+weeks, so a committed replay case stops working; and it stands up someone's real
+conversation on the eval instance, which is exactly what scrubbing exists to avoid.
+So run it, confirm the failure, then scrub the workflow it hands you into a seeded
+case that will still be there next quarter. Details and limits in
+[`case-shapes.md`](case-shapes.md).
 
 ## Sourcing a regression baseline (successful builds)
 

--- a/.agents/skills/create-instance-ai-eval/sourcing-cases.md
+++ b/.agents/skills/create-instance-ai-eval/sourcing-cases.md
@@ -64,121 +64,146 @@ connected.)
 
 ## Scrubbing a real workflow into a synthetic seed
 
-A reviewed real conversation becomes a durable `inline` seed by being scrubbed
-**once, at authoring time, with a human reading it** — that is what makes the
-committed artifact synthetic by construction, with no run-time gate to trust.
-Nothing downstream saves you: the harness strips node credentials on restore and
-never seeds data-table rows, but message text, tool-call bodies, node parameters and
-sticky notes are restored **verbatim**. What you paste is what runs.
+A seeded case carries a workflow inside it, and that file is committed and runs for
+as long as the case lives. So the workflow has to be **written, not copied**: read
+the real one, then author a stand-in that keeps its technical shape and none of its
+personal data. One careful pass, with a person reading it, and the committed fixture
+is clean from the start — nothing further down the line will clean it up for you.
 
-### Get the pre-anchor workflow
+### What to look for
 
-Scrub the state the live turn opened on — the last build **before** your anchor turn,
-not the thread's final state.
+Identifying data hides in more places than the obvious ones:
 
-- **The agent built it.** `list_conversation_workflow_builds` returns one row per
-  workflow per turn with `seq` / `turnRunId`, so you can identify that pre-anchor
-  build; `get_conversation_workflow_build` then returns its content. Read
-  `contentStatus` — about one SDK-source build in five stored no JSON, so coverage is
-  not a given: `stored-json` is ready to scrub, `compilable-source` means the recorded
-  SDK source survived whole and compiles with
-  [`parseSeedWorkflowCode`](../../../packages/@n8n/instance-ai/evaluations/harness/parse-seed-workflow.ts),
-  and `unrecoverable` / `unrecoverable-intermediate` have nothing to give. **Never
-  substitute a later final build** — that is a different workflow state, and the case
-  would test the repair rather than the defect.
-- **The user brought it.** The editor handed the workflow over and the agent resolved
-  it by id, so the workflow is the *output* of the `workflows[get]` call whose input
-  carries that id.
-- **Nothing recoverable.** A thread imported before build persistence existed has no
-  rows at all, and the read says so in a `note` rather than returning an empty list —
-  an empty answer is never "the user had no workflow". Hand-author the smallest
-  topology that can exhibit the complaint instead. The scrub rule below then has
-  nothing to diff against, so the pre-ship checks carry the whole load.
+- **Parameters** — email addresses, phone numbers, channel names, folder paths,
+  spreadsheet / document / table ids, internal hostnames, and any token someone
+  pasted into a header or a query string. A token sitting in a parameter is not a
+  credential, so nothing strips it for you.
+- **Free text inside the workflow** — sticky notes and node notes, string literals in
+  a Code node, sample rows in a Set node. Sample rows are often real records.
+- **The earlier messages you seed alongside it** — someone's own wording, their name,
+  their employer, links they pasted. Write those turns yourself, in a user's voice.
+- **Recorded tool calls, if you keep any** — the builder's own code and the results it
+  got back contain everything above. Keep only the calls the story needs, and only the
+  parts of their output that matter.
 
-### The rule: scrub values, never shape
+### Which version of the workflow to start from
 
-| Must survive untouched — this *is* the test | Fair to replace |
+Take the workflow as it stood when the turn you're testing began, not the state it
+ended the thread in.
+
+- **The assistant built it.** `list_conversation_workflow_builds` lists each build
+  with a `seq` and `turnRunId`, so you can find the one just before your turn, and
+  `get_conversation_workflow_build` returns it. Its `contentStatus` says what you
+  actually get: `stored-json` is ready to work with; `compilable-source` means only
+  the builder's code was kept, which
+  [`parseSeedWorkflowCode`](../../../packages/@n8n/instance-ai/evaluations/harness/parse-seed-workflow.ts)
+  turns back into a workflow; `unrecoverable` and `unrecoverable-intermediate` mean
+  there is nothing to read. About one build in five has no stored JSON, so don't
+  assume. And don't reach for a **later** build instead — that one is the workflow
+  after the fix, so the case would test the repair rather than the problem.
+- **The person already had it.** When the editor hands a workflow to the assistant,
+  the assistant looks it up by id — so the workflow you want is the *result* of the
+  `workflows[get]` call whose input mentions that id.
+- **Nothing was stored.** Older threads pre-date this being kept at all, and the read
+  says so in a `note` rather than returning an empty list. An empty answer never means
+  "there was no workflow". Write the stand-in yourself: the simplest set of nodes that
+  can still show the problem. There's then no original to compare against, so the
+  before-you-ship checks are the only safety net left.
+
+### What to keep, and what to replace
+
+Keep the technical shape, since that is what the case tests. Replace the values that
+point at a real person, company or account.
+
+| Keep exactly as it is | Safe to replace |
 |---|---|
 | node `type` and `typeVersion` | URLs, hostnames, webhook paths |
-| `connections` topology, and the node `name`s that key it | emails, person names, channel names |
-| parameter *keys*, and expression structure (`={{ $json.url }}`, `$('Prepare rows')`) | spreadsheet / document / data-table ids |
-| structural values: `batchSize`, `resource` / `operation` / `mode`, condition shape | sticky notes, node notes, Code-node literals, sample data |
+| how the nodes are wired (`connections`), and the node names it refers to | email addresses, people's names, channel names |
+| parameter names, and the shape of an expression (`={{ $json.url }}`, `$('Prepare rows')`) | spreadsheet / document / data-table ids |
+| settings that change behaviour: `batchSize`, `resource` / `operation` / `mode`, the shape of a condition | sticky notes, node notes, Code-node text, sample data |
 
-**Replace type-preserving** — a URL stays a URL, an id keeps its shape and length.
-Two reasons beyond readability. Restore validates every node (`id`, `name`, `type`,
-numeric `typeVersion`, a two-number `position`, an object `parameters`) and refuses
-the whole seed if one is missing, so don't drop fields while you are in there. And
-the id remaps are blind whole-document `replaceAll`s: seed workflow and data-table
-ids under 8 characters are refused outright, and a short-but-legal token is precisely
-how you rewrite an unrelated substring.
+**Swap like for like** — a URL stays a URL, an id keeps the same look and length.
+That's not only about readability:
 
-**Trim while you scrub.** The seed is one case field — drop `load_skill` bodies and
-any tool output the history doesn't need (the storage ceiling is 256KB serialized).
-Keep the tool-call blocks the story needs, and keep each one's `output.workflowId`
-matching a workflow the seed declares, per [`case-shapes.md`](case-shapes.md).
+- Loading a seed checks every node for `id`, `name`, `type`, a numeric `typeVersion`,
+  a two-number `position` and a `parameters` object, and rejects the whole seed if one
+  is missing. So don't delete fields while you're in there.
+- Ids get swapped for fresh ones by a plain search-and-replace across the seed.
+  Anything under 8 characters is rejected outright, and a short id that squeaks
+  through is exactly how you end up rewriting unrelated text that happens to contain
+  it.
 
-### Three traps
+**Trim as you go.** The seed is one field on the case, with a 256KB ceiling: drop
+`load_skill` bodies and any tool output the story doesn't need. If you keep a
+build-workflow call, its `output.workflowId` has to match a workflow the seed
+declares — see [`case-shapes.md`](case-shapes.md).
 
-**Node names are references.** A rename has to reach every `connections` key, every
-`$('Old Name')` in an expression, and every mention inside recorded SDK source and
-prose — miss one and the workflow silently breaks, which is the over-scrub that makes
-the eval pointless. Default to **not renaming**; a node name is rarely identifying on
-its own. If you must, `grep -c 'Old Name' <case>.json` has to return 0. (Seeded
-*workflow* names are rewritten per run by the harness, which deliberately leaves node
-names and tool-call payloads alone for the same reason — and refuses two seeded
-workflows that share a name, because the rewrite can't tell which mention means
-which.)
+### Three easy mistakes
 
-**Sometimes the value IS the test.** `queue.fal.run` is load-bearing in
-`http-keep-generic-credential-unknown-service`: the case exists because that host has
-no dedicated n8n credential, so swapping it for a household hostname grades the
-opposite steering. Same for the guessed column identifiers in
-`flags-unverified-sql-identifiers`. Expectations also quote values — "posts to
-`#growth`", a specific model name — so a replacement has to land in both places, or
-be hedged the way the corpus hedges values that aren't the point ("an unset or
-placeholder value is acceptable — it's a value to fill in at setup, not a build
-mistake"). Scrubbing safely means knowing what the case asserts, which is why this is
-a human step and not a blind pass.
+**Renaming a node.** A node's name is how the rest of the workflow points at it — the
+wiring is keyed by name, and expressions call it by name (`$('Old Name')`). It can
+also turn up in recorded builder code and in the prose. Miss one reference and the
+workflow quietly stops working, which is the kind of over-cleaning that leaves the
+case testing nothing. Node names are rarely identifying on their own, so the default
+is to leave them be. If you do rename one, `grep -c 'Old Name' <case>.json` should
+come back 0. (Workflow names are a different story: each run gets its own copy with a
+`[seed …]` suffix, and a seed declaring two workflows with the same name is refused,
+because there's no way to tell which one a mention refers to.)
 
-**`typeVersion` is not tidying.** Split In Batches v2 declares
-`outputNames: ['loop', 'done']`; v3 declares `['done', 'loop']`. Same two outputs,
-opposite meaning — so "modernizing" a seeded node's version silently rewires the loop
-while the topology stays byte-identical. Leave every version at what the conversation
-had.
+**Replacing the value the case is about.** In
+`http-keep-generic-credential-unknown-service`, the host `queue.fal.run` matters
+precisely because n8n has no built-in credential for it — swap in a well-known host
+and the case tests the opposite thing. Same with the invented column names in
+`flags-unverified-sql-identifiers`. Expectations quote values too ("posts to
+`#growth`", a particular model name), so a replacement has to be made in both places,
+or the expectation loosened the way others already are for values that don't matter
+("an unset or placeholder value is acceptable — it's something to fill in at setup,
+not a build mistake"). Knowing what the case asserts is part of scrubbing it, which
+is why this is a person's job and not a script's.
 
-### The check: only string leaves moved
+**Tidying up a node's version.** Split In Batches v2 lists its outputs as
+`['loop', 'done']`; v3 lists them as `['done', 'loop']`. Same two outputs, opposite
+meaning — so bumping the version quietly sends the loop the other way while the wiring
+still looks untouched. Leave versions as the conversation had them.
 
-Diff the `workflowJson` you started from against the workflow you authored into the
-case:
+### Check that only values changed
+
+Compare the JSON you started from with the workflow you put in the case:
 
 ```bash
 leaves() { jq -r '{nodes,connections} | paths(scalars) as $p | "\($p|map(tostring)|join("."))\t\(getpath($p)|tojson)"' | sort; }
 diff <(leaves < original-workflow.json) <(jq '.seed.workflows[0]' <case>.json | leaves)
 ```
 
-Every line in the diff must be a value you replaced on purpose. A `type`,
-`typeVersion`, `connections.*` or structural-parameter line means you moved shape
-rather than values; a path on one side only means you dropped or added a leaf.
-Non-graph keys (`settings`, `meta`, `pinData`) are ignored, so a raw build JSON
-compares cleanly against the trimmed seed workflow. This is the third of
-[Before you ship a seeded case](case-shapes.md#before-you-ship-a-seeded-case--three-checks);
-the other two — the defect still bites, and the case fails without the seed — are what
-catch a scrub that kept the shape and lost the point.
+`leaves` prints one line per value in the file, so the diff is a plain list of what
+you changed. Every line should be a value you meant to replace. A line mentioning
+`type`, `typeVersion`, `connections` or a behaviour setting means the shape moved, not
+just the values; a line on one side only means something was added or dropped. Keys
+that aren't part of the graph (`settings`, `meta`, `pinData`) are ignored, so the
+original compares cleanly against the trimmed version.
+
+This is the third of
+[Before you ship a seeded case](case-shapes.md#before-you-ship-a-seeded-case--three-checks).
+The other two — the problem is still there, and the case fails without the seed — are
+what catch a clean-up that kept the shape but lost the point.
 
 ### What the harness already handles
 
-Don't redo these by hand:
+You don't need to do these by hand:
 
-- **Node credentials are stripped on restore.** The case's `credentials[]` plus the
-  thread's credential pin own that view, and a credential's display name goes with it.
-- **Data tables are schema-only, always.** The seed schema has no `rows` field, and a
-  `rows` key is refused rather than stripped — so row values, the most sensitive part
-  of a trace, cannot ride along by accident.
-- **Ids and workflow names are per-run.** Seeded workflow ids are remapped and names
-  take a `[seed <8hex>]` suffix, with mentions rewritten in prose and `workflowName`
-  fields — but not inside `workflows[].nodes` or tool-call payloads.
+- **Credential references on nodes are dropped as the seed loads.** The case's own
+  `credentials[]` decides what the assistant can see, and a credential's display name
+  goes with the reference.
+- **Data tables are columns only.** The seed format has no place for rows, and a
+  `rows` key is rejected rather than quietly removed — so table contents can't come
+  along by accident.
+- **A seed workflow is only `id`, `name`, `nodes` and `connections`.** Pinned example
+  data, instance metadata and settings never travel.
+- **Ids and workflow names are per run.** Ids are replaced with fresh ones and names
+  get a `[seed <8hex>]` suffix, with mentions updated in the prose — though not inside
+  node definitions or recorded tool calls.
 
-Everything else in the seed is yours to sanitise.
+Everything else in the seed is yours to check.
 
 ## Sourcing a regression baseline (successful builds)
 

--- a/.agents/skills/create-instance-ai-eval/sourcing-cases.md
+++ b/.agents/skills/create-instance-ai-eval/sourcing-cases.md
@@ -62,6 +62,124 @@ connected.)
    its trace is pruned or deleted — so it has no durable home; that's exactly why
    step 4 turns the confirmed failure into a durable synthetic case.
 
+## Scrubbing a real workflow into a synthetic seed
+
+A reviewed real conversation becomes a durable `inline` seed by being scrubbed
+**once, at authoring time, with a human reading it** — that is what makes the
+committed artifact synthetic by construction, with no run-time gate to trust.
+Nothing downstream saves you: the harness strips node credentials on restore and
+never seeds data-table rows, but message text, tool-call bodies, node parameters and
+sticky notes are restored **verbatim**. What you paste is what runs.
+
+### Get the pre-anchor workflow
+
+Scrub the state the live turn opened on — the last build **before** your anchor turn,
+not the thread's final state.
+
+- **The agent built it.** `list_conversation_workflow_builds` returns one row per
+  workflow per turn with `seq` / `turnRunId`, so you can identify that pre-anchor
+  build; `get_conversation_workflow_build` then returns its content. Read
+  `contentStatus` — about one SDK-source build in five stored no JSON, so coverage is
+  not a given: `stored-json` is ready to scrub, `compilable-source` means the recorded
+  SDK source survived whole and compiles with
+  [`parseSeedWorkflowCode`](../../../packages/@n8n/instance-ai/evaluations/harness/parse-seed-workflow.ts),
+  and `unrecoverable` / `unrecoverable-intermediate` have nothing to give. **Never
+  substitute a later final build** — that is a different workflow state, and the case
+  would test the repair rather than the defect.
+- **The user brought it.** The editor handed the workflow over and the agent resolved
+  it by id, so the workflow is the *output* of the `workflows[get]` call whose input
+  carries that id.
+- **Nothing recoverable.** A thread imported before build persistence existed has no
+  rows at all, and the read says so in a `note` rather than returning an empty list —
+  an empty answer is never "the user had no workflow". Hand-author the smallest
+  topology that can exhibit the complaint instead. The scrub rule below then has
+  nothing to diff against, so the pre-ship checks carry the whole load.
+
+### The rule: scrub values, never shape
+
+| Must survive untouched — this *is* the test | Fair to replace |
+|---|---|
+| node `type` and `typeVersion` | URLs, hostnames, webhook paths |
+| `connections` topology, and the node `name`s that key it | emails, person names, channel names |
+| parameter *keys*, and expression structure (`={{ $json.url }}`, `$('Prepare rows')`) | spreadsheet / document / data-table ids |
+| structural values: `batchSize`, `resource` / `operation` / `mode`, condition shape | sticky notes, node notes, Code-node literals, sample data |
+
+**Replace type-preserving** — a URL stays a URL, an id keeps its shape and length.
+Two reasons beyond readability. Restore validates every node (`id`, `name`, `type`,
+numeric `typeVersion`, a two-number `position`, an object `parameters`) and refuses
+the whole seed if one is missing, so don't drop fields while you are in there. And
+the id remaps are blind whole-document `replaceAll`s: seed workflow and data-table
+ids under 8 characters are refused outright, and a short-but-legal token is precisely
+how you rewrite an unrelated substring.
+
+**Trim while you scrub.** The seed is one case field — drop `load_skill` bodies and
+any tool output the history doesn't need (the storage ceiling is 256KB serialized).
+Keep the tool-call blocks the story needs, and keep each one's `output.workflowId`
+matching a workflow the seed declares, per [`case-shapes.md`](case-shapes.md).
+
+### Three traps
+
+**Node names are references.** A rename has to reach every `connections` key, every
+`$('Old Name')` in an expression, and every mention inside recorded SDK source and
+prose — miss one and the workflow silently breaks, which is the over-scrub that makes
+the eval pointless. Default to **not renaming**; a node name is rarely identifying on
+its own. If you must, `grep -c 'Old Name' <case>.json` has to return 0. (Seeded
+*workflow* names are rewritten per run by the harness, which deliberately leaves node
+names and tool-call payloads alone for the same reason — and refuses two seeded
+workflows that share a name, because the rewrite can't tell which mention means
+which.)
+
+**Sometimes the value IS the test.** `queue.fal.run` is load-bearing in
+`http-keep-generic-credential-unknown-service`: the case exists because that host has
+no dedicated n8n credential, so swapping it for a household hostname grades the
+opposite steering. Same for the guessed column identifiers in
+`flags-unverified-sql-identifiers`. Expectations also quote values — "posts to
+`#growth`", a specific model name — so a replacement has to land in both places, or
+be hedged the way the corpus hedges values that aren't the point ("an unset or
+placeholder value is acceptable — it's a value to fill in at setup, not a build
+mistake"). Scrubbing safely means knowing what the case asserts, which is why this is
+a human step and not a blind pass.
+
+**`typeVersion` is not tidying.** Split In Batches v2 declares
+`outputNames: ['loop', 'done']`; v3 declares `['done', 'loop']`. Same two outputs,
+opposite meaning — so "modernizing" a seeded node's version silently rewires the loop
+while the topology stays byte-identical. Leave every version at what the conversation
+had.
+
+### The check: only string leaves moved
+
+Diff the `workflowJson` you started from against the workflow you authored into the
+case:
+
+```bash
+leaves() { jq -r '{nodes,connections} | paths(scalars) as $p | "\($p|map(tostring)|join("."))\t\(getpath($p)|tojson)"' | sort; }
+diff <(leaves < original-workflow.json) <(jq '.seed.workflows[0]' <case>.json | leaves)
+```
+
+Every line in the diff must be a value you replaced on purpose. A `type`,
+`typeVersion`, `connections.*` or structural-parameter line means you moved shape
+rather than values; a path on one side only means you dropped or added a leaf.
+Non-graph keys (`settings`, `meta`, `pinData`) are ignored, so a raw build JSON
+compares cleanly against the trimmed seed workflow. This is the third of
+[Before you ship a seeded case](case-shapes.md#before-you-ship-a-seeded-case--three-checks);
+the other two — the defect still bites, and the case fails without the seed — are what
+catch a scrub that kept the shape and lost the point.
+
+### What the harness already handles
+
+Don't redo these by hand:
+
+- **Node credentials are stripped on restore.** The case's `credentials[]` plus the
+  thread's credential pin own that view, and a credential's display name goes with it.
+- **Data tables are schema-only, always.** The seed schema has no `rows` field, and a
+  `rows` key is refused rather than stripped — so row values, the most sensitive part
+  of a trace, cannot ride along by accident.
+- **Ids and workflow names are per-run.** Seeded workflow ids are remapped and names
+  take a `[seed <8hex>]` suffix, with mentions rewritten in prose and `workflowName`
+  fields — but not inside `workflows[].nodes` or tool-call payloads.
+
+Everything else in the seed is yours to sanitise.
+
 ## Sourcing a regression baseline (successful builds)
 
 The discover→verify→encode flow above hunts **failures**. The complementary need


### PR DESCRIPTION
## Summary

The seeding docs still read as if replaying a real thread were the normal way to build a seeded case. It isn't — it's the fallback: it needs a live LangSmith trace, and it stands someone's own conversation up on the eval instance. The durable path is to read the real thread and **author** the case, which is only safe if the workflow inside it has been scrubbed properly. There was no guidance on how to do that.

**`sourcing-cases.md` — new section, "Scrubbing a real workflow into a synthetic seed":**

- Where identifying data hides in a workflow: parameters (addresses, ids, internal hostnames, a token pasted into a header — which is *not* a credential, so nothing strips it), sticky notes and node notes, Code-node text, sample rows, the workflow's own name, the messages seeded alongside it, and recorded tool calls.
- Which version of the workflow to start from — the state the tested turn opened on — and what to do when nothing was stored.
- What must survive untouched (node `type`/`typeVersion`, wiring, expression shape, behaviour settings like `batchSize`) versus what is safe to replace, with a before/after on one node's parameters.
- Three easy mistakes: renaming a node (its name is how everything else points at it), replacing the value the case is actually about, and "tidying" a node's version — Split In Batches v2 lists its outputs as `['loop','done']` and v3 as `['done','loop']`, so a version bump quietly sends the loop the other way.
- One runnable `jq` check that only string values moved.
- What the harness already handles (credential references dropped, tables columns-only, ids and names per run), so nobody hand-rolls it.

**Reframing, so the authored seed is the default:** the file intro leads with it, replay is documented as the local check that precedes it, and the mode table in `case-shapes.md` no longer labels replay "the common case". Wording that read like we reproduce user conversations wholesale is softened, and the data-handling note now says plainly what a replay puts on the eval instance and that cleanup is best-effort.

## How to test

Docs only. The `jq` check was run against a real seeded case's workflow: a value-only scrub yields a clean diff, while a `typeVersion` bump, an expression flattened to a literal, a node rename, and a changed behaviour setting each show up as expected.

Two notes for reviewers:

- One link points at "Before you ship a seeded case" in `case-shapes.md`, which lands in #35304 — merging that first makes the anchor resolve.
- The workflow-build reads the recipe names (`list_conversation_workflow_builds`) are lang-tracer#116, still in review.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-363

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- Docs-only change; the jq check in the section was verified by hand against a real case fixture. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

