### PR TITLE
fix(core): Gate error workflows behind primary readiness

### DIFF
--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -155,8 +155,7 @@ again.
 
 ## Error workflow follow-up
 
-Offer or build an error workflow only after the latest primary version passes a
-real, full-path live test and that version is published. Until then, keep
+Offer or build an error workflow only after the latest primary version is tested and that version is published. Until then, keep
 working on the primary workflow.
 
 If you just built an Error Trigger workflow because the user opted into adding

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -159,7 +159,7 @@ again.
 
 ## Error workflow follow-up
 
-This follow-up comes after only after a direct new primary workflow is successfully published.
+This follow-up comes only after a direct new primary workflow is successfully published.
 
 If you just built an Error Trigger workflow because the user opted into adding
 one for a known target workflow, do not ask whether to build another error

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -144,30 +144,23 @@ again.
    setup tool. The user chose to set things up later.
 6. After setup completes or is applied, follow
    [Mocked verification live-test follow-up](#mocked-verification-live-test-follow-up)
-   when the latest verification evidence used mocks or simulations. If this
-   follow-up is due, ask only that question now; do not also ask about the error
-   workflow in the same response.
-7. For a direct new primary workflow, follow
-   [Error workflow follow-up](#error-workflow-follow-up) after the mocked
-   live-test follow-up is no longer pending for this workflow. If no mocked
-   live-test follow-up is due, ask about the error workflow before any generic
-   testing prompt. Do not replace this explicit opt-in with a generic "add
-   anything else?", publish, or test question.
+   when the latest verification evidence used mocks or simulations.
+7. For a direct new primary workflow, ask about one step at a time: live test,
+   publish, then error workflow. Move to publishing only after the latest
+   version passes a real, full-path live test without mocks. Move to the error
+   workflow only after that version is published with user approval.
 8. Ask the user if they want to test the workflow (skip this if
    `verify-built-workflow` already proved it works end-to-end with full
-   coverage). If you need to ask about both generic testing and an error
-   workflow, ask the error-workflow opt-in first and leave generic testing as a
-   later follow-up unless the user already requested testing.
-9. Only call `workflows(action="publish")` when the user explicitly asks to
-   publish. Never publish automatically.
+   coverage). Only call `workflows(action="publish")` when the user explicitly
+   asks to publish. Never publish automatically.
+9. After the tested primary is published, follow
+   [Error workflow follow-up](#error-workflow-follow-up).
 
 ## Error workflow follow-up
 
-This follow-up comes after the mocked verification live-test follow-up when that
-follow-up is due, and before generic "want to test it?" prompts. For a direct
-new primary workflow, ask about the error workflow after the user answers,
-declines, or defers any pending live/no-mock testing question. If no mocked
-live-test follow-up is due, ask about the error workflow first.
+Offer or build an error workflow only after the latest primary version passes a
+real, full-path live test and that version is published. Until then, keep
+working on the primary workflow.
 
 If you just built an Error Trigger workflow because the user opted into adding
 one for a known target workflow, do not ask whether to build another error
@@ -175,10 +168,9 @@ workflow. Continue the publish-before-assign flow for the target workflow:
 ask whether to publish the error workflow and set it on that target workflow,
 then publish and assign only after the user approves.
 
-After saving and handling verification/setup for a direct new primary workflow,
-ask once whether the user wants to build an error workflow for that workflow.
-Use `ask-user` with a yes/no choice or a concise visible question. Do **not**
-create an error workflow before the user opts in.
+After the primary workflow is ready, ask once whether the user wants to build
+an error workflow for it. Use `ask-user` with a yes/no choice or a concise
+visible question. Do **not** create one before the user opts in.
 
 The opt-in must explicitly mention an error workflow and the target workflow
 name. A generic follow-up like "Want me to add anything else?", "Want me to
@@ -227,15 +219,12 @@ that workflow used mocked credentials, simulated node output, fixture overrides,
 temporary pin data, or another mocked input, ask whether the user wants a live
 test without mocks. Do not run the live test automatically.
 
-This follow-up has priority over the error-workflow opt-in for a direct new
-primary workflow. If both follow-ups are due, ask about the live/no-mock test
-first and ask the error-workflow question only after the user has answered,
-declined, or deferred the live/no-mock test follow-up.
+This follow-up comes before publishing and the error-workflow opt-in.
 
 If the user agrees, use the explicit live execution path (`executions(action="run")`
 for a direct live run) and report the result separately from the earlier mocked
-verification. If the user declines or defers, state what remains untested and do
-not claim live end-to-end verification.
+verification. If the user declines or defers, state what remains untested and do not
+claim live end-to-end verification.
 
 ## Claiming success
 

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -147,9 +147,9 @@ again.
    when the latest verification evidence used mocks or simulations. If this
    follow-up is due, ask only that question now; do not also ask about the error
    workflow in the same response.
-7. Ask the user if they want to test the workflow (skip this if
-   `verify-built-workflow` already proved it works end-to-end with full
-   coverage).
+7. If testing has not already been offered or completed, ask whether the user
+   wants to test the workflow. Skip this if `verify-built-workflow` already
+   proved it works end-to-end with full coverage.
 8. Only call `workflows(action="publish")` when the user explicitly asks to
    publish. Never publish automatically.
 9. After a direct new primary workflow is successfully published, follow

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -144,19 +144,22 @@ again.
    setup tool. The user chose to set things up later.
 6. After setup completes or is applied, follow
    [Mocked verification live-test follow-up](#mocked-verification-live-test-follow-up)
-   when the latest verification evidence used mocks or simulations.
-7. For a direct new primary workflow, if the latest version has not passed a
-   real, full-path live test, ask whether the user wants to run
-   one. `verify-built-workflow` alone does not satisfy this requirement. If the user declines or defers, state what remains untested.
-8. After offering live test, ask whether the user wants to publish the primary
-   workflow. Only call `workflows(action="publish")` when the user explicitly
-   asks to publish. Never publish automatically. After publication succeeds,
-   follow [Error workflow follow-up](#error-workflow-follow-up).
+   when the latest verification evidence used mocks or simulations. If this
+   follow-up is due, ask only that question now; do not also ask about the error
+   workflow in the same response.
+7. Ask the user if they want to test the workflow (skip this if
+   `verify-built-workflow` already proved it works end-to-end with full
+   coverage).
+8. Only call `workflows(action="publish")` when the user explicitly asks to
+   publish. Never publish automatically.
+9. After a direct new primary workflow is successfully published, follow
+   [Error workflow follow-up](#error-workflow-follow-up).
+   Do not replace this explicit opt-in with a generic "add
+   anything else?", publish, or test question.
 
 ## Error workflow follow-up
 
-Offer or build an error workflow only after the latest primary version is tested and that version is published. Until then, keep
-working on the primary workflow.
+This follow-up comes after only after a direct new primary workflow is successfully published.
 
 If you just built an Error Trigger workflow because the user opted into adding
 one for a known target workflow, do not ask whether to build another error
@@ -164,9 +167,10 @@ workflow. Continue the publish-before-assign flow for the target workflow:
 ask whether to publish the error workflow and set it on that target workflow,
 then publish and assign only after the user approves.
 
-After the primary workflow is ready, ask once whether the user wants to build
-an error workflow for it. Use `ask-user` with a yes/no choice or a concise
-visible question. Do **not** create one before the user opts in.
+After successfully publishing a direct new primary workflow,
+ask once whether the user wants to build an error workflow for that workflow.
+Use `ask-user` with a yes/no choice or a concise visible question. Do **not**
+create an error workflow before the user opts in.
 
 The opt-in must explicitly mention an error workflow and the target workflow
 name. A generic follow-up like "Want me to add anything else?", "Want me to
@@ -215,12 +219,9 @@ that workflow used mocked credentials, simulated node output, fixture overrides,
 temporary pin data, or another mocked input, ask whether the user wants a live
 test without mocks. Do not run the live test automatically.
 
-This follow-up comes before publishing and the error-workflow opt-in.
-
 If the user agrees, use the explicit live execution path (`executions(action="run")`
 for a direct live run) and report the result separately from the earlier mocked
-verification. If the user declines or defers, state what remains untested and do not
-claim live end-to-end verification.
+verification. If the user declines or defers, state what remains untested and do not claim live end-to-end verification.
 
 ## Claiming success
 

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -145,16 +145,13 @@ again.
 6. After setup completes or is applied, follow
    [Mocked verification live-test follow-up](#mocked-verification-live-test-follow-up)
    when the latest verification evidence used mocks or simulations.
-7. For a direct new primary workflow, ask about one step at a time: live test,
-   publish, then error workflow. Move to publishing only after the latest
-   version passes a real, full-path live test without mocks. Move to the error
-   workflow only after that version is published with user approval.
-8. Ask the user if they want to test the workflow (skip this if
-   `verify-built-workflow` already proved it works end-to-end with full
-   coverage). Only call `workflows(action="publish")` when the user explicitly
-   asks to publish. Never publish automatically.
-9. After the tested primary is published, follow
-   [Error workflow follow-up](#error-workflow-follow-up).
+7. For a direct new primary workflow, if the latest version has not passed a
+   real, full-path live test, ask whether the user wants to run
+   one. `verify-built-workflow` alone does not satisfy this requirement. If the user declines or defers, state what remains untested.
+8. After offering live test, ask whether the user wants to publish the primary
+   workflow. Only call `workflows(action="publish")` when the user explicitly
+   asks to publish. Never publish automatically. After publication succeeds,
+   follow [Error workflow follow-up](#error-workflow-follow-up).
 
 ## Error workflow follow-up
 

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -150,10 +150,10 @@ Error workflows are per-target-workflow (`settings.errorWorkflow` must be the
 real workflow ID of a separate **published** workflow with an active Error
 Trigger — never a name, placeholder, `activeVersionId`, or local SDK id).
 n8n has no global error workflow setting; mention that only if the user asks
-about global behavior. Before offering, building, or attaching one, require the
-latest primary version to be published and pass a real, full-path live test.
-Before building or attaching an error workflow, load `references/error-workflows.md`
-and follow build → publish → assign.
+about global behavior. Do not offer or build an error workflow before the
+primary workflow is published. Before building or attaching an error
+workflow, load this skill's `references/error-workflows.md` linked file and
+follow its build → publish → assign steps.
 
 ## Mandatory Process
 
@@ -446,7 +446,7 @@ unsolicited `sticky()`, forbidden builder constructs (e.g. `.map()`), and
 repeated `.onTrue()` / `.onFalse()` overwrites on the same IF variable. Fix
 every reported error and warning before calling `build-workflow`.
 
-- Code nodes need not always be necessary. You can use other n8n nodes to do the same thing. 
+- Code nodes need not always be necessary. You can use other n8n nodes to do the same thing.
 - SDK builder code is a restricted subset of TypeScript that builds a static
   graph; it is not a Code node and does not run. Build strings with template
   literals; do runtime joining, aggregation, or transforms in a Code node or

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -150,9 +150,10 @@ Error workflows are per-target-workflow (`settings.errorWorkflow` must be the
 real workflow ID of a separate **published** workflow with an active Error
 Trigger — never a name, placeholder, `activeVersionId`, or local SDK id).
 n8n has no global error workflow setting; mention that only if the user asks
-about global behavior. Before building or attaching an error workflow, load
-this skill's `references/error-workflows.md` linked file and follow its
-build → publish → assign steps. Do not create one before the user opts in.
+about global behavior. Before offering, building, or attaching one, require the
+latest primary version to be published and pass a real, full-path live test.
+Before building or attaching an error workflow, load `references/error-workflows.md`
+and follow build → publish → assign.
 
 ## Mandatory Process
 

--- a/packages/@n8n/instance-ai/skills/workflow-builder/references/error-workflows.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/references/error-workflows.md
@@ -20,13 +20,15 @@ instance-wide error workflow behavior.
 
 When creating an error workflow to attach to another workflow:
 
-1. Ask once whether the user wants an error workflow, unless they already
-   requested one.
+1. Wait until the target workflow is published, then ask whether the user wants
+   an error workflow for it.
 2. Build the error workflow as a separate workflow. It starts with an Error
    Trigger and sends the notification the user requested.
 3. Publish the error workflow with `workflows(action="publish")` before setting
    it on the target workflow: `settings.errorWorkflow` only accepts a published
    workflow, and publishing goes through HITL approval, so the user confirms it.
+   This applies to the error workflow only; never publish the target workflow
+   unless the user explicitly asks.
 4. Patch the original target workflow's source and set
    `.settings({ errorWorkflow: '<published-error-workflow-id>' })`, then call
    `build-workflow` for the original workflow. This assigns the error workflow

--- a/packages/@n8n/instance-ai/skills/workflow-builder/references/error-workflows.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/references/error-workflows.md
@@ -20,15 +20,13 @@ instance-wide error workflow behavior.
 
 When creating an error workflow to attach to another workflow:
 
-1. Build the target workflow first, then ask whether the user wants an error
-   workflow for it. Do not create one before the user opts in.
+1. Ask once whether the user wants an error workflow, unless they already
+   requested one.
 2. Build the error workflow as a separate workflow. It starts with an Error
    Trigger and sends the notification the user requested.
 3. Publish the error workflow with `workflows(action="publish")` before setting
    it on the target workflow: `settings.errorWorkflow` only accepts a published
    workflow, and publishing goes through HITL approval, so the user confirms it.
-   This applies to the error workflow only; never publish the target workflow
-   unless the user explicitly asks.
 4. Patch the original target workflow's source and set
    `.settings({ errorWorkflow: '<published-error-workflow-id>' })`, then call
    `build-workflow` for the original workflow. This assigns the error workflow

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -385,9 +385,6 @@ describe('Instance AI runtime skills', () => {
 		expect(normalizedInstructions).toContain(
 			'ask once whether the user wants to build an error workflow',
 		);
-		expect(normalizedInstructions).toMatch(
-			/Offer or build an error workflow only after .* live test .* published/,
-		);
 		expect(loaded?.instructions).toContain(
 			'The error workflow must be published before it can be assigned',
 		);

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -381,17 +381,12 @@ describe('Instance AI runtime skills', () => {
 		expect(loaded?.instructions).toContain('verificationReadiness.status === "not_verifiable"');
 		expect(loaded?.instructions).toContain('setupRequirement.status === "required"');
 		expect(loaded?.instructions).toContain('inline setup card in the AI Assistant panel');
-		expect(loaded?.instructions).toContain(
-			'ask once whether the user wants to build an error workflow for that workflow',
+		const normalizedInstructions = loaded?.instructions.replace(/\s+/g, ' ');
+		expect(normalizedInstructions).toContain(
+			'ask once whether the user wants to build an error workflow',
 		);
-		expect(loaded?.instructions).toContain(
-			'Do not replace this explicit opt-in with a generic "add\n   anything else?", publish, or test question.',
-		);
-		expect(loaded?.instructions).toMatch(
-			/ask only that question now; do not also ask about the error\s+workflow/,
-		);
-		expect(loaded?.instructions).toContain(
-			'This follow-up comes after the mocked verification live-test follow-up',
+		expect(normalizedInstructions).toMatch(
+			/Offer or build an error workflow only after .* live test .* published/,
 		);
 		expect(loaded?.instructions).toContain(
 			'The error workflow must be published before it can be assigned',
@@ -406,7 +401,7 @@ describe('Instance AI runtime skills', () => {
 		);
 		expect(loaded?.instructions).toContain('Mocked verification live-test follow-up');
 		expect(loaded?.instructions).toContain(
-			'This follow-up has priority over the error-workflow opt-in',
+			'This follow-up comes before publishing and the error-workflow opt-in',
 		);
 		expect(loaded?.instructions).toMatch(
 			/Do not ask whether to build now and set up\s+credentials later/,
@@ -417,7 +412,7 @@ describe('Instance AI runtime skills', () => {
 		expect(loaded?.instructions).toContain(
 			'Ask which auth type to use when a service supports more than one',
 		);
-		expect(loaded?.instructions).toContain(
+		expect(normalizedInstructions).toContain(
 			'Only call `workflows(action="publish")` when the user explicitly asks',
 		);
 

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -381,9 +381,14 @@ describe('Instance AI runtime skills', () => {
 		expect(loaded?.instructions).toContain('verificationReadiness.status === "not_verifiable"');
 		expect(loaded?.instructions).toContain('setupRequirement.status === "required"');
 		expect(loaded?.instructions).toContain('inline setup card in the AI Assistant panel');
-		const normalizedInstructions = loaded?.instructions.replace(/\s+/g, ' ');
-		expect(normalizedInstructions).toContain(
-			'ask once whether the user wants to build an error workflow',
+		expect(loaded?.instructions).toContain(
+			'ask once whether the user wants to build an error workflow for that workflow',
+		);
+		expect(loaded?.instructions).toContain(
+			'Do not replace this explicit opt-in with a generic "add\n   anything else?", publish, or test question.',
+		);
+		expect(loaded?.instructions).toMatch(
+			/ask only that question now; do not also ask about the error\s+workflow/,
 		);
 		expect(loaded?.instructions).toContain(
 			'The error workflow must be published before it can be assigned',
@@ -397,9 +402,6 @@ describe('Instance AI runtime skills', () => {
 			'Mention that n8n has\n   no global or instance-wide error workflow setting only when the user\n   explicitly asked about',
 		);
 		expect(loaded?.instructions).toContain('Mocked verification live-test follow-up');
-		expect(loaded?.instructions).toContain(
-			'This follow-up comes before publishing and the error-workflow opt-in',
-		);
 		expect(loaded?.instructions).toMatch(
 			/Do not ask whether to build now and set up\s+credentials later/,
 		);
@@ -409,7 +411,7 @@ describe('Instance AI runtime skills', () => {
 		expect(loaded?.instructions).toContain(
 			'Ask which auth type to use when a service supports more than one',
 		);
-		expect(normalizedInstructions).toContain(
+		expect(loaded?.instructions).toContain(
 			'Only call `workflows(action="publish")` when the user explicitly asks',
 		);
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -251,9 +251,6 @@ describe('createBuildWorkflowTool', () => {
 		expect(result.postBuildFlow?.instructions).not.toContain('## Setup follow-up');
 		expect(result.postBuildFlow?.instructions).not.toContain('## Credentials before build');
 		expect(result.postBuildFlow?.instructions).toContain('## After build-workflow succeeds');
-		expect(result.postBuildFlow?.instructions.replace(/\s+/g, ' ')).toMatch(
-			/Offer or build an error workflow only after .* live test .* published/,
-		);
 		expect(result.postBuildFlow?.guidance).toContain(
 			'run a real full-path test, ask to publish the primary workflow after it passes',
 		);

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -251,11 +251,11 @@ describe('createBuildWorkflowTool', () => {
 		expect(result.postBuildFlow?.instructions).not.toContain('## Setup follow-up');
 		expect(result.postBuildFlow?.instructions).not.toContain('## Credentials before build');
 		expect(result.postBuildFlow?.instructions).toContain('## After build-workflow succeeds');
-		expect(result.postBuildFlow?.guidance).toContain(
-			'then mocked/no-mock live-test when latest verification used mocks or simulations',
+		expect(result.postBuildFlow?.instructions.replace(/\s+/g, ' ')).toMatch(
+			/Offer or build an error workflow only after .* live test .* published/,
 		);
 		expect(result.postBuildFlow?.guidance).toContain(
-			'Do not replace the error-workflow opt-in with a generic add-anything',
+			'then required testing and primary publication, then explicit error-workflow opt-in',
 		);
 		expect(compileWorkflowSource).toHaveBeenCalledWith(context, filePath, source, undefined);
 		expect(context.workflowService.createFromWorkflowJSON).toHaveBeenCalledWith(

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -252,7 +252,10 @@ describe('createBuildWorkflowTool', () => {
 		expect(result.postBuildFlow?.instructions).not.toContain('## Credentials before build');
 		expect(result.postBuildFlow?.instructions).toContain('## After build-workflow succeeds');
 		expect(result.postBuildFlow?.guidance).toContain(
-			'run a real full-path test, ask to publish the primary workflow after it passes',
+			'then mocked/no-mock live-test when latest verification used mocks or simulations',
+		);
+		expect(result.postBuildFlow?.guidance).toContain(
+			'Do not replace the error-workflow opt-in with a generic add-anything',
 		);
 		expect(compileWorkflowSource).toHaveBeenCalledWith(context, filePath, source, undefined);
 		expect(context.workflowService.createFromWorkflowJSON).toHaveBeenCalledWith(

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -255,7 +255,7 @@ describe('createBuildWorkflowTool', () => {
 			/Offer or build an error workflow only after .* live test .* published/,
 		);
 		expect(result.postBuildFlow?.guidance).toContain(
-			'then required testing and primary publication, then explicit error-workflow opt-in',
+			'run a real full-path test, ask to publish the primary workflow after it passes',
 		);
 		expect(compileWorkflowSource).toHaveBeenCalledWith(context, filePath, source, undefined);
 		expect(context.workflowService.createFromWorkflowJSON).toHaveBeenCalledWith(

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -225,7 +225,7 @@ export function autoImportMissingSdkSymbols(
 const POST_BUILD_FLOW_SKILL_ID = 'post-build-flow';
 
 const POST_BUILD_FLOW_GUIDANCE =
-	'This direct build is not complete yet. Follow the post-build instructions in `instructions` now (do NOT load the post-build-flow skill — they are the same instructions) before verification, setup, error-workflow follow-up, publishing, testing, or any final user-visible summary. Follow-up order is verification/setup first, then mocked/no-mock live-test when latest verification used mocks or simulations, then explicit error-workflow opt-in for direct new primary workflows, then generic testing prompts. Do not replace the error-workflow opt-in with a generic add-anything, publish, or test question.';
+	'This direct build is not complete yet. Follow the post-build instructions in `instructions` now (do NOT load the post-build-flow skill — they are the same instructions) before verification, setup, error-workflow follow-up, publishing, testing, or any final user-visible summary. Follow-up order is verification/setup first, then required testing and primary publication, then explicit error-workflow opt-in for direct new primary workflows, then generic testing prompts. Do not replace the error-workflow opt-in with a generic add-anything, publish, or test question.';
 
 // Inlined into successful build results; the skill stays registered for tag-driven follow-up turns.
 let postBuildFlowInstructionsCache: string | undefined;

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -225,7 +225,7 @@ export function autoImportMissingSdkSymbols(
 const POST_BUILD_FLOW_SKILL_ID = 'post-build-flow';
 
 const POST_BUILD_FLOW_GUIDANCE =
-	'This direct build is not complete yet. Follow the post-build instructions in `instructions` now (do NOT load the post-build-flow skill — they are the same instructions) before verification, setup, error-workflow follow-up, publishing, testing, or any final user-visible summary. After verification and setup, handle one follow-up at a time: run a real full-path test, ask to publish the primary workflow after it passes, then offer an error workflow after publication succeeds. Never require publication before testing.';
+	'This direct build is not complete yet. Follow the post-build instructions in `instructions` now (do NOT load the post-build-flow skill — they are the same instructions) before verification, setup, error-workflow follow-up, publishing, testing, or any final user-visible summary. Follow-up order is verification/setup first, then mocked/no-mock live-test when latest verification used mocks or simulations, then generic testing prompts. Offer the explicit error-workflow opt-in for direct new primary workflows only after the primary workflow is successfully published. Do not replace the error-workflow opt-in with a generic add-anything, publish, or test question.';
 
 // Inlined into successful build results; the skill stays registered for tag-driven follow-up turns.
 let postBuildFlowInstructionsCache: string | undefined;

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -225,7 +225,7 @@ export function autoImportMissingSdkSymbols(
 const POST_BUILD_FLOW_SKILL_ID = 'post-build-flow';
 
 const POST_BUILD_FLOW_GUIDANCE =
-	'This direct build is not complete yet. Follow the post-build instructions in `instructions` now (do NOT load the post-build-flow skill — they are the same instructions) before verification, setup, error-workflow follow-up, publishing, testing, or any final user-visible summary. Follow-up order is verification/setup first, then required testing and primary publication, then explicit error-workflow opt-in for direct new primary workflows, then generic testing prompts. Do not replace the error-workflow opt-in with a generic add-anything, publish, or test question.';
+	'This direct build is not complete yet. Follow the post-build instructions in `instructions` now (do NOT load the post-build-flow skill — they are the same instructions) before verification, setup, error-workflow follow-up, publishing, testing, or any final user-visible summary. After verification and setup, handle one follow-up at a time: run a real full-path test, ask to publish the primary workflow after it passes, then offer an error workflow after publication succeeds. Never require publication before testing.';
 
 // Inlined into successful build results; the skill stays registered for tag-driven follow-up turns.
 let postBuildFlowInstructionsCache: string | undefined;


### PR DESCRIPTION
## Summary

- Preserve the existing post-build verification and testing flow.
- Offer an error workflow only as a separate next step after the primary workflow is successfully published.
- Keep error-workflow creation explicit and preserve the build → publish → assign sequence.

## How to test

From `packages/@n8n/instance-ai`:

- `pnpm test src/skills/__tests__/runtime-skills.test.ts src/tools/workflows/__tests__/build-workflow.tool.test.ts` (54 passed)
- `pnpm lint`
- `pnpm typecheck`
- [LangTracer case #564](https://lang-tracer.n8n-maintenance.workers.dev/test-cases/564) verifies the error-workflow offer happens only after primary publication.
- [LangTracer case #168](https://lang-tracer.n8n-maintenance.workers.dev/test-cases/168) verifies the handler is published before assignment.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-968

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
