### PR TITLE
fix(Microsoft SharePoint Node): Require subdomain in OAuth2 credential

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.middleware.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.middleware.ts
@@ -22,12 +22,22 @@ function validateCredentialData(
 	credentialType: string,
 	data: IDataObject,
 	res: express.Response,
+	options?: { partialData?: boolean },
 ): express.Response | void {
 	const properties = Container.get(CredentialsHelper)
 		.getCredentialsProperties(credentialType)
 		.filter((property) => property.type !== 'hidden');
 
 	const schema = toJsonSchema(properties);
+
+	// A partial payload is merged into the stored data after validation, so
+	// key-presence requirements (top-level `required` and conditional `allOf`
+	// blocks) cannot be checked against the payload alone; per-key type checks
+	// still apply.
+	if (options?.partialData) {
+		delete schema.required;
+		delete schema.allOf;
+	}
 
 	const { valid, errors } = validate(data, schema, { nestedErrors: true });
 
@@ -107,7 +117,9 @@ export const validCredentialsPropertiesForUpdate = async (
 		}
 
 		// Validate data against type
-		const validationResult = validateCredentialData(type, data, res);
+		const validationResult = validateCredentialData(type, data, res, {
+			partialData: req.body.isPartialData === true,
+		});
 		if (validationResult) {
 			return validationResult;
 		}

--- a/packages/cli/test/integration/public-api/credentials.test.ts
+++ b/packages/cli/test/integration/public-api/credentials.test.ts
@@ -4,6 +4,7 @@ import { createTeamProject, linkUserToProject, randomName, testDb } from '@n8n/b
 import type { User } from '@n8n/db';
 import { CredentialsRepository, SharedCredentialsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { Snowflake } from 'n8n-nodes-base/credentials/Snowflake.credentials';
 import {
 	CREDENTIAL_BLANKING_VALUE,
 	type ICredentialDataDecryptedObject,
@@ -12,6 +13,7 @@ import {
 import { mock } from 'vitest-mock-extended';
 
 import { CredentialsService } from '@/credentials/credentials.service';
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { CredentialsTester } from '@/services/credentials-tester.service';
 
 import {
@@ -48,6 +50,14 @@ beforeAll(async () => {
 	saveCredential = affixRoleToSaveCredential('credential:owner');
 
 	await utils.initCredentialsTypes();
+
+	// `snowflake` carries a conditionally-required field (`privateKey` under
+	// `authentication: keyPair`), which none of the shared test credential types
+	// do; the partial-update tests below need that schema shape.
+	Container.get(LoadNodesAndCredentials).loaded.credentials.snowflake = {
+		type: new Snowflake(),
+		sourcePath: '',
+	};
 });
 
 beforeEach(async () => {
@@ -1310,6 +1320,41 @@ describe('PATCH /credentials/:id', () => {
 			.send({ data: { password: 'newPassword' } });
 
 		expect(response.statusCode).toBe(400);
+	});
+
+	test('should not require conditionally-required fields when isPartialData is true', async () => {
+		// `snowflake` requires `privateKey` only while `authentication` is `keyPair`,
+		// a conditional `allOf` block in the schema (unlike ftp's flat `required`).
+		const savedCredential = await saveCredential(
+			{
+				name: randomName(),
+				type: 'snowflake',
+				data: {
+					account: 'acme',
+					database: 'db',
+					warehouse: 'wh',
+					authentication: 'password',
+					username: 'user',
+					password: 'oldPassword',
+				},
+			},
+			{ user: owner },
+		);
+
+		// Pins the partial-update semantics: the payload is validated per key only,
+		// so flipping a mode field without its conditionally-required dependents is
+		// accepted and merged; the merged result is not re-validated against the
+		// full schema.
+		const response = await authOwnerAgent
+			.patch(`/credentials/${savedCredential.id}`)
+			.send({ data: { authentication: 'keyPair' }, isPartialData: true });
+
+		expect(response.statusCode).toBe(200);
+
+		const updatedData = await getDecryptedCredentialData(savedCredential.id);
+		expect(updatedData.authentication).toBe('keyPair');
+		expect(updatedData.privateKey).toBeUndefined();
+		expect(updatedData.password).toBe('oldPassword');
 	});
 });
 

--- a/packages/cli/test/integration/public-api/credentials.test.ts
+++ b/packages/cli/test/integration/public-api/credentials.test.ts
@@ -1267,6 +1267,50 @@ describe('PATCH /credentials/:id', () => {
 		expect(updatedData.user).toBe('newUserValue'); // Should be updated
 		expect(updatedData.server).toBe(originalServer); // Should be preserved
 	});
+
+	test('should not require omitted fields when isPartialData is true', async () => {
+		// `ftp` marks `host` and `port` as unconditionally required in its schema
+		const savedCredential = await saveCredential(
+			{
+				name: randomName(),
+				type: 'ftp',
+				data: { host: 'ftp.example.com', port: 21, username: 'user', password: 'oldPassword' },
+			},
+			{ user: owner },
+		);
+
+		// A partial payload omits required keys by design: it is validated per key
+		// and merged with the stored data, so it must not fail key-presence checks.
+		const response = await authOwnerAgent
+			.patch(`/credentials/${savedCredential.id}`)
+			.send({ data: { password: 'newPassword' }, isPartialData: true });
+
+		expect(response.statusCode).toBe(200);
+
+		const updatedData = await getDecryptedCredentialData(savedCredential.id);
+		expect(updatedData.password).toBe('newPassword');
+		expect(updatedData.host).toBe('ftp.example.com');
+		expect(updatedData.port).toBe(21);
+	});
+
+	test('should keep requiring fields on a full-replace update', async () => {
+		const savedCredential = await saveCredential(
+			{
+				name: randomName(),
+				type: 'ftp',
+				data: { host: 'ftp.example.com', port: 21, username: 'user', password: 'oldPassword' },
+			},
+			{ user: owner },
+		);
+
+		// Without isPartialData the payload replaces the whole data object, so
+		// required keys must still be present.
+		const response = await authOwnerAgent
+			.patch(`/credentials/${savedCredential.id}`)
+			.send({ data: { password: 'newPassword' } });
+
+		expect(response.statusCode).toBe(400);
+	});
 });
 
 describe('GET /credentials/schema/:credentialType', () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.test.ts
@@ -1053,7 +1053,7 @@ describe('CredentialConfig', () => {
 		});
 	});
 
-	describe('Connect banner gating by connect permission', () => {
+	describe('Connect banner gating', () => {
 		const oAuthNotConnectedProps = {
 			isManaged: false,
 			mode: 'edit' as const,
@@ -1088,6 +1088,18 @@ describe('CredentialConfig', () => {
 
 			expect(screen.getByTestId('oauth-not-connected-banner')).toBeInTheDocument();
 			expect(screen.queryByTestId('quick-connect-button')).not.toBeInTheDocument();
+		});
+
+		it('hides the connect banner while required properties are not filled', () => {
+			renderComponent({
+				props: {
+					...oAuthNotConnectedProps,
+					requiredPropertiesFilled: false,
+					credentialPermissions: { read: true, connect: true },
+				},
+			});
+
+			expect(screen.getByTestId('oauth-not-connected-banner')).not.toBeVisible();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -1261,7 +1261,12 @@ describe('CredentialEdit', () => {
 
 		const setupExistingOAuthCredential = (
 			credentialModalState: Partial<NewCredentialsModal> = {},
-			dataOverrides: { scopes?: Scope[]; isResolvable?: boolean; connectedByMe?: boolean } = {},
+			dataOverrides: {
+				scopes?: Scope[];
+				isResolvable?: boolean;
+				connectedByMe?: boolean;
+				data?: Record<string, string>;
+			} = {},
 		) => {
 			vi.stubGlobal('BroadcastChannel', BroadcastChannelMock);
 			vi.stubGlobal(
@@ -1283,7 +1288,7 @@ describe('CredentialEdit', () => {
 			};
 			credentialsStore.getCredentialData.mockResolvedValueOnce({
 				// @ts-expect-error data is decrypted
-				data: {
+				data: dataOverrides.data ?? {
 					grantType: 'authorizationCode',
 					authUrl: 'https://auth.example.com',
 					accessTokenUrl: 'https://token.example.com',
@@ -1576,6 +1581,33 @@ describe('CredentialEdit', () => {
 			await waitFor(() => expect(credentialsStore.oAuth2Authorize).toHaveBeenCalledTimes(2));
 
 			expect(confirmMock).not.toHaveBeenCalled();
+		});
+
+		test('reveals the connect banner without saving once missing required fields are filled', async () => {
+			const { credentialsStore, queryByTestId, getAllByTestId } = setupExistingOAuthCredential(
+				{},
+				{
+					// clientId is missing, so the modal opens with the validation
+					// warning latched and the connect banner suppressed
+					data: {
+						grantType: 'authorizationCode',
+						authUrl: 'https://auth.example.com',
+						accessTokenUrl: 'https://token.example.com',
+						clientSecret: 'secret',
+					},
+				},
+			);
+
+			await waitFor(() => expect(credentialsStore.getCredentialData).toHaveBeenCalled());
+			await waitFor(() => expect(queryByTestId('oauth-not-connected-banner')).not.toBeVisible());
+
+			const clientIdForm = getAllByTestId('credential-connection-parameter').find((form) =>
+				form.textContent?.includes('Client ID'),
+			);
+			expect(clientIdForm).toBeDefined();
+			await userEvent.type(within(clientIdForm!).getByRole('textbox'), 'client');
+
+			await waitFor(() => expect(queryByTestId('oauth-not-connected-banner')).toBeVisible());
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue';
 
 import type { IUpdateInformation, NewCredentialsModal } from '@/Interface';
 import type { ICredentialsDecryptedResponse, ICredentialsResponse } from '../../credentials.types';
@@ -436,6 +436,15 @@ onMounted(async () => {
 		console.error('[CredentialEdit] Initialization error', error);
 	} finally {
 		loading.value = false;
+	}
+});
+
+// The missing-required-fields warning latches on open/save/close attempts;
+// release it as soon as the form satisfies the requirements so the OAuth
+// connect banner reappears without needing a save first.
+watch(requiredPropertiesFilled, (filled) => {
+	if (filled) {
+		showValidationWarning.value = false;
 	}
 });
 

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
@@ -89,6 +89,13 @@ const templatedCustomAuth: ICredentialType = {
 	],
 };
 
+// A type with a plain required string field.
+const requiredStringAuth: ICredentialType = {
+	name: 'requiredStringApi',
+	displayName: 'Required String API',
+	properties: [{ displayName: 'Host', name: 'host', type: 'string', required: true, default: '' }],
+};
+
 // Plain per-auth-option types for a node with an auth selector.
 const alphaApi: ICredentialType = {
 	name: 'alphaApi',
@@ -108,6 +115,7 @@ const typesByName: Record<string, ICredentialType> = {
 	privateOAuth2Api: privateOAuth,
 	skipOAuth2Api: skipManagedOAuth,
 	httpTemplatedCustomAuth: templatedCustomAuth,
+	requiredStringApi: requiredStringAuth,
 	alphaApi,
 	betaApi,
 };
@@ -301,6 +309,16 @@ describe('useCredentialForm', () => {
 	});
 
 	describe('requiredPropertiesFilled', () => {
+		it('is false while a required string field is empty and true once it is set', async () => {
+			const form = useCredentialForm({ mode: 'new', activeId: 'requiredStringApi' });
+			await form.initialize();
+
+			expect(form.requiredPropertiesFilled.value).toBe(false);
+
+			form.credentialData.value = { ...form.credentialData.value, host: 'example.com' };
+			expect(form.requiredPropertiesFilled.value).toBe(true);
+		});
+
 		it('blocks save and test while a required placeholder has no value', async () => {
 			const form = useCredentialForm({ mode: 'new', activeId: 'httpTemplatedCustomAuth' });
 			await form.initialize();

--- a/packages/nodes-base/credentials/MicrosoftSharePointOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftSharePointOAuth2Api.credentials.ts
@@ -24,6 +24,14 @@ export class MicrosoftSharePointOAuth2Api implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
+			displayName: 'Subdomain',
+			name: 'subdomain',
+			type: 'string',
+			required: true,
+			default: '',
+			hint: 'You can extract the subdomain from the URL. For example, in the URL "https://tenant123.sharepoint.com", the subdomain is "tenant123".',
+		},
+		{
 			displayName: 'Custom Scopes',
 			name: 'customScopes',
 			type: 'boolean',
@@ -32,7 +40,7 @@ export class MicrosoftSharePointOAuth2Api implements ICredentialType {
 		},
 		{
 			displayName:
-				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly. Use the <code>{subdomain}</code> placeholder to reference the Subdomain value below.',
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly. Use the <code>{subdomain}</code> placeholder to reference the Subdomain value above.',
 			name: 'customScopesNotice',
 			type: 'notice',
 			default: '',
@@ -63,13 +71,6 @@ export class MicrosoftSharePointOAuth2Api implements ICredentialType {
 				'={{($self["customScopes"] ? $self["enabledScopes"] : "' +
 				defaultScopes.join(' ') +
 				'").replace(/\\{subdomain\\}/g, $self["subdomain"])}}',
-		},
-		{
-			displayName: 'Subdomain',
-			name: 'subdomain',
-			type: 'string',
-			default: '',
-			hint: 'You can extract the subdomain from the URL. For example, in the URL "https://tenant123.sharepoint.com", the subdomain is "tenant123".',
 		},
 		{
 			displayName: 'Microsoft Graph API Base URL',

--- a/packages/nodes-base/credentials/MicrosoftSharePointOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftSharePointOAuth2Api.credentials.ts
@@ -28,6 +28,7 @@ export class MicrosoftSharePointOAuth2Api implements ICredentialType {
 			name: 'subdomain',
 			type: 'string',
 			required: true,
+			placeholder: 'tenant123',
 			default: '',
 			hint: 'You can extract the subdomain from the URL. For example, in the URL "https://tenant123.sharepoint.com", the subdomain is "tenant123".',
 		},
@@ -70,7 +71,7 @@ export class MicrosoftSharePointOAuth2Api implements ICredentialType {
 			default:
 				'={{($self["customScopes"] ? $self["enabledScopes"] : "' +
 				defaultScopes.join(' ') +
-				'").replace(/\\{subdomain\\}/g, $self["subdomain"])}}',
+				'").replace(/\\{subdomain\\}/g, ($self["subdomain"] || "").trim())}}',
 		},
 		{
 			displayName: 'Microsoft Graph API Base URL',

--- a/packages/nodes-base/credentials/test/MicrosoftSharePointOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftSharePointOAuth2Api.credentials.test.ts
@@ -82,10 +82,12 @@ describe('MicrosoftSharePointOAuth2Api Credential', () => {
 			expect(enabledScopesProperty?.displayOptions).toEqual({ show: { customScopes: [true] } });
 		});
 
-		it('should expose a subdomain input', () => {
+		it('should expose a required subdomain input as the first property', () => {
 			const subdomainProperty = credential.properties.find((p) => p.name === 'subdomain');
 			expect(subdomainProperty).toBeDefined();
 			expect(subdomainProperty?.type).toBe('string');
+			expect(subdomainProperty?.required).toBe(true);
+			expect(credential.properties[0]?.name).toBe('subdomain');
 		});
 
 		it('should define a hidden scope expression that substitutes the subdomain placeholder', () => {

--- a/packages/nodes-base/credentials/test/MicrosoftSharePointOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftSharePointOAuth2Api.credentials.test.ts
@@ -87,6 +87,7 @@ describe('MicrosoftSharePointOAuth2Api Credential', () => {
 			expect(subdomainProperty).toBeDefined();
 			expect(subdomainProperty?.type).toBe('string');
 			expect(subdomainProperty?.required).toBe(true);
+			// The customScopesNotice text says "Subdomain value above", so subdomain must stay above it.
 			expect(credential.properties[0]?.name).toBe('subdomain');
 		});
 
@@ -95,7 +96,7 @@ describe('MicrosoftSharePointOAuth2Api Credential', () => {
 			expect(scopeProperty).toBeDefined();
 			expect(scopeProperty?.type).toBe('hidden');
 			expect(scopeProperty?.default).toBe(
-				'={{($self["customScopes"] ? $self["enabledScopes"] : "openid offline_access https://{subdomain}.sharepoint.com/.default").replace(/\\{subdomain\\}/g, $self["subdomain"])}}',
+				'={{($self["customScopes"] ? $self["enabledScopes"] : "openid offline_access https://{subdomain}.sharepoint.com/.default").replace(/\\{subdomain\\}/g, ($self["subdomain"] || "").trim())}}',
 			);
 		});
 	});

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/MicrosoftSharePoint.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/MicrosoftSharePoint.node.test.ts
@@ -19,6 +19,14 @@ describe('MicrosoftSharePoint (versioned root)', () => {
 		expect(v1.methods?.resourceMapping).toBeDefined();
 	});
 
+	it('should trim the subdomain in the declarative base URL', () => {
+		const node = new MicrosoftSharePoint();
+
+		expect(node.nodeVersions[1].description.requestDefaults?.baseURL).toBe(
+			'=https://{{ ($credentials.subdomain || "").trim() }}.sharepoint.com/_api/v2.0/',
+		);
+	});
+
 	it('should not register the under-construction version 2', () => {
 		const node = new MicrosoftSharePoint();
 

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/transport.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/transport.test.ts
@@ -1,0 +1,40 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+
+import { credentials } from './credentials';
+import { microsoftSharePointApiRequest } from '../v1/transport';
+
+describe('Microsoft SharePoint Node', () => {
+	describe('Transport', () => {
+		let executeFunctions: MockProxy<IExecuteFunctions>;
+		let mockRequestWithAuthentication: Mock;
+
+		beforeEach(() => {
+			executeFunctions = mock<IExecuteFunctions>();
+			mockRequestWithAuthentication = vi.fn();
+			executeFunctions.helpers.httpRequestWithAuthentication = mockRequestWithAuthentication;
+		});
+
+		afterEach(() => {
+			vi.resetAllMocks();
+		});
+
+		it('should trim whitespace around the subdomain when building the request URL', async () => {
+			executeFunctions.getCredentials.mockResolvedValue({
+				...credentials.microsoftSharePointOAuth2Api,
+				subdomain: ' mydomain ',
+			});
+
+			await microsoftSharePointApiRequest.call(executeFunctions, 'GET', '/sites');
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftSharePointOAuth2Api',
+				expect.objectContaining({
+					url: 'https://mydomain.sharepoint.com/_api/v2.0/sites',
+				}),
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v1/MicrosoftSharePointV1.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v1/MicrosoftSharePointV1.node.ts
@@ -29,7 +29,7 @@ export const versionDescription: INodeTypeDescription = {
 		},
 	],
 	requestDefaults: {
-		baseURL: '=https://{{ $credentials.subdomain }}.sharepoint.com/_api/v2.0/',
+		baseURL: '=https://{{ ($credentials.subdomain || "").trim() }}.sharepoint.com/_api/v2.0/',
 	},
 	properties: [
 		{

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v1/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v1/transport/index.ts
@@ -16,13 +16,15 @@ export async function microsoftSharePointApiRequest(
 	headers?: IDataObject,
 	url?: string,
 ): Promise<any> {
-	const credentials: { subdomain: string } = await this.getCredentials(
+	// Legacy credentials may lack the subdomain (it only recently became required).
+	const credentials: { subdomain?: string } = await this.getCredentials(
 		'microsoftSharePointOAuth2Api',
 	);
 
 	const options: IHttpRequestOptions = {
 		method,
-		url: url ?? `https://${credentials.subdomain}.sharepoint.com/_api/v2.0${endpoint}`,
+		url:
+			url ?? `https://${(credentials.subdomain ?? '').trim()}.sharepoint.com/_api/v2.0${endpoint}`,
 		json: true,
 		headers,
 		body,


### PR DESCRIPTION
## Summary

The Microsoft SharePoint OAuth2 credential could be connected without the Subdomain field. The OAuth scope then resolved to `https://.sharepoint.com/.default` and Microsoft rejected the authorization with `AADSTS70011`, in two places:

1. The credential modal showed the Connect banner immediately, before the user had a chance to enter the subdomain.
2. The node's quick-connect button ("Connect to Microsoft SharePoint") launched the OAuth flow directly with an empty credential.

This PR marks `subdomain` as `required: true` and moves it to the top of the SharePoint-specific fields (fields inherited from the shared Microsoft OAuth2 credential still render above it), mirroring `MicrosoftDynamicsOAuth2Api` (which uses the same `{subdomain}` scope interpolation). Both UI paths already gate on required properties, so the modal now hides Connect until the subdomain is filled, and quick-connect falls back to the credential modal. The custom-scopes notice wording changes from "Subdomain value below" to "above" accordingly. The subdomain is now trimmed everywhere it is consumed (the OAuth scope expression, the v1 declarative `baseURL`, and the v1 transport), so surrounding whitespace (e.g. a trailing space from pasting) can neither break the scope nor produce a credential that connects but then fails on every node request.

Two changes outside the credential file, both prompted by review:

- **Public API partial updates** (`PATCH /api/v1/credentials/{id}` with `isPartialData: true`): the middleware validated the raw partial payload against the full type schema before the merge with stored data, so any type with an unconditionally required property rejected partial payloads that omitted it. This already affects e.g. Dynamics, ServiceNow, and OpenAI credentials today and would have extended to SharePoint through this PR, breaking secret-rotation scripts that only resend the rotated key. Partial payloads are now validated per key only (types and unknown-key rejection still apply); full-replace updates still require all required keys.
- **Credential modal repair flow**: the missing-required-fields warning used to latch until the next save, so a user repairing a legacy credential (typing the missing subdomain) kept seeing the warning and no Connect button until they saved. The warning now clears, and the Connect banner returns, as soon as the required fields are filled.

Notes for reviewers:

- Quick connect is intentionally gone for SharePoint in the default setups: neither the Cloud overwrite set nor a typical self-hosted `clientId`/`clientSecret` overwrite supplies the per-tenant subdomain, so one-click connect always launched a broken OAuth flow (`AADSTS70011`). Falling back to the credential modal is the accepted tradeoff. Overwrite keys are not restricted, so a single-tenant self-hosted admin who additionally overwrites `subdomain` keeps fully working one-click connect; that remains a supported configuration.
- Behavior change worth a release note: the Public API (`POST /api/v1/credentials`, and `PATCH /api/v1/credentials/{id}` without `isPartialData`) now returns 400 for payloads that omit the `subdomain` key for this credential type, matching how Dynamics and ServiceNow already behave. This is key-presence validation only; `subdomain: ""` still passes, since the generated JSON schema does not enforce `minLength`.
- The internal REST create/update path is intentionally unchanged: `validateCredentialData` only enforces `required` when `displayOptions` is defined, which `subdomain` (like its Dynamics/ServiceNow siblings) does not set.
- Existing credentials with a subdomain are unaffected (property order is UI-only; data is stored by name; `required` is never checked at execution time). Credentials whose default scopes never resolved (empty subdomain with the `{subdomain}` placeholder) were already broken and need the subdomain filled in plus a reconnect, since the previously issued token was minted without the SharePoint scope. One cohort deserves a release-note mention: credentials using **custom scopes without the `{subdomain}` placeholder** (e.g. Graph-only scopes, or the tenant hardcoded in the scope string) worked fine with an empty subdomain via the HTTP Request node, and their executions keep working after this PR. What changes for them is the modal: editing or reconnecting now requires entering the real tenant subdomain first, which is harmless since their scopes never consume it.

Tests: the credential metadata test pins `required` and first position, a `useCredentialForm` test covers the plain required-string branch of `requiredPropertiesFilled`, a `CredentialConfig` test pins that the Connect banner stays hidden while required properties are unfilled, a `CredentialEdit` test pins that the banner returns as soon as the missing field is typed (no save needed), transport/node tests pin the subdomain trimming, and two Public API integration tests pin that partial updates skip key-presence checks while full-replace updates keep them.

## How to test

1. Open a Microsoft SharePoint node and create a new credential for it, or create one from Credentials directly.
2. The Subdomain field is now the first SharePoint-specific field (below the inherited OAuth fields) and marked required; the "Connect my account" banner is hidden while it is empty (previously the OAuth popup opened immediately and showed `AADSTS70011`).
3. Enter the subdomain (e.g. `tenant123` for `https://tenant123.sharepoint.com`), then connect: the OAuth flow succeeds with scope `https://tenant123.sharepoint.com/.default`.
4. On Cloud (managed OAuth), the node's quick-connect button for SharePoint now opens the credential modal instead of launching OAuth directly.
5. Open an existing SharePoint credential saved without a subdomain: the validation warning shows and Connect is hidden; type the subdomain and the warning clears and the Connect banner returns without saving first.
6. Public API: `PATCH /api/v1/credentials/{id}` with `{ "data": { "clientSecret": "..." }, "isPartialData": true }` succeeds without resending the subdomain; the same payload without `isPartialData` returns 400.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-318

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
