### PR TITLE
fix(core): Honor dry run on data table row delete

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-table.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table.controller.integration.test.ts
@@ -2927,6 +2927,75 @@ describe('DELETE /projects/:projectId/data-tables/:dataTableId/rows', () => {
 			},
 		]);
 	});
+
+	describe('dryRun', () => {
+		const filter = JSON.stringify({
+			type: 'and',
+			filters: [{ columnName: 'first', condition: 'eq', value: 'keep me' }],
+		});
+
+		const createTable = async () =>
+			await createDataTable(memberProject, {
+				columns: [{ name: 'first', type: 'string' }],
+				data: [{ first: 'keep me' }, { first: 'untouched' }],
+			});
+
+		test('should not delete rows when dryRun is set', async () => {
+			const dataTable = await createTable();
+
+			await authMemberAgent
+				.delete(`/projects/${memberProject.id}/data-tables/${dataTable.id}/rows`)
+				.query({ filter, dryRun: true })
+				.expect(200);
+
+			const remaining = await authMemberAgent
+				.get(`/projects/${memberProject.id}/data-tables/${dataTable.id}/rows`)
+				.expect(200);
+
+			expect(remaining.body.data.count).toBe(2);
+		});
+
+		test('should return the rows that would be deleted when dryRun is set', async () => {
+			const dataTable = await createTable();
+
+			const result = await authMemberAgent
+				.delete(`/projects/${memberProject.id}/data-tables/${dataTable.id}/rows`)
+				.query({ filter, dryRun: true })
+				.expect(200);
+
+			expect(result.body.data).toEqual([
+				{
+					id: expect.any(Number),
+					first: 'keep me',
+					createdAt: expect.any(String),
+					updatedAt: expect.any(String),
+					dryRunState: 'before',
+				},
+				{
+					id: null,
+					first: null,
+					createdAt: null,
+					updatedAt: null,
+					dryRunState: 'after',
+				},
+			]);
+		});
+
+		test('should still delete rows when dryRun is not set', async () => {
+			const dataTable = await createTable();
+
+			await authMemberAgent
+				.delete(`/projects/${memberProject.id}/data-tables/${dataTable.id}/rows`)
+				.query({ filter })
+				.expect(200);
+
+			const remaining = await authMemberAgent
+				.get(`/projects/${memberProject.id}/data-tables/${dataTable.id}/rows`)
+				.expect(200);
+
+			expect(remaining.body.data.count).toBe(1);
+		});
+	});
 });
 
 describe('POST /projects/:projectId/data-tables/:dataTableId/upsert', () => {

--- a/packages/cli/src/modules/data-table/data-table.controller.ts
+++ b/packages/cli/src/modules/data-table/data-table.controller.ts
@@ -417,35 +417,12 @@ export class DataTableController {
 	) {
 		this.checkInstanceWriteAccess();
 		try {
-			// because of strict overloads, we need separate paths
-			const dryRun = dto.dryRun;
-			if (dryRun) {
-				return await this.dataTableService.upsertRow(
-					dataTableId,
-					req.params.projectId,
-					dto,
-					true, // we want to always return data for dry runs
-					dryRun,
-				);
-			}
-
-			const returnData = dto.returnData;
-			if (returnData) {
-				return await this.dataTableService.upsertRow(
-					dataTableId,
-					req.params.projectId,
-					dto,
-					returnData,
-					dryRun,
-				);
-			}
-
 			return await this.dataTableService.upsertRow(
 				dataTableId,
 				req.params.projectId,
 				dto,
-				returnData,
-				dryRun,
+				dto.returnData,
+				dto.dryRun,
 			);
 		} catch (e: unknown) {
 			if (e instanceof DataTableNotFoundError) {
@@ -470,35 +447,12 @@ export class DataTableController {
 	) {
 		this.checkInstanceWriteAccess();
 		try {
-			// because of strict overloads, we need separate paths
-			const dryRun = dto.dryRun;
-			if (dryRun) {
-				return await this.dataTableService.updateRows(
-					dataTableId,
-					req.params.projectId,
-					dto,
-					true, // we want to always return data for dry runs
-					dryRun,
-				);
-			}
-
-			const returnData = dto.returnData;
-			if (returnData) {
-				return await this.dataTableService.updateRows(
-					dataTableId,
-					req.params.projectId,
-					dto,
-					returnData,
-					dryRun,
-				);
-			}
-
 			return await this.dataTableService.updateRows(
 				dataTableId,
 				req.params.projectId,
 				dto,
-				returnData,
-				dryRun,
+				dto.returnData,
+				dto.dryRun,
 			);
 		} catch (e: unknown) {
 			if (e instanceof DataTableNotFoundError) {

--- a/packages/cli/src/modules/data-table/data-table.controller.ts
+++ b/packages/cli/src/modules/data-table/data-table.controller.ts
@@ -528,6 +528,7 @@ export class DataTableController {
 				req.params.projectId,
 				dto,
 				dto.returnData,
+				dto.dryRun,
 			);
 		} catch (e: unknown) {
 			if (e instanceof DataTableNotFoundError) {

--- a/packages/cli/src/modules/data-table/data-table.service.ts
+++ b/packages/cli/src/modules/data-table/data-table.service.ts
@@ -395,6 +395,13 @@ export class DataTableService {
 		dataTableId: string,
 		projectId: string,
 		dto: Omit<UpsertDataTableRowDto, 'returnData' | 'dryRun'>,
+		returnData: boolean,
+		dryRun: boolean,
+	): Promise<DataTableRowReturn[] | DataTableRowReturnWithState[] | true>;
+	async upsertRow(
+		dataTableId: string,
+		projectId: string,
+		dto: Omit<UpsertDataTableRowDto, 'returnData' | 'dryRun'>,
 		returnData: boolean = false,
 		dryRun: boolean = false,
 	) {
@@ -492,6 +499,13 @@ export class DataTableService {
 		returnData?: false,
 		dryRun?: false,
 	): Promise<true>;
+	async updateRows(
+		dataTableId: string,
+		projectId: string,
+		dto: Omit<UpdateDataTableRowDto, 'returnData' | 'dryRun'>,
+		returnData: boolean,
+		dryRun: boolean,
+	): Promise<DataTableRowReturn[] | DataTableRowReturnWithState[] | true>;
 	async updateRows(
 		dataTableId: string,
 		projectId: string,

--- a/packages/cli/src/modules/data-table/data-table.service.ts
+++ b/packages/cli/src/modules/data-table/data-table.service.ts
@@ -560,6 +560,13 @@ export class DataTableService {
 		dataTableId: string,
 		projectId: string,
 		dto: Omit<DeleteDataTableRowsDto, 'returnData' | 'dryRun'>,
+		returnData: boolean,
+		dryRun: boolean,
+	): Promise<DataTableRowReturn[] | true>;
+	async deleteRows(
+		dataTableId: string,
+		projectId: string,
+		dto: Omit<DeleteDataTableRowsDto, 'returnData' | 'dryRun'>,
 		returnData: boolean = false,
 		dryRun: boolean = false,
 	) {

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
@@ -148,11 +148,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 				const { filter, data, returnData = false, dryRun = false } = payload.data;
 				const params = { filter, data };
 
-				const result = dryRun
-					? await service.updateRows(dataTableId, projectId, params, returnData, true)
-					: returnData
-						? await service.updateRows(dataTableId, projectId, params, true, false)
-						: await service.updateRows(dataTableId, projectId, params, false, false);
+				const result = await service.updateRows(dataTableId, projectId, params, returnData, dryRun);
 
 				return res.json(result);
 			} catch (error) {
@@ -179,11 +175,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 				const { filter, data, returnData = false, dryRun = false } = payload.data;
 				const params = { filter, data };
 
-				const result = dryRun
-					? await service.upsertRow(dataTableId, projectId, params, returnData, true)
-					: returnData
-						? await service.upsertRow(dataTableId, projectId, params, true, false)
-						: await service.upsertRow(dataTableId, projectId, params, false, false);
+				const result = await service.upsertRow(dataTableId, projectId, params, returnData, dryRun);
 
 				return res.json(result);
 			} catch (error) {
@@ -229,11 +221,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 				const { filter, returnData = false, dryRun = false } = payload.data;
 				const params = { filter };
 
-				const result = dryRun
-					? await service.deleteRows(dataTableId, projectId, params, returnData, true)
-					: returnData
-						? await service.deleteRows(dataTableId, projectId, params, true, false)
-						: await service.deleteRows(dataTableId, projectId, params, false, false);
+				const result = await service.deleteRows(dataTableId, projectId, params, returnData, dryRun);
 
 				return res.json(result);
 			} catch (error) {


### PR DESCRIPTION
## Summary

- Fixes a bug where the internal REST `DELETE /rows` endpoint accepted `dryRun` but never forwarded it, deleting rows for real and returning `true` instead of a preview
- Widens row-operation overloads to accept runtime booleans, eliminating branching in internal and public handlers.

## How to test

- New integration tests cover the delete `dryRun` fix
- Everything else is behavior-neutral and covered by existing tests

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/ADO-5745/bug-internal-rest-data-table-delete-rows-endpoint-ignores-dryrun-and

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

