### PR TITLE
fix(editor): Keep node dirtiness after a rename following a partial execution

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.test.ts
@@ -5,6 +5,7 @@ import { useHistoryHelper } from '@/app/composables/useHistoryHelper';
 import { useNodeDirtiness } from '@/app/composables/useNodeDirtiness';
 import { MANUAL_TRIGGER_NODE_TYPE, SET_NODE_TYPE } from '@/app/constants';
 import { type INodeUi } from '@/Interface';
+import { useHistoryStore } from '@/app/stores/history.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -392,7 +393,7 @@ describe(useNodeDirtiness, () => {
 	});
 
 	describe('renaming a node', () => {
-		it.todo('should preserve the dirtiness', async () => {
+		it('should preserve the dirtiness', async () => {
 			useNodeTypesStore().setNodeTypes(defaultNodeDescriptions);
 
 			setupTestWorkflow('a🚨✅ -> b✅ -> c✅');
@@ -409,6 +410,54 @@ describe(useNodeDirtiness, () => {
 
 			expect(useNodeDirtiness(TEST_DOCUMENT_ID).dirtinessByName.value).toEqual({
 				d: CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED,
+			});
+		});
+
+		it('should preserve the dirtiness through a chain of renames recorded in one bulk command', async () => {
+			useNodeTypesStore().setNodeTypes(defaultNodeDescriptions);
+
+			setupTestWorkflow('a🚨✅ -> b✅ -> c✅');
+
+			canvasOperations.deleteNodes([workflowDocumentStore.nodesByName.b.id], {
+				trackHistory: true,
+			}); // 'a' becomes new parent of 'c'
+
+			// `trackBulk: false` records the rename in the caller's bulk, as useWorkflowUpdate does
+			useHistoryStore().startRecordingUndo();
+			await canvasOperations.renameNode('c', 'd', { trackHistory: true, trackBulk: false });
+			await canvasOperations.renameNode('d', 'e', { trackHistory: true, trackBulk: false });
+			useHistoryStore().stopRecordingUndo();
+
+			expect(useNodeDirtiness(TEST_DOCUMENT_ID).dirtinessByName.value).toEqual({
+				e: CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED,
+			});
+		});
+
+		// Already passed before names were resolved through the undo stack — 'b' is never
+		// renamed, so the injected connection matches it directly. Kept as a guard on the
+		// add-node branch, which now resolves its payload name like every other branch.
+		it('should preserve the dirtiness of a node whose newly injected parent is renamed', async () => {
+			useNodeTypesStore().setNodeTypes(defaultNodeDescriptions);
+
+			setupTestWorkflow('a🚨✅ -> b✅');
+
+			uiStore.lastInteractedWithNodeConnection = {
+				source: workflowDocumentStore.nodesByName.a.id,
+				target: workflowDocumentStore.nodesByName.b.id,
+			};
+			uiStore.lastInteractedWithNodeId = workflowDocumentStore.nodesByName.a.id;
+			uiStore.lastInteractedWithNodeHandle = 'outputs/main/0';
+
+			await canvasOperations.addNodes([createTestNode({ name: 'c' })], { trackHistory: true });
+
+			expect(useNodeDirtiness(TEST_DOCUMENT_ID).dirtinessByName.value).toEqual({
+				b: CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED,
+			});
+
+			await canvasOperations.renameNode('c', 'x', { trackHistory: true });
+
+			expect(useNodeDirtiness(TEST_DOCUMENT_ID).dirtinessByName.value).toEqual({
+				b: CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED,
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.ts
@@ -5,6 +5,7 @@ import {
 	EnableNodeToggleCommand,
 	RemoveConnectionCommand,
 	RemoveNodeCommand,
+	RenameNodeCommand,
 	type Undoable,
 } from '@/app/models/history';
 import { useHistoryStore } from '@/app/stores/history.store';
@@ -22,7 +23,33 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import { computed, toValue, type MaybeRefOrGetter } from 'vue';
 
 /**
+ * Resolves a node name as recorded in a command payload to the name that node goes by now.
+ */
+type ResolveName = (nameInCommand: string) => string;
+
+/**
+ * Records the renames a command performs, so that commands recorded *before* it can have their
+ * payload names resolved forward. Call while walking a command list newest-first: mapping onto
+ * the already-known name collapses a chain of renames straight to the node's current name.
+ */
+function collectRenames(command: Undoable, renamedSince: Map<string, string>) {
+	if (command instanceof BulkCommand) {
+		for (let i = command.commands.length - 1; i >= 0; i--) {
+			collectRenames(command.commands[i], renamedSince);
+		}
+		return;
+	}
+
+	if (command instanceof RenameNodeCommand) {
+		renamedSince.set(command.currentName, renamedSince.get(command.newName) ?? command.newName);
+	}
+}
+
+/**
  * Does the command make the given node dirty?
+ *
+ * `nodeName` and the connection lookups are in current names; command payloads hold the names
+ * used when the command was recorded, so they go through `resolveName` before being compared.
  */
 function shouldCommandMarkDirty(
 	command: Undoable,
@@ -30,27 +57,46 @@ function shouldCommandMarkDirty(
 	siblingCommands: Undoable[],
 	getIncomingConnections: (nodeName: string) => INodeConnections,
 	getOutgoingConnectors: (nodeName: string) => INodeConnections,
+	resolveName: ResolveName,
 ): boolean {
 	if (command instanceof BulkCommand) {
-		return command.commands.some((cmd) =>
-			shouldCommandMarkDirty(
-				cmd,
-				nodeName,
-				command.commands,
-				getIncomingConnections,
-				getOutgoingConnectors,
-			),
-		);
+		// Sub-commands are recorded in order, so walk them newest-first like the undo stack:
+		// a rename only applies to the names recorded before it.
+		const renamedSince = new Map<string, string>();
+		const resolveNameInBulk: ResolveName = (name) => resolveName(renamedSince.get(name) ?? name);
+
+		for (let i = command.commands.length - 1; i >= 0; i--) {
+			const cmd = command.commands[i];
+
+			if (
+				shouldCommandMarkDirty(
+					cmd,
+					nodeName,
+					command.commands,
+					getIncomingConnections,
+					getOutgoingConnectors,
+					resolveNameInBulk,
+				)
+			) {
+				return true;
+			}
+
+			collectRenames(cmd, renamedSince);
+		}
+
+		return false;
 	}
 
 	if (command instanceof AddConnectionCommand) {
-		return command.connectionData[1]?.node === nodeName;
+		const target = command.connectionData[1];
+
+		return target !== undefined && resolveName(target.node) === nodeName;
 	}
 
 	if (command instanceof RemoveConnectionCommand) {
 		const [from, to] = command.connectionData;
 
-		if (to.node !== nodeName) {
+		if (resolveName(to.node) !== nodeName) {
 			return false;
 		}
 
@@ -67,14 +113,16 @@ function shouldCommandMarkDirty(
 		.map((connection) => connection.node);
 
 	if (command instanceof AddNodeCommand) {
-		return incomingNodes.includes(command.node.name);
+		return incomingNodes.includes(resolveName(command.node.name));
 	}
 
 	if (command instanceof EnableNodeToggleCommand) {
+		const toggledNode = resolveName(command.nodeName);
+
 		return (
-			incomingNodes.includes(command.nodeName) &&
+			incomingNodes.includes(toggledNode) &&
 			(command.newState ||
-				Object.keys(getOutgoingConnectors(command.nodeName)).some(
+				Object.keys(getOutgoingConnectors(toggledNode)).some(
 					(type) => (type as NodeConnectionType) !== NodeConnectionTypes.Main,
 				))
 		);
@@ -180,6 +228,11 @@ export function useNodeDirtiness(workflowDocumentId: MaybeRefOrGetter<WorkflowDo
 		nodeName: string,
 		after: number,
 	): CanvasNodeDirtinessType | undefined {
+		// Renames encountered on the way down, so older commands can be matched against the
+		// name the node goes by now rather than the one they were recorded with.
+		const renamedSince = new Map<string, string>();
+		const resolveName: ResolveName = (name) => renamedSince.get(name) ?? name;
+
 		for (let i = historyStore.undoStack.length - 1; i >= 0; i--) {
 			const command = historyStore.undoStack[i];
 
@@ -194,10 +247,13 @@ export function useNodeDirtiness(workflowDocumentId: MaybeRefOrGetter<WorkflowDo
 					[],
 					getIncomingConnections,
 					getOutgoingConnections,
+					resolveName,
 				)
 			) {
 				return CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED;
 			}
+
+			collectRenames(command, renamedSince);
 		}
 
 		for (const connection of getParentSubNodes(nodeName)) {


### PR DESCRIPTION
## Summary

After a partial execution, renaming a node cleared its needs-re-run indicator. The node read as up to date on the canvas while its upstream data had changed and it had not re-run — a shared canvas signal quietly telling the user the wrong thing.

**Root cause.** Dirtiness is derived by matching a node against the undo stack. Command payloads hold the names nodes had *when the command was recorded* — that is deliberate, it is what lets undo replay in reverse — while `renameNode` re-keys the workflow document and run data to the new name. Nothing related the two names, so the match failed and the marker vanished.

**The fix.** Resolve payload names *forward* to current names while walking the stack, folding each rename as it is passed. One detail matters: the walk is newest-first, so folding a rename maps onto the already-known name, which collapses a chain of renames (`c → d → e`) straight to the current name. Renames nested inside a `BulkCommand` are folded the same way, since that is where a rename is normally recorded.

Two notes on scope:

- The ticket proposed translating the node's name *backwards* through the stack, which then forces a split between historical-name matching and current-name connection lookups. Resolving forward instead is smaller: every comparison stays in current-name space, so `getIncomingConnections` / `getOutgoingConnections` — keyed by current name — are untouched.
- History payloads are only ever **read** here, never written. Undo/redo keeps replaying against the original names, by design.

`AddNodeCommand` and `EnableNodeToggleCommand` resolve their payload names too, for consistency — a payload name is a payload name, and leaving two of them comparing historical names against a current-name lookup set is the same bug waiting to happen. Being precise about evidence, though: I could not construct a failing case for those two branches, so that part is defensive, not a demonstrated fix.

## How to test

1. Open a workflow of three nodes in a row, e.g. `Manual Trigger → Set A → Set B`.
2. Run it, then delete `Set A` so the trigger becomes `Set B`'s new parent. `Set B` shows the needs-re-run indicator.
3. Rename `Set B`.
4. **Before:** the indicator disappears — `Set B` looks up to date though its input changed. **After:** the indicator stays on the renamed node.

Automated coverage, in `useNodeDirtiness.test.ts`:

- `should preserve the dirtiness` — the regression test for this defect. It existed as an `it.todo` **with a full body that had never executed** (N8N-155); promoted here, it fails on master with `expected {} to deeply equal { d: 'incoming-connections-updated' }` and passes with the fix.
- `should preserve the dirtiness through a chain of renames recorded in one bulk command` — new. Two chained renames recorded in a caller's bulk with `trackBulk: false`, the shape `useWorkflowUpdate` produces. Also fails on master. This one pins the newest-first fold order: walking forward resolves `c` to `d` instead of `e`.
- `should preserve the dirtiness of a node whose newly injected parent is renamed` — new, but **green before the fix too**, so it is a guard on the add-node branch rather than proof of a fix. Labelled as such in the test.

Verified locally, from `packages/frontend/editor-ui`:

| Check | Result |
| --- | --- |
| `useNodeDirtiness.test.ts` | 24 passed (2 of them red before the fix) |
| `useCanvasOperations.test.ts` | 238 passed |
| `useHistoryHelper.test.ts` | 9 passed |
| `useWorkflowDocumentRenderData.test.ts` + `useRunWorkflow.test.ts` (consumers) | 82 passed |
| `pnpm typecheck` | clean |
| `pnpm lint` | clean |

Undo/redo is covered by `useHistoryHelper` and the `revertRenameNode` cases in `useCanvasOperations` rather than by a new assertion in this file: the rename revert is delivered over `historyBus`, whose listener lives in `NodeView.vue` and is not mounted in this harness, so an undo assertion here would encode a harness artifact instead of real behaviour.

## Related Linear tickets, Github issues, and Community forum posts

Fixes N8N-194. Found while resolving N8N-155 (#35636), which promoted the `it.todo` and deleted it once it failed rather than leaving CI red.

**Merge order note:** this branch is cut from `master`, where the `it.todo` still exists, so the diff promotes it in place. #35636 deletes those same lines. Whichever lands second needs a rebase — if #35636 goes first, this `describe` block has to be re-added.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — no docs impact, internal canvas signal
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

