### PR TITLE
refactor(core): Unify OIDC login and token-exchange identity resolution (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/logging.config.ts
+++ b/packages/@n8n/config/src/configs/logging.config.ts
@@ -37,6 +37,7 @@ export const LOG_SCOPES = [
 	'data-table-csv-import',
 	'ssrf-protection',
 	'token-exchange',
+	'identity-binding',
 	'instance-ai',
 	'agents',
 	'sub-agent-eval',

--- a/packages/@n8n/db/src/repositories/user.repository.ts
+++ b/packages/@n8n/db/src/repositories/user.repository.ts
@@ -9,7 +9,8 @@ import type {
 } from '@n8n/typeorm';
 import { Brackets, DataSource, In, IsNull, Not, Repository } from '@n8n/typeorm';
 
-import { ApiKey, Project, ProjectRelation, User } from '../entities';
+import { ApiKey, AuthIdentity, Project, ProjectRelation, User } from '../entities';
+import type { AuthProviderType } from '../entities/types-db';
 
 @Service()
 export class UserRepository extends Repository<User> {
@@ -153,6 +154,33 @@ export class UserRepository extends Repository<User> {
 		// TODO: use a transactions
 		// This is blocked by TypeORM having concurrency issues with transactions
 		return await createInner(this.manager);
+	}
+
+	/**
+	 * Create a user, their personal project and the external `AuthIdentity`
+	 * binding them to an identity provider, in a single transaction — so a
+	 * failure can never leave a user without the binding that is the only way
+	 * they can authenticate.
+	 */
+	async createUserWithExternalIdentity(
+		user: DeepPartial<User>,
+		identity: { providerId: string; providerType: AuthProviderType },
+	): Promise<User> {
+		return await this.manager.transaction(async (trx) => {
+			const { user: newUser } = await this.createUserWithProject(user, trx);
+
+			// `insert`, not `save`: `(providerId, providerType)` is the primary key,
+			// so `save` would silently re-point an existing binding at this brand-new
+			// user. Losing the race must fail, not quietly take over an identity.
+			await trx.insert(AuthIdentity, {
+				providerId: identity.providerId,
+				providerType: identity.providerType,
+				userId: newUser.id,
+				status: 'active',
+			});
+
+			return newUser;
+		});
 	}
 
 	/**

--- a/packages/cli/src/modules/sso-oidc/__tests__/oidc.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-oidc/__tests__/oidc.service.ee.test.ts
@@ -29,6 +29,7 @@ import { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { JwtService } from '@/services/jwt.service';
 import { TrustedKeySourceRegistrationProxy } from '@/services/trusted-key-source-registration-proxy.service';
 import type { UrlService } from '@/services/url.service';
+import { IdentityBindingService } from '@/services/identity-binding.service';
 import * as ssoHelpers from '@/sso.ee/sso-helpers';
 
 import { OIDC_PREFERENCES_DB_KEY } from '../constants';
@@ -45,6 +46,7 @@ describe('OidcService', () => {
 	let provisioningService: ProvisioningService;
 	let userRepository: UserRepository;
 	let authIdentityRepository: AuthIdentityRepository;
+	let identityBinding: IdentityBindingService;
 	let outboundHttp: Mocked<OutboundHttp>;
 	let customFetch: Mock;
 
@@ -86,6 +88,10 @@ describe('OidcService', () => {
 		});
 		userRepository = mock<UserRepository>();
 		authIdentityRepository = mock<AuthIdentityRepository>();
+		// The shared resolution core is wired for real against the mocked
+		// repositories, so these stay regression tests of the login behaviour
+		// rather than tests of the delegation.
+		identityBinding = new IdentityBindingService(logger, userRepository, authIdentityRepository);
 		customFetch = vi.fn();
 		outboundHttp = mock<OutboundHttp>();
 		outboundHttp.transport.mockReturnValue(
@@ -97,10 +103,9 @@ describe('OidcService', () => {
 
 		oidcService = new OidcService(
 			settingsRepository,
-			authIdentityRepository,
+			identityBinding,
 			mock<UrlService>(),
 			globalConfig,
-			userRepository,
 			cipher,
 			logger,
 			jwtService,
@@ -657,7 +662,7 @@ describe('OidcService', () => {
 			oidcService.applySsoProvisioning = vi.fn().mockResolvedValue(undefined);
 			authIdentityRepository.findOne = vi
 				.fn()
-				.mockResolvedValue({ user: { email: 'john.doe@test.com' } as any });
+				.mockResolvedValue({ user: { email: 'john.doe@test.com' } as any, status: 'active' });
 
 			vi.mocked(client.authorizationCodeGrant).mockResolvedValue({
 				access_token: 'valid-access-token',
@@ -733,7 +738,7 @@ describe('OidcService', () => {
 			oidcService.getOidcConfiguration = vi.fn().mockResolvedValue({} as client.Configuration);
 			// @ts-expect-error - applySsoProvisioning is private and only accessible within class 'OidcService'
 			oidcService.applySsoProvisioning = vi.fn().mockResolvedValue(undefined);
-			userRepository.manager.transaction = vi
+			userRepository.createUserWithExternalIdentity = vi
 				.fn()
 				.mockResolvedValue({ email: 'john.doe@test.com' } as any);
 
@@ -807,7 +812,7 @@ describe('OidcService', () => {
 				.mockRejectedValue(new ForbiddenError('Access denied by SSO role mapping configuration'));
 			authIdentityRepository.findOne = vi
 				.fn()
-				.mockResolvedValue({ user: { email: 'john.doe@test.com' } as any });
+				.mockResolvedValue({ user: { email: 'john.doe@test.com' } as any, status: 'active' });
 
 			vi.mocked(client.authorizationCodeGrant).mockResolvedValue({
 				access_token: 'valid-access-token',
@@ -858,7 +863,7 @@ describe('OidcService', () => {
 			provisioningService.provisionExpressionMappedRolesForUser = vi
 				.fn()
 				.mockResolvedValue(undefined);
-			authIdentityRepository.findOne = vi.fn().mockResolvedValue({ user });
+			authIdentityRepository.findOne = vi.fn().mockResolvedValue({ user, status: 'active' });
 
 			const callbackUrl = new URL('https://example.com/callback');
 			const storedState = oidcService.generateState().signed;
@@ -880,7 +885,7 @@ describe('OidcService', () => {
 				scopesProjectsRolesClaimName: 'n8n_projects',
 			});
 			provisioningService.provisionInstanceRoleForUser = vi.fn().mockResolvedValue(undefined);
-			authIdentityRepository.findOne = vi.fn().mockResolvedValue({ user });
+			authIdentityRepository.findOne = vi.fn().mockResolvedValue({ user, status: 'active' });
 
 			const callbackUrl = new URL('https://example.com/callback');
 			const storedState = oidcService.generateState().signed;
@@ -967,10 +972,9 @@ describe('OidcService', () => {
 			const realOutboundHttp = new OutboundHttp(mock<SsrfProtectionService>(), logger);
 			realOidcService = new OidcService(
 				settingsRepository,
-				authIdentityRepository,
+				identityBinding,
 				mock<UrlService>(),
 				globalConfig,
-				userRepository,
 				cipher,
 				logger,
 				jwtService,
@@ -1156,7 +1160,7 @@ describe('OidcService', () => {
 		mockAuthCallbackWith({ email_verified: false, email: 'john.doe@test.com' });
 		authIdentityRepository.findOne = vi
 			.fn()
-			.mockResolvedValue({ user: { email: 'john.doe@test.com' } } as any);
+			.mockResolvedValue({ user: { email: 'john.doe@test.com' }, status: 'active' } as any);
 
 		const user = await login();
 

--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -2,15 +2,7 @@ import { OidcConfigDto } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { OutboundHttp } from '@n8n/backend-network';
 import { GlobalConfig } from '@n8n/config';
-import {
-	AuthIdentity,
-	AuthIdentityRepository,
-	isValidEmail,
-	GLOBAL_MEMBER_ROLE,
-	SettingsRepository,
-	type User,
-	UserRepository,
-} from '@n8n/db';
+import { isValidEmail, GLOBAL_MEMBER_ROLE, SettingsRepository, type User } from '@n8n/db';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import { randomUUID } from 'crypto';
@@ -23,6 +15,16 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { buildOidcClaimsContext } from '@/modules/provisioning.ee/claims-context.builder';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
+import {
+	IdentityBindingService,
+	interpretEmailVerified,
+} from '@/services/identity-binding.service';
+import {
+	IdentityResolutionError,
+	type IdentityPolicy,
+	type IdentitySource,
+} from '@/services/identity-binding.types';
+import type { VerifiedIdentityClaim } from '@/services/identity-resolution-proxy.service';
 import { JwtService } from '@/services/jwt.service';
 import { TrustedKeySourceRegistrationProxy } from '@/services/trusted-key-source-registration-proxy.service';
 import { UrlService } from '@/services/url.service';
@@ -92,10 +94,9 @@ export class OidcService {
 
 	constructor(
 		private readonly settingsRepository: SettingsRepository,
-		private readonly authIdentityRepository: AuthIdentityRepository,
+		private readonly identityBinding: IdentityBindingService,
 		private readonly urlService: UrlService,
 		private readonly globalConfig: GlobalConfig,
-		private readonly userRepository: UserRepository,
 		private readonly cipher: Cipher,
 		private readonly logger: Logger,
 		private readonly jwtService: JwtService,
@@ -348,86 +349,65 @@ export class OidcService {
 			userInfo as Record<string, unknown>,
 		);
 
-		const openidUser = await this.authIdentityRepository.findOne({
-			where: { providerId: claims.sub, providerType: 'oidc' },
-			relations: {
-				user: {
-					role: true,
-				},
-			},
-		});
-
-		if (openidUser) {
-			await this.applySsoProvisioning(
-				openidUser.user,
-				claims as Record<string, unknown>,
-				userInfo as Record<string, unknown>,
-			);
-
-			return { user: openidUser.user, idToken: tokens.id_token };
-		}
-
-		const foundUser = await this.userRepository.findOne({
-			where: { email: userInfo.email },
-			relations: ['authIdentities', 'role'],
-		});
-
-		if (foundUser) {
-			// Linking to an existing account uses the email as the key, so only do it
-			// when the IdP says the email is verified.
-			this.assertEmailVerified(userInfo.email_verified);
-
-			this.logger.debug(
-				`OIDC login: User with email ${userInfo.email} already exists, linking OIDC identity.`,
-			);
-			// If the user already exists, we just add the OIDC identity to the user
-			const id = this.authIdentityRepository.create({
-				providerId: claims.sub,
-				providerType: 'oidc',
-				userId: foundUser.id,
-			});
-
-			await this.authIdentityRepository.save(id);
-			await this.applySsoProvisioning(
-				foundUser,
-				claims as Record<string, unknown>,
-				userInfo as Record<string, unknown>,
-			);
-
-			return { user: foundUser, idToken: tokens.id_token };
-		}
-
-		const user = await this.userRepository.manager.transaction(async (trx) => {
-			const { user: newUser } = await this.userRepository.createUserWithProject(
-				{
-					firstName: userInfo.given_name,
-					lastName: userInfo.family_name,
-					email: userInfo.email,
-					authIdentities: [],
-					role: GLOBAL_MEMBER_ROLE,
-					password: 'no password set',
-				},
-				trx,
-			);
-
-			await trx.save(
-				trx.create(AuthIdentity, {
-					providerId: claims.sub,
-					providerType: 'oidc',
-					userId: newUser.id,
-				}),
-			);
-
-			return newUser;
-		});
-
-		await this.applySsoProvisioning(
-			user,
+		const user = await this.resolveUserFromClaims(
 			claims as Record<string, unknown>,
 			userInfo as Record<string, unknown>,
 		);
 
 		return { user, idToken: tokens.id_token };
+	}
+
+	/**
+	 * Hand the verified claims to the shared resolver. The subject comes from
+	 * the ID token while the profile fields come from the UserInfo response —
+	 * that asymmetry is deliberate, since UserInfo is the authoritative source
+	 * for email and name but the binding must key off the ID token's `sub`.
+	 */
+	private async resolveUserFromClaims(
+		claims: Record<string, unknown>,
+		userInfo: Record<string, unknown>,
+	): Promise<User> {
+		const normalizedClaims: VerifiedIdentityClaim = {
+			iss: String(claims.iss ?? ''),
+			sub: String(claims.sub),
+			email: typeof userInfo.email === 'string' ? userInfo.email : undefined,
+			email_verified: interpretEmailVerified(userInfo.email_verified) === 'verified',
+			given_name: typeof userInfo.given_name === 'string' ? userInfo.given_name : undefined,
+			family_name: typeof userInfo.family_name === 'string' ? userInfo.family_name : undefined,
+		};
+
+		const source: IdentitySource = {
+			providerType: 'oidc',
+			// Raw `sub`, unqualified. A modelled `(sourceId, subject)` key, with a
+			// migration for the existing rows, is tracked separately; until then
+			// changing it here would strand every account provisioned so far.
+			keyFor: (c) => c.sub,
+		};
+
+		const policy: IdentityPolicy = {
+			assertEmailVerified: () => this.assertEmailVerified(userInfo.email_verified),
+			// Role assignment belongs entirely to `ProvisioningService`, applied
+			// below in `onResolved`; every new account starts as a plain member.
+			roleForNewUser: async () => GLOBAL_MEMBER_ROLE,
+			profileSync: 'every-resolution',
+			onResolved: async (user) => {
+				await this.applySsoProvisioning(user, claims, userInfo);
+				return user;
+			},
+		};
+
+		try {
+			return await this.identityBinding.resolve(source, normalizedClaims, policy, {
+				allowProvisioning: true,
+			});
+		} catch (error) {
+			if (error instanceof IdentityResolutionError) {
+				throw error.failure === 'missing-email'
+					? new BadRequestError('An email is required')
+					: new ForbiddenError('This identity is no longer allowed to sign in');
+			}
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
@@ -3,13 +3,13 @@ import {
 	GLOBAL_MEMBER_ROLE,
 	type AuthIdentity,
 	type AuthIdentityRepository,
-	type EntityManager,
 	type User,
 	type UserRepository,
 } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
 import type { EventService } from '@/events/event.service';
+import { IdentityBindingService } from '@/services/identity-binding.service';
 import type { RoleService } from '@/services/role.service';
 import type { UserService } from '@/services/user.service';
 
@@ -17,18 +17,22 @@ import type { TokenExchangeConfig } from '../../token-exchange.config';
 import { TokenExchangeAuthError } from '../../token-exchange.errors';
 import type { ExternalTokenClaims } from '../../token-exchange.schemas';
 import { TokenExchangeFailureReason } from '../../token-exchange.types';
-import { IdentityResolutionService } from '../identity-resolution.service';
+import { IdentityResolutionService, qualifiedProviderId } from '../identity-resolution.service';
 import type { TrustedKeyService } from '../trusted-key.service';
 
 const logger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
-const entityManager = mock<EntityManager>();
-const userRepository = mock<UserRepository>({ manager: entityManager });
+const userRepository = mock<UserRepository>();
 const authIdentityRepository = mock<AuthIdentityRepository>();
 const eventService = mock<EventService>();
 const userService = mock<UserService>();
 const trustedKeyService = mock<TrustedKeyService>();
 const roleService = mock<RoleService>();
 const config = mock<TokenExchangeConfig>();
+
+// The shared core is wired for real, against mocked repositories, so these
+// stay end-to-end regression tests of the resolution behaviour rather than
+// tests of the delegation.
+const identityBinding = new IdentityBindingService(logger, userRepository, authIdentityRepository);
 
 const service = new IdentityResolutionService(
 	logger,
@@ -39,6 +43,7 @@ const service = new IdentityResolutionService(
 	trustedKeyService,
 	roleService,
 	config,
+	identityBinding,
 );
 
 const CUSTOM_ROLE = 'global:custom-abc123';
@@ -83,30 +88,24 @@ describe('IdentityResolutionService', () => {
 	});
 
 	describe('JIT provisioning (new user)', () => {
-		const trx = entityManager;
+		const identity = { providerId: expect.any(String), providerType: 'token-exchange' };
 
 		beforeEach(() => {
 			// No existing identity, no existing user by email → JIT path.
 			authIdentityRepository.findOne.mockResolvedValue(null);
 			userRepository.findOne.mockResolvedValue(null);
-			entityManager.transaction.mockImplementation(
-				// @ts-expect-error overloaded signature
-				async (runInTransaction: (em: EntityManager) => Promise<unknown>) =>
-					await runInTransaction(trx),
+			userRepository.createUserWithExternalIdentity.mockResolvedValue(
+				mock<User>({ id: 'new-user-1' }),
 			);
-			userRepository.createUserWithProject.mockResolvedValue({
-				user: mock<User>({ id: 'new-user-1' }),
-				project: mock(),
-			});
 		});
 
 		it('provisions a licensed custom global role', async () => {
 			const user = await service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), true);
 
 			expect(user.id).toBe('new-user-1');
-			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+			expect(userRepository.createUserWithExternalIdentity).toHaveBeenCalledWith(
 				expect.objectContaining({ role: { slug: CUSTOM_ROLE } }),
-				trx,
+				identity,
 			);
 			expect(eventService.emit).toHaveBeenCalledWith(
 				'token-exchange-user-provisioned',
@@ -118,22 +117,34 @@ describe('IdentityResolutionService', () => {
 			await service.resolve(makeClaims({ role: 'global:member' }), undefined, ctx(), true);
 
 			expect(roleService.isRoleLicensed).not.toHaveBeenCalled();
-			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+			expect(userRepository.createUserWithExternalIdentity).toHaveBeenCalledWith(
 				expect.objectContaining({ role: { slug: 'global:member' } }),
-				trx,
+				identity,
 			);
 		});
 
 		it('defaults to global:member when no role claim is present', async () => {
 			await service.resolve(makeClaims(), undefined, ctx(), true);
 
-			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+			expect(userRepository.createUserWithExternalIdentity).toHaveBeenCalledWith(
 				expect.objectContaining({ role: GLOBAL_MEMBER_ROLE }),
-				trx,
+				identity,
 			);
 			expect(eventService.emit).toHaveBeenCalledWith(
 				'token-exchange-user-provisioned',
 				expect.objectContaining({ role: GLOBAL_MEMBER_ROLE.slug }),
+			);
+		});
+
+		it('keys the binding on the qualified sub, not the raw one', async () => {
+			await service.resolve(makeClaims(), undefined, ctx(), true);
+
+			expect(userRepository.createUserWithExternalIdentity).toHaveBeenCalledWith(
+				expect.anything(),
+				{
+					providerId: qualifiedProviderId('https://issuer.example.com', 'external-user-1'),
+					providerType: 'token-exchange',
+				},
 			);
 		});
 
@@ -143,7 +154,7 @@ describe('IdentityResolutionService', () => {
 			await expect(
 				service.resolve(makeClaims({ role: 'global:nonexistent' }), undefined, ctx(), true),
 			).rejects.toThrow(TokenExchangeAuthError);
-			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+			expect(userRepository.createUserWithExternalIdentity).not.toHaveBeenCalled();
 		});
 
 		it('throws when a custom role is unlicensed', async () => {
@@ -152,7 +163,7 @@ describe('IdentityResolutionService', () => {
 			await expect(
 				service.resolve(makeClaims({ role: CUSTOM_ROLE }), undefined, ctx(), true),
 			).rejects.toThrow(TokenExchangeAuthError);
-			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+			expect(userRepository.createUserWithExternalIdentity).not.toHaveBeenCalled();
 		});
 
 		it('throws on a global:owner role claim', async () => {
@@ -170,9 +181,9 @@ describe('IdentityResolutionService', () => {
 		it('provisions when the role is in the key allowedRoles', async () => {
 			await service.resolve(makeClaims({ role: CUSTOM_ROLE }), [CUSTOM_ROLE], ctx(), true);
 
-			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+			expect(userRepository.createUserWithExternalIdentity).toHaveBeenCalledWith(
 				expect.objectContaining({ role: { slug: CUSTOM_ROLE } }),
-				trx,
+				identity,
 			);
 		});
 	});
@@ -180,7 +191,9 @@ describe('IdentityResolutionService', () => {
 	describe('role sync (existing user resolved by identity)', () => {
 		function mockLinkedUser(currentRoleSlug: string) {
 			const user = mock<User>({ id: 'existing-1', role: { slug: currentRoleSlug } });
-			authIdentityRepository.findOne.mockResolvedValueOnce(mock<AuthIdentity>({ user }));
+			authIdentityRepository.findOne.mockResolvedValueOnce(
+				mock<AuthIdentity>({ user, status: 'active' }),
+			);
 			userRepository.findOneOrFail.mockResolvedValue(user);
 			return user;
 		}
@@ -257,7 +270,7 @@ describe('IdentityResolutionService', () => {
 
 		it('rejects when an already-linked identity resolves to a user whose role exceeds allowedRoles', async () => {
 			authIdentityRepository.findOne.mockResolvedValueOnce(
-				mock<AuthIdentity>({ user: makeUser('global:owner') }),
+				mock<AuthIdentity>({ user: makeUser('global:owner'), status: 'active' }),
 			);
 
 			await expect(
@@ -352,7 +365,7 @@ describe('IdentityResolutionService', () => {
 			expect(authIdentityRepository.findOne).toHaveBeenCalledWith(
 				expect.objectContaining({ where: { providerId: 'external-user-1', providerType: 'oidc' } }),
 			);
-			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+			expect(userRepository.createUserWithExternalIdentity).not.toHaveBeenCalled();
 		});
 
 		it('resolves via the bridge with allowProvisioning: false, performing no writes', async () => {
@@ -361,7 +374,7 @@ describe('IdentityResolutionService', () => {
 
 			await expect(service.resolve(makeClaims(), undefined, ctx(), false)).resolves.toEqual(user);
 
-			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+			expect(userRepository.createUserWithExternalIdentity).not.toHaveBeenCalled();
 			expect(authIdentityRepository.save).not.toHaveBeenCalled();
 			expect(authIdentityRepository.update).not.toHaveBeenCalled();
 			expect(userService.changeUserRole).not.toHaveBeenCalled();
@@ -383,7 +396,9 @@ describe('IdentityResolutionService', () => {
 
 		it('does not consult the bridge when a token-exchange binding already matches', async () => {
 			const user = mock<User>({ id: 'existing-1' });
-			authIdentityRepository.findOne.mockResolvedValueOnce(mock<AuthIdentity>({ user }));
+			authIdentityRepository.findOne.mockResolvedValueOnce(
+				mock<AuthIdentity>({ user, status: 'active' }),
+			);
 			userRepository.findOneOrFail.mockResolvedValue(user);
 			trustedKeyService.isSsoIssuer.mockResolvedValue(true);
 
@@ -397,7 +412,7 @@ describe('IdentityResolutionService', () => {
 		it('returns null for an unknown (iss, sub) without creating a user', async () => {
 			await expect(service.resolve(makeClaims(), undefined, ctx(), false)).resolves.toBeNull();
 
-			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+			expect(userRepository.createUserWithExternalIdentity).not.toHaveBeenCalled();
 			expect(authIdentityRepository.save).not.toHaveBeenCalled();
 			expect(eventService.emit).not.toHaveBeenCalled();
 		});

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -1,16 +1,19 @@
 import { Logger } from '@n8n/backend-common';
-import {
-	AuthIdentity,
-	AuthIdentityRepository,
-	GLOBAL_MEMBER_ROLE,
-	UserRepository,
-	type User,
-} from '@n8n/db';
+import { AuthIdentityRepository, GLOBAL_MEMBER_ROLE, UserRepository, type User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { GLOBAL_OWNER_ROLE_SLUG, isBuiltInRole } from '@n8n/permissions';
 import { createHash } from 'node:crypto';
 
 import { EventService } from '@/events/event.service';
+import {
+	IdentityBindingService,
+	interpretEmailVerified,
+} from '@/services/identity-binding.service';
+import {
+	IdentityResolutionError,
+	type IdentityPolicy,
+	type IdentitySource,
+} from '@/services/identity-binding.types';
 import type { IdentityResolver } from '@/services/identity-resolution-proxy.service';
 import { RoleService } from '@/services/role.service';
 import { UserService } from '@/services/user.service';
@@ -21,24 +24,19 @@ import type { ExternalTokenClaims } from '../token-exchange.schemas';
 import { TokenExchangeFailureReason } from '../token-exchange.types';
 import { TrustedKeyService } from './trusted-key.service';
 
-/**
- * Password placeholder for JIT-provisioned users. This is not a valid bcrypt
- * hash, so it can never match any input — the user can only authenticate
- * through token exchange.
- */
-const INVALID_PASSWORD_PLACEHOLDER = '!token-exchange-no-password';
-
-/** Maximum length for first/last name columns in the database. */
-const MAX_NAME_LENGTH = 32;
-
-function trimName(value: string | undefined, fallback = ''): string {
-	return (value ?? fallback).slice(0, MAX_NAME_LENGTH);
-}
+type TokenContext = { kid?: string; issuer: string; requireVerifiedEmail?: boolean };
 
 export function qualifiedProviderId(issuer: string, sub: string): string {
 	return `${createHash('sha256').update(issuer).digest('hex')}::${sub}`;
 }
 
+/**
+ * Adapter binding token-exchange's policy — per-key `allowedRoles`,
+ * `excludeOwner`, the `role` claim and `requireVerifiedEmail` — to the shared
+ * resolution algorithm in `IdentityBindingService`. The three-path lookup,
+ * linking and provisioning all live there; this class owns only the decisions
+ * that are specific to a token-exchange key.
+ */
 @Service()
 export class IdentityResolutionService implements IdentityResolver {
 	private readonly logger: Logger;
@@ -52,8 +50,172 @@ export class IdentityResolutionService implements IdentityResolver {
 		private readonly trustedKeyService: TrustedKeyService,
 		private readonly roleService: RoleService,
 		private readonly config: TokenExchangeConfig,
+		private readonly identityBinding: IdentityBindingService,
 	) {
 		this.logger = logger.scoped('token-exchange');
+	}
+
+	/**
+	 * Map external identity claims to a local n8n user.
+	 *
+	 * `allowProvisioning: true` (login/exchange flows) — creates a user if
+	 * necessary. `allowProvisioning: false` (per-access resolution) — a cheap,
+	 * read-only, indexed lookup only, returning `null` when there is no active
+	 * binding: a trigger must never create a user, and an unbound identity must
+	 * not block execution.
+	 *
+	 * Role handling: the role claim is only applied when it is both valid and
+	 * permitted by the key's allowedRoles. A disallowed role claim throws —
+	 * OAuth flows are strict to avoid silent misconfiguration.
+	 */
+	async resolve(
+		claims: ExternalTokenClaims,
+		allowedRoles: string[] | undefined,
+		tokenContext: TokenContext,
+		allowProvisioning: true,
+	): Promise<User>;
+	async resolve(
+		claims: ExternalTokenClaims,
+		allowedRoles: string[] | undefined,
+		tokenContext: TokenContext,
+		allowProvisioning: boolean,
+	): Promise<User | null>;
+	async resolve(
+		claims: ExternalTokenClaims,
+		allowedRoles: string[] | undefined,
+		tokenContext: TokenContext,
+		allowProvisioning: boolean,
+	): Promise<User | null> {
+		try {
+			return await this.identityBinding.resolve(
+				this.buildSource(claims, tokenContext),
+				claims,
+				this.buildPolicy(allowedRoles, tokenContext),
+				{ allowProvisioning },
+			);
+		} catch (error) {
+			// Re-map the shared core's errors onto this module's error type.
+			if (error instanceof IdentityResolutionError) {
+				throw error.failure === 'missing-email'
+					? new TokenExchangeAuthError(
+							TokenExchangeFailureReason.InvalidClaims,
+							'Email claim is required for user provisioning',
+						)
+					: new TokenExchangeAuthError(
+							TokenExchangeFailureReason.Other,
+							'This identity binding is no longer active',
+						);
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Bindings are keyed by `sha256(iss)::sub`, so the same `sub` from two
+	 * issuers can never collide. Two fallbacks cover rows written before that:
+	 * the unqualified sub, and — for the instance's own SSO provider — the
+	 * `oidc` row that already exists for anyone who has logged in through SSO.
+	 * The bridge is last so it can never shadow a token-exchange binding.
+	 */
+	private buildSource(claims: ExternalTokenClaims, tokenContext: TokenContext): IdentitySource {
+		const qualifiedSub = qualifiedProviderId(claims.iss, claims.sub);
+
+		return {
+			providerType: 'token-exchange',
+			keyFor: () => qualifiedSub,
+			fallbacks: [
+				{
+					providerId: claims.sub,
+					providerType: 'token-exchange',
+					// An unqualified sub is only unambiguous when there is a single
+					// trusted issuer; with more than one, treat it as not found.
+					accepts: async () => await this.trustedKeyService.hasSingleTrustedIssuer(),
+					rebind: async (identity) => {
+						await this.authIdentityRepository.update(
+							{ providerId: claims.sub, providerType: 'token-exchange' },
+							{ providerId: qualifiedSub },
+						);
+						this.eventService.emit('token-exchange-identity-rebound', {
+							userId: identity.user.id,
+							sub: claims.sub,
+							kid: tokenContext.kid ?? '',
+							issuer: tokenContext.issuer,
+						});
+					},
+				},
+				{
+					providerId: claims.sub,
+					providerType: 'oidc',
+					// Cheap indexed check, so it gates the lookup rather than
+					// filtering its result — a non-SSO issuer never touches an
+					// `oidc` row at all.
+					applies: async () => await this.trustedKeyService.isSsoIssuer(claims.iss),
+				},
+			],
+		};
+	}
+
+	private buildPolicy(
+		allowedRoles: string[] | undefined,
+		tokenContext: TokenContext,
+	): IdentityPolicy {
+		// Resolved by the pre-write gate and reused by `onResolved`, so a
+		// disallowed role claim throws before a binding is written rather than
+		// after. A fresh policy is built per resolution, so this cannot leak
+		// between callers.
+		let pendingRole: string | undefined;
+
+		return {
+			assertEmailVerified: (claims) =>
+				this.assertEmailVerified(claims.email_verified, tokenContext),
+
+			assertMayActAs: (user) => this.assertKeyMayActAsUser(user, allowedRoles),
+
+			assertClaimAcceptable: async (user, claims) => {
+				pendingRole = await this.resolveRoleForExistingUser(
+					claims.role,
+					allowedRoles,
+					user.role?.slug,
+				);
+			},
+
+			roleForNewUser: async (claims) => {
+				const jitRole = await this.resolveRoleForNewUser(claims.role, allowedRoles);
+				return jitRole ? { slug: jitRole } : GLOBAL_MEMBER_ROLE;
+			},
+
+			profileSync: 'every-resolution',
+
+			onLinked: (user, claims) => {
+				this.logger.debug('Linked external identity to existing user by email', {
+					sub: claims.sub,
+				});
+				this.eventService.emit('token-exchange-identity-linked', {
+					userId: user.id,
+					sub: claims.sub,
+					email: user.email,
+					kid: tokenContext.kid ?? '',
+					issuer: tokenContext.issuer,
+				});
+			},
+
+			onProvisioned: (user, claims, roleSlug) => {
+				this.eventService.emit('token-exchange-user-provisioned', {
+					userId: user.id,
+					sub: claims.sub,
+					email: user.email,
+					role: roleSlug,
+					kid: tokenContext.kid ?? '',
+					issuer: tokenContext.issuer,
+				});
+			},
+
+			onResolved: async (user, _claims, path) => {
+				// A user provisioned moments ago already has the claimed role.
+				if (path === 'provisioned') return user;
+				return await this.applyRole(user, pendingRole, tokenContext);
+			},
+		};
 	}
 
 	private assertKeyMayActAsUser(user: User, allowedRoles?: string[]) {
@@ -71,11 +233,17 @@ export class IdentityResolutionService implements IdentityResolver {
 		}
 	}
 
-	private assertEmailVerified(
-		claims: ExternalTokenClaims,
-		tokenContext: { requireVerifiedEmail: boolean },
-	) {
-		if (tokenContext?.requireVerifiedEmail && !claims.email_verified) {
+	/**
+	 * A key may waive the requirement that the IdP vouch for the email, but not
+	 * override the IdP actively saying it is unverified.
+	 */
+	private assertEmailVerified(emailVerified: unknown, tokenContext: TokenContext) {
+		const verification = interpretEmailVerified(emailVerified);
+
+		if (
+			verification === 'explicitly-unverified' ||
+			(tokenContext.requireVerifiedEmail && verification !== 'verified')
+		) {
 			throw new TokenExchangeAuthError(
 				TokenExchangeFailureReason.EmailNotVerified,
 				'Email is not verified',
@@ -84,242 +252,34 @@ export class IdentityResolutionService implements IdentityResolver {
 	}
 
 	/**
-	 * Map external identity claims to a local n8n user.
-	 *
-	 * `allowProvisioning: true` (login/exchange flows) — creates a user if
-	 * necessary. Resolution order:
-	 * 1. AuthIdentity lookup by sub + token-exchange provider (incl. the SSO bridge)
-	 * 2. Email fallback — link existing user to this sub
-	 * 3. JIT provision — create user + personal project + identity in a transaction
-	 *
-	 * `allowProvisioning: false` (per-access resolution) — a cheap, read-only,
-	 * indexed lookup only: no email fallback, no provisioning, no profile/role
-	 * sync, no writes. Returns `null` (never throws in a way that stops the
-	 * caller) when there is no active binding — a trigger must never create a
-	 * user, and an unbound identity must not block execution.
-	 *
-	 * Role handling: the role claim is only applied when it is both valid and
-	 * permitted by the key's allowedRoles. A disallowed role claim throws —
-	 * OAuth flows are strict to avoid silent misconfiguration.
+	 * Apply a role resolved by the pre-write gate. Goes through
+	 * `UserService.changeUserRole` so the side effects (API key revocation,
+	 * project relation cleanup, cache invalidation) are applied.
 	 */
-	async resolve(
-		claims: ExternalTokenClaims,
-		allowedRoles: string[] | undefined,
-		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
-		allowProvisioning: true,
-	): Promise<User>;
-	async resolve(
-		claims: ExternalTokenClaims,
-		allowedRoles: string[] | undefined,
-		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
-		allowProvisioning: boolean,
-	): Promise<User | null>;
-	async resolve(
-		claims: ExternalTokenClaims,
-		allowedRoles: string[] | undefined,
-		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
-		allowProvisioning: boolean,
-	): Promise<User | null> {
-		const identity = await this.findBoundIdentity(claims, allowProvisioning, tokenContext);
+	private async applyRole(
+		user: User,
+		resolvedRole: string | undefined,
+		tokenContext: TokenContext,
+	): Promise<User> {
+		const previousRole = user.role?.slug;
+		if (!resolvedRole || resolvedRole === previousRole) return user;
 
-		if (identity) {
-			if (!allowProvisioning) {
-				return this.isBindingActive(identity) ? identity.user : null;
-			}
-			return await this.resolveByIdentity(claims, identity, allowedRoles, tokenContext);
-		}
+		await this.userService.changeUserRole(user, { newRoleName: resolvedRole });
 
-		if (!allowProvisioning) {
-			return null;
-		}
-
-		// Path 2: email fallback
-		const email = claims.email?.toLowerCase();
-		if (email) {
-			const existingUser = await this.userRepository.findOne({
-				where: { email },
-				relations: ['authIdentities', 'role'],
+		if (previousRole) {
+			this.eventService.emit('token-exchange-role-updated', {
+				userId: user.id,
+				previousRole,
+				newRole: resolvedRole,
+				kid: tokenContext.kid ?? '',
+				issuer: tokenContext.issuer,
 			});
-
-			if (existingUser) {
-				return await this.resolveByEmail(claims, email, existingUser, allowedRoles, tokenContext);
-			}
 		}
 
-		// Path 3: JIT provisioning
-		if (!email) {
-			throw new TokenExchangeAuthError(
-				TokenExchangeFailureReason.InvalidClaims,
-				'Email claim is required for user provisioning',
-			);
-		}
-
-		return await this.provisionUser(claims, email, allowedRoles, tokenContext);
-	}
-
-	/**
-	 * Read-only lookup of an existing binding. Tries, in order: the qualified
-	 * token-exchange sub, the legacy unqualified token-exchange sub, then the
-	 * OIDC SSO bridge (Change 1) — same human, different login surface, whose
-	 * AuthIdentity row already exists for anyone who has logged in via SSO.
-	 * The bridge is tried last so it never shadows an existing token-exchange
-	 * binding for the same claim.
-	 */
-	private async findBoundIdentity(
-		claims: ExternalTokenClaims,
-		allowProvisioning: boolean,
-		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
-	): Promise<AuthIdentity | null> {
-		const qualifiedSub = qualifiedProviderId(claims.iss, claims.sub);
-
-		let identity = await this.authIdentityRepository.findOne({
-			where: { providerId: qualifiedSub, providerType: 'token-exchange' },
-			relations: { user: { role: true } },
+		return await this.userRepository.findOneOrFail({
+			where: { id: user.id },
+			relations: ['role'],
 		});
-		if (identity) return identity;
-
-		identity = await this.authIdentityRepository.findOne({
-			where: { providerId: claims.sub, providerType: 'token-exchange' },
-			relations: { user: { role: true } },
-		});
-		// An unqualified sub is only unambiguous when there's a single trusted
-		// issuer; with more than one, treat it as not found, same as before.
-		if (identity && (await this.trustedKeyService.hasSingleTrustedIssuer())) {
-			// Rebind is a write; keep the per-access (read-only) path free of it.
-			if (allowProvisioning) {
-				await this.authIdentityRepository.update(
-					{ providerId: claims.sub, providerType: 'token-exchange' },
-					{ providerId: qualifiedSub },
-				);
-				this.eventService.emit('token-exchange-identity-rebound', {
-					userId: identity.user.id,
-					sub: claims.sub,
-					kid: tokenContext.kid,
-					issuer: tokenContext.issuer,
-				});
-			}
-			return identity;
-		}
-
-		if (await this.trustedKeyService.isSsoIssuer(claims.iss)) {
-			identity = await this.authIdentityRepository.findOne({
-				where: { providerId: claims.sub, providerType: 'oidc' },
-				relations: { user: { role: true } },
-			});
-			if (identity) return identity;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Deliberately does not consult the claim's `expiresAt` — binding status is
-	 * the access gate, not token freshness; an execution outliving the token's
-	 * `exp` must still resolve.
-	 */
-	private isBindingActive(identity: AuthIdentity): boolean {
-		return identity.status === 'active';
-	}
-
-	/** Path 1: resolve an already-linked identity and sync profile/role. */
-	private async resolveByIdentity(
-		claims: ExternalTokenClaims,
-		identity: AuthIdentity,
-		allowedRoles: string[] | undefined,
-		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean } | undefined,
-	): Promise<User> {
-		this.assertKeyMayActAsUser(identity.user, allowedRoles);
-
-		this.logger.debug('Resolved user by auth identity', { sub: claims.sub });
-		const resolvedRole = await this.resolveRoleForExistingUser(
-			claims.role,
-			allowedRoles,
-			identity.user.role?.slug,
-		);
-		return await this.syncProfile(identity.user, claims, resolvedRole, tokenContext);
-	}
-
-	/** Path 2: link an external identity to an existing user found by email. */
-	private async resolveByEmail(
-		claims: ExternalTokenClaims,
-		email: string,
-		existingUser: User,
-		allowedRoles: string[] | undefined,
-		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
-	): Promise<User> {
-		this.logger.debug('Linking external identity to existing user by email', {
-			sub: claims.sub,
-			email,
-		});
-		this.assertKeyMayActAsUser(existingUser, allowedRoles);
-		this.assertEmailVerified(claims, tokenContext);
-		const resolvedRole = await this.resolveRoleForExistingUser(
-			claims.role,
-			allowedRoles,
-			existingUser.role?.slug,
-		);
-		const qualifiedSub = qualifiedProviderId(claims.iss, claims.sub);
-		await this.authIdentityRepository.save(
-			AuthIdentity.create(existingUser, qualifiedSub, 'token-exchange'),
-		);
-		this.eventService.emit('token-exchange-identity-linked', {
-			userId: existingUser.id,
-			sub: claims.sub,
-			email,
-			kid: tokenContext?.kid ?? '',
-			issuer: tokenContext?.issuer ?? claims.iss,
-		});
-		return await this.syncProfile(existingUser, claims, resolvedRole, tokenContext);
-	}
-
-	/** Path 3: JIT-provision a new user with a personal project and identity link. */
-	private async provisionUser(
-		claims: ExternalTokenClaims,
-		email: string,
-		allowedRoles: string[] | undefined,
-		tokenContext: { kid: string; issuer: string; requireVerifiedEmail: boolean },
-	): Promise<User> {
-		this.assertEmailVerified(claims, tokenContext);
-		this.logger.debug('JIT provisioning new user', { sub: claims.sub, email });
-
-		const jitRole = await this.resolveRoleForNewUser(claims.role, allowedRoles);
-		const targetRole = jitRole ? { slug: jitRole } : GLOBAL_MEMBER_ROLE;
-
-		const qualifiedSub = qualifiedProviderId(claims.iss, claims.sub);
-
-		const user = await this.userRepository.manager.transaction(async (trx) => {
-			const { user: newUser } = await this.userRepository.createUserWithProject(
-				{
-					email,
-					firstName: trimName(claims.given_name),
-					lastName: trimName(claims.family_name),
-					role: targetRole,
-					password: INVALID_PASSWORD_PLACEHOLDER,
-				},
-				trx,
-			);
-
-			await trx.save(
-				trx.create(AuthIdentity, {
-					providerId: qualifiedSub,
-					providerType: 'token-exchange',
-					userId: newUser.id,
-				}),
-			);
-
-			return newUser;
-		});
-
-		this.eventService.emit('token-exchange-user-provisioned', {
-			userId: user.id,
-			sub: claims.sub,
-			email,
-			role: targetRole.slug,
-			kid: tokenContext?.kid ?? '',
-			issuer: tokenContext?.issuer ?? claims.iss,
-		});
-
-		return user;
 	}
 
 	/**
@@ -423,67 +383,5 @@ export class IdentityResolutionService implements IdentityResolver {
 		}
 
 		return role;
-	}
-
-	/**
-	 * Sync profile fields and role from claims to user when present and changed.
-	 * Uses `UserService.changeUserRole` for role changes to ensure side effects
-	 * (API key revocation, project relation cleanup, cache invalidation) are applied.
-	 */
-	private async syncProfile(
-		user: User,
-		claims: ExternalTokenClaims,
-		resolvedRole?: string,
-		tokenContext?: { kid: string; issuer: string; requireVerifiedEmail: boolean },
-	): Promise<User> {
-		let needsReload = false;
-
-		// Sync profile fields (firstName, lastName)
-		const profileUpdates: Pick<Partial<User>, 'firstName' | 'lastName'> = {};
-
-		if (claims.given_name !== undefined) {
-			const trimmed = trimName(claims.given_name);
-			if (trimmed !== user.firstName) {
-				profileUpdates.firstName = trimmed;
-			}
-		}
-
-		if (claims.family_name !== undefined) {
-			const trimmed = trimName(claims.family_name);
-			if (trimmed !== user.lastName) {
-				profileUpdates.lastName = trimmed;
-			}
-		}
-
-		if (Object.keys(profileUpdates).length > 0) {
-			await this.userRepository.update(user.id, profileUpdates);
-			needsReload = true;
-		}
-
-		// Sync role via UserService.changeUserRole for proper side effects
-		const previousRole = user.role?.slug;
-		if (resolvedRole && resolvedRole !== previousRole) {
-			await this.userService.changeUserRole(user, { newRoleName: resolvedRole });
-			needsReload = true;
-
-			if (previousRole) {
-				this.eventService.emit('token-exchange-role-updated', {
-					userId: user.id,
-					previousRole,
-					newRole: resolvedRole,
-					kid: tokenContext?.kid ?? '',
-					issuer: tokenContext?.issuer ?? claims.iss,
-				});
-			}
-		}
-
-		if (needsReload) {
-			return await this.userRepository.findOneOrFail({
-				where: { id: user.id },
-				relations: ['role'],
-			});
-		}
-
-		return user;
 	}
 }

--- a/packages/cli/src/services/__tests__/identity-binding.service.test.ts
+++ b/packages/cli/src/services/__tests__/identity-binding.service.test.ts
@@ -1,0 +1,474 @@
+import type { Logger } from '@n8n/backend-common';
+import type { AuthIdentity, AuthIdentityRepository, User, UserRepository } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import { IdentityBindingService } from '../identity-binding.service';
+import {
+	IdentityResolutionError,
+	type IdentityPolicy,
+	type IdentitySource,
+} from '../identity-binding.types';
+import type { VerifiedIdentityClaim } from '../identity-resolution-proxy.service';
+
+const logger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
+const userRepository = mock<UserRepository>();
+const authIdentityRepository = mock<AuthIdentityRepository>();
+
+const service = new IdentityBindingService(logger, userRepository, authIdentityRepository);
+
+function makeUser(overrides: Partial<User> = {}): User {
+	return {
+		...mock<User>(),
+		id: 'user-id',
+		email: 'user@example.com',
+		firstName: 'Ada',
+		lastName: 'Lovelace',
+		...overrides,
+	} as User;
+}
+
+function makeClaims(overrides: Partial<VerifiedIdentityClaim> = {}): VerifiedIdentityClaim {
+	return {
+		iss: 'https://issuer.example.com',
+		sub: 'external-user-1',
+		email: 'user@example.com',
+		email_verified: true,
+		...overrides,
+	};
+}
+
+function makeIdentity(user: User, overrides: Partial<AuthIdentity> = {}): AuthIdentity {
+	return {
+		...mock<AuthIdentity>(),
+		providerId: 'external-user-1',
+		providerType: 'token-exchange',
+		userId: user.id,
+		user,
+		status: 'active',
+		...overrides,
+	} as AuthIdentity;
+}
+
+const source: IdentitySource = {
+	providerType: 'token-exchange',
+	keyFor: (claims) => `qualified::${claims.sub}`,
+};
+
+function makePolicy(overrides: Partial<IdentityPolicy> = {}): IdentityPolicy {
+	return {
+		assertEmailVerified: vi.fn(),
+		roleForNewUser: vi.fn().mockResolvedValue({ slug: 'global:member' }),
+		profileSync: 'on-provision',
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	authIdentityRepository.findOne.mockResolvedValue(null);
+	userRepository.findOne.mockResolvedValue(null);
+});
+
+describe('path 1 — known subject', () => {
+	it('resolves by the primary key without touching the email path', async () => {
+		const user = makeUser();
+		authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(user));
+		const policy = makePolicy();
+
+		const result = await service.resolve(source, makeClaims(), policy, {
+			allowProvisioning: true,
+		});
+
+		expect(result).toBe(user);
+		expect(authIdentityRepository.findOne).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { providerId: 'qualified::external-user-1', providerType: 'token-exchange' },
+			}),
+		);
+		expect(userRepository.findOne).not.toHaveBeenCalled();
+		expect(policy.assertEmailVerified).not.toHaveBeenCalled();
+	});
+
+	it('runs the pre-write gates before returning', async () => {
+		const user = makeUser();
+		authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(user));
+		const policy = makePolicy({
+			assertMayActAs: vi.fn(),
+			assertClaimAcceptable: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await service.resolve(source, makeClaims(), policy, { allowProvisioning: true });
+
+		expect(policy.assertMayActAs).toHaveBeenCalledWith(user);
+		expect(policy.assertClaimAcceptable).toHaveBeenCalledWith(user, expect.anything());
+	});
+
+	it('does not apply key-scoped gates on the read-only path', async () => {
+		const user = makeUser();
+		authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(user));
+		const policy = makePolicy({
+			assertMayActAs: vi.fn(),
+			assertClaimAcceptable: vi.fn().mockResolvedValue(undefined),
+			onResolved: vi.fn(),
+		});
+
+		const result = await service.resolve(source, makeClaims(), policy, {
+			allowProvisioning: false,
+		});
+
+		expect(result).toBe(user);
+		expect(policy.assertMayActAs).not.toHaveBeenCalled();
+		expect(policy.assertClaimAcceptable).not.toHaveBeenCalled();
+		expect(policy.onResolved).not.toHaveBeenCalled();
+	});
+});
+
+describe('non-active bindings', () => {
+	it.each(['suspended', 'revoked'] as const)(
+		'throws on a %s binding when logging in',
+		async (status) => {
+			authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(makeUser(), { status }));
+
+			await expect(
+				service.resolve(source, makeClaims(), makePolicy(), { allowProvisioning: true }),
+			).rejects.toThrow(IdentityResolutionError);
+		},
+	);
+
+	it.each(['suspended', 'revoked'] as const)(
+		'returns null on a %s binding on the read-only path',
+		async (status) => {
+			authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(makeUser(), { status }));
+
+			await expect(
+				service.resolve(source, makeClaims(), makePolicy(), { allowProvisioning: false }),
+			).resolves.toBeNull();
+		},
+	);
+
+	it('does not fall through to the email path', async () => {
+		authIdentityRepository.findOne.mockResolvedValueOnce(
+			makeIdentity(makeUser(), { status: 'revoked' }),
+		);
+
+		await expect(
+			service.resolve(source, makeClaims(), makePolicy(), { allowProvisioning: true }),
+		).rejects.toThrow();
+
+		expect(userRepository.findOne).not.toHaveBeenCalled();
+		expect(userRepository.createUserWithExternalIdentity).not.toHaveBeenCalled();
+	});
+});
+
+describe('fallback lookups', () => {
+	const legacyUser = makeUser({ id: 'legacy-user' });
+
+	it('tries fallbacks only after the primary key misses, in order', async () => {
+		const rebind = vi.fn();
+		const withFallbacks: IdentitySource = {
+			...source,
+			fallbacks: [
+				{ providerId: 'legacy-sub', providerType: 'token-exchange', rebind },
+				{ providerId: 'bridged-sub', providerType: 'oidc' },
+			],
+		};
+		authIdentityRepository.findOne
+			.mockResolvedValueOnce(null) // primary
+			.mockResolvedValueOnce(makeIdentity(legacyUser)); // first fallback
+
+		const result = await service.resolve(withFallbacks, makeClaims(), makePolicy(), {
+			allowProvisioning: true,
+		});
+
+		expect(result).toBe(legacyUser);
+		expect(rebind).toHaveBeenCalled();
+		// The second fallback is never queried once the first one hits.
+		expect(authIdentityRepository.findOne).toHaveBeenCalledTimes(2);
+	});
+
+	it('skips the lookup entirely when a pre-query guard says it does not apply', async () => {
+		const applies = vi.fn().mockResolvedValue(false);
+		const withFallbacks: IdentitySource = {
+			...source,
+			fallbacks: [{ providerId: 'bridged-sub', providerType: 'oidc', applies }],
+		};
+		userRepository.findOne.mockResolvedValue(makeUser());
+
+		await service.resolve(withFallbacks, makeClaims(), makePolicy(), {
+			allowProvisioning: true,
+		});
+
+		expect(applies).toHaveBeenCalled();
+		// Only the primary lookup ran.
+		expect(authIdentityRepository.findOne).toHaveBeenCalledTimes(1);
+	});
+
+	it('discards a matched row when a post-query guard rejects it', async () => {
+		const accepts = vi.fn().mockResolvedValue(false);
+		const withFallbacks: IdentitySource = {
+			...source,
+			fallbacks: [{ providerId: 'legacy-sub', providerType: 'token-exchange', accepts }],
+		};
+		const emailUser = makeUser({ id: 'by-email' });
+		authIdentityRepository.findOne
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce(makeIdentity(legacyUser));
+		userRepository.findOne.mockResolvedValue(emailUser);
+
+		const result = await service.resolve(withFallbacks, makeClaims(), makePolicy(), {
+			allowProvisioning: true,
+		});
+
+		expect(accepts).toHaveBeenCalled();
+		// Rejected, so resolution continues to the email path.
+		expect(result).toBe(emailUser);
+	});
+
+	it('does not rebind on the read-only path', async () => {
+		const rebind = vi.fn();
+		const withFallbacks: IdentitySource = {
+			...source,
+			fallbacks: [{ providerId: 'legacy-sub', providerType: 'token-exchange', rebind }],
+		};
+		authIdentityRepository.findOne
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce(makeIdentity(legacyUser));
+
+		await service.resolve(withFallbacks, makeClaims(), makePolicy(), {
+			allowProvisioning: false,
+		});
+
+		expect(rebind).not.toHaveBeenCalled();
+	});
+});
+
+describe('path 2 — link by email', () => {
+	it('links the subject to the existing account and reports it', async () => {
+		const existing = makeUser();
+		userRepository.findOne.mockResolvedValue(existing);
+		const policy = makePolicy({ onLinked: vi.fn() });
+
+		const result = await service.resolve(source, makeClaims(), policy, {
+			allowProvisioning: true,
+		});
+
+		expect(result).toBe(existing);
+		expect(policy.assertEmailVerified).toHaveBeenCalled();
+		expect(authIdentityRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				providerId: 'qualified::external-user-1',
+				providerType: 'token-exchange',
+				userId: existing.id,
+			}),
+		);
+		expect(policy.onLinked).toHaveBeenCalledWith(existing, expect.anything());
+	});
+
+	it('lowercases the claim email before looking the account up', async () => {
+		userRepository.findOne.mockResolvedValue(makeUser());
+
+		await service.resolve(source, makeClaims({ email: 'User@Example.COM' }), makePolicy(), {
+			allowProvisioning: true,
+		});
+
+		expect(userRepository.findOne).toHaveBeenCalledWith(
+			expect.objectContaining({ where: { email: 'user@example.com' } }),
+		);
+	});
+
+	it('writes nothing when a pre-write gate rejects the claim', async () => {
+		userRepository.findOne.mockResolvedValue(makeUser());
+		const policy = makePolicy({
+			assertClaimAcceptable: vi.fn().mockRejectedValue(new Error('role not allowed')),
+		});
+
+		await expect(
+			service.resolve(source, makeClaims(), policy, { allowProvisioning: true }),
+		).rejects.toThrow('role not allowed');
+
+		expect(authIdentityRepository.save).not.toHaveBeenCalled();
+	});
+
+	it('writes nothing when the email is not verified', async () => {
+		userRepository.findOne.mockResolvedValue(makeUser());
+		const policy = makePolicy({
+			assertEmailVerified: vi.fn().mockImplementation(() => {
+				throw new Error('email not verified');
+			}),
+		});
+
+		await expect(
+			service.resolve(source, makeClaims(), policy, { allowProvisioning: true }),
+		).rejects.toThrow('email not verified');
+
+		expect(authIdentityRepository.save).not.toHaveBeenCalled();
+	});
+});
+
+describe('path 3 — JIT provision', () => {
+	it('creates the user, project and binding atomically', async () => {
+		const created = makeUser({ id: 'new-user' });
+		userRepository.createUserWithExternalIdentity.mockResolvedValue(created);
+		const policy = makePolicy({ onProvisioned: vi.fn() });
+
+		const result = await service.resolve(source, makeClaims(), policy, {
+			allowProvisioning: true,
+		});
+
+		expect(result).toBe(created);
+		expect(userRepository.createUserWithExternalIdentity).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: 'user@example.com',
+				role: { slug: 'global:member' },
+			}),
+			{ providerId: 'qualified::external-user-1', providerType: 'token-exchange' },
+		);
+		expect(policy.onProvisioned).toHaveBeenCalledWith(created, expect.anything(), 'global:member');
+	});
+
+	it('asserts the email is verified before provisioning', async () => {
+		const policy = makePolicy({
+			assertEmailVerified: vi.fn().mockImplementation(() => {
+				throw new Error('email not verified');
+			}),
+		});
+
+		await expect(
+			service.resolve(source, makeClaims(), policy, { allowProvisioning: true }),
+		).rejects.toThrow('email not verified');
+
+		expect(userRepository.createUserWithExternalIdentity).not.toHaveBeenCalled();
+	});
+
+	it('resolves the role before opening the transaction', async () => {
+		const calls: string[] = [];
+		userRepository.createUserWithExternalIdentity.mockImplementation(async () => {
+			calls.push('create');
+			return makeUser();
+		});
+		const policy = makePolicy({
+			roleForNewUser: vi.fn().mockImplementation(async () => {
+				calls.push('role');
+				return { slug: 'global:admin' };
+			}),
+		});
+
+		await service.resolve(source, makeClaims(), policy, { allowProvisioning: true });
+
+		expect(calls).toEqual(['role', 'create']);
+	});
+
+	it('truncates names to the column length', async () => {
+		userRepository.createUserWithExternalIdentity.mockResolvedValue(makeUser());
+
+		await service.resolve(
+			source,
+			makeClaims({ given_name: 'x'.repeat(50), family_name: 'y'.repeat(50) }),
+			makePolicy(),
+			{ allowProvisioning: true },
+		);
+
+		expect(userRepository.createUserWithExternalIdentity).toHaveBeenCalledWith(
+			expect.objectContaining({ firstName: 'x'.repeat(32), lastName: 'y'.repeat(32) }),
+			expect.anything(),
+		);
+	});
+
+	it('throws when there is no email to key off', async () => {
+		await expect(
+			service.resolve(source, makeClaims({ email: undefined }), makePolicy(), {
+				allowProvisioning: true,
+			}),
+		).rejects.toThrow(IdentityResolutionError);
+	});
+
+	it('returns null instead of provisioning on the read-only path', async () => {
+		await expect(
+			service.resolve(source, makeClaims(), makePolicy(), { allowProvisioning: false }),
+		).resolves.toBeNull();
+
+		expect(userRepository.findOne).not.toHaveBeenCalled();
+		expect(userRepository.createUserWithExternalIdentity).not.toHaveBeenCalled();
+	});
+});
+
+describe('profile sync', () => {
+	it('leaves names alone under on-provision', async () => {
+		authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(makeUser()));
+
+		await service.resolve(
+			source,
+			makeClaims({ given_name: 'Grace', family_name: 'Hopper' }),
+			makePolicy({ profileSync: 'on-provision' }),
+			{ allowProvisioning: true },
+		);
+
+		expect(userRepository.update).not.toHaveBeenCalled();
+	});
+
+	it('writes back changed names under every-resolution and returns the reloaded user', async () => {
+		const reloaded = makeUser({ firstName: 'Grace', lastName: 'Hopper' });
+		authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(makeUser()));
+		userRepository.findOneOrFail.mockResolvedValue(reloaded);
+
+		const result = await service.resolve(
+			source,
+			makeClaims({ given_name: 'Grace', family_name: 'Hopper' }),
+			makePolicy({ profileSync: 'every-resolution' }),
+			{ allowProvisioning: true },
+		);
+
+		expect(userRepository.update).toHaveBeenCalledWith('user-id', {
+			firstName: 'Grace',
+			lastName: 'Hopper',
+		});
+		expect(result).toBe(reloaded);
+	});
+
+	it('does not write when the claim matches what is stored', async () => {
+		authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(makeUser()));
+
+		await service.resolve(
+			source,
+			makeClaims({ given_name: 'Ada', family_name: 'Lovelace' }),
+			makePolicy({ profileSync: 'every-resolution' }),
+			{ allowProvisioning: true },
+		);
+
+		expect(userRepository.update).not.toHaveBeenCalled();
+	});
+});
+
+describe('onResolved', () => {
+	it('is called with the path and can substitute the returned user', async () => {
+		const substituted = makeUser({ id: 'substituted' });
+		authIdentityRepository.findOne.mockResolvedValueOnce(makeIdentity(makeUser()));
+		const policy = makePolicy({ onResolved: vi.fn().mockResolvedValue(substituted) });
+
+		const result = await service.resolve(source, makeClaims(), policy, {
+			allowProvisioning: true,
+		});
+
+		expect(policy.onResolved).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			'known-subject',
+		);
+		expect(result).toBe(substituted);
+	});
+
+	it.each([
+		['linked-by-email', () => userRepository.findOne.mockResolvedValue(makeUser())],
+		[
+			'provisioned',
+			() => userRepository.createUserWithExternalIdentity.mockResolvedValue(makeUser()),
+		],
+	])('reports the %s path', async (path, arrange) => {
+		arrange();
+		const policy = makePolicy({ onResolved: vi.fn().mockImplementation(async (user) => user) });
+
+		await service.resolve(source, makeClaims(), policy, { allowProvisioning: true });
+
+		expect(policy.onResolved).toHaveBeenCalledWith(expect.anything(), expect.anything(), path);
+	});
+});

--- a/packages/cli/src/services/identity-binding.service.ts
+++ b/packages/cli/src/services/identity-binding.service.ts
@@ -1,0 +1,276 @@
+import { Logger } from '@n8n/backend-common';
+import { AuthIdentity, AuthIdentityRepository, UserRepository, type User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import {
+	IdentityResolutionError,
+	type IdentityPolicy,
+	type IdentitySource,
+	type ResolutionPath,
+} from './identity-binding.types';
+import type { VerifiedIdentityClaim } from './identity-resolution-proxy.service';
+
+/**
+ * Password placeholder for JIT-provisioned users. Not a valid bcrypt hash, so
+ * it can never match any input — the user can only authenticate through the
+ * identity provider that created them.
+ */
+export const EXTERNAL_IDENTITY_PASSWORD_PLACEHOLDER = '!external-identity-no-password';
+
+/** `User.firstName` / `User.lastName` are `length: 32`. */
+const MAX_NAME_LENGTH = 32;
+
+export function trimName(value: string | undefined, fallback = ''): string {
+	return (value ?? fallback).slice(0, MAX_NAME_LENGTH);
+}
+
+export type EmailVerification = 'verified' | 'explicitly-unverified' | 'unknown';
+
+/**
+ * Read an `email_verified` claim as three states rather than two. "Absent" and
+ * "the IdP says no" are different facts and each source is entitled to treat
+ * them differently — but they should at least be *read* the same way. Some
+ * providers emit the value as a string, hence the `'true'`/`'false'` cases.
+ */
+export function interpretEmailVerified(value: unknown): EmailVerification {
+	if (value === true || value === 'true') return 'verified';
+	if (value === false || value === 'false') return 'explicitly-unverified';
+	return 'unknown';
+}
+
+/**
+ * The one implementation of "map a verified external claim to an n8n user".
+ *
+ * Owns the three-path algorithm and the DB work, and nothing else. Every
+ * decision that differs between identity providers — how the `AuthIdentity`
+ * row is keyed, what counts as a verified email, which role a new user gets,
+ * whether names re-sync on every login — is injected via `IdentitySource` and
+ * `IdentityPolicy`, so neither `sso-oidc` nor `token-exchange` needs to know
+ * the other exists.
+ *
+ * The three paths:
+ * 1. **Known subject** — an active `AuthIdentity` for this claim → that user.
+ * 2. **Email fallback** — an existing account with the claim's email → link it.
+ * 3. **JIT provision** — create user, personal project and binding atomically.
+ */
+@Service()
+export class IdentityBindingService {
+	private readonly logger: Logger;
+
+	constructor(
+		logger: Logger,
+		private readonly userRepository: UserRepository,
+		private readonly authIdentityRepository: AuthIdentityRepository,
+	) {
+		this.logger = logger.scoped('identity-binding');
+	}
+
+	/**
+	 * `allowProvisioning` is required at the call site rather than defaulted,
+	 * so a trigger-originated, unauthenticated access path can never create a
+	 * user. When `false` this is a read-only indexed lookup that returns `null`
+	 * instead of throwing — an unbound identity must not stop an execution.
+	 */
+	async resolve(
+		source: IdentitySource,
+		claims: VerifiedIdentityClaim,
+		policy: IdentityPolicy,
+		opts: { allowProvisioning: true },
+	): Promise<User>;
+	async resolve(
+		source: IdentitySource,
+		claims: VerifiedIdentityClaim,
+		policy: IdentityPolicy,
+		opts: { allowProvisioning: boolean },
+	): Promise<User | null>;
+	async resolve(
+		source: IdentitySource,
+		claims: VerifiedIdentityClaim,
+		policy: IdentityPolicy,
+		{ allowProvisioning }: { allowProvisioning: boolean },
+	): Promise<User | null> {
+		const identity = await this.findBoundIdentity(source, claims, allowProvisioning);
+
+		if (identity) {
+			// Fail closed on a suspended or revoked binding, on every path. On the
+			// read-only path that means "no principal"; on a login it is an error.
+			if (identity.status !== 'active') {
+				this.logger.warn('Refusing a non-active identity binding', {
+					providerType: source.providerType,
+					status: identity.status,
+				});
+				if (!allowProvisioning) return null;
+				throw new IdentityResolutionError(
+					'binding-not-active',
+					'This identity binding is no longer active',
+				);
+			}
+
+			// Key-scoped restrictions deliberately do not apply to the read-only
+			// path: it re-derives a principal for an execution that is already
+			// running, and must not throw.
+			if (!allowProvisioning) return identity.user;
+
+			policy.assertMayActAs?.(identity.user);
+			await policy.assertClaimAcceptable?.(identity.user, claims);
+
+			return await this.finish(identity.user, claims, policy, 'known-subject');
+		}
+
+		if (!allowProvisioning) return null;
+
+		// Emails are stored lowercased (`User.email` carries a lower-casing
+		// transformer and a `@BeforeInsert` hook), so match that here rather
+		// than relying on the driver to normalise the comparison.
+		const email = claims.email?.toLowerCase();
+		if (!email) {
+			throw new IdentityResolutionError(
+				'missing-email',
+				'Email claim is required to link or provision a user',
+			);
+		}
+
+		const existingUser = await this.userRepository.findOne({
+			where: { email },
+			relations: ['authIdentities', 'role'],
+		});
+
+		if (existingUser) {
+			return await this.linkToExistingUser(source, claims, policy, existingUser);
+		}
+
+		return await this.provisionUser(source, claims, policy, email);
+	}
+
+	/**
+	 * Primary key first, then each declared fallback in order — so a legacy or
+	 * bridged row never shadows a binding written in the current key format.
+	 */
+	private async findBoundIdentity(
+		source: IdentitySource,
+		claims: VerifiedIdentityClaim,
+		allowWrites: boolean,
+	): Promise<AuthIdentity | null> {
+		const primary = await this.authIdentityRepository.findOne({
+			where: { providerId: source.keyFor(claims), providerType: source.providerType },
+			relations: { user: { role: true } },
+		});
+		if (primary) return primary;
+
+		for (const fallback of source.fallbacks ?? []) {
+			if (fallback.applies && !(await fallback.applies())) continue;
+
+			const identity = await this.authIdentityRepository.findOne({
+				where: { providerId: fallback.providerId, providerType: fallback.providerType },
+				relations: { user: { role: true } },
+			});
+			if (!identity) continue;
+			if (fallback.accepts && !(await fallback.accepts(identity))) continue;
+
+			// Rebinding is a write; keep the per-access read-only path free of it.
+			if (allowWrites && fallback.rebind) {
+				await fallback.rebind(identity);
+			}
+			return identity;
+		}
+
+		return null;
+	}
+
+	/** Path 2: an account already exists for this email — bind this subject to it. */
+	private async linkToExistingUser(
+		source: IdentitySource,
+		claims: VerifiedIdentityClaim,
+		policy: IdentityPolicy,
+		existingUser: User,
+	): Promise<User> {
+		policy.assertMayActAs?.(existingUser);
+		// Linking keys off the email, so it has to be one the IdP vouches for.
+		policy.assertEmailVerified(claims);
+		await policy.assertClaimAcceptable?.(existingUser, claims);
+
+		this.logger.debug('Linking external identity to an existing user by email', {
+			providerType: source.providerType,
+		});
+
+		await this.authIdentityRepository.save(
+			AuthIdentity.create(existingUser, source.keyFor(claims), source.providerType),
+		);
+		policy.onLinked?.(existingUser, claims);
+
+		return await this.finish(existingUser, claims, policy, 'linked-by-email');
+	}
+
+	/** Path 3: no account and no binding — create both. */
+	private async provisionUser(
+		source: IdentitySource,
+		claims: VerifiedIdentityClaim,
+		policy: IdentityPolicy,
+		email: string,
+	): Promise<User> {
+		policy.assertEmailVerified(claims);
+
+		const role = await policy.roleForNewUser(claims);
+
+		this.logger.debug('Provisioning a new user from an external identity', {
+			providerType: source.providerType,
+			role: role.slug,
+		});
+
+		const user = await this.userRepository.createUserWithExternalIdentity(
+			{
+				email,
+				firstName: trimName(claims.given_name),
+				lastName: trimName(claims.family_name),
+				role,
+				password: EXTERNAL_IDENTITY_PASSWORD_PLACEHOLDER,
+			},
+			{ providerId: source.keyFor(claims), providerType: source.providerType },
+		);
+
+		policy.onProvisioned?.(user, claims, role.slug);
+
+		// Names were just written from the claim, so there is nothing to re-sync.
+		return (await policy.onResolved?.(user, claims, 'provisioned')) ?? user;
+	}
+
+	/** Profile sync then the adapter's final hook — shared by paths 1 and 2. */
+	private async finish(
+		user: User,
+		claims: VerifiedIdentityClaim,
+		policy: IdentityPolicy,
+		path: ResolutionPath,
+	): Promise<User> {
+		const synced =
+			policy.profileSync === 'every-resolution' ? await this.syncProfile(user, claims) : user;
+
+		return (await policy.onResolved?.(synced, claims, path)) ?? synced;
+	}
+
+	/**
+	 * Write back `firstName`/`lastName` when the claim disagrees with what we
+	 * have. Returns a reloaded user so the caller never sees a stale copy.
+	 */
+	private async syncProfile(user: User, claims: VerifiedIdentityClaim): Promise<User> {
+		const updates: Pick<Partial<User>, 'firstName' | 'lastName'> = {};
+
+		if (claims.given_name !== undefined) {
+			const trimmed = trimName(claims.given_name);
+			if (trimmed !== user.firstName) updates.firstName = trimmed;
+		}
+
+		if (claims.family_name !== undefined) {
+			const trimmed = trimName(claims.family_name);
+			if (trimmed !== user.lastName) updates.lastName = trimmed;
+		}
+
+		if (Object.keys(updates).length === 0) return user;
+
+		await this.userRepository.update(user.id, updates);
+
+		return await this.userRepository.findOneOrFail({
+			where: { id: user.id },
+			relations: ['role'],
+		});
+	}
+}

--- a/packages/cli/src/services/identity-binding.types.ts
+++ b/packages/cli/src/services/identity-binding.types.ts
@@ -1,0 +1,108 @@
+import type { AuthIdentity, AuthProviderType, User } from '@n8n/db';
+
+import type { VerifiedIdentityClaim } from './identity-resolution-proxy.service';
+
+/** Which of the three resolution paths produced the user. */
+export type ResolutionPath = 'known-subject' | 'linked-by-email' | 'provisioned';
+
+export type IdentityResolutionFailure = 'missing-email' | 'binding-not-active';
+
+/**
+ * The only error the shared core raises itself. Everything else is thrown by
+ * an injected policy hook, so each adapter keeps its own error type.
+ */
+export class IdentityResolutionError extends Error {
+	constructor(
+		readonly failure: IdentityResolutionFailure,
+		message: string,
+	) {
+		super(message);
+	}
+}
+
+/**
+ * A read-only lookup tried after the primary key missed.
+ *
+ * This is how a source declares the key formats it used to write, without the
+ * core knowing anything about issuers or SSO. Once `AuthIdentity` gains a
+ * modelled `(sourceId, subject)` key, both of today's fallbacks
+ * (token-exchange's legacy unqualified sub, and the OIDC bridge) disappear
+ * along with this type.
+ */
+export interface IdentityFallback {
+	providerId: string;
+	providerType: AuthProviderType;
+	/**
+	 * Guard evaluated before the lookup. Use when the check is cheaper than the
+	 * lookup it would skip.
+	 */
+	applies?: () => Promise<boolean>;
+	/**
+	 * Guard evaluated only once a row has actually matched. Use when the check
+	 * is the expensive part, so it is not paid on every resolution that ends up
+	 * provisioning.
+	 */
+	accepts?: (identity: AuthIdentity) => Promise<boolean>;
+	/**
+	 * Rewrite the row to the primary key. Called only when the caller allows
+	 * writes, so the per-access read-only path never mutates a binding.
+	 */
+	rebind?: (identity: AuthIdentity) => Promise<void>;
+}
+
+/**
+ * Where an identity comes from. Supplies the `AuthIdentity` key format, which
+ * is the one thing that genuinely differs between OIDC and token-exchange.
+ */
+export interface IdentitySource {
+	providerType: AuthProviderType;
+	/** Primary `AuthIdentity.providerId` for this claim. */
+	keyFor(claims: VerifiedIdentityClaim): string;
+	/** Tried in order, after the primary key misses. */
+	fallbacks?: IdentityFallback[];
+}
+
+/**
+ * Everything the core deliberately does not decide. Each hook is owned by the
+ * adapter, so the core encodes no email-verification, role or profile policy.
+ */
+export interface IdentityPolicy {
+	/**
+	 * Throws when the claim's email is not verified to this source's standard.
+	 * Called before linking to an existing account and before provisioning a
+	 * new one — never on the known-subject path, where the binding already
+	 * proves the association.
+	 */
+	assertEmailVerified(claims: VerifiedIdentityClaim): void;
+
+	/** Throws when this caller may not act as `user` (e.g. a key's allowedRoles). */
+	assertMayActAs?(user: User): void;
+
+	/**
+	 * Second pre-write gate for an existing user, run after
+	 * `assertEmailVerified` on the email-link path. Exists so a policy can
+	 * reject a claim it may not assert (a disallowed role, say) *before* the
+	 * core writes a binding — a rejected login must leave no trace. Anything
+	 * expensive it resolves can be memoised on the policy instance and reused
+	 * in `onResolved`, since adapters build a fresh policy per resolution.
+	 */
+	assertClaimAcceptable?(user: User, claims: VerifiedIdentityClaim): Promise<void>;
+
+	/** Resolved before the provisioning transaction opens. */
+	roleForNewUser(claims: VerifiedIdentityClaim): Promise<{ slug: string }>;
+
+	/**
+	 * `'every-resolution'` re-syncs `firstName`/`lastName` from the claim on
+	 * every login; `'on-provision'` sets them once, at provisioning.
+	 */
+	profileSync: 'on-provision' | 'every-resolution';
+
+	onLinked?(user: User, claims: VerifiedIdentityClaim): void;
+	onProvisioned?(user: User, claims: VerifiedIdentityClaim, roleSlug: string): void;
+
+	/**
+	 * Last hook on every path. Returns the user to hand back, so an adapter
+	 * that mutates the user (role provisioning) can return a reloaded copy.
+	 */
+	onResolved?(user: User, claims: VerifiedIdentityClaim, path: ResolutionPath): Promise<User>;
+}

--- a/packages/cli/test/integration/identity-binding.service.test.ts
+++ b/packages/cli/test/integration/identity-binding.service.test.ts
@@ -1,0 +1,228 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { AuthIdentity, AuthIdentityRepository, UserRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { OidcService } from '@/modules/sso-oidc/oidc.service.ee';
+import {
+	IdentityResolutionService,
+	qualifiedProviderId,
+} from '@/modules/token-exchange/services/identity-resolution.service';
+import { TrustedKeyService } from '@/modules/token-exchange/services/trusted-key.service';
+
+import { createUser } from './shared/db/users';
+
+/**
+ * Cross-surface resolution against a real database.
+ *
+ * Both login surfaces now share one resolution algorithm but still key
+ * `AuthIdentity` differently — OIDC on the raw `sub`, token-exchange on
+ * `sha256(iss)::sub` — until the key is modelled properly. The risk that
+ * matters is an account fork: a row written by one surface silently stops
+ * resolving and the user gets a fresh, empty account. These tests seed rows in
+ * the exact format each surface writes and assert the same user comes back.
+ */
+
+const ISSUER = 'https://sso.example.com';
+
+let oidcService: OidcService;
+let identityResolution: IdentityResolutionService;
+let authIdentityRepository: AuthIdentityRepository;
+let userRepository: UserRepository;
+let trustedKeyService: TrustedKeyService;
+
+/** Resolve through the OIDC login path, skipping only the openid-client flow. */
+async function resolveViaOidc(sub: string, userInfo: Record<string, unknown>) {
+	// @ts-expect-error - resolveUserFromClaims is private; the openid-client
+	// flow above it is not what these tests guard.
+	return await oidcService.resolveUserFromClaims({ sub, iss: ISSUER }, userInfo);
+}
+
+/** Resolve through token-exchange, which is where the SSO bridge lives. */
+async function resolveViaTokenExchange(sub: string, email?: string) {
+	return await identityResolution.resolve(
+		{
+			sub,
+			iss: ISSUER,
+			aud: 'n8n',
+			iat: Math.floor(Date.now() / 1000),
+			exp: Math.floor(Date.now() / 1000) + 30,
+			jti: `jti-${sub}`,
+			email,
+			email_verified: true,
+		},
+		undefined,
+		{ kid: 'kid-1', issuer: ISSUER, requireVerifiedEmail: false },
+		true,
+	);
+}
+
+beforeAll(async () => {
+	await testModules.loadModules(['token-exchange']);
+	await testDb.init();
+
+	oidcService = Container.get(OidcService);
+	identityResolution = Container.get(IdentityResolutionService);
+	authIdentityRepository = Container.get(AuthIdentityRepository);
+	userRepository = Container.get(UserRepository);
+	trustedKeyService = Container.get(TrustedKeyService);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['AuthIdentity', 'ProjectRelation', 'Project', 'User']);
+	// Role provisioning is exercised in the OIDC service's own tests; here it
+	// would only add settings-table setup noise to a resolution test.
+	// @ts-expect-error - applySsoProvisioning is private
+	oidcService.applySsoProvisioning = vi.fn().mockResolvedValue(undefined);
+	vi.spyOn(trustedKeyService, 'isSsoIssuer').mockResolvedValue(true);
+	vi.spyOn(trustedKeyService, 'hasSingleTrustedIssuer').mockResolvedValue(false);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('an OIDC identity written before the refactor', () => {
+	it('still resolves to the same account on the OIDC login path', async () => {
+		const user = await createUser({ email: 'legacy-sso@example.com' });
+		// Exactly what the pre-refactor OIDC code wrote: the raw `sub`.
+		await authIdentityRepository.save(AuthIdentity.create(user, 'sso-subject-1', 'oidc'));
+
+		const resolved = await resolveViaOidc('sso-subject-1', { email: 'legacy-sso@example.com' });
+
+		expect(resolved.id).toBe(user.id);
+		// No fork: still exactly one account and one binding.
+		await expect(userRepository.count()).resolves.toBe(1);
+		await expect(authIdentityRepository.count()).resolves.toBe(1);
+	});
+
+	it('still resolves to the same account through the token-exchange SSO bridge', async () => {
+		const user = await createUser({ email: 'bridged@example.com' });
+		await authIdentityRepository.save(AuthIdentity.create(user, 'sso-subject-2', 'oidc'));
+
+		const resolved = await resolveViaTokenExchange('sso-subject-2', 'bridged@example.com');
+
+		expect(resolved.id).toBe(user.id);
+		await expect(userRepository.count()).resolves.toBe(1);
+	});
+
+	it('resolves even when the account email no longer matches the claim', async () => {
+		// The binding, not the email, is what identifies the user — an email
+		// change in the IdP must not fork the account.
+		const user = await createUser({ email: 'old-address@example.com' });
+		await authIdentityRepository.save(AuthIdentity.create(user, 'sso-subject-3', 'oidc'));
+
+		const resolved = await resolveViaOidc('sso-subject-3', { email: 'new-address@example.com' });
+
+		expect(resolved.id).toBe(user.id);
+		await expect(userRepository.count()).resolves.toBe(1);
+	});
+});
+
+describe('the two surfaces converge on one account', () => {
+	it('reuses the OIDC-provisioned account when the same human arrives via token exchange', async () => {
+		const provisioned = await resolveViaOidc('shared-subject-1', {
+			email: 'converge-a@example.com',
+			given_name: 'Ada',
+			family_name: 'Lovelace',
+		});
+
+		const viaTokenExchange = await resolveViaTokenExchange(
+			'shared-subject-1',
+			'converge-a@example.com',
+		);
+
+		expect(viaTokenExchange.id).toBe(provisioned.id);
+		await expect(userRepository.count()).resolves.toBe(1);
+	});
+
+	it('reuses the token-exchange-provisioned account when the same human logs in via OIDC', async () => {
+		const provisioned = await resolveViaTokenExchange('shared-subject-2', 'converge-b@example.com');
+
+		const viaOidc = await resolveViaOidc('shared-subject-2', {
+			email: 'converge-b@example.com',
+		});
+
+		expect(viaOidc.id).toBe(provisioned.id);
+		await expect(userRepository.count()).resolves.toBe(1);
+	});
+});
+
+describe('the two key formats stay distinct', () => {
+	it('writes the raw sub for OIDC and the qualified sub for token exchange', async () => {
+		// Distinct subjects, so the SSO bridge does not reuse one row for both.
+		await resolveViaOidc('oidc-only-subject', { email: 'formats-oidc@example.com' });
+		await resolveViaTokenExchange('te-only-subject', 'formats-te@example.com');
+
+		const identities = await authIdentityRepository.find();
+		const byType = Object.fromEntries(identities.map((i) => [i.providerType, i.providerId]));
+
+		expect(byType.oidc).toBe('oidc-only-subject');
+		expect(byType['token-exchange']).toBe(qualifiedProviderId(ISSUER, 'te-only-subject'));
+	});
+
+	it('bridges to the existing oidc row instead of writing a second binding', async () => {
+		const provisioned = await resolveViaOidc('bridge-subject', {
+			email: 'bridge-once@example.com',
+		});
+
+		await resolveViaTokenExchange('bridge-subject', 'bridge-once@example.com');
+
+		const identities = await authIdentityRepository.find();
+		expect(identities).toHaveLength(1);
+		expect(identities[0]).toMatchObject({
+			providerType: 'oidc',
+			providerId: 'bridge-subject',
+			userId: provisioned.id,
+		});
+	});
+
+	it('does not let the SSO bridge shadow an existing token-exchange binding', async () => {
+		const oidcUser = await createUser({ email: 'shadow-oidc@example.com' });
+		const tokenExchangeUser = await createUser({ email: 'shadow-te@example.com' });
+		await authIdentityRepository.save(AuthIdentity.create(oidcUser, 'shadow-subject', 'oidc'));
+		await authIdentityRepository.save(
+			AuthIdentity.create(
+				tokenExchangeUser,
+				qualifiedProviderId(ISSUER, 'shadow-subject'),
+				'token-exchange',
+			),
+		);
+
+		const resolved = await resolveViaTokenExchange('shadow-subject');
+
+		expect(resolved.id).toBe(tokenExchangeUser.id);
+	});
+});
+
+describe('a revoked binding fails closed on both surfaces', () => {
+	it('refuses an OIDC login', async () => {
+		const user = await createUser({ email: 'revoked-sso@example.com' });
+		const identity = AuthIdentity.create(user, 'revoked-subject', 'oidc');
+		identity.status = 'revoked';
+		await authIdentityRepository.save(identity);
+
+		await expect(
+			resolveViaOidc('revoked-subject', { email: 'revoked-sso@example.com' }),
+		).rejects.toThrow();
+		// Rejected, not forked into a second account.
+		await expect(userRepository.count()).resolves.toBe(1);
+	});
+
+	it('refuses a token exchange', async () => {
+		const user = await createUser({ email: 'revoked-te@example.com' });
+		const identity = AuthIdentity.create(
+			user,
+			qualifiedProviderId(ISSUER, 'revoked-te-subject'),
+			'token-exchange',
+		);
+		identity.status = 'revoked';
+		await authIdentityRepository.save(identity);
+
+		await expect(resolveViaTokenExchange('revoked-te-subject')).rejects.toThrow();
+		await expect(userRepository.count()).resolves.toBe(1);
+	});
+});

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -16,6 +16,7 @@ import {
 import { TrustedKeyService } from '@/modules/token-exchange/services/trusted-key.service';
 import { TokenExchangeConfig } from '@/modules/token-exchange/token-exchange.config';
 import type { ExternalTokenClaims } from '@/modules/token-exchange/token-exchange.schemas';
+import { EXTERNAL_IDENTITY_PASSWORD_PLACEHOLDER } from '@/services/identity-binding.service';
 
 import { createOwner, createUser } from '../shared/db/users';
 
@@ -219,7 +220,7 @@ describe('IdentityResolutionService (integration)', () => {
 				where: { id: result.id },
 				select: ['id', 'password'],
 			});
-			expect(dbUser!.password).toBe('!token-exchange-no-password');
+			expect(dbUser!.password).toBe(EXTERNAL_IDENTITY_PASSWORD_PLACEHOLDER);
 
 			const identity = await authIdentityRepository.findOne({
 				where: { providerId: providerIdFor('ext-jit'), providerType: 'token-exchange' },

--- a/packages/cli/test/integration/user.repository.test.ts
+++ b/packages/cli/test/integration/user.repository.test.ts
@@ -1,6 +1,11 @@
 import type { UsersListFilterDto } from '@n8n/api-types';
 import { createTeamProject, linkUserToProject, randomEmail, testDb } from '@n8n/backend-test-utils';
-import { ProjectRelationRepository, type User, UserRepository } from '@n8n/db';
+import {
+	AuthIdentityRepository,
+	ProjectRelationRepository,
+	type User,
+	UserRepository,
+} from '@n8n/db';
 import { Container } from '@n8n/di';
 
 import { createAdmin, createChatUser, createMember, createOwner } from './shared/db/users';
@@ -80,6 +85,56 @@ describe('UserRepository', () => {
 			});
 
 			expect(projectRelation.project.id).toBe(project.id);
+		});
+	});
+
+	describe('createUserWithExternalIdentity()', () => {
+		// Identity rows reference users, so leaving them behind breaks the
+		// `User` truncate the next describe block does.
+		afterAll(async () => {
+			await testDb.truncate(['AuthIdentity']);
+		});
+
+		test('should create the user, their personal project and the identity binding', async () => {
+			const email = randomEmail();
+
+			const user = await userRepository.createUserWithExternalIdentity(
+				{ email, role: { slug: 'global:member' } },
+				{ providerId: 'external-subject-1', providerType: 'oidc' },
+			);
+
+			const projectRelation = await Container.get(ProjectRelationRepository).findOneOrFail({
+				where: { userId: user.id, project: { type: 'personal' } },
+				relations: ['project'],
+			});
+			expect(projectRelation.project.type).toBe('personal');
+
+			const identity = await Container.get(AuthIdentityRepository).findOneOrFail({
+				where: { providerId: 'external-subject-1', providerType: 'oidc' },
+			});
+			expect(identity.userId).toBe(user.id);
+			expect(identity.status).toBe('active');
+		});
+
+		test('should not leave a user behind when the identity insert fails', async () => {
+			const email = randomEmail();
+			const takenProviderId = 'external-subject-conflict';
+
+			await userRepository.createUserWithExternalIdentity(
+				{ email: randomEmail(), role: { slug: 'global:member' } },
+				{ providerId: takenProviderId, providerType: 'oidc' },
+			);
+
+			// The (providerId, providerType) pair is the primary key, so a second
+			// user claiming the same one must roll the whole thing back.
+			await expect(
+				userRepository.createUserWithExternalIdentity(
+					{ email, role: { slug: 'global:member' } },
+					{ providerId: takenProviderId, providerType: 'oidc' },
+				),
+			).rejects.toThrow();
+
+			await expect(userRepository.findOneBy({ email })).resolves.toBeNull();
 		});
 	});
 


### PR DESCRIPTION
## Summary

`OidcService.loginUser()` and `IdentityResolutionService.resolve()` each implemented the same three-path algorithm — known subject → link by email → JIT provision. This extracts it into **`IdentityBindingService`** (`packages/cli/src/services/identity-binding.service.ts`), which lives outside both modules and owns only the lookup/link/provision work. Both callers become thin adapters that supply an `IdentitySource` (the `AuthIdentity` key format + fallback lookups) and an `IdentityPolicy` (email verification, role, profile sync). Neither module imports the other.

Supporting change: `UserRepository.createUserWithExternalIdentity` puts the user + personal project + binding in one transaction inside the persistence layer, so the shared core doesn't reach for `.manager.transaction` from business logic.

### The six delta decisions

Unifying two implementations silently picks a winner, so each difference was decided explicitly. Three are from the ticket; three more surfaced while reading the code.

| # | Decision | Behaviour change |
| --- | --- | --- |
| 1 | **Profile sync: `every-resolution` for both.** OIDC now re-syncs `firstName`/`lastName` from the IdP on every login. `me.controller.ts:78-85` already makes those fields read-only for SSO users, so there is nothing user-authored to clobber — the old behaviour was a bug (a rename in the IdP never propagated, and the user couldn't self-correct). | **Yes, OIDC** |
| 2 | **`email_verified`: shared tri-state reading, per-source strictness.** One `interpretEmailVerified` handles `true`/`'true'`/`false`/`'false'`/absent. OIDC keeps `emailVerifiedRequired`; token-exchange keeps per-key `requireVerifiedEmail`. Both now reject an *explicit* `false` unconditionally, even on a lenient key. | **Yes, token-exchange** (lenient keys) |
| 3 | **Role: the core owns nothing.** `roleForNewUser` before the transaction, `onResolved(user, claims, path)` after. Block-access stays in the OIDC adapter, ahead of the core call; `allowedRoles`/`excludeOwner` stay in token-exchange. | No |
| 4 | **Email verification is asserted on the JIT path too.** OIDC previously checked only when linking, so it would provision a fresh account from an unverified email. | **Yes, OIDC** |
| 5 | **Non-active bindings fail closed on every path, both sources.** `null` on the read-only path, throw on login. Previously only token-exchange's read-only branch checked `status`. Inert today — nothing writes a status other than `active` yet. | **Yes**, but inert |
| 6 | **Names truncated to 32 chars for both.** OIDC passed `userInfo.given_name` through untruncated and overflowed the column. | **Yes, OIDC** |

Delta 6 originally also covered email casing. That turned out to be a **non-issue**: `User.email` carries a `lowerCaser` column transformer plus a `@BeforeInsert` hook and a unique index (`user.ts:34-40, 82-85`), so storage is always lowercase and duplicate-by-case accounts cannot exist. The core lowercases the claim before lookup, which is sufficient.

### AuthIdentity key format — deferred, deliberately

OIDC keys on the raw `sub`; token-exchange on `sha256(iss)::sub`. **Unifying them is deferred**, and this PR makes the format an injected `source.keyFor()` so there is a single seam to change later.

The reason for deferring is concrete: a SQL backfill of OIDC rows is not possible today. Qualifying the key needs the issuer, but the OIDC settings row stores only `discoveryEndpoint`. The issuer exists solely at runtime (from discovery) or in `trusted_key_source.issuer`, which requires token-exchange to be licensed. So any key change has to be an online migration — against a key that the modelled `(sourceId, subject)` work replaces wholesale. Doing a narrower rewrite now would be throwaway work carrying the highest-blast-radius risk in this change.

### Incidental fix

`createUserWithExternalIdentity` uses `trx.insert`, not `trx.save`. With `(providerId, providerType)` as the primary key, `save` silently re-points an existing binding at the newly created user instead of failing — an identity-takeover race the previous code also had.

## How to test

Automated coverage is the intended proof here; there is no UI surface.

```bash
cd packages/cli
pnpm test src/services/__tests__/identity-binding.service.test.ts \
          src/modules/sso-oidc src/modules/token-exchange
pnpm test:integration test/integration/identity-binding.service.test.ts \
          test/integration/token-exchange test/integration/user.repository.test.ts
```

Manually, on an instance with OIDC SSO configured: log in with an existing SSO account and confirm you land on the same account (not a fresh one), and that a name changed in the IdP now propagates on the next login.

**Note for reviewers:** both pre-existing unit suites were kept as genuine regression guards by wiring a *real* `IdentityBindingService` against mocked repositories rather than mocking the core. Edits to the 1165-line `oidc.service.ee.test.ts` are limited to constructor wiring, `status: 'active'` on five mocked bindings (delta 5), and one transaction assertion — any other diff there would be a signal the refactor changed something unintended.

`packages/cli` typecheck reports 3 errors in `src/services/__tests__/protected-resource.registry.test.ts`. Those arrived with #35697 on the base branch and are present without this PR's changes (verified by stashing).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1186

Blocked-by (for the key format + backfill): https://linear.app/n8n/issue/IAM-1177

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

