### PR TITLE
feat(editor): Disable command bar in canvas-only mode

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.test.ts
@@ -113,18 +113,24 @@ describe('MainSidebarHeader', () => {
 		expect(emitted('collapse')).toHaveLength(1);
 	});
 
-	test.each([
-		[false, true],
-		[true, false],
-	])('renders command bar button when canvasOnly is %s: %s', (canvasOnly, shouldRender) => {
-		settingsStore.settings = { ...defaultSettings, canvasOnly };
+	it('renders the command bar button by default', () => {
+		const { queryByRole } = createComponentRenderer(MainSidebarHeader, {
+			pinia,
+			props: { isCollapsed: false, hideCreate: true },
+		})();
+
+		expect(queryByRole('button', { name: 'Open command palette' })).toBeInTheDocument();
+	});
+
+	it('hides the command bar button in canvas-only mode', () => {
+		settingsStore.settings = { ...defaultSettings, canvasOnly: true };
 
 		const { queryByRole } = createComponentRenderer(MainSidebarHeader, {
 			pinia,
 			props: { isCollapsed: false, hideCreate: true },
 		})();
 
-		expect(queryByRole('button', { name: 'Open command palette' }) !== null).toBe(shouldRender);
+		expect(queryByRole('button', { name: 'Open command palette' })).not.toBeInTheDocument();
 	});
 
 	it('emits "openCommandBar" with the click event when command bar button is clicked', async () => {

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.test.ts
@@ -113,6 +113,20 @@ describe('MainSidebarHeader', () => {
 		expect(emitted('collapse')).toHaveLength(1);
 	});
 
+	test.each([
+		[false, true],
+		[true, false],
+	])('renders command bar button when canvasOnly is %s: %s', (canvasOnly, shouldRender) => {
+		settingsStore.settings = { ...defaultSettings, canvasOnly };
+
+		const { queryByRole } = createComponentRenderer(MainSidebarHeader, {
+			pinia,
+			props: { isCollapsed: false, hideCreate: true },
+		})();
+
+		expect(queryByRole('button', { name: 'Open command palette' }) !== null).toBe(shouldRender);
+	});
+
 	it('emits "openCommandBar" with the click event when command bar button is clicked', async () => {
 		const { getByRole, emitted } = createComponentRenderer(MainSidebarHeader, {
 			pinia,

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarHeader.vue
@@ -161,6 +161,7 @@ const {
 			</template>
 		</N8nNavigationDropdown>
 		<KeyboardShortcutTooltip
+			v-if="!settingsStore.isCanvasOnly"
 			:placement="isCollapsed ? 'right' : 'bottom'"
 			:show-after="500"
 			:label="i18n.baseText('nodeView.openCommandBar')"

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
@@ -3,7 +3,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
 import { defaultSettings } from '@/__tests__/defaults';
-import { useSettingsStore } from '@/app/stores/settings.store';
+import { useSettingsStore } from '@n8n/stores/settings.store';
 import AppCommandBar from './AppCommandBar.vue';
 
 vi.mock('@/app/utils/rbac/permissions', () => ({

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
@@ -1,0 +1,60 @@
+import { computed, reactive, ref } from 'vue';
+import { waitFor } from '@testing-library/vue';
+import { createTestingPinia } from '@pinia/testing';
+import { createComponentRenderer } from '@/__tests__/render';
+import { type MockedStore, mockedStore } from '@/__tests__/utils';
+import { defaultSettings } from '@/__tests__/defaults';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import AppCommandBar from './AppCommandBar.vue';
+
+vi.mock('@/app/utils/rbac/permissions', () => ({
+	hasPermission: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('vue-router', async (importOriginal) => ({
+	...(await importOriginal<typeof import('vue-router')>()),
+	useRoute: () => reactive({ name: 'WorkflowView' }),
+}));
+
+vi.mock('@/features/shared/commandBar/composables/useCommandBar', () => ({
+	useCommandBar: () => ({
+		initialize: vi.fn(),
+		items: computed(() => []),
+		placeholder: computed(() => ''),
+		context: computed(() => undefined),
+		isLoading: ref(false),
+		onCommandBarChange: vi.fn(),
+		onCommandBarNavigateTo: vi.fn(),
+	}),
+}));
+
+const renderComponent = createComponentRenderer(AppCommandBar, {
+	global: {
+		stubs: {
+			N8nCommandBar: { template: '<div data-test-id="command-bar-stub" />' },
+		},
+	},
+});
+
+let settingsStore: MockedStore<typeof useSettingsStore>;
+let pinia: ReturnType<typeof createTestingPinia>;
+
+describe('AppCommandBar', () => {
+	beforeEach(() => {
+		pinia = createTestingPinia();
+		settingsStore = mockedStore(useSettingsStore);
+		settingsStore.settings = defaultSettings;
+	});
+
+	it('hides the command bar when canvas-only mode arrives after mount', async () => {
+		const { queryByTestId } = renderComponent({ pinia });
+
+		expect(queryByTestId('command-bar-stub')).toBeInTheDocument();
+
+		settingsStore.settings = { ...defaultSettings, canvasOnly: true };
+
+		await waitFor(() => {
+			expect(queryByTestId('command-bar-stub')).not.toBeInTheDocument();
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.test.ts
@@ -1,5 +1,4 @@
 import { computed, reactive, ref } from 'vue';
-import { waitFor } from '@testing-library/vue';
 import { createTestingPinia } from '@pinia/testing';
 import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
@@ -46,15 +45,17 @@ describe('AppCommandBar', () => {
 		settingsStore.settings = defaultSettings;
 	});
 
-	it('hides the command bar when canvas-only mode arrives after mount', async () => {
+	it('renders the command bar by default', () => {
 		const { queryByTestId } = renderComponent({ pinia });
 
 		expect(queryByTestId('command-bar-stub')).toBeInTheDocument();
+	});
 
+	it('does not render the command bar in canvas-only mode', () => {
 		settingsStore.settings = { ...defaultSettings, canvasOnly: true };
 
-		await waitFor(() => {
-			expect(queryByTestId('command-bar-stub')).not.toBeInTheDocument();
-		});
+		const { queryByTestId } = renderComponent({ pinia });
+
+		expect(queryByTestId('command-bar-stub')).not.toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
@@ -7,9 +7,11 @@ import { useStyles } from '@n8n/composables/useStyles';
 import { useCommandBar } from '@/features/shared/commandBar/composables/useCommandBar';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { commandBarEventBus } from '@/features/shared/commandBar/commandBar.eventBus';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 const route = useRoute();
 const { APP_Z_INDEXES } = useStyles();
+const settingsStore = useSettingsStore();
 
 const {
 	initialize: initializeCommandBar,
@@ -23,7 +25,9 @@ const {
 
 const isDemoMode = computed(() => route.name === VIEWS.DEMO);
 
-const showCommandBar = computed(() => hasPermission(['authenticated']) && !isDemoMode.value);
+const showCommandBar = computed(
+	() => hasPermission(['authenticated']) && !isDemoMode.value && !settingsStore.isCanvasOnly,
+);
 
 watch(showCommandBar, (newVal) => {
 	if (newVal) {

--- a/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
+++ b/packages/frontend/editor-ui/src/app/components/app/AppCommandBar.vue
@@ -7,7 +7,7 @@ import { useStyles } from '@n8n/composables/useStyles';
 import { useCommandBar } from '@/features/shared/commandBar/composables/useCommandBar';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { commandBarEventBus } from '@/features/shared/commandBar/commandBar.eventBus';
-import { useSettingsStore } from '@/app/stores/settings.store';
+import { useSettingsStore } from '@n8n/stores/settings.store';
 
 const route = useRoute();
 const { APP_Z_INDEXES } = useStyles();

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.test.ts
@@ -1,6 +1,9 @@
 import type * as Vue from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { createComponentRenderer } from '@/__tests__/render';
+import { type MockedStore, mockedStore } from '@/__tests__/utils';
+import { defaultSettings } from '@/__tests__/defaults';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import NodeCreation from './NodeCreation.vue';
 import type { AddedNodesAndConnections } from '@/Interface';
 
@@ -34,6 +37,11 @@ vi.mock('vue', async (importOriginal) => {
 	};
 });
 
+vi.mock('vue-router', async (importOriginal) => ({
+	...(await importOriginal<typeof import('vue-router')>()),
+	useRoute: () => ({ name: 'NodeViewExisting' }),
+}));
+
 vi.mock('@/app/composables/useWorkflowId', () => ({
 	useWorkflowId: () => ({ value: 'test-workflow-id' }),
 	useRouteWorkflowId: () => ({ value: 'test-workflow-id' }),
@@ -59,7 +67,6 @@ vi.mock('../composables/useNodeCreatorShortcutCoachmark', () => ({
 }));
 
 const renderComponent = createComponentRenderer(NodeCreation, {
-	pinia: createTestingPinia(),
 	props: {
 		nodeViewScale: 1,
 		createNodeActive: true,
@@ -67,9 +74,15 @@ const renderComponent = createComponentRenderer(NodeCreation, {
 	},
 });
 
+let settingsStore: MockedStore<typeof useSettingsStore>;
+let pinia: ReturnType<typeof createTestingPinia>;
+
 describe('NodeCreation', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		pinia = createTestingPinia();
+		settingsStore = mockedStore(useSettingsStore);
+		settingsStore.settings = defaultSettings;
 	});
 
 	it('emits addNodes with the result of getAddedNodesAndConnections when a node type is selected', async () => {
@@ -79,7 +92,7 @@ describe('NodeCreation', () => {
 		};
 		mockGetAddedNodesAndConnections.mockReturnValue(addedNodesAndConnections);
 
-		const { findByTestId, emitted } = renderComponent();
+		const { findByTestId, emitted } = renderComponent({ pinia });
 		const selectButton = await findByTestId('node-creator-stub-select');
 
 		selectButton.click();
@@ -92,5 +105,19 @@ describe('NodeCreation', () => {
 			{ type: 'n8n-nodes-base.slack' },
 		]);
 		expect(emitted('addNodes')).toEqual([[addedNodesAndConnections]]);
+	});
+
+	test.each([
+		[false, true],
+		[true, false],
+	])('renders command bar button when canvasOnly is %s: %s', (canvasOnly, shouldRender) => {
+		settingsStore.settings = { ...defaultSettings, canvasOnly };
+
+		const { queryByTestId } = renderComponent({
+			pinia,
+			props: { nodeViewScale: 1, createNodeActive: false, focusPanelActive: false },
+		});
+
+		expect(queryByTestId('command-bar-button') !== null).toBe(shouldRender);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.test.ts
@@ -107,17 +107,23 @@ describe('NodeCreation', () => {
 		expect(emitted('addNodes')).toEqual([[addedNodesAndConnections]]);
 	});
 
-	test.each([
-		[false, true],
-		[true, false],
-	])('renders command bar button when canvasOnly is %s: %s', (canvasOnly, shouldRender) => {
-		settingsStore.settings = { ...defaultSettings, canvasOnly };
+	it('renders the command bar button by default', () => {
+		const { queryByTestId } = renderComponent({
+			pinia,
+			props: { nodeViewScale: 1, createNodeActive: false, focusPanelActive: false },
+		});
+
+		expect(queryByTestId('command-bar-button')).toBeInTheDocument();
+	});
+
+	it('hides the command bar button in canvas-only mode', () => {
+		settingsStore.settings = { ...defaultSettings, canvasOnly: true };
 
 		const { queryByTestId } = renderComponent({
 			pinia,
 			props: { nodeViewScale: 1, createNodeActive: false, focusPanelActive: false },
 		});
 
-		expect(queryByTestId('command-bar-button') !== null).toBe(shouldRender);
+		expect(queryByTestId('command-bar-button')).not.toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.test.ts
@@ -3,7 +3,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
 import { defaultSettings } from '@/__tests__/defaults';
-import { useSettingsStore } from '@/app/stores/settings.store';
+import { useSettingsStore } from '@n8n/stores/settings.store';
 import NodeCreation from './NodeCreation.vue';
 import type { AddedNodesAndConnections } from '@/Interface';
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
@@ -35,7 +35,7 @@ import {
 } from '@n8n/design-system';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import { useWorkflowId } from '@/app/composables/useWorkflowId';
-import { useSettingsStore } from '@/app/stores/settings.store';
+import { useSettingsStore } from '@n8n/stores/settings.store';
 
 type Props = {
 	nodeViewScale: number;

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
@@ -35,6 +35,7 @@ import {
 } from '@n8n/design-system';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import { useWorkflowId } from '@/app/composables/useWorkflowId';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 type Props = {
 	nodeViewScale: number;
@@ -65,6 +66,7 @@ const telemetry = useTelemetry();
 const assistantStore = useAssistantStore();
 const chatPanelStore = useChatPanelStore();
 const workflowId = useWorkflowId();
+const settingsStore = useSettingsStore();
 
 const { getAddedNodesAndConnections } = useActions();
 const { shouldShowCoachmark, onDismissCoachmark } = useNodeCreatorShortcutCoachmark();
@@ -183,6 +185,7 @@ function openCommandBar(event: MouseEvent) {
 			</KeyboardShortcutTooltip>
 		</NodeCreatorShortcutCoachmark>
 		<KeyboardShortcutTooltip
+			v-if="!settingsStore.isCanvasOnly"
 			:label="i18n.baseText('nodeView.openCommandBar')"
 			:shortcut="{ keys: ['k'], metaKey: true }"
 			placement="left"


### PR DESCRIPTION
## Summary

The command bar exposes navigation actions (jump to executions, credentials, projects, settings) that don't make sense for embedded, canvas-only deployments where the surrounding n8n chrome is intentionally hidden. This gates it behind the existing `N8N_CANVAS_ONLY` flag, so no new env var is introduced.

Three gates, in `packages/frontend/editor-ui`:

| File | Gate |
|---|---|
| `app/components/app/AppCommandBar.vue` | `showCommandBar` computed |
| `app/components/MainSidebarHeader.vue` | `v-if` on the sidebar palette button |
| `features/shared/nodeCreator/views/NodeCreation.vue` | `v-if` on the canvas rail button |

`AppCommandBar` is the real chokepoint: the <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd> listener is registered by `N8nCommandBar` itself on `document` at mount, so unmounting the component removes the listener and makes the shortcut a no-op. The two buttons are hidden separately so no dead controls remain. The sidebar gate also covers Chat Hub, which reuses `MainSidebarHeader`.

## How to test

Set `N8N_CANVAS_ONLY=true` in `packages/@n8n/config/src/index.ts` and try restarting the server.

1. Open a workflow.
2. Press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>K</kbd> → the command bar must **not** open.
3. Confirm the search/palette button is gone from the sidebar header and from the canvas node-creation rail.
4. Restart **without** the env var and repeat → all three entry points work as before.

## UI Changes
<img width="1509" height="764" alt="Screenshot 2026-08-05 at 11 10 15" src="https://github.com/user-attachments/assets/4e50e070-3d11-4f9f-92ca-a5f6ef0ae6b6" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-113

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
