### PR TITLE
test(editor): Wait for expression editor focus before typing in FilterConditions test (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.test.ts
@@ -340,10 +340,16 @@ describe('FilterConditions.vue', () => {
 
 		const expressionEditor = within(condition)
 			.getByTestId('filter-condition-left')
-			.querySelector('.cm-line');
+			.querySelector('.cm-content');
+
+		expect(expressionEditor).toBeInTheDocument();
 
 		if (expressionEditor) {
-			await userEvent.type(expressionEditor, 'test');
+			// Focus the editor and wait until focus has landed before typing,
+			// otherwise the first keystroke can be dropped on slow runs
+			await userEvent.click(expressionEditor);
+			await waitFor(() => expect(expressionEditor).toHaveFocus());
+			await userEvent.type(expressionEditor, 'test', { skipClick: true });
 		}
 
 		await waitFor(() => {


### PR DESCRIPTION
## Summary

The 'can edit conditions' test started typing into the CodeMirror expression editor before focus had landed, so on slow runs the first keystroke was dropped ('test' arrived as 'est'). Click the editor's contenteditable and wait for it to hold focus before typing.

## How to test

Hard to locally test as simulating a load in a local test environment is a bit difficult.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-689

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

