### PR TITLE
fix(core): Sanitize the browser PostHog session header (no-changelog)

### DIFF
--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -1,5 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
+import type { Application, Request, RequestHandler, Response } from 'express';
 import { InstanceSettings } from 'n8n-core';
 import type { FeatureFlags } from 'n8n-workflow';
 import { PostHog } from 'posthog-node';
@@ -295,6 +296,97 @@ describe('PostHog', () => {
 
 				expect(flags).toEqual({ '101_agent_evals': true });
 			});
+		});
+	});
+
+	describe('setupExpressSessionContext', () => {
+		function createApp() {
+			const handlers: RequestHandler[] = [];
+			const app = {
+				use: (handler: RequestHandler) => handlers.push(handler),
+			} as unknown as Application;
+
+			return { app, handlers };
+		}
+
+		function createRequest(sessionId?: string) {
+			return { get: () => sessionId } as unknown as Request;
+		}
+
+		async function setupWithApp() {
+			const ph = new PostHogClient(instanceSettings, globalConfig);
+			await ph.init();
+
+			const { app, handlers } = createApp();
+			ph.setupExpressSessionContext(app);
+
+			return handlers;
+		}
+
+		beforeEach(() => {
+			globalConfig.deployment.type = 'cloud';
+			(PostHog.prototype.withContext as Mock).mockImplementation(
+				(_context: unknown, fn: () => unknown) => fn(),
+			);
+		});
+
+		it('attaches the browser session ID to the PostHog context', async () => {
+			const [handler] = await setupWithApp();
+			const next = vi.fn();
+
+			void handler(createRequest('0192f1c2-session'), mock<Response>(), next);
+
+			expect(PostHog.prototype.withContext).toHaveBeenCalledWith(
+				{ sessionId: '0192f1c2-session' },
+				next,
+			);
+			expect(next).toHaveBeenCalled();
+		});
+
+		it('passes the request through when the session header is absent', async () => {
+			const [handler] = await setupWithApp();
+			const next = vi.fn();
+
+			void handler(createRequest(undefined), mock<Response>(), next);
+
+			expect(PostHog.prototype.withContext).not.toHaveBeenCalled();
+			expect(next).toHaveBeenCalled();
+		});
+
+		it('strips non-printable characters from the session ID', async () => {
+			const [handler] = await setupWithApp();
+			const next = vi.fn();
+
+			// A NUL and a newline, spelled out so they survive a trip through an editor.
+			const hostile = `0192${String.fromCharCode(0)}-abc${String.fromCharCode(10)}`;
+
+			void handler(createRequest(hostile), mock<Response>(), next);
+
+			expect(PostHog.prototype.withContext).toHaveBeenCalledWith({ sessionId: '0192-abc' }, next);
+		});
+
+		it('caps the length of the session ID', async () => {
+			const [handler] = await setupWithApp();
+			const next = vi.fn();
+
+			void handler(createRequest('a'.repeat(1500)), mock<Response>(), next);
+
+			expect(PostHog.prototype.withContext).toHaveBeenCalledWith(
+				{ sessionId: 'a'.repeat(1000) },
+				next,
+			);
+		});
+
+		it('does not register the middleware outside cloud deployments', async () => {
+			globalConfig.deployment.type = 'default';
+
+			expect(await setupWithApp()).toHaveLength(0);
+		});
+
+		it('does not register the middleware when diagnostics are disabled', async () => {
+			globalConfig.diagnostics.enabled = false;
+
+			expect(await setupWithApp()).toHaveLength(0);
 		});
 	});
 });

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -20,6 +20,13 @@ const POSTHOG_GROUP_TYPE_INSTANCE = 'company';
 
 const FLAGS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
+const SESSION_ID_MAX_LENGTH = 1000;
+
+function sanitizeSessionId(value: string | undefined): string | undefined {
+	const sanitized = value?.replace(/[^\x20-\x7E]/g, '').trim();
+	return sanitized ? sanitized.slice(0, SESSION_ID_MAX_LENGTH) : undefined;
+}
+
 interface CachedFlags {
 	flags: FeatureFlags;
 	expiresAt: number;
@@ -53,7 +60,7 @@ export class PostHogClient {
 		if (!postHog || this.globalConfig.deployment.type !== 'cloud') return;
 
 		app.use((req, _res, next) => {
-			const sessionId = req.get('x-posthog-session-id');
+			const sessionId = sanitizeSessionId(req.get('x-posthog-session-id'));
 			if (!sessionId) return next();
 
 			postHog.withContext({ sessionId }, next);

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
@@ -188,6 +188,34 @@ describe('Posthog store', () => {
 			);
 		});
 
+		it('does not request tracing headers when session recording is disabled', () => {
+			const posthog = usePostHog();
+			posthog.init();
+
+			expect(window.posthog?.init).toHaveBeenCalledWith(
+				DEFAULT_POSTHOG_SETTINGS.apiKey,
+				expect.not.objectContaining({
+					tracing_headers: expect.anything(),
+				}),
+			);
+		});
+
+		it('requests tracing headers for the REST host when session recording is enabled', () => {
+			setSettings({
+				posthog: { ...DEFAULT_POSTHOG_SETTINGS, disableSessionRecording: false },
+			});
+
+			const posthog = usePostHog();
+			posthog.init();
+
+			expect(window.posthog?.init).toHaveBeenCalledWith(
+				DEFAULT_POSTHOG_SETTINGS.apiKey,
+				expect.objectContaining({
+					tracing_headers: [window.location.hostname],
+				}),
+			);
+		});
+
 		it('should identify user', () => {
 			const posthog = usePostHog();
 			posthog.init();


### PR DESCRIPTION
## Summary

Follow-up to #35613, stacked on top of it. Review that one first.

The session ID arrives in a header the client controls, and #35613 forwards whatever it receives straight into `$session_id` on every backend event for that request. This bounds the value at 1000 characters and drops anything outside printable ASCII. posthog-node applies the same sanitization in its own tracing-header helper (`sanitizeTracingHeaderValue`), but keeps it in a module the package does not export, hence the small local copy.

It also writes down two decisions that currently read as arbitrary. Neither is recoverable from the code:

posthog-node exports `setupExpressRequestContext(client, app)`, which is this middleware, already written and already sanitized. We do not use it because it also adopts the browser's distinct ID and attaches `$ip` and `$user_agent` to every backend event. Sending those would cut against an existing deliberate choice: `Telemetry.track` overwrites the IP with `0.0.0.0` on its way out, with a comment saying that is to stop the analytics backend from using the user's real one. (`user_agent` does appear in `telemetry.event-relay.ts` for `public-api-invoked`, but that path runs through `trackApiInvocation`, which returns early unless RudderStack is configured and never reaches PostHog.) A telemetry-plumbing PR is the wrong place to reverse that, and without a comment saying so the obvious cleanup is to swap in the SDK helper and start shipping client IPs by accident.

The `deployment.type === 'cloud'` check looks redundant with the frontend only setting `tracing_headers` when Session Replay is on, since both resolve to the same condition. It is not redundant. Diagnostics default to n8n's own PostHog project (`ph.n8n.io`), so without that check any self-hosted instance on the internet would accept a forged session ID into n8n's production analytics. The frontend gate saves useless bytes; the backend gate is the part a client cannot bypass.

Finally, coverage. #35613 had none and codecov reported 0% patch coverage on it. This adds 6 backend tests over the middleware (context attach, passthrough when the header is absent, sanitization, the length cap, and both registration gates) and 2 frontend tests over the `tracing_headers` option.

A well-behaved browser sees no change in behaviour.

## How to test

```
pnpm --filter n8n test src/posthog/__tests__/posthog.test.ts
pnpm --filter n8n-editor-ui test src/app/stores/posthog.store.test.ts
```

I mutation-checked both suites rather than trusting a green run: reverting the sanitizer to an identity function fails the sanitization test, and removing the frontend gate fails the negative tracing-headers test.

Also verified against the upstream sources while reviewing #35613, in case it saves anyone else the trip: `tracing_headers` is the current posthog-js option name (`addTracingHeaders` and `__add_tracing_headers` are deprecated aliases it falls back to), the browser injects all three `X-POSTHOG-*` headers that the CORS change allows, relative request URLs are resolved against `window.location.href` before the hostname match, and posthog-node only applies the context session ID when the event has not set `$session_id` itself.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-545

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


