### PR TITLE
refactor(core): Add deprecation warning for N8N_WORKFLOW_TAGS_DISABLED

### DIFF
--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -69,6 +69,10 @@ describe('DeprecationService', () => {
 		['N8N_DEFAULT_BINARY_DATA_MODE', 'filesystem', false],
 		['N8N_EXPRESSION_ENGINE', 'legacy', true],
 		['N8N_EXPRESSION_ENGINE', 'vm', false],
+		['N8N_WORKFLOW_TAGS_DISABLED', 'true', true],
+		['N8N_WORKFLOW_TAGS_DISABLED', '1', true],
+		['N8N_WORKFLOW_TAGS_DISABLED', 'false', false],
+		['N8N_WORKFLOW_TAGS_DISABLED', undefined, false],
 	])('should detect when %s is `%s`', (envVar, value, mustWarn) => {
 		toTest(envVar, value, mustWarn);
 	});

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -104,6 +104,13 @@ export class DeprecationService {
 			checkValue: (value?: string) => value === 'default',
 		},
 		{
+			envVar: 'N8N_WORKFLOW_TAGS_DISABLED',
+			message:
+				'Disabling workflow tags is deprecated. Tags will always be enabled in a future version and this environment variable will be removed, so the tags feature will become visible again after upgrading.',
+			checkValue: (value?: string) =>
+				value !== undefined && ['true', '1'].includes(value.toLowerCase()),
+		},
+		{
 			envVar: 'EXECUTIONS_PROCESS',
 			message: SAFE_TO_REMOVE,
 			checkValue: (value: string | undefined) => value !== undefined && value !== 'own',


### PR DESCRIPTION
## Summary

Adds a startup deprecation warning for the `N8N_WORKFLOW_TAGS_DISABLED` environment variable, as part of the v3 breaking-changes preparation. Tags will always be enabled in a future major version and the variable will be removed.

The warning only fires when the variable actually disables tags (`true` or `1`). Instances that don't set it, or that set it to `false`, don't get a warning.

## How to test

1. Start n8n with `N8N_WORKFLOW_TAGS_DISABLED=true` and check the startup log for the deprecation warning.
2. Start n8n without the variable (or with `N8N_WORKFLOW_TAGS_DISABLED=false`) and confirm there is no warning.

Both cases are covered by unit tests in `deprecation.service.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

Internal: [v3 breaking changes tracker entry](https://app.notion.com/p/38b5b6e0c94f80cb89d4cdef8ab32331)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

