### PR TITLE
feat(core): Bind a verified inbound token when connecting a credential (no-changelog)

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -17,6 +17,7 @@ import {
 	CredentialConnectionStatusService,
 	DynamicCredentialResolverRegistry,
 	DynamicCredentialService,
+	InboundClaimConnectService,
 } from '@/modules/dynamic-credentials.ee/services';
 import { OauthService } from '@/oauth/oauth.service';
 import { UrlService } from '@/services/url.service';
@@ -39,6 +40,7 @@ describe('DynamicCredentialsController', () => {
 	const authorizeIntentService = mockInstance(AuthorizeIntentService);
 	const credentialsFinderService = mockInstance(CredentialsFinderService);
 	const dynamicCredentialService = mockInstance(DynamicCredentialService);
+	const inboundClaimConnectService = mockInstance(InboundClaimConnectService);
 	const urlService = mockInstance(UrlService);
 	const eventService = mockInstance(EventService);
 	mockInstance(CredentialConnectionStatusService);
@@ -55,7 +57,7 @@ describe('DynamicCredentialsController', () => {
 		vi.clearAllMocks();
 
 		// Configure default credential context mock
-		dynamicCredentialWebService.getCredentialContextFromRequest.mockReturnValue({
+		dynamicCredentialWebService.getCredentialContextFromRequest.mockResolvedValue({
 			identity: 'token123',
 			version: 1 as const,
 			metadata: {},
@@ -215,6 +217,63 @@ describe('DynamicCredentialsController', () => {
 			);
 		});
 
+		it('binds an inbound claim to an n8n user before issuing the auth URI', async () => {
+			const mockCredential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer idp-token' },
+			});
+			const res = mock<Response>();
+
+			const claim = {
+				version: 1 as const,
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'external-subject-1',
+				audience: 'https://n8n.example.com',
+				expiresAt: Date.now() + 60_000,
+				boundWorkflowId: '',
+			};
+			dynamicCredentialWebService.getCredentialContextFromRequest.mockResolvedValue({
+				identity: 'idp-token',
+				version: 1,
+				metadata: { source: 'external-idp' },
+				claims: claim,
+			});
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
+				'https://example.domain/oauth2/auth',
+			);
+
+			await controller.authorizeCredential(req, res);
+
+			expect(inboundClaimConnectService.ensureBinding).toHaveBeenCalledWith(claim);
+		});
+
+		it('does not attempt to bind anything when the context carries no claim', async () => {
+			const mockCredential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer opaque-token' },
+			});
+			const res = mock<Response>();
+
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
+				'https://example.domain/oauth2/auth',
+			);
+
+			await controller.authorizeCredential(req, res);
+
+			expect(inboundClaimConnectService.ensureBinding).not.toHaveBeenCalled();
+		});
+
 		it('should return auth URI for OAuth2 credential', async () => {
 			const mockCredential = mock<CredentialsEntity>({
 				id: '1',
@@ -320,7 +379,9 @@ describe('DynamicCredentialsController', () => {
 			};
 
 			// Set up all mocks before calling the controller
-			dynamicCredentialWebService.getCredentialContextFromRequest.mockReturnValue(expectedContext);
+			dynamicCredentialWebService.getCredentialContextFromRequest.mockResolvedValue(
+				expectedContext,
+			);
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
 			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
 			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolverWithValidation);
@@ -875,7 +936,9 @@ describe('DynamicCredentialsController', () => {
 				metadata: {},
 			};
 
-			dynamicCredentialWebService.getCredentialContextFromRequest.mockReturnValue(expectedContext);
+			dynamicCredentialWebService.getCredentialContextFromRequest.mockResolvedValue(
+				expectedContext,
+			);
 			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
 			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
 			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -23,6 +23,7 @@ import {
 	CredentialConnectionStatusService,
 	DynamicCredentialResolverRegistry,
 	DynamicCredentialService,
+	InboundClaimConnectService,
 } from './services';
 import { DynamicCredentialCorsService } from './services/dynamic-credential-cors.service';
 import { DynamicCredentialWebService } from './services/dynamic-credential-web.service';
@@ -45,6 +46,7 @@ export class DynamicCredentialsController {
 		private readonly eventService: EventService,
 		private readonly authorizeIntentService: AuthorizeIntentService,
 		private readonly dynamicCredentialService: DynamicCredentialService,
+		private readonly inboundClaimConnectService: InboundClaimConnectService,
 		private readonly urlService: UrlService,
 	) {}
 
@@ -116,7 +118,8 @@ export class DynamicCredentialsController {
 	})
 	async revokeCredential(req: Request, res: Response): Promise<void> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['delete', 'options']);
-		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
+		const credentialContext =
+			await this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 		const user = isAuthenticatedRequest(req) ? req.user : undefined;
 		const credential = await this.findCredentialToUse(req.params.id, user, 'credential:update');
 
@@ -158,7 +161,8 @@ export class DynamicCredentialsController {
 	})
 	async authorizeCredential(req: Request, res: Response): Promise<string> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['post', 'options']);
-		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
+		const credentialContext =
+			await this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 		const user = isAuthenticatedRequest(req) ? req.user : undefined;
 		const credential = await this.findCredentialToUse(req.params.id, user, 'credential:update');
 
@@ -175,6 +179,14 @@ export class DynamicCredentialsController {
 				resolverName: resolverEntity.type,
 				configuration: resolverConfig,
 			});
+		}
+
+		// Connecting is the point at which an inbound identity may be bound to an
+		// n8n user: it is interactive, and the caller just presented a verified
+		// token. Without this, someone arriving with an IdP token they have never
+		// logged into n8n with would have nothing to store their connection under.
+		if (credentialContext.claims) {
+			await this.inboundClaimConnectService.ensureBinding(credentialContext.claims);
 		}
 
 		// Best-effort: bind the callback to the intended n8n user when the resolver

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-storage.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-storage.service.test.ts
@@ -17,6 +17,7 @@ import type { DynamicCredentialResolverRepository } from '../../database/reposit
 import { CredentialStorageError } from '../../errors/credential-storage.error';
 import type { DynamicCredentialResolverRegistry } from '../credential-resolver-registry.service';
 import { DynamicCredentialStorageService } from '../dynamic-credential-storage.service';
+import type { InboundClaimConnectService } from '../inbound-claim-connect.service';
 
 describe('DynamicCredentialStorageService', () => {
 	let service: DynamicCredentialStorageService;
@@ -26,6 +27,7 @@ describe('DynamicCredentialStorageService', () => {
 	let mockCipher: Mocked<Cipher>;
 	let mockLogger: Mocked<Logger>;
 	let mockDynamicCredentialsProxy: Mocked<DynamicCredentialsProxy>;
+	let mockInboundClaimConnectService: Mocked<InboundClaimConnectService>;
 
 	const createMockCredentialMetadata = (
 		overrides: Partial<CredentialStoreMetadata> = {},
@@ -103,6 +105,11 @@ describe('DynamicCredentialStorageService', () => {
 			decryptV2: vi.fn(),
 		} as unknown as Mocked<Cipher>;
 
+		mockInboundClaimConnectService = {
+			// No claim to derive in these tests: pass the context through untouched.
+			attachVerifiedClaim: vi.fn(async (context) => context),
+		} as unknown as Mocked<InboundClaimConnectService>;
+
 		mockDynamicCredentialsProxy = {
 			getSystemResolverId: vi.fn().mockReturnValue(null),
 			// Default to the real semantics with no system resolver seeded:
@@ -117,6 +124,7 @@ describe('DynamicCredentialStorageService', () => {
 			mockCipher,
 			mockLogger,
 			mockDynamicCredentialsProxy,
+			mockInboundClaimConnectService,
 		);
 	});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-web.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-web.service.test.ts
@@ -5,10 +5,12 @@ import { mock } from 'vitest-mock-extended';
 import type { AuthService } from '@/auth/auth.service';
 
 import { DynamicCredentialWebService } from '../dynamic-credential-web.service';
+import type { InboundClaimConnectService } from '../inbound-claim-connect.service';
 
 describe('DynamicCredentialWebService', () => {
 	let service: DynamicCredentialWebService;
 	let mockAuthService: Mocked<AuthService>;
+	let mockInboundClaimConnectService: Mocked<InboundClaimConnectService>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -20,18 +22,55 @@ describe('DynamicCredentialWebService', () => {
 			getEndpoint: vi.fn(),
 		});
 
-		service = new DynamicCredentialWebService(mockAuthService);
+		mockInboundClaimConnectService = mock<InboundClaimConnectService>({
+			// Default: no trusted source vouches for the token, so contexts pass
+			// through untagged - today's behaviour for opaque bearer tokens.
+			attachVerifiedClaim: vi.fn(async (context) => context),
+		});
+
+		service = new DynamicCredentialWebService(mockAuthService, mockInboundClaimConnectService);
 	});
 
 	describe('getCredentialContextFromRequest', () => {
+		it('returns an external-idp context when a presented bearer token verifies', async () => {
+			const claim = {
+				version: 1 as const,
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'external-subject-1',
+				audience: 'https://n8n.example.com',
+				expiresAt: Date.now() + 60_000,
+				boundWorkflowId: '',
+			};
+			mockInboundClaimConnectService.attachVerifiedClaim.mockResolvedValue({
+				version: 1,
+				identity: 'idp-token',
+				metadata: { source: 'external-idp' },
+				claims: claim,
+			});
+			const req = mock<Request>({
+				query: { authSource: 'bearer' },
+				headers: { authorization: 'Bearer idp-token' },
+			});
+
+			const result = await service.getCredentialContextFromRequest(req);
+
+			expect(mockInboundClaimConnectService.attachVerifiedClaim).toHaveBeenCalledWith({
+				version: 1,
+				identity: 'idp-token',
+				metadata: {},
+			});
+			expect(result.claims).toEqual(claim);
+		});
+
 		describe('with explicit authSource=bearer', () => {
-			it('should extract bearer token when authSource query param is "bearer"', () => {
+			it('should extract bearer token when authSource query param is "bearer"', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'Bearer my-token-123' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result).toEqual({
 					identity: 'my-token-123',
@@ -41,64 +80,64 @@ describe('DynamicCredentialWebService', () => {
 				expect(mockAuthService.getCookieToken).not.toHaveBeenCalled();
 			});
 
-			it('should accept case-insensitive bearer prefix', () => {
+			it('should accept case-insensitive bearer prefix', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'bearer lowercase-token' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('lowercase-token');
 			});
 
-			it('should accept mixed-case bearer prefix', () => {
+			it('should accept mixed-case bearer prefix', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'BeArEr mixed-case-token' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('mixed-case-token');
 			});
 
-			it('should throw error when bearer token is missing with authSource=bearer', () => {
+			it('should throw error when bearer token is missing with authSource=bearer', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: {},
 				});
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Bearer token is missing',
 				);
 			});
 
-			it('should throw error when authorization header has no Bearer prefix', () => {
+			it('should throw error when authorization header has no Bearer prefix', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'token-without-bearer' },
 				});
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Bearer token is missing',
 				);
 			});
 
-			it('should throw error when bearer token is empty after prefix', () => {
+			it('should throw error when bearer token is empty after prefix', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: 'Bearer ' },
 				});
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Bearer token is missing',
 				);
 			});
 		});
 
 		describe('with explicit authSource=cookie', () => {
-			it('should extract cookie token when authSource query param is "cookie"', () => {
+			it('should extract cookie token when authSource query param is "cookie"', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'cookie' },
 					headers: {},
@@ -109,7 +148,7 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('GET');
 				mockAuthService.getEndpoint.mockReturnValue('/api/test');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result).toEqual({
 					identity: 'cookie-session-123',
@@ -127,7 +166,7 @@ describe('DynamicCredentialWebService', () => {
 				expect(mockAuthService.getEndpoint).toHaveBeenCalledWith(req);
 			});
 
-			it('should throw error when session cookie is missing with authSource=cookie', () => {
+			it('should throw error when session cookie is missing with authSource=cookie', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'cookie' },
 					headers: {},
@@ -135,20 +174,20 @@ describe('DynamicCredentialWebService', () => {
 
 				mockAuthService.getCookieToken.mockReturnValue(undefined);
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Session cookie is missing',
 				);
 			});
 		});
 
 		describe('fallback behavior (no authSource query param)', () => {
-			it('should extract bearer token when present without authSource param', () => {
+			it('should extract bearer token when present without authSource param', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: { authorization: 'Bearer fallback-token' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result).toEqual({
 					identity: 'fallback-token',
@@ -158,7 +197,7 @@ describe('DynamicCredentialWebService', () => {
 				expect(mockAuthService.getCookieToken).not.toHaveBeenCalled();
 			});
 
-			it('should fall back to cookie when bearer token is not present', () => {
+			it('should fall back to cookie when bearer token is not present', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: {},
@@ -169,7 +208,7 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('POST');
 				mockAuthService.getEndpoint.mockReturnValue('/api/workflow');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result).toEqual({
 					identity: 'cookie-fallback-123',
@@ -184,7 +223,7 @@ describe('DynamicCredentialWebService', () => {
 				expect(mockAuthService.getCookieToken).toHaveBeenCalledWith(req);
 			});
 
-			it('should fall back to cookie when authorization header is malformed', () => {
+			it('should fall back to cookie when authorization header is malformed', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: { authorization: 'malformed-header' },
@@ -195,13 +234,13 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('GET');
 				mockAuthService.getEndpoint.mockReturnValue('/api/test');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('cookie-fallback-456');
 				expect(mockAuthService.getCookieToken).toHaveBeenCalledWith(req);
 			});
 
-			it('should throw error when both bearer and cookie are missing', () => {
+			it('should throw error when both bearer and cookie are missing', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: {},
@@ -209,38 +248,38 @@ describe('DynamicCredentialWebService', () => {
 
 				mockAuthService.getCookieToken.mockReturnValue(undefined);
 
-				expect(() => service.getCredentialContextFromRequest(req)).toThrow(
+				await expect(service.getCredentialContextFromRequest(req)).rejects.toThrow(
 					'Session cookie is missing',
 				);
 			});
 		});
 
 		describe('edge cases', () => {
-			it('should handle bearer token with special characters', () => {
+			it('should handle bearer token with special characters', async () => {
 				const specialToken = 'token-with-special!@#$%^&*()chars';
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: `Bearer ${specialToken}` },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe(specialToken);
 			});
 
-			it('should handle very long bearer tokens', () => {
+			it('should handle very long bearer tokens', async () => {
 				const longToken = 'a'.repeat(1000);
 				const req = mock<Request>({
 					query: { authSource: 'bearer' },
 					headers: { authorization: `Bearer ${longToken}` },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe(longToken);
 			});
 
-			it('should handle undefined browserId from AuthService', () => {
+			it('should handle undefined browserId from AuthService', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'cookie' },
 					headers: {},
@@ -251,7 +290,7 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('GET');
 				mockAuthService.getEndpoint.mockReturnValue('/api/test');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.metadata).toEqual({
 					source: 'cookie-source',
@@ -261,7 +300,7 @@ describe('DynamicCredentialWebService', () => {
 				});
 			});
 
-			it('should prioritize authSource=bearer over existing bearer token in fallback mode', () => {
+			it('should prioritize authSource=bearer over existing bearer token in fallback mode', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'cookie' },
 					headers: { authorization: 'Bearer should-be-ignored' },
@@ -272,31 +311,31 @@ describe('DynamicCredentialWebService', () => {
 				mockAuthService.getMethod.mockReturnValue('GET');
 				mockAuthService.getEndpoint.mockReturnValue('/api/test');
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('cookie-token');
 				expect(result.metadata?.source).toBe('cookie-source');
 			});
 
-			it('should handle empty query object', () => {
+			it('should handle empty query object', async () => {
 				const req = mock<Request>({
 					query: {},
 					headers: { authorization: 'Bearer empty-query-token' },
 				});
 
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('empty-query-token');
 			});
 
-			it('should handle authSource with invalid value', () => {
+			it('should handle authSource with invalid value', async () => {
 				const req = mock<Request>({
 					query: { authSource: 'invalid' as any },
 					headers: { authorization: 'Bearer token' },
 				});
 
 				// Should fall back to default behavior (bearer first)
-				const result = service.getCredentialContextFromRequest(req);
+				const result = await service.getCredentialContextFromRequest(req);
 
 				expect(result.identity).toBe('token');
 			});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/inbound-claim-connect.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/inbound-claim-connect.service.test.ts
@@ -1,0 +1,150 @@
+import type { Logger } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import type { ICredentialContext, IVerifiedClaim } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { ExternalTokenVerifierProxy } from '@/services/external-token-verifier-proxy.service';
+import type { IdentityResolutionProxy } from '@/services/identity-resolution-proxy.service';
+
+import { InboundClaimConnectService } from '../inbound-claim-connect.service';
+
+describe('InboundClaimConnectService', () => {
+	let service: InboundClaimConnectService;
+	let verifier: ExternalTokenVerifierProxy;
+	let identityResolution: IdentityResolutionProxy;
+
+	const expiresAt = new Date('2026-01-01T00:00:00.000Z');
+
+	const verifiedClaim = {
+		sourceId: 'idp-1',
+		issuer: 'https://idp.example.com',
+		subject: 'external-subject-1',
+		audience: 'https://n8n.example.com',
+		attributes: { role: 'admin' },
+		expiresAt,
+	};
+
+	const bearerContext: ICredentialContext = {
+		version: 1,
+		identity: 'inbound-token',
+		metadata: {},
+	};
+
+	beforeEach(() => {
+		verifier = mock<ExternalTokenVerifierProxy>();
+		identityResolution = mock<IdentityResolutionProxy>();
+		service = new InboundClaimConnectService(mock<Logger>(), verifier, identityResolution);
+	});
+
+	describe('attachVerifiedClaim', () => {
+		it('tags the context and attaches the claim when the token verifies', async () => {
+			vi.mocked(verifier.verifyInboundToken).mockResolvedValue({ claim: verifiedClaim });
+
+			const result = await service.attachVerifiedClaim(bearerContext);
+
+			expect(verifier.verifyInboundToken).toHaveBeenCalledWith('inbound-token');
+			expect(result.metadata?.source).toBe('external-idp');
+			expect(result.claims).toEqual({
+				version: 1,
+				sourceId: 'idp-1',
+				issuer: 'https://idp.example.com',
+				subject: 'external-subject-1',
+				audience: 'https://n8n.example.com',
+				expiresAt: expiresAt.getTime(),
+				boundWorkflowId: '',
+			});
+			// The token stays available for resolvers that key on its own subject.
+			expect(result.identity).toBe('inbound-token');
+		});
+
+		it('strips a Bearer prefix before verifying', async () => {
+			vi.mocked(verifier.verifyInboundToken).mockResolvedValue({ claim: verifiedClaim });
+
+			await service.attachVerifiedClaim({ ...bearerContext, identity: 'Bearer inbound-token' });
+
+			expect(verifier.verifyInboundToken).toHaveBeenCalledWith('inbound-token');
+		});
+
+		it('normalizes a multi-value audience to its first entry', async () => {
+			vi.mocked(verifier.verifyInboundToken).mockResolvedValue({
+				claim: { ...verifiedClaim, audience: ['first', 'second'] },
+			});
+
+			const result = await service.attachVerifiedClaim(bearerContext);
+
+			expect(result.claims?.audience).toBe('first');
+		});
+
+		it('leaves an unverifiable token untouched, so introspection resolvers keep working', async () => {
+			vi.mocked(verifier.verifyInboundToken).mockResolvedValue({
+				claim: null,
+				context: { reason: 'invalid_token' },
+			});
+
+			const result = await service.attachVerifiedClaim(bearerContext);
+
+			expect(result).toEqual(bearerContext);
+			expect(result.claims).toBeUndefined();
+		});
+
+		it('leaves a context that already names its source untouched', async () => {
+			const cookieContext: ICredentialContext = {
+				version: 1,
+				identity: 'n8n-auth-cookie',
+				metadata: { source: 'cookie-source' },
+			};
+
+			const result = await service.attachVerifiedClaim(cookieContext);
+
+			expect(result).toEqual(cookieContext);
+			expect(verifier.verifyInboundToken).not.toHaveBeenCalled();
+		});
+
+		it('does not verify an empty identity', async () => {
+			const result = await service.attachVerifiedClaim({ ...bearerContext, identity: '' });
+
+			expect(result.claims).toBeUndefined();
+			expect(verifier.verifyInboundToken).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('ensureBinding', () => {
+		const claim: IVerifiedClaim = {
+			version: 1,
+			sourceId: 'idp-1',
+			issuer: 'https://idp.example.com',
+			subject: 'external-subject-1',
+			audience: 'https://n8n.example.com',
+			expiresAt: expiresAt.getTime(),
+			boundWorkflowId: '',
+		};
+
+		it('resolves the claim with provisioning allowed and returns the bound user', async () => {
+			vi.mocked(identityResolution.resolve).mockResolvedValue(mock<User>({ id: 'user-1' }));
+
+			const userId = await service.ensureBinding(claim);
+
+			expect(userId).toBe('user-1');
+			expect(identityResolution.resolve).toHaveBeenCalledWith(
+				{ iss: 'https://idp.example.com', sub: 'external-subject-1' },
+				undefined,
+				{ issuer: 'https://idp.example.com' },
+				// Connecting is interactive, so binding (and provisioning) is allowed here
+				// and nowhere else.
+				true,
+			);
+		});
+
+		it('returns undefined when no binding could be established', async () => {
+			vi.mocked(identityResolution.resolve).mockResolvedValue(null);
+
+			expect(await service.ensureBinding(claim)).toBeUndefined();
+		});
+
+		it('returns undefined rather than throwing when the identity policy refuses', async () => {
+			vi.mocked(identityResolution.resolve).mockRejectedValue(new Error('Role not allowed'));
+
+			expect(await service.ensureBinding(claim)).toBeUndefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
@@ -16,6 +16,7 @@ import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 
 import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
+import { InboundClaimConnectService } from './inbound-claim-connect.service';
 import { extractSharedFields } from './shared-fields';
 import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
 import { CredentialStorageError } from '../errors/credential-storage.error';
@@ -29,6 +30,7 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 		private readonly cipher: Cipher,
 		private readonly logger: Logger,
 		private readonly dynamicCredentialsProxy: DynamicCredentialsProxy,
+		private readonly inboundClaimConnectService: InboundClaimConnectService,
 	) {}
 
 	async storeIfNeeded(
@@ -92,7 +94,12 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 				}
 			}
 
-			await resolver.setSecret(credentialStoreMetadata.id, credentialContext, mergedDynamicData, {
+			// The OAuth callback rebuilds this context from the CSRF state, which
+			// carries the presented token but no claim, so re-derive it here.
+			const resolutionContext =
+				await this.inboundClaimConnectService.attachVerifiedClaim(credentialContext);
+
+			await resolver.setSecret(credentialStoreMetadata.id, resolutionContext, mergedDynamicData, {
 				configuration: resolverConfig,
 				resolverName: resolverEntity.name,
 				resolverId: resolverEntity.id,

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-web.service.ts
@@ -1,11 +1,13 @@
 import { Z } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import { Request } from 'express';
-import { ICredentialContext } from 'n8n-workflow';
+import { ICredentialContext, ICredentialResolutionContext } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { AuthService } from '@/auth/auth.service';
 import { UnauthenticatedError } from '@/errors/response-errors/unauthenticated.error';
+
+import { InboundClaimConnectService } from './inbound-claim-connect.service';
 
 class AuthSourceQuerySchema extends Z.class({
 	authSource: z.enum(['bearer', 'cookie']).optional(),
@@ -32,7 +34,10 @@ function getBearerToken(req: Request): string | null {
 
 @Service()
 export class DynamicCredentialWebService {
-	constructor(private readonly authService: AuthService) {}
+	constructor(
+		private readonly authService: AuthService,
+		private readonly inboundClaimConnectService: InboundClaimConnectService,
+	) {}
 
 	private buildCookieCredentialContext(req: Request): ICredentialContext {
 		const sessionCookie = this.authService.getCookieToken(req);
@@ -51,7 +56,13 @@ export class DynamicCredentialWebService {
 		};
 	}
 
-	getCredentialContextFromRequest(req: Request): ICredentialContext {
+	/**
+	 * A presented bearer token is verified here, so a caller arriving with an
+	 * external IdP token resolves as that identity. Tokens no trusted source
+	 * vouches for are returned untagged, exactly as before - they belong to a
+	 * resolver that keys on the token's own subject.
+	 */
+	async getCredentialContextFromRequest(req: Request): Promise<ICredentialResolutionContext> {
 		const parseResult = AuthSourceQuerySchema.safeParse(req.query);
 
 		if (parseResult.success && parseResult.data.authSource !== undefined) {
@@ -61,11 +72,7 @@ export class DynamicCredentialWebService {
 				if (token === null) {
 					throw new UnauthenticatedError('Bearer token is missing');
 				}
-				return {
-					identity: token,
-					version: 1,
-					metadata: {},
-				};
+				return await this.buildBearerCredentialContext(token);
 			} else if (authSource === 'cookie') {
 				return this.buildCookieCredentialContext(req);
 			} else {
@@ -75,13 +82,18 @@ export class DynamicCredentialWebService {
 
 		const token = getBearerToken(req);
 		if (token !== null) {
-			return {
-				identity: token,
-				version: 1,
-				metadata: {},
-			};
+			return await this.buildBearerCredentialContext(token);
 		}
 
 		return this.buildCookieCredentialContext(req);
+	}
+
+	private async buildBearerCredentialContext(token: string): Promise<ICredentialResolutionContext> {
+		const context: ICredentialContext = {
+			identity: token,
+			version: 1,
+			metadata: {},
+		};
+		return await this.inboundClaimConnectService.attachVerifiedClaim(context);
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/inbound-claim-connect.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/inbound-claim-connect.service.ts
@@ -1,0 +1,98 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type {
+	ICredentialContext,
+	ICredentialResolutionContext,
+	IVerifiedClaim,
+} from 'n8n-workflow';
+
+import { ExternalTokenVerifierProxy } from '@/services/external-token-verifier-proxy.service';
+import { IdentityResolutionProxy } from '@/services/identity-resolution-proxy.service';
+
+/** `Authorization: Bearer <token>` values are stored whole in some flows. */
+function stripBearerPrefix(identity: string): string {
+	return identity.replace(/^Bearer\s+/i, '').trim();
+}
+
+/**
+ * Turns a presented inbound token into a usable identity on the credential
+ * *connect* routes: verifies it, and establishes the binding to an n8n user if
+ * one doesn't exist yet.
+ *
+ * Provisioning lives here and nowhere else. Connecting is an interactive act by
+ * a caller who just presented a token, so binding then is sound; resolution
+ * during an execution stays strictly read-only, which is what stops an inbound
+ * trigger from creating users.
+ */
+@Service()
+export class InboundClaimConnectService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly externalTokenVerifierProxy: ExternalTokenVerifierProxy,
+		private readonly identityResolutionProxy: IdentityResolutionProxy,
+	) {}
+
+	/**
+	 * Verifies the token carried as the context identity and, when it checks
+	 * out, returns an `external-idp` context carrying the claim.
+	 *
+	 * Anything else is returned untouched: a context that already names its
+	 * source (cookie, manual, n8n-oauth), and a token no trusted source
+	 * vouches for - opaque tokens meant for an introspection resolver land
+	 * here, and must keep resolving the way they do today.
+	 */
+	async attachVerifiedClaim(context: ICredentialContext): Promise<ICredentialResolutionContext> {
+		if (context.metadata?.source !== undefined && context.metadata.source !== 'external-idp') {
+			return context;
+		}
+
+		const token = stripBearerPrefix(context.identity);
+		if (!token) return context;
+
+		const { claim } = await this.externalTokenVerifierProxy.verifyInboundToken(token);
+		if (!claim) return context;
+
+		return {
+			...context,
+			metadata: { ...context.metadata, source: 'external-idp' },
+			claims: {
+				version: 1,
+				sourceId: claim.sourceId,
+				issuer: claim.issuer,
+				subject: claim.subject,
+				audience: Array.isArray(claim.audience) ? claim.audience[0] : claim.audience,
+				expiresAt: claim.expiresAt.getTime(),
+				// Only sealed onto an execution context; nothing to bind here.
+				boundWorkflowId: '',
+			},
+		};
+	}
+
+	/**
+	 * Ensures the claim is bound to an n8n user, provisioning one if the
+	 * instance's identity policy allows it, so the read-only resolution that
+	 * runs on every later credential access finds a binding.
+	 *
+	 * Returns the bound user id, or `undefined` when no binding could be
+	 * established (no verifier, provisioning refused, role not permitted). The
+	 * caller decides what that means - it must not be treated as an error on
+	 * paths that also serve resolvers keyed on external subjects.
+	 */
+	async ensureBinding(claim: IVerifiedClaim): Promise<string | undefined> {
+		try {
+			const user = await this.identityResolutionProxy.resolve(
+				{ iss: claim.issuer, sub: claim.subject },
+				undefined,
+				{ issuer: claim.issuer },
+				true,
+			);
+			return user?.id;
+		} catch (error) {
+			this.logger.warn('Could not bind an inbound claim to an n8n user', {
+				subject: claim.subject,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/index.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/index.ts
@@ -7,3 +7,5 @@ export * from './credential-check-proxy.service';
 export * from './authorize-intent.service';
 export * from './n8n-resolver-seeder.service';
 export * from './credential-connection-status.service';
+export * from './credential-resolution-context.builder';
+export * from './inbound-claim-connect.service';

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -60,7 +60,8 @@ export class WorkflowStatusController {
 	async checkWorkflowForExecution(req: Request, res: Response): Promise<WorkflowExecutionStatus> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['get', 'options']);
 		const workflowId = req.params['workflowId'];
-		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
+		const credentialContext =
+			await this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
 
 		if (!workflowId) {
 			throw new BadRequestError('Workflow ID is missing');

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -8,6 +8,7 @@ import { AuthError } from '@/errors/response-errors/auth.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { JwtService } from '@/services/jwt.service';
 
+import type { InboundAudienceService } from '../../context-establishment-hooks/inbound-audience.service';
 import type { TokenExchangeConfig } from '../../token-exchange.config';
 import { TokenExchangeAuthError } from '../../token-exchange.errors';
 import type { ResolvedTrustedKey } from '../../token-exchange.schemas';
@@ -22,6 +23,7 @@ const jtiStore = mock<JtiStoreService>();
 const identityResolutionService = mock<IdentityResolutionService>();
 const config = mock<TokenExchangeConfig>();
 const jwtService = mock<JwtService>();
+const inboundAudienceService = mock<InboundAudienceService>();
 
 const service = new TokenExchangeService(
 	logger,
@@ -30,6 +32,7 @@ const service = new TokenExchangeService(
 	identityResolutionService,
 	config,
 	jwtService,
+	inboundAudienceService,
 );
 
 const resolvedKey: ResolvedTrustedKey = {

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/services/external-token-verifier-proxy.service';
 import { JwtService } from '@/services/jwt.service';
 
+import { InboundAudienceService } from '../context-establishment-hooks/inbound-audience.service';
 import { TokenExchangeConfig } from '../token-exchange.config';
 import { TokenExchangeAuthError, TokenExchangeRequestError } from '../token-exchange.errors';
 import type {
@@ -46,6 +47,7 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 		private readonly identityResolutionService: IdentityResolutionService,
 		private readonly config: TokenExchangeConfig,
 		private readonly jwtService: JwtService,
+		private readonly inboundAudienceService: InboundAudienceService,
 	) {
 		this.logger = logger.scoped('token-exchange');
 	}
@@ -232,6 +234,16 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 			this.logger.warn('External token verification failed', { error: message });
 			return { claim: null, context: { reason: 'invalid_token', errorDetails: message } };
 		}
+	}
+
+	/**
+	 * Verify an inbound token against the audience this instance accepts for
+	 * inbound identity. Same decision as the context-establishment hook, so a
+	 * token that establishes a claim on a webhook also verifies on the
+	 * credential-connect routes.
+	 */
+	async verifyInboundToken(token: string): Promise<VerifiedClaimResult> {
+		return await this.verifyExternalToken(token, this.inboundAudienceService.getExpectedAudience());
 	}
 
 	async embedLogin(

--- a/packages/cli/src/services/external-token-verifier-proxy.service.ts
+++ b/packages/cli/src/services/external-token-verifier-proxy.service.ts
@@ -23,6 +23,13 @@ export type VerifiedClaimResult =
 
 export interface ExternalTokenVerifier {
 	verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult>;
+
+	/**
+	 * Same verification, but against the audience this instance accepts for
+	 * inbound tokens. Keeps that decision inside the module that owns inbound
+	 * identity, so callers don't each have to know what to expect.
+	 */
+	verifyInboundToken(token: string): Promise<VerifiedClaimResult>;
 }
 
 /**
@@ -39,14 +46,25 @@ export class ExternalTokenVerifierProxy implements ExternalTokenVerifier {
 
 	async verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult> {
 		if (!this.provider) {
-			return {
-				claim: null,
-				context: {
-					reason: 'verifier_not_registered',
-					errorDetails: 'No external token verifier is registered on this instance',
-				},
-			};
+			return this.notRegistered();
 		}
 		return await this.provider.verifyExternalToken(token, expectedAudience);
+	}
+
+	async verifyInboundToken(token: string): Promise<VerifiedClaimResult> {
+		if (!this.provider) {
+			return this.notRegistered();
+		}
+		return await this.provider.verifyInboundToken(token);
+	}
+
+	private notRegistered(): VerifiedClaimResult {
+		return {
+			claim: null,
+			context: {
+				reason: 'verifier_not_registered',
+				errorDetails: 'No external token verifier is registered on this instance',
+			},
+		};
 	}
 }


### PR DESCRIPTION
## Summary

**Spike.** Stacked on #35643 (T7) — review that first; this PR targets its branch.

Closes the gap T7 surfaced: a caller arriving with an external IdP token cannot connect an end-user credential unless they have already logged into n8n, because resolution keys on an n8n principal and nothing establishes one for them.

Connecting is the right place to fix that. It is interactive, and the caller has just presented a verified token — so the binding is established there, while resolution during an execution stays strictly read-only (`allowProvisioning: false`), which is what stops an inbound trigger from creating users.

- **`InboundClaimConnectService`** — verifies a presented bearer token and, when a trusted source vouches for it, returns an `external-idp` context carrying the claim. A token nothing vouches for passes through untouched, so credentials resolved by introspecting the token's own subject behave exactly as today. Provisioning lives in this service's `ensureBinding` and nowhere else.
- **`ExternalTokenVerifierProxy.verifyInboundToken`** — keeps "which audience do we accept for inbound tokens" inside the module that owns inbound identity (`InboundAudienceService`), instead of each caller having to know. Natural seam for per-surface `acceptedSources` later.
- **Connect route** (`POST /credentials/:id/authorize`) — establishes the binding before resolving ownership, so the authorization link binds to the right user and the OAuth callback stores the connection under it.
- **Store path** — re-derives the claim, because the OAuth callback rebuilds the credential context from the CSRF state, which carries the presented token but no claim.

Net effect: an IdP user with no prior n8n login can connect via the existing API route with their token, and then execute the workflow with that same token — the behaviour that external-subject resolvers already offer, now available on the principal-keyed path.

### What this spike does not cover

- The **credential gate** still withholds the authorization link for a claim with no binding yet (`resolveOwningUserIdForAuthorization` fails closed), since binding cannot happen at trigger time. Making the gate issue a link for a bindable claim needs the claim (or its subject) to ride in the authorize intent — deliberately left out.
- Provisioning is not separately config-gated yet; it inherits the token-exchange identity policy (email claim required, `allowedRoles`, `excludeOwner`). Worth an explicit switch before this is more than a spike.
- `IVerifiedClaim.boundWorkflowId` is `''` on the connect path — there is no workflow to bind to. Harmless (the binding check only runs when unsealing an execution context) but it suggests the connect-side claim wants its own type.

## How to test

Requires `N8N_ENV_FEAT_TOKEN_EXCHANGE=true`, a trusted key source, the dynamic-credentials module, and an end-user credential on a webhook workflow.

1. Mint a JWT for a subject that has **never** logged into n8n, `aud` = instance base URL (or `N8N_TOKEN_EXCHANGE_INBOUND_AUDIENCE`).
2. `POST /rest/credentials/<id>/authorize?authSource=bearer` with `Authorization: Bearer <jwt>` → follow the returned URL through the provider consent screen. A user + `auth_identity` row is created, and the connection is stored against that user under the system resolver.
3. Call the webhook with the same token — the credential resolves. Confirm the connection appears in the connection-status surface for that user.
4. Repeat with an opaque token against an introspection resolver — unchanged from before (no claim, no binding, resolves by external subject).
5. Repeat with a cookie session — unchanged.

Covered by unit tests on the new service (verify/attach, Bearer prefix, multi-value audience, pass-through for unverifiable tokens and already-sourced contexts, `ensureBinding` provisioning flag and failure modes), the connect route (binds when a claim is present, doesn't when it isn't) and the web service.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1188

Part of the sequence toward merging the two end-user-credential behaviours: IAM-1188 (this) → https://linear.app/n8n/issue/IAM-1189 → https://linear.app/n8n/issue/IAM-1190 → https://linear.app/n8n/issue/IAM-1191.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

