### PR TITLE
fix(editor): Make DropdownMenus more obviously scrollable

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
@@ -387,6 +387,7 @@ defineExpose({ open, close });
 
 <style module lang="scss">
 @use '../../css/common/var';
+@use '../../css/mixins/mixins' as scrollbar-mixins;
 @use '../../css/mixins/motion';
 
 .content {
@@ -401,7 +402,8 @@ defineExpose({ open, close });
 	width: fit-content;
 	min-width: var(--spacing--4xl);
 	max-width: var(--n8n--dropdown-menu-width);
-	max-height: min(var(--reka-dropdown-menu-content-available-height), calc(var(--height--5xl) * 3));
+	/** This stops dropdown menus expanding beyond the viewport height **/
+	max-height: min(var(--reka-dropdown-menu-content-available-height), 75vh);
 	overflow-y: auto;
 	border-radius: var(--radius--xs);
 	background-color: var(--background--surface);
@@ -410,7 +412,7 @@ defineExpose({ open, close });
 	will-change: transform, opacity;
 	transform-origin: var(--n8n--dropdown--offset--origin-x) var(--n8n--dropdown--offset--origin-y);
 	z-index: var.$index-popper;
-	scrollbar-width: none;
+	@include scrollbar-mixins.hoverable-scroll-bar;
 
 	&.searchable {
 		overflow-y: hidden;

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
@@ -425,6 +425,7 @@ onBeforeUnmount(() => {
 
 <style module lang="scss">
 @use '../../css/common/var';
+@use '../../css/mixins/mixins' as scrollbar-mixins;
 
 .wrapper {
 	display: contents;
@@ -434,17 +435,13 @@ onBeforeUnmount(() => {
 	padding: var(--spacing--4xs);
 	max-height: inherit;
 	overflow-y: auto;
-	scrollbar-width: none;
+	@include scrollbar-mixins.hoverable-scroll-bar;
 	mask-image: linear-gradient(
 		to bottom,
 		black 0,
 		black calc(100% - var(--spacing--sm)),
 		transparent 100%
 	);
-
-	&::-webkit-scrollbar {
-		display: none;
-	}
 }
 
 .section-header {
@@ -522,7 +519,7 @@ onBeforeUnmount(() => {
 	max-width: var(--n8n--dropdown-menu-width);
 	max-height: min(
 		var(--reka-dropdown-menu-content-available-height),
-		var(--n8n-dropdown-sub-max-height, var(--spacing--5xl))
+		var(--n8n-dropdown-sub-max-height, 75vh)
 	);
 	transform-origin: var(--n8n--dropdown--offset--origin-x) var(--n8n--dropdown--offset--origin-y);
 	overflow: hidden;

--- a/packages/frontend/@n8n/design-system/src/css/mixins/mixins.scss
+++ b/packages/frontend/@n8n/design-system/src/css/mixins/mixins.scss
@@ -24,8 +24,8 @@ $E: null;
 /* Scrollbar
  -------------------------- */
 @mixin scroll-bar {
-	$scrollbar-thumb-background: #b4bccc;
-	$scrollbar-track-background: var(--color--foreground--tint-2);
+	scrollbar-width: thin;
+	scrollbar-color: var.$scrollbar-background-color transparent;
 
 	&::-webkit-scrollbar {
 		z-index: 11;
@@ -38,19 +38,37 @@ $E: null;
 		&-thumb {
 			border-radius: 5px;
 			width: 6px;
-			background: $scrollbar-thumb-background;
+			background-color: var.$scrollbar-background-color;
+
+			&:hover {
+				background-color: var.$scrollbar-hover-background-color;
+			}
 		}
 
-		&-corner {
-			background: $scrollbar-track-background;
+		&-corner,
+		&-track,
+		&-track-piece {
+			background-color: transparent;
 		}
+	}
+}
 
-		&-track {
-			background: $scrollbar-track-background;
+@mixin hoverable-scroll-bar {
+	@include scroll-bar;
+	scrollbar-color: transparent transparent;
 
-			&-piece {
-				background: $scrollbar-track-background;
-				width: 6px;
+	&::-webkit-scrollbar-thumb {
+		background-color: transparent;
+	}
+
+	&:hover {
+		scrollbar-color: var.$scrollbar-background-color transparent;
+
+		&::-webkit-scrollbar-thumb {
+			background-color: var.$scrollbar-background-color;
+
+			&:hover {
+				background-color: var.$scrollbar-hover-background-color;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #35679 

It appears items are missing from DropdownMenus. However, the items are merely clipped and need to be scrolled into view.

This can be made clearer by showing dropdown menu and submenu scrollbars when the user hovers over scrollable content, as well as showing a subtle mask at the bottom. Also increasing the `max-height` to a less strict value, whilst still preventing a full viewport height menu, will help show more items in the viewport on mount.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/ece1eca9-9a40-4e34-a49b-99ac6352cef2" width="960" /> | <img width="1406" height="752" alt="CleanShot 2026-08-06 at 11 23 21@2x" src="https://github.com/user-attachments/assets/92c484d8-e8c6-4427-a19c-83d78d735837" />





## How to test

1. Open a dropdown menu with enough items to exceed its maximum height.
2. Confirm that the menu remains scrollable and its scrollbar appears on hover.
3. Open a submenu with enough items to overflow.
4. Confirm that the submenu scrollbar appears on hover.
5. Open menus without overflow and confirm that they do not have a scrollbar gutter.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-609
https://github.com/n8n-io/n8n/issues/35679

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
