### PR TITLE
ci: Keep bundle branches in sync with their base branch (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -405,6 +405,7 @@ Push to master/1.x
 
 | Schedule (UTC)            | Workflow                          | Purpose                  |
 |---------------------------|-----------------------------------|--------------------------|
+| Hourly :00                | `sec-sync-public-to-private.yml`  | Mirror public → private, refresh bundle branches |
 | Daily 00:00               | `docker-build-push.yml`           | Nightly Docker images    |
 | Daily 00:00               | `test-db.yml`                     | Database compatibility   |
 | Daily 00:00               | `test-e2e-performance-reusable.yml`| Performance E2E         |
@@ -701,6 +702,27 @@ cosign verify-attestation --type openvex \
   ]
 }
 ```
+
+### Public ↔ private sync (bundle branches)
+
+Embargoed security work happens in `n8n-io/n8n-private`. `sec-sync-public-to-private.yml`
+runs hourly there (and on `workflow_dispatch` with `force` for conflict recovery),
+mirroring public `master` and `1.x` into private with `reset --hard` +
+`--force-with-lease` — skipping a branch when private is ahead, ignoring `chore: Bundle`
+commits when judging "ahead". Fixes are never committed to private `master`/`1.x`
+directly: `ci-restrict-private-merges.yml` requires PRs into them to come from the
+long-lived integration branches `bundle/2.x` and `bundle/1.x` (a `bundle/2.x` merge is
+backported to `bundle/1.x` by `util-backport-bundle.yml`). The sync creates those
+branches if missing and then **merges `master` into `bundle/2.x` and `1.x` into
+`bundle/1.x`** so they don't drift; on a conflict it aborts the merge, leaves the branch
+untouched, and emits a warning annotation while **keeping the run green** — the other
+bundle branch still syncs, and a human resolves the conflict by hand. Once a bundle
+branch is merged into private `master`/`1.x` as a `chore: Bundle/*` PR,
+`sec-publish-fix.yml` / `sec-publish-fix-1x.yml` cherry-pick that merge commit onto a
+fresh branch in the public repo and open the PR there.
+
+See **[`../AGENTS.md`](../AGENTS.md)** ("Security Fix Hygiene") for the naming rules that
+keep the vulnerability out of public branch names, commits, and test descriptions.
 
 ---
 

--- a/.github/workflows/sec-sync-public-to-private.yml
+++ b/.github/workflows/sec-sync-public-to-private.yml
@@ -112,3 +112,36 @@ jobs:
             git checkout -b bundle/1.x
             git push origin bundle/1.x
           fi
+
+      - name: Update bundle/2.x from master
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin bundle/2.x
+          git checkout -B bundle/2.x FETCH_HEAD
+
+          if git merge --no-edit master; then
+            git push origin bundle/2.x
+          else
+            # A conflict needs a human; keep the run green so the rest of the sync still reports success
+            git merge --abort || true
+            echo "::warning title=bundle/2.x is out of sync::Merging master into bundle/2.x hit a conflict. Resolve it manually, then re-run this workflow."
+            exit 0
+          fi
+
+      - name: Update bundle/1.x from 1.x
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin bundle/1.x
+          git checkout -B bundle/1.x FETCH_HEAD
+
+          if git merge --no-edit 1.x; then
+            git push origin bundle/1.x
+          else
+            git merge --abort || true
+            echo "::warning title=bundle/1.x is out of sync::Merging 1.x into bundle/1.x hit a conflict. Resolve it manually, then re-run this workflow."
+            exit 0
+          fi


### PR DESCRIPTION
## Summary

`sec-sync-public-to-private.yml` mirrors public `master`/`1.x` into `n8n-io/n8n-private` hourly, and only **creates** `bundle/2.x` / `bundle/1.x` when they are missing — it never refreshes an existing one. Since those branches are long-lived, they drift behind their base for as long as they live, and the eventual `chore: Bundle/*` PR is stale by the time someone opens it.

This adds two steps after the existing existence checks: merge `master` into `bundle/2.x`, and `1.x` into `bundle/1.x`.

## How to test

The job is gated on `github.repository == 'n8n-io/n8n-private'`, so it can't run from a public PR. Verification was done two ways.

**After merge**, trigger `Security: Sync from Public` manually in `n8n-io/n8n-private` and confirm the bundle branches advance. Then push a deliberate conflicting commit onto `bundle/2.x`, re-run, and confirm the run is green with the warning annotation while `bundle/1.x` still syncs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-699

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- .github/WORKFLOWS.md updated in this PR -->
- [ ] Tests included. <!-- Workflow-only change; verified by replaying the step bodies against scratch git repos (see How to test). -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

