### PR TITLE
fix(engine): apply N8N_PAYLOAD_SIZE_MAX to engine server body-parser limit

### DIFF
--- a/packages/@n8n/engine/src/serve.ts
+++ b/packages/@n8n/engine/src/serve.ts
@@ -1,4 +1,4 @@
-import { EngineConfig } from '@n8n/config';
+import { EngineConfig, GlobalConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import type { DataSource } from '@n8n/typeorm';
 
@@ -47,7 +47,12 @@ async function main(): Promise<void> {
 
 	const { app } = createEngineServer(
 		dataSource
-			? { dataSource, admittance: new AllowAllAdmittance(), workQueue: orchestrationQueue }
+			? {
+					dataSource,
+					admittance: new AllowAllAdmittance(),
+					workQueue: orchestrationQueue,
+					payloadSizeMax: Container.get(GlobalConfig).endpoints.payloadSizeMax,
+				}
 			: undefined,
 	);
 

--- a/packages/@n8n/engine/src/server/create-engine-server.ts
+++ b/packages/@n8n/engine/src/server/create-engine-server.ts
@@ -7,8 +7,12 @@ import { StartExecutionService } from '../execution/start-execution.service';
 import type { OrchestrationMessage, WorkQueue } from '../queue';
 import { createWorkflowExecutionsRouter } from './routes/workflow-executions';
 
+const DEFAULT_PAYLOAD_SIZE_MB = 16;
+
 export interface EngineServerDeps {
 	dataSource: DataSource;
+	/** Maximum request payload size in MiB. Defaults to 16. */
+	payloadSizeMax?: number;
 	admittance: AdmittanceService;
 	workQueue: WorkQueue<OrchestrationMessage>;
 }
@@ -20,7 +24,8 @@ export interface EngineServerDeps {
  */
 export function createEngineServer(deps?: EngineServerDeps): { app: Application } {
 	const app = express();
-	app.use(express.json());
+	const limitMb = deps?.payloadSizeMax ?? DEFAULT_PAYLOAD_SIZE_MB;
+	app.use(express.json({ limit: `${limitMb}mb` }));
 
 	app.get('/healthz', (_req, res) => {
 		res.status(200).json({ status: 'ok' });


### PR DESCRIPTION
## What changed

`createEngineServer` called `express.json()` with no `limit` option, so body-parser silently capped request bodies at 100 KiB. The `N8N_PAYLOAD_SIZE_MAX` env var was already wired to the main CLI and public API servers but never propagated to the engine server.

Any workflow node that sends a payload larger than ~100 KB to the engine (e.g. large AI model responses via the OpenAI Chat Model node) received a `413 PayloadTooLargeError` before the request reached the handler.

## Fix

- Added an optional `payloadSizeMax` field to `EngineServerDeps`
- Pass `{ limit: `${limitMb}mb` }` to `express.json()`, defaulting to 16 MiB when not provided
- In `serve.ts`, read `GlobalConfig.endpoints.payloadSizeMax` (which maps to `N8N_PAYLOAD_SIZE_MAX`) and pass it through

Fixes #35484.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

