### PR TITLE
fix(core): Fail fast on already-closed streamed HTTP error bodies

### DIFF
--- a/packages/@n8n/backend-network/src/http/__tests__/binary-buffer.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/binary-buffer.test.ts
@@ -106,4 +106,27 @@ describe('streamToBuffer inactivity timeout', () => {
 			Container.set(HttpRequestConfig, new HttpRequestConfig());
 		}
 	});
+
+	it(
+		'returns buffered bytes immediately when the stream is already destroyed',
+		{ timeout: 1000 },
+		async () => {
+			// Axios + https-proxy-agent on a failed CONNECT (e.g. Squid 403 with an
+			// unsatisfied Content-Length) hands back an IncomingMessage that is
+			// already destroyed/closed, with the partial body still in its buffer.
+			// Attaching 'end'/'close' listeners then never settles — see #35519.
+			const stream = new Readable({ read() {} });
+			stream.push(Buffer.from('Access Denied'));
+			stream.destroy();
+
+			await expect(streamToBuffer(stream, 60_000)).resolves.toEqual(Buffer.from('Access Denied'));
+		},
+	);
+
+	it('returns immediately when the stream has already ended', { timeout: 1000 }, async () => {
+		const stream = Readable.from(Buffer.from('done'));
+		await binaryToBuffer(stream);
+
+		await expect(streamToBuffer(stream, 60_000)).resolves.toEqual(Buffer.from(''));
+	});
 });

--- a/packages/@n8n/backend-network/src/http/__tests__/binary-buffer.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/binary-buffer.test.ts
@@ -129,4 +129,34 @@ describe('streamToBuffer inactivity timeout', () => {
 
 		await expect(streamToBuffer(stream, 60_000)).resolves.toEqual(Buffer.from(''));
 	});
+
+	it(
+		'returns empty buffer immediately when the stream has readableEnded set',
+		{ timeout: 1000 },
+		async () => {
+			// After fully consuming a stream, readableEnded becomes true and future
+			// streamToBuffer calls must return immediately rather than waiting for events.
+			const stream = Readable.from(Buffer.from('consumed'));
+			const first = await streamToBuffer(stream, 60_000);
+			expect(first.toString()).toBe('consumed');
+
+			// Now the stream has readableEnded === true. This should return immediately.
+			await expect(streamToBuffer(stream, 60_000)).resolves.toEqual(Buffer.from(''));
+		},
+	);
+
+	it(
+		'flushes mixed chunk types (Buffer, string, Uint8Array) from an already-destroyed stream',
+		{ timeout: 1000 },
+		async () => {
+			const stream = new Readable({ read() {} });
+			stream.push(Buffer.from('buf'));
+			stream.push('str');
+			stream.push(new Uint8Array([0x61, 0x72, 0x72])); // 'arr' in bytes
+			stream.destroy();
+
+			const result = await streamToBuffer(stream, 60_000);
+			expect(result.toString()).toBe('bufstrarr');
+		},
+	);
 });

--- a/packages/@n8n/backend-network/src/http/__tests__/legacy-request.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/legacy-request.test.ts
@@ -5,7 +5,7 @@ import { jsonParse } from 'n8n-workflow';
 import nock from 'nock';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import type { Readable } from 'node:stream';
+import type { Duplex, Readable } from 'node:stream';
 import { mock } from 'vitest-mock-extended';
 
 import type { SsrfBridge, SsrfProtectionService } from '../../ssrf';
@@ -432,16 +432,17 @@ describe('OutboundHttp.requests requestLegacy', () => {
 		});
 
 		it(
-			'rejects instead of hanging when the error-response body never terminates',
+			'rejects with the HTTP status instead of hanging when the error-response body never terminates',
 			{ timeout: 5000 },
 			async () => {
 				// No per-request `timeout`: axios then sets no socket timeout, so nothing
-				// tears the stalled body stream down — without the guard it hangs forever.
+				// tears the stalled body stream down. The body-read guard aborts the
+				// drain; we still surface the original 403 rather than the drain error.
 				const client = makeFacade().requests({ useDefaultSsrfPolicy: 'unsafe' });
 
 				await expect(
 					client.requestLegacy({ url: `http://127.0.0.1:${port}/stall`, useStream: true }),
-				).rejects.toThrow(/timed out/i);
+				).rejects.toMatchObject({ statusCode: 403 });
 			},
 		);
 
@@ -451,7 +452,7 @@ describe('OutboundHttp.requests requestLegacy', () => {
 			async () => {
 				// The HTTP Request node always sets a per-request timeout (default 300_000ms).
 				// The configured guard must still apply, so the read aborts at ~500ms here,
-				// not at the 30s request timeout.
+				// not at the 30s request timeout — and the caller still sees the 403.
 				const client = makeFacade().requests({ useDefaultSsrfPolicy: 'unsafe' });
 				const start = Date.now();
 
@@ -461,7 +462,7 @@ describe('OutboundHttp.requests requestLegacy', () => {
 						useStream: true,
 						timeout: 30_000,
 					}),
-				).rejects.toThrow(/timed out/i);
+				).rejects.toMatchObject({ statusCode: 403 });
 				expect(Date.now() - start).toBeLessThan(3000);
 			},
 		);
@@ -483,6 +484,73 @@ describe('OutboundHttp.requests requestLegacy', () => {
 
 				await expect(binaryToString(body)).rejects.toThrow(/timed out/i);
 				expect(Date.now() - start).toBeLessThan(3000);
+			},
+		);
+	});
+
+	describe('HTTPS CONNECT proxy denial', () => {
+		let proxyServer: Server;
+		let proxyPort: number;
+		const hijackedSockets: Duplex[] = [];
+
+		beforeAll(async () => {
+			// Real sockets only — nock's net-connect gate interferes with tunneling
+			// agents (it sees the target host, not the proxy hop).
+			nock.cleanAll();
+			nock.restore();
+
+			proxyServer = createServer((_req, res) => {
+				res.writeHead(400).end('use CONNECT\n');
+			});
+			proxyServer.on('connect', (_req, clientSocket) => {
+				hijackedSockets.push(clientSocket);
+				clientSocket.write(
+					'HTTP/1.1 403 Forbidden\r\n' +
+						'Content-Type: text/html\r\n' +
+						'Content-Length: 100000\r\n' +
+						'\r\n' +
+						'<html><body><h1>Access Denied.</h1></body></html>\n',
+				);
+				// intentionally never end — mirrors a sticky forward proxy
+			});
+			await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
+			proxyPort = (proxyServer.address() as AddressInfo).port;
+		});
+
+		afterAll(async () => {
+			for (const socket of hijackedSockets) {
+				socket.destroy();
+			}
+			proxyServer.closeAllConnections();
+			await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+			nock.activate();
+			nock.disableNetConnect();
+		});
+
+		it(
+			'fails fast on Autodetect-style streaming when CONNECT is denied',
+			{ timeout: 5000 },
+			async () => {
+				Container.set(
+					HttpRequestConfig,
+					Object.assign(new HttpRequestConfig(), { responseBodyReadTimeout: 60_000 }),
+				);
+				try {
+					const client = makeFacade().requests({ useDefaultSsrfPolicy: 'unsafe' });
+					const start = Date.now();
+
+					await expect(
+						client.requestLegacy({
+							url: 'https://denied.example/',
+							proxy: `http://127.0.0.1:${proxyPort}`,
+							useStream: true,
+							timeout: 30_000,
+						}),
+					).rejects.toMatchObject({ statusCode: 403 });
+					expect(Date.now() - start).toBeLessThan(3000);
+				} finally {
+					Container.set(HttpRequestConfig, new HttpRequestConfig());
+				}
 			},
 		);
 	});

--- a/packages/@n8n/backend-network/src/http/__tests__/legacy-request.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/legacy-request.test.ts
@@ -5,7 +5,7 @@ import { jsonParse } from 'n8n-workflow';
 import nock from 'nock';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import type { Readable } from 'node:stream';
+import type { Duplex, Readable } from 'node:stream';
 import { mock } from 'vitest-mock-extended';
 
 import type { SsrfBridge, SsrfProtectionService } from '../../ssrf';
@@ -384,16 +384,17 @@ describe('OutboundHttp.requests requestLegacy', () => {
 		});
 
 		it(
-			'rejects instead of hanging when the error-response body never terminates',
+			'rejects with the HTTP status instead of hanging when the error-response body never terminates',
 			{ timeout: 5000 },
 			async () => {
 				// No per-request `timeout`: axios then sets no socket timeout, so nothing
-				// tears the stalled body stream down — without the guard it hangs forever.
+				// tears the stalled body stream down. The body-read guard aborts the
+				// drain; we still surface the original 403 rather than the drain error.
 				const client = makeFacade().requests({ ssrf: 'disabled' });
 
 				await expect(
 					client.requestLegacy({ url: `http://127.0.0.1:${port}/stall`, useStream: true }),
-				).rejects.toThrow(/timed out/i);
+				).rejects.toMatchObject({ statusCode: 403 });
 			},
 		);
 
@@ -403,7 +404,7 @@ describe('OutboundHttp.requests requestLegacy', () => {
 			async () => {
 				// The HTTP Request node always sets a per-request timeout (default 300_000ms).
 				// The configured guard must still apply, so the read aborts at ~500ms here,
-				// not at the 30s request timeout.
+				// not at the 30s request timeout — and the caller still sees the 403.
 				const client = makeFacade().requests({ ssrf: 'disabled' });
 				const start = Date.now();
 
@@ -413,7 +414,7 @@ describe('OutboundHttp.requests requestLegacy', () => {
 						useStream: true,
 						timeout: 30_000,
 					}),
-				).rejects.toThrow(/timed out/i);
+				).rejects.toMatchObject({ statusCode: 403 });
 				expect(Date.now() - start).toBeLessThan(3000);
 			},
 		);
@@ -435,6 +436,73 @@ describe('OutboundHttp.requests requestLegacy', () => {
 
 				await expect(binaryToString(body)).rejects.toThrow(/timed out/i);
 				expect(Date.now() - start).toBeLessThan(3000);
+			},
+		);
+	});
+
+	describe('HTTPS CONNECT proxy denial', () => {
+		let proxyServer: Server;
+		let proxyPort: number;
+		const hijackedSockets: Duplex[] = [];
+
+		beforeAll(async () => {
+			// Real sockets only — nock's net-connect gate interferes with tunneling
+			// agents (it sees the target host, not the proxy hop).
+			nock.cleanAll();
+			nock.restore();
+
+			proxyServer = createServer((_req, res) => {
+				res.writeHead(400).end('use CONNECT\n');
+			});
+			proxyServer.on('connect', (_req, clientSocket) => {
+				hijackedSockets.push(clientSocket);
+				clientSocket.write(
+					'HTTP/1.1 403 Forbidden\r\n' +
+						'Content-Type: text/html\r\n' +
+						'Content-Length: 100000\r\n' +
+						'\r\n' +
+						'<html><body><h1>Access Denied.</h1></body></html>\n',
+				);
+				// intentionally never end — mirrors a sticky forward proxy
+			});
+			await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
+			proxyPort = (proxyServer.address() as AddressInfo).port;
+		});
+
+		afterAll(async () => {
+			for (const socket of hijackedSockets) {
+				socket.destroy();
+			}
+			proxyServer.closeAllConnections();
+			await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+			nock.activate();
+			nock.disableNetConnect();
+		});
+
+		it(
+			'fails fast on Autodetect-style streaming when CONNECT is denied',
+			{ timeout: 5000 },
+			async () => {
+				Container.set(
+					HttpRequestConfig,
+					Object.assign(new HttpRequestConfig(), { responseBodyReadTimeout: 60_000 }),
+				);
+				try {
+					const client = makeFacade().requests({ ssrf: 'disabled' });
+					const start = Date.now();
+
+					await expect(
+						client.requestLegacy({
+							url: 'https://denied.example/',
+							proxy: `http://127.0.0.1:${proxyPort}`,
+							useStream: true,
+							timeout: 30_000,
+						}),
+					).rejects.toMatchObject({ statusCode: 403 });
+					expect(Date.now() - start).toBeLessThan(3000);
+				} finally {
+					Container.set(HttpRequestConfig, new HttpRequestConfig());
+				}
 			},
 		);
 	});

--- a/packages/@n8n/backend-network/src/http/__tests__/legacy-request.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/legacy-request.test.ts
@@ -468,6 +468,33 @@ describe('OutboundHttp.requests requestLegacy', () => {
 		);
 
 		it(
+			'preserves the original HTTP status when error-body drain times out',
+			{ timeout: 5000 },
+			async () => {
+				// When binaryToString fails on a stalled error body, the catch block
+				// in legacy-request.ts should return an empty string and still surface
+				// the original 403 status, not a drain timeout error.
+				const client = makeFacade().requests({ useDefaultSsrfPolicy: 'unsafe' });
+
+				const error = (await client
+					.requestLegacy({
+						url: `http://127.0.0.1:${port}/stall`,
+						useStream: true,
+						timeout: 30_000,
+					})
+					.catch((e: Error & { statusCode?: number; status?: number }) => e)) as Error & {
+					statusCode: number;
+					status: number;
+					message: string;
+				};
+
+				expect(error.statusCode).toBe(403);
+				expect(error.status).toBe(403);
+				expect(error.message).toContain('403');
+			},
+		);
+
+		it(
 			'guards a stalled success-response (2xx) body that the caller drains',
 			{ timeout: 5000 },
 			async () => {
@@ -548,6 +575,40 @@ describe('OutboundHttp.requests requestLegacy', () => {
 						}),
 					).rejects.toMatchObject({ statusCode: 403 });
 					expect(Date.now() - start).toBeLessThan(3000);
+				} finally {
+					Container.set(HttpRequestConfig, new HttpRequestConfig());
+				}
+			},
+		);
+
+		it(
+			'includes partial error body when CONNECT is denied with already-closed stream',
+			{ timeout: 5000 },
+			async () => {
+				// Verifies that when the proxy error body is buffered but the stream
+				// is already closed, we still surface the partial body in the error
+				Container.set(
+					HttpRequestConfig,
+					Object.assign(new HttpRequestConfig(), { responseBodyReadTimeout: 60_000 }),
+				);
+				try {
+					const client = makeFacade().requests({ useDefaultSsrfPolicy: 'unsafe' });
+
+					const error = (await client
+						.requestLegacy({
+							url: 'https://denied.example/',
+							proxy: `http://127.0.0.1:${proxyPort}`,
+							useStream: true,
+							timeout: 30_000,
+						})
+						.catch((e: Error & { statusCode?: number }) => e)) as Error & {
+						statusCode: number;
+						message: string;
+					};
+
+					expect(error.statusCode).toBe(403);
+					expect(error.message).toContain('403');
+					expect(error.message).toContain('Access Denied');
 				} finally {
 					Container.set(HttpRequestConfig, new HttpRequestConfig());
 				}

--- a/packages/@n8n/backend-network/src/http/binary-buffer.ts
+++ b/packages/@n8n/backend-network/src/http/binary-buffer.ts
@@ -3,6 +3,22 @@ import { Container } from '@n8n/di';
 import { UnexpectedError } from 'n8n-workflow';
 import type { Readable } from 'stream';
 
+/** Drain any bytes still sitting in the Readable's internal buffer. */
+function flushBufferedChunks(stream: Readable): Buffer {
+	const chunks: Buffer[] = [];
+	let chunk: unknown;
+	while ((chunk = stream.read()) !== null) {
+		if (Buffer.isBuffer(chunk)) {
+			chunks.push(chunk);
+		} else if (typeof chunk === 'string') {
+			chunks.push(Buffer.from(chunk));
+		} else if (chunk instanceof Uint8Array) {
+			chunks.push(Buffer.from(chunk));
+		}
+	}
+	return Buffer.concat(chunks);
+}
+
 /**
  * Converts a readable stream to a buffer, rejecting if the stream stalls.
  *
@@ -12,8 +28,22 @@ import type { Readable } from 'stream';
  * cut off) — meaning it bounds inactivity, not total read time; a stream that
  * keeps trickling data is intentionally not capped. `idleTimeoutMs` defaults to
  * `HttpRequestConfig.responseBodyReadTimeout`.
+ *
+ * Axios can also hand back a stream that is already `destroyed`/`closed`
+ * (typical for HTTPS CONNECT proxy errors with `responseType: 'stream'`). In
+ * that case no further `end`/`error`/`close` events fire, so we must settle
+ * from the stream's current state instead of waiting on listeners.
  */
 export async function streamToBuffer(stream: Readable, idleTimeoutMs?: number): Promise<Buffer> {
+	// Axios error responses with responseType:'stream' often arrive already
+	// destroyed/closed (e.g. a proxy CONNECT 403 whose Content-Length was never
+	// satisfied). Late 'end'/'close' listeners never fire — without this check
+	// we'd only escape via the inactivity timeout (default 5 minutes). Return
+	// whatever is still buffered so callers can surface the HTTP status + body.
+	if (stream.readableEnded || stream.destroyed || stream.closed) {
+		return flushBufferedChunks(stream);
+	}
+
 	const timeout = idleTimeoutMs ?? Container.get(HttpRequestConfig).responseBodyReadTimeout;
 	const useTimer = Number.isFinite(timeout) && timeout > 0;
 

--- a/packages/@n8n/backend-network/src/http/legacy-request.ts
+++ b/packages/@n8n/backend-network/src/http/legacy-request.ts
@@ -120,7 +120,14 @@ export async function executeLegacyRequest(
 				let responseData = response.data;
 
 				if (Buffer.isBuffer(responseData) || responseData instanceof Readable) {
-					responseData = await binaryToString(responseData);
+					// Error bodies with responseType:'stream' may already be destroyed
+					// (truncated Content-Length after a proxy CONNECT failure). Prefer
+					// surfacing the HTTP status over failing the drain itself.
+					try {
+						responseData = await binaryToString(responseData);
+					} catch {
+						responseData = '';
+					}
 				}
 
 				if (requestObject.simple === false) {

--- a/packages/@n8n/backend-network/src/http/legacy-request.ts
+++ b/packages/@n8n/backend-network/src/http/legacy-request.ts
@@ -114,7 +114,14 @@ export async function executeLegacyRequest(
 				let responseData = response.data;
 
 				if (Buffer.isBuffer(responseData) || responseData instanceof Readable) {
-					responseData = await binaryToString(responseData);
+					// Error bodies with responseType:'stream' may already be destroyed
+					// (truncated Content-Length after a proxy CONNECT failure). Prefer
+					// surfacing the HTTP status over failing the drain itself.
+					try {
+						responseData = await binaryToString(responseData);
+					} catch {
+						responseData = '';
+					}
 				}
 
 				if (requestObject.simple === false) {


### PR DESCRIPTION
## Summary

When the HTTP Request node uses **Response Format = Autodetect** (the default), requests go out with `responseType: 'stream'`. If an HTTPS forward proxy (e.g. Squid) denies `CONNECT` with a `403` whose `Content-Length` is never satisfied, axios hands back an `IncomingMessage` that is already **destroyed/closed**, with any partial body still sitting in its buffer.

`streamToBuffer` previously only settled on `end` / `error` / `close` listeners. Those events never fire again on an already-closed stream, so the drain waited for `N8N_HTTP_RESPONSE_BODY_READ_TIMEOUT` (default **5 minutes**) — which looks like a hang. With **Response Format = Text**, axios buffers instead of streaming and the same proxy error fails immediately.

This PR:

1. **Settles immediately** in `streamToBuffer` when the stream is already ended, destroyed, or closed — flushing any leftover buffered bytes.
2. **Preserves the HTTP status** on the legacy request error path: if draining an error body still fails, return an empty body and throw the original status (e.g. `403`) instead of a drain timeout.

## How to test

### Automated

```bash
cd packages/@n8n/backend-network
pnpm test src/http/__tests__/binary-buffer.test.ts src/http/__tests__/legacy-request.test.ts
```

Coverage added for:

* already-destroyed / already-ended streams in `streamToBuffer`
* stalled error-body drains still surfacing `403`
* HTTPS CONNECT denial with Autodetect-style `useStream: true` failing in < 3s (not the idle timeout)

### Manual

1. Run a Squid-style CONNECT denier (or any HTTP proxy that returns `403` on `CONNECT` with an inflated `Content-Length` and leaves the socket open).
2. Point an **HTTP Request** node at `https://<denied-domain>/` with default **Response Format = Autodetect**.
3. **Before:** node stays *Running* for up to \~5 minutes (or until cancelled).
4. **After:** node fails quickly with the proxy `403`.
5. Confirm **Response Format = Text** still fails with `403` as before.

<details><summary>Minimal CONNECT-denial mock</summary>

```js
import { createServer } from 'node:http';

const server = createServer((_req, res) => res.end('use CONNECT\n'));
server.on('connect', (_req, clientSocket) => {
  clientSocket.write(
    'HTTP/1.1 403 Forbidden\r\n' +
      'Content-Type: text/html\r\n' +
      'Content-Length: 100000\r\n' +
      '\r\n' +
      '<html><body><h1>Access Denied.</h1></body></html>\n',
  );
  // intentionally never end — sticky proxy body
});
server.listen(3128, '127.0.0.1');
```

Then configure the HTTP Request node (or `HTTPS_PROXY=http://127.0.0.1:3128`) against `https://denied.example/`.

</details>

## Related Linear tickets, Github issues, and Community forum posts

* [NODE-5666](https://linear.app/n8n/issue/NODE-5666)
* fixes [#35519](<https://github.com/n8n-io/n8n/issues/35519>)

Related prior work: n8n-io/n8n#32411 (inactivity timeout for stalled body reads). This PR covers the complementary case where the stream is **already closed** before drain starts, so listeners alone never settle.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)