### PR TITLE
fix(core): Keep n8n-docs always loaded so n8n questions do not route to web search

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/__tests__/instance-agent.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/instance-agent.test.ts
@@ -66,6 +66,7 @@ vi.mock('../../tools', () => ({
 				['workflows', mockBuiltTool(`workflows-${context.runLabel ?? 'unknown'}`)],
 				['evals', mockBuiltTool(`evals-${context.runLabel ?? 'unknown'}`)],
 				['research', mockBuiltTool(`research-${context.runLabel ?? 'unknown'}`)],
+				['n8n-docs', mockBuiltTool(`n8n-docs-${context.runLabel ?? 'unknown'}`)],
 				['nodes', mockBuiltTool(`nodes-${context.runLabel ?? 'unknown'}`)],
 				['executions', mockBuiltTool(`executions-${context.runLabel ?? 'unknown'}`)],
 				['build-workflow', mockBuiltTool(`build-workflow-${context.runLabel ?? 'unknown'}`)],
@@ -288,6 +289,39 @@ describe('createInstanceAgent', () => {
 			expect(attachedTools[scopedName]).toMatchObject({ name: scopedName });
 			expect(deferredTools[scopedName]).toBeUndefined();
 		}
+	});
+
+	// INS-749: `research` (web-search) is always loaded while `n8n-docs` used to be
+	// deferred, so answering an n8n question from n8n's own docs cost a search_tools +
+	// load_tool round trip that web search did not. That price gap pushed the agent to
+	// web-search things the docs already answer.
+	it('keeps n8n-docs always loaded so it is no costlier to reach than web search', async () => {
+		await createInstanceAgent({
+			modelId: 'test-model',
+			context: {
+				runLabel: 'docs-parity-run',
+				localGatewayStatus: undefined,
+				licenseHints: undefined,
+				localMcpServer: undefined,
+			},
+			orchestrationContext: {
+				runId: 'docs-parity-run',
+			},
+			memoryConfig: {},
+			mcpManager: createMcpManagerStub(),
+		} as never);
+
+		const attachedTools = getAttachedTools();
+		const deferredTools = getDeferredTools();
+
+		expect(attachedTools['n8n-docs-docs-parity-run']).toMatchObject({
+			name: 'n8n-docs-docs-parity-run',
+		});
+		expect(deferredTools['n8n-docs-docs-parity-run']).toBeUndefined();
+		// Parity is the point: both routes must be one call away.
+		expect(attachedTools['research-docs-parity-run']).toMatchObject({
+			name: 'research-docs-parity-run',
+		});
 	});
 
 	it('attaches the orchestration workspace when provided', async () => {

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.discovery.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.discovery.test.ts
@@ -167,6 +167,29 @@ describe('getSystemPrompt — browser/computer-use discoverability', () => {
 		});
 	});
 
+	// INS-749: n8n-docs is always loaded now, so telling the orchestrator to
+	// discover it via search_tools is both wrong and a nudge away from the tool
+	// it should reach for first on n8n questions.
+	describe('n8n-docs is presented as already available, not as something to discover', () => {
+		// The Tool Discovery section only renders with tool search on, which is where
+		// the stale "search for n8n docs" example lived.
+		const toolSearchOptions = { ...browserCapableOptions, toolSearchEnabled: true };
+
+		it('does not offer n8n docs as a search_tools discovery example', () => {
+			const prompt = getSystemPrompt(toolSearchOptions);
+
+			expect(prompt).toContain('## Tool Discovery');
+			expect(prompt).not.toMatch(/search "n8n docs"/i);
+		});
+
+		it('tells the orchestrator to answer n8n questions from n8n-docs rather than web search', () => {
+			const prompt = getSystemPrompt(toolSearchOptions);
+
+			expect(prompt).toMatch(/prefer[^.]{0,60}n8n-docs/i);
+			expect(prompt).toMatch(/n8n-docs[^.]{0,120}already (loaded|available)/i);
+		});
+	});
+
 	describe('browser availability state propagates to the prompt', () => {
 		it('includes browser automation rules when browser is available', () => {
 			const prompt = getSystemPrompt({

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -65,7 +65,9 @@ function getToolDiscoverySection(
 
 ${mcpSearchGuidance}When the available tools do not cover the user's request, remember that you have access to more tools. Use \`search_tools\` with keyword queries to find relevant tools, then \`load_tool\` to activate them. Loaded tools persist for the rest of the conversation. When a loaded skill names a tool you do not see, search for that tool name and load it before proceeding.
 
-Examples: ${mcpExamples}search "n8n docs" for \`n8n-docs\`, search "create tasks" for \`create-tasks\`, search "eval" for \`evals\`.
+Examples: ${mcpExamples}search "create tasks" for \`create-tasks\`, search "eval" for \`evals\`.
+
+For questions about n8n itself — how a node behaves, the shape of its output, what a parameter does, product semantics — prefer \`n8n-docs\` and the node type definitions, both already loaded and needing no search, over web search, which is for third-party services and APIs.
 `;
 }
 

--- a/packages/@n8n/instance-ai/src/tools/tool-ids.ts
+++ b/packages/@n8n/instance-ai/src/tools/tool-ids.ts
@@ -64,6 +64,11 @@ export const ALWAYS_LOADED_TOOL_NAMES = new Set<string>([
 	DOMAIN_TOOL_IDS.NODES,
 	ORCHESTRATION_TOOL_IDS.VERIFY_BUILT_WORKFLOW,
 	DOMAIN_TOOL_IDS.RESEARCH,
+	// Paired with RESEARCH on purpose: the research tool tells the agent to prefer
+	// n8n's own docs for n8n questions, but deferring n8n-docs priced that route at
+	// search_tools + load_tool while web search stayed one call away — so the agent
+	// web-searched things the docs answer (INS-749).
+	DOMAIN_TOOL_IDS.N8N_DOCS,
 	DOMAIN_TOOL_IDS.AGENTS,
 	// Deferring this one defeats its purpose: it exists for the case where
 	// nothing is connected, which is exactly when `search_tools` has no MCP tool


### PR DESCRIPTION
## Summary

The builder was web-searching questions that n8n already answers about itself — node output shapes, parameter behaviour — which interrupts the user with a web-search approval prompt for information the instance already holds.

The `research` tool's own description already tells the agent not to do this:

> For n8n-specific questions — product behavior, node setup, credentials, hosting, or feature docs — prefer the sandbox knowledge base and `n8n-docs`.

That guidance was losing because of a **price gap**, not a wording problem. `research` sits in `ALWAYS_LOADED_TOOL_NAMES`; `n8n-docs` did not. So web search was one call away while the docs cost a `search_tools` + `load_tool` round trip (2 extra LLM rounds plus a prompt-cache rewrite). The agent took the cheap route.

This puts `n8n-docs` on the same footing as `research`, and replaces the now-stale Tool Discovery example that told the orchestrator to go *searching* for `n8n-docs` with a line routing n8n questions to `n8n-docs` and the node type definitions.

## The reported case

From the trace on the ticket, mid-build the agent needed the Google Gemini node's output shape with `jsonOutput` on, because the downstream IF reads `$json.content.resolved`. Its reasoning states the assumption outright — *"I'm expecting the parsed JSON to come back under the `content` field"* — then instead of confirming it against n8n's own sources it searched the web:

> `n8n Google Gemini node message a model jsonOutput output shape content field`

The run suspended on the web-search approval for **7 minutes** waiting on the user, and the results were generic `docs.n8n.io` landing pages that changed nothing.

## Measured effect

Eval case **#551 `prefers-n8n-sources-over-web-search`** (`baseline` suite), which asks that uncertainty as a direct user question:

| | web-searched | used `n8n-docs` |
|---|---|---|
| before | 2 / 3 runs | 0 / 3 |
| after | 1 / 6 runs | 2 / 6 |

Two post-fix runs called `n8n-docs` **directly, with no `search_tools` first** — the mechanism doing exactly what it should. The other three correct runs answered from node type definitions alone.

Being straight about the statistics: 2/3 vs 1/6 is directionally strong but not significant at these sample sizes (Fisher's exact ≈ 0.11). What is solid is the mechanism — the docs route is now reachable in one call, and runs demonstrably take it.

**Residual gap, not fixed here:** one run still web-searched, and went further than before — `fetch-url` against `raw.githubusercontent.com` to read the node's source. So the pull toward external sources for node-internals questions isn't fully closed. Enforcing it (deterministically redirecting n8n-specific web-search queries) is a bigger, riskier change — it needs a false-positive story for legitimate n8n-adjacent searches like community nodes on npm. Worth a follow-up if the eval keeps flagging it.

## Review notes

- Adding a tool to `ALWAYS_LOADED_TOOL_NAMES` grows the always-on tool surface. There is precedent immediately below it (`build-agent`, always loaded for the same round-trip reason, with a comment saying so).
- The eval case is a `capability_gap` in the `baseline` suite. Once this lands and holds, it should flip to `regression`.

## Test plan

- [x] `pnpm test` in `packages/@n8n/instance-ai` — 3636 passed (258 files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Eval case #551, 6 iterations against a locally built instance with a Brave key configured
- [x] TDD: both new tests watched failing first (`n8n-docs` deferred; prompt missing the routing line), then passing

New tests:
- `instance-agent.test.ts` — `n8n-docs` lands in the core toolset, not the deferred one, at parity with `research`
- `system-prompt.discovery.test.ts` — the prompt no longer offers n8n docs as a `search_tools` example, and does route n8n questions to `n8n-docs`

https://linear.app/n8n/issue/INS-749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

