### PR TITLE
feat(core): Resolve verified claims to n8n users via IdentityResolutionService

### DIFF
--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -63,6 +63,7 @@ import { ChangeInstalledNodeVersionType1785162364000 } from './1785162364000-Cha
 import { AddIsFirstPartyToOAuthClients1785162364001 } from './1785162364001-AddIsFirstPartyToOAuthClients';
 import { AddMisfirePolicyToScheduler1785247194307 } from './1785247194307-AddMisfirePolicyToScheduler';
 import { AddSetupCompletedAtToAgents1785500832626 } from './1785500832626-AddSetupCompletedAtToAgents';
+import { AddManagedByAndIssuerToTrustedKeySource1785924000000 } from './1785924000000-AddManagedByAndIssuerToTrustedKeySource';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';
@@ -230,7 +231,6 @@ import { AddAgentFileStorageColumns1785186578138 } from '../common/1785186578138
 import { CrashStaleEnqueuedExecutions1785247194306 } from '../common/1785247194306-CrashStaleEnqueuedExecutions';
 import { CreateAgentChatAttachmentsTable1785255306000 } from '../common/1785255306000-CreateAgentChatAttachmentsTable';
 import { AddAgentExecutionRuntimeState1785828155091 } from '../common/1785828155091-AddAgentExecutionRuntimeState';
-import { AddManagedByAndIssuerToTrustedKeySource1785924000000 } from './1785924000000-AddManagedByAndIssuerToTrustedKeySource';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,

--- a/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
@@ -78,6 +78,8 @@ describe('IdentityResolutionService', () => {
 		// Default: no linked identity, no existing user (JIT territory unless overridden).
 		authIdentityRepository.findOne.mockResolvedValue(null);
 		userRepository.findOne.mockResolvedValue(null);
+		// Default: claim issuer isn't SSO-derived, so the bridge is never consulted.
+		trustedKeyService.isSsoIssuer.mockResolvedValue(false);
 	});
 
 	describe('JIT provisioning (new user)', () => {
@@ -99,7 +101,7 @@ describe('IdentityResolutionService', () => {
 		});
 
 		it('provisions a licensed custom global role', async () => {
-			const user = await service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx());
+			const user = await service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), true);
 
 			expect(user.id).toBe('new-user-1');
 			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
@@ -113,7 +115,7 @@ describe('IdentityResolutionService', () => {
 		});
 
 		it('provisions a built-in global role without a license check', async () => {
-			await service.resolve(makeClaims({ role: 'global:member' }), undefined, ctx());
+			await service.resolve(makeClaims({ role: 'global:member' }), undefined, ctx(), true);
 
 			expect(roleService.isRoleLicensed).not.toHaveBeenCalled();
 			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
@@ -123,7 +125,7 @@ describe('IdentityResolutionService', () => {
 		});
 
 		it('defaults to global:member when no role claim is present', async () => {
-			await service.resolve(makeClaims(), undefined, ctx());
+			await service.resolve(makeClaims(), undefined, ctx(), true);
 
 			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
 				expect.objectContaining({ role: GLOBAL_MEMBER_ROLE }),
@@ -139,7 +141,7 @@ describe('IdentityResolutionService', () => {
 			roleService.isGlobalRole.mockResolvedValue(false);
 
 			await expect(
-				service.resolve(makeClaims({ role: 'global:nonexistent' }), undefined, ctx()),
+				service.resolve(makeClaims({ role: 'global:nonexistent' }), undefined, ctx(), true),
 			).rejects.toThrow(TokenExchangeAuthError);
 			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
 		});
@@ -148,25 +150,25 @@ describe('IdentityResolutionService', () => {
 			roleService.isRoleLicensed.mockReturnValue(false);
 
 			await expect(
-				service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx()),
+				service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), true),
 			).rejects.toThrow(TokenExchangeAuthError);
 			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
 		});
 
 		it('throws on a global:owner role claim', async () => {
 			await expect(
-				service.resolve(makeClaims({ role: 'global:owner' }), undefined, ctx()),
+				service.resolve(makeClaims({ role: 'global:owner' }), undefined, ctx(), true),
 			).rejects.toThrow(TokenExchangeAuthError);
 		});
 
 		it('throws when the role is not in the key allowedRoles', async () => {
 			await expect(
-				service.resolve(makeClaims({ role: CUSTOM_ROLE }), ['global:member'], ctx()),
+				service.resolve(makeClaims({ role: CUSTOM_ROLE }), ['global:member'], ctx(), true),
 			).rejects.toThrow(TokenExchangeAuthError);
 		});
 
 		it('provisions when the role is in the key allowedRoles', async () => {
-			await service.resolve(makeClaims({ role: CUSTOM_ROLE }), [CUSTOM_ROLE], ctx());
+			await service.resolve(makeClaims({ role: CUSTOM_ROLE }), [CUSTOM_ROLE], ctx(), true);
 
 			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
 				expect.objectContaining({ role: { slug: CUSTOM_ROLE } }),
@@ -186,7 +188,7 @@ describe('IdentityResolutionService', () => {
 		it('changes to a licensed custom role and emits an update event', async () => {
 			mockLinkedUser('global:member');
 
-			await service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx());
+			await service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), true);
 
 			expect(userService.changeUserRole).toHaveBeenCalledWith(expect.anything(), {
 				newRoleName: CUSTOM_ROLE,
@@ -201,7 +203,7 @@ describe('IdentityResolutionService', () => {
 			mockLinkedUser('global:member');
 			roleService.isGlobalRole.mockResolvedValue(false);
 
-			await service.resolve(makeClaims({ role: 'global:nonexistent' }), undefined, ctx());
+			await service.resolve(makeClaims({ role: 'global:nonexistent' }), undefined, ctx(), true);
 
 			expect(userService.changeUserRole).not.toHaveBeenCalled();
 		});
@@ -211,7 +213,7 @@ describe('IdentityResolutionService', () => {
 			roleService.isRoleLicensed.mockReturnValue(false);
 
 			await expect(
-				service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx()),
+				service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), true),
 			).rejects.toThrow(TokenExchangeAuthError);
 			expect(userService.changeUserRole).not.toHaveBeenCalled();
 		});
@@ -219,7 +221,7 @@ describe('IdentityResolutionService', () => {
 		it('never changes the role of an existing owner', async () => {
 			mockLinkedUser('global:owner');
 
-			await service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx());
+			await service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), true);
 
 			expect(userService.changeUserRole).not.toHaveBeenCalled();
 		});
@@ -227,7 +229,7 @@ describe('IdentityResolutionService', () => {
 		it('ignores a global:owner role claim', async () => {
 			mockLinkedUser('global:member');
 
-			await service.resolve(makeClaims({ role: 'global:owner' }), undefined, ctx());
+			await service.resolve(makeClaims({ role: 'global:owner' }), undefined, ctx(), true);
 
 			expect(userService.changeUserRole).not.toHaveBeenCalled();
 		});
@@ -236,7 +238,7 @@ describe('IdentityResolutionService', () => {
 			mockLinkedUser('global:member');
 
 			await expect(
-				service.resolve(makeClaims({ role: CUSTOM_ROLE }), ['global:member'], ctx()),
+				service.resolve(makeClaims({ role: CUSTOM_ROLE }), ['global:member'], ctx(), true),
 			).rejects.toThrow(TokenExchangeAuthError);
 			expect(userService.changeUserRole).not.toHaveBeenCalled();
 		});
@@ -246,7 +248,9 @@ describe('IdentityResolutionService', () => {
 		it('rejects when a key authenticates as an existing user whose role exceeds allowedRoles (email match)', async () => {
 			userRepository.findOne.mockResolvedValue(makeUser('global:owner'));
 
-			await expect(service.resolve(makeClaims(), ['global:member'], ctx())).rejects.toMatchObject({
+			await expect(
+				service.resolve(makeClaims(), ['global:member'], ctx(), true),
+			).rejects.toMatchObject({
 				reason: TokenExchangeFailureReason.RoleNotAllowed,
 			});
 		});
@@ -256,23 +260,25 @@ describe('IdentityResolutionService', () => {
 				mock<AuthIdentity>({ user: makeUser('global:owner') }),
 			);
 
-			await expect(service.resolve(makeClaims(), ['global:member'], ctx())).rejects.toBeInstanceOf(
-				TokenExchangeAuthError,
-			);
+			await expect(
+				service.resolve(makeClaims(), ['global:member'], ctx(), true),
+			).rejects.toBeInstanceOf(TokenExchangeAuthError);
 		});
 
 		it('resolves the existing user when its role is within allowedRoles', async () => {
 			const member = makeUser('global:member');
 			userRepository.findOne.mockResolvedValue(member);
 
-			await expect(service.resolve(makeClaims(), ['global:member'], ctx())).resolves.toBe(member);
+			await expect(service.resolve(makeClaims(), ['global:member'], ctx(), true)).resolves.toBe(
+				member,
+			);
 		});
 
 		it('resolves any existing user when allowedRoles is undefined (unrestricted)', async () => {
 			const owner = makeUser('global:owner');
 			userRepository.findOne.mockResolvedValue(owner);
 
-			await expect(service.resolve(makeClaims(), undefined, ctx())).resolves.toBe(owner);
+			await expect(service.resolve(makeClaims(), undefined, ctx(), true)).resolves.toBe(owner);
 		});
 	});
 
@@ -281,7 +287,9 @@ describe('IdentityResolutionService', () => {
 			config.excludeOwner = true;
 			userRepository.findOne.mockResolvedValue(makeUser('global:owner'));
 
-			await expect(service.resolve(makeClaims(), ['global:owner'], ctx())).rejects.toMatchObject({
+			await expect(
+				service.resolve(makeClaims(), ['global:owner'], ctx(), true),
+			).rejects.toMatchObject({
 				reason: TokenExchangeFailureReason.RoleNotAllowed,
 			});
 		});
@@ -292,14 +300,14 @@ describe('IdentityResolutionService', () => {
 			userRepository.findOne.mockResolvedValue(makeUser('global:member'));
 
 			await expect(
-				service.resolve(makeClaims(), ['global:member'], ctx(true)),
+				service.resolve(makeClaims(), ['global:member'], ctx(true), true),
 			).rejects.toMatchObject({ reason: TokenExchangeFailureReason.EmailNotVerified });
 		});
 
 		it('rejects JIT provisioning when email_verified is missing', async () => {
 			// No existing identity and no existing user → JIT path.
 			await expect(
-				service.resolve(makeClaims(), ['global:member'], ctx(true)),
+				service.resolve(makeClaims(), ['global:member'], ctx(true), true),
 			).rejects.toMatchObject({ reason: TokenExchangeFailureReason.EmailNotVerified });
 		});
 
@@ -308,7 +316,7 @@ describe('IdentityResolutionService', () => {
 			userRepository.findOne.mockResolvedValue(member);
 
 			await expect(
-				service.resolve(makeClaims({ email_verified: true }), ['global:member'], ctx(true)),
+				service.resolve(makeClaims({ email_verified: true }), ['global:member'], ctx(true), true),
 			).resolves.toBe(member);
 		});
 
@@ -316,9 +324,108 @@ describe('IdentityResolutionService', () => {
 			const member = makeUser('global:member');
 			userRepository.findOne.mockResolvedValue(member);
 
-			await expect(service.resolve(makeClaims(), ['global:member'], ctx(false))).resolves.toBe(
-				member,
+			await expect(
+				service.resolve(makeClaims(), ['global:member'], ctx(false), true),
+			).resolves.toBe(member);
+		});
+	});
+
+	describe('SSO bridge (oidc → token-exchange)', () => {
+		function mockOidcBoundUser(): User {
+			const user = mock<User>({ id: 'oidc-user-1' });
+			// 1st call: qualified token-exchange sub → miss. 2nd: legacy sub → miss.
+			// 3rd: the bridge lookup, providerType 'oidc' → hit.
+			authIdentityRepository.findOne
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce(mock<AuthIdentity>({ user }));
+			return user;
+		}
+
+		it('resolves a user bound only via OIDC SSO login when the claim issuer matches', async () => {
+			const user = mockOidcBoundUser();
+			trustedKeyService.isSsoIssuer.mockResolvedValue(true);
+			userRepository.findOneOrFail.mockResolvedValue(user);
+
+			await expect(service.resolve(makeClaims(), undefined, ctx(), true)).resolves.toEqual(user);
+
+			expect(authIdentityRepository.findOne).toHaveBeenCalledWith(
+				expect.objectContaining({ where: { providerId: 'external-user-1', providerType: 'oidc' } }),
 			);
+			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+		});
+
+		it('resolves via the bridge with allowProvisioning: false, performing no writes', async () => {
+			const user = mockOidcBoundUser();
+			trustedKeyService.isSsoIssuer.mockResolvedValue(true);
+
+			await expect(service.resolve(makeClaims(), undefined, ctx(), false)).resolves.toEqual(user);
+
+			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+			expect(authIdentityRepository.save).not.toHaveBeenCalled();
+			expect(authIdentityRepository.update).not.toHaveBeenCalled();
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('does not consult the bridge when the claim issuer is not SSO-derived', async () => {
+			// Only the qualified + legacy token-exchange lookups are reached (both miss);
+			// the bridge lookup itself must never be queried, so don't queue a 3rd value for it.
+			authIdentityRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+			trustedKeyService.isSsoIssuer.mockResolvedValue(false);
+
+			await expect(service.resolve(makeClaims(), undefined, ctx(), false)).resolves.toBeNull();
+
+			expect(authIdentityRepository.findOne).not.toHaveBeenCalledWith(
+				expect.objectContaining({ where: expect.objectContaining({ providerType: 'oidc' }) }),
+			);
+		});
+
+		it('does not consult the bridge when a token-exchange binding already matches', async () => {
+			const user = mock<User>({ id: 'existing-1' });
+			authIdentityRepository.findOne.mockResolvedValueOnce(mock<AuthIdentity>({ user }));
+			userRepository.findOneOrFail.mockResolvedValue(user);
+			trustedKeyService.isSsoIssuer.mockResolvedValue(true);
+
+			await expect(service.resolve(makeClaims(), undefined, ctx(), true)).resolves.toEqual(user);
+
+			expect(trustedKeyService.isSsoIssuer).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('allowProvisioning: false (per-access resolution)', () => {
+		it('returns null for an unknown (iss, sub) without creating a user', async () => {
+			await expect(service.resolve(makeClaims(), undefined, ctx(), false)).resolves.toBeNull();
+
+			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+			expect(authIdentityRepository.save).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('does not fall back to email matching when unbound', async () => {
+			userRepository.findOne.mockResolvedValue(makeUser('global:member'));
+
+			await expect(service.resolve(makeClaims(), undefined, ctx(), false)).resolves.toBeNull();
+
+			expect(userRepository.findOne).not.toHaveBeenCalled();
+		});
+
+		it('resolves an already-bound identity without syncing profile or role', async () => {
+			const user = mock<User>({ id: 'existing-1', role: { slug: 'global:member' } });
+			authIdentityRepository.findOne.mockResolvedValueOnce(mock<AuthIdentity>({ user }));
+
+			await expect(
+				service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), false),
+			).resolves.toEqual(user);
+
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
+			expect(userRepository.update).not.toHaveBeenCalled();
+		});
+
+		it('never throws for an unbound identity — resolves to null', async () => {
+			await expect(
+				service.resolve(makeClaims({ role: 'global:owner' }), undefined, ctx(), false),
+			).resolves.toBeNull();
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -103,6 +103,7 @@ describe('TokenExchangeService', () => {
 					issuer: resolvedKey.issuer,
 					requireVerifiedEmail: resolvedKey.requireVerifiedEmail,
 				},
+				true,
 			);
 		});
 

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -11,6 +11,7 @@ import { GLOBAL_OWNER_ROLE_SLUG, isBuiltInRole } from '@n8n/permissions';
 import { createHash } from 'node:crypto';
 
 import { EventService } from '@/events/event.service';
+import type { IdentityResolver } from '@/services/identity-resolution-proxy.service';
 import { RoleService } from '@/services/role.service';
 import { UserService } from '@/services/user.service';
 
@@ -39,7 +40,7 @@ export function qualifiedProviderId(issuer: string, sub: string): string {
 }
 
 @Service()
-export class IdentityResolutionService {
+export class IdentityResolutionService implements IdentityResolver {
 	private readonly logger: Logger;
 
 	constructor(
@@ -83,12 +84,19 @@ export class IdentityResolutionService {
 	}
 
 	/**
-	 * Map external identity claims to a local n8n user, creating one if necessary.
+	 * Map external identity claims to a local n8n user.
 	 *
-	 * Resolution order:
-	 * 1. AuthIdentity lookup by sub + token-exchange provider
+	 * `allowProvisioning: true` (login/exchange flows) — creates a user if
+	 * necessary. Resolution order:
+	 * 1. AuthIdentity lookup by sub + token-exchange provider (incl. the SSO bridge)
 	 * 2. Email fallback — link existing user to this sub
 	 * 3. JIT provision — create user + personal project + identity in a transaction
+	 *
+	 * `allowProvisioning: false` (per-access resolution) — a cheap, read-only,
+	 * indexed lookup only: no email fallback, no provisioning, no profile/role
+	 * sync, no writes. Returns `null` (never throws in a way that stops the
+	 * caller) when there is no active binding — a trigger must never create a
+	 * user, and an unbound identity must not block execution.
 	 *
 	 * Role handling: the role claim is only applied when it is both valid and
 	 * permitted by the key's allowedRoles. A disallowed role claim throws —
@@ -98,41 +106,35 @@ export class IdentityResolutionService {
 		claims: ExternalTokenClaims,
 		allowedRoles: string[] | undefined,
 		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
-	): Promise<User> {
-		const email = claims.email?.toLowerCase();
-
-		const qualifiedSub = qualifiedProviderId(claims.iss, claims.sub);
-
-		// Path 1: known sub
-		let identity = await this.authIdentityRepository.findOne({
-			where: { providerId: qualifiedSub, providerType: 'token-exchange' },
-			relations: { user: { role: true } },
-		});
+		allowProvisioning: true,
+	): Promise<User>;
+	async resolve(
+		claims: ExternalTokenClaims,
+		allowedRoles: string[] | undefined,
+		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
+		allowProvisioning: boolean,
+	): Promise<User | null>;
+	async resolve(
+		claims: ExternalTokenClaims,
+		allowedRoles: string[] | undefined,
+		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
+		allowProvisioning: boolean,
+	): Promise<User | null> {
+		const identity = await this.findBoundIdentity(claims, allowProvisioning, tokenContext);
 
 		if (identity) {
+			if (!allowProvisioning) {
+				return this.isBindingActive(identity) ? identity.user : null;
+			}
 			return await this.resolveByIdentity(claims, identity, allowedRoles, tokenContext);
 		}
 
-		identity = await this.authIdentityRepository.findOne({
-			where: { providerId: claims.sub, providerType: 'token-exchange' },
-			relations: { user: { role: true } },
-		});
-
-		if (identity && (await this.trustedKeyService.hasSingleTrustedIssuer())) {
-			await this.authIdentityRepository.update(
-				{ providerId: claims.sub, providerType: 'token-exchange' },
-				{ providerId: qualifiedSub },
-			);
-			this.eventService.emit('token-exchange-identity-rebound', {
-				userId: identity.user.id,
-				sub: claims.sub,
-				kid: tokenContext.kid,
-				issuer: tokenContext.issuer,
-			});
-			return await this.resolveByIdentity(claims, identity, allowedRoles, tokenContext);
+		if (!allowProvisioning) {
+			return null;
 		}
 
 		// Path 2: email fallback
+		const email = claims.email?.toLowerCase();
 		if (email) {
 			const existingUser = await this.userRepository.findOne({
 				where: { email },
@@ -153,6 +155,71 @@ export class IdentityResolutionService {
 		}
 
 		return await this.provisionUser(claims, email, allowedRoles, tokenContext);
+	}
+
+	/**
+	 * Read-only lookup of an existing binding. Tries, in order: the qualified
+	 * token-exchange sub, the legacy unqualified token-exchange sub, then the
+	 * OIDC SSO bridge (Change 1) — same human, different login surface, whose
+	 * AuthIdentity row already exists for anyone who has logged in via SSO.
+	 * The bridge is tried last so it never shadows an existing token-exchange
+	 * binding for the same claim.
+	 */
+	private async findBoundIdentity(
+		claims: ExternalTokenClaims,
+		allowProvisioning: boolean,
+		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
+	): Promise<AuthIdentity | null> {
+		const qualifiedSub = qualifiedProviderId(claims.iss, claims.sub);
+
+		let identity = await this.authIdentityRepository.findOne({
+			where: { providerId: qualifiedSub, providerType: 'token-exchange' },
+			relations: { user: { role: true } },
+		});
+		if (identity) return identity;
+
+		identity = await this.authIdentityRepository.findOne({
+			where: { providerId: claims.sub, providerType: 'token-exchange' },
+			relations: { user: { role: true } },
+		});
+		// An unqualified sub is only unambiguous when there's a single trusted
+		// issuer; with more than one, treat it as not found, same as before.
+		if (identity && (await this.trustedKeyService.hasSingleTrustedIssuer())) {
+			// Rebind is a write; keep the per-access (read-only) path free of it.
+			if (allowProvisioning) {
+				await this.authIdentityRepository.update(
+					{ providerId: claims.sub, providerType: 'token-exchange' },
+					{ providerId: qualifiedSub },
+				);
+				this.eventService.emit('token-exchange-identity-rebound', {
+					userId: identity.user.id,
+					sub: claims.sub,
+					kid: tokenContext.kid,
+					issuer: tokenContext.issuer,
+				});
+			}
+			return identity;
+		}
+
+		if (await this.trustedKeyService.isSsoIssuer(claims.iss)) {
+			identity = await this.authIdentityRepository.findOne({
+				where: { providerId: claims.sub, providerType: 'oidc' },
+				relations: { user: { role: true } },
+			});
+			if (identity) return identity;
+		}
+
+		return null;
+	}
+
+	/**
+	 * TODO(IAM-1171): gate on `identity.status === 'active'` once the column lands.
+	 * Deliberately does not consult the claim's `expiresAt` — binding status is
+	 * the access gate, not token freshness; an execution outliving the token's
+	 * `exp` must still resolve.
+	 */
+	private isBindingActive(_identity: AuthIdentity): boolean {
+		return true;
 	}
 
 	/** Path 1: resolve an already-linked identity and sync profile/role. */

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -240,11 +240,16 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 		const { claims, resolvedKey } = await this.verifyToken(subjectToken, {
 			maxLifetimeSeconds: MAX_TOKEN_LIFETIME_SECONDS,
 		});
-		const user = await this.identityResolutionService.resolve(claims, resolvedKey.allowedRoles, {
-			kid: resolvedKey.kid,
-			issuer: resolvedKey.issuer,
-			requireVerifiedEmail: resolvedKey.requireVerifiedEmail,
-		});
+		const user = await this.identityResolutionService.resolve(
+			claims,
+			resolvedKey.allowedRoles,
+			{
+				kid: resolvedKey.kid,
+				issuer: resolvedKey.issuer,
+				requireVerifiedEmail: resolvedKey.requireVerifiedEmail,
+			},
+			true,
+		);
 		return { user, subject: claims.sub, issuer: resolvedKey.issuer, kid: resolvedKey.kid };
 	}
 
@@ -259,12 +264,14 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 					actorClaims.claims,
 					actorClaims.resolvedKey.allowedRoles,
 					actorClaims.resolvedKey,
+					true,
 				)
 			: undefined;
 		const subject = await this.identityResolutionService.resolve(
 			subjectClaims.claims,
 			subjectClaims.resolvedKey.allowedRoles,
 			subjectClaims.resolvedKey,
+			true,
 		);
 
 		const now = Math.floor(Date.now() / 1000);

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -277,6 +277,19 @@ export class TrustedKeyService {
 		return issuers.size === 1;
 	}
 
+	/**
+	 * Whether `issuer` is the instance's configured SSO provider — i.e. it
+	 * matches a `sso-derived` trusted key source (see
+	 * `registerSsoDerivedSource`). Indexed read only: no network, no crypto,
+	 * safe to call on every access.
+	 */
+	async isSsoIssuer(issuer: string): Promise<boolean> {
+		const source = await this.trustedKeySourceRepository.findOne({
+			where: { issuer, managedBy: 'sso-derived' },
+		});
+		return source !== null;
+	}
+
 	// ─── Private: source sync ──────────────────────────────────────────
 
 	private generateSourceId(source: TrustedKeySource): string {

--- a/packages/cli/src/modules/token-exchange/token-exchange.module.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.module.ts
@@ -52,6 +52,14 @@ export class TokenExchangeModule implements ModuleInterface {
 		const { TokenExchangeService } = await import('./services/token-exchange.service.js');
 		Container.get(ExternalTokenVerifierProxy).registerProvider(Container.get(TokenExchangeService));
 
+		const { IdentityResolutionProxy } = await import(
+			'@/services/identity-resolution-proxy.service.js'
+		);
+		const { IdentityResolutionService } = await import('./services/identity-resolution.service.js');
+		Container.get(IdentityResolutionProxy).registerProvider(
+			Container.get(IdentityResolutionService),
+		);
+
 		await import('./controllers/token-exchange.controller.js');
 		await import('./controllers/embed-auth.controller.js');
 

--- a/packages/cli/src/services/identity-resolution-proxy.service.ts
+++ b/packages/cli/src/services/identity-resolution-proxy.service.ts
@@ -1,0 +1,69 @@
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+/**
+ * Structurally compatible with token-exchange's `ExternalTokenClaims`, and
+ * intended to also fit the sealed `VerifiedClaim` once it lands (IAM-1166 /
+ * IAM-1168) — a JWT-claim shape, not a bespoke one.
+ */
+export interface VerifiedIdentityClaim {
+	iss: string;
+	sub: string;
+	email?: string;
+	email_verified?: boolean;
+	given_name?: string;
+	family_name?: string;
+	role?: string;
+}
+
+export interface IdentityBindingContext {
+	issuer: string;
+	kid?: string;
+	requireVerifiedEmail?: boolean;
+}
+
+export interface IdentityResolver {
+	/**
+	 * Resolve a verified claim to the n8n user it is bound to.
+	 *
+	 * `allowProvisioning` is required at the call site (not optional/defaulted)
+	 * so a trigger-originated, unauthenticated access path can never create a
+	 * user. When `false`, this must be a cheap, read-only, indexed lookup —
+	 * no network call, no crypto — and must return `null` (never throw in a
+	 * way that stops the caller) when there is no active binding.
+	 */
+	resolve(
+		claims: VerifiedIdentityClaim,
+		allowedRoles: string[] | undefined,
+		tokenContext: IdentityBindingContext,
+		allowProvisioning: boolean,
+	): Promise<User | null>;
+}
+
+/**
+ * Proxy through which callers resolve a verified external identity to an
+ * n8n user without importing the `token-exchange` module directly.
+ *
+ * `token-exchange` registers its `IdentityResolutionService` as the provider
+ * on init — same pattern as `OAuthTokenVerifierProxy` / `RuntimeCredentialProxyService`.
+ * Until a provider is registered (e.g. the module is disabled on this
+ * instance), resolution degrades to "no principal" rather than throwing.
+ */
+@Service()
+export class IdentityResolutionProxy implements IdentityResolver {
+	private provider: IdentityResolver | null = null;
+
+	registerProvider(provider: IdentityResolver): void {
+		this.provider = provider;
+	}
+
+	async resolve(
+		claims: VerifiedIdentityClaim,
+		allowedRoles: string[] | undefined,
+		tokenContext: IdentityBindingContext,
+		allowProvisioning: boolean,
+	): Promise<User | null> {
+		if (!this.provider) return null;
+		return await this.provider.resolve(claims, allowedRoles, tokenContext, allowProvisioning);
+	}
+}

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -1,4 +1,4 @@
-import { testDb } from '@n8n/backend-test-utils';
+import { testDb, testModules } from '@n8n/backend-test-utils';
 import {
 	AuthIdentity,
 	AuthIdentityRepository,
@@ -27,6 +27,7 @@ let trustedKeyService: TrustedKeyService;
 let eventService: EventService;
 
 beforeAll(async () => {
+	await testModules.loadModules(['token-exchange']);
 	await testDb.init();
 
 	service = Container.get(IdentityResolutionService);
@@ -85,6 +86,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				undefined,
 				ctx(),
+				true,
 			);
 
 			expect(result.id).toBe(user.id);
@@ -114,6 +116,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				undefined,
 				ctx(),
+				true,
 			);
 
 			expect(result.id).toBe(user.id);
@@ -134,12 +137,12 @@ describe('IdentityResolutionService (integration)', () => {
 			};
 
 			// First call: email fallback creates the identity link
-			const result = await service.resolve(claims, undefined, ctx());
+			const result = await service.resolve(claims, undefined, ctx(), true);
 			expect(result.id).toBe(user.id);
 
 			// Second call: should now resolve via Path 1 (known sub),
 			// proving the identity was correctly linked to the user
-			const secondResult = await service.resolve(claims, undefined, ctx());
+			const secondResult = await service.resolve(claims, undefined, ctx(), true);
 			expect(secondResult.id).toBe(user.id);
 			expect(secondResult.role).toBeDefined();
 			expect(secondResult.role.slug).toBe('global:member');
@@ -157,6 +160,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				['global:member', 'global:admin'],
 				ctx(),
+				true,
 			);
 
 			expect(result.id).toBe(user.id);
@@ -180,6 +184,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				undefined,
 				ctx(),
+				true,
 			);
 
 			expect(result.id).toBe(user.id);
@@ -202,7 +207,7 @@ describe('IdentityResolutionService (integration)', () => {
 				family_name: 'Tee',
 			};
 
-			const result = await service.resolve(claims, undefined, ctx());
+			const result = await service.resolve(claims, undefined, ctx(), true);
 
 			expect(result.email).toBe('jit@example.com');
 			expect(result.firstName).toBe('Jay');
@@ -245,6 +250,7 @@ describe('IdentityResolutionService (integration)', () => {
 					{ ...baseClaims, sub: 'ext-rejected', email: 'rejected@example.com', role },
 					allowedRoles,
 					ctx(),
+					true,
 				),
 			).rejects.toThrow(errorMsg);
 		});
@@ -252,7 +258,7 @@ describe('IdentityResolutionService (integration)', () => {
 		it('should throw when email is missing and no identity match exists', async () => {
 			const claimsWithoutEmail = { ...baseClaims, sub: 'ext-no-email', email: undefined };
 
-			await expect(service.resolve(claimsWithoutEmail, undefined, ctx())).rejects.toThrow(
+			await expect(service.resolve(claimsWithoutEmail, undefined, ctx(), true)).rejects.toThrow(
 				'Email claim is required for user provisioning',
 			);
 		});
@@ -268,6 +274,7 @@ describe('IdentityResolutionService (integration)', () => {
 					},
 					undefined,
 					ctx(),
+					true,
 				),
 			).rejects.toThrow("Unrecognized role 'global:nonsense' cannot be assigned to new user");
 		});
@@ -282,6 +289,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				['global:admin', 'global:member'],
 				ctx(),
+				true,
 			);
 
 			expect(result.role.slug).toBe('global:admin');
@@ -312,6 +320,7 @@ describe('IdentityResolutionService (integration)', () => {
 					},
 					undefined,
 					ctx(),
+					true,
 				),
 			).rejects.toThrow('User role is not allowed for this key');
 		});
@@ -332,6 +341,7 @@ describe('IdentityResolutionService (integration)', () => {
 					},
 					['global:member'],
 					ctx(),
+					true,
 				),
 			).rejects.toThrow("Role 'global:admin' is not allowed for this token exchange key");
 		});
@@ -349,6 +359,7 @@ describe('IdentityResolutionService (integration)', () => {
 					},
 					['global:member'],
 					ctx(),
+					true,
 				),
 			).rejects.toThrow("Role 'global:admin' is not allowed for this token exchange key");
 
@@ -374,6 +385,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				undefined,
 				ctx(),
+				true,
 			);
 
 			expect(result.id).toBe(user.id);
@@ -395,6 +407,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				undefined,
 				ctx(),
+				true,
 			);
 
 			expect(result.id).toBe(user.id);
@@ -419,6 +432,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				['global:admin', 'global:member'],
 				ctx(),
+				true,
 			);
 
 			expect(result.id).toBe(admin.id);
@@ -452,6 +466,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				['global:member', 'global:admin'],
 				ctx(),
+				true,
 			);
 
 			expect(result.firstName).toBe('New');
@@ -484,6 +499,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				undefined,
 				ctx(),
+				true,
 			);
 			const userB = await service.resolve(
 				{
@@ -494,6 +510,7 @@ describe('IdentityResolutionService (integration)', () => {
 				},
 				undefined,
 				ctx(),
+				true,
 			);
 
 			expect(userB.id).not.toBe(userA.id);
@@ -517,6 +534,7 @@ describe('IdentityResolutionService (integration)', () => {
 				{ ...baseClaims, sub: 'legacy-sub', email: undefined },
 				undefined,
 				ctx(),
+				true,
 			);
 
 			expect(result.id).toBe(user.id);
@@ -544,6 +562,7 @@ describe('IdentityResolutionService (integration)', () => {
 					{ ...baseClaims, sub: 'legacy-multi-sub', email: undefined },
 					undefined,
 					ctx(),
+					true,
 				),
 			).rejects.toThrow('Email claim is required for user provisioning');
 


### PR DESCRIPTION
## Summary
- Puts `IdentityResolutionService` behind a new `IdentityResolutionProxy` port in `packages/cli/src/services/` so a caller can resolve a verified external claim to its bound n8n user without importing `token-exchange` directly.
- Adds the OIDC SSO bridge: an `AuthIdentity` row written by SSO login (`providerId: raw sub, providerType: 'oidc'`) doesn't join with one written by token-exchange (`providerId: sha256(iss)::sub, providerType: 'token-exchange'`) for the same person. The bridge tries the `'oidc'` row when the claim's issuer matches a `sso-derived` trusted key source (reusing the `managedBy`/`issuer` columns just landed in #35593) — an indexed DB read, no network, no crypto.
- Makes `allowProvisioning` a required parameter (via TS overloads) so a trigger-originated, unauthenticated caller can never provision a user. Existing login/exchange call sites pass `true` and keep their exact prior behaviour, including a regression-preserving fix: an unqualified legacy sub match is only trusted when there's a single trusted issuer, same as before.
- `allowProvisioning: false` is a cheap, read-only, indexed-only path: no email fallback, no provisioning, no profile/role sync, no writes. Returns `null` (never throws in a way that stops the caller) when there's no active binding.
- `AuthIdentity.status` (IAM-1171) doesn't exist on this branch yet, so the active-binding check is a stubbed `isBindingActive()` returning `true` with a `TODO(IAM-1171)`.

## Test plan
- [x] `pnpm typecheck` (packages/cli)
- [x] `pnpm lint` on changed files
- [x] Unit tests: `identity-resolution.service.test.ts`, `token-exchange.service.test.ts`, `trusted-key.service.test.ts`, `oidc.service.ee.test.ts`
- [x] Integration tests: `test/integration/token-exchange/*` (fixed a pre-existing gap where `identity-resolution.service.test.ts`'s `beforeAll` never loaded the `token-exchange` module's entities, so `TrustedKeySourceEntity` was never registered on the test DataSource)

Linear: https://linear.app/n8n/issue/IAM-1165/t4-bind-a-verified-claim-to-an-n8n-user-reuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

