### PR TITLE
fix: Include node behavior flags in instance-ai eval judge context (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -78,6 +78,10 @@ export interface WorkflowNodeResponse {
 	position?: [number, number];
 	parameters?: Record<string, unknown>;
 	executeOnce?: boolean;
+	alwaysOutputData?: boolean;
+	retryOnFail?: boolean;
+	maxTries?: number;
+	waitBetweenTries?: number;
 	onError?: 'stopWorkflow' | 'continueRegularOutput' | 'continueErrorOutput';
 	disabled?: boolean;
 	credentials?: Record<string, unknown>;

--- a/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
+++ b/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
@@ -86,6 +86,10 @@ const CREDENTIAL_TEMPLATES: Record<string, CredentialTemplate> = {
 		defaultName: '[eval] HTTP Header',
 		buildData: () => ({ name: 'Authorization', value: 'Bearer eval-placeholder' }),
 	},
+	httpBearerAuth: {
+		defaultName: '[eval] HTTP Bearer',
+		buildData: (token) => ({ token }),
+	},
 	httpBasicAuth: {
 		defaultName: '[eval] HTTP Basic',
 		buildData: () => ({ user: 'eval-user', password: 'eval-pass' }),

--- a/packages/@n8n/instance-ai/evaluations/harness/workflow-context.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/workflow-context.ts
@@ -18,6 +18,13 @@ export function buildWorkflowContextBlock(wf: WorkflowResponse | undefined): str
 				typeVersion: node.typeVersion,
 				...(node.disabled !== undefined ? { disabled: node.disabled } : {}),
 				...(node.onError !== undefined ? { onError: node.onError } : {}),
+				// Node-level behavior flags — preservation-style expectations assert on
+				// these, so omitting them makes the judge read a correct build as a fail.
+				...(node.alwaysOutputData !== undefined ? { alwaysOutputData: node.alwaysOutputData } : {}),
+				...(node.retryOnFail !== undefined ? { retryOnFail: node.retryOnFail } : {}),
+				...(node.maxTries !== undefined ? { maxTries: node.maxTries } : {}),
+				...(node.waitBetweenTries !== undefined ? { waitBetweenTries: node.waitBetweenTries } : {}),
+				...(node.executeOnce !== undefined ? { executeOnce: node.executeOnce } : {}),
 				...(node.credentials !== undefined ? { credentials: node.credentials } : {}),
 				parameters: node.parameters ?? {},
 			})),


### PR DESCRIPTION
## Summary

The Instance AI eval expectation judge grades outcome expectations from a rendered workflow context (`evaluations/harness/workflow-context.ts`). The rendering included `parameters`, `onError`, `disabled` and `credentials`, but omitted the other node-level behavior flags: `alwaysOutputData`, `retryOnFail`, `maxTries`, `waitBetweenTries`, `executeOnce`.

Preservation-style eval expectations assert on exactly these flags (for example: an edit must not strip `alwaysOutputData` from an unrelated node). With the flags missing from the judge context, a correct build was graded as a fail — verified by fetching the built workflow via `GET /rest/workflows/:id`, which showed the flags intact while the judge reported them absent.

Also adds an `httpBearerAuth` template to the eval credential seeder so the user proxy can fill setup cards for bearer-auth credentials instead of erroring with 'No credential template for type httpBearerAuth'.

Eval harness only — no product code.

## How to test

Run an eval case whose seeded workflow carries `alwaysOutputData`/`retryOnFail` on a node and whose outcome expectations assert those flags survive an edit. Before this change the judge fails the expectation on a correct build; after it, the flags appear in the judge's workflow context and the expectation passes.

## Related Linear tickets, Github issues, and Community forum posts

Found while calibrating new edit-safety eval cases.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

