### PR TITLE
refactor(editor): Remove unreachable executions tag filter (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/components/ExecutionsFilter.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/ExecutionsFilter.test.ts
@@ -38,17 +38,9 @@ vi.mock('@/features/shared/tags/components/AnnotationTagsDropdown.ee.vue', () =>
 	},
 }));
 
-vi.mock('@/features/shared/tags/components/WorkflowTagsDropdown.vue', () => ({
-	default: {
-		name: 'WorkflowTagsDropdown',
-		template: '<div data-test-id="executions-filter-tags-select"></div>',
-	},
-}));
-
 const defaultFilterState: ExecutionFilterType = {
 	status: 'all',
 	workflowId: 'all',
-	tags: [],
 	annotationTags: [],
 	startDate: '',
 	endDate: '',

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/ExecutionsFilter.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/ExecutionsFilter.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import AnnotationTagsDropdown from '@/features/shared/tags/components/AnnotationTagsDropdown.ee.vue';
-import WorkflowTagsDropdown from '@/features/shared/tags/components/WorkflowTagsDropdown.vue';
 import { useDebounce } from '@n8n/composables/useDebounce';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
@@ -64,12 +63,10 @@ const isAdvancedExecutionFilterEnabled = computed(
 	() => settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.AdvancedExecutionFilters],
 );
 const isAnnotationFiltersEnabled = computed(() => isAdvancedExecutionFilterEnabled.value);
-const showTags = computed(() => false);
 
 const getDefaultFilter = (): ExecutionFilterType => ({
 	status: 'all',
 	workflowId: 'all',
-	tags: [],
 	annotationTags: [],
 	startDate: '',
 	endDate: '',
@@ -156,7 +153,6 @@ const countSelectedFilterProps = computed(() => {
 	const nonDefaultFilters = [
 		filter.status !== 'all',
 		filter.workflowId !== 'all' && props.workflows.length,
-		!isEmpty(filter.tags),
 		!isEmpty(filter.annotationTags),
 		filter.vote !== 'all',
 		filter.workflowVersionId !== 'all',
@@ -192,12 +188,8 @@ const onFilterMetaChange = <K extends keyof ExecutionFilterMetadata>(
 	debouncedEmit('filterChanged', filter);
 };
 
-// Can't use v-model on TagsDropdown component and thus vModel.tags is useless
+// Can't use v-model on TagsDropdown component and thus vModel.annotationTags is useless
 // We just emit the updated filter
-const onTagsChange = () => {
-	emit('filterChanged', filter);
-};
-
 const onAnnotationTagsChange = () => {
 	emit('filterChanged', filter);
 };
@@ -274,17 +266,6 @@ onBeforeMount(() => {
 							/>
 						</div>
 					</N8nSelect>
-				</div>
-				<div v-if="showTags" :class="$style.group">
-					<label for="execution-filter-tags">{{ locale.baseText('workflows.filters.tags') }}</label>
-					<WorkflowTagsDropdown
-						id="execution-filter-tags"
-						v-model="filter.tags"
-						:placeholder="locale.baseText('workflowOpen.filterWorkflows')"
-						:create-enabled="false"
-						data-test-id="executions-filter-tags-select"
-						@update:model-value="onTagsChange"
-					/>
 				</div>
 				<div :class="$style.group">
 					<label for="execution-filter-status">{{

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.types.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.types.ts
@@ -22,7 +22,6 @@ export type ExecutionFilterType = {
 	workflowId: 'all' | string;
 	startDate: string | Date;
 	endDate: string | Date;
-	tags: string[];
 	annotationTags: string[];
 	vote: ExecutionFilterVote;
 	metadata: ExecutionFilterMetadata[];

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.ts
@@ -59,7 +59,6 @@ export function getDefaultExecutionFilters(): ExecutionFilterType {
 		status: 'all',
 		startDate: '',
 		endDate: '',
-		tags: [],
 		annotationTags: [],
 		metadata: [],
 		vote: 'all',
@@ -73,10 +72,6 @@ export const executionFilterToQueryFilter = (
 	const queryFilter: IDataObject = {};
 	if (filter.workflowId !== 'all') {
 		queryFilter.workflowId = filter.workflowId;
-	}
-
-	if (!isEmpty(filter.tags)) {
-		queryFilter.tags = filter.tags;
 	}
 
 	if (!isEmpty(filter.annotationTags)) {


### PR DESCRIPTION
## Summary

`showTags` in `ExecutionsFilter.vue` was `computed(() => false)`, so the executions tag filter never rendered. It has been hardcoded `false` since the control was introduced in #5496 (2023-03-23) — it has never been visible to a user, and its markup shipped in every build.

No screenshots: there is no visual change. The control this removes has never rendered, and `annotationTags` — the live tag filter directly below it — is untouched.

**Why the state goes too, rather than just the gate.** A permanently hidden control over live filter state would be worse than an inert one: it could be set with no UI to show or clear it. That is not the case here — the state is inert in both directions:

- **Nothing can set it.** The hidden `WorkflowTagsDropdown` was the only writer. The component seeds `filter` from `getDefaultFilter()` and takes no initial-filter prop, so nothing can push a value in; `executionsStore.setFilters` is fed only by this component's `filterChanged` emit. No URL param or persisted filter reaches it.
- **Nothing would read it if set.** `executionFilterToQueryFilter` mapped `tags` onto the outgoing query, but `tags` is absent from `schemaGetExecutionsQueryFilter` (`packages/cli/src/executions/execution.service.ts:68`), so `parseRangeQuery` deletes the key before validation (`packages/cli/src/executions/parse-range-query.middleware.ts:44`). It never affected results. The mapping type-checked only because `queryFilter` is built as an `IDataObject` before being returned as `ExecutionsQueryFilter`, which has no `tags` field.

So `tags` is removed from `ExecutionFilterType` along with the control. That also drops it from the badge count in `countSelectedFilterProps`, where it could only ever have been empty.

Kept, because both still have live consumers: the `workflows.filters.tags` i18n key (used by `WorkflowsView.vue`) and the `WorkflowTagsDropdown` component (3 other call sites).

## How to test

Nothing should change. Executions list → filter button:

1. The tag filter was never there and still isn't. The **Annotation tags** filter (Enterprise: advanced execution filters) still renders, filters, and counts toward the badge.
2. Status / workflow / date / version / saved-data filters unaffected; badge count and reset button behave as before.

Verified in `packages/frontend/editor-ui`:

- `pnpm vitest run src/features/execution/executions/{components/ExecutionsFilter.test.ts,executions.utils.test.ts,executions.store.test.ts,components/global/GlobalExecutionsList.test.ts}` → **106 passed** (4 files)
- `pnpm typecheck` → **clean**. This is the load-bearing check: removing `tags` from `ExecutionFilterType` would surface any other consumer, and none appeared.
- `eslint` on the 4 changed files → 0 errors, and the same 6 warnings present at `master` (verified against a stashed baseline), so no new findings.

## Related Linear tickets, Github issues, and Community forum posts

Introduced in #5496.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- n/a: removes a control that was never user-visible; no documented behaviour changes. -->
- [x] Tests included. <!-- Existing ExecutionsFilter/utils/store suites updated and passing; no new behaviour to cover. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

