### PR TITLE
test: Use fake timers for history compaction tests

### DIFF
--- a/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
@@ -64,6 +64,16 @@ describe('WorkflowHistoryCompactionService', () => {
 	});
 
 	describe('startCompacting', () => {
+		beforeEach(() => {
+			// Set the system to a time that isn't 3 AM to avoid hitting the "trim once a day" window
+			const mockDate = new Date(2026, 10, 10, 1, 0, 0);
+			vi.setSystemTime(mockDate);
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
 		it('should start compacting if service is enabled and DB is migrated', () => {
 			const compactingService = new WorkflowHistoryCompactionService(
 				config,
@@ -193,5 +203,65 @@ describe('WorkflowHistoryCompactionService', () => {
 		expect(trimLongRunningHistoriesSpy).toHaveBeenCalled();
 		// should still call recent history compaction
 		expect(optimizeHistoriesSpy).toHaveBeenCalled();
+	});
+
+	it('should trim if triggered at 3 AM with trimOnStartUp as false', () => {
+		const mockDate = new Date(2026, 10, 10, 3, 0, 0);
+		vi.setSystemTime(mockDate);
+
+		const compactingService = new WorkflowHistoryCompactionService(
+			{ ...config, trimOnStartUp: false },
+			globalConfig,
+			mockLogger(),
+			mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
+			dbConnection,
+			mock(),
+			mock<EventService>(),
+		);
+
+		const optimizeHistoriesSpy = vi
+			// @ts-expect-error Private method
+			.spyOn(compactingService, 'optimizeHistories')
+			.mockImplementation((() => {}) as never);
+		const trimLongRunningHistoriesSpy = vi
+			// @ts-expect-error Private method
+			.spyOn(compactingService, 'trimLongRunningHistories')
+			.mockImplementation((() => {}) as never);
+
+		compactingService.startCompacting();
+
+		expect(trimLongRunningHistoriesSpy).toHaveBeenCalled();
+
+		vi.useRealTimers();
+	});
+
+	it('should not trim if triggered outside of 3 AM with trimOnStartUp as false', () => {
+		const mockDate = new Date(2026, 10, 10, 5, 0, 0);
+		vi.setSystemTime(mockDate);
+
+		const compactingService = new WorkflowHistoryCompactionService(
+			{ ...config, trimOnStartUp: false },
+			globalConfig,
+			mockLogger(),
+			mock<InstanceSettings>({ isLeader: true, instanceType: 'main', isMultiMain: true }),
+			dbConnection,
+			mock(),
+			mock<EventService>(),
+		);
+
+		const optimizeHistoriesSpy = vi
+			// @ts-expect-error Private method
+			.spyOn(compactingService, 'optimizeHistories')
+			.mockImplementation((() => {}) as never);
+		const trimLongRunningHistoriesSpy = vi
+			// @ts-expect-error Private method
+			.spyOn(compactingService, 'trimLongRunningHistories')
+			.mockImplementation((() => {}) as never);
+
+		compactingService.startCompacting();
+
+		expect(trimLongRunningHistoriesSpy).not.toHaveBeenCalled();
+
+		vi.useRealTimers();
 	});
 });

--- a/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
@@ -219,7 +219,7 @@ describe('WorkflowHistoryCompactionService', () => {
 			mock<EventService>(),
 		);
 
-		const optimizeHistoriesSpy = vi
+		vi
 			// @ts-expect-error Private method
 			.spyOn(compactingService, 'optimizeHistories')
 			.mockImplementation((() => {}) as never);
@@ -249,7 +249,7 @@ describe('WorkflowHistoryCompactionService', () => {
 			mock<EventService>(),
 		);
 
-		const optimizeHistoriesSpy = vi
+		vi
 			// @ts-expect-error Private method
 			.spyOn(compactingService, 'optimizeHistories')
 			.mockImplementation((() => {}) as never);


### PR DESCRIPTION
## Summary

Tests on https://github.com/n8n-io/n8n/actions/workflows/ci-master.yml kept failing if the timer schedule ran the tests between 3:00 and 3:59, due to [how our history compaction works](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/services/pruning/workflow-history-compaction.service.ts#L111).

Moved to fake timers for this test suite to keep them consistent.

## How to test

```bash
cd packages/cli
pnpm test src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-684/workflow-history-compaction-test-depends-on-wall-clock-hour-breaks

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

