### PR TITLE
feat(core): Teach the AI assistant to organise workflows into node groups

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -445,7 +445,7 @@ unsolicited `sticky()`, forbidden builder constructs (e.g. `.map()`), and
 repeated `.onTrue()` / `.onFalse()` overwrites on the same IF variable. Fix
 every reported error and warning before calling `build-workflow`.
 
-- Code nodes need not always be necessary. You can use other n8n nodes to do the same thing. 
+- Code nodes need not always be necessary. You can use other n8n nodes to do the same thing.
 - SDK builder code is a restricted subset of TypeScript that builds a static
   graph; it is not a Code node and does not run. Build strings with template
   literals; do runtime joining, aggregation, or transforms in a Code node or
@@ -533,6 +533,20 @@ import {
   expr,
 } from '@n8n/workflow-sdk';
 ```
+
+## Node Groups
+
+Organise multi-stage workflows into named node groups — visual frames on the canvas — so the
+result is readable the first time the user sees it. Group each clear stage (ingest → transform
+→ deliver); small workflows don't need groups. Give every group a one-sentence
+`description` — groups are collapsed by default, so name + description is what the user sees
+first.
+
+`.group(name, members, { description })` on the workflow builder; members are the node handles.
+Read `knowledge-base/reference/node-groups.md` for the exact rules (trigger nodes excluded,
+one connected section, AI sub-nodes stay with their Agent) before creating groups — an invalid
+group is rejected on save. When editing an existing workflow, keep existing `.group(...)` calls
+and their descriptions intact unless the change is about grouping.
 
 ## Workflow Rules
 

--- a/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
@@ -107,6 +107,13 @@ describe('buildKnowledgeBaseWorkspaceBundle', () => {
 			bundle.files.get(`${ROOT}/${SANDBOX_KNOWLEDGE_BASE_DIR}/reference/workflow-sdk-language.md`),
 		).toContain('# Workflow SDK language reference');
 
+		// Generated from two constants: the rules, then the when-to-group guidance.
+		const nodeGroupsReference = bundle.files.get(
+			`${ROOT}/${SANDBOX_KNOWLEDGE_BASE_DIR}/reference/node-groups.md`,
+		);
+		expect(nodeGroupsReference).toContain('## Node groups');
+		expect(nodeGroupsReference).toContain('## Grouping');
+
 		const rootIndex = jsonParse<{
 			bestPractices: { indexFile: string; entries: Array<{ id: string }> };
 			templates: { indexFile: string; entries?: unknown[] };
@@ -134,6 +141,10 @@ describe('buildKnowledgeBaseWorkspaceBundle', () => {
 			expect.objectContaining({
 				id: 'workflow-sdk-language',
 				file: 'reference/workflow-sdk-language.md',
+			}),
+			expect.objectContaining({
+				id: 'node-groups',
+				file: 'reference/node-groups.md',
 			}),
 		]);
 		expect(rootIndex.bestPractices.entries.some((entry) => entry.id === 'scheduling')).toBe(true);

--- a/packages/@n8n/instance-ai/src/knowledge-base/materialize-knowledge-base.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/materialize-knowledge-base.ts
@@ -4,7 +4,11 @@ import {
 	WorkflowTechnique,
 	type WorkflowTechniqueType as BestPracticesGuideId,
 } from '@n8n/workflow-sdk/prompts/best-practices';
-import { SDK_LANGUAGE_REFERENCE } from '@n8n/workflow-sdk/prompts/sdk-reference';
+import {
+	GROUPING_GUIDANCE,
+	NODE_GROUPS_REFERENCE,
+	SDK_LANGUAGE_REFERENCE,
+} from '@n8n/workflow-sdk/prompts/sdk-reference';
 import { readdir, readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { join as posixJoin } from 'node:path/posix';
@@ -155,9 +159,16 @@ const KNOWLEDGE_BASE_REFERENCE_ENTRIES: Array<
 	{
 		id: 'workflow-sdk-language',
 		description:
-			'Allowed/forbidden constructs in workflow SDK builder code: methods, globals, language subset',
+			'Allowed/forbidden constructs in workflow SDK builder code: methods, globals, language subset, node groups',
 		fileName: 'workflow-sdk-language.md',
 		content: SDK_LANGUAGE_REFERENCE,
+	},
+	{
+		id: 'node-groups',
+		description:
+			'Node group rules for SDK builder code: .group(name, members, { description }), what makes a group valid, when to group',
+		fileName: 'node-groups.md',
+		content: `${NODE_GROUPS_REFERENCE}\n\n${GROUPING_GUIDANCE}`,
 	},
 ];
 

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -24,6 +24,18 @@ describe('Instance AI runtime skills', () => {
 		expect(skill).toContain('knowledge-base/reference/workflow-sdk-language.md');
 	});
 
+	// The builder agent has been observed recalling a pre-ADO-5627 `.group()` signature
+	// with no description argument, so the call is spelled out in the skill itself
+	// rather than only linked — a wrong prior is not corrected by a pointer.
+	it('states the node-group call and points at the node-groups reference', () => {
+		const skill = readFileSync(
+			join(INSTANCE_AI_SKILLS_DIR, 'workflow-builder', 'SKILL.md'),
+			'utf-8',
+		);
+		expect(skill).toContain('knowledge-base/reference/node-groups.md');
+		expect(skill).toContain('.group(name, members, { description })');
+	});
+
 	it('defers sticky and other SDK defects to workflow-sdk validate', () => {
 		const skill = readFileSync(
 			join(INSTANCE_AI_SKILLS_DIR, 'workflow-builder', 'SKILL.md'),

--- a/packages/@n8n/workflow-sdk/src/prompts/index.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/index.ts
@@ -3,6 +3,7 @@ export {
 	ADDITIONAL_FUNCTIONS,
 	WORKFLOW_RULES,
 	WORKFLOW_SDK_PATTERNS,
+	GROUPING_GUIDANCE,
 } from './sdk-reference';
 
 export * from './node-guidance';

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/index.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/index.ts
@@ -4,6 +4,7 @@ export { WORKFLOW_RULES } from './workflow-rules';
 export { WORKFLOW_SDK_PATTERNS } from './workflow-patterns';
 export { WORKFLOW_PATTERNS_DETAILED } from './workflow-patterns-detailed';
 export {
+	GROUPING_GUIDANCE,
 	NODE_GROUPS_REFERENCE,
 	SDK_LANGUAGE_REFERENCE,
 	buildSdkLanguageReference,

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -114,6 +114,22 @@ ${renderRulesLines()}
 `;
 
 /**
+ * Grouping judgement guidance, appended to the technique list when the canvas
+ * groups feature flag is on. Covers *when* to group; the exact rules live in the
+ * SDK reference's "groups" section (see `NODE_GROUPS_REFERENCE`).
+ */
+export const GROUPING_GUIDANCE = `## Grouping
+
+Organise larger workflows into named node groups — visual frames drawn on the canvas — so the result is readable the first time the user sees it.
+
+- **When to group:** larger workflows that split into clear stages (e.g. ingest → transform → deliver). Give each stage its own group. Small workflows don't need groups — a group there is just noise.
+- **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is a separately-executed, reusable unit. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
+- **Naming:** short, outcome-first titles ("Fetch new recordings", not "HTTP + Drive").
+- Groups are created collapsed by default, so the name is what the user sees first — make it descriptive.
+
+Fetch the "groups" section of the SDK reference for the exact rules before creating groups.`;
+
+/**
  * Render the full language reference. The node-groups section is included by
  * default (Instance AI's knowledge base); the MCP SDK reference passes its
  * `canvasGroupsEnabled` flag state as `includeGroups`.

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/sdk-language.ts
@@ -114,9 +114,10 @@ ${renderRulesLines()}
 `;
 
 /**
- * Grouping judgement guidance, appended to the technique list when the canvas
- * groups feature flag is on. Covers *when* to group; the exact rules live in the
- * SDK reference's "groups" section (see `NODE_GROUPS_REFERENCE`).
+ * Grouping judgement guidance: *when* to group — the rules that make a group
+ * valid live in `NODE_GROUPS_REFERENCE`. MCP appends it to the technique list
+ * only when the canvas-groups flag is on; Instance AI always materializes it
+ * into the knowledge base.
  */
 export const GROUPING_GUIDANCE = `## Grouping
 
@@ -127,7 +128,7 @@ Organise larger workflows into named node groups — visual frames drawn on the 
 - **Naming:** short, outcome-first titles ("Fetch new recordings", not "HTTP + Drive").
 - Groups are created collapsed by default, so the name is what the user sees first — make it descriptive.
 
-Fetch the "groups" section of the SDK reference for the exact rules before creating groups.`;
+Read the node groups reference for the exact rules before creating groups.`;
 
 /**
  * Render the full language reference. The node-groups section is included by

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-best-practices.tool.ts
@@ -5,6 +5,7 @@ import {
 	WorkflowTechnique,
 	type WorkflowTechniqueType,
 } from '@n8n/workflow-sdk/prompts/best-practices';
+import { GROUPING_GUIDANCE } from '@n8n/workflow-sdk/prompts/sdk-reference';
 import z from 'zod';
 
 import type { Telemetry } from '@/telemetry';
@@ -14,22 +15,6 @@ import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 
 const LIST_SENTINEL = 'list';
-
-/**
- * Grouping judgement guidance, appended to the technique list when the canvas
- * groups feature flag is on. Covers *when* to group; the exact rules live in the
- * SDK reference's "groups" section (see `NODE_GROUPS_REFERENCE`).
- */
-const GROUPING_GUIDANCE = `## Grouping
-
-Organise larger workflows into named node groups — visual frames drawn on the canvas — so the result is readable the first time the user sees it.
-
-- **When to group:** larger workflows that split into clear stages (e.g. ingest → transform → deliver). Give each stage its own group. Small workflows don't need groups — a group there is just noise.
-- **Groups vs sub-workflows:** a group is cosmetic organisation *inside* one workflow; a sub-workflow is a separately-executed, reusable unit. Group to make one canvas readable; extract a sub-workflow to reuse logic or isolate execution.
-- **Naming:** short, outcome-first titles ("Fetch new recordings", not "HTTP + Drive").
-- Groups are created collapsed by default, so the name is what the user sees first — make it descriptive.
-
-Fetch the "groups" section of the SDK reference for the exact rules before creating groups.`;
 
 const inputSchema = {
 	technique: z


### PR DESCRIPTION
## Summary

Gives the Instance AI workflow builder what it needs to create node groups on the canvas.

- **Node Groups section in the builder skill** — states the `.group(name, members, { description })` call inline and points at the node-groups reference. The call is spelled out rather than only linked because the builder agent was observed recalling an older signature without the `description` argument, and a wrong prior isn't corrected by a pointer alone.
- **New `reference/node-groups.md` knowledge-base file** — materialized from `NODE_GROUPS_REFERENCE` (the hard validity rules) plus `GROUPING_GUIDANCE` (when to group, groups vs sub-workflows, naming), so the agent can read the exact rules on demand before emitting `.group(...)`.
- **`GROUPING_GUIDANCE` moved** from the MCP `get-workflow-best-practices` tool into `@n8n/workflow-sdk/prompts/sdk-reference` and exported, so both the MCP tool and the Instance AI knowledge base share one copy. Behaviour of the MCP tool is unchanged — it still appends the guidance only when the canvas-groups flag is on.

## How to test

Node groups require the canvas groups feature flag to be enabled on the instance.

1. Enable the canvas groups feature flag, start n8n, and open the AI assistant.
2. Ask it to build a multi-stage workflow, e.g. *"Every hour, fetch new rows from a Google Sheet, enrich each one with an HTTP call, then post a summary to Slack."*
3. The built workflow should come back with named groups per stage (collapsed by default), each with a one-sentence description, and no group containing the trigger node.
4. Ask for a follow-up edit unrelated to grouping and confirm existing groups and their descriptions survive.

Unit coverage:

```
pnpm --filter @n8n/instance-ai test src/knowledge-base/__tests__/materialize-knowledge-base.test.ts src/skills/__tests__/runtime-skills.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5578

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
    - https://linear.app/n8n/issue/ADO-5739
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

