### PR TITLE
fix(core): Keep database ping loop alive across connection recovery

### DIFF
--- a/packages/@n8n/db/src/connection/__tests__/db-connection-monitor.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection-monitor.test.ts
@@ -310,6 +310,33 @@ describe('DbConnectionMonitor', () => {
 			expect(pool.connect).not.toHaveBeenCalled();
 		});
 
+		it('should still schedule the next ping if data source is not initialized', async () => {
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = false;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const scheduleNextPingSpy = vi.spyOn(monitor as any, 'scheduleNextPing');
+
+			// @ts-expect-error private property
+			await monitor.ping();
+
+			expect(pool.connect).not.toHaveBeenCalled();
+			expect(scheduleNextPingSpy).toHaveBeenCalled();
+		});
+
+		it('should still schedule the next ping while recovery is in progress', async () => {
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = true;
+			// @ts-expect-error private property
+			monitor.recovering = true;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const scheduleNextPingSpy = vi.spyOn(monitor as any, 'scheduleNextPing');
+
+			// @ts-expect-error private property
+			await monitor.ping();
+
+			expect(scheduleNextPingSpy).toHaveBeenCalled();
+		});
+
 		it('should not query if monitor is stopped', async () => {
 			// @ts-expect-error readonly property
 			dataSource.isInitialized = true;
@@ -473,6 +500,40 @@ describe('DbConnectionMonitor', () => {
 				vi.advanceTimersByTime(1000);
 
 				expect(pingSpy).toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should resume pinging after a tick lands while the data source is uninitialized', async () => {
+			vi.useFakeTimers();
+			try {
+				const scheduledMonitor = new DbConnectionMonitor(
+					dataSource,
+					onConnectedChange,
+					mock<DatabaseConfig>({ pingIntervalSeconds: 1, pingTimeoutMs: 5_000 }),
+					logger,
+					errorReporter,
+					dbConnectionMetrics,
+				);
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const pingSpy = vi.spyOn(scheduledMonitor as any, 'ping');
+
+				// @ts-expect-error readonly property
+				dataSource.isInitialized = false;
+				// @ts-expect-error private property
+				scheduledMonitor.scheduleNextPing();
+				await vi.advanceTimersByTimeAsync(1000);
+
+				expect(pingSpy).toHaveBeenCalledTimes(1);
+
+				// Recovery finished: the loop must still be ticking.
+				// @ts-expect-error readonly property
+				dataSource.isInitialized = true;
+				await vi.advanceTimersByTimeAsync(1000);
+
+				expect(pingSpy).toHaveBeenCalledTimes(2);
+				expect(pool.connect).toHaveBeenCalled();
 			} finally {
 				vi.useRealTimers();
 			}

--- a/packages/@n8n/db/src/connection/db-connection-monitor.ts
+++ b/packages/@n8n/db/src/connection/db-connection-monitor.ts
@@ -147,11 +147,11 @@ export class DbConnectionMonitor {
 	}
 
 	private async ping() {
-		if (this.stopped || !this.dataSource.isInitialized) {
+		if (this.stopped) {
 			return;
 		}
 
-		if (this.recovering) {
+		if (!this.dataSource.isInitialized || this.recovering) {
 			this.scheduleNextPing();
 			return;
 		}


### PR DESCRIPTION
## Summary

The DB connection ping loop could die permanently during a connection recovery. Recovery destroys and reinits the `DataSource`, so `isInitialized` is briefly false during this check.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C069KJBJ8HE/p1785993382697819

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)