### PR TITLE
fix(Github Node): Revalidate pull request reads with ETag conditional requests

### DIFF
--- a/packages/nodes-base/nodes/Github/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Github/GenericFunctions.ts
@@ -9,6 +9,90 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
+// Maximum number of ETag entries retained in workflow static data. Bounds the
+// growth of the conditional-request cache for workflows that read many
+// different resources over their lifetime.
+const ETAG_CACHE_LIMIT = 100;
+
+// Per-entry and total byte budgets for the conditional-request cache. Entry
+// count alone does not bound memory (or the size of the persisted static data),
+// so a single large response — or many medium ones — could still grow it
+// without limit. A body larger than the per-entry budget is not cached at all;
+// the total budget evicts oldest entries until the cache fits.
+const ETAG_CACHE_MAX_ENTRY_BYTES = 1024 * 1024; // 1 MiB
+const ETAG_CACHE_MAX_TOTAL_BYTES = 8 * 1024 * 1024; // 8 MiB
+
+interface GithubEtagEntry {
+	etag: string;
+	body: unknown;
+	// Optional so eviction stays correct if a future entry shape omits it; every
+	// entry written here records it (this PR introduces the cache, so no persisted
+	// entry is missing it today).
+	bytes?: number;
+}
+
+// Approximate serialized size of a cache entry. The body is measured as UTF-8
+// JSON since that is how it is persisted in workflow static data; a body that
+// cannot be serialized (e.g. a circular structure) is treated as zero so it
+// still counts against the entry-count limit without breaking the request.
+function etagEntryBytes(etag: string, body: unknown): number {
+	let bodyBytes = 0;
+	try {
+		bodyBytes = Buffer.byteLength(JSON.stringify(body) ?? '', 'utf8');
+	} catch {
+		bodyBytes = 0;
+	}
+	return bodyBytes + Buffer.byteLength(etag, 'utf8');
+}
+
+// Size of a cache entry. Every entry this revision writes carries `bytes`, so
+// the fast path returns it directly. The fallback is forward compatibility only:
+// workflow static data outlives n8n upgrades, so a future change to the entry
+// shape could leave `bytes` undefined — recomputing from etag+body keeps the
+// running total finite (a stray undefined would make it NaN and silently disable
+// the byte budget) rather than depending on a not-yet-existing migration.
+function entryBytes(entry: GithubEtagEntry): number {
+	return typeof entry.bytes === 'number' && Number.isFinite(entry.bytes)
+		? entry.bytes
+		: etagEntryBytes(entry.etag, entry.body);
+}
+
+// Evict oldest entries until the cache is within both the entry-count and
+// total-byte budgets. Eviction is deliberately by insertion order (first write),
+// not last use: a 304 returns the cached body without re-inserting the entry, so
+// a steadily-revalidating entry keeps its original position. This bounds memory
+// simply; last-use ordering is not needed for the poll-heavy workloads this cache
+// targets.
+function evictEtagCache(cache: Record<string, GithubEtagEntry>): void {
+	const keys = Object.keys(cache);
+	let total = 0;
+	for (const key of keys) {
+		total += entryBytes(cache[key]);
+	}
+	let index = 0;
+	while (
+		index < keys.length &&
+		(keys.length - index > ETAG_CACHE_LIMIT || total > ETAG_CACHE_MAX_TOTAL_BYTES)
+	) {
+		const oldest = keys[index];
+		total -= entryBytes(cache[oldest]);
+		delete cache[oldest];
+		index++;
+	}
+}
+
+function conditionalRequestKey(credentialType: string, uri: string, qs?: IDataObject): string {
+	const sortedQs = qs
+		? Object.keys(qs)
+				.sort()
+				.reduce<IDataObject>((acc, key) => {
+					acc[key] = qs[key];
+					return acc;
+				}, {})
+		: {};
+	return `${credentialType} ${uri} ${JSON.stringify(sortedQs)}`;
+}
+
 /**
  * Make an API request to Github
  *
@@ -21,6 +105,13 @@ export async function githubApiRequest(
 	query?: IDataObject,
 	option: IDataObject = {},
 ): Promise<any> {
+	// `conditionalRequest` is an internal flag (not a request option) that opts a
+	// GET into ETag / If-None-Match revalidation. It is stripped before the
+	// remaining options are forwarded to the HTTP client.
+	const useConditionalRequest = method === 'GET' && option.conditionalRequest === true;
+	const requestOption = { ...option };
+	delete requestOption.conditionalRequest;
+
 	const options: IRequestOptions = {
 		method,
 		body,
@@ -29,8 +120,8 @@ export async function githubApiRequest(
 		json: true,
 	};
 
-	if (Object.keys(option).length !== 0) {
-		Object.assign(options, option);
+	if (Object.keys(requestOption).length !== 0) {
+		Object.assign(options, requestOption);
 	}
 
 	try {
@@ -61,8 +152,65 @@ export async function githubApiRequest(
 			options.uri = `${baseUrl}${endpoint}`;
 		}
 
-		return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
+		if (!useConditionalRequest) {
+			return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
+		}
+
+		const staticData = this.getWorkflowStaticData('node');
+		const cache =
+			(staticData.githubEtagCache as unknown as Record<string, GithubEtagEntry>) ?? {};
+		staticData.githubEtagCache = cache as unknown as IDataObject;
+
+		const cacheKey = conditionalRequestKey(credentialType, options.uri, query);
+		const cached = cache[cacheKey];
+
+		// Ask the API to revalidate. A 304 Not Modified does not count against the
+		// primary rate limit, so an unchanged resource is served from cache below.
+		options.resolveWithFullResponse = true;
+		options.simple = false;
+		if (cached?.etag) {
+			options.headers = {
+				...(options.headers as IDataObject),
+				'If-None-Match': cached.etag,
+			};
+		}
+
+		const response = await this.helpers.requestWithAuthentication.call(
+			this,
+			credentialType,
+			options,
+		);
+
+		if (response.statusCode === 304 && cached) {
+			return cached.body;
+		}
+
+		if (response.statusCode < 200 || response.statusCode >= 300) {
+			throw new NodeApiError(this.getNode(), {
+				statusCode: response.statusCode,
+				...(response.body as IDataObject),
+			} as JsonObject);
+		}
+
+		const etag = (response.headers?.etag as string) ?? '';
+		if (etag) {
+			// Always drop any stale entry for this key first.
+			delete cache[cacheKey];
+			const bytes = etagEntryBytes(etag, response.body);
+			// A body that on its own exceeds the per-entry budget is left uncached;
+			// storing it would evict many smaller, more reusable entries for one
+			// oversized result that is unlikely to revalidate cheaply.
+			if (bytes <= ETAG_CACHE_MAX_ENTRY_BYTES) {
+				cache[cacheKey] = { etag, body: response.body, bytes };
+				evictEtagCache(cache);
+			}
+		}
+
+		return response.body;
 	} catch (error) {
+		if (error instanceof NodeApiError) {
+			throw error;
+		}
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
 }

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -2419,6 +2419,7 @@ export class Github implements INodeType {
 
 		let requestMethod: IHttpRequestMethods;
 		let endpoint: string;
+		let requestOption: IDataObject = {};
 
 		const operation = this.getNodeParameter('operation', 0);
 		const resource = this.getNodeParameter('resource', 0) as string;
@@ -2485,6 +2486,7 @@ export class Github implements INodeType {
 				endpoint = '';
 				body = {};
 				qs = {};
+				requestOption = {};
 
 				let owner = '';
 				if (fullOperation !== 'user:invite' && fullOperation !== 'user:getUserIssues') {
@@ -2744,6 +2746,10 @@ export class Github implements INodeType {
 
 						const pullRequestNumber = this.getNodeParameter('pullRequestNumber', i);
 						endpoint = `/repos/${owner}/${repository}/pulls/${pullRequestNumber}`;
+
+						// Revalidate with ETag / If-None-Match so an unchanged pull
+						// request is answered with a 304 instead of a full body.
+						requestOption = { conditionalRequest: true };
 					} else if (operation === 'createComment') {
 						// ----------------------------------
 						//         createComment
@@ -3162,7 +3168,14 @@ export class Github implements INodeType {
 						qs,
 					);
 				} else {
-					responseData = await githubApiRequest.call(this, requestMethod, endpoint, body, qs);
+					responseData = await githubApiRequest.call(
+						this,
+						requestMethod,
+						endpoint,
+						body,
+						qs,
+						requestOption,
+					);
 				}
 
 				if (fullOperation === 'file:get') {

--- a/packages/nodes-base/nodes/Github/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/GenericFunctions.test.ts
@@ -25,6 +25,7 @@ const mockExecuteHookFunctions = {
 	getWebhookName: vi.fn(),
 	getWebhookDescription: vi.fn(),
 	getNodeWebhookUrl: vi.fn(),
+	getWorkflowStaticData: vi.fn().mockReturnValue({}),
 	getNode: vi.fn().mockReturnValue({
 		id: 'test-node-id',
 		name: 'test-node',
@@ -34,6 +35,8 @@ const mockExecuteHookFunctions = {
 describe('GenericFunctions', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Fresh conditional-request cache per test.
+		(mockExecuteHookFunctions.getWorkflowStaticData as Mock).mockReturnValue({});
 	});
 
 	describe('githubApiRequest', () => {
@@ -60,6 +63,227 @@ describe('GenericFunctions', () => {
 					json: true,
 				},
 			);
+		});
+
+		it('should send a conditional request and cache the ETag when opted in', async () => {
+			const method = 'GET';
+			const endpoint = '/repos/test-owner/test-repo/pulls/1';
+			const body = {};
+			const staticData: Record<string, unknown> = {};
+			(mockExecuteHookFunctions.getWorkflowStaticData as Mock).mockReturnValue(staticData);
+
+			const pullRequest = { number: 1, title: 'Example' };
+			(mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mockResolvedValue({
+				statusCode: 200,
+				headers: { etag: '"abc123"' },
+				body: pullRequest,
+			});
+
+			const result = await githubApiRequest.call(
+				mockExecuteHookFunctions,
+				method,
+				endpoint,
+				body,
+				undefined,
+				{ conditionalRequest: true },
+			);
+
+			expect(result).toEqual(pullRequest);
+			const call = (mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mock
+				.calls[0][1];
+			// The conditionalRequest flag must not leak into the HTTP options.
+			expect(call.conditionalRequest).toBeUndefined();
+			expect(call.resolveWithFullResponse).toBe(true);
+			expect(call.simple).toBe(false);
+			// First request must not carry a conditional header.
+			expect(call.headers?.['If-None-Match']).toBeUndefined();
+		});
+
+		it('should reuse the cached response on a 304 Not Modified', async () => {
+			const method = 'GET';
+			const endpoint = '/repos/test-owner/test-repo/pulls/1';
+			const body = {};
+			const staticData: Record<string, unknown> = {};
+			(mockExecuteHookFunctions.getWorkflowStaticData as Mock).mockReturnValue(staticData);
+
+			const pullRequest = { number: 1, title: 'Example' };
+			(mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock)
+				.mockResolvedValueOnce({
+					statusCode: 200,
+					headers: { etag: '"abc123"' },
+					body: pullRequest,
+				})
+				.mockResolvedValueOnce({ statusCode: 304, headers: {}, body: '' });
+
+			const first = await githubApiRequest.call(
+				mockExecuteHookFunctions,
+				method,
+				endpoint,
+				body,
+				undefined,
+				{ conditionalRequest: true },
+			);
+			const second = await githubApiRequest.call(
+				mockExecuteHookFunctions,
+				method,
+				endpoint,
+				body,
+				undefined,
+				{ conditionalRequest: true },
+			);
+
+			expect(first).toEqual(pullRequest);
+			// The cached body is served on a 304 instead of the empty response body.
+			expect(second).toEqual(pullRequest);
+
+			const calls = (mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mock.calls;
+			expect(calls[0][1].headers?.['If-None-Match']).toBeUndefined();
+			expect(calls[1][1].headers?.['If-None-Match']).toBe('"abc123"');
+		});
+
+		it('should not cache a response body that exceeds the per-entry byte budget', async () => {
+			const method = 'GET';
+			const endpoint = '/repos/test-owner/test-repo/pulls/1';
+			const body = {};
+			const staticData: Record<string, unknown> = {};
+			(mockExecuteHookFunctions.getWorkflowStaticData as Mock).mockReturnValue(staticData);
+
+			// A body larger than the 1 MiB per-entry budget must not be cached, so a
+			// following request cannot revalidate it and re-fetches in full.
+			const largeBody = { data: 'x'.repeat(1024 * 1024 + 1) };
+			(mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mockResolvedValue({
+				statusCode: 200,
+				headers: { etag: '"big"' },
+				body: largeBody,
+			});
+
+			await githubApiRequest.call(mockExecuteHookFunctions, method, endpoint, body, undefined, {
+				conditionalRequest: true,
+			});
+			await githubApiRequest.call(mockExecuteHookFunctions, method, endpoint, body, undefined, {
+				conditionalRequest: true,
+			});
+
+			const calls = (mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mock.calls;
+			expect(calls[1][1].headers?.['If-None-Match']).toBeUndefined();
+			expect(staticData.githubEtagCache).toEqual({});
+		});
+
+		it('should evict the oldest entry when the total byte budget is exceeded', async () => {
+			const method = 'GET';
+			const body = {};
+			const staticData: Record<string, unknown> = {};
+			(mockExecuteHookFunctions.getWorkflowStaticData as Mock).mockReturnValue(staticData);
+
+			// Each body is just under the 1 MiB per-entry budget; caching nine of them
+			// exceeds the 8 MiB total budget and evicts the oldest (first) entry.
+			const chunk = 'y'.repeat(1000 * 1024);
+			(mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mockImplementation(
+				async (_type: string, options: { uri: string }) => ({
+					statusCode: 200,
+					headers: { etag: `"${options.uri}"` },
+					body: { uri: options.uri, data: chunk },
+				}),
+			);
+
+			for (let i = 0; i < 9; i++) {
+				await githubApiRequest.call(
+					mockExecuteHookFunctions,
+					method,
+					`/repos/test-owner/test-repo/pulls/${i}`,
+					body,
+					undefined,
+					{ conditionalRequest: true },
+				);
+			}
+
+			// The oldest endpoint (0) was evicted, so revalidating it sends no
+			// conditional header; the newest (8) is still cached and does.
+			await githubApiRequest.call(
+				mockExecuteHookFunctions,
+				method,
+				'/repos/test-owner/test-repo/pulls/0',
+				body,
+				undefined,
+				{ conditionalRequest: true },
+			);
+			await githubApiRequest.call(
+				mockExecuteHookFunctions,
+				method,
+				'/repos/test-owner/test-repo/pulls/8',
+				body,
+				undefined,
+				{ conditionalRequest: true },
+			);
+
+			const calls = (mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mock.calls;
+			const reqZero = calls[9][1];
+			const reqEight = calls[10][1];
+			expect(reqZero.uri).toBe('https://api.github.com/repos/test-owner/test-repo/pulls/0');
+			expect(reqZero.headers?.['If-None-Match']).toBeUndefined();
+			expect(reqEight.uri).toBe('https://api.github.com/repos/test-owner/test-repo/pulls/8');
+			expect(reqEight.headers?.['If-None-Match']).toBe(
+				'"https://api.github.com/repos/test-owner/test-repo/pulls/8"',
+			);
+		});
+
+		it('should enforce the byte budget over entries persisted without a byte count', async () => {
+			const method = 'GET';
+			const body = {};
+
+			// Construct entries that lack the per-entry `bytes` field (the fallback
+			// path in entryBytes): ten large entries with `bytes` absent, keyed the
+			// same way githubApiRequest keys them.
+			const chunk = 'z'.repeat(1000 * 1024);
+			const cache: Record<string, unknown> = {};
+			for (let i = 0; i < 10; i++) {
+				const uri = `https://api.github.com/repos/test-owner/test-repo/pulls/legacy-${i}`;
+				cache[`githubApi ${uri} {}`] = { etag: `"legacy-${i}"`, body: chunk };
+			}
+			const oldestLegacyKey = Object.keys(cache)[0];
+			const staticData: Record<string, unknown> = { githubEtagCache: cache };
+			(mockExecuteHookFunctions.getWorkflowStaticData as Mock).mockReturnValue(staticData);
+
+			(mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mockResolvedValue({
+				statusCode: 200,
+				headers: { etag: '"fresh"' },
+				body: { number: 1 },
+			});
+
+			// Writing one fresh entry runs eviction. If the entries' missing
+			// `bytes` poisoned the running total to NaN, the byte budget would be
+			// silently skipped and every entry would survive.
+			await githubApiRequest.call(
+				mockExecuteHookFunctions,
+				method,
+				'/repos/test-owner/test-repo/pulls/fresh',
+				body,
+				undefined,
+				{ conditionalRequest: true },
+			);
+
+			// The byte budget must still apply: the oldest entries are evicted
+			// down to within the 8 MiB total, rather than all eleven surviving.
+			expect(Object.keys(cache).length).toBeLessThanOrEqual(9);
+			expect(cache[oldestLegacyKey]).toBeUndefined();
+		});
+
+		it('should throw a NodeApiError on a non-success conditional response', async () => {
+			const method = 'GET';
+			const endpoint = '/repos/test-owner/test-repo/pulls/1';
+			(mockExecuteHookFunctions.getWorkflowStaticData as Mock).mockReturnValue({});
+
+			(mockExecuteHookFunctions.helpers.requestWithAuthentication as Mock).mockResolvedValue({
+				statusCode: 404,
+				headers: {},
+				body: { message: 'Not Found' },
+			});
+
+			await expect(
+				githubApiRequest.call(mockExecuteHookFunctions, method, endpoint, {}, undefined, {
+					conditionalRequest: true,
+				}),
+			).rejects.toThrow(NodeApiError);
 		});
 
 		it('should throw a NodeApiError on API failure', async () => {

--- a/packages/nodes-base/nodes/Github/__tests__/Github.pullRequest.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/Github.pullRequest.test.ts
@@ -21,6 +21,7 @@ function createMockExecuteFunction(params: Record<string, any>) {
 			return paramName in merged ? merged[paramName] : fallback;
 		}),
 		getInputData: vi.fn().mockReturnValue([{ json: {} }]),
+		getWorkflowStaticData: vi.fn().mockReturnValue({}),
 		getNode: vi.fn().mockReturnValue({
 			id: 'test-node-id',
 			name: 'Github',
@@ -601,17 +602,32 @@ describe('Github Node - Pull Request Operations', () => {
 				operation: 'get',
 				pullRequestNumber: 1,
 			});
-			mock.helpers.requestWithAuthentication.mockResolvedValue(pr);
+			// pullRequest:get uses a conditional request, so the transport returns
+			// the full response and the body is unwrapped by githubApiRequest.
+			mock.helpers.requestWithAuthentication.mockResolvedValue({
+				statusCode: 200,
+				headers: { etag: '"abc123"' },
+				body: pr,
+			});
 
 			const result = await github.execute.call(mock);
 
+			const getCallArgs = mock.helpers.requestWithAuthentication.mock.calls[0][1] as {
+				resolveWithFullResponse?: boolean;
+				simple?: boolean;
+				conditionalRequest?: boolean;
+			};
 			expect(mock.helpers.requestWithAuthentication).toHaveBeenCalledWith(
 				'githubApi',
 				expect.objectContaining({
 					method: 'GET',
 					uri: 'https://api.github.com/repos/test-owner/test-repo/pulls/1',
+					resolveWithFullResponse: true,
+					simple: false,
 				}),
 			);
+			// The internal opt-in flag must not be forwarded as an HTTP option.
+			expect(getCallArgs.conditionalRequest).toBeUndefined();
 			expect(result[0][0].json).toEqual(pr);
 		});
 
@@ -620,7 +636,11 @@ describe('Github Node - Pull Request Operations', () => {
 				operation: 'get',
 				pullRequestNumber: 9999,
 			});
-			mock.helpers.requestWithAuthentication.mockRejectedValue(makeGithubError(404, 'Not Found'));
+			mock.helpers.requestWithAuthentication.mockResolvedValue({
+				statusCode: 404,
+				headers: {},
+				body: { message: 'Not Found' },
+			});
 
 			await expect(github.execute.call(mock)).rejects.toBeInstanceOf(NodeApiError);
 		});
@@ -1058,7 +1078,13 @@ describe('Github Node - Pull Request Operations', () => {
 			const [, op] = fullOp.split(':');
 			const mock = createMockExecuteFunction({ operation: op });
 			mock.helpers.requestWithAuthentication.mockResolvedValue(
-				op === 'getDiff' ? 'diff' : op === 'getPatch' ? 'patch' : { ok: true },
+				op === 'getDiff'
+					? 'diff'
+					: op === 'getPatch'
+						? 'patch'
+						: op === 'get'
+							? { statusCode: 200, headers: {}, body: { ok: true } }
+							: { ok: true },
 			);
 
 			const result = await github.execute.call(mock);


### PR DESCRIPTION
## Summary

The Github node issues every request unconditionally. The `ETag` returned by the GitHub REST API is never stored or replayed, so repeatedly reading a pull request re-downloads the full body each time even when nothing has changed upstream.

This change makes the **Pull Request → Get** operation revalidate with an HTTP conditional request:

- The `ETag` and response body are cached in the node's workflow static data (`getWorkflowStaticData('node')`).
- On the next read of the same pull request, the cached `ETag` is sent as `If-None-Match`.
- When the API answers `304 Not Modified`, the cached body is returned instead of re-downloading it.

Per the [GitHub REST API docs](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#use-conditional-requests-if-appropriate), a `304 Not Modified` does not count against the token's primary rate limit, so repeated reads consume less rate-limit budget and bandwidth while returning identical data.

## Scope & safety

- **Opt-in per operation.** Conditional requests are gated by an internal `conditionalRequest` flag on `githubApiRequest`, stripped before the options reach the HTTP client. Other operations and list pagination are unaffected.
- **Bounded cache.** 100 entries max, oldest evicted, keyed by credential type + URL + query, so entries are never shared across credentials.
- **Error handling unchanged.** Non-success responses still surface as `NodeApiError`.

## How to test

1. Add a **Github** node and select **Pull Request → Get** for a repository/PR you can read.
2. Execute the node twice without changing the pull request upstream.
3. The second execution returns the same data. With request logging enabled, the second request carries an `If-None-Match` header and the API responds `304 Not Modified` (served from cache) rather than a full `200` body.

> **Note:** workflow static data persists between executions of a **saved** workflow (e.g. a scheduled or triggered run), not between ad-hoc manual node executions in the editor. Exercise the two reads within a saved workflow run to observe the `304`; a manual re-execution starts from empty static data and issues a fresh `200` each time.

## Tests

Regression tests added/updated in `packages/nodes-base/nodes/Github/__tests__/`:

- `GenericFunctions.test.ts` — conditional request sends/omits `If-None-Match` correctly, caches the `ETag`, serves the cached body on `304`, keeps the internal flag out of the HTTP options, and throws `NodeApiError` on non-success.
- `Github.pullRequest.test.ts` — `pullRequest:get` now uses the conditional request path.

## Related Linear tickets, Github issues, and Community forum posts

Closes #36083

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. _No docs change needed: `conditionalRequest` is an internal flag on `githubApiRequest` (stripped before the HTTP call) and adds no new node parameter or operation, so the user-facing GitHub node docs are unaffected._
- [x] Tests included.

<!-- This is an auto-generated description by cubic. --> <a href="https://cubic.dev/pr/n8n-io/n8n/pull/35677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a> <!-- End of auto-generated description by cubic. -->


