### PR TITLE
test: Stop local Playwright runs orphaning Vite dev servers (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -18,7 +18,7 @@
     "lint:styles:fix": "stylelint \"src/**/*.{scss,sass,vue}\" --fix --cache",
     "format": "biome format --write . && prettier --write . --ignore-path ../../../.prettierignore",
     "format:check": "biome ci . && prettier --check . --ignore-path ../../../.prettierignore",
-    "serve": "cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 dev",
+    "serve": "cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 --strictPort dev",
     "test": "vitest run",
     "test:changed": "janitor test-scoped",
     "test:dev": "vitest --silent=false"

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -72,9 +72,15 @@ if (BACKEND_URL && !SKIP_WEB_SERVER) {
 	});
 }
 
-if (FRONTEND_URL) {
+// Only spawn a Vite dev server when N8N_EDITOR_URL explicitly asks for one.
+// Without this gate, FRONTEND_URL falls back to N8N_BASE_URL in `test:local`
+// and spawns a Vite server on 8080 that nothing uses (the health check on the
+// backend port passes anyway) and that outlives the run.
+// Invoke vite via pnpm, not `turbo run dev`: turbo detaches tasks into their
+// own process group, which puts them out of reach of Playwright's tree-kill.
+if (IS_DEV && FRONTEND_URL) {
 	webServer.push({
-		command: 'cd .. && pnpm dev:fe:editor',
+		command: 'pnpm --filter=n8n-editor-ui dev',
 		url: `${FRONTEND_URL}/favicon.ico`,
 		timeout: 30000,
 		reuseExistingServer: IS_DEV ? false : true,

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -72,12 +72,8 @@ if (BACKEND_URL && !SKIP_WEB_SERVER) {
 	});
 }
 
-// Only spawn a Vite dev server when N8N_EDITOR_URL explicitly asks for one.
-// Without this gate, FRONTEND_URL falls back to N8N_BASE_URL in `test:local`
-// and spawns a Vite server on 8080 that nothing uses (the health check on the
-// backend port passes anyway) and that outlives the run.
-// Invoke vite via pnpm, not `turbo run dev`: turbo detaches tasks into their
-// own process group, which puts them out of reach of Playwright's tree-kill.
+// Gate on N8N_EDITOR_URL: FRONTEND_URL alone falls back to N8N_BASE_URL. Invoke vite via
+// pnpm, not turbo — turbo detaches tasks into process groups Playwright's tree-kill misses.
 if (IS_DEV && FRONTEND_URL) {
 	webServer.push({
 		command: 'pnpm --filter=n8n-editor-ui dev',


### PR DESCRIPTION
## Summary

Local Playwright runs were leaving orphaned Vite dev servers (PPID 1) on port 8080. On the next `pnpm dev`, Vite found 8080 busy and silently drifted to the next free port — a new browser origin, so the backend cleared the session cookie and logged the developer out on every restart.

Three small fixes:

- **Only spawn the frontend Vite webServer when `N8N_EDITOR_URL` is set.** `getFrontendUrl()` falls back to `N8N_BASE_URL`, so `test:local` (which sets only `N8N_BASE_URL=…:5680`) was spawning a Vite server on 8080 that nothing used — the health check hits the backend port, which answers, so the mismatch was silent. `getFrontendUrl()` itself is unchanged: its fallback is correct for its other consumers (`baseURL`, the `frontendUrl` fixture).
- **Invoke Vite via `pnpm --filter=n8n-editor-ui dev` instead of `turbo run dev`.** Turbo detaches tasks into their own process groups, putting the Vite server out of reach of Playwright's tree-kill — that's how the orphans survived. Turbo's `dev` task has no `dependsOn`, so the direct invocation is equivalent.
- **Add `--strictPort` to the editor-ui `serve` script** so a busy 8080 fails loudly instead of silently drifting to a new port/origin.

Deliberately *not* done: registering `globalTeardown` for `test:local`. It hard-kills whatever is on 5678/8080 — for `test:local` (which runs on 5680) that would be the developer's own dev servers. With the first fix, `test:local` no longer creates the orphans at all.

## How to test

1. `pnpm --filter=n8n-playwright test:local <some spec>` — no Vite server is spawned; after the run, `lsof -ti :8080` is empty.
2. `pnpm --filter=n8n-playwright test:dev-server-smoke` (sets `N8N_EDITOR_URL`) — Vite spawns as before and is gone after the run.
3. With something already on 8080, `pnpm dev` — Vite now exits with an error instead of silently taking another port.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-703

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

