### PR TITLE
fix(backend-network): strip target TLS options from proxy agents

### DIFF
--- a/packages/@n8n/backend-network/src/http/__tests__/node-agents.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/node-agents.test.ts
@@ -20,8 +20,19 @@ function getAgentLookup(agent: http.Agent | https.Agent): unknown {
 }
 
 // `http.Agent['options']` is not exposed on the public Node types.
-function getAgentOptions(agent: http.Agent | https.Agent): { keepAlive?: boolean } {
-	return (agent as unknown as { options?: { keepAlive?: boolean } }).options ?? {};
+function getAgentOptions(
+	agent: http.Agent | https.Agent,
+): { keepAlive?: boolean } & Record<string, unknown> {
+	return (
+		(agent as unknown as { options?: { keepAlive?: boolean } & Record<string, unknown> }).options ??
+		{}
+	);
+}
+
+// HttpsProxyAgent stores TLS settings in `connectOpts` (used for the
+// tls.connect call), not in `options`.
+function getProxyConnectOpts(agent: http.Agent | https.Agent): Record<string, unknown> {
+	return (agent as unknown as { connectOpts?: Record<string, unknown> }).connectOpts ?? {};
 }
 
 // ---------------------------------------------------------------------------
@@ -67,6 +78,32 @@ describe('buildNodeAgents', () => {
 			const { httpAgent } = buildNodeAgents('env', 'disabled', { keepAlive: true });
 
 			expect(getAgentOptions(httpAgent).keepAlive).toBe(true);
+		});
+
+		it('strips target-specific TLS options from the explicit-proxy agent', () => {
+			// `servername`, `rejectUnauthorized` and `secureOptions` describe the
+			// tunnelled target session, not the proxy socket. Forwarding them makes
+			// `https-proxy-agent` validate the proxy certificate against the target
+			// hostname (ERR_TLS_CERT_ALTNAME_INVALID). They must be omitted.
+			const { httpAgent, httpsAgent } = buildNodeAgents('http://proxy.internal:3128', 'disabled', {
+				keepAlive: true,
+				servername: 'target.example.com',
+				rejectUnauthorized: false,
+				secureOptions: 1,
+			});
+
+			const httpOpts = getAgentOptions(httpAgent);
+			const httpsOpts = getProxyConnectOpts(httpsAgent);
+
+			expect(httpOpts.keepAlive).toBe(true);
+			expect(httpOpts).not.toHaveProperty('servername');
+			expect(httpOpts).not.toHaveProperty('rejectUnauthorized');
+			expect(httpOpts).not.toHaveProperty('secureOptions');
+
+			expect(httpsOpts.keepAlive).toBe(true);
+			expect(httpsOpts).not.toHaveProperty('servername');
+			expect(httpsOpts).not.toHaveProperty('rejectUnauthorized');
+			expect(httpsOpts).not.toHaveProperty('secureOptions');
 		});
 	});
 

--- a/packages/@n8n/backend-network/src/http/__tests__/node-agents.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/node-agents.test.ts
@@ -80,31 +80,44 @@ describe('buildNodeAgents', () => {
 			expect(getAgentOptions(httpAgent).keepAlive).toBe(true);
 		});
 
-		it('strips target-specific TLS options from the explicit-proxy agent', () => {
-			// `servername`, `rejectUnauthorized` and `secureOptions` describe the
-			// tunnelled target session, not the proxy socket. Forwarding them makes
-			// `https-proxy-agent` validate the proxy certificate against the target
-			// hostname (ERR_TLS_CERT_ALTNAME_INVALID). They must be omitted.
-			const { httpAgent, httpsAgent } = buildNodeAgents('http://proxy.internal:3128', 'disabled', {
-				keepAlive: true,
-				servername: 'target.example.com',
-				rejectUnauthorized: false,
-				secureOptions: 1,
-			});
+		it.each([
+			// An http:// proxy performs a cleartext CONNECT and never runs
+			// tls.connect on the proxy socket, so the stripped options had no
+			// observable effect there.
+			['http://proxy.internal:3128', 'http proxy'],
+			// The reported bug (ERR_TLS_CERT_ALTNAME_INVALID) only occurs with an
+			// https:// proxy, where HttpsProxyAgent runs tls.connect on the proxy
+			// socket and https-proxy-agent validates the proxy certificate against
+			// the target hostname when `servername` is forwarded.
+			['https://proxy.internal:3128', 'https proxy'],
+		])(
+			'strips target-specific TLS options from the explicit-proxy agent (%s)',
+			(proxyUrl: string) => {
+				// `servername`, `rejectUnauthorized` and `secureOptions` describe the
+				// tunnelled target session, not the proxy socket. Forwarding them makes
+				// `https-proxy-agent` validate the proxy certificate against the target
+				// hostname (ERR_TLS_CERT_ALTNAME_INVALID). They must be omitted.
+				const { httpAgent, httpsAgent } = buildNodeAgents(proxyUrl, 'disabled', {
+					keepAlive: true,
+					servername: 'target.example.com',
+					rejectUnauthorized: false,
+					secureOptions: 1,
+				});
 
-			const httpOpts = getAgentOptions(httpAgent);
-			const httpsOpts = getProxyConnectOpts(httpsAgent);
+				const httpOpts = getAgentOptions(httpAgent);
+				const httpsOpts = getProxyConnectOpts(httpsAgent);
 
-			expect(httpOpts.keepAlive).toBe(true);
-			expect(httpOpts).not.toHaveProperty('servername');
-			expect(httpOpts).not.toHaveProperty('rejectUnauthorized');
-			expect(httpOpts).not.toHaveProperty('secureOptions');
+				expect(httpOpts.keepAlive).toBe(true);
+				expect(httpOpts).not.toHaveProperty('servername');
+				expect(httpOpts).not.toHaveProperty('rejectUnauthorized');
+				expect(httpOpts).not.toHaveProperty('secureOptions');
 
-			expect(httpsOpts.keepAlive).toBe(true);
-			expect(httpsOpts).not.toHaveProperty('servername');
-			expect(httpsOpts).not.toHaveProperty('rejectUnauthorized');
-			expect(httpsOpts).not.toHaveProperty('secureOptions');
-		});
+				expect(httpsOpts.keepAlive).toBe(true);
+				expect(httpsOpts).not.toHaveProperty('servername');
+				expect(httpsOpts).not.toHaveProperty('rejectUnauthorized');
+				expect(httpsOpts).not.toHaveProperty('secureOptions');
+			},
+		);
 	});
 
 	describe('rejects a caller-provided lookup (managed by the SSRF policy)', () => {

--- a/packages/@n8n/backend-network/src/http/node-agents.ts
+++ b/packages/@n8n/backend-network/src/http/node-agents.ts
@@ -99,10 +99,41 @@ export function buildNodeAgents(
 	}
 
 	// Explicit proxy URL. No direct path, so no SSRF lookup is injected.
+	// Target-specific TLS options (servername, rejectUnauthorized, secureOptions)
+	// describe the connection to the final target, not to the proxy. Forwarding
+	// them to the proxy agent makes `https-proxy-agent` validate the proxy's
+	// certificate against the target hostname (ERR_TLS_CERT_ALTNAME_INVALID) and
+	// apply the target's relaxed-TLS flags to the proxy handshake. Strip them so
+	// the proxy socket is validated against the proxy URL's own hostname.
 	return {
-		httpAgent: new HttpProxyAgent(proxy as string, { ...agentOptions }),
-		httpsAgent: new HttpsProxyAgent(proxy as string, { ...agentOptions }),
+		httpAgent: new HttpProxyAgent(proxy as string, stripTargetTlsOptions(agentOptions)),
+		httpsAgent: new HttpsProxyAgent(proxy as string, stripTargetTlsOptions(agentOptions)),
 	};
+}
+
+/**
+ * Target-specific TLS options that must not be forwarded to a proxy agent.
+ * `servername` sets TLS SNI, `rejectUnauthorized`/`secureOptions` control
+ * certificate validation — all of which describe the tunnelled target session,
+ * not the connection to the proxy itself.
+ */
+const TARGET_TLS_OPTIONS = ['servername', 'rejectUnauthorized', 'secureOptions'] as const;
+
+/**
+ * Returns a shallow copy of `agentOptions` without target-specific TLS fields,
+ * so they are not applied to the proxy socket. Leaves all other options intact.
+ */
+function stripTargetTlsOptions(
+	agentOptions: NodeAgentOptions | undefined,
+): NodeAgentOptions | undefined {
+	if (!agentOptions) return undefined;
+	const stripped: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(agentOptions)) {
+		if (!TARGET_TLS_OPTIONS.includes(key as (typeof TARGET_TLS_OPTIONS)[number])) {
+			stripped[key] = value;
+		}
+	}
+	return stripped as NodeAgentOptions;
 }
 
 /** Subset of an agent's connection options we read to find the target host. */


### PR DESCRIPTION
When `buildNodeAgents` constructs a `HttpsProxyAgent` for an explicit `https://` proxy URL, it spreads the full `agentOptions` object — including `servername`, `rejectUnauthorized` and `secureOptions` — into the proxy agent constructor. These fields describe the TLS session to the final target, not the socket to the proxy, so `https-proxy-agent` ends up validating the proxy's certificate against the target hostname and aborts the handshake with `ERR_TLS_CERT_ALTNAME_INVALID` before CONNECT is ever sent. The practical effect is that `https://` proxy URLs are unusable, which forces users back to cleartext `http://` proxies where Basic credentials travel unprotected.

The fix strips those three target-specific fields before passing the options to `HttpProxyAgent` / `HttpsProxyAgent`, so the proxy socket falls back to its default behaviour of deriving SNI from the proxy URL's own hostname. All other agent options (keep-alive, etc.) are still forwarded unchanged. The direct (`proxy: false`) and env paths are untouched because there the TLS options correctly apply to the target.

Added a regression test in node-agents.test.ts that builds agents with `servername`, `rejectUnauthorized` and `secureOptions` set and asserts none of them reach the proxy agent's options or connectOpts, while `keepAlive` still does.

Fixes #35509


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

