### PR TITLE
test(core): Guard DB migration registry against duplicate timestamps and lost registrations

### DIFF
--- a/packages/@n8n/db/src/migrations/migration-registry.test.ts
+++ b/packages/@n8n/db/src/migrations/migration-registry.test.ts
@@ -25,25 +25,40 @@ function parseIndexFile(folder: string) {
 	const source = readFileSync(join(__dirname, folder, 'index.ts'), 'utf8');
 	const imports = [...source.matchAll(IMPORT_PATTERN)].map((match) => {
 		const { className, specifier } = match.groups!;
+		const timestamp = TIMESTAMP_PATTERN.exec(specifier)?.groups?.timestamp;
+		if (!timestamp) {
+			throw new Error(
+				`No timestamp found in import specifier '${specifier}' in ${folder}/index.ts`,
+			);
+		}
 		return {
 			className,
-			timestamp: TIMESTAMP_PATTERN.exec(specifier)?.groups?.timestamp,
+			timestamp,
 			filePath: normalize(join(__dirname, folder, `${specifier}.ts`)),
 		};
 	});
+	if (imports.length === 0) {
+		throw new Error(`No migration imports matched in ${folder}/index.ts — did its format change?`);
+	}
 	const arraySection = source.slice(source.indexOf('= ['));
 	const arrayEntries = [...arraySection.matchAll(ARRAY_ENTRY_PATTERN)].map(
 		(match) => match.groups!.className,
 	);
+	if (arrayEntries.length === 0) {
+		throw new Error(
+			`No migrations array entries matched in ${folder}/index.ts — did its format change?`,
+		);
+	}
 	return { imports, arrayEntries };
 }
 
+const parsedIndexes = new Map(INDEX_FOLDERS.map((folder) => [folder, parseIndexFile(folder)]));
+
 describe.each(INDEX_FOLDERS)('%s migrations index', (folder) => {
-	const { imports, arrayEntries } = parseIndexFile(folder);
+	const { imports, arrayEntries } = parsedIndexes.get(folder)!;
 
 	test('every imported migration is in the migrations array exactly once, and vice versa', () => {
 		const importedNames = imports.map(({ className }) => className);
-		expect(importedNames.length).toBeGreaterThan(0);
 		expect([...arrayEntries].sort()).toEqual([...importedNames].sort());
 		expect(new Set(arrayEntries).size).toBe(arrayEntries.length);
 	});
@@ -51,8 +66,7 @@ describe.each(INDEX_FOLDERS)('%s migrations index', (folder) => {
 	test('every registered migration has a unique timestamp', () => {
 		const byTimestamp = new Map<string, string[]>();
 		for (const { className, timestamp } of imports) {
-			expect(timestamp).toBeDefined();
-			byTimestamp.set(timestamp!, [...(byTimestamp.get(timestamp!) ?? []), className]);
+			byTimestamp.set(timestamp, [...(byTimestamp.get(timestamp) ?? []), className]);
 		}
 		const duplicates = [...byTimestamp.entries()].filter(
 			([timestamp, classNames]) =>
@@ -64,9 +78,7 @@ describe.each(INDEX_FOLDERS)('%s migrations index', (folder) => {
 
 test('every migration file is registered in at least one index', () => {
 	const registeredFiles = new Set(
-		INDEX_FOLDERS.flatMap((folder) =>
-			parseIndexFile(folder).imports.map(({ filePath }) => filePath),
-		),
+		[...parsedIndexes.values()].flatMap(({ imports }) => imports.map(({ filePath }) => filePath)),
 	);
 	const orphans = MIGRATION_FOLDERS.flatMap((folder) =>
 		readdirSync(join(__dirname, folder))

--- a/packages/@n8n/db/src/migrations/migration-registry.test.ts
+++ b/packages/@n8n/db/src/migrations/migration-registry.test.ts
@@ -1,0 +1,78 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, normalize } from 'node:path';
+
+/**
+ * Guards the hand-maintained migration index files. Migrations created in
+ * parallel PRs can merge cleanly while sharing a timestamp, or lose their
+ * index registration in a conflict resolution — neither is caught by
+ * typecheck, so we assert the registry invariants here.
+ *
+ * Use `pnpm --filter=@n8n/db migration:new <Name>` to create migrations;
+ * it picks a fresh timestamp and wires up the index files.
+ */
+
+const MIGRATION_FOLDERS = ['common', 'sqlite', 'postgresdb'];
+const INDEX_FOLDERS = ['sqlite', 'postgresdb'];
+
+// Historical pairs that already shipped sharing a timestamp. Never extend this list.
+const LEGACY_DUPLICATE_TIMESTAMPS = new Set(['1750252139166', '1770000000000']);
+
+const IMPORT_PATTERN = /^import \{ (?<className>\w+) \} from '(?<specifier>\.[^']+)';$/gm;
+const ARRAY_ENTRY_PATTERN = /^\t(?<className>\w+),$/gm;
+const TIMESTAMP_PATTERN = /(?<timestamp>\d{10,16})-[^/]+$/;
+
+function parseIndexFile(folder: string) {
+	const source = readFileSync(join(__dirname, folder, 'index.ts'), 'utf8');
+	const imports = [...source.matchAll(IMPORT_PATTERN)].map((match) => {
+		const { className, specifier } = match.groups!;
+		return {
+			className,
+			timestamp: TIMESTAMP_PATTERN.exec(specifier)?.groups?.timestamp,
+			filePath: normalize(join(__dirname, folder, `${specifier}.ts`)),
+		};
+	});
+	const arraySection = source.slice(source.indexOf('= ['));
+	const arrayEntries = [...arraySection.matchAll(ARRAY_ENTRY_PATTERN)].map(
+		(match) => match.groups!.className,
+	);
+	return { imports, arrayEntries };
+}
+
+describe.each(INDEX_FOLDERS)('%s migrations index', (folder) => {
+	const { imports, arrayEntries } = parseIndexFile(folder);
+
+	test('every imported migration is in the migrations array exactly once, and vice versa', () => {
+		const importedNames = imports.map(({ className }) => className);
+		expect(importedNames.length).toBeGreaterThan(0);
+		expect([...arrayEntries].sort()).toEqual([...importedNames].sort());
+		expect(new Set(arrayEntries).size).toBe(arrayEntries.length);
+	});
+
+	test('every registered migration has a unique timestamp', () => {
+		const byTimestamp = new Map<string, string[]>();
+		for (const { className, timestamp } of imports) {
+			expect(timestamp).toBeDefined();
+			byTimestamp.set(timestamp!, [...(byTimestamp.get(timestamp!) ?? []), className]);
+		}
+		const duplicates = [...byTimestamp.entries()].filter(
+			([timestamp, classNames]) =>
+				classNames.length > 1 && !LEGACY_DUPLICATE_TIMESTAMPS.has(timestamp),
+		);
+		expect(duplicates).toEqual([]);
+	});
+});
+
+test('every migration file is registered in at least one index', () => {
+	const registeredFiles = new Set(
+		INDEX_FOLDERS.flatMap((folder) =>
+			parseIndexFile(folder).imports.map(({ filePath }) => filePath),
+		),
+	);
+	const orphans = MIGRATION_FOLDERS.flatMap((folder) =>
+		readdirSync(join(__dirname, folder))
+			.filter((fileName) => /^\d+-.+\.ts$/.test(fileName))
+			.map((fileName) => join(folder, fileName))
+			.filter((relativePath) => !registeredFiles.has(normalize(join(__dirname, relativePath)))),
+	);
+	expect(orphans).toEqual([]);
+});

--- a/packages/@n8n/db/src/migrations/sqlite/1695128658538-AddWorkflowMetadata.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/1695128658538-AddWorkflowMetadata.ts
@@ -1,5 +1,0 @@
-import { AddWorkflowMetadata1695128658538 as BaseMigration } from '../common/1695128658538-AddWorkflowMetadata';
-
-export class AddWorkflowMetadata1695128658538 extends BaseMigration {
-	withFKsDisabled = true as const;
-}


### PR DESCRIPTION
## Summary

The `migration-timestamp` code-health rule already guards new migration **files** (strict ordering above the existing head, no fabricated future timestamps) in pre-commit, PR CI, and the merge queue. What it doesn't look at is the hand-maintained registries — `sqlite/index.ts` and `postgresdb/index.ts` — which are the usual merge-conflict site for parallel migration PRs. A conflict resolution can silently drop an array entry, leave an import diverged from the array, or orphan a file on disk; none of that is caught by typecheck or the existing rule.

Both hazards have concrete precedents on `master`:
- Two duplicate-timestamp pairs shipped (predating the code-health rule): `1750252139166` (`AddLastActiveAtColumnToUser` / `AddScopeTables`) and `1770000000000` (`CreateChatHubToolsTable` / `ExpandProviderIdColumnLength`).
- `sqlite/1695128658538-AddWorkflowMetadata.ts` is an orphaned override (adds `withFKsDisabled`) that neither index references — both import the `common/` copy, so the override has no effect. Deleted here; current behavior is preserved.

This adds a unit test in `@n8n/db` asserting, for each DB index:
- every imported migration appears in the migrations array exactly once, and vice versa (catches registrations dropped in conflict resolutions),
- every registered migration has a unique timestamp — a git-independent backstop for the invariant the code-health rule enforces on added files (the two shipped pairs are grandfathered),
- every migration file on disk is registered in at least one index.

No new CI infrastructure: unit tests already run in the merge queue against master + PR combined, which is where cross-PR breakage of these invariants first becomes visible.

## How to test

`pnpm --filter=@n8n/db test src/migrations/migration-registry.test.ts`

To see it fail: comment out an array entry in an index file, or duplicate a timestamp in an import path.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-690

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
