### PR TITLE
test(API): Make workflow id ordering assertion collation-independent

### DIFF
--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -708,9 +708,11 @@ describe('GET /workflows', () => {
 	});
 
 	test('should return workflows ordered by id', async () => {
-		const first = await createWorkflowWithHistory({ name: 'First' }, member);
-		const second = await createWorkflowWithHistory({ name: 'Second' }, member);
-		const third = await createWorkflowWithHistory({ name: 'Third' }, member);
+		// Lowercase ids so the expected order holds under every DB collation: generated
+		// ids mix cases, which sqlite and postgres order differently.
+		const first = await createWorkflowWithHistory({ id: 'sortid01', name: 'First' }, member);
+		const second = await createWorkflowWithHistory({ id: 'sortid02', name: 'Second' }, member);
+		const third = await createWorkflowWithHistory({ id: 'sortid03', name: 'Third' }, member);
 
 		// Editing must not change id order (would move the row under updatedAt sort).
 		const editResponse = await authMemberAgent.put(`/workflows/${second.id}`).send({
@@ -724,9 +726,11 @@ describe('GET /workflows', () => {
 		const response = await authMemberAgent.get('/workflows');
 
 		expect(response.statusCode).toBe(200);
-		expect(response.body.data.map((w: { id: string }) => w.id)).toEqual(
-			[first.id, second.id, third.id].sort(),
-		);
+		expect(response.body.data.map((w: { id: string }) => w.id)).toEqual([
+			first.id,
+			second.id,
+			third.id,
+		]);
 	});
 
 	test('should return share rows without the owning project', async () => {

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -708,8 +708,6 @@ describe('GET /workflows', () => {
 	});
 
 	test('should return workflows ordered by id', async () => {
-		// Lowercase ids so the expected order holds under every DB collation: generated
-		// ids mix cases, which sqlite and postgres order differently.
 		const first = await createWorkflowWithHistory({ id: 'sortid01', name: 'First' }, member);
 		const second = await createWorkflowWithHistory({ id: 'sortid02', name: 'Second' }, member);
 		const third = await createWorkflowWithHistory({ id: 'sortid03', name: 'Third' }, member);


### PR DESCRIPTION
## Summary

`GET /workflows > should return workflows ordered by id` is flaky on Postgres —
it fails roughly **38% of runs** (measured below).

The test compared the API's DB-ordered ids against a JS `.sort()` of the same
strings. Those two only agree on binary collations:

- **JS `.sort()`** orders by UTF-16 code unit, so uppercase (65–90) sorts before
  lowercase (97–122).
- **Postgres** (glibc, `en_US.utf8`) treats case as a secondary weight, so
  primary letter weights decide first.

Workflow ids are 16-char nanoids over `0-9A-Za-z`, so whether the two orders
agree comes down to which characters the generator happened to produce. Taking
the exact ids from the reported failure:

```
$ docker run --rm -e POSTGRES_PASSWORD=pw -d --name c postgres:16
$ docker exec c psql -U postgres -tAc "SELECT x FROM (VALUES
    ('HTfkV8NidSO0iOf0'),('gBYVXtkNTHMHZFjV'),('hl3eBRIWSkJTc8Zg')) t(x) ORDER BY x;"
gBYVXtkNTHMHZFjV
hl3eBRIWSkJTc8Zg
HTfkV8NidSO0iOf0
```

That's exactly the "Received" from the failure; JS `.sort()` gives the
"Expected" (`HTfkV8…`, `gBYVX…`, `hl3eB…`). Over 2000 random nanoid triples, JS
sort disagrees with `postgres:16` collation **769 times (38.5%)**.

**No production change.** `findWorkflowsForUser` sorts `id:asc`, which gives a
stable total order within any given instance — all the offset pagination needs.
Postgres and sqlite disagreeing on the absolute sequence isn't user-visible.

The fix pins lowercase ids, which order identically under binary *and*
locale-aware collation. The test's actual intent — a guard against someone
swapping `id:asc` for `updatedAt:desc`, per its own comment — is preserved:
`second` is still edited after creation, so an `updatedAt` sort would still fail
the assertion.

Alternatives rejected:

| Option | Why not |
| --- | --- |
| Sort both sides in JS | Becomes a set comparison; would pass under `updatedAt:desc` despite the test name. |
| `localeCompare` in the expectation | Reimplements DB collation in JS. Depends on the cluster's `LC_COLLATE` — future flake. |
| `ORDER BY id COLLATE "C"` | Changes API ordering for real users to fix nothing, and likely stops the `id` index serving the sort. |

## How to test

> [!IMPORTANT]
> The default local image (`postgres:18-alpine`) **cannot reproduce this** —
> Alpine/musl has no locales, so it collates in `C` (byte order), which matches
> JS. You have to pin CI's Debian-based image:

```bash
cd packages/cli
TEST_IMAGE_POSTGRES=postgres:16 pnpm test:postgres:integration:tc \
  test/integration/public-api/workflows.test.ts -t "ordered by id"
```

Verified: passes on `postgres:16` and on sqlite, and biome/lint/typecheck are
clean. Note that reverting this commit and re-running won't reliably fail — at
~38% it takes a few attempts, which is why the SQL repro above is the more
useful demonstration.

I also swept the other `.sort()` assertions in `packages/cli/test/integration/`
— every other one sorts *both* sides, so they're order-insensitive set
comparisons and are fine. This was the only one-sided case.

## Related Linear tickets, Github issues, and Community forum posts

None — spotted from a failing CI run.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`