### PR TITLE
ci: Add node-pc base image with pointer-compressed Node.js

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -5,4 +5,6 @@ self-hosted-runner:
     - blacksmith-2vcpu-ubuntu-2204-arm
     - blacksmith-8vcpu-ubuntu-2204
     - blacksmith-8vcpu-ubuntu-2204-arm
+    - blacksmith-32vcpu-ubuntu-2204
+    - blacksmith-32vcpu-ubuntu-2204-arm
     - ubuntu-slim

--- a/.github/workflows/build-node-pc-image.yml
+++ b/.github/workflows/build-node-pc-image.yml
@@ -1,0 +1,135 @@
+name: 'Build: Node PC Image'
+
+# Publishes n8nio/node-pc, the pointer-compressed Node runtime consumed by the
+# n8n `-pc` image variant. Compiling Node from source is too slow under QEMU,
+# so each architecture builds on its native runner and a manifest job stitches
+# the per-arch images, following docker-build-push.yml.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docker/images/node-pc/Dockerfile'
+      - '.github/workflows/build-node-pc-image.yml'
+  pull_request:
+    paths:
+      - 'docker/images/node-pc/Dockerfile'
+      - '.github/workflows/build-node-pc-image.yml'
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push to registries'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  NODE_VERSION: '26.5.1'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2204
+            arch: amd64
+          - platform: linux/arm64
+            runner: blacksmith-8vcpu-ubuntu-2204-arm
+            arch: arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Login to DHI Registry (for pulling the runtime base)
+        uses: ./.github/actions/docker-registry-login
+        with:
+          login-ghcr: 'false'
+          login-dhi: 'true'
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to Docker registries (for pushing)
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true)
+        uses: ./.github/actions/docker-registry-login
+        with:
+          login-ghcr: 'true'
+          login-dockerhub: 'true'
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push runtime target
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        with:
+          context: .
+          file: ./docker/images/node-pc/Dockerfile
+          target: runtime
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+          provenance: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true) }}
+          sbom: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true) }}
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true) }}
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/node-pc:${{ env.NODE_VERSION }}-${{ matrix.arch }}
+            ${{ secrets.DOCKER_USERNAME }}/node-pc:${{ env.NODE_VERSION }}-${{ github.sha }}-${{ matrix.arch }}
+            ghcr.io/${{ github.repository_owner }}/node-pc:${{ env.NODE_VERSION }}-${{ matrix.arch }}
+            ghcr.io/${{ github.repository_owner }}/node-pc:${{ env.NODE_VERSION }}-${{ github.sha }}-${{ matrix.arch }}
+          no-cache: true
+
+      # No no-cache here: reuses the compile layers from the runtime build
+      # above, so Node compiles once per architecture
+      - name: Build and push dev target
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+        with:
+          context: .
+          file: ./docker/images/node-pc/Dockerfile
+          target: dev
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+          provenance: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true) }}
+          sbom: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true) }}
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true) }}
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/node-pc:${{ env.NODE_VERSION }}-dev-${{ matrix.arch }}
+            ${{ secrets.DOCKER_USERNAME }}/node-pc:${{ env.NODE_VERSION }}-${{ github.sha }}-dev-${{ matrix.arch }}
+            ghcr.io/${{ github.repository_owner }}/node-pc:${{ env.NODE_VERSION }}-dev-${{ matrix.arch }}
+            ghcr.io/${{ github.repository_owner }}/node-pc:${{ env.NODE_VERSION }}-${{ github.sha }}-dev-${{ matrix.arch }}
+
+  create-multi-arch-manifest:
+    needs: build
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == true)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Login to Docker registries
+        uses: ./.github/actions/docker-registry-login
+        with:
+          login-ghcr: 'true'
+          login-dockerhub: 'true'
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create multi-arch manifests
+        run: |
+          for REPO in \
+            "${{ secrets.DOCKER_USERNAME }}/node-pc" \
+            "ghcr.io/${{ github.repository_owner }}/node-pc" \
+          ; do
+            for DEV in "" "-dev"; do
+              AMD64="$REPO:${{ env.NODE_VERSION }}-${{ github.sha }}$DEV-amd64"
+              ARM64="$REPO:${{ env.NODE_VERSION }}-${{ github.sha }}$DEV-arm64"
+              for TAG in \
+                "$REPO:${{ env.NODE_VERSION }}$DEV" \
+                "$REPO:${{ env.NODE_VERSION }}-${{ github.sha }}$DEV" \
+              ; do
+                echo "Creating manifest $TAG"
+                docker buildx imagetools create --tag "$TAG" "$AMD64" "$ARM64"
+              done
+            done
+          done

--- a/.github/workflows/build-node-pc-image.yml
+++ b/.github/workflows/build-node-pc-image.yml
@@ -36,10 +36,10 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: blacksmith-4vcpu-ubuntu-2204
+            runner: blacksmith-32vcpu-ubuntu-2204
             arch: amd64
           - platform: linux/arm64
-            runner: blacksmith-8vcpu-ubuntu-2204-arm
+            runner: blacksmith-32vcpu-ubuntu-2204-arm
             arch: arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docker/images/node-pc/Dockerfile
+++ b/docker/images/node-pc/Dockerfile
@@ -91,9 +91,9 @@ ENV npm_config_nodedir=/usr/local
 # Docker's OS-layer patching and attestations. Only the Node binary is ours:
 # DHI's stock Node (at /usr/bin on Alpine) is removed and replaced by the
 # pointer-compressed build.
-# TODO: pin the digest on the first authenticated pull, tag+digest together
-# like n8n-base.
-FROM dhi.io/node:26.5.1-alpine3.24-dev AS runtime
+# Pinned to a multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
+# Bump the tag and digest together when updating.
+FROM dhi.io/node:26.5.1-alpine3.24-dev@sha256:c4062f85acd1ca91ffb7d15048dcc5f15a922d630e65eb3c3c0dcdcef6ea36d8 AS runtime
 
 RUN rm -f /usr/bin/node /usr/bin/nodejs /usr/bin/npm /usr/bin/npx /usr/bin/corepack
 COPY --from=builder /node-install/usr/local /usr/local

--- a/docker/images/node-pc/Dockerfile
+++ b/docker/images/node-pc/Dockerfile
@@ -1,0 +1,130 @@
+# Node.js compiled with V8 pointer compression, for the n8n `-pc` image variant.
+#
+# No official pointer-compressed Node binaries exist (nodejs.org publishes none,
+# and Docker Hub node images are stock), so this image compiles Node from the
+# GPG-verified source tarball, following the source-build path of the official
+# docker-node Alpine recipe with one added configure flag.
+#
+# Two published targets:
+#   runtime (default) - drop-in sibling of n8nio/base, layered on the same DHI
+#                       base with our compiled Node swapped in
+#   dev               - plain Alpine with apk usable, for the n8n builder
+#                       stage, which must compile native addons against this
+#                       Node's headers
+ARG NODE_VERSION=26.5.1
+# Compiling V8 needs 1.5-2 GB of memory per parallel job. Lower this on
+# builders whose memory-to-core ratio cannot cover all cores.
+ARG MAKE_JOBS=
+
+# Pinned to a multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
+# Bump the tag and digest together when updating.
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS builder
+ARG NODE_VERSION
+ARG MAKE_JOBS
+
+RUN apk add --no-cache --virtual .build-deps \
+        binutils-gold \
+        curl \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+        py-setuptools \
+        rust \
+        cargo \
+    && OPENSSL_ARCH= && alpineArch="$(apk --print-arch)" \
+    && case "${alpineArch##*-}" in \
+        x86_64) OPENSSL_ARCH=linux-x86_64;; \
+        aarch64) OPENSSL_ARCH=linux-aarch64;; \
+        *) echo "unsupported architecture: $alpineArch" && exit 1;; \
+    esac \
+    && export GNUPGHOME="$(mktemp -d)" \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+        5BE8A3F6C8A5C01D106C0AD820B1A390B168D356 \
+        DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
+        CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
+        8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+        890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
+        C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+        108F52B48DB57BB0CC439B2997B01419BD92F80A \
+        A363A499291CBBC940DD62E41F10027AF002F8B0 \
+        655F3B5C1FB3FA8D1A0CA6BDE4A7D232B936D2FD \
+    ; do \
+        { gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" && gpg --batch --fingerprint "$key"; } || \
+        { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key"; } ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && gpgconf --kill all \
+    && rm -rf "$GNUPGHOME" \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure --experimental-enable-pointer-compression \
+    && make -j"${MAKE_JOBS:-$(getconf _NPROCESSORS_ONLN)}" V= \
+    && make install DESTDIR=/node-install \
+    # Remove unused OpenSSL headers to save ~34MB. See https://github.com/nodejs/node/issues/46451
+    && find /node-install/usr/local/include/node/openssl/archs -mindepth 1 -maxdepth 1 ! -name "$OPENSSL_ARCH" -exec rm -rf {} \;
+
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS base
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache libstdc++
+COPY --from=builder /node-install/usr/local /usr/local
+RUN node --version && npm --version \
+    && node -e "if (!process.config.variables.v8_enable_pointer_compression) { throw new Error('pointer compression is not enabled') }"
+
+FROM base AS dev
+# node-gyp must compile native addons against this build's headers so they pick
+# up the pointer compression defines, never against downloaded stock headers.
+ENV npm_config_nodedir=/usr/local
+
+# ---------------------------------------------------------------------------
+
+# Runtime layers on the same DHI base as n8n-base, so both siblings share
+# Docker's OS-layer patching and attestations. Only the Node binary is ours:
+# DHI's stock Node (at /usr/bin on Alpine) is removed and replaced by the
+# pointer-compressed build.
+# TODO: pin the digest on the first authenticated pull, tag+digest together
+# like n8n-base.
+FROM dhi.io/node:26.5.1-alpine3.24-dev AS runtime
+
+RUN rm -f /usr/bin/node /usr/bin/nodejs /usr/bin/npm /usr/bin/npx /usr/bin/corepack
+COPY --from=builder /node-install/usr/local /usr/local
+RUN node --version \
+    && node -e "if (!process.config.variables.v8_enable_pointer_compression) { throw new Error('pointer compression is not enabled') }"
+
+# Mirrors docker/images/n8n-base/Dockerfile so the n8n runtime stage can swap
+# between the two.
+RUN apk add --no-cache busybox-binsh && \
+    apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontconfig && \
+    update-ms-fonts && \
+    fc-cache -f && \
+    apk del .build-deps-fonts && \
+    find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \; && \
+    # No blanket `apk upgrade` — patched bytes come from bumping the pinned
+    # DHI digest instead, same policy as n8n-base.
+    apk add --no-cache \
+        openssh \
+        graphicsmagick \
+        tini \
+        tzdata \
+        ca-certificates \
+        libc6-compat && \
+    rm -rf /tmp/* /root/.npm /root/.cache/node /opt/yarn* && \
+    apk del apk-tools
+
+# The compiled build lives at /usr/local/bin, which is what the cloud launch
+# and AppArmor profile expect. Keep the stock /usr/bin path working for
+# anything that references it.
+RUN ln -sf /usr/local/bin/node /usr/bin/node
+
+WORKDIR /home/node
+ENV NODE_PATH=/usr/local/lib/node_modules
+EXPOSE 5678/tcp


### PR DESCRIPTION
## Summary

Adds `n8nio/node-pc`, a base image whose Node.js is compiled from the source tarball with V8 pointer compression enabled. No official pointer-compressed Node binaries exist anywhere, so we build our own following the source-build path of the official docker-node Alpine recipe plus the one PC configure flag.

## Related Linear tickets, Github issues, and Community forum posts

https://app.notion.com/p/n8n/Halving-memory-usage-via-pointer-compression-3ac5b6e0c94f8005af87e93a9f837b53

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

