### PR TITLE
feat(core): Parameterise token-exchange verifyToken for a resource-server caller

### DIFF
--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -8,6 +8,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { JwtService } from '@/services/jwt.service';
 
 import type { TokenExchangeConfig } from '../../token-exchange.config';
+import { TokenExchangeAuthError } from '../../token-exchange.errors';
 import type { ResolvedTrustedKey } from '../../token-exchange.schemas';
 import type { IdentityResolutionService } from '../identity-resolution.service';
 import type { JtiStoreService } from '../jti-store.service';
@@ -228,6 +229,108 @@ describe('TokenExchangeService', () => {
 			identityResolutionService.resolve.mockRejectedValue(new Error('User not found'));
 
 			await expect(service.embedLogin('token')).rejects.toThrow('User not found');
+		});
+	});
+
+	describe('verifyToken', () => {
+		const mockValidToken = () => {
+			vi.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: validClaims,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			vi.spyOn(jwt, 'verify').mockReturnValue(
+				validClaims as unknown as ReturnType<typeof jwt.verify>,
+			);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
+		};
+
+		it('defaults consume the jti and honour the source-level audience', async () => {
+			mockValidToken();
+			jtiStore.consume.mockResolvedValue(true);
+
+			await service.verifyToken('valid-token');
+
+			expect(jwt.verify).toHaveBeenCalledWith(
+				'valid-token',
+				resolvedKey.key,
+				expect.objectContaining({ audience: resolvedKey.expectedAudience }),
+			);
+			expect(jtiStore.consume).toHaveBeenCalledWith(
+				validClaims.jti,
+				new Date(validClaims.exp * 1000),
+			);
+		});
+
+		it('rejects when consumeJti is false and no expectedAudience is supplied', async () => {
+			// The overload signatures require `expectedAudience` whenever `consumeJti: false`
+			// is passed; bypass that compile-time guard to exercise the runtime fail-closed
+			// check, since it also protects callers whose audience is only optional at runtime
+			// (e.g. sourced from config).
+			const verifyTokenUnsafe = service.verifyToken.bind(service) as (
+				token: string,
+				options?: Record<string, unknown>,
+			) => Promise<unknown>;
+
+			await expect(verifyTokenUnsafe('token', { consumeJti: false })).rejects.toThrow(
+				TokenExchangeAuthError,
+			);
+		});
+
+		it('rejects when the token audience does not match the supplied expectedAudience', async () => {
+			mockValidToken();
+			vi.spyOn(jwt, 'verify').mockImplementation(() => {
+				throw new Error('jwt audience invalid');
+			});
+
+			await expect(
+				service.verifyToken('token', {
+					expectedAudience: 'unexpected-audience',
+					consumeJti: false,
+				}),
+			).rejects.toThrow(TokenExchangeAuthError);
+			expect(jwt.verify).toHaveBeenCalledWith(
+				'token',
+				resolvedKey.key,
+				expect.objectContaining({ audience: 'unexpected-audience' }),
+			);
+		});
+
+		it('verifies the same token twice when consumeJti is false', async () => {
+			mockValidToken();
+
+			await service.verifyToken('token', {
+				expectedAudience: 'n8n',
+				consumeJti: false,
+			});
+			await service.verifyToken('token', {
+				expectedAudience: 'n8n',
+				consumeJti: false,
+			});
+
+			expect(jtiStore.consume).not.toHaveBeenCalled();
+		});
+
+		it('accepts a token without jti when requireJti is false', async () => {
+			const { jti: _, ...claimsWithoutJti } = validClaims;
+			vi.spyOn(jwt, 'decode').mockReturnValue({
+				header: { alg: 'RS256', kid: 'test-kid' },
+				payload: claimsWithoutJti,
+				signature: 'sig',
+			} as unknown as ReturnType<typeof jwt.decode>);
+			vi.spyOn(jwt, 'verify').mockReturnValue(
+				claimsWithoutJti as unknown as ReturnType<typeof jwt.verify>,
+			);
+			trustedKeyStore.getByKidAndIss.mockResolvedValue(resolvedKey);
+
+			const result = await service.verifyToken('token', {
+				expectedAudience: 'n8n',
+				consumeJti: false,
+				requireJti: false,
+			});
+
+			expect(result.claims.jti).toBeUndefined();
+			expect(jtiStore.consume).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -11,9 +11,13 @@ import { TokenExchangeAuthError, TokenExchangeRequestError } from '../token-exch
 import type {
 	ExternalTokenClaims,
 	ResolvedTrustedKey,
+	ResourceServerTokenClaims,
 	TokenExchangeRequest,
 } from '../token-exchange.schemas';
-import { ExternalTokenClaimsSchema } from '../token-exchange.schemas';
+import {
+	ExternalTokenClaimsSchema,
+	ResourceServerTokenClaimsSchema,
+} from '../token-exchange.schemas';
 import {
 	TOKEN_EXCHANGE_ISSUER,
 	TokenExchangeFailureReason,
@@ -48,15 +52,64 @@ export class TokenExchangeService {
 	 * Performs the full verification pipeline:
 	 * 1. Decode and extract the `kid` from the JWT header
 	 * 2. Look up the trusted key source by `kid`
-	 * 3. Cryptographically verify the signature
+	 * 3. Cryptographically verify the signature (audience: `expectedAudience`,
+	 *    falling back to the trust source's configured audience)
 	 * 4. Parse and validate the claims against the expected schema
 	 * 5. Optionally enforce maximum token lifetime (for login tokens)
-	 * 6. Consume the JTI to prevent replay attacks
+	 * 6. Consume the JTI to prevent replay attacks, unless `consumeJti` is `false`
+	 *
+	 * `consumeJti: false` is for callers that present the same token on every
+	 * request (e.g. a resource server validating a bearer token) rather than a
+	 * one-shot exchange — such callers can't use JTI-based replay protection, so
+	 * `expectedAudience` becomes mandatory instead: `jsonwebtoken` silently skips
+	 * audience validation when `audience` is `undefined`, and a caller that can't
+	 * rely on replay protection must not also silently skip audience checks.
 	 */
 	async verifyToken(
 		subjectToken: string,
-		{ maxLifetimeSeconds }: { maxLifetimeSeconds?: number } = {},
-	): Promise<{ claims: ExternalTokenClaims; resolvedKey: ResolvedTrustedKey }> {
+		options?: {
+			expectedAudience?: string;
+			consumeJti?: true;
+			requireJti?: true;
+			maxLifetimeSeconds?: number;
+		},
+	): Promise<{ claims: ExternalTokenClaims; resolvedKey: ResolvedTrustedKey }>;
+	async verifyToken(
+		subjectToken: string,
+		options: {
+			expectedAudience: string;
+			consumeJti: false;
+			requireJti?: boolean;
+			maxLifetimeSeconds?: number;
+		},
+	): Promise<{
+		claims: ExternalTokenClaims | ResourceServerTokenClaims;
+		resolvedKey: ResolvedTrustedKey;
+	}>;
+	async verifyToken(
+		subjectToken: string,
+		{
+			expectedAudience,
+			consumeJti = true,
+			requireJti = true,
+			maxLifetimeSeconds,
+		}: {
+			expectedAudience?: string;
+			consumeJti?: boolean;
+			requireJti?: boolean;
+			maxLifetimeSeconds?: number;
+		} = {},
+	): Promise<{
+		claims: ExternalTokenClaims | ResourceServerTokenClaims;
+		resolvedKey: ResolvedTrustedKey;
+	}> {
+		if (!consumeJti && !expectedAudience) {
+			throw new TokenExchangeAuthError(
+				TokenExchangeFailureReason.AudienceRequired,
+				'expectedAudience is required when JTI consumption is disabled',
+			);
+		}
+
 		const decoded = jwt.decode(subjectToken, { complete: true });
 		if (!decoded || typeof decoded === 'string') {
 			throw new TokenExchangeRequestError(
@@ -96,7 +149,7 @@ export class TokenExchangeService {
 				// EdDSA is valid at runtime but missing from @types/jsonwebtoken
 				algorithms: resolvedKey.algorithms as jwt.Algorithm[],
 				issuer: resolvedKey.issuer,
-				audience: resolvedKey.expectedAudience,
+				audience: expectedAudience ?? resolvedKey.expectedAudience,
 				ignoreExpiration: false,
 				ignoreNotBefore: false,
 			});
@@ -117,7 +170,9 @@ export class TokenExchangeService {
 			);
 		}
 
-		const claims = ExternalTokenClaimsSchema.parse(payload);
+		const claims = requireJti
+			? ExternalTokenClaimsSchema.parse(payload)
+			: ResourceServerTokenClaimsSchema.parse(payload);
 
 		if (maxLifetimeSeconds !== undefined) {
 			const tokenLifetime = claims.exp - claims.iat;
@@ -129,12 +184,20 @@ export class TokenExchangeService {
 			}
 		}
 
-		const consumed = await this.jtiStore.consume(claims.jti, new Date(claims.exp * 1000));
-		if (!consumed) {
-			throw new TokenExchangeAuthError(
-				TokenExchangeFailureReason.TokenReplay,
-				'Token has already been used',
-			);
+		if (consumeJti) {
+			if (!claims.jti) {
+				throw new TokenExchangeAuthError(
+					TokenExchangeFailureReason.InvalidClaims,
+					'Token missing jti required for replay protection',
+				);
+			}
+			const consumed = await this.jtiStore.consume(claims.jti, new Date(claims.exp * 1000));
+			if (!consumed) {
+				throw new TokenExchangeAuthError(
+					TokenExchangeFailureReason.TokenReplay,
+					'Token has already been used',
+				);
+			}
 		}
 
 		return { claims, resolvedKey };

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -47,6 +47,17 @@ export const ExternalTokenClaimsSchema = z.object({
 export type ExternalTokenClaims = z.infer<typeof ExternalTokenClaimsSchema>;
 
 /**
+ * Same claims as `ExternalTokenClaimsSchema`, but `jti` is optional.
+ * Some providers (e.g. Entra ID) don't emit `jti` on access tokens; used by
+ * callers that don't rely on JTI-based replay protection.
+ */
+export const ResourceServerTokenClaimsSchema = ExternalTokenClaimsSchema.extend({
+	jti: z.string().min(1).optional(),
+});
+
+export type ResourceServerTokenClaims = z.infer<typeof ResourceServerTokenClaimsSchema>;
+
+/**
  * Validates a trusted key source configuration.
  * Discriminated union on 'type':
  *   - 'static': inline public key with kid, algorithms, key, issuer

--- a/packages/cli/src/modules/token-exchange/token-exchange.types.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.types.ts
@@ -9,6 +9,7 @@ export const TokenExchangeFailureReason = {
 	InvalidFormat: 'invalid_format',
 	MissingKid: 'missing_kid',
 	MissingIss: 'missing_iss',
+	AudienceRequired: 'audience_required',
 	InvalidClaims: 'invalid_claims',
 	InternalError: 'internal_error',
 	RoleNotAllowed: 'role_not_allowed',


### PR DESCRIPTION
## Summary

- Adds an options bag to `TokenExchangeService.verifyToken` — `expectedAudience`, `consumeJti`, `requireJti`, `maxLifetimeSeconds` — so a second, non-exchange caller (a resource server validating a bearer token on every request) can reuse the same verification pipeline (kid/iss key selection, signature check, issuer/audience/exp/nbf, claim schema, max-lifetime, replay).
- `consumeJti: false` skips JTI consumption for callers that present the same token repeatedly instead of once.
- `requireJti: false` uses a new `ResourceServerTokenClaimsSchema` (same as `ExternalTokenClaimsSchema`, `jti` optional) for providers that don't emit `jti` (e.g. Entra ID uses `uti`).
- `expectedAudience` becomes a per-call parameter (falls back to the trust source's configured audience, so today's per-issuer behaviour is unchanged) — audience is a property of the resource, not the issuer.
- Fail-closed: `expectedAudience` is required whenever `consumeJti: false` is passed, both at the type level (overloads) and at runtime — a caller that can't rely on JTI replay protection must not silently skip audience validation either.
- No behaviour change for the existing token-exchange callers (`embedLogin`, `exchange`): both call `verifyToken` with the default options, so JTI is still consumed, `jti` is still required, and source-level audience is still honoured.

## How to test

- `cd packages/cli && pnpm test src/modules/token-exchange` — 168 tests pass, including a new `describe('verifyToken', ...)` block covering all four options.
- `pnpm typecheck` / `pnpm lint` pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1162

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

