### PR TITLE
refactor(editor): Add type safety to N8nButton type prop (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.test.ts
@@ -63,6 +63,16 @@ describe('components', () => {
 				expect(wrapper.getByRole('button')).toHaveAttribute('type', 'button');
 			});
 
+			it('should use the provided native button type', () => {
+				const wrapper = render(N8nButton, {
+					props: { type: 'submit' },
+					slots: { default: 'Submit' },
+					global: { stubs },
+				});
+
+				expect(wrapper.getByRole('button')).toHaveAttribute('type', 'submit');
+			});
+
 			it('should not have type attribute when rendered as link', () => {
 				const wrapper = render(N8nButton, {
 					props: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -47,7 +47,7 @@ const componentTag = computed(() => {
 
 const buttonType = computed(() => {
 	if (componentTag.value === 'a') return undefined;
-	return (attrs.type as string | undefined) ?? 'button';
+	return props.type ?? 'button';
 });
 
 const isDisabled = computed(() => props.disabled || props.loading);

--- a/packages/frontend/@n8n/design-system/src/types/button.ts
+++ b/packages/frontend/@n8n/design-system/src/types/button.ts
@@ -18,6 +18,8 @@ export interface ButtonProps {
 	variant?: ButtonVariant | LegacyButtonVariant;
 	/** Determines the size of the button */
 	size?: ButtonSize;
+	/** Determines the type of the button (e.g. 'submit', 'reset', 'button') */
+	type?: NonNullable<HTMLButtonElement['type']>;
 	/** If passed, the button will be rendered as a link */
 	href?: string;
 	/** If true, the button will show a loading spinner */

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -765,7 +765,7 @@ defineExpose({
 			v-if="showSaveButton && !isArchived && workflowPermissions.update"
 			:loading="isSaving"
 			:disabled="!uiStore.stateIsDirty || collaborationReadOnly"
-			type="secondary"
+			variant="subtle"
 			data-test-id="workflow-save-button"
 			@click="onSaveButtonClick"
 		>

--- a/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppSelectionPage.vue
+++ b/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppSelectionPage.vue
@@ -363,7 +363,7 @@ watch(isCredentialModalOpen, async (isOpen, wasOpen) => {
 				<N8nButton
 					v-else
 					:label="i18n.baseText('appSelection.connectLater')"
-					type="tertiary"
+					variant="subtle"
 					size="large"
 					data-test-id="app-selection-skip"
 					@click="handleContinue"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentSkillsListPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentSkillsListPanel.vue
@@ -49,7 +49,7 @@ const totalCount = computed(() => props.skills.length);
 		>
 			<template #actions>
 				<N8nButton
-					type="primary"
+					variant="solid"
 					size="small"
 					:disabled="props.disabled"
 					data-testid="agent-skills-add"

--- a/packages/frontend/editor-ui/src/features/agents/components/interactive/ApprovalCard.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/interactive/ApprovalCard.vue
@@ -70,7 +70,7 @@ function submit(approved: boolean) {
 			<div v-else :class="$style.actions">
 				<N8nButton
 					size="medium"
-					type="primary"
+					variant="solid"
 					:disabled="disabled"
 					data-testid="agent-approval-approve"
 					@click="submit(true)"

--- a/packages/frontend/editor-ui/src/features/agents/components/settings/AgentBuilderModelSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/settings/AgentBuilderModelSection.vue
@@ -222,7 +222,7 @@ function onCancel() {
 		</N8nText>
 
 		<div v-if="canSave" :class="$style.actions">
-			<N8nButton type="secondary" size="small" @click="onCancel">
+			<N8nButton variant="subtle" size="small" @click="onCancel">
 				{{ i18n.baseText('generic.cancel') }}
 			</N8nButton>
 			<N8nButton size="small" :loading="store.isSaving" @click="onSave">

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderNodeGroupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderNodeGroupCard.vue
@@ -256,7 +256,7 @@ watch(hoveredSection, (section) => {
 				<N8nButton
 					v-if="showContinue"
 					data-test-id="builder-node-group-card-continue"
-					type="primary"
+					variant="solid"
 					size="small"
 					:class="$style.actionButton"
 					:label="i18n.baseText('aiAssistant.builder.setupWizard.continue' as BaseTextKey)"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupCard.vue
@@ -229,7 +229,7 @@ watch(isActive, (active, wasActive) => {
 				<N8nButton
 					v-if="showContinue"
 					data-test-id="builder-setup-card-continue"
-					type="primary"
+					variant="solid"
 					size="small"
 					:class="$style.actionButton"
 					:disabled="isContinueDisabled"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
@@ -315,7 +315,7 @@ watch(hasValidationIssues, (hasIssues, hadIssues) => {
 			<!-- Unpin All Section (hidden when post-execution follow-ups provide the same actions) -->
 			<div v-if="showUnpinSection && !showPostExecutionFollowUps" :class="$style.unpinSection">
 				<N8nButton
-					type="secondary"
+					variant="subtle"
 					size="medium"
 					icon="pin"
 					:label="i18n.baseText('aiAssistant.builder.executeMessage.unpinAll')"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/PlanDisplayMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/PlanDisplayMessage.vue
@@ -72,7 +72,7 @@ function approve() {
 			<!-- Actions (only if showActions) - just Implement button, users can type in chat to modify -->
 			<div v-if="showActions" :class="$style.actions">
 				<N8nButton
-					type="primary"
+					variant="solid"
 					:disabled="disabled || isSubmitted"
 					data-test-id="plan-mode-plan-approve"
 					@click="approve"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/PlanQuestionsMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/PlanQuestionsMessage.vue
@@ -583,7 +583,7 @@ function onOptionMouseEnter(idx: number) {
 
 					<N8nButton
 						v-if="showNextButton"
-						:type="isNextEnabled ? 'primary' : 'secondary'"
+						:variant="isNextEnabled ? 'solid' : 'subtle'"
 						size="small"
 						:disabled="disabled || isSubmitted || !isNextEnabled"
 						data-test-id="plan-mode-questions-next"

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.vue
@@ -667,7 +667,6 @@ watch(documentVisibility, (visibility) => {
 							/>
 						</div>
 						<N8nButton
-							type="tertiary"
 							icon="plus"
 							variant="subtle"
 							:class="$style.addFileButton"

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatButtons.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatButtons.vue
@@ -33,7 +33,7 @@ async function onClick(link: string, index: number) {
 		<template v-for="(button, index) in buttons" :key="button.link">
 			<N8nButton
 				v-if="clickedButtonIndex === null || index === clickedButtonIndex"
-				:type="button.type"
+				:variant="button.type === 'primary' ? 'solid' : 'subtle'"
 				:disabled="isDisabled || isLoading || clickedButtonIndex !== null"
 				:loading="isLoading && clickedButtonIndex === null"
 				size="small"

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPromptCallouts.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPromptCallouts.vue
@@ -99,8 +99,9 @@ const i18n = useI18n();
 		}}</N8nText>
 		<template #trailingContent>
 			<N8nButton
-				type="warning"
-				native-type="button"
+				variant="solid"
+				type="button"
+				class="n8n-button--warning"
 				size="small"
 				data-testid="dynamic-credentials-connect-button"
 				@click="emit('openDynamicCredentials')"

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/DynamicCredentialsDrawer.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/DynamicCredentialsDrawer.vue
@@ -26,7 +26,7 @@ const i18n = useI18n();
 					i18n.baseText('chatHub.dynamicCredentials.drawer.title')
 				}}</N8nText>
 				<N8nIconButton
-					type="tertiary"
+					variant="subtle"
 					text
 					icon="x"
 					data-testid="dynamic-credentials-drawer-close"
@@ -70,7 +70,7 @@ const i18n = useI18n();
 							<N8nSpinner v-if="cred.isConnecting" size="small" />
 							<N8nButton
 								v-else-if="cred.credentialStatus === 'configured'"
-								type="tertiary"
+								variant="subtle"
 								size="small"
 								data-testid="dynamic-credential-disconnect"
 								@click="emit('revoke', cred.credentialId)"
@@ -79,7 +79,7 @@ const i18n = useI18n();
 							</N8nButton>
 							<N8nButton
 								v-else
-								type="secondary"
+								variant="subtle"
 								size="small"
 								data-testid="dynamic-credential-connect"
 								@click="emit('authorize', cred.credentialId)"

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/ExecutionRow.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/ExecutionRow.vue
@@ -115,7 +115,7 @@ const outputEntries = computed(() => toEntries(items.value.output));
 
 			<N8nButton
 				size="mini"
-				type="primary"
+				variant="solid"
 				:class="[$style.createButton, expanded ? $style.createButtonVisible : null]"
 				:data-test-id="`tests-execution-create-${execution.id}`"
 				@click="emit('create')"

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/TestsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/TestsPanel.vue
@@ -201,7 +201,7 @@ watch(
 			</N8nText>
 			<N8nButton
 				size="small"
-				type="primary"
+				variant="solid"
 				data-test-id="tests-panel-add-node-button"
 				@click="openNodeCreator"
 			>
@@ -225,7 +225,7 @@ watch(
 				@select="onTriggerSelect"
 			>
 				<template #activator>
-					<N8nButton size="small" type="primary">
+					<N8nButton size="small" variant="solid">
 						{{ locale.baseText('evaluations.tests.empty.chooseTrigger') }}
 						<N8nIcon icon="chevron-down" size="small" />
 					</N8nButton>
@@ -234,7 +234,7 @@ watch(
 			<N8nButton
 				v-else
 				size="small"
-				type="primary"
+				variant="solid"
 				data-test-id="tests-panel-gate-run"
 				@click="runWorkflow"
 			>

--- a/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.vue
@@ -265,7 +265,7 @@ onMounted(async () => {
 				<div v-if="hasMore && entries.length > 0" :class="$style.loadMore">
 					<N8nButton
 						:label="i18n.baseText('settings.n8nConnect.usage.loadMore')"
-						type="secondary"
+						variant="subtle"
 						:loading="isLoading && isAppending"
 						@click="loadMore"
 					/>

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/DownloadDataTableModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/DownloadDataTableModal.vue
@@ -46,7 +46,7 @@ const onConfirm = () => {
 		<template #footer>
 			<div :class="$style.footer">
 				<N8nButton
-					type="secondary"
+					variant="subtle"
 					size="large"
 					:label="i18n.baseText('dataTable.download.modal.cancel')"
 					data-test-id="download-modal-cancel"

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialCard.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialCard.vue
@@ -290,7 +290,7 @@ function moveResource() {
 						{{ locale.baseText('credentials.item.connect.tooltip') }}
 					</template>
 					<N8nButton
-						type="primary"
+						variant="solid"
 						size="mini"
 						:loading="isConnecting"
 						data-test-id="credential-card-connect"

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDateRangeAlert.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDateRangeAlert.vue
@@ -78,7 +78,6 @@ function dismiss() {
 		</N8nText>
 		<template #aside>
 			<N8nButton
-				type="secondary"
 				size="small"
 				variant="subtle"
 				:label="i18n.baseText('insights.dashboard.dataRangeAlert.dismiss')"

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullResultModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullResultModal.vue
@@ -153,7 +153,7 @@ function close() {
 
 		<template #footer>
 			<div :class="$style.footer">
-				<N8nButton type="primary" @click="close">
+				<N8nButton variant="solid" @click="close">
 					{{ i18n.baseText('settings.sourceControl.modals.pullResult.buttons.close') }}
 				</N8nButton>
 			</div>

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AgentSelectorParameterInput/AgentSelectorParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AgentSelectorParameterInput/AgentSelectorParameterInput.vue
@@ -317,7 +317,7 @@ defineExpose({ showDropdown });
 						{{ i18n.baseText('resourceLocator.mode.list.error.title') }}
 					</N8nText>
 					<N8nButton
-						type="tertiary"
+						variant="subtle"
 						size="small"
 						:label="i18n.baseText('generic.retry')"
 						data-test-id="rlc-error-retry"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/MappingFields.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/MappingFields.vue
@@ -423,7 +423,8 @@ defineExpose({
 		>
 			<N8nButton
 				v-if="hasSingleFieldOption"
-				type="highlightFill"
+				variant="subtle"
+				class="n8n-button--highlightFill"
 				icon="plus"
 				:label="
 					locale.baseText('resourceMapper.addFieldToSend', {
@@ -441,7 +442,8 @@ defineExpose({
 			>
 				<template #trigger>
 					<N8nButton
-						type="highlightFill"
+						variant="subtle"
+						class="n8n-button--highlightFill"
 						icon="plus"
 						:label="
 							locale.baseText('resourceMapper.addFieldToSend', {

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -1787,7 +1787,7 @@ defineExpose({ enterEditMode });
 				<N8nButton
 					v-if="pinnedData.hasData.value"
 					class="mt-s"
-					type="secondary"
+					variant="subtle"
 					size="small"
 					data-test-id="ndv-trimmed-corrupted-unpin"
 					@click="onTogglePinData({ source: 'context-menu' })"

--- a/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRuleDetail.vue
+++ b/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRuleDetail.vue
@@ -372,7 +372,7 @@ const sortedWorkflows = computed(() => {
 				<N8nButton
 					v-else
 					size="small"
-					type="secondary"
+					variant="subtle"
 					:label="i18n.baseText('settings.migrationReport.detail.migrate.button')"
 					data-test-id="migrate-workflow-button"
 					@click.stop="openMigrateModal(item)"

--- a/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailTabs.vue
+++ b/packages/frontend/editor-ui/src/features/workflow-reviews/components/WorkflowReviewDetailTabs.vue
@@ -78,7 +78,7 @@ const tabOptions = computed(() => [
 				<N8nTooltip :disabled="!ineligibilityHint" :content="ineligibilityHint" :show-after="300">
 					<N8nButton
 						size="small"
-						type="secondary"
+						variant="subtle"
 						:disabled="deciding || !viewerCanDecide"
 						data-test-id="workflow-review-request-changes-button"
 						@click="emit('decide', 'changes_requested')"


### PR DESCRIPTION
## Summary

- Add the native HTML button type to `N8nButton` props for type-safe `button`, `submit`, and `reset` values
- Replace legacy visual values passed through `type` with their corresponding `variant` values
- Preserve warning and highlight button styling while separating it from native button behavior

## How to test

1. Run the design-system typecheck.
2. Run the editor UI typecheck.
3. Verify affected buttons retain their existing visual styles and behavior.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-606

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)