### PR TITLE
feat(core): Add ExternalTokenVerifierProxy port for cross-module token verification (no-changelog)

### DIFF
--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@n8n/backend-common';
 import { GLOBAL_MEMBER_ROLE, type User } from '@n8n/db';
 import jwt from 'jsonwebtoken';
+import { generateKeyPairSync } from 'node:crypto';
 import { mock } from 'vitest-mock-extended';
 
 import { AuthError } from '@/errors/response-errors/auth.error';
@@ -32,6 +33,7 @@ const service = new TokenExchangeService(
 );
 
 const resolvedKey: ResolvedTrustedKey = {
+	sourceId: 'test-source',
 	kid: 'test-kid',
 	algorithms: ['RS256'],
 	key: 'test-public-key',
@@ -331,6 +333,63 @@ describe('TokenExchangeService', () => {
 
 			expect(result.claims.jti).toBeUndefined();
 			expect(jtiStore.consume).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('verifyExternalToken', () => {
+		it('verifies a Keycloak-issued token end-to-end and returns attested claims', async () => {
+			const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+			const keycloakClaims = {
+				sub: 'a1b2c3d4-keycloak-subject',
+				iss: 'https://keycloak.example.com/realms/n8n',
+				aud: 'n8n-resource-server',
+				iat: now,
+				exp: now + 300,
+				jti: 'keycloak-token-id',
+				email: 'user@example.com',
+				email_verified: true,
+				given_name: 'Ada',
+				family_name: 'Lovelace',
+			};
+			const token = jwt.sign(keycloakClaims, privateKey, {
+				algorithm: 'RS256',
+				keyid: 'keycloak-kid',
+			});
+
+			trustedKeyStore.getByKidAndIss.mockResolvedValue({
+				sourceId: 'keycloak-realm',
+				kid: 'keycloak-kid',
+				algorithms: ['RS256'],
+				key: publicKey,
+				issuer: keycloakClaims.iss,
+				requireVerifiedEmail: false,
+			});
+
+			const result = await service.verifyExternalToken(token, keycloakClaims.aud);
+
+			expect(result).toEqual({
+				claim: {
+					sourceId: 'keycloak-realm',
+					issuer: keycloakClaims.iss,
+					subject: keycloakClaims.sub,
+					audience: keycloakClaims.aud,
+					attributes: {
+						email: keycloakClaims.email,
+						email_verified: true,
+						given_name: 'Ada',
+						family_name: 'Lovelace',
+					},
+					expiresAt: new Date(keycloakClaims.exp * 1000),
+				},
+			});
+			expect(jtiStore.consume).not.toHaveBeenCalled();
+		});
+
+		it('returns a typed context instead of throwing when verification fails', async () => {
+			await expect(service.verifyExternalToken('garbage-token', 'n8n')).resolves.toEqual({
+				claim: null,
+				context: { reason: 'invalid_token', errorDetails: expect.any(String) },
+			});
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -4,6 +4,10 @@ import { Service } from '@n8n/di';
 import { randomUUID } from 'crypto';
 import jwt from 'jsonwebtoken';
 
+import type {
+	ExternalTokenVerifier,
+	VerifiedClaimResult,
+} from '@/services/external-token-verifier-proxy.service';
 import { JwtService } from '@/services/jwt.service';
 
 import { TokenExchangeConfig } from '../token-exchange.config';
@@ -32,7 +36,7 @@ const MAX_TOKEN_LIFETIME_SECONDS = 60;
 const MIN_REMAINING_LIFETIME_SECONDS = 5;
 
 @Service()
-export class TokenExchangeService {
+export class TokenExchangeService implements ExternalTokenVerifier {
 	private readonly logger: Logger;
 
 	constructor(
@@ -201,6 +205,33 @@ export class TokenExchangeService {
 		}
 
 		return { claims, resolvedKey };
+	}
+
+	/** Registered as the `ExternalTokenVerifierProxy` provider on module init. Never throws. */
+	async verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult> {
+		try {
+			const { claims, resolvedKey } = await this.verifyToken(token, {
+				expectedAudience,
+				consumeJti: false,
+				requireJti: false,
+			});
+			const { sub, iss, aud, iat, exp, jti, ...attributes } = claims;
+
+			return {
+				claim: {
+					sourceId: resolvedKey.sourceId,
+					issuer: iss,
+					subject: sub,
+					audience: aud,
+					attributes,
+					expiresAt: new Date(exp * 1000),
+				},
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'unknown error';
+			this.logger.warn('External token verification failed', { error: message });
+			return { claim: null, context: { reason: 'invalid_token', errorDetails: message } };
+		}
 	}
 
 	async embedLogin(

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -186,6 +186,7 @@ export class TrustedKeyService {
 			if (!cryptoKey) continue;
 
 			return {
+				sourceId: entity.sourceId,
 				kid,
 				algorithms: data.algorithms,
 				key: cryptoKey,

--- a/packages/cli/src/modules/token-exchange/token-exchange.module.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.module.ts
@@ -30,6 +30,13 @@ export class TokenExchangeModule implements ModuleInterface {
 		const { TrustedKeyService } = await import('./services/trusted-key.service.js');
 		await Container.get(TrustedKeyService).initialize();
 
+		// Register as the ExternalTokenVerifierProxy provider so other modules can verify without importing this one.
+		const { ExternalTokenVerifierProxy } = await import(
+			'@/services/external-token-verifier-proxy.service.js'
+		);
+		const { TokenExchangeService } = await import('./services/token-exchange.service.js');
+		Container.get(ExternalTokenVerifierProxy).registerProvider(Container.get(TokenExchangeService));
+
 		await import('./controllers/token-exchange.controller.js');
 		await import('./controllers/embed-auth.controller.js');
 

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -117,6 +117,9 @@ export type TrustedKeyData = z.infer<typeof TrustedKeyDataSchema>;
  * already been parsed into a type accepted by `jwt.verify()`.
  */
 export interface ResolvedTrustedKey {
+	/** The trusted key source this key resolved from. */
+	sourceId: string;
+
 	/** The Key ID that identifies this key in JWT headers. */
 	kid: string;
 

--- a/packages/cli/src/services/__tests__/external-token-verifier-proxy.service.test.ts
+++ b/packages/cli/src/services/__tests__/external-token-verifier-proxy.service.test.ts
@@ -1,0 +1,38 @@
+import { mock } from 'vitest-mock-extended';
+
+import type {
+	ExternalTokenVerifier,
+	VerifiedClaim,
+} from '../external-token-verifier-proxy.service';
+import { ExternalTokenVerifierProxy } from '../external-token-verifier-proxy.service';
+
+describe('ExternalTokenVerifierProxy', () => {
+	it('should fail verification gracefully when no provider is registered', async () => {
+		const proxy = new ExternalTokenVerifierProxy();
+
+		const result = await proxy.verifyExternalToken('some-token', 'https://n8n.example.com');
+
+		expect(result.claim).toBeNull();
+		expect(result.context).toMatchObject({ reason: 'verifier_not_registered' });
+	});
+
+	it('should delegate to the registered provider', async () => {
+		const proxy = new ExternalTokenVerifierProxy();
+		const claim = mock<VerifiedClaim>({ sourceId: 'source-1', subject: 'external-user-1' });
+		const provider = mock<ExternalTokenVerifier>();
+		provider.verifyExternalToken.mockResolvedValue({ claim });
+
+		proxy.registerProvider(provider);
+
+		const result = await proxy.verifyExternalToken(
+			'some-token',
+			'https://n8n.example.com/resource',
+		);
+
+		expect(provider.verifyExternalToken).toHaveBeenCalledWith(
+			'some-token',
+			'https://n8n.example.com/resource',
+		);
+		expect(result).toEqual({ claim });
+	});
+});

--- a/packages/cli/src/services/external-token-verifier-proxy.service.ts
+++ b/packages/cli/src/services/external-token-verifier-proxy.service.ts
@@ -1,0 +1,52 @@
+import { Service } from '@n8n/di';
+
+export type ExternalTokenVerificationFailureReason = 'verifier_not_registered' | 'invalid_token';
+
+export type ExternalVerificationContext = {
+	reason: ExternalTokenVerificationFailureReason;
+	errorDetails?: string;
+};
+
+/** Attested facts from an externally-issued token. No `User`, no principal. */
+export interface VerifiedClaim {
+	sourceId: string;
+	issuer: string;
+	subject: string;
+	audience: string | string[];
+	attributes: Record<string, unknown>;
+	expiresAt: Date;
+}
+
+export type VerifiedClaimResult =
+	| { claim: VerifiedClaim; context?: undefined }
+	| { claim: null; context: ExternalVerificationContext };
+
+export interface ExternalTokenVerifier {
+	verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult>;
+}
+
+/**
+ * Lets modules verify externally-issued tokens without importing
+ * `token-exchange` directly — same pattern as `OAuthTokenVerifierProxy`.
+ */
+@Service()
+export class ExternalTokenVerifierProxy implements ExternalTokenVerifier {
+	private provider: ExternalTokenVerifier | null = null;
+
+	registerProvider(provider: ExternalTokenVerifier): void {
+		this.provider = provider;
+	}
+
+	async verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult> {
+		if (!this.provider) {
+			return {
+				claim: null,
+				context: {
+					reason: 'verifier_not_registered',
+					errorDetails: 'No external token verifier is registered on this instance',
+				},
+			};
+		}
+		return await this.provider.verifyExternalToken(token, expectedAudience);
+	}
+}


### PR DESCRIPTION
## Summary

Adds `ExternalTokenVerifierProxy`, a port through which other modules can verify externally-issued tokens without importing `token-exchange` directly — following the established `OAuthTokenVerifierProxy` / `DynamicCredentialsProxy` / `RuntimeCredentialProxyService` pattern.

- `VerifiedClaim` type: attested facts only (`sourceId`, `issuer`, `subject`, `audience`, `attributes`, `expiresAt`) — no `User`, no principal.
- `TokenExchangeService` implements the port (`verifyExternalToken`), adapting the existing resource-server `verifyToken()` path (audience-checked, JTI not consumed).
- `TokenExchangeModule` registers itself as the provider on `init()` (main-only).
- With no provider registered (e.g. on a worker, or when the module is disabled), callers get a typed unavailable result rather than a thrown error — this is what keeps queue-mode manual-offload behaving as it does today.
- Added `sourceId` to `ResolvedTrustedKey` (needed to populate `VerifiedClaim.sourceId`).

## How to test

- `pnpm --filter n8n test external-token-verifier-proxy.service.test.ts token-exchange.service.test.ts trusted-key.service.test.ts` (run from `packages/cli`)
- `pnpm typecheck` in `packages/cli`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1163

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.