### PR TITLE
feat(core): Reject graphs with multiple trigger nodes (no-changelog)

### DIFF
--- a/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
@@ -27,6 +27,16 @@ describe('validateExecutableGraph', () => {
 		expect(() => validateExecutableGraph(graph)).toThrow('no trigger node');
 	});
 
+	it('rejects a graph with more than one trigger node', () => {
+		const graph: WorkflowGraph = {
+			nodes: [...validGraph.nodes, { id: 'trigger-2', name: 'T2', type: 'trigger' }],
+			edges: validGraph.edges,
+		};
+
+		expect(() => validateExecutableGraph(graph)).toThrow(GraphValidationError);
+		expect(() => validateExecutableGraph(graph)).toThrow('one trigger node');
+	});
+
 	it('rejects a graph with a back-edge as unimplemented', () => {
 		const graph: WorkflowGraph = {
 			nodes: [...validGraph.nodes, { id: 'b', name: 'B', type: 'v1-node' }],

--- a/packages/@n8n/engine/src/graph/validate-executable-graph.ts
+++ b/packages/@n8n/engine/src/graph/validate-executable-graph.ts
@@ -1,6 +1,5 @@
 import { UnimplementedError } from '../common';
 import type { WorkflowGraph } from './workflow-graph';
-import { findTriggerNode } from './workflow-graph-queries';
 
 /** Thrown when a graph fails a structural rule and can never execute. */
 export class GraphValidationError extends Error {
@@ -19,11 +18,15 @@ export class GraphValidationError extends Error {
  * `UnimplementedError` for shapes the engine doesn't support yet.
  */
 export function validateExecutableGraph(graph: WorkflowGraph): void {
-	if (!findTriggerNode(graph)) {
+	const triggers = graph.nodes.filter((node) => node.type === 'trigger');
+	if (triggers.length === 0) {
 		throw new GraphValidationError('Graph has no trigger node to start from');
 	}
+	if (triggers.length > 1) {
+		throw new GraphValidationError('Graph must have exactly one trigger node');
+	}
 
-	// TODO(CAT-3854): loop iteration needs re-runnable steps; until that lands,
+	// TODO(CAT-2875): loop iteration needs re-runnable steps; until that lands,
 	// graphs with back-edges are rejected outright rather than deadlocking.
 	if (graph.edges.some((edge) => edge.isBackEdge)) {
 		throw new UnimplementedError('Graphs with back-edges (loops) are not supported yet');


### PR DESCRIPTION
## Summary

Follow-up to the post-approval review comments on #35387:

- `validateExecutableGraph` now rejects graphs with more than one trigger node (`GraphValidationError`, mapped to 400 `invalid_graph` by the existing route handling), alongside the existing no-trigger rule.
- Fixes the loop-iteration TODO in the back-edge rule to reference the correct ticket (CAT-2875 instead of CAT-3854).

## How to test

Unit test added in `packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts`. Run in `packages/@n8n/engine`:

```bash
pnpm test src/graph/__tests__/validate-executable-graph.test.ts
```

Or POST a graph with two `trigger` nodes to `/api/workflow-executions` on the engine server and observe the 400 `invalid_graph` response.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2871

Follow-up to #35387.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

