### PR TITLE
fix(editor): Render unregistered modal keys as closed instead of throwing (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/frontend-module-sdk/src/registries/modalRegistry.test.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/registries/modalRegistry.test.ts
@@ -28,9 +28,7 @@ describe('modalRegistry', () => {
 	};
 
 	beforeEach(() => {
-		// Clear all modals before each test
-		const keys = modalRegistry.getKeys();
-		keys.forEach((key) => modalRegistry.unregister(key));
+		modalRegistry.clear();
 	});
 
 	describe('register', () => {
@@ -111,6 +109,53 @@ describe('modalRegistry', () => {
 
 			expect(listener).toHaveBeenCalledWith(expect.any(Map));
 			expect(listener).toHaveBeenCalledTimes(1);
+		});
+
+		it('should allow a key to be registered again after it was unregistered', () => {
+			modalRegistry.register(mockModal1);
+			modalRegistry.unregister('test-modal-1');
+
+			const replacement: ModalDefinition = {
+				key: 'test-modal-1',
+				component: mockComponent2,
+				initialState: { open: true },
+			};
+			modalRegistry.register(replacement);
+
+			expect(modalRegistry.get('test-modal-1')).toEqual(replacement);
+		});
+	});
+
+	describe('clear', () => {
+		it('should remove all registered modals', () => {
+			modalRegistry.register(mockModal1);
+			modalRegistry.register(mockModal2);
+
+			modalRegistry.clear();
+
+			expect(modalRegistry.getKeys()).toEqual([]);
+			expect(modalRegistry.has('test-modal-1')).toBe(false);
+			expect(modalRegistry.getAll().size).toBe(0);
+		});
+
+		it('should notify listeners so renderers drop the cleared modals', () => {
+			modalRegistry.register(mockModal1);
+			const listener = vi.fn<(modals: Map<string, ModalDefinition>) => void>();
+			modalRegistry.subscribe(listener);
+
+			modalRegistry.clear();
+
+			expect(listener).toHaveBeenCalledTimes(1);
+			expect(listener.mock.calls[0][0].size).toBe(0);
+		});
+
+		it('should allow registration again after clearing', () => {
+			modalRegistry.register(mockModal1);
+			modalRegistry.clear();
+
+			modalRegistry.register(mockModal1);
+
+			expect(modalRegistry.get('test-modal-1')).toEqual(mockModal1);
 		});
 	});
 

--- a/packages/frontend/@n8n/frontend-module-sdk/src/registries/modalRegistry.ts
+++ b/packages/frontend/@n8n/frontend-module-sdk/src/registries/modalRegistry.ts
@@ -45,3 +45,11 @@ export function subscribe(listener: (modals: Map<string, ModalDefinition>) => vo
 		listeners.delete(listener);
 	};
 }
+
+/**
+ * Remove all registered modals. Primarily for test isolation.
+ */
+export function clear(): void {
+	modals.clear();
+	notifyListeners();
+}

--- a/packages/frontend/editor-ui/src/app/components/ModalRoot.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/ModalRoot.test.ts
@@ -1,0 +1,103 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
+import { screen } from '@testing-library/vue';
+import { modalRegistry } from '@n8n/frontend-module-sdk';
+
+import ModalRoot from '@/app/components/ModalRoot.vue';
+import { useUIStore } from '@/app/stores/ui.store';
+import { createComponentRenderer } from '@/__tests__/render';
+import {
+	CHANGE_PASSWORD_MODAL_KEY,
+	CONFIRM_PASSWORD_MODAL_KEY,
+	MFA_SETUP_MODAL_KEY,
+	PROMPT_MFA_CODE_MODAL_KEY,
+} from '@/app/constants';
+
+/**
+ * The four modal keys `Modals.vue` renders on unauthenticated routes. `<AppModals />`
+ * is not auth-gated, so these mount before any registration has run.
+ */
+const AUTH_ROUTE_MODAL_KEYS = [
+	CHANGE_PASSWORD_MODAL_KEY,
+	CONFIRM_PASSWORD_MODAL_KEY,
+	MFA_SETUP_MODAL_KEY,
+	PROMPT_MFA_CODE_MODAL_KEY,
+];
+
+const MODAL_KEY = 'someFeatureModal';
+
+const renderModalRoot = createComponentRenderer(ModalRoot, {
+	// `params` is how vue-test-utils exposes scoped-slot props to a string slot.
+	slots: {
+		default: '<div data-test-id="modal-content">{{ JSON.stringify(params) }}</div>',
+	},
+});
+
+const renderedSlotProps = () => JSON.parse(screen.getByTestId('modal-content').textContent ?? '');
+
+describe('ModalRoot', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		modalRegistry.clear();
+		// Nothing has registered yet — the state every reader sees on first paint.
+		useUIStore().modalsById = {};
+	});
+
+	it('renders nothing for a key that is not registered', () => {
+		expect(() => renderModalRoot({ props: { name: MODAL_KEY } })).not.toThrow();
+
+		expect(screen.queryByTestId('modal-content')).not.toBeInTheDocument();
+	});
+
+	it.each(AUTH_ROUTE_MODAL_KEYS)(
+		'renders %s closed when the registry and store are both empty',
+		(modalKey) => {
+			expect(() => renderModalRoot({ props: { name: modalKey } })).not.toThrow();
+
+			expect(screen.queryByTestId('modal-content')).not.toBeInTheDocument();
+		},
+	);
+
+	it('renders the slot with a closed state for an unregistered key when keepAlive is set', () => {
+		expect(() => renderModalRoot({ props: { name: MODAL_KEY, keepAlive: true } })).not.toThrow();
+
+		expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+		expect(renderedSlotProps()).toMatchObject({
+			modalName: MODAL_KEY,
+			open: false,
+			active: false,
+		});
+	});
+
+	it('passes modal state to the slot once the key is open', () => {
+		const uiStore = useUIStore();
+		uiStore.modalsById = {
+			[MODAL_KEY]: { open: true, mode: 'edit', activeId: '42', data: { foo: 'bar' } },
+		};
+		uiStore.openModal(MODAL_KEY);
+
+		renderModalRoot({ props: { name: MODAL_KEY } });
+
+		expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+		expect(renderedSlotProps()).toEqual({
+			modalName: MODAL_KEY,
+			active: true,
+			open: true,
+			activeId: '42',
+			mode: 'edit',
+			data: { foo: 'bar' },
+		});
+	});
+
+	it('opens a modal registered after it was already mounted', async () => {
+		const uiStore = useUIStore();
+		renderModalRoot({ props: { name: MODAL_KEY } });
+		expect(screen.queryByTestId('modal-content')).not.toBeInTheDocument();
+
+		uiStore.registerModal(MODAL_KEY);
+		uiStore.openModal(MODAL_KEY);
+		await nextTick();
+
+		expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/components/ModalRoot.vue
+++ b/packages/frontend/editor-ui/src/app/components/ModalRoot.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useUIStore } from '@/app/stores/ui.store';
 
-defineProps<{
+const props = defineProps<{
 	name: string;
 	keepAlive?: boolean;
 }>();
@@ -18,17 +19,21 @@ defineSlots<{
 }>();
 
 const uiStore = useUIStore();
+
+// Resolves to a closed state while `name` is not registered, so this renders
+// nothing instead of throwing when it mounts ahead of registration.
+const modalState = computed(() => uiStore.modalStateById[props.name]);
 </script>
 
 <template>
-	<div v-if="uiStore.modalsById[name].open || keepAlive">
+	<div v-if="modalState.open || keepAlive">
 		<slot
 			:modal-name="name"
 			:active="uiStore.isModalActiveById[name]"
-			:open="uiStore.modalsById[name].open"
-			:active-id="uiStore.modalsById[name].activeId"
-			:mode="uiStore.modalsById[name].mode"
-			:data="uiStore.modalsById[name].data"
+			:open="modalState.open"
+			:active-id="modalState.activeId"
+			:mode="modalState.mode"
+			:data="modalState.data"
 		></slot>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.test.ts
@@ -77,4 +77,57 @@ describe('UI Store', () => {
 			expect(uiStore.hasUnsavedWorkflowChanges).toBe(false);
 		});
 	});
+
+	describe('modalStateById', () => {
+		const MODAL_KEY = 'someFeatureModal';
+
+		it('should resolve an unregistered key to a closed state instead of undefined', () => {
+			const uiStore = useUIStore();
+			uiStore.modalsById = {};
+
+			expect(uiStore.modalStateById[MODAL_KEY]).toEqual({ open: false });
+		});
+
+		it('should return the stored state for a registered key', () => {
+			const uiStore = useUIStore();
+			uiStore.modalsById = {};
+			uiStore.registerModal(MODAL_KEY, { open: false, mode: 'edit' });
+
+			expect(uiStore.modalStateById[MODAL_KEY]).toEqual({ open: false, mode: 'edit' });
+		});
+
+		it('should reflect a key registered after the first read', () => {
+			const uiStore = useUIStore();
+			uiStore.modalsById = {};
+			expect(uiStore.modalStateById[MODAL_KEY].open).toBe(false);
+
+			uiStore.registerModal(MODAL_KEY, { open: true });
+
+			expect(uiStore.modalStateById[MODAL_KEY].open).toBe(true);
+		});
+	});
+
+	describe('isModalActiveById', () => {
+		const MODAL_KEY = 'someFeatureModal';
+
+		it('should report an unregistered key as inactive instead of undefined', () => {
+			const uiStore = useUIStore();
+			uiStore.modalsById = {};
+
+			expect(uiStore.isModalActiveById[MODAL_KEY]).toBe(false);
+		});
+
+		it('should still report only the topmost open modal as active', () => {
+			const uiStore = useUIStore();
+			uiStore.modalsById = {};
+			uiStore.registerModal('first');
+			uiStore.registerModal('second');
+
+			uiStore.openModal('first');
+			uiStore.openModal('second');
+
+			expect(uiStore.isModalActiveById.second).toBe(true);
+			expect(uiStore.isModalActiveById.first).toBe(false);
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -119,6 +119,22 @@ try {
 
 type UiStore = ReturnType<typeof useUIStore>;
 
+/** State a modal key resolves to while it is not registered. */
+const CLOSED_MODAL_STATE: ModalState = Object.freeze({ open: false });
+
+/**
+ * Read-only view of `source` in which an unknown key reads as `fallback` instead
+ * of `undefined`. Modals register at different points in the boot sequence (shell
+ * keys eagerly, module keys post-login), so a reader can legitimately run before
+ * its key exists — it should see a closed modal, not throw.
+ */
+function withFallback<T>(source: Record<string, T>, fallback: T): Record<string, T> {
+	return new Proxy(source, {
+		get: (target, key) =>
+			typeof key === 'string' ? (target[key] ?? fallback) : Reflect.get(target, key),
+	});
+}
+
 export const useUIStore = defineStore(STORES.UI, () => {
 	const telemetry = useTelemetry();
 	const activeActions = ref<string[]>([]);
@@ -421,11 +437,21 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		} as const;
 	});
 
+	/**
+	 * Modal state by key, for reading. `modalsById` remains the writable state;
+	 * this is the accessor components should read through, because it tolerates a
+	 * key that is not registered.
+	 */
+	const modalStateById = computed(() => withFallback(modalsById.value, CLOSED_MODAL_STATE));
+
 	const isModalActiveById = computed(() =>
-		Object.keys(modalsById.value).reduce((acc: { [key: string]: boolean }, name) => {
-			acc[name] = name === modalStack.value[0];
-			return acc;
-		}, {}),
+		withFallback(
+			Object.keys(modalsById.value).reduce((acc: { [key: string]: boolean }, name) => {
+				acc[name] = name === modalStack.value[0];
+				return acc;
+			}, {}),
+			false,
+		),
 	);
 
 	const activeModals = computed(() => modalStack.value.map((modalName) => modalName));
@@ -769,6 +795,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		sidebarWidth,
 		theme: computed(() => theme.value),
 		modalsById,
+		modalStateById,
 		currentView,
 		isAnyModalOpen,
 		activeModals,

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -188,7 +188,7 @@ const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.document
 
 const contextNode = computed<INode | null>(() => {
 	if (ndvStore.value.activeNode) return ndvStore.value.activeNode;
-	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 	if (isCredentialModalState(modalState) && modalState.contextNode) {
 		return modalState.contextNode;
 	}
@@ -197,7 +197,7 @@ const contextNode = computed<INode | null>(() => {
 });
 
 const overrideProjectId = computed(() => {
-	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 	return isCredentialModalState(modalState) ? modalState.projectId : undefined;
 });
 
@@ -208,7 +208,7 @@ const form = useCredentialForm({
 	projectId: () => overrideProjectId.value,
 	showAuthSelector: () => requiredCredentials.value,
 	suggestedName: () => {
-		const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+		const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 		return isCredentialModalState(modalState) ? modalState.suggestedName : undefined;
 	},
 	// Scroll the auth-error/success banner into view after a test (parity with the
@@ -255,30 +255,30 @@ const {
 } = form;
 
 const hideAskAssistant = computed<boolean>(() => {
-	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 	return isCredentialModalState(modalState) && modalState.hideAskAssistant === true;
 });
 
 // The host's Instance AI credential-help behavior, stashed in the modal state by
 // whoever opened the modal (the editor capability or the credentials list).
 const instanceAiCredentialHelp = computed(() => {
-	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 	return isCredentialModalState(modalState) ? modalState.instanceAiCredentialHelp : undefined;
 });
 
 const closeOnSave = computed<boolean>(() => {
-	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 	return isCredentialModalState(modalState) && modalState.closeOnSave === true;
 });
 
 const presetUsageScope = computed<NewCredentialsModal['usageScope']>(() => {
 	if (props.mode !== 'new') return undefined;
-	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 	return isCredentialModalState(modalState) ? modalState.usageScope : undefined;
 });
 
 const appendToBody = computed<boolean>(() => {
-	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 	return isCredentialModalState(modalState) && modalState.appendToBody === true;
 });
 
@@ -349,7 +349,7 @@ const showSharingContent = computed(() => activeTab.value === 'sharing' && !!cre
 onMounted(async () => {
 	// Inner try isolates optional secrets loading; outer try catches all other initialization failures.
 	try {
-		const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+		const modalState = uiStore.modalStateById[CREDENTIAL_EDIT_MODAL_KEY];
 		requiredCredentials.value =
 			isCredentialModalState(modalState) && modalState.showAuthSelector === true;
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ImportCurlModal.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ImportCurlModal.vue
@@ -23,7 +23,7 @@ const modalBus = createEventBus();
 const inputRef = ref<{ focus: () => void; blur: () => void; select: () => void } | null>(null);
 
 onMounted(() => {
-	const curlCommands = uiStore.modalsById[IMPORT_CURL_MODAL_KEY].data?.curlCommands as Record<
+	const curlCommands = uiStore.modalStateById[IMPORT_CURL_MODAL_KEY].data?.curlCommands as Record<
 		string,
 		string
 	>;
@@ -59,7 +59,8 @@ function onImportFailure(data: { invalidProtocol: boolean; protocol?: string }) 
 function onAfterImport() {
 	const nodeId = ndvStore.value.activeNode?.id as string;
 	const curlCommands =
-		(uiStore.modalsById[IMPORT_CURL_MODAL_KEY].data?.curlCommands as Record<string, string>) ?? {};
+		(uiStore.modalStateById[IMPORT_CURL_MODAL_KEY].data?.curlCommands as Record<string, string>) ??
+		{};
 	curlCommands[nodeId] = curlCommand.value;
 	uiStore.setModalData({
 		name: IMPORT_CURL_MODAL_KEY,

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.ts
@@ -229,7 +229,8 @@ export async function resolveAutocompleteExpression(
 //        state-based utils
 // ----------------------------------
 
-export const isCredentialsModalOpen = () => useUIStore().modalsById[CREDENTIAL_EDIT_MODAL_KEY].open;
+export const isCredentialsModalOpen = () =>
+	useUIStore().modalStateById[CREDENTIAL_EDIT_MODAL_KEY].open;
 
 export const isInHttpNodePagination = (
 	workflowDocumentId: WorkflowDocumentId,


### PR DESCRIPTION
## Summary

Seam A of the modal-key inversion (CAT-3688): make late modal registration survivable. **Pure hardening — no user-visible change today.**

`ModalRoot.vue` dereferenced `uiStore.modalsById[name].open` with no guard, while `<AppModals />` renders on every route including `/signin` (no auth gate, `App.vue`) and module modals only register post-login (`init/index.ts`). Any key absent from `modalsById` therefore threw `TypeError: Cannot read properties of undefined (reading 'open')` on first paint — which is what would have happened to every user the moment a later seam removed a key from the store literal.

### 🔴 Zero modals change registration in this PR

The table of modals whose registration changed is **empty, by design** — stated explicitly rather than left to be inferred from the diff. No modal key moves, no `<ModalRoot>` block is removed, no descriptor gains or loses a `modals` entry, `modalsById`'s object literal is byte-identical, and `Modals.vue` is untouched. Every modal opens by exactly the path it did before.

### What changed

**Store (`ui.store.ts`)** — one internal helper, `withFallback`, returns a read-only view of a record in which an unknown key reads as a fallback instead of `undefined`. Applied twice:

- new `modalStateById` — modal state for reading; an unregistered key resolves to `{ open: false }`. `modalsById` stays the writable state (it must remain a plain `ref`: `createTestingPinia`'s `initialState` skips computeds, and ~29 test files stub `modalsById` through it).
- `isModalActiveById` — an unknown key now reports `false`, not `undefined`.

**All five unguarded readers** now go through `modalStateById`:

| # | Reader | Status before |
| --- | --- | --- |
| 1 | `app/components/ModalRoot.vue:24,28-31` | 🔴 live crash — 5 dereferences, incl. 3 reached even when `keepAlive` short-circuits the `v-if` |
| 2 | `features/ndv/parameters/components/ImportCurlModal.vue:26` | 🔴 live crash |
| 3 | `features/ndv/parameters/components/ImportCurlModal.vue:62` | 🔴 live crash |
| 4 | `features/shared/editors/plugins/codemirror/completions/utils.ts:232` | 🔴 live crash |
| 5 | `features/credentials/.../CredentialEdit.vue:191–352` (9 sites) | 🟡 **safe today, but only incidentally** — every site feeds the value into `isCredentialModalState(value: unknown)`, which returns `false` for `undefined`. Routed through the accessor anyway so the safety is structural, not a property of one type guard's signature. |

**SDK** — `modalRegistry.clear()`, matching the `clear()` on `commandRegistry` and `pushHandlerRegistry`. Its own test suite was hand-rolling teardown by iterating `getKeys()` precisely because this was missing; that `beforeEach` now calls `clear()`.

Scope note: `clear()` empties the registry, not the store's mirror of it — collapsing those two sources of truth is Seam B's job, not this PR's.

## How to test

No env vars, license, or feature flags needed — this is not gated.

```bash
pnpm --filter @n8n/frontend-module-sdk test    # 29 pass
pnpm --filter n8n-editor-ui test src/app/components/ModalRoot.test.ts src/app/stores/ui.store.test.ts
pnpm --filter n8n-editor-ui typecheck
```

**Proof the regression tests regress.** Reverting only `ModalRoot.vue` and re-running `ModalRoot.test.ts` gives **7 of 8 failures**, each `TypeError: Cannot read properties of undefined (reading 'open')` — the exact crash, reproduced.

**Manual check (no behaviour should change):** load `/signin` and confirm a clean console; then open the credential editor (from NDV and from the Credentials list), workflow settings (canvas menu and the `?settings=1` deep link), and the workflow-share modal — all should behave identically to master. The `Import cURL` modal in NDV exercises reader #2/#3, and expression-editor autocomplete inside an open credential modal exercises reader #4.

**Verification run on this branch**

| Check | Result |
| --- | --- |
| `@n8n/frontend-module-sdk` vitest | ✅ 29 passed (+4 new) |
| editor-ui vitest, new + all affected consumer suites | ✅ 166 files / 2155 tests passed |
| editor-ui vitest `src/features/shared/editors` | ✅ 29 files / 282 tests passed |
| editor-ui `vue-tsc --noEmit` | ✅ exit 0 |
| eslint (both packages) + biome | ✅ clean |

### Tests added

- `ModalRoot.test.ts` (new, 8 tests): unregistered key renders nothing; the **four auth modal keys `Modals.vue` renders on unauthenticated routes** (`changePassword`, `confirmPassword`, `mfaSetup`, `promptMfaCode`) render closed with an empty registry *and* empty store — the `/signin` first-paint regression; `keepAlive` + unregistered key renders the slot with a closed state; state reaches the slot once open; and a modal registered *after mount* opens correctly, which is the "registration order is no longer a correctness property" outcome.
  - Fidelity note: this covers `ModalRoot`, not a mounted `Modals.vue` — that file statically imports 62 components, so mounting it in a unit test buys brittleness rather than coverage. `ModalRoot` is the component that actually threw. Real first-paint verification stays with QA (CAT-3972).
- `ui.store.test.ts` (+5): `modalStateById` defaults, returns stored state, reflects late registration; `isModalActiveById` unknown-key default, and topmost-modal semantics unregressed.
- `modalRegistry.test.ts` (+4): `clear()` removes all / notifies subscribers / allows re-registration, and register-after-unregister.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3967 (this PR)
- https://linear.app/n8n/issue/CAT-3688 (parent — mechanism + component moves + ratchet)
- https://linear.app/n8n/issue/CAT-3680 (initiative)

Gating relationship: CAT-3968 / CAT-3969 / CAT-3973 all move modal keys, and none is safe to land before this one.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — no user-facing docs affected; the frontend-module guide is updated in the ratchet seam (CAT-3970)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported) — not needed, the crash is not reachable on master yet

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

