### PR TITLE
refactor(core): Enforce package entity export decisions (no-changelog)

### DIFF
--- a/packages/@n8n/utils/src/types.ts
+++ b/packages/@n8n/utils/src/types.ts
@@ -12,3 +12,47 @@
  * type WithoutKind = DistributiveOmit<Event, never>;
  */
 export type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+/**
+ * Converts a union into an intersection of its members.
+ *
+ * @example
+ * type Merged = UnionToIntersection<{ a: string } | { b: number }>;
+ * // => { a: string } & { b: number }
+ */
+export type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (
+	x: infer I,
+) => void
+	? I
+	: never;
+
+/**
+ * Picks one member of a union (the last one in the compiler's internal order).
+ * Mainly a building block for iterating over union members.
+ *
+ * @example
+ * type Last = LastOf<'a' | 'b'>;
+ * // => 'b'
+ */
+export type LastOf<U> = UnionToIntersection<
+	U extends unknown ? () => U : never
+> extends () => infer R
+	? R
+	: never;
+
+/**
+ * Joins a union of string literals into a single quoted, comma-separated string literal.
+ * Useful for building readable custom compile-error messages. Uses single quotes so the
+ * result renders without escapes when the compiler prints it inside a double-quoted string.
+ *
+ * @example
+ * type Keys = JoinKeys<'a' | 'b'>;
+ * // => "'a', 'b'"
+ */
+export type JoinKeys<U extends string> = [U] extends [never]
+	? ''
+	: JoinKeys<Exclude<U, LastOf<U>>> extends infer TRest extends string
+		? TRest extends ''
+			? `'${LastOf<U> & string}'`
+			: `${TRest}, '${LastOf<U> & string}'`
+		: never;

--- a/packages/cli/src/modules/n8n-packages/entities/credential/credential.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/credential/credential.serializer.ts
@@ -5,14 +5,42 @@ import {
 	serializedCredentialSchema,
 	type SerializedCredential,
 } from '../../spec/serialized/credential.schema';
+import {
+	definePackageSerializationPayload,
+	type PackageEntityKeyHandling,
+} from '../package-serialization.types';
+
+const credentialPackageKeyHandling = {
+	id: 'copy',
+	createdAt: 'exclude',
+	updatedAt: 'exclude',
+	name: 'copy',
+	data: 'exclude',
+	type: 'copy',
+	shared: 'exclude',
+	isManaged: 'exclude',
+	isGlobal: 'exclude',
+	isResolvable: 'exclude',
+	resolvableAllowFallback: 'exclude',
+	resolverId: 'exclude',
+	usageScope: 'exclude',
+} as const satisfies PackageEntityKeyHandling<CredentialsEntity>;
+
+const serializePayload = definePackageSerializationPayload<
+	CredentialsEntity,
+	SerializedCredential,
+	typeof credentialPackageKeyHandling
+>();
 
 @Service()
 export class CredentialSerializer {
 	serialize(credential: CredentialsEntity): SerializedCredential {
-		return serializedCredentialSchema.parse({
-			id: credential.id,
-			name: credential.name,
-			type: credential.type,
-		});
+		return serializedCredentialSchema.parse(
+			serializePayload({
+				id: credential.id,
+				name: credential.name,
+				type: credential.type,
+			}),
+		);
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/entities/credential/credential.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/credential/credential.serializer.ts
@@ -5,31 +5,28 @@ import {
 	serializedCredentialSchema,
 	type SerializedCredential,
 } from '../../spec/serialized/credential.schema';
-import {
-	definePackageSerializationPayload,
-	type PackageEntityKeyHandling,
-} from '../package-serialization.types';
+import { definePackageSerializationPayload } from '../package-serialization.types';
 
-const credentialPackageKeyHandling = {
-	id: 'copy',
-	createdAt: 'exclude',
-	updatedAt: 'exclude',
-	name: 'copy',
-	data: 'exclude',
-	type: 'copy',
-	shared: 'exclude',
-	isManaged: 'exclude',
-	isGlobal: 'exclude',
-	isResolvable: 'exclude',
-	resolvableAllowFallback: 'exclude',
-	resolverId: 'exclude',
-	usageScope: 'exclude',
-} as const satisfies PackageEntityKeyHandling<CredentialsEntity>;
+type CredentialPackageKeyHandling = {
+	id: 'copy';
+	createdAt: 'exclude';
+	updatedAt: 'exclude';
+	name: 'copy';
+	data: 'exclude';
+	type: 'copy';
+	shared: 'exclude';
+	isManaged: 'exclude';
+	isGlobal: 'exclude';
+	isResolvable: 'exclude';
+	resolvableAllowFallback: 'exclude';
+	resolverId: 'exclude';
+	usageScope: 'exclude';
+};
 
 const serializePayload = definePackageSerializationPayload<
 	CredentialsEntity,
 	SerializedCredential,
-	typeof credentialPackageKeyHandling
+	CredentialPackageKeyHandling
 >();
 
 @Service()

--- a/packages/cli/src/modules/n8n-packages/entities/data-table/data-table.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/data-table/data-table.serializer.ts
@@ -1,25 +1,70 @@
 import { Service } from '@n8n/di';
 
+import type { DataTableColumn } from '@/modules/data-table/data-table-column.entity';
 import type { DataTable } from '@/modules/data-table/data-table.entity';
 
 import {
 	serializedDataTableSchema,
+	type SerializedDataTableColumn,
 	type SerializedDataTable,
 } from '../../spec/serialized/data-table.schema';
+import {
+	definePackageSerializationPayload,
+	type PackageEntityKeyHandling,
+} from '../package-serialization.types';
+
+const dataTablePackageKeyHandling = {
+	id: 'copy',
+	createdAt: 'exclude',
+	updatedAt: 'exclude',
+	name: 'copy',
+	columns: 'transform',
+	project: 'transform',
+	projectId: 'transform',
+} as const satisfies PackageEntityKeyHandling<DataTable>;
+
+const dataTableColumnPackageKeyHandling = {
+	id: 'exclude',
+	createdAt: 'exclude',
+	updatedAt: 'exclude',
+	dataTableId: 'exclude',
+	name: 'copy',
+	type: 'copy',
+	index: 'copy',
+	dataTable: 'exclude',
+} as const satisfies PackageEntityKeyHandling<DataTableColumn>;
+
+const serializeDataTablePayload = definePackageSerializationPayload<
+	DataTable,
+	SerializedDataTable,
+	typeof dataTablePackageKeyHandling
+>();
+
+const serializeColumnPayload = definePackageSerializationPayload<
+	DataTableColumn,
+	SerializedDataTableColumn,
+	typeof dataTableColumnPackageKeyHandling
+>();
 
 @Service()
 export class DataTableSerializer {
 	serialize(dataTable: DataTable): SerializedDataTable {
-		return serializedDataTableSchema.parse({
-			id: dataTable.id,
-			name: dataTable.name,
-			columns: [...dataTable.columns]
-				.sort((a, b) => a.index - b.index)
-				.map((column) => ({
+		const columns = [...dataTable.columns]
+			.sort((a, b) => a.index - b.index)
+			.map((column) =>
+				serializeColumnPayload({
 					name: column.name,
 					type: column.type,
 					index: column.index,
-				})),
-		});
+				}),
+			);
+
+		return serializedDataTableSchema.parse(
+			serializeDataTablePayload({
+				id: dataTable.id,
+				name: dataTable.name,
+				columns,
+			}),
+		);
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/entities/data-table/data-table.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/data-table/data-table.serializer.ts
@@ -8,42 +8,39 @@ import {
 	type SerializedDataTableColumn,
 	type SerializedDataTable,
 } from '../../spec/serialized/data-table.schema';
-import {
-	definePackageSerializationPayload,
-	type PackageEntityKeyHandling,
-} from '../package-serialization.types';
+import { definePackageSerializationPayload } from '../package-serialization.types';
 
-const dataTablePackageKeyHandling = {
-	id: 'copy',
-	createdAt: 'exclude',
-	updatedAt: 'exclude',
-	name: 'copy',
-	columns: 'transform',
-	project: 'transform',
-	projectId: 'transform',
-} as const satisfies PackageEntityKeyHandling<DataTable>;
+type DataTablePackageKeyHandling = {
+	id: 'copy';
+	createdAt: 'exclude';
+	updatedAt: 'exclude';
+	name: 'copy';
+	columns: 'transform';
+	project: 'transform';
+	projectId: 'transform';
+};
 
-const dataTableColumnPackageKeyHandling = {
-	id: 'exclude',
-	createdAt: 'exclude',
-	updatedAt: 'exclude',
-	dataTableId: 'exclude',
-	name: 'copy',
-	type: 'copy',
-	index: 'copy',
-	dataTable: 'exclude',
-} as const satisfies PackageEntityKeyHandling<DataTableColumn>;
+type DataTableColumnPackageKeyHandling = {
+	id: 'exclude';
+	createdAt: 'exclude';
+	updatedAt: 'exclude';
+	dataTableId: 'exclude';
+	name: 'copy';
+	type: 'copy';
+	index: 'copy';
+	dataTable: 'exclude';
+};
 
 const serializeDataTablePayload = definePackageSerializationPayload<
 	DataTable,
 	SerializedDataTable,
-	typeof dataTablePackageKeyHandling
+	DataTablePackageKeyHandling
 >();
 
 const serializeColumnPayload = definePackageSerializationPayload<
 	DataTableColumn,
 	SerializedDataTableColumn,
-	typeof dataTableColumnPackageKeyHandling
+	DataTableColumnPackageKeyHandling
 >();
 
 @Service()

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder.serializer.ts
@@ -2,28 +2,25 @@ import type { Folder } from '@n8n/db';
 import { Service } from '@n8n/di';
 
 import { serializedFolderSchema, type SerializedFolder } from '../../spec/serialized/folder.schema';
-import {
-	definePackageSerializationPayload,
-	type PackageEntityKeyHandling,
-} from '../package-serialization.types';
+import { definePackageSerializationPayload } from '../package-serialization.types';
 
-const folderPackageKeyHandling = {
-	id: 'copy',
-	createdAt: 'exclude',
-	updatedAt: 'exclude',
-	name: 'copy',
-	parentFolderId: 'transform',
-	parentFolder: 'exclude',
-	subFolders: 'exclude',
-	homeProject: 'transform',
-	workflows: 'exclude',
-	tags: 'exclude',
-} as const satisfies PackageEntityKeyHandling<Folder>;
+type FolderPackageKeyHandling = {
+	id: 'copy';
+	createdAt: 'exclude';
+	updatedAt: 'exclude';
+	name: 'copy';
+	parentFolderId: 'transform';
+	parentFolder: 'exclude';
+	subFolders: 'exclude';
+	homeProject: 'transform';
+	workflows: 'exclude';
+	tags: 'exclude';
+};
 
 const serializePayload = definePackageSerializationPayload<
 	Folder,
 	SerializedFolder,
-	typeof folderPackageKeyHandling
+	FolderPackageKeyHandling
 >();
 
 @Service()

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder.serializer.ts
@@ -2,14 +2,39 @@ import type { Folder } from '@n8n/db';
 import { Service } from '@n8n/di';
 
 import { serializedFolderSchema, type SerializedFolder } from '../../spec/serialized/folder.schema';
+import {
+	definePackageSerializationPayload,
+	type PackageEntityKeyHandling,
+} from '../package-serialization.types';
+
+const folderPackageKeyHandling = {
+	id: 'copy',
+	createdAt: 'exclude',
+	updatedAt: 'exclude',
+	name: 'copy',
+	parentFolderId: 'transform',
+	parentFolder: 'exclude',
+	subFolders: 'exclude',
+	homeProject: 'transform',
+	workflows: 'exclude',
+	tags: 'exclude',
+} as const satisfies PackageEntityKeyHandling<Folder>;
+
+const serializePayload = definePackageSerializationPayload<
+	Folder,
+	SerializedFolder,
+	typeof folderPackageKeyHandling
+>();
 
 @Service()
 export class FolderSerializer {
 	serialize(folder: Folder, parentFolderId: string | null): SerializedFolder {
-		return serializedFolderSchema.parse({
-			id: folder.id,
-			name: folder.name,
-			parentFolderId,
-		});
+		return serializedFolderSchema.parse(
+			serializePayload({
+				id: folder.id,
+				name: folder.name,
+				parentFolderId,
+			}),
+		);
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/entities/package-serialization.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/package-serialization.types.ts
@@ -1,3 +1,10 @@
+/**
+ * The types below are hairy, but they exist for one reason: whenever a field is added to,
+ * renamed on, or removed from a core entity (workflow, credential, ...), package import/export
+ * must be updated too. Each serializer declares an export decision (`copy`, `transform`,
+ * `exclude`) for every entity key, and these types turn any drift between the entity and its
+ * decisions into a compile error — instead of silently dropping data from packages.
+ */
 import type { JoinKeys } from '@n8n/utils/types';
 
 // Entity properties only; methods are ignored.

--- a/packages/cli/src/modules/n8n-packages/entities/package-serialization.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/package-serialization.types.ts
@@ -18,7 +18,7 @@ type ExportDecisionConstraint<TEntity, TKeyHandling> = [
 	Exclude<EntityDataKeys<TEntity>, keyof TKeyHandling>,
 ] extends [never]
 	? [Exclude<keyof TKeyHandling, EntityDataKeys<TEntity>>] extends [never]
-		? Partial<PackageEntityKeyHandling<TEntity>>
+		? PackageEntityKeyHandling<TEntity>
 		: `Export decisions include key(s) that do not exist on the entity: ${JoinKeys<
 				Extract<Exclude<keyof TKeyHandling, EntityDataKeys<TEntity>>, string>
 			>}`

--- a/packages/cli/src/modules/n8n-packages/entities/package-serialization.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/package-serialization.types.ts
@@ -1,36 +1,62 @@
+import type { JoinKeys } from '@n8n/utils/types';
+
 // Entity properties only; methods are ignored.
 type EntityDataKeys<TEntity> = {
 	[K in keyof TEntity]-?: TEntity[K] extends (...args: never[]) => unknown ? never : K;
 }[keyof TEntity];
 
 // Forces every entity property to be classified for export.
-export type PackageEntityKeyHandling<TEntity> = Record<
+type PackageEntityKeyHandling<TEntity> = Record<
 	EntityDataKeys<TEntity>,
 	'copy' | 'transform' | 'exclude'
 >;
 
+// Turns into a readable constraint error in two cases:
+// - entity keys without a decision (e.g. `nodeGroups` added to the entity but not here)
+// - decisions for keys not on the entity (e.g. `nodeGroups` renamed but still listed here)
+type ExportDecisionConstraint<TEntity, TKeyHandling> = [
+	Exclude<EntityDataKeys<TEntity>, keyof TKeyHandling>,
+] extends [never]
+	? [Exclude<keyof TKeyHandling, EntityDataKeys<TEntity>>] extends [never]
+		? Partial<PackageEntityKeyHandling<TEntity>>
+		: `Export decisions include key(s) that do not exist on the entity: ${JoinKeys<
+				Extract<Exclude<keyof TKeyHandling, EntityDataKeys<TEntity>>, string>
+			>}`
+	: `Every entity key has a package export decision, missing export decision for key(s): ${JoinKeys<
+			Extract<Exclude<EntityDataKeys<TEntity>, keyof TKeyHandling>, string>
+		>}`;
+
 // Entity keys exported unchanged (copy key handling).
-type PackageCopiedEntityKeys<TEntity, TKeyHandling extends PackageEntityKeyHandling<TEntity>> = {
-	[K in EntityDataKeys<TEntity>]-?: TKeyHandling[K] extends 'copy' ? K : never;
+type PackageCopiedEntityKeys<TEntity, TKeyHandling> = {
+	[K in EntityDataKeys<TEntity>]-?: K extends keyof TKeyHandling
+		? TKeyHandling[K] extends 'copy'
+			? K
+			: never
+		: never;
 }[EntityDataKeys<TEntity>];
 
 // Entity keys intentionally omitted from export (exclude key handling).
-type PackageExcludedEntityKeys<TEntity, TKeyHandling extends PackageEntityKeyHandling<TEntity>> = {
-	[K in EntityDataKeys<TEntity>]-?: TKeyHandling[K] extends 'exclude' ? K : never;
+type PackageExcludedEntityKeys<TEntity, TKeyHandling> = {
+	[K in EntityDataKeys<TEntity>]-?: K extends keyof TKeyHandling
+		? TKeyHandling[K] extends 'exclude'
+			? K
+			: never
+		: never;
 }[EntityDataKeys<TEntity>];
 
 // Copied entity keys absent from the inferred payload.
-type CopiedEntityKeysMissingFromPayload<
-	TEntity,
-	TKeyHandling extends PackageEntityKeyHandling<TEntity>,
-	TPayload,
-> = Exclude<PackageCopiedEntityKeys<TEntity, TKeyHandling>, keyof TPayload>;
+type CopiedEntityKeysMissingFromPayload<TEntity, TKeyHandling, TPayload> = Exclude<
+	PackageCopiedEntityKeys<TEntity, TKeyHandling>,
+	keyof TPayload
+>;
 
 // Preserves exact payload keys while enforcing the export decisions and serialized schema.
+// The handling map must give every entity key a decision, or this fails to compile with a
+// message listing the undecided keys.
 export function definePackageSerializationPayload<
 	TEntity,
 	TSerialized extends object,
-	TKeyHandling extends PackageEntityKeyHandling<TEntity>,
+	TKeyHandling extends ExportDecisionConstraint<TEntity, TKeyHandling>,
 >() {
 	return <const TPayload extends TSerialized>(
 		payload: TPayload &

--- a/packages/cli/src/modules/n8n-packages/entities/package-serialization.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/package-serialization.types.ts
@@ -1,0 +1,44 @@
+// Entity properties only; methods are ignored.
+type EntityDataKeys<TEntity> = {
+	[K in keyof TEntity]-?: TEntity[K] extends (...args: never[]) => unknown ? never : K;
+}[keyof TEntity];
+
+// Forces every entity property to be classified for export.
+export type PackageEntityKeyHandling<TEntity> = Record<
+	EntityDataKeys<TEntity>,
+	'copy' | 'transform' | 'exclude'
+>;
+
+// Entity keys exported unchanged (copy key handling).
+type PackageCopiedEntityKeys<TEntity, TKeyHandling extends PackageEntityKeyHandling<TEntity>> = {
+	[K in EntityDataKeys<TEntity>]-?: TKeyHandling[K] extends 'copy' ? K : never;
+}[EntityDataKeys<TEntity>];
+
+// Entity keys intentionally omitted from export (exclude key handling).
+type PackageExcludedEntityKeys<TEntity, TKeyHandling extends PackageEntityKeyHandling<TEntity>> = {
+	[K in EntityDataKeys<TEntity>]-?: TKeyHandling[K] extends 'exclude' ? K : never;
+}[EntityDataKeys<TEntity>];
+
+// Copied entity keys absent from the inferred payload.
+type CopiedEntityKeysMissingFromPayload<
+	TEntity,
+	TKeyHandling extends PackageEntityKeyHandling<TEntity>,
+	TPayload,
+> = Exclude<PackageCopiedEntityKeys<TEntity, TKeyHandling>, keyof TPayload>;
+
+// Preserves exact payload keys while enforcing the export decisions and serialized schema.
+export function definePackageSerializationPayload<
+	TEntity,
+	TSerialized extends object,
+	TKeyHandling extends PackageEntityKeyHandling<TEntity>,
+>() {
+	return <const TPayload extends TSerialized>(
+		payload: TPayload &
+			// Every copied key must be present, including optional keys.
+			Record<CopiedEntityKeysMissingFromPayload<TEntity, TKeyHandling, TPayload>, never> &
+			// Excluded entity keys cannot be emitted.
+			Partial<Record<PackageExcludedEntityKeys<TEntity, TKeyHandling>, never>> &
+			// Payload keys must exist in the serialized schema.
+			Record<Exclude<keyof TPayload, keyof TSerialized>, never>,
+	): TPayload => payload;
+}

--- a/packages/cli/src/modules/n8n-packages/entities/project/project.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project.serializer.ts
@@ -5,34 +5,31 @@ import {
 	serializedProjectSchema,
 	type SerializedProject,
 } from '../../spec/serialized/project.schema';
-import {
-	definePackageSerializationPayload,
-	type PackageEntityKeyHandling,
-} from '../package-serialization.types';
+import { definePackageSerializationPayload } from '../package-serialization.types';
 
-const projectPackageKeyHandling = {
-	id: 'copy',
-	createdAt: 'exclude',
-	updatedAt: 'exclude',
-	name: 'copy',
-	type: 'exclude',
-	icon: 'copy',
-	description: 'copy',
-	customTelemetryTags: 'copy',
-	projectRelations: 'exclude',
-	sharedCredentials: 'exclude',
-	sharedWorkflows: 'exclude',
-	secretsProviderAccess: 'exclude',
-	variables: 'exclude',
-	roleMappingRules: 'exclude',
-	creatorId: 'exclude',
-	creator: 'exclude',
-} as const satisfies PackageEntityKeyHandling<Project>;
+type ProjectPackageKeyHandling = {
+	id: 'copy';
+	createdAt: 'exclude';
+	updatedAt: 'exclude';
+	name: 'copy';
+	type: 'exclude';
+	icon: 'copy';
+	description: 'copy';
+	customTelemetryTags: 'copy';
+	projectRelations: 'exclude';
+	sharedCredentials: 'exclude';
+	sharedWorkflows: 'exclude';
+	secretsProviderAccess: 'exclude';
+	variables: 'exclude';
+	roleMappingRules: 'exclude';
+	creatorId: 'exclude';
+	creator: 'exclude';
+};
 
 const serializePayload = definePackageSerializationPayload<
 	Project,
 	SerializedProject,
-	typeof projectPackageKeyHandling
+	ProjectPackageKeyHandling
 >();
 
 @Service()

--- a/packages/cli/src/modules/n8n-packages/entities/project/project.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project.serializer.ts
@@ -5,18 +5,49 @@ import {
 	serializedProjectSchema,
 	type SerializedProject,
 } from '../../spec/serialized/project.schema';
+import {
+	definePackageSerializationPayload,
+	type PackageEntityKeyHandling,
+} from '../package-serialization.types';
+
+const projectPackageKeyHandling = {
+	id: 'copy',
+	createdAt: 'exclude',
+	updatedAt: 'exclude',
+	name: 'copy',
+	type: 'exclude',
+	icon: 'copy',
+	description: 'copy',
+	customTelemetryTags: 'copy',
+	projectRelations: 'exclude',
+	sharedCredentials: 'exclude',
+	sharedWorkflows: 'exclude',
+	secretsProviderAccess: 'exclude',
+	variables: 'exclude',
+	roleMappingRules: 'exclude',
+	creatorId: 'exclude',
+	creator: 'exclude',
+} as const satisfies PackageEntityKeyHandling<Project>;
+
+const serializePayload = definePackageSerializationPayload<
+	Project,
+	SerializedProject,
+	typeof projectPackageKeyHandling
+>();
 
 @Service()
 export class ProjectSerializer {
 	serialize(project: Project): SerializedProject {
-		return serializedProjectSchema.parse({
-			id: project.id,
-			name: project.name,
-			...(project.description !== null ? { description: project.description } : {}),
-			...(project.icon !== null ? { icon: project.icon } : {}),
-			...(project.customTelemetryTags?.length
-				? { customTelemetryTags: project.customTelemetryTags }
-				: {}),
-		});
+		return serializedProjectSchema.parse(
+			serializePayload({
+				id: project.id,
+				name: project.name,
+				...(project.description !== null ? { description: project.description } : {}),
+				...(project.icon !== null ? { icon: project.icon } : {}),
+				...(project.customTelemetryTags?.length
+					? { customTelemetryTags: project.customTelemetryTags }
+					: {}),
+			}),
+		);
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
@@ -1,11 +1,32 @@
+import type { TagEntity } from '@n8n/db';
 import { Service } from '@n8n/di';
 
 import type { PackageWriter } from '../../io/package-writer';
 import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
 import type { ManifestEntry } from '../../spec/manifest.schema';
 import type { PackageTagRequirement } from '../../spec/requirements.schema';
-import { serializedTagSchema } from '../../spec/serialized/tag.schema';
+import { serializedTagSchema, type SerializedTag } from '../../spec/serialized/tag.schema';
+import {
+	definePackageSerializationPayload,
+	type PackageEntityKeyHandling,
+} from '../package-serialization.types';
 import { compareTagsByName, type WorkflowTagUsage } from './tag.types';
+
+const tagPackageKeyHandling = {
+	id: 'copy',
+	createdAt: 'exclude',
+	updatedAt: 'exclude',
+	name: 'copy',
+	workflows: 'exclude',
+	workflowMappings: 'exclude',
+	folderMappings: 'exclude',
+} as const satisfies PackageEntityKeyHandling<TagEntity>;
+
+const serializePayload = definePackageSerializationPayload<
+	TagEntity,
+	SerializedTag,
+	typeof tagPackageKeyHandling
+>();
 
 export interface TagExportRequest {
 	usages: WorkflowTagUsage[];
@@ -41,7 +62,7 @@ export class TagExporter {
 
 		for (const { id, name } of requirements) {
 			const tagDirectory = allocator.allocate(name);
-			const serializedTag = serializedTagSchema.parse({ id, name });
+			const serializedTag = serializedTagSchema.parse(serializePayload({ id, name }));
 			request.writer.writeDirectory(tagDirectory);
 			request.writer.writeFile(
 				`${tagDirectory}/tag.json`,

--- a/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/tag/tag.exporter.ts
@@ -6,26 +6,23 @@ import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
 import type { ManifestEntry } from '../../spec/manifest.schema';
 import type { PackageTagRequirement } from '../../spec/requirements.schema';
 import { serializedTagSchema, type SerializedTag } from '../../spec/serialized/tag.schema';
-import {
-	definePackageSerializationPayload,
-	type PackageEntityKeyHandling,
-} from '../package-serialization.types';
+import { definePackageSerializationPayload } from '../package-serialization.types';
 import { compareTagsByName, type WorkflowTagUsage } from './tag.types';
 
-const tagPackageKeyHandling = {
-	id: 'copy',
-	createdAt: 'exclude',
-	updatedAt: 'exclude',
-	name: 'copy',
-	workflows: 'exclude',
-	workflowMappings: 'exclude',
-	folderMappings: 'exclude',
-} as const satisfies PackageEntityKeyHandling<TagEntity>;
+type TagPackageKeyHandling = {
+	id: 'copy';
+	createdAt: 'exclude';
+	updatedAt: 'exclude';
+	name: 'copy';
+	workflows: 'exclude';
+	workflowMappings: 'exclude';
+	folderMappings: 'exclude';
+};
 
 const serializePayload = definePackageSerializationPayload<
 	TagEntity,
 	SerializedTag,
-	typeof tagPackageKeyHandling
+	TagPackageKeyHandling
 >();
 
 export interface TagExportRequest {

--- a/packages/cli/src/modules/n8n-packages/entities/variable/variable.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/variable/variable.serializer.ts
@@ -5,6 +5,24 @@ import {
 	serializedVariableSchema,
 	type SerializedVariable,
 } from '../../spec/serialized/variable.schema';
+import {
+	definePackageSerializationPayload,
+	type PackageEntityKeyHandling,
+} from '../package-serialization.types';
+
+const variablePackageKeyHandling = {
+	id: 'exclude',
+	key: 'transform',
+	type: 'copy',
+	value: 'copy',
+	project: 'transform',
+} as const satisfies PackageEntityKeyHandling<Variables>;
+
+const serializePayload = definePackageSerializationPayload<
+	Variables,
+	SerializedVariable,
+	typeof variablePackageKeyHandling
+>();
 
 @Service()
 export class VariableSerializer {
@@ -12,10 +30,14 @@ export class VariableSerializer {
 		variable: Variables,
 		{ includeValue = true }: { includeValue?: boolean } = {},
 	): SerializedVariable {
-		return serializedVariableSchema.parse({
-			name: variable.key,
-			type: variable.type,
-			...(includeValue ? { value: variable.value } : {}),
-		});
+		const type = serializedVariableSchema.shape.type.parse(variable.type);
+
+		return serializedVariableSchema.parse(
+			serializePayload({
+				name: variable.key,
+				type,
+				...(includeValue ? { value: variable.value } : {}),
+			}),
+		);
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/entities/variable/variable.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/variable/variable.serializer.ts
@@ -5,23 +5,20 @@ import {
 	serializedVariableSchema,
 	type SerializedVariable,
 } from '../../spec/serialized/variable.schema';
-import {
-	definePackageSerializationPayload,
-	type PackageEntityKeyHandling,
-} from '../package-serialization.types';
+import { definePackageSerializationPayload } from '../package-serialization.types';
 
-const variablePackageKeyHandling = {
-	id: 'exclude',
-	key: 'transform',
-	type: 'copy',
-	value: 'copy',
-	project: 'transform',
-} as const satisfies PackageEntityKeyHandling<Variables>;
+type VariablePackageKeyHandling = {
+	id: 'exclude';
+	key: 'transform';
+	type: 'copy';
+	value: 'copy';
+	project: 'transform';
+};
 
 const serializePayload = definePackageSerializationPayload<
 	Variables,
 	SerializedVariable,
-	typeof variablePackageKeyHandling
+	VariablePackageKeyHandling
 >();
 
 @Service()

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -54,6 +54,14 @@ type WorkflowPackageContentKey = {
 
 type WorkflowPackageContent = Pick<WorkflowEntity, WorkflowPackageContentKey>;
 
+// Copy fields must exist in both the serialized schema and the payload, even when optional.
+// The record allows package-only keys such as `parentFolderId`.
+type SerializePayload = {
+	[K in WorkflowPackageContentKey]-?: K extends keyof SerializedWorkflow
+		? WorkflowEntity[K]
+		: never;
+} & Record<string, unknown>;
+
 @Service()
 export class WorkflowSerializer {
 	serialize(workflow: WorkflowEntity, options: { includeTags: boolean }): SerializedWorkflow {
@@ -74,7 +82,7 @@ export class WorkflowSerializer {
 			isPublished: workflow.activeVersionId === workflow.versionId,
 			isArchived: workflow.isArchived,
 			...(tags ? { tagIds: tags.map((tag) => tag.id) } : {}),
-		});
+		} satisfies SerializePayload);
 	}
 
 	/**

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -6,20 +6,14 @@ import {
 	serializedWorkflowSchema,
 	type SerializedWorkflow,
 } from '../../spec/serialized/workflow.schema';
+import {
+	definePackageSerializationPayload,
+	type PackageEntityKeyHandling,
+} from '../package-serialization.types';
 import { compareTagsByName } from '../tag/tag.types';
 
-type WorkflowEntityDataKey = {
-	[K in keyof WorkflowEntity]-?: WorkflowEntity[K] extends (...args: never[]) => unknown
-		? never
-		: K;
-}[keyof WorkflowEntity];
-
-// `copy` writes and restores the same field. `transform` uses the field in the package
-// without restoring it directly (for example, tags become tagIds). `exclude` omits it.
-type WorkflowPackageDecision = 'copy' | 'transform' | 'exclude';
-
-const workflowPackagePolicy = {
-	id: 'transform',
+const workflowPackageKeyHandling = {
+	id: 'copy',
 	createdAt: 'exclude',
 	updatedAt: 'exclude',
 	name: 'copy',
@@ -36,7 +30,7 @@ const workflowPackagePolicy = {
 	tagMappings: 'exclude',
 	shared: 'exclude',
 	pinData: 'exclude',
-	versionId: 'transform',
+	versionId: 'copy',
 	activeVersionId: 'transform',
 	activeVersion: 'exclude',
 	versionCounter: 'exclude',
@@ -44,23 +38,18 @@ const workflowPackagePolicy = {
 	parentFolder: 'transform',
 	testRuns: 'exclude',
 	sourceWorkflowId: 'exclude',
-} as const satisfies Record<WorkflowEntityDataKey, WorkflowPackageDecision>;
+} as const satisfies PackageEntityKeyHandling<WorkflowEntity>;
 
-type WorkflowPackageContentKey = {
-	[K in keyof typeof workflowPackagePolicy]-?: (typeof workflowPackagePolicy)[K] extends 'copy'
-		? K
-		: never;
-}[keyof typeof workflowPackagePolicy];
+type WorkflowPackageContent = Pick<
+	WorkflowEntity,
+	'name' | 'nodes' | 'connections' | 'isArchived' | 'settings'
+>;
 
-type WorkflowPackageContent = Pick<WorkflowEntity, WorkflowPackageContentKey>;
-
-// Copy fields must exist in both the serialized schema and the payload, even when optional.
-// The record allows package-only keys such as `parentFolderId`.
-type SerializePayload = {
-	[K in WorkflowPackageContentKey]-?: K extends keyof SerializedWorkflow
-		? WorkflowEntity[K]
-		: never;
-} & Record<string, unknown>;
+const serializePayload = definePackageSerializationPayload<
+	WorkflowEntity,
+	SerializedWorkflow,
+	typeof workflowPackageKeyHandling
+>();
 
 @Service()
 export class WorkflowSerializer {
@@ -71,18 +60,20 @@ export class WorkflowSerializer {
 			? [...(workflow.tags ?? [])].sort(compareTagsByName)
 			: undefined;
 
-		return serializedWorkflowSchema.parse({
-			id: workflow.id,
-			name: workflow.name,
-			nodes: workflow.nodes,
-			connections: workflow.connections,
-			settings: workflow.settings,
-			versionId: workflow.versionId,
-			parentFolderId: workflow.parentFolder?.id ?? null,
-			isPublished: workflow.activeVersionId === workflow.versionId,
-			isArchived: workflow.isArchived,
-			...(tags ? { tagIds: tags.map((tag) => tag.id) } : {}),
-		} satisfies SerializePayload);
+		return serializedWorkflowSchema.parse(
+			serializePayload({
+				id: workflow.id,
+				name: workflow.name,
+				nodes: workflow.nodes,
+				connections: workflow.connections,
+				settings: workflow.settings ? { ...workflow.settings } : undefined,
+				versionId: workflow.versionId,
+				parentFolderId: workflow.parentFolder?.id ?? null,
+				isPublished: workflow.activeVersionId === workflow.versionId,
+				isArchived: workflow.isArchived,
+				...(tags ? { tagIds: tags.map((tag) => tag.id) } : {}),
+			}),
+		);
 	}
 
 	/**

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -6,39 +6,36 @@ import {
 	serializedWorkflowSchema,
 	type SerializedWorkflow,
 } from '../../spec/serialized/workflow.schema';
-import {
-	definePackageSerializationPayload,
-	type PackageEntityKeyHandling,
-} from '../package-serialization.types';
+import { definePackageSerializationPayload } from '../package-serialization.types';
 import { compareTagsByName } from '../tag/tag.types';
 
-const workflowPackageKeyHandling = {
-	id: 'copy',
-	createdAt: 'exclude',
-	updatedAt: 'exclude',
-	name: 'copy',
-	description: 'exclude',
-	active: 'exclude',
-	isArchived: 'copy',
-	nodes: 'copy',
-	connections: 'copy',
-	settings: 'copy',
-	staticData: 'exclude',
-	meta: 'exclude',
-	nodeGroups: 'exclude',
-	tags: 'transform',
-	tagMappings: 'exclude',
-	shared: 'exclude',
-	pinData: 'exclude',
-	versionId: 'copy',
-	activeVersionId: 'transform',
-	activeVersion: 'exclude',
-	versionCounter: 'exclude',
-	triggerCount: 'exclude',
-	parentFolder: 'transform',
-	testRuns: 'exclude',
-	sourceWorkflowId: 'exclude',
-} as const satisfies PackageEntityKeyHandling<WorkflowEntity>;
+type WorkflowPackageKeyHandling = {
+	id: 'copy';
+	createdAt: 'exclude';
+	updatedAt: 'exclude';
+	name: 'copy';
+	description: 'exclude';
+	active: 'exclude';
+	isArchived: 'copy';
+	nodes: 'copy';
+	connections: 'copy';
+	settings: 'copy';
+	staticData: 'exclude';
+	meta: 'exclude';
+	nodeGroups: 'exclude';
+	tags: 'transform';
+	tagMappings: 'exclude';
+	shared: 'exclude';
+	pinData: 'exclude';
+	versionId: 'copy';
+	activeVersionId: 'transform';
+	activeVersion: 'exclude';
+	versionCounter: 'exclude';
+	triggerCount: 'exclude';
+	parentFolder: 'transform';
+	testRuns: 'exclude';
+	sourceWorkflowId: 'exclude';
+};
 
 type WorkflowPackageContent = Pick<
 	WorkflowEntity,
@@ -48,7 +45,7 @@ type WorkflowPackageContent = Pick<
 const serializePayload = definePackageSerializationPayload<
 	WorkflowEntity,
 	SerializedWorkflow,
-	typeof workflowPackageKeyHandling
+	WorkflowPackageKeyHandling
 >();
 
 @Service()

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.serializer.ts
@@ -8,11 +8,51 @@ import {
 } from '../../spec/serialized/workflow.schema';
 import { compareTagsByName } from '../tag/tag.types';
 
-/** Fields restored from package workflow.json; the target instance assigns the rest. */
-type WorkflowPackageContent = Pick<
-	WorkflowEntity,
-	'name' | 'nodes' | 'connections' | 'isArchived' | 'settings'
->;
+type WorkflowEntityDataKey = {
+	[K in keyof WorkflowEntity]-?: WorkflowEntity[K] extends (...args: never[]) => unknown
+		? never
+		: K;
+}[keyof WorkflowEntity];
+
+// `copy` writes and restores the same field. `transform` uses the field in the package
+// without restoring it directly (for example, tags become tagIds). `exclude` omits it.
+type WorkflowPackageDecision = 'copy' | 'transform' | 'exclude';
+
+const workflowPackagePolicy = {
+	id: 'transform',
+	createdAt: 'exclude',
+	updatedAt: 'exclude',
+	name: 'copy',
+	description: 'exclude',
+	active: 'exclude',
+	isArchived: 'copy',
+	nodes: 'copy',
+	connections: 'copy',
+	settings: 'copy',
+	staticData: 'exclude',
+	meta: 'exclude',
+	nodeGroups: 'exclude',
+	tags: 'transform',
+	tagMappings: 'exclude',
+	shared: 'exclude',
+	pinData: 'exclude',
+	versionId: 'transform',
+	activeVersionId: 'transform',
+	activeVersion: 'exclude',
+	versionCounter: 'exclude',
+	triggerCount: 'exclude',
+	parentFolder: 'transform',
+	testRuns: 'exclude',
+	sourceWorkflowId: 'exclude',
+} as const satisfies Record<WorkflowEntityDataKey, WorkflowPackageDecision>;
+
+type WorkflowPackageContentKey = {
+	[K in keyof typeof workflowPackagePolicy]-?: (typeof workflowPackagePolicy)[K] extends 'copy'
+		? K
+		: never;
+}[keyof typeof workflowPackagePolicy];
+
+type WorkflowPackageContent = Pick<WorkflowEntity, WorkflowPackageContentKey>;
 
 @Service()
 export class WorkflowSerializer {


### PR DESCRIPTION
## Summary

- Require every exported package entity field to be explicitly classified as copied, transformed, or excluded
- Enforce that copied fields, including optional ones, are present in serializer payloads and excluded fields cannot leak
- Keep the contract intentionally export-only: transformed fields retain their existing package representation and import behavior remains unchanged

## How to test

1. Run `pnpm --dir packages/cli typecheck`
2. Add a temporary data field to `WorkflowEntity`, rebuild `@n8n/db`, and confirm CLI typecheck reports the missing package-policy decision

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-899

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->