### PR TITLE
fix(core): Compare workflow versions by node id in the versions diff (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-versions-diff.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-versions-diff.tool.test.ts
@@ -194,9 +194,154 @@ describe('get-workflow-versions-diff MCP tool', () => {
 
 			expect(result.structuredContent).toMatchObject({
 				success: true,
-				connectionsAdded: [{ from: 'B', to: 'A', type: 'main' }],
-				connectionsRemoved: [{ from: 'A', to: 'B', type: 'main' }],
+				connectionsAdded: [{ from: 'B', to: 'A', type: 'main', fromOutput: 0, toInput: 0 }],
+				connectionsRemoved: [{ from: 'A', to: 'B', type: 'main', fromOutput: 0, toInput: 0 }],
 			});
+		});
+
+		describe('node identity in the connection diff', () => {
+			const trigger = makeNode({ id: 'node-t', name: 'Trigger' });
+			const slack = makeNode({ id: 'node-s', name: 'Slack' });
+			// Trigger -> <middle> -> Slack. Connections are keyed by node name, which
+			// is exactly what makes a rename look like a rewire.
+			const chainVia = (middle: string) => ({
+				[trigger.name]: { main: [[{ node: middle, type: 'main', index: 0 }]] },
+				[middle]: { main: [[{ node: slack.name, type: 'main', index: 0 }]] },
+			});
+			const triggerStraightToSlack = {
+				[trigger.name]: { main: [[{ node: slack.name, type: 'main', index: 0 }]] },
+			};
+
+			const diffVersions = async (
+				fromNodes: INode[],
+				toNodes: INode[],
+				fromConnections: object,
+				toConnections: object,
+			) => {
+				mockVersions(fromNodes, toNodes, fromConnections, toConnections);
+				const result = await buildTool().handler(
+					{ workflowId: 'wf-1', fromVersionId: 'v1', toVersionId: 'v2' },
+					callContext,
+				);
+				return result.structuredContent as {
+					nodesModified: Array<Record<string, unknown>>;
+					connectionsAdded: Array<Record<string, unknown>>;
+					connectionsRemoved: Array<Record<string, unknown>>;
+				};
+			};
+
+			test('a rename alone does not change the connection diff', async () => {
+				const content = await diffVersions(
+					[trigger, makeNode({ id: 'node-f', name: 'Fetch' }), slack],
+					[trigger, makeNode({ id: 'node-f', name: 'Get Data' }), slack],
+					chainVia('Fetch'),
+					chainVia('Get Data'),
+				);
+
+				// The wiring is unchanged, so only the node itself is reported.
+				expect(content.connectionsAdded).toEqual([]);
+				expect(content.connectionsRemoved).toEqual([]);
+				expect(content.nodesModified).toMatchObject([
+					{
+						id: 'node-f',
+						name: 'Get Data',
+						changes: { name: { __old: 'Fetch', __new: 'Get Data' } },
+					},
+				]);
+			});
+
+			test('a rewire in the same version as a rename still reports the rewire', async () => {
+				const content = await diffVersions(
+					[trigger, makeNode({ id: 'node-f', name: 'Fetch' }), slack],
+					[trigger, makeNode({ id: 'node-f', name: 'Get Data' }), slack],
+					chainVia('Fetch'),
+					triggerStraightToSlack,
+				);
+
+				expect(content.connectionsAdded).toMatchObject([{ from: 'Trigger', to: 'Slack' }]);
+				// Reported under the renamed node's current name, which still resolves.
+				expect(content.connectionsRemoved).toMatchObject([
+					{ from: 'Trigger', to: 'Get Data' },
+					{ from: 'Get Data', to: 'Slack' },
+				]);
+			});
+
+			test('a removed node keeps its base-version name on removed connections', async () => {
+				const content = await diffVersions(
+					[trigger, makeNode({ id: 'node-f', name: 'Fetch' }), slack],
+					[trigger, slack],
+					chainVia('Fetch'),
+					{},
+				);
+
+				expect(content.connectionsRemoved).toMatchObject([
+					{ from: 'Trigger', to: 'Fetch' },
+					{ from: 'Fetch', to: 'Slack' },
+				]);
+			});
+
+			test('empty output slots do not register as connection changes', async () => {
+				const ifNode = makeNode({ id: 'node-if', name: 'If', type: 'n8n-nodes-base.if' });
+				const connections = {
+					[ifNode.name]: { main: [null, [{ node: slack.name, type: 'main', index: 0 }]] },
+				};
+
+				const content = await diffVersions([ifNode, slack], [ifNode, slack], connections, {
+					...connections,
+				});
+
+				expect(content.connectionsAdded).toEqual([]);
+				expect(content.connectionsRemoved).toEqual([]);
+			});
+		});
+
+		test('distinguishes a rewire between two outputs of the same node', async () => {
+			const ifNode = makeNode({ id: 'node-if', name: 'If', type: 'n8n-nodes-base.if' });
+			const slack = makeNode({ id: 'node-s', name: 'Slack' });
+			const target = [{ node: slack.name, type: 'main', index: 0 }];
+
+			mockVersions(
+				[ifNode, slack],
+				[ifNode, slack],
+				{ [ifNode.name]: { main: [target, []] } },
+				{ [ifNode.name]: { main: [[], target] } },
+			);
+
+			const tool = buildTool();
+			const result = await tool.handler(
+				{ workflowId: 'wf-1', fromVersionId: 'v1', toVersionId: 'v2' },
+				callContext,
+			);
+
+			// Without the output index both entries would be identical, hiding the
+			// move from the true branch to the false branch.
+			expect(result.structuredContent).toMatchObject({
+				connectionsAdded: [{ from: 'If', to: 'Slack', fromOutput: 1 }],
+				connectionsRemoved: [{ from: 'If', to: 'Slack', fromOutput: 0 }],
+			});
+		});
+
+		test.each([
+			['disabled', { disabled: true }],
+			['onError', { onError: 'continueRegularOutput' as const }],
+			['retryOnFail', { retryOnFail: true }],
+			['executeOnce', { executeOnce: true }],
+			['alwaysOutputData', { alwaysOutputData: true }],
+			['notes', { notes: 'handle rate limits here' }],
+		])('reports a change to the %s node setting', async (property, override) => {
+			mockVersions([makeNode({})], [makeNode(override)]);
+
+			const tool = buildTool();
+			const result = await tool.handler(
+				{ workflowId: 'wf-1', fromVersionId: 'v1', toVersionId: 'v2' },
+				callContext,
+			);
+
+			const content = result.structuredContent as {
+				nodesModified: Array<{ changes: Record<string, unknown> }>;
+			};
+			expect(content.nodesModified).toHaveLength(1);
+			expect(content.nodesModified[0].changes).toHaveProperty(`${property}__added`);
 		});
 
 		test('reduces credentials to id and name in the delta', async () => {

--- a/packages/cli/src/modules/mcp/tools/get-workflow-versions-diff.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-versions-diff.tool.ts
@@ -1,8 +1,8 @@
 import type { User } from '@n8n/db';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { diff } from 'json-diff';
-import pick from 'lodash/pick';
-import type { INode, INodeConnectionsDiff } from 'n8n-workflow';
+import omit from 'lodash/omit';
+import type { IConnections, INode, INodeConnectionsDiff } from 'n8n-workflow';
 import { compareConnections, compareWorkflowsNodes, NodeDiffStatus } from 'n8n-workflow';
 import z from 'zod';
 
@@ -42,9 +42,21 @@ const modifiedNodeSchema = nodeChangeSummarySchema.extend({
 });
 
 const connectionChangeSchema = z.object({
-	from: z.string().describe('Source node name'),
-	to: z.string().describe('Target node name'),
+	from: z
+		.string()
+		.describe(
+			'Source node name, using its target-version name, or its base-version name if the node no longer exists there',
+		),
+	to: z
+		.string()
+		.describe(
+			'Target node name, using its target-version name, or its base-version name if the node no longer exists there',
+		),
 	type: z.string().describe("Connection type (e.g. 'main', 'ai_tool')"),
+	fromOutput: z
+		.number()
+		.describe('Index of the source node output (e.g. 0 = true branch, 1 = false branch on an If)'),
+	toInput: z.number().describe('Index of the target node input (e.g. 1 = second input of a Merge)'),
 });
 
 const outputSchema = {
@@ -67,8 +79,14 @@ const outputSchema = {
 		.describe(
 			'Nodes present in both versions whose content changed (position-only moves are not reported). Listed by their name in the target version.',
 		),
-	connectionsAdded: z.array(connectionChangeSchema),
-	connectionsRemoved: z.array(connectionChangeSchema),
+	connectionsAdded: z
+		.array(connectionChangeSchema)
+		.describe(
+			'Connections present in the target version but not the base version. Renaming a node does not by itself produce connection changes; endpoints are matched by node id.',
+		),
+	connectionsRemoved: z
+		.array(connectionChangeSchema)
+		.describe('Connections present in the base version but not the target version.'),
 	error: z.string().optional(),
 } satisfies z.ZodRawShape;
 
@@ -95,22 +113,22 @@ type GetWorkflowVersionsDiffOutput = GetWorkflowVersionsDiffResult & {
 	error?: string;
 };
 
-// The property set compareWorkflowsNodes marks a node "modified" by, so the
-// delta explains exactly why the node is listed.
-const DIFFED_NODE_PROPS = ['name', 'type', 'typeVersion', 'webhookId', 'credentials', 'parameters'];
+// Everything but `position` is diffed. An allowlist silently hides whatever it
+// omits, and node settings that change behaviour (`disabled`, `onError`,
+// `retryOnFail`, `executeOnce`, ...) belong in the delta. Moving a node on the
+// canvas does not.
+const IGNORED_NODE_PROPS = ['position'] as const;
 
 // json-diff types its return as `any`; pin the delta shape at the boundary
 // (undefined when both sides are equal).
 const structuredDiff: (a: unknown, b: unknown) => Record<string, unknown> | undefined = diff;
 
-function diffNodeContents(fromNode: INode, toNode: INode): Record<string, unknown> {
+function diffNodeContents(fromNode: INode, toNode: INode): Record<string, unknown> | undefined {
 	// Credentials are reduced to `{ id, name }` per slot before diffing,
 	// mirroring the get_workflow_version read path.
-	return (
-		structuredDiff(
-			pick(sanitizeNodeCredentials(fromNode), DIFFED_NODE_PROPS),
-			pick(sanitizeNodeCredentials(toNode), DIFFED_NODE_PROPS),
-		) ?? {}
+	return structuredDiff(
+		omit(sanitizeNodeCredentials(fromNode), IGNORED_NODE_PROPS),
+		omit(sanitizeNodeCredentials(toNode), IGNORED_NODE_PROPS),
 	);
 }
 
@@ -118,15 +136,49 @@ function toNodeChangeSummary(node: INode): NodeChangeSummary {
 	return { id: node.id, name: node.name, type: node.type };
 }
 
+/**
+ * Rewrites a version's connections so the source key and each connection's
+ * target hold node ids instead of names. Names are the persisted connection
+ * identity, so without this a rename reads as every edge on that node being
+ * removed and re-added. A name matching no node (a stale entry) is kept as-is.
+ */
+function toIdKeyedConnections(connections: IConnections, nodes: INode[]): IConnections {
+	const idByName = new Map(nodes.map((node) => [node.name, node.id]));
+	const keyed: IConnections = {};
+	for (const [sourceName, byType] of Object.entries(connections)) {
+		keyed[idByName.get(sourceName) ?? sourceName] = Object.fromEntries(
+			Object.entries(byType).map(([type, outputs]) => [
+				type,
+				outputs.map(
+					(connections) =>
+						connections?.map((connection) => ({
+							...connection,
+							node: idByName.get(connection.node) ?? connection.node,
+						})) ?? null,
+				),
+			]),
+		);
+	}
+	return keyed;
+}
+
 function flattenConnectionsDiff(
 	connectionsDiff: Record<string, INodeConnectionsDiff>,
+	nameById: Map<string, string>,
 ): ConnectionChange[] {
 	const changes: ConnectionChange[] = [];
 	for (const [from, byType] of Object.entries(connectionsDiff)) {
 		for (const [type, entries] of Object.entries(byType)) {
 			for (const entry of entries) {
 				if (!entry.value) continue;
-				changes.push({ from, to: entry.value.connection.node, type });
+				const { node, index } = entry.value.connection;
+				changes.push({
+					from: nameById.get(from) ?? from,
+					to: nameById.get(node) ?? node,
+					type,
+					fromOutput: entry.sourceIndex,
+					toInput: index,
+				});
 			}
 		}
 	}
@@ -235,7 +287,14 @@ export async function getWorkflowVersionsDiff(
 
 	const fromNodes = fromVersion.nodes ?? [];
 	const toNodes = toVersion.nodes ?? [];
-	const nodeDiff = compareWorkflowsNodes(fromNodes, toNodes);
+	// Classify with our own comparator rather than the default `compareNodes`,
+	// which only looks at six properties. Widening that shared list is not an
+	// option: it also drives workflow-history pruning via `groupWorkflows`.
+	// A node is Modified if and only if its delta is non-empty, so `changes`
+	// always explains why the node is listed.
+	const nodeDiff = compareWorkflowsNodes(fromNodes, toNodes, (base, target) =>
+		base && target ? !diffNodeContents(base, target) : base === target,
+	);
 	// The diff stores the pre-change node for modified entries; report the
 	// post-change node so a renamed node is listed by a name that still exists.
 	const toNodesById = new Map(toNodes.map((node) => [node.id, node]));
@@ -249,18 +308,24 @@ export async function getWorkflowVersionsDiff(
 		if (status === NodeDiffStatus.Added) nodesAdded.push(sanitizeNodeCredentials(node));
 		else if (status === NodeDiffStatus.Deleted) nodesRemoved.push(toNodeChangeSummary(node));
 		else if (status === NodeDiffStatus.Modified) {
+			// Modified implies the id is present in the target version; the guard
+			// only narrows the type.
 			const toNode = toNodesById.get(node.id);
 			if (!toNode) continue;
 			nodesModified.push({
 				...toNodeChangeSummary(toNode),
-				changes: diffNodeContents(node, toNode),
+				changes: diffNodeContents(node, toNode) ?? {},
 			});
 		}
 	}
 
+	// Compare by node id so a rename doesn't read as edge churn, then report
+	// names again. Target names win so a renamed node is listed by a name that
+	// still exists; base names cover endpoints only present in the base version.
+	const nameById = new Map([...fromNodes, ...toNodes].map((node) => [node.id, node.name]));
 	const connectionsDiff = compareConnections(
-		fromVersion.connections ?? {},
-		toVersion.connections ?? {},
+		toIdKeyedConnections(fromVersion.connections ?? {}, fromNodes),
+		toIdKeyedConnections(toVersion.connections ?? {}, toNodes),
 	);
 
 	return {
@@ -270,7 +335,7 @@ export async function getWorkflowVersionsDiff(
 		nodesAdded,
 		nodesRemoved,
 		nodesModified,
-		connectionsAdded: flattenConnectionsDiff(connectionsDiff.added),
-		connectionsRemoved: flattenConnectionsDiff(connectionsDiff.removed),
+		connectionsAdded: flattenConnectionsDiff(connectionsDiff.added, nameById),
+		connectionsRemoved: flattenConnectionsDiff(connectionsDiff.removed, nameById),
 	};
 }


### PR DESCRIPTION
## Summary

Stacked on #35492. Fixes the three blocking issues from [my review there](https://github.com/n8n-io/n8n/pull/35492#pullrequestreview-4858368371), so review that one first.

All three made `get_workflow_versions_diff` describe the workflow **incorrectly** rather than incompletely, and a client had no way to detect any of them. Every output below is a value the tool actually returned, before and after.

---

### 1. Renaming a node looked like rewiring the workflow

Connections are stored keyed by node **name**, in two places at once: the outer key (the source) and each `IConnection.node` (the target).

```js
// before the rename
{ "Trigger": { main: [[{ node: "Fetch",    ... }]] },
  "Fetch":   { main: [[{ node: "Slack",    ... }]] } }

// after renaming Fetch to Get Data. Same graph, different text on both sides.
{ "Trigger":  { main: [[{ node: "Get Data", ... }]] },
  "Get Data": { main: [[{ node: "Slack",    ... }]] } }
```

So `compareConnections` saw a source appear and another vanish. Rename `Fetch` to `Get Data` and change nothing else:

| | before | after |
|---|---|---|
| `connectionsAdded` | `[{Trigger->Get Data}, {Get Data->Slack}]` | `[]` |
| `connectionsRemoved` | `[{Trigger->Fetch}, {Fetch->Slack}]` | `[]` |
| `nodesModified` | the rename | the rename (unchanged) |

The rename is still reported, on the node where it belongs:

```json
{ "id": "node-f", "name": "Get Data",
  "changes": { "name": { "__old": "Fetch", "__new": "Get Data" } } }
```

**Why it mattered.** The noise scaled with the renamed node's degree, not the size of the edit, so renaming one node wired to five others produced 5 phantom additions and 5 phantom removals. Worse, `connectionsRemoved` was *byte-identical* whether you renamed a node or genuinely rewired around it, so the connection lists could not tell a client which had happened. Every client had to look up `nodesModified` and cancel the entries out by hand.

**Fix.** Map endpoints to node ids before comparing, then back to names on the way out. Target names win, so a renamed node is reported by a name that still resolves. A node deleted in the target version has no current name, so it keeps its base-version one.

A rename **and** a real rewire in the same version still reports the rewire, because ids pin the endpoints:

```
connectionsAdded   [{"from":"Trigger","to":"Slack"}]                            <- the real change
connectionsRemoved [{"from":"Trigger","to":"Get Data"},{"from":"Get Data","to":"Slack"}]
```

### 2. Six node settings were invisible

`compareNodes` only inspects `name, type, typeVersion, webhookId, credentials, parameters`. Everything else compared equal, so:

```
disabled: false -> true      nodesModified []      <- before
onError changed              nodesModified []
retryOnFail enabled          nodesModified []
executeOnce enabled          nodesModified []
alwaysOutputData enabled     nodesModified []
notes added                  nodesModified []
```

Someone disables a node, the workflow stops working, you ask what changed between the two versions, and the tool answers **nothing**. That is worse than an incomplete answer, because nothing signals that a field was skipped.

**Fix.** Diff everything except `position`. An allowlist silently hides whatever it omits and has to be kept in sync with an array in another package; a denylist covers future node fields for free. Position-only moves are still not reported, which is deliberate and tested.

Note that widening the shared `propsToCompare` in `workflow-diff.ts` was **not** an option: it also drives workflow-history pruning via `groupWorkflows` / `mergeAdditiveChanges`, so touching it would change which versions get merged away in production. Instead this uses the comparator parameter `compareWorkflowsNodes` already accepts, so nothing outside this file changes behaviour.

A side effect worth having: a node is now `Modified` if and only if its delta is non-empty, so `changes: {}` is no longer representable. That also removes `DIFFED_NODE_PROPS`, which was a copy of the unexported `propsToCompare` and would have drifted silently.

### 3. Moving a connection between two outputs was undetectable

`flattenConnectionsDiff` discarded the output and input indices. Move a node from an If's true branch to its false branch:

```
before   added   [{"from":"If","to":"Slack","type":"main"}]
         removed [{"from":"If","to":"Slack","type":"main"}]     <- identical, change unrecoverable

after    added   [{"from":"If","to":"Slack","fromOutput":1,"toInput":0}]
         removed [{"from":"If","to":"Slack","fromOutput":0,"toInput":0}]
```

The same applied to Switch, Merge inputs, and any AI node with parallel same-type ports. Both values were already sitting in the `ConnectionEntry` being thrown away, so this adds `fromOutput` and `toInput` to `connectionChangeSchema`.

---

Also tightened the output schema descriptions, since a client previously had to infer that entries use target-version names and that a rename does not produce connection changes.

Left alone deliberately, as noted in the review: the unbounded response size (`get_workflow_version` has the same property, so it wants its own follow-up covering both) and the `json-diff` delta format.

## How to test

Unit tests, from `packages/cli`:

```bash
pnpm vitest run src/modules/mcp/__tests__/get-workflow-versions-diff.tool.test.ts
```

19 tests, up from 8. **10 of the 11 new ones fail on the base branch**, which is the point. The other two are regression guards for base-version naming and for `null` output slots.

Manually, against an instance with the MCP server enabled and a workflow available in MCP:

1. Rename a node and save. Diff the two versions and confirm `connectionsAdded` and `connectionsRemoved` are empty while `nodesModified` shows the rename.
2. Disable a node and save. Diff and confirm the node appears in `nodesModified` with `disabled__added`.
3. On an If node, drag a connection from the true branch to the false branch and save. Diff and confirm the added and removed entries differ by `fromOutput`.
4. Rename a node and rewire it in the same edit. Confirm only the real rewire shows up.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35492.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

