### PR TITLE
refactor: Use type-based defineProps in ConditionalRouterLink (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/ConditionalRouterLink/CondtionalRouterLink.vue
+++ b/packages/frontend/@n8n/design-system/src/components/ConditionalRouterLink/CondtionalRouterLink.vue
@@ -4,9 +4,12 @@
  * just the slot content based on whether the `to` or `href` prop is
  * passed or not.
  */
-import type { PropType } from 'vue';
 import { useAttrs } from 'vue';
-import type { RouterLinkProps } from 'vue-router';
+import type {
+	RouteLocationAsPathGeneric,
+	RouteLocationAsRelativeGeneric,
+	RouterLinkProps,
+} from 'vue-router';
 import { RouterLink } from 'vue-router';
 
 defineOptions({
@@ -15,33 +18,44 @@ defineOptions({
 });
 
 /**
- * Declared explicitly rather than spread from `RouterLink.props`, which is
- * typed as `any` and so collapsed this component's whole props type to `{}` in
- * the emitted declarations. Mirrors RouterLink's runtime prop declarations
- * exactly, except that `to` is optional here — without it the component falls
- * back to an `<a>` or to the bare slot.
+ * Declared here rather than spread from `RouterLink.props`, which does not exist
+ * on RouterLink's type at all (`_RouterLinkI` declares only `new()` and
+ * `useLink`) — the spread needed a `@ts-expect-error`, and the recovered `any`
+ * collapsed this component's whole props type to `{}` in the emitted
+ * declarations. Mirrors RouterLink's runtime prop declarations exactly, except
+ * that `to` is optional here — without it the component falls back to an `<a>`
+ * or to the bare slot.
  *
  * Deliberately absent: `viewTransition`. It is in the `RouterLinkProps` *type*
  * but is not one of RouterLink's declared props — it is a `useLink()` option, and
  * `RouterLinkImpl.setup` passes only the declared props to `useLink`, so it is
  * unreachable through `<RouterLink>` itself (vue-router 4.5.0). Declaring it here
- * would add a prop RouterLink does not have and bind it as a stray DOM attribute.
- * `ConditionalRouterLink.test.ts` pins both lists so this cannot drift silently.
+ * adds a prop RouterLink does not have, which Vue then binds as a stray
+ * `viewtransition="false"` DOM attribute on every rendered link — measured, not
+ * predicted. `ConditionalRouterLink.test.ts` compares this list against
+ * `RouterLink.props` at run time, so a vue-router that promotes `viewTransition`
+ * to a real prop fails that test and tells us to add it then.
  */
-const props = defineProps({
-	to: {
-		type: [String, Object] as PropType<RouterLinkProps['to'] | undefined>,
-		default: undefined,
-	},
-	replace: Boolean,
-	activeClass: String,
-	exactActiveClass: String,
-	custom: Boolean,
-	ariaCurrentValue: {
-		type: String as PropType<RouterLinkProps['ariaCurrentValue']>,
-		default: 'page',
-	},
+type Props = {
+	/**
+	 * `RouteLocationRaw` expanded by hand. It is a conditional type, which Vue's
+	 * compile-time resolver cannot evaluate — leaving `to` with no runtime prop
+	 * type at all, silently dropping the `[String, Object]` the test pins. This
+	 * union is what it resolves to without typed routes (no `RouteMap`
+	 * augmentation exists in this repo).
+	 */
+	to?: string | RouteLocationAsRelativeGeneric | RouteLocationAsPathGeneric;
+	replace?: boolean;
+	activeClass?: string;
+	exactActiveClass?: string;
+	custom?: boolean;
+	ariaCurrentValue?: RouterLinkProps['ariaCurrentValue'];
 	// <a> element "props" are passed as attributes
+};
+
+const props = withDefaults(defineProps<Props>(), {
+	to: undefined,
+	ariaCurrentValue: 'page',
 });
 const attrs = useAttrs();
 </script>


### PR DESCRIPTION
## Summary

Converts `ConditionalRouterLink` to the type-based prop declaration the rest of the package uses — `withDefaults(defineProps<Props>(), { … })`. It was one of the last three components on the runtime object form, against 115+ already converted.

Supersedes #35148, whose substantive content landed via #35447. This is the one piece that did not.

### Why this is not a cosmetic swap

Type-based declaration **regenerates the runtime props from the types**, and `ConditionalRouterLink.test.ts` (added in #35447) pins those props against `RouterLink.props`.

The obvious translation, `to?: RouterLinkProps['to']`, resolves to `RouteLocationRaw` — a *conditional* type. Vue's compile-time resolver cannot evaluate conditional types, so it emits **no runtime prop type at all**, silently dropping the `[String, Object]` that test asserts. No error, no warning.

`to` is therefore declared as the union `RouteLocationRaw` expands to without typed routes:

```ts
to?: string | RouteLocationAsRelativeGeneric | RouteLocationAsPathGeneric;
```

Both are plain exported interfaces, so they resolve. There is no `RouteMap` augmentation anywhere in the repo, so the union is exactly equivalent here.

Result: the parity test passes unchanged — same six prop names, `to.type` still `[String, Object]`, `to.required` still falsy, snapshots byte-identical.

### `viewTransition` stays out — measured

It was proposed that `viewTransition` be added to preserve the prop surface the old `...RouterLink.props` spread would have picked up. Measured on the pinned `vue-router@4.5.0`, adding it is a live regression, not a no-op:

```html
<!-- with `viewTransition: Boolean` declared -->
<div><a href="/" class="" viewtransition="false">Button</a></div>
```

`viewTransition` is a `useLink()` option, not one of RouterLink's six declared props, so declaring it adds a prop RouterLink does not have — which Vue then binds as a stray DOM attribute on **every rendered link**. It also fails the parity guard outright (7 declared keys vs RouterLink's 6).

The existing test already handles the forward case correctly, and better: it reads `RouterLink.props` **at run time**, so a vue-router that promotes `viewTransition` to a real prop fails the assertion and prompts adding it then. The comment in the component now records this with the measured evidence.

### Comment correction

The note above the props claimed `RouterLink.props` is "typed as `any`". It is not — `props` is absent from `_RouterLinkI` entirely, which declares only `new()` and `useLink`. The old spread needed a `@ts-expect-error`, and the recovered `any` is what collapsed the emitted declaration to `{}`. (`ElSelect.props` is the genuine `any`.)

## Evidence

Emitted declaration, from the real `pnpm build` (not a probe — #35447 landed the pipeline):

```ts
type Props = {
    to?: string | RouteLocationAsRelativeGeneric | RouteLocationAsPathGeneric;
    replace?: boolean;
    activeClass?: string;
    exactActiveClass?: string;
    custom?: boolean;
    ariaCurrentValue?: RouterLinkProps['ariaCurrentValue'];
};
declare const __VLS_component: DefineComponent<Props, …>
```

## How to test

No user-visible behaviour changes.

```bash
pnpm --filter @n8n/design-system typecheck   # 0 errors
pnpm --filter @n8n/design-system lint        # clean
pnpm --filter @n8n/design-system test        # 124 files, 1421 tests
pnpm --filter @n8n/design-system build       # 160 .vue.d.ts, 0 TS errors
pnpm --filter n8n-editor-ui typecheck        # 0 errors
pnpm --filter @n8n/storybook typecheck       # 0 errors
```

`ConditionalRouterLink` is exercised through the navigation dropdown — menu items with a route, with an `href`, and with neither should still render as router links, anchors and bare content respectively.

## Related Linear tickets, Github issues, and Community forum posts

Tracked as N8N-119 in the Multica workspace (no Linear ticket). Parent: N8N-110, "Get @n8n/design-system ready for publication". Supersedes #35148; builds on #35447.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Note on tests: no new test is added — `ConditionalRouterLink.test.ts` from #35447 already pins exactly what this change could break (prop names, `to.type`, `to.required`, rendered output), and it passes unchanged. That guard is also what caught the `viewTransition` regression above.

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

