### PR TITLE
ci: Verify out-of-order migration timestamps fail CI (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1785840960000-CiTimestampOrderingCanary.ts
+++ b/packages/@n8n/db/src/migrations/common/1785840960000-CiTimestampOrderingCanary.ts
@@ -1,0 +1,9 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+// Deliberately timestamped below the current head migration to verify the
+// migration-timestamp CI check rejects out-of-order migrations. Do not merge.
+export class CiTimestampOrderingCanary1785840960000 implements ReversibleMigration {
+	async up(_context: MigrationContext) {}
+
+	async down(_context: MigrationContext) {}
+}


### PR DESCRIPTION
## Summary

**Do not merge.** Throwaway canary PR: adds a no-op migration deliberately timestamped *below* the current head migration, to verify the `migration-timestamp` code-health rule in `ci-pr-quality.yml` actually fails a PR that adds an out-of-order migration.

Expected result: the **Quality checks** job fails with one `migration-timestamp` error. The rule already fails locally with the same input (`CODE_HEALTH_ADDED_FILES` set to the canary file → exit 1).

Will be closed once CI confirms the failure.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up verification for https://linear.app/n8n/issue/DEVP-690

## Review / Merge checklist

- [ ] PR title and summary are descriptive
- [ ] Tests included — n/a, canary PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

