### PR TITLE
chore(editor): Make dev server backend port configurable via env var (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -167,7 +167,7 @@ const plugins: UserConfig['plugins'] = [
 			return ctx.server
 				? html
 						.replace('%CONFIG_TAGS%', '')
-						.replaceAll('/{{BASE_PATH}}', '//localhost:5678')
+						.replaceAll('/{{BASE_PATH}}', `//localhost:${process.env.N8N_DEV_BE_PORT ?? '5678'}`)
 						.replaceAll('/{{REST_ENDPOINT}}', '/rest')
 				: html;
 		},

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -167,7 +167,7 @@ const plugins: UserConfig['plugins'] = [
 			return ctx.server
 				? html
 						.replace('%CONFIG_TAGS%', '')
-						.replaceAll('/{{BASE_PATH}}', `//localhost:${process.env.N8N_DEV_BE_PORT ?? '5678'}`)
+						.replaceAll('/{{BASE_PATH}}', `//localhost:${process.env.N8N_PORT ?? '5678'}`)
 						.replaceAll('/{{REST_ENDPOINT}}', '/rest')
 				: html;
 		},


### PR DESCRIPTION
## Summary

Two hardcoded backend URLs prevented pointing a dev frontend at a backend on a non-default port (e.g. a second isolated n8n instance for PR testing, running alongside the main dev servers):

1. `vite.config.mts` injected `//localhost:5678` as `BASE_PATH` into `index.html` (static assets: `base-path.js`, css, posthog).
2. The `serve` script hardcoded `VUE_APP_URL_BASE_API=http://localhost:5678/` (the REST base URL used by `useRootStore`).

Both now derive from `N8N_PORT` (the same env var the backend uses for its listen port), falling back to `5678`. The `VUE_APP_URL_BASE_API` default is applied in the vite config, dev server only, so production builds keep falling back to `window.BASE_PATH`; an explicitly set `VUE_APP_URL_BASE_API` still wins. No behavior change for anyone not setting `N8N_PORT`.

## How to test

1. Start the backend on a non-default port: `N8N_PORT=5680 pnpm dev` from `packages/cli` (add `N8N_RUNNERS_BROKER_PORT` if 5679 is taken too).
2. Start the frontend with the same var: `N8N_PORT=5680 pnpm exec vite dev --port 8081` from `packages/frontend/editor-ui`.
3. The editor at http://localhost:8081 loads, signs in, and every `/rest/*` and `/static/*` request goes to port 5680 (verified via DevTools network log against an isolated instance with a fresh DB).
4. Without `N8N_PORT` set, `pnpm dev` works as before against 5678.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-331

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)