### PR TITLE
fix: Stop blocking save/publish on dynamic-credential and webhook incompatibility (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -1010,6 +1010,49 @@ describe('WorkflowService', () => {
 				);
 			});
 		});
+
+		test('republishes the active version when settings change on an already-active workflow', async () => {
+			const existingWorkflow = setupExistingWorkflow();
+			existingWorkflow.activeVersionId = 'v1';
+
+			const activateWorkflowSpy = vi
+				.spyOn(workflowService, 'activateWorkflow')
+				.mockResolvedValue(mock<WorkflowEntity>());
+
+			const user = mock<User>();
+			await workflowService.update(user, createUpdateData({ executionOrder: 'v1' }), 'workflow-1', {
+				forceSave: true,
+			});
+
+			expect(activateWorkflowSpy).toHaveBeenCalledWith(
+				user,
+				'workflow-1',
+				expect.objectContaining({ versionId: 'v1' }),
+			);
+		});
+
+		test('republishes the active version when the Public API republishes an already-active workflow', async () => {
+			const existingWorkflow = setupExistingWorkflow();
+			existingWorkflow.activeVersionId = 'v1';
+
+			const activateWorkflowSpy = vi
+				.spyOn(workflowService, 'activateWorkflow')
+				.mockResolvedValue(mock<WorkflowEntity>());
+
+			const user = mock<User>();
+			await workflowService.update(
+				user,
+				{ name: 'Renamed workflow' } as unknown as WorkflowEntity,
+				'workflow-1',
+				{ publishIfActive: true },
+			);
+
+			expect(activateWorkflowSpy).toHaveBeenCalledWith(
+				user,
+				'workflow-1',
+				expect.objectContaining({ versionId: 'v1' }),
+			);
+		});
 	});
 
 	describe('workflow.activate hook', () => {
@@ -1027,6 +1070,7 @@ describe('WorkflowService', () => {
 		let workflowHookContextServiceMock: MockProxy<WorkflowHookContextService>;
 		let pollTriggerJobRegistrarMock: MockProxy<PollTriggerJobRegistrar>;
 		let workflowPublishGuardMock: MockProxy<WorkflowPublishGuardProxy>;
+		let workflowValidationServiceMock: MockProxy<WorkflowValidationService>;
 
 		const WORKFLOW_ID = 'workflow-1';
 		const PREVIOUS_VERSION_ID = 'v1';
@@ -1081,6 +1125,9 @@ describe('WorkflowService', () => {
 			workflowHookContextServiceMock = mock<WorkflowHookContextService>();
 			pollTriggerJobRegistrarMock = mock();
 			workflowPublishGuardMock = mock<WorkflowPublishGuardProxy>();
+			workflowValidationServiceMock = Object.assign(mock<WorkflowValidationService>(), {
+				validateCredentialNodeRestrictions: () => ({ isValid: true }),
+			});
 
 			workflowRepositoryMock.create.mockImplementation(
 				(data) => Object.assign(new WorkflowEntity(), data) as WorkflowEntity,
@@ -1105,9 +1152,7 @@ describe('WorkflowService', () => {
 				workflowFinderServiceMock, // workflowFinderService
 				workflowPublishHistoryRepositoryMock, // workflowPublishHistoryRepository
 				outboxRepositoryMock, // outboxRepository
-				Object.assign(mock<WorkflowValidationService>(), {
-					validateCredentialNodeRestrictions: () => ({ isValid: true }),
-				}), // workflowValidationService
+				workflowValidationServiceMock, // workflowValidationService
 				mock(), // nodeTypes
 				mock(), // webhookService
 				mock(), // licenseState
@@ -1325,6 +1370,54 @@ describe('WorkflowService', () => {
 				role: 'global:admin',
 			});
 			expect(context).toBe(workflowHookContextServiceMock);
+		});
+
+		test('runs the dynamic-credentials guard by default', async () => {
+			const workflow = makeWorkflowEntity({ activeVersionId: PREVIOUS_VERSION_ID });
+			workflowFinderServiceMock.findWorkflowForUser.mockResolvedValue(workflow);
+			workflowHistoryServiceMock.getVersion.mockResolvedValue(makeVersionToActivate());
+			workflowRepositoryMock.findOne.mockResolvedValue(workflow);
+			externalHooksMock.run.mockResolvedValue(undefined);
+			vi.spyOn(
+				workflowService as unknown as { _addToActiveWorkflowManager: () => Promise<void> },
+				'_addToActiveWorkflowManager',
+			).mockResolvedValue(undefined);
+
+			await workflowService.activateWorkflow(mock<User>(), WORKFLOW_ID, {
+				versionId: TARGET_VERSION_ID,
+			});
+
+			const internals = workflowService as unknown as { _validateDynamicCredentials: Mock };
+			expect(internals._validateDynamicCredentials).toHaveBeenCalled();
+		});
+
+		test('does not block activation when the workflow has incompatible dynamic credentials (hotfix)', async () => {
+			const workflow = makeWorkflowEntity({ activeVersionId: PREVIOUS_VERSION_ID });
+			workflowFinderServiceMock.findWorkflowForUser.mockResolvedValue(workflow);
+			workflowHistoryServiceMock.getVersion.mockResolvedValue(makeVersionToActivate());
+			workflowRepositoryMock.findOne.mockResolvedValue(workflow);
+			externalHooksMock.run.mockResolvedValue(undefined);
+			vi.spyOn(
+				workflowService as unknown as { _addToActiveWorkflowManager: () => Promise<void> },
+				'_addToActiveWorkflowManager',
+			).mockResolvedValue(undefined);
+
+			// Let the real _validateDynamicCredentials run (undoing the blanket bypass from
+			// beforeEach) so it consults the underlying validation service for real.
+			const internals = workflowService as unknown as { _validateDynamicCredentials: Mock };
+			internals._validateDynamicCredentials.mockRestore();
+			workflowValidationServiceMock.validateDynamicCredentials.mockResolvedValue({
+				isValid: false,
+				error: 'End-user credentials are not supported by this trigger',
+			});
+
+			await expect(
+				workflowService.activateWorkflow(mock<User>(), WORKFLOW_ID, {
+					versionId: TARGET_VERSION_ID,
+				}),
+			).resolves.toBeInstanceOf(WorkflowEntity);
+
+			expect(workflowValidationServiceMock.validateDynamicCredentials).toHaveBeenCalled();
 		});
 
 		test('with the publication outbox enabled, updates the version, writes history, enqueues and emits events without touching the active workflow manager', async () => {

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -1439,6 +1439,11 @@ export class WorkflowService {
 		}
 	}
 
+	/**
+	 * Hotfix: log-only. Dynamic credentials + webhook incompatibility is surfaced as a
+	 * canvas warning; it must not block save or activation while the compatibility model
+	 * is still being worked out.
+	 */
 	private async _validateDynamicCredentials(
 		workflowId: string,
 		nodes: INode[],
@@ -1451,13 +1456,10 @@ export class WorkflowService {
 		);
 
 		if (!validation.isValid) {
-			this.logger.warn('Workflow activation failed dynamic credentials validation', {
+			this.logger.warn('Workflow has incompatible dynamic credentials', {
 				workflowId,
 				error: validation.error,
 			});
-			throw new WorkflowValidationError(
-				validation.error ?? 'Dynamic credentials validation failed',
-			);
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -1073,7 +1073,7 @@ describe('useNodeHelpers()', () => {
 				const { getNodeCredentialIssues } = useNodeHelpers();
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-				expect(result?.credentials?.[NOTION_API]).toEqual([
+				expect(result?.identityTrigger?.[NOTION_API]).toEqual([
 					"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Chat, MCP, and Sub-workflow. To use another trigger, switch this credential to Fixed.",
 				]);
 			});
@@ -1115,7 +1115,7 @@ describe('useNodeHelpers()', () => {
 					const { getNodeCredentialIssues } = useNodeHelpers();
 					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-					expect(result?.credentials?.[NOTION_API]).toEqual([
+					expect(result?.identityTrigger?.[NOTION_API]).toEqual([
 						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Chat, MCP, and Sub-workflow. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
@@ -1128,7 +1128,7 @@ describe('useNodeHelpers()', () => {
 					const { getNodeCredentialIssues } = useNodeHelpers();
 					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-					expect(result?.credentials?.[NOTION_API]).toEqual([
+					expect(result?.identityTrigger?.[NOTION_API]).toEqual([
 						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Chat, MCP, Sub-workflow, and Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
@@ -1157,7 +1157,7 @@ describe('useNodeHelpers()', () => {
 					const { getNodeCredentialIssues } = useNodeHelpers();
 					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-					expect(result?.credentials?.[NOTION_API]).toEqual([
+					expect(result?.identityTrigger?.[NOTION_API]).toEqual([
 						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Chat, MCP, Sub-workflow, and Form with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
@@ -1172,7 +1172,7 @@ describe('useNodeHelpers()', () => {
 					const { getNodeCredentialIssues } = useNodeHelpers();
 					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-					expect(result?.credentials?.[NOTION_API]).toEqual([
+					expect(result?.identityTrigger?.[NOTION_API]).toEqual([
 						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Chat, MCP, and Sub-workflow. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
@@ -1186,7 +1186,7 @@ describe('useNodeHelpers()', () => {
 					const { getNodeCredentialIssues } = useNodeHelpers();
 					const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-					expect(result?.credentials?.[NOTION_API]).toEqual([
+					expect(result?.identityTrigger?.[NOTION_API]).toEqual([
 						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Chat, MCP, Sub-workflow, and Form or Webhook with n8n user authentication. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
@@ -1221,7 +1221,7 @@ describe('useNodeHelpers()', () => {
 				const { getNodeCredentialIssues } = useNodeHelpers();
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-				expect(result?.credentials?.[NOTION_API]).toBeDefined();
+				expect(result?.identityTrigger?.[NOTION_API]).toBeDefined();
 			});
 
 			it('does not warn under a custom resolver when the trigger extracts an external identity', () => {
@@ -1253,7 +1253,7 @@ describe('useNodeHelpers()', () => {
 				const { getNodeCredentialIssues } = useNodeHelpers();
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-				expect(result?.credentials?.[NOTION_API]?.[0]).toContain(
+				expect(result?.identityTrigger?.[NOTION_API]?.[0]).toContain(
 					'need a trigger that extracts an identity',
 				);
 			});
@@ -1303,7 +1303,7 @@ describe('useNodeHelpers()', () => {
 				const { getNodeCredentialIssues } = useNodeHelpers();
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-				expect(result?.credentials?.[NOTION_API]?.[0]).toContain(
+				expect(result?.identityTrigger?.[NOTION_API]?.[0]).toContain(
 					"End-user credentials aren't supported by this workflow's trigger",
 				);
 			});
@@ -1318,7 +1318,7 @@ describe('useNodeHelpers()', () => {
 				const { getNodeCredentialIssues } = useNodeHelpers();
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
-				expect(result?.credentials?.[NOTION_API]?.[0]).toContain(
+				expect(result?.identityTrigger?.[NOTION_API]?.[0]).toContain(
 					"End-user credentials aren't supported by this workflow's trigger",
 				);
 			});
@@ -1408,7 +1408,7 @@ describe('useNodeHelpers()', () => {
 					const { getNodeCredentialIssues } = useNodeHelpers();
 					const result = getNodeCredentialIssues(buildGenericAuthNode(), httpRequestWithSslAuth);
 
-					expect(result?.credentials?.[OAUTH2_API]).toEqual([
+					expect(result?.identityTrigger?.[OAUTH2_API]).toEqual([
 						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Chat, MCP, and Sub-workflow. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
@@ -1440,7 +1440,7 @@ describe('useNodeHelpers()', () => {
 					const { getNodeCredentialIssues } = useNodeHelpers();
 					const result = getNodeCredentialIssues(buildPredefinedAuthNode(), httpRequestWithSslAuth);
 
-					expect(result?.credentials?.[OAUTH2_API]).toEqual([
+					expect(result?.identityTrigger?.[OAUTH2_API]).toEqual([
 						"End-user credentials aren't supported by this workflow's trigger. Supported triggers: Manual, Chat, MCP, and Sub-workflow. To use another trigger, switch this credential to Fixed.",
 					]);
 				});
@@ -1469,7 +1469,7 @@ describe('useNodeHelpers()', () => {
 
 				// Trigger incompatibility blocks publish regardless of who connected the
 				// credential, so the editor warns even when the user did not connect it.
-				expect(result?.credentials?.[NOTION_API]?.[0]).toContain(
+				expect(result?.identityTrigger?.[NOTION_API]?.[0]).toContain(
 					"End-user credentials aren't supported by this workflow's trigger",
 				);
 			});

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -333,15 +333,15 @@ export function useNodeHelpers() {
 	function updateNodeCredentialIssues(node: INodeUi): void {
 		const fullNodeIssues: INodeIssues | null = getNodeCredentialIssues(node);
 
-		let newIssues: INodeIssueObjectProperty | null = null;
-		if (fullNodeIssues !== null) {
-			newIssues = fullNodeIssues.credentials!;
-		}
-
 		workflowDocumentStore.value.setNodeIssue({
 			node: node.name,
 			type: 'credentials',
-			value: newIssues,
+			value: fullNodeIssues?.credentials ?? null,
+		});
+		workflowDocumentStore.value.setNodeIssue({
+			node: node.name,
+			type: 'identityTrigger',
+			value: fullNodeIssues?.identityTrigger ?? null,
 		});
 	}
 
@@ -457,13 +457,22 @@ export function useNodeHelpers() {
 			: null;
 	}
 
+	/**
+	 * Writes into `identityTriggerIssues`, a category kept separate from `foundIssues`
+	 * (credentials) so it stays informational on the canvas without tripping
+	 * `hasPublishBlockingIssues` — a hotfix so save/publish aren't blocked while this
+	 * compatibility model is still being worked out. `foundIssues` is only consulted to
+	 * avoid double-messaging a credential that already has a real (blocking) issue.
+	 */
 	function collectPrivateCredentialIssues(
 		node: INodeUi,
 		foundIssues: INodeIssueObjectProperty,
+		identityTriggerIssues: INodeIssueObjectProperty,
 	): void {
 		if (!isPrivateCredentialsEnabled.value) return;
 
 		const blockingTrigger = getBlockingTrigger();
+		if (!blockingTrigger) return;
 
 		for (const [credTypeName, details] of Object.entries(node.credentials ?? {})) {
 			if (foundIssues[credTypeName]?.length) continue;
@@ -472,29 +481,26 @@ export function useNodeHelpers() {
 			const credential = credentialsStore.getCredentialById(details.id);
 			if (!credential?.isResolvable) continue;
 
-			// Mirror the backend publish check: trigger incompatibility blocks publish
-			// regardless of who connected the credential, so warn on it here too. A
-			// merely-not-yet-connected credential is surfaced via the callout/banner.
-			// The message depends on the resolver: the system resolver needs a trigger
-			// that establishes the n8n user identity, a custom resolver needs one that
-			// extracts an external identity. Form and webhook are only listed as
-			// supported while their respective OAuth2 flags are on — without them
-			// neither establishes an identity, so listing them would advertise a fix
-			// that doesn't work.
-			if (blockingTrigger) {
-				let messageKey: BaseTextKey = 'nodeIssues.credentials.privateRequiresIdentityTrigger';
+			// Mirror the backend publish check: warn on trigger incompatibility
+			// regardless of who connected the credential. A merely-not-yet-connected
+			// credential is surfaced via the callout/banner. The message depends on the
+			// resolver: the system resolver needs a trigger that establishes the n8n user
+			// identity, a custom resolver needs one that extracts an external identity.
+			// Form and webhook are only listed as supported while their respective OAuth2
+			// flags are on — without them neither establishes an identity, so listing them
+			// would advertise a fix that doesn't work.
+			let messageKey: BaseTextKey = 'nodeIssues.credentials.privateRequiresIdentityTrigger';
 
-				if (!blockingTrigger.isSystemResolver) {
-					messageKey = 'nodeIssues.credentials.privateRequiresIdentityExtractor';
-				} else if (blockingTrigger.formOAuth2Enabled && blockingTrigger.webhookOAuth2Enabled) {
-					messageKey = 'nodeIssues.credentials.privateRequiresIdentityTriggerWithFormAndWebhook';
-				} else if (blockingTrigger.formOAuth2Enabled) {
-					messageKey = 'nodeIssues.credentials.privateRequiresIdentityTriggerWithForm';
-				} else if (blockingTrigger.webhookOAuth2Enabled) {
-					messageKey = 'nodeIssues.credentials.privateRequiresIdentityTriggerWithWebhook';
-				}
-				foundIssues[credTypeName] = [i18n.baseText(messageKey)];
+			if (!blockingTrigger.isSystemResolver) {
+				messageKey = 'nodeIssues.credentials.privateRequiresIdentityExtractor';
+			} else if (blockingTrigger.formOAuth2Enabled && blockingTrigger.webhookOAuth2Enabled) {
+				messageKey = 'nodeIssues.credentials.privateRequiresIdentityTriggerWithFormAndWebhook';
+			} else if (blockingTrigger.formOAuth2Enabled) {
+				messageKey = 'nodeIssues.credentials.privateRequiresIdentityTriggerWithForm';
+			} else if (blockingTrigger.webhookOAuth2Enabled) {
+				messageKey = 'nodeIssues.credentials.privateRequiresIdentityTriggerWithWebhook';
 			}
+			identityTriggerIssues[credTypeName] = [i18n.baseText(messageKey)];
 		}
 	}
 
@@ -646,16 +652,22 @@ export function useNodeHelpers() {
 			}
 		}
 
-		collectPrivateCredentialIssues(node, foundIssues);
+		const identityTriggerIssues: INodeIssueObjectProperty = {};
+		collectPrivateCredentialIssues(node, foundIssues, identityTriggerIssues);
 
 		// TODO: Could later check also if the node has access to the credentials
-		if (Object.keys(foundIssues).length === 0) {
+		if (Object.keys(foundIssues).length === 0 && Object.keys(identityTriggerIssues).length === 0) {
 			return null;
 		}
 
-		return {
-			credentials: foundIssues,
-		};
+		const issues: INodeIssues = {};
+		if (Object.keys(foundIssues).length > 0) {
+			issues.credentials = foundIssues;
+		}
+		if (Object.keys(identityTriggerIssues).length > 0) {
+			issues.identityTrigger = identityTriggerIssues;
+		}
+		return issues;
 	}
 	/**
 	 * Whether the node has no selected credentials, or none of the node's
@@ -694,6 +706,11 @@ export function useNodeHelpers() {
 				node: node.name,
 				type: 'credentials',
 				value: issues?.credentials ?? null,
+			});
+			workflowDocumentStore.value.setNodeIssue({
+				node: node.name,
+				type: 'identityTrigger',
+				value: issues?.identityTrigger ?? null,
 			});
 		}
 	}

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodesIssues.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodesIssues.test.ts
@@ -80,5 +80,26 @@ describe('useWorkflowDocumentNodesIssues', () => {
 
 			expect(hasPublishBlockingIssues.value).toBe(true);
 		});
+
+		it('does not count identityTrigger issues as publish-blocking (hotfix)', () => {
+			const node = connectedNode({
+				issues: { identityTrigger: { cred1: ["End-user credentials aren't supported..."] } },
+			});
+			const { hasPublishBlockingIssues } = useWorkflowDocumentNodesIssues(createDeps([node]));
+
+			expect(hasPublishBlockingIssues.value).toBe(false);
+		});
+
+		it('blocks on credential issues even when identityTrigger issues are also present', () => {
+			const node = connectedNode({
+				issues: {
+					identityTrigger: { cred1: ["End-user credentials aren't supported..."] },
+					credentials: { cred2: ['Not set'] },
+				},
+			});
+			const { hasPublishBlockingIssues } = useWorkflowDocumentNodesIssues(createDeps([node]));
+
+			expect(hasPublishBlockingIssues.value).toBe(true);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodesIssues.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodesIssues.ts
@@ -37,10 +37,13 @@ export function useWorkflowDocumentNodesIssues(deps: WorkflowDocumentNodesIssues
 	const hasNodeValidationIssues = computed(() => nodesWithValidationIssuesCount.value > 0);
 
 	/** Whether any connected node has issues that should block publishing.
-	 *  Execution issues are excluded — they are runtime errors, not configuration problems. */
+	 *  Execution issues are excluded — they are runtime errors, not configuration
+	 *  problems. `identityTrigger` issues (dynamic-credential/trigger identity
+	 *  incompatibility) are also excluded — hotfix: informational on the canvas only,
+	 *  must not block save/publish. */
 	const hasPublishBlockingIssues = computed(() =>
 		deps.allNodes.value.some((node) => {
-			const { execution: _, ...configIssues } = node.issues ?? {};
+			const { execution: _, identityTrigger: __, ...configIssues } = node.issues ?? {};
 			if (Object.keys(configIssues).length === 0) return false;
 
 			const isConnected =

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2575,7 +2575,13 @@ export interface INodeCredentialDescription {
 	testedBy?: ICredentialTestRequest | string; // Name of a function inside `loadOptions.credentialTest`
 }
 
-export type INodeIssueTypes = 'credentials' | 'execution' | 'input' | 'parameters' | 'typeUnknown';
+export type INodeIssueTypes =
+	| 'credentials'
+	| 'execution'
+	| 'input'
+	| 'parameters'
+	| 'typeUnknown'
+	| 'identityTrigger';
 
 export interface INodeIssueObjectProperty {
 	[key: string]: string[];
@@ -2593,6 +2599,12 @@ export interface INodeIssues {
 	input?: INodeIssueObjectProperty;
 	parameters?: INodeIssueObjectProperty;
 	typeUnknown?: boolean;
+	/**
+	 * Trigger/credential-identity incompatibility (e.g. an end-user credential on a
+	 * trigger that can't establish an identity). Informational only — deliberately
+	 * excluded from publish-blocking checks; see `hasPublishBlockingIssues`.
+	 */
+	identityTrigger?: INodeIssueObjectProperty;
 	[key: string]: undefined | boolean | INodeIssueObjectProperty;
 }
 

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -1294,7 +1294,12 @@ export function nodeIssuesToString(issues: INodeIssues, node?: INode): string[] 
 		messages.push('Execution Error.');
 	}
 
-	for (const propertyIssues of [issues.parameters, issues.credentials, issues.input]) {
+	for (const propertyIssues of [
+		issues.parameters,
+		issues.credentials,
+		issues.input,
+		issues.identityTrigger,
+	]) {
 		if (propertyIssues === undefined) continue;
 		for (const parameterName of Object.keys(propertyIssues)) {
 			messages.push(...propertyIssues[parameterName]);
@@ -1738,7 +1743,7 @@ export function mergeIssues(destination: INodeIssues, source: INodeIssues | null
 		destination.execution = true;
 	}
 
-	const objectProperties = ['parameters', 'credentials'];
+	const objectProperties = ['parameters', 'credentials', 'identityTrigger'];
 
 	let destinationProperty: INodeIssueObjectProperty;
 	for (const propertyName of objectProperties) {


### PR DESCRIPTION
## Summary

Hotfix for the Hackmation PoC: a workflow whose trigger and dynamic/resolvable
credential(s) are incompatible (e.g. a plain Webhook trigger paired with an
end-user credential) can now be saved and activated. The incompatibility is
still surfaced, just non-blocking:

- **Backend** (`packages/cli/src/workflows/workflow.service.ts`): the dynamic-credentials
  compatibility check no longer throws on activation or on a save that
  internally republishes an already-active workflow (settings change, or a
  Public API `PATCH`). It now only logs a warning.
- **Frontend**: the same check now writes into its own `identityTrigger`
  node-issue category (`packages/workflow/src/interfaces.ts`,
  `packages/workflow/src/node-helpers.ts`) instead of `credentials`, so it's
  excluded from `hasPublishBlockingIssues`
  (`useWorkflowDocumentNodesIssues.ts`) — the Activate/Publish toggle is no
  longer disabled by it. The warning still renders on the canvas via the
  existing node-issue tooltip (`useNodeHelpers.ts`).

## How to test

1. Enable the `dynamic-credentials` module locally (see
   `packages/cli/src/controllers/e2e.controller.ts` — boot with `E2E_TESTS=true`
   and `PATCH /rest/e2e/feature` with `{"feature":"feat:dynamicCredentials","enabled":true}`).
2. In the editor, add a plain **Webhook** trigger (default auth) and another
   node using a credential toggled to resolvable/end-user mode.
3. Confirm the node still shows the "End-user credentials aren't supported by
   this workflow's trigger..." warning badge on the canvas.
4. Confirm **Save** and **Activate/Publish** both succeed despite the warning
   (previously activation was blocked, and a save that republished an
   already-active workflow could be rejected).
5. Unit coverage: `pnpm test workflow.service.test.ts` (packages/cli),
   `pnpm test useNodeHelpers` and `pnpm test useWorkflowDocumentNodesIssues`
   (packages/frontend/editor-ui), `pnpm test node-helpers` (packages/workflow).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1194

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)