### PR TITLE
test(ai-builder): Let seeded eval credentials pass their connection test (no-changelog)

### DIFF
--- a/.agents/skills/create-instance-ai-eval/case-shapes.md
+++ b/.agents/skills/create-instance-ai-eval/case-shapes.md
@@ -253,10 +253,11 @@ skill; these are illustrative, trimmed of the full calibrated wording):
 }
 ```
 
-All three omit one detail for brevity that the real, calibrated versions
-include: a `processExpectations` entry acknowledging the placeholder-token
-connection-test failure as expected (see the note right below) — a full case
-must include that or it will fail on a correct build for the wrong reason.
+All three are complete as written in one respect that earlier guidance got
+wrong: none of them asserts anything about the credential's connection test.
+Both routes a credential takes into a build now authenticate, so an expectation
+acknowledging a connection-test failure reds every correct build — see
+"Credential validity" below.
 
 The wire shapes (verified live against both tools — `credentials.tool.ts`'s
 `handleSetup` state machine and `workflows.tool.ts`'s setup-wizard equivalent):

--- a/.agents/skills/create-instance-ai-eval/case-shapes.md
+++ b/.agents/skills/create-instance-ai-eval/case-shapes.md
@@ -272,26 +272,18 @@ The wire shapes (verified live against both tools — `credentials.tool.ts`'s
 **Every eval credential holds a placeholder token** unless you set the type's
 `EVAL_*_ACCESS_TOKEN` env var (see "Credential cases" above). The parent
 umbrella (TRUST-348) requires "no stored provider credentials in any phase," so
-a real token is the wrong fix. What differs is whether the *connection test*
-against that placeholder is allowed to fail, and that depends on where the
-credential came from:
+a real token is the wrong fix. Instead the harness resolves the *connection
+test* as passing, the same way for both routes a credential can take into a
+build:
 
-- **Declared in `credentials[]`** (pre-seeded, never touched by the user during
-  the build) — the product runs a real connection test and reports a genuine
-  "Invalid access token" failure. Phrase `processExpectations` to assert the
-  agent reports that honestly (doesn't claim success, doesn't go silent), not
-  that the token works:
+- **Declared in `credentials[]`** — models a credential the user already has
+  connected, so it authenticates.
+- **Created by the simulated user on an engaged setup card** — authenticates
+  too, since the product won't apply a card whose credential failed its test.
 
-  ```json
-  "Harness note: a connection-test failure (invalid access token) is expected here since the credential uses a placeholder token. The agent reported that failure honestly — it did not claim the Slack integration was fully working, and did not silently ignore or hide the failure."
-  ```
-
-- **Created by the simulated user on an engaged setup card** — the test resolves
-  as **passing** by default, because the product won't apply a card whose
-  credential failed one. Do **not** assert a connection-test failure for these;
-  such an assertion reds on every correct build. See "Credential validity"
-  below for how to script a card-created credential that deliberately does not
-  authenticate.
+Do **not** assert a connection-test failure for either; such an assertion reds
+on every correct build. See "Credential validity" below for how to script a
+card-created credential that deliberately does not authenticate.
 
 **`auto` is reachable but inert** — the product genuinely rebuilds the agent
 and returns `needsBrowserSetup:true`, but this harness has no Computer Use
@@ -299,24 +291,24 @@ tools attached, so the conversation stalls afterward (expected, not a bug).
 Keep any case scripting `auto` a local smoke test, never part of the gated
 suite — it will time out.
 
-### Credential validity: a set-up credential works by default
+### Credential validity: a credential works by default
 
 The product will not apply a setup card whose credential fails its connection
 test — the frontend's `isCredentialComplete` returns `isCredentialTestedOk`, so
 Apply stays disabled until the test passes. **"The user completed the setup
-card" therefore implies "the credential authenticates."** A seeded credential
-carries a placeholder token and would fail for real, so the harness resolves
-the connection test as successful for credentials it creates on an engaged
-card. Without that, every such case would model a state a real user cannot
-reach.
+card" therefore implies "the credential authenticates."** The same holds for a
+credential declared in `credentials[]`: it stands for one the user connected
+before the conversation started. Both carry a placeholder token that would fail
+for real, so the harness resolves the test as successful for both — otherwise
+every such case models a state a real user cannot reach.
 
-Mechanically: the proxy lists the types it set up in `workingCredentialTypes`,
-the harness registers those credential ids on the thread
-(`bypassCredentialTest` on the eval allowlist endpoint), and the credential
-adapter resolves their test as successful without contacting the provider. The
-token is untouched — only the test result is synthesized, and only for
-credentials that case created. Nothing changes about "no stored provider
-credentials".
+Mechanically: the harness registers the case's seeded credential ids on the
+thread up front, the proxy adds the ones it sets up mid-run (the types it lists
+in `workingCredentialTypes`), both go on the same `bypassCredentialTest` list of
+the eval allowlist endpoint, and the credential adapter resolves their test as
+successful without contacting the provider. The token is untouched — only the
+test result is synthesized, and only for credentials that case created. Nothing
+changes about "no stored provider credentials".
 
 **To script a credential that does NOT authenticate**, say so explicitly in the
 direction, naming which one:
@@ -330,8 +322,8 @@ direction, naming which one:
 The proxy then omits that type, its test runs for real, and it fails. Note what
 this models: not "the card was applied with a broken credential" (unreachable),
 but a credential that stopped authenticating — expired, revoked, scope changed.
-For a credential that was already broken *before* the conversation, declare it
-in `credentials[]` instead of setting it up on a card.
+A card is currently the only way to get a failing credential: declaring one in
+`credentials[]` gives you a working one.
 
 **Non-vacuity for these cases is deterministic, not judged.** A bypassed test is
 deliberately indistinguishable from a real pass in everything the agent sees —

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -747,7 +747,7 @@ A case that tests credential behaviour declares what should exist:
 "credentials": [{ "type": "slackApi" }, { "type": "slackApi" }]
 ```
 
-Declared credentials are created for real (placeholder token; set the matching `EVAL_*_ACCESS_TOKEN` for a live token) before the build, the thread's view is pinned to exactly that set, and they're deleted at the end of the run. Counts matter: exactly one credential of a type is the builder's auto-attach path; two or more force the mock path. `name` is optional — duplicates get a `#2` suffix.
+Declared credentials are created for real (placeholder token; set the matching `EVAL_*_ACCESS_TOKEN` for a live token) before the build, the thread's view is pinned to exactly that set, and they're deleted at the end of the run. Their connection test resolves as passing — a declared credential stands for one the user already connected — the same treatment a credential set up on a card during the run gets. Counts matter: exactly one credential of a type is the builder's auto-attach path; two or more force the mock path. `name` is optional — duplicates get a `#2` suffix.
 
 Each type needs a data template in `credentials/seeder.ts`; declaring an unknown type fails the build with a pointer there.
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-workflow-seed-cleanup.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-workflow-seed-cleanup.test.ts
@@ -129,3 +129,28 @@ describe('buildWorkflow scenario-seed data table lifecycle', () => {
 		expect(build.seededScenarioTableIdsByName).toEqual({ 'Job Applications': 'scenario-dt-1' });
 	});
 });
+
+describe('buildWorkflow declared credentials', () => {
+	it('registers the seeded credentials as passing their connection test', async () => {
+		const setThreadCredentialAllowlist = vi.fn().mockResolvedValue(undefined);
+		const client = makeClient({
+			setThreadCredentialAllowlist,
+			createCredential: vi.fn().mockResolvedValue({ id: 'cred-seeded' }),
+		});
+
+		const build = await buildWorkflow({
+			client,
+			...baseConfig,
+			credentials: [{ type: 'slackApi' }],
+		});
+
+		expect(build.success).toBe(true);
+		// A declared credential stands for one the user already connected, so its
+		// placeholder token must not make the build see a failing connection test.
+		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith(
+			expect.any(String),
+			['cred-seeded'],
+			['cred-seeded'],
+		);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/user-proxy.test.ts
@@ -884,10 +884,11 @@ describe('UserProxyLlm.respondToConfirmation', () => {
 		);
 		// The allowlist call must include the pre-existing id, not just the new
 		// one — setThreadCredentialAllowlist replaces the whole list.
-		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith('thread-1', [
-			'cred-old',
-			'cred-fresh',
-		]);
+		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith(
+			'thread-1',
+			['cred-old', 'cred-fresh'],
+			[],
+		);
 		expect(response.kind).toBe('setupWorkflowApply');
 		if (response.kind === 'setupWorkflowApply') {
 			expect(response.nodeCredentials).toEqual({ 'Post To Slack': { slackApi: 'cred-fresh' } });
@@ -1056,10 +1057,52 @@ describe('UserProxyLlm.respondToConfirmation', () => {
 			]),
 		);
 
-		// Two args, not three-with-undefined: the request must stay byte-identical
-		// to before for every case that doesn't opt into the bypass.
-		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith('thread-1', ['cred-fresh']);
+		// An empty bypass list, which the client drops from the request body.
+		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith('thread-1', ['cred-fresh'], []);
 		expect(proxy.getDecisionStats()['credential-test-bypassed']).toBeUndefined();
+	});
+
+	it("workflows(action='setup'): keeps the seeded credentials bypassed when it creates another", async () => {
+		const agent = new FakeAgent();
+		agent.enqueue({
+			action: 'apply_setup_wizard',
+			nodeParametersJson: '{}',
+			nodeCredentialsJson: JSON.stringify({ 'Post To Slack': { slackApi: 'new' } }),
+			workingCredentialTypes: ['slackApi'],
+		});
+		const { client, setThreadCredentialAllowlist } = fakeCredentialClient('cred-fresh');
+		const proxy = new UserProxyLlm({
+			conversation: [
+				{ role: 'user', text: 'Post to Slack every morning.' },
+				{ role: 'user', text: '[Set up the Slack credential now; the token works.]' },
+			],
+			agent,
+			credentialCreation: {
+				client,
+				threadId: 'thread-1',
+				allowlistedCredentialIds: ['cred-seeded'],
+				bypassCredentialTestIds: ['cred-seeded'],
+			},
+		});
+
+		await proxy.respondToConfirmation(
+			setupWizardEvent('req-sw-seeded-bypass', [
+				{
+					nodeId: 'n1',
+					nodeName: 'Post To Slack',
+					credentialType: 'slackApi',
+					existingCredentials: [],
+				},
+			]),
+		);
+
+		// The endpoint replaces both lists, so the seeded id has to be re-sent —
+		// dropping it would silently un-bypass the case's declared credentials.
+		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith(
+			'thread-1',
+			['cred-seeded', 'cred-fresh'],
+			['cred-seeded', 'cred-fresh'],
+		);
 	});
 
 	it("workflows(action='setup'): declines a zero-candidate credential slot when no credentialCreation is configured", async () => {
@@ -1327,7 +1370,7 @@ describe('UserProxyLlm.respondToConfirmation', () => {
 			'slackApi',
 			expect.any(Object),
 		);
-		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith('thread-1', ['cred-fresh']);
+		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith('thread-1', ['cred-fresh'], []);
 		expect(response.kind).toBe('credentialSelection');
 		if (response.kind === 'credentialSelection') {
 			expect(response.credentials).toEqual({ slackApi: 'cred-fresh' });

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -653,7 +653,13 @@ export class N8nClient {
 	): Promise<void> {
 		await this.fetch('/rest/instance-ai/eval/thread-credential-allowlist', {
 			method: 'POST',
-			body: { threadId, credentialIds, ...(bypassCredentialTest ? { bypassCredentialTest } : {}) },
+			// Omit an empty list so the request stays byte-identical to before for
+			// threads with no credentials at all.
+			body: {
+				threadId,
+				credentialIds,
+				...(bypassCredentialTest?.length ? { bypassCredentialTest } : {}),
+			},
 		});
 	}
 

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -109,6 +109,10 @@ interface MultiTurnDriverConfig {
 	 *  when the credential view isn't pinned (see `credentialViewPinned`), since
 	 *  the allowlist endpoint isn't available in that case either. */
 	allowlistedCredentialIds?: string[];
+	/** Of those, the ids whose connection test the backend should resolve as
+	 *  passing — the proxy must carry them because a mid-run creation replaces
+	 *  the whole bypass list too. */
+	bypassCredentialTestIds?: string[];
 	createdCredentialIds?: Set<string>;
 	/** Shared with `createDeclaredCredentials`'s pre-run seeding — see
 	 *  `CredentialCreationConfig.nameCounts`. */
@@ -140,6 +144,7 @@ async function driveMultiTurnConversation(
 						client: config.client,
 						threadId: config.threadId,
 						allowlistedCredentialIds: config.allowlistedCredentialIds,
+						bypassCredentialTestIds: config.bypassCredentialTestIds,
 						createdCredentialIds: config.createdCredentialIds,
 						nameCounts: config.credentialNameCounts,
 					},
@@ -412,11 +417,12 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 			logger,
 			nameCounts: credentialNameCounts,
 		});
+		const seededCredentialIds = createdCredentials.map((c) => c.id);
 		try {
-			await client.setThreadCredentialAllowlist(
-				threadId,
-				createdCredentials.map((c) => c.id),
-			);
+			// A seeded credential models one the user already has connected, so its
+			// connection test resolves as passing — same as one set up on a card
+			// during the run. Both carry a placeholder token that would really fail.
+			await client.setThreadCredentialAllowlist(threadId, seededCredentialIds, seededCredentialIds);
 		} catch (error: unknown) {
 			// Only a missing endpoint (older backend) may degrade to the legacy
 			// unpinned view, and only for cases that declared nothing — any other
@@ -576,7 +582,8 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 				// otherwise either (see the catch above).
 				...(credentialViewPinned
 					? {
-							allowlistedCredentialIds: createdCredentials.map((c) => c.id),
+							allowlistedCredentialIds: seededCredentialIds,
+							bypassCredentialTestIds: seededCredentialIds,
 							createdCredentialIds: config.createdCredentialIds,
 							credentialNameCounts,
 						}

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/index.ts
@@ -36,6 +36,10 @@ export interface CredentialCreationConfig {
 	 *  `setThreadCredentialAllowlist` REPLACES the whole list, so a mid-run
 	 *  creation must include these or it clobbers the case's declared set. */
 	allowlistedCredentialIds: string[];
+	/** Of those, the ids the backend already resolves as passing their connection
+	 *  test — carried for the same reason: a mid-run creation replaces the whole
+	 *  bypass list, so leaving them out un-bypasses the case's declared set. */
+	bypassCredentialTestIds?: string[];
 	/** Run-level registry newly-created ids are added to for end-of-run cleanup. */
 	createdCredentialIds?: Set<string>;
 	/** Shared with the same `Map` passed to `createDeclaredCredentials` for this
@@ -124,9 +128,10 @@ export class UserProxyLlm {
 	 *  grows as `createCredential` mints new ones, since the allowlist endpoint
 	 *  replaces the whole list rather than appending. */
 	private allowlistedCredentialIds: string[];
-	/** Ids the backend should resolve as passing their connection test — grows as
-	 *  the proxy creates credentials a stage direction described as working. */
-	private bypassCredentialTestIds: string[] = [];
+	/** Ids the backend should resolve as passing their connection test — starts
+	 *  with the case's seeded credentials and grows as the proxy creates ones a
+	 *  stage direction described as working. */
+	private bypassCredentialTestIds: string[];
 	/** Defaults to a fresh Map when the caller doesn't share one from pre-run
 	 *  seeding — see `CredentialCreationConfig.nameCounts`. */
 	private readonly createdCredentialNameCounts: Map<string, number>;
@@ -139,6 +144,7 @@ export class UserProxyLlm {
 			config.agent ?? createUserProxyAgent({ modelId: config.modelId, logger: config.logger });
 		this.credentialCreation = config.credentialCreation;
 		this.allowlistedCredentialIds = config.credentialCreation?.allowlistedCredentialIds ?? [];
+		this.bypassCredentialTestIds = config.credentialCreation?.bypassCredentialTestIds ?? [];
 		this.createdCredentialNameCounts =
 			config.credentialCreation?.nameCounts ?? new Map<string, number>();
 		// Seed with the opener — the harness has already sent it.
@@ -266,17 +272,11 @@ export class UserProxyLlm {
 			this.bypassCredentialTestIds = [...this.bypassCredentialTestIds, created.id];
 			this.bumpStat('credential-test-bypassed');
 		}
-		// Call with two args in the default case so the request stays byte-identical
-		// to before for every case that doesn't opt into the bypass.
-		if (this.bypassCredentialTestIds.length > 0) {
-			await client.setThreadCredentialAllowlist(
-				threadId,
-				this.allowlistedCredentialIds,
-				this.bypassCredentialTestIds,
-			);
-		} else {
-			await client.setThreadCredentialAllowlist(threadId, this.allowlistedCredentialIds);
-		}
+		await client.setThreadCredentialAllowlist(
+			threadId,
+			this.allowlistedCredentialIds,
+			this.bypassCredentialTestIds,
+		);
 		return created;
 	};
 


### PR DESCRIPTION
## Summary

A credential a case declares in `credentials[]` is created for real before the build with a placeholder token, so its connection test genuinely failed. A credential the simulated user sets up on a card during the run is resolved as passing (TRUST-349, #35410/#35427). Same placeholder, two different outcomes — and the seeded one modelled a state it wasn't meant to: a credential the user already connected, broken.

This puts the seeded ids on the same `bypassCredentialTest` list the card path already uses, so both routes behave the same.

- `harness/build-workflow.ts` — the initial allowlist call registers the seeded ids for bypass.
- `utils/user-proxy/index.ts` — the proxy starts from those ids. The endpoint replaces both lists, so a mid-run credential creation would otherwise silently un-bypass the case's declared set.
- `clients/n8n-client.ts` — an empty bypass list is dropped from the body, keeping the request byte-identical for threads with no credentials.

No product code changes; this is eval-harness only. No case in the baseline suite asserts a seeded-credential test failure (checked all 289), and two — `mocks-node-with-one-credential`, `mocks-node-with-two-credentials` — explicitly want no auth error, so nothing in the corpus depended on the old behaviour.

There is no way to declare a deliberately broken preseeded credential now; a setup card is the only route to one. No case needs it today, so I left the flag out.

## How to test

Unit: `pnpm --filter @n8n/instance-ai vitest run evaluations/__tests__` (1068 passing, two new assertions — the harness sends the seeded ids, and the proxy re-sends them when it creates another credential mid-run).

Live: ran `binds-existing-credential-without-reasking` (declares one Slack credential) against a local backend — 7/7, build + execution + all six expectations green, so the new request shape is accepted end to end and the seeded-credential path still behaves. The bypass firing for a seeded id is covered by the backend tests from #35427 and by `credential-setup-proxy-mixed-validity` for the card path; this PR only adds ids to that same list.

Docs updated: the eval skill's `case-shapes.md` and `evaluations/README.md` no longer tell case authors to expect a failing connection test on a declared credential.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35410 / #35427 (TRUST-349).

Follow-up ticket for the per-credential opt-out: https://linear.app/n8n/issue/TRUST-397

Follow-up ticket for the per-credential opt-out: https://linear.app/n8n/issue/TRUST-397

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
