### PR TITLE
chore(editor): Remove two experiment constants with no readers (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/app/constants/experiments.ts
@@ -81,8 +81,6 @@ export const INSTANCE_AI_PROACTIVE_AGENT_EXPERIMENT = createExperiment(
 export const INSTANCE_AI_PROMPT_SUGGESTIONS_V2_EXPERIMENT = createExperiment(
 	'085_instance_ai_prompt_suggestions_v2',
 );
-// A/A test validating the experimentation system itself (#26387): both arms are
-// identical, so having no reader is the point. Keep it out of unread-flag cleanups.
 export const AA_EXPERIMENT_CHECK = createExperiment('078_experiment_check_aa');
 
 export const CHAT_HUB_SEMANTIC_SEARCH_EXPERIMENT = createExperiment('077_chat_hub_semantic_search');

--- a/packages/frontend/editor-ui/src/app/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/app/constants/experiments.ts
@@ -39,8 +39,6 @@ export const COLLECTION_OVERHAUL_EXPERIMENT = createExperiment('048_collection_o
 
 export const TEMPLATE_SETUP_EXPERIENCE = createExperiment('055_template_setup_experience');
 
-export const AI_BUILDER_PLAN_MODE_EXPERIMENT = createExperiment('073_builder_plan_mode');
-
 export const AI_BUILDER_REVIEW_CHANGES_EXPERIMENT = createExperiment(
 	'075_ai_builder_review_changes',
 );
@@ -150,7 +148,6 @@ export const EXPERIMENTS_TO_TRACK = [
 	BATCH_11AUG_EXPERIMENT.name,
 	TEMPLATE_RECO_V2.name,
 	READY_TO_RUN_V2_P3_EXPERIMENT.name,
-	AI_BUILDER_PLAN_MODE_EXPERIMENT.name,
 	TEMPLATE_SETUP_EXPERIENCE.name,
 	RESOURCE_CENTER_EXPERIMENT.name,
 	EXECUTION_LOGIC_V2_EXPERIMENT.name,

--- a/packages/frontend/editor-ui/src/app/constants/experiments.ts
+++ b/packages/frontend/editor-ui/src/app/constants/experiments.ts
@@ -27,12 +27,6 @@ export const BATCH_11AUG_EXPERIMENT = createExperiment('37_onboarding_experiment
 
 export const TEMPLATE_RECO_V2 = createExperiment('039_template_onboarding_v2');
 
-export const READY_TO_RUN_V2_EXPERIMENT = createExperiment('042_ready-to-run-worfklow_v2', {
-	control: 'control',
-	variant1: 'variant-1-singlebox',
-	variant2: 'variant-2-twoboxes',
-});
-
 export const READY_TO_RUN_V2_P3_EXPERIMENT = createExperiment('059_ready-to-run-worfklow_v2-3', {
 	control: 'control',
 	variant5: 'variant-5',
@@ -89,6 +83,8 @@ export const INSTANCE_AI_PROACTIVE_AGENT_EXPERIMENT = createExperiment(
 export const INSTANCE_AI_PROMPT_SUGGESTIONS_V2_EXPERIMENT = createExperiment(
 	'085_instance_ai_prompt_suggestions_v2',
 );
+// A/A test validating the experimentation system itself (#26387): both arms are
+// identical, so having no reader is the point. Keep it out of unread-flag cleanups.
 export const AA_EXPERIMENT_CHECK = createExperiment('078_experiment_check_aa');
 
 export const CHAT_HUB_SEMANTIC_SEARCH_EXPERIMENT = createExperiment('077_chat_hub_semantic_search');


### PR DESCRIPTION
## Summary

Removes the two experiment constants in `experiments.ts` that no code reads, and documents why the one remaining reader-less constant is supposed to stay that way. One file, +2/-9.

**`042_ready-to-run-worfklow_v2`** (`READY_TO_RUN_V2_EXPERIMENT`) — left behind when `059_ready-to-run-worfklow_v2-3` superseded it. No symbol reader, no flag-string reader, and it was never in `EXPERIMENTS_TO_TRACK`, so nothing referenced it at all.

**`073_builder_plan_mode`** (`AI_BUILDER_PLAN_MODE_EXPERIMENT`) — this one is a resurrected deletion, not a new call:

| when | what |
| --- | --- |
| 2026-02-09 | #25498 ships planning mode behind the flag |
| 2026-06-04 | #31744 "Remove retired AI builder experiment flags" deletes the constant, its `EXPERIMENTS_TO_TRACK` entry, and every read of it |
| 2026-06-08 | #31763 (removing `056_ai_builder_template_examples`) was cut from a branch predating #31744, so rewriting those same two lines reintroduced the constant and the tracking entry as collateral |

No read came back with it, and planning mode has shipped unconditionally since. The leftover `EXPERIMENTS_TO_TRACK` entry means `posthog.store.ts:155` still emits a participation event for an experiment no code can respond to. The second commit here restores exactly the shape #31744 left.

**`AA_EXPERIMENT_CHECK` (`078_experiment_check_aa`) is deliberately left alone**, with a comment added saying why. It is the A/A test added in #26387 to validate the experimentation system: both arms are identical, so having no behavioural reader is the entire point and adding one would defeat it. Without that note it looks identical to the dead constants above — this is the third time a sweep has had to reason it out from scratch.

The `worfklow` typo in the surviving `059_` flag name is untouched. It is the real PostHog key; renaming it would silently detach the flag.

## How to test

Static change to flag declarations, no user-facing behaviour. Verified on this branch:

- `pnpm --filter n8n-editor-ui typecheck` — passes (exit 0)
- `pnpm --filter n8n-editor-ui lint` — passes (exit 0, 0 errors)
- Whole-repo grep for both removed symbols and both flag strings, excluding `node_modules`/`dist` — zero hits outside the deleted lines
- `EXPERIMENTS_TO_TRACK` now matches its state at #31744 for the plan-mode entry

Nothing reads either constant, so there is no behaviour to exercise beyond the editor building and loading normally.

## Related Linear tickets, Github issues, and Community forum posts

Found by a janitor sweep of `packages/frontend`.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- n/a: no documented surface -->
- [x] Tests included. <!-- n/a: removes unread constants; no behaviour to test. Existing EXPERIMENTS_TO_TRACK assertions cover other flags and still pass. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

### One open question, and a one-command answer either way

Draft because of a single outstanding confirmation on the plan-mode flag: **is anyone still watching the `073_builder_plan_mode` participation event in PostHog?** No agent can query PostHog, so this needs a human nod.

The repo argues strongly that nobody can be: its owner retired the flag in #31744, the event stopped being emitted for the four days between #31744 and #31763, and it only resumed by accident — so the series already has a hole in it and no code has been able to respond to the flag since June.

- **If that holds** — mark ready, merge as-is.
- **If someone is still watching it** — drop the second commit (`250c98aa71`); the first commit stands on its own and needs no PostHog answer. The right fix in that case is restoring a real flag read, not keeping a participation event with no reader.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

