### PR TITLE
test(core): Guard log streaming event names against known event groups

### DIFF
--- a/packages/cli/src/eventbus/event-message-classes/__tests__/event-names.test.ts
+++ b/packages/cli/src/eventbus/event-message-classes/__tests__/event-names.test.ts
@@ -1,0 +1,36 @@
+import { eventNamesAll } from '../index';
+
+/**
+ * Every log-streaming event group in existence. The destination UI derives its
+ * group checkboxes from the first two segments of the event name, and external
+ * consumers (SIEM and compliance pipelines) filter the audit trail by the
+ * `n8n.audit.` prefix.
+ */
+const KNOWN_EVENT_GROUPS = [
+	'n8n.audit.',
+	'n8n.workflow.',
+	'n8n.node.',
+	'n8n.worker.',
+	'n8n.ai.',
+	'n8n.runner.',
+	'n8n.queue.',
+	'n8n.execution.',
+];
+
+describe('log streaming event names', () => {
+	it('should only contain names under a known event group prefix', () => {
+		const offenders = eventNamesAll.filter(
+			(eventName) => !KNOWN_EVENT_GROUPS.some((prefix) => eventName.startsWith(prefix)),
+		);
+
+		expect(
+			offenders,
+			'Event names are a public contract with log-streaming consumers and cannot be renamed once released. ' +
+				'Events that record a user action belong under the `n8n.audit.` prefix: SIEM pipelines filter the ' +
+				'audit trail by that prefix, and a new top-level prefix creates its own opt-in group in the ' +
+				'destination UI (see `eventNamesMcp` for a group with its own payload shape named under the audit ' +
+				'prefix). Only deliberately introduce a new operational group with sign-off from the owning team, ' +
+				'then add its prefix to KNOWN_EVENT_GROUPS.',
+		).toEqual([]);
+	});
+});

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -8,6 +8,21 @@ import type { EventMessageQueue } from './event-message-queue';
 import type { EventMessageRunner } from './event-message-runner';
 import type { EventMessageWorkflow } from './event-message-workflow';
 
+/**
+ * Naming rules for log streaming events:
+ *
+ * Event names are a public contract with log streaming consumers and cannot be
+ * renamed once released. Events that record a user action (logins, grants,
+ * tool calls, settings changes) must be named under `n8n.audit.`: external
+ * pipelines filter the audit trail by that prefix, and the destination UI
+ * groups events by the first two name segments, so a new top-level prefix
+ * creates its own opt-in group outside the audit trail. A group can keep its
+ * own name list and message class while living under the audit prefix (see
+ * `eventNamesMcp`). Introducing a new operational group (like `n8n.runner.`)
+ * is a taxonomy decision that needs sign-off from the owning team; the guard
+ * test in `__tests__/event-names.test.ts` enforces this.
+ */
+
 export const eventNamesAiNodes = [
 	'n8n.ai.memory.get.messages',
 	'n8n.ai.memory.added.message',


### PR DESCRIPTION
## Summary

Adds a guard test over `eventNamesAll` that fails whenever a log streaming event name is added outside the known event group prefixes (`n8n.audit.`, `n8n.workflow.`, `n8n.node.`, `n8n.worker.`, `n8n.ai.`, `n8n.runner.`, `n8n.queue.`, `n8n.execution.`).

Event names are a public contract with log streaming consumers and cannot be renamed once released: SIEM and compliance pipelines filter the audit trail by the `n8n.audit.` prefix, and the destination UI derives its group checkboxes from the first two name segments, so a new top-level prefix silently creates an opt-in group outside the audit trail. This nearly shipped in #33300, where the MCP events were initially named `n8n.mcp.*` and had to be renamed to `n8n.audit.mcp.*` in review.

The naming rules are also documented in a comment at the top of `event-message-classes/index.ts`, where the next event name gets added, so developers see them at authoring time. With the test, introducing a new top-level prefix fails CI with a message explaining the naming rules, turning silent taxonomy drift into a deliberate, reviewed decision (adding the prefix to the known list).

## How to test

1. Run the test: `pnpm vitest run src/eventbus/event-message-classes/__tests__/event-names.test.ts` in `packages/cli`.
2. Add a hypothetical event name like `n8n.foo.bar` to any list composed into `eventNamesAll` and run it again: it fails, naming the offender and explaining where user-action events belong.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to https://github.com/n8n-io/n8n/pull/33300

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


