### PR TITLE
fix(ai-builder): Give a case's scenario data tables per-run names (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-orchestrator.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-orchestrator.test.ts
@@ -89,6 +89,7 @@ function makeLane(num: number, tracedBuild: LaneState['tracedBuild']): LaneState
 			client: {} as unknown as N8nClient,
 			baseUrl: `http://lane${String(num)}.test`,
 			preRunWorkflowIds: new Set<string>(),
+			preRunDataTableIds: new Set<string>(),
 			claimedWorkflowIds: new Set<string>(),
 			createdCredentialIds: new Set<string>(),
 			workflowIdsToDelete: new Set<string>(),

--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-workflow-conversation-seed.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-workflow-conversation-seed.test.ts
@@ -63,13 +63,15 @@ function inlineSeed(): ConversationSeed {
 
 function makeClient(
 	restoreThread: ReturnType<typeof vi.fn>,
-	overrides: Partial<Record<'listWorkflows' | 'deleteWorkflow', ReturnType<typeof vi.fn>>> = {},
+	overrides: Partial<
+		Record<'listWorkflows' | 'deleteWorkflow' | 'sendMessage', ReturnType<typeof vi.fn>>
+	> = {},
 ): N8nClient {
 	return {
 		getPersonalProjectId: vi.fn().mockResolvedValue('project-1'),
 		ensureThread: vi.fn().mockResolvedValue(undefined),
 		setThreadCredentialAllowlist: vi.fn().mockResolvedValue(undefined),
-		sendMessage: vi.fn().mockResolvedValue(undefined),
+		sendMessage: overrides.sendMessage ?? vi.fn().mockResolvedValue(undefined),
 		getThreadMessages: vi.fn().mockResolvedValue({ messages: [] }),
 		listWorkflows: overrides.listWorkflows ?? vi.fn().mockResolvedValue([]),
 		deleteWorkflow: overrides.deleteWorkflow ?? vi.fn().mockResolvedValue(undefined),
@@ -267,5 +269,57 @@ describe('buildWorkflow with an inline seed', () => {
 
 		expect(build.success).toBe(true);
 		expect(restoreThread).not.toHaveBeenCalled();
+	});
+});
+
+describe('buildWorkflow with scenario seed data tables', () => {
+	const jobApplications = {
+		id: 'job-applications-1234',
+		name: 'Job Applications',
+		columns: [{ name: 'application_id', type: 'string' as const }],
+		rows: [{ application_id: 'row_001' }],
+	};
+
+	it('creates the table under a per-run name and tells the agent THAT name', async () => {
+		// The name is project-unique, so a per-run suffix is what lets two iterations of
+		// one case coexist. The agent binds by discovery, so it has to be told the real
+		// name — sending the declared one would make it create a duplicate.
+		const sendMessage = vi.fn().mockResolvedValue({ runId: 'run-1' });
+		const restoreThread = vi
+			.fn()
+			.mockResolvedValue({ restored: 0, workflowIds: [], dataTableIds: ['dt-real-1'] });
+
+		const build = await buildWorkflow({
+			client: makeClient(restoreThread, { sendMessage }),
+			...baseConfig,
+			executionScenarios: [
+				{
+					name: 's1',
+					description: 'd',
+					dataSetup: 'setup',
+					successCriteria: 'ok',
+					seedDataTables: [jobApplications],
+				},
+			],
+		});
+
+		const [, , , dataTables] = restoreThread.mock.calls[0] as [
+			string,
+			unknown,
+			unknown,
+			Array<{ name: string; rows?: unknown }>,
+		];
+		const created = dataTables[0].name;
+		expect(created).toMatch(/^Job Applications \[seed [0-9a-f]{8}\]$/);
+		// Schema only before the build — rows are reseeded per scenario.
+		expect(dataTables[0].rows).toBeUndefined();
+
+		const [, sentText] = sendMessage.mock.calls[0] as [string, string];
+		expect(sentText).toContain(created);
+
+		// Keyed by the DECLARED name, which is what a scenario's seedDataTables writes.
+		expect(build.seededScenarioTableIdsByName).toEqual({ 'Job Applications': 'dt-real-1' });
+		// Tracked for cleanup by id, so the rename can't orphan it.
+		expect(build.createdDataTableIds).toContain('dt-real-1');
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/case-pipeline.test.ts
@@ -56,6 +56,7 @@ function makeLane(): LaneState {
 			client: {} as never,
 			baseUrl: 'http://lane1.test',
 			preRunWorkflowIds: new Set<string>(),
+			preRunDataTableIds: new Set<string>(),
 			claimedWorkflowIds: new Set<string>(),
 			createdCredentialIds: new Set<string>(),
 			workflowIdsToDelete: new Set<string>(),

--- a/packages/@n8n/instance-ai/evaluations/__tests__/conversation-seed.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/conversation-seed.test.ts
@@ -2,7 +2,7 @@ import {
 	ConversationSeedSchema,
 	expandSeedMessageShorthand,
 	remapSeedWorkflowIds,
-	SEED_WORKFLOW_NAME_RE,
+	SEED_NAME_RE,
 	transcriptPrefixFromSeed,
 	type ConversationSeed,
 } from '../harness/conversation-seed';
@@ -248,7 +248,7 @@ describe('remapSeedWorkflowIds', () => {
 		const newName = remapped.workflows[0].name;
 
 		expect(newName).toMatch(/^Digest \[seed [0-9a-f]{8}\]$/);
-		expect(SEED_WORKFLOW_NAME_RE.exec(newName)?.[1]).toBe('Digest');
+		expect(SEED_NAME_RE.exec(newName)?.[1]).toBe('Digest');
 		const mention = remapped.messages.find((m) => m.id === 'm-name');
 		expect(JSON.stringify(mention)).toContain(`workflow ${newName} failed`);
 	});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/n8n-client-data-tables.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/n8n-client-data-tables.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, vi } from 'vitest';
+
+import { N8nClient } from '../clients/n8n-client';
+
+function mockFetch(body: unknown) {
+	const fn = vi.fn((_url: string | URL, _init?: RequestInit) => ({
+		ok: true,
+		status: 200,
+		// The client reads `set-cookie` off every response to capture the login cookie.
+		headers: { get: () => null },
+		json: () => body,
+	}));
+	vi.stubGlobal('fetch', fn);
+	return fn;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('N8nClient.listDataTables', () => {
+	// Burned live: reading `data` as the array returned [] for every project, with no
+	// error path — so the seed-table eviction and computer-use's data-table cleanup
+	// both silently did nothing.
+	it('unwraps the paginated `{ data: { count, data } }` envelope', async () => {
+		mockFetch({
+			data: {
+				count: 2,
+				data: [
+					{ id: 'dt-1', name: 'Orders' },
+					{ id: 'dt-2', name: 'B' },
+				],
+			},
+		});
+
+		const tables = await new N8nClient('http://n8n.test').listDataTables('project-1');
+
+		expect(tables).toEqual([
+			{ id: 'dt-1', name: 'Orders' },
+			{ id: 'dt-2', name: 'B' },
+		]);
+	});
+
+	it('still accepts a flat `{ data: [...] }` envelope', async () => {
+		mockFetch({ data: [{ id: 'dt-1', name: 'Orders' }] });
+
+		const tables = await new N8nClient('http://n8n.test').listDataTables('project-1');
+
+		expect(tables).toEqual([{ id: 'dt-1', name: 'Orders' }]);
+	});
+
+	it('returns an empty list rather than throwing when the payload has no rows', async () => {
+		mockFetch({ data: { count: 0 } });
+
+		expect(await new N8nClient('http://n8n.test').listDataTables('project-1')).toEqual([]);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/n8n-client-data-tables.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/n8n-client-data-tables.test.ts
@@ -52,4 +52,14 @@ describe('N8nClient.listDataTables', () => {
 
 		expect(await new N8nClient('http://n8n.test').listDataTables('project-1')).toEqual([]);
 	});
+
+	// The default page is 10; every caller enumerates the whole set, so a short
+	// page silently leaves leftover seed tables behind.
+	it('asks for a full page rather than the default 10', async () => {
+		const fn = mockFetch({ data: { count: 0, data: [] } });
+
+		await new N8nClient('http://n8n.test').listDataTables('project-1');
+
+		expect(String(fn.mock.calls[0][0])).toContain('take=250');
+	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/scenario-seed-tables.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/scenario-seed-tables.test.ts
@@ -127,16 +127,6 @@ describe('buildSeededTablesNote', () => {
 		expect(note).toContain('application_id');
 		expect(note).toContain('string');
 	});
-
-	// Without this the agent sees no table by the name the request uses, reasonably
-	// concludes it's missing, and creates a duplicate — defeating the pre-seed.
-	it('ties a per-run name back to the name the request uses', () => {
-		const [created] = uniquifyScenarioTableNames([jobApplications]);
-		const note = buildSeededTablesNote([created]);
-
-		expect(note).toContain(created.name);
-		expect(note).toContain('refers to this table as "Job Applications"');
-	});
 });
 
 describe('scenariosRequireSerialSeeding', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/scenario-seed-tables.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/scenario-seed-tables.test.ts
@@ -2,12 +2,15 @@ import { vi } from 'vitest';
 import type { Mock } from 'vitest';
 
 import type { N8nClient } from '../clients/n8n-client';
+import { SEED_NAME_RE } from '../harness/conversation-seed';
 import type { EvalLogger } from '../harness/logger';
 import {
 	buildSeededTablesNote,
 	dedupeScenarioSeedTables,
+	evictLeftoverSeedTables,
 	reseedScenarioTables,
 	scenariosRequireSerialSeeding,
+	uniquifyScenarioTableNames,
 } from '../harness/seed-tables';
 import type { ExecutionScenario } from '../types';
 
@@ -199,5 +202,104 @@ describe('reseedScenarioTables', () => {
 			),
 		).rejects.toThrow(/Job Applications/);
 		expect(seedDataTableRows).not.toHaveBeenCalled();
+	});
+});
+
+describe('uniquifyScenarioTableNames', () => {
+	it('suffixes each table so two runs of one case do not contend for the name', () => {
+		const [first] = uniquifyScenarioTableNames([jobApplications]);
+		const [second] = uniquifyScenarioTableNames([jobApplications]);
+
+		expect(first.name).toMatch(/^Job Applications \[seed [0-9a-f]{8}\]$/);
+		expect(second.name).not.toBe(first.name);
+		expect(SEED_NAME_RE.exec(first.name)?.[1]).toBe('Job Applications');
+	});
+
+	it('shares one suffix across a case, and keeps columns and rows intact', () => {
+		const other = { ...jobApplications, id: 'other-1234', name: 'Other' };
+		const [a, b] = uniquifyScenarioTableNames([jobApplications, other]);
+
+		expect(a.name.replace('Job Applications', '')).toBe(b.name.replace('Other', ''));
+		expect(a.columns).toEqual(jobApplications.columns);
+		expect(a.rows).toEqual(jobApplications.rows);
+	});
+
+	it('keeps the suffixed name inside the 128-char column bound', () => {
+		const [long] = uniquifyScenarioTableNames([{ ...jobApplications, name: 'x'.repeat(200) }]);
+		expect(long.name.length).toBe(128);
+	});
+});
+
+describe('evictLeftoverSeedTables', () => {
+	const leftover = { id: 'left-1', name: 'Job Applications [seed 1a2b3c4d]' };
+
+	function evictClient(
+		tables: Array<{ id: string; name: string }>,
+		deleteDataTable: Mock = vi.fn(),
+	): N8nClient {
+		return {
+			getPersonalProjectId: vi.fn().mockResolvedValue('project-1'),
+			listDataTables: vi.fn().mockResolvedValue(tables),
+			deleteDataTable,
+		} as unknown as N8nClient;
+	}
+
+	it('deletes a leftover seed table for a declared name', async () => {
+		const deleteDataTable = vi.fn();
+		await evictLeftoverSeedTables(
+			evictClient([leftover], deleteDataTable),
+			[jobApplications],
+			new Set(['left-1']),
+			silentLogger,
+		);
+		expect(deleteDataTable).toHaveBeenCalledWith('project-1', 'left-1');
+	});
+
+	// The snapshot is taken before any build on the lane, so a table created DURING
+	// the run belongs to an in-flight iteration — deleting it would break that run.
+	it('leaves a table absent from the pre-run snapshot alone', async () => {
+		const deleteDataTable = vi.fn();
+		await evictLeftoverSeedTables(
+			evictClient([leftover], deleteDataTable),
+			[jobApplications],
+			new Set(['someone-else']),
+			silentLogger,
+		);
+		expect(deleteDataTable).not.toHaveBeenCalled();
+	});
+
+	it('never touches a table without the seed suffix, or one of another case', async () => {
+		const deleteDataTable = vi.fn();
+		await evictLeftoverSeedTables(
+			evictClient(
+				[
+					{ id: 'real', name: 'Job Applications' },
+					{ id: 'other', name: 'Invoices [seed 1a2b3c4d]' },
+				],
+				deleteDataTable,
+			),
+			[jobApplications],
+			new Set(['real', 'other']),
+			silentLogger,
+		);
+		expect(deleteDataTable).not.toHaveBeenCalled();
+	});
+
+	it('does nothing without a snapshot, and never fails the build on an API error', async () => {
+		const deleteDataTable = vi.fn();
+		await evictLeftoverSeedTables(
+			evictClient([leftover], deleteDataTable),
+			[jobApplications],
+			undefined,
+			silentLogger,
+		);
+		expect(deleteDataTable).not.toHaveBeenCalled();
+
+		const broken = {
+			getPersonalProjectId: vi.fn().mockRejectedValue(new Error('boom')),
+		} as unknown as N8nClient;
+		await expect(
+			evictLeftoverSeedTables(broken, [jobApplications], new Set(['left-1']), silentLogger),
+		).resolves.toBeUndefined();
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/scenario-seed-tables.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/scenario-seed-tables.test.ts
@@ -278,6 +278,22 @@ describe('evictLeftoverSeedTables', () => {
 		expect(deleteDataTable).not.toHaveBeenCalled();
 	});
 
+	// A name past the column bound loses its tail before the suffix goes on, so the
+	// stored base is the truncated one — matching on the declared name found nothing
+	// and the leftover accumulated run after run.
+	it('matches a leftover whose base was truncated to fit the column bound', async () => {
+		const deleteDataTable = vi.fn();
+		const longName = 'x'.repeat(200);
+		const [stored] = uniquifyScenarioTableNames([{ ...jobApplications, name: longName }]);
+		await evictLeftoverSeedTables(
+			evictClient([{ id: 'left-long', name: stored.name }], deleteDataTable),
+			[{ ...jobApplications, name: longName }],
+			new Set(['left-long']),
+			silentLogger,
+		);
+		expect(deleteDataTable).toHaveBeenCalledWith('project-1', 'left-long');
+	});
+
 	it('never touches a table without the seed suffix, or one of another case', async () => {
 		const deleteDataTable = vi.fn();
 		await evictLeftoverSeedTables(

--- a/packages/@n8n/instance-ai/evaluations/__tests__/scenario-seed-tables.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/scenario-seed-tables.test.ts
@@ -127,6 +127,16 @@ describe('buildSeededTablesNote', () => {
 		expect(note).toContain('application_id');
 		expect(note).toContain('string');
 	});
+
+	// Without this the agent sees no table by the name the request uses, reasonably
+	// concludes it's missing, and creates a duplicate — defeating the pre-seed.
+	it('ties a per-run name back to the name the request uses', () => {
+		const [created] = uniquifyScenarioTableNames([jobApplications]);
+		const note = buildSeededTablesNote([created]);
+
+		expect(note).toContain(created.name);
+		expect(note).toContain('refers to this table as "Job Applications"');
+	});
 });
 
 describe('scenariosRequireSerialSeeding', () => {

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -718,7 +718,13 @@ export class N8nClient {
 		// The list endpoint paginates: `{ data: { count, data: [...] } }`. Reading
 		// `result.data` as the array made this return [] for every project, silently —
 		// it has no error path, so every caller just saw "no tables".
-		const result = (await this.fetch(`/rest/projects/${projectId}/data-tables`)) as {
+		//
+		// `take` is explicit because the default page is 10, and every caller here
+		// enumerates the WHOLE set (seed eviction, CU cleanup, discovery's pre-existing
+		// set) — a short page silently leaves leftovers behind. 250 is the server's
+		// per-page cap; a case declares at most 20 tables and eviction runs before
+		// every build, so the backlog drains rather than outgrowing one page.
+		const result = (await this.fetch(`/rest/projects/${projectId}/data-tables?take=250`)) as {
 			data?: { data?: Array<{ id: string; name: string }> } | Array<{ id: string; name: string }>;
 		};
 		const payload = result.data;

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -715,10 +715,15 @@ export class N8nClient {
 	 * GET /rest/projects/:projectId/data-tables
 	 */
 	async listDataTables(projectId: string): Promise<Array<{ id: string; name: string }>> {
+		// The list endpoint paginates: `{ data: { count, data: [...] } }`. Reading
+		// `result.data` as the array made this return [] for every project, silently —
+		// it has no error path, so every caller just saw "no tables".
 		const result = (await this.fetch(`/rest/projects/${projectId}/data-tables`)) as {
-			data: Array<{ id: string; name: string }>;
+			data?: { data?: Array<{ id: string; name: string }> } | Array<{ id: string; name: string }>;
 		};
-		return Array.isArray(result.data) ? result.data : [];
+		const payload = result.data;
+		if (Array.isArray(payload)) return payload;
+		return payload?.data ?? [];
 	}
 
 	/** List data table IDs for a project. */

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -22,14 +22,19 @@ import {
 import { runWorkflowChecks, summarizeMissingWorkflowError } from './cleanup';
 import {
 	remapSeedWorkflowIds,
-	SEED_WORKFLOW_NAME_RE,
+	SEED_NAME_RE,
 	transcriptPrefixFromSeed,
 	type ConversationSeed,
 } from './conversation-seed';
 import { reconstructSeedFromThread } from './langsmith-seed';
 import type { EvalLogger } from './logger';
 import type { CaseSeed } from './schema';
-import { buildSeededTablesNote, dedupeScenarioSeedTables } from './seed-tables';
+import {
+	buildSeededTablesNote,
+	dedupeScenarioSeedTables,
+	evictLeftoverSeedTables,
+	uniquifyScenarioTableNames,
+} from './seed-tables';
 import type { CheckOutcome } from '../binaryChecks/types';
 import { N8nApiError, type N8nClient, type WorkflowResponse } from '../clients/n8n-client';
 import { createDeclaredCredentials } from '../credentials/seeder';
@@ -242,6 +247,9 @@ export interface BuildWorkflowConfig {
 	executionScenarios?: ExecutionScenario[];
 	timeoutMs?: number;
 	preRunWorkflowIds: Set<string>;
+	/** Data tables present before any build on this lane — the only ones the
+	 *  scenario-table eviction may delete. Omitted = no eviction. */
+	preRunDataTableIds?: Set<string>;
 	claimedWorkflowIds: Set<string>;
 	logger: EvalLogger;
 	/** Optional " [lane N/M]" suffix appended to the scenario log line. */
@@ -439,18 +447,30 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 		}
 
 		// TRUST-311 follow-up: create the case's execution-scenario data tables EMPTY
-		// under their EXACT declared names BEFORE the build turn, so the agent
-		// discovers the real table (Data Table list/schema) and binds its real id —
-		// the production-faithful flow where the user's table pre-exists. Rows are
-		// reset+seeded per scenario (reseedScenarioTables) because a build-time
-		// self-verification execution can mutate them. The created ids fold into
-		// restoredDataTableIds so the outer catch and cleanupBuild already cover them
-		// (a build failure still cleans them up); a create failure is a harness
-		// problem, so flag seedingFailed → the CLI attributes framework_issue.
+		// BEFORE the build turn, so the agent discovers the real table (Data Table
+		// list/schema) and binds its real id — the production-faithful flow where the
+		// user's table pre-exists. Rows are reset+seeded per scenario
+		// (reseedScenarioTables) because a build-time self-verification execution can
+		// mutate them. The created ids fold into restoredDataTableIds so the outer
+		// catch and cleanupBuild already cover them (a build failure still cleans them
+		// up); a create failure is a harness problem, so flag seedingFailed → the CLI
+		// attributes framework_issue.
 		try {
 			const scenarioSeedTables = dedupeScenarioSeedTables(config.executionScenarios ?? [], logger);
 			if (scenarioSeedTables.length > 0) {
-				const schemasOnly = scenarioSeedTables.map((table) => ({ ...table, rows: undefined }));
+				await evictLeftoverSeedTables(
+					client,
+					scenarioSeedTables,
+					config.preRunDataTableIds,
+					logger,
+					config.laneTag,
+				);
+				// `uniquifyNames: false` stays — the harness mints the suffix so it knows
+				// which name to give the agent below.
+				const schemasOnly = uniquifyScenarioTableNames(scenarioSeedTables).map((table) => ({
+					...table,
+					rows: undefined,
+				}));
 				const { dataTableIds } = await client.restoreThread(threadId, [], [], schemasOnly, {
 					uniquifyNames: false,
 				});
@@ -461,11 +481,13 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 						`Pre-seeding created ${String(dataTableIds.length)} data table(s) but the case declares ${String(scenarioSeedTables.length)}; cannot map names to ids.`,
 					);
 				}
+				// Keyed by the DECLARED name — what a scenario writes.
 				scenarioSeedTables.forEach((table, index) => {
 					scenarioTableIdsByName[table.name] = dataTableIds[index];
 				});
 				restoredDataTableIds = [...restoredDataTableIds, ...dataTableIds];
-				scenarioSeedTablesNote = buildSeededTablesNote(scenarioSeedTables);
+				// The agent looks up the name that exists, not the declared one.
+				scenarioSeedTablesNote = buildSeededTablesNote(schemasOnly);
 				logger.info(
 					`  Pre-seeded ${String(dataTableIds.length)} scenario data table schema(s)${config.laneTag ?? ''}`,
 				);
@@ -700,9 +722,7 @@ async function evictLeftoverSeedWorkflows(
 	laneTag?: string,
 ): Promise<void> {
 	const baseNames = new Set(
-		seed.workflows.map(
-			(workflow) => SEED_WORKFLOW_NAME_RE.exec(workflow.name)?.[1] ?? workflow.name,
-		),
+		seed.workflows.map((workflow) => SEED_NAME_RE.exec(workflow.name)?.[1] ?? workflow.name),
 	);
 	if (baseNames.size === 0) return;
 	try {
@@ -721,7 +741,7 @@ async function evictLeftoverSeedWorkflows(
 			// what was already lying there — a previous run's `--keep-workflows`
 			// leftover, or a crashed run that skipped its own cleanup.
 			if (!preRunWorkflowIds.has(workflow.id)) return false;
-			const base = SEED_WORKFLOW_NAME_RE.exec(workflow.name)?.[1];
+			const base = SEED_NAME_RE.exec(workflow.name)?.[1];
 			return base !== undefined && baseNames.has(base);
 		});
 		// Per-workflow, because best-effort has to mean each one: letting a single

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -23,6 +23,7 @@ import { runWorkflowChecks, summarizeMissingWorkflowError } from './cleanup';
 import {
 	remapSeedWorkflowIds,
 	SEED_NAME_RE,
+	seedNameBase,
 	transcriptPrefixFromSeed,
 	type ConversationSeed,
 } from './conversation-seed';
@@ -722,7 +723,9 @@ async function evictLeftoverSeedWorkflows(
 	laneTag?: string,
 ): Promise<void> {
 	const baseNames = new Set(
-		seed.workflows.map((workflow) => SEED_NAME_RE.exec(workflow.name)?.[1] ?? workflow.name),
+		seed.workflows.map((workflow) =>
+			seedNameBase(SEED_NAME_RE.exec(workflow.name)?.[1] ?? workflow.name),
+		),
 	);
 	if (baseNames.size === 0) return;
 	try {

--- a/packages/@n8n/instance-ai/evaluations/harness/conversation-seed.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/conversation-seed.ts
@@ -244,6 +244,12 @@ export function uniquifySeedName(name: string, suffix: string): string {
 	return `${name.slice(0, MAX_SEED_NAME - suffix.length)}${suffix}`;
 }
 
+/** The base a declared name will actually carry once suffixed. Eviction matches on
+ *  the stored base, so it has to truncate the declared name the same way or a long
+ *  name never matches its own leftover. */
+export const seedNameBase = (name: string) =>
+	name.slice(0, MAX_SEED_NAME - seedNameSuffix('0'.repeat(8)).length);
+
 const escapeForRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /** Rewrite every string inside a parsed value, leaving structure untouched. */

--- a/packages/@n8n/instance-ai/evaluations/harness/conversation-seed.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/conversation-seed.ts
@@ -227,19 +227,22 @@ export function clampFutureSeedTimestamps(messages: unknown[]): unknown[] {
 // Workflow id + name remapping
 // ---------------------------------------------------------------------------
 
-/** Marks a workflow as created by a seed restore, and makes its name unique per
- *  restore. Load-bearing twice over: a leftover copy from an earlier
- *  run can no longer be mistaken for this run's workflow by name, and the suffix
- *  identifies seed artifacts precisely — so the pre-restore eviction can only ever
- *  delete one of ours, never a real workflow and never one the agent built. Same
- *  shape the server already uses for seeded data tables. */
+/** Marks an artifact as seed-created and unique per restore, so a leftover can't
+ *  be mistaken for this run's — and the eviction can only ever delete one of ours,
+ *  never a real artifact or one the agent built. Shared with `seed-tables.ts`. */
 const seedNameSuffix = (token: string) => ` [seed ${token}]`;
 
-/** Matches a name this module produced, capturing the original base name. */
-export const SEED_WORKFLOW_NAME_RE = /^(.*) \[seed [0-9a-f]{8}\]$/;
+export const freshSeedNameSuffix = () => seedNameSuffix(randomUUID().slice(0, 8));
 
-/** n8n's workflow-name column bound. */
-const MAX_WORKFLOW_NAME = 128;
+/** Matches a suffixed name, capturing the base. Workflows and data tables both. */
+export const SEED_NAME_RE = /^(.*) \[seed [0-9a-f]{8}\]$/;
+
+/** n8n's name-column bound. */
+const MAX_SEED_NAME = 128;
+
+export function uniquifySeedName(name: string, suffix: string): string {
+	return `${name.slice(0, MAX_SEED_NAME - suffix.length)}${suffix}`;
+}
 
 const escapeForRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -329,13 +332,10 @@ export function remapSeedWorkflowIds(seed: ConversationSeed): ConversationSeed {
 	}
 
 	// Uniquify names after the id pass, so the rename can't perturb id matching.
-	const workflows = remapped.workflows.map((workflow) => {
-		const suffix = seedNameSuffix(randomUUID().slice(0, 8));
-		return {
-			...workflow,
-			name: `${workflow.name.slice(0, MAX_WORKFLOW_NAME - suffix.length)}${suffix}`,
-		};
-	});
+	const workflows = remapped.workflows.map((workflow) => ({
+		...workflow,
+		name: uniquifySeedName(workflow.name, freshSeedNameSuffix()),
+	}));
 
 	// Any mention in the seeded history follows the workflow, so the agent's own
 	// record of what it built still matches what is on the instance.

--- a/packages/@n8n/instance-ai/evaluations/harness/seed-tables.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/seed-tables.ts
@@ -76,7 +76,11 @@ export function buildSeededTablesNote(tables: InstanceAiEvalSeedDataTable[]): st
 	if (tables.length === 0) return '';
 	const lines = tables.map((table) => {
 		const columns = table.columns.map((column) => `${column.name}: ${column.type}`).join(', ');
-		return `- "${table.name}" (columns: ${columns})`;
+		// The request calls it `Orders`; what exists is `Orders [seed …]`. Say so, or the
+		// agent reasonably concludes its table is missing and creates a duplicate.
+		const base = SEED_NAME_RE.exec(table.name)?.[1];
+		const alias = base === undefined ? '' : ` — the request refers to this table as "${base}"`;
+		return `- "${table.name}" (columns: ${columns})${alias}`;
 	});
 	return `\n\nThe following data table(s) already exist in this workspace — reuse them (look them up with the Data Table node's list/schema) instead of creating new ones:\n${lines.join('\n')}`;
 }

--- a/packages/@n8n/instance-ai/evaluations/harness/seed-tables.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/seed-tables.ts
@@ -8,7 +8,12 @@
 
 import type { InstanceAiEvalSeedDataTable } from '@n8n/api-types';
 
-import { freshSeedNameSuffix, SEED_NAME_RE, uniquifySeedName } from './conversation-seed';
+import {
+	freshSeedNameSuffix,
+	SEED_NAME_RE,
+	seedNameBase,
+	uniquifySeedName,
+} from './conversation-seed';
 import type { EvalLogger } from './logger';
 import type { N8nClient } from '../clients/n8n-client';
 import type { ExecutionScenario } from '../types';
@@ -108,7 +113,7 @@ export async function evictLeftoverSeedTables(
 	laneTag?: string,
 ): Promise<void> {
 	if (!preRunDataTableIds || preRunDataTableIds.size === 0) return;
-	const baseNames = new Set(declared.map((table) => table.name));
+	const baseNames = new Set(declared.map((table) => seedNameBase(table.name)));
 	try {
 		const projectId = await client.getPersonalProjectId();
 		const stale = (await client.listDataTables(projectId)).filter((table) => {

--- a/packages/@n8n/instance-ai/evaluations/harness/seed-tables.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/seed-tables.ts
@@ -8,6 +8,7 @@
 
 import type { InstanceAiEvalSeedDataTable } from '@n8n/api-types';
 
+import { freshSeedNameSuffix, SEED_NAME_RE, uniquifySeedName } from './conversation-seed';
 import type { EvalLogger } from './logger';
 import type { N8nClient } from '../clients/n8n-client';
 import type { ExecutionScenario } from '../types';
@@ -78,6 +79,60 @@ export function buildSeededTablesNote(tables: InstanceAiEvalSeedDataTable[]): st
 		return `- "${table.name}" (columns: ${columns})`;
 	});
 	return `\n\nThe following data table(s) already exist in this workspace — reuse them (look them up with the Data Table node's list/schema) instead of creating new ones:\n${lines.join('\n')}`;
+}
+
+/** Per-run table names (`Orders [seed 1a2b3c4d]`). A table name is unique per
+ *  project, so under the declared name two iterations of one case collide — they
+ *  overlap on a lane, which is released when the build returns while the tables
+ *  live to the last scenario row. Callers keep the declared name as the map key. */
+export function uniquifyScenarioTableNames(
+	tables: InstanceAiEvalSeedDataTable[],
+): InstanceAiEvalSeedDataTable[] {
+	const suffix = freshSeedNameSuffix();
+	return tables.map((table) => ({ ...table, name: uniquifySeedName(table.name, suffix) }));
+}
+
+/** Delete a previous run's seed tables (a crash or `--keep-workflows` skips the
+ *  id-based cleanup), so the agent isn't offered 20 near-identical ones to ground
+ *  on. Only ids in the pre-run snapshot, so a concurrent iteration's live table
+ *  can't match — same rule as `evictLeftoverSeedWorkflows`. Best-effort. */
+export async function evictLeftoverSeedTables(
+	client: N8nClient,
+	declared: InstanceAiEvalSeedDataTable[],
+	preRunDataTableIds: Set<string> | undefined,
+	logger: EvalLogger,
+	laneTag?: string,
+): Promise<void> {
+	if (!preRunDataTableIds || preRunDataTableIds.size === 0) return;
+	const baseNames = new Set(declared.map((table) => table.name));
+	try {
+		const projectId = await client.getPersonalProjectId();
+		const stale = (await client.listDataTables(projectId)).filter((table) => {
+			if (!preRunDataTableIds.has(table.id)) return false;
+			const base = SEED_NAME_RE.exec(table.name)?.[1];
+			return base !== undefined && baseNames.has(base);
+		});
+		let evicted = 0;
+		for (const table of stale) {
+			try {
+				await client.deleteDataTable(projectId, table.id);
+				evicted++;
+			} catch (error: unknown) {
+				logger.info(
+					`  Could not evict leftover seed data table "${table.name}" (continuing): ${error instanceof Error ? error.message : String(error)}${laneTag ?? ''}`,
+				);
+			}
+		}
+		if (evicted > 0) {
+			logger.info(
+				`  Evicted ${String(evicted)} leftover seed data table(s) before pre-seeding${laneTag ?? ''}`,
+			);
+		}
+	} catch (error: unknown) {
+		logger.info(
+			`  Could not evict leftover seed data tables (continuing): ${error instanceof Error ? error.message : String(error)}${laneTag ?? ''}`,
+		);
+	}
 }
 
 /**

--- a/packages/@n8n/instance-ai/evaluations/harness/seed-tables.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/seed-tables.ts
@@ -81,11 +81,7 @@ export function buildSeededTablesNote(tables: InstanceAiEvalSeedDataTable[]): st
 	if (tables.length === 0) return '';
 	const lines = tables.map((table) => {
 		const columns = table.columns.map((column) => `${column.name}: ${column.type}`).join(', ');
-		// The request calls it `Orders`; what exists is `Orders [seed …]`. Say so, or the
-		// agent reasonably concludes its table is missing and creates a duplicate.
-		const base = SEED_NAME_RE.exec(table.name)?.[1];
-		const alias = base === undefined ? '' : ` — the request refers to this table as "${base}"`;
-		return `- "${table.name}" (columns: ${columns})${alias}`;
+		return `- "${table.name}" (columns: ${columns})`;
 	});
 	return `\n\nThe following data table(s) already exist in this workspace — reuse them (look them up with the Data Table node's list/schema) instead of creating new ones:\n${lines.join('\n')}`;
 }

--- a/packages/@n8n/instance-ai/evaluations/outcome/workflow-discovery.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/workflow-discovery.ts
@@ -27,6 +27,15 @@ export async function snapshotWorkflowIds(client: N8nClient): Promise<Set<string
 	}
 }
 
+/** Same, for data tables — the scenario seed-table eviction's allowlist. */
+export async function snapshotDataTableIds(client: N8nClient): Promise<Set<string>> {
+	try {
+		return new Set(await client.listDataTableIds(await client.getPersonalProjectId()));
+	} catch {
+		return new Set();
+	}
+}
+
 // ---------------------------------------------------------------------------
 // buildAgentOutcome
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -57,6 +57,9 @@ export interface Lane {
 	/** Base URL the client was constructed with, forwarded for the HTML report. */
 	baseUrl: string;
 	preRunWorkflowIds: Set<string>;
+	/** Data tables present before any build here — the scenario-table eviction's
+	 *  allowlist, so it can't delete a concurrent iteration's live table. */
+	preRunDataTableIds: Set<string>;
 	claimedWorkflowIds: Set<string>;
 	/** Credentials created for test cases on this lane; cleaned up after the run. */
 	createdCredentialIds: Set<string>;

--- a/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/eval-session.ts
@@ -145,6 +145,7 @@ export function createEvalSession(config: EvalSessionConfig): EvalSession {
 						createdCredentialIds: lane.createdCredentialIds,
 						timeoutMs: buildArgs.timeoutMs,
 						preRunWorkflowIds: lane.preRunWorkflowIds,
+						preRunDataTableIds: lane.preRunDataTableIds,
 						claimedWorkflowIds: lane.claimedWorkflowIds,
 						logger,
 						laneTag,

--- a/packages/@n8n/instance-ai/evaluations/run/lane-setup.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/lane-setup.ts
@@ -14,7 +14,7 @@ import { cleanupCredentials } from '../credentials/seeder';
 import type { EvalLogger } from '../harness/logger';
 import { cleanupPrebuiltWorkflows } from '../harness/prebuilt-workflows';
 import { seedMcpRegistry } from '../mcp-registry/seeder';
-import { snapshotWorkflowIds } from '../outcome/workflow-discovery';
+import { snapshotDataTableIds, snapshotWorkflowIds } from '../outcome/workflow-discovery';
 
 export interface LaneSetup {
 	lanes: Lane[];
@@ -80,6 +80,7 @@ export async function setupLanes(args: CliArgs, logger: EvalLogger): Promise<Lan
 			}
 
 			const preRunWorkflowIds = await snapshotWorkflowIds(client);
+			const preRunDataTableIds = await snapshotDataTableIds(client);
 			const claimedWorkflowIds = new Set<string>();
 			const createdCredentialIds = new Set<string>();
 			const workflowIdsToDelete = new Set<string>();
@@ -87,6 +88,7 @@ export async function setupLanes(args: CliArgs, logger: EvalLogger): Promise<Lan
 				client,
 				baseUrl,
 				preRunWorkflowIds,
+				preRunDataTableIds,
 				claimedWorkflowIds,
 				createdCredentialIds,
 				workflowIdsToDelete,


### PR DESCRIPTION
## Summary

A data-table name is **unique per project**, so creating a case's execution-scenario
tables under their *exact declared name* meant a second run of the same case couldn't
create its own — the pre-seed hit `DataTableNameConflictError` and the case scored a
framework issue.

This needs no debug flag to hit. The lane is released the moment `buildWorkflow`
returns (`build-orchestrator.ts:370,457`, deliberately, so judging doesn't idle build
capacity), but the tables live until `releaseCaseRow` runs after the case's **last**
scenario row. Two iterations of one case therefore overlap on the same lane. A
leftover from a crashed run or `--keep-workflows` poisoned every later run the same
way.

Nothing uses `seedDataTables` in a suite yet, which is why this has never been seen —
it was the last open item on the TRUST-311 follow-up list, and it has to land before
the first case adopts the feature.

### The fix

Scenario tables now carry the same `[seed <8 hex>]` suffix the seed *workflows* already
do, so two runs never contend for a name:

- the **declared** name stays the id-map key, so `reseedScenarioTables` needs no
  knowledge of the suffix;
- `uniquifyNames: false` stays — the harness mints the suffix so it knows which name to
  give the agent. (`restoreThread` returns only ids, so letting the server uniquify
  would leave the harness unable to name the table.)
- the note telling the agent which tables exist now names the **created** ones, so it
  still binds by discovery instead of creating a duplicate;
- the naming convention (`seedNameSuffix` / `SEED_NAME_RE` / `uniquifySeedName`) now has
  one definition, shared with the workflow path.

### And the cleanup

`cleanupBuild` deletes by id, so the rename can't orphan anything on the normal path
(asserted in a test). But a crash or `--keep-workflows` skips that, and a unique name
means a leftover no longer fails loudly — it just sits there, and the agent is *told*
to reuse tables that already exist. So leftovers get the same pre-run-snapshot eviction
the seed workflows have. The snapshot is taken once per lane before any build, so a
concurrent iteration's live table is absent by construction and can never be deleted.

The trade: the agent and judge see `Orders [seed 1a2b3c4d]` where the author's
`successCriteria` says `Orders`. That's the identical trade the seed-workflow path
already made, and `SEED_NAME_RE` exists so consumers can strip the suffix.

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm test evaluations   # 1225 pass
pnpm typecheck && pnpm lint
```

New tests cover the suffixing (per-run, shared across a case, inside the 128-char
column bound), the eviction (deletes a leftover; **leaves a table absent from the
pre-run snapshot alone**; never touches an unsuffixed table or another case's; no-ops
without a snapshot; never fails a build on an API error), and the wiring: the table is
created under the suffixed name, the agent is told **that** name, the id map is keyed
by the **declared** name, and the id is tracked for cleanup.

### Exercised live (TRUST-311 follow-up #2, now done)

Ran a purpose-built seeded-table case against a local instance. Three runs on one
instance, `--keep-workflows` so each left its table behind:

| | |
|---|---|
| Table created | `Order Backlog [seed c0befef0]` — the per-run name, confirmed via the REST API |
| Agent's binding | `dataTableId: { mode: 'id', value: 'UIKnWTznbOTZow8I', cachedResultName: 'Order Backlog [seed c0befef0]' }` — **discovered and bound the seeded table; created no duplicate** |
| Rows | `reseeded data table "Order Backlog" (3 row(s))` — declared-name keying resolves to the real id |
| Verifier | *"Read Order Backlog returned exactly 3 items … Slack sent 'there are 3 orders in the backlog'"* |
| Repeat runs | pass; run 3 logged `Evicted 2 leftover seed data table(s) before pre-seeding` and left exactly one table behind |

**Dropped along the way:** an extra hint in the note ("the request refers to this table
as X"). It was insurance against the agent not recognising the suffixed table — but
every live run had it in place, so the failure it guarded against was never observed.
Removed rather than kept on a hunch. What *is* load-bearing is passing the created names
to the note, which stays.

**This run found a real bug — see the third commit.** Run 2 evicted nothing and the
tables piled up: `N8nClient.listDataTables` read `data` as the array while the endpoint
answers `{ data: { count, data } }`, so it returned `[]` for every project with no error
path. The eviction was dead code as written. That also means computer-use's
`cleanupDelta` has been comparing two empty lists and deleting no data tables at all;
fixed and unit-tested for both envelope shapes.

The case itself is deliberately **not committed** — the corpus lives in LangTracer. It's
on disk at `evaluations/data/workflows/binds-pre-seeded-data-table.json` and is the
natural first suite case to adopt `seedDataTables`, once someone decides to push it.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to TRUST-311 (typed `seedDataTables`, #34420) — the last item on its
follow-up list. Adjacent to TRUST-186 (eval data-table isolation), which this does not
address.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



