### PR TITLE
fix(editor): Improve resource locator link preview handling

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.constants.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.constants.ts
@@ -166,3 +166,26 @@ export const TEST_NODE_URL_REDIRECT: INode = {
 		options: {},
 	},
 };
+
+// A mode whose `url` is an expression template with a `{{$value}}` placeholder,
+// mirroring nodes like Airtable Trigger (`=https://airtable.com/{{$value}}`).
+export const TEST_PARAMETER_URL_TEMPLATE: INodeProperties = {
+	...TEST_PARAMETER_MULTI_MODE,
+	name: 'testParameterUrlTemplate',
+	modes: [
+		{
+			displayName: 'ID',
+			name: 'id',
+			type: 'string',
+			url: '=https://test.com/{{$value}}',
+		},
+	],
+};
+
+export const TEST_NODE_URL_TEMPLATE: INode = {
+	...TEST_NODE_MULTI_MODE,
+	name: 'Test Node - URL Template',
+	parameters: {
+		testParameterUrlTemplate: { __rl: true, mode: 'id', value: '' },
+	},
+};

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
@@ -17,7 +17,11 @@ import {
 	TEST_PARAMETER_SINGLE_MODE,
 	TEST_PARAMETER_SKIP_CREDENTIALS_CHECK,
 	TEST_PARAMETER_URL_REDIRECT,
+	TEST_PARAMETER_URL_TEMPLATE,
+	TEST_NODE_URL_TEMPLATE,
 } from './ResourceLocator.test.constants';
+import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
+import { flushPromises } from '@vue/test-utils';
 
 vi.mock('vue-router', async () => {
 	const actual = await vi.importActual('vue-router');
@@ -515,5 +519,88 @@ describe('ResourceLocator', () => {
 		await userEvent.click(link);
 
 		expect(windowOpenSpy).not.toHaveBeenCalled();
+	});
+
+	describe('url template link resolution', () => {
+		const mockResolveExpression = vi.fn().mockImplementation((val) => val);
+
+		beforeEach(() => {
+			vi.mocked(useWorkflowHelpers).mockReturnValue({
+				resolveExpression: mockResolveExpression,
+				resolveRequiredParameters: vi.fn().mockImplementation((_, params) => params),
+			} as unknown as ReturnType<typeof useWorkflowHelpers>);
+		});
+
+		afterEach(() => {
+			mockResolveExpression.mockClear();
+		});
+
+		it('resolves a link when the value is a literal', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					modelValue: { __rl: true, mode: 'id', value: 'clean-id' },
+					parameter: TEST_PARAMETER_URL_TEMPLATE,
+					path: `parameters.${TEST_PARAMETER_URL_TEMPLATE.name}`,
+					node: TEST_NODE_URL_TEMPLATE,
+					displayTitle: 'Test Resource Locator',
+					expressionComputedValue: '',
+					isValueExpression: false,
+				},
+			});
+
+			await waitFor(() => {
+				expect(mockResolveExpression).toHaveBeenCalledWith(
+					'=https://test.com/clean-id',
+					expect.anything(),
+					expect.anything(),
+				);
+			});
+			expect(await waitFor(() => getByTestId('rlc-open-resource-link'))).toBeInTheDocument();
+		});
+
+		it.each([
+			['opening braces', '{{ 1 + 1 }}'],
+			['a closing brace fragment', 'abc }}'],
+			['an opening brace fragment', '{{ abc'],
+		])(
+			'does not splice a literal value containing %s into the url template',
+			async (_label, value) => {
+				const { queryByTestId } = renderComponent({
+					props: {
+						modelValue: { __rl: true, mode: 'id', value },
+						parameter: TEST_PARAMETER_URL_TEMPLATE,
+						path: `parameters.${TEST_PARAMETER_URL_TEMPLATE.name}`,
+						node: TEST_NODE_URL_TEMPLATE,
+						displayTitle: 'Test Resource Locator',
+						expressionComputedValue: '',
+						isValueExpression: false,
+					},
+				});
+
+				await flushPromises();
+
+				expect(mockResolveExpression).not.toHaveBeenCalled();
+				expect(queryByTestId('rlc-open-resource-link')).not.toBeInTheDocument();
+			},
+		);
+
+		it('does not splice a computed expression value containing braces into the url template', async () => {
+			const { queryByTestId } = renderComponent({
+				props: {
+					modelValue: { __rl: true, mode: 'id', value: '={{ $json.id }}' },
+					parameter: TEST_PARAMETER_URL_TEMPLATE,
+					path: `parameters.${TEST_PARAMETER_URL_TEMPLATE.name}`,
+					node: TEST_NODE_URL_TEMPLATE,
+					displayTitle: 'Test Resource Locator',
+					expressionComputedValue: '{{ 1 + 1 }}',
+					isValueExpression: true,
+				},
+			});
+
+			await flushPromises();
+
+			expect(mockResolveExpression).not.toHaveBeenCalled();
+			expect(queryByTestId('rlc-open-resource-link')).not.toBeInTheDocument();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
@@ -549,11 +549,7 @@ describe('ResourceLocator', () => {
 			});
 
 			await waitFor(() => {
-				expect(mockResolveExpression).toHaveBeenCalledWith(
-					'=https://test.com/clean-id',
-					expect.anything(),
-					expect.anything(),
-				);
+				expect(mockResolveExpression).toHaveBeenCalledWith('=https://test.com/clean-id');
 			});
 			expect(await waitFor(() => getByTestId('rlc-open-resource-link'))).toBeInTheDocument();
 		});

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -268,7 +268,9 @@ const urlValue = computed(() => {
 
 	if (currentMode.value.url) {
 		const value = props.isValueExpression ? props.expressionComputedValue : valueToDisplay.value;
-		if (typeof value === 'string') {
+		// The value is spliced into the mode's url expression template and resolved,
+		// so only build a link from a literal value, never one carrying `{{ }}`.
+		if (typeof value === 'string' && !value.includes('{{') && !value.includes('}}')) {
 			const expression = currentMode.value.url.replace(/\{\{\$value\}\}/g, value);
 			const resolved = workflowHelpers.resolveExpression(expression);
 


### PR DESCRIPTION
## Summary

https://linear.app/n8n/issue/ADO-5655

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

