### PR TITLE
feat(core): Verify the inbound token at context establishment and carry the VerifiedClaim (no-changelog)

### DIFF
--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/extract-bearer-token.test.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/extract-bearer-token.test.ts
@@ -1,0 +1,63 @@
+import type { INodeExecutionData } from 'n8n-workflow';
+
+import { extractBearerToken } from '../extract-bearer-token';
+
+function triggerItem(headers: Record<string, unknown> | undefined): INodeExecutionData[] {
+	return [{ json: { headers } }];
+}
+
+describe('extractBearerToken', () => {
+	it('returns the token from a well-formed Authorization header', () => {
+		expect(extractBearerToken(triggerItem({ authorization: 'Bearer abc.def.ghi' }))).toBe(
+			'abc.def.ghi',
+		);
+	});
+
+	it('is case-insensitive on the Bearer scheme', () => {
+		expect(extractBearerToken(triggerItem({ authorization: 'bearer abc' }))).toBe('abc');
+	});
+
+	it('returns null when triggerItems is null', () => {
+		expect(extractBearerToken(null)).toBeNull();
+	});
+
+	it('returns null when triggerItems is empty', () => {
+		expect(extractBearerToken([])).toBeNull();
+	});
+
+	it('returns null when there is no headers object', () => {
+		expect(extractBearerToken(triggerItem(undefined))).toBeNull();
+	});
+
+	it('returns null when headers is not an object', () => {
+		expect(extractBearerToken([{ json: { headers: 'not-an-object' } }])).toBeNull();
+	});
+
+	it('returns null when headers is an array', () => {
+		expect(extractBearerToken([{ json: { headers: ['a', 'b'] } }])).toBeNull();
+	});
+
+	it('returns null when there is no authorization header', () => {
+		expect(extractBearerToken(triggerItem({ 'x-other': 'value' }))).toBeNull();
+	});
+
+	it('returns null for a non-Bearer scheme', () => {
+		expect(extractBearerToken(triggerItem({ authorization: 'Basic abc' }))).toBeNull();
+	});
+
+	it('returns null when the authorization header is not a string', () => {
+		expect(extractBearerToken([{ json: { headers: { authorization: 12345 } } }])).toBeNull();
+	});
+
+	it('returns null when the Bearer value is only whitespace', () => {
+		expect(extractBearerToken(triggerItem({ authorization: 'Bearer    ' }))).toBeNull();
+	});
+
+	it('truncates and never throws on an extremely long header value', () => {
+		const longValue = `Bearer ${'a'.repeat(20000)}`;
+		expect(() => extractBearerToken(triggerItem({ authorization: longValue }))).not.toThrow();
+		const result = extractBearerToken(triggerItem({ authorization: longValue }));
+		expect(result).not.toBeNull();
+		expect(result!.length).toBeLessThanOrEqual(8192);
+	});
+});

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-audience.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-audience.service.test.ts
@@ -1,0 +1,31 @@
+import type { Mocked } from 'vitest';
+
+import type { UrlService } from '@/services/url.service';
+
+import type { TokenExchangeConfig } from '../../token-exchange.config';
+import { InboundAudienceService } from '../inbound-audience.service';
+
+describe('InboundAudienceService', () => {
+	let config: TokenExchangeConfig;
+	let urlService: Mocked<UrlService>;
+	let service: InboundAudienceService;
+
+	beforeEach(() => {
+		config = { inboundAudience: '' } as TokenExchangeConfig;
+		urlService = {
+			getInstanceBaseUrl: vi.fn().mockReturnValue('https://n8n.example.com'),
+		} as unknown as Mocked<UrlService>;
+		service = new InboundAudienceService(config, urlService);
+	});
+
+	it('returns the configured audience when set', () => {
+		config.inboundAudience = 'https://configured-audience.example.com';
+
+		expect(service.getExpectedAudience()).toBe('https://configured-audience.example.com');
+		expect(urlService.getInstanceBaseUrl).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the instance base URL when unset', () => {
+		expect(service.getExpectedAudience()).toBe('https://n8n.example.com');
+	});
+});

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.integration.test.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.integration.test.ts
@@ -1,0 +1,233 @@
+import { Container } from '@n8n/di';
+import {
+	ExecutionContextHookRegistry,
+	ExecutionContextService,
+	establishExecutionContext,
+	type Cipher,
+} from 'n8n-core';
+import {
+	createRunExecutionData,
+	type INode,
+	type IVerifiedClaim,
+	type IWorkflowExecuteAdditionalData,
+	type Workflow,
+} from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { ExternalTokenVerifierProxy } from '@/services/external-token-verifier-proxy.service';
+import type { ExternalTokenVerifier } from '@/services/external-token-verifier-proxy.service';
+
+import type { InboundAudienceService } from '../inbound-audience.service';
+import { InboundClaimVerificationHook } from '../inbound-claim-verification-hook';
+
+/**
+ * Wires the real InboundClaimVerificationHook, ExternalTokenVerifierProxy and
+ * ExecutionContextService together and drives them through
+ * establishExecutionContext, proving the end-to-end contract from the
+ * ticket's acceptance criteria - in particular that verification happens
+ * exactly once per request and that the second establishExecutionContext
+ * call (main -> worker) is a true no-op, not just an assumption about the
+ * runtimeData early-exit.
+ */
+describe('InboundClaimVerificationHook integration with establishExecutionContext', () => {
+	const buildWorkflow = () => mock<Workflow>({ id: 'wf-1' });
+
+	const buildRunExecutionData = (headers?: Record<string, unknown>) => {
+		const startNode = mock<INode>({ name: 'Webhook', type: 'n8n-nodes-base.webhook' });
+		return createRunExecutionData({
+			startData: {},
+			resultData: { runData: {} },
+			executionData: {
+				contextData: {},
+				nodeExecutionStack: [
+					{ node: startNode, data: { main: [[{ json: { headers } }]] }, source: null },
+				],
+				metadata: {},
+				waitingExecution: {},
+				waitingExecutionSource: {},
+			},
+		});
+	};
+
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({
+		webhookWaitingBaseUrl: 'http://localhost:5678/webhook-waiting',
+		formWaitingBaseUrl: 'http://localhost:5678/form-waiting',
+		encryptedRunnerIdentity: undefined,
+	});
+
+	// Encrypt/decrypt as plain JSON round-trip so assertions can inspect the
+	// sealed claim without needing real crypto - sealing/unsealing itself is
+	// already covered by ExecutionContextService's own unit tests.
+	const passthroughCipher = mock<Cipher>({
+		encryptV2: async (data) => (typeof data === 'string' ? data : JSON.stringify(data)),
+		decryptV2: async (data) => (typeof data === 'string' ? data : JSON.stringify(data)),
+	});
+
+	let proxy: ExternalTokenVerifierProxy;
+	let provider: ReturnType<typeof mock<ExternalTokenVerifier>>;
+	let audienceService: ReturnType<typeof mock<InboundAudienceService>>;
+
+	beforeEach(() => {
+		proxy = new ExternalTokenVerifierProxy();
+		provider = mock<ExternalTokenVerifier>();
+		proxy.registerProvider(provider);
+
+		audienceService = mock<InboundAudienceService>();
+		audienceService.getExpectedAudience.mockReturnValue('https://n8n.example.com');
+
+		const hook = new InboundClaimVerificationHook(mock(), proxy, audienceService);
+
+		const hookRegistry = mock<ExecutionContextHookRegistry>();
+		hookRegistry.getGlobalHooks.mockReturnValue([hook]);
+		hookRegistry.getSubExecutionHooks.mockReturnValue([]);
+
+		const executionContextService = new ExecutionContextService(
+			mock(),
+			hookRegistry,
+			passthroughCipher,
+		);
+
+		Container.set(ExecutionContextHookRegistry, hookRegistry);
+		Container.set(ExecutionContextService, executionContextService);
+	});
+
+	afterEach(() => {
+		Container.reset();
+	});
+
+	it('AC1: a valid token results in a sealed claim on runtimeData with no principal field', async () => {
+		const expiresAt = new Date('2026-06-01T00:00:00.000Z');
+		provider.verifyExternalToken.mockResolvedValue({
+			claim: {
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'user-42',
+				audience: 'https://n8n.example.com',
+				attributes: {},
+				expiresAt,
+			},
+		});
+
+		const workflow = buildWorkflow();
+		const runExecutionData = buildRunExecutionData({ authorization: 'Bearer good-token' });
+
+		await establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook');
+
+		const runtimeData = runExecutionData.executionData!.runtimeData!;
+		expect(runtimeData.claims).toBeDefined();
+
+		const sealedClaim = JSON.parse(runtimeData.claims as string) as IVerifiedClaim;
+		expect(sealedClaim).toMatchObject({
+			version: 1,
+			sourceId: 'idp-1',
+			subject: 'user-42',
+			audience: 'https://n8n.example.com',
+			expiresAt: expiresAt.getTime(),
+			boundWorkflowId: 'wf-1',
+		});
+		expect(Object.keys(sealedClaim)).not.toContain('principalId');
+		expect(runtimeData.authFailureReason).toBeUndefined();
+	});
+
+	it('AC2: an invalid token records authFailureReason and sets no claim', async () => {
+		provider.verifyExternalToken.mockResolvedValue({
+			claim: null,
+			context: { reason: 'invalid_token', errorDetails: 'bad signature' },
+		});
+
+		const workflow = buildWorkflow();
+		const runExecutionData = buildRunExecutionData({ authorization: 'Bearer bad-token' });
+
+		await establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook');
+
+		const runtimeData = runExecutionData.executionData!.runtimeData!;
+		expect(runtimeData.claims).toBeUndefined();
+		expect(runtimeData.authFailureReason).toBe('invalid_token');
+	});
+
+	it('AC3: no token presented leaves the context exactly as it would be today', async () => {
+		const workflow = buildWorkflow();
+		const runExecutionData = buildRunExecutionData(undefined);
+
+		await establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook');
+
+		const runtimeData = runExecutionData.executionData!.runtimeData!;
+		expect(runtimeData.claims).toBeUndefined();
+		expect(runtimeData.authFailureReason).toBeUndefined();
+		expect(provider.verifyExternalToken).not.toHaveBeenCalled();
+	});
+
+	it('AC4: an unregistered verifier proxy proceeds without throwing', async () => {
+		const unregisteredProxy = new ExternalTokenVerifierProxy();
+		const hook = new InboundClaimVerificationHook(mock(), unregisteredProxy, audienceService);
+		const hookRegistry = mock<ExecutionContextHookRegistry>();
+		hookRegistry.getGlobalHooks.mockReturnValue([hook]);
+		hookRegistry.getSubExecutionHooks.mockReturnValue([]);
+		Container.set(
+			ExecutionContextService,
+			new ExecutionContextService(mock(), hookRegistry, passthroughCipher),
+		);
+
+		const workflow = buildWorkflow();
+		const runExecutionData = buildRunExecutionData({ authorization: 'Bearer some-token' });
+
+		await expect(
+			establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook'),
+		).resolves.not.toThrow();
+
+		const runtimeData = runExecutionData.executionData!.runtimeData!;
+		expect(runtimeData.claims).toBeUndefined();
+		expect(runtimeData.authFailureReason).toBe('verifier_not_registered');
+	});
+
+	it('AC5 & AC6: verification happens exactly once, and a second establishExecutionContext call is a no-op', async () => {
+		provider.verifyExternalToken.mockResolvedValue({
+			claim: {
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'user-42',
+				audience: 'https://n8n.example.com',
+				attributes: {},
+				expiresAt: new Date('2026-06-01T00:00:00.000Z'),
+			},
+		});
+
+		const workflow = buildWorkflow();
+		const runExecutionData = buildRunExecutionData({ authorization: 'Bearer good-token' });
+
+		// First call: e.g. workflow-runner.ts on the main process.
+		await establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook');
+		expect(provider.verifyExternalToken).toHaveBeenCalledTimes(1);
+		const runtimeDataAfterFirstCall = runExecutionData.executionData!.runtimeData;
+
+		// Second call: e.g. workflow-execute.ts on the worker. The runtimeData
+		// early-exit must make this a no-op - not a new mechanism this hook adds.
+		await establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook');
+		expect(provider.verifyExternalToken).toHaveBeenCalledTimes(1);
+		expect(runExecutionData.executionData!.runtimeData).toBe(runtimeDataAfterFirstCall);
+	});
+
+	it('AC7: a claim whose token has already expired is still sealed and attached', async () => {
+		const pastExpiry = new Date(Date.now() - 1000 * 60 * 60);
+		provider.verifyExternalToken.mockResolvedValue({
+			claim: {
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'user-42',
+				audience: 'https://n8n.example.com',
+				attributes: {},
+				expiresAt: pastExpiry,
+			},
+		});
+
+		const workflow = buildWorkflow();
+		const runExecutionData = buildRunExecutionData({ authorization: 'Bearer stale-but-valid-sig' });
+
+		await establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook');
+
+		const runtimeData = runExecutionData.executionData!.runtimeData!;
+		const sealedClaim = JSON.parse(runtimeData.claims as string) as IVerifiedClaim;
+		expect(sealedClaim.expiresAt).toBe(pastExpiry.getTime());
+		expect(runtimeData.authFailureReason).toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.test.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.test.ts
@@ -1,0 +1,207 @@
+import type { Logger } from '@n8n/backend-common';
+import type { ContextEstablishmentOptions } from '@n8n/decorators';
+import type { INode, INodeExecutionData, PlaintextExecutionContext, Workflow } from 'n8n-workflow';
+import type { Mocked } from 'vitest';
+
+import type { ExternalTokenVerifierProxy } from '@/services/external-token-verifier-proxy.service';
+
+import { InboundClaimVerificationHook } from '../inbound-claim-verification-hook';
+import type { InboundAudienceService } from '../inbound-audience.service';
+
+function triggerItems(headers?: Record<string, unknown>): INodeExecutionData[] {
+	return [{ json: { headers } }];
+}
+
+function createOptions(
+	overrides?: Partial<ContextEstablishmentOptions>,
+): ContextEstablishmentOptions {
+	const baseContext: PlaintextExecutionContext = {
+		version: 1,
+		establishedAt: Date.now(),
+		source: 'webhook',
+	};
+
+	return {
+		triggerNode: { name: 'Webhook', parameters: {} } as INode,
+		workflow: {} as Workflow,
+		triggerItems: triggerItems({ authorization: 'Bearer valid-token' }),
+		context: baseContext,
+		options: {},
+		...overrides,
+	};
+}
+
+describe('InboundClaimVerificationHook', () => {
+	let hook: InboundClaimVerificationHook;
+	let mockLogger: Mocked<Logger>;
+	let mockProxy: Mocked<ExternalTokenVerifierProxy>;
+	let mockAudienceService: Mocked<InboundAudienceService>;
+
+	beforeEach(() => {
+		mockLogger = {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		} as unknown as Mocked<Logger>;
+
+		mockProxy = {
+			verifyExternalToken: vi.fn(),
+		} as unknown as Mocked<ExternalTokenVerifierProxy>;
+
+		mockAudienceService = {
+			getExpectedAudience: vi.fn().mockReturnValue('https://n8n.example.com'),
+		} as unknown as Mocked<InboundAudienceService>;
+
+		hook = new InboundClaimVerificationHook(mockLogger, mockProxy, mockAudienceService);
+	});
+
+	it('is never applicable to a trigger node (global hook only)', () => {
+		expect(hook.isApplicableToTriggerNode('n8n-nodes-base.webhook')).toBe(false);
+	});
+
+	describe('AC1: valid token -> sealed claim, no principal field', () => {
+		it('maps a verified claim onto contextUpdate.claims with no principal-shaped field', async () => {
+			const expiresAt = new Date('2026-01-01T00:00:00.000Z');
+			mockProxy.verifyExternalToken.mockResolvedValue({
+				claim: {
+					sourceId: 'idp-1',
+					issuer: 'https://idp.example.com',
+					subject: 'user-42',
+					audience: 'https://n8n.example.com',
+					attributes: { role: 'admin' },
+					expiresAt,
+				},
+			});
+
+			const result = await hook.execute(createOptions());
+
+			expect(result.contextUpdate?.claims).toEqual({
+				version: 1,
+				sourceId: 'idp-1',
+				subject: 'user-42',
+				audience: 'https://n8n.example.com',
+				expiresAt: expiresAt.getTime(),
+				boundWorkflowId: 'not-yet-sealed',
+			});
+			expect(result.contextUpdate?.authFailureReason).toBeUndefined();
+
+			const keys = Object.keys(result.contextUpdate?.claims ?? {});
+			expect(keys).not.toContain('principalId');
+			expect(keys).not.toContain('userId');
+			expect(keys).not.toContain('principal');
+			// Confirms issuer/attributes are deliberately dropped (not carried
+			// into the sealed claim - see plan §6.5).
+			expect(keys).not.toContain('issuer');
+			expect(keys).not.toContain('attributes');
+		});
+
+		it('normalizes a multi-value audience array to its first entry', async () => {
+			mockProxy.verifyExternalToken.mockResolvedValue({
+				claim: {
+					sourceId: 'idp-1',
+					issuer: 'https://idp.example.com',
+					subject: 'user-42',
+					audience: ['aud-a', 'aud-b'],
+					attributes: {},
+					expiresAt: new Date(),
+				},
+			});
+
+			const result = await hook.execute(createOptions());
+
+			expect(result.contextUpdate?.claims?.audience).toBe('aud-a');
+		});
+
+		it('calls the verifier exactly once per execute() call', async () => {
+			mockProxy.verifyExternalToken.mockResolvedValue({
+				claim: null,
+				context: { reason: 'invalid_token' },
+			});
+
+			await hook.execute(createOptions());
+
+			expect(mockProxy.verifyExternalToken).toHaveBeenCalledTimes(1);
+			expect(mockProxy.verifyExternalToken).toHaveBeenCalledWith(
+				'valid-token',
+				'https://n8n.example.com',
+			);
+		});
+	});
+
+	describe('AC2: invalid/expired/wrong-audience token -> no claim, reason recorded', () => {
+		it('records authFailureReason and sets no claim when verification fails', async () => {
+			mockProxy.verifyExternalToken.mockResolvedValue({
+				claim: null,
+				context: { reason: 'invalid_token', errorDetails: 'signature mismatch' },
+			});
+
+			const result = await hook.execute(createOptions());
+
+			expect(result.contextUpdate).toEqual({ authFailureReason: 'invalid_token' });
+			expect(result.contextUpdate?.claims).toBeUndefined();
+		});
+	});
+
+	describe('AC3: no token presented -> identical to today', () => {
+		it('returns an empty result (no contextUpdate at all) when there is no bearer token', async () => {
+			const result = await hook.execute(
+				createOptions({ triggerItems: triggerItems({ 'x-other': 'value' }) }),
+			);
+
+			expect(result).toEqual({});
+			expect(mockProxy.verifyExternalToken).not.toHaveBeenCalled();
+		});
+
+		it('returns an empty result when there are no trigger items', async () => {
+			const result = await hook.execute(createOptions({ triggerItems: null }));
+
+			expect(result).toEqual({});
+			expect(mockProxy.verifyExternalToken).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('AC4: verifier unavailable / unexpected failure -> no throw, identical to today', () => {
+		it('records verifier_not_registered without throwing', async () => {
+			mockProxy.verifyExternalToken.mockResolvedValue({
+				claim: null,
+				context: { reason: 'verifier_not_registered', errorDetails: 'no provider registered' },
+			});
+
+			const result = await hook.execute(createOptions());
+
+			expect(result.contextUpdate).toEqual({ authFailureReason: 'verifier_not_registered' });
+		});
+
+		it('never throws even when the proxy itself rejects unexpectedly', async () => {
+			mockProxy.verifyExternalToken.mockRejectedValue(new Error('network exploded'));
+
+			await expect(hook.execute(createOptions())).resolves.toEqual({
+				contextUpdate: { authFailureReason: 'internal_error' },
+			});
+			expect(mockLogger.warn).toHaveBeenCalled();
+		});
+	});
+
+	describe('AC7: claim expiry does not gate whether it is attached', () => {
+		it('attaches a claim whose expiresAt is already in the past, identically to a future one', async () => {
+			const pastExpiry = new Date(Date.now() - 1000 * 60 * 60);
+			mockProxy.verifyExternalToken.mockResolvedValue({
+				claim: {
+					sourceId: 'idp-1',
+					issuer: 'https://idp.example.com',
+					subject: 'user-42',
+					audience: 'https://n8n.example.com',
+					attributes: {},
+					expiresAt: pastExpiry,
+				},
+			});
+
+			const result = await hook.execute(createOptions());
+
+			expect(result.contextUpdate?.claims).toBeDefined();
+			expect(result.contextUpdate?.claims?.expiresAt).toBe(pastExpiry.getTime());
+			expect(result.contextUpdate?.authFailureReason).toBeUndefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/extract-bearer-token.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/extract-bearer-token.ts
@@ -1,0 +1,25 @@
+import type { INodeExecutionData } from 'n8n-workflow';
+
+const MAX_HEADER_LENGTH = 8192;
+const BEARER_PATTERN = /^Bearer\s+(.+)$/i;
+
+/**
+ * Extracts a bearer token from the first trigger item's `authorization`
+ * header. Never throws - returns `null` for any input it can't extract a
+ * token from (no items, no header, wrong scheme, non-string value), since a
+ * global context-establishment hook must never fail the execution over a
+ * missing or malformed header.
+ */
+export function extractBearerToken(triggerItems: INodeExecutionData[] | null): string | null {
+	if (!triggerItems || triggerItems.length === 0) return null;
+
+	const headers = triggerItems[0]?.json?.['headers'];
+	if (headers === null || typeof headers !== 'object' || Array.isArray(headers)) return null;
+
+	const value = (headers as Record<string, unknown>)['authorization'];
+	if (typeof value !== 'string') return null;
+
+	const match = BEARER_PATTERN.exec(value.slice(0, MAX_HEADER_LENGTH));
+	const token = match?.[1]?.trim();
+	return token || null;
+}

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-audience.service.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-audience.service.ts
@@ -1,0 +1,24 @@
+import { Service } from '@n8n/di';
+
+import { UrlService } from '@/services/url.service';
+
+import { TokenExchangeConfig } from '../token-exchange.config';
+
+/**
+ * Single source of truth for the audience external tokens must target to be
+ * accepted at context establishment. Kept separate from
+ * `InboundClaimVerificationHook` so this decision is independently testable
+ * and swappable later (e.g. by IAM-1175's per-surface work) without touching
+ * the hook.
+ */
+@Service()
+export class InboundAudienceService {
+	constructor(
+		private readonly config: TokenExchangeConfig,
+		private readonly urlService: UrlService,
+	) {}
+
+	getExpectedAudience(): string {
+		return this.config.inboundAudience || this.urlService.getInstanceBaseUrl();
+	}
+}

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-claim-verification-hook.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-claim-verification-hook.ts
@@ -1,0 +1,101 @@
+import { Logger } from '@n8n/backend-common';
+import type {
+	ContextEstablishmentOptions,
+	ContextEstablishmentResult,
+	HookDescription,
+	IContextEstablishmentHook,
+} from '@n8n/decorators';
+import { ContextEstablishmentHook } from '@n8n/decorators';
+import type { IVerifiedClaim } from 'n8n-workflow';
+
+import { ExternalTokenVerifierProxy } from '@/services/external-token-verifier-proxy.service';
+
+import { extractBearerToken } from './extract-bearer-token';
+import { InboundAudienceService } from './inbound-audience.service';
+
+/**
+ * Verifies the inbound bearer token, once, at context establishment, and
+ * carries the resulting attested facts forward as a sealed `IVerifiedClaim`.
+ * Deliberately does not resolve or store an n8n principal - the principal is
+ * re-derived from the claim on every access (see IAM-1168/IAM-1169), never
+ * stored here, since a stored principal id would itself work as a bearer
+ * credential.
+ *
+ * Global (`alwaysExecute`), not a per-node opt-in: verification should apply
+ * automatically wherever a bearer token shows up, not require a trigger node
+ * to explicitly list this hook. That means the per-node `isAllowedToFail`
+ * gate never applies to it - global hooks that throw fail the execution
+ * outright. So this hook must never throw, full stop; every failure mode
+ * degrades to "no claim" (optionally with `authFailureReason` recorded),
+ * never an exception. Not re-run for sub-executions
+ * (`runForSubExecution: false`): sub-executions receive `triggerItems: null`
+ * (no fresh inbound request of their own), and the parent's claim is already
+ * re-sealed for the child workflow by `augmentSubExecutionContext`.
+ */
+@ContextEstablishmentHook({ alwaysExecute: true, runForSubExecution: false })
+export class InboundClaimVerificationHook implements IContextEstablishmentHook {
+	constructor(
+		private readonly logger: Logger,
+		private readonly externalTokenVerifierProxy: ExternalTokenVerifierProxy,
+		private readonly inboundAudienceService: InboundAudienceService,
+	) {}
+
+	hookDescription: HookDescription = {
+		name: 'InboundClaimVerificationHook',
+	};
+
+	isApplicableToTriggerNode(_nodeType: string): boolean {
+		// Global hook, never user-facing.
+		return false;
+	}
+
+	async execute(options: ContextEstablishmentOptions): Promise<ContextEstablishmentResult> {
+		try {
+			const token = extractBearerToken(options.triggerItems);
+			if (!token) {
+				// No credential presented - proceed, no claim, exactly as today.
+				return {};
+			}
+
+			const expectedAudience = this.inboundAudienceService.getExpectedAudience();
+			const result = await this.externalTokenVerifierProxy.verifyExternalToken(
+				token,
+				expectedAudience,
+			);
+
+			if (!result.claim) {
+				// Covers both 'verifier_not_registered' and 'invalid_token' - both
+				// must proceed with no claim; record why for diagnostics.
+				return { contextUpdate: { authFailureReason: result.context.reason } };
+			}
+
+			const claim: IVerifiedClaim = {
+				version: 1,
+				sourceId: result.claim.sourceId,
+				subject: result.claim.subject,
+				audience: Array.isArray(result.claim.audience)
+					? result.claim.audience[0]
+					: result.claim.audience,
+				// Attribution only - whether an active binding exists, and whether
+				// the claim is still fresh enough to matter, are decided at access
+				// time, not here.
+				expiresAt: result.claim.expiresAt.getTime(),
+				// actorClaim intentionally omitted - OBO is out of scope here.
+				// ExecutionContextService.sealClaims() overwrites this with the
+				// real workflow id when sealing; see its own tests for this convention.
+				boundWorkflowId: 'not-yet-sealed',
+			};
+
+			return { contextUpdate: { claims: claim } };
+		} catch (error) {
+			// Defense in depth: extractBearerToken and the proxy are themselves
+			// designed not to throw, but a global hook throwing fails the whole
+			// execution, so this is the backstop, not the primary mechanism.
+			this.logger.warn(
+				'InboundClaimVerificationHook failed unexpectedly, proceeding without a claim',
+				{ error },
+			);
+			return { contextUpdate: { authFailureReason: 'internal_error' } };
+		}
+	}
+}

--- a/packages/cli/src/modules/token-exchange/token-exchange.config.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.config.ts
@@ -46,4 +46,13 @@ export class TokenExchangeConfig {
 	/** Maximum number of token exchanges per ip per minute. */
 	@Env('N8N_TOKEN_EXCHANGE_TOKEN_EXCHANGE_PER_MINUTE')
 	rateLimitTokenExchange: number = 20;
+
+	/**
+	 * Audience external tokens must target to be accepted at context
+	 * establishment (see `InboundAudienceService`). Defaults to the instance
+	 * base URL when unset. Instance-wide, not per-surface - see IAM-1175 for
+	 * per-surface `acceptedSources`.
+	 */
+	@Env('N8N_TOKEN_EXCHANGE_INBOUND_AUDIENCE')
+	inboundAudience: string = '';
 }

--- a/packages/cli/src/modules/token-exchange/token-exchange.module.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.module.ts
@@ -60,6 +60,12 @@ export class TokenExchangeModule implements ModuleInterface {
 			Container.get(IdentityResolutionService),
 		);
 
+		// Import-for-side-effect: the @ContextEstablishmentHook decorator
+		// registers this class into ContextEstablishmentHookMetadata at
+		// class-evaluation time; ExecutionContextHookRegistry.init() discovers
+		// it later.
+		await import('./context-establishment-hooks/inbound-claim-verification-hook.js');
+
 		await import('./controllers/token-exchange.controller.js');
 		await import('./controllers/embed-auth.controller.js');
 

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -665,6 +665,57 @@ describe('ExecutionContextService', () => {
 
 			expect(result).toEqual(baseContext);
 		});
+
+		it('should replace claims whole rather than merging fields from two verification passes', () => {
+			const baseContext: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: 100,
+				source: 'webhook',
+				claims: {
+					version: 1,
+					sourceId: 'idp-a',
+					subject: 'user-a',
+					audience: 'aud-a',
+					expiresAt: 1000,
+					boundWorkflowId: 'wf-1',
+				},
+			};
+
+			const contextToMerge: Partial<PlaintextExecutionContext> = {
+				claims: {
+					version: 1,
+					sourceId: 'idp-b',
+					subject: 'user-b',
+					audience: 'aud-b',
+					expiresAt: 2000,
+					boundWorkflowId: 'wf-1',
+				},
+			};
+
+			const result = service.mergeExecutionContexts(baseContext, contextToMerge);
+
+			expect(result.claims).toEqual(contextToMerge.claims);
+		});
+
+		it('should preserve baseContext claims when contextToMerge has no claims', () => {
+			const baseContext: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: 100,
+				source: 'webhook',
+				claims: {
+					version: 1,
+					sourceId: 'idp-a',
+					subject: 'user-a',
+					audience: 'aud-a',
+					expiresAt: 1000,
+					boundWorkflowId: 'wf-1',
+				},
+			};
+
+			const result = service.mergeExecutionContexts(baseContext, { source: 'manual' });
+
+			expect(result.claims).toEqual(baseContext.claims);
+		});
 	});
 
 	describe('augmentSubExecutionContext()', () => {

--- a/packages/core/src/execution-engine/execution-context.service.ts
+++ b/packages/core/src/execution-engine/execution-context.service.ts
@@ -145,15 +145,20 @@ export class ExecutionContextService {
 	}
 
 	/**
-	 * Note for later: this deep-merges `claims` field-by-field like everything
-	 * else, which could mix fields from two different verification passes. A
-	 * claim should probably be replaced whole, not merged.
+	 * A claim is one atomic verification result, so replace it whole rather
+	 * than deep-merging field-by-field like the rest of the context - a
+	 * field-by-field merge could otherwise mix fields from two different
+	 * verification passes.
 	 */
 	mergeExecutionContexts(
 		baseContext: PlaintextExecutionContext,
 		contextToMerge: Partial<PlaintextExecutionContext>,
 	): PlaintextExecutionContext {
-		return deepMerge(baseContext, contextToMerge);
+		const merged = deepMerge(baseContext, contextToMerge);
+		if (contextToMerge.claims) {
+			merged.claims = contextToMerge.claims;
+		}
+		return merged;
 	}
 
 	/**

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -246,6 +246,15 @@ const ExecutionContextSchemaV1 = z.object({
 	}),
 
 	/**
+	 * Set when a bearer token was presented at context establishment but
+	 * failed verification, or no verifier was available to check it.
+	 * Diagnostic only - does not gate access and carries no token material.
+	 * Absent when no token was presented, or when a token verified
+	 * successfully.
+	 */
+	authFailureReason: z.string().optional(),
+
+	/**
 	 * Encrypted artifacts produced by context-establishment hooks
 	 * (e.g. a trigger stripper) for later consumption by node backends.
 	 * Always encrypted when stored, decrypted on demand by


### PR DESCRIPTION
## Summary

Adds a global, permissive context-establishment hook (`InboundClaimVerificationHook`, in `token-exchange`) that verifies an inbound bearer token **once**, at context establishment, and carries the result forward as a sealed `VerifiedClaim` on the execution context. It deliberately does **not** resolve or store an n8n principal — the principal is re-derived from the claim at every access by a later ticket, never stored here, since a stored principal id would itself function as an unsigned, unexpiring bearer credential.

Behavior:
- No token presented → unchanged from today.
- Token presented but fails verification (bad signature, expired, wrong audience) or no verifier registered → execution still runs, no claim, reason recorded in `context.authFailureReason`.
- Token verifies → sealed claim (`sourceId`, `subject`, `audience`, `expiresAt`) attached to `context.claims`.

The hook is registered as `alwaysExecute: true` (global), not a per-node opt-in — so it runs on every execution regardless of trigger type, and per-node `isAllowedToFail` semantics don't apply to it. Since global hooks have no try/catch at the framework level, the hook's own `execute()` guarantees it never throws (every failure mode degrades to "no claim", never an exception).

Also fixes a pre-existing bug in `ExecutionContextService.mergeExecutionContexts`: it was deep-merging `claims` field-by-field like every other context field, which could mix fields from two different verification passes. This PR is the first to actually exercise that path with a real write, so it fixes it to replace `claims` whole instead.

## How to test

Requires the `token-exchange` module enabled (`N8N_ENV_FEAT_TOKEN_EXCHANGE=true`) with at least one trusted key source configured (`N8N_TOKEN_EXCHANGE_TRUSTED_KEYS`), and a webhook-triggered workflow.

1. Send a request to a webhook trigger with `Authorization: Bearer <valid-signed-jwt>`, where the JWT's `aud` matches the instance base URL (or `N8N_TOKEN_EXCHANGE_INBOUND_AUDIENCE` if set).
2. Inspect the execution's context (`runtimeData` / `IExecutionContext`) — `claims` should be a sealed (encrypted) string; decrypting it should recover `{ version: 1, sourceId, subject, audience, expiresAt, boundWorkflowId }` and no `principalId`/`userId` anywhere.
3. Repeat with a garbage/expired token — execution still completes normally, `claims` absent, `authFailureReason` set.
4. Repeat with no `Authorization` header at all — execution behaves identically to before this change.

Covered by unit tests (`extract-bearer-token.test.ts`, `inbound-audience.service.test.ts`, `inbound-claim-verification-hook.test.ts`) and an integration test (`inbound-claim-verification-hook.integration.test.ts`) driving the real hook through `establishExecutionContext`, including proving verification happens exactly once and a second `establishExecutionContext` call (main → worker) is a no-op.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1166

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI