### PR TITLE
feat: Add RustFS as supported S3-compatible service

### DIFF
--- a/packages/nodes-base/credentials/S3.credentials.ts
+++ b/packages/nodes-base/credentials/S3.credentials.ts
@@ -7,6 +7,8 @@ export class S3 implements ICredentialType {
 
 	documentationUrl = 's3';
 
+	description = 'For use with S3-compatible services like MinIO, RustFS, DigitalOcean Spaces, etc.';
+
 	properties: INodeProperties[] = [
 		{
 			displayName: 'S3 Endpoint',

--- a/packages/nodes-base/nodes/S3/S3.node.ts
+++ b/packages/nodes-base/nodes/S3/S3.node.ts
@@ -41,7 +41,7 @@ export class S3 implements INodeType {
 		properties: [
 			{
 				displayName:
-					"This node is for services that use the S3 standard, e.g. Minio or Digital Ocean Spaces. For AWS S3 use the 'AWS S3' node.",
+					"This node is for services that use the S3 standard, e.g. MinIO, RustFS or Digital Ocean Spaces. For AWS S3 use the 'AWS S3' node.",
 				name: 's3StandardNotice',
 				type: 'notice',
 				default: '',


### PR DESCRIPTION
## Description

Add [RustFS](https://rustfs.com/) to the list of known S3-compatible services in the S3 node description and credential documentation.

### Changes

1. **S3 Node Description**: Added RustFS alongside MinIO and DigitalOcean Spaces as an example of S3-compatible service
2. **S3 Credential Description**: Added description mentioning RustFS as a supported S3-compatible service

### Testing

Verified RustFS compatibility with all standard S3 API operations:

| Operation | Status |
|-----------|--------|
| List Buckets | ✅ |
| List Objects | ✅ |
| Create Bucket | ✅ |
| Upload Object | ✅ |
| Download Object | ✅ |
| Delete Object | ✅ |
| Delete Bucket | ✅ |

### Configuration

To use RustFS with n8n's S3 node, configure the S3 credential with:

| Field | Value |
|-------|-------|
| S3 Endpoint | `http://<rustfs-host>:9000` |
| Region | `us-east-1` |
| Access Key ID | Your RustFS access key |
| Secret Access Key | Your RustFS secret key |
| Force Path Style | `true` |

> **Note**: RustFS uses port 9000 for S3 API (not 9001 which is the console port).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

