### PR TITLE
fix: Send n8n version on backend posthog flag retrieval

### DIFF
--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -6,6 +6,7 @@ import { PostHog } from 'posthog-node';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
+import { N8N_VERSION } from '@/constants';
 import { PostHogClient } from '@/posthog';
 
 vi.mock('posthog-node');
@@ -161,6 +162,8 @@ describe('PostHog', () => {
 			expect(PostHog.prototype.evaluateFlags).toHaveBeenCalledWith(`${instanceId}#${userId}`, {
 				personProperties: {
 					created_at_timestamp: createdAt.getTime().toString(),
+					instance_id: instanceId,
+					version_cli: N8N_VERSION,
 				},
 				groups: { company: instanceId },
 			});

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -11,6 +11,8 @@ import { InstanceSettings } from 'n8n-core';
 import type { FeatureFlags, ITelemetryTrackProperties } from 'n8n-workflow';
 import type { PostHog, FeatureFlagEvaluations } from 'posthog-node';
 
+import { N8N_VERSION } from '@/constants';
+
 /**
  * PostHog group type for instance-level properties.
  * Note: Aliased as "instance" on PostHog dashboard
@@ -136,6 +138,8 @@ export class PostHogClient {
 		const evaluatedFlags = await this.postHog.evaluateFlags(fullId, {
 			personProperties: {
 				created_at_timestamp: user.createdAt.getTime().toString(),
+				instance_id: instanceId,
+				version_cli: N8N_VERSION,
 			},
 			...(instanceId && { groups: { [POSTHOG_GROUP_TYPE_INSTANCE]: instanceId } }),
 		});


### PR DESCRIPTION
## Summary

Added `version_cli` and `instance_id` to Posthog flag retrieval in the backend.

Posthog feature flags are retrieved via a backend cache/proxy in the `/login` endpoint and only fallback to retrieving flags directly if the backend call fails. The backend flag retrieval did not send `version_cli` and `instance_id` resulting in any feature flags that have a rollout condition on these being evaluated as false. This is currently the case for flags like `073_quick_connect` and `048_collection_overhaul`

## How to test

Delete browser cache, session store and local store for localhost or use an incognito window or a deployed test instance.

test via workflow
1. use the test workflow
2. open the Airtable node and observe that it has the new style for collection fields

New and correct
<img width="538" height="310" alt="Bildschirmfoto 2026-08-05 um 14 33 42" src="https://github.com/user-attachments/assets/000762c0-9e0d-4279-b2c4-295f573ff5fd" />

Old and incorrect
<img width="529" height="301" alt="Bildschirmfoto 2026-08-05 um 14 33 28" src="https://github.com/user-attachments/assets/b9a054b8-a049-4a0c-a316-79cf05ea58d9" />


test what the backend returns 
1. open the devtools network tab and reload the page
2. observe that the `/login` endpoint returns `variant` and not `false` for following flags `073_quick_connect` and `048_collection_overhaul`

<details>
<summary>Test workflow</summary>
```json
{
  "nodes": [
    {
      "parameters": {
        "pollTimes": {
          "item": [
            {
              "mode": "everyMinute"
            }
          ]
        },
        "baseId": {
          "__rl": true,
          "mode": "url",
          "value": ""
        },
        "tableId": {
          "__rl": true,
          "mode": "url",
          "value": ""
        },
        "additionalFields": {}
      },
      "type": "n8n-nodes-base.airtableTrigger",
      "typeVersion": 1,
      "position": [
        144,
        144
      ],
      "id": "8cea744f-d2ec-409e-af23-0d3ba7f880ca",
      "name": "Airtable Trigger"
    }
  ],
  "connections": {},
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "acd7615bcc3af421bbd7517e305cc16505176a6a47045dbe39e25d904c940573"
  }
}
```
</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5680/posthog-feature-flag-loading-does-not-send-n8n-version


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

