### PR TITLE
chore: Add ESLint rule catching test bodies passed to .todo (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-config/src/plugin.test.ts
+++ b/packages/@n8n/eslint-config/src/plugin.test.ts
@@ -9,4 +9,12 @@ describe('localRulesPlugin recommended config', () => {
 			],
 		).toBe('error');
 	});
+
+	// Every package's `lint` script passes `--quiet`, which drops warnings, so a
+	// discarded test body only fails a build while this rule is an error.
+	it('enables the discarded test body ban as an error', () => {
+		expect(
+			localRulesPlugin.configs.recommended.rules['n8n-local-rules/no-todo-test-with-body'],
+		).toBe('error');
+	});
 });

--- a/packages/@n8n/eslint-config/src/plugin.ts
+++ b/packages/@n8n/eslint-config/src/plugin.ts
@@ -31,6 +31,10 @@ export const localRulesPlugin = {
 				'n8n-local-rules/no-dynamic-regexp': 'warn',
 				'n8n-local-rules/no-restricted-sleep-definition': 'error',
 				'n8n-local-rules/no-restricted-sleep-import': 'error',
+				// Enabled repo-wide rather than in the test-file override in base.ts: the
+				// override's globs miss `*.spec.ts`, and some packages narrow them further.
+				// The rule only matches `it.todo`-shaped calls, so it is inert elsewhere.
+				'n8n-local-rules/no-todo-test-with-body': 'error',
 			},
 		},
 	},

--- a/packages/@n8n/eslint-config/src/rules/index.ts
+++ b/packages/@n8n/eslint-config/src/rules/index.ts
@@ -29,6 +29,7 @@ import { NoRestrictedSleepImportRule } from './no-restricted-sleep-import.js';
 import { NoRepositoryInPublicApiHandlerRule } from './no-repository-in-public-api-handler.js';
 import { RequirePublicApiControllerRule } from './require-public-api-controller.js';
 import { NoPublicApiGuardrailDisableRule } from './no-public-api-guardrail-disable.js';
+import { NoTodoTestWithBodyRule } from './no-todo-test-with-body.js';
 
 export const rules = {
 	'no-uncaught-json-parse': NoUncaughtJsonParseRule,
@@ -61,4 +62,5 @@ export const rules = {
 	'no-repository-in-public-api-handler': NoRepositoryInPublicApiHandlerRule,
 	'require-public-api-controller': RequirePublicApiControllerRule,
 	'no-public-api-guardrail-disable': NoPublicApiGuardrailDisableRule,
+	'no-todo-test-with-body': NoTodoTestWithBodyRule,
 } satisfies Record<string, AnyRuleModule>;

--- a/packages/@n8n/eslint-config/src/rules/no-todo-test-with-body.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-todo-test-with-body.test.ts
@@ -1,0 +1,69 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { NoTodoTestWithBodyRule } from './no-todo-test-with-body.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-todo-test-with-body', NoTodoTestWithBodyRule, {
+	valid: [
+		// A name-only todo is the whole point of `.todo`
+		{ code: "it.todo('name')" },
+		{ code: "test.todo('name')" },
+		{ code: "describe.todo('name')" },
+		// A test that actually runs
+		{ code: "it('name', () => {})" },
+		{ code: "test('name', async () => {})" },
+		// `.skip` keeps the callback, so it can be un-skipped
+		{ code: "it.skip('name', () => {})" },
+		// A second argument that is not a body
+		{ code: "it.todo('name', { timeout: 1000 })" },
+		// `.todo` on something that is not a test runner
+		{ code: "migrations.todo('name', () => {})" },
+		{ code: "helpers.it.todo('name', () => {})" },
+	],
+	invalid: [
+		{
+			code: "it.todo('name', () => {})",
+			errors: [{ messageId: 'discardedBody', data: { callee: 'it.todo', runner: 'it' } }],
+		},
+		{
+			code: "it.todo('name', function () {})",
+			errors: [{ messageId: 'discardedBody', data: { callee: 'it.todo', runner: 'it' } }],
+		},
+		{
+			code: "it.todo('name', async () => {})",
+			errors: [{ messageId: 'discardedBody', data: { callee: 'it.todo', runner: 'it' } }],
+		},
+		{
+			code: "test.todo('name', () => {})",
+			errors: [{ messageId: 'discardedBody', data: { callee: 'test.todo', runner: 'test' } }],
+		},
+		{
+			code: "test.todo('name', function () {})",
+			errors: [{ messageId: 'discardedBody', data: { callee: 'test.todo', runner: 'test' } }],
+		},
+		// A todo suite does run its collection callback, but marks every test it
+		// declares as todo — so it gets the suite-shaped message, not the same one.
+		{
+			code: "describe.todo('name', () => {})",
+			errors: [
+				{ messageId: 'todoSuiteBody', data: { callee: 'describe.todo', runner: 'describe' } },
+			],
+		},
+		{
+			code: "suite.todo('name', function () {})",
+			errors: [{ messageId: 'todoSuiteBody', data: { callee: 'suite.todo', runner: 'suite' } }],
+		},
+		// Chained modifiers still resolve to the runner
+		{
+			code: "it.concurrent.todo('name', () => {})",
+			errors: [
+				{ messageId: 'discardedBody', data: { callee: 'it.concurrent.todo', runner: 'it' } },
+			],
+		},
+		// A body after an options object is discarded just the same
+		{
+			code: "it.todo('name', { timeout: 1000 }, () => {})",
+			errors: [{ messageId: 'discardedBody', data: { callee: 'it.todo', runner: 'it' } }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-config/src/rules/no-todo-test-with-body.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-todo-test-with-body.ts
@@ -1,0 +1,86 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+/**
+ * `.todo` runners, by what they do with a callback they are handed. Verified on
+ * vitest 4.1.9: `it.todo`/`test.todo` never invoke the callback at all, while
+ * `describe.todo`/`suite.todo` do collect the block but mark every test in it
+ * todo, so nothing inside ever executes. Same harm, different mechanism — hence
+ * two messages.
+ */
+const TEST_RUNNERS = new Set(['it', 'test']);
+const SUITE_RUNNERS = new Set(['describe', 'suite']);
+
+const FUNCTION_TYPES = new Set<TSESTree.AST_NODE_TYPES>([
+	TSESTree.AST_NODE_TYPES.ArrowFunctionExpression,
+	TSESTree.AST_NODE_TYPES.FunctionExpression,
+]);
+
+/**
+ * Resolve `it` from `it.todo` or `it.concurrent.todo` by walking the member
+ * chain left. Returns undefined for anything not rooted in a bare identifier.
+ */
+const rootIdentifier = (node: TSESTree.Expression): TSESTree.Identifier | undefined => {
+	let current: TSESTree.Node = node;
+
+	while (current.type === TSESTree.AST_NODE_TYPES.MemberExpression) {
+		current = current.object;
+	}
+
+	return current.type === TSESTree.AST_NODE_TYPES.Identifier ? current : undefined;
+};
+
+export const NoTodoTestWithBodyRule = ESLintUtils.RuleCreator.withoutDocs({
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Disallow passing a body to `.todo()`. Unlike `.skip()`, a `.todo()` body never executes, so the test reads as covered in review, reports as todo, and asserts nothing.',
+		},
+		messages: {
+			discardedBody:
+				'`{{ callee }}()` discards its callback: this body never runs and can never fail. Either promote it to `{{ runner }}()` so it executes, or delete the body and leave `{{ callee }}()` as a name-only placeholder.',
+			todoSuiteBody:
+				'`{{ callee }}()` marks every test in this block as todo, so none of them ever run or can fail. Either promote it to `{{ runner }}()` so they execute, or delete the block and leave `{{ callee }}()` as a name-only placeholder.',
+		},
+		schema: [],
+	},
+	defaultOptions: [],
+	create(context) {
+		return {
+			CallExpression(node) {
+				const { callee } = node;
+
+				if (
+					callee.type !== TSESTree.AST_NODE_TYPES.MemberExpression ||
+					callee.computed ||
+					callee.property.type !== TSESTree.AST_NODE_TYPES.Identifier ||
+					callee.property.name !== 'todo'
+				) {
+					return;
+				}
+
+				const runner = rootIdentifier(callee);
+
+				if (!runner) return;
+
+				const isTest = TEST_RUNNERS.has(runner.name);
+
+				if (!isTest && !SUITE_RUNNERS.has(runner.name)) return;
+
+				// Only inline bodies — an options object as second argument is legitimate.
+				const hasBody = node.arguments.slice(1).some((arg) => FUNCTION_TYPES.has(arg.type));
+
+				if (!hasBody) return;
+
+				context.report({
+					node: callee,
+					messageId: isTest ? 'discardedBody' : 'todoSuiteBody',
+					data: {
+						callee: context.sourceCode.getText(callee),
+						runner: runner.name,
+					},
+				});
+			},
+		};
+	},
+});


### PR DESCRIPTION
## Summary

Adds `n8n-local-rules/no-todo-test-with-body`, which flags `.todo()` calls that
are handed a test body.

`it.todo(name, fn)` is not `it.skip` — there is no "would run if enabled"
relationship. Vitest marks the test todo and never invokes `fn`. A fully written
body sits in the file, reads as covered in review, reports as `todo`, and
asserts nothing. The diff looks like a test being added, so review cannot catch
it; only a rule can.

Two call sites in `editor-ui` were found this way. One of them covered
behaviour that had been broken the whole time — nobody knew, because the
assertion never ran.

### Behaviour, verified on vitest 4.1.9 (the version `pnpm-workspace.yaml` pins)

Two mechanisms, so the rule has two messages:

| form | what happens to the body | reported as |
| --- | --- | --- |
| `it.todo(name, fn)` / `test.todo(name, fn)` | `fn` is never invoked | `todo` |
| `describe.todo(name, fn)` / `suite.todo(name, fn)` | callback **does** run, but every test it declares is marked todo and never executes | `todo` |

Both messages report at the call site and name the two exits: promote it so it
runs, or drop the body and keep a name-only placeholder. There is deliberately
no autofix — choosing between those exits is a judgement call, and promoting a
months-old body can legitimately turn CI red.

### What it does not flag

`it.todo('name')` (the entire point of `.todo`), `it.skip('name', fn)` (which
keeps its callback), `it.todo('name', { timeout: 1000 })` (options, not a body),
and `.todo` on anything not rooted in a test runner. Only inline function
bodies count — chained forms like `it.concurrent.todo(...)` resolve to their
runner and are flagged.

### Where it runs

Registered in the plugin's `recommended` config rather than the test-file
override in `base.ts`. That override's globs (`**/*.test.ts`, `test/**/*.ts`,
`**/__tests__/*.ts`, `**/*.cy.ts`) miss `*.spec.ts` entirely, and several
packages narrow them further. The rule only matches `.todo`-shaped calls on a
test runner, so it is inert in non-test sources. `plugin.test.ts` asserts it
resolves to `error`, not `warn` — every package's `lint` script passes
`--quiet`, which drops warnings.

## How to test

```bash
pnpm --filter @n8n/eslint-config build
pnpm --filter @n8n/eslint-config test    # 265 tests, 18 of them this rule's
```

To see it fire against real code, temporarily change an `it.todo('x')` in any
package to `it.todo('x', () => {})` and run that package's `pnpm lint`.

## Coverage — measured, not assumed

The rule is only worth having if it actually executes against test sources, so
this was measured per package by asking ESLint itself
(`isPathIgnored` + `calculateConfigForFile`) about every test file in the repo:

- **5487** test files repo-wide
- **4340** have the rule active at `error` (52 packages fully covered)
- **1050** are ignored by ESLint — **1045 of them in `editor-ui`**, 5 under `packages/testing/playwright/scripts`
- **97** sit outside the path their package's `lint` script hands to eslint
  (`n8n-workflow/test` 78, `@n8n/json-schema-to-zod/test` 15, `@n8n/tournament/test` 4)

The `editor-ui` gap is not caused by this PR and is not fixed by it.
`packages/frontend/editor-ui/.oxlintrc.json` lists `**/*.test.ts` under
`ignorePatterns`, and `eslint.config.mjs` ends with
`...oxlint.buildFromOxlintConfigFile('./.oxlintrc.json')`, which translates
those patterns into **ESLint's** global ignores. So no `*.test.ts` file in
`editor-ui` is linted at all — which also means `no-skipped-tests` and
`no-error-instance-in-to-throw` are dead there, and the two test-file rule
overrides in `eslint.config.mjs` are dead config. `--quiet` hides the
"File ignored" warning, so nothing says so out loud.

Consequence worth stating plainly: **this rule does not yet cover the two call
sites that motivated it.** Lifting that ignore locally exposes 19 errors across
14 of 1069 files (17 pre-existing, plus the 2 `it.todo` bodies) — small, but a
separate change with its own review. Filed as a follow-up rather than dragged
in here.

## Repo is clean under the rule

`pnpm lint` stays green on this branch. Independently of lint reachability, a
repo-wide grep for `(it|test|describe|suite|bench).todo` finds four call sites
total: the two `editor-ui` ones with bodies (owned by #35636, and invisible to
eslint today either way) and two bodiless — and therefore valid — ones in
`@n8n/ai-workflow-builder.ee`. No suppressions were needed anywhere.

If #35636 merges first, nothing here changes. If this merges first, #35636 still
applies cleanly — it deletes the `it.todo` tokens this rule would flag.

## Related tickets

Two `editor-ui` call sites (#35636). No Linear ticket exists for this work.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

