### PR TITLE
feat(core): Skip repeat OAuth consent for n8n's own triggers (no-changelog)

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
@@ -6,6 +6,7 @@ import { mock } from 'vitest-mock-extended';
 
 import { OAuthAuthorizationCodeService } from '../oauth-authorization-code.service';
 import { OAuthConsentService } from '../oauth-consent.service';
+import { OAuth2FlowService } from '../oauth-flow.service';
 import { OAuthClientRepository } from '../database/repositories/oauth-client.repository';
 import { OAuthSessionService } from '../oauth-session.service';
 import type { UserConsent } from '../database/entities/oauth-user-consent.entity';
@@ -36,6 +37,7 @@ let userConsentRepository: Mocked<UserConsentRepository>;
 let authorizationCodeService: Mocked<OAuthAuthorizationCodeService>;
 let protectedResourceRegistry: Mocked<ProtectedResourceRegistry>;
 let urlService: Mocked<UrlService>;
+let oauth2FlowService: Mocked<OAuth2FlowService>;
 let service: OAuthConsentService;
 
 describe('OAuthConsentService', () => {
@@ -49,6 +51,7 @@ describe('OAuthConsentService', () => {
 			ProtectedResourceRegistry,
 		) as Mocked<ProtectedResourceRegistry>;
 		urlService = mockInstance(UrlService) as Mocked<UrlService>;
+		oauth2FlowService = mockInstance(OAuth2FlowService) as Mocked<OAuth2FlowService>;
 
 		service = new OAuthConsentService(
 			logger,
@@ -58,6 +61,7 @@ describe('OAuthConsentService', () => {
 			authorizationCodeService,
 			protectedResourceRegistry,
 			urlService,
+			oauth2FlowService,
 		);
 	});
 
@@ -318,6 +322,111 @@ describe('OAuthConsentService', () => {
 			const result = await service.getConsentDetails(sessionToken, mock<User>({ id: 'user-1' }));
 
 			expect(result).toEqual({ ok: false, reason: 'resource_unavailable' });
+		});
+	});
+
+	// A first-party trigger (form, webhook) re-runs the whole flow on every visit, so
+	// an unchanged grant is re-approved without showing the screen — but only when a
+	// human navigated there, since the screen is what otherwise stops a scripted
+	// cross-site navigation from running a workflow as the logged-in user.
+	describe('getConsentDetails silent approval', () => {
+		const TRIGGER_URL = 'https://n8n.example.com/webhook/abc?method=GET';
+		const sessionPayload = {
+			clientId: TRIGGER_URL,
+			redirectUri: TRIGGER_URL,
+			codeChallenge: 'challenge',
+			state: 'flow-state-1',
+			resource: TRIGGER_URL,
+		};
+
+		const firstPartyResource = (scopes: string[] = []) =>
+			({
+				displayName: 'My Workflow',
+				scopes,
+				isFirstParty: true,
+				authorize: async () => true,
+			}) as unknown as ProtectedResource;
+
+		const consentGranted = (scope: string[] = [], ageMs = 0) =>
+			mock<UserConsent>({ scope, grantedAt: Date.now() - ageMs });
+
+		beforeEach(() => {
+			oauthSessionService.verifySession.mockReturnValue(sessionPayload);
+			oauthClientRepository.findOne.mockResolvedValue(
+				mock<OAuthClient>({ id: TRIGGER_URL, name: 'My Workflow' }),
+			);
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue(firstPartyResource());
+			oauth2FlowService.getNavigationIntent.mockResolvedValue('user-navigation');
+			userConsentRepository.findOneBy.mockResolvedValue(consentGranted());
+		});
+
+		const detailsFor = async () =>
+			await service.getConsentDetails('session-token', mock<User>({ id: 'user-1' }));
+
+		it('should approve silently when the same consent was already granted', async () => {
+			expect(await detailsFor()).toMatchObject({ ok: true, silentApproval: true });
+			expect(oauth2FlowService.getNavigationIntent).toHaveBeenCalledWith('flow-state-1');
+			expect(userConsentRepository.findOneBy).toHaveBeenCalledWith({
+				userId: 'user-1',
+				clientId: TRIGGER_URL,
+			});
+		});
+
+		it('should prompt when the flow was not started by a user navigation', async () => {
+			oauth2FlowService.getNavigationIntent.mockResolvedValue('unknown');
+
+			expect(await detailsFor()).not.toHaveProperty('silentApproval');
+		});
+
+		// An expired flow or a third-party client's own `state` resolves to no intent.
+		it('should prompt when the flow has no recorded intent', async () => {
+			oauth2FlowService.getNavigationIntent.mockResolvedValue(undefined);
+
+			expect(await detailsFor()).not.toHaveProperty('silentApproval');
+		});
+
+		it('should prompt when the resource is not first-party', async () => {
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue({
+				scopes: [],
+				authorize: async () => true,
+			} as unknown as ProtectedResource);
+
+			expect(await detailsFor()).not.toHaveProperty('silentApproval');
+			expect(oauth2FlowService.getNavigationIntent).not.toHaveBeenCalled();
+		});
+
+		it('should prompt on the first visit, when no consent exists yet', async () => {
+			userConsentRepository.findOneBy.mockResolvedValue(null);
+
+			expect(await detailsFor()).not.toHaveProperty('silentApproval');
+		});
+
+		it('should prompt when the grant is older than the silent-approval window', async () => {
+			userConsentRepository.findOneBy.mockResolvedValue(
+				consentGranted([], 31 * 24 * 60 * 60 * 1000),
+			);
+
+			expect(await detailsFor()).not.toHaveProperty('silentApproval');
+		});
+
+		it('should prompt when a scope is now grantable that was not granted before', async () => {
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue(
+				firstPartyResource(['workflow:read', 'workflow:write']),
+			);
+			userConsentRepository.findOneBy.mockResolvedValue(consentGranted(['workflow:read']));
+
+			expect(await detailsFor()).not.toHaveProperty('silentApproval');
+		});
+
+		it('should approve silently when every grantable scope was already granted', async () => {
+			protectedResourceRegistry.getByResourceUrl.mockResolvedValue(
+				firstPartyResource(['workflow:read']),
+			);
+			userConsentRepository.findOneBy.mockResolvedValue(
+				consentGranted(['workflow:read', 'workflow:write']),
+			);
+
+			expect(await detailsFor()).toMatchObject({ silentApproval: true });
 		});
 	});
 

--- a/packages/cli/src/modules/oauth-server/oauth-consent.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.controller.ts
@@ -53,6 +53,7 @@ export class OAuthConsentController {
 					scopes: consentDetails.scopes,
 					previousScopes: consentDetails.previousScopes,
 					scopeTools: consentDetails.scopeTools,
+					silentApproval: consentDetails.silentApproval,
 				},
 			});
 		} catch (error) {

--- a/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import { Time } from '@n8n/constants';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { UserError } from 'n8n-workflow';
@@ -6,6 +7,7 @@ import { UserError } from 'n8n-workflow';
 import { OAuthClientRepository } from './database/repositories/oauth-client.repository';
 import { UserConsentRepository } from './database/repositories/oauth-user-consent.repository';
 import { OAuthAuthorizationCodeService } from './oauth-authorization-code.service';
+import { OAuth2FlowService } from './oauth-flow.service';
 import { OAuthSessionService, type OAuthSessionPayload } from './oauth-session.service';
 import { OAuthHelpers } from './oauth.helpers';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -29,9 +31,23 @@ type ConsentDetailsResult =
 			previousScopes?: string[];
 			/** Tool names each scope unlocks, shown per scope group in the picker. */
 			scopeTools?: Record<string, string[]>;
+			/**
+			 * The user already granted this exact consent and a human navigated here, so
+			 * the screen has nothing new to ask: the caller may approve without rendering
+			 * it. See {@link OAuthConsentService.mayApproveSilently}.
+			 */
+			silentApproval?: boolean;
 	  }
 	| { ok: false; reason: 'resource_unavailable' }
 	| { ok: false; reason: 'forbidden' };
+
+/**
+ * How long a consent keeps letting a first-party flow through without re-prompting.
+ * A grant on a first-party trigger is invisible in the connected-clients list (it
+ * filters to `isFirstParty: false`), so it must lapse on its own rather than
+ * becoming a permanent silent permission the user can't find.
+ */
+const SILENT_APPROVAL_MAX_AGE_MS = 30 * Time.days.toMilliseconds;
 
 /**
  * Manages the consent flow for the shared OAuth server.
@@ -47,6 +63,7 @@ export class OAuthConsentService {
 		private readonly authorizationCodeService: OAuthAuthorizationCodeService,
 		private readonly protectedResourceRegistry: ProtectedResourceRegistry,
 		private readonly urlService: UrlService,
+		private readonly oauth2FlowService: OAuth2FlowService,
 	) {}
 
 	/**
@@ -91,6 +108,11 @@ export class OAuthConsentService {
 					scopes,
 					previousScopes: await this.previousScopes(user.id, client.id, scopes),
 					scopeTools: resource.getScopeTools?.(),
+					// Only present when it applies, so a third-party client's payload — and the
+					// shape every existing caller asserts on — is untouched.
+					...((await this.mayApproveSilently(sessionPayload, user, resource, scopes)) && {
+						silentApproval: true,
+					}),
 				};
 			}
 
@@ -122,6 +144,53 @@ export class OAuthConsentService {
 	private grantableScopes(supportedScopes: string[], requestedScopes?: string[]): string[] {
 		if (!requestedScopes || requestedScopes.length === 0) return supportedScopes;
 		return supportedScopes.filter((scope) => requestedScopes.includes(scope));
+	}
+
+	/**
+	 * Whether this flow may complete without showing the consent screen.
+	 *
+	 * A first-party trigger (form, webhook) re-runs the whole authorization flow on
+	 * every visit, so without this the user re-approves the same thing on every
+	 * click. These resources also grant no scopes, which makes the screen a pure
+	 * "did you mean to do this?" interstitial rather than a permission grant — and
+	 * that question is worth asking once, not every time.
+	 *
+	 * All five conditions must hold:
+	 * 1. **First-party resource.** A registered third-party client always prompts.
+	 * 2. **A prior consent exists** for this (user, client).
+	 * 3. **Nothing new is being asked**: everything grantable now was granted then,
+	 *    so any future scope addition re-prompts on its own.
+	 * 4. **The grant is still fresh** ({@link SILENT_APPROVAL_MAX_AGE_MS}).
+	 * 5. **A human navigated here.** The consent screen is what currently stops a
+	 *    cross-site page from scripting a navigation to a trigger URL and running a
+	 *    workflow as whoever is logged in — `n8n-auth` is `SameSite=Lax`, so the
+	 *    session rides along on top-level cross-site GETs. Skipping the screen
+	 *    therefore requires the flow to have started from a real user navigation
+	 *    (see `classifyNavigationIntent`). Anything else — including a client that
+	 *    sends no fetch metadata — still gets the screen.
+	 */
+	private async mayApproveSilently(
+		sessionPayload: OAuthSessionPayload,
+		user: User,
+		resource: { isFirstParty?: boolean },
+		grantableScopes: string[],
+	): Promise<boolean> {
+		if (!resource.isFirstParty || !sessionPayload.state) return false;
+
+		const intent = await this.oauth2FlowService.getNavigationIntent(sessionPayload.state);
+		if (intent !== 'user-navigation') return false;
+
+		const consent = await this.userConsentRepository.findOneBy({
+			userId: user.id,
+			clientId: sessionPayload.clientId,
+		});
+		if (!consent) return false;
+
+		const granted = consent.scope ?? [];
+		if (!grantableScopes.every((scope) => granted.includes(scope))) return false;
+
+		// `grantedAt` is a bigint column, so it can surface as a string.
+		return Date.now() - Number(consent.grantedAt) <= SILENT_APPROVAL_MAX_AGE_MS;
 	}
 
 	/**

--- a/packages/cli/src/modules/oauth-server/oauth-flow.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-flow.service.ts
@@ -1,7 +1,12 @@
 import { InvalidGrantError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { Time } from '@n8n/constants';
 import { Service } from '@n8n/di';
-import { UserError, type N8nOAuth2FlowResult } from 'n8n-workflow';
+import {
+	N8N_OAUTH2_INTENT_KEY,
+	UserError,
+	type N8nOAuth2FlowResult,
+	type N8nOAuth2NavigationIntent,
+} from 'n8n-workflow';
 import { createHash, randomBytes } from 'node:crypto';
 import pkceChallenge from 'pkce-challenge';
 
@@ -60,6 +65,19 @@ export class OAuth2FlowService implements N8nOAuth2Flow {
 		url.searchParams.set('code_challenge_method', 'S256');
 		url.searchParams.set('state', state);
 		return url.toString();
+	}
+
+	/**
+	 * How the request that started this flow was initiated, as recorded server-side
+	 * when it began. Read without consuming the state — `complete` still needs it.
+	 *
+	 * Returns `undefined` for a `state` that isn't one of ours (a third-party client's
+	 * own `state`, or an expired flow), which callers must treat as "unknown".
+	 */
+	async getNavigationIntent(state: string): Promise<N8nOAuth2NavigationIntent | undefined> {
+		const flow = await this.cacheService.get<FlowState>(FLOW_STATE_PREFIX + state);
+		const intent = flow?.metadata?.[N8N_OAUTH2_INTENT_KEY];
+		return intent === 'user-navigation' || intent === 'unknown' ? intent : undefined;
 	}
 
 	/**

--- a/packages/frontend/@n8n/rest-api-client/src/api/consent.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/consent.ts
@@ -15,6 +15,12 @@ export interface ConsentDetails {
 	previousScopes?: string[];
 	/** Tool names each scope unlocks, shown per scope group in the picker. */
 	scopeTools?: Record<string, string[]>;
+	/**
+	 * The user already granted this exact consent and a human navigated here, so the
+	 * server considers the screen redundant — approve without rendering it. Only ever
+	 * set for n8n's own triggers (form, webhook), never for registered clients.
+	 */
+	silentApproval?: boolean;
 }
 
 export interface ConsentApprovalResponse {

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
@@ -155,6 +155,67 @@ describe('OAuthConsentView', () => {
 		expect(window.location.href).toBe(redirectUrl);
 	});
 
+	// The server only sets this for n8n's own triggers, when the user already granted
+	// this exact consent and a human navigated there — so re-asking is noise.
+	describe('when the server marks the grant as silently approvable', () => {
+		const redirectUrl = 'https://legitimate-client.com/callback?code=silent';
+
+		const withSilentApproval = (extra: Record<string, unknown> = {}) => {
+			const details = {
+				clientName: 'My Workflow',
+				clientId: 'https://n8n.example.com/webhook/abc?method=GET',
+				resourceName: 'My Workflow',
+				scopes: [],
+				silentApproval: true,
+				...extra,
+			};
+			consentStore.consentDetails = details;
+			consentStore.fetchConsentDetails.mockImplementation(async () => {
+				consentStore.consentDetails = details;
+				return details;
+			});
+			consentStore.approveConsent.mockResolvedValue({ status: 'approved', redirectUrl });
+		};
+
+		it('should complete the flow without rendering the consent prompt', async () => {
+			withSilentApproval();
+
+			const { queryByTestId, getByTestId } = renderComponent();
+			await waitAllPromises();
+
+			expect(consentStore.approveConsent).toHaveBeenCalledWith(true, undefined);
+			expect(window.location.href).toBe(redirectUrl);
+			// Never shows Allow/Deny — the user sees only the "connecting" screen.
+			expect(queryByTestId('consent-allow-button')).toBeNull();
+			expect(queryByTestId('consent-deny-button')).toBeNull();
+			expect(getByTestId('consent-success-screen')).toBeVisible();
+		});
+
+		// Scopes come from the server's record of the earlier grant, not from the picker,
+		// whose watcher may not have flushed by the time we auto-approve.
+		it('should re-grant the previously granted scopes', async () => {
+			withSilentApproval({
+				scopes: ['workflow:read', 'workflow:write'],
+				previousScopes: ['workflow:read'],
+			});
+
+			renderComponent();
+			await waitAllPromises();
+
+			expect(consentStore.approveConsent).toHaveBeenCalledWith(true, ['workflow:read']);
+		});
+
+		it('should render the prompt as usual when the server does not mark it', async () => {
+			withSilentApproval({ silentApproval: undefined });
+
+			const { getByTestId } = renderComponent();
+			await waitAllPromises();
+
+			expect(consentStore.approveConsent).not.toHaveBeenCalled();
+			expect(getByTestId('consent-allow-button')).toBeVisible();
+		});
+	});
+
 	it('should disable the allow button until the redirect URL is acknowledged', async () => {
 		const { getByTestId, getByLabelText } = renderComponent();
 		await waitAllPromises();

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -90,17 +90,16 @@ watch(
 	{ immediate: true },
 );
 
-const handleAllow = async () => {
+const approve = async (scopes: string[] | undefined, silent: boolean) => {
 	try {
-		const response = await consentStore.approveConsent(
-			true,
-			hasScopes.value ? selectedScopes.value : undefined,
-		);
+		const response = await consentStore.approveConsent(true, scopes);
 		telemetry.track('User approved MCP consent', {
 			client_name: clientDetails.value?.clientName,
-			selected_scopes: selectedScopes.value,
-			selected_scopes_count: selectedScopes.value.length,
-			all_scopes_selected: selectedScopes.value.length === availableScopes.value.length,
+			selected_scopes: scopes ?? [],
+			selected_scopes_count: scopes?.length ?? 0,
+			all_scopes_selected: (scopes?.length ?? 0) === availableScopes.value.length,
+			// Re-approval of an unchanged grant, completed without showing this screen.
+			silent,
 		});
 		waitingForRedirect.value = true;
 		window.location.href = response.redirectUrl;
@@ -108,6 +107,9 @@ const handleAllow = async () => {
 		toast.showError(err, i18n.baseText('oauth.consentView.error.allow'));
 	}
 };
+
+const handleAllow = async () =>
+	await approve(hasScopes.value ? selectedScopes.value : undefined, false);
 
 const handleDeny = async () => {
 	try {
@@ -131,6 +133,17 @@ onMounted(async () => {
 	documentTitle.set(i18n.baseText('oauth.consentView.title'));
 	try {
 		await consentStore.fetchConsentDetails();
+
+		// The server decided this grant is a re-approval of something unchanged (only
+		// possible for n8n's own triggers), so asking again would be noise: complete the
+		// flow and never render the picker. Scopes come from the server's record of the
+		// earlier grant, not from `selectedScopes` — its watcher may not have flushed yet.
+		if (clientDetails.value?.silentApproval) {
+			waitingForRedirect.value = true;
+			await approve(hasScopes.value ? (clientDetails.value.previousScopes ?? []) : undefined, true);
+			return;
+		}
+
 		telemetry.track('User viewed MCP consent screen', {
 			client_name: clientDetails.value?.clientName,
 			available_scopes_count: availableScopes.value.length,

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -1110,12 +1110,33 @@ describe('FormTrigger, formWebhook', () => {
 
 			const result = await formWebhook(ctx);
 
-			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, undefined);
+			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, { intent: 'unknown' });
 			expect(writeHead).toHaveBeenCalledWith(302, {
 				Location: 'http://localhost:5678/oauth/authorize?state=abc',
 			});
 			expect(end).toHaveBeenCalled();
 			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		// Lets the consent step skip re-prompting a returning user; a mock with no fetch
+		// metadata stays 'unknown', which keeps the prompt.
+		it('records a clicked link as a user navigation for the consent step', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			setupContext(ctx, {
+				method: 'GET',
+				headers: {
+					'sec-fetch-mode': 'navigate',
+					'sec-fetch-site': 'cross-site',
+					'sec-fetch-user': '?1',
+				},
+			});
+			ctx.beginN8nOAuth2Flow.mockResolvedValue('http://localhost:5678/oauth/authorize?state=abc');
+
+			await formWebhook(ctx);
+
+			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, {
+				intent: 'user-navigation',
+			});
 		});
 
 		it('responds 403 without restarting the flow when consent is denied', async () => {
@@ -1145,7 +1166,7 @@ describe('FormTrigger, formWebhook', () => {
 			const result = await formWebhook(ctx);
 
 			expect(ctx.completeN8nOAuth2Flow).toHaveBeenCalledWith('the-code', 'the-state');
-			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, undefined);
+			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, { intent: 'unknown' });
 			expect(writeHead).toHaveBeenCalledWith(302, {
 				Location: 'http://localhost:5678/oauth/authorize?state=fresh',
 			});
@@ -1190,7 +1211,10 @@ describe('FormTrigger, formWebhook', () => {
 
 			const result = await formWebhook(ctx);
 
-			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, { query: 'foo=bar' });
+			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, {
+				query: 'foo=bar',
+				intent: 'unknown',
+			});
 			expect(writeHead).toHaveBeenCalledWith(302, {
 				Location: 'http://localhost:5678/oauth/authorize?state=abc',
 			});
@@ -1211,7 +1235,10 @@ describe('FormTrigger, formWebhook', () => {
 			await formWebhook(ctx);
 
 			expect(ctx.completeN8nOAuth2Flow).not.toHaveBeenCalled();
-			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, { query: 'foo=bar&code=x' });
+			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, {
+				query: 'foo=bar&code=x',
+				intent: 'unknown',
+			});
 		});
 
 		it('re-appends the query stashed as flow metadata on a valid callback', async () => {
@@ -1245,7 +1272,7 @@ describe('FormTrigger, formWebhook', () => {
 
 			await formWebhook(ctx);
 
-			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, undefined);
+			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, { intent: 'unknown' });
 		});
 
 		it('renders the form on the clean GET carrying the oauth cookie', async () => {
@@ -1280,7 +1307,7 @@ describe('FormTrigger, formWebhook', () => {
 			const result = await formWebhook(ctx);
 
 			expect(ctx.validateN8nOAuth2Token).toHaveBeenCalledWith('stale-token', resourceUrl);
-			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, undefined);
+			expect(ctx.beginN8nOAuth2Flow).toHaveBeenCalledWith(resourceUrl, { intent: 'unknown' });
 			expect(writeHead).toHaveBeenCalledWith(302, {
 				Location: 'http://localhost:5678/oauth/authorize?state=fresh',
 			});

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -28,6 +28,8 @@ import {
 	BINARY_MODE_COMBINED,
 	tryToParseJsonToFormFields,
 	UnexpectedError,
+	classifyNavigationIntent,
+	N8N_OAUTH2_INTENT_KEY,
 } from 'n8n-workflow';
 import * as a from 'node:assert';
 import sanitize from 'sanitize-html';
@@ -852,10 +854,12 @@ async function authenticateFormUserOrRespond(
 
 			try {
 				// start authentication flow by redirecting to the OAuth2 provider's authorization URL
-				const authorizationUrl = await context.beginN8nOAuth2Flow(
-					resourceUrl,
-					originalQuery ? { query: originalQuery } : undefined,
-				);
+				const authorizationUrl = await context.beginN8nOAuth2Flow(resourceUrl, {
+					...(originalQuery ? { query: originalQuery } : {}),
+					// Recorded server-side against this flow's `state`, so the consent step can
+					// tell a real navigation from a script-driven one before skipping a prompt.
+					[N8N_OAUTH2_INTENT_KEY]: classifyNavigationIntent(req.headers),
+				});
 				res.writeHead(302, {
 					Location: authorizationUrl,
 				});

--- a/packages/workflow/src/n8n-browser-oauth2-flow.ts
+++ b/packages/workflow/src/n8n-browser-oauth2-flow.ts
@@ -13,6 +13,47 @@ const BROWSER_OAUTH_COOKIE_NAME = 'n8n-webhook-oauth';
 /** Query params owned by the OAuth callback, stripped before handing the URL back. */
 const CALLBACK_PARAMS = ['code', 'state', 'error', 'error_description', 'iss'];
 
+/**
+ * How the request that started an OAuth flow was initiated.
+ *
+ * - `user-navigation`: a top-level navigation the person actually performed —
+ *   clicking a link (from anywhere), typing the URL, or a bookmark.
+ * - `unknown`: everything else, including script-driven navigation
+ *   (`location = …`, meta refresh, iframes, prefetch) and requests from clients
+ *   that send no fetch metadata at all.
+ *
+ * Only used to decide whether a *previously consented* flow may complete without
+ * re-prompting, so `unknown` degrades to showing the consent screen — never to a
+ * hard failure.
+ */
+export type N8nOAuth2NavigationIntent = 'user-navigation' | 'unknown';
+
+/** Flow-metadata key carrying {@link N8nOAuth2NavigationIntent} to the consent step. */
+export const N8N_OAUTH2_INTENT_KEY = 'intent';
+
+const firstHeaderValue = (header: string | string[] | undefined): string | undefined =>
+	typeof header === 'string' ? header : header?.[0];
+
+/**
+ * Classify how a browser request was initiated, from Fetch Metadata headers.
+ *
+ * `Sec-Fetch-*` are forbidden header names, so page scripts cannot spoof them
+ * (same property `push/origin-validator.ts` relies on). The distinction that
+ * matters here is *user activation*, not origin: a click from an email or a chat
+ * message is cross-site and must qualify, because that is the whole point of a
+ * clickable trigger URL. What must not qualify is a navigation no one asked for —
+ * a page setting `location` to a webhook URL would otherwise run a workflow as
+ * whoever happens to be logged in.
+ */
+export function classifyNavigationIntent(headers: Request['headers']): N8nOAuth2NavigationIntent {
+	if (firstHeaderValue(headers['sec-fetch-mode']) !== 'navigate') return 'unknown';
+
+	// `none` = typed/bookmarked, `same-origin` = from n8n itself, `?1` = user activation.
+	const site = firstHeaderValue(headers['sec-fetch-site']);
+	if (site === 'none' || site === 'same-origin') return 'user-navigation';
+	return firstHeaderValue(headers['sec-fetch-user']) === '?1' ? 'user-navigation' : 'unknown';
+}
+
 export type N8nBrowserOAuth2Outcome =
 	/** Authenticated: the caller should establish the trigger identity and run the workflow. */
 	| { status: 'ok'; token: string }
@@ -148,6 +189,9 @@ export const n8nBrowserOAuth2Flow = async (
 
 	const authorizationUrl = await context.beginN8nOAuth2Flow(resourceUrl, {
 		returnTo: returnToUrl(req),
+		// Recorded server-side against this flow's `state`: the consent step needs to know
+		// a human actually navigated here before it may skip re-prompting.
+		[N8N_OAUTH2_INTENT_KEY]: classifyNavigationIntent(req.headers),
 	});
 	return redirect(res, authorizationUrl);
 };

--- a/packages/workflow/test/n8n-browser-oauth2-flow.test.ts
+++ b/packages/workflow/test/n8n-browser-oauth2-flow.test.ts
@@ -20,6 +20,7 @@ const buildContext = (
 		cookie?: string;
 		query?: Record<string, string>;
 		originalUrl?: string;
+		fetchMetadata?: Record<string, string>;
 	} = {},
 ) => {
 	const response = mock<Response>();
@@ -39,6 +40,12 @@ const buildContext = (
 		headers: {
 			...(req.accept === undefined ? { accept: 'text/html' } : { accept: req.accept }),
 			...(req.cookie ? { cookie: req.cookie } : {}),
+			// A clicked link from another site: navigation with user activation.
+			...(req.fetchMetadata ?? {
+				'sec-fetch-mode': 'navigate',
+				'sec-fetch-site': 'cross-site',
+				'sec-fetch-user': '?1',
+			}),
 		},
 		query: req.query ?? {},
 		originalUrl: req.originalUrl ?? '/webhook/abc?ref=email',
@@ -57,8 +64,55 @@ describe('n8nBrowserOAuth2Flow', () => {
 		expect(outcome).toBe('handled');
 		expect(context.beginN8nOAuth2Flow).toHaveBeenCalledWith(RESOURCE_URL, {
 			returnTo: '/webhook/abc?ref=email',
+			intent: 'user-navigation',
 		});
 		expect(response.writeHead).toHaveBeenCalledWith(302, { Location: AUTHORIZE_URL });
+	});
+
+	// The consent step may only skip re-prompting for a flow a human actually started,
+	// so the classification travels with the flow (server-side, never in the URL).
+	it.each([
+		[
+			'a link clicked on another site',
+			{ 'sec-fetch-mode': 'navigate', 'sec-fetch-site': 'cross-site', 'sec-fetch-user': '?1' },
+			'user-navigation',
+		],
+		[
+			'a typed URL or bookmark',
+			{ 'sec-fetch-mode': 'navigate', 'sec-fetch-site': 'none' },
+			'user-navigation',
+		],
+		[
+			'a link from n8n itself',
+			{ 'sec-fetch-mode': 'navigate', 'sec-fetch-site': 'same-origin' },
+			'user-navigation',
+		],
+		// `location = …` from a cross-site page: a navigation nobody asked for.
+		[
+			'a script-driven navigation',
+			{ 'sec-fetch-mode': 'navigate', 'sec-fetch-site': 'cross-site' },
+			'unknown',
+		],
+		[
+			'a sibling-subdomain script navigation',
+			{ 'sec-fetch-mode': 'navigate', 'sec-fetch-site': 'same-site' },
+			'unknown',
+		],
+		[
+			'an embedded (non-navigation) load',
+			{ 'sec-fetch-mode': 'no-cors', 'sec-fetch-site': 'cross-site', 'sec-fetch-user': '?1' },
+			'unknown',
+		],
+		['a client sending no fetch metadata', {}, 'unknown'],
+	] as const)('records %s as %s', async (_label, fetchMetadata, expected) => {
+		const { context } = buildContext({ fetchMetadata: { ...fetchMetadata } });
+
+		await n8nBrowserOAuth2Flow(context, RESOURCE_URL);
+
+		expect(context.beginN8nOAuth2Flow).toHaveBeenCalledWith(
+			RESOURCE_URL,
+			expect.objectContaining({ intent: expected }),
+		);
 	});
 
 	it.each([
@@ -140,6 +194,7 @@ describe('n8nBrowserOAuth2Flow', () => {
 		expect(await n8nBrowserOAuth2Flow(context, RESOURCE_URL)).toBe('handled');
 		expect(context.beginN8nOAuth2Flow).toHaveBeenCalledWith(RESOURCE_URL, {
 			returnTo: '/webhook/abc?method=GET',
+			intent: 'user-navigation',
 		});
 		expect(response.writeHead).toHaveBeenCalledWith(302, { Location: AUTHORIZE_URL });
 	});

--- a/packages/workflow/test/n8n-oauth2-auth.test.ts
+++ b/packages/workflow/test/n8n-oauth2-auth.test.ts
@@ -135,9 +135,10 @@ describe('n8nOAuth2Auth', () => {
 			});
 
 			expect(result).toBe('handled');
-			expect(context.beginN8nOAuth2Flow).toHaveBeenCalledWith(`${WEBHOOK_URL}?method=GET`, {
-				returnTo: '/webhook/protected-path',
-			});
+			expect(context.beginN8nOAuth2Flow).toHaveBeenCalledWith(
+				`${WEBHOOK_URL}?method=GET`,
+				expect.objectContaining({ returnTo: '/webhook/protected-path' }),
+			);
 			expect(response.writeHead).toHaveBeenCalledWith(302, {
 				Location: 'https://n8n.example.com/oauth/authorize?state=s1',
 			});


### PR DESCRIPTION
## Summary

Stacked on #35583 — **review that one first**; this PR's diff is only the consent change.

A form or webhook trigger re-runs the whole authorization flow on every visit, so the user re-approves the same thing on every click. Since these resources grant no scopes (`FORM_TRIGGER_SCOPES` and `WEBHOOK_TRIGGER_SCOPES` are both `[]`), the screen is a bare "did you mean to do this?" interstitial rather than a permission grant — worth asking once, not every time. This makes an unchanged re-approval silent.

That screen is also load-bearing today: it's what stops a cross-site page from scripting a navigation to a trigger URL and running a workflow as whoever is logged in (`n8n-auth` is `SameSite=Lax`, so the session rides along on top-level cross-site GETs). So skipping it requires knowing a human navigated there. That's classified from Fetch Metadata at the trigger hop — `Sec-Fetch-*` are forbidden header names, so page scripts can't spoof them, the same property `push/origin-validator.ts` relies on — and carried to the consent step in the flow's server-side state, never in the URL. A click from an email or Slack qualifies (that's the whole point of a clickable trigger); a scripted `location = …`, an iframe, or a prefetch does not.

Re-approval is silent only when **all** of: the resource is first-party, a prior consent exists, every currently grantable scope was already granted, the grant is under 30 days old, and the flow started from a real user navigation. Anything else — including a client that sends no fetch metadata — still gets today's screen. The 30-day lapse exists because first-party consents are excluded from the connected-clients list (`oauth-user-consent.repository.ts:60`), so without it this would become a permanent permission the user can neither see nor revoke; surfacing them there is the better follow-up.

**Note for reviewers:** this changes behaviour for the **form trigger** too (behind `N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2`), which is deliberate — it has the identical re-prompt and the identical exposure today, so this is one shared fix rather than a webhook-specific patch. Happy to narrow it to the webhook flow if you'd rather keep the blast radius smaller.

## How to test

Same setup as #35583 (`N8N_ENV_FEAT_WEBHOOK_PRIVATE_CREDENTIALS=true`, `N8N_ENV_FEAT_WEBHOOK_OAUTH2_BROWSER_FLOW=true`, `dynamic-credentials` module active), or `N8N_ENV_FEAT_FORM_TRIGGER_OAUTH2=true` for a form trigger.

1. Open the trigger URL in a browser → consent screen, click Allow → workflow runs.
2. Open it again → **no consent screen**; you land straight on the response.
3. From another site, run `location = '<trigger url>'` in the console → the consent screen is back (scripted navigation, no user activation).
4. `curl` the URL → unchanged `401` with `WWW-Authenticate`.
5. Register a normal OAuth client (MCP) and consent twice → still prompts every time.

## Related Linear tickets, Github issues, and Community forum posts

Stacked on #35583. No Linear ticket — exploratory, opened for discussion.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

