### PR TITLE
docs(core): Remove outdated AI node verification note from ai-node-sdk README

### DIFF
--- a/packages/@n8n/ai-node-sdk/README.md
+++ b/packages/@n8n/ai-node-sdk/README.md
@@ -1,6 +1,6 @@
 # @n8n/ai-node-sdk
 
-> **Preview:** This package is in preview. The API may change without notice. AI nodes are not yet accepted for verification.
+> **Preview:** This package is in preview. The API may change without notice.
 
 Public SDK for building AI nodes in n8n. This package provides a simplified API for creating chat model and memory nodes without LangChain dependencies.
 


### PR DESCRIPTION
## Summary

Removes the "AI nodes are not yet accepted for verification" note from the `@n8n/ai-node-sdk` package README, as this is no longer accurate.

## How to test

Read the updated `packages/@n8n/ai-node-sdk/README.md` — the preview notice now only states that the API may change without notice.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-1858/verification-policy-flags-package-with-two-non-trigger-nodes-manifest

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->