### PR TITLE
refactor(core): Migrate the workflow-reviews module to TransactionRunner (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/workflow-review-request-author.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow-review-request-author.repository.test.ts
@@ -4,6 +4,7 @@ import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { WorkflowReviewRequestAuthor } from '../../entities/workflow-review-request-author.ee';
+import { TypeOrmTransaction } from '../../services/typeorm-transaction';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { WorkflowReviewRequestAuthorRepository } from '../workflow-review-request-author.repository';
 
@@ -11,21 +12,27 @@ describe('WorkflowReviewRequestAuthorRepository', () => {
 	const entityManager = mockEntityManager(WorkflowReviewRequestAuthor);
 	const repo = Container.get(WorkflowReviewRequestAuthorRepository);
 
+	/** A transaction manager plus the context that resolves to it. */
+	const transacted = () => {
+		const transactionManager = mock<EntityManager>();
+		return { transactionManager, ctx: { trx: new TypeOrmTransaction(transactionManager) } };
+	};
+
 	beforeEach(() => {
 		vi.resetAllMocks();
 	});
 
 	describe('addAuthor', () => {
-		it('maps and saves the author through the provided transaction manager', async () => {
+		it("maps and saves the author through the context's transaction manager", async () => {
 			(entityManager.create as Mock).mockImplementation(
 				(_target: unknown, entityLike: unknown) => entityLike as WorkflowReviewRequestAuthor,
 			);
-			const trx = mock<EntityManager>();
-			trx.save.mockImplementation(async (_target, entity) => entity);
+			const { transactionManager, ctx } = transacted();
+			transactionManager.save.mockImplementation(async (_target, entity) => entity);
 
-			await repo.addAuthor({ workflowReviewRequestId: 'req-1', userId: 'user-1' }, trx);
+			await repo.addAuthor({ workflowReviewRequestId: 'req-1', userId: 'user-1' }, ctx);
 
-			expect(trx.save.mock.calls[0]?.[1]).toMatchObject({
+			expect(transactionManager.save.mock.calls[0]?.[1]).toMatchObject({
 				workflowReviewRequestId: 'req-1',
 				userId: 'user-1',
 			});
@@ -38,29 +45,29 @@ describe('WorkflowReviewRequestAuthorRepository', () => {
 			(entityManager.create as Mock).mockImplementation(
 				(_target: unknown, entityLike: unknown) => entityLike as WorkflowReviewRequestAuthor,
 			);
-			const trx = mock<EntityManager>();
-			trx.existsBy.mockResolvedValue(false);
-			trx.save.mockImplementation(async (_target, entity) => entity);
+			const { transactionManager, ctx } = transacted();
+			transactionManager.existsBy.mockResolvedValue(false);
+			transactionManager.save.mockImplementation(async (_target, entity) => entity);
 
-			await repo.addAuthorIfMissing({ workflowReviewRequestId: 'req-1', userId: 'user-1' }, trx);
+			await repo.addAuthorIfMissing({ workflowReviewRequestId: 'req-1', userId: 'user-1' }, ctx);
 
-			expect(trx.existsBy).toHaveBeenCalledWith(WorkflowReviewRequestAuthor, {
+			expect(transactionManager.existsBy).toHaveBeenCalledWith(WorkflowReviewRequestAuthor, {
 				workflowReviewRequestId: 'req-1',
 				userId: 'user-1',
 			});
-			expect(trx.save.mock.calls[0]?.[1]).toMatchObject({
+			expect(transactionManager.save.mock.calls[0]?.[1]).toMatchObject({
 				workflowReviewRequestId: 'req-1',
 				userId: 'user-1',
 			});
 		});
 
 		it('is a no-op when the author row already exists', async () => {
-			const trx = mock<EntityManager>();
-			trx.existsBy.mockResolvedValue(true);
+			const { transactionManager, ctx } = transacted();
+			transactionManager.existsBy.mockResolvedValue(true);
 
-			await repo.addAuthorIfMissing({ workflowReviewRequestId: 'req-1', userId: 'user-1' }, trx);
+			await repo.addAuthorIfMissing({ workflowReviewRequestId: 'req-1', userId: 'user-1' }, ctx);
 
-			expect(trx.save).not.toHaveBeenCalled();
+			expect(transactionManager.save).not.toHaveBeenCalled();
 			expect(entityManager.save).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/@n8n/db/src/repositories/__tests__/workflow-review-request-workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow-review-request-workflow.repository.test.ts
@@ -4,6 +4,7 @@ import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { WorkflowReviewRequestWorkflow } from '../../entities/workflow-review-request-workflow.ee';
+import { TypeOrmTransaction } from '../../services/typeorm-transaction';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { WorkflowReviewRequestWorkflowRepository } from '../workflow-review-request-workflow.repository';
 
@@ -22,12 +23,15 @@ describe('WorkflowReviewRequestWorkflowRepository', () => {
 			);
 			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
 
-			await repo.createWorkflowRow({
-				id: 'child-1',
-				workflowReviewRequestId: 'req-1',
-				workflowId: 'wf-1',
-				workflowVersionId: 'ver-1',
-			});
+			await repo.createWorkflowRow(
+				{
+					id: 'child-1',
+					workflowReviewRequestId: 'req-1',
+					workflowId: 'wf-1',
+					workflowVersionId: 'ver-1',
+				},
+				{},
+			);
 
 			const savedEntity = entityManager.save.mock.calls[0]?.[1];
 			expect(savedEntity).toMatchObject({
@@ -44,10 +48,13 @@ describe('WorkflowReviewRequestWorkflowRepository', () => {
 			);
 			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
 
-			await repo.createWorkflowRow({
-				workflowReviewRequestId: 'req-1',
-				workflowId: 'wf-1',
-			});
+			await repo.createWorkflowRow(
+				{
+					workflowReviewRequestId: 'req-1',
+					workflowId: 'wf-1',
+				},
+				{},
+			);
 
 			const savedEntity = entityManager.save.mock.calls[0]?.[1];
 			expect(savedEntity).toMatchObject({
@@ -58,11 +65,14 @@ describe('WorkflowReviewRequestWorkflowRepository', () => {
 
 	describe('updateWorkflowVersion', () => {
 		it('updates only the row matching the (requestId, workflowId) pair', async () => {
-			await repo.updateWorkflowVersion({
-				workflowReviewRequestId: 'req-1',
-				workflowId: 'wf-1',
-				workflowVersionId: 'ver-2',
-			});
+			await repo.updateWorkflowVersion(
+				{
+					workflowReviewRequestId: 'req-1',
+					workflowId: 'wf-1',
+					workflowVersionId: 'ver-2',
+				},
+				{},
+			);
 
 			expect(entityManager.update).toHaveBeenCalledWith(
 				WorkflowReviewRequestWorkflow,
@@ -71,15 +81,15 @@ describe('WorkflowReviewRequestWorkflowRepository', () => {
 			);
 		});
 
-		it('writes through the provided transaction manager', async () => {
-			const trx = mock<EntityManager>();
+		it("writes through the context's transaction manager", async () => {
+			const transactionManager = mock<EntityManager>();
 
 			await repo.updateWorkflowVersion(
 				{ workflowReviewRequestId: 'req-1', workflowId: 'wf-1', workflowVersionId: 'ver-2' },
-				trx,
+				{ trx: new TypeOrmTransaction(transactionManager) },
 			);
 
-			expect(trx.update).toHaveBeenCalledWith(
+			expect(transactionManager.update).toHaveBeenCalledWith(
 				WorkflowReviewRequestWorkflow,
 				{ workflowReviewRequestId: 'req-1', workflowId: 'wf-1' },
 				{ workflowVersionId: 'ver-2' },

--- a/packages/@n8n/db/src/repositories/__tests__/workflow-review-request.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow-review-request.repository.test.ts
@@ -4,6 +4,7 @@ import type { Mock, Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { WorkflowReviewRequest } from '../../entities/workflow-review-request.ee';
+import { TypeOrmTransaction } from '../../services/typeorm-transaction';
 import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
 import { WorkflowReviewRequestRepository } from '../workflow-review-request.repository';
 
@@ -39,13 +40,16 @@ describe('WorkflowReviewRequestRepository', () => {
 			);
 			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
 
-			await repo.createRequest({
-				id: 'req-1',
-				projectId: 'proj-1',
-				title: 'Review title',
-				description: 'Optional description',
-				createdById: 'user-1',
-			});
+			await repo.createRequest(
+				{
+					id: 'req-1',
+					projectId: 'proj-1',
+					title: 'Review title',
+					description: 'Optional description',
+					createdById: 'user-1',
+				},
+				{},
+			);
 
 			const savedEntity = entityManager.save.mock.calls[0]?.[1];
 			expect(savedEntity).toMatchObject({
@@ -68,12 +72,15 @@ describe('WorkflowReviewRequestRepository', () => {
 			);
 			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
 
-			await repo.createRequest({
-				projectId: 'proj-1',
-				title: 'Review title',
-				createdById: 'user-1',
-				updatedById: 'user-2',
-			});
+			await repo.createRequest(
+				{
+					projectId: 'proj-1',
+					title: 'Review title',
+					createdById: 'user-1',
+					updatedById: 'user-2',
+				},
+				{},
+			);
 
 			const savedEntity = entityManager.save.mock.calls[0]?.[1];
 			expect(savedEntity).toMatchObject({
@@ -201,15 +208,19 @@ describe('WorkflowReviewRequestRepository', () => {
 	});
 
 	describe('findById', () => {
-		it('reads through the provided transaction manager', async () => {
-			const trx = mock<EntityManager>();
+		it("reads through the context's transaction manager", async () => {
+			const transactionManager = mock<EntityManager>();
 			const request = mock<WorkflowReviewRequest>({ id: 'req-1' });
-			trx.findOne.mockResolvedValue(request);
+			transactionManager.findOne.mockResolvedValue(request);
 
-			const result = await repo.findById('req-1', trx);
+			const result = await repo.findById('req-1', {
+				trx: new TypeOrmTransaction(transactionManager),
+			});
 
 			expect(result).toBe(request);
-			expect(trx.findOne).toHaveBeenCalledWith(WorkflowReviewRequest, { where: { id: 'req-1' } });
+			expect(transactionManager.findOne).toHaveBeenCalledWith(WorkflowReviewRequest, {
+				where: { id: 'req-1' },
+			});
 			expect(entityManager.findOne).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/@n8n/db/src/repositories/workflow-review-request-author.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-review-request-author.repository.ts
@@ -1,11 +1,12 @@
 import { Service } from '@n8n/di';
-import type { EntityManager } from '@n8n/typeorm';
-import { DataSource, In, Repository } from '@n8n/typeorm';
+import { DataSource, In } from '@n8n/typeorm';
 
+import { BaseRepository } from './base-repository';
 import { WorkflowReviewRequestAuthor } from '../entities/workflow-review-request-author.ee';
+import type { OperationContext } from '../services/transaction';
 
 @Service()
-export class WorkflowReviewRequestAuthorRepository extends Repository<WorkflowReviewRequestAuthor> {
+export class WorkflowReviewRequestAuthorRepository extends BaseRepository<WorkflowReviewRequestAuthor> {
 	constructor(dataSource: DataSource) {
 		super(WorkflowReviewRequestAuthor, dataSource.manager);
 	}
@@ -15,15 +16,14 @@ export class WorkflowReviewRequestAuthorRepository extends Repository<WorkflowRe
 			workflowReviewRequestId: string;
 			userId: string;
 		},
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<WorkflowReviewRequestAuthor> {
-		const manager = trx ?? this.manager;
 		const entity = this.create({
 			workflowReviewRequestId: input.workflowReviewRequestId,
 			userId: input.userId,
 		});
 
-		return await manager.save(WorkflowReviewRequestAuthor, entity);
+		return await this.managerFor(ctx).save(WorkflowReviewRequestAuthor, entity);
 	}
 
 	/** Idempotent: checks the composite PK explicitly instead of relying on `save` upsert semantics. */
@@ -32,11 +32,11 @@ export class WorkflowReviewRequestAuthorRepository extends Repository<WorkflowRe
 			workflowReviewRequestId: string;
 			userId: string;
 		},
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<void> {
-		if (await this.isAuthor(input, trx)) return;
+		if (await this.isAuthor(input, ctx)) return;
 
-		await this.addAuthor(input, trx);
+		await this.addAuthor(input, ctx);
 	}
 
 	async isAuthor(
@@ -44,10 +44,9 @@ export class WorkflowReviewRequestAuthorRepository extends Repository<WorkflowRe
 			workflowReviewRequestId: string;
 			userId: string;
 		},
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<boolean> {
-		const manager = trx ?? this.manager;
-		return await manager.existsBy(WorkflowReviewRequestAuthor, {
+		return await this.managerFor(ctx).existsBy(WorkflowReviewRequestAuthor, {
 			workflowReviewRequestId: input.workflowReviewRequestId,
 			userId: input.userId,
 		});

--- a/packages/@n8n/db/src/repositories/workflow-review-request-reviewer.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-review-request-reviewer.repository.ts
@@ -1,11 +1,12 @@
 import { Service } from '@n8n/di';
-import type { EntityManager } from '@n8n/typeorm';
-import { DataSource, In, Repository } from '@n8n/typeorm';
+import { DataSource, In } from '@n8n/typeorm';
 
+import { BaseRepository } from './base-repository';
 import { WorkflowReviewRequestReviewer } from '../entities/workflow-review-request-reviewer.ee';
+import type { OperationContext } from '../services/transaction';
 
 @Service()
-export class WorkflowReviewRequestReviewerRepository extends Repository<WorkflowReviewRequestReviewer> {
+export class WorkflowReviewRequestReviewerRepository extends BaseRepository<WorkflowReviewRequestReviewer> {
 	constructor(dataSource: DataSource) {
 		super(WorkflowReviewRequestReviewer, dataSource.manager);
 	}
@@ -16,14 +17,13 @@ export class WorkflowReviewRequestReviewerRepository extends Repository<Workflow
 			workflowReviewRequestId: string;
 			userIds: string[];
 		},
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<WorkflowReviewRequestReviewer[]> {
 		const uniqueUserIds = [...new Set(input.userIds)];
 		if (uniqueUserIds.length === 0) {
 			return [];
 		}
 
-		const manager = trx ?? this.manager;
 		const entities = uniqueUserIds.map((userId) =>
 			this.create({
 				workflowReviewRequestId: input.workflowReviewRequestId,
@@ -31,7 +31,7 @@ export class WorkflowReviewRequestReviewerRepository extends Repository<Workflow
 			}),
 		);
 
-		return await manager.save(WorkflowReviewRequestReviewer, entities);
+		return await this.managerFor(ctx).save(WorkflowReviewRequestReviewer, entities);
 	}
 
 	async setReviewers(

--- a/packages/@n8n/db/src/repositories/workflow-review-request-workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-review-request-workflow.repository.ts
@@ -1,9 +1,10 @@
 import { Service } from '@n8n/di';
-import type { EntityManager } from '@n8n/typeorm';
-import { DataSource, Repository } from '@n8n/typeorm';
+import { DataSource } from '@n8n/typeorm';
 
+import { BaseRepository } from './base-repository';
 import { WorkflowEntity } from '../entities/workflow-entity';
 import { WorkflowReviewRequestWorkflow } from '../entities/workflow-review-request-workflow.ee';
+import type { OperationContext } from '../services/transaction';
 
 /** The review's linked workflow as shown in cross-request lists (inbox). */
 export type WorkflowReviewRequestLinkedWorkflow = {
@@ -18,7 +19,7 @@ export type WorkflowReviewRequestWorkflowDetailRow = {
 };
 
 @Service()
-export class WorkflowReviewRequestWorkflowRepository extends Repository<WorkflowReviewRequestWorkflow> {
+export class WorkflowReviewRequestWorkflowRepository extends BaseRepository<WorkflowReviewRequestWorkflow> {
 	constructor(dataSource: DataSource) {
 		super(WorkflowReviewRequestWorkflow, dataSource.manager);
 	}
@@ -30,9 +31,8 @@ export class WorkflowReviewRequestWorkflowRepository extends Repository<Workflow
 			workflowId: string;
 			workflowVersionId?: string | null;
 		},
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<WorkflowReviewRequestWorkflow> {
-		const manager = trx ?? this.manager;
 		const entity = this.create({
 			id: input.id,
 			workflowReviewRequestId: input.workflowReviewRequestId,
@@ -40,7 +40,7 @@ export class WorkflowReviewRequestWorkflowRepository extends Repository<Workflow
 			workflowVersionId: input.workflowVersionId ?? null,
 		});
 
-		return await manager.save(WorkflowReviewRequestWorkflow, entity);
+		return await this.managerFor(ctx).save(WorkflowReviewRequestWorkflow, entity);
 	}
 
 	/** Targets the (requestId, workflowId) pair so another workflow's row can never be re-pinned. */
@@ -50,10 +50,9 @@ export class WorkflowReviewRequestWorkflowRepository extends Repository<Workflow
 			workflowId: string;
 			workflowVersionId: string;
 		},
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<void> {
-		const manager = trx ?? this.manager;
-		await manager.update(
+		await this.managerFor(ctx).update(
 			WorkflowReviewRequestWorkflow,
 			{
 				workflowReviewRequestId: input.workflowReviewRequestId,
@@ -65,10 +64,9 @@ export class WorkflowReviewRequestWorkflowRepository extends Repository<Workflow
 
 	async findByRequestId(
 		requestId: string,
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<WorkflowReviewRequestWorkflow[]> {
-		const manager = trx ?? this.manager;
-		return await manager.find(WorkflowReviewRequestWorkflow, {
+		return await this.managerFor(ctx).find(WorkflowReviewRequestWorkflow, {
 			where: { workflowReviewRequestId: requestId },
 			order: { id: 'ASC' },
 		});

--- a/packages/@n8n/db/src/repositories/workflow-review-request.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-review-request.repository.ts
@@ -1,13 +1,15 @@
 import { Service } from '@n8n/di';
-import type { EntityManager, SelectQueryBuilder } from '@n8n/typeorm';
-import { DataSource, Repository } from '@n8n/typeorm';
+import type { SelectQueryBuilder } from '@n8n/typeorm';
+import { DataSource } from '@n8n/typeorm';
 
+import { BaseRepository } from './base-repository';
 import { WorkflowReviewRequestWorkflow } from '../entities/workflow-review-request-workflow.ee';
 import {
 	WorkflowReviewRequest,
 	type WorkflowReviewRequestDecision,
 	type WorkflowReviewRequestState,
 } from '../entities/workflow-review-request.ee';
+import type { OperationContext } from '../services/transaction';
 
 /**
  * Keyset pagination boundary. The caller carries `createdAt`/`id` in the cursor
@@ -60,7 +62,7 @@ export type InboxStateCounts = {
 };
 
 @Service()
-export class WorkflowReviewRequestRepository extends Repository<WorkflowReviewRequest> {
+export class WorkflowReviewRequestRepository extends BaseRepository<WorkflowReviewRequest> {
 	constructor(dataSource: DataSource) {
 		super(WorkflowReviewRequest, dataSource.manager);
 	}
@@ -76,9 +78,8 @@ export class WorkflowReviewRequestRepository extends Repository<WorkflowReviewRe
 			createdById: string | null;
 			updatedById?: string | null;
 		},
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<WorkflowReviewRequest> {
-		const manager = trx ?? this.manager;
 		const entity = this.create({
 			id: input.id,
 			projectId: input.projectId,
@@ -92,12 +93,22 @@ export class WorkflowReviewRequestRepository extends Repository<WorkflowReviewRe
 			approvedAt: null,
 		});
 
-		return await manager.save(WorkflowReviewRequest, entity);
+		return await this.managerFor(ctx).save(WorkflowReviewRequest, entity);
 	}
 
-	async findById(id: string, trx?: EntityManager): Promise<WorkflowReviewRequest | null> {
-		const manager = trx ?? this.manager;
-		return await manager.findOne(WorkflowReviewRequest, { where: { id } });
+	/**
+	 * Persists an already-loaded request. Deliberately `save` and not `update`, so the
+	 * entity's `@BeforeUpdate` hook bumps `updatedAt`.
+	 */
+	async saveRequest(
+		request: WorkflowReviewRequest,
+		ctx: OperationContext,
+	): Promise<WorkflowReviewRequest> {
+		return await this.managerFor(ctx).save(WorkflowReviewRequest, request);
+	}
+
+	async findById(id: string, ctx: OperationContext): Promise<WorkflowReviewRequest | null> {
+		return await this.managerFor(ctx).findOne(WorkflowReviewRequest, { where: { id } });
 	}
 
 	async findRequestsForWorkflow(
@@ -154,12 +165,11 @@ export class WorkflowReviewRequestRepository extends Repository<WorkflowReviewRe
 
 	async findOpenRequestForWorkflow(
 		workflowId: string,
-		trx?: EntityManager,
+		ctx: OperationContext,
 	): Promise<WorkflowReviewRequest | null> {
-		const manager = trx ?? this.manager;
 		const state: WorkflowReviewRequestState = 'open';
 
-		return await manager
+		return await this.managerFor(ctx)
 			.createQueryBuilder(WorkflowReviewRequest, 'request')
 			.innerJoin(
 				WorkflowReviewRequestWorkflow,

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.decide.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.decide.service.test.ts
@@ -15,9 +15,10 @@ import type {
 	WorkflowReviewRequestReviewerRepository,
 	WorkflowReviewRequestWorkflow,
 	WorkflowReviewRequestWorkflowRepository,
+	Transaction,
+	OperationContext,
 } from '@n8n/db';
 import { DbLock } from '@n8n/db';
-import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
 import type { CollaborationService } from '@/collaboration/collaboration.service';
@@ -60,7 +61,8 @@ describe('WorkflowReviewRequestService.decide', () => {
 	const collaborationService = mock<CollaborationService>();
 	const workflowService = mock<WorkflowService>();
 	const logger = mock<Logger>();
-	const tx = mock<EntityManager>();
+	/** The lock's context. Distinct from the root `{}` so tests can tell the two apart. */
+	const ctx: OperationContext = { trx: mock<Transaction>() };
 
 	const service = new WorkflowReviewRequestService(
 		logger,
@@ -116,7 +118,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 		);
 		authorRepository.isAuthor.mockResolvedValue(false);
 		projectRelationRepository.getAccessibleProjectsByRoles.mockResolvedValue([]);
-		tx.save.mockImplementation(async (entity) => entity);
+		requestRepository.saveRequest.mockImplementation(async (request) => request);
 	};
 
 	beforeEach(() => {
@@ -125,7 +127,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 		licenseState.isWorkflowReviewsLicensed.mockReturnValue(true);
 		workflowReviewPolicyService.get.mockResolvedValue({ enabled: true });
 		// By default, run the critical section against the mocked transaction.
-		dbLockService.withLock.mockImplementation(async (_id, fn) => await fn(tx, {}));
+		dbLockService.withLockContext.mockImplementation(async (_id, fn) => await fn(ctx));
 		collaborationService.broadcastWorkflowReviewStateChanged.mockResolvedValue(undefined);
 		collaborationService.broadcastWorkflowUpdate.mockResolvedValue(undefined);
 	});
@@ -138,7 +140,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 		);
 
 		expect(requestRepository.findById).not.toHaveBeenCalled();
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('throws NotFoundError when the review request does not exist', async () => {
@@ -148,7 +150,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 			NotFoundError,
 		);
 
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('throws NotFoundError when the request has no linked workflow row', async () => {
@@ -160,7 +162,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 		);
 
 		expect(workflowFinderService.findWorkflowForUser).not.toHaveBeenCalled();
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('throws NotFoundError when the user lacks publish access to the workflow', async () => {
@@ -176,7 +178,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 			expect.anything(),
 			['workflow:publish'],
 		);
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it.each([
@@ -190,7 +192,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 			ConflictError,
 		);
 
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	describe('author eligibility', () => {
@@ -203,7 +205,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 				ForbiddenError,
 			);
 
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		});
 
 		it('rejects a caller who became an author while waiting for the lock', async () => {
@@ -221,9 +223,9 @@ describe('WorkflowReviewRequestService.decide', () => {
 			expect(authorRepository.isAuthor).toHaveBeenNthCalledWith(
 				2,
 				expect.objectContaining({ workflowReviewRequestId: requestId }),
-				tx,
+				ctx,
 			);
-			expect(tx.save).not.toHaveBeenCalled();
+			expect(requestRepository.saveRequest).not.toHaveBeenCalled();
 		});
 
 		it.each([['global:admin'], ['global:owner']])(
@@ -263,7 +265,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 				ForbiddenError,
 			);
 
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		});
 
 		it('resolves the admin override once, before taking the lock', async () => {
@@ -275,7 +277,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 			// single-connection pool it would deadlock waiting for a second connection.
 			const [overrideOrder] =
 				projectRelationRepository.getAccessibleProjectsByRoles.mock.invocationCallOrder;
-			const [lockOrder] = dbLockService.withLock.mock.invocationCallOrder;
+			const [lockOrder] = dbLockService.withLockContext.mock.invocationCallOrder;
 			expect(overrideOrder).toBeLessThan(lockOrder);
 			expect(projectRelationRepository.getAccessibleProjectsByRoles).toHaveBeenCalledOnce();
 		});
@@ -286,13 +288,13 @@ describe('WorkflowReviewRequestService.decide', () => {
 
 		const result = await service.decide(memberUser(), requestId, approveDto);
 
-		expect(dbLockService.withLock).toHaveBeenCalledWith(
+		expect(dbLockService.withLockContext).toHaveBeenCalledWith(
 			DbLock.WORKFLOW_REVIEW_REQUEST_CREATE,
 			expect.any(Function),
 		);
 		// Re-checked under the lock through the transaction manager.
-		expect(requestRepository.findById).toHaveBeenCalledWith(requestId, tx);
-		const savedEntity = tx.save.mock.calls[0]?.[0] as unknown as WorkflowReviewRequest;
+		expect(requestRepository.findById).toHaveBeenCalledWith(requestId, ctx);
+		const savedEntity = requestRepository.saveRequest.mock.calls[0]?.[0];
 		expect(savedEntity).toMatchObject({
 			decision: 'approved',
 			state: 'closed',
@@ -317,7 +319,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 
 		const result = await service.decide(memberUser(), requestId, requestChangesDto);
 
-		const savedEntity = tx.save.mock.calls[0]?.[0] as unknown as WorkflowReviewRequest;
+		const savedEntity = requestRepository.saveRequest.mock.calls[0]?.[0];
 		expect(savedEntity).toMatchObject({
 			decision: 'changes_requested',
 			state: 'open',
@@ -337,7 +339,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 		const result = await service.decide(memberUser('user-2'), requestId, requestChangesDto);
 
 		expect(result.decision).toBe('changes_requested');
-		const savedEntity = tx.save.mock.calls[0]?.[0] as unknown as WorkflowReviewRequest;
+		const savedEntity = requestRepository.saveRequest.mock.calls[0]?.[0];
 		expect(savedEntity).toMatchObject({ updatedById: 'user-2' });
 	});
 
@@ -361,7 +363,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 			ConflictError,
 		);
 
-		expect(tx.save).not.toHaveBeenCalled();
+		expect(requestRepository.saveRequest).not.toHaveBeenCalled();
 		expect(collaborationService.broadcastWorkflowReviewStateChanged).not.toHaveBeenCalled();
 	});
 
@@ -374,7 +376,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 
 		const result = await service.decide(memberUser(), requestId, approveDto);
 
-		expect(workflowRepository.findByRequestId).toHaveBeenLastCalledWith(requestId, tx);
+		expect(workflowRepository.findByRequestId).toHaveBeenLastCalledWith(requestId, ctx);
 		expect(result.workflowVersionId).toBe('ver-2');
 		// The published version must be the one the approval was recorded against.
 		expect(workflowService.activateWorkflow).toHaveBeenCalledWith(
@@ -397,7 +399,7 @@ describe('WorkflowReviewRequestService.decide', () => {
 			);
 			// The approval must commit before publishing: the closed review is what
 			// lets the publish gate pass without a bypass.
-			const [lockOrder] = dbLockService.withLock.mock.invocationCallOrder;
+			const [lockOrder] = dbLockService.withLockContext.mock.invocationCallOrder;
 			const [publishOrder] = workflowService.activateWorkflow.mock.invocationCallOrder;
 			expect(lockOrder).toBeLessThan(publishOrder);
 			expect(result.autoPublish).toEqual({ status: 'published' });
@@ -427,7 +429,10 @@ describe('WorkflowReviewRequestService.decide', () => {
 			const result = await service.decide(memberUser(), requestId, approveDto);
 
 			// The approval is committed and never reverted by a publish failure.
-			expect(tx.save.mock.calls[0]?.[0]).toMatchObject({ decision: 'approved', state: 'closed' });
+			expect(requestRepository.saveRequest.mock.calls[0]?.[0]).toMatchObject({
+				decision: 'approved',
+				state: 'closed',
+			});
 			expect(result).toMatchObject({
 				state: 'closed',
 				decision: 'approved',

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.service.test.ts
@@ -23,7 +23,6 @@ import type {
 	Transaction,
 	OperationContext,
 } from '@n8n/db';
-import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
 import type { CollaborationService } from '@/collaboration/collaboration.service';
@@ -77,7 +76,6 @@ describe('WorkflowReviewRequestService', () => {
 	const collaborationService = mock<CollaborationService>();
 	const workflowService = mock<WorkflowService>();
 	const logger = mock<Logger>();
-	const tx = mock<EntityManager>();
 	/** The lock's context. Distinct from the root `{}` so tests can tell the two apart. */
 	const ctx: OperationContext = { trx: mock<Transaction>() };
 
@@ -108,7 +106,7 @@ describe('WorkflowReviewRequestService', () => {
 		// Feature enabled by default; the disabled path is exercised explicitly.
 		workflowReviewPolicyService.get.mockResolvedValue({ enabled: true });
 		// By default, run the critical section against the mocked transaction.
-		dbLockService.withLock.mockImplementation(async (_id, fn) => await fn(tx, ctx));
+		dbLockService.withLockContext.mockImplementation(async (_id, fn) => await fn(ctx));
 		collaborationService.broadcastWorkflowReviewStateChanged.mockResolvedValue(undefined);
 	});
 
@@ -138,7 +136,7 @@ describe('WorkflowReviewRequestService', () => {
 			await expect(service.create(user, dto)).rejects.toThrow(ForbiddenError);
 
 			expect(workflowFinderService.findWorkflowForUser).not.toHaveBeenCalled();
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		});
 
 		it('creates the review request, workflow reference, and author in one transaction', async () => {
@@ -161,7 +159,7 @@ describe('WorkflowReviewRequestService', () => {
 			const result = await service.create(user, dto);
 
 			expect(result.id).toBe('req-1');
-			expect(dbLockService.withLock).toHaveBeenCalledWith(
+			expect(dbLockService.withLockContext).toHaveBeenCalledWith(
 				DbLock.WORKFLOW_REVIEW_REQUEST_CREATE,
 				expect.any(Function),
 			);
@@ -172,15 +170,15 @@ describe('WorkflowReviewRequestService', () => {
 					description: 'A description',
 					createdById: 'user-1',
 				},
-				tx,
+				ctx,
 			);
 			expect(workflowRepository.createWorkflowRow).toHaveBeenCalledWith(
 				{ workflowReviewRequestId: 'req-1', workflowId: 'wf-1', workflowVersionId: 'ver-1' },
-				tx,
+				ctx,
 			);
 			expect(authorRepository.addAuthor).toHaveBeenCalledWith(
 				{ workflowReviewRequestId: 'req-1', userId: 'user-1' },
-				tx,
+				ctx,
 			);
 		});
 
@@ -192,7 +190,7 @@ describe('WorkflowReviewRequestService', () => {
 			expect(workflowFinderService.findWorkflowForUser).toHaveBeenCalledWith('wf-1', user, [
 				'workflow:publish',
 			]);
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		});
 
 		it('throws BadRequestError and never takes the lock for an archived workflow', async () => {
@@ -201,7 +199,7 @@ describe('WorkflowReviewRequestService', () => {
 			);
 
 			await expect(service.create(user, dto)).rejects.toThrow(BadRequestError);
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		});
 
 		it('throws BadRequestError and never takes the lock when the version does not exist', async () => {
@@ -211,7 +209,7 @@ describe('WorkflowReviewRequestService', () => {
 			workflowHistoryService.findVersion.mockResolvedValue(null);
 
 			await expect(service.create(user, dto)).rejects.toThrow(BadRequestError);
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		});
 
 		it('throws NotFoundError when the workflow has no owning project', async () => {
@@ -222,7 +220,7 @@ describe('WorkflowReviewRequestService', () => {
 			sharedWorkflowRepository.getWorkflowOwningProject.mockResolvedValue(undefined);
 
 			await expect(service.create(user, dto)).rejects.toThrow(NotFoundError);
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		});
 
 		it('throws ConflictError carrying the existing id and writes nothing when an open review exists', async () => {
@@ -265,7 +263,7 @@ describe('WorkflowReviewRequestService', () => {
 
 				expect(reviewerRepository.addReviewers).toHaveBeenCalledWith(
 					{ workflowReviewRequestId: 'req-1', userIds: ['user-2', 'user-3'] },
-					tx,
+					ctx,
 				);
 			});
 
@@ -277,7 +275,7 @@ describe('WorkflowReviewRequestService', () => {
 				);
 
 				expect(userRepository.findEligibleByProjectOrGlobalRoles).not.toHaveBeenCalled();
-				expect(dbLockService.withLock).not.toHaveBeenCalled();
+				expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 			});
 
 			it('rejects reviewers outside the eligible set before taking the lock, naming them', async () => {
@@ -288,7 +286,7 @@ describe('WorkflowReviewRequestService', () => {
 					service.create(user, { ...dto, reviewerUserIds: ['user-2', 'user-99'] }),
 				).rejects.toThrow('These users are not eligible to review this workflow: user-99');
 
-				expect(dbLockService.withLock).not.toHaveBeenCalled();
+				expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 			});
 
 			it('rejects a pending user as reviewer even when their role qualifies', async () => {
@@ -363,8 +361,8 @@ describe('WorkflowReviewRequestService', () => {
 			it('broadcasts exactly once after the lock resolves', async () => {
 				mockSuccessfulCreatePath();
 				let lockResolved = false;
-				dbLockService.withLock.mockImplementation(async (_id, fn) => {
-					const result = await fn(tx, {});
+				dbLockService.withLockContext.mockImplementation(async (_id, fn) => {
+					const result = await fn(ctx);
 					lockResolved = true;
 					return result;
 				});

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.update.service.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-request.update.service.test.ts
@@ -19,7 +19,6 @@ import type {
 	Transaction,
 	OperationContext,
 } from '@n8n/db';
-import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'vitest-mock-extended';
 
 import type { CollaborationService } from '@/collaboration/collaboration.service';
@@ -65,7 +64,6 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 	const collaborationService = mock<CollaborationService>();
 	const workflowService = mock<WorkflowService>();
 	const logger = mock<Logger>();
-	const tx = mock<EntityManager>();
 	/** The lock's context. Distinct from the root `{}` so tests can tell the two apart. */
 	const ctx: OperationContext = { trx: mock<Transaction>() };
 
@@ -113,7 +111,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 		);
 		workflowHistoryService.findVersion.mockResolvedValue(mock());
 		workflowHistoryRepository.updateVersionName.mockResolvedValue(1);
-		tx.save.mockImplementation(async (entity) => entity);
+		requestRepository.saveRequest.mockImplementation(async (request) => request);
 	};
 
 	beforeEach(() => {
@@ -122,7 +120,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 		licenseState.isWorkflowReviewsLicensed.mockReturnValue(true);
 		workflowReviewPolicyService.get.mockResolvedValue({ enabled: true });
 		// By default, run the critical section against the mocked transaction.
-		dbLockService.withLock.mockImplementation(async (_id, fn) => await fn(tx, ctx));
+		dbLockService.withLockContext.mockImplementation(async (_id, fn) => await fn(ctx));
 		collaborationService.broadcastWorkflowReviewStateChanged.mockResolvedValue(undefined);
 	});
 
@@ -133,7 +131,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 
 		expect(requestRepository.findById).not.toHaveBeenCalled();
 		expect(workflowFinderService.findWorkflowForUser).not.toHaveBeenCalled();
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('throws NotFoundError when the review request does not exist', async () => {
@@ -141,7 +139,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 
 		await expect(service.updateVersion(user, requestId, dto)).rejects.toThrow(NotFoundError);
 
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('throws NotFoundError when the request does not cover the given workflow', async () => {
@@ -153,7 +151,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 		await expect(service.updateVersion(user, requestId, dto)).rejects.toThrow(NotFoundError);
 
 		expect(workflowFinderService.findWorkflowForUser).not.toHaveBeenCalled();
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('throws NotFoundError when the user lacks publish access to the workflow', async () => {
@@ -165,7 +163,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 		expect(workflowFinderService.findWorkflowForUser).toHaveBeenCalledWith('wf-1', user, [
 			'workflow:publish',
 		]);
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('throws BadRequestError and never takes the lock for an archived workflow', async () => {
@@ -176,7 +174,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 
 		await expect(service.updateVersion(user, requestId, dto)).rejects.toThrow(BadRequestError);
 
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it.each([
@@ -188,7 +186,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 
 		await expect(service.updateVersion(user, requestId, dto)).rejects.toThrow(ConflictError);
 
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('throws BadRequestError and never takes the lock when the version does not exist', async () => {
@@ -198,7 +196,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 		await expect(service.updateVersion(user, requestId, dto)).rejects.toThrow(BadRequestError);
 
 		expect(workflowHistoryService.findVersion).toHaveBeenCalledWith('wf-1', 'ver-2');
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 	});
 
 	it('returns the current summary without lock, writes, or broadcast when the version is unchanged', async () => {
@@ -221,7 +219,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 			createdAt: '2026-07-20T10:00:00.000Z',
 			updatedAt: '2026-07-20T11:00:00.000Z',
 		});
-		expect(dbLockService.withLock).not.toHaveBeenCalled();
+		expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		expect(workflowRepository.updateWorkflowVersion).not.toHaveBeenCalled();
 		expect(authorRepository.addAuthorIfMissing).not.toHaveBeenCalled();
 		expect(collaborationService.broadcastWorkflowReviewStateChanged).not.toHaveBeenCalled();
@@ -232,21 +230,23 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 
 		const result = await service.updateVersion(user, requestId, dto);
 
-		expect(dbLockService.withLock).toHaveBeenCalledWith(
+		expect(dbLockService.withLockContext).toHaveBeenCalledWith(
 			DbLock.WORKFLOW_REVIEW_REQUEST_CREATE,
 			expect.any(Function),
 		);
 		// Re-checked under the lock through the transaction manager.
-		expect(requestRepository.findById).toHaveBeenCalledWith(requestId, tx);
+		expect(requestRepository.findById).toHaveBeenCalledWith(requestId, ctx);
 		expect(workflowRepository.updateWorkflowVersion).toHaveBeenCalledWith(
 			{ workflowReviewRequestId: requestId, workflowId: 'wf-1', workflowVersionId: 'ver-2' },
-			tx,
+			ctx,
 		);
-		const savedEntity = tx.save.mock.calls[0]?.[0] as unknown as WorkflowReviewRequest;
-		expect(savedEntity).toMatchObject({ decision: 'pending', updatedById: 'user-1' });
+		expect(requestRepository.saveRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ decision: 'pending', updatedById: 'user-1' }),
+			ctx,
+		);
 		expect(authorRepository.addAuthorIfMissing).toHaveBeenCalledWith(
 			{ workflowReviewRequestId: requestId, userId: 'user-1' },
-			tx,
+			ctx,
 		);
 		expect(result).toEqual({
 			id: requestId,
@@ -267,7 +267,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 		await expect(service.updateVersion(user, requestId, dto)).rejects.toThrow(ConflictError);
 
 		expect(workflowRepository.updateWorkflowVersion).not.toHaveBeenCalled();
-		expect(tx.save).not.toHaveBeenCalled();
+		expect(requestRepository.saveRequest).not.toHaveBeenCalled();
 		expect(authorRepository.addAuthorIfMissing).not.toHaveBeenCalled();
 	});
 
@@ -292,10 +292,10 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 
 		const result = await service.updateVersion(user, requestId, dto);
 
-		expect(workflowRepository.findByRequestId).toHaveBeenLastCalledWith(requestId, tx);
+		expect(workflowRepository.findByRequestId).toHaveBeenLastCalledWith(requestId, ctx);
 		expect(result.workflowVersionId).toBe('ver-2');
 		expect(workflowRepository.updateWorkflowVersion).not.toHaveBeenCalled();
-		expect(tx.save).not.toHaveBeenCalled();
+		expect(requestRepository.saveRequest).not.toHaveBeenCalled();
 		expect(authorRepository.addAuthorIfMissing).not.toHaveBeenCalled();
 		expect(collaborationService.broadcastWorkflowReviewStateChanged).not.toHaveBeenCalled();
 	});
@@ -361,7 +361,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 				// Root context, not the lock's — this path deliberately runs untransacted.
 				{},
 			);
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 			expect(collaborationService.broadcastWorkflowReviewStateChanged).not.toHaveBeenCalled();
 		});
 
@@ -371,7 +371,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 			await service.updateVersion(user, requestId, { ...dto, workflowVersionName: 'Same name' });
 
 			expect(workflowHistoryRepository.updateVersionName).not.toHaveBeenCalled();
-			expect(dbLockService.withLock).not.toHaveBeenCalled();
+			expect(dbLockService.withLockContext).not.toHaveBeenCalled();
 		});
 
 		it('still names the version when a concurrent sync re-pinned it first', async () => {
@@ -405,7 +405,7 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 			);
 			// The re-pin itself stays skipped — only the name was outstanding.
 			expect(workflowRepository.updateWorkflowVersion).not.toHaveBeenCalled();
-			expect(tx.save).not.toHaveBeenCalled();
+			expect(requestRepository.saveRequest).not.toHaveBeenCalled();
 		});
 	});
 
@@ -413,8 +413,8 @@ describe('WorkflowReviewRequestService.updateVersion', () => {
 		it('broadcasts exactly once after the lock resolves', async () => {
 			mockSuccessfulUpdatePath();
 			let lockResolved = false;
-			dbLockService.withLock.mockImplementation(async (_id, fn) => {
-				const result = await fn(tx, {});
+			dbLockService.withLockContext.mockImplementation(async (_id, fn) => {
+				const result = await fn(ctx);
 				lockResolved = true;
 				return result;
 			});

--- a/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-requests.controller.integration.test.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/__tests__/workflow-review-requests.controller.integration.test.ts
@@ -132,21 +132,30 @@ async function createOpenReview(
 	versionId: string,
 	decision: 'pending' | 'changes_requested' = 'pending',
 ) {
-	const request = await requestRepository.createRequest({
-		projectId: ownerProject.id,
-		title: 'Review before publishing',
-		createdById: owner.id,
-		decision,
-	});
-	await workflowRepository.createWorkflowRow({
-		workflowReviewRequestId: request.id,
-		workflowId,
-		workflowVersionId: versionId,
-	});
-	await authorRepository.addAuthor({
-		workflowReviewRequestId: request.id,
-		userId: owner.id,
-	});
+	const request = await requestRepository.createRequest(
+		{
+			projectId: ownerProject.id,
+			title: 'Review before publishing',
+			createdById: owner.id,
+			decision,
+		},
+		{},
+	);
+	await workflowRepository.createWorkflowRow(
+		{
+			workflowReviewRequestId: request.id,
+			workflowId,
+			workflowVersionId: versionId,
+		},
+		{},
+	);
+	await authorRepository.addAuthor(
+		{
+			workflowReviewRequestId: request.id,
+			userId: owner.id,
+		},
+		{},
+	);
 	return request;
 }
 
@@ -490,16 +499,22 @@ describe('POST /workflow-review-requests', () => {
 		const { workflow } = await createReviewableWorkflow('version-1');
 		await createWorkflowHistoryItem(workflow.id, { versionId: 'version-2' });
 
-		const existing = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			title: 'Existing',
-			createdById: owner.id,
-		});
-		await workflowRepository.createWorkflowRow({
-			workflowReviewRequestId: existing.id,
-			workflowId: workflow.id,
-			workflowVersionId: 'version-1',
-		});
+		const existing = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				title: 'Existing',
+				createdById: owner.id,
+			},
+			{},
+		);
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: existing.id,
+				workflowId: workflow.id,
+				workflowVersionId: 'version-1',
+			},
+			{},
+		);
 
 		const response = await ownerAgent
 			.post('/workflow-review-requests')
@@ -525,18 +540,24 @@ describe('POST /workflow-review-requests', () => {
 	test('returns 409 when the existing open review is already approved', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
 
-		const existing = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			state: 'open',
-			decision: 'approved',
-			title: 'Existing',
-			createdById: owner.id,
-		});
-		await workflowRepository.createWorkflowRow({
-			workflowReviewRequestId: existing.id,
-			workflowId: workflow.id,
-			workflowVersionId: versionId,
-		});
+		const existing = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				state: 'open',
+				decision: 'approved',
+				title: 'Existing',
+				createdById: owner.id,
+			},
+			{},
+		);
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: existing.id,
+				workflowId: workflow.id,
+				workflowVersionId: versionId,
+			},
+			{},
+		);
 
 		const response = await ownerAgent
 			.post('/workflow-review-requests')
@@ -558,17 +579,23 @@ describe('POST /workflow-review-requests', () => {
 	test('creates a new review when only a closed review exists', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
 
-		const closed = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			state: 'closed',
-			title: 'Closed',
-			createdById: owner.id,
-		});
-		await workflowRepository.createWorkflowRow({
-			workflowReviewRequestId: closed.id,
-			workflowId: workflow.id,
-			workflowVersionId: versionId,
-		});
+		const closed = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				state: 'closed',
+				title: 'Closed',
+				createdById: owner.id,
+			},
+			{},
+		);
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: closed.id,
+				workflowId: workflow.id,
+				workflowVersionId: versionId,
+			},
+			{},
+		);
 
 		await ownerAgent
 			.post('/workflow-review-requests')
@@ -910,18 +937,27 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/update-version
 		projectId = ownerProject.id,
 		overrides: { state?: 'open' | 'closed'; decision?: 'pending' | 'changes_requested' } = {},
 	) {
-		const request = await requestRepository.createRequest({
-			projectId,
-			title: 'Existing review',
-			createdById: author.id,
-			...overrides,
-		});
-		await workflowRepository.createWorkflowRow({
-			workflowReviewRequestId: request.id,
-			workflowId,
-			workflowVersionId: versionId,
-		});
-		await authorRepository.addAuthor({ workflowReviewRequestId: request.id, userId: author.id });
+		const request = await requestRepository.createRequest(
+			{
+				projectId,
+				title: 'Existing review',
+				createdById: author.id,
+				...overrides,
+			},
+			{},
+		);
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: request.id,
+				workflowId,
+				workflowVersionId: versionId,
+			},
+			{},
+		);
+		await authorRepository.addAuthor(
+			{ workflowReviewRequestId: request.id, userId: author.id },
+			{},
+		);
 		return request;
 	}
 
@@ -955,7 +991,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/update-version
 		expect(childRows).toHaveLength(1);
 		expect(childRows[0]).toMatchObject({ workflowVersionId: 'version-2' });
 
-		const updated = await requestRepository.findById(request.id);
+		const updated = await requestRepository.findById(request.id, {});
 		expect(updated).toMatchObject({ decision: 'pending', updatedById: owner.id });
 
 		const authorRows = await authorRepository.find();
@@ -981,7 +1017,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/update-version
 		const authorRows = await authorRepository.find();
 		expect(authorRows.map((row) => row.userId).sort()).toEqual([member.id, owner.id].sort());
 
-		const updated = await requestRepository.findById(request.id);
+		const updated = await requestRepository.findById(request.id, {});
 		expect(updated).toMatchObject({ updatedById: member.id });
 	});
 
@@ -1007,7 +1043,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/update-version
 			workflowVersionId: versionId,
 		});
 
-		const unchanged = await requestRepository.findById(request.id);
+		const unchanged = await requestRepository.findById(request.id, {});
 		expect(unchanged?.updatedAt).toEqual(request.updatedAt);
 		expect(unchanged?.decision).toBe('changes_requested');
 	});
@@ -1176,7 +1212,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/update-version
 
 			expect(await findVersionName(workflow.id, versionId)).toBe('Renamed');
 			// Still a no-op for the review itself.
-			const unchanged = await requestRepository.findById(request.id);
+			const unchanged = await requestRepository.findById(request.id, {});
 			expect(unchanged?.updatedAt).toEqual(request.updatedAt);
 		});
 
@@ -1219,18 +1255,27 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/decision', () 
 	) {
 		const workflow = await createWorkflow({}, teamProject);
 		await createWorkflowHistoryItem(workflow.id, { versionId: 'version-1' });
-		const request = await requestRepository.createRequest({
-			projectId: teamProject.id,
-			title: 'Review me',
-			createdById: author.id,
-			...overrides,
-		});
-		await workflowRepository.createWorkflowRow({
-			workflowReviewRequestId: request.id,
-			workflowId: workflow.id,
-			workflowVersionId: 'version-1',
-		});
-		await authorRepository.addAuthor({ workflowReviewRequestId: request.id, userId: author.id });
+		const request = await requestRepository.createRequest(
+			{
+				projectId: teamProject.id,
+				title: 'Review me',
+				createdById: author.id,
+				...overrides,
+			},
+			{},
+		);
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: request.id,
+				workflowId: workflow.id,
+				workflowVersionId: 'version-1',
+			},
+			{},
+		);
+		await authorRepository.addAuthor(
+			{ workflowReviewRequestId: request.id, userId: author.id },
+			{},
+		);
 		return { request, workflow };
 	}
 
@@ -1257,7 +1302,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/decision', () 
 		// updatedAt — assert the timestamp actually moves.
 		expect(new Date(response.body.data.updatedAt).getTime()).toBeGreaterThan(seededUpdatedAt);
 
-		const updated = await requestRepository.findById(request.id);
+		const updated = await requestRepository.findById(request.id, {});
 		expect(updated).toMatchObject({
 			state: 'closed',
 			decision: 'approved',
@@ -1302,7 +1347,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/decision', () 
 			(await workflowEntityRepository.findOneByOrFail({ id: workflow.id })).activeVersionId,
 		).toBeNull();
 
-		const updated = await requestRepository.findById(request.id);
+		const updated = await requestRepository.findById(request.id, {});
 		expect(updated).toMatchObject({
 			state: 'open',
 			decision: 'changes_requested',
@@ -1320,7 +1365,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/decision', () 
 			.send({ decision: 'approved' })
 			.expect(200);
 
-		expect(await requestRepository.findById(request.id)).toMatchObject({
+		expect(await requestRepository.findById(request.id, {})).toMatchObject({
 			state: 'closed',
 			decision: 'approved',
 		});
@@ -1334,7 +1379,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/decision', () 
 			.send({ decision: 'changes_requested' })
 			.expect(200);
 
-		expect(await requestRepository.findById(request.id)).toMatchObject({
+		expect(await requestRepository.findById(request.id, {})).toMatchObject({
 			state: 'open',
 			decision: 'changes_requested',
 			updatedById: member.id,
@@ -1349,7 +1394,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/decision', () 
 			.send({ decision: 'approved' })
 			.expect(403);
 
-		expect(await requestRepository.findById(request.id)).toMatchObject({
+		expect(await requestRepository.findById(request.id, {})).toMatchObject({
 			state: 'open',
 			decision: 'pending',
 		});
@@ -1492,7 +1537,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/decision', () 
 		]);
 
 		expect([first.status, second.status].sort()).toEqual([200, 409]);
-		expect(await requestRepository.findById(request.id)).toMatchObject({
+		expect(await requestRepository.findById(request.id, {})).toMatchObject({
 			state: 'closed',
 			decision: 'approved',
 		});
@@ -1518,7 +1563,7 @@ describe('POST /workflow-review-requests/:workflowReviewRequestId/decision', () 
 		expect(decide.status).toBe(200);
 		expect([200, 409]).toContain(sync.status);
 
-		const final = await requestRepository.findById(request.id);
+		const final = await requestRepository.findById(request.id, {});
 		expect(final?.state === 'closed' && final?.decision === 'pending').toBe(false);
 		expect(final).toMatchObject({ state: 'closed', decision: 'approved' });
 	});
@@ -1658,11 +1703,14 @@ describe('GET /workflow-review-requests/eligible-reviewers', () => {
 describe('GET /workflow-review-requests', () => {
 	/** Link an existing review request to a workflow. */
 	async function linkRequestToWorkflow(requestId: string, workflowId: string, versionId: string) {
-		await workflowRepository.createWorkflowRow({
-			workflowReviewRequestId: requestId,
-			workflowId,
-			workflowVersionId: versionId,
-		});
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: requestId,
+				workflowId,
+				workflowVersionId: versionId,
+			},
+			{},
+		);
 	}
 
 	test('returns 400 without a workflowId', async () => {
@@ -1682,14 +1730,17 @@ describe('GET /workflow-review-requests', () => {
 
 	test('returns the open request as a minimal summary with state=open&take=1', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
-		const request = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			title: 'Confidential title',
-			description: 'Confidential description',
-			createdById: owner.id,
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				title: 'Confidential title',
+				description: 'Confidential description',
+				createdById: owner.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(request.id, workflow.id, versionId);
-		await authorRepository.addAuthor({ workflowReviewRequestId: request.id, userId: owner.id });
+		await authorRepository.addAuthor({ workflowReviewRequestId: request.id, userId: owner.id }, {});
 
 		const response = await ownerAgent
 			.get('/workflow-review-requests')
@@ -1714,19 +1765,25 @@ describe('GET /workflow-review-requests', () => {
 
 	test('returns the newest review, closed included, with take=1 and no state filter', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
-		const older = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			state: 'closed',
-			title: 'Older',
-			createdById: owner.id,
-		});
+		const older = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				state: 'closed',
+				title: 'Older',
+				createdById: owner.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(older.id, workflow.id, versionId);
-		const newest = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			state: 'open',
-			title: 'Newest',
-			createdById: owner.id,
-		});
+		const newest = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				state: 'open',
+				title: 'Newest',
+				createdById: owner.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(newest.id, workflow.id, versionId);
 		// Both rows are created within the same millisecond, so state the age
 		// explicitly instead of asserting against a timestamp tie.
@@ -1744,13 +1801,16 @@ describe('GET /workflow-review-requests', () => {
 
 	test('resolves the actor of a changes-requested decision', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
-		const request = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			decision: 'changes_requested',
-			title: 'Needs work',
-			createdById: owner.id,
-			updatedById: member.id,
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				decision: 'changes_requested',
+				title: 'Needs work',
+				createdById: owner.id,
+				updatedById: member.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(request.id, workflow.id, versionId);
 
 		const response = await ownerAgent
@@ -1773,13 +1833,16 @@ describe('GET /workflow-review-requests', () => {
 	test('returns no actor when the deciding user was deleted', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
 		const reviewer = await createMember();
-		const request = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			decision: 'changes_requested',
-			title: 'Needs work',
-			createdById: owner.id,
-			updatedById: reviewer.id,
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				decision: 'changes_requested',
+				title: 'Needs work',
+				createdById: owner.id,
+				updatedById: reviewer.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(request.id, workflow.id, versionId);
 		await userRepository.delete(reviewer.id);
 
@@ -1796,14 +1859,17 @@ describe('GET /workflow-review-requests', () => {
 
 	test('reports an approved version that was never published', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
-		const request = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			state: 'closed',
-			decision: 'approved',
-			title: 'Approved',
-			createdById: owner.id,
-			updatedById: member.id,
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				state: 'closed',
+				decision: 'approved',
+				title: 'Approved',
+				createdById: owner.id,
+				updatedById: member.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(request.id, workflow.id, versionId);
 
 		const response = await ownerAgent
@@ -1822,13 +1888,16 @@ describe('GET /workflow-review-requests', () => {
 
 	test('reports an approved version that has been published', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
-		const request = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			state: 'closed',
-			decision: 'approved',
-			title: 'Approved',
-			createdById: owner.id,
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				state: 'closed',
+				decision: 'approved',
+				title: 'Approved',
+				createdById: owner.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(request.id, workflow.id, versionId);
 		await publishHistoryRepository.addRecord({
 			workflowId: workflow.id,
@@ -1849,12 +1918,15 @@ describe('GET /workflow-review-requests', () => {
 
 	test('excludes closed-only history with state=open, includes it without the filter', async () => {
 		const { workflow, versionId } = await createReviewableWorkflow();
-		const closed = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			state: 'closed',
-			title: 'Closed',
-			createdById: owner.id,
-		});
+		const closed = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				state: 'closed',
+				title: 'Closed',
+				createdById: owner.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(closed.id, workflow.id, versionId);
 
 		const openResponse = await ownerAgent
@@ -1874,11 +1946,14 @@ describe('GET /workflow-review-requests', () => {
 	test('does not include requests of other workflows', async () => {
 		const { workflow } = await createReviewableWorkflow();
 		const { workflow: otherWorkflow } = await createReviewableWorkflow('version-other');
-		const request = await requestRepository.createRequest({
-			projectId: ownerProject.id,
-			title: 'For the other workflow',
-			createdById: owner.id,
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: ownerProject.id,
+				title: 'For the other workflow',
+				createdById: owner.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(request.id, otherWorkflow.id, 'version-other');
 
 		const response = await ownerAgent
@@ -1903,11 +1978,14 @@ describe('GET /workflow-review-requests', () => {
 		await linkUserToProject(member, project, 'project:viewer');
 		const workflow = await createWorkflow({}, project);
 		await createWorkflowHistoryItem(workflow.id, { versionId: 'version-1' });
-		const request = await requestRepository.createRequest({
-			projectId: project.id,
-			title: 'Open review',
-			createdById: owner.id,
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: project.id,
+				title: 'Open review',
+				createdById: owner.id,
+			},
+			{},
+		);
 		await linkRequestToWorkflow(request.id, workflow.id, 'version-1');
 
 		const response = await memberAgent
@@ -1939,18 +2017,24 @@ describe('GET /workflow-review-requests', () => {
 });
 
 async function seedInboxRequests() {
-	const openRequest = await requestRepository.createRequest({
-		projectId: teamProject.id,
-		title: 'Open review request',
-		createdById: owner.id,
-		state: 'open',
-	});
-	const closedRequest = await requestRepository.createRequest({
-		projectId: teamProject.id,
-		title: 'Closed review request',
-		createdById: owner.id,
-		state: 'closed',
-	});
+	const openRequest = await requestRepository.createRequest(
+		{
+			projectId: teamProject.id,
+			title: 'Open review request',
+			createdById: owner.id,
+			state: 'open',
+		},
+		{},
+	);
+	const closedRequest = await requestRepository.createRequest(
+		{
+			projectId: teamProject.id,
+			title: 'Closed review request',
+			createdById: owner.id,
+			state: 'closed',
+		},
+		{},
+	);
 	return { openRequest, closedRequest };
 }
 
@@ -1980,12 +2064,15 @@ describe('GET /workflow-review-requests/summary', () => {
 	});
 
 	test('counts a requester their own review regardless of project scope', async () => {
-		await requestRepository.createRequest({
-			projectId: teamProject.id,
-			title: 'Review submitted by viewer',
-			createdById: viewer.id,
-			state: 'open',
-		});
+		await requestRepository.createRequest(
+			{
+				projectId: teamProject.id,
+				title: 'Review submitted by viewer',
+				createdById: viewer.id,
+				state: 'open',
+			},
+			{},
+		);
 
 		const response = await viewerAgent.get('/workflow-review-requests/summary').expect(200);
 
@@ -2037,12 +2124,15 @@ describe('GET /workflow-review-requests/inbox', () => {
 
 	test('returns cursor pagination metadata', async () => {
 		await seedInboxRequests();
-		await requestRepository.createRequest({
-			projectId: teamProject.id,
-			title: 'Second open review',
-			createdById: owner.id,
-			state: 'open',
-		});
+		await requestRepository.createRequest(
+			{
+				projectId: teamProject.id,
+				title: 'Second open review',
+				createdById: owner.id,
+				state: 'open',
+			},
+			{},
+		);
 
 		const firstPage = await ownerAgent
 			.get('/workflow-review-requests/inbox')
@@ -2068,17 +2158,23 @@ describe('GET /workflow-review-requests/inbox', () => {
 
 	test('includes workflow name on list items', async () => {
 		const workflow = await createWorkflow({ name: 'Inbox Workflow' }, teamProject);
-		const enrichedRequest = await requestRepository.createRequest({
-			projectId: teamProject.id,
-			title: 'Enriched review request',
-			createdById: owner.id,
-			state: 'open',
-		});
+		const enrichedRequest = await requestRepository.createRequest(
+			{
+				projectId: teamProject.id,
+				title: 'Enriched review request',
+				createdById: owner.id,
+				state: 'open',
+			},
+			{},
+		);
 
-		await workflowRepository.createWorkflowRow({
-			workflowReviewRequestId: enrichedRequest.id,
-			workflowId: workflow.id,
-		});
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: enrichedRequest.id,
+				workflowId: workflow.id,
+			},
+			{},
+		);
 
 		const response = await ownerAgent
 			.get('/workflow-review-requests/inbox')
@@ -2099,12 +2195,15 @@ describe('GET /workflow-review-requests/inbox', () => {
 
 	test('hides reviews from projects the member cannot access', async () => {
 		const otherProject = await createTeamProject('Other Reviews Project', owner);
-		await requestRepository.createRequest({
-			projectId: otherProject.id,
-			title: 'Private other-project review',
-			createdById: owner.id,
-			state: 'open',
-		});
+		await requestRepository.createRequest(
+			{
+				projectId: otherProject.id,
+				title: 'Private other-project review',
+				createdById: owner.id,
+				state: 'open',
+			},
+			{},
+		);
 
 		const memberResponse = await memberAgent.get('/workflow-review-requests/inbox').expect(200);
 		expect(memberResponse.body.data.data).toEqual([]);
@@ -2121,12 +2220,15 @@ describe('GET /workflow-review-requests/inbox', () => {
 
 	test('shows requesters their own reviews even without project access', async () => {
 		const otherProject = await createTeamProject('Unrelated Project', owner);
-		const ownRequest = await requestRepository.createRequest({
-			projectId: otherProject.id,
-			title: 'Review I submitted',
-			createdById: member.id,
-			state: 'open',
-		});
+		const ownRequest = await requestRepository.createRequest(
+			{
+				projectId: otherProject.id,
+				title: 'Review I submitted',
+				createdById: member.id,
+				state: 'open',
+			},
+			{},
+		);
 
 		const response = await memberAgent.get('/workflow-review-requests/inbox').expect(200);
 
@@ -2137,12 +2239,15 @@ describe('GET /workflow-review-requests/inbox', () => {
 
 	test('does not truncate pagination when the cursor row is deleted', async () => {
 		await seedInboxRequests();
-		await requestRepository.createRequest({
-			projectId: teamProject.id,
-			title: 'Second open review',
-			createdById: owner.id,
-			state: 'open',
-		});
+		await requestRepository.createRequest(
+			{
+				projectId: teamProject.id,
+				title: 'Second open review',
+				createdById: owner.id,
+				state: 'open',
+			},
+			{},
+		);
 
 		const firstPage = await ownerAgent
 			.get('/workflow-review-requests/inbox')
@@ -2165,16 +2270,22 @@ describe('GET /workflow-review-requests/inbox', () => {
 
 	test('hydrates the requester and requested reviewers on list items', async () => {
 		const reviewer = await createUser();
-		const request = await requestRepository.createRequest({
-			projectId: teamProject.id,
-			title: 'Needs review',
-			createdById: owner.id,
-			state: 'open',
-		});
-		await reviewerRepository.addReviewers({
-			workflowReviewRequestId: request.id,
-			userIds: [reviewer.id],
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: teamProject.id,
+				title: 'Needs review',
+				createdById: owner.id,
+				state: 'open',
+			},
+			{},
+		);
+		await reviewerRepository.addReviewers(
+			{
+				workflowReviewRequestId: request.id,
+				userIds: [reviewer.id],
+			},
+			{},
+		);
 
 		const response = await ownerAgent
 			.get('/workflow-review-requests/inbox')
@@ -2199,12 +2310,15 @@ describe('GET /workflow-review-requests/inbox', () => {
 	});
 
 	test('sets the requester to null when the request has no creator', async () => {
-		const request = await requestRepository.createRequest({
-			projectId: teamProject.id,
-			title: 'Authorless',
-			createdById: null,
-			state: 'open',
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: teamProject.id,
+				title: 'Authorless',
+				createdById: null,
+				state: 'open',
+			},
+			{},
+		);
 
 		const response = await ownerAgent
 			.get('/workflow-review-requests/inbox')
@@ -2221,16 +2335,22 @@ describe('GET /workflow-review-requests/inbox', () => {
 		const departedCreator = await createUser();
 		const survivingReviewer = await createUser();
 		const departedReviewer = await createUser();
-		const request = await requestRepository.createRequest({
-			projectId: teamProject.id,
-			title: 'With departed users',
-			createdById: departedCreator.id,
-			state: 'open',
-		});
-		await reviewerRepository.addReviewers({
-			workflowReviewRequestId: request.id,
-			userIds: [survivingReviewer.id, departedReviewer.id],
-		});
+		const request = await requestRepository.createRequest(
+			{
+				projectId: teamProject.id,
+				title: 'With departed users',
+				createdById: departedCreator.id,
+				state: 'open',
+			},
+			{},
+		);
+		await reviewerRepository.addReviewers(
+			{
+				workflowReviewRequestId: request.id,
+				userIds: [survivingReviewer.id, departedReviewer.id],
+			},
+			{},
+		);
 
 		await userRepository.delete({ id: departedCreator.id });
 		await userRepository.delete({ id: departedReviewer.id });
@@ -2270,18 +2390,27 @@ describe('GET /workflow-review-requests/:workflowReviewRequestId', () => {
 		author: User,
 		projectId = teamProject.id,
 	) {
-		const request = await requestRepository.createRequest({
-			projectId,
-			title: 'Please review',
-			description: 'Some context',
-			createdById: author.id,
-		});
-		await workflowRepository.createWorkflowRow({
-			workflowReviewRequestId: request.id,
-			workflowId,
-			workflowVersionId: versionId,
-		});
-		await authorRepository.addAuthor({ workflowReviewRequestId: request.id, userId: author.id });
+		const request = await requestRepository.createRequest(
+			{
+				projectId,
+				title: 'Please review',
+				description: 'Some context',
+				createdById: author.id,
+			},
+			{},
+		);
+		await workflowRepository.createWorkflowRow(
+			{
+				workflowReviewRequestId: request.id,
+				workflowId,
+				workflowVersionId: versionId,
+			},
+			{},
+		);
+		await authorRepository.addAuthor(
+			{ workflowReviewRequestId: request.id, userId: author.id },
+			{},
+		);
 		return request;
 	}
 
@@ -2297,10 +2426,13 @@ describe('GET /workflow-review-requests/:workflowReviewRequestId', () => {
 		await publishedVersionRepository.setPublishedVersion(workflow.id, baseline.versionId);
 		const reviewer = await createAdmin();
 		const request = await seedRequest(workflow.id, 'version-pinned', owner);
-		await reviewerRepository.addReviewers({
-			workflowReviewRequestId: request.id,
-			userIds: [reviewer.id],
-		});
+		await reviewerRepository.addReviewers(
+			{
+				workflowReviewRequestId: request.id,
+				userIds: [reviewer.id],
+			},
+			{},
+		);
 
 		const response = await ownerAgent.get(`/workflow-review-requests/${request.id}`).expect(200);
 

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-decision-eligibility.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-decision-eligibility.service.ts
@@ -78,10 +78,10 @@ export class WorkflowReviewDecisionEligibilityService {
 			return { canDecide: false, reason: 'missing_publish_permission' };
 		}
 
-		const isAuthor = await this.workflowReviewRequestAuthorRepository.isAuthor({
-			workflowReviewRequestId: request.id,
-			userId: user.id,
-		});
+		const isAuthor = await this.workflowReviewRequestAuthorRepository.isAuthor(
+			{ workflowReviewRequestId: request.id, userId: user.id },
+			{},
+		);
 		if (isAuthor && !(await this.hasAdminOverride(user, request.projectId))) {
 			return { canDecide: false, reason: 'author' };
 		}

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-inbox.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-inbox.service.ts
@@ -123,7 +123,10 @@ export class WorkflowReviewInboxService {
 	): Promise<WorkflowReviewRequestDetail> {
 		await this.featureGate.assertAvailable();
 
-		const request = await this.workflowReviewRequestRepository.findById(workflowReviewRequestId);
+		const request = await this.workflowReviewRequestRepository.findById(
+			workflowReviewRequestId,
+			{},
+		);
 		if (!request || !(await this.canAccessRequest(user, request))) {
 			throw new NotFoundError('Could not find review request');
 		}

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-publish-guard.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-publish-guard.service.ts
@@ -17,8 +17,10 @@ export class WorkflowReviewPublishGuard implements WorkflowPublishGuard {
 	async assertCanPublish(workflowId: string): Promise<void> {
 		if (!(await this.featureGate.isAvailable())) return;
 
-		const request =
-			await this.workflowReviewRequestRepository.findOpenRequestForWorkflow(workflowId);
+		const request = await this.workflowReviewRequestRepository.findOpenRequestForWorkflow(
+			workflowId,
+			{},
+		);
 		if (!request) return;
 
 		const reason: WorkflowPublishBlockedReason =

--- a/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
+++ b/packages/cli/src/modules/workflow-reviews.ee/workflow-review-request.service.ts
@@ -318,12 +318,12 @@ export class WorkflowReviewRequestService {
 			}
 		}
 
-		const request = await this.dbLockService.withLock(
+		const request = await this.dbLockService.withLockContext(
 			DbLock.WORKFLOW_REVIEW_REQUEST_CREATE,
-			async (tx, ctx) => {
+			async (ctx) => {
 				const existing = await this.workflowReviewRequestRepository.findOpenRequestForWorkflow(
 					workflowId,
-					tx,
+					ctx,
 				);
 				if (existing) {
 					throw new ConflictError(
@@ -340,7 +340,7 @@ export class WorkflowReviewRequestService {
 						description: dto.description ?? null,
 						createdById: user.id,
 					},
-					tx,
+					ctx,
 				);
 
 				await this.workflowReviewRequestWorkflowRepository.createWorkflowRow(
@@ -349,7 +349,7 @@ export class WorkflowReviewRequestService {
 						workflowId,
 						workflowVersionId,
 					},
-					tx,
+					ctx,
 				);
 
 				// After the conflict check, so a 409 never renames the version.
@@ -359,13 +359,13 @@ export class WorkflowReviewRequestService {
 
 				await this.workflowReviewRequestAuthorRepository.addAuthor(
 					{ workflowReviewRequestId: created.id, userId: user.id },
-					tx,
+					ctx,
 				);
 
 				if (reviewerUserIds.length > 0) {
 					await this.workflowReviewRequestReviewerRepository.addReviewers(
 						{ workflowReviewRequestId: created.id, userIds: reviewerUserIds },
-						tx,
+						ctx,
 					);
 				}
 
@@ -389,13 +389,18 @@ export class WorkflowReviewRequestService {
 	): Promise<WorkflowReviewRequestSummary> {
 		await this.featureGate.assertAvailable();
 
-		const request = await this.workflowReviewRequestRepository.findById(workflowReviewRequestId);
+		const request = await this.workflowReviewRequestRepository.findById(
+			workflowReviewRequestId,
+			{},
+		);
 		if (!request) {
 			throw new NotFoundError('Could not find review request');
 		}
 
-		const workflowRows =
-			await this.workflowReviewRequestWorkflowRepository.findByRequestId(workflowReviewRequestId);
+		const workflowRows = await this.workflowReviewRequestWorkflowRepository.findByRequestId(
+			workflowReviewRequestId,
+			{},
+		);
 		const workflowRow = workflowRows.find((row) => row.workflowId === dto.workflowId);
 		if (!workflowRow) {
 			throw new NotFoundError('Could not find review request');
@@ -440,13 +445,13 @@ export class WorkflowReviewRequestService {
 			return this.toSummary(request, workflowRow.workflowVersionId);
 		}
 
-		const { request: updated, changed } = await this.dbLockService.withLock(
+		const { request: updated, changed } = await this.dbLockService.withLockContext(
 			DbLock.WORKFLOW_REVIEW_REQUEST_CREATE,
-			async (tx, ctx) => {
+			async (ctx) => {
 				// Re-check under the lock so update can't race a concurrent close/approve.
 				const current = await this.workflowReviewRequestRepository.findById(
 					workflowReviewRequestId,
-					tx,
+					ctx,
 				);
 				if (!current) {
 					throw new NotFoundError('Could not find review request');
@@ -458,7 +463,7 @@ export class WorkflowReviewRequestService {
 				// reset the decision, and broadcast for a no-op.
 				const currentRows = await this.workflowReviewRequestWorkflowRepository.findByRequestId(
 					workflowReviewRequestId,
-					tx,
+					ctx,
 				);
 				const currentRow = currentRows.find((row) => row.workflowId === dto.workflowId);
 				if (!currentRow) {
@@ -481,7 +486,7 @@ export class WorkflowReviewRequestService {
 						workflowId: dto.workflowId,
 						workflowVersionId: dto.workflowVersionId,
 					},
-					tx,
+					ctx,
 				);
 
 				if (versionName) {
@@ -490,12 +495,11 @@ export class WorkflowReviewRequestService {
 
 				current.decision = 'pending';
 				current.updatedById = user.id;
-				// save (not update) so @BeforeUpdate bumps updatedAt
-				const saved = await tx.save(current);
+				const saved = await this.workflowReviewRequestRepository.saveRequest(current, ctx);
 
 				await this.workflowReviewRequestAuthorRepository.addAuthorIfMissing(
 					{ workflowReviewRequestId, userId: user.id },
-					tx,
+					ctx,
 				);
 
 				return { request: saved, changed: true };
@@ -521,13 +525,18 @@ export class WorkflowReviewRequestService {
 	): Promise<DecideWorkflowReviewRequestResponse> {
 		await this.featureGate.assertAvailable();
 
-		const request = await this.workflowReviewRequestRepository.findById(workflowReviewRequestId);
+		const request = await this.workflowReviewRequestRepository.findById(
+			workflowReviewRequestId,
+			{},
+		);
 		if (!request) {
 			throw new NotFoundError('Could not find review request');
 		}
 
-		const workflowRows =
-			await this.workflowReviewRequestWorkflowRepository.findByRequestId(workflowReviewRequestId);
+		const workflowRows = await this.workflowReviewRequestWorkflowRepository.findByRequestId(
+			workflowReviewRequestId,
+			{},
+		);
 		const workflowRow = workflowRows[0];
 		if (!workflowRow) {
 			throw new NotFoundError('Could not find review request');
@@ -554,20 +563,20 @@ export class WorkflowReviewRequestService {
 		);
 
 		// Fast path: reject a known author before queueing on the lock.
-		const isAuthor = await this.workflowReviewRequestAuthorRepository.isAuthor({
-			workflowReviewRequestId,
-			userId: user.id,
-		});
+		const isAuthor = await this.workflowReviewRequestAuthorRepository.isAuthor(
+			{ workflowReviewRequestId, userId: user.id },
+			{},
+		);
 		this.assertDecisionAllowed(isAuthor, hasAdminOverride);
 
-		const { request: saved, pinnedVersionId } = await this.dbLockService.withLock(
+		const { request: saved, pinnedVersionId } = await this.dbLockService.withLockContext(
 			DbLock.WORKFLOW_REVIEW_REQUEST_CREATE,
-			async (tx) => {
+			async (ctx) => {
 				// Re-check under the lock so a decision can't race a concurrent
 				// version sync (which resets the decision to pending) or another decision.
 				const current = await this.workflowReviewRequestRepository.findById(
 					workflowReviewRequestId,
-					tx,
+					ctx,
 				);
 				if (!current) {
 					throw new NotFoundError('Could not find review request');
@@ -579,7 +588,7 @@ export class WorkflowReviewRequestService {
 				// syncer must not be able to decide.
 				const isAuthorNow = await this.workflowReviewRequestAuthorRepository.isAuthor(
 					{ workflowReviewRequestId, userId: user.id },
-					tx,
+					ctx,
 				);
 				this.assertDecisionAllowed(isAuthorNow, hasAdminOverride);
 
@@ -587,7 +596,7 @@ export class WorkflowReviewRequestService {
 				// have re-pinned, and the summary must reflect the version being decided on.
 				const currentRows = await this.workflowReviewRequestWorkflowRepository.findByRequestId(
 					workflowReviewRequestId,
-					tx,
+					ctx,
 				);
 				const currentRow = currentRows.find((row) => row.workflowId === workflowRow.workflowId);
 				if (!currentRow) {
@@ -602,8 +611,7 @@ export class WorkflowReviewRequestService {
 					current.approvedAt = new Date();
 				}
 
-				// save (not update) so @BeforeUpdate bumps updatedAt
-				const savedRequest = await tx.save(current);
+				const savedRequest = await this.workflowReviewRequestRepository.saveRequest(current, ctx);
 				return { request: savedRequest, pinnedVersionId: currentRow.workflowVersionId };
 			},
 		);


### PR DESCRIPTION
## Summary

Pure refactor of the workflow-reviews module onto the sanctioned transaction pattern documented in `AGENTS.md` (inject the runner, thread an `OperationContext`, resolve the manager inside the repository). **No behaviour change.**

Before this, `workflow-review-request.service.ts` passed a raw TypeORM `EntityManager` (`tx`) into repository calls and called `await tx.save(current)` directly in business logic — the exact anti-pattern `AGENTS.md` calls out ("Don't reach for `.manager` / `.manager.transaction(...)` or `createQueryBuilder(...)` in business logic"). The `misplaced-n8n-typeorm-import` lint rule can't catch it, because the leak is a *type* threaded through a signature, not an import.

**Repositories** — the four `workflow_review_request*` repositories now extend `BaseRepository`, and each optional `trx?: EntityManager` parameter became a required `ctx: OperationContext` resolved via `this.managerFor(ctx)`:

| File | Methods |
|---|---|
| `workflow-review-request.repository.ts` | `createRequest`, `findById`, `findOpenRequestForWorkflow`, **+ new `saveRequest`** |
| `workflow-review-request-workflow.repository.ts` | `createWorkflowRow`, `updateWorkflowVersion`, `findByRequestId` |
| `workflow-review-request-author.repository.ts` | `addAuthor`, `addAuthorIfMissing`, `isAuthor` |
| `workflow-review-request-reviewer.repository.ts` | `addReviewers` |

These four have no callers outside the reviews module, so the signature change is contained.

**Service** — all three lock blocks moved from `withLock(id, async (tx, ctx) => …)` to `withLockContext(id, async (ctx) => …)`, so no driver handle reaches business logic. The advisory lock itself stays: it is functionally required to serialize review creation, and `TransactionRunner.run` provides no locking. The two raw `tx.save(current)` calls moved behind the new `saveRequest`, which deliberately uses `save` and **not** `update` so the entity's `@BeforeUpdate` hook keeps bumping `updatedAt`. Non-transactional callers in the module (the pre-lock reads in `updateVersion`/`decide`, plus the inbox, publish-guard and decision-eligibility services) pass the root `{}`.

**Deliberately out of scope:** `WorkflowPublishHistoryRepository` and the publish flow (`workflow.service.ts:_publishViaOutbox` uses `this.workflowRepository.manager.transaction(...)` — a separate pre-existing violation of the same rule), and auto-publish on approval, which still runs after the lock and outside the transaction.

Two notes for review:
- `withLock` is still used by seven other call sites, so nothing became dead code.
- This makes reviews the canonical `ctx` adopter while its neighbours still use `trx` — normal for incremental adoption (only `settings`, `tag`, `credentials`, `instance-credential-assignment` and `workflow-history` have moved so far), but worth knowing why the two idioms sit side by side.

## How to test

This is a refactor with no user-visible surface, so the test suites are the signal. Note the module is gated: a manual instance needs `N8N_ENABLED_MODULES` to include `workflow-reviews`, `N8N_ENV_FEAT_WORKFLOW_REVIEWS=true`, and a licence with the workflow-reviews feature.

```bash
# @n8n/db must be rebuilt before packages/cli typechecks against it
cd packages/@n8n/db && pnpm build && pnpm typecheck
pnpm test src/repositories/__tests__/

cd ../../cli && pnpm typecheck
pnpm test src/modules/workflow-reviews.ee/__tests__/

# `pnpm test` excludes **/*.integration.test.ts, so these must be run separately
pnpm test:integration src/modules/workflow-reviews.ee/__tests__/
```

Results on this branch: `@n8n/db` build + typecheck pass, 225 repository unit tests pass; `packages/cli` typecheck passes, 126 reviews unit tests and 137 reviews integration tests pass; eslint and biome clean.

The two behaviours most at risk from this change are both covered by existing, passing integration tests:
- **`updatedAt` still bumps** — *"approves: closes the request and stamps decision fields"* asserts the returned `updatedAt` is strictly greater than the seeded one, which only holds if `saveRequest` uses `save` rather than `update`.
- **The naming write still rolls back** — *"rolls the name back when the create conflicts with an open review"* depends on `updateVersionName`'s affected-count contract (`0` → `BadRequestError` → rollback) surviving intact.

Test changes are limited to mocks and assertions; nothing asserted was weakened or deleted. The integration test's only change is a root `{}` added at 56 fixture call sites (verified byte-for-byte). The decide unit test gained a named `ctx` carrying a `Transaction`, which sharpens its "the re-check must run against the lock's transaction" assertion — it previously compared against a bare `{}`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-940

Follow-up to the LIGO-927 review, which migrated `WorkflowHistoryRepository.updateVersionName` and deliberately left the rest of the module alone to keep that PR reviewable.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

