### PR TITLE
fix: Link backend events to PostHog session recordings (no-changelog)

### DIFF
--- a/packages/cli/src/middlewares/cors.ts
+++ b/packages/cli/src/middlewares/cors.ts
@@ -8,7 +8,7 @@ export const corsMiddleware: RequestHandler = (req, res, next) => {
 		res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
 		res.header(
 			'Access-Control-Allow-Headers',
-			'Origin, X-Requested-With, Content-Type, Accept, push-ref, browser-id, anonymousid, authorization, x-authorization',
+			'Origin, X-Requested-With, Content-Type, Accept, push-ref, browser-id, anonymousid, authorization, x-authorization, x-posthog-session-id, x-posthog-distinct-id, x-posthog-window-id',
 		);
 	}
 

--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -1,5 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
+import type { Application, Request, RequestHandler, Response } from 'express';
 import { InstanceSettings } from 'n8n-core';
 import type { FeatureFlags } from 'n8n-workflow';
 import { PostHog } from 'posthog-node';
@@ -295,6 +296,97 @@ describe('PostHog', () => {
 
 				expect(flags).toEqual({ '101_agent_evals': true });
 			});
+		});
+	});
+
+	describe('setupExpressSessionContext', () => {
+		function createApp() {
+			const handlers: RequestHandler[] = [];
+			const app = {
+				use: (handler: RequestHandler) => handlers.push(handler),
+			} as unknown as Application;
+
+			return { app, handlers };
+		}
+
+		function createRequest(sessionId?: string) {
+			return { get: () => sessionId } as unknown as Request;
+		}
+
+		async function setupWithApp() {
+			const ph = new PostHogClient(instanceSettings, globalConfig);
+			await ph.init();
+
+			const { app, handlers } = createApp();
+			ph.setupExpressSessionContext(app);
+
+			return handlers;
+		}
+
+		beforeEach(() => {
+			globalConfig.deployment.type = 'cloud';
+			(PostHog.prototype.withContext as Mock).mockImplementation(
+				(_context: unknown, fn: () => unknown) => fn(),
+			);
+		});
+
+		it('attaches the browser session ID to the PostHog context', async () => {
+			const [handler] = await setupWithApp();
+			const next = vi.fn();
+
+			void handler(createRequest('0192f1c2-session'), mock<Response>(), next);
+
+			expect(PostHog.prototype.withContext).toHaveBeenCalledWith(
+				{ sessionId: '0192f1c2-session' },
+				next,
+			);
+			expect(next).toHaveBeenCalled();
+		});
+
+		it('passes the request through when the session header is absent', async () => {
+			const [handler] = await setupWithApp();
+			const next = vi.fn();
+
+			void handler(createRequest(undefined), mock<Response>(), next);
+
+			expect(PostHog.prototype.withContext).not.toHaveBeenCalled();
+			expect(next).toHaveBeenCalled();
+		});
+
+		it('strips non-printable characters from the session ID', async () => {
+			const [handler] = await setupWithApp();
+			const next = vi.fn();
+
+			// A NUL and a newline, spelled out so they survive a trip through an editor.
+			const hostile = `0192${String.fromCharCode(0)}-abc${String.fromCharCode(10)}`;
+
+			void handler(createRequest(hostile), mock<Response>(), next);
+
+			expect(PostHog.prototype.withContext).toHaveBeenCalledWith({ sessionId: '0192-abc' }, next);
+		});
+
+		it('caps the length of the session ID', async () => {
+			const [handler] = await setupWithApp();
+			const next = vi.fn();
+
+			void handler(createRequest('a'.repeat(1500)), mock<Response>(), next);
+
+			expect(PostHog.prototype.withContext).toHaveBeenCalledWith(
+				{ sessionId: 'a'.repeat(1000) },
+				next,
+			);
+		});
+
+		it('does not register the middleware outside cloud deployments', async () => {
+			globalConfig.deployment.type = 'default';
+
+			expect(await setupWithApp()).toHaveLength(0);
+		});
+
+		it('does not register the middleware when diagnostics are disabled', async () => {
+			globalConfig.diagnostics.enabled = false;
+
+			expect(await setupWithApp()).toHaveLength(0);
 		});
 	});
 });

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -7,6 +7,7 @@ import {
 import { GlobalConfig } from '@n8n/config';
 import type { PublicUser } from '@n8n/db';
 import { Service } from '@n8n/di';
+import type { Application } from 'express';
 import { InstanceSettings } from 'n8n-core';
 import type { FeatureFlags, ITelemetryTrackProperties } from 'n8n-workflow';
 import type { PostHog, FeatureFlagEvaluations } from 'posthog-node';
@@ -44,6 +45,18 @@ export class PostHogClient {
 		const { PostHog } = await import('posthog-node');
 		this.postHog = new PostHog(posthogConfig.apiKey, {
 			host: posthogConfig.apiHost,
+		});
+	}
+
+	setupExpressSessionContext(app: Application): void {
+		const postHog = this.postHog;
+		if (!postHog || this.globalConfig.deployment.type !== 'cloud') return;
+
+		app.use((req, _res, next) => {
+			const sessionId = req.get('x-posthog-session-id');
+			if (!sessionId) return next();
+
+			postHog.withContext({ sessionId }, next);
 		});
 	}
 

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -20,6 +20,13 @@ const POSTHOG_GROUP_TYPE_INSTANCE = 'company';
 
 const FLAGS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
+const SESSION_ID_MAX_LENGTH = 1000;
+
+function sanitizeSessionId(value: string | undefined): string | undefined {
+	const sanitized = value?.replace(/[^\x20-\x7E]/g, '').trim();
+	return sanitized ? sanitized.slice(0, SESSION_ID_MAX_LENGTH) : undefined;
+}
+
 interface CachedFlags {
 	flags: FeatureFlags;
 	expiresAt: number;
@@ -53,7 +60,7 @@ export class PostHogClient {
 		if (!postHog || this.globalConfig.deployment.type !== 'cloud') return;
 
 		app.use((req, _res, next) => {
-			const sessionId = req.get('x-posthog-session-id');
+			const sessionId = sanitizeSessionId(req.get('x-posthog-session-id'));
 			if (!sessionId) return next();
 
 			postHog.withContext({ sessionId }, next);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -177,6 +177,7 @@ export class Server extends AbstractServer {
 		}
 
 		await this.postHogClient.init();
+		this.postHogClient.setupExpressSessionContext(this.app);
 
 		const publicApiEndpoint = this.globalConfig.publicApi.path;
 

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -77,6 +77,7 @@ declare global {
 				key: string,
 				options?: {
 					api_host?: string;
+					tracing_headers?: string[];
 					autocapture?: boolean;
 					disable_session_recording?: boolean;
 					advanced_disable_feature_flags?: boolean;

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
@@ -188,6 +188,34 @@ describe('Posthog store', () => {
 			);
 		});
 
+		it('does not request tracing headers when session recording is disabled', () => {
+			const posthog = usePostHog();
+			posthog.init();
+
+			expect(window.posthog?.init).toHaveBeenCalledWith(
+				DEFAULT_POSTHOG_SETTINGS.apiKey,
+				expect.not.objectContaining({
+					tracing_headers: expect.anything(),
+				}),
+			);
+		});
+
+		it('requests tracing headers for the REST host when session recording is enabled', () => {
+			setSettings({
+				posthog: { ...DEFAULT_POSTHOG_SETTINGS, disableSessionRecording: false },
+			});
+
+			const posthog = usePostHog();
+			posthog.init();
+
+			expect(window.posthog?.init).toHaveBeenCalledWith(
+				DEFAULT_POSTHOG_SETTINGS.apiKey,
+				expect.objectContaining({
+					tracing_headers: [window.location.hostname],
+				}),
+			);
+		});
+
 		it('should identify user', () => {
 			const posthog = usePostHog();
 			posthog.init();

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -184,6 +184,9 @@ export const usePostHog = defineStore('posthog', () => {
 			session_recording: {
 				maskAllInputs: false,
 			},
+			...(!config.disableSessionRecording && {
+				tracing_headers: [new URL(rootStore.restUrl, window.location.origin).hostname],
+			}),
 		};
 
 		if (evaluatedFeatureFlags && Object.keys(evaluatedFeatureFlags).length) {


### PR DESCRIPTION
## Summary

This PR introduces request-scoped PostHog session context for backend telemetry. When Session Replay is enabled, the editor sends PostHog tracing headers to its REST API. The backend reads the browser's session ID and makes it available through `posthog-node`'s asynchronous context for the lifetime of that request.

As a result, any backend PostHog event captured while handling an editor request can automatically receive the reserved `$session_id` property and be associated with the originating browser recording. Agent lifecycle events are the initial use case, but the mechanism is global rather than agent-specific, so other request-bound backend events can use the same recording association without adding session IDs to individual endpoints or event payloads.

The implementation intentionally keeps the context narrow:

- Only the PostHog session ID is added to backend capture context. The browser's distinct ID and additional request metadata are not adopted by the backend.
- Propagation is enabled only when browser Session Replay is enabled and the backend is running as a cloud deployment.
- Requests without a browser session header, including server-only and MCP operations, continue to capture events without `$session_id`.
- n8n's existing `session_id` telemetry property remains unchanged and continues to represent the editor push session (`pushRef`).
- PostHog tracing headers are allowed by development CORS so split-origin editor and API setups behave the same way.

## How to test

1. Start n8n with diagnostics configured, `N8N_DEPLOYMENT_TYPE=cloud`, and `N8N_ENABLED_MODULES=agents,instance-ai`. Enable Session Replay in the PostHog project. For a split local setup, set `N8N_EDITOR_BASE_URL=http://localhost:5678`.
2. Open the editor and note the value of `posthog.get_session_id()` in the browser console.
3. Trigger an editor action that emits backend PostHog telemetry. Creating, modifying, publishing, or unpublishing an agent provides the acceptance path for this ticket.
4. Find the corresponding backend event in PostHog and confirm its `$session_id` matches the browser value while the existing `session_id`, when present, retains its `pushRef` value.
5. Filter Session Replay by that backend event and confirm the originating recording is returned.
6. Trigger a server-only agent operation and confirm its event remains valid without `$session_id`.

Verified locally against a real PostHog project: the browser recording appeared and filtering by a backend agent event returned the originating replay.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-545

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->