### PR TITLE
fix(core): Reject stale Instance AI confirmations instead of hijacking the live run

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -1869,6 +1869,7 @@ type SuspendedRunResumeServiceInternals = {
 	runState: {
 		findSuspendedByRequestId: Mock;
 		activateSuspendedRun: Mock;
+		getActiveRun: Mock;
 	};
 	logger: { warn: Mock };
 	dbSnapshotStorage: unknown;
@@ -1906,6 +1907,7 @@ function createSuspendedRunResumeService(): SuspendedRunResumeServiceInternals {
 			runHandoff: undefined,
 		})),
 		activateSuspendedRun: vi.fn(() => ({})),
+		getActiveRun: vi.fn(() => undefined),
 	};
 	service.logger = { warn: vi.fn() };
 	service.dbSnapshotStorage = {};
@@ -2581,6 +2583,23 @@ describe('InstanceAiService — suspended run user revalidation', () => {
 	});
 });
 
+describe('InstanceAiService — stale confirmation resume guard', () => {
+	it('rejects a suspended-run confirmation when the thread already has an active run', async () => {
+		const service = createSuspendedRunResumeService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1', disabled: false } as User);
+		service.runState.getActiveRun.mockReturnValue({ runId: 'run-2' });
+
+		const result = await service.resumeSuspendedRun('user-1', 'req-1', { approved: true });
+
+		expect(result).toBeNull();
+		// The active run's registry entry and the pending row must stay untouched.
+		expect(service.runState.activateSuspendedRun).not.toHaveBeenCalled();
+		expect(service.suspendedThreads.dropPendingConfirmation).not.toHaveBeenCalled();
+		expect(service.processResumedStream).not.toHaveBeenCalled();
+		expect(service.cancelRun).not.toHaveBeenCalled();
+	});
+});
+
 describe('InstanceAiService — rebuildAgentForAutoSetupResume', () => {
 	type RebuildAgentServiceInternals = {
 		rebuildAgentForAutoSetupResume: (
@@ -2860,6 +2879,73 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			error_source: 'exception',
 			user_id: 'user-1',
 		});
+	});
+
+	it('terminates the run visibly when a resume fails before the claim', async () => {
+		const service = createTerminalGuardOrderService();
+		const abortController = new AbortController();
+		const resumeExecutionToken = Symbol('resume-token');
+		vi.mocked(resumeAgentRun).mockImplementationOnce(async () => {
+			throw new Error('Invalid resume payload: data must NOT have additional properties');
+		});
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: {},
+				resumeExecutionToken,
+			},
+		);
+
+		// A silently consumed confirmation wedges the thread: the client saw
+		// {ok:true} and would wait forever without a terminal event.
+		expect(service.eventBus.events.map((event) => event.type)).toEqual(['error', 'run-finish']);
+		expect(service.instanceAiErrorReporter.report).toHaveBeenCalledWith(
+			expect.any(Error),
+			expect.objectContaining({ component: 'instance-ai-resume-claim' }),
+		);
+		expect(service.runState.clearActiveRun).toHaveBeenCalledWith('thread-a', resumeExecutionToken);
+	});
+
+	it('stays silent when the pre-claim failure is a stale resume owned elsewhere', async () => {
+		const service = createTerminalGuardOrderService();
+		const abortController = new AbortController();
+		const resumeExecutionToken = Symbol('resume-token');
+		vi.mocked(resumeAgentRun).mockImplementationOnce(async () => {
+			throw Object.assign(new Error('Run agent-run-1 is not suspended. Cannot resume.'), {
+				name: 'StaleResumeError',
+			});
+		});
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: {},
+				resumeExecutionToken,
+			},
+		);
+
+		// Another consumer owns the run; emitting a terminal event here would
+		// clobber its healthy stream. Only our registry entry gets released.
+		expect(service.eventBus.events).toEqual([]);
+		expect(service.instanceAiErrorReporter.report).not.toHaveBeenCalled();
+		expect(service.runState.clearActiveRun).toHaveBeenCalledWith('thread-a', resumeExecutionToken);
 	});
 
 	it('tracks "Builder generation errored" when a resumed stream reports an error', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -2592,7 +2592,6 @@ describe('InstanceAiService — stale confirmation resume guard', () => {
 		const result = await service.resumeSuspendedRun('user-1', 'req-1', { approved: true });
 
 		expect(result).toBeNull();
-		// The active run's registry entry and the pending row must stay untouched.
 		expect(service.runState.activateSuspendedRun).not.toHaveBeenCalled();
 		expect(service.suspendedThreads.dropPendingConfirmation).not.toHaveBeenCalled();
 		expect(service.processResumedStream).not.toHaveBeenCalled();
@@ -2905,8 +2904,6 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			},
 		);
 
-		// A silently consumed confirmation wedges the thread: the client saw
-		// {ok:true} and would wait forever without a terminal event.
 		expect(service.eventBus.events.map((event) => event.type)).toEqual(['error', 'run-finish']);
 		expect(service.instanceAiErrorReporter.report).toHaveBeenCalledWith(
 			expect.any(Error),
@@ -2941,8 +2938,6 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			},
 		);
 
-		// Another consumer owns the run; emitting a terminal event here would
-		// clobber its healthy stream. Only our registry entry gets released.
 		expect(service.eventBus.events).toEqual([]);
 		expect(service.instanceAiErrorReporter.report).not.toHaveBeenCalled();
 		expect(service.runState.clearActiveRun).toHaveBeenCalledWith('thread-a', resumeExecutionToken);

--- a/packages/cli/src/modules/instance-ai/__tests__/suspended-run-restorer.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/suspended-run-restorer.service.test.ts
@@ -151,6 +151,52 @@ describe('SuspendedRunRestorer — orphan restoration', () => {
 		expect(mocks.eventBus.publish).not.toHaveBeenCalled();
 	});
 
+	it('rejects a claimed suspended-kind row without touching the thread when it already has a live run', async () => {
+		const { restorer, mocks } = createRestorer();
+		mocks.runState.hasLiveRun.mockReturnValue(true);
+		mocks.pendingConfirmationRepo.claim.mockResolvedValue(
+			orphanRow({
+				requestId: 'req-stale',
+				threadId: 'thread-1',
+				userId: 'user-1',
+				kind: 'suspended',
+				runId: 'run-old',
+				toolCallId: 'tool-1',
+				checkpointKey: 'cp-1',
+			}),
+		);
+		mocks.rebuilder.rebuildSuspendedRun.mockResolvedValue(ready);
+
+		const result = await restorer.resolveOrphanedConfirmation('user-1', 'req-stale', approval);
+
+		expect(result).toBeNull();
+		expect(mocks.rebuilder.rebuildSuspendedRun).not.toHaveBeenCalled();
+		expect(mocks.runState.suspendRun).not.toHaveBeenCalled();
+		expect(mocks.rebuilder.resumeSuspendedRun).not.toHaveBeenCalled();
+		expect(mocks.eventBus.publish).not.toHaveBeenCalled();
+		expect(mocks.dbSnapshotStorage.markRunCancelled).not.toHaveBeenCalled();
+	});
+
+	it('rejects a stale inline-kind row without cancelling anything when the thread has a live run', async () => {
+		const { restorer, mocks } = createRestorer();
+		mocks.runState.hasLiveRun.mockReturnValue(true);
+		mocks.pendingConfirmationRepo.claim.mockResolvedValue(
+			orphanRow({
+				requestId: 'req-stale',
+				threadId: 'thread-1',
+				userId: 'user-1',
+				kind: 'inline',
+				runId: 'run-old',
+			}),
+		);
+
+		const result = await restorer.resolveOrphanedConfirmation('user-1', 'req-stale', approval);
+
+		expect(result).toBeNull();
+		expect(mocks.eventBus.publish).not.toHaveBeenCalled();
+		expect(mocks.dbSnapshotStorage.markRunCancelled).not.toHaveBeenCalled();
+	});
+
 	it('falls back to the terminal UserError when the rebuild fails', async () => {
 		const { restorer, mocks } = createRestorer();
 		mocks.pendingConfirmationRepo.claim.mockResolvedValue(

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -310,6 +310,9 @@ const WORKFLOW_SETUP_ROUTING_CLAIM_TTL_MS = 15 * 60 * 1000;
 const CONFIRMATION_EXPIRED_MESSAGE =
 	'This confirmation has expired. Send a new message to continue.';
 
+const RESUME_REJECTED_MESSAGE =
+	'I could not apply that confirmation. Send a new message to continue.';
+
 /**
  * Upper bound on how long `shutdown()` will wait for in-flight executeRun /
  * processResumedStream promises to drain after their abortControllers fire.
@@ -4766,6 +4769,21 @@ export class InstanceAiService {
 		} = suspended;
 		if (user.id !== requestingUserId) return null;
 
+		// An active run on this thread means the suspension is stale — the thread
+		// moved on since the confirmation card was rendered. Activating it would
+		// overwrite the active run's registry entry and message-group mapping
+		// (INS-1092), so reject like a consumed requestId instead.
+		const activeRun = this.runState.getActiveRun(threadId);
+		if (activeRun) {
+			this.logger.warn('Rejecting suspended-run confirmation: thread already has an active run', {
+				requestId,
+				threadId,
+				suspendedRunId: runId,
+				activeRunId: activeRun.runId,
+			});
+			return null;
+		}
+
 		const activeUser = await this.revalidateActiveUser(user.id);
 		if (!activeUser) {
 			this.logger.warn('Cancelling suspended run: user no longer authorized for AI Assistant', {
@@ -5315,6 +5333,25 @@ export class InstanceAiService {
 						error: getErrorMessage(error),
 						metadata: { completion_source: 'resume_claim' },
 					},
+				);
+				// The claim never happened, so no other finalizer owns this segment.
+				// The confirmation endpoint already answered {ok}, the suspension was
+				// consumed on activation, and nothing else will emit for this run —
+				// without a terminal event the thread stays dead until an external
+				// timeout (INS-1092). Unlike the stale case above, no concurrent
+				// consumer owns the run, so terminating it visibly is safe.
+				await this.terminalOutcome.evaluateTerminalResponse(opts.threadId, opts.runId, 'errored', {
+					messageGroupId: this.tracing.getMessageGroupId(opts.runId),
+					errorMessage: RESUME_REJECTED_MESSAGE,
+				});
+				this.publishRunFinish(
+					opts.threadId,
+					opts.runId,
+					'errored',
+					RESUME_REJECTED_MESSAGE,
+					undefined,
+					opts.user.id,
+					{ errorMessage: getErrorMessage(error), errorSource: 'exception' },
 				);
 				return;
 			}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -4769,10 +4769,6 @@ export class InstanceAiService {
 		} = suspended;
 		if (user.id !== requestingUserId) return null;
 
-		// An active run on this thread means the suspension is stale — the thread
-		// moved on since the confirmation card was rendered. Activating it would
-		// overwrite the active run's registry entry and message-group mapping
-		// (INS-1092), so reject like a consumed requestId instead.
 		const activeRun = this.runState.getActiveRun(threadId);
 		if (activeRun) {
 			this.logger.warn('Rejecting suspended-run confirmation: thread already has an active run', {
@@ -5334,12 +5330,6 @@ export class InstanceAiService {
 						metadata: { completion_source: 'resume_claim' },
 					},
 				);
-				// The claim never happened, so no other finalizer owns this segment.
-				// The confirmation endpoint already answered {ok}, the suspension was
-				// consumed on activation, and nothing else will emit for this run —
-				// without a terminal event the thread stays dead until an external
-				// timeout (INS-1092). Unlike the stale case above, no concurrent
-				// consumer owns the run, so terminating it visibly is safe.
 				await this.terminalOutcome.evaluateTerminalResponse(opts.threadId, opts.runId, 'errored', {
 					messageGroupId: this.tracing.getMessageGroupId(opts.runId),
 					errorMessage: RESUME_REJECTED_MESSAGE,

--- a/packages/cli/src/modules/instance-ai/suspended-run-restorer.service.ts
+++ b/packages/cli/src/modules/instance-ai/suspended-run-restorer.service.ts
@@ -142,12 +142,6 @@ export class SuspendedRunRestorer {
 		}
 		if (!orphan) return null;
 
-		// A live run on this thread means it isn't an orphan — the thread moved on
-		// and this row is a leftover from an earlier turn. Restoring it would
-		// overwrite the live run's registry entry and message-group mapping, and
-		// its resume payload would race the live run (INS-1092). Reject like a
-		// consumed requestId: `claim()` above already dropped the row, so retries
-		// fail cleanly too.
 		if (this.runState.hasLiveRun(orphan.threadId)) {
 			this.logger.warn('Rejecting stale pending confirmation: thread already has a live run', {
 				requestId,

--- a/packages/cli/src/modules/instance-ai/suspended-run-restorer.service.ts
+++ b/packages/cli/src/modules/instance-ai/suspended-run-restorer.service.ts
@@ -63,8 +63,8 @@ export interface SuspendedRunRebuilder {
 /** The slice of the pending-confirmation repository the restorer reads from. */
 export type OrphanConfirmationStore = Pick<InstanceAiPendingConfirmationRepository, 'claim'>;
 
-/** The slice of the run-state registry the restorer writes to. */
-export type SuspendedRunStateRegistry = Pick<RunStateRegistry<User>, 'suspendRun'>;
+/** The slice of the run-state registry the restorer reads and writes. */
+export type SuspendedRunStateRegistry = Pick<RunStateRegistry<User>, 'suspendRun' | 'hasLiveRun'>;
 
 /** The slice of snapshot storage the restorer uses to terminalise a snapshot. */
 export type RunSnapshotCanceller = Pick<DbSnapshotStorage, 'markRunCancelled'>;
@@ -141,6 +141,22 @@ export class SuspendedRunRestorer {
 			return null;
 		}
 		if (!orphan) return null;
+
+		// A live run on this thread means it isn't an orphan — the thread moved on
+		// and this row is a leftover from an earlier turn. Restoring it would
+		// overwrite the live run's registry entry and message-group mapping, and
+		// its resume payload would race the live run (INS-1092). Reject like a
+		// consumed requestId: `claim()` above already dropped the row, so retries
+		// fail cleanly too.
+		if (this.runState.hasLiveRun(orphan.threadId)) {
+			this.logger.warn('Rejecting stale pending confirmation: thread already has a live run', {
+				requestId,
+				threadId: orphan.threadId,
+				runId: orphan.runId,
+				kind: orphan.kind,
+			});
+			return null;
+		}
 
 		this.logger.info('Reclaiming pending confirmation orphaned by a process restart', {
 			requestId,


### PR DESCRIPTION
## Summary

Answering a leftover confirmation card after the thread had moved on to a new run could overwrite the new run's registry state, and when the resume payload was rejected by the tool's schema the failure was silent: no error, no terminal event, thread dead until a 30 minute timeout (INS-1092).

Fix:

- A confirmation for a thread that already has a live run is rejected like an already-answered card (404). The live run is untouched. Applies to both the in-memory resume path and the orphan-restore path.
- A resume that fails before claiming the checkpoint now ends the run with a visible error instead of returning silently.

## How to test

```bash
cd packages/cli
pnpm vitest run src/modules/instance-ai/__tests__/instance-ai.service.test.ts src/modules/instance-ai/__tests__/suspended-run-restorer.service.test.ts
```

Also validated by running the multi-turn eval case that hit this 3x against this branch: all completed in minutes, no wedge (previously 2 of 3 stalled for 30 minutes).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1092

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.