### PR TITLE
feat(core): Resolve the principal from the verified claim at every access (no-changelog)

### DIFF
--- a/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
+++ b/packages/@n8n/decorators/src/credential-resolver/credential-resolver.ts
@@ -1,7 +1,7 @@
 import type { Constructable } from '@n8n/di';
 import type {
-	ICredentialContext,
 	ICredentialDataDecryptedObject,
+	ICredentialResolutionContext,
 	INodeProperties,
 } from 'n8n-workflow';
 
@@ -48,7 +48,7 @@ export interface ICredentialResolver {
 	 */
 	getSecret(
 		credentialId: string,
-		context: ICredentialContext,
+		context: ICredentialResolutionContext,
 		handle: CredentialResolverHandle,
 	): Promise<ICredentialDataDecryptedObject>;
 
@@ -58,7 +58,7 @@ export interface ICredentialResolver {
 	 */
 	setSecret(
 		credentialId: string,
-		context: ICredentialContext,
+		context: ICredentialResolutionContext,
 		data: ICredentialDataDecryptedObject,
 		handle: CredentialResolverHandle,
 	): Promise<void>;
@@ -70,7 +70,7 @@ export interface ICredentialResolver {
 	 */
 	deleteSecret?(
 		credentialId: string,
-		context: ICredentialContext,
+		context: ICredentialResolutionContext,
 		handle: CredentialResolverHandle,
 	): Promise<void>;
 
@@ -94,7 +94,10 @@ export interface ICredentialResolver {
 	 * @param context - The identity of the entity to validate access for
 	 * @throws {CredentialResolverAccessValidationError} When access is invalid
 	 */
-	validateIdentity?(context: ICredentialContext, handle: CredentialResolverHandle): Promise<void>;
+	validateIdentity?(
+		context: ICredentialResolutionContext,
+		handle: CredentialResolverHandle,
+	): Promise<void>;
 
 	/**
 	 * Returns the n8n user id the resolved credentials belong to, when this
@@ -107,7 +110,7 @@ export interface ICredentialResolver {
 	 * Optional - not all resolvers map to n8n users.
 	 */
 	resolveOwningUserId?(
-		context: ICredentialContext,
+		context: ICredentialResolutionContext,
 		handle: CredentialResolverHandle,
 	): Promise<string | undefined>;
 

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -1221,6 +1221,7 @@ describe('CredentialsHelper', () => {
 				{ apiKey: 'static-key' },
 				mockAdditionalData.executionContext,
 				mockAdditionalData.workflowSettings,
+				mockAdditionalData.workflowId,
 			);
 			expect(result).toEqual(resolvedData);
 		});

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -561,6 +561,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 				decryptedDataOriginal,
 				additionalData.executionContext,
 				additionalData.workflowSettings,
+				additionalData.workflowId,
 			);
 			decryptedDataOriginal = resolveResult.data;
 			if (resolveResult.isDynamic) {

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -531,17 +531,22 @@ export class CredentialsHelper extends ICredentialsHelper {
 		let decryptedDataOriginal = await credentials.getData();
 
 		// In manual or internal mode (or when the root execution is manual, e.g. a subworkflow
-		// called from a manual parent), skip dynamic resolution unless a credentials context is
-		// present (set by webhook triggers with an identity extractor). Canvas node tests
-		// have no incoming request, so we fall back to static data for easier developer
-		// testing. Internal mode is used by OAuth authorize/revoke flows which are not
-		// actual workflow executions and should not trigger dynamic resolution.
+		// called from a manual parent), skip dynamic resolution unless a credentials context or
+		// a verified claim is present (set by webhook triggers with an identity extractor, or by
+		// inbound claim verification respectively — a claim-only execution never populates
+		// `credentials`). Canvas node tests have no incoming request, so we fall back to static
+		// data for easier developer testing. Internal mode is used by OAuth authorize/revoke
+		// flows which are not actual workflow executions and should not trigger dynamic resolution.
 		// For all other modes (especially production), always attempt resolution —
 		// missing credentials will surface an error rather than silently falling back to
 		// static data.
 		const effectiveMode = additionalData.rootExecutionMode ?? mode;
 		const skipDynamicResolution = effectiveMode === 'manual' || effectiveMode === 'internal';
-		if (additionalData.executionContext?.credentials !== undefined || !skipDynamicResolution) {
+		if (
+			additionalData.executionContext?.credentials !== undefined ||
+			additionalData.executionContext?.claims !== undefined ||
+			!skipDynamicResolution
+		) {
 			// Mark that this execution attempted to run with a private credential before
 			// resolution is attempted, so the flag survives even when resolution throws
 			// (e.g. the running user has not connected the credential). Telemetry-only;

--- a/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
+++ b/packages/cli/src/credentials/__tests__/dynamic-credentials-proxy.test.ts
@@ -89,6 +89,7 @@ describe('DynamicCredentialsProxy', () => {
 				staticData,
 				undefined,
 				undefined,
+				undefined,
 			);
 		});
 
@@ -113,6 +114,7 @@ describe('DynamicCredentialsProxy', () => {
 				staticData,
 				executionContext,
 				workflowSettings,
+				'workflow-1',
 			);
 
 			expect(mockResolverProvider.resolveIfNeeded).toHaveBeenCalledWith(
@@ -120,6 +122,7 @@ describe('DynamicCredentialsProxy', () => {
 				staticData,
 				executionContext,
 				workflowSettings,
+				'workflow-1',
 			);
 		});
 	});

--- a/packages/cli/src/credentials/credential-resolution-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-resolution-provider.interface.ts
@@ -39,6 +39,8 @@ export interface ICredentialResolutionProvider {
 	 * @param credentialsResolveMetadata The credential resolve metadata
 	 * @param staticData The decrypted static credential data
 	 * @param additionalData Additional workflow execution data for context and settings
+	 * @param workflowId The workflow being executed, needed to unseal a claim carried
+	 *                   by the execution context (a claim is sealed per workflow)
 	 * @returns Resolved credential data and a flag indicating whether dynamic resolution occurred
 	 */
 	resolveIfNeeded(
@@ -46,6 +48,7 @@ export interface ICredentialResolutionProvider {
 		staticData: ICredentialDataDecryptedObject,
 		executionContext?: IExecutionContext,
 		workflowSettings?: IWorkflowSettings,
+		workflowId?: string,
 	): Promise<CredentialResolutionResult>;
 
 	/**

--- a/packages/cli/src/credentials/dynamic-credentials-proxy.ts
+++ b/packages/cli/src/credentials/dynamic-credentials-proxy.ts
@@ -66,6 +66,7 @@ export class DynamicCredentialsProxy
 		staticData: ICredentialDataDecryptedObject,
 		executionContext?: IExecutionContext,
 		workflowSettings?: IWorkflowSettings,
+		workflowId?: string,
 	): Promise<CredentialResolutionResult> {
 		if (!this.resolvingProvider) {
 			if (credentialsResolveMetadata.isResolvable) {
@@ -81,6 +82,7 @@ export class DynamicCredentialsProxy
 			staticData,
 			executionContext,
 			workflowSettings,
+			workflowId,
 		);
 	}
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -17,6 +17,7 @@ import {
 	CredentialConnectionStatusService,
 	DynamicCredentialResolverRegistry,
 	DynamicCredentialService,
+	InboundClaimConnectService,
 } from '@/modules/dynamic-credentials.ee/services';
 import { OauthService } from '@/oauth/oauth.service';
 import { UrlService } from '@/services/url.service';
@@ -39,6 +40,7 @@ describe('DynamicCredentialsController', () => {
 	const authorizeIntentService = mockInstance(AuthorizeIntentService);
 	const credentialsFinderService = mockInstance(CredentialsFinderService);
 	const dynamicCredentialService = mockInstance(DynamicCredentialService);
+	const inboundClaimConnectService = mockInstance(InboundClaimConnectService);
 	const urlService = mockInstance(UrlService);
 	const eventService = mockInstance(EventService);
 	mockInstance(CredentialConnectionStatusService);
@@ -55,7 +57,7 @@ describe('DynamicCredentialsController', () => {
 		vi.clearAllMocks();
 
 		// Configure default credential context mock
-		dynamicCredentialWebService.getCredentialContextFromRequest.mockReturnValue({
+		dynamicCredentialWebService.getCredentialContextFromRequest.mockResolvedValue({
 			identity: 'token123',
 			version: 1 as const,
 			metadata: {},
@@ -215,6 +217,63 @@ describe('DynamicCredentialsController', () => {
 			);
 		});
 
+		it('binds an inbound claim to an n8n user before issuing the auth URI', async () => {
+			const mockCredential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer idp-token' },
+			});
+			const res = mock<Response>();
+
+			const claim = {
+				version: 1 as const,
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'external-subject-1',
+				audience: 'https://n8n.example.com',
+				expiresAt: Date.now() + 60_000,
+				boundWorkflowId: '',
+			};
+			dynamicCredentialWebService.getCredentialContextFromRequest.mockResolvedValue({
+				identity: 'idp-token',
+				version: 1,
+				metadata: { source: 'external-idp' },
+				claims: claim,
+			});
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
+				'https://example.domain/oauth2/auth',
+			);
+
+			await controller.authorizeCredential(req, res);
+
+			expect(inboundClaimConnectService.ensureBinding).toHaveBeenCalledWith(claim);
+		});
+
+		it('does not attempt to bind anything when the context carries no claim', async () => {
+			const mockCredential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer opaque-token' },
+			});
+			const res = mock<Response>();
+
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
+				'https://example.domain/oauth2/auth',
+			);
+
+			await controller.authorizeCredential(req, res);
+
+			expect(inboundClaimConnectService.ensureBinding).not.toHaveBeenCalled();
+		});
+
 		it('should return auth URI for OAuth2 credential', async () => {
 			const mockCredential = mock<CredentialsEntity>({
 				id: '1',
@@ -320,7 +379,9 @@ describe('DynamicCredentialsController', () => {
 			};
 
 			// Set up all mocks before calling the controller
-			dynamicCredentialWebService.getCredentialContextFromRequest.mockReturnValue(expectedContext);
+			dynamicCredentialWebService.getCredentialContextFromRequest.mockResolvedValue(
+				expectedContext,
+			);
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
 			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
 			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolverWithValidation);
@@ -875,7 +936,9 @@ describe('DynamicCredentialsController', () => {
 				metadata: {},
 			};
 
-			dynamicCredentialWebService.getCredentialContextFromRequest.mockReturnValue(expectedContext);
+			dynamicCredentialWebService.getCredentialContextFromRequest.mockResolvedValue(
+				expectedContext,
+			);
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
 			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
 			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
@@ -1,10 +1,12 @@
 import type { Mocked } from 'vitest';
 import type { User } from '@n8n/db';
-import { CredentialResolverError } from '@n8n/decorators';
+import { CredentialResolverDataNotFoundError, CredentialResolverError } from '@n8n/decorators';
+import type { IVerifiedClaim } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { AuthService } from '@/auth/auth.service';
 import { AuthError } from '@/errors/response-errors/auth.error';
+import type { IdentityResolutionProxy } from '@/services/identity-resolution-proxy.service';
 import type { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
 
 import { N8NIdentifier } from '../n8n-identifier';
@@ -13,14 +15,33 @@ describe('N8NIdentifier', () => {
 	let identifier: N8NIdentifier;
 	let mockAuthService: Mocked<AuthService>;
 	let mockOAuthVerifier: Mocked<OAuthTokenVerifierProxy>;
+	let mockIdentityResolution: Mocked<IdentityResolutionProxy>;
 
 	const mockUser = mock<User>({ id: 'user-123' });
+
+	const claim: IVerifiedClaim = {
+		version: 1,
+		sourceId: 'source-1',
+		issuer: 'https://idp.example.com',
+		subject: 'external-subject-1',
+		audience: 'https://n8n.example.com',
+		expiresAt: Date.now() + 60_000,
+		boundWorkflowId: 'workflow-1',
+	};
+
+	const externalIdpContext = (claims?: IVerifiedClaim) => ({
+		identity: '',
+		version: 1 as const,
+		metadata: { source: 'external-idp' as const },
+		claims,
+	});
 
 	beforeEach(() => {
 		mockAuthService = mock<AuthService>();
 		mockOAuthVerifier = mock<OAuthTokenVerifierProxy>();
+		mockIdentityResolution = mock<IdentityResolutionProxy>();
 
-		identifier = new N8NIdentifier(mockAuthService, mockOAuthVerifier);
+		identifier = new N8NIdentifier(mockAuthService, mockOAuthVerifier, mockIdentityResolution);
 	});
 
 	afterEach(() => {
@@ -360,6 +381,83 @@ describe('N8NIdentifier', () => {
 				};
 
 				await expect(identifier.resolve(context, {})).rejects.toThrow(CredentialResolverError);
+			});
+		});
+
+		describe('external-idp branch', () => {
+			it('should resolve the principal from the claim on every access', async () => {
+				mockIdentityResolution.resolve.mockResolvedValue(mockUser);
+
+				const result = await identifier.resolve(externalIdpContext(claim), {});
+
+				expect(result).toBe('user-123');
+				expect(mockIdentityResolution.resolve).toHaveBeenCalledWith(
+					{ iss: 'https://idp.example.com', sub: 'external-subject-1' },
+					undefined,
+					{ issuer: 'https://idp.example.com' },
+					false,
+				);
+				expect(mockAuthService.authenticateUserByCookie).not.toHaveBeenCalled();
+				expect(mockAuthService.authenticateUserBasedOnToken).not.toHaveBeenCalled();
+				expect(mockOAuthVerifier.verifyOAuthAccessToken).not.toHaveBeenCalled();
+			});
+
+			it('should never allow provisioning from an inbound trigger', async () => {
+				mockIdentityResolution.resolve.mockResolvedValue(mockUser);
+
+				await identifier.resolve(externalIdpContext(claim), {});
+
+				const allowProvisioning = mockIdentityResolution.resolve.mock.calls[0][3];
+				expect(allowProvisioning).toBe(false);
+			});
+
+			it('should re-resolve on each access rather than caching the principal', async () => {
+				mockIdentityResolution.resolve.mockResolvedValue(mockUser);
+				const context = externalIdpContext(claim);
+
+				await identifier.resolve(context, {});
+				await identifier.resolve(context, {});
+				await identifier.resolve(context, {});
+
+				expect(mockIdentityResolution.resolve).toHaveBeenCalledTimes(3);
+			});
+
+			it('should stop resolving once the binding is revoked mid-execution', async () => {
+				mockIdentityResolution.resolve.mockResolvedValueOnce(mockUser);
+				const context = externalIdpContext(claim);
+
+				await expect(identifier.resolve(context, {})).resolves.toBe('user-123');
+
+				// Binding revoked between accesses: read-only resolution returns null.
+				mockIdentityResolution.resolve.mockResolvedValue(null);
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow(
+					CredentialResolverDataNotFoundError,
+				);
+			});
+
+			it('should still resolve when the claim has outlived the token expiry', async () => {
+				mockIdentityResolution.resolve.mockResolvedValue(mockUser);
+				const expiredClaim = { ...claim, expiresAt: Date.now() - 60_000 };
+
+				await expect(identifier.resolve(externalIdpContext(expiredClaim), {})).resolves.toBe(
+					'user-123',
+				);
+			});
+
+			it('should report as unconnected when the context carries no claim', async () => {
+				await expect(identifier.resolve(externalIdpContext(undefined), {})).rejects.toThrow(
+					CredentialResolverDataNotFoundError,
+				);
+				expect(mockIdentityResolution.resolve).not.toHaveBeenCalled();
+			});
+
+			it('should report as unconnected when no binding exists for the claim', async () => {
+				mockIdentityResolution.resolve.mockResolvedValue(null);
+
+				await expect(identifier.resolve(externalIdpContext(claim), {})).rejects.toThrow(
+					CredentialResolverDataNotFoundError,
+				);
 			});
 		});
 	});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/identifier-interface.ts
@@ -1,4 +1,4 @@
-import type { ICredentialContext } from 'n8n-workflow';
+import type { ICredentialResolutionContext } from 'n8n-workflow';
 
 import { CredentialResolutionError } from '../../errors/credential-resolution.error';
 
@@ -20,12 +20,16 @@ export interface ITokenIdentifier {
 	/**
 	 * Resolves a unique identifier for the entity in the given context
 	 *
-	 * @param context - Credential context with execution details
+	 * @param context - Credential context with execution details, including the
+	 *                  caller's verified claim when the execution carries one
 	 * @param identifierOptions - Implementation-specific options
 	 * @returns Unique identifier string
 	 * @throws {IdentifierValidationError} When validation or resolution fails
 	 */
-	resolve(context: ICredentialContext, identifierOptions: Record<string, unknown>): Promise<string>;
+	resolve(
+		context: ICredentialResolutionContext,
+		identifierOptions: Record<string, unknown>,
+	): Promise<string>;
 
 	/**
 	 * Validates identifier options before use

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
@@ -1,9 +1,10 @@
 import { Service } from '@n8n/di';
-import type { ICredentialContext } from 'n8n-workflow';
+import type { ICredentialResolutionContext } from 'n8n-workflow';
 import { ITokenIdentifier } from './identifier-interface';
 import { AuthService } from '@/auth/auth.service';
 import { z } from 'zod';
-import { CredentialResolverError } from '@n8n/decorators';
+import { CredentialResolverDataNotFoundError, CredentialResolverError } from '@n8n/decorators';
+import { IdentityResolutionProxy } from '@/services/identity-resolution-proxy.service';
 import { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
 
 const ManualExecutionMetadataSchema = z.object({
@@ -22,10 +23,15 @@ const N8nOAuthMetadataSchema = z.object({
 	resource: z.string(),
 });
 
+const ExternalIdpMetadataSchema = z.object({
+	source: z.literal('external-idp'),
+});
+
 const N8NIdentifierMetadataSchema = z.discriminatedUnion('source', [
 	ManualExecutionMetadataSchema,
 	RequestBoundMetadataSchema,
 	N8nOAuthMetadataSchema,
+	ExternalIdpMetadataSchema,
 ]);
 
 /**
@@ -34,26 +40,34 @@ const N8NIdentifierMetadataSchema = z.discriminatedUnion('source', [
  * Used by the N8N credential resolver to authenticate users via n8n's
  * built-in JWT authentication and store credentials per user.
  *
- * Supports two metadata shapes, discriminated by `source`:
+ * Supports these metadata shapes, discriminated by `source`:
  * - `manual-execution`: editor-triggered run; identity is the n8n auth cookie (JWT).
  *   Validated cryptographically without request-bound checks (browserId / endpoint).
  * - `chat-hub-injected` / `cookie-source`: request-bound run (chat-hub or
  *   web/cookie-based dynamic-credential resolution); identity is the n8n auth
  *   cookie captured from the HTTP request, validated with full request context
  *   (method, endpoint, browserId).
+ * - `n8n-oauth`: the caller presented an n8n-issued OAuth2 access token.
+ * - `external-idp`: the caller presented an externally-issued token, verified once
+ *   at context establishment. There is no identity token here - the principal is
+ *   derived from the sealed claim on every access. See {@link resolveFromClaim}.
  */
 @Service()
 export class N8NIdentifier implements ITokenIdentifier {
 	constructor(
 		private readonly authService: AuthService,
 		private readonly oauthTokenVerifierProxy: OAuthTokenVerifierProxy,
+		private readonly identityResolutionProxy: IdentityResolutionProxy,
 	) {}
 
 	async validateOptions(_: Record<string, unknown>): Promise<void> {
 		return;
 	}
 
-	async resolve(context: ICredentialContext, _: Record<string, unknown>): Promise<string> {
+	async resolve(
+		context: ICredentialResolutionContext,
+		_: Record<string, unknown>,
+	): Promise<string> {
 		const metadataResult = N8NIdentifierMetadataSchema.safeParse(context.metadata);
 		if (!metadataResult.success) {
 			throw new CredentialResolverError(
@@ -65,6 +79,10 @@ export class N8NIdentifier implements ITokenIdentifier {
 			// No HTTP request context at credential-resolution time; skip browserId/endpoint checks.
 			const user = await this.authService.authenticateUserByCookie(context.identity);
 			return user.id;
+		}
+
+		if (metadataResult.data.source === 'external-idp') {
+			return await this.resolveFromClaim(context);
 		}
 
 		if (metadataResult.data.source === 'n8n-oauth') {
@@ -88,6 +106,43 @@ export class N8NIdentifier implements ITokenIdentifier {
 			metadataResult.data.endpoint,
 			metadataResult.data.browserId,
 		);
+		return user.id;
+	}
+
+	/**
+	 * Re-derives the n8n principal from the caller's verified claim, on every
+	 * access, so revoking the binding takes effect mid-execution and a resumed
+	 * execution re-checks authority instead of trusting a stored principal.
+	 *
+	 * The expensive part (crypto, JWKS, trust sources) happened once, at context
+	 * establishment; this is an indexed read plus a status check. Provisioning is
+	 * never allowed here - an inbound trigger must not create users - and claim
+	 * expiry deliberately does not gate access: the binding status is the live
+	 * gate, so an execution outliving the token's `exp` still resolves.
+	 *
+	 * Every "no principal" case (no claim, claim sealed for another workflow,
+	 * no binding, revoked binding, token-exchange module disabled) surfaces as
+	 * `CredentialResolverDataNotFoundError`, so the credential reports "not
+	 * connected" exactly as an unconnected credential does today.
+	 */
+	private async resolveFromClaim(context: ICredentialResolutionContext): Promise<string> {
+		const claim = context.claims;
+		if (!claim) {
+			throw new CredentialResolverDataNotFoundError();
+		}
+
+		const user = await this.identityResolutionProxy.resolve(
+			{ iss: claim.issuer, sub: claim.subject },
+			// Key-scoped role restrictions are not applied on this read-only path.
+			undefined,
+			{ issuer: claim.issuer },
+			false,
+		);
+
+		if (!user) {
+			throw new CredentialResolverDataNotFoundError();
+		}
+
 		return user.id;
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -23,6 +23,7 @@ import {
 	CredentialConnectionStatusService,
 	DynamicCredentialResolverRegistry,
 	DynamicCredentialService,
+	InboundClaimConnectService,
 } from './services';
 import { DynamicCredentialCorsService } from './services/dynamic-credential-cors.service';
 import { DynamicCredentialWebService } from './services/dynamic-credential-web.service';
@@ -45,6 +46,7 @@ export class DynamicCredentialsController {
 		private readonly eventService: EventService,
 		private readonly authorizeIntentService: AuthorizeIntentService,
 		private readonly dynamicCredentialService: DynamicCredentialService,
+		private readonly inboundClaimConnectService: InboundClaimConnectService,
 		private readonly urlService: UrlService,
 	) {}
 
@@ -116,7 +118,8 @@ export class DynamicCredentialsController {
 	})
 	async revokeCredential(req: Request, res: Response): Promise<void> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['delete', 'options']);
-		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
+		const credentialContext =
+			await this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 		const user = isAuthenticatedRequest(req) ? req.user : undefined;
 		const credential = await this.findCredentialToUse(req.params.id, user, 'credential:update');
 
@@ -158,7 +161,8 @@ export class DynamicCredentialsController {
 	})
 	async authorizeCredential(req: Request, res: Response): Promise<string> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['post', 'options']);
-		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
+		const credentialContext =
+			await this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 		const user = isAuthenticatedRequest(req) ? req.user : undefined;
 		const credential = await this.findCredentialToUse(req.params.id, user, 'credential:update');
 
@@ -175,6 +179,14 @@ export class DynamicCredentialsController {
 				resolverName: resolverEntity.type,
 				configuration: resolverConfig,
 			});
+		}
+
+		// Connecting is the point at which an inbound identity may be bound to an
+		// n8n user: it is interactive, and the caller just presented a verified
+		// token. Without this, someone arriving with an IdP token they have never
+		// logged into n8n with would have nothing to store their connection under.
+		if (credentialContext.claims) {
+			await this.inboundClaimConnectService.ensureBinding(credentialContext.claims);
 		}
 
 		// Best-effort: bind the callback to the intended n8n user when the resolver

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-check-proxy.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-check-proxy.service.test.ts
@@ -1,17 +1,18 @@
 import type { Mocked } from 'vitest';
 import type { GlobalConfig } from '@n8n/config';
 import type {
-	ICredentialContext,
+	ICredentialResolutionContext,
 	IExecutionContext,
+	IVerifiedClaim,
 	PlaintextExecutionContext,
 } from 'n8n-workflow';
 
 import type { EnterpriseCredentialsService } from '@/credentials/credentials.service.ee';
 import type { UrlService } from '@/services/url.service';
-import type { ExecutionContextService } from 'n8n-core';
 import { CredentialsEntity } from '@n8n/db';
 
 import type { AuthorizeIntentService } from '../authorize-intent.service';
+import type { CredentialResolutionContextBuilder } from '../credential-resolution-context.builder';
 import type { CredentialResolverWorkflowService } from '../credential-resolver-workflow.service';
 import { CredentialCheckProxyService } from '../credential-check-proxy.service';
 import type { DynamicCredentialService } from '../dynamic-credential.service';
@@ -39,7 +40,7 @@ const createMockCredentialEntity = (
 describe('CredentialCheckProxyService', () => {
 	let service: CredentialCheckProxyService;
 	let mockCredentialResolverWorkflowService: Mocked<CredentialResolverWorkflowService>;
-	let mockExecutionContextService: Mocked<ExecutionContextService>;
+	let mockResolutionContextBuilder: Mocked<CredentialResolutionContextBuilder>;
 	let mockEnterpriseCredentialsService: Mocked<EnterpriseCredentialsService>;
 	let mockAuthorizeIntentService: Mocked<AuthorizeIntentService>;
 	let mockDynamicCredentialService: Mocked<DynamicCredentialService>;
@@ -70,9 +71,9 @@ describe('CredentialCheckProxyService', () => {
 			getWorkflowStatus: vi.fn(),
 		} as unknown as Mocked<CredentialResolverWorkflowService>;
 
-		mockExecutionContextService = {
-			decryptCredentialContext: vi.fn().mockResolvedValue(plaintextContext.credentials),
-		} as unknown as Mocked<ExecutionContextService>;
+		mockResolutionContextBuilder = {
+			build: vi.fn().mockResolvedValue(plaintextContext.credentials),
+		} as unknown as Mocked<CredentialResolutionContextBuilder>;
 
 		mockEnterpriseCredentialsService = {
 			getOne: vi.fn(),
@@ -94,7 +95,7 @@ describe('CredentialCheckProxyService', () => {
 
 		service = new CredentialCheckProxyService(
 			mockCredentialResolverWorkflowService,
-			mockExecutionContextService,
+			mockResolutionContextBuilder,
 			mockEnterpriseCredentialsService,
 			mockAuthorizeIntentService,
 			mockDynamicCredentialService,
@@ -181,9 +182,9 @@ describe('CredentialCheckProxyService', () => {
 			expect(mockAuthorizeIntentService.create).toHaveBeenCalledTimes(1);
 		});
 
-		it('should throw when no credential context in execution context', async () => {
-			mockExecutionContextService.decryptCredentialContext.mockResolvedValue(
-				undefined as unknown as ICredentialContext,
+		it('should throw when the execution context carries no identity at all', async () => {
+			mockResolutionContextBuilder.build.mockResolvedValue(
+				undefined as unknown as ICredentialResolutionContext,
 			);
 
 			await expect(service.checkCredentialStatus('workflow-1', executionContext)).rejects.toThrow(
@@ -245,10 +246,10 @@ describe('CredentialCheckProxyService', () => {
 		});
 
 		it('should capture an empty identity in the intent when identity is missing', async () => {
-			mockExecutionContextService.decryptCredentialContext.mockResolvedValue({
+			mockResolutionContextBuilder.build.mockResolvedValue({
 				version: 1,
 				metadata: {},
-			} as unknown as ICredentialContext);
+			} as unknown as ICredentialResolutionContext);
 
 			mockCredentialResolverWorkflowService.getWorkflowStatus.mockResolvedValue([
 				{
@@ -372,6 +373,52 @@ describe('CredentialCheckProxyService', () => {
 
 			expect(result.readyToExecute).toBe(true);
 			expect(result.credentials).toHaveLength(0);
+		});
+
+		it('should check a context that carries only a claim', async () => {
+			const claim: IVerifiedClaim = {
+				version: 1,
+				sourceId: 'source-1',
+				issuer: 'https://idp.example.com',
+				subject: 'external-subject-1',
+				audience: 'https://n8n.example.com',
+				expiresAt: Date.now() + 60_000,
+				boundWorkflowId: 'workflow-1',
+			};
+			const claimsOnlyContext: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				claims: 'sealed-claim',
+			};
+			mockResolutionContextBuilder.build.mockResolvedValue({
+				version: 1,
+				identity: '',
+				metadata: { source: 'external-idp' },
+				claims: claim,
+			});
+			mockCredentialResolverWorkflowService.getWorkflowStatus.mockResolvedValue([
+				{
+					credentialId: 'cred-1',
+					credentialName: 'OAuth2 API',
+					credentialType: 'oauth2Api',
+					resolverId: 'resolver-1',
+					status: 'configured',
+				},
+			]);
+
+			const result = await service.checkCredentialStatus('workflow-1', claimsOnlyContext);
+
+			expect(result.readyToExecute).toBe(true);
+			// The claim is sealed per workflow, so the workflow id must reach the builder.
+			expect(mockResolutionContextBuilder.build).toHaveBeenCalledWith(
+				claimsOnlyContext,
+				'workflow-1',
+			);
+			expect(mockCredentialResolverWorkflowService.getWorkflowStatus).toHaveBeenCalledWith(
+				'workflow-1',
+				expect.objectContaining({ claims: claim }),
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolution-context.builder.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolution-context.builder.test.ts
@@ -1,0 +1,97 @@
+import type { Logger } from '@n8n/backend-common';
+import type { ExecutionContextService } from 'n8n-core';
+import type { ICredentialContext, IVerifiedClaim } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { CredentialResolutionContextBuilder } from '../credential-resolution-context.builder';
+
+describe('CredentialResolutionContextBuilder', () => {
+	let builder: CredentialResolutionContextBuilder;
+	let logger: Logger;
+	let executionContextService: ExecutionContextService;
+
+	const claim: IVerifiedClaim = {
+		version: 1,
+		sourceId: 'source-1',
+		issuer: 'https://idp.example.com',
+		subject: 'external-subject-1',
+		audience: 'https://n8n.example.com',
+		expiresAt: Date.now() + 60_000,
+		boundWorkflowId: 'workflow-1',
+	};
+
+	const cookieContext: ICredentialContext = {
+		version: 1,
+		identity: 'n8n-auth-cookie',
+		metadata: { source: 'cookie-source' },
+	};
+
+	beforeEach(() => {
+		logger = mock<Logger>();
+		executionContextService = mock<ExecutionContextService>();
+		builder = new CredentialResolutionContextBuilder(logger, executionContextService);
+	});
+
+	it('returns undefined when there is no execution context', async () => {
+		expect(await builder.build(undefined, 'workflow-1')).toBeUndefined();
+	});
+
+	it('returns undefined when the execution context carries no identity', async () => {
+		expect(await builder.build({}, 'workflow-1')).toBeUndefined();
+	});
+
+	it('synthesizes an external-idp context when only a claim is present', async () => {
+		vi.mocked(executionContextService.decryptClaims).mockResolvedValue(claim);
+
+		const result = await builder.build({ claims: 'sealed' }, 'workflow-1');
+
+		expect(result).toEqual({
+			version: 1,
+			identity: '',
+			metadata: { source: 'external-idp' },
+			claims: claim,
+		});
+		expect(executionContextService.decryptClaims).toHaveBeenCalledWith('sealed', 'workflow-1');
+	});
+
+	it('keeps an existing credential context and attaches the claim to it', async () => {
+		vi.mocked(executionContextService.decryptCredentialContext).mockResolvedValue(cookieContext);
+		vi.mocked(executionContextService.decryptClaims).mockResolvedValue(claim);
+
+		const result = await builder.build(
+			{ credentials: 'encrypted', claims: 'sealed' },
+			'workflow-1',
+		);
+
+		expect(result).toEqual({ ...cookieContext, claims: claim });
+	});
+
+	it('returns the credential context untouched when there is no claim', async () => {
+		vi.mocked(executionContextService.decryptCredentialContext).mockResolvedValue(cookieContext);
+
+		const result = await builder.build({ credentials: 'encrypted' }, 'workflow-1');
+
+		expect(result).toEqual(cookieContext);
+		expect(executionContextService.decryptClaims).not.toHaveBeenCalled();
+	});
+
+	it('drops a claim sealed for another workflow', async () => {
+		// decryptClaims returns undefined on a workflow-binding mismatch.
+		vi.mocked(executionContextService.decryptClaims).mockResolvedValue(undefined);
+
+		expect(await builder.build({ claims: 'sealed-elsewhere' }, 'workflow-2')).toBeUndefined();
+	});
+
+	it('drops the claim when no workflow id is available to check the seal against', async () => {
+		expect(await builder.build({ claims: 'sealed' }, undefined)).toBeUndefined();
+		expect(executionContextService.decryptClaims).not.toHaveBeenCalled();
+	});
+
+	it('returns undefined when the credential context cannot be decrypted', async () => {
+		vi.mocked(executionContextService.decryptCredentialContext).mockRejectedValue(
+			new Error('bad decrypt'),
+		);
+
+		expect(await builder.build({ credentials: 'corrupt' }, 'workflow-1')).toBeUndefined();
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-storage.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-storage.service.test.ts
@@ -17,6 +17,7 @@ import type { DynamicCredentialResolverRepository } from '../../database/reposit
 import { CredentialStorageError } from '../../errors/credential-storage.error';
 import type { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 import { DynamicCredentialStorageService } from '../dynamic-credential-storage.service';
+import type { InboundClaimConnectService } from '../inbound-claim-connect.service';
 
 describe('DynamicCredentialStorageService', () => {
 	let service: DynamicCredentialStorageService;
@@ -26,6 +27,7 @@ describe('DynamicCredentialStorageService', () => {
 	let mockCipher: Mocked<Cipher>;
 	let mockLogger: Mocked<Logger>;
 	let mockDynamicCredentialsProxy: Mocked<DynamicCredentialsProxy>;
+	let mockInboundClaimConnectService: Mocked<InboundClaimConnectService>;
 
 	const createMockCredentialMetadata = (
 		overrides: Partial<CredentialStoreMetadata> = {},
@@ -103,6 +105,11 @@ describe('DynamicCredentialStorageService', () => {
 			decryptV2: vi.fn(),
 		} as unknown as Mocked<Cipher>;
 
+		mockInboundClaimConnectService = {
+			// No claim to derive in these tests: pass the context through untouched.
+			attachVerifiedClaim: vi.fn(async (context) => context),
+		} as unknown as Mocked<InboundClaimConnectService>;
+
 		mockDynamicCredentialsProxy = {
 			getSystemResolverId: vi.fn().mockReturnValue(null),
 			// Default to the real semantics with no system resolver seeded:
@@ -117,6 +124,7 @@ describe('DynamicCredentialStorageService', () => {
 			mockCipher,
 			mockLogger,
 			mockDynamicCredentialsProxy,
+			mockInboundClaimConnectService,
 		);
 	});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-web.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-web.service.test.ts
@@ -5,10 +5,12 @@ import { mock } from 'vitest-mock-extended';
 import type { AuthService } from '@/auth/auth.service';
 
 import { DynamicCredentialWebService } from '../dynamic-credential-web.service';
+import type { InboundClaimConnectService } from '../inbound-claim-connect.service';
 
 describe('DynamicCredentialWebService', () => {
 	let service: DynamicCredentialWebService;
 	let mockAuthService: Mocked<AuthService>;
+	let mockInboundClaimConnectService: Mocked<InboundClaimConnectService>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -20,18 +22,55 @@ describe('DynamicCredentialWebService', () => {
 			getEndpoint: vi.fn(),
 		});
 
-		service = new DynamicCredentialWebService(mockAuthService);
+		mockInboundClaimConnectService = mock<InboundClaimConnectService>({
+			// Default: no trusted source vouches for the token, so contexts pass
+			// through untagged - today's behaviour for opaque bearer tokens.
+			attachVerifiedClaim: vi.fn(async (context) => context),
+		});
+
+		service = new DynamicCredentialWebService(mockAuthService, mockInboundClaimConnectService);
 	});
 
 	describe('getCredentialContextFromRequest', () => {
+		it('returns an external-idp context when a presented bearer token verifies', async () => {
+			const claim = {
+				version: 1 as const,
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'external-subject-1',
+				audience: 'https://n8n.example.com',
+				expiresAt: Date.now() + 60_000,
+				boundWorkflowId: '',
+			};
+			mockInboundClaimConnectService.attachVerifiedClaim.mockResolvedValue({
+				version: 1,
+				identity: 'idp-token',
+				metadata: { source: 'external-idp' },
+				claims: claim,
+			});
+			const req = mock<Request>({
+				query: { authSource: 'bearer' },
+				headers: { authorization: 'Bearer idp-token' },
+			});
+
+			const result = await service.getCredentialContextFromRequest(req);
+
+			expect(mockInboundClaimConnectService.attachVerifiedClaim).toHaveBeenCalledWith({
+				version: 1,
+				identity: 'idp-token',
+				metadata: {},
+			});
+			expect(result.claims).toEqual(claim);
+		});
+
 		describe('with explicit authSource=bearer', () => {
-			it('should extract bearer token when authSource query param is "bearer"', () => {
+			it('should extract bearer token when authSource query param is "bearer"', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'Bearer my-token-123' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result).toEqual({
 					identity: 'my-token-123',
@@ -41,64 +80,64 @@ describe('DynamicCredentialWebService', () => {
 				expect(mockAuthService.getCookieToken).not.toHaveBeenCalled();
 			});
 
-			it('should accept case-insensitive bearer prefix', () => {
+			it('should accept case-insensitive bearer prefix', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'bearer lowercase-token' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('lowercase-token');
 			});
 
-			it('should accept mixed-case bearer prefix', () => {
+			it('should accept mixed-case bearer prefix', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'BeArEr mixed-case-token' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('mixed-case-token');
 			});
 
-			it('should throw error when bearer token is missing with authSource=bearer', () => {
+			it('should throw error when bearer token is missing with authSource=bearer', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: {},
 				});
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Bearer token is missing',
 				);
 			});
 
-			it('should throw error when authorization header has no Bearer prefix', () => {
+			it('should throw error when authorization header has no Bearer prefix', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'token-without-bearer' },
 				});
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Bearer token is missing',
 				);
 			});
 
-			it('should throw error when bearer token is empty after prefix', () => {
+			it('should throw error when bearer token is empty after prefix', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'Bearer ' },
 				});
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Bearer token is missing',
 				);
 			});
 		});
 
 		describe('with explicit authSource=cookie', () => {
-			it('should extract cookie token when authSource query param is "cookie"', () => {
+			it('should extract cookie token when authSource query param is "cookie"', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'cookie' },
 					headers: {},
@@ -109,7 +148,7 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('GET');
 				mockAuthService.getEndpoint.mockReturnValue('/api/test');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result).toEqual({
 					identity: 'cookie-session-123',
@@ -127,7 +166,7 @@ describe('DynamicCredentialWebService', () => {
 				expect(mockAuthService.getEndpoint).toHaveBeenCalledWith(req);
 			});
 
-			it('should throw error when session cookie is missing with authSource=cookie', () => {
+			it('should throw error when session cookie is missing with authSource=cookie', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'cookie' },
 					headers: {},
@@ -135,20 +174,20 @@ describe('DynamicCredentialWebService', () => {
 
 				mockAuthService.getCookieToken.mockReturnValue(undefined);
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Session cookie is missing',
 				);
 			});
 		});
 
 		describe('fallback behavior (no authSource query param)', () => {
-			it('should extract bearer token when present without authSource param', () => {
+			it('should extract bearer token when present without authSource param', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: { authorization: 'Bearer fallback-token' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result).toEqual({
 					identity: 'fallback-token',
@@ -158,7 +197,7 @@ describe('DynamicCredentialWebService', () => {
 				expect(mockAuthService.getCookieToken).not.toHaveBeenCalled();
 			});
 
-			it('should fall back to cookie when bearer token is not present', () => {
+			it('should fall back to cookie when bearer token is not present', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: {},
@@ -169,7 +208,7 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('POST');
 				mockAuthService.getEndpoint.mockReturnValue('/api/workflow');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result).toEqual({
 					identity: 'cookie-fallback-123',
@@ -184,7 +223,7 @@ describe('DynamicCredentialWebService', () => {
 				expect(mockAuthService.getCookieToken).toHaveBeenCalledWith(req);
 			});
 
-			it('should fall back to cookie when authorization header is malformed', () => {
+			it('should fall back to cookie when authorization header is malformed', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: { authorization: 'malformed-header' },
@@ -195,13 +234,13 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('GET');
 				mockAuthService.getEndpoint.mockReturnValue('/api/test');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('cookie-fallback-456');
 				expect(mockAuthService.getCookieToken).toHaveBeenCalledWith(req);
 			});
 
-			it('should throw error when both bearer and cookie are missing', () => {
+			it('should throw error when both bearer and cookie are missing', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: {},
@@ -209,38 +248,38 @@ describe('DynamicCredentialWebService', () => {
 
 				mockAuthService.getCookieToken.mockReturnValue(undefined);
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Session cookie is missing',
 				);
 			});
 		});
 
 		describe('edge cases', () => {
-			it('should handle bearer token with special characters', () => {
+			it('should handle bearer token with special characters', async () => {
 				const specialToken = 'token-with-special!@#$%^&*()chars';
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: `Bearer ${specialToken}` },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe(specialToken);
 			});
 
-			it('should handle very long bearer tokens', () => {
+			it('should handle very long bearer tokens', async () => {
 				const longToken = 'a'.repeat(1000);
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: `Bearer ${longToken}` },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe(longToken);
 			});
 
-			it('should handle undefined browserId from AuthService', () => {
+			it('should handle undefined browserId from AuthService', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'cookie' },
 					headers: {},
@@ -251,7 +290,7 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('GET');
 				mockAuthService.getEndpoint.mockReturnValue('/api/test');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.metadata).toEqual({
 					source: 'cookie-source',
@@ -261,7 +300,7 @@ describe('DynamicCredentialWebService', () => {
 				});
 			});
 
-			it('should prioritize authSource=bearer over existing bearer token in fallback mode', () => {
+			it('should prioritize authSource=bearer over existing bearer token in fallback mode', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'cookie' },
 					headers: { authorization: 'Bearer should-be-ignored' },
@@ -272,31 +311,31 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('GET');
 				mockAuthService.getEndpoint.mockReturnValue('/api/test');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('cookie-token');
 				expect(result.metadata?.source).toBe('cookie-source');
 			});
 
-			it('should handle empty query object', () => {
+			it('should handle empty query object', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: { authorization: 'Bearer empty-query-token' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('empty-query-token');
 			});
 
-			it('should handle authSource with invalid value', () => {
+			it('should handle authSource with invalid value', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'invalid' as any },
 					headers: { authorization: 'Bearer token' },
 				});
 
 				// Should fall back to default behavior (bearer first)
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('token');
 			});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -7,6 +7,7 @@ import type {
 	ICredentialContext,
 	ICredentialDataDecryptedObject,
 	IExecutionContext,
+	IVerifiedClaim,
 } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
 
@@ -27,6 +28,7 @@ import { CredentialResolutionError } from '../../errors/credential-resolution.er
 import { CredentialResolverNotConfiguredError } from '../../errors/credential-resolver-not-configured.error';
 import { CredentialResolverNotFoundError } from '../../errors/credential-resolver-not-found.error';
 import { MissingExecutionContextError } from '../../errors/missing-execution-context.error';
+import type { CredentialResolutionContextBuilder } from '../credential-resolution-context.builder';
 import type { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 import { DynamicCredentialService } from '../dynamic-credential.service';
 import type { ResolverConfigExpressionService } from '../resolver-config-expression.service';
@@ -41,6 +43,7 @@ describe('DynamicCredentialService', () => {
 	let mockExpressionService: Mocked<ResolverConfigExpressionService>;
 	let mockDynamicCredentialConfig: Mocked<DynamicCredentialsConfig>;
 	let mockDynamicCredentialsProxy: Mocked<DynamicCredentialsProxy>;
+	let mockResolutionContextBuilder: Mocked<CredentialResolutionContextBuilder>;
 
 	beforeEach(() => {
 		mockDynamicCredentialConfig = {
@@ -216,6 +219,22 @@ describe('DynamicCredentialService', () => {
 			}),
 		} as unknown as Mocked<ResolverConfigExpressionService>;
 
+		// Mirrors the real builder: decrypts the credentials field (consuming a
+		// `decryptV2` call, so the tests' mock ordering stays meaningful) and
+		// synthesizes an external-idp context from a claim when there is none.
+		mockResolutionContextBuilder = {
+			build: vi.fn(async (executionContext?: { credentials?: string }) => {
+				if (!executionContext?.credentials) return undefined;
+				try {
+					const decrypted = await mockCipher.decryptV2(executionContext.credentials);
+					return JSON.parse(decrypted) as ICredentialContext;
+				} catch {
+					// The real builder logs and degrades to "no identity" rather than throwing.
+					return undefined;
+				}
+			}),
+		} as unknown as Mocked<CredentialResolutionContextBuilder>;
+
 		service = new DynamicCredentialService(
 			mockDynamicCredentialConfig,
 			mockResolverRegistry,
@@ -225,6 +244,7 @@ describe('DynamicCredentialService', () => {
 			mockLogger,
 			mockExpressionService,
 			mockDynamicCredentialsProxy,
+			mockResolutionContextBuilder,
 		);
 	});
 
@@ -233,6 +253,124 @@ describe('DynamicCredentialService', () => {
 			token: 'static-token',
 			apiKey: 'static-key',
 		};
+
+		describe('claim-based resolution', () => {
+			const claim: IVerifiedClaim = {
+				version: 1,
+				sourceId: 'source-1',
+				issuer: 'https://idp.example.com',
+				subject: 'external-subject-1',
+				audience: 'https://n8n.example.com',
+				expiresAt: Date.now() + 60_000,
+				boundWorkflowId: 'workflow-1',
+			};
+
+			const claimsOnlyContext: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				claims: 'sealed-claim',
+			};
+
+			it('resolves through the claim when the execution carries no credential context', async () => {
+				const credentialsEntity = createMockCredentialsMetadata();
+				const resolverEntity = createMockResolverEntity();
+				const mockResolver = createMockResolver();
+
+				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+				mockResolutionContextBuilder.build.mockResolvedValue({
+					version: 1,
+					identity: '',
+					metadata: { source: 'external-idp' },
+					claims: claim,
+				});
+				mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ prefix: 'test' }));
+
+				const result = await service.resolveIfNeeded(
+					credentialsEntity,
+					staticData,
+					claimsOnlyContext,
+					undefined,
+					'workflow-1',
+				);
+
+				expect(result.isDynamic).toBe(true);
+				expect(mockResolver.getSecret).toHaveBeenCalledWith(
+					'cred-123',
+					expect.objectContaining({ claims: claim, metadata: { source: 'external-idp' } }),
+					expect.anything(),
+				);
+			});
+
+			it('passes the workflow id to the builder so the sealed claim can be checked', async () => {
+				const credentialsEntity = createMockCredentialsMetadata();
+				const resolverEntity = createMockResolverEntity();
+
+				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(createMockResolver());
+				mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ prefix: 'test' }));
+
+				await service
+					.resolveIfNeeded(
+						credentialsEntity,
+						staticData,
+						claimsOnlyContext,
+						undefined,
+						'workflow-1',
+					)
+					.catch(() => {});
+
+				expect(mockResolutionContextBuilder.build).toHaveBeenCalledWith(
+					claimsOnlyContext,
+					'workflow-1',
+				);
+			});
+
+			it('reports a missing context when the claim yields no usable identity', async () => {
+				const credentialsEntity = createMockCredentialsMetadata();
+				const resolverEntity = createMockResolverEntity();
+
+				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(createMockResolver());
+				// e.g. claim sealed for another workflow, or no workflow id to check it against
+				mockResolutionContextBuilder.build.mockResolvedValue(undefined);
+
+				await expect(
+					service.resolveIfNeeded(credentialsEntity, staticData, claimsOnlyContext, undefined, ''),
+				).rejects.toThrow(MissingExecutionContextError);
+			});
+
+			it('re-resolves on every access rather than caching the identity', async () => {
+				const credentialsEntity = createMockCredentialsMetadata();
+				const resolverEntity = createMockResolverEntity();
+				const mockResolver = createMockResolver();
+
+				mockResolverRepository.findOneBy.mockResolvedValue(resolverEntity);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+				mockResolutionContextBuilder.build.mockResolvedValue({
+					version: 1,
+					identity: '',
+					metadata: { source: 'external-idp' },
+					claims: claim,
+				});
+				mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ prefix: 'test' }));
+
+				const resolve = async () =>
+					await service.resolveIfNeeded(
+						credentialsEntity,
+						staticData,
+						claimsOnlyContext,
+						undefined,
+						'workflow-1',
+					);
+				await resolve();
+				await resolve();
+
+				expect(mockResolutionContextBuilder.build).toHaveBeenCalledTimes(2);
+				expect(mockResolver.getSecret).toHaveBeenCalledTimes(2);
+			});
+		});
 
 		const expectStaticResult = (result: CredentialResolutionResult) => {
 			expect(result.data).toBe(staticData);
@@ -493,12 +631,9 @@ describe('DynamicCredentialService', () => {
 						additionalData.executionContext,
 						undefined,
 					),
-				).rejects.toThrow(CredentialResolutionError);
-
-				expect(mockLogger.error).toHaveBeenCalledWith(
-					'Failed to decrypt credential context from execution context',
-					expect.any(Object),
-				);
+					// A context that can't be decrypted carries no identity, so this is
+					// reported as a missing context (the builder logs the decrypt failure).
+				).rejects.toThrow(MissingExecutionContextError);
 			});
 
 			it('external-identity resolver throws CredentialResolverDataNotFoundError keeps the generic message', async () => {
@@ -1151,6 +1286,7 @@ describe('DynamicCredentialService', () => {
 					mockLogger,
 					mockExpressionService,
 					mockDynamicCredentialsProxy,
+					mockResolutionContextBuilder,
 				);
 				const middleware = service.getDynamicCredentialsEndpointsMiddleware();
 				const mockReq = {
@@ -1183,6 +1319,7 @@ describe('DynamicCredentialService', () => {
 					mockLogger,
 					mockExpressionService,
 					mockDynamicCredentialsProxy,
+					mockResolutionContextBuilder,
 				);
 				service.getDynamicCredentialsEndpointsMiddleware();
 				expect(getStaticAuthMiddlewareSpy).toHaveBeenCalledWith('test-token', 'x-authorization');
@@ -1201,6 +1338,7 @@ describe('DynamicCredentialService', () => {
 						mockLogger,
 						mockExpressionService,
 						mockDynamicCredentialsProxy,
+						mockResolutionContextBuilder,
 					);
 
 					const middleware = service.getDynamicCredentialsEndpointsMiddleware();
@@ -1237,6 +1375,7 @@ describe('DynamicCredentialService', () => {
 						mockLogger,
 						mockExpressionService,
 						mockDynamicCredentialsProxy,
+						mockResolutionContextBuilder,
 					);
 
 					const middleware = service.getDynamicCredentialsEndpointsMiddleware();

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/inbound-claim-connect.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/inbound-claim-connect.service.test.ts
@@ -1,0 +1,150 @@
+import type { Logger } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import type { ICredentialContext, IVerifiedClaim } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { ExternalTokenVerifierProxy } from '@/services/external-token-verifier-proxy.service';
+import type { IdentityResolutionProxy } from '@/services/identity-resolution-proxy.service';
+
+import { InboundClaimConnectService } from '../inbound-claim-connect.service';
+
+describe('InboundClaimConnectService', () => {
+	let service: InboundClaimConnectService;
+	let verifier: ExternalTokenVerifierProxy;
+	let identityResolution: IdentityResolutionProxy;
+
+	const expiresAt = new Date('2026-01-01T00:00:00.000Z');
+
+	const verifiedClaim = {
+		sourceId: 'idp-1',
+		issuer: 'https://idp.example.com',
+		subject: 'external-subject-1',
+		audience: 'https://n8n.example.com',
+		attributes: { role: 'admin' },
+		expiresAt,
+	};
+
+	const bearerContext: ICredentialContext = {
+		version: 1,
+		identity: 'inbound-token',
+		metadata: {},
+	};
+
+	beforeEach(() => {
+		verifier = mock<ExternalTokenVerifierProxy>();
+		identityResolution = mock<IdentityResolutionProxy>();
+		service = new InboundClaimConnectService(mock<Logger>(), verifier, identityResolution);
+	});
+
+	describe('attachVerifiedClaim', () => {
+		it('tags the context and attaches the claim when the token verifies', async () => {
+			vi.mocked(verifier.verifyInboundToken).mockResolvedValue({ claim: verifiedClaim });
+
+			const result = await service.attachVerifiedClaim(bearerContext);
+
+			expect(verifier.verifyInboundToken).toHaveBeenCalledWith('inbound-token');
+			expect(result.metadata?.source).toBe('external-idp');
+			expect(result.claims).toEqual({
+				version: 1,
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'external-subject-1',
+				audience: 'https://n8n.example.com',
+				expiresAt: expiresAt.getTime(),
+				boundWorkflowId: '',
+			});
+			// The token stays available for resolvers that key on its own subject.
+			expect(result.identity).toBe('inbound-token');
+		});
+
+		it('strips a Bearer prefix before verifying', async () => {
+			vi.mocked(verifier.verifyInboundToken).mockResolvedValue({ claim: verifiedClaim });
+
+			await service.attachVerifiedClaim({ ...bearerContext, identity: 'Bearer inbound-token' });
+
+			expect(verifier.verifyInboundToken).toHaveBeenCalledWith('inbound-token');
+		});
+
+		it('normalizes a multi-value audience to its first entry', async () => {
+			vi.mocked(verifier.verifyInboundToken).mockResolvedValue({
+				claim: { ...verifiedClaim, audience: ['first', 'second'] },
+			});
+
+			const result = await service.attachVerifiedClaim(bearerContext);
+
+			expect(result.claims?.audience).toBe('first');
+		});
+
+		it('leaves an unverifiable token untouched, so introspection resolvers keep working', async () => {
+			vi.mocked(verifier.verifyInboundToken).mockResolvedValue({
+				claim: null,
+				context: { reason: 'invalid_token' },
+			});
+
+			const result = await service.attachVerifiedClaim(bearerContext);
+
+			expect(result).toEqual(bearerContext);
+			expect(result.claims).toBeUndefined();
+		});
+
+		it('leaves a context that already names its source untouched', async () => {
+			const cookieContext: ICredentialContext = {
+				version: 1,
+				identity: 'n8n-auth-cookie',
+				metadata: { source: 'cookie-source' },
+			};
+
+			const result = await service.attachVerifiedClaim(cookieContext);
+
+			expect(result).toEqual(cookieContext);
+			expect(verifier.verifyInboundToken).not.toHaveBeenCalled();
+		});
+
+		it('does not verify an empty identity', async () => {
+			const result = await service.attachVerifiedClaim({ ...bearerContext, identity: '' });
+
+			expect(result.claims).toBeUndefined();
+			expect(verifier.verifyInboundToken).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('ensureBinding', () => {
+		const claim: IVerifiedClaim = {
+			version: 1,
+			sourceId: 'idp-1',
+			issuer: 'https://idp.example.com',
+			subject: 'external-subject-1',
+			audience: 'https://n8n.example.com',
+			expiresAt: expiresAt.getTime(),
+			boundWorkflowId: '',
+		};
+
+		it('resolves the claim with provisioning allowed and returns the bound user', async () => {
+			vi.mocked(identityResolution.resolve).mockResolvedValue(mock<User>({ id: 'user-1' }));
+
+			const userId = await service.ensureBinding(claim);
+
+			expect(userId).toBe('user-1');
+			expect(identityResolution.resolve).toHaveBeenCalledWith(
+				{ iss: 'https://idp.example.com', sub: 'external-subject-1' },
+				undefined,
+				{ issuer: 'https://idp.example.com' },
+				// Connecting is interactive, so binding (and provisioning) is allowed here
+				// and nowhere else.
+				true,
+			);
+		});
+
+		it('returns undefined when no binding could be established', async () => {
+			vi.mocked(identityResolution.resolve).mockResolvedValue(null);
+
+			expect(await service.ensureBinding(claim)).toBeUndefined();
+		});
+
+		it('returns undefined rather than throwing when the identity policy refuses', async () => {
+			vi.mocked(identityResolution.resolve).mockRejectedValue(new Error('Role not allowed'));
+
+			expect(await service.ensureBinding(claim)).toBeUndefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
@@ -4,14 +4,14 @@ import type {
 	CredentialCheckResult,
 	CredentialCheckStatus,
 	DynamicCredentialCheckProxyProvider,
-	ICredentialContext,
+	ICredentialResolutionContext,
 } from 'n8n-workflow';
 
 import { EnterpriseCredentialsService } from '@/credentials/credentials.service.ee';
 import { UrlService } from '@/services/url.service';
 
-import { ExecutionContextService } from 'n8n-core';
 import { AuthorizeIntentService } from './authorize-intent.service';
+import { CredentialResolutionContextBuilder } from './credential-resolution-context.builder';
 import { CredentialResolverWorkflowService } from './credential-resolver-workflow.service';
 import { DynamicCredentialService } from './dynamic-credential.service';
 
@@ -19,7 +19,7 @@ import { DynamicCredentialService } from './dynamic-credential.service';
 export class CredentialCheckProxyService implements DynamicCredentialCheckProxyProvider {
 	constructor(
 		private readonly credentialResolverWorkflowService: CredentialResolverWorkflowService,
-		private readonly executionContextService: ExecutionContextService,
+		private readonly resolutionContextBuilder: CredentialResolutionContextBuilder,
 		private readonly enterpriseCredentialsService: EnterpriseCredentialsService,
 		private readonly authorizeIntentService: AuthorizeIntentService,
 		private readonly dynamicCredentialService: DynamicCredentialService,
@@ -31,16 +31,12 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 		workflowId: string,
 		executionContext: {
 			credentials?: string;
+			claims?: string;
 		},
 	): Promise<CredentialCheckResult> {
-		if (!executionContext.credentials) {
-			throw new Error(
-				'Execution context is present but contains no credential context. Ensure credential context establishment hooks are configured for this workflow.',
-			);
-		}
-		const plaintext = await this.executionContextService.decryptCredentialContext(
-			executionContext.credentials,
-		);
+		// A claim-only context is a valid identity too (inbound IdP token), so the
+		// gate reports on it exactly as it does for a captured credential context.
+		const plaintext = await this.resolutionContextBuilder.build(executionContext, workflowId);
 
 		if (!plaintext) {
 			throw new Error(
@@ -90,7 +86,7 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 	private async generateAuthorizationUrl(
 		credentialId: string,
 		resolverId: string,
-		credentialContext: ICredentialContext,
+		credentialContext: ICredentialResolutionContext,
 	): Promise<string | undefined> {
 		const credential = await this.enterpriseCredentialsService.getOne(credentialId);
 		if (!credential) return undefined;

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolution-context.builder.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolution-context.builder.ts
@@ -1,0 +1,87 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import { ExecutionContextService } from 'n8n-core';
+import type { ICredentialResolutionContext, IVerifiedClaim } from 'n8n-workflow';
+
+/** The parts of an execution context credential resolution needs. */
+export type ResolvableExecutionContext = {
+	credentials?: string;
+	claims?: string;
+};
+
+/**
+ * Builds the context resolvers see, from the encrypted fields of an execution
+ * context. Single place where "which identity does this execution carry?" is
+ * decided, so the node-execution path and the pre-execution credential-status
+ * gate can never disagree.
+ */
+@Service()
+export class CredentialResolutionContextBuilder {
+	constructor(
+		private readonly logger: Logger,
+		private readonly executionContextService: ExecutionContextService,
+	) {}
+
+	/**
+	 * Runs on every credential access - the caller's verified claim is unsealed
+	 * here and handed to the resolver, never cached, so the principal is
+	 * re-derived (and re-authorized) each time.
+	 *
+	 * An explicit credential context always wins: a run that captured an n8n
+	 * identity (manual, chat-hub, cookie, n8n-oauth) keeps resolving through it,
+	 * and the claim only rides along. When there is no credential context but the
+	 * execution carries a claim, an `external-idp` context is synthesized so
+	 * resolution keys on the claim instead - there is no identity token to carry
+	 * in that flow.
+	 *
+	 * @param workflowId Required to unseal a claim, which is sealed per workflow.
+	 *                   Without it the claim is dropped, i.e. resolution fails
+	 *                   closed rather than accepting a claim sealed elsewhere.
+	 * @returns `undefined` when the execution carries no identity at all.
+	 */
+	async build(
+		executionContext: ResolvableExecutionContext | undefined,
+		workflowId: string | undefined,
+	): Promise<ICredentialResolutionContext | undefined> {
+		if (!executionContext) return undefined;
+
+		const claims = await this.unsealClaims(executionContext.claims, workflowId);
+
+		if (!executionContext.credentials) {
+			if (!claims) return undefined;
+			return {
+				version: 1,
+				// No identity token in this flow; the claim is the identity.
+				identity: '',
+				metadata: { source: 'external-idp' },
+				claims,
+			};
+		}
+
+		try {
+			const credentialContext = await this.executionContextService.decryptCredentialContext(
+				executionContext.credentials,
+			);
+			return claims ? { ...credentialContext, claims } : credentialContext;
+		} catch (error) {
+			this.logger.error('Failed to decrypt credential context from execution context', {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+
+	private async unsealClaims(
+		claims: string | undefined,
+		workflowId: string | undefined,
+	): Promise<IVerifiedClaim | undefined> {
+		if (!claims) return undefined;
+
+		if (!workflowId) {
+			this.logger.warn('Cannot unseal claim without a workflow id, dropping it');
+			return undefined;
+		}
+
+		return await this.executionContextService.decryptClaims(claims, workflowId);
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
@@ -2,7 +2,12 @@ import { CredentialsEntity, CredentialsRepository, In, User, WorkflowRepository 
 import { ICredentialResolver } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { Cipher } from 'n8n-core';
-import { ICredentialContext, INode, isNodeWithWorkflowSelector, jsonParse } from 'n8n-workflow';
+import {
+	ICredentialResolutionContext,
+	INode,
+	isNodeWithWorkflowSelector,
+	jsonParse,
+} from 'n8n-workflow';
 
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -92,7 +97,7 @@ export class CredentialResolverWorkflowService {
 	 */
 	async getWorkflowStatus(
 		workflowId: string,
-		credentialContext: ICredentialContext,
+		credentialContext: ICredentialResolutionContext,
 		user?: User,
 	): Promise<CredentialStatus[]> {
 		const visited = new Set<string>();
@@ -268,7 +273,7 @@ export class CredentialResolverWorkflowService {
 		credential: CredentialsEntity,
 		options: {
 			fallbackResolverId: string | null;
-			credentialContext: ICredentialContext;
+			credentialContext: ICredentialResolutionContext;
 			resolverCache: Map<string, ResolvedResolver>;
 		},
 	): Promise<CredentialStatus> {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
@@ -16,6 +16,7 @@ import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 
 import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
+import { InboundClaimConnectService } from './inbound-claim-connect.service';
 import { extractSharedFields } from './shared-fields';
 import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
 import { CredentialStorageError } from '../errors/credential-storage.error';
@@ -29,6 +30,7 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 		private readonly cipher: Cipher,
 		private readonly logger: Logger,
 		private readonly dynamicCredentialsProxy: DynamicCredentialsProxy,
+		private readonly inboundClaimConnectService: InboundClaimConnectService,
 	) {}
 
 	async storeIfNeeded(
@@ -92,7 +94,12 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 				}
 			}
 
-			await resolver.setSecret(credentialStoreMetadata.id, credentialContext, mergedDynamicData, {
+			// The OAuth callback rebuilds this context from the CSRF state, which
+			// carries the presented token but no claim, so re-derive it here.
+			const resolutionContext =
+				await this.inboundClaimConnectService.attachVerifiedClaim(credentialContext);
+
+			await resolver.setSecret(credentialStoreMetadata.id, resolutionContext, mergedDynamicData, {
 				configuration: resolverConfig,
 				resolverName: resolverEntity.name,
 				resolverId: resolverEntity.id,

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
@@ -1,11 +1,13 @@
 import { Z } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import { Request } from 'express';
-import { ICredentialContext } from 'n8n-workflow';
+import { ICredentialContext, ICredentialResolutionContext } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { AuthService } from '@/auth/auth.service';
 import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
+
+import { InboundClaimConnectService } from './inbound-claim-connect.service';
 
 class AuthSourceQuerySchema extends Z.class({
 	authSource: z.enum(['bearer', 'cookie']).optional(),
@@ -32,7 +34,10 @@ function getBearerToken(req: Request): string | null {
 
 @Service()
 export class DynamicCredentialWebService {
-	constructor(private readonly authService: AuthService) {}
+	constructor(
+		private readonly authService: AuthService,
+		private readonly inboundClaimConnectService: InboundClaimConnectService,
+	) {}
 
 	private buildCookieCredentialContext(req: Request): ICredentialContext {
 		const sessionCookie = this.authService.getCookieToken(req);
@@ -51,7 +56,13 @@ export class DynamicCredentialWebService {
 		};
 	}
 
-	getCredentialContextFromRequest(req: Request): ICredentialContext {
+	/**
+	 * A presented bearer token is verified here, so a caller arriving with an
+	 * external IdP token resolves as that identity. Tokens no trusted source
+	 * vouches for are returned untagged, exactly as before - they belong to a
+	 * resolver that keys on the token's own subject.
+	 */
+	async getCredentialContextFromRequest(req: Request): Promise<ICredentialResolutionContext> {
 		const parseResult = AuthSourceQuerySchema.safeParse(req.query);
 
 		if (parseResult.success && parseResult.data.authSource !== undefined) {
@@ -61,11 +72,7 @@ export class DynamicCredentialWebService {
 				if (token === null) {
 					throw new UnauthenticatedError('Bearer token is missing');
 				}
-				return {
-					identity: token,
-					version: 1,
-					metadata: {},
-				};
+				return await this.buildBearerCredentialContext(token);
 			} else if (authSource === 'cookie') {
 				return this.buildCookieCredentialContext(req);
 			} else {
@@ -75,13 +82,18 @@ export class DynamicCredentialWebService {
 
 		const token = getBearerToken(req);
 		if (token !== null) {
-			return {
-				identity: token,
-				version: 1,
-				metadata: {},
-			};
+			return await this.buildBearerCredentialContext(token);
 		}
 
 		return this.buildCookieCredentialContext(req);
+	}
+
+	private async buildBearerCredentialContext(token: string): Promise<ICredentialResolutionContext> {
+		const context: ICredentialContext = {
+			identity: token,
+			version: 1,
+			metadata: {},
+		};
+		return await this.inboundClaimConnectService.attachVerifiedClaim(context);
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -5,17 +5,18 @@ import { Service } from '@n8n/di';
 import type { NextFunction, Response } from 'express';
 import { Cipher } from 'n8n-core';
 import type {
-	ICredentialContext,
+	ICredentialResolutionContext,
 	ICredentialDataDecryptedObject,
 	IExecutionContext,
 	IWorkflowSettings,
 } from 'n8n-workflow';
-import { jsonParse, toCredentialContext } from 'n8n-workflow';
+import { jsonParse } from 'n8n-workflow';
 
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { StaticAuthService } from '@/services/static-auth-service';
 
+import { CredentialResolutionContextBuilder } from './credential-resolution-context.builder';
 import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
 import { ResolverConfigExpressionService } from './resolver-config-expression.service';
 import { extractSharedFields } from './shared-fields';
@@ -47,6 +48,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		private readonly logger: Logger,
 		private readonly expressionService: ResolverConfigExpressionService,
 		private readonly dynamicCredentialsProxy: DynamicCredentialsProxy,
+		private readonly resolutionContextBuilder: CredentialResolutionContextBuilder,
 	) {}
 
 	/**
@@ -56,6 +58,8 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 	 * @param credentialsResolveMetadata The credential resolve metadata
 	 * @param staticData The decrypted static credential data
 	 * @param additionalData Additional workflow execution data for context and settings
+	 * @param workflowId The workflow being executed, needed to unseal a claim carried
+	 *                   by the execution context (a claim is sealed per workflow)
 	 * @returns Resolved credential data (either dynamic or static)
 	 * @throws {CredentialResolutionError} If resolution fails and fallback is not allowed
 	 */
@@ -64,6 +68,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 		staticData: ICredentialDataDecryptedObject,
 		executionContext?: IExecutionContext,
 		workflowSettings?: IWorkflowSettings,
+		workflowId?: string,
 	): Promise<CredentialResolutionResult> {
 		// Determine which resolver ID to use: credential's own resolver or workflow's fallback
 		// (explicit workflow override, or the seeded system resolver looked up via the proxy).
@@ -96,8 +101,12 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			return this.handleResolverNotFound(credentialsResolveMetadata, resolverId);
 		}
 
-		// Build credential context from execution context
-		const credentialContext = await this.buildCredentialContext(executionContext);
+		// Build the resolution context from the execution context (unsealing the
+		// caller's claim, when there is one, on every access)
+		const credentialContext = await this.resolutionContextBuilder.build(
+			executionContext,
+			workflowId,
+		);
 
 		if (!credentialContext) {
 			return this.handleMissingContext(credentialsResolveMetadata);
@@ -188,7 +197,7 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 	 * touching that hot path).
 	 */
 	async resolveOwningUserIdForAuthorization(
-		credentialContext: ICredentialContext,
+		credentialContext: ICredentialResolutionContext,
 		resolverId: string,
 	): Promise<
 		{ status: 'unbound' } | { status: 'bound'; userId: string } | { status: 'unresolved' }
@@ -213,26 +222,6 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 			return userId ? { status: 'bound', userId } : { status: 'unresolved' };
 		} catch {
 			return { status: 'unresolved' };
-		}
-	}
-
-	/**
-	 * Builds credential context from execution context by decrypting the credentials field
-	 */
-	private async buildCredentialContext(executionContext: IExecutionContext | undefined) {
-		if (!executionContext?.credentials) {
-			return undefined;
-		}
-
-		try {
-			// Decrypt credential context from execution context
-			const decrypted = await this.cipher.decryptV2(executionContext.credentials);
-			return toCredentialContext(decrypted);
-		} catch (error) {
-			this.logger.error('Failed to decrypt credential context from execution context', {
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return undefined;
 		}
 	}
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/inbound-claim-connect.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/inbound-claim-connect.service.ts
@@ -1,0 +1,98 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type {
+	ICredentialContext,
+	ICredentialResolutionContext,
+	IVerifiedClaim,
+} from 'n8n-workflow';
+
+import { ExternalTokenVerifierProxy } from '@/services/external-token-verifier-proxy.service';
+import { IdentityResolutionProxy } from '@/services/identity-resolution-proxy.service';
+
+/** `Authorization: Bearer <token>` values are stored whole in some flows. */
+function stripBearerPrefix(identity: string): string {
+	return identity.replace(/^Bearer\s+/i, '').trim();
+}
+
+/**
+ * Turns a presented inbound token into a usable identity on the credential
+ * *connect* routes: verifies it, and establishes the binding to an n8n user if
+ * one doesn't exist yet.
+ *
+ * Provisioning lives here and nowhere else. Connecting is an interactive act by
+ * a caller who just presented a token, so binding then is sound; resolution
+ * during an execution stays strictly read-only, which is what stops an inbound
+ * trigger from creating users.
+ */
+@Service()
+export class InboundClaimConnectService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly externalTokenVerifierProxy: ExternalTokenVerifierProxy,
+		private readonly identityResolutionProxy: IdentityResolutionProxy,
+	) {}
+
+	/**
+	 * Verifies the token carried as the context identity and, when it checks
+	 * out, returns an `external-idp` context carrying the claim.
+	 *
+	 * Anything else is returned untouched: a context that already names its
+	 * source (cookie, manual, n8n-oauth), and a token no trusted source
+	 * vouches for - opaque tokens meant for an introspection resolver land
+	 * here, and must keep resolving the way they do today.
+	 */
+	async attachVerifiedClaim(context: ICredentialContext): Promise<ICredentialResolutionContext> {
+		if (context.metadata?.source !== undefined && context.metadata.source !== 'external-idp') {
+			return context;
+		}
+
+		const token = stripBearerPrefix(context.identity);
+		if (!token) return context;
+
+		const { claim } = await this.externalTokenVerifierProxy.verifyInboundToken(token);
+		if (!claim) return context;
+
+		return {
+			...context,
+			metadata: { ...context.metadata, source: 'external-idp' },
+			claims: {
+				version: 1,
+				sourceId: claim.sourceId,
+				issuer: claim.issuer,
+				subject: claim.subject,
+				audience: Array.isArray(claim.audience) ? claim.audience[0] : claim.audience,
+				expiresAt: claim.expiresAt.getTime(),
+				// Only sealed onto an execution context; nothing to bind here.
+				boundWorkflowId: '',
+			},
+		};
+	}
+
+	/**
+	 * Ensures the claim is bound to an n8n user, provisioning one if the
+	 * instance's identity policy allows it, so the read-only resolution that
+	 * runs on every later credential access finds a binding.
+	 *
+	 * Returns the bound user id, or `undefined` when no binding could be
+	 * established (no verifier, provisioning refused, role not permitted). The
+	 * caller decides what that means - it must not be treated as an error on
+	 * paths that also serve resolvers keyed on external subjects.
+	 */
+	async ensureBinding(claim: IVerifiedClaim): Promise<string | undefined> {
+		try {
+			const user = await this.identityResolutionProxy.resolve(
+				{ iss: claim.issuer, sub: claim.subject },
+				undefined,
+				{ issuer: claim.issuer },
+				true,
+			);
+			return user?.id;
+		} catch (error) {
+			this.logger.warn('Could not bind an inbound claim to an n8n user', {
+				subject: claim.subject,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/index.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/index.ts
@@ -7,3 +7,5 @@ export * from './credential-check-proxy.service';
 export * from './authorize-intent.service';
 export * from './n8n-resolver-seeder.service';
 export * from './credential-connection-status.service';
+export * from './credential-resolution-context.builder';
+export * from './inbound-claim-connect.service';

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -60,7 +60,8 @@ export class WorkflowStatusController {
 	async checkWorkflowForExecution(req: Request, res: Response): Promise<WorkflowExecutionStatus> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['get', 'options']);
 		const workflowId = req.params['workflowId'];
-		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
+		const credentialContext =
+			await this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 
 		if (!workflowId) {
 			throw new BadRequestError('Workflow ID is missing');

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.test.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.test.ts
@@ -79,6 +79,9 @@ describe('InboundClaimVerificationHook', () => {
 			expect(result.contextUpdate?.claims).toEqual({
 				version: 1,
 				sourceId: 'idp-1',
+				// Carried because a binding is keyed by issuer + subject, so resolution
+				// at access time needs it (see the external-idp source in N8NIdentifier).
+				issuer: 'https://idp.example.com',
 				subject: 'user-42',
 				audience: 'https://n8n.example.com',
 				expiresAt: expiresAt.getTime(),
@@ -90,9 +93,7 @@ describe('InboundClaimVerificationHook', () => {
 			expect(keys).not.toContain('principalId');
 			expect(keys).not.toContain('userId');
 			expect(keys).not.toContain('principal');
-			// Confirms issuer/attributes are deliberately dropped (not carried
-			// into the sealed claim - see plan §6.5).
-			expect(keys).not.toContain('issuer');
+			// Attributes stay out of the sealed claim - nothing resolves on them.
 			expect(keys).not.toContain('attributes');
 		});
 

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-claim-verification-hook.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-claim-verification-hook.ts
@@ -72,6 +72,7 @@ export class InboundClaimVerificationHook implements IContextEstablishmentHook {
 			const claim: IVerifiedClaim = {
 				version: 1,
 				sourceId: result.claim.sourceId,
+				issuer: result.claim.issuer,
 				subject: result.claim.subject,
 				audience: Array.isArray(result.claim.audience)
 					? result.claim.audience[0]

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -43,6 +43,7 @@ const resolvedKey: ResolvedTrustedKey = {
 	issuer: 'https://issuer.example.com',
 	allowedRoles: ['global:member', 'global:admin'],
 	requireVerifiedEmail: false,
+	subjectClaim: 'sub',
 };
 
 const mockUser = mock<User>({
@@ -338,6 +339,57 @@ describe('TokenExchangeService', () => {
 			expect(result.claims.jti).toBeUndefined();
 			expect(jtiStore.consume).not.toHaveBeenCalled();
 		});
+
+		describe('subjectClaim override', () => {
+			it('leaves sub unchanged when subjectClaim is the default', async () => {
+				mockValidToken();
+				jtiStore.consume.mockResolvedValue(true);
+
+				const result = await service.verifyToken('valid-token');
+
+				expect(result.claims.sub).toBe(validClaims.sub);
+			});
+
+			it('substitutes the configured claim for sub when present', async () => {
+				const payload = { ...validClaims, uid: 'stable-okta-id' };
+				vi.spyOn(jwt, 'decode').mockReturnValue({
+					header: { alg: 'RS256', kid: 'test-kid' },
+					payload,
+					signature: 'sig',
+				} as unknown as ReturnType<typeof jwt.decode>);
+				vi.spyOn(jwt, 'verify').mockReturnValue(
+					payload as unknown as ReturnType<typeof jwt.verify>,
+				);
+				trustedKeyStore.getByKidAndIss.mockResolvedValue({ ...resolvedKey, subjectClaim: 'uid' });
+				jtiStore.consume.mockResolvedValue(true);
+
+				const result = await service.verifyToken('valid-token');
+
+				expect(result.claims.sub).toBe('stable-okta-id');
+			});
+
+			it('rejects when the configured claim is missing from the payload', async () => {
+				mockValidToken();
+				trustedKeyStore.getByKidAndIss.mockResolvedValue({ ...resolvedKey, subjectClaim: 'uid' });
+
+				await expect(service.verifyToken('valid-token')).rejects.toThrow(TokenExchangeAuthError);
+			});
+
+			it('rejects when the configured claim is present but not a string', async () => {
+				const payload = { ...validClaims, uid: 12345 };
+				vi.spyOn(jwt, 'decode').mockReturnValue({
+					header: { alg: 'RS256', kid: 'test-kid' },
+					payload,
+					signature: 'sig',
+				} as unknown as ReturnType<typeof jwt.decode>);
+				vi.spyOn(jwt, 'verify').mockReturnValue(
+					payload as unknown as ReturnType<typeof jwt.verify>,
+				);
+				trustedKeyStore.getByKidAndIss.mockResolvedValue({ ...resolvedKey, subjectClaim: 'uid' });
+
+				await expect(service.verifyToken('valid-token')).rejects.toThrow(TokenExchangeAuthError);
+			});
+		});
 	});
 
 	describe('verifyExternalToken', () => {
@@ -367,6 +419,7 @@ describe('TokenExchangeService', () => {
 				key: publicKey,
 				issuer: keycloakClaims.iss,
 				requireVerifiedEmail: false,
+				subjectClaim: 'sub',
 			});
 
 			const result = await service.verifyExternalToken(token, keycloakClaims.aud);
@@ -394,6 +447,34 @@ describe('TokenExchangeService', () => {
 				claim: null,
 				context: { reason: 'invalid_token', errorDetails: expect.any(String) },
 			});
+		});
+
+		it('substitutes a configured subjectClaim for sub end-to-end (Okta-style divergence)', async () => {
+			const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+			const oktaClaims = {
+				sub: 'alice.example@acme.com',
+				uid: 'okta-immutable-id-42',
+				iss: 'https://acme.okta.com/oauth2/aus1abc',
+				aud: 'n8n-resource-server',
+				iat: now,
+				exp: now + 300,
+				jti: 'okta-token-id',
+			};
+			const token = jwt.sign(oktaClaims, privateKey, { algorithm: 'RS256', keyid: 'okta-kid' });
+
+			trustedKeyStore.getByKidAndIss.mockResolvedValue({
+				sourceId: 'okta-custom-as',
+				kid: 'okta-kid',
+				algorithms: ['RS256'],
+				key: publicKey,
+				issuer: oktaClaims.iss,
+				requireVerifiedEmail: false,
+				subjectClaim: 'uid',
+			});
+
+			const result = await service.verifyExternalToken(token, oktaClaims.aud);
+
+			expect(result).toMatchObject({ claim: { subject: oktaClaims.uid } });
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -8,6 +8,7 @@ import { AuthError } from '@/errors/response-errors/auth.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { JwtService } from '@/services/jwt.service';
 
+import type { InboundAudienceService } from '../../context-establishment-hooks/inbound-audience.service';
 import type { TokenExchangeConfig } from '../../token-exchange.config';
 import { TokenExchangeAuthError } from '../../token-exchange.errors';
 import type { ResolvedTrustedKey } from '../../token-exchange.schemas';
@@ -22,6 +23,7 @@ const jtiStore = mock<JtiStoreService>();
 const identityResolutionService = mock<IdentityResolutionService>();
 const config = mock<TokenExchangeConfig>();
 const jwtService = mock<JwtService>();
+const inboundAudienceService = mock<InboundAudienceService>();
 
 const service = new TokenExchangeService(
 	logger,
@@ -30,6 +32,7 @@ const service = new TokenExchangeService(
 	identityResolutionService,
 	config,
 	jwtService,
+	inboundAudienceService,
 );
 
 const resolvedKey: ResolvedTrustedKey = {

--- a/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/trusted-key.service.test.ts
@@ -2,6 +2,7 @@ import type { Logger } from '@n8n/backend-common';
 import type { DbLockService } from '@n8n/db';
 import type { EntityManager } from '@n8n/typeorm';
 import type { InstanceSettings } from 'n8n-core';
+import { jsonParse } from 'n8n-workflow';
 import { createHash } from 'node:crypto';
 import { mock } from 'vitest-mock-extended';
 
@@ -62,10 +63,12 @@ function makeTrustedKeyEntity(
 function createMocks({
 	isLeader = true,
 	trustedKeys = '',
-}: { isLeader?: boolean; trustedKeys?: string } = {}) {
+	inboundSubjectClaim = '',
+}: { isLeader?: boolean; trustedKeys?: string; inboundSubjectClaim?: string } = {}) {
 	const config = mock<TokenExchangeConfig>({
 		trustedKeys,
 		keyRefreshIntervalSeconds: 300,
+		inboundSubjectClaim,
 	});
 	const sourceRepo = mock<TrustedKeySourceRepository>();
 	const keyRepo = mock<TrustedKeyRepository>();
@@ -94,6 +97,7 @@ function createMocks({
 
 	return {
 		service,
+		config,
 		keyRepo,
 		sourceRepo,
 		dbLockService,
@@ -153,6 +157,28 @@ describe('TrustedKeyService', () => {
 
 			// Different KeyObject (cache miss due to hash mismatch)
 			expect(result1!.key).not.toBe(result2!.key);
+		});
+	});
+
+	describe('subjectClaim resolution', () => {
+		it('defaults subjectClaim to sub when the stored data omits it', async () => {
+			const { service, keyRepo } = createMocks();
+			keyRepo.findAllByKid.mockResolvedValue([makeTrustedKeyEntity()]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			expect(result!.subjectClaim).toBe('sub');
+		});
+
+		it('returns the configured subjectClaim when present in stored data', async () => {
+			const { service, keyRepo } = createMocks();
+			keyRepo.findAllByKid.mockResolvedValue([
+				makeTrustedKeyEntity({ data: makeTrustedKeyData({ subjectClaim: 'uid' }) }),
+			]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			expect(result!.subjectClaim).toBe('uid');
 		});
 	});
 
@@ -413,6 +439,28 @@ describe('TrustedKeyService', () => {
 
 			await expect(service.registerSsoDerivedSource(issuer, jwksUri)).resolves.not.toThrow();
 			expect(tx.save).toHaveBeenCalled();
+		});
+
+		it('includes subjectClaim from config.inboundSubjectClaim when set', async () => {
+			const { service, tx, sourceRepo } = createMocks({ inboundSubjectClaim: 'uid' });
+			tx.findOneBy.mockResolvedValueOnce(null);
+			sourceRepo.findOneBy.mockResolvedValue(mock<TrustedKeySourceEntity>());
+
+			await service.registerSsoDerivedSource(issuer, jwksUri);
+
+			const [, saved] = tx.save.mock.calls[0] as [unknown, { config: string }];
+			expect(jsonParse(saved.config)).toMatchObject({ subjectClaim: 'uid' });
+		});
+
+		it('omits subjectClaim when config.inboundSubjectClaim is empty', async () => {
+			const { service, tx, sourceRepo } = createMocks({ inboundSubjectClaim: '' });
+			tx.findOneBy.mockResolvedValueOnce(null);
+			sourceRepo.findOneBy.mockResolvedValue(mock<TrustedKeySourceEntity>());
+
+			await service.registerSsoDerivedSource(issuer, jwksUri);
+
+			const [, saved] = tx.save.mock.calls[0] as [unknown, { config: string }];
+			expect(jsonParse(saved.config)).not.toHaveProperty('subjectClaim');
 		});
 	});
 });

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/services/external-token-verifier-proxy.service';
 import { JwtService } from '@/services/jwt.service';
 
+import { InboundAudienceService } from '../context-establishment-hooks/inbound-audience.service';
 import { TokenExchangeConfig } from '../token-exchange.config';
 import { TokenExchangeAuthError, TokenExchangeRequestError } from '../token-exchange.errors';
 import type {
@@ -46,6 +47,7 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 		private readonly identityResolutionService: IdentityResolutionService,
 		private readonly config: TokenExchangeConfig,
 		private readonly jwtService: JwtService,
+		private readonly inboundAudienceService: InboundAudienceService,
 	) {
 		this.logger = logger.scoped('token-exchange');
 	}
@@ -232,6 +234,16 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 			this.logger.warn('External token verification failed', { error: message });
 			return { claim: null, context: { reason: 'invalid_token', errorDetails: message } };
 		}
+	}
+
+	/**
+	 * Verify an inbound token against the audience this instance accepts for
+	 * inbound identity. Same decision as the context-establishment hook, so a
+	 * token that establishes a claim on a webhook also verifies on the
+	 * credential-connect routes.
+	 */
+	async verifyInboundToken(token: string): Promise<VerifiedClaimResult> {
+		return await this.verifyExternalToken(token, this.inboundAudienceService.getExpectedAudience());
 	}
 
 	async embedLogin(

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -53,6 +53,25 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 	}
 
 	/**
+	 * Some IdPs put a mutable identifier (e.g. the user's login) in `sub` on
+	 * access tokens, while an immutable one lives in a differently-named
+	 * claim (e.g. Okta's `uid`). When a trust source configures
+	 * `subjectClaim`, its value substitutes for `sub` so every downstream
+	 * consumer - the SSO bridge, qualified-sub binding, JIT provisioning -
+	 * keys on the stable identifier without needing to know about this.
+	 */
+	private resolveEffectiveSubject(payload: jwt.JwtPayload, subjectClaim: string): string {
+		const configuredSubject: unknown = payload[subjectClaim];
+		if (typeof configuredSubject !== 'string' || !configuredSubject) {
+			throw new TokenExchangeAuthError(
+				TokenExchangeFailureReason.InvalidClaims,
+				`Configured subject claim '${subjectClaim}' is missing or not a string`,
+			);
+		}
+		return configuredSubject;
+	}
+
+	/**
 	 * Verify and validate an external JWT subject token.
 	 *
 	 * Performs the full verification pipeline:
@@ -179,6 +198,10 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 		const claims = requireJti
 			? ExternalTokenClaimsSchema.parse(payload)
 			: ResourceServerTokenClaimsSchema.parse(payload);
+
+		if (resolvedKey.subjectClaim !== 'sub') {
+			claims.sub = this.resolveEffectiveSubject(payload, resolvedKey.subjectClaim);
+		}
 
 		if (maxLifetimeSeconds !== undefined) {
 			const tokenLifetime = claims.exp - claims.iat;

--- a/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/trusted-key.service.ts
@@ -194,6 +194,7 @@ export class TrustedKeyService {
 				expectedAudience: data.expectedAudience,
 				allowedRoles: data.allowedRoles,
 				requireVerifiedEmail: data.requireVerifiedEmail ?? true,
+				subjectClaim: data.subjectClaim ?? 'sub',
 			};
 		}
 
@@ -364,7 +365,12 @@ export class TrustedKeyService {
 	 */
 	async registerSsoDerivedSource(issuer: string, jwksUri: string): Promise<void> {
 		const sourceId = createHash('sha256').update(issuer).digest('hex').slice(0, 36);
-		const config: JwksKeySource = { type: 'jwks', url: jwksUri, issuer };
+		const config: JwksKeySource = {
+			type: 'jwks',
+			url: jwksUri,
+			issuer,
+			subjectClaim: this.config.inboundSubjectClaim || undefined,
+		};
 
 		await this.dbLockService.withLock(DbLock.TRUSTED_KEY_REFRESH, async (tx) => {
 			const existingForIssuer = await tx.findOneBy(TrustedKeySourceEntity, { issuer });
@@ -569,6 +575,7 @@ export class TrustedKeyService {
 					expectedAudience: key.expectedAudience,
 					allowedRoles: key.allowedRoles,
 					requireVerifiedEmail: jwksConfig.requireVerifiedEmail ?? true,
+					subjectClaim: jwksConfig.subjectClaim,
 					expiresAt: new Date(Date.now() + result.ttlSeconds * 1000).toISOString(),
 				},
 			})),
@@ -615,6 +622,7 @@ export class TrustedKeyService {
 				expectedAudience,
 				allowedRoles,
 				requireVerifiedEmail,
+				subjectClaim,
 			} = config;
 
 			if (seenKids.has(kid)) {
@@ -633,6 +641,7 @@ export class TrustedKeyService {
 					expectedAudience,
 					allowedRoles,
 					requireVerifiedEmail,
+					subjectClaim,
 				},
 			});
 		}

--- a/packages/cli/src/modules/token-exchange/token-exchange.config.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.config.ts
@@ -55,4 +55,14 @@ export class TokenExchangeConfig {
 	 */
 	@Env('N8N_TOKEN_EXCHANGE_INBOUND_AUDIENCE')
 	inboundAudience: string = '';
+
+	/**
+	 * Claim to use as the effective subject for SSO-derived trusted key
+	 * sources, instead of the standard `sub` claim - e.g. `uid` for an Okta
+	 * custom authorization server, whose access-token `sub` is often the
+	 * user's login rather than a stable id. Instance-wide, not per-issuer -
+	 * same limitation as `inboundAudience` above.
+	 */
+	@Env('N8N_TOKEN_EXCHANGE_INBOUND_SUBJECT_CLAIM')
+	inboundSubjectClaim: string = '';
 }

--- a/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.schemas.ts
@@ -73,6 +73,7 @@ export const TrustedKeySourceSchema = z.discriminatedUnion('type', [
 		requireVerifiedEmail: z.boolean().optional(),
 		expectedAudience: z.string().optional(),
 		allowedRoles: z.array(z.string()).optional(),
+		subjectClaim: z.string().optional(),
 	}),
 	z.object({
 		type: z.literal('jwks'),
@@ -82,6 +83,7 @@ export const TrustedKeySourceSchema = z.discriminatedUnion('type', [
 		expectedAudience: z.string().optional(),
 		allowedRoles: z.array(z.string()).optional(),
 		cacheTtlSeconds: z.number().int().positive().optional(),
+		subjectClaim: z.string().optional(),
 	}),
 ]);
 
@@ -116,6 +118,7 @@ export const TrustedKeyDataSchema = z.object({
 	allowedRoles: z.array(z.string()).optional(),
 	expiresAt: z.string().optional(),
 	requireVerifiedEmail: z.boolean().optional(),
+	subjectClaim: z.string().optional(),
 });
 
 export type TrustedKeyData = z.infer<typeof TrustedKeyDataSchema>;
@@ -150,6 +153,16 @@ export interface ResolvedTrustedKey {
 
 	/** Flag indicating that the token's `email_verified` claim must be true, for email linking. */
 	requireVerifiedEmail: boolean;
+
+	/**
+	 * Claim to use as the effective subject when resolving identity, instead
+	 * of the standard `sub` claim (e.g. `uid` for an Okta custom Authorization
+	 * Server, whose access-token `sub` is often the user's login rather than
+	 * a stable id). Must be an immutable, issuer-assigned identifier —
+	 * pointing this at a mutable attribute (email, username) turns the
+	 * binding key into a forgeable value.
+	 */
+	subjectClaim: string;
 }
 
 /**

--- a/packages/cli/src/services/external-token-verifier-proxy.service.ts
+++ b/packages/cli/src/services/external-token-verifier-proxy.service.ts
@@ -23,6 +23,13 @@ export type VerifiedClaimResult =
 
 export interface ExternalTokenVerifier {
 	verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult>;
+
+	/**
+	 * Same verification, but against the audience this instance accepts for
+	 * inbound tokens. Keeps that decision inside the module that owns inbound
+	 * identity, so callers don't each have to know what to expect.
+	 */
+	verifyInboundToken(token: string): Promise<VerifiedClaimResult>;
 }
 
 /**
@@ -39,14 +46,25 @@ export class ExternalTokenVerifierProxy implements ExternalTokenVerifier {
 
 	async verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult> {
 		if (!this.provider) {
-			return {
-				claim: null,
-				context: {
-					reason: 'verifier_not_registered',
-					errorDetails: 'No external token verifier is registered on this instance',
-				},
-			};
+			return this.notRegistered();
 		}
 		return await this.provider.verifyExternalToken(token, expectedAudience);
+	}
+
+	async verifyInboundToken(token: string): Promise<VerifiedClaimResult> {
+		if (!this.provider) {
+			return this.notRegistered();
+		}
+		return await this.provider.verifyInboundToken(token);
+	}
+
+	private notRegistered(): VerifiedClaimResult {
+		return {
+			claim: null,
+			context: {
+				reason: 'verifier_not_registered',
+				errorDetails: 'No external token verifier is registered on this instance',
+			},
+		};
 	}
 }

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -19,6 +19,7 @@ import {
 	WAITING_TOKEN_QUERY_PARAM,
 } from 'n8n-core';
 import type {
+	CheckableExecutionContext,
 	IBinaryData,
 	IDataObject,
 	IExecuteData,
@@ -641,7 +642,7 @@ export async function executeWebhook(
 		if (!credentialCheckProxy || !workflow.id) {
 			return undefined;
 		}
-		const executionContext =
+		const executionContext: CheckableExecutionContext | undefined =
 			runExecutionData?.executionData?.runtimeData ??
 			(additionalData.encryptedRunnerIdentity
 				? {
@@ -653,7 +654,9 @@ export async function executeWebhook(
 			return undefined;
 		}
 
-		if (!executionContext.credentials) {
+		// An inbound IdP token establishes a claim without capturing a credential
+		// context, so either field on its own is enough to have something to check.
+		if (!executionContext.credentials && !executionContext.claims) {
 			return undefined;
 		}
 

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -209,6 +209,7 @@ describe('ExecutionContextService', () => {
 		const sampleClaim = {
 			version: 1,
 			sourceId: 'idp-1',
+			issuer: 'https://idp-1.example.com',
 			subject: 'user-42',
 			audience: 'aud-1',
 			expiresAt: 999,
@@ -372,6 +373,7 @@ describe('ExecutionContextService', () => {
 			const claim: IVerifiedClaim = {
 				version: 1,
 				sourceId: 'idp-1',
+				issuer: 'https://idp-1.example.com',
 				subject: 'user-42',
 				audience: 'aud-1',
 				expiresAt: 999,
@@ -396,6 +398,7 @@ describe('ExecutionContextService', () => {
 			const claim: IVerifiedClaim = {
 				version: 1,
 				sourceId: 'idp-1',
+				issuer: 'https://idp-1.example.com',
 				subject: 'user-42',
 				audience: 'aud-1',
 				expiresAt: 999,
@@ -468,6 +471,7 @@ describe('ExecutionContextService', () => {
 		const sampleClaim: IVerifiedClaim = {
 			version: 1,
 			sourceId: 'idp-1',
+			issuer: 'https://idp-1.example.com',
 			subject: 'user-42',
 			audience: 'aud-1',
 			expiresAt: Date.now() + 60_000,
@@ -556,6 +560,7 @@ describe('ExecutionContextService', () => {
 			const claim: IVerifiedClaim = {
 				version: 1,
 				sourceId: 'idp-1',
+				issuer: 'https://idp-1.example.com',
 				subject: 'user-42',
 				audience: 'aud-1',
 				expiresAt: 12345,
@@ -674,6 +679,7 @@ describe('ExecutionContextService', () => {
 				claims: {
 					version: 1,
 					sourceId: 'idp-a',
+					issuer: 'https://idp-a.example.com',
 					subject: 'user-a',
 					audience: 'aud-a',
 					expiresAt: 1000,
@@ -685,6 +691,7 @@ describe('ExecutionContextService', () => {
 				claims: {
 					version: 1,
 					sourceId: 'idp-b',
+					issuer: 'https://idp-b.example.com',
 					subject: 'user-b',
 					audience: 'aud-b',
 					expiresAt: 2000,
@@ -705,6 +712,7 @@ describe('ExecutionContextService', () => {
 				claims: {
 					version: 1,
 					sourceId: 'idp-a',
+					issuer: 'https://idp-a.example.com',
 					subject: 'user-a',
 					audience: 'aud-a',
 					expiresAt: 1000,
@@ -781,6 +789,7 @@ describe('ExecutionContextService', () => {
 			const parentClaim = {
 				version: 1,
 				sourceId: 'idp-1',
+				issuer: 'https://idp-1.example.com',
 				subject: 'user-42',
 				audience: 'aud-1',
 				expiresAt: Date.now() + 60_000,
@@ -818,6 +827,7 @@ describe('ExecutionContextService', () => {
 			const parentClaim = {
 				version: 1,
 				sourceId: 'idp-1',
+				issuer: 'https://idp-1.example.com',
 				subject: 'user-42',
 				audience: 'aud-1',
 				expiresAt: Date.now() + 60_000,
@@ -1369,6 +1379,7 @@ describe('ExecutionContextService — no principal is ever persisted on the exec
 		const claim: IVerifiedClaim = {
 			version: 1,
 			sourceId: 'idp-1',
+			issuer: 'https://idp-1.example.com',
 			subject: 'user-42',
 			audience: 'aud-1',
 			expiresAt: Date.now() + 60_000,

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -88,6 +88,20 @@ export const CredentialContextSchema = z
  */
 export type ICredentialContext = z.output<typeof CredentialContextSchema>;
 
+/**
+ * Credential context as seen by a resolver, plus the caller's verified claim
+ * when the execution carries one.
+ *
+ * Runtime-only, and deliberately not part of `CredentialContextSchema`: the
+ * claim is unsealed per access from `IExecutionContext.claims` and attached
+ * here, so it can never be written into the persisted credential envelope.
+ * Resolvers that key on n8n users derive the principal from it on every
+ * access - a stored principal id would itself work as a bearer credential.
+ */
+export type ICredentialResolutionContext = ICredentialContext & {
+	claims?: IVerifiedClaim;
+};
+
 const ActorClaimSchemaV1 = z.object({
 	version: z.literal(1),
 	/** IdP that verified the actor (the caller), not the principal (who they're acting as). */
@@ -102,6 +116,12 @@ const VerifiedClaimSchemaV1 = z.object({
 	version: z.literal(1),
 	/** Which IdP verified this claim. */
 	sourceId: z.string(),
+	/**
+	 * The issuer that vouched for the subject (mirrors JWT `iss`). Needed to
+	 * resolve the claim: a binding is keyed by issuer + subject, and the
+	 * SSO bridge only applies to issuers n8n knows as SSO providers.
+	 */
+	issuer: z.string(),
 	/** The verified external subject, e.g. IdP `sub`. Not a principal id - see IVerifiedClaim. */
 	subject: z.string(),
 	/** What the claim was verified for (mirrors JWT `aud`). */

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1167,12 +1167,20 @@ export type CredentialCheckResult = {
 	credentials: CredentialCheckStatus[];
 };
 
+/**
+ * The encrypted execution-context fields a credential-status check needs: a
+ * captured credential context and/or the caller's sealed claim (both stay
+ * encrypted until the check unseals them).
+ */
+export type CheckableExecutionContext = {
+	credentials?: string;
+	claims?: string;
+};
+
 export type DynamicCredentialCheckProxyProvider = {
 	checkCredentialStatus(
 		workflowId: string,
-		executionContext: {
-			credentials?: string;
-		},
+		executionContext: CheckableExecutionContext,
 	): Promise<CredentialCheckResult>;
 };
 
@@ -1180,9 +1188,7 @@ export type CredentialCheckProxyFunctions = {
 	// Optional to account for situations where the dynamic-credentials module is disabled
 	checkCredentialStatus?(
 		workflowId: string,
-		executionContext: {
-			credentials?: string;
-		},
+		executionContext: CheckableExecutionContext,
 	): Promise<CredentialCheckResult>;
 };
 

--- a/packages/workflow/test/execution-context.test.ts
+++ b/packages/workflow/test/execution-context.test.ts
@@ -131,7 +131,7 @@ describe('toVerifiedClaim', () => {
 		expect(parsed).toEqual(baseClaim);
 	});
 
-	it.each(['sourceId', 'subject', 'audience', 'expiresAt', 'boundWorkflowId'])(
+	it.each(['sourceId', 'issuer', 'subject', 'audience', 'expiresAt', 'boundWorkflowId'])(
 		'rejects a claim missing %s',
 		(field) => {
 			const invalid: Record<string, unknown> = { ...baseClaim };

--- a/packages/workflow/test/execution-context.test.ts
+++ b/packages/workflow/test/execution-context.test.ts
@@ -96,6 +96,7 @@ describe('toVerifiedClaim', () => {
 	const baseClaim = {
 		version: 1 as const,
 		sourceId: 'idp-1',
+		issuer: 'https://idp-1.example.com',
 		subject: 'user-42',
 		audience: 'aud-1',
 		expiresAt: 1234567890,


### PR DESCRIPTION
## Summary

Re-derives the n8n principal from the caller's sealed `VerifiedClaim` **on every credential access**, instead of reading a principal off the execution context. Builds on #35631 (T5), which verifies an inbound bearer token once at context establishment and seals the resulting claim onto the context.

Adds an `external-idp` source to `N8NIdentifier`. `resolverId` stays `SYSTEM_RESOLVER_ID`, so per-user credential storage, the connection-status surface and `resolveOwningUserIdForAuthorization` keep working untouched — no new resolver, no new storage namespace, and the connection the human made in the n8n UI is the one an inbound IdP token finds.

Resolving late is the point: revoking a binding takes effect mid-execution, a resumed execution re-checks authority, and a binding that appears while the execution waits starts working. Verification (crypto, JWKS, trust sources) already happened once at establishment; this is an indexed read plus a binding-status check, so it is cheap to run N+1 times. Nothing caches the principal — not across nodes, not across a resume.

**Two commits:**

**1. Carry the claim into credential resolution.** The sealed claim lives on its own execution-context field, which resolvers never see — they only get the decrypted credential context. So:
- `ICredentialResolutionContext` widens the resolver-facing context with the claim. Runtime-only and deliberately *outside* the persisted credential schema, so a claim can never be written into the credential envelope (or into an authorize intent).
- `CredentialResolutionContextBuilder` is the single place that decides which identity an execution carries, so the node-execution path and the pre-execution credential-status gate cannot disagree. An explicit credential context always wins (manual / chat-hub / cookie / n8n-oauth are untouched); a claim-only context synthesizes an `external-idp` context, since that flow has no identity token to carry.
- The workflow id is threaded into resolution to check the per-workflow seal. Without it the claim is dropped — resolution fails closed rather than accepting a claim sealed elsewhere.
- The sealed claim now carries `issuer`. A binding is keyed by issuer + subject (`sha256(iss)::sub`) and the SSO bridge only applies to known SSO issuers, so resolution cannot work without it. The T5 hook has it in hand from the verifier; this stores it (and the test asserting it was dropped is flipped, with the reason).

**2. The `external-idp` source.** Reads the claim, resolves it through `IdentityResolutionProxy` with `allowProvisioning: false` — an inbound trigger must never create a user — and returns the principal id. Claim expiry deliberately does not gate access: access tokens live minutes, executions can outlive them, so **binding status is the live gate**. Every "no principal" case (absent claim, claim sealed for another workflow, no binding, revoked binding, token-exchange module disabled) throws `CredentialResolverDataNotFoundError`, so the credential reports "not connected" exactly as an unconnected credential does today, and the execution proceeds to that point.

### Consequences, stated explicitly

- **Partial failure.** Revoke a binding mid-execution and earlier nodes have already succeeded while later ones fail. Same shape as a credential revoked mid-run.
- **Behaviour change for existing workflows.** The T5 hook is global, so any webhook run whose `Authorization: Bearer` token verifies against a trusted key source now carries a claim. With the synthesis above, a workflow using end-user credentials and *no* identity-extractor hook goes from "not connected" to "resolves to the token's user" — gated on the token verifying *and* an active binding. Statically-configured credentials are unaffected (`resolveIfNeeded` early-returns unless `isResolvable`).
- **An IdP user who has never logged into n8n cannot resolve**, because there is no binding to find, and the gate withholds the authorize link. Not a regression — the existing external-subject resolvers (OAuth introspection/userinfo, Slack) are untouched, and connecting against the system resolver already required an n8n session. Follow-up: let the interactive connect route bind a verified inbound token (see tickets below).
- **Not enforced on this path:** `excludeOwner` / key-scoped `allowedRoles` are only applied when provisioning, so a claim bound to a privileged user still resolves. Pre-existing in T4, surfaced by this usage — follow-up ticket.

## How to test

Requires `N8N_ENV_FEAT_TOKEN_EXCHANGE=true`, a trusted key source (`N8N_TOKEN_EXCHANGE_TRUSTED_KEYS`, or an OIDC SSO provider — its discovery document registers one automatically), the dynamic-credentials module, and a webhook-triggered workflow using an end-user credential.

1. As a user who has logged in via OIDC SSO, connect the end-user credential in the n8n UI.
2. `curl` the webhook with `Authorization: Bearer <JWT>` signed by that IdP, `sub` = the same subject, `aud` = the instance base URL (or `N8N_TOKEN_EXCHANGE_INBOUND_AUDIENCE`). The credential resolves to *that user's* connection, and the pre-execution gate reports `configured`.
3. Set the user's `auth_identity.status` to `revoked` mid-run (a Wait node makes this easy) — the next credential resolution fails with "not connected", while nodes that already ran are unaffected.
4. Use a token whose `exp` has passed but which was verified while valid (resume a waiting execution) — it still resolves. Binding status, not claim expiry, is the gate.
5. Send a request with no `Authorization` header, or a garbage token — identical behaviour to before.

Covered by unit tests on the identifier (revoke-between-accesses, re-resolution per access, expired claim, absent claim, no binding, provisioning never allowed), the context builder (synthesis, precedence, seal mismatch, missing workflow id, undecryptable context), the resolution service and the gate.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1168

Builds on #35631 (https://linear.app/n8n/issue/IAM-1166). Unblocks https://linear.app/n8n/issue/IAM-1169.

Follow-ups filed from this work:
- https://linear.app/n8n/issue/IAM-1192 — apply the key's role restrictions on the read-only resolution path
- https://linear.app/n8n/issue/IAM-1188 — bind a verified inbound token at the connect route, so a caller who never logged into n8n can connect (spiked in #35650)
- https://linear.app/n8n/issue/IAM-1189 / https://linear.app/n8n/issue/IAM-1190 / https://linear.app/n8n/issue/IAM-1191 — the sequence toward merging the two end-user-credential behaviours onto one substrate

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


