### PR TITLE
fix(editor): Remove unsupported button type attributes

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nDialog/Dialog.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDialog/Dialog.stories.ts
@@ -56,7 +56,7 @@ export const Default: Story = {
 
 				<N8nDialogFooter>
 					<N8nDialogClose as-child>
-						<N8nButton type="secondary" label="Cancel" />
+						<N8nButton label="Cancel" />
 					</N8nDialogClose>
 					<N8nButton label="Save changes" />
 				</N8nDialogFooter>
@@ -228,9 +228,9 @@ export const AccessibilityFallback: Story = {
 
 				<N8nDialogFooter>
 					<N8nDialogClose as-child>
-						<N8nButton type="secondary" label="Cancel" />
+						<N8nButton label="Cancel" />
 					</N8nDialogClose>
-					<N8nButton type="danger" label="Delete" />
+					<N8nButton label="Delete" />
 				</N8nDialogFooter>
 			</N8nDialog>
 		</div>
@@ -270,7 +270,7 @@ export const AccessibilityFallbackTitleOnly: Story = {
 
 				<N8nDialogFooter>
 					<N8nDialogClose as-child>
-						<N8nButton type="secondary" label="No" />
+						<N8nButton label="No" />
 					</N8nDialogClose>
 					<N8nButton label="Yes" />
 				</N8nDialogFooter>
@@ -320,7 +320,7 @@ export const CustomHeader: Story = {
 
 				<N8nDialogFooter>
 					<N8nDialogClose as-child>
-						<N8nButton type="secondary" label="Cancel" />
+						<N8nButton label="Cancel" />
 					</N8nDialogClose>
 					<N8nButton label="Save" />
 				</N8nDialogFooter>

--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.stories.ts
@@ -36,7 +36,7 @@ const WorkflowPreviewTemplate: StoryFn = (args) => ({
 		<div style="padding: 96px; display: flex; justify-content: center;">
 			<N8nHoverCard v-bind="args">
 				<template #trigger>
-					<N8nButton type="secondary">Customer onboarding</N8nButton>
+					<N8nButton>Customer onboarding</N8nButton>
 				</template>
 				<template #content>
 					<section style="width: 360px; padding: var(--spacing--sm); display: flex; flex-direction: column; gap: var(--spacing--sm);">
@@ -335,7 +335,7 @@ const ScrollableTemplate: StoryFn = (args) => ({
 		<div style="padding: 96px; display: flex; justify-content: center;">
 			<N8nHoverCard v-bind="args">
 				<template #trigger>
-					<N8nButton type="secondary">Recent executions</N8nButton>
+					<N8nButton>Recent executions</N8nButton>
 				</template>
 				<template #content>
 					<section style="width: 380px; padding: var(--spacing--sm); display: flex; flex-direction: column; gap: var(--spacing--sm);">

--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/component-hover-card.md
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/component-hover-card.md
@@ -91,7 +91,7 @@ import { N8nHoverCard, N8nButton, N8nText } from '@n8n/design-system';
 <template>
 	<N8nHoverCard side="right" max-width="280px">
 		<template #trigger>
-			<N8nButton type="secondary">View workflow details</N8nButton>
+			<N8nButton>View workflow details</N8nButton>
 		</template>
 		<template #content>
 			<div class="workflow-preview">

--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.stories.ts
@@ -65,7 +65,7 @@ const Template: StoryFn = (args) => ({
 		<div style="padding: 50px;">
 			<N8nPopover v-model:open="isOpen" v-bind="args">
 				<template #trigger>
-					<N8nButton type="primary">Open Form</N8nButton>
+					<N8nButton>Open Form</N8nButton>
 				</template>
 				<template #content="{ close }">
 					<div style="display: flex; flex-direction: column; gap: 12px; padding: var(--spacing--sm);">
@@ -82,8 +82,8 @@ const Template: StoryFn = (args) => ({
 							type="email"
 						/>
 						<div style="display: flex; gap: 8px; margin-top: 8px;">
-							<N8nButton size="small" type="primary">Save</N8nButton>
-							<N8nButton size="small" type="secondary" @click="close">Cancel</N8nButton>
+							<N8nButton size="small">Save</N8nButton>
+							<N8nButton size="small" @click="close">Cancel</N8nButton>
 						</div>
 					</div>
 				</template>
@@ -109,7 +109,7 @@ const ScrollableTemplate: StoryFn = (args) => ({
 		<div style="padding: 50px;">
 			<N8nPopover v-model:open="isOpen" v-bind="args">
 				<template #trigger>
-					<N8nButton type="primary">Open Scrollable Menu</N8nButton>
+					<N8nButton>Open Scrollable Menu</N8nButton>
 				</template>
 				<template #content="{ close }">
 					<div style="display: flex; flex-direction: column; gap: 8px; padding: var(--spacing--sm);">
@@ -204,7 +204,7 @@ const AlignmentVariantsTemplate: StoryFn = (args) => ({
 						:align="align"
 					>
 						<template #trigger>
-							<N8nButton type="primary">{{ align }}</N8nButton>
+							<N8nButton>{{ align }}</N8nButton>
 						</template>
 						<template #content>
 							<div style="padding: var(--spacing--sm); min-width: 160px; text-transform: capitalize;">

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -765,7 +765,6 @@ defineExpose({
 			v-if="showSaveButton && !isArchived && workflowPermissions.update"
 			:loading="isSaving"
 			:disabled="!uiStore.stateIsDirty || collaborationReadOnly"
-			type="secondary"
 			data-test-id="workflow-save-button"
 			@click="onSaveButtonClick"
 		>

--- a/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppSelectionPage.vue
+++ b/packages/frontend/editor-ui/src/experiments/credentialsAppSelection/components/AppSelectionPage.vue
@@ -363,7 +363,6 @@ watch(isCredentialModalOpen, async (isOpen, wasOpen) => {
 				<N8nButton
 					v-else
 					:label="i18n.baseText('appSelection.connectLater')"
-					type="tertiary"
 					size="large"
 					data-test-id="app-selection-skip"
 					@click="handleContinue"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentSkillsListPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentSkillsListPanel.vue
@@ -49,7 +49,6 @@ const totalCount = computed(() => props.skills.length);
 		>
 			<template #actions>
 				<N8nButton
-					type="primary"
 					size="small"
 					:disabled="props.disabled"
 					data-testid="agent-skills-add"

--- a/packages/frontend/editor-ui/src/features/agents/components/interactive/ApprovalCard.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/interactive/ApprovalCard.vue
@@ -70,7 +70,6 @@ function submit(approved: boolean) {
 			<div v-else :class="$style.actions">
 				<N8nButton
 					size="medium"
-					type="primary"
 					:disabled="disabled"
 					data-testid="agent-approval-approve"
 					@click="submit(true)"

--- a/packages/frontend/editor-ui/src/features/agents/components/settings/AgentBuilderModelSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/settings/AgentBuilderModelSection.vue
@@ -222,7 +222,7 @@ function onCancel() {
 		</N8nText>
 
 		<div v-if="canSave" :class="$style.actions">
-			<N8nButton type="secondary" size="small" @click="onCancel">
+			<N8nButton size="small" @click="onCancel">
 				{{ i18n.baseText('generic.cancel') }}
 			</N8nButton>
 			<N8nButton size="small" :loading="store.isSaving" @click="onSave">

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderNodeGroupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderNodeGroupCard.vue
@@ -256,7 +256,6 @@ watch(hoveredSection, (section) => {
 				<N8nButton
 					v-if="showContinue"
 					data-test-id="builder-node-group-card-continue"
-					type="primary"
 					size="small"
 					:class="$style.actionButton"
 					:label="i18n.baseText('aiAssistant.builder.setupWizard.continue' as BaseTextKey)"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/BuilderSetupCard.vue
@@ -229,7 +229,6 @@ watch(isActive, (active, wasActive) => {
 				<N8nButton
 					v-if="showContinue"
 					data-test-id="builder-setup-card-continue"
-					type="primary"
 					size="small"
 					:class="$style.actionButton"
 					:disabled="isContinueDisabled"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
@@ -315,7 +315,6 @@ watch(hasValidationIssues, (hasIssues, hadIssues) => {
 			<!-- Unpin All Section (hidden when post-execution follow-ups provide the same actions) -->
 			<div v-if="showUnpinSection && !showPostExecutionFollowUps" :class="$style.unpinSection">
 				<N8nButton
-					type="secondary"
 					size="medium"
 					icon="pin"
 					:label="i18n.baseText('aiAssistant.builder.executeMessage.unpinAll')"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/PlanDisplayMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/PlanDisplayMessage.vue
@@ -72,7 +72,6 @@ function approve() {
 			<!-- Actions (only if showActions) - just Implement button, users can type in chat to modify -->
 			<div v-if="showActions" :class="$style.actions">
 				<N8nButton
-					type="primary"
 					:disabled="disabled || isSubmitted"
 					data-test-id="plan-mode-plan-approve"
 					@click="approve"

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/PlanQuestionsMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/PlanQuestionsMessage.vue
@@ -583,7 +583,6 @@ function onOptionMouseEnter(idx: number) {
 
 					<N8nButton
 						v-if="showNextButton"
-						:type="isNextEnabled ? 'primary' : 'secondary'"
 						size="small"
 						:disabled="disabled || isSubmitted || !isNextEnabled"
 						data-test-id="plan-mode-questions-next"

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/AgentEditorModal.vue
@@ -667,7 +667,6 @@ watch(documentVisibility, (visibility) => {
 							/>
 						</div>
 						<N8nButton
-							type="tertiary"
 							icon="plus"
 							variant="subtle"
 							:class="$style.addFileButton"

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/DynamicCredentialsDrawer.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/DynamicCredentialsDrawer.vue
@@ -70,7 +70,6 @@ const i18n = useI18n();
 							<N8nSpinner v-if="cred.isConnecting" size="small" />
 							<N8nButton
 								v-else-if="cred.credentialStatus === 'configured'"
-								type="tertiary"
 								size="small"
 								data-testid="dynamic-credential-disconnect"
 								@click="emit('revoke', cred.credentialId)"
@@ -79,7 +78,6 @@ const i18n = useI18n();
 							</N8nButton>
 							<N8nButton
 								v-else
-								type="secondary"
 								size="small"
 								data-testid="dynamic-credential-connect"
 								@click="emit('authorize', cred.credentialId)"

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/ExecutionRow.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/ExecutionRow.vue
@@ -115,7 +115,6 @@ const outputEntries = computed(() => toEntries(items.value.output));
 
 			<N8nButton
 				size="mini"
-				type="primary"
 				:class="[$style.createButton, expanded ? $style.createButtonVisible : null]"
 				:data-test-id="`tests-execution-create-${execution.id}`"
 				@click="emit('create')"

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/TestsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/TestsPanel.vue
@@ -201,7 +201,6 @@ watch(
 			</N8nText>
 			<N8nButton
 				size="small"
-				type="primary"
 				data-test-id="tests-panel-add-node-button"
 				@click="openNodeCreator"
 			>
@@ -225,7 +224,7 @@ watch(
 				@select="onTriggerSelect"
 			>
 				<template #activator>
-					<N8nButton size="small" type="primary">
+					<N8nButton size="small">
 						{{ locale.baseText('evaluations.tests.empty.chooseTrigger') }}
 						<N8nIcon icon="chevron-down" size="small" />
 					</N8nButton>
@@ -234,7 +233,6 @@ watch(
 			<N8nButton
 				v-else
 				size="small"
-				type="primary"
 				data-test-id="tests-panel-gate-run"
 				@click="runWorkflow"
 			>

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/TestsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/Tests/TestsPanel.vue
@@ -199,11 +199,7 @@ watch(
 			<N8nText size="large" color="text-dark" :class="$style.gateMessage">
 				{{ locale.baseText('evaluations.tests.empty.noNode') }}
 			</N8nText>
-			<N8nButton
-				size="small"
-				data-test-id="tests-panel-add-node-button"
-				@click="openNodeCreator"
-			>
+			<N8nButton size="small" data-test-id="tests-panel-add-node-button" @click="openNodeCreator">
 				{{ locale.baseText('evaluations.tests.empty.noNode.button') }}
 			</N8nButton>
 		</div>
@@ -230,12 +226,7 @@ watch(
 					</N8nButton>
 				</template>
 			</N8nActionDropdown>
-			<N8nButton
-				v-else
-				size="small"
-				data-test-id="tests-panel-gate-run"
-				@click="runWorkflow"
-			>
+			<N8nButton v-else size="small" data-test-id="tests-panel-gate-run" @click="runWorkflow">
 				{{ locale.baseText('evaluations.tests.empty.execute') }}
 			</N8nButton>
 		</div>

--- a/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.vue
@@ -265,7 +265,6 @@ onMounted(async () => {
 				<div v-if="hasMore && entries.length > 0" :class="$style.loadMore">
 					<N8nButton
 						:label="i18n.baseText('settings.n8nConnect.usage.loadMore')"
-						type="secondary"
 						:loading="isLoading && isAppending"
 						@click="loadMore"
 					/>

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/DownloadDataTableModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/DownloadDataTableModal.vue
@@ -46,7 +46,6 @@ const onConfirm = () => {
 		<template #footer>
 			<div :class="$style.footer">
 				<N8nButton
-					type="secondary"
 					size="large"
 					:label="i18n.baseText('dataTable.download.modal.cancel')"
 					data-test-id="download-modal-cancel"

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialCard.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialCard.vue
@@ -290,7 +290,6 @@ function moveResource() {
 						{{ locale.baseText('credentials.item.connect.tooltip') }}
 					</template>
 					<N8nButton
-						type="primary"
 						size="mini"
 						:loading="isConnecting"
 						data-test-id="credential-card-connect"

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDateRangeAlert.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDateRangeAlert.vue
@@ -78,7 +78,6 @@ function dismiss() {
 		</N8nText>
 		<template #aside>
 			<N8nButton
-				type="secondary"
 				size="small"
 				variant="subtle"
 				:label="i18n.baseText('insights.dashboard.dataRangeAlert.dismiss')"

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullResultModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPullResultModal.vue
@@ -153,7 +153,7 @@ function close() {
 
 		<template #footer>
 			<div :class="$style.footer">
-				<N8nButton type="primary" @click="close">
+				<N8nButton @click="close">
 					{{ i18n.baseText('settings.sourceControl.modals.pullResult.buttons.close') }}
 				</N8nButton>
 			</div>

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AgentSelectorParameterInput/AgentSelectorParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AgentSelectorParameterInput/AgentSelectorParameterInput.vue
@@ -317,7 +317,6 @@ defineExpose({ showDropdown });
 						{{ i18n.baseText('resourceLocator.mode.list.error.title') }}
 					</N8nText>
 					<N8nButton
-						type="tertiary"
 						size="small"
 						:label="i18n.baseText('generic.retry')"
 						data-test-id="rlc-error-retry"

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -1787,7 +1787,6 @@ defineExpose({ enterEditMode });
 				<N8nButton
 					v-if="pinnedData.hasData.value"
 					class="mt-s"
-					type="secondary"
 					size="small"
 					data-test-id="ndv-trimmed-corrupted-unpin"
 					@click="onTogglePinData({ source: 'context-menu' })"

--- a/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRuleDetail.vue
+++ b/packages/frontend/editor-ui/src/features/settings/migrationReport/MigrationRuleDetail.vue
@@ -372,7 +372,6 @@ const sortedWorkflows = computed(() => {
 				<N8nButton
 					v-else
 					size="small"
-					type="secondary"
 					:label="i18n.baseText('settings.migrationReport.detail.migrate.button')"
 					data-test-id="migrate-workflow-button"
 					@click.stop="openMigrateModal(item)"


### PR DESCRIPTION
## Summary

Remove unsupported visual-style `type` attributes from `N8nButton` usages in the editor UI and design-system examples.

Values such as `primary`, `secondary`, `tertiary`, and `danger` are not supported button types. When forwarded to the native button element, browsers treat these invalid values as `submit`. Removing them preserves the component default of `button` and avoids unintended form submission.

> [!NOTE]
> I confirmed that I'm only supposed to remove the prop in this PR, not replace it with the corresponding `variant` replacement. @heymynameisrob Maybe we can remove all references to this legacy prop from the docs now also, so both agents and humans are not accidentally adding this back?

## How to test

1. Run `pnpm lint` and `pnpm typecheck` from `packages/frontend/@n8n/design-system`.
2. Run `pnpm lint` and `pnpm typecheck` from `packages/frontend/editor-ui`.
3. Confirm affected buttons render normally and do not submit an ancestor form unless explicitly configured with a valid native submit type.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-934

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

