### PR TITLE
feat(core): Enable 'instance-ai' module by default and remove startup warning

### DIFF
--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -30,7 +30,16 @@ describe('getModuleEntryUrl', () => {
 describe('eligibleModules', () => {
 	it('should not include opt-in modules by default', () => {
 		const eligible = Container.get(ModuleRegistry).eligibleModules;
-		expect(eligible).not.toContain('instance-ai');
+		expect(eligible).not.toContain('agents');
+	});
+
+	it('should include instance-ai by default', () => {
+		expect(Container.get(ModuleRegistry).eligibleModules).toContain('instance-ai');
+	});
+
+	it('should allow opting out of a default module via env var', () => {
+		process.env.N8N_DISABLED_MODULES = 'instance-ai';
+		expect(Container.get(ModuleRegistry).eligibleModules).not.toContain('instance-ai');
 	});
 
 	it('should consider a module ineligible if it was disabled via env var', () => {
@@ -64,11 +73,12 @@ describe('eligibleModules', () => {
 			'runtime-credentials',
 			'mcp-registry',
 			'workflow-reviews',
+			'instance-ai',
 		]);
 	});
 
 	it('should consider a module eligible if it was enabled via env var', () => {
-		process.env.N8N_ENABLED_MODULES = 'instance-ai';
+		process.env.N8N_ENABLED_MODULES = 'agents';
 		expect(Container.get(ModuleRegistry).eligibleModules).toEqual([
 			'insights',
 			'external-secrets',
@@ -100,6 +110,7 @@ describe('eligibleModules', () => {
 			'mcp-registry',
 			'workflow-reviews',
 			'instance-ai',
+			'agents',
 		]);
 	});
 

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -72,6 +72,7 @@ export class ModuleRegistry {
 		'runtime-credentials',
 		'mcp-registry',
 		'workflow-reviews',
+		'instance-ai',
 	];
 
 	private readonly activeModules: string[] = [];

--- a/packages/cli/src/modules/instance-ai/instance-ai.module.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.module.ts
@@ -3,19 +3,9 @@ import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 
-const YELLOW = '\x1b[33m';
-const CLEAR = '\x1b[0m';
-const WARNING_MESSAGE =
-	"[Instance AI] 'instance-ai' module is experimental, undocumented and subject to change. " +
-	'Before its official release any features may become inaccessible at any point, ' +
-	'and using the module could compromise the stability of your system. Use at your own risk!';
-
 @BackendModule({ name: 'instance-ai', instanceTypes: ['main'] })
 export class InstanceAiModule implements ModuleInterface {
 	async init() {
-		const logger = Container.get(Logger).scoped('instance-ai');
-		logger.warn(`${YELLOW}${WARNING_MESSAGE}${CLEAR}`);
-
 		const { InstanceCredentialBroker } = await import(
 			'@/credentials/instance-credential-broker.js'
 		);
@@ -48,6 +38,7 @@ export class InstanceAiModule implements ModuleInterface {
 		if (Container.get(GlobalConfig).instanceAi.durableLog) {
 			const { InterruptedRunSweeper } = await import('./event-bus/interrupted-run-sweeper.js');
 			const { InstanceAiService } = await import('./instance-ai.service.js');
+			const logger = Container.get(Logger).scoped('instance-ai');
 			const sweeper = Container.get(InterruptedRunSweeper);
 			sweeper.setResumeHost(Container.get(InstanceAiService));
 			void sweeper.sweep().catch((error: unknown) => {

--- a/packages/testing/playwright/pages/n8nPage.ts
+++ b/packages/testing/playwright/pages/n8nPage.ts
@@ -239,7 +239,19 @@ export class n8nPage {
 		this.clipboard = new ClipboardHelper(page);
 	}
 
+	/**
+	 * Navigate to the workflow overview. Goes there directly rather than via `/`,
+	 * because the root route lands users on the AI Assistant when the `instance-ai`
+	 * module is active. Use {@link goToRoot} to exercise that root routing itself.
+	 */
 	async goHome() {
+		await this.page.goto('/home/workflows');
+	}
+
+	/**
+	 * Navigate to the app root and let it decide where the user lands.
+	 */
+	async goToRoot() {
 		await this.page.goto('/');
 	}
 }

--- a/packages/testing/playwright/tests/e2e/auth/authenticated.spec.ts
+++ b/packages/testing/playwright/tests/e2e/auth/authenticated.spec.ts
@@ -6,17 +6,19 @@ test.describe(
 		annotation: [{ type: 'owner', description: 'Identity & Access' }],
 	},
 	() => {
+		// Every signed-in role holds `instanceAi:message`, so the root route lands
+		// them on the AI Assistant while the `instance-ai` module is active.
 		const testCases = [
-			{ role: 'default', expectedUrl: /\/workflow/, auth: '' },
-			{ role: 'owner', expectedUrl: /\/workflow/, auth: '@auth:owner' },
-			{ role: 'admin', expectedUrl: /\/workflow/, auth: '@auth:admin' },
-			{ role: 'member', expectedUrl: /\/workflow/, auth: '@auth:member' },
+			{ role: 'default', expectedUrl: /\/assistant/, auth: '' },
+			{ role: 'owner', expectedUrl: /\/assistant/, auth: '@auth:owner' },
+			{ role: 'admin', expectedUrl: /\/assistant/, auth: '@auth:admin' },
+			{ role: 'member', expectedUrl: /\/assistant/, auth: '@auth:member' },
 			{ role: 'none', expectedUrl: /\/signin/, auth: '@auth:none' },
 		];
 
 		for (const { role, expectedUrl, auth } of testCases) {
 			test(`${role} authentication ${auth}`, async ({ n8n }) => {
-				await n8n.goHome();
+				await n8n.goToRoot();
 				await expect(n8n.page).toHaveURL(expectedUrl);
 			});
 		}

--- a/packages/testing/playwright/tests/e2e/auth/signin.spec.ts
+++ b/packages/testing/playwright/tests/e2e/auth/signin.spec.ts
@@ -8,7 +8,7 @@ test.describe(
 	},
 	() => {
 		test('should login and logout @auth:none', async ({ n8n }) => {
-			await n8n.goHome();
+			await n8n.goToRoot();
 
 			await n8n.signIn.goto();
 

--- a/packages/testing/playwright/tests/e2e/chat-hub/chat-hub-chat-user.spec.ts
+++ b/packages/testing/playwright/tests/e2e/chat-hub/chat-hub-chat-user.spec.ts
@@ -22,8 +22,8 @@ test.describe(
 				},
 			});
 
-			await n8n.goHome();
-			await n8n.page.waitForURL('/home/chat'); // home is chat UI for chat users
+			await n8n.goToRoot();
+			await n8n.page.waitForURL('/home/chat'); // root is the chat UI for chat users
 
 			// Verify global credential is available and pre-selected
 			await expect(n8n.chatHubChat.getModelSelectorButton()).toContainText(/claude/i); // pre-selected


### PR DESCRIPTION
## Summary

Make the new `instance-ai` module enabled by default instead of requiring it to be turned on explicitely with `N8N_ENABLED_MODULES=instance-ai`.

The module can be turned off with `N8N_DISABLED_MODULES=instance-ai`, and the feature can also be disabled at runtime through the settings by admins, but that leaves the module loaded.

This change will (probably) go live next week, at version `2.35.0`.

## How to test

Try running n8n locally and see how `N8N_DISABLED_MODULES=instance-ai` behaves, and that instance-ai module gets loaded even without `N8N_ENABLED_MODULES=instance-ai`.

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1070/make-instance-ai-module-enabled-by-default-and-remove-experimental

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

