### PR TITLE
ci(ai-builder): Gate the mcp-gate eval tier absolutely (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
@@ -111,7 +111,9 @@ function makeEval(totalRuns: number, cases: CaseSpec[]) {
 describe('isGatedTier', () => {
 	it('is true only for known gated tiers', () => {
 		expect(isGatedTier('pr')).toBe(true);
+		expect(isGatedTier('mcp-gate')).toBe(true);
 		expect(isGatedTier('full')).toBe(false);
+		expect(isGatedTier('mcp')).toBe(false);
 		expect(isGatedTier(undefined)).toBe(false);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/run/tiers.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/tiers.ts
@@ -11,4 +11,4 @@
 // ---------------------------------------------------------------------------
 
 /** Tiers whose runs assert the absolute gate instead of comparing to a baseline. */
-export const GATED_TIER_NAMES: ReadonlySet<string> = new Set(['pr']);
+export const GATED_TIER_NAMES: ReadonlySet<string> = new Set(['pr', 'mcp-gate']);


### PR DESCRIPTION
The `mcp-gate` dataset tag marks the curated MCP regression subset: cases the MCP build path passes reliably, validated per-case. Register it in GATED_TIER_NAMES so its runs assert the absolute pass@k green bar instead of comparing to a baseline, mirroring the `pr` tier.

## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

