### PR TITLE
feat(core): Resolve inbound audience from the protected resource, not the trust

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/workflow-webhook-trigger-resource.resolver.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/workflow-webhook-trigger-resource.resolver.api.test.ts
@@ -8,7 +8,7 @@ import { GlobalConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import { WebhookRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type { IHttpRequestMethods, INode } from 'n8n-workflow';
+import type { IHttpRequestMethods, INode, Workflow } from 'n8n-workflow';
 import { WEBHOOK_NODE_TYPE } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
 
@@ -132,6 +132,64 @@ afterEach(async () => {
 		'WorkflowEntity',
 		'WorkflowHistory',
 	]);
+});
+
+describe('resolveByNode (IAM-1173 - resolve directly from live workflow/node objects)', () => {
+	const asWorkflow = (workflow: { id: string; name: string }): Workflow =>
+		({ id: workflow.id, name: workflow.name }) as Workflow;
+
+	test('resolves a webhook trigger with no n8nOAuth2 authentication set', async () => {
+		const webhookPath = randomUUID();
+		const node = webhookNode({ authentication: 'none' });
+		const workflow = await createPublishedWebhookWorkflow(webhookPath, node);
+
+		const resource = await Container.get(ProtectedResourceRegistry).getByWorkflowNode(
+			asWorkflow(workflow),
+			node,
+		);
+
+		expect(resource).toBeDefined();
+		expect(resource!.getResourceUrl()).toBe(resourceUrlFor(webhookPath));
+	});
+
+	test('unions every configured method into getAudiences(), with no requested method known', async () => {
+		const webhookPath = randomUUID();
+		const node = webhookNode();
+		const workflow = await createPublishedWebhookWorkflow(webhookPath, node, {
+			methods: ['GET', 'POST'],
+		});
+
+		const resource = await Container.get(ProtectedResourceRegistry).getByWorkflowNode(
+			asWorkflow(workflow),
+			node,
+		);
+
+		expect(resource!.getAudiences().sort()).toEqual(
+			[resourceUrlFor(webhookPath, 'GET'), resourceUrlFor(webhookPath, 'POST')].sort(),
+		);
+	});
+
+	test('returns undefined for a disabled node', async () => {
+		const webhookPath = randomUUID();
+		const node = webhookNode({ disabled: true });
+		const workflow = await createPublishedWebhookWorkflow(webhookPath, node);
+
+		expect(
+			await Container.get(ProtectedResourceRegistry).getByWorkflowNode(asWorkflow(workflow), node),
+		).toBeUndefined();
+	});
+
+	test('returns undefined for a node with no registered webhook', async () => {
+		const workflow = await createPublishedWebhookWorkflow(randomUUID(), webhookNode());
+		const otherNode = webhookNode({ name: 'NotRegistered' });
+
+		expect(
+			await Container.get(ProtectedResourceRegistry).getByWorkflowNode(
+				asWorkflow(workflow),
+				otherNode,
+			),
+		).toBeUndefined();
+	});
 });
 
 describe('protected resource metadata for webhook triggers', () => {

--- a/packages/cli/src/modules/oauth-server/protected-resource-resolvers/workflow-webhook-trigger-resource.resolver.ts
+++ b/packages/cli/src/modules/oauth-server/protected-resource-resolvers/workflow-webhook-trigger-resource.resolver.ts
@@ -2,7 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { User, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { WEBHOOK_NODE_TYPE } from 'n8n-workflow';
+import { WEBHOOK_NODE_TYPE, type INode, type Workflow } from 'n8n-workflow';
 
 import { isWebhookOAuth2Enabled } from '@/constants/oauth2-triggers';
 import type {
@@ -154,43 +154,102 @@ export class WorkflowWebhookTriggerResourceResolver implements ProtectedResource
 			!node.disabled &&
 			node.parameters.authentication === 'n8nOAuth2'
 		) {
-			const baseUrl = `${trimTrailingSlash(this.urlService.getWebhookBaseUrl())}/${this.config.endpoints.webhook}/${resourcePath}`;
-			const urlFor = (method: string) => `${baseUrl}${methodQueryString(method)}`;
-			const methods = [...new Set(triggerMethods.map((method) => method.toUpperCase()))].sort();
-			const requireExecute = node.parameters.requireExecuteAccess !== false;
-			return {
-				// Identity = the trigger, so the method is deliberately absent: editing the
-				// node's method list must not rotate the id and drop the user's consent.
-				// The path is included because — unlike an MCP trigger — a workflow can hold
-				// several webhook nodes, each its own resource.
-				id: `workflow-webhook:${workflow.id}:${resourcePath}`,
-				// Canonical URL = the method being resolved, so the metadata document served
-				// at `?method=POST` advertises `?method=POST` back (RFC 9728 §3.1).
-				getResourceUrl: () => urlFor(requestedMethod),
-				// A token minted for any of this trigger's methods is accepted at all of
-				// them; cross-trigger replay stays impossible because the list is built
-				// only from rows sharing this (workflowId, node).
-				getAudiences: () => methods.map(urlFor),
-				scopes: WEBHOOK_TRIGGER_SCOPES,
-				displayName: workflow.name,
-				authorize: async (user: User) => {
-					if (requireExecute) {
-						return (
-							await this.workflowFinderService.findWorkflowIdsWithScopeForUser(
-								[workflow.id],
-								user,
-								['workflow:execute'],
-							)
-						).has(workflow.id);
-					}
-					return true;
-				},
-			};
+			return this.buildResource(
+				workflow.id,
+				workflow.name,
+				resourcePath,
+				requestedMethod,
+				triggerMethods,
+				node.parameters.requireExecuteAccess !== false,
+			);
 		}
 
 		this.logger.debug(
 			`Node with name ${nodeName} in active version of workflow with ID: ${workflowId} is not an enabled webhook trigger with n8nOAuth2 authentication`,
 		);
 		return undefined;
+	}
+
+	private buildResource(
+		workflowId: string,
+		workflowName: string | undefined,
+		resourcePath: string,
+		requestedMethod: string,
+		triggerMethods: string[],
+		requireExecute: boolean,
+	): ProtectedResource {
+		const baseUrl = `${trimTrailingSlash(this.urlService.getWebhookBaseUrl())}/${this.config.endpoints.webhook}/${resourcePath}`;
+		const urlFor = (method: string) => `${baseUrl}${methodQueryString(method)}`;
+		const methods = [...new Set(triggerMethods.map((method) => method.toUpperCase()))].sort();
+		return {
+			// Identity = the trigger, so the method is deliberately absent: editing the
+			// node's method list must not rotate the id and drop the user's consent.
+			// The path is included because — unlike an MCP trigger — a workflow can hold
+			// several webhook nodes, each its own resource.
+			id: `workflow-webhook:${workflowId}:${resourcePath}`,
+			// Canonical URL = the method being resolved, so the metadata document served
+			// at `?method=POST` advertises `?method=POST` back (RFC 9728 §3.1).
+			getResourceUrl: () => urlFor(requestedMethod),
+			// A token minted for any of this trigger's methods is accepted at all of
+			// them; cross-trigger replay stays impossible because the list is built
+			// only from rows sharing this (workflowId, node).
+			getAudiences: () => methods.map(urlFor),
+			scopes: WEBHOOK_TRIGGER_SCOPES,
+			displayName: workflowName,
+			authorize: async (user: User) => {
+				if (requireExecute) {
+					return (
+						await this.workflowFinderService.findWorkflowIdsWithScopeForUser([workflowId], user, [
+							'workflow:execute',
+						])
+					).has(workflowId);
+				}
+				return true;
+			},
+		};
+	}
+
+	/**
+	 * Resolve a resource directly from the live workflow/node objects a
+	 * context-establishment hook already holds mid-execution, instead of
+	 * reconstructing a resource URL/path and looking it back up through the
+	 * DB-by-name path above. Deliberately does NOT gate on
+	 * `isWebhookOAuth2Enabled()` or `authentication === 'n8nOAuth2'` (unlike
+	 * `resolveByPath`/`resolveByUrl`): both gates are about this instance's own
+	 * first-party OAuth flow, not about whether the node names a resource at
+	 * all - a node verifying external tokens (e.g. via token-exchange) is by
+	 * definition not using that flow, and must still resolve here.
+	 */
+	async resolveByNode(workflow: Workflow, node: INode): Promise<ProtectedResource | undefined> {
+		if (node.type !== WEBHOOK_NODE_TYPE || node.disabled) {
+			return undefined;
+		}
+
+		const rows = (await this.webhookService.getRegisteredWebhooks(workflow.id)).filter(
+			(row) => row.node === node.name,
+		);
+		if (rows.length === 0) {
+			this.logger.debug(`No registered webhooks for node ${node.name} in workflow ${workflow.id}`);
+			return undefined;
+		}
+
+		const resourcePath = webhookResourcePath(rows[0].webhookPath, rows[0].webhookId);
+		const triggerMethods = rows.map((row) => row.method);
+		const requireExecute = node.parameters.requireExecuteAccess !== false;
+
+		// No live HTTP method to echo back as the canonical URL here (unlike
+		// resolveByPath, which knows the requested method from the query
+		// string) - the lowest sorted method is an arbitrary but stable choice.
+		// Audience membership (getAudiences()) covers every method regardless.
+		const [placeholderMethod] = [...new Set(triggerMethods.map((m) => m.toUpperCase()))].sort();
+
+		return this.buildResource(
+			workflow.id,
+			workflow.name,
+			resourcePath,
+			placeholderMethod,
+			triggerMethods,
+			requireExecute,
+		);
 	}
 }

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-audience.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-audience.service.test.ts
@@ -1,31 +1,53 @@
+import type { INode, Workflow } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
+import { mock } from 'vitest-mock-extended';
 
-import type { UrlService } from '@/services/url.service';
+import type {
+	ProtectedResource,
+	ProtectedResourceRegistry,
+} from '@/services/protected-resource.registry';
 
-import type { TokenExchangeConfig } from '../../token-exchange.config';
 import { InboundAudienceService } from '../inbound-audience.service';
 
 describe('InboundAudienceService', () => {
-	let config: TokenExchangeConfig;
-	let urlService: Mocked<UrlService>;
+	let registry: Mocked<ProtectedResourceRegistry>;
 	let service: InboundAudienceService;
 
+	const workflow = mock<Workflow>({ id: 'wf-1' });
+	const triggerNode = mock<INode>({ name: 'Webhook' });
+
 	beforeEach(() => {
-		config = { inboundAudience: '' } as TokenExchangeConfig;
-		urlService = {
-			getInstanceBaseUrl: vi.fn().mockReturnValue('https://n8n.example.com'),
-		} as unknown as Mocked<UrlService>;
-		service = new InboundAudienceService(config, urlService);
+		registry = {
+			getByWorkflowNode: vi.fn(),
+		} as unknown as Mocked<ProtectedResourceRegistry>;
+		service = new InboundAudienceService(registry);
 	});
 
-	it('returns the configured audience when set', () => {
-		config.inboundAudience = 'https://configured-audience.example.com';
+	it('returns the resolved resource audiences when a resource is found', async () => {
+		const resource = mock<ProtectedResource>({
+			getAudiences: () => [
+				'https://n8n.example.com/webhook/abc',
+				'https://n8n.example.com/webhook/abc?method=GET',
+			],
+		});
+		registry.getByWorkflowNode.mockResolvedValue(resource);
 
-		expect(service.getExpectedAudience()).toBe('https://configured-audience.example.com');
-		expect(urlService.getInstanceBaseUrl).not.toHaveBeenCalled();
+		const result = await service.getExpectedAudiences(workflow, triggerNode);
+
+		expect(result).toEqual({
+			audiences: [
+				'https://n8n.example.com/webhook/abc',
+				'https://n8n.example.com/webhook/abc?method=GET',
+			],
+		});
+		expect(registry.getByWorkflowNode).toHaveBeenCalledWith(workflow, triggerNode);
 	});
 
-	it('falls back to the instance base URL when unset', () => {
-		expect(service.getExpectedAudience()).toBe('https://n8n.example.com');
+	it('fails closed with resource_not_found when no resource resolves', async () => {
+		registry.getByWorkflowNode.mockResolvedValue(undefined);
+
+		const result = await service.getExpectedAudiences(workflow, triggerNode);
+
+		expect(result).toEqual({ reason: 'resource_not_found' });
 	});
 });

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.integration.test.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.integration.test.ts
@@ -73,7 +73,9 @@ describe('InboundClaimVerificationHook integration with establishExecutionContex
 		proxy.registerProvider(provider);
 
 		audienceService = mock<InboundAudienceService>();
-		audienceService.getExpectedAudience.mockReturnValue('https://n8n.example.com');
+		audienceService.getExpectedAudiences.mockResolvedValue({
+			audiences: ['https://n8n.example.com'],
+		});
 
 		const hook = new InboundClaimVerificationHook(mock(), proxy, audienceService);
 
@@ -129,6 +131,29 @@ describe('InboundClaimVerificationHook integration with establishExecutionContex
 		expect(runtimeData.authFailureReason).toBeUndefined();
 	});
 
+	it('IAM-1173: passes every accepted audience for the resolved resource through to the verifier', async () => {
+		audienceService.getExpectedAudiences.mockResolvedValue({
+			audiences: [
+				'https://n8n.example.com/webhook/abc?method=GET',
+				'https://n8n.example.com/webhook/abc?method=POST',
+			],
+		});
+		provider.verifyExternalToken.mockResolvedValue({
+			claim: null,
+			context: { reason: 'invalid_token' },
+		});
+
+		const workflow = buildWorkflow();
+		const runExecutionData = buildRunExecutionData({ authorization: 'Bearer some-token' });
+
+		await establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook');
+
+		expect(provider.verifyExternalToken).toHaveBeenCalledWith('some-token', [
+			'https://n8n.example.com/webhook/abc?method=GET',
+			'https://n8n.example.com/webhook/abc?method=POST',
+		]);
+	});
+
 	it('AC2: an invalid token records authFailureReason and sets no claim', async () => {
 		provider.verifyExternalToken.mockResolvedValue({
 			claim: null,
@@ -178,6 +203,20 @@ describe('InboundClaimVerificationHook integration with establishExecutionContex
 		const runtimeData = runExecutionData.executionData!.runtimeData!;
 		expect(runtimeData.claims).toBeUndefined();
 		expect(runtimeData.authFailureReason).toBe('verifier_not_registered');
+	});
+
+	it('IAM-1173: no resolvable resource for the trigger fails closed without calling the verifier', async () => {
+		audienceService.getExpectedAudiences.mockResolvedValue({ reason: 'resource_not_found' });
+
+		const workflow = buildWorkflow();
+		const runExecutionData = buildRunExecutionData({ authorization: 'Bearer some-token' });
+
+		await establishExecutionContext(workflow, runExecutionData, additionalData, 'webhook');
+
+		const runtimeData = runExecutionData.executionData!.runtimeData!;
+		expect(runtimeData.claims).toBeUndefined();
+		expect(runtimeData.authFailureReason).toBe('resource_not_found');
+		expect(provider.verifyExternalToken).not.toHaveBeenCalled();
 	});
 
 	it('AC5 & AC6: verification happens exactly once, and a second establishExecutionContext call is a no-op', async () => {

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.test.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/__tests__/inbound-claim-verification-hook.test.ts
@@ -50,7 +50,7 @@ describe('InboundClaimVerificationHook', () => {
 		} as unknown as Mocked<ExternalTokenVerifierProxy>;
 
 		mockAudienceService = {
-			getExpectedAudience: vi.fn().mockReturnValue('https://n8n.example.com'),
+			getExpectedAudiences: vi.fn().mockResolvedValue({ audiences: ['https://n8n.example.com'] }),
 		} as unknown as Mocked<InboundAudienceService>;
 
 		hook = new InboundClaimVerificationHook(mockLogger, mockProxy, mockAudienceService);
@@ -122,10 +122,42 @@ describe('InboundClaimVerificationHook', () => {
 			await hook.execute(createOptions());
 
 			expect(mockProxy.verifyExternalToken).toHaveBeenCalledTimes(1);
-			expect(mockProxy.verifyExternalToken).toHaveBeenCalledWith(
-				'valid-token',
+			expect(mockProxy.verifyExternalToken).toHaveBeenCalledWith('valid-token', [
 				'https://n8n.example.com',
-			);
+			]);
+		});
+
+		it('passes the full audience set through to the verifier when a resource has several', async () => {
+			mockAudienceService.getExpectedAudiences.mockResolvedValue({
+				audiences: [
+					'https://n8n.example.com/webhook/abc?method=GET',
+					'https://n8n.example.com/webhook/abc?method=POST',
+				],
+			});
+			mockProxy.verifyExternalToken.mockResolvedValue({
+				claim: null,
+				context: { reason: 'invalid_token' },
+			});
+
+			await hook.execute(createOptions());
+
+			expect(mockProxy.verifyExternalToken).toHaveBeenCalledWith('valid-token', [
+				'https://n8n.example.com/webhook/abc?method=GET',
+				'https://n8n.example.com/webhook/abc?method=POST',
+			]);
+		});
+	});
+
+	describe('resource_not_found: no resolvable resource for the trigger -> no claim, no throw', () => {
+		it('records authFailureReason without calling the verifier', async () => {
+			mockAudienceService.getExpectedAudiences.mockResolvedValue({
+				reason: 'resource_not_found',
+			});
+
+			const result = await hook.execute(createOptions());
+
+			expect(result.contextUpdate).toEqual({ authFailureReason: 'resource_not_found' });
+			expect(mockProxy.verifyExternalToken).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-audience.service.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-audience.service.ts
@@ -1,24 +1,38 @@
 import { Service } from '@n8n/di';
+import type { INode, Workflow } from 'n8n-workflow';
 
-import { UrlService } from '@/services/url.service';
+import { ProtectedResourceRegistry } from '@/services/protected-resource.registry';
 
-import { TokenExchangeConfig } from '../token-exchange.config';
+export type ExpectedAudienceResult =
+	| { audiences: string[]; reason?: undefined }
+	| { audiences?: undefined; reason: 'resource_not_found' };
 
 /**
- * Single source of truth for the audience external tokens must target to be
- * accepted at context establishment. Kept separate from
+ * Single source of truth for the audience(s) external tokens must target to
+ * be accepted at context establishment. Kept separate from
  * `InboundClaimVerificationHook` so this decision is independently testable
- * and swappable later (e.g. by IAM-1175's per-surface work) without touching
- * the hook.
+ * and swappable without touching the hook.
+ *
+ * Audience belongs to the resource being called (e.g. a specific webhook or
+ * MCP trigger), not to the trust source that signed the token - so this
+ * resolves per-`(workflow, triggerNode)` via `ProtectedResourceRegistry`
+ * rather than returning one fixed, instance-wide value. When no resource can
+ * be resolved (e.g. a trigger type no resolver covers, or the resolvers'
+ * owning module is disabled), this fails closed: there is no instance-wide
+ * fallback to guess an audience from.
  */
 @Service()
 export class InboundAudienceService {
-	constructor(
-		private readonly config: TokenExchangeConfig,
-		private readonly urlService: UrlService,
-	) {}
+	constructor(private readonly protectedResourceRegistry: ProtectedResourceRegistry) {}
 
-	getExpectedAudience(): string {
-		return this.config.inboundAudience || this.urlService.getInstanceBaseUrl();
+	async getExpectedAudiences(
+		workflow: Workflow,
+		triggerNode: INode,
+	): Promise<ExpectedAudienceResult> {
+		const resource = await this.protectedResourceRegistry.getByWorkflowNode(workflow, triggerNode);
+		if (!resource) {
+			return { reason: 'resource_not_found' };
+		}
+		return { audiences: resource.getAudiences() };
 	}
 }

--- a/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-claim-verification-hook.ts
+++ b/packages/cli/src/modules/token-exchange/context-establishment-hooks/inbound-claim-verification-hook.ts
@@ -57,10 +57,21 @@ export class InboundClaimVerificationHook implements IContextEstablishmentHook {
 				return {};
 			}
 
-			const expectedAudience = this.inboundAudienceService.getExpectedAudience();
+			const audienceResult = await this.inboundAudienceService.getExpectedAudiences(
+				options.workflow,
+				options.triggerNode,
+			);
+			if (!audienceResult.audiences) {
+				// Audience belongs to the resource being called - with no resource
+				// resolvable, there is nothing to verify against. Fail closed
+				// rather than guess an instance-wide value (D4 still applies: this
+				// only withholds the claim, it never blocks the execution).
+				return { contextUpdate: { authFailureReason: audienceResult.reason } };
+			}
+
 			const result = await this.externalTokenVerifierProxy.verifyExternalToken(
 				token,
-				expectedAudience,
+				audienceResult.audiences,
 			);
 
 			if (!result.claim) {

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -299,6 +299,32 @@ describe('TokenExchangeService', () => {
 			);
 		});
 
+		it('accepts a set of acceptable audiences, passing them through as a tuple to jwt.verify', async () => {
+			mockValidToken();
+
+			await service.verifyToken('token', {
+				expectedAudience: ['aud-a', 'aud-b'],
+				consumeJti: false,
+			});
+
+			expect(jwt.verify).toHaveBeenCalledWith(
+				'token',
+				resolvedKey.key,
+				expect.objectContaining({ audience: ['aud-a', 'aud-b'] }),
+			);
+		});
+
+		it('rejects when consumeJti is false and expectedAudience is an empty array', async () => {
+			const verifyTokenUnsafe = service.verifyToken.bind(service) as (
+				token: string,
+				options?: Record<string, unknown>,
+			) => Promise<unknown>;
+
+			await expect(
+				verifyTokenUnsafe('token', { expectedAudience: [], consumeJti: false }),
+			).rejects.toThrow(TokenExchangeAuthError);
+		});
+
 		it('verifies the same token twice when consumeJti is false', async () => {
 			mockValidToken();
 

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -68,11 +68,16 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 	 * `expectedAudience` becomes mandatory instead: `jsonwebtoken` silently skips
 	 * audience validation when `audience` is `undefined`, and a caller that can't
 	 * rely on replay protection must not also silently skip audience checks.
+	 *
+	 * `expectedAudience` accepts a single value or a set of acceptable values -
+	 * a resource can have several accepted audiences (e.g. a multi-method
+	 * webhook trigger unions every method's URL), and the token is accepted if
+	 * its `aud` matches any one of them.
 	 */
 	async verifyToken(
 		subjectToken: string,
 		options?: {
-			expectedAudience?: string;
+			expectedAudience?: string | string[];
 			consumeJti?: true;
 			requireJti?: true;
 			maxLifetimeSeconds?: number;
@@ -81,7 +86,7 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 	async verifyToken(
 		subjectToken: string,
 		options: {
-			expectedAudience: string;
+			expectedAudience: string | string[];
 			consumeJti: false;
 			requireJti?: boolean;
 			maxLifetimeSeconds?: number;
@@ -98,7 +103,7 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 			requireJti = true,
 			maxLifetimeSeconds,
 		}: {
-			expectedAudience?: string;
+			expectedAudience?: string | string[];
 			consumeJti?: boolean;
 			requireJti?: boolean;
 			maxLifetimeSeconds?: number;
@@ -107,7 +112,10 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 		claims: ExternalTokenClaims | ResourceServerTokenClaims;
 		resolvedKey: ResolvedTrustedKey;
 	}> {
-		if (!consumeJti && !expectedAudience) {
+		const hasExpectedAudience =
+			expectedAudience !== undefined &&
+			(!Array.isArray(expectedAudience) || expectedAudience.length > 0);
+		if (!consumeJti && !hasExpectedAudience) {
 			throw new TokenExchangeAuthError(
 				TokenExchangeFailureReason.AudienceRequired,
 				'expectedAudience is required when JTI consumption is disabled',
@@ -153,7 +161,9 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 				// EdDSA is valid at runtime but missing from @types/jsonwebtoken
 				algorithms: resolvedKey.algorithms as jwt.Algorithm[],
 				issuer: resolvedKey.issuer,
-				audience: expectedAudience ?? resolvedKey.expectedAudience,
+				audience: this.toVerifyAudience(
+					hasExpectedAudience ? expectedAudience : resolvedKey.expectedAudience,
+				),
 				ignoreExpiration: false,
 				ignoreNotBefore: false,
 			});
@@ -207,8 +217,24 @@ export class TokenExchangeService implements ExternalTokenVerifier {
 		return { claims, resolvedKey };
 	}
 
+	/**
+	 * `jsonwebtoken`'s `VerifyOptions.audience` wants a non-empty tuple, not a
+	 * general array, so a plain `string[]` doesn't structurally satisfy it even
+	 * though it's runtime-equivalent. `hasExpectedAudience` already guarantees
+	 * a non-empty array reaches here for the call-parameter case; the
+	 * source-level fallback is always a single string or undefined.
+	 */
+	private toVerifyAudience(audience: string | string[] | undefined): jwt.VerifyOptions['audience'] {
+		if (audience === undefined || typeof audience === 'string') return audience;
+		const [first, ...rest] = audience;
+		return [first, ...rest];
+	}
+
 	/** Registered as the `ExternalTokenVerifierProxy` provider on module init. Never throws. */
-	async verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult> {
+	async verifyExternalToken(
+		token: string,
+		expectedAudience: string | string[],
+	): Promise<VerifiedClaimResult> {
 		try {
 			const { claims, resolvedKey } = await this.verifyToken(token, {
 				expectedAudience,

--- a/packages/cli/src/modules/token-exchange/token-exchange.config.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.config.ts
@@ -46,13 +46,4 @@ export class TokenExchangeConfig {
 	/** Maximum number of token exchanges per ip per minute. */
 	@Env('N8N_TOKEN_EXCHANGE_TOKEN_EXCHANGE_PER_MINUTE')
 	rateLimitTokenExchange: number = 20;
-
-	/**
-	 * Audience external tokens must target to be accepted at context
-	 * establishment (see `InboundAudienceService`). Defaults to the instance
-	 * base URL when unset. Instance-wide, not per-surface - see IAM-1175 for
-	 * per-surface `acceptedSources`.
-	 */
-	@Env('N8N_TOKEN_EXCHANGE_INBOUND_AUDIENCE')
-	inboundAudience: string = '';
 }

--- a/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
+++ b/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@n8n/backend-common';
+import type { INode, Workflow } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { ProtectedResource, ProtectedResourceResolver } from '../protected-resource.registry';
@@ -159,6 +160,57 @@ describe('ProtectedResourceRegistry', () => {
 			await resolverRegistry.getByResourcePath('/webhook/orders');
 
 			expect(resolver.resolveByPath).toHaveBeenCalledWith('/webhook/orders', '');
+		});
+	});
+
+	describe('getByWorkflowNode', () => {
+		const workflow = mock<Workflow>({ id: 'wf-1' });
+		const node = mock<INode>({ name: 'Webhook' });
+
+		it('should resolve via a resolver implementing resolveByNode', async () => {
+			const resolverRegistry = new ProtectedResourceRegistry(mock<Logger>());
+			const resolver = mock<ProtectedResourceResolver>({ id: 'webhook', scopes: [] });
+			resolver.resolveByNode!.mockResolvedValue(resourceB);
+			resolverRegistry.registerResolver(resolver);
+
+			expect(await resolverRegistry.getByWorkflowNode(workflow, node)).toBe(resourceB);
+			expect(resolver.resolveByNode).toHaveBeenCalledWith(workflow, node);
+		});
+
+		it('should skip resolvers that do not implement resolveByNode', async () => {
+			const resolverRegistry = new ProtectedResourceRegistry(mock<Logger>());
+			const resolverWithoutMethod: ProtectedResourceResolver = {
+				id: 'no-node-lookup',
+				scopes: [],
+				resolveByUrl: async () => undefined,
+				resolveByPath: async () => undefined,
+			};
+			resolverRegistry.registerResolver(resolverWithoutMethod);
+
+			expect(await resolverRegistry.getByWorkflowNode(workflow, node)).toBeUndefined();
+		});
+
+		it('should return undefined when no resolver matches', async () => {
+			const resolverRegistry = new ProtectedResourceRegistry(mock<Logger>());
+			const resolver = mock<ProtectedResourceResolver>({ id: 'webhook', scopes: [] });
+			resolver.resolveByNode!.mockResolvedValue(undefined);
+			resolverRegistry.registerResolver(resolver);
+
+			expect(await resolverRegistry.getByWorkflowNode(workflow, node)).toBeUndefined();
+		});
+
+		it('should treat a throwing resolver as a non-match and log a warning', async () => {
+			const logger = mock<Logger>();
+			const failingRegistry = new ProtectedResourceRegistry(logger);
+			const resolver = mock<ProtectedResourceResolver>({ id: 'boom', scopes: [] });
+			resolver.resolveByNode!.mockRejectedValue(new Error('backing store unavailable'));
+			failingRegistry.registerResolver(resolver);
+
+			expect(await failingRegistry.getByWorkflowNode(workflow, node)).toBeUndefined();
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Protected resource resolver "boom" failed to resolve',
+				{ error: 'backing store unavailable' },
+			);
 		});
 	});
 

--- a/packages/cli/src/services/external-token-verifier-proxy.service.ts
+++ b/packages/cli/src/services/external-token-verifier-proxy.service.ts
@@ -22,7 +22,16 @@ export type VerifiedClaimResult =
 	| { claim: null; context: ExternalVerificationContext };
 
 export interface ExternalTokenVerifier {
-	verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult>;
+	/**
+	 * `expectedAudience` accepts a single value or a set of acceptable values -
+	 * a resource can have several accepted audiences (e.g. a multi-method
+	 * webhook trigger), and the token is accepted if its `aud` matches any one
+	 * of them.
+	 */
+	verifyExternalToken(
+		token: string,
+		expectedAudience: string | string[],
+	): Promise<VerifiedClaimResult>;
 }
 
 /**
@@ -37,7 +46,10 @@ export class ExternalTokenVerifierProxy implements ExternalTokenVerifier {
 		this.provider = provider;
 	}
 
-	async verifyExternalToken(token: string, expectedAudience: string): Promise<VerifiedClaimResult> {
+	async verifyExternalToken(
+		token: string,
+		expectedAudience: string | string[],
+	): Promise<VerifiedClaimResult> {
 		if (!this.provider) {
 			return {
 				claim: null,

--- a/packages/cli/src/services/protected-resource.registry.ts
+++ b/packages/cli/src/services/protected-resource.registry.ts
@@ -2,6 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
+import type { INode, Workflow } from 'n8n-workflow';
 
 /**
  * Descriptor for an OAuth 2.1 protected resource served by this instance.
@@ -113,6 +114,19 @@ export interface ProtectedResourceResolver {
 	 * `?method=`. Resolvers keyed on path alone ignore it.
 	 */
 	resolveByPath(pathname: string, search?: string): Promise<ProtectedResource | undefined>;
+
+	/**
+	 * Resolve a resource directly from an already-loaded workflow and trigger
+	 * node, or `undefined` if this resolver owns no such resource. For callers
+	 * that already hold the live objects (e.g. a context-establishment hook
+	 * mid-execution) and would otherwise have to reconstruct a resource URL/path
+	 * from workflow/node internals just to look it back up - a lossy,
+	 * duplicative round-trip. Unlike `resolveByUrl`/`resolveByPath`, this is not
+	 * gated on the node's own `authentication` setting: it answers "is this
+	 * node a protectable resource at all", not "does it use this instance's
+	 * first-party OAuth flow".
+	 */
+	resolveByNode?(workflow: Workflow, node: INode): Promise<ProtectedResource | undefined>;
 }
 
 const trimTrailingSlash = (url: string): string => url.replace(/\/$/, '');
@@ -191,6 +205,25 @@ export class ProtectedResourceRegistry {
 		for (const resolver of this.resolvers) {
 			try {
 				const resource = await resolver.resolveByPath(normalized, search);
+				if (resource) return resource;
+			} catch (error) {
+				this.logResolverFailure(resolver, error);
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Look up a resource directly from an already-loaded workflow and trigger
+	 * node, bypassing URL/path reconstruction entirely. See
+	 * {@link ProtectedResourceResolver.resolveByNode}. Resolvers that don't
+	 * implement it are skipped, not treated as a miss for the whole lookup.
+	 */
+	async getByWorkflowNode(workflow: Workflow, node: INode): Promise<ProtectedResource | undefined> {
+		for (const resolver of this.resolvers) {
+			if (!resolver.resolveByNode) continue;
+			try {
+				const resource = await resolver.resolveByNode(workflow, node);
 				if (resource) return resource;
 			} catch (error) {
 				this.logResolverFailure(resolver, error);


### PR DESCRIPTION
## Summary
- Resolves the audience(s) an external token must target per `(workflow, triggerNode)` via `ProtectedResourceRegistry.getByWorkflowNode`, instead of a single fixed, instance-wide value from `TokenExchangeConfig`.
- Adds `ProtectedResourceResolver.resolveByNode` (and `ProtectedResourceRegistry.getByWorkflowNode`) so context-establishment hooks that already hold the live workflow/node can resolve a resource without reconstructing a URL/path.
- `InboundClaimVerificationHook` now fails closed (withholds the claim, does not block execution) when no resource can be resolved for the trigger, rather than falling back to an instance-wide guess.
- Removes the now-unused `N8N_TOKEN_EXCHANGE_INBOUND_AUDIENCE` config option.

Reference: https://linear.app/n8n/issue/IAM-1173

## Test plan
- [x] Unit tests updated for `InboundAudienceService`, `InboundClaimVerificationHook`, `TokenExchangeService`, `ProtectedResourceRegistry`, and the workflow/webhook trigger resource resolver
- [ ] `pnpm typecheck` / `pnpm lint` in `packages/cli`
- [ ] Manual verification against a running instance with a webhook/MCP trigger protected resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)