### PR TITLE
fix(core): Keep valid resume payloads intact when ignoring undeclared fields

### DIFF
--- a/packages/@n8n/agents/src/utils/__tests__/parse.test.ts
+++ b/packages/@n8n/agents/src/utils/__tests__/parse.test.ts
@@ -233,4 +233,30 @@ describe('parseWithSchema — stripUnknown', () => {
 
 		expect(result.success).toBe(false);
 	});
+
+	it('keeps properties a later anyOf branch declares', async () => {
+		const unionSchema = {
+			anyOf: [
+				strictSchema,
+				{
+					type: 'object',
+					properties: {
+						approved: { type: 'boolean' },
+						answers: { type: 'array', items: { type: 'string' } },
+					},
+					required: ['approved'],
+					additionalProperties: false,
+				},
+			],
+		} as JSONSchema7;
+
+		const result = await parseWithSchema(
+			unionSchema,
+			{ approved: true, answers: ['a'] },
+			{ stripUnknown: true },
+		);
+
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toEqual({ approved: true, answers: ['a'] });
+	});
 });

--- a/packages/@n8n/agents/src/utils/parse.ts
+++ b/packages/@n8n/agents/src/utils/parse.ts
@@ -1,5 +1,4 @@
 import type AjvType from 'ajv';
-import type { ValidateFunction } from 'ajv';
 import type { JSONSchema7 } from 'json-schema';
 import type { ZodType } from 'zod';
 
@@ -32,6 +31,17 @@ function getAjv(unicodeRegExp = true, stripUnknown = false): InstanceType<typeof
 	return instance;
 }
 
+function compile(schema: JSONSchema7, stripUnknown: boolean) {
+	let ajv = getAjv(true, stripUnknown);
+	try {
+		return { ajv, validate: ajv.compile(schema) };
+	} catch (error) {
+		if (!(error instanceof SyntaxError)) throw error;
+		ajv = getAjv(false, stripUnknown);
+		return { ajv, validate: ajv.compile(schema) };
+	}
+}
+
 /**
  * Validate `data` against a Zod schema or a raw JSON Schema.
  * Returns a unified success/failure result, with parsed data on success.
@@ -47,19 +57,17 @@ export async function parseWithSchema(
 		return { success: false, error: result.error.message };
 	}
 
-	const { stripUnknown = false } = options;
-	// Ajv strips in place, so clone to leave the caller's object intact as Zod does.
-	const target = stripUnknown ? structuredClone(data) : data;
-
-	let ajv = getAjv(true, stripUnknown);
-	let validate: ValidateFunction;
-	try {
-		validate = ajv.compile(schema);
-	} catch (error) {
-		if (!(error instanceof SyntaxError)) throw error;
-		ajv = getAjv(false, stripUnknown);
-		validate = ajv.compile(schema);
+	// Strict first: Ajv's `removeAdditional` drops properties while trying a failing
+	// `anyOf`/`oneOf` branch, so a payload that already matches a branch must never reach it.
+	const strict = compile(schema, false);
+	if (strict.validate(data)) return { success: true, data };
+	if (!options.stripUnknown) {
+		return { success: false, error: strict.ajv.errorsText(strict.validate.errors) };
 	}
-	if (validate(target)) return { success: true, data: target };
-	return { success: false, error: ajv.errorsText(validate.errors) };
+
+	// Ajv strips in place, so clone to leave the caller's object intact as Zod does.
+	const target = structuredClone(data);
+	const stripping = compile(schema, true);
+	if (stripping.validate(target)) return { success: true, data: target };
+	return { success: false, error: stripping.ajv.errorsText(stripping.validate.errors) };
 }


### PR DESCRIPTION
## Summary

Follow-up to #35607, which made `AgentRuntime.resume` drop payload fields the tool's `resumeSchema` doesn't declare (so `scope: 'session'` from "always allow" stops hanging the thread).

That used Ajv's `removeAdditional: true`, which is unsafe with `anyOf`/`oneOf`: Ajv deletes properties while evaluating a branch that then fails, and a later branch declaring those properties never sees them. The evals tool's resume schema is `z.union([{ approved }, { approved, answers }])`, so a questions submission silently lost its answers and resumed as a bare approval:

```
input : { approved: true, answers: [{ questionId: 'q1', selectedOptions: ['a'] }] }
before: valid: true, data: { approved: true }   ← answers deleted, no error
```

This validates strictly first and only falls back to the stripping validator when that fails. Payloads that already conform are returned untouched, so the only outcome that changes is `error → success` — nothing that previously validated behaves differently. The `scope` case still gets stripped as intended.

Not covered (unreachable today, no code for it): a payload that is both union-shaped *and* carries an undeclared field still strips via the failing branch. The evals tool is the only union resume schema, and `kind: 'questions'` submissions never carry `scope`.

## How to test

`pnpm --filter @n8n/agents test src/utils/__tests__/parse.test.ts`

New case `keeps properties a later anyOf branch declares` covers the evals-tool shape; it fails on master and passes here. The existing `stripUnknown` and `agent-runtime` resume cases still pass, covering the original "always allow" fix.

## Related Linear tickets, Github issues, and Community forum posts

Context: https://linear.app/n8n/issue/INS-1094 — the reported hang ("always allow" on data-table creation) is fixed by #35607, which is merged and backported to `release-candidate/2.34.x` but not in any release yet (`n8n@2.34.2` was cut before it landed). This PR fixes a regression that #35607 introduced for union resume schemas, so both need to ship together.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)