### PR TITLE
fix(editor): Require an explicit answer or Skip on Instance AI questions

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import InstanceAiQuestions, { type QuestionItem } from '../components/InstanceAiQuestions.vue';
@@ -34,6 +34,10 @@ function render(questions: QuestionItem[]) {
 }
 
 describe('InstanceAiQuestions', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it('submits the final empty text question as skipped', async () => {
 		const { emitted, getByTestId } = render([textQuestion]);
 
@@ -59,17 +63,44 @@ describe('InstanceAiQuestions', () => {
 		]);
 	});
 
-	it('shows enabled Submit for the final empty single-select question', async () => {
-		const { emitted, getByTestId, queryByTestId } = render([singleQuestion]);
+	it('submits the clicked option on the final single-select question', async () => {
+		vi.useFakeTimers();
+		const { emitted, getByText } = render([singleQuestion]);
 
-		expect(queryByTestId('instance-ai-questions-skip')).toBeNull();
+		await fireEvent.click(getByText('Production'));
+		vi.advanceTimersByTime(250);
 
-		const submitButton = getByTestId('instance-ai-questions-next');
+		expect(emitted().submit).toEqual([
+			[
+				[
+					{
+						questionId: 'q-single',
+						question: 'Which credential should I use?',
+						selectedOptions: ['Production'],
+						customText: '',
+						skipped: false,
+					},
+				],
+			],
+		]);
+	});
 
-		expect(submitButton).toHaveTextContent('Submit');
-		expect(submitButton).not.toHaveAttribute('disabled');
+	it('keeps Submit disabled while an option is only highlighted, not selected', async () => {
+		const { container, getByTestId } = render([singleQuestion]);
 
-		await fireEvent.click(submitButton);
+		const firstOption = container.querySelector('[data-option-index="0"]');
+		expect(firstOption).not.toBeNull();
+		await fireEvent.mouseEnter(firstOption as Element);
+
+		expect(getByTestId('instance-ai-questions-next')).toHaveAttribute('disabled');
+	});
+
+	it('skips the final single-select question via the explicit Skip button', async () => {
+		const { emitted, getByTestId } = render([singleQuestion]);
+
+		expect(getByTestId('instance-ai-questions-next')).toHaveAttribute('disabled');
+
+		await fireEvent.click(getByTestId('instance-ai-questions-skip'));
 
 		expect(emitted().submit).toEqual([
 			[
@@ -86,17 +117,12 @@ describe('InstanceAiQuestions', () => {
 		]);
 	});
 
-	it('submits the final empty multi-select question as skipped', async () => {
-		const { emitted, getByTestId, queryByTestId } = render([multiQuestion]);
+	it('skips the final empty multi-select question via the explicit Skip button', async () => {
+		const { emitted, getByTestId } = render([multiQuestion]);
 
-		expect(queryByTestId('instance-ai-questions-skip')).toBeNull();
+		expect(getByTestId('instance-ai-questions-next')).toHaveAttribute('disabled');
 
-		const submitButton = getByTestId('instance-ai-questions-next');
-
-		expect(submitButton).toHaveTextContent('Submit');
-		expect(submitButton).not.toHaveAttribute('disabled');
-
-		await fireEvent.click(submitButton);
+		await fireEvent.click(getByTestId('instance-ai-questions-skip'));
 
 		expect(emitted().submit).toEqual([
 			[
@@ -113,13 +139,38 @@ describe('InstanceAiQuestions', () => {
 		]);
 	});
 
-	it('keeps an empty non-final text question skippable but not nextable', () => {
-		const { getByTestId } = render([textQuestion, singleQuestion]);
+	it('advances past a blank non-final text question via Next and marks it skipped', async () => {
+		vi.useFakeTimers();
+		const { emitted, getByTestId, getByText } = render([textQuestion, singleQuestion]);
 
 		const nextButton = getByTestId('instance-ai-questions-next');
-
-		expect(getByTestId('instance-ai-questions-skip')).toBeInTheDocument();
 		expect(nextButton).toHaveTextContent('Next');
-		expect(nextButton).toHaveAttribute('disabled');
+		expect(nextButton).not.toHaveAttribute('disabled');
+
+		await fireEvent.click(nextButton);
+
+		await fireEvent.click(getByText('Staging'));
+		vi.advanceTimersByTime(250);
+
+		expect(emitted().submit).toEqual([
+			[
+				[
+					{
+						questionId: 'q-text',
+						question: 'Leave blank for no filter',
+						selectedOptions: [],
+						customText: '',
+						skipped: true,
+					},
+					{
+						questionId: 'q-single',
+						question: 'Which credential should I use?',
+						selectedOptions: ['Staging'],
+						customText: '',
+						skipped: false,
+					},
+				],
+			],
+		]);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
@@ -82,7 +82,6 @@ const hasValidAnswer = computed(() => {
 });
 
 const showSkipButton = computed(() => {
-	if (isLastQuestion.value) return false;
 	if (currentQuestion.value?.type === 'single' && hasCustomText.value) return false;
 	return true;
 });
@@ -96,13 +95,13 @@ const showNextButton = computed(() => {
 const isNextEnabled = computed(() => {
 	const q = currentQuestion.value;
 	if (!q) return false;
-	if (isLastQuestion.value) return true;
-	if (q.type === 'single') return hasCustomText.value;
+	// Blank text is a valid submission — it advances marked as skipped
+	if (q.type === 'text') return true;
+	if (q.type === 'single') return hasValidAnswer.value;
 	if (q.type === 'multi') {
 		const answer = currentAnswer.value;
 		return (answer?.selectedOptions.length ?? 0) > 0 || hasCustomText.value;
 	}
-	if (q.type === 'text') return hasCustomText.value;
 	return false;
 });
 


### PR DESCRIPTION
## Summary

In the Instance AI questions wizard, the final question's Submit button was always enabled and silently doubled as a skip (introduced in [#29563](https://github.com/n8n-io/n8n/pull/29563) to make the last question skippable). Single-select options only commit on click, while hover and arrow keys merely highlight, so a user who highlighted an option and clicked Submit had their answer recorded as skipped. The assistant then replied "You skipped, so I'll keep the workflow as built".

Blank text steps had the inverse problem: Next stayed disabled for an intentionally blank input, so the user could not proceed.

Changes:

- The Skip button now also shows on the last question, so skipping is always an explicit action
- Submit/Next is enabled only when the current question has a committed answer, so a highlighted-but-unselected option can no longer be submitted as a skip
- Text questions accept a blank value: advancing with an empty field marks the answer as skipped, matching the semantics the agent already understands

## How to test

1. Ask the AI Assistant something that makes it respond with a single-select question (with options and a Submit button)
2. Hover an option without clicking it and observe Submit stays disabled instead of submitting a skip
3. Click an option and observe it is submitted as the answer
4. Click Skip on the last question and observe an explicit skip
5. For a multi-step form with a text question, leave the field blank and observe Next is enabled and advances

Unit tests: `pnpm vitest run src/features/ai/instanceAi/__tests__/InstanceAiQuestions.test.ts` in `packages/frontend/editor-ui`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-967
- https://linear.app/n8n/issue/INS-478

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

