### PR TITLE
feat(core): Add status to AuthIdentity and fail closed on a non-active binding

### DIFF
--- a/docs/generated/postgres-schema/README.md
+++ b/docs/generated/postgres-schema/README.md
@@ -35,7 +35,7 @@ Auto-generated from the PostgreSQL migrations in @n8n/db. Do not edit by hand.
 | [public.agents_threads](public.agents_threads.md) | 6 |  | BASE TABLE |
 | [public.ai_builder_temporary_workflow](public.ai_builder_temporary_workflow.md) | 4 |  | BASE TABLE |
 | [public.annotation_tag_entity](public.annotation_tag_entity.md) | 4 |  | BASE TABLE |
-| [public.auth_identity](public.auth_identity.md) | 5 |  | BASE TABLE |
+| [public.auth_identity](public.auth_identity.md) | 6 |  | BASE TABLE |
 | [public.auth_provider_sync_history](public.auth_provider_sync_history.md) | 11 |  | BASE TABLE |
 | [public.binary_data](public.binary_data.md) | 9 |  | BASE TABLE |
 | [public.chat_hub_agent_tools](public.chat_hub_agent_tools.md) | 2 |  | BASE TABLE |
@@ -634,6 +634,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   varchar_255_ providerId
   varchar_32_ providerType
+  varchar_32_ status
   timestamp_3__with_time_zone updatedAt
   uuid userId FK
 }

--- a/docs/generated/postgres-schema/public.auth_identity.md
+++ b/docs/generated/postgres-schema/public.auth_identity.md
@@ -7,7 +7,7 @@
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | providerId | varchar(255) |  | false |  |  |  |
 | providerType | varchar(32) |  | false |  |  |  |
-| status | varchar(32) | 'active'::character varying | false |  |  |  |
+| status | varchar(32) | 'active'::character varying | false |  |  | Live authority gate for this binding: a non-active row resolves no principal |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | userId | uuid |  | true |  | [public.user](public.user.md) |  |
 

--- a/docs/generated/postgres-schema/public.auth_identity.md
+++ b/docs/generated/postgres-schema/public.auth_identity.md
@@ -7,6 +7,7 @@
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | providerId | varchar(255) |  | false |  |  |  |
 | providerType | varchar(32) |  | false |  |  |  |
+| status | varchar(32) | 'active'::character varying | false |  |  |  |
 | updatedAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | userId | uuid |  | true |  | [public.user](public.user.md) |  |
 
@@ -14,10 +15,12 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| CHK_auth_identity_status | CHECK | CHECK (((status)::text = ANY ((ARRAY['active'::character varying, 'suspended'::character varying, 'revoked'::character varying])::text[]))) |
 | auth_identity_createdAt_not_null | n | NOT NULL "createdAt" |
 | auth_identity_pkey | PRIMARY KEY | PRIMARY KEY ("providerId", "providerType") |
 | auth_identity_providerId_not_null | n | NOT NULL "providerId" |
 | auth_identity_providerType_not_null | n | NOT NULL "providerType" |
+| auth_identity_status_not_null | n | NOT NULL status |
 | auth_identity_updatedAt_not_null | n | NOT NULL "updatedAt" |
 | auth_identity_userId_fkey | FOREIGN KEY | FOREIGN KEY ("userId") REFERENCES "user"(id) |
 
@@ -38,6 +41,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   varchar_255_ providerId
   varchar_32_ providerType
+  varchar_32_ status
   timestamp_3__with_time_zone updatedAt
   uuid userId FK
 }

--- a/docs/generated/postgres-schema/public.user.md
+++ b/docs/generated/postgres-schema/public.user.md
@@ -147,6 +147,7 @@ erDiagram
   timestamp_3__with_time_zone createdAt
   varchar_255_ providerId
   varchar_32_ providerType
+  varchar_32_ status
   timestamp_3__with_time_zone updatedAt
   uuid userId FK
 }

--- a/docs/generated/sqlite-schema/README.md
+++ b/docs/generated/sqlite-schema/README.md
@@ -35,7 +35,7 @@ Auto-generated from the SQLite migrations in @n8n/db. Do not edit by hand.
 | [agents_threads](agents_threads.md) | 6 |  | table |
 | [ai_builder_temporary_workflow](ai_builder_temporary_workflow.md) | 4 |  | table |
 | [annotation_tag_entity](annotation_tag_entity.md) | 4 |  | table |
-| [auth_identity](auth_identity.md) | 5 |  | table |
+| [auth_identity](auth_identity.md) | 6 |  | table |
 | [auth_provider_sync_history](auth_provider_sync_history.md) | 11 |  | table |
 | [binary_data](binary_data.md) | 9 |  | table |
 | [chat_hub_agent_tools](chat_hub_agent_tools.md) | 2 |  | table |
@@ -619,10 +619,11 @@ erDiagram
 }
 "auth_identity" {
   timestamp createdAt
-  VARCHAR_64_ providerId PK
-  VARCHAR_32_ providerType PK
+  varchar_64_ providerId PK
+  varchar_32_ providerType PK
+  varchar_32_ status
   timestamp updatedAt
-  VARCHAR_36_ userId FK
+  varchar_36_ userId FK
 }
 "auth_provider_sync_history" {
   INTEGER created

--- a/docs/generated/sqlite-schema/auth_identity.md
+++ b/docs/generated/sqlite-schema/auth_identity.md
@@ -6,14 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "auth_identity" (
-				"userId" VARCHAR(36) REFERENCES "user" (id),
-				"providerId" VARCHAR(64) NOT NULL,
-				"providerType" VARCHAR(32) NOT NULL,
-				"createdAt" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				"updatedAt" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				PRIMARY KEY("providerId", "providerType")
-			)
+CREATE TABLE "auth_identity" ("userId" varchar(36), "providerId" varchar(64) NOT NULL, "providerType" varchar(32) NOT NULL, "createdAt" timestamp NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" timestamp NOT NULL DEFAULT (CURRENT_TIMESTAMP), "status" varchar(32) NOT NULL DEFAULT ('active'), CONSTRAINT "CHK_auth_identity_status" CHECK ("status" IN ('active', 'suspended', 'revoked')), CONSTRAINT "FK_2325ca218e23aa2ef1acf60187e" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION, PRIMARY KEY ("providerId", "providerType"))
 ```
 
 </details>
@@ -23,15 +16,17 @@ CREATE TABLE "auth_identity" (
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | createdAt | timestamp | CURRENT_TIMESTAMP | false |  |  |  |
-| providerId | VARCHAR(64) |  | false |  |  |  |
-| providerType | VARCHAR(32) |  | false |  |  |  |
+| providerId | varchar(64) |  | false |  |  |  |
+| providerType | varchar(32) |  | false |  |  |  |
+| status | varchar(32) | 'active' | false |  |  |  |
 | updatedAt | timestamp | CURRENT_TIMESTAMP | false |  |  |  |
-| userId | VARCHAR(36) |  | true |  | [user](user.md) |  |
+| userId | varchar(36) |  | true |  | [user](user.md) |  |
 
 ## Constraints
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| - | CHECK | CHECK ("status" IN ('active', 'suspended', 'revoked')) |
 | - (Foreign key ID: 0) | FOREIGN KEY | FOREIGN KEY (userId) REFERENCES user (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE |
 | providerId | PRIMARY KEY | PRIMARY KEY (providerId) |
 | providerType | PRIMARY KEY | PRIMARY KEY (providerType) |
@@ -52,10 +47,11 @@ erDiagram
 
 "auth_identity" {
   timestamp createdAt
-  VARCHAR_64_ providerId PK
-  VARCHAR_32_ providerType PK
+  varchar_64_ providerId PK
+  varchar_32_ providerType PK
+  varchar_32_ status
   timestamp updatedAt
-  VARCHAR_36_ userId FK
+  varchar_36_ userId FK
 }
 "user" {
   datetime_3_ createdAt

--- a/docs/generated/sqlite-schema/user.md
+++ b/docs/generated/sqlite-schema/user.md
@@ -151,10 +151,11 @@ erDiagram
 }
 "auth_identity" {
   timestamp createdAt
-  VARCHAR_64_ providerId PK
-  VARCHAR_32_ providerType PK
+  varchar_64_ providerId PK
+  varchar_32_ providerType PK
+  varchar_32_ status
   timestamp updatedAt
-  VARCHAR_36_ userId FK
+  varchar_36_ userId FK
 }
 "chat_hub_agents" {
   datetime_3_ createdAt

--- a/packages/@n8n/db/src/entities/auth-identity.ts
+++ b/packages/@n8n/db/src/entities/auth-identity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, ManyToOne, PrimaryColumn, Unique } from '@n8n/typeorm';
 
 import { WithTimestamps } from './abstract-entity';
-import { AuthProviderType } from './types-db';
+import { AuthIdentityStatus, AuthProviderType } from './types-db';
 import { User } from './user';
 
 @Entity()
@@ -22,6 +22,9 @@ export class AuthIdentity extends WithTimestamps {
 	@PrimaryColumn()
 	providerType: AuthProviderType;
 
+	@Column({ default: 'active' })
+	status: AuthIdentityStatus;
+
 	static create(
 		user: User,
 		providerId: string,
@@ -32,6 +35,7 @@ export class AuthIdentity extends WithTimestamps {
 		identity.userId = user.id;
 		identity.providerId = providerId;
 		identity.providerType = providerType;
+		identity.status = 'active';
 		return identity;
 	}
 }

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -340,6 +340,14 @@ export function isAuthProviderType(value: string): value is AuthProviderType {
 	return ALL_AUTH_PROVIDERS.safeParse(value).success;
 }
 
+const ALL_AUTH_IDENTITY_STATUSES = z.enum(['active', 'suspended', 'revoked']);
+
+export type AuthIdentityStatus = z.infer<typeof ALL_AUTH_IDENTITY_STATUSES>;
+
+export function isAuthIdentityStatus(value: string): value is AuthIdentityStatus {
+	return ALL_AUTH_IDENTITY_STATUSES.safeParse(value).success;
+}
+
 export type FolderWithWorkflowAndSubFolderCount = Folder & {
 	workflowCount?: boolean;
 	subFolderCount?: number;

--- a/packages/@n8n/db/src/migrations/common/1785930000000-AddStatusToAuthIdentity.ts
+++ b/packages/@n8n/db/src/migrations/common/1785930000000-AddStatusToAuthIdentity.ts
@@ -1,0 +1,23 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const AUTH_IDENTITY_TABLE = 'auth_identity';
+const STATUS_COLUMN = 'status';
+const STATUSES = ['active', 'suspended', 'revoked'];
+
+export class AddStatusToAuthIdentity1785930000000 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, addEnumCheck, column } }: MigrationContext) {
+		await addColumns(
+			AUTH_IDENTITY_TABLE,
+			[column(STATUS_COLUMN).varchar(32).notNull.default("'active'")],
+			{ recreatesOnSqlite: true },
+		);
+		await addEnumCheck(AUTH_IDENTITY_TABLE, STATUS_COLUMN, STATUSES, {
+			recreatesOnSqlite: true,
+		});
+	}
+
+	async down({ schemaBuilder: { dropEnumCheck, dropColumns } }: MigrationContext) {
+		await dropEnumCheck(AUTH_IDENTITY_TABLE, STATUS_COLUMN, { recreatesOnSqlite: true });
+		await dropColumns(AUTH_IDENTITY_TABLE, [STATUS_COLUMN], { recreatesOnSqlite: true });
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1785930000000-AddStatusToAuthIdentity.ts
+++ b/packages/@n8n/db/src/migrations/common/1785930000000-AddStatusToAuthIdentity.ts
@@ -5,18 +5,23 @@ const STATUS_COLUMN = 'status';
 const STATUSES = ['active', 'suspended', 'revoked'];
 
 export class AddStatusToAuthIdentity1785930000000 implements ReversibleMigration {
-	async up({ schemaBuilder: { addColumns, addEnumCheck, column } }: MigrationContext) {
+	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
 		await addColumns(
 			AUTH_IDENTITY_TABLE,
-			[column(STATUS_COLUMN).varchar(32).notNull.default("'active'")],
+			[
+				column(STATUS_COLUMN)
+					.varchar(32)
+					.notNull.default("'active'")
+					.withEnumCheck(STATUSES)
+					.comment('Live authority gate for this binding: a non-active row resolves no principal'),
+			],
 			{ recreatesOnSqlite: true },
 		);
-		await addEnumCheck(AUTH_IDENTITY_TABLE, STATUS_COLUMN, STATUSES, {
-			recreatesOnSqlite: true,
-		});
 	}
 
 	async down({ schemaBuilder: { dropEnumCheck, dropColumns } }: MigrationContext) {
+		// Must precede the column drop: SQLite carries the CHECK over to the
+		// rebuilt table, where it would reference a column that no longer exists.
 		await dropEnumCheck(AUTH_IDENTITY_TABLE, STATUS_COLUMN, { recreatesOnSqlite: true });
 		await dropColumns(AUTH_IDENTITY_TABLE, [STATUS_COLUMN], { recreatesOnSqlite: true });
 	}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -239,6 +239,7 @@ import { CreateAgentChatAttachmentsTable1785255306000 } from '../common/17852553
 import { AddSetupCompletedAtToAgents1785500832626 } from '../common/1785500832626-AddSetupCompletedAtToAgents';
 import { AddAgentExecutionRuntimeState1785828155091 } from '../common/1785828155091-AddAgentExecutionRuntimeState';
 import { AddManagedByAndIssuerToTrustedKeySource1785924000000 } from '../common/1785924000000-AddManagedByAndIssuerToTrustedKeySource';
+import { AddStatusToAuthIdentity1785930000000 } from '../common/1785930000000-AddStatusToAuthIdentity';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -483,4 +484,5 @@ export const postgresMigrations: Migration[] = [
 	AddSetupCompletedAtToAgents1785500832626,
 	AddAgentExecutionRuntimeState1785828155091,
 	AddManagedByAndIssuerToTrustedKeySource1785924000000,
+	AddStatusToAuthIdentity1785930000000,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -231,6 +231,7 @@ import { AddAgentFileStorageColumns1785186578138 } from '../common/1785186578138
 import { CrashStaleEnqueuedExecutions1785247194306 } from '../common/1785247194306-CrashStaleEnqueuedExecutions';
 import { CreateAgentChatAttachmentsTable1785255306000 } from '../common/1785255306000-CreateAgentChatAttachmentsTable';
 import { AddAgentExecutionRuntimeState1785828155091 } from '../common/1785828155091-AddAgentExecutionRuntimeState';
+import { AddStatusToAuthIdentity1785930000000 } from '../common/1785930000000-AddStatusToAuthIdentity';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -465,6 +466,7 @@ const sqliteMigrations: Migration[] = [
 	AddSetupCompletedAtToAgents1785500832626,
 	AddAgentExecutionRuntimeState1785828155091,
 	AddManagedByAndIssuerToTrustedKeySource1785924000000,
+	AddStatusToAuthIdentity1785930000000,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
@@ -338,7 +338,7 @@ describe('IdentityResolutionService', () => {
 			authIdentityRepository.findOne
 				.mockResolvedValueOnce(null)
 				.mockResolvedValueOnce(null)
-				.mockResolvedValueOnce(mock<AuthIdentity>({ user }));
+				.mockResolvedValueOnce(mock<AuthIdentity>({ user, status: 'active' }));
 			return user;
 		}
 
@@ -412,7 +412,9 @@ describe('IdentityResolutionService', () => {
 
 		it('resolves an already-bound identity without syncing profile or role', async () => {
 			const user = mock<User>({ id: 'existing-1', role: { slug: 'global:member' } });
-			authIdentityRepository.findOne.mockResolvedValueOnce(mock<AuthIdentity>({ user }));
+			authIdentityRepository.findOne.mockResolvedValueOnce(
+				mock<AuthIdentity>({ user, status: 'active' }),
+			);
 
 			await expect(
 				service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), false),
@@ -427,5 +429,15 @@ describe('IdentityResolutionService', () => {
 				service.resolve(makeClaims({ role: 'global:owner' }), undefined, ctx(), false),
 			).resolves.toBeNull();
 		});
+
+		it.each(['suspended', 'revoked'] as const)(
+			'returns null for a %s binding instead of the bound user',
+			async (status) => {
+				const user = mock<User>({ id: 'existing-1' });
+				authIdentityRepository.findOne.mockResolvedValueOnce(mock<AuthIdentity>({ user, status }));
+
+				await expect(service.resolve(makeClaims(), undefined, ctx(), false)).resolves.toBeNull();
+			},
+		);
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -213,13 +213,12 @@ export class IdentityResolutionService implements IdentityResolver {
 	}
 
 	/**
-	 * TODO(IAM-1171): gate on `identity.status === 'active'` once the column lands.
 	 * Deliberately does not consult the claim's `expiresAt` — binding status is
 	 * the access gate, not token freshness; an execution outliving the token's
 	 * `exp` must still resolve.
 	 */
-	private isBindingActive(_identity: AuthIdentity): boolean {
-		return true;
+	private isBindingActive(identity: AuthIdentity): boolean {
+		return identity.status === 'active';
 	}
 
 	/** Path 1: resolve an already-linked identity and sync profile/role. */

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -571,4 +571,41 @@ describe('IdentityResolutionService (integration)', () => {
 			expect(identities[0].providerId).toBe('legacy-multi-sub');
 		});
 	});
+
+	describe('allowProvisioning: false (per-access resolution)', () => {
+		it('resolves an active binding to its user', async () => {
+			const user = await createUser({ email: 'active-binding@example.com' });
+			await authIdentityRepository.save(
+				AuthIdentity.create(user, providerIdFor('ext-active'), 'token-exchange'),
+			);
+
+			const result = await service.resolve(
+				{ ...baseClaims, sub: 'ext-active' },
+				undefined,
+				ctx(),
+				false,
+			);
+
+			expect(result?.id).toBe(user.id);
+		});
+
+		it('revoking the binding makes the next resolution fail closed', async () => {
+			const user = await createUser({ email: 'revoked-binding@example.com' });
+			await authIdentityRepository.save(
+				AuthIdentity.create(user, providerIdFor('ext-revoked'), 'token-exchange'),
+			);
+			const claims = { ...baseClaims, sub: 'ext-revoked' };
+
+			await expect(service.resolve(claims, undefined, ctx(), false)).resolves.toMatchObject({
+				id: user.id,
+			});
+
+			await authIdentityRepository.update(
+				{ providerId: providerIdFor('ext-revoked'), providerType: 'token-exchange' },
+				{ status: 'revoked' },
+			);
+
+			await expect(service.resolve(claims, undefined, ctx(), false)).resolves.toBeNull();
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Adds a `status: 'active' | 'suspended' | 'revoked'` column to `AuthIdentity` (migration, default `active` — existing rows unaffected).
- Replaces the `isBindingActive()` stub in `IdentityResolutionService` (left as a `TODO(IAM-1171)` by #35597) with a real check: `identity.status === 'active'`. This is the single per-access resolve path (`allowProvisioning: false`) that IAM-1168 [T7] will also call through, so no second enforcement point is needed.
- Does not gate the interactive login/provisioning path (`allowProvisioning: true`) — only per-access resolution, per the ticket's scope.

## How to test
- Unit: `pnpm --filter n8n test src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts`
- Integration: `pnpm --filter n8n test:sqlite -- test/integration/token-exchange/identity-resolution.service.test.ts` — includes a new test that binds an identity, resolves it, flips `status` to `revoked`, and asserts the next resolution returns `null`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1171

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

