### PR TITLE
test(editor): Cover dirtiness of a disabled node renamed afterwards (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.test.ts
@@ -460,6 +460,24 @@ describe(useNodeDirtiness, () => {
 				b: CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED,
 			});
 		});
+
+		it('should preserve the dirtiness caused by disabling a node that is renamed afterwards', async () => {
+			setupTestWorkflow('a🚨✅ -> b✅ -> c✅ -> d✅');
+
+			canvasOperations.toggleNodesDisabled([workflowDocumentStore.nodesByName.b.id], {
+				trackHistory: true,
+			});
+
+			expect(useNodeDirtiness(TEST_DOCUMENT_ID).dirtinessByName.value).toEqual({
+				c: CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED,
+			});
+
+			await canvasOperations.renameNode('b', 'z', { trackHistory: true });
+
+			expect(useNodeDirtiness(TEST_DOCUMENT_ID).dirtinessByName.value).toEqual({
+				c: CanvasNodeDirtiness.INCOMING_CONNECTIONS_UPDATED,
+			});
+		});
 	});
 
 	/**


### PR DESCRIPTION
## Summary

One test, stacked on top of #35649. Targets `agent/palette/a631d3a5` so it can be merged into that branch before it lands on `master`.

#35649 notes that the `EnableNodeToggleCommand` name resolution is defensive because no failing case could be constructed. It is not defensive — it fixes a second, independently reachable instance of the same defect, and nothing in the suite covers it.

**The case.** `EnableNodeToggleCommand` records the node name as a plain string (`useNodeHelpers.ts`), and `renameNode` rebuilds the document from a cloned workflow, so that string goes stale on rename. Disable a node after a partial execution — the downstream node correctly shows the needs-re-run marker — then rename the disabled node, and the marker disappears. Same user-visible symptom as the rename case #35649 fixes, reached through the toggle branch instead of the connection branches.

Before #35649's fix the branch fails twice over: `incomingNodes.includes(command.nodeName)` misses, and `getOutgoingConnectors(command.nodeName)` is queried with a name the document no longer has.

**Why this test and not the one already there.** `should preserve the dirtiness of a node whose newly injected parent is renamed` is documented in #35649 as a guard on the add-node branch. It is not one — the `AddConnectionCommand` recorded in the same bulk targets the never-renamed node and matches first, so the add-node branch never decides the outcome.

Measured, per-line, against #35649's head:

| Mutation applied to `useNodeDirtiness.ts` | Suite result |
| --- | --- |
| none (branch as-is) | 25 passed |
| `resolveName` dropped from the `AddNodeCommand` branch | 25 passed — line unexercised |
| `resolveName` dropped from the `EnableNodeToggleCommand` branch | 1 failed: this test, alone |

So the new test pins exactly one line, and the add-node resolution remains genuinely untested by anything (it stays reasonable as consistency, but the comment on that third test overstates what it guards).

## How to test

1. Open a workflow of four nodes in a row, e.g. `Manual Trigger → Set A → Set B → Set C`.
2. Run it. Disable `Set A`. `Set B` shows the needs-re-run indicator.
3. Rename `Set A`.
4. **Before #35649:** `Set B`'s indicator disappears. **After:** it stays.

Automated, from `packages/frontend/editor-ui`:

| Check | Result |
| --- | --- |
| `useNodeDirtiness.test.ts` | 25 passed (24 of them are #35649's) |
| the new test against `master`'s `useNodeDirtiness.ts` | fails, `expected {} to deeply equal { c: 'incoming-connections-updated' }` |
| `useCanvasOperations` + `useHistoryHelper` + consumers | 329 passed |
| `pnpm typecheck` | clean |
| `pnpm exec eslint` on the changed file | clean (note: the test file matches an eslint ignore pattern) |

## Related Linear tickets, Github issues, and Community forum posts

Stacked on #35649 (N8N-194). Sibling of #35636.

If #35649 is rebased or force-pushed, this branch needs the same.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — test-only
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

