### PR TITLE
fix(core): Normalize the $fromAI type argument before coercing defaults

### DIFF
--- a/packages/workflow/src/from-ai-parse-utils.ts
+++ b/packages/workflow/src/from-ai-parse-utils.ts
@@ -213,10 +213,13 @@ function parseArguments(argsString: string): FromAIArgument {
 		return trimmed;
 	});
 
-	const type = cleanArgs?.[2] ?? 'string';
+	const rawType = cleanArgs?.[2] ?? 'string';
+	// `isFromAIArgumentType` accepts any casing, so normalize before narrowing:
+	// consumers of `FromAIArgument.type` compare against the lowercase literals.
+	const type = rawType.toLowerCase();
 
 	if (!isFromAIArgumentType(type)) {
-		throw new ParseError(`Invalid type: ${type}`);
+		throw new ParseError(`Invalid type: ${rawType}`);
 	}
 
 	return {

--- a/packages/workflow/test/from-ai-parse-utils.test.ts
+++ b/packages/workflow/test/from-ai-parse-utils.test.ts
@@ -30,6 +30,13 @@ describe('extractFromAICalls', () => {
 		['{{ $fromAI("a", "b", "string", "5") }}', ['a', 'b', 'string', '5']],
 		['{{ $fromAI("a", "b", "string", "true") }}', ['a', 'b', 'string', 'true']],
 		['{{ $fromAI("a", "b", "string", "{}") }}', ['a', 'b', 'string', '{}']],
+		// The type argument is accepted case-insensitively, so it has to be normalized
+		// before it is used to coerce the default value.
+		['{{ $fromAI("a", "b", "String", "true") }}', ['a', 'b', 'string', 'true']],
+		['{{ $fromAI("a", "b", "STRING", "5") }}', ['a', 'b', 'string', '5']],
+		['{{ $fromAI("a", "b", "String", "{}") }}', ['a', 'b', 'string', '{}']],
+		['{{ $fromAI("a", "b", "Number", "5") }}', ['a', 'b', 'number', 5]],
+		['{{ $fromAI("a", "b", "Boolean", "true") }}', ['a', 'b', 'boolean', true]],
 	])('should parse args as expected for %s', (formula, [key, description, type, defaultValue]) => {
 		expect(extractFromAICalls(formula)).toEqual([
 			{


### PR DESCRIPTION
## Summary

`isFromAIArgumentType` validates the `$fromAI` type argument case-insensitively:

```ts
function isFromAIArgumentType(value: string): value is FromAIArgumentType {
	return ['string', 'number', 'boolean', 'json'].includes(value.toLowerCase());
}
```

but `parseArguments` then hands the **raw** string to `parseDefaultValue`, which compares it against the lowercase literals (`type === 'string'`, …). A type written as `String` passes validation, misses every branch, and falls through to the JSON fallback:

| expression | `type` | `defaultValue` (before) | (after) |
| --- | --- | --- | --- |
| `$fromAI('k', 'd', 'string', 'true')` | `string` | `'true'` (string) | unchanged |
| `$fromAI('k', 'd', 'String', 'true')` | `String` | `true` (**boolean**) | `'true'` (string) |
| `$fromAI('k', 'd', 'String', '5')` | `String` | `5` (**number**) | `'5'` (string) |
| `$fromAI('k', 'd', 'String', '{}')` | `String` | `{}` (**object**) | `'{}'` (string) |

Two things go wrong downstream:

- `generateZodSchema` *does* lowercase (`placeholder.type?.toLowerCase()`), so it correctly builds `z.string()` — and then gets a boolean/number/object passed to `.default()`.
- In the editor, `useToolParameters.ts` reads `mapTypes[value.type ?? 'string'].inputType`, and `mapTypes` is keyed by the lowercase names only, so a non-lowercase type dereferences `undefined`.

The type predicate is also unsound as written: it narrows `'String'` to `FromAIArgumentType`, a union that does not contain it, so the returned `FromAIArgument` violates its own declared type.

This is reachable from hand-written expressions only — every generator in the repo (`fromAIOverride.utils.ts`, `subnodeBuilders.fromAi`, the workflow-sdk prompts) already emits lowercase.

## Fix

Lowercase the type argument before narrowing it, so `FromAIArgument.type` is genuinely one of the declared literals and both consumers see the canonical value. The `ParseError` still reports the type as the user wrote it.

## How to test

```
cd packages/workflow
pnpm vitest run test/from-ai-parse-utils.test.ts
```

The five new rows in the `extractFromAICalls` table (`String` / `STRING` / `Number` / `Boolean`) fail on current `master` — 10 failures across the `legacy-engine` and `vm-engine` projects — and pass with this change.

In the UI: add a tool node, set a parameter to `={{ $fromAI('flag', 'a flag', 'String', 'true') }}`, and inspect the generated tool schema — the default arrives as a boolean before this change and as a string after.

## Related Linear tickets, Github issues, and Community forum posts

None — found while reading `from-ai-parse-utils.ts`; no existing issue or open PR covers it.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- lowercase stays the documented, canonical spelling; nothing documented changes -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

---

Verification run locally: `packages/workflow` full suite 5442 passed (the 2 `date-extensions.test.ts` failures also fail on a clean `master` checkout here, unrelated to this diff); `packages/core` `create-node-as-tool.test.ts` 37 passed; `packages/@n8n/ai-utilities` 686 passed; `pnpm lint` and `tsc --noEmit` clean in `packages/workflow`.

AI-assisted with agentic coding tools; all changes were reviewed and tested by me.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

