### PR TITLE
fix(core): Probe azure blob with list instead of exists()

### DIFF
--- a/packages/@n8n/blob-storage/src/azure-blob/__tests__/azure-blob.service.ee.test.ts
+++ b/packages/@n8n/blob-storage/src/azure-blob/__tests__/azure-blob.service.ee.test.ts
@@ -15,6 +15,7 @@ const { mockBlockBlobClient, mockContainerClient } = vi.hoisted(() => {
 	};
 	const container = {
 		exists: vi.fn(),
+		listBlobsFlat: vi.fn(),
 		getBlockBlobClient: vi.fn(() => blockBlob),
 	};
 	return { mockBlockBlobClient: blockBlob, mockContainerClient: container };
@@ -40,7 +41,55 @@ describe('AzureBlobService', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockContainerClient.getBlockBlobClient.mockReturnValue(mockBlockBlobClient);
+		mockContainerClient.listBlobsFlat.mockReturnValue({
+			byPage: () => ({
+				next: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+			}),
+		});
 		service = new AzureBlobService(logger, config);
+	});
+
+	describe('checkConnection', () => {
+		it('should probe access with a single-page list (works with container SAS)', async () => {
+			const byPage = vi.fn().mockReturnValue({
+				next: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+			});
+			mockContainerClient.listBlobsFlat.mockReturnValue({ byPage });
+
+			await service.checkConnection();
+
+			expect(mockContainerClient.listBlobsFlat).toHaveBeenCalled();
+			expect(byPage).toHaveBeenCalledWith({ maxPageSize: 1 });
+			expect(mockContainerClient.exists).not.toHaveBeenCalled();
+		});
+
+		it('should map a 404 from list to a missing-container UserError', async () => {
+			mockContainerClient.listBlobsFlat.mockReturnValue({
+				byPage: () => ({
+					next: vi
+						.fn()
+						.mockRejectedValue(Object.assign(new Error('NotFound'), { statusCode: 404 })),
+				}),
+			});
+
+			await expect(service.checkConnection()).rejects.toThrow(
+				`Azure Blob container "${config.containerName}" does not exist or is not accessible.`,
+			);
+		});
+
+		it('should wrap non-404 list failures as UnexpectedError', async () => {
+			mockContainerClient.listBlobsFlat.mockReturnValue({
+				byPage: () => ({
+					next: vi
+						.fn()
+						.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 })),
+				}),
+			});
+
+			await expect(service.checkConnection()).rejects.toThrow(
+				'Request to Azure Blob storage failed: Forbidden',
+			);
+		});
 	});
 
 	describe('put', () => {

--- a/packages/@n8n/blob-storage/src/azure-blob/azure-blob.service.ee.ts
+++ b/packages/@n8n/blob-storage/src/azure-blob/azure-blob.service.ee.ts
@@ -59,14 +59,21 @@ export class AzureBlobService {
 			this.logger.debug('Checking connection to Azure Blob container', {
 				container: this.config.containerName,
 			});
-			const exists = await this.containerClient.exists();
-			if (!exists) {
+			// Do not use containerClient.exists() here. That calls Get Container
+			// Properties, which Azure rejects (403) for container-scoped SAS even
+			// when the container is present and the SAS is valid.
+			const pager = this.containerClient.listBlobsFlat().byPage({ maxPageSize: 1 });
+			await pager.next();
+		} catch (e) {
+			const statusCode =
+				typeof e === 'object' && e !== null && 'statusCode' in e
+					? (e as { statusCode?: number }).statusCode
+					: undefined;
+			if (statusCode === 404) {
 				throw new UserError(
 					`Azure Blob container "${this.config.containerName}" does not exist or is not accessible.`,
 				);
 			}
-		} catch (e) {
-			if (e instanceof UserError) throw e;
 			this.handleError(e);
 		}
 	}


### PR DESCRIPTION
## Summary

Change Azure Blob `checkConnection` to list one page of blobs instead of `containerClient.exists()`. 

Cloud hands instances a container SAS (list/read/write on one container only), not the account key. Listing with maxPageSize 1 works with the `l` permission and succeeds on an empty container, so it is a reliable connectivity check for both account-key and SAS credentials.

This path of code is not used by anything yet (at least from my investigation) so should be safe to change 🤞🏼 

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

