### PR TITLE
build: Update AI SDK dependencies (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/integration/thinking.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/thinking.test.ts
@@ -43,10 +43,9 @@ describeAnthropic('reasoning stream (Anthropic)', () => {
 describeAnthropic('reasoning stream (Anthropic, adaptive thinking)', () => {
 	/**
 	 * Adaptive-thinking models (Sonnet 5, Opus 4.6+) return thinking blocks with
-	 * empty text unless the request asks for `display: 'summarized'`, which the
-	 * SDK's mapping of the generic reasoning level does not do. The cassette
-	 * pins the outgoing request, so an SDK upgrade that stops sending the flag
-	 * fails here instead of silently emptying every trace.
+	 * empty text unless the request asks for `display: 'summarized'`. The cassette
+	 * pins the AI SDK's generic reasoning mapping, so an SDK regression that stops
+	 * sending the flag fails here instead of silently emptying every trace.
 	 *
 	 * High effort because adaptive models decide per request whether to think at
 	 * all, and at lower effort they routinely answer this prompt without it.

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -5248,45 +5248,6 @@ describe('provider-specific thinking', () => {
 			anthropic: { thinking: { type: 'enabled', budgetTokens: 4096 } },
 		});
 	});
-
-	// Adaptive models return empty thinking blocks unless display is summarized,
-	// and the SDK's mapping of the reasoning level doesn't set it.
-	it('asks an adaptive Anthropic model for summarized thinking when reasoning is set', async () => {
-		generateText.mockResolvedValue(makeGenerateSuccess());
-
-		const runtime = new AgentRuntime({
-			name: 'test',
-			model: 'anthropic/claude-sonnet-5',
-			instructions: 'You are a test assistant.',
-			reasoning: 'medium',
-		});
-
-		await runtime.generate('hello');
-
-		const callArgs = generateText.mock.calls[0][0] as Record<string, unknown>;
-		// The level still goes through as the SDK's own option, which maps it to effort.
-		expect(callArgs.reasoning).toBe('medium');
-		expect(callArgs.providerOptions).toEqual({
-			anthropic: { thinking: { type: 'adaptive', display: 'summarized' } },
-		});
-	});
-
-	it('leaves a budget-thinking Anthropic model to the SDK when reasoning is set', async () => {
-		generateText.mockResolvedValue(makeGenerateSuccess());
-
-		const runtime = new AgentRuntime({
-			name: 'test',
-			model: 'anthropic/claude-sonnet-4-5',
-			instructions: 'You are a test assistant.',
-			reasoning: 'medium',
-		});
-
-		await runtime.generate('hello');
-
-		const callArgs = generateText.mock.calls[0][0] as Record<string, unknown>;
-		expect(callArgs.reasoning).toBe('medium');
-		expect(callArgs.providerOptions).toBeUndefined();
-	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/provider-quirks.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 
-import type { ReasoningLevel } from '../../types';
 import { applyToolProviderOptionDefaults, getProviderQuirks } from '../model/provider-quirks';
 
 describe('getProviderQuirks', () => {
@@ -115,37 +114,5 @@ describe('thinkingToProviderOptions', () => {
 		expect(getProviderQuirks('xai').thinkingToProviderOptions?.({}, 'xai/grok-4')).toEqual({
 			xai: { reasoningEffort: 'high' },
 		});
-	});
-});
-
-describe('reasoningToProviderOptions', () => {
-	const anthropicReasoning = (modelId: string, level: ReasoningLevel = 'medium') =>
-		getProviderQuirks('anthropic').reasoningToProviderOptions?.(level, modelId);
-
-	// Adaptive models withhold the thinking text unless display is summarized, so
-	// the reasoning level on its own produces empty thinking blocks.
-	it.each([
-		'anthropic/claude-sonnet-5',
-		'anthropic/claude-opus-5',
-		'anthropic/claude-opus-4-8',
-		'anthropic/claude-sonnet-4-6',
-		// Unknown Claude models follow the AI SDK's own adaptive fallback.
-		'anthropic/claude-sonnet-7',
-	])('asks %s for summarized thinking', (modelId) => {
-		expect(anthropicReasoning(modelId)).toEqual({
-			anthropic: { thinking: { type: 'adaptive', display: 'summarized' } },
-		});
-	});
-
-	it.each([
-		'anthropic/claude-sonnet-4-5',
-		'anthropic/claude-haiku-4-5',
-		'anthropic/claude-opus-4-1',
-	])('leaves %s to the SDK, which maps the level to a token budget', (modelId) => {
-		expect(anthropicReasoning(modelId)).toBeUndefined();
-	});
-
-	it.each(['none', 'provider-default'] as const)('adds nothing for reasoning %s', (level) => {
-		expect(anthropicReasoning('anthropic/claude-sonnet-5', level)).toBeUndefined();
 	});
 });

--- a/packages/@n8n/agents/src/runtime/loop/runtime-context.ts
+++ b/packages/@n8n/agents/src/runtime/loop/runtime-context.ts
@@ -271,17 +271,12 @@ export class RuntimeContextBuilder {
 		};
 	}
 
-	/** Build the providerOptions object for thinking/reasoning config. */
+	/** Build the providerOptions object for provider-specific thinking config. */
 	private buildThinkingProviderOptions(): Record<string, Record<string, unknown>> | undefined {
-		const quirks = getProviderQuirks(providerIdFromModelId(this.modelId));
+		if (!this.config.thinking) return undefined;
 
-		if (this.config.thinking) {
-			return quirks.thinkingToProviderOptions?.(this.config.thinking, this.modelId);
-		}
-		if (this.config.reasoning) {
-			return quirks.reasoningToProviderOptions?.(this.config.reasoning, this.modelId);
-		}
-		return undefined;
+		const quirks = getProviderQuirks(providerIdFromModelId(this.modelId));
+		return quirks.thinkingToProviderOptions?.(this.config.thinking, this.modelId);
 	}
 
 	/**

--- a/packages/@n8n/agents/src/runtime/model/provider-quirks.ts
+++ b/packages/@n8n/agents/src/runtime/model/provider-quirks.ts
@@ -4,7 +4,6 @@ import type {
 	GoogleThinkingConfig,
 	JSONObject,
 	OpenAIThinkingConfig,
-	ReasoningLevel,
 	ThinkingConfig,
 	XaiThinkingConfig,
 } from '../../types';
@@ -21,14 +20,6 @@ export interface ProviderQuirks {
 		thinking: ThinkingConfig,
 		modelId: string,
 	) => Record<string, Record<string, unknown>>;
-	/**
-	 * Provider options the generic reasoning level alone doesn't produce. The AI
-	 * SDK maps the level itself, so this only fills gaps it leaves open.
-	 */
-	reasoningToProviderOptions?: (
-		reasoning: ReasoningLevel,
-		modelId: string,
-	) => Record<string, Record<string, unknown>> | undefined;
 }
 
 /** Anthropic model families that take the adaptive thinking API. */
@@ -87,15 +78,6 @@ export const PROVIDER_QUIRKS: Partial<Record<ProviderId, ProviderQuirks>> = {
 					thinking: { type: 'enabled', budgetTokens: budgetTokens ?? 10000 },
 				},
 			};
-		},
-		// QUIRK(anthropic): adaptive models default `display` to "omitted", so the
-		// generic reasoning level on its own buys thinking whose text never comes
-		// back — signed, billed, and invisible. Ask for the text; the SDK still
-		// derives the effort from the level.
-		reasoningToProviderOptions: (reasoning, modelId) => {
-			if (reasoning === 'none' || reasoning === 'provider-default') return undefined;
-			if (!anthropicUsesAdaptiveThinking(modelId)) return undefined;
-			return { anthropic: { thinking: { type: 'adaptive', display: 'summarized' } } };
 		},
 	},
 	openai: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^5.0.31
       version: 5.0.31
     '@ai-sdk/anthropic':
-      specifier: ^4.0.20
-      version: 4.0.20
+      specifier: ^4.0.27
+      version: 4.0.27
     '@ai-sdk/azure':
       specifier: ^4.0.21
       version: 4.0.21
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^3.0.13
       version: 3.0.13
     '@ai-sdk/gateway':
-      specifier: ^4.0.28
-      version: 4.0.28
+      specifier: ^4.0.37
+      version: 4.0.37
     '@ai-sdk/google':
       specifier: ^4.0.24
       version: 4.0.24
@@ -40,11 +40,11 @@ catalogs:
       specifier: ^3.0.14
       version: 3.0.14
     '@ai-sdk/otel':
-      specifier: ^1.0.37
-      version: 1.0.37
+      specifier: ^1.0.48
+      version: 1.0.48
     '@ai-sdk/provider-utils':
-      specifier: ^5.0.12
-      version: 5.0.12
+      specifier: ^5.0.18
+      version: 5.0.18
     '@ai-sdk/xai':
       specifier: ^4.0.18
       version: 4.0.18
@@ -310,8 +310,8 @@ catalogs:
       specifier: 0.26.0
       version: 0.26.0
     ai:
-      specifier: ^7.0.37
-      version: 7.0.37
+      specifier: ^7.0.48
+      version: 7.0.48
     basic-auth:
       specifier: 2.0.1
       version: 2.0.1
@@ -934,7 +934,7 @@ importers:
         version: 5.0.31(zod@3.25.76)
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 4.0.20(zod@3.25.76)
+        version: 4.0.27(zod@3.25.76)
       '@ai-sdk/azure':
         specifier: 'catalog:'
         version: 4.0.21(zod@3.25.76)
@@ -946,7 +946,7 @@ importers:
         version: 3.0.13(zod@3.25.76)
       '@ai-sdk/gateway':
         specifier: 'catalog:'
-        version: 4.0.28(zod@3.25.76)
+        version: 4.0.37(zod@3.25.76)
       '@ai-sdk/google':
         specifier: 'catalog:'
         version: 4.0.24(zod@3.25.76)
@@ -964,10 +964,10 @@ importers:
         version: 3.0.14(zod@3.25.76)
       '@ai-sdk/otel':
         specifier: 'catalog:'
-        version: 1.0.37(zod@3.25.76)
+        version: 1.0.48(zod@3.25.76)
       '@ai-sdk/provider-utils':
         specifier: 'catalog:'
-        version: 5.0.12(zod@3.25.76)
+        version: 5.0.18(zod@3.25.76)
       '@ai-sdk/xai':
         specifier: 'catalog:'
         version: 4.0.18(zod@3.25.76)
@@ -988,7 +988,7 @@ importers:
         version: link:../utils
       '@openrouter/ai-sdk-provider':
         specifier: 'catalog:'
-        version: 3.0.0(ai@7.0.37(zod@3.25.76))(zod@3.25.76)
+        version: 3.0.0(ai@7.0.48(zod@3.25.76))(zod@3.25.76)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: '>=0.50.0'
         version: 0.217.0(@opentelemetry/api@1.9.1)
@@ -1000,7 +1000,7 @@ importers:
         version: 2.7.1(@opentelemetry/api@1.9.1)
       ai:
         specifier: 'catalog:'
-        version: 7.0.37(zod@3.25.76)
+        version: 7.0.48(zod@3.25.76)
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -2638,7 +2638,7 @@ importers:
         version: 2.0.12
       ai:
         specifier: 'catalog:'
-        version: 7.0.37(zod@3.25.76)
+        version: 7.0.48(zod@3.25.76)
       csv-parse:
         specifier: 'catalog:'
         version: 6.2.1
@@ -2693,7 +2693,7 @@ importers:
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 4.0.20(zod@3.25.76)
+        version: 4.0.27(zod@3.25.76)
       '@langchain/core':
         specifier: 'catalog:'
         version: 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -4045,7 +4045,7 @@ importers:
         version: 1.4.2
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 4.0.20(zod@3.25.76)
+        version: 4.0.27(zod@3.25.76)
       '@apidevtools/json-schema-ref-parser':
         specifier: 12.0.2
         version: 12.0.2
@@ -4231,7 +4231,7 @@ importers:
         version: 2.50.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       ai:
         specifier: 'catalog:'
-        version: 7.0.37(zod@3.25.76)
+        version: 7.0.48(zod@3.25.76)
       aws4:
         specifier: 1.11.0
         version: 1.11.0
@@ -7162,6 +7162,12 @@ packages:
     peerDependencies:
       zod: 3.25.76
 
+  '@ai-sdk/anthropic@4.0.27':
+    resolution: {integrity: sha512-ecrPWkYf+sHDLHErHAU/yjJfNevUzT0i6TuoQLb58oadnquSHcLQ5NMLLWjbr6d1rxYdzI7ftulIJ03VH9yM3w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: 3.25.76
+
   '@ai-sdk/azure@4.0.21':
     resolution: {integrity: sha512-2DbEPXIdj6dvc30tPE7Rz+t3ELbjOvIDawAHUvLIipc15sY7+uvS203jh1cjiPUyZ+NAIa3B+HWEpHrjlAoyKg==}
     engines: {node: '>=22'}
@@ -7180,8 +7186,8 @@ packages:
     peerDependencies:
       zod: 3.25.76
 
-  '@ai-sdk/gateway@4.0.28':
-    resolution: {integrity: sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q==}
+  '@ai-sdk/gateway@4.0.37':
+    resolution: {integrity: sha512-YBCTsSlX0ETVsjo0ihfBOeJ3p3y1wXKXDzF9Ygp9dscUY06dzOGmyWJSGsKg+khKVArzBWUW4UCSAKms20ZDmg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: 3.25.76
@@ -7216,8 +7222,8 @@ packages:
     peerDependencies:
       zod: 3.25.76
 
-  '@ai-sdk/otel@1.0.37':
-    resolution: {integrity: sha512-qaXUeOTZfbugaYKcqgqho79YOdvLWFlBQt984n5fOozChfgkybJJHotkqsKy3aJGU5GcgJuMM+oamb9JtPQnwA==}
+  '@ai-sdk/otel@1.0.48':
+    resolution: {integrity: sha512-Yr6Zvc0VUbsHCKJo/3r5tK3jUd/B5j+5RSXYIWEFD7ClEsKkfgpC9+Hf7Ub1bj1qkYkc4EdYNEY4bx+rjWHIXQ==}
     engines: {node: '>=22'}
 
   '@ai-sdk/provider-utils@5.0.12':
@@ -7226,8 +7232,18 @@ packages:
     peerDependencies:
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@5.0.18':
+    resolution: {integrity: sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: 3.25.76
+
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
     engines: {node: '>=22'}
 
   '@ai-sdk/xai@4.0.18':
@@ -13876,8 +13892,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@7.0.37:
-    resolution: {integrity: sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw==}
+  ai@7.0.48:
+    resolution: {integrity: sha512-QmqshWFEDdkFFqSgdJ4cogaoDIYaedqbv73q/NXEYNkSIocJCzXnGFVyM9lrtAGTSBfm+5hq3/292ooXJ1jDSw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: 3.25.76
@@ -23113,6 +23129,12 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.12(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/anthropic@4.0.27(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/azure@4.0.21(zod@3.25.76)':
     dependencies:
       '@ai-sdk/deepseek': 3.0.13(zod@3.25.76)
@@ -23133,10 +23155,10 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.12(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/gateway@4.0.28(zod@3.25.76)':
+  '@ai-sdk/gateway@4.0.37(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.12(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@3.25.76)
       '@vercel/oidc': 3.2.0
       zod: 3.25.76
 
@@ -23170,11 +23192,11 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.12(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/otel@1.0.37(zod@3.25.76)':
+  '@ai-sdk/otel@1.0.48(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider': 4.0.4
       '@opentelemetry/api': 1.9.1
-      ai: 7.0.37(zod@3.25.76)
+      ai: 7.0.48(zod@3.25.76)
     transitivePeerDependencies:
       - zod
 
@@ -23186,7 +23208,20 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@5.0.18(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.0.8
+      undici: 7.29.0
+      zod: 3.25.76
+
   '@ai-sdk/provider@4.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
 
@@ -27744,9 +27779,9 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openrouter/ai-sdk-provider@3.0.0(ai@7.0.37(zod@3.25.76))(zod@3.25.76)':
+  '@openrouter/ai-sdk-provider@3.0.0(ai@7.0.48(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      ai: 7.0.37(zod@3.25.76)
+      ai: 7.0.48(zod@3.25.76)
       zod: 3.25.76
 
   '@opentelemetry/api-logs@0.213.0':
@@ -31660,11 +31695,11 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@7.0.37(zod@3.25.76):
+  ai@7.0.48(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 4.0.28(zod@3.25.76)
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.12(zod@3.25.76)
+      '@ai-sdk/gateway': 4.0.37(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@3.25.76)
       zod: 3.25.76
 
   ajv-draft-04@1.0.0(ajv@8.18.0):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,18 +7,18 @@ packages:
 
 catalog:
   '@ai-sdk/amazon-bedrock': ^5.0.31
-  '@ai-sdk/anthropic': ^4.0.20
+  '@ai-sdk/anthropic': ^4.0.27
   '@ai-sdk/azure': ^4.0.21
   '@ai-sdk/cohere': ^4.0.12
   '@ai-sdk/deepseek': ^3.0.13
-  '@ai-sdk/gateway': ^4.0.28
+  '@ai-sdk/gateway': ^4.0.37
   '@ai-sdk/google': ^4.0.24
   '@ai-sdk/groq': ^4.0.13
   '@ai-sdk/mistral': ^4.0.14
   '@ai-sdk/openai': ^4.0.20
   '@ai-sdk/openai-compatible': ^3.0.14
-  '@ai-sdk/otel': ^1.0.37
-  '@ai-sdk/provider-utils': ^5.0.12
+  '@ai-sdk/otel': ^1.0.48
+  '@ai-sdk/provider-utils': ^5.0.18
   '@ai-sdk/xai': ^4.0.18
   '@azure/identity': 4.13.0
   '@azure/storage-blob': ^12.32.0
@@ -117,7 +117,7 @@ catalog:
   '@vitest/browser-playwright': ^4.1.9
   '@vitest/coverage-v8': 4.1.9
   agent-browser: 0.26.0
-  ai: ^7.0.37
+  ai: ^7.0.48
   axios: 1.18.0
   basic-auth: 2.0.1
   cache-manager: 5.2.3


### PR DESCRIPTION
## Summary

- Update the AI SDK packages to the newest versions allowed by the repository's 72-hour release-age policy
- Remove the local Anthropic adaptive-reasoning workaround now handled by `@ai-sdk/anthropic`
- Keep the recorded integration regression that verifies adaptive reasoning returns visible summaries

## How to test

- `pushd packages/@n8n/agents && pnpm test && popd`
- `pushd packages/@n8n/agents && pnpm test:integration:replay src/__tests__/integration/thinking.test.ts && popd`
- `pushd packages/@n8n/agents && pnpm lint && pnpm typecheck && popd`
- `pnpm build > build.log 2>&1`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm lint --concurrency=1`
- `pnpm typecheck`

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AGENT-523
- https://github.com/vercel/ai/issues/18238
- https://github.com/vercel/ai/pull/18247

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [ ] Docs updated or follow-up ticket created.
- [ ] PR labeled with `Backport` when applicable.

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

