### PR TITLE
feat(Merge Node): Add "Append" and "Combine" search aliases

### DIFF
--- a/packages/nodes-base/nodes/Merge/Merge.node.json
+++ b/packages/nodes-base/nodes/Merge/Merge.node.json
@@ -41,7 +41,7 @@
 			}
 		]
 	},
-	"alias": ["Join", "Concatenate", "Wait"],
+	"alias": ["Join", "Concatenate", "Wait", "Append", "Combine"],
 	"subcategories": {
 		"Core Nodes": ["Flow", "Data Transformation"]
 	}


### PR DESCRIPTION
## Summary

Adds `Append` and `Combine` as search aliases for the **Merge** node.

When looking for the Merge node, people often search for terms like "append" or "combine" (that is the outcome they are after), but those searches don't currently surface the Merge node. This adds those keywords as aliases so the node shows up for them.

## How to test

1. Open the nodes panel in the workflow editor.
2. Search for `Append`.
3. Confirm the **Merge** node appears in the results.
4. Repeat for `Combine`.

## Related Linear tickets, Github issues, and Community forum posts

<!-- No related ticket or issue. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
