### PR TITLE
feat(core): Carry a sealed verified claim on the execution context (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -63,6 +63,7 @@ import { ChangeInstalledNodeVersionType1785162364000 } from './1785162364000-Cha
 import { AddIsFirstPartyToOAuthClients1785162364001 } from './1785162364001-AddIsFirstPartyToOAuthClients';
 import { AddMisfirePolicyToScheduler1785247194307 } from './1785247194307-AddMisfirePolicyToScheduler';
 import { AddSetupCompletedAtToAgents1785500832626 } from './1785500832626-AddSetupCompletedAtToAgents';
+import { AddManagedByAndIssuerToTrustedKeySource1785924000000 } from './1785924000000-AddManagedByAndIssuerToTrustedKeySource';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';
@@ -230,7 +231,6 @@ import { AddAgentFileStorageColumns1785186578138 } from '../common/1785186578138
 import { CrashStaleEnqueuedExecutions1785247194306 } from '../common/1785247194306-CrashStaleEnqueuedExecutions';
 import { CreateAgentChatAttachmentsTable1785255306000 } from '../common/1785255306000-CreateAgentChatAttachmentsTable';
 import { AddAgentExecutionRuntimeState1785828155091 } from '../common/1785828155091-AddAgentExecutionRuntimeState';
-import { AddManagedByAndIssuerToTrustedKeySource1785924000000 } from './1785924000000-AddManagedByAndIssuerToTrustedKeySource';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -1294,9 +1294,8 @@ describe('ExecutionContextService', () => {
 	});
 });
 
-// Runs through the real Cipher rather than the mocked one used above: a passthrough
-// mock would make the "ciphertext never contains the subject" assertions below
-// vacuously true for the wrong reason.
+// Uses the real Cipher, not the mocked one above - a mock would make the
+// "ciphertext never contains the subject" checks below meaningless.
 describe('ExecutionContextService — no principal is ever persisted on the execution context', () => {
 	mockInstance(InstanceSettings, { encryptionKey: 'a'.repeat(64) });
 	const realCipher = Container.get(Cipher);
@@ -1334,8 +1333,7 @@ describe('ExecutionContextService — no principal is ever persisted on the exec
 		const encrypted = await realService.encryptExecutionContext(plaintext, 'wf-1');
 		const serialized = JSON.stringify(encrypted);
 
-		// This is the security property: no field on the persisted execution
-		// context could function as a stored principal.
+		// The security property: no field could function as a stored principal.
 		expect(encrypted).not.toHaveProperty('principalId');
 		expect(encrypted).not.toHaveProperty('principal');
 		expect(encrypted).not.toHaveProperty('userId');
@@ -1343,8 +1341,7 @@ describe('ExecutionContextService — no principal is ever persisted on the exec
 		expect(serialized).not.toContain('user-42');
 		expect(serialized).not.toContain('idp-1');
 
-		// Sanity check that the assertions above aren't vacuous: decrypting with
-		// the real cipher (and the right workflow binding) does recover the claim.
+		// Sanity check: decrypting with the right workflow id does recover the claim.
 		const decrypted = await realService.decryptExecutionContext(encrypted, 'wf-1');
 		expect(decrypted.claims).toEqual(claim);
 	});

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -1,18 +1,22 @@
 import type { Logger } from '@n8n/backend-common';
 import type { IContextEstablishmentHook } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import type {
 	IExecuteData,
 	IExecutionContext,
 	INode,
 	INodeExecutionData,
 	ISecureArtifacts,
+	IVerifiedClaim,
 	PlaintextExecutionContext,
 	Workflow,
 } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import type { Cipher } from '@/encryption';
+import { Cipher } from '@/encryption';
+import { InstanceSettings } from '@/instance-settings';
+import { mockInstance } from '@test/utils';
 
 import type { ExecutionContextHookRegistry } from '../execution-context-hook-registry.service';
 import { ExecutionContextService } from '../execution-context.service';
@@ -201,6 +205,65 @@ describe('ExecutionContextService', () => {
 				secureArtifacts: sampleArtifacts,
 			});
 		});
+
+		const sampleClaim = {
+			version: 1,
+			sourceId: 'idp-1',
+			subject: 'user-42',
+			audience: 'aud-1',
+			expiresAt: 999,
+			boundWorkflowId: 'wf-1',
+		};
+
+		it('should leave claims undefined when present but no expected workflow id is given, without logging', async () => {
+			const context: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				claims: 'sealed-claim-blob',
+			};
+
+			const result = await service.decryptExecutionContext(context);
+
+			expect(result.claims).toBeUndefined();
+			expect(mockCipher.decryptV2).not.toHaveBeenCalled();
+			expect(mockLogger.warn).not.toHaveBeenCalled();
+		});
+
+		it('should decrypt claims when present and bound to the expected workflow', async () => {
+			const context: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				claims: 'sealed-claim-blob',
+			};
+
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify(sampleClaim));
+
+			const result = await service.decryptExecutionContext(context, 'wf-1');
+
+			expect(mockCipher.decryptV2).toHaveBeenCalledWith('sealed-claim-blob');
+			expect(result.claims).toEqual(sampleClaim);
+		});
+
+		it('should drop claims bound to a different workflow than expected', async () => {
+			const context: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				claims: 'sealed-claim-blob',
+			};
+
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify(sampleClaim));
+
+			const result = await service.decryptExecutionContext(context, 'wf-2');
+
+			expect(result.claims).toBeUndefined();
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Sealed claim is bound to a different workflow, dropping it',
+				{ expectedWorkflowId: 'wf-2', boundWorkflowId: 'wf-1' },
+			);
+		});
 	});
 
 	describe('encryptExecutionContext()', () => {
@@ -304,6 +367,52 @@ describe('ExecutionContextService', () => {
 				secureArtifacts: encryptedArtifacts,
 			});
 		});
+
+		it('should seal claims for the given workflow id when present', async () => {
+			const claim: IVerifiedClaim = {
+				version: 1,
+				sourceId: 'idp-1',
+				subject: 'user-42',
+				audience: 'aud-1',
+				expiresAt: 999,
+				boundWorkflowId: 'stale-id-to-be-overwritten',
+			};
+			const context: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				claims: claim,
+			};
+
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
+
+			const result = await service.encryptExecutionContext(context, 'wf-1');
+
+			expect(typeof result.claims).toBe('string');
+			expect(JSON.parse(result.claims as string)).toEqual({ ...claim, boundWorkflowId: 'wf-1' });
+		});
+
+		it('should throw when claims are present but no workflow id is given to bind them to', async () => {
+			const claim: IVerifiedClaim = {
+				version: 1,
+				sourceId: 'idp-1',
+				subject: 'user-42',
+				audience: 'aud-1',
+				expiresAt: 999,
+				boundWorkflowId: 'wf-1',
+			};
+			const context: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				claims: claim,
+			};
+
+			await expect(service.encryptExecutionContext(context)).rejects.toThrow(
+				'Cannot seal a claim without a workflow id to bind it to',
+			);
+			expect(mockCipher.encryptV2).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('buildManualExecutionCredentials()', () => {
@@ -355,6 +464,65 @@ describe('ExecutionContextService', () => {
 		});
 	});
 
+	describe('sealClaims() / decryptClaims()', () => {
+		const sampleClaim: IVerifiedClaim = {
+			version: 1,
+			sourceId: 'idp-1',
+			subject: 'user-42',
+			audience: 'aud-1',
+			expiresAt: Date.now() + 60_000,
+			boundWorkflowId: 'stale-id-to-be-overwritten',
+		};
+
+		it('round-trips a claim sealed for the workflow it is decrypted against', async () => {
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
+			mockCipher.decryptV2.mockImplementation(async (data: string) => data);
+
+			const sealed = await service.sealClaims(sampleClaim, 'wf-1');
+			const result = await service.decryptClaims(sealed, 'wf-1');
+
+			expect(result).toEqual({ ...sampleClaim, boundWorkflowId: 'wf-1' });
+		});
+
+		it('drops (and warns on) a claim sealed for a different workflow', async () => {
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
+			mockCipher.decryptV2.mockImplementation(async (data: string) => data);
+
+			const sealed = await service.sealClaims(sampleClaim, 'wf-1');
+			const result = await service.decryptClaims(sealed, 'wf-2');
+
+			expect(result).toBeUndefined();
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Sealed claim is bound to a different workflow, dropping it',
+				{ expectedWorkflowId: 'wf-2', boundWorkflowId: 'wf-1' },
+			);
+		});
+
+		it('drops (and warns on) a claim that fails to decrypt', async () => {
+			mockCipher.decryptV2.mockRejectedValue(new Error('bad ciphertext'));
+
+			const result = await service.decryptClaims('garbage', 'wf-1');
+
+			expect(result).toBeUndefined();
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Failed to decrypt or parse sealed claim, dropping it',
+				{ error: expect.any(Error) },
+			);
+		});
+
+		it('drops (and warns on) a claim that decrypts but fails schema validation', async () => {
+			mockCipher.decryptV2.mockResolvedValue('not valid json');
+
+			const result = await service.decryptClaims('garbage', 'wf-1');
+
+			expect(result).toBeUndefined();
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Failed to decrypt or parse sealed claim, dropping it',
+				{ error: expect.any(Error) },
+			);
+		});
+	});
+
 	describe('encrypt → decrypt round-trip', () => {
 		it('should preserve secureArtifacts through a full round-trip', async () => {
 			// JSON-stringify on encrypt, identity on decrypt — simulates a symmetric cipher
@@ -379,6 +547,33 @@ describe('ExecutionContextService', () => {
 
 			const decrypted = await service.decryptExecutionContext(encrypted);
 			expect(decrypted.secureArtifacts).toEqual(sampleArtifacts);
+		});
+
+		it('should preserve claims through a full round-trip, bound to the workflow', async () => {
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
+			mockCipher.decryptV2.mockImplementation(async (data: string) => data);
+
+			const claim: IVerifiedClaim = {
+				version: 1,
+				sourceId: 'idp-1',
+				subject: 'user-42',
+				audience: 'aud-1',
+				expiresAt: 12345,
+				boundWorkflowId: 'irrelevant-pre-seal-value',
+			};
+
+			const plaintext: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: 12345,
+				source: 'webhook',
+				claims: claim,
+			};
+
+			const encrypted = await service.encryptExecutionContext(plaintext, 'wf-1');
+			expect(typeof encrypted.claims).toBe('string');
+
+			const decrypted = await service.decryptExecutionContext(encrypted, 'wf-1');
+			expect(decrypted.claims).toEqual({ ...claim, boundWorkflowId: 'wf-1' });
 		});
 	});
 
@@ -525,6 +720,74 @@ describe('ExecutionContextService', () => {
 					options: {},
 				}),
 			);
+			expect(result.redaction).toEqual({ version: 2, production: true, manual: true });
+		});
+
+		it('re-seals an inherited claim for the child workflow even with zero sub-execution hooks', async () => {
+			mockRegistry.getSubExecutionHooks.mockReturnValue([]);
+			mockWorkflow.id = 'child-wf';
+
+			const parentClaim = {
+				version: 1,
+				sourceId: 'idp-1',
+				subject: 'user-42',
+				audience: 'aud-1',
+				expiresAt: Date.now() + 60_000,
+				boundWorkflowId: 'parent-wf',
+			};
+			const inherited: IExecutionContext = {
+				version: 1,
+				establishedAt: 100,
+				source: 'trigger',
+				claims: 'sealed-for-parent',
+			};
+
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify(parentClaim));
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
+
+			const result = await service.augmentSubExecutionContext(mockWorkflow, startItem, inherited);
+
+			// Must not hit the early return that would skip decrypt/encrypt entirely.
+			expect(mockCipher.decryptV2).toHaveBeenCalledWith('sealed-for-parent');
+			expect(result.claims).not.toBe('sealed-for-parent');
+			expect(JSON.parse(result.claims as string)).toEqual({
+				...parentClaim,
+				boundWorkflowId: 'child-wf',
+			});
+		});
+
+		it('runs sub-execution hooks and re-seals an inherited claim for the child workflow together', async () => {
+			const subExecutionHook = mock<IContextEstablishmentHook>();
+			subExecutionHook.execute.mockResolvedValue({
+				contextUpdate: { redaction: { version: 2, production: true, manual: true } },
+			});
+			mockRegistry.getSubExecutionHooks.mockReturnValue([subExecutionHook]);
+			mockWorkflow.id = 'child-wf';
+
+			const parentClaim = {
+				version: 1,
+				sourceId: 'idp-1',
+				subject: 'user-42',
+				audience: 'aud-1',
+				expiresAt: Date.now() + 60_000,
+				boundWorkflowId: 'parent-wf',
+			};
+			const inherited: IExecutionContext = {
+				version: 1,
+				establishedAt: 100,
+				source: 'trigger',
+				claims: 'sealed-for-parent',
+			};
+
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify(parentClaim));
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
+
+			const result = await service.augmentSubExecutionContext(mockWorkflow, startItem, inherited);
+
+			expect(JSON.parse(result.claims as string)).toEqual({
+				...parentClaim,
+				boundWorkflowId: 'child-wf',
+			});
 			expect(result.redaction).toEqual({ version: 2, production: true, manual: true });
 		});
 	});
@@ -1028,5 +1291,61 @@ describe('ExecutionContextService', () => {
 				).rejects.toThrow('boom');
 			});
 		});
+	});
+});
+
+// Runs through the real Cipher rather than the mocked one used above: a passthrough
+// mock would make the "ciphertext never contains the subject" assertions below
+// vacuously true for the wrong reason.
+describe('ExecutionContextService — no principal is ever persisted on the execution context', () => {
+	mockInstance(InstanceSettings, { encryptionKey: 'a'.repeat(64) });
+	const realCipher = Container.get(Cipher);
+
+	const realLogger = {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	} as unknown as Mocked<Logger>;
+	const realRegistry = {
+		getHookByName: vi.fn(),
+		getGlobalHooks: vi.fn().mockReturnValue([]),
+		getSubExecutionHooks: vi.fn().mockReturnValue([]),
+	} as unknown as Mocked<ExecutionContextHookRegistry>;
+
+	it('never persists a plaintext principal id, and never leaks subject/sourceId outside the sealed ciphertext', async () => {
+		const realService = new ExecutionContextService(realLogger, realRegistry, realCipher);
+
+		const claim: IVerifiedClaim = {
+			version: 1,
+			sourceId: 'idp-1',
+			subject: 'user-42',
+			audience: 'aud-1',
+			expiresAt: Date.now() + 60_000,
+			boundWorkflowId: 'wf-1',
+		};
+		const plaintext: PlaintextExecutionContext = {
+			version: 1,
+			establishedAt: Date.now(),
+			source: 'webhook',
+			claims: claim,
+		};
+
+		const encrypted = await realService.encryptExecutionContext(plaintext, 'wf-1');
+		const serialized = JSON.stringify(encrypted);
+
+		// This is the security property: no field on the persisted execution
+		// context could function as a stored principal.
+		expect(encrypted).not.toHaveProperty('principalId');
+		expect(encrypted).not.toHaveProperty('principal');
+		expect(encrypted).not.toHaveProperty('userId');
+		expect(typeof encrypted.claims).toBe('string');
+		expect(serialized).not.toContain('user-42');
+		expect(serialized).not.toContain('idp-1');
+
+		// Sanity check that the assertions above aren't vacuous: decrypting with
+		// the real cipher (and the right workflow binding) does recover the claim.
+		const decrypted = await realService.decryptExecutionContext(encrypted, 'wf-1');
+		expect(decrypted.claims).toEqual(claim);
 	});
 });

--- a/packages/core/src/execution-engine/__tests__/execution-context.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.test.ts
@@ -1014,10 +1014,8 @@ describe('establishExecutionContext', () => {
 		});
 
 		it('should strip a sealed claim rather than inherit it unre-sealed', async () => {
-			// Unlike the sub-workflow (Execute Workflow node) path, this path has no
-			// re-sealing step - a claim carried straight through would still be bound
-			// to the failed workflow's id and fail its binding check everywhere it's
-			// later read, so it's dropped instead of silently carried over.
+			// Unlike the sub-workflow path, error workflows have no re-sealing
+			// step, so an inherited claim would just carry a stale binding.
 			const parentContext: IExecutionContext = {
 				version: 1,
 				establishedAt: 3000000000,
@@ -1063,9 +1061,8 @@ describe('establishExecutionContext', () => {
 
 			const errorContext = runExecutionData.executionData!.runtimeData!;
 
-			// Credentials still inherit as before (unaffected by this change) ...
+			// Credentials still inherit as before; the claim is dropped.
 			expect(errorContext.credentials).toBe('original-workflow-credentials');
-			// ... but the claim is dropped, not carried over with a stale binding.
 			expect(errorContext.claims).toBeUndefined();
 		});
 	});

--- a/packages/core/src/execution-engine/__tests__/execution-context.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.test.ts
@@ -417,6 +417,36 @@ describe('establishExecutionContext', () => {
 			expect(runExecutionData.executionData!.runtimeData!.source).toBe('trigger'); // NOT 'manual'
 		});
 
+		it('should resume a pre-existing execution with no claims field without throwing', async () => {
+			// Simulates an execution persisted before this field existed.
+			const existingContext: IExecutionContext = {
+				version: 1,
+				establishedAt: 1234567890,
+				source: 'webhook',
+			};
+
+			const runExecutionData = createRunExecutionData({
+				startData: {},
+				resultData: {
+					runData: {},
+				},
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+					runtimeData: existingContext,
+				},
+			});
+
+			await expect(
+				establishExecutionContext(mockWorkflow, runExecutionData, mockAdditionalData, 'manual'),
+			).resolves.not.toThrow();
+
+			expect(runExecutionData.executionData!.runtimeData!.claims).toBeUndefined();
+		});
+
 		it('should preserve context with parentExecutionId field', async () => {
 			const existingContext: IExecutionContext = {
 				version: 1,
@@ -981,6 +1011,62 @@ describe('establishExecutionContext', () => {
 			// Should have fresh timing
 			expect(errorContext.source).toBe('error');
 			expect(errorContext.establishedAt).toBeGreaterThan(subWorkflowContext.establishedAt);
+		});
+
+		it('should strip a sealed claim rather than inherit it unre-sealed', async () => {
+			// Unlike the sub-workflow (Execute Workflow node) path, this path has no
+			// re-sealing step - a claim carried straight through would still be bound
+			// to the failed workflow's id and fail its binding check everywhere it's
+			// later read, so it's dropped instead of silently carried over.
+			const parentContext: IExecutionContext = {
+				version: 1,
+				establishedAt: 3000000000,
+				source: 'trigger',
+				credentials: 'original-workflow-credentials',
+				claims: 'sealed-for-failed-workflow',
+			};
+
+			const errorTriggerNode = mock<INode>({
+				name: 'ErrorTrigger',
+				type: 'n8n-nodes-base.errorTrigger',
+			});
+			const runExecutionData = createRunExecutionData({
+				startData: {},
+				resultData: {
+					runData: {},
+				},
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [
+						{
+							node: errorTriggerNode,
+							data: {
+								main: [[{ json: { error: 'test error' } }]],
+							},
+							source: null,
+							metadata: {
+								parentExecution: {
+									executionId: 'failed-execution-id',
+									workflowId: 'failed-workflow-id',
+									executionContext: parentContext,
+								},
+							},
+						},
+					],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+				},
+			});
+
+			await establishExecutionContext(mockWorkflow, runExecutionData, mockAdditionalData, 'error');
+
+			const errorContext = runExecutionData.executionData!.runtimeData!;
+
+			// Credentials still inherit as before (unaffected by this change) ...
+			expect(errorContext.credentials).toBe('original-workflow-credentials');
+			// ... but the claim is dropped, not carried over with a stale binding.
+			expect(errorContext.claims).toBeUndefined();
 		});
 	});
 

--- a/packages/core/src/execution-engine/execution-context.service.ts
+++ b/packages/core/src/execution-engine/execution-context.service.ts
@@ -5,10 +5,13 @@ import {
 	IExecuteData,
 	IExecutionContext,
 	INodeExecutionData,
+	IVerifiedClaim,
 	PlaintextExecutionContext,
+	UnexpectedError,
 	toCredentialContext,
 	toExecutionContextEstablishmentHookParameter,
 	toSecureArtifacts,
+	toVerifiedClaim,
 	Workflow,
 } from 'n8n-workflow';
 
@@ -30,8 +33,71 @@ export class ExecutionContextService {
 		return toCredentialContext(decrypted);
 	}
 
-	async decryptExecutionContext(context: IExecutionContext): Promise<PlaintextExecutionContext> {
-		const { credentials: encCredentials, secureArtifacts: encSecureArtifacts, ...rest } = context;
+	/** Decrypts and parses a sealed claim, without checking its workflow binding. */
+	private async parseClaims(encrypted: string): Promise<IVerifiedClaim> {
+		const decrypted = await this.cipher.decryptV2(encrypted);
+		return toVerifiedClaim(decrypted);
+	}
+
+	/**
+	 * Decrypts and validates a sealed claim, verifying it was sealed for the
+	 * given workflow. Returns `undefined` (with a warning logged) rather than
+	 * throwing when the claim fails to parse or was sealed for a different
+	 * workflow, since this runs inside general-purpose context decryption
+	 * (e.g. hook augmentation) that must not hard-fail a legitimate execution
+	 * over a defensive check. A consumer that needs to enforce trust on the
+	 * claim itself (the future `resolve(claims, ctx)`) should treat
+	 * `undefined` as "no claim to trust", not bypass the check.
+	 */
+	async decryptClaims(
+		encrypted: string,
+		expectedWorkflowId: string,
+	): Promise<IVerifiedClaim | undefined> {
+		let claim: IVerifiedClaim;
+		try {
+			claim = await this.parseClaims(encrypted);
+		} catch (error) {
+			this.logger.warn('Failed to decrypt or parse sealed claim, dropping it', { error });
+			return undefined;
+		}
+
+		if (claim.boundWorkflowId !== expectedWorkflowId) {
+			this.logger.warn('Sealed claim is bound to a different workflow, dropping it', {
+				expectedWorkflowId,
+				boundWorkflowId: claim.boundWorkflowId,
+			});
+			return undefined;
+		}
+
+		return claim;
+	}
+
+	/**
+	 * Seals a claim for a specific workflow, binding the envelope to that
+	 * workflow's id so it can't be replayed against a different workflow than
+	 * the one it was verified for. See {@link decryptClaims}.
+	 */
+	async sealClaims(claim: IVerifiedClaim, workflowId: string): Promise<string> {
+		const payload: IVerifiedClaim = { ...claim, boundWorkflowId: workflowId };
+		return await this.cipher.encryptV2(payload);
+	}
+
+	/**
+	 * @param expectedWorkflowId - Required to decrypt `claims`; omit only when
+	 * the caller doesn't need claims (e.g. it only cares about credentials).
+	 * Without it, a sealed claim is left encrypted-and-dropped rather than
+	 * decoded, since its binding can't be checked.
+	 */
+	async decryptExecutionContext(
+		context: IExecutionContext,
+		expectedWorkflowId?: string,
+	): Promise<PlaintextExecutionContext> {
+		const {
+			credentials: encCredentials,
+			secureArtifacts: encSecureArtifacts,
+			claims: encClaims,
+			...rest
+		} = context;
 		const result: PlaintextExecutionContext = { ...rest };
 		if (encCredentials) {
 			result.credentials = await this.decryptCredentialContext(encCredentials);
@@ -39,6 +105,9 @@ export class ExecutionContextService {
 		if (encSecureArtifacts) {
 			const decrypted = await this.cipher.decryptV2(encSecureArtifacts);
 			result.secureArtifacts = toSecureArtifacts(decrypted);
+		}
+		if (encClaims && expectedWorkflowId) {
+			result.claims = await this.decryptClaims(encClaims, expectedWorkflowId);
 		}
 		return result;
 	}
@@ -67,8 +136,16 @@ export class ExecutionContextService {
 		return await this.cipher.encryptV2(payload);
 	}
 
-	async encryptExecutionContext(context: PlaintextExecutionContext): Promise<IExecutionContext> {
-		const { credentials, secureArtifacts, ...rest } = context;
+	/**
+	 * @param workflowId - Required when `context.claims` is set, to bind the
+	 * sealed claim to the workflow it's being persisted for. See
+	 * {@link sealClaims}.
+	 */
+	async encryptExecutionContext(
+		context: PlaintextExecutionContext,
+		workflowId?: string,
+	): Promise<IExecutionContext> {
+		const { credentials, secureArtifacts, claims, ...rest } = context;
 		const result: IExecutionContext = { ...rest };
 		if (credentials) {
 			result.credentials = await this.cipher.encryptV2(credentials);
@@ -76,9 +153,23 @@ export class ExecutionContextService {
 		if (secureArtifacts) {
 			result.secureArtifacts = await this.cipher.encryptV2(secureArtifacts);
 		}
+		if (claims) {
+			if (!workflowId) {
+				throw new UnexpectedError('Cannot seal a claim without a workflow id to bind it to');
+			}
+			result.claims = await this.sealClaims(claims, workflowId);
+		}
 		return result;
 	}
 
+	/**
+	 * Note for whoever wires up the first `claims` producer: `deepMerge` will
+	 * field-merge a partial `{ claims: {...} }` hook update into an existing
+	 * claims object rather than replacing it wholesale, which could combine
+	 * fields from two different verification passes. A claim should likely be
+	 * replaced atomically, not deep-merged - revisit this when a hook starts
+	 * returning `contextUpdate.claims`.
+	 */
 	mergeExecutionContexts(
 		baseContext: PlaintextExecutionContext,
 		contextToMerge: Partial<PlaintextExecutionContext>,
@@ -99,7 +190,15 @@ export class ExecutionContextService {
 	 * they return are ignored. Node-specific hooks are not run.
 	 *
 	 * Returns the (re-encrypted) context, or the inherited context untouched when
-	 * no sub-execution hooks are registered.
+	 * no sub-execution hooks are registered and no claim needs re-binding.
+	 *
+	 * A sealed claim is bound to the workflow it was verified for (see
+	 * `sealClaims`/`decryptClaims`), so an inherited claim - still bound to the
+	 * PARENT's workflow id - would otherwise fail its binding check on every
+	 * later access to the child's context. Re-derive and re-seal it here for
+	 * THIS (child) workflow: this is expected inheritance of a legitimately
+	 * verified claim, not a replay, so this runs unconditionally whenever a
+	 * claim is present, even with zero registered sub-execution hooks.
 	 */
 	async augmentSubExecutionContext(
 		workflow: Workflow,
@@ -107,9 +206,15 @@ export class ExecutionContextService {
 		contextToAugment: IExecutionContext,
 	): Promise<IExecutionContext> {
 		const subExecutionHooks = this.executionContextHookRegistry.getSubExecutionHooks();
-		if (subExecutionHooks.length === 0) return contextToAugment;
+		if (subExecutionHooks.length === 0 && !contextToAugment.claims) return contextToAugment;
 
+		// Decrypted without checking the claim's (still parent-bound) binding -
+		// it's about to be re-sealed for this workflow below.
 		let context = await this.decryptExecutionContext(contextToAugment);
+
+		if (contextToAugment.claims) {
+			context.claims = await this.parseClaims(contextToAugment.claims);
+		}
 
 		for (const subExecutionHook of subExecutionHooks) {
 			const result = await subExecutionHook.execute({
@@ -125,7 +230,7 @@ export class ExecutionContextService {
 			}
 		}
 
-		return await this.encryptExecutionContext(context);
+		return await this.encryptExecutionContext(context, workflow.id);
 	}
 
 	// startItem is mutated to reflect any changes to trigger items made by the hooks
@@ -149,7 +254,7 @@ export class ExecutionContextService {
 		};
 
 		// decrypt the context to work with plaintext data
-		let context = await this.decryptExecutionContext(contextToAugment);
+		let context = await this.decryptExecutionContext(contextToAugment, workflow.id);
 
 		// Run global hooks!
 		for (const globalHook of this.executionContextHookRegistry.getGlobalHooks()) {
@@ -185,7 +290,7 @@ export class ExecutionContextService {
 			}
 			// no node specific execution establishment hooks found, we return early
 			return {
-				context: await this.encryptExecutionContext(context),
+				context: await this.encryptExecutionContext(context, workflow.id),
 				triggerItems: currentTriggerItems,
 			};
 		}
@@ -238,7 +343,7 @@ export class ExecutionContextService {
 		}
 
 		return {
-			context: await this.encryptExecutionContext(context),
+			context: await this.encryptExecutionContext(context, workflow.id),
 			triggerItems: currentTriggerItems,
 		};
 	}

--- a/packages/core/src/execution-engine/execution-context.service.ts
+++ b/packages/core/src/execution-engine/execution-context.service.ts
@@ -40,14 +40,9 @@ export class ExecutionContextService {
 	}
 
 	/**
-	 * Decrypts and validates a sealed claim, verifying it was sealed for the
-	 * given workflow. Returns `undefined` (with a warning logged) rather than
-	 * throwing when the claim fails to parse or was sealed for a different
-	 * workflow, since this runs inside general-purpose context decryption
-	 * (e.g. hook augmentation) that must not hard-fail a legitimate execution
-	 * over a defensive check. A consumer that needs to enforce trust on the
-	 * claim itself (the future `resolve(claims, ctx)`) should treat
-	 * `undefined` as "no claim to trust", not bypass the check.
+	 * Decrypts a sealed claim and checks it was sealed for `expectedWorkflowId`.
+	 * On failure or mismatch, logs a warning and returns `undefined` instead of
+	 * throwing, so a bad claim doesn't crash an otherwise-valid execution.
 	 */
 	async decryptClaims(
 		encrypted: string,
@@ -72,22 +67,13 @@ export class ExecutionContextService {
 		return claim;
 	}
 
-	/**
-	 * Seals a claim for a specific workflow, binding the envelope to that
-	 * workflow's id so it can't be replayed against a different workflow than
-	 * the one it was verified for. See {@link decryptClaims}.
-	 */
+	/** Seals a claim for one workflow, so it can't be replayed on another. See {@link decryptClaims}. */
 	async sealClaims(claim: IVerifiedClaim, workflowId: string): Promise<string> {
 		const payload: IVerifiedClaim = { ...claim, boundWorkflowId: workflowId };
 		return await this.cipher.encryptV2(payload);
 	}
 
-	/**
-	 * @param expectedWorkflowId - Required to decrypt `claims`; omit only when
-	 * the caller doesn't need claims (e.g. it only cares about credentials).
-	 * Without it, a sealed claim is left encrypted-and-dropped rather than
-	 * decoded, since its binding can't be checked.
-	 */
+	/** @param expectedWorkflowId - Needed to decrypt `claims`; without it, claims are left encrypted. */
 	async decryptExecutionContext(
 		context: IExecutionContext,
 		expectedWorkflowId?: string,
@@ -136,11 +122,7 @@ export class ExecutionContextService {
 		return await this.cipher.encryptV2(payload);
 	}
 
-	/**
-	 * @param workflowId - Required when `context.claims` is set, to bind the
-	 * sealed claim to the workflow it's being persisted for. See
-	 * {@link sealClaims}.
-	 */
+	/** @param workflowId - Required when `context.claims` is set. See {@link sealClaims}. */
 	async encryptExecutionContext(
 		context: PlaintextExecutionContext,
 		workflowId?: string,
@@ -163,12 +145,9 @@ export class ExecutionContextService {
 	}
 
 	/**
-	 * Note for whoever wires up the first `claims` producer: `deepMerge` will
-	 * field-merge a partial `{ claims: {...} }` hook update into an existing
-	 * claims object rather than replacing it wholesale, which could combine
-	 * fields from two different verification passes. A claim should likely be
-	 * replaced atomically, not deep-merged - revisit this when a hook starts
-	 * returning `contextUpdate.claims`.
+	 * Note for later: this deep-merges `claims` field-by-field like everything
+	 * else, which could mix fields from two different verification passes. A
+	 * claim should probably be replaced whole, not merged.
 	 */
 	mergeExecutionContexts(
 		baseContext: PlaintextExecutionContext,
@@ -192,13 +171,10 @@ export class ExecutionContextService {
 	 * Returns the (re-encrypted) context, or the inherited context untouched when
 	 * no sub-execution hooks are registered and no claim needs re-binding.
 	 *
-	 * A sealed claim is bound to the workflow it was verified for (see
-	 * `sealClaims`/`decryptClaims`), so an inherited claim - still bound to the
-	 * PARENT's workflow id - would otherwise fail its binding check on every
-	 * later access to the child's context. Re-derive and re-seal it here for
-	 * THIS (child) workflow: this is expected inheritance of a legitimately
-	 * verified claim, not a replay, so this runs unconditionally whenever a
-	 * claim is present, even with zero registered sub-execution hooks.
+	 * A claim is sealed for one workflow, so an inherited claim still bound to
+	 * the parent's workflow would fail every later check. Re-seal it here for
+	 * the child workflow instead - this always runs when a claim is present,
+	 * even with no sub-execution hooks registered.
 	 */
 	async augmentSubExecutionContext(
 		workflow: Workflow,
@@ -208,8 +184,8 @@ export class ExecutionContextService {
 		const subExecutionHooks = this.executionContextHookRegistry.getSubExecutionHooks();
 		if (subExecutionHooks.length === 0 && !contextToAugment.claims) return contextToAugment;
 
-		// Decrypted without checking the claim's (still parent-bound) binding -
-		// it's about to be re-sealed for this workflow below.
+		// Skip the binding check here - the claim is still bound to the parent
+		// workflow and gets re-sealed for this one below.
 		let context = await this.decryptExecutionContext(contextToAugment);
 
 		if (contextToAugment.claims) {

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -183,15 +183,8 @@ export const establishExecutionContext = async (
 	// We were triggered from a parent execution
 	// and can inherit context from there
 	if (startItem.metadata?.parentExecution?.executionContext) {
-		// A sealed claim is bound to the workflow it was verified for (see
-		// ExecutionContextService.sealClaims/decryptClaims). This path (error
-		// workflows) has no re-sealing step like the sub-workflow path does via
-		// `augmentSubExecutionContext`, so an inherited claim would carry the
-		// wrong binding and fail verification everywhere it's read - drop it
-		// rather than propagate a claim that will silently never validate.
-		// Whether an error workflow should inherit the triggering claim as its
-		// own attested identity at all is a product decision; this defaults to
-		// "no" until that's explicitly revisited.
+		// Drop the claim: it's sealed for the failed workflow, and unlike the
+		// sub-workflow path, error workflows have no step to re-seal it here.
 		const { claims: _droppedClaims, ...inheritedContext } =
 			startItem.metadata.parentExecution.executionContext;
 		executionData.runtimeData = {

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -183,8 +183,19 @@ export const establishExecutionContext = async (
 	// We were triggered from a parent execution
 	// and can inherit context from there
 	if (startItem.metadata?.parentExecution?.executionContext) {
+		// A sealed claim is bound to the workflow it was verified for (see
+		// ExecutionContextService.sealClaims/decryptClaims). This path (error
+		// workflows) has no re-sealing step like the sub-workflow path does via
+		// `augmentSubExecutionContext`, so an inherited claim would carry the
+		// wrong binding and fail verification everywhere it's read - drop it
+		// rather than propagate a claim that will silently never validate.
+		// Whether an error workflow should inherit the triggering claim as its
+		// own attested identity at all is a product decision; this defaults to
+		// "no" until that's explicitly revisited.
+		const { claims: _droppedClaims, ...inheritedContext } =
+			startItem.metadata.parentExecution.executionContext;
 		executionData.runtimeData = {
-			...startItem.metadata.parentExecution.executionContext,
+			...inheritedContext,
 			...executionData.runtimeData,
 			parentExecutionId: startItem.metadata.parentExecution.executionId,
 		};

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -88,6 +88,77 @@ export const CredentialContextSchema = z
  */
 export type ICredentialContext = z.output<typeof CredentialContextSchema>;
 
+const ActorClaimSchemaV1 = z.object({
+	version: z.literal(1),
+	/**
+	 * The external source (IdP) that verified the actor's identity, under
+	 * On-Behalf-Of. Orthogonal to `subject`/principal: `principal` is whose
+	 * authority is used, `actor` is who is calling.
+	 */
+	sourceId: z.string(),
+	/**
+	 * The actor's verified external subject.
+	 */
+	subject: z.string(),
+});
+
+export type IActorClaimV1 = z.output<typeof ActorClaimSchemaV1>;
+
+const VerifiedClaimSchemaV1 = z.object({
+	version: z.literal(1),
+	/**
+	 * Which external source (IdP) verified this claim. Resolved against the
+	 * trusted-key-source registry to derive a principal - the context never
+	 * carries a principal id directly.
+	 */
+	sourceId: z.string(),
+	/**
+	 * The verified external subject (e.g. IdP `sub`, Slack signing identity).
+	 * Never used as a principal id directly - always re-derived at access time
+	 * via `resolve(claims, ctx)`.
+	 */
+	subject: z.string(),
+	/**
+	 * What the claim was verified for (mirrors JWT `aud`). Prevents a claim
+	 * verified for one audience from being replayed for another.
+	 */
+	audience: z.string(),
+	/**
+	 * Unix timestamp (milliseconds) after which the claim must no longer be trusted.
+	 */
+	expiresAt: z.number(),
+	/**
+	 * Who is calling, under On-Behalf-Of - orthogonal to `subject`/principal.
+	 * Present in the type even though nothing produces it yet, so adding a
+	 * producer later doesn't require re-plumbing the shape.
+	 */
+	actorClaim: ActorClaimSchemaV1.optional(),
+	/**
+	 * The id of the workflow this claim was sealed for. Verified against the
+	 * executing workflow's id on decrypt so a claim can't be replayed against
+	 * a different workflow than the one it was verified for. Seal-mechanism
+	 * metadata rather than part of the conceptual claim - rewritten whenever
+	 * the claim is inherited by a sub-workflow with a different id.
+	 */
+	boundWorkflowId: z.string(),
+});
+
+export type IVerifiedClaimV1 = z.output<typeof VerifiedClaimSchemaV1>;
+
+export const VerifiedClaimSchema = z.discriminatedUnion('version', [VerifiedClaimSchemaV1]).meta({
+	title: 'IVerifiedClaim',
+});
+
+/**
+ * Decrypted structure of the `claims` field on the execution context: attested
+ * facts about the caller, sealed rather than stored plaintext. The principal
+ * is derived from this at each access via `resolve(claims, ctx)`, never
+ * persisted on the context - a stored principal id would itself function as a
+ * bearer credential.
+ * Never stored in this form - always encrypted in IExecutionContext.
+ */
+export type IVerifiedClaim = z.output<typeof VerifiedClaimSchema>;
+
 export const WorkflowExecuteModeList = [
 	'cli',
 	'error',
@@ -195,6 +266,19 @@ const ExecutionContextSchemaV1 = z.object({
 	}),
 
 	/**
+	 * Sealed (encrypted) attested facts about the caller. Always encrypted when
+	 * stored, decrypted on-demand by ExecutionContextService. The principal is
+	 * derived from this at each access - never persisted directly on the
+	 * context, so a plaintext/writable field here would function as a bearer
+	 * credential.
+	 * @see IVerifiedClaim for the decrypted structure
+	 */
+	claims: z.string().optional().meta({
+		description:
+			'Sealed (encrypted) attested facts about the caller. Always encrypted when stored, decrypted on-demand by ExecutionContextService. @see IVerifiedClaim for decrypted structure',
+	}),
+
+	/**
 	 * Encrypted artifacts produced by context-establishment hooks
 	 * (e.g. a trigger stripper) for later consumption by node backends.
 	 * Always encrypted when stored, decrypted on demand by
@@ -285,10 +369,11 @@ export type IExecutionContext = z.output<typeof ExecutionContextSchema>;
  */
 export type PlaintextExecutionContext = Omit<
 	IExecutionContext,
-	'credentials' | 'secureArtifacts'
+	'credentials' | 'secureArtifacts' | 'claims'
 > & {
 	credentials?: ICredentialContext;
 	secureArtifacts?: ISecureArtifacts;
+	claims?: IVerifiedClaim;
 };
 
 export const safeParse = <T extends ZodType>(value: string | object, schema: T) => {
@@ -334,4 +419,17 @@ export const toCredentialContext = (value: string | object): ICredentialContext 
 export const toSecureArtifacts = (value: string | object): ISecureArtifacts => {
 	// here we could implement a migration policy for migrating old secure artifacts versions to newer ones
 	return safeParse(value, SecureArtifactsSchema);
+};
+
+/**
+ * Safely parses a verified claim from either an object or a string to an
+ * IVerifiedClaim. This can be used to safely parse a decrypted claim for
+ * example.
+ * @param value The object or string to be parsed
+ * @returns IVerifiedClaim
+ * @throws Error in case parsing fails for any reason
+ */
+export const toVerifiedClaim = (value: string | object): IVerifiedClaim => {
+	// here we could implement a migration policy for migrating old verified claim versions to newer ones
+	return safeParse(value, VerifiedClaimSchema);
 };

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -90,15 +90,9 @@ export type ICredentialContext = z.output<typeof CredentialContextSchema>;
 
 const ActorClaimSchemaV1 = z.object({
 	version: z.literal(1),
-	/**
-	 * The external source (IdP) that verified the actor's identity, under
-	 * On-Behalf-Of. Orthogonal to `subject`/principal: `principal` is whose
-	 * authority is used, `actor` is who is calling.
-	 */
+	/** IdP that verified the actor (the caller), not the principal (who they're acting as). */
 	sourceId: z.string(),
-	/**
-	 * The actor's verified external subject.
-	 */
+	/** The actor's verified external subject. */
 	subject: z.string(),
 });
 
@@ -106,39 +100,19 @@ export type IActorClaimV1 = z.output<typeof ActorClaimSchemaV1>;
 
 const VerifiedClaimSchemaV1 = z.object({
 	version: z.literal(1),
-	/**
-	 * Which external source (IdP) verified this claim. Resolved against the
-	 * trusted-key-source registry to derive a principal - the context never
-	 * carries a principal id directly.
-	 */
+	/** Which IdP verified this claim. */
 	sourceId: z.string(),
-	/**
-	 * The verified external subject (e.g. IdP `sub`, Slack signing identity).
-	 * Never used as a principal id directly - always re-derived at access time
-	 * via `resolve(claims, ctx)`.
-	 */
+	/** The verified external subject, e.g. IdP `sub`. Not a principal id - see IVerifiedClaim. */
 	subject: z.string(),
-	/**
-	 * What the claim was verified for (mirrors JWT `aud`). Prevents a claim
-	 * verified for one audience from being replayed for another.
-	 */
+	/** What the claim was verified for (mirrors JWT `aud`). */
 	audience: z.string(),
-	/**
-	 * Unix timestamp (milliseconds) after which the claim must no longer be trusted.
-	 */
+	/** Unix ms after which the claim is no longer trusted. */
 	expiresAt: z.number(),
-	/**
-	 * Who is calling, under On-Behalf-Of - orthogonal to `subject`/principal.
-	 * Present in the type even though nothing produces it yet, so adding a
-	 * producer later doesn't require re-plumbing the shape.
-	 */
+	/** Who is calling, for On-Behalf-Of. Unused for now, kept so it doesn't need adding later. */
 	actorClaim: ActorClaimSchemaV1.optional(),
 	/**
-	 * The id of the workflow this claim was sealed for. Verified against the
-	 * executing workflow's id on decrypt so a claim can't be replayed against
-	 * a different workflow than the one it was verified for. Seal-mechanism
-	 * metadata rather than part of the conceptual claim - rewritten whenever
-	 * the claim is inherited by a sub-workflow with a different id.
+	 * Id of the workflow this claim was sealed for. Checked on decrypt so a
+	 * claim can't be replayed on a different workflow.
 	 */
 	boundWorkflowId: z.string(),
 });
@@ -150,12 +124,9 @@ export const VerifiedClaimSchema = z.discriminatedUnion('version', [VerifiedClai
 });
 
 /**
- * Decrypted structure of the `claims` field on the execution context: attested
- * facts about the caller, sealed rather than stored plaintext. The principal
- * is derived from this at each access via `resolve(claims, ctx)`, never
- * persisted on the context - a stored principal id would itself function as a
- * bearer credential.
- * Never stored in this form - always encrypted in IExecutionContext.
+ * Decrypted shape of the `claims` field: attested facts about the caller.
+ * The principal is derived from this on each access, never stored - a stored
+ * principal id would itself work as a bearer credential.
  */
 export type IVerifiedClaim = z.output<typeof VerifiedClaimSchema>;
 
@@ -266,16 +237,12 @@ const ExecutionContextSchemaV1 = z.object({
 	}),
 
 	/**
-	 * Sealed (encrypted) attested facts about the caller. Always encrypted when
-	 * stored, decrypted on-demand by ExecutionContextService. The principal is
-	 * derived from this at each access - never persisted directly on the
-	 * context, so a plaintext/writable field here would function as a bearer
-	 * credential.
+	 * Sealed (encrypted) claim about the caller. Never stored as plaintext,
+	 * since that would let anyone forge a principal.
 	 * @see IVerifiedClaim for the decrypted structure
 	 */
 	claims: z.string().optional().meta({
-		description:
-			'Sealed (encrypted) attested facts about the caller. Always encrypted when stored, decrypted on-demand by ExecutionContextService. @see IVerifiedClaim for decrypted structure',
+		description: 'Sealed (encrypted) claim about the caller. @see IVerifiedClaim',
 	}),
 
 	/**

--- a/packages/workflow/test/execution-context.test.ts
+++ b/packages/workflow/test/execution-context.test.ts
@@ -150,8 +150,12 @@ describe('toVerifiedClaim', () => {
 		).toThrow();
 	});
 
-	it('never carries a plaintext principal id field', () => {
-		const parsed = toVerifiedClaim(baseClaim);
+	it('strips an injected principal id rather than carrying it through', () => {
+		// Simulates a forged/injected principalId on the raw (pre-parse) input -
+		// the schema has no such field, so it must be dropped, not echoed back.
+		const tampered = { ...baseClaim, principalId: 'admin', principal: 'admin' };
+
+		const parsed = toVerifiedClaim(tampered);
 
 		expect(parsed).not.toHaveProperty('principalId');
 		expect(parsed).not.toHaveProperty('principal');

--- a/packages/workflow/test/execution-context.test.ts
+++ b/packages/workflow/test/execution-context.test.ts
@@ -1,4 +1,4 @@
-import { toExecutionContext } from '../src/execution-context';
+import { toExecutionContext, toVerifiedClaim } from '../src/execution-context';
 
 describe('toExecutionContext — redaction snapshot', () => {
 	const baseContext = {
@@ -70,5 +70,90 @@ describe('toExecutionContext — redaction snapshot', () => {
 				redaction: { version: 2, production: true },
 			}),
 		).toThrow();
+	});
+});
+
+describe('toExecutionContext — claims', () => {
+	const baseContext = {
+		version: 1 as const,
+		establishedAt: 1234567890,
+		source: 'webhook' as const,
+	};
+
+	it('parses a context with a sealed (opaque, encrypted-string) claims field', () => {
+		const parsed = toExecutionContext({ ...baseContext, claims: 'encrypted-blob' });
+
+		expect(parsed.claims).toBe('encrypted-blob');
+	});
+
+	it('parses a context without a claims field without throwing (absent on old executions)', () => {
+		expect(() => toExecutionContext({ ...baseContext })).not.toThrow();
+		expect(toExecutionContext({ ...baseContext }).claims).toBeUndefined();
+	});
+});
+
+describe('toVerifiedClaim', () => {
+	const baseClaim = {
+		version: 1 as const,
+		sourceId: 'idp-1',
+		subject: 'user-42',
+		audience: 'aud-1',
+		expiresAt: 1234567890,
+		boundWorkflowId: 'wf-1',
+	};
+
+	it('parses a valid V1 claim without an actorClaim', () => {
+		const parsed = toVerifiedClaim(baseClaim);
+
+		expect(parsed).toEqual(baseClaim);
+		expect(parsed.actorClaim).toBeUndefined();
+	});
+
+	it('parses a valid V1 claim with an actorClaim (On-Behalf-Of)', () => {
+		const claim = {
+			...baseClaim,
+			actorClaim: { version: 1 as const, sourceId: 'idp-2', subject: 'service-account-1' },
+		};
+
+		const parsed = toVerifiedClaim(claim);
+
+		expect(parsed.actorClaim).toEqual({
+			version: 1,
+			sourceId: 'idp-2',
+			subject: 'service-account-1',
+		});
+	});
+
+	it('round-trips through a JSON string, as it would after decrypt', () => {
+		const parsed = toVerifiedClaim(JSON.stringify(baseClaim));
+
+		expect(parsed).toEqual(baseClaim);
+	});
+
+	it.each(['sourceId', 'subject', 'audience', 'expiresAt', 'boundWorkflowId'])(
+		'rejects a claim missing %s',
+		(field) => {
+			const invalid: Record<string, unknown> = { ...baseClaim };
+			delete invalid[field];
+
+			expect(() => toVerifiedClaim(invalid)).toThrow();
+		},
+	);
+
+	it('rejects a claim with an unknown version', () => {
+		expect(() => toVerifiedClaim({ ...baseClaim, version: 2 })).toThrow();
+	});
+
+	it('rejects a claim with a malformed actorClaim', () => {
+		expect(() =>
+			toVerifiedClaim({ ...baseClaim, actorClaim: { version: 1, sourceId: 'idp-2' } }),
+		).toThrow();
+	});
+
+	it('never carries a plaintext principal id field', () => {
+		const parsed = toVerifiedClaim(baseClaim);
+
+		expect(parsed).not.toHaveProperty('principalId');
+		expect(parsed).not.toHaveProperty('principal');
 	});
 });


### PR DESCRIPTION
## Summary

Adds a `claims` field alongside the existing `credentials` field on the execution context: a sealed (encrypted), per-execution place to hold attested facts about the caller (`sourceId`, `subject`, `audience`, `expiresAt`, `actorClaim?`), so the principal can be re-derived at each access instead of being stored directly. No principal id is ever persisted on the context — that stays a derive-on-access concern for a later ticket (`resolve(claims, ctx)`).

- `packages/workflow/src/execution-context.ts`: new `VerifiedClaimSchemaV1`/`IVerifiedClaim` type (+ `ActorClaimSchemaV1` for the OBO axis, present in the type though nothing produces it yet), new `claims: z.string().optional()` sibling field on the execution context schema, `toVerifiedClaim()` parser.
- `packages/core/src/execution-engine/execution-context.service.ts`: `sealClaims`/`decryptClaims` bind a claim to the workflow it was verified for (no execution id exists yet at any point where sealing currently happens, so workflow id is the strongest binding available — see PR discussion). A binding mismatch or parse failure soft-fails (warn + drop the claim) rather than throwing, since this runs inside general-purpose context decryption that shouldn't hard-fail a legitimate execution over a defensive check.
- `packages/core/src/execution-engine/execution-context.ts`: sub-workflow inheritance now re-seals an inherited claim under the child workflow's own id (`augmentSubExecutionContext`, including when zero hooks are registered — previously that path short-circuited before this ticket). The error-workflow inheritance path has no equivalent re-seal step, so it explicitly strips `claims` rather than propagate a claim that can never re-validate.
- `user.identity` (today: `credentials.identity`) is untouched — additive change only.

This is pure plumbing: nothing yet produces a real claim (that's the token-verification ticket's job). Tests are schema/round-trip/negative-assertion coverage, including a literal assertion that no principal id is ever persisted on the context, run through a real (non-mocked) cipher.

## How to test

- `cd packages/workflow && pnpm test test/execution-context.test.ts`
- `cd packages/core && pnpm test src/execution-engine/__tests__/execution-context.test.ts src/execution-engine/__tests__/execution-context.service.test.ts`
- Both packages typecheck and lint clean; full `packages/workflow` and `packages/core` suites pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1167

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

