### PR TITLE
fix(editor): Preserve new agent artifact lifecycle

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -887,6 +887,8 @@ export const instanceAiAgentAttachmentSchema = z.object({
 	name: z.string().max(255).optional(),
 	/** Project that owns the agent — required so the FE artifact preview can render. */
 	projectId: z.string().min(1).max(64),
+	/** The New Agent artifact has no persisted agent row yet. */
+	pending: z.literal(true).optional(),
 });
 export type InstanceAiAgentAttachment = z.infer<typeof instanceAiAgentAttachmentSchema>;
 

--- a/packages/cli/src/modules/instance-ai/__tests__/internal-messages.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/internal-messages.test.ts
@@ -8,7 +8,7 @@ import {
 
 type EditorContextAttachment =
 	| { type: 'workflow'; id: string; name?: string; executionId?: string }
-	| { type: 'agent'; id: string; name?: string; projectId: string };
+	| { type: 'agent'; id: string; name?: string; projectId: string; pending?: true };
 
 /** Mirrors the marker the service writes in buildContextResourcesBlock. */
 function editorContextMarker(
@@ -138,13 +138,27 @@ describe('extractEditorContextResourceAttachments', () => {
 		]);
 	});
 
-	it('reconstructs agent attachments from the marker', () => {
+	it('reconstructs pending agent attachments from the marker', () => {
 		const stored = editorContextMarker(
-			[{ type: 'agent', id: 'agent-1', name: 'Support Agent', projectId: 'proj-1' }],
+			[
+				{
+					type: 'agent',
+					id: 'agent-1',
+					name: 'Support Agent',
+					projectId: 'proj-1',
+					pending: true,
+				},
+			],
 			'The user opened this conversation from the agent editor.',
 		);
 		expect(extractEditorContextResourceAttachments(stored)).toEqual([
-			{ type: 'agent', id: 'agent-1', name: 'Support Agent', projectId: 'proj-1' },
+			{
+				type: 'agent',
+				id: 'agent-1',
+				name: 'Support Agent',
+				projectId: 'proj-1',
+				pending: true,
+			},
 		]);
 	});
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -235,6 +235,9 @@ function buildContextResourcesBlock(contextAttachments: InstanceAiResourceAttach
 	const lines = contextAttachments.map((attachment) => {
 		const name = attachment.name ? ` "${attachment.name}"` : '';
 		if (attachment.type === 'agent') {
+			if (attachment.pending) {
+				return `- New unsaved Agent artifact${name} (pending id: \`${attachment.id}\`, in project \`${attachment.projectId}\`).`;
+			}
 			return `- Agent${name} (id: \`${attachment.id}\`, in project \`${attachment.projectId}\`).`;
 		}
 		// Only mention the execution when one was actually handed off.
@@ -246,11 +249,19 @@ function buildContextResourcesBlock(contextAttachments: InstanceAiResourceAttach
 	const header = contextAttachments.some((attachment) => attachment.type === 'agent')
 		? 'The user opened this conversation from the agent editor, where they are looking at:'
 		: 'The user opened this conversation from the workflow editor, where they are looking at:';
+	const pendingAgentGuidance = contextAttachments.some(
+		(attachment) => attachment.type === 'agent' && attachment.pending,
+	)
+		? "Treat references such as “the agent” as this pending artifact. It has no persisted agent row yet. When the user asks to build or change it, use `build-agent`'s new-agent path with a name; do not pass its pending id as an existing `agentId`. The thread's pending target will make creation reuse that id."
+		: '';
 	const prose = [
 		header,
 		...lines,
+		pendingAgentGuidance,
 		"Treat this purely as context. Until the user tells you what they need, don't read, inspect, run, or otherwise call tools on these resources, and don't make claims about their contents — just briefly acknowledge what they're working on and ask how you can help.",
-	].join('\n');
+	]
+		.filter(Boolean)
+		.join('\n');
 	// Wrap in EDITOR_CONTEXT_BLOCK so the UI strips it from the visible message
 	// (cleanStoredUserMessage) and the parser can reconstruct the attachments on
 	// reload from the leading JSON line — keeping the resource durable without

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -120,6 +120,7 @@ const getAgentMock = vi.fn();
 const createAgentMock = vi.fn();
 const updateConfigMock = vi.fn();
 const fetchConfigMock = vi.fn();
+const repointConfigMock = vi.fn();
 const deleteAgentMock = vi.fn().mockResolvedValue(undefined);
 const listAgentFilesMock = vi.fn().mockResolvedValue([]);
 const uploadAgentFilesMock = vi.fn().mockResolvedValue([]);
@@ -251,6 +252,7 @@ vi.mock('../composables/useAgentConfig', () => ({
 			mockConfig.value = withDefaultLlm(intendedConfig);
 		}),
 		updateConfig: updateConfigMock,
+		repoint: repointConfigMock,
 	}),
 }));
 
@@ -525,6 +527,7 @@ function resetViewMocks() {
 	mockConfig.value = withDefaultLlm(intendedConfig);
 	updateConfigMock.mockReset();
 	updateConfigMock.mockResolvedValue({ versionId: 'v1', stale: false });
+	repointConfigMock.mockReset();
 	getAgentMock.mockResolvedValue(makeAgentResponse());
 	createAgentMock.mockReset();
 	createAgentMock.mockResolvedValue(makeAgentResponse({ id: 'aBcDeFgHiJkLmNoP' }));
@@ -1608,11 +1611,22 @@ describe('AgentBuilderView — three-column shell', () => {
 			expect(createAgentMock).not.toHaveBeenCalled();
 		});
 
-		it('creates the agent once on the first edits, under the minted id', async () => {
+		it('creates the pending agent once and refreshes validation after the first save', async () => {
+			let configTarget: string | undefined;
+			repointConfigMock.mockImplementation((projectId: string, agentId: string) => {
+				configTarget = `${projectId}:${agentId}`;
+			});
+			updateConfigMock.mockImplementation(async (projectId: string, agentId: string) => ({
+				versionId: 'v1',
+				stale: configTarget !== `${projectId}:${agentId}`,
+			}));
 			const wrapper = await renderView({ props: pendingProps });
 			const editor = wrapper.findComponent({ name: 'AgentBuilderEditorColumn' });
 
-			editor.vm.$emit('update:config', { instructions: 'Answer support mail' });
+			editor.vm.$emit('update:config', {
+				name: 'Support Agent',
+				instructions: 'Answer support mail',
+			});
 			editor.vm.$emit('update:config', { model: 'anthropic/claude-sonnet-4-5' });
 			await vi.waitFor(() => expect(updateConfigMock).toHaveBeenCalled());
 
@@ -1625,6 +1639,14 @@ describe('AgentBuilderView — three-column shell', () => {
 				'aBcDeFgHiJkLmNoP',
 				expect.objectContaining({ instructions: 'Answer support mail' }),
 			);
+			await vi.waitFor(() =>
+				expect(
+					wrapper
+						.find('[data-testid="stub-agent-builder-header"]')
+						.attributes('data-config-validation-status'),
+				).toBe('valid'),
+			);
+			expect(wrapper.emitted('name-saved')).toContainEqual(['Support Agent']);
 		});
 
 		it('persists the icon and gradient with the first save, so a new agent keeps them', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/NewAgentView.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import NewAgentView from '../views/NewAgentView.vue';
 import { INSTANCE_AI_THREAD_VIEW } from '@/features/ai/instanceAi/constants';
+import { getPendingAgentAttachment } from '@/features/ai/instanceAi/composables/useInstanceAiHandoff';
 import { AGENTS_LIST_VIEW, PROJECT_AGENTS } from '../constants';
 
 const mocks = vi.hoisted(() => ({
@@ -37,6 +38,7 @@ describe('NewAgentView', () => {
 		vi.clearAllMocks();
 		mocks.route.query = { projectId: 'project-1' };
 		history.replaceState({}, '');
+		localStorage.clear();
 	});
 
 	it('opens an unsaved agent artifact without creating the agent', async () => {
@@ -53,6 +55,12 @@ describe('NewAgentView', () => {
 				projectId: 'project-1',
 				agentId: 'aBcDeFgHiJkLmNoP',
 			},
+		});
+		expect(getPendingAgentAttachment('thread-1')).toMatchObject({
+			type: 'agent',
+			id: 'aBcDeFgHiJkLmNoP',
+			projectId: 'project-1',
+			pending: true,
 		});
 		expect(mocks.replace).toHaveBeenCalledWith({
 			name: INSTANCE_AI_THREAD_VIEW,

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -108,6 +108,8 @@ const props = withDefaults(
 const emit = defineEmits<{
 	/** The agent behind an unsaved artifact now exists. */
 	persisted: [agent: AgentResource];
+	/** The agent name was successfully saved. */
+	'name-saved': [name: string];
 }>();
 
 const route = useRoute();
@@ -235,7 +237,7 @@ const sessionOptions = computed<Array<DropdownMenuItemProps<string>>>(() =>
 );
 
 // Config
-const { config, fetchConfig, updateConfig } = useAgentConfig();
+const { config, fetchConfig, updateConfig, repoint: repointConfig } = useAgentConfig();
 const {
 	validation: configValidation,
 	repoint: repointConfigValidation,
@@ -714,6 +716,7 @@ async function saveConfig(snapshot: ConfigAutosaveSnapshot): Promise<'skipped' |
 	// `agent.versionId` would otherwise be polluted with values for the
 	// previous agent.
 	if (result.stale) return undefined;
+	emit('name-saved', snapshot.config.name);
 	if (agent.value && agent.value.id === snapshot.agentId && result.versionId !== undefined) {
 		agent.value = { ...agent.value, versionId: result.versionId };
 	}
@@ -1273,6 +1276,7 @@ async function initialize({ preserveState = false }: { preserveState?: boolean }
 			agentFilesLoading.value = false;
 			agentFilesUploading.value = false;
 			deletingAgentFileId.value = null;
+			repointConfig(projectId.value, agentId.value);
 			repointConfigValidation(projectId.value, agentId.value);
 		}
 

--- a/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
@@ -11,6 +11,7 @@ import {
 	INSTANCE_AI_PENDING_AGENT_METADATA_KEY,
 	INSTANCE_AI_THREAD_VIEW,
 } from '@/features/ai/instanceAi/constants';
+import { stashPendingAgentAttachment } from '@/features/ai/instanceAi/composables/useInstanceAiHandoff';
 import { useInstanceAiStore } from '@/features/ai/instanceAi/instanceAi.store';
 import { AGENTS_LIST_VIEW, PROJECT_AGENTS } from '../constants';
 
@@ -58,6 +59,13 @@ onMounted(async () => {
 		});
 		await instanceAiStore.updateThreadMetadata(threadId, {
 			[INSTANCE_AI_PENDING_AGENT_METADATA_KEY]: { projectId, agentId },
+		});
+		stashPendingAgentAttachment(threadId, {
+			type: 'agent',
+			id: agentId,
+			name: i18n.baseText('agents.new.defaultName'),
+			projectId,
+			pending: true,
 		});
 		await router.replace({
 			name: INSTANCE_AI_THREAD_VIEW,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -33,6 +33,7 @@ import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHe
 import { COLLAPSED_MAIN_SIDEBAR_WIDTH, useSidebarLayout } from '@/app/composables/useSidebarLayout';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { provideThread, useInstanceAiStore } from './instanceAi.store';
+import { getAgentBuilderTargetFromThreadMetadata } from './instanceAi.threadRuntime';
 import { useInstanceAiSettingsStore } from './instanceAiSettings.store';
 import { isPendingItemFloating } from './confirmationKinds';
 import { scrubSecretsInText } from '@n8n/utils/scrub-secrets';
@@ -93,6 +94,27 @@ const { isCollapsed: isMainSidebarCollapsed, sidebarWidth: mainSidebarWidth } = 
 const telemetry = useTelemetry();
 const pendingComposerContext = ref<InstanceAiHandoffContext | null>(null);
 const pendingAgentAttachment = ref<InstanceAiAgentAttachment | null>(null);
+const currentAgentAttachment = computed<InstanceAiAgentAttachment | null>(() => {
+	const queued = pendingAgentAttachment.value;
+	if (!queued) return null;
+
+	const boundTarget = getAgentBuilderTargetFromThreadMetadata(store.getThreadMetadata(thread.id));
+	if (
+		boundTarget?.agentId !== queued.id ||
+		boundTarget.projectId !== queued.projectId ||
+		!queued.pending
+	) {
+		return queued;
+	}
+
+	const name = boundTarget.name ?? queued.name;
+	return {
+		type: 'agent',
+		id: queued.id,
+		projectId: queued.projectId,
+		...(name ? { name } : {}),
+	};
+});
 
 // Running builders render in a dedicated bottom section of the conversation.
 // Once a builder finishes it falls out of this list and AgentTimeline renders
@@ -166,6 +188,8 @@ const currentThreadTitle = computed<string | undefined>(() => {
 const preview = useCanvasPreview({
 	thread,
 	threadId: () => props.threadId,
+	initialAgentId: () =>
+		getAgentBuilderTargetFromThreadMetadata(store.getThreadMetadata(props.threadId))?.agentId,
 });
 
 provide('openWorkflowPreview', preview.openWorkflowPreview);
@@ -285,7 +309,10 @@ const isArtifactsPanelInLayout = computed(
 		availableWidthForPinnedArtifactsPanel.value >= MIN_AVAILABLE_WIDTH_FOR_PINNED_ARTIFACTS_PANEL,
 );
 const canShowArtifactsPanel = computed(
-	() => thread.hasMessages || (Boolean(props.threadId) && thread.isHydratingThread),
+	() =>
+		thread.hasMessages ||
+		preview.allArtifactTabs.value.length > 0 ||
+		(Boolean(props.threadId) && thread.isHydratingThread),
 );
 const showArtifactsPanel = computed(
 	() =>
@@ -504,6 +531,16 @@ function isCurrentThreadRuntime(): boolean {
 }
 
 const composerContextChip = computed(() => {
+	const agentAttachment = currentAgentAttachment.value;
+	if (pendingAgentAttachment.value?.pending && agentAttachment) {
+		return {
+			key: `pending-agent:${agentAttachment.id}`,
+			label: agentAttachment.name ?? i18n.baseText('agents.new.defaultName'),
+			icon: 'robot',
+			isPending: true,
+		};
+	}
+
 	if (pendingComposerContext.value?.source === 'agent-preview') {
 		return {
 			key: handoffContextKey(pendingComposerContext.value),
@@ -658,7 +695,8 @@ function handleSubmit(message: string, attachments?: InstanceAiAttachment[]) {
 	}
 
 	const handoffContext = pendingComposerContext.value ?? undefined;
-	const agentAttachment = pendingAgentAttachment.value;
+	const queuedAgentAttachment = pendingAgentAttachment.value;
+	const agentAttachment = currentAgentAttachment.value;
 	const submittedAttachments = agentAttachment
 		? [...(attachments ?? []), agentAttachment]
 		: attachments;
@@ -670,7 +708,7 @@ function handleSubmit(message: string, attachments?: InstanceAiAttachment[]) {
 			if (handoffContext && pendingComposerContext.value === handoffContext) {
 				pendingComposerContext.value = null;
 			}
-			if (agentAttachment && pendingAgentAttachment.value === agentAttachment) {
+			if (queuedAgentAttachment && pendingAgentAttachment.value === queuedAgentAttachment) {
 				clearPendingAgentAttachment(props.threadId);
 				pendingAgentAttachment.value = null;
 			}
@@ -706,6 +744,12 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 
 async function dismissComposerContextChip() {
 	if (!composerContextChip.value) return;
+
+	if (pendingAgentAttachment.value?.pending) {
+		clearPendingAgentAttachment(props.threadId);
+		pendingAgentAttachment.value = null;
+		return;
+	}
 
 	if (composerContextChip.value.isPending) {
 		pendingComposerContext.value = null;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiAgentPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiAgentPreview.test.ts
@@ -1,0 +1,84 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentResource } from '@/features/agents/types';
+import InstanceAiAgentPreview from '../components/InstanceAiAgentPreview.vue';
+import {
+	getAgentBuilderTargetFromThreadMetadata,
+	getPendingAgentTargetFromThreadMetadata,
+} from '../instanceAi.threadRuntime';
+
+const threadState = {
+	id: 'thread-1',
+	messages: [],
+};
+const metadataState = ref<Record<string, unknown>>();
+const updateThreadMetadataMock = vi.fn(
+	async (_threadId: string, metadata: Record<string, unknown>) => {
+		metadataState.value = { ...metadataState.value, ...metadata };
+	},
+);
+
+vi.mock('../instanceAi.store', () => ({
+	useThread: () => threadState,
+	useInstanceAiStore: () => ({
+		getThreadMetadata: () => metadataState.value,
+		updateThreadMetadata: updateThreadMetadataMock,
+	}),
+}));
+
+const persistedAgent = {
+	id: 'agent-1',
+	name: 'Support Agent',
+} as AgentResource;
+
+const AgentBuilderViewStub = {
+	name: 'AgentBuilderView',
+	emits: ['persisted', 'name-saved'],
+	template: '<div />',
+};
+
+describe('InstanceAiAgentPreview', () => {
+	beforeEach(() => {
+		metadataState.value = {
+			instanceAiPendingAgentTarget: {
+				agentId: 'agent-1',
+				projectId: 'project-1',
+			},
+		};
+		updateThreadMetadataMock.mockClear();
+	});
+
+	it('keeps the bound thread target in sync across persistence and renames', async () => {
+		const wrapper = mount(InstanceAiAgentPreview, {
+			props: {
+				agentId: 'agent-1',
+				projectId: 'project-1',
+				pending: true,
+			},
+			global: {
+				stubs: {
+					AgentBuilderView: AgentBuilderViewStub,
+				},
+			},
+		});
+		const builder = wrapper.findComponent({ name: 'AgentBuilderView' });
+
+		builder.vm.$emit('persisted', persistedAgent);
+		await flushPromises();
+
+		expect(getPendingAgentTargetFromThreadMetadata(metadataState.value)).toBeUndefined();
+		expect(getAgentBuilderTargetFromThreadMetadata(metadataState.value)).toEqual({
+			agentId: 'agent-1',
+			projectId: 'project-1',
+			name: 'Support Agent',
+		});
+
+		builder.vm.$emit('name-saved', 'Renamed Support Agent');
+		await flushPromises();
+
+		expect(getAgentBuilderTargetFromThreadMetadata(metadataState.value)?.name).toBe(
+			'Renamed Support Agent',
+		);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiArtifactsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiArtifactsPanel.test.ts
@@ -416,6 +416,52 @@ describe('InstanceAiArtifactsPanel', () => {
 		expect(openAgentPreview).toHaveBeenCalledExactlyOnceWith('agent-1', 'proj-1');
 	});
 
+	it('keeps pending agents in the preview without exposing a standalone link', () => {
+		const openAgentPreview = vi.fn();
+		storeState.producedArtifacts = new Map<string, ResourceEntry>([
+			[
+				'agent-1',
+				{
+					type: 'agent',
+					id: 'agent-1',
+					projectId: 'proj-1',
+					name: 'New Agent',
+					pending: true,
+				},
+			],
+		]);
+
+		const { getByRole } = renderComponent({
+			global: {
+				provide: {
+					openAgentPreview,
+				},
+			},
+		});
+
+		const artifactLink = getByRole('link', { name: 'Open New Agent' });
+		expect(artifactLink).toHaveAttribute('href', '#');
+
+		const normalClick = new MouseEvent('click', { bubbles: true, cancelable: true });
+		expect(artifactLink.dispatchEvent(normalClick)).toBe(false);
+		expect(openAgentPreview).toHaveBeenCalledExactlyOnceWith('agent-1', 'proj-1');
+
+		openAgentPreview.mockClear();
+		let wasDefaultPreventedByComponent: boolean | undefined;
+		artifactLink.addEventListener('click', (event) => {
+			wasDefaultPreventedByComponent = event.defaultPrevented;
+		});
+		const modifiedClick = new MouseEvent('click', {
+			bubbles: true,
+			cancelable: true,
+			metaKey: true,
+		});
+		artifactLink.dispatchEvent(modifiedClick);
+
+		expect(wasDefaultPreventedByComponent).toBe(true);
+		expect(openAgentPreview).not.toHaveBeenCalled();
+	});
+
 	it('leaves modified agent artifact clicks to the browser', () => {
 		const openAgentPreview = vi.fn();
 		storeState.producedArtifacts = new Map<string, ResourceEntry>([

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -374,6 +374,9 @@ describe('InstanceAiThreadView', () => {
 				updatedAt: '2026-04-01T00:00:00.000Z',
 			},
 		] as typeof store.threads;
+		store.getThreadMetadata.mockImplementation(
+			(threadId) => store.threads.find((item) => item.id === threadId)?.metadata ?? undefined,
+		);
 		mockWindowSizeState.width.value = 1200;
 
 		// Auto-stubbed push-store actions return undefined by default; addEventListener's
@@ -619,9 +622,20 @@ describe('InstanceAiThreadView', () => {
 		});
 	});
 
-	it('opens a pending agent and attaches it only to the first submitted message', async () => {
+	it('shows the new-agent context until the first successful message submission', async () => {
 		thread.sseState = 'disconnected';
 		vi.mocked(thread.loadHistoricalMessages).mockResolvedValue('skipped');
+		store.threads = [
+			{
+				...store.threads[0],
+				metadata: {
+					instanceAiPendingAgentTarget: {
+						agentId: 'agent-1',
+						projectId: 'project-1',
+					},
+				},
+			},
+		] as typeof store.threads;
 		thread.producedArtifacts = new Map([
 			[
 				'agent-1',
@@ -629,16 +643,19 @@ describe('InstanceAiThreadView', () => {
 					type: 'agent',
 					id: 'agent-1',
 					projectId: 'project-1',
-					name: 'New agent',
+					name: 'New Agent',
+					pending: true,
 				},
 			],
 		]) as typeof thread.producedArtifacts;
 		stashPendingAgentAttachment('thread-1', {
 			type: 'agent',
 			id: 'agent-1',
-			name: 'New agent',
+			name: 'New Agent',
 			projectId: 'project-1',
+			pending: true,
 		});
+		vi.mocked(thread.sendMessage).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
 		const { findByTestId, getByTestId } = renderView({ props: { threadId: 'thread-1' } });
 
@@ -646,6 +663,7 @@ describe('InstanceAiThreadView', () => {
 		expect(preview).toHaveAttribute('data-agent-id', 'agent-1');
 		expect(preview).toHaveAttribute('data-project-id', 'project-1');
 		expect(thread.sendMessage).not.toHaveBeenCalled();
+		expect(getByTestId('instance-ai-input-context-chip')).toHaveTextContent('New Agent');
 
 		await userEvent.click(getByTestId('instance-ai-input-submit'));
 
@@ -656,8 +674,29 @@ describe('InstanceAiThreadView', () => {
 				{
 					type: 'agent',
 					id: 'agent-1',
-					name: 'New agent',
+					name: 'New Agent',
 					projectId: 'project-1',
+					pending: true,
+				},
+			],
+			expect.any(String),
+			undefined,
+		);
+		expect(getPendingAgentAttachment('thread-1')).not.toBeNull();
+		expect(getByTestId('instance-ai-input-context-chip')).toHaveTextContent('New Agent');
+
+		await userEvent.click(getByTestId('instance-ai-input-submit'));
+
+		expect(thread.sendMessage).toHaveBeenNthCalledWith(
+			2,
+			'Normal message',
+			[
+				{
+					type: 'agent',
+					id: 'agent-1',
+					name: 'New Agent',
+					projectId: 'project-1',
+					pending: true,
 				},
 			],
 			expect.any(String),
@@ -665,12 +704,98 @@ describe('InstanceAiThreadView', () => {
 		);
 		await vi.waitFor(() => {
 			expect(getPendingAgentAttachment('thread-1')).toBeNull();
+			expect(getByTestId('instance-ai-input-context-chip')).toHaveTextContent('');
 		});
 
 		await userEvent.click(getByTestId('instance-ai-input-submit'));
 
 		expect(thread.sendMessage).toHaveBeenNthCalledWith(
-			2,
+			3,
+			'Normal message',
+			undefined,
+			expect.any(String),
+			undefined,
+		);
+	});
+
+	it('attaches the bound target when the new agent was persisted before the first message', async () => {
+		thread.sseState = 'disconnected';
+		vi.mocked(thread.loadHistoricalMessages).mockResolvedValue('skipped');
+		store.threads = [
+			{
+				...store.threads[0],
+				metadata: {
+					instanceAiAgentBuilderTarget: {
+						agentId: 'agent-1',
+						projectId: 'project-1',
+						name: 'Support Agent',
+					},
+				},
+			},
+		] as typeof store.threads;
+		stashPendingAgentAttachment('thread-1', {
+			type: 'agent',
+			id: 'agent-1',
+			name: 'New Agent',
+			projectId: 'project-1',
+			pending: true,
+		});
+
+		const { getByTestId } = renderView({ props: { threadId: 'thread-1' } });
+
+		await vi.waitFor(() => {
+			expect(getByTestId('instance-ai-input-context-chip')).toHaveTextContent('Support Agent');
+		});
+		await userEvent.click(getByTestId('instance-ai-input-submit'));
+
+		expect(thread.sendMessage).toHaveBeenCalledWith(
+			'Normal message',
+			[
+				{
+					type: 'agent',
+					id: 'agent-1',
+					name: 'Support Agent',
+					projectId: 'project-1',
+				},
+			],
+			expect.any(String),
+			undefined,
+		);
+	});
+
+	it('detaches dismissed new-agent context without closing its preview', async () => {
+		thread.sseState = 'disconnected';
+		vi.mocked(thread.loadHistoricalMessages).mockResolvedValue('skipped');
+		thread.producedArtifacts = new Map([
+			[
+				'agent-1',
+				{
+					type: 'agent',
+					id: 'agent-1',
+					projectId: 'project-1',
+					name: 'New Agent',
+					pending: true,
+				},
+			],
+		]) as typeof thread.producedArtifacts;
+		stashPendingAgentAttachment('thread-1', {
+			type: 'agent',
+			id: 'agent-1',
+			name: 'New Agent',
+			projectId: 'project-1',
+			pending: true,
+		});
+
+		const { findByTestId, getByTestId } = renderView({ props: { threadId: 'thread-1' } });
+		const preview = await findByTestId('instance-ai-agent-preview-stub');
+
+		await userEvent.click(getByTestId('instance-ai-input-dismiss-context-chip'));
+
+		expect(getPendingAgentAttachment('thread-1')).toBeNull();
+		expect(getByTestId('instance-ai-input-context-chip')).toHaveTextContent('');
+		expect(preview).toBeInTheDocument();
+		await userEvent.click(getByTestId('instance-ai-input-submit'));
+		expect(thread.sendMessage).toHaveBeenCalledWith(
 			'Normal message',
 			undefined,
 			expect.any(String),
@@ -1046,69 +1171,67 @@ describe('InstanceAiThreadView', () => {
 		expect(queryByTestId('instance-ai-assistant-message')).not.toBeInTheDocument();
 	});
 
-	it('closes the agent artifact preview from the wrapper toggle', async () => {
+	it('keeps the new-agent artifact accessible when closed and restores it after refresh', async () => {
+		mockWindowSizeState.width.value = 1700;
 		thread.producedArtifacts = new Map([
-			['agent-1', { type: 'agent', id: 'agent-1', projectId: 'proj-1', name: 'SEO Auditor' }],
+			[
+				'agent-1',
+				{
+					type: 'agent',
+					id: 'agent-1',
+					projectId: 'proj-1',
+					name: 'New Agent',
+					pending: true,
+				},
+			],
 		]) as typeof thread.producedArtifacts;
 
 		const user = userEvent.setup();
-		const { findByTestId, queryByTestId } = renderView({ props: { threadId: 'thread-1' } });
+		const firstRender = renderView({ props: { threadId: 'thread-1' } });
 
-		thread.messages.push({
-			id: 'msg-agent',
-			role: 'assistant',
-			content: '',
-			reasoning: '',
-			isStreaming: false,
-			createdAt: '2026-04-01T00:00:00.000Z',
-			agentTree: {
-				agentId: 'agent-builder',
-				role: 'orchestrator',
-				status: 'completed',
-				textContent: '',
-				reasoning: '',
-				timeline: [],
-				children: [
-					{
-						agentId: 'agent-builder-child',
-						role: 'agent-builder',
-						kind: 'agent-builder',
-						status: 'completed',
-						textContent: '',
-						reasoning: '',
-						timeline: [],
-						children: [],
-						toolCalls: [],
-						targetResource: {
-							type: 'agent',
-							id: 'agent-1',
-							projectId: 'proj-1',
-							name: 'SEO Auditor',
-						},
-					},
-				],
-				toolCalls: [
-					{
-						toolCallId: 'tc-create-agent',
-						toolName: 'build-agent',
-						args: { message: 'build me an SEO auditor', name: 'SEO Auditor' },
-						isLoading: false,
-						result: { ok: true, builderReply: 'Created the agent.' },
-					},
-				],
-			},
-		} as never);
-
-		await findByTestId('instance-ai-agent-preview-stub');
-		const previewPanel = await findByTestId('instance-ai-preview-panel');
+		await firstRender.findByTestId('instance-ai-agent-preview-stub');
+		const previewPanel = await firstRender.findByTestId('instance-ai-preview-panel');
 		expect(previewPanel).toBeVisible();
 
-		await user.click(await findByTestId('instance-ai-artifacts-preview-toggle'));
+		await user.click(await firstRender.findByTestId('instance-ai-artifacts-preview-toggle'));
 
 		await vi.waitFor(() => {
 			expect(previewPanel).not.toBeVisible();
 		});
-		expect(queryByTestId('instance-ai-agent-preview-stub')).not.toBeInTheDocument();
+		expect(firstRender.queryByTestId('instance-ai-agent-preview-stub')).not.toBeInTheDocument();
+		expect(firstRender.getByTestId('instance-ai-artifacts-sidebar-slot')).toBeInTheDocument();
+		expect(firstRender.getByTestId('instance-ai-artifacts-panel-toggle')).toBeInTheDocument();
+
+		store.threads = [
+			{
+				...store.threads[0],
+				metadata: {
+					instanceAiAgentBuilderTarget: {
+						agentId: 'agent-1',
+						projectId: 'proj-1',
+						name: 'Support Agent',
+					},
+				},
+			},
+		] as typeof store.threads;
+		thread.producedArtifacts = new Map([
+			[
+				'agent-1',
+				{
+					type: 'agent',
+					id: 'agent-1',
+					projectId: 'proj-1',
+					name: 'Support Agent',
+				},
+			],
+		]) as typeof thread.producedArtifacts;
+
+		firstRender.unmount();
+		const refreshedRender = renderView({ props: { threadId: 'thread-1' } });
+		const restoredPreview = await refreshedRender.findByTestId('instance-ai-agent-preview-stub');
+
+		expect(restoredPreview).toHaveAttribute('data-agent-id', 'agent-1');
+		expect(await refreshedRender.findByTestId('instance-ai-preview-panel')).toBeVisible();
 	});
 
 	describe('Fix with AI card', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
@@ -229,8 +229,8 @@ describe('useResourceRegistry', () => {
 	});
 
 	describe('producedArtifacts — message attachments', () => {
-		test('preserves pending state from a new-agent attachment', async () => {
-			const { messages, producedArtifacts } = setup();
+		test('keeps a pending new-agent attachment produced but not linkable', async () => {
+			const { messages, producedArtifacts, linkableResourceNameIndex } = setup();
 
 			messages.value = [
 				makeMessage({
@@ -255,6 +255,7 @@ describe('useResourceRegistry', () => {
 				projectId: 'proj-1',
 				pending: true,
 			});
+			expect(linkableResourceNameIndex.get('support agent')).toBeUndefined();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
@@ -229,7 +229,7 @@ describe('useResourceRegistry', () => {
 	});
 
 	describe('producedArtifacts — message attachments', () => {
-		test('registers agent attachment from a user message', async () => {
+		test('preserves pending state from a new-agent attachment', async () => {
 			const { messages, producedArtifacts } = setup();
 
 			messages.value = [
@@ -241,6 +241,7 @@ describe('useResourceRegistry', () => {
 							id: 'agent-1',
 							name: 'Support Agent',
 							projectId: 'proj-1',
+							pending: true,
 						},
 					],
 				}),
@@ -252,6 +253,7 @@ describe('useResourceRegistry', () => {
 				id: 'agent-1',
 				name: 'Support Agent',
 				projectId: 'proj-1',
+				pending: true,
 			});
 		});
 	});
@@ -928,11 +930,25 @@ describe('useResourceRegistry', () => {
 		});
 
 		test('drops the pending flag once the agent is bound to the thread', async () => {
-			const { producedArtifacts } = setup(
+			const { messages, producedArtifacts } = setup(
 				undefined,
 				() => ({ agentId: 'aBcDeFgHiJkLmNoP', projectId: 'project-1', name: 'Support Triage' }),
 				() => ({ agentId: 'aBcDeFgHiJkLmNoP', projectId: 'project-1', name: 'New agent' }),
 			);
+			messages.value = [
+				makeMessage({
+					role: 'user',
+					attachments: [
+						{
+							type: 'agent',
+							id: 'aBcDeFgHiJkLmNoP',
+							name: 'New agent',
+							projectId: 'project-1',
+							pending: true,
+						},
+					],
+				}),
+			];
 			await nextTick();
 
 			const entry = producedArtifacts.get('aBcDeFgHiJkLmNoP');

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiAgentPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiAgentPreview.vue
@@ -3,8 +3,15 @@ import { computed } from 'vue';
 import AgentBuilderView from '@/features/agents/views/AgentBuilderView.vue';
 import type { AgentResource } from '@/features/agents/types';
 import { isAgentEditingAgent } from '../canvasPreview.utils';
+import {
+	getAgentBuilderTargetFromThreadMetadata,
+	getPendingAgentTargetFromThreadMetadata,
+} from '../instanceAi.threadRuntime';
 import { useThread, useInstanceAiStore } from '../instanceAi.store';
-import { INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY } from '../constants';
+import {
+	INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY,
+	INSTANCE_AI_PENDING_AGENT_METADATA_KEY,
+} from '../constants';
 
 const props = defineProps<{
 	projectId: string;
@@ -31,20 +38,31 @@ const isAgentBuilding = computed(() => {
 	return false;
 });
 
-/**
- * Bind the agent to the thread once the builder has actually created it. This
- * is what stops a reload from treating the artifact as pending again: the
- * pending marker cannot be removed (thread metadata merges rather than
- * deletes), so a real binding is how the registry tells the two apart.
- */
-async function onAgentPersisted(agent: AgentResource) {
+async function syncAgentTarget(name: string) {
+	const metadata = instanceAiStore.getThreadMetadata(thread.id);
+	const target = getAgentBuilderTargetFromThreadMetadata(metadata);
+	const pendingTarget = getPendingAgentTargetFromThreadMetadata(metadata);
+	if (
+		target?.agentId === props.agentId &&
+		target.projectId === props.projectId &&
+		target.name === name &&
+		!pendingTarget
+	) {
+		return;
+	}
+
 	await instanceAiStore.updateThreadMetadata(thread.id, {
+		[INSTANCE_AI_PENDING_AGENT_METADATA_KEY]: null,
 		[INSTANCE_AI_AGENT_BUILDER_TARGET_METADATA_KEY]: {
-			agentId: agent.id,
+			agentId: props.agentId,
 			projectId: props.projectId,
-			name: agent.name,
+			name,
 		},
 	});
+}
+
+async function onAgentPersisted(agent: AgentResource) {
+	await syncAgentTarget(agent.name);
 }
 </script>
 
@@ -57,6 +75,7 @@ async function onAgentPersisted(agent: AgentResource) {
 			:artifact-agent-pending="props.pending"
 			:artifact-editing-locked="isAgentBuilding"
 			@persisted="onAgentPersisted"
+			@name-saved="syncAgentTarget"
 		/>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiArtifactsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiArtifactsPanel.vue
@@ -61,6 +61,7 @@ interface ContextEntry {
 }
 
 function handleArtifactClick(artifact: ResourceEntry, e: MouseEvent) {
+	if (artifact.type === 'agent' && artifact.pending) e.preventDefault();
 	if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
 
 	if (artifact.type === 'workflow' && artifact.id) {
@@ -119,6 +120,7 @@ function artifactHref(artifact: ResourceEntry) {
 			: '/data-tables';
 	}
 	if (artifact.type === 'agent') {
+		if (artifact.pending) return '#';
 		return artifact.projectId
 			? `/projects/${artifact.projectId}/agents/${artifact.id}`
 			: '/home/agents';

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useCanvasPreview.ts
@@ -34,9 +34,10 @@ const ARTIFACT_ICON_MAP: Record<string, IconName> = {
 interface UseCanvasPreviewOptions {
 	thread: ThreadRuntime;
 	threadId: () => string;
+	initialAgentId?: () => string | undefined;
 }
 
-export function useCanvasPreview({ thread }: UseCanvasPreviewOptions) {
+export function useCanvasPreview({ thread, initialAgentId }: UseCanvasPreviewOptions) {
 	// --- Tab state ---
 	const activeTabId = ref<string>();
 	const isPreviewOpen = ref(false);
@@ -128,9 +129,14 @@ export function useCanvasPreview({ thread }: UseCanvasPreviewOptions) {
 	// attach yet), so it opens off the thread's pending marker instead — the user
 	// arrived here by asking for a new agent, so it should already be on screen.
 	const pendingAgentTabId = computed(() => allArtifactTabs.value.find((tab) => tab.pending)?.id);
+	const initialAgentTabId = computed(() => {
+		const agentId = initialAgentId?.();
+		if (!agentId) return undefined;
+		return allArtifactTabs.value.find((tab) => tab.type === 'agent' && tab.id === agentId)?.id;
+	});
 
 	const initialArtifactId = computed(
-		() => firstAttachedArtifactId.value ?? pendingAgentTabId.value,
+		() => firstAttachedArtifactId.value ?? pendingAgentTabId.value ?? initialAgentTabId.value,
 	);
 
 	// Open the arriving resource. Only when nothing is open, so it never steals

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
@@ -343,13 +343,17 @@ function collectFromMessageAttachments(message: InstanceAiMessage, col: Collecti
 				name: attachment.name ?? 'Untitled',
 			});
 		} else if (attachment.type === 'agent') {
-			recordProduced(col, {
-				type: 'agent',
-				id: attachment.id,
-				name: attachment.name ?? 'Untitled',
-				projectId: attachment.projectId,
-				...(attachment.pending ? { pending: true } : {}),
-			});
+			recordProduced(
+				col,
+				{
+					type: 'agent',
+					id: attachment.id,
+					name: attachment.name ?? 'Untitled',
+					projectId: attachment.projectId,
+					...(attachment.pending ? { pending: true } : {}),
+				},
+				{ linkable: !attachment.pending },
+			);
 		}
 	}
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
@@ -348,6 +348,7 @@ function collectFromMessageAttachments(message: InstanceAiMessage, col: Collecti
 				id: attachment.id,
 				name: attachment.name ?? 'Untitled',
 				projectId: attachment.projectId,
+				...(attachment.pending ? { pending: true } : {}),
 			});
 		}
 	}
@@ -363,7 +364,8 @@ function enrichAgentFromBuilderTarget(
 	// Event-derived names are canonical; the persisted metadata name only fills
 	// in when no run event carried one (e.g. historical threads whose events
 	// aren't loaded). The 'Untitled' placeholder is not a real name.
-	const eventName = existing && existing.name !== 'Untitled' ? existing.name : undefined;
+	const eventName =
+		existing && !existing.pending && existing.name !== 'Untitled' ? existing.name : undefined;
 	recordProduced(
 		col,
 		{


### PR DESCRIPTION
## Summary

- Keep pending New Agent artifacts accessible through close, refresh, persistence, and rename transitions
- Attach the pending agent to the composer and first successful user message so Instance AI targets the correct artifact
- Refresh embedded validation after the first save and prevent pending artifacts from linking to nonexistent agent routes

## How to test

1. Start n8n with `N8N_ENABLED_MODULES=agents,instance-ai` and open **New Agent** from the sidebar.
2. Confirm the pending preview opens, then close it and reopen it from the artifact summary.
3. Confirm the composer shows **New Agent** context, submit an agent-building request, and verify the user message carries the attachment.
4. Configure and rename the agent manually, refresh the thread, and verify the bound agent preview, current name, and valid configuration are restored.
5. Run the focused frontend and backend tests documented below.

Focused verification:
- `pnpm test src/features/agents/__tests__/NewAgentView.test.ts src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts` from `packages/frontend/editor-ui`
- `pnpm test src/modules/instance-ai/__tests__/internal-messages.test.ts` from `packages/cli`
- `pnpm typecheck` in `packages/@n8n/api-types`, `packages/cli`, and `packages/frontend/editor-ui`
- Full `pnpm build`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-577

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

