### PR TITLE
build(editor): Externalize design-system dependencies and pre-build lucide icon chunks (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/package.json
+++ b/packages/frontend/@n8n/design-system/package.json
@@ -59,6 +59,8 @@
     "vite-svg-loader": "catalog:frontend",
     "vitest": "catalog:",
     "vitest-mock-extended": "catalog:",
+    "vue": "catalog:frontend",
+    "vue-router": "catalog:frontend",
     "vue-tsc": "catalog:frontend"
   },
   "dependencies": {
@@ -93,10 +95,12 @@
     "parse-diff": "^0.11.1",
     "reka-ui": "^2.5.0",
     "sanitize-html": "catalog:",
-    "vue": "catalog:frontend",
     "vue-boring-avatars": "^1.3.0",
-    "vue-router": "catalog:frontend",
     "xss": "catalog:"
+  },
+  "peerDependencies": {
+    "vue": "catalog:frontend",
+    "vue-router": "catalog:frontend"
   },
   "license": "LicenseRef-n8n-sustainable-use"
 }

--- a/packages/frontend/@n8n/design-system/src/components/N8nDataTableServer/N8nDataTableServer.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDataTableServer/N8nDataTableServer.vue
@@ -40,7 +40,10 @@ import type {
 import { createColumnHelper, FlexRender, getCoreRowModel, useVueTable } from '@tanstack/vue-table';
 import { useThrottleFn } from '@vueuse/core';
 import { ElOption, ElSelect, ElSkeletonItem } from 'element-plus';
-import get from 'lodash/get';
+// `.js` on purpose, unlike the extensionless form used elsewhere in the repo:
+// `lodash` is CJS with no `exports` map, so Node cannot resolve the extensionless
+// subpath once a consumer loads our `dist` as native ESM. Bundlers accept both.
+import get from 'lodash/get.js';
 import { computed, h, shallowRef, useSlots, watch } from 'vue';
 
 import N8nCheckbox from '@n8n/design-system/v2/components/Checkbox/Checkbox.vue';

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -5,7 +5,8 @@ import markdownEmoji from 'markdown-it-emoji';
 import markdownLink from 'markdown-it-link-attributes';
 import markdownTaskLists from 'markdown-it-task-lists';
 import { computed, ref } from 'vue';
-import xss, { whiteList } from 'xss';
+import type { IWhiteList } from 'xss';
+import xss from 'xss';
 
 import { markdownYoutubeEmbed, YOUTUBE_EMBED_SRC_REGEX, type YoutubeEmbedConfig } from './youtube';
 import { toggleCheckbox, serializeAttr } from '../../utils/markdown';
@@ -72,6 +73,12 @@ const md = new Markdown(options.markdown)
 	.use(markdownEmoji)
 	.use(markdownTaskLists, options.tasklists)
 	.use(markdownYoutubeEmbed, options.youtube);
+
+// `xss` is CJS with no `exports` map. Node's lexer cannot see `whiteList` as a
+// named export, so `import { whiteList }` throws at link time under native ESM
+// once a consumer loads our `dist`. At runtime `module.exports` is the filter
+// function with the helpers hung off it, which the shipped typings don't model.
+const { whiteList } = xss as unknown as { whiteList: IWhiteList };
 
 const xssWhiteList = {
 	...whiteList,

--- a/packages/frontend/@n8n/design-system/src/utils/markdown.ts
+++ b/packages/frontend/@n8n/design-system/src/utils/markdown.ts
@@ -1,4 +1,11 @@
-import { safeAttrValue } from 'xss';
+import type { SafeAttrValueHandler } from 'xss';
+import xss from 'xss';
+
+// `xss` is CJS with no `exports` map. Node's lexer cannot see `safeAttrValue` as
+// a named export, so `import { safeAttrValue }` throws at link time under native
+// ESM once a consumer loads our `dist`. At runtime `module.exports` is the filter
+// function with the helpers hung off it, which the shipped typings don't model.
+const { safeAttrValue } = xss as unknown as { safeAttrValue: SafeAttrValueHandler };
 
 const checkedRegEx = /(\*|-) \[x\]/;
 const uncheckedRegEx = /(\*|-) \[\s\]/;

--- a/packages/frontend/@n8n/design-system/vite.config.mts
+++ b/packages/frontend/@n8n/design-system/vite.config.mts
@@ -1,5 +1,5 @@
 import vue from '@vitejs/plugin-vue';
-import { cpSync } from 'node:fs';
+import { cpSync, readFileSync } from 'node:fs';
 import { resolve } from 'path';
 import { build, defineConfig, mergeConfig, type InlineConfig, type Plugin } from 'vite';
 import icons from 'unplugin-icons/vite';
@@ -8,9 +8,33 @@ import { vitestConfig } from '@n8n/vitest-config/frontend';
 import svgLoader from 'vite-svg-loader';
 import { lucideIconsPlugin } from './src/icons/lucide/vite';
 
-const packagesDir = resolve(__dirname, '..', '..', '..');
 const srcDir = resolve(__dirname, 'src');
 const distDir = resolve(__dirname, 'dist');
+
+const manifest = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8')) as {
+	dependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+};
+
+/**
+ * Everything the manifest declares stays out of the bundle — inlining a
+ * dependency ships a second copy the consumer cannot dedupe (two element-plus
+ * instances, two Vue reactivity contexts).
+ *
+ * Read from the manifest rather than hand-listed: the previous `['vue']`
+ * silently inlined every dependency added to the package after it was written.
+ *
+ * Sub-path imports (`@n8n/utils/event-bus`) belong to the package owning the
+ * prefix, so match `name` and `name/…` but not `name-something-else`. Nothing
+ * declares the build-time virtuals (`virtual:lucide-icons`, `~icons/…`), so
+ * they stay inlined — which is what makes `dist` work without our Vite plugin.
+ */
+const externalPackages = [
+	...Object.keys(manifest.dependencies ?? {}),
+	...Object.keys(manifest.peerDependencies ?? {}),
+];
+const isExternal = (id: string) =>
+	externalPackages.some((name) => id === name || id.startsWith(`${name}/`));
 
 /** Emit stylesheets at the dist root, everything else under `assets/`. */
 const assetFileNames = (name: string) => (asset: { names?: string[] }) =>
@@ -122,34 +146,37 @@ export default mergeConfig(
 			alias: {
 				'@': resolve(__dirname, 'src'),
 				'@n8n/design-system': resolve(__dirname, 'src'),
-				'@n8n/composables(.*)': resolve(packagesDir, 'frontend', '@n8n', 'composables', 'src$1'),
-				'@n8n/frontend-utils(.*)': resolve(
-					packagesDir,
-					'frontend',
-					'@n8n',
-					'frontend-utils',
-					'src$1',
-				),
-				'@n8n/utils(.*)': resolve(packagesDir, '@n8n', 'utils', 'src$1'),
+				// No entries for the sibling `@n8n/composables`, `@n8n/frontend-utils` and
+				// `@n8n/utils`: they publish their own `dist` + `exports`, so they resolve
+				// through node and externalise with everything else.
 			},
 		},
 		build: {
 			lib: {
-				entry: resolve(__dirname, 'src', 'index.ts'),
-				name: 'N8nDesignSystem',
-				fileName: (format) => `n8n-design-system.${format}.js`,
+				entry: {
+					index: resolve(srcDir, 'index.ts'),
+					// Second entry so the icon bodies are compiled into `dist` here, once,
+					// instead of every consumer having to register `lucideIconsPlugin()` to
+					// resolve `virtual:lucide-icons`.
+					//
+					// It stays a separate entry — never re-exported from `src/index.ts` —
+					// because a barrel export would make this opt-in capability mandatory
+					// for everyone who imports the barrel, including consumers that alias
+					// this package to source and register no plugin.
+					'icons/lucide/index': resolve(srcDir, 'icons', 'lucide', 'index.ts'),
+				},
+				// ES only. UMD supports neither multiple entries nor code splitting, and
+				// both are requirements here — the icon buckets have to stay lazy chunks.
+				// Nothing consumed the UMD output.
+				formats: ['es'],
+				// Sits the emitted JS next to the declarations `dts` writes for the same
+				// module, so each entry is one `dist/<path>/index.{js,d.ts}` pair.
+				fileName: (_format, entryName) => `${entryName}.js`,
 			},
 			rollupOptions: {
-				// make sure to externalize deps that shouldn't be bundled
-				// into your library
-				external: ['vue'],
+				external: isExternal,
 				output: {
 					exports: 'named',
-					// Provide global variables to use in the UMD build
-					// for externalized deps
-					globals: {
-						vue: 'Vue',
-					},
 					assetFileNames: assetFileNames('style.css'),
 				},
 			},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5197,15 +5197,9 @@ importers:
       sanitize-html:
         specifier: 'catalog:'
         version: 2.17.4
-      vue:
-        specifier: catalog:frontend
-        version: 3.5.26(typescript@6.0.2)
       vue-boring-avatars:
         specifier: ^1.3.0
         version: 1.3.0(vue@3.5.26(typescript@6.0.2))
-      vue-router:
-        specifier: catalog:frontend
-        version: 4.5.0(vue@3.5.26(typescript@6.0.2))
       xss:
         specifier: 'catalog:'
         version: 1.0.15
@@ -5321,6 +5315,12 @@ importers:
       vitest-mock-extended:
         specifier: 'catalog:'
         version: 3.1.0(typescript@6.0.2)(vitest@4.1.9)
+      vue:
+        specifier: catalog:frontend
+        version: 3.5.26(typescript@6.0.2)
+      vue-router:
+        specifier: catalog:frontend
+        version: 4.5.0(vue@3.5.26(typescript@6.0.2))
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.8(patch_hash=e2aee939ccac8a57fe449bfd92bedd8117841579526217bc39aca26c6b8c317f)(typescript@6.0.2)


### PR DESCRIPTION
## Summary

Step 4 of 6 toward publishing `@n8n/design-system`. `dist` gets the right JS shape; nothing reads it yet (`main` still points at `src/index.ts`, and the `exports` map is step 5).

**Externalized dependencies.** `external` is now built from the manifest — `dependencies` + `peerDependencies`, matching exact names and `name/` prefixes — instead of the hardcoded `['vue']`, which had been silently inlining every dependency added to the package since it was written. `@n8n/composables`, `@n8n/frontend-utils` and `@n8n/utils` are consumed as externals; all three publish their own `dist` + `exports`, so they resolve through node like any other dependency.

`dist/index.js`: **2.80 MB → 626 kB (−78%)**. Nothing is inlined any more — 31 declared packages externalize, `@tiptap/core` and `@tiptap/pm` are type-only imports that erase, and `@internationalized/date` and `highlight.js` are declared but unimported (pre-existing; left alone).

**Peers declared honestly.** `vue` and `vue-router` move to `peerDependencies`, both **required**. Six components import `vue-router`, and the root barrel statically reaches `RouterLink` as a *value* via `components/index.ts:111` → `N8nRoute/Route.vue`, so an `optional` peer would be a manifest that contradicts the code. Both stay in `devDependencies` so the package still builds and tests standalone.

**Pre-built lucide icon chunks.** `src/icons/lucide` gets its own build entry, so the icon bodies compile into `dist` once as **16 lazy chunks** (521 kB total, still code-split). Consumers need neither `lucideIconsPlugin()` nor `@iconify/json`.

The loader stays **off the root barrel**. Exporting it there turns an opt-in subpath into a mandatory build-time plugin requirement for every consumer that aliases this package to source — that is exactly what broke `@n8n/mcp-apps` and `@n8n/mcp-browser-extension` during the spike. The general rule: never re-export an optional capability from the root barrel.

**Drops the UMD output**, which nothing in the repo consumed. UMD supports neither multiple entries nor the code splitting the lazy buckets require. Entry files are now `dist/index.js` and `dist/icons/lucide/index.js`, each sitting next to the declarations `dts` emits for it.

Also removes three dead `resolve.alias` entries (`'@n8n/utils(.*)'` and friends). An object alias key is matched as a literal prefix, not a regex, so they never fired — and left in place beside the new external list they would read as "these are bundled from source".

## How to test

```bash
pnpm turbo build --filter=@n8n/design-system --force
```

Then, from `packages/frontend/@n8n/design-system`:

```bash
# 16 lazy icon chunks, code-split
ls dist | grep -c lucide-icons-bucket          # 16

# the root barrel never pulls a bucket in
grep -c lucide-icons-bucket dist/index.js      # 0

# the pre-built loader works with no Vite and no plugin
node --input-type=module -e \
  'import{loadLucideIconBody as l}from"./dist/icons/lucide/index.js";console.log(await l("house"))'
```

Consumer builds, forced and uncached:

```bash
pnpm turbo build --filter=@n8n/mcp-apps --filter=@n8n/mcp-browser-extension --force
pnpm turbo build --filter=n8n-editor-ui --filter=@n8n/storybook --force
```

### Verified

- `@n8n/mcp-apps` + `@n8n/mcp-browser-extension` **built** (not resolution-checked) green — `--force`, 0 cached. A resolution-only check reported PASS against a broken build during the spike, so these were run as real builds.
- `editor-ui` + `@n8n/storybook` build green, `--force`, 0 cached; both keep their **deep** import of the loader. `preview.ts` still documents why it must not use the barrel (TurboSnap global — the barrel would make every component a global dep and force a full Chromatic snapshot on any component change).
- 16 bucket chunks in `dist`, still dynamic imports; loader entry is 1.5 kB of lazy thunks.
- Loader executed from `dist` in plain Node: real SVG bodies returned, unknown names return `null`.
- `pnpm pack` tarball ships `dist/index.js`, `dist/icons/lucide/index.js` + declarations, all 16 buckets, and `style.css`/`theme.css`. The Vite plugin is **not** shipped. The published manifest resolves to `"vue": "^3.5.13"`, `"vue-router": "^4.5.0"` with no `peerDependenciesMeta`, i.e. both genuinely required.
- design-system: 1421 tests pass (124 files), typecheck, lint and format clean.

## Native-ESM interop (second commit)

Externalizing the dependencies means `dist` now emits real import statements against them, so CJS packages have to be imported in a form Node can link. Two weren't, and both were invisible to every consumer build because bundlers paper over them — they fire only for a native-ESM consumer of `dist` (Vite SSR externals, Vitest `server.deps.external`), i.e. the moment step 5 points `main` at `dist`.

- **`xss`** — CJS, no `exports` map. Node's lexer cannot see `safeAttrValue` or `whiteList` as named exports, so the emitted named imports threw `SyntaxError` at link time. Both are now read off the default export, which at runtime is `module.exports` with the helpers attached. The shipped typings model them only as separate named exports, hence the narrow cast at each site. A namespace import (`import * as xss`) was rejected: it typechecks but silently yields `undefined` at runtime, which is worse than the loud error.
- **`lodash/get`** — extensionless. Node cannot resolve an extensionless subpath of a CJS package with no `exports` map. Now `lodash/get.js`; bundlers accept either. This is the package's only lodash deep import.

Verified by probing all 32 external specifiers emitted across `dist/*.js` with a real native-ESM `import()`: **31 of 32 resolve and link**. Call sites are unchanged in both fixes; 1421 tests, typecheck, lint, format still clean; all six consumers rebuilt green (`--force`, 0 cached); 16 buckets, 0 barrel→bucket refs, nothing inlined.

**Known remaining, not fixed here:** `@n8n/frontend-utils/htmlUtils` has the identical `xss` defect in its own source (`import xss, { escapeAttrValue, escapeHtml } from 'xss'`), so it is the one specifier still failing the probe. It's a separate published package with its own consumers, so it wants its own PR rather than a rider on this one. **`dist` is therefore not yet fully native-ESM loadable** — that needs the frontend-utils fix too.

## Related Linear tickets, Github issues, and Community forum posts

Follows #35452 (step 3).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


