### PR TITLE
feat(core): Split TrustedKeyService into a read-only lookup and a main-only sync service (no-changelog)

### DIFF
--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -291,7 +291,7 @@ export default defineConfig(
 			'./src/modules/source-control.ee/source-control-import.service.ee.ts',
 			'./src/modules/source-control.ee/source-control-scoped.service.ts',
 			'./src/modules/source-control.ee/source-control-status.service.ee.ts',
-			'./src/modules/token-exchange/services/trusted-key.service.ts',
+			'./src/modules/identity-substrate/services/trusted-key-sync.service.ts',
 			'./src/modules/workflow-index/workflow-dependency-query.service.ts',
 		],
 		rules: {

--- a/packages/cli/src/modules/identity-substrate/services/__tests__/trusted-key-sync.service.test.ts
+++ b/packages/cli/src/modules/identity-substrate/services/__tests__/trusted-key-sync.service.test.ts
@@ -6,15 +6,13 @@ import { jsonParse } from 'n8n-workflow';
 import { createHash } from 'node:crypto';
 import { mock } from 'vitest-mock-extended';
 
-import { TrustedKeySourceEntity } from '@/modules/identity-substrate/database/entities/trusted-key-source.entity';
-import { TrustedKeyEntity } from '@/modules/identity-substrate/database/entities/trusted-key.entity';
-import type { TrustedKeySourceRepository } from '@/modules/identity-substrate/database/repositories/trusted-key-source.repository';
-import type { TrustedKeyRepository } from '@/modules/identity-substrate/database/repositories/trusted-key.repository';
-import type { JwksResolverService } from '@/modules/identity-substrate/services/jwks-resolver';
+import type { TokenExchangeConfig } from '@/modules/token-exchange/token-exchange.config';
 
-import type { TokenExchangeConfig } from '../../token-exchange.config';
-import type { TrustedKeyData } from '../../token-exchange.schemas';
-import { TrustedKeyService } from '../trusted-key.service';
+import { TrustedKeySourceEntity } from '../../database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '../../database/entities/trusted-key.entity';
+import type { TrustedKeySourceRepository } from '../../database/repositories/trusted-key-source.repository';
+import type { JwksResolverService } from '../jwks-resolver';
+import { TrustedKeySyncService } from '../trusted-key-sync.service';
 
 // ──────────────────────────────────────────────────────────────────────
 // Pre-generated PEM public keys (test-only, no secrets)
@@ -30,36 +28,11 @@ o6LNz3KqejtBEOT+/IbnbgIShhWcTuh8Ehw0EUtkOXdqykqoXuEtcoLj3c4efQ/n
 dQIDAQAB
 -----END PUBLIC KEY-----`;
 
-const EC_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpCuPN2BHQ7G0A2qD2Bd27bwwUB9M
-Npzv5WS/ygt55l8y2X+Vfm5TQFRMNkqEx+/GXaPIU/hDmtnBdCxAUIRM9g==
------END PUBLIC KEY-----`;
-
 // ──────────────────────────────────────────────────────────────────────
 // Helpers
 // ──────────────────────────────────────────────────────────────────────
 
 const mockLogger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
-
-function makeTrustedKeyData(overrides: Partial<TrustedKeyData> = {}): TrustedKeyData {
-	return {
-		algorithms: ['RS256'],
-		keyMaterial: RSA_PUBLIC_KEY,
-		issuer: 'https://issuer.example.com',
-		...overrides,
-	};
-}
-
-function makeTrustedKeyEntity(
-	overrides: Partial<{ sourceId: string; kid: string; data: TrustedKeyData }> = {},
-): TrustedKeyEntity {
-	const entity = new TrustedKeyEntity();
-	entity.sourceId = overrides.sourceId ?? 'static';
-	entity.kid = overrides.kid ?? 'test-kid';
-	entity.data = JSON.stringify(overrides.data ?? makeTrustedKeyData());
-	entity.createdAt = new Date();
-	return entity;
-}
 
 function createMocks({
 	isLeader = true,
@@ -82,7 +55,6 @@ function createMocks({
 		ssoInboundAudiences,
 	});
 	const sourceRepo = mock<TrustedKeySourceRepository>();
-	const keyRepo = mock<TrustedKeyRepository>();
 	const instanceSettings = mock<InstanceSettings>({ isLeader });
 	const dbLockService = mock<DbLockService>();
 	const jwksResolverService = mock<JwksResolverService>();
@@ -96,11 +68,10 @@ function createMocks({
 
 	sourceRepo.find.mockResolvedValue([]);
 
-	const service = new TrustedKeyService(
+	const service = new TrustedKeySyncService(
 		mockLogger,
 		config,
 		sourceRepo,
-		keyRepo,
 		instanceSettings,
 		dbLockService,
 		jwksResolverService,
@@ -109,7 +80,6 @@ function createMocks({
 	return {
 		service,
 		config,
-		keyRepo,
 		sourceRepo,
 		dbLockService,
 		instanceSettings,
@@ -122,7 +92,7 @@ function createMocks({
 // Tests
 // ──────────────────────────────────────────────────────────────────────
 
-describe('TrustedKeyService', () => {
+describe('TrustedKeySyncService', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
@@ -130,68 +100,6 @@ describe('TrustedKeyService', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
-	});
-
-	describe('crypto cache', () => {
-		it('should reuse cached crypto key when keyMaterial is unchanged', async () => {
-			const { service, keyRepo } = createMocks();
-
-			const entity = makeTrustedKeyEntity();
-			keyRepo.findAllByKid.mockResolvedValue([entity]);
-
-			const result1 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-			const result2 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			// Same KeyObject instance (from cache)
-			expect(result1!.key).toBe(result2!.key);
-		});
-
-		it('should create new crypto key when keyMaterial changes', async () => {
-			const { service, keyRepo } = createMocks();
-
-			const entity1 = makeTrustedKeyEntity({
-				data: makeTrustedKeyData({ keyMaterial: RSA_PUBLIC_KEY }),
-			});
-			keyRepo.findAllByKid.mockResolvedValueOnce([entity1]);
-
-			const result1 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			// Change key material to EC key
-			const entity2 = makeTrustedKeyEntity({
-				data: makeTrustedKeyData({
-					keyMaterial: EC_PUBLIC_KEY,
-					algorithms: ['ES256'],
-				}),
-			});
-			keyRepo.findAllByKid.mockResolvedValueOnce([entity2]);
-
-			const result2 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			// Different KeyObject (cache miss due to hash mismatch)
-			expect(result1!.key).not.toBe(result2!.key);
-		});
-	});
-
-	describe('subjectClaim resolution', () => {
-		it('defaults subjectClaim to sub when the stored data omits it', async () => {
-			const { service, keyRepo } = createMocks();
-			keyRepo.findAllByKid.mockResolvedValue([makeTrustedKeyEntity()]);
-
-			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			expect(result!.subjectClaim).toBe('sub');
-		});
-
-		it('returns the configured subjectClaim when present in stored data', async () => {
-			const { service, keyRepo } = createMocks();
-			keyRepo.findAllByKid.mockResolvedValue([
-				makeTrustedKeyEntity({ data: makeTrustedKeyData({ subjectClaim: 'uid' }) }),
-			]);
-
-			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-
-			expect(result!.subjectClaim).toBe('uid');
-		});
 	});
 
 	describe('initialize', () => {

--- a/packages/cli/src/modules/identity-substrate/services/__tests__/trusted-key.service.test.ts
+++ b/packages/cli/src/modules/identity-substrate/services/__tests__/trusted-key.service.test.ts
@@ -1,0 +1,157 @@
+import type { Logger } from '@n8n/backend-common';
+import { mock } from 'vitest-mock-extended';
+
+import type { TrustedKeyData } from '@/modules/token-exchange/token-exchange.schemas';
+
+import { TrustedKeySourceEntity } from '../../database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '../../database/entities/trusted-key.entity';
+import type { TrustedKeySourceRepository } from '../../database/repositories/trusted-key-source.repository';
+import type { TrustedKeyRepository } from '../../database/repositories/trusted-key.repository';
+import { TrustedKeyService } from '../trusted-key.service';
+
+// ──────────────────────────────────────────────────────────────────────
+// Pre-generated PEM public keys (test-only, no secrets)
+// ──────────────────────────────────────────────────────────────────────
+
+const RSA_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1A5I3JA3ylWxNFZcNqp9
+qo3dhhO/7wAKUVH73Ryc/UWeHQPon5K+cVchPG2td4yg9llV6LDqurdI5wO1b1tg
+XZjky3Brbh6LISZNjQJr0YvhCVW7NU6jjqgrLqNVrPeAGP51h9ozSIHUm1UyWm2J
+wquhuvVhFlgaeHwA5HtBrYuwihEHJBJueIn9CiGYGwTModwT+WrhK5SxuXhtkD9w
+6SJrbXZIdOnTtAFxH0bn+OYriRD7SgEn5UWiVpXyaRNkKhiFpozK2U1MqtKLrWgC
+o6LNz3KqejtBEOT+/IbnbgIShhWcTuh8Ehw0EUtkOXdqykqoXuEtcoLj3c4efQ/n
+dQIDAQAB
+-----END PUBLIC KEY-----`;
+
+const EC_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpCuPN2BHQ7G0A2qD2Bd27bwwUB9M
+Npzv5WS/ygt55l8y2X+Vfm5TQFRMNkqEx+/GXaPIU/hDmtnBdCxAUIRM9g==
+-----END PUBLIC KEY-----`;
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────
+
+const mockLogger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
+
+function makeTrustedKeyData(overrides: Partial<TrustedKeyData> = {}): TrustedKeyData {
+	return {
+		algorithms: ['RS256'],
+		keyMaterial: RSA_PUBLIC_KEY,
+		issuer: 'https://issuer.example.com',
+		...overrides,
+	};
+}
+
+function makeTrustedKeyEntity(
+	overrides: Partial<{ sourceId: string; kid: string; data: TrustedKeyData }> = {},
+): TrustedKeyEntity {
+	const entity = new TrustedKeyEntity();
+	entity.sourceId = overrides.sourceId ?? 'static';
+	entity.kid = overrides.kid ?? 'test-kid';
+	entity.data = JSON.stringify(overrides.data ?? makeTrustedKeyData());
+	entity.createdAt = new Date();
+	return entity;
+}
+
+function createMocks() {
+	const sourceRepo = mock<TrustedKeySourceRepository>();
+	const keyRepo = mock<TrustedKeyRepository>();
+
+	const service = new TrustedKeyService(mockLogger, sourceRepo, keyRepo);
+
+	return { service, keyRepo, sourceRepo };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────
+
+describe('TrustedKeyService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('crypto cache', () => {
+		it('should reuse cached crypto key when keyMaterial is unchanged', async () => {
+			const { service, keyRepo } = createMocks();
+
+			const entity = makeTrustedKeyEntity();
+			keyRepo.findAllByKid.mockResolvedValue([entity]);
+
+			const result1 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+			const result2 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			// Same KeyObject instance (from cache)
+			expect(result1!.key).toBe(result2!.key);
+		});
+
+		it('should create new crypto key when keyMaterial changes', async () => {
+			const { service, keyRepo } = createMocks();
+
+			const entity1 = makeTrustedKeyEntity({
+				data: makeTrustedKeyData({ keyMaterial: RSA_PUBLIC_KEY }),
+			});
+			keyRepo.findAllByKid.mockResolvedValueOnce([entity1]);
+
+			const result1 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			// Change key material to EC key
+			const entity2 = makeTrustedKeyEntity({
+				data: makeTrustedKeyData({
+					keyMaterial: EC_PUBLIC_KEY,
+					algorithms: ['ES256'],
+				}),
+			});
+			keyRepo.findAllByKid.mockResolvedValueOnce([entity2]);
+
+			const result2 = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			// Different KeyObject (cache miss due to hash mismatch)
+			expect(result1!.key).not.toBe(result2!.key);
+		});
+	});
+
+	describe('subjectClaim resolution', () => {
+		it('defaults subjectClaim to sub when the stored data omits it', async () => {
+			const { service, keyRepo } = createMocks();
+			keyRepo.findAllByKid.mockResolvedValue([makeTrustedKeyEntity()]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			expect(result!.subjectClaim).toBe('sub');
+		});
+
+		it('returns the configured subjectClaim when present in stored data', async () => {
+			const { service, keyRepo } = createMocks();
+			keyRepo.findAllByKid.mockResolvedValue([
+				makeTrustedKeyEntity({ data: makeTrustedKeyData({ subjectClaim: 'uid' }) }),
+			]);
+
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+
+			expect(result!.subjectClaim).toBe('uid');
+		});
+	});
+
+	describe('isSsoIssuer', () => {
+		it('returns true when a sso-derived source matches the issuer', async () => {
+			const { service, sourceRepo } = createMocks();
+			sourceRepo.findOne.mockResolvedValue(
+				Object.assign(new TrustedKeySourceEntity(), { issuer: 'https://idp.example.com' }),
+			);
+
+			await expect(service.isSsoIssuer('https://idp.example.com')).resolves.toBe(true);
+			expect(sourceRepo.findOne).toHaveBeenCalledWith({
+				where: { issuer: 'https://idp.example.com', managedBy: 'sso-derived' },
+			});
+		});
+
+		it('returns false when no sso-derived source matches the issuer', async () => {
+			const { service, sourceRepo } = createMocks();
+			sourceRepo.findOne.mockResolvedValue(null);
+
+			await expect(service.isSsoIssuer('https://idp.example.com')).resolves.toBe(false);
+		});
+	});
+});

--- a/packages/cli/src/modules/identity-substrate/services/trusted-key-sync.service.ts
+++ b/packages/cli/src/modules/identity-substrate/services/trusted-key-sync.service.ts
@@ -7,31 +7,27 @@ import type { EntityManager } from '@n8n/typeorm';
 import { In, Not } from '@n8n/typeorm';
 import { InstanceSettings } from 'n8n-core';
 import { UnexpectedError, UserError, jsonParse } from 'n8n-workflow';
-import type { KeyObject } from 'node:crypto';
 import { createHash, createPublicKey } from 'node:crypto';
 import { z } from 'zod';
 
-import { TrustedKeySourceEntity } from '@/modules/identity-substrate/database/entities/trusted-key-source.entity';
-import { TrustedKeyEntity } from '@/modules/identity-substrate/database/entities/trusted-key.entity';
-import { TrustedKeySourceRepository } from '@/modules/identity-substrate/database/repositories/trusted-key-source.repository';
-import { TrustedKeyRepository } from '@/modules/identity-substrate/database/repositories/trusted-key.repository';
-import { JwksResolverService } from '@/modules/identity-substrate/services/jwks-resolver';
-
-import { TokenExchangeConfig } from '../token-exchange.config';
+import { TokenExchangeConfig } from '@/modules/token-exchange/token-exchange.config';
 import type {
 	JwksKeySource,
 	JwtAlgorithm,
-	ResolvedTrustedKey,
 	StaticKeySource,
 	TrustedKeyData,
 	TrustedKeySource,
 	TrustedKeySourcePolicy,
-} from '../token-exchange.schemas';
+} from '@/modules/token-exchange/token-exchange.schemas';
 import {
-	TrustedKeyDataSchema,
 	TrustedKeySourcePolicySchema,
 	TrustedKeySourceSchema,
-} from '../token-exchange.schemas';
+} from '@/modules/token-exchange/token-exchange.schemas';
+
+import { JwksResolverService } from './jwks-resolver';
+import { TrustedKeySourceEntity } from '../database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '../database/entities/trusted-key.entity';
+import { TrustedKeySourceRepository } from '../database/repositories/trusted-key-source.repository';
 
 type AlgorithmFamily = 'RSA' | 'EC' | 'EdDSA';
 
@@ -54,7 +50,7 @@ const STATIC_SOURCE_ID = 'static';
 const REFRESH_POLL_INTERVAL_MS = 30 * Time.seconds.toMilliseconds;
 
 /**
- * Manages trusted public keys for JWT signature verification.
+ * Syncs and refreshes trusted public key sources into the database.
  *
  * Every instance resolves all configured key sources (env-var static keys,
  * JWKS endpoints) and writes them to the database at startup. Concurrent
@@ -65,28 +61,21 @@ const REFRESH_POLL_INTERVAL_MS = 30 * Time.seconds.toMilliseconds;
  * keys available in the database, avoiding a multi-main startup race where
  * a follower could previously verify against an empty table.
  *
- * All instances read keys from the database on every lookup, so multi-instance
- * consistency is preserved. A local crypto-primitive cache avoids repeated
- * `createPublicKey()` calls when the underlying key material has not changed.
+ * Only ever instantiated where it matters (`main`) — see
+ * `TrustedKeyService` for the read-only lookups every instance type uses.
  */
 @Service()
-export class TrustedKeyService {
+export class TrustedKeySyncService {
 	private readonly logger: Logger;
 
 	private refreshInterval: NodeJS.Timeout | undefined;
 
 	private isShuttingDown = false;
 
-	private readonly cryptoCache = new Map<
-		string,
-		{ keyMaterialHash: string; cryptoKey: KeyObject }
-	>();
-
 	constructor(
 		logger: Logger,
 		private readonly config: TokenExchangeConfig,
 		private readonly trustedKeySourceRepository: TrustedKeySourceRepository,
-		private readonly trustedKeyRepository: TrustedKeyRepository,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly dbLockService: DbLockService,
 		private readonly jwksResolverService: JwksResolverService,
@@ -151,63 +140,6 @@ export class TrustedKeyService {
 		this.stopRefresh();
 	}
 
-	// ─── Public read path ──────────────────────────────────────────────
-
-	/**
-	 * Look up a resolved trusted key by its `kid` and `issuer`.
-	 *
-	 * Queries the database on every call (no stale reads). The local
-	 * crypto cache avoids repeated `createPublicKey()` calls when the
-	 * key material has not changed.
-	 */
-	async getByKidAndIss(kid: string, issuer: string): Promise<ResolvedTrustedKey | undefined> {
-		const entities = await this.trustedKeyRepository.findAllByKid(kid);
-		if (entities.length === 0) return undefined;
-
-		for (const entity of entities) {
-			let data: TrustedKeyData;
-			try {
-				const parsed = TrustedKeyDataSchema.safeParse(JSON.parse(entity.data));
-				if (!parsed.success) {
-					this.logger.warn('Skipping corrupted trusted key entity', {
-						kid,
-						sourceId: entity.sourceId,
-						error: parsed.error.message,
-					});
-					continue;
-				}
-				data = parsed.data;
-			} catch {
-				this.logger.warn('Skipping corrupted trusted key entity', {
-					kid,
-					sourceId: entity.sourceId,
-					error: 'invalid JSON',
-				});
-				continue;
-			}
-
-			if (data.issuer !== issuer) continue;
-
-			const cryptoKey = this.resolveCryptoKey(`${entity.sourceId}:${kid}`, data.keyMaterial);
-			if (!cryptoKey) continue;
-
-			return {
-				sourceId: entity.sourceId,
-				kid,
-				algorithms: data.algorithms,
-				key: cryptoKey,
-				issuer: data.issuer,
-				expectedAudience: data.expectedAudience,
-				inboundAudiences: data.inboundAudiences,
-				allowedRoles: data.allowedRoles,
-				requireVerifiedEmail: data.requireVerifiedEmail ?? true,
-				subjectClaim: data.subjectClaim ?? 'sub',
-			};
-		}
-
-		return undefined;
-	}
-
 	// ─── Public admin/diagnostic methods ───────────────────────────────
 
 	/**
@@ -220,14 +152,6 @@ export class TrustedKeyService {
 			throw new UnexpectedError(`Trusted key source not found: ${sourceId}`);
 		}
 		await this.refreshSourceInternal(source);
-	}
-
-	async listAll(): Promise<TrustedKeyEntity[]> {
-		return await this.trustedKeyRepository.find();
-	}
-
-	async listSources(): Promise<TrustedKeySourceEntity[]> {
-		return await this.trustedKeySourceRepository.find();
 	}
 
 	/**
@@ -292,46 +216,6 @@ export class TrustedKeyService {
 		}
 
 		return result.data;
-	}
-
-	async hasSingleTrustedIssuer(): Promise<boolean> {
-		const sources = await this.listAll();
-		const issuers = new Set<string>();
-
-		sources.forEach((entity) => {
-			try {
-				const parsed = TrustedKeyDataSchema.safeParse(JSON.parse(entity.data));
-				if (!parsed.success) {
-					this.logger.warn('Skipping corrupted trusted key entity', {
-						kid: entity.kid,
-						sourceId: entity.sourceId,
-						error: parsed.error.message,
-					});
-					return;
-				}
-				issuers.add(parsed.data.issuer);
-			} catch {
-				this.logger.warn('Skipping corrupted trusted key entity', {
-					kid: entity.kid,
-					sourceId: entity.sourceId,
-					error: 'invalid JSON',
-				});
-			}
-		});
-		return issuers.size === 1;
-	}
-
-	/**
-	 * Whether `issuer` is the instance's configured SSO provider — i.e. it
-	 * matches a `sso-derived` trusted key source (see
-	 * `registerSsoDerivedSource`). Indexed read only: no network, no crypto,
-	 * safe to call on every access.
-	 */
-	async isSsoIssuer(issuer: string): Promise<boolean> {
-		const source = await this.trustedKeySourceRepository.findOne({
-			where: { issuer, managedBy: 'sso-derived' },
-		});
-		return source !== null;
 	}
 
 	// ─── Private: source sync ──────────────────────────────────────────
@@ -799,29 +683,6 @@ export class TrustedKeyService {
 			throw new UnexpectedError(
 				`Trusted key "${kid}": key type "${keyType}" does not match algorithm family "${family}"`,
 			);
-		}
-	}
-
-	// ─── Private: crypto cache ─────────────────────────────────────────
-
-	private resolveCryptoKey(cacheKey: string, keyMaterial: string): KeyObject | undefined {
-		const hash = createHash('sha256').update(keyMaterial).digest('hex');
-		const cached = this.cryptoCache.get(cacheKey);
-
-		if (cached && cached.keyMaterialHash === hash) {
-			return cached.cryptoKey;
-		}
-
-		try {
-			const cryptoKey = createPublicKey(keyMaterial);
-			this.cryptoCache.set(cacheKey, { keyMaterialHash: hash, cryptoKey });
-			return cryptoKey;
-		} catch (error) {
-			this.logger.warn('Failed to parse key material from DB', {
-				cacheKey,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return undefined;
 		}
 	}
 }

--- a/packages/cli/src/modules/identity-substrate/services/trusted-key.service.ts
+++ b/packages/cli/src/modules/identity-substrate/services/trusted-key.service.ts
@@ -1,0 +1,173 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type { KeyObject } from 'node:crypto';
+import { createHash, createPublicKey } from 'node:crypto';
+
+import type {
+	ResolvedTrustedKey,
+	TrustedKeyData,
+} from '@/modules/token-exchange/token-exchange.schemas';
+import { TrustedKeyDataSchema } from '@/modules/token-exchange/token-exchange.schemas';
+
+import { TrustedKeySourceEntity } from '../database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '../database/entities/trusted-key.entity';
+import { TrustedKeySourceRepository } from '../database/repositories/trusted-key-source.repository';
+import { TrustedKeyRepository } from '../database/repositories/trusted-key.repository';
+
+/**
+ * Read-only lookups over trusted public keys for JWT signature verification.
+ *
+ * Every instance reads keys from the database on every lookup, so
+ * multi-instance consistency is preserved without any local write path here.
+ * A local crypto-primitive cache avoids repeated `createPublicKey()` calls
+ * when the underlying key material has not changed.
+ *
+ * Deliberately has no dependency on the write/refresh lifecycle (config,
+ * distributed lock, JWKS fetching, leader/shutdown hooks) - see
+ * `TrustedKeySyncService` for that half. This split lets every instance type
+ * (main, worker, webhook) resolve keys safely, while only `main` runs the
+ * sync/refresh machinery that populates the table.
+ */
+@Service()
+export class TrustedKeyService {
+	private readonly logger: Logger;
+
+	private readonly cryptoCache = new Map<
+		string,
+		{ keyMaterialHash: string; cryptoKey: KeyObject }
+	>();
+
+	constructor(
+		logger: Logger,
+		private readonly trustedKeySourceRepository: TrustedKeySourceRepository,
+		private readonly trustedKeyRepository: TrustedKeyRepository,
+	) {
+		this.logger = logger.scoped('token-exchange');
+	}
+
+	/**
+	 * Look up a resolved trusted key by its `kid` and `issuer`.
+	 *
+	 * Queries the database on every call (no stale reads). The local
+	 * crypto cache avoids repeated `createPublicKey()` calls when the
+	 * key material has not changed.
+	 */
+	async getByKidAndIss(kid: string, issuer: string): Promise<ResolvedTrustedKey | undefined> {
+		const entities = await this.trustedKeyRepository.findAllByKid(kid);
+		if (entities.length === 0) return undefined;
+
+		for (const entity of entities) {
+			let data: TrustedKeyData;
+			try {
+				const parsed = TrustedKeyDataSchema.safeParse(JSON.parse(entity.data));
+				if (!parsed.success) {
+					this.logger.warn('Skipping corrupted trusted key entity', {
+						kid,
+						sourceId: entity.sourceId,
+						error: parsed.error.message,
+					});
+					continue;
+				}
+				data = parsed.data;
+			} catch {
+				this.logger.warn('Skipping corrupted trusted key entity', {
+					kid,
+					sourceId: entity.sourceId,
+					error: 'invalid JSON',
+				});
+				continue;
+			}
+
+			if (data.issuer !== issuer) continue;
+
+			const cryptoKey = this.resolveCryptoKey(`${entity.sourceId}:${kid}`, data.keyMaterial);
+			if (!cryptoKey) continue;
+
+			return {
+				sourceId: entity.sourceId,
+				kid,
+				algorithms: data.algorithms,
+				key: cryptoKey,
+				issuer: data.issuer,
+				expectedAudience: data.expectedAudience,
+				inboundAudiences: data.inboundAudiences,
+				allowedRoles: data.allowedRoles,
+				requireVerifiedEmail: data.requireVerifiedEmail ?? true,
+				subjectClaim: data.subjectClaim ?? 'sub',
+			};
+		}
+
+		return undefined;
+	}
+
+	async listAll(): Promise<TrustedKeyEntity[]> {
+		return await this.trustedKeyRepository.find();
+	}
+
+	async listSources(): Promise<TrustedKeySourceEntity[]> {
+		return await this.trustedKeySourceRepository.find();
+	}
+
+	async hasSingleTrustedIssuer(): Promise<boolean> {
+		const sources = await this.listAll();
+		const issuers = new Set<string>();
+
+		sources.forEach((entity) => {
+			try {
+				const parsed = TrustedKeyDataSchema.safeParse(JSON.parse(entity.data));
+				if (!parsed.success) {
+					this.logger.warn('Skipping corrupted trusted key entity', {
+						kid: entity.kid,
+						sourceId: entity.sourceId,
+						error: parsed.error.message,
+					});
+					return;
+				}
+				issuers.add(parsed.data.issuer);
+			} catch {
+				this.logger.warn('Skipping corrupted trusted key entity', {
+					kid: entity.kid,
+					sourceId: entity.sourceId,
+					error: 'invalid JSON',
+				});
+			}
+		});
+		return issuers.size === 1;
+	}
+
+	/**
+	 * Whether `issuer` is the instance's configured SSO provider — i.e. it
+	 * matches a `sso-derived` trusted key source (see
+	 * `TrustedKeySyncService.registerSsoDerivedSource`). Indexed read only: no
+	 * network, no crypto, safe to call on every access.
+	 */
+	async isSsoIssuer(issuer: string): Promise<boolean> {
+		const source = await this.trustedKeySourceRepository.findOne({
+			where: { issuer, managedBy: 'sso-derived' },
+		});
+		return source !== null;
+	}
+
+	// ─── Private: crypto cache ─────────────────────────────────────────
+
+	private resolveCryptoKey(cacheKey: string, keyMaterial: string): KeyObject | undefined {
+		const hash = createHash('sha256').update(keyMaterial).digest('hex');
+		const cached = this.cryptoCache.get(cacheKey);
+
+		if (cached && cached.keyMaterialHash === hash) {
+			return cached.cryptoKey;
+		}
+
+		try {
+			const cryptoKey = createPublicKey(keyMaterial);
+			this.cryptoCache.set(cacheKey, { keyMaterialHash: hash, cryptoKey });
+			return cryptoKey;
+		} catch (error) {
+			this.logger.warn('Failed to parse key material from DB', {
+				cacheKey,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+}

--- a/packages/cli/src/modules/token-exchange/controllers/__tests__/trusted-key-source.controller.test.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/__tests__/trusted-key-source.controller.test.ts
@@ -4,13 +4,19 @@ import type { AuthenticatedRequest } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
 import type { TrustedKeySourceEntity } from '@/modules/identity-substrate/database/entities/trusted-key-source.entity';
+import type { TrustedKeySyncService } from '@/modules/identity-substrate/services/trusted-key-sync.service';
+import type { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
 
-import type { TrustedKeyService } from '../../services/trusted-key.service';
 import { TrustedKeySourceController } from '../trusted-key-source.controller';
 
 const trustedKeyService = mock<TrustedKeyService>();
+const trustedKeySyncService = mock<TrustedKeySyncService>();
 
-const controller = new TrustedKeySourceController(trustedKeyService, mock<Logger>());
+const controller = new TrustedKeySourceController(
+	trustedKeyService,
+	trustedKeySyncService,
+	mock<Logger>(),
+);
 
 describe('TrustedKeySourceController', () => {
 	beforeEach(() => {
@@ -182,7 +188,7 @@ describe('TrustedKeySourceController', () => {
 
 	describe('updateSource', () => {
 		it('applies the policy and returns the sanitized source', async () => {
-			trustedKeyService.updateSourcePolicy.mockResolvedValue(
+			trustedKeySyncService.updateSourcePolicy.mockResolvedValue(
 				mock<TrustedKeySourceEntity>({
 					id: 'jwks-1',
 					type: 'jwks',
@@ -205,14 +211,14 @@ describe('TrustedKeySourceController', () => {
 				{ policy: { inboundAudiences: ['api://n8n'] } } as UpdateTrustedKeySourceDto,
 			);
 
-			expect(trustedKeyService.updateSourcePolicy).toHaveBeenCalledWith('jwks-1', {
+			expect(trustedKeySyncService.updateSourcePolicy).toHaveBeenCalledWith('jwks-1', {
 				inboundAudiences: ['api://n8n'],
 			});
 			expect(result.policy).toEqual({ inboundAudiences: ['api://n8n'] });
 		});
 
 		it('never leaks key material in the response', async () => {
-			trustedKeyService.updateSourcePolicy.mockResolvedValue(
+			trustedKeySyncService.updateSourcePolicy.mockResolvedValue(
 				mock<TrustedKeySourceEntity>({
 					id: 'static',
 					type: 'static',

--- a/packages/cli/src/modules/token-exchange/controllers/trusted-key-source.controller.ts
+++ b/packages/cli/src/modules/token-exchange/controllers/trusted-key-source.controller.ts
@@ -10,8 +10,9 @@ import { Body, Get, GlobalScope, Licensed, Param, Patch, RestController } from '
 import { jsonParse } from 'n8n-workflow';
 
 import type { TrustedKeySourceEntity } from '@/modules/identity-substrate/database/entities/trusted-key-source.entity';
+import { TrustedKeySyncService } from '@/modules/identity-substrate/services/trusted-key-sync.service';
+import { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
 
-import { TrustedKeyService } from '../services/trusted-key.service';
 import type {
 	JwksKeySource,
 	StaticKeySource,
@@ -61,6 +62,7 @@ function sanitizeSource(source: TrustedKeySourceEntity): TrustedKeySource {
 export class TrustedKeySourceController {
 	constructor(
 		private readonly trustedKeyService: TrustedKeyService,
+		private readonly trustedKeySyncService: TrustedKeySyncService,
 		private readonly logger: Logger,
 	) {}
 
@@ -90,7 +92,7 @@ export class TrustedKeySourceController {
 		@Param('id') id: string,
 		@Body payload: UpdateTrustedKeySourceDto,
 	): Promise<TrustedKeySource> {
-		const updated = await this.trustedKeyService.updateSourcePolicy(id, payload.policy);
+		const updated = await this.trustedKeySyncService.updateSourcePolicy(id, payload.policy);
 
 		this.logger.info('Trusted key source policy updated', {
 			sourceId: id,

--- a/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
@@ -9,6 +9,7 @@ import {
 import { mock } from 'vitest-mock-extended';
 
 import type { EventService } from '@/events/event.service';
+import type { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
 import { IdentityBindingService } from '@/services/identity-binding.service';
 import type { RoleService } from '@/services/role.service';
 import type { UserService } from '@/services/user.service';
@@ -18,7 +19,6 @@ import { TokenExchangeAuthError } from '../../token-exchange.errors';
 import type { ExternalTokenClaims } from '../../token-exchange.schemas';
 import { TokenExchangeFailureReason } from '../../token-exchange.types';
 import { IdentityResolutionService, qualifiedProviderId } from '../identity-resolution.service';
-import type { TrustedKeyService } from '../trusted-key.service';
 
 const logger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
 const userRepository = mock<UserRepository>();

--- a/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/token-exchange.service.test.ts
@@ -7,6 +7,7 @@ import { mock } from 'vitest-mock-extended';
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { JtiStoreService } from '@/modules/identity-substrate/services/jti-store.service';
+import type { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
 import type { JwtService } from '@/services/jwt.service';
 
 import type { InboundAudienceService } from '../../context-establishment-hooks/inbound-audience.service';
@@ -15,7 +16,6 @@ import { TokenExchangeAuthError } from '../../token-exchange.errors';
 import type { ResolvedTrustedKey } from '../../token-exchange.schemas';
 import type { IdentityResolutionService } from '../identity-resolution.service';
 import { TokenExchangeService } from '../token-exchange.service';
-import type { TrustedKeyService } from '../trusted-key.service';
 
 const logger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
 const trustedKeyStore = mock<TrustedKeyService>();

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -5,6 +5,7 @@ import { GLOBAL_OWNER_ROLE_SLUG, isBuiltInRole } from '@n8n/permissions';
 import { createHash } from 'node:crypto';
 
 import { EventService } from '@/events/event.service';
+import { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
 import {
 	IdentityBindingService,
 	interpretEmailVerified,
@@ -22,7 +23,6 @@ import { TokenExchangeConfig } from '../token-exchange.config';
 import { TokenExchangeAuthError } from '../token-exchange.errors';
 import type { ExternalTokenClaims } from '../token-exchange.schemas';
 import { TokenExchangeFailureReason } from '../token-exchange.types';
-import { TrustedKeyService } from './trusted-key.service';
 
 type TokenContext = { kid?: string; issuer: string; requireVerifiedEmail?: boolean };
 

--- a/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/token-exchange.service.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import jwt from 'jsonwebtoken';
 
 import { JtiStoreService } from '@/modules/identity-substrate/services/jti-store.service';
+import { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
 import type {
 	ExternalTokenVerifier,
 	VerifiedClaimResult,
@@ -31,7 +32,6 @@ import {
 	type IssuedTokenResult,
 } from '../token-exchange.types';
 import { IdentityResolutionService } from './identity-resolution.service';
-import { TrustedKeyService } from './trusted-key.service';
 
 const MAX_TOKEN_LIFETIME_SECONDS = 60;
 const MIN_REMAINING_LIFETIME_SECONDS = 5;

--- a/packages/cli/src/modules/token-exchange/token-exchange.module.ts
+++ b/packages/cli/src/modules/token-exchange/token-exchange.module.ts
@@ -18,9 +18,11 @@ export class TokenExchangeModule implements ModuleInterface {
 			return;
 		}
 
-		const { TrustedKeyService } = await import('./services/trusted-key.service.js');
-		const trustedKeyService = Container.get(TrustedKeyService);
-		await trustedKeyService.initialize();
+		const { TrustedKeySyncService } = await import(
+			'@/modules/identity-substrate/services/trusted-key-sync.service.js'
+		);
+		const trustedKeySyncService = Container.get(TrustedKeySyncService);
+		await trustedKeySyncService.initialize();
 
 		// Let `sso-oidc` register itself as a trusted key source (from its OIDC
 		// discovery document) without this module importing it. Must run before
@@ -33,7 +35,7 @@ export class TokenExchangeModule implements ModuleInterface {
 		);
 		Container.get(TrustedKeySourceRegistrationProxy).registerProvider({
 			registerFromDiscovery: async (issuer, jwksUri) =>
-				await trustedKeyService.registerSsoDerivedSource(issuer, jwksUri),
+				await trustedKeySyncService.registerSsoDerivedSource(issuer, jwksUri),
 		});
 
 		// Register as the ExternalTokenVerifierProxy provider so other modules can verify without importing this one.

--- a/packages/cli/test/integration/identity-binding.service.test.ts
+++ b/packages/cli/test/integration/identity-binding.service.test.ts
@@ -2,12 +2,12 @@ import { testDb, testModules } from '@n8n/backend-test-utils';
 import { AuthIdentity, AuthIdentityRepository, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 
+import { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
 import { OidcService } from '@/modules/sso-oidc/oidc.service.ee';
 import {
 	IdentityResolutionService,
 	qualifiedProviderId,
 } from '@/modules/token-exchange/services/identity-resolution.service';
-import { TrustedKeyService } from '@/modules/token-exchange/services/trusted-key.service';
 
 import { createUser } from './shared/db/users';
 

--- a/packages/cli/test/integration/identity-substrate/trusted-key-sync.service.integration.test.ts
+++ b/packages/cli/test/integration/identity-substrate/trusted-key-sync.service.integration.test.ts
@@ -1,13 +1,11 @@
 import { mockInstance, testDb, testModules } from '@n8n/backend-test-utils';
 import { Container } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
-import type { KeyObject } from 'node:crypto';
 
 import type { TrustedKeySourceEntity } from '@/modules/identity-substrate/database/entities/trusted-key-source.entity';
-import { TrustedKeyEntity } from '@/modules/identity-substrate/database/entities/trusted-key.entity';
 import { TrustedKeySourceRepository } from '@/modules/identity-substrate/database/repositories/trusted-key-source.repository';
 import { TrustedKeyRepository } from '@/modules/identity-substrate/database/repositories/trusted-key.repository';
-import { TrustedKeyService } from '@/modules/token-exchange/services/trusted-key.service';
+import { TrustedKeySyncService } from '@/modules/identity-substrate/services/trusted-key-sync.service';
 import { TokenExchangeConfig } from '@/modules/token-exchange/token-exchange.config';
 import type { TrustedKeyData } from '@/modules/token-exchange/token-exchange.schemas';
 
@@ -58,15 +56,6 @@ function staticKeyEntry(
 	};
 }
 
-function makeTrustedKeyData(overrides: Partial<TrustedKeyData> = {}): TrustedKeyData {
-	return {
-		algorithms: ['RS256'],
-		keyMaterial: RSA_PUBLIC_KEY,
-		issuer: 'https://issuer.example.com',
-		...overrides,
-	};
-}
-
 async function insertSource(
 	overrides: Partial<TrustedKeySourceEntity> = {},
 ): Promise<TrustedKeySourceEntity> {
@@ -82,18 +71,6 @@ async function insertSource(
 	});
 }
 
-async function insertKey(
-	overrides: Partial<{ sourceId: string; kid: string; data: TrustedKeyData }> = {},
-): Promise<TrustedKeyEntity> {
-	const keyRepo = Container.get(TrustedKeyRepository);
-	const entity = new TrustedKeyEntity();
-	entity.sourceId = overrides.sourceId ?? 'static';
-	entity.kid = overrides.kid ?? 'test-kid';
-	entity.data = JSON.stringify(overrides.data ?? makeTrustedKeyData());
-	entity.createdAt = new Date();
-	return await keyRepo.save(entity);
-}
-
 // ──────────────────────────────────────────────────────────────────────
 // Setup / Teardown
 // ──────────────────────────────────────────────────────────────────────
@@ -103,17 +80,17 @@ const config = mockInstance(TokenExchangeConfig, {
 	keyRefreshIntervalSeconds: 300,
 });
 
-let service: TrustedKeyService;
+let service: TrustedKeySyncService;
 let sourceRepo: TrustedKeySourceRepository;
 let keyRepo: TrustedKeyRepository;
 let instanceSettings: InstanceSettings;
 
 beforeAll(async () => {
-	await testModules.loadModules(['identity-substrate', 'token-exchange']);
+	await testModules.loadModules(['identity-substrate']);
 	await testDb.init();
 
 	instanceSettings = Container.get(InstanceSettings);
-	service = Container.get(TrustedKeyService);
+	service = Container.get(TrustedKeySyncService);
 	sourceRepo = Container.get(TrustedKeySourceRepository);
 	keyRepo = Container.get(TrustedKeyRepository);
 });
@@ -139,7 +116,7 @@ afterAll(async () => {
 // Tests
 // ──────────────────────────────────────────────────────────────────────
 
-describe('TrustedKeyService (integration)', () => {
+describe('TrustedKeySyncService (integration)', () => {
 	describe('initialize', () => {
 		it('should sync sources to DB, refresh keys to healthy, and persist key data', async () => {
 			config.trustedKeys = JSON.stringify([
@@ -269,83 +246,6 @@ describe('TrustedKeyService (integration)', () => {
 		});
 	});
 
-	describe('getByKidAndIss', () => {
-		it('should find matching key, return undefined for wrong issuer and unknown kid', async () => {
-			await insertSource();
-			await insertKey();
-
-			// Matching kid + issuer
-			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
-			expect(result).toBeDefined();
-			expect(result!.kid).toBe('test-kid');
-			expect(result!.algorithms).toEqual(['RS256']);
-			expect(result!.issuer).toBe('https://issuer.example.com');
-			expect(result!.key).toBeDefined();
-			expect((result!.key as KeyObject).type).toBe('public');
-
-			// Wrong issuer
-			expect(
-				await service.getByKidAndIss('test-kid', 'https://other-issuer.example.com'),
-			).toBeUndefined();
-
-			// Unknown kid
-			expect(
-				await service.getByKidAndIss('unknown-kid', 'https://issuer.example.com'),
-			).toBeUndefined();
-		});
-
-		it('should skip corrupted entities and still resolve valid ones', async () => {
-			await insertSource();
-
-			// Corrupted JSON
-			const corruptedJson = new TrustedKeyEntity();
-			corruptedJson.sourceId = 'static';
-			corruptedJson.kid = 'bad-json-kid';
-			corruptedJson.data = 'not-valid-json';
-			corruptedJson.createdAt = new Date();
-			await keyRepo.save(corruptedJson);
-
-			// Invalid PEM
-			await insertKey({
-				kid: 'bad-pem-kid',
-				data: makeTrustedKeyData({ keyMaterial: 'not-a-pem' }),
-			});
-
-			// Valid key
-			await insertKey({ kid: 'good-kid' });
-
-			expect(
-				await service.getByKidAndIss('bad-json-kid', 'https://issuer.example.com'),
-			).toBeUndefined();
-			expect(
-				await service.getByKidAndIss('bad-pem-kid', 'https://issuer.example.com'),
-			).toBeUndefined();
-
-			const valid = await service.getByKidAndIss('good-kid', 'https://issuer.example.com');
-			expect(valid).toBeDefined();
-			expect(valid!.kid).toBe('good-kid');
-		});
-
-		it('should select the entity matching the requested issuer', async () => {
-			await insertSource({ id: 'source-a' });
-			await insertSource({ id: 'source-b' });
-			await insertKey({
-				sourceId: 'source-a',
-				kid: 'shared-kid',
-				data: makeTrustedKeyData({ issuer: 'https://issuer-a.com' }),
-			});
-			await insertKey({
-				sourceId: 'source-b',
-				kid: 'shared-kid',
-				data: makeTrustedKeyData({ issuer: 'https://issuer-b.com' }),
-			});
-
-			const result = await service.getByKidAndIss('shared-kid', 'https://issuer-b.com');
-			expect(result).toBeDefined();
-			expect(result!.issuer).toBe('https://issuer-b.com');
-		});
-	});
-
 	describe('refreshSource', () => {
 		it('should refresh keys and replace them on subsequent refresh', async () => {
 			const initialConfig = [staticKeyEntry({ kid: 'key-v1' }), staticKeyEntry({ kid: 'key-v2' })];
@@ -447,70 +347,6 @@ describe('TrustedKeyService (integration)', () => {
 			expect(source!.status).toBe('error');
 			expect(source!.lastError).toBeDefined();
 			expect(await keyRepo.find()).toHaveLength(0);
-		});
-	});
-
-	describe('listAll and listSources', () => {
-		it('should return all entities from the database', async () => {
-			await insertSource({ id: 'source-1' });
-			await insertSource({ id: 'source-2' });
-			await insertKey({ sourceId: 'source-1', kid: 'kid-1' });
-			await insertKey({ sourceId: 'source-1', kid: 'kid-2' });
-			await insertKey({ sourceId: 'source-2', kid: 'kid-3' });
-
-			expect(await service.listSources()).toHaveLength(2);
-			expect(await service.listAll()).toHaveLength(3);
-		});
-	});
-
-	describe('hasSingleTrustedIssuer', () => {
-		it('should return false when no keys are configured', async () => {
-			expect(await service.hasSingleTrustedIssuer()).toBe(false);
-		});
-
-		it('should return true when every key shares one issuer', async () => {
-			await insertSource();
-			await insertKey({
-				kid: 'kid-1',
-				data: makeTrustedKeyData({ issuer: 'https://only.example.com' }),
-			});
-			await insertKey({
-				kid: 'kid-2',
-				data: makeTrustedKeyData({ issuer: 'https://only.example.com' }),
-			});
-
-			expect(await service.hasSingleTrustedIssuer()).toBe(true);
-		});
-
-		it('should return false when keys span multiple issuers', async () => {
-			await insertSource();
-			await insertKey({
-				kid: 'kid-1',
-				data: makeTrustedKeyData({ issuer: 'https://a.example.com' }),
-			});
-			await insertKey({
-				kid: 'kid-2',
-				data: makeTrustedKeyData({ issuer: 'https://b.example.com' }),
-			});
-
-			expect(await service.hasSingleTrustedIssuer()).toBe(false);
-		});
-
-		it('should skip corrupted key rows when counting issuers', async () => {
-			await insertSource();
-			await insertKey({
-				kid: 'kid-1',
-				data: makeTrustedKeyData({ issuer: 'https://only.example.com' }),
-			});
-
-			const corrupted = new TrustedKeyEntity();
-			corrupted.sourceId = 'static';
-			corrupted.kid = 'kid-corrupt';
-			corrupted.data = 'not-json';
-			corrupted.createdAt = new Date();
-			await keyRepo.save(corrupted);
-
-			expect(await service.hasSingleTrustedIssuer()).toBe(true);
 		});
 	});
 });

--- a/packages/cli/test/integration/identity-substrate/trusted-key.service.integration.test.ts
+++ b/packages/cli/test/integration/identity-substrate/trusted-key.service.integration.test.ts
@@ -1,0 +1,256 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+import type { KeyObject } from 'node:crypto';
+
+import type { TrustedKeySourceEntity } from '@/modules/identity-substrate/database/entities/trusted-key-source.entity';
+import { TrustedKeyEntity } from '@/modules/identity-substrate/database/entities/trusted-key.entity';
+import { TrustedKeySourceRepository } from '@/modules/identity-substrate/database/repositories/trusted-key-source.repository';
+import { TrustedKeyRepository } from '@/modules/identity-substrate/database/repositories/trusted-key.repository';
+import { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
+import type { TrustedKeyData } from '@/modules/token-exchange/token-exchange.schemas';
+
+// ──────────────────────────────────────────────────────────────────────
+// Pre-generated PEM public keys (test-only, no secrets)
+// ──────────────────────────────────────────────────────────────────────
+
+const RSA_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1A5I3JA3ylWxNFZcNqp9
+qo3dhhO/7wAKUVH73Ryc/UWeHQPon5K+cVchPG2td4yg9llV6LDqurdI5wO1b1tg
+XZjky3Brbh6LISZNjQJr0YvhCVW7NU6jjqgrLqNVrPeAGP51h9ozSIHUm1UyWm2J
+wquhuvVhFlgaeHwA5HtBrYuwihEHJBJueIn9CiGYGwTModwT+WrhK5SxuXhtkD9w
+6SJrbXZIdOnTtAFxH0bn+OYriRD7SgEn5UWiVpXyaRNkKhiFpozK2U1MqtKLrWgC
+o6LNz3KqejtBEOT+/IbnbgIShhWcTuh8Ehw0EUtkOXdqykqoXuEtcoLj3c4efQ/n
+dQIDAQAB
+-----END PUBLIC KEY-----`;
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────
+
+function makeTrustedKeyData(overrides: Partial<TrustedKeyData> = {}): TrustedKeyData {
+	return {
+		algorithms: ['RS256'],
+		keyMaterial: RSA_PUBLIC_KEY,
+		issuer: 'https://issuer.example.com',
+		...overrides,
+	};
+}
+
+async function insertSource(
+	overrides: Partial<TrustedKeySourceEntity> = {},
+): Promise<TrustedKeySourceEntity> {
+	const sourceRepo = Container.get(TrustedKeySourceRepository);
+	return await sourceRepo.save({
+		id: 'static',
+		type: 'static' as const,
+		config: JSON.stringify([
+			{
+				type: 'static',
+				kid: 'test-kid',
+				algorithms: ['RS256'],
+				key: RSA_PUBLIC_KEY,
+				issuer: 'https://issuer.example.com',
+			},
+		]),
+		status: 'pending' as const,
+		lastError: null,
+		lastRefreshedAt: null,
+		...overrides,
+	});
+}
+
+async function insertKey(
+	overrides: Partial<{ sourceId: string; kid: string; data: TrustedKeyData }> = {},
+): Promise<TrustedKeyEntity> {
+	const keyRepo = Container.get(TrustedKeyRepository);
+	const entity = new TrustedKeyEntity();
+	entity.sourceId = overrides.sourceId ?? 'static';
+	entity.kid = overrides.kid ?? 'test-kid';
+	entity.data = JSON.stringify(overrides.data ?? makeTrustedKeyData());
+	entity.createdAt = new Date();
+	return await keyRepo.save(entity);
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Setup / Teardown
+// ──────────────────────────────────────────────────────────────────────
+
+let service: TrustedKeyService;
+let keyRepo: TrustedKeyRepository;
+
+beforeAll(async () => {
+	await testModules.loadModules(['identity-substrate']);
+	await testDb.init();
+
+	service = Container.get(TrustedKeyService);
+	keyRepo = Container.get(TrustedKeyRepository);
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['TrustedKeyEntity', 'TrustedKeySourceEntity']);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────
+
+describe('TrustedKeyService (integration)', () => {
+	describe('getByKidAndIss', () => {
+		it('should find matching key, return undefined for wrong issuer and unknown kid', async () => {
+			await insertSource();
+			await insertKey();
+
+			// Matching kid + issuer
+			const result = await service.getByKidAndIss('test-kid', 'https://issuer.example.com');
+			expect(result).toBeDefined();
+			expect(result!.kid).toBe('test-kid');
+			expect(result!.algorithms).toEqual(['RS256']);
+			expect(result!.issuer).toBe('https://issuer.example.com');
+			expect(result!.key).toBeDefined();
+			expect((result!.key as KeyObject).type).toBe('public');
+
+			// Wrong issuer
+			expect(
+				await service.getByKidAndIss('test-kid', 'https://other-issuer.example.com'),
+			).toBeUndefined();
+
+			// Unknown kid
+			expect(
+				await service.getByKidAndIss('unknown-kid', 'https://issuer.example.com'),
+			).toBeUndefined();
+		});
+
+		it('should skip corrupted entities and still resolve valid ones', async () => {
+			await insertSource();
+
+			// Corrupted JSON
+			const corruptedJson = new TrustedKeyEntity();
+			corruptedJson.sourceId = 'static';
+			corruptedJson.kid = 'bad-json-kid';
+			corruptedJson.data = 'not-valid-json';
+			corruptedJson.createdAt = new Date();
+			await keyRepo.save(corruptedJson);
+
+			// Invalid PEM
+			await insertKey({
+				kid: 'bad-pem-kid',
+				data: makeTrustedKeyData({ keyMaterial: 'not-a-pem' }),
+			});
+
+			// Valid key
+			await insertKey({ kid: 'good-kid' });
+
+			expect(
+				await service.getByKidAndIss('bad-json-kid', 'https://issuer.example.com'),
+			).toBeUndefined();
+			expect(
+				await service.getByKidAndIss('bad-pem-kid', 'https://issuer.example.com'),
+			).toBeUndefined();
+
+			const valid = await service.getByKidAndIss('good-kid', 'https://issuer.example.com');
+			expect(valid).toBeDefined();
+			expect(valid!.kid).toBe('good-kid');
+		});
+
+		it('should select the entity matching the requested issuer', async () => {
+			await insertSource({ id: 'source-a' });
+			await insertSource({ id: 'source-b' });
+			await insertKey({
+				sourceId: 'source-a',
+				kid: 'shared-kid',
+				data: makeTrustedKeyData({ issuer: 'https://issuer-a.com' }),
+			});
+			await insertKey({
+				sourceId: 'source-b',
+				kid: 'shared-kid',
+				data: makeTrustedKeyData({ issuer: 'https://issuer-b.com' }),
+			});
+
+			const result = await service.getByKidAndIss('shared-kid', 'https://issuer-b.com');
+			expect(result).toBeDefined();
+			expect(result!.issuer).toBe('https://issuer-b.com');
+		});
+	});
+
+	describe('listAll and listSources', () => {
+		it('should return all entities from the database', async () => {
+			await insertSource({ id: 'source-1' });
+			await insertSource({ id: 'source-2' });
+			await insertKey({ sourceId: 'source-1', kid: 'kid-1' });
+			await insertKey({ sourceId: 'source-1', kid: 'kid-2' });
+			await insertKey({ sourceId: 'source-2', kid: 'kid-3' });
+
+			expect(await service.listSources()).toHaveLength(2);
+			expect(await service.listAll()).toHaveLength(3);
+		});
+	});
+
+	describe('hasSingleTrustedIssuer', () => {
+		it('should return false when no keys are configured', async () => {
+			expect(await service.hasSingleTrustedIssuer()).toBe(false);
+		});
+
+		it('should return true when every key shares one issuer', async () => {
+			await insertSource();
+			await insertKey({
+				kid: 'kid-1',
+				data: makeTrustedKeyData({ issuer: 'https://only.example.com' }),
+			});
+			await insertKey({
+				kid: 'kid-2',
+				data: makeTrustedKeyData({ issuer: 'https://only.example.com' }),
+			});
+
+			expect(await service.hasSingleTrustedIssuer()).toBe(true);
+		});
+
+		it('should return false when keys span multiple issuers', async () => {
+			await insertSource();
+			await insertKey({
+				kid: 'kid-1',
+				data: makeTrustedKeyData({ issuer: 'https://a.example.com' }),
+			});
+			await insertKey({
+				kid: 'kid-2',
+				data: makeTrustedKeyData({ issuer: 'https://b.example.com' }),
+			});
+
+			expect(await service.hasSingleTrustedIssuer()).toBe(false);
+		});
+
+		it('should skip corrupted key rows when counting issuers', async () => {
+			await insertSource();
+			await insertKey({
+				kid: 'kid-1',
+				data: makeTrustedKeyData({ issuer: 'https://only.example.com' }),
+			});
+
+			const corrupted = new TrustedKeyEntity();
+			corrupted.sourceId = 'static';
+			corrupted.kid = 'kid-corrupt';
+			corrupted.data = 'not-json';
+			corrupted.createdAt = new Date();
+			await keyRepo.save(corrupted);
+
+			expect(await service.hasSingleTrustedIssuer()).toBe(true);
+		});
+	});
+
+	describe('isSsoIssuer', () => {
+		it('should return true only for sso-derived sources matching the issuer', async () => {
+			await insertSource({
+				id: 'sso-source',
+				managedBy: 'sso-derived',
+				issuer: 'https://idp.example.com',
+			});
+			await insertSource({ id: 'static', managedBy: 'env-config', issuer: null });
+
+			expect(await service.isSsoIssuer('https://idp.example.com')).toBe(true);
+			expect(await service.isSsoIssuer('https://issuer.example.com')).toBe(false);
+		});
+	});
+});

--- a/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
+++ b/packages/cli/test/integration/token-exchange/identity-resolution.service.test.ts
@@ -9,11 +9,11 @@ import {
 import { Container } from '@n8n/di';
 
 import { EventService } from '@/events/event.service';
+import { TrustedKeyService } from '@/modules/identity-substrate/services/trusted-key.service';
 import {
 	IdentityResolutionService,
 	qualifiedProviderId,
 } from '@/modules/token-exchange/services/identity-resolution.service';
-import { TrustedKeyService } from '@/modules/token-exchange/services/trusted-key.service';
 import { TokenExchangeConfig } from '@/modules/token-exchange/token-exchange.config';
 import type { ExternalTokenClaims } from '@/modules/token-exchange/token-exchange.schemas';
 import { EXTERNAL_IDENTITY_PASSWORD_PLACEHOLDER } from '@/services/identity-binding.service';

--- a/packages/cli/test/integration/token-exchange/token-exchange.controller.test.ts
+++ b/packages/cli/test/integration/token-exchange/token-exchange.controller.test.ts
@@ -5,8 +5,8 @@ import { generateKeyPairSync, randomUUID } from 'crypto';
 import jwt from 'jsonwebtoken';
 import { InstanceSettings } from 'n8n-core';
 
+import { TrustedKeySyncService } from '@/modules/identity-substrate/services/trusted-key-sync.service';
 import { qualifiedProviderId } from '@/modules/token-exchange/services/identity-resolution.service';
-import { TrustedKeyService } from '@/modules/token-exchange/services/trusted-key.service';
 import { TokenExchangeConfig } from '@/modules/token-exchange/token-exchange.config';
 import { TOKEN_EXCHANGE_GRANT_TYPE } from '@/modules/token-exchange/token-exchange.schemas';
 import {
@@ -77,7 +77,7 @@ let config: TokenExchangeConfig;
 let jwtService: JwtService;
 
 beforeAll(async () => {
-	// TrustedKeyService.initialize() only runs on the leader instance.
+	// TrustedKeySyncService.initialize() only runs on the leader instance.
 	const instanceSettings = Container.get(InstanceSettings);
 	Object.defineProperty(instanceSettings, 'isLeader', { value: true, configurable: true });
 
@@ -104,7 +104,7 @@ beforeAll(async () => {
 		},
 	]);
 
-	await Container.get(TrustedKeyService).initialize();
+	await Container.get(TrustedKeySyncService).initialize();
 
 	jwtService = Container.get(JwtService);
 });
@@ -123,11 +123,11 @@ beforeEach(async () => {
 	config.maxTokenTtl = 900;
 
 	// Re-initialize keys after truncation clears the trusted key tables.
-	await Container.get(TrustedKeyService).initialize();
+	await Container.get(TrustedKeySyncService).initialize();
 });
 
 afterEach(() => {
-	Container.get(TrustedKeyService).stopRefresh();
+	Container.get(TrustedKeySyncService).stopRefresh();
 });
 
 const postToken = (body: Record<string, string>) =>


### PR DESCRIPTION
## Summary

PR 2 of 5 splitting `token-exchange` into an identity substrate + consumer ([IAM-1181](https://linear.app/n8n/issue/IAM-1181)). Stacked on #35763.

`TrustedKeyService` bundled two lifecycles in one class:
- **Read-only lookups** (`getByKidAndIss`, `hasSingleTrustedIssuer`, `isSsoIssuer`, `listAll`, `listSources`) — safe on every instance type.
- **Write/refresh** (config parsing, DB sync, JWKS polling, leader/shutdown hooks) — only ever runs on `main`.

Splits these into `identity-substrate/services/trusted-key.service.ts` (read-only) and a new `trusted-key-sync.service.ts` (write/refresh). Every dependent (`identity-resolution.service.ts`, `token-exchange.service.ts`, `trusted-key-source.controller.ts`) now depends on the read-only class; `token-exchange.module.ts` calls `TrustedKeySyncService.initialize()`/`registerSsoDerivedSource()` for the write path.

Still no module-boundary change — both classes stay behind `token-exchange`'s main-only `init()`, so this is behaviorally a no-op.

## How to test

`pnpm test` and `pnpm test:sqlite` in `packages/cli` for the `identity-substrate`/`token-exchange`/`sso-oidc` suites.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1181

Stacked series — PR 2 of 5. Base for PR 3: `iam-1181-pr3-split-token-exchange-service`.