### PR TITLE
chore(core): Exempt trigger nodes from usableAsTool lint requirement (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/node-usable-as-tool.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/node-usable-as-tool.md
@@ -10,7 +10,10 @@
 
 Ensures your nodes declare whether they can be used as tools in AI workflows. This property helps n8n determine if your node is suitable for AI-assisted automation.
 
-Trigger nodes are exempt from the "must declare `usableAsTool`" requirement, and are additionally forbidden from setting `usableAsTool: true`: trigger nodes cannot be invoked as AI tools, and doing so gets them converted into a synthetic tool variant that pollutes the AI Agent's tool picker. A node is treated as a trigger if `description.group` includes `'trigger'`, or (as a fallback) its class name ends with `Trigger`.
+Two categories of node are exempt from the "must declare `usableAsTool`" requirement, and are additionally forbidden from setting `usableAsTool: true`, since doing so gets them converted into a synthetic tool variant that pollutes the AI Agent's tool picker even though they can't be meaningfully invoked as one:
+
+- **Trigger nodes** — cannot be invoked as AI tools. A node is treated as a trigger if `description.group` includes `'trigger'`, or (as a fallback) its class name ends with `Trigger`.
+- **AI-only nodes** — nodes with a non-`main` output (e.g. `NodeConnectionTypes.AiLanguageModel`, `AiMemory`, `AiEmbedding`) and no inputs. These are only usable through their AI connection type (e.g. plugged into an Agent as its memory or language model), not as a generic callable tool.
 
 ## Examples
 
@@ -43,6 +46,21 @@ export class MyTrigger implements INodeType {
 }
 ```
 
+```typescript
+export class MyMemory implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'My Memory',
+    name: 'myMemory',
+    version: 1,
+    inputs: [],
+    outputs: [NodeConnectionTypes.AiMemory],
+    // AI-only nodes must not opt into the AI tool picker
+    usableAsTool: true,
+    properties: [],
+  };
+}
+```
+
 ### ✅ Correct
 
 ```typescript
@@ -65,6 +83,19 @@ export class MyTrigger implements INodeType {
     name: 'myTrigger',
     group: ['trigger'],
     version: 1,
+    properties: [],
+  };
+}
+```
+
+```typescript
+export class MyMemory implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'My Memory',
+    name: 'myMemory',
+    version: 1,
+    inputs: [],
+    outputs: [NodeConnectionTypes.AiMemory],
     properties: [],
   };
 }

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/node-usable-as-tool.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/node-usable-as-tool.md
@@ -10,7 +10,7 @@
 
 Ensures your nodes declare whether they can be used as tools in AI workflows. This property helps n8n determine if your node is suitable for AI-assisted automation.
 
-Trigger nodes are exempt from this check, since they aren't invoked as tools. A node is treated as a trigger if `description.group` includes `'trigger'`, or (as a fallback) its class name ends with `Trigger`. A trigger node that legitimately supports tool usage can still set `usableAsTool: true` explicitly.
+Trigger nodes are exempt from the "must declare `usableAsTool`" requirement, and are additionally forbidden from setting `usableAsTool: true`: trigger nodes cannot be invoked as AI tools, and doing so gets them converted into a synthetic tool variant that pollutes the AI Agent's tool picker. A node is treated as a trigger if `description.group` includes `'trigger'`, or (as a fallback) its class name ends with `Trigger`.
 
 ## Examples
 
@@ -29,6 +29,20 @@ export class MyNode implements INodeType {
 }
 ```
 
+```typescript
+export class MyTrigger implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'My Trigger',
+    name: 'myTrigger',
+    group: ['trigger'],
+    version: 1,
+    // Trigger nodes must not opt into the AI tool picker
+    usableAsTool: true,
+    properties: [],
+  };
+}
+```
+
 ### ✅ Correct
 
 ```typescript
@@ -39,6 +53,18 @@ export class MyNode implements INodeType {
     group: ['input'],
     version: 1,
     usableAsTool: true,
+    properties: [],
+  };
+}
+```
+
+```typescript
+export class MyTrigger implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'My Trigger',
+    name: 'myTrigger',
+    group: ['trigger'],
+    version: 1,
     properties: [],
   };
 }

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/node-usable-as-tool.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/node-usable-as-tool.md
@@ -10,7 +10,7 @@
 
 Ensures your nodes declare whether they can be used as tools in AI workflows. This property helps n8n determine if your node is suitable for AI-assisted automation.
 
-Trigger nodes (class name ends with `Trigger`) are exempt from this check, since they aren't invoked as tools. A trigger node that legitimately supports tool usage can still set `usableAsTool: true` explicitly.
+Trigger nodes are exempt from this check, since they aren't invoked as tools. A node is treated as a trigger if `description.group` includes `'trigger'`, or (as a fallback) its class name ends with `Trigger`. A trigger node that legitimately supports tool usage can still set `usableAsTool: true` explicitly.
 
 ## Examples
 

--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/node-usable-as-tool.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/node-usable-as-tool.md
@@ -10,6 +10,8 @@
 
 Ensures your nodes declare whether they can be used as tools in AI workflows. This property helps n8n determine if your node is suitable for AI-assisted automation.
 
+Trigger nodes (class name ends with `Trigger`) are exempt from this check, since they aren't invoked as tools. A trigger node that legitimately supports tool usage can still set `usableAsTool: true` explicitly.
+
 ## Examples
 
 ### ❌ Incorrect

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.test.ts
@@ -51,25 +51,33 @@ export class RegularClass {
 }`;
 }
 
-function createTriggerNodeCode(usableAsTool?: boolean): string {
-	const usableAsToolProperty = usableAsTool === true ? ',\n\t\tusableAsTool: true' : '';
+function createTriggerNodeCode(
+	options: { className?: string; usableAsTool?: boolean } = {},
+): string {
+	const { className = 'TestTrigger', usableAsTool } = options;
+	const group = className.endsWith('Trigger') ? "['trigger']" : "['trigger', 'schedule']";
+
+	const properties = [
+		`displayName: '${className}'`,
+		`name: '${className.charAt(0).toLowerCase()}${className.slice(1)}'`,
+		`group: ${group}`,
+		'version: 1',
+		"description: 'A test trigger node'",
+		`defaults: { name: '${className}' }`,
+		'inputs: []',
+		"outputs: ['main']",
+		'properties: []',
+	];
+	if (usableAsTool) {
+		properties.push('usableAsTool: true');
+	}
 
 	return `
 import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
 
-export class TestTrigger implements INodeType {
+export class ${className} implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Test Trigger',
-		name: 'testTrigger',
-		group: ['trigger'],
-		version: 1,
-		description: 'A test trigger node',
-		defaults: {
-			name: 'Test Trigger',
-		},
-		inputs: [],
-		outputs: ['main'],
-		properties: []${usableAsToolProperty},
+		${properties.join(',\n\t\t')},
 	};
 }`;
 }
@@ -140,7 +148,11 @@ ruleTester.run('node-usable-as-tool', NodeUsableAsToolRule, {
 		},
 		{
 			name: 'trigger node (class name ends with Trigger) with usableAsTool set to true',
-			code: createTriggerNodeCode(true),
+			code: createTriggerNodeCode({ usableAsTool: true }),
+		},
+		{
+			name: "trigger node identified by group: ['trigger'] (class name does not end with Trigger) skips check",
+			code: createTriggerNodeCode({ className: 'TestCron' }),
 		},
 	],
 	invalid: [

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.test.ts
@@ -147,15 +147,21 @@ ruleTester.run('node-usable-as-tool', NodeUsableAsToolRule, {
 			code: createTriggerNodeCode(),
 		},
 		{
-			name: 'trigger node (class name ends with Trigger) with usableAsTool set to true',
-			code: createTriggerNodeCode({ usableAsTool: true }),
-		},
-		{
 			name: "trigger node identified by group: ['trigger'] (class name does not end with Trigger) skips check",
 			code: createTriggerNodeCode({ className: 'TestCron' }),
 		},
 	],
 	invalid: [
+		{
+			name: 'trigger node (class name ends with Trigger) with usableAsTool set to true is forbidden',
+			code: createTriggerNodeCode({ usableAsTool: true }),
+			errors: [{ messageId: 'triggerUsableAsTool' }],
+		},
+		{
+			name: "trigger node identified by group: ['trigger'] with usableAsTool set to true is forbidden",
+			code: createTriggerNodeCode({ className: 'TestCron', usableAsTool: true }),
+			errors: [{ messageId: 'triggerUsableAsTool' }],
+		},
 		{
 			name: 'node missing usableAsTool property',
 			code: createNodeCode('missing'),

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.test.ts
@@ -51,6 +51,29 @@ export class RegularClass {
 }`;
 }
 
+function createTriggerNodeCode(usableAsTool?: boolean): string {
+	const usableAsToolProperty = usableAsTool === true ? ',\n\t\tusableAsTool: true' : '';
+
+	return `
+import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
+
+export class TestTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Test Trigger',
+		name: 'testTrigger',
+		group: ['trigger'],
+		version: 1,
+		description: 'A test trigger node',
+		defaults: {
+			name: 'Test Trigger',
+		},
+		inputs: [],
+		outputs: ['main'],
+		properties: []${usableAsToolProperty},
+	};
+}`;
+}
+
 function createNodeCodeWithOutputsInputs(
 	outputs: string,
 	inputs: string,
@@ -110,6 +133,14 @@ ruleTester.run('node-usable-as-tool', NodeUsableAsToolRule, {
 		{
 			name: 'AI-only node: non-main string literal output and empty inputs skips usableAsTool check',
 			code: createNodeCodeWithOutputsInputs("['ai_agent']", '[]'),
+		},
+		{
+			name: 'trigger node (class name ends with Trigger) without usableAsTool skips check',
+			code: createTriggerNodeCode(),
+		},
+		{
+			name: 'trigger node (class name ends with Trigger) with usableAsTool set to true',
+			code: createTriggerNodeCode(true),
 		},
 	],
 	invalid: [

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.test.ts
@@ -128,18 +128,18 @@ ruleTester.run('node-usable-as-tool', NodeUsableAsToolRule, {
 			code: createNodeCode(undefined, false),
 		},
 		{
-			name: 'AI-only node: NodeConnectionTypes non-Main output and empty inputs skips usableAsTool check',
+			name: 'AI-only node: NodeConnectionTypes non-Main output and empty inputs does not require usableAsTool',
 			code: createNodeCodeWithOutputsInputs('[NodeConnectionTypes.AiAgent]', '[]'),
 		},
 		{
-			name: 'AI-only node: multiple non-Main NodeConnectionTypes outputs and empty inputs skips usableAsTool check',
+			name: 'AI-only node: multiple non-Main NodeConnectionTypes outputs and empty inputs does not require usableAsTool',
 			code: createNodeCodeWithOutputsInputs(
 				'[NodeConnectionTypes.AiAgent, NodeConnectionTypes.AiTool]',
 				'[]',
 			),
 		},
 		{
-			name: 'AI-only node: non-main string literal output and empty inputs skips usableAsTool check',
+			name: 'AI-only node: non-main string literal output and empty inputs does not require usableAsTool',
 			code: createNodeCodeWithOutputsInputs("['ai_agent']", '[]'),
 		},
 		{
@@ -161,6 +161,16 @@ ruleTester.run('node-usable-as-tool', NodeUsableAsToolRule, {
 			name: "trigger node identified by group: ['trigger'] with usableAsTool set to true is forbidden",
 			code: createTriggerNodeCode({ className: 'TestCron', usableAsTool: true }),
 			errors: [{ messageId: 'triggerUsableAsTool' }],
+		},
+		{
+			name: 'AI-only node: non-Main output and empty inputs with usableAsTool set to true is forbidden',
+			code: createNodeCodeWithOutputsInputs('[NodeConnectionTypes.AiAgent]', '[]', true),
+			errors: [{ messageId: 'aiOnlyUsableAsTool' }],
+		},
+		{
+			name: 'AI-only node: non-main string literal output and empty inputs with usableAsTool set to true is forbidden',
+			code: createNodeCodeWithOutputsInputs("['ai_agent']", '[]', true),
+			errors: [{ messageId: 'aiOnlyUsableAsTool' }],
 		},
 		{
 			name: 'node missing usableAsTool property',

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
@@ -28,6 +28,8 @@ export const NodeUsableAsToolRule = createRule({
 		messages: {
 			missingUsableAsTool:
 				'Node class should have usableAsTool property. When in doubt, set it to true.',
+			triggerUsableAsTool:
+				'Trigger nodes must not set usableAsTool: true. Trigger nodes cannot be invoked as AI tools and doing so pollutes the tool picker. Remove this property.',
 		},
 		fixable: 'code',
 		schema: [],
@@ -50,13 +52,23 @@ export const NodeUsableAsToolRule = createRule({
 					return;
 				}
 
+				const usableAsToolProperty = findObjectProperty(descriptionValue, 'usableAsTool');
+
 				// `group` is the authoritative signal (also catches e.g. Cron, Webhook, versioned
 				// `*TriggerV1` classes); the name suffix is kept as a fallback for dynamic `group` values.
 				if (hasTriggerGroup(descriptionValue) || isTriggerNodeClass(node)) {
+					if (
+						usableAsToolProperty?.value.type === TSESTree.AST_NODE_TYPES.Literal &&
+						usableAsToolProperty.value.value === true
+					) {
+						context.report({
+							node: usableAsToolProperty,
+							messageId: 'triggerUsableAsTool',
+						});
+					}
 					return;
 				}
 
-				const usableAsToolProperty = findObjectProperty(descriptionValue, 'usableAsTool');
 				const outputsProperty = findObjectProperty(descriptionValue, 'outputs');
 				const inputsProperty = findObjectProperty(descriptionValue, 'inputs');
 				if (

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
@@ -18,6 +18,10 @@ function hasTriggerGroup(descriptionValue: TSESTree.ObjectExpression): boolean {
 	);
 }
 
+function isSetToTrue(property: TSESTree.Property | null): property is TSESTree.Property {
+	return property?.value.type === TSESTree.AST_NODE_TYPES.Literal && property.value.value === true;
+}
+
 export const NodeUsableAsToolRule = createRule({
 	name: 'node-usable-as-tool',
 	meta: {
@@ -30,6 +34,8 @@ export const NodeUsableAsToolRule = createRule({
 				'Node class should have usableAsTool property. When in doubt, set it to true.',
 			triggerUsableAsTool:
 				'Trigger nodes must not set usableAsTool: true. Trigger nodes cannot be invoked as AI tools and doing so pollutes the tool picker. Remove this property.',
+			aiOnlyUsableAsTool:
+				'AI-only nodes (non-main output, no inputs) must not set usableAsTool: true. These nodes are only usable through their AI connection type, not as a generic tool, and doing so pollutes the tool picker. Remove this property.',
 		},
 		fixable: 'code',
 		schema: [],
@@ -57,10 +63,7 @@ export const NodeUsableAsToolRule = createRule({
 				// `group` is the authoritative signal (also catches e.g. Cron, Webhook, versioned
 				// `*TriggerV1` classes); the name suffix is kept as a fallback for dynamic `group` values.
 				if (hasTriggerGroup(descriptionValue) || isTriggerNodeClass(node)) {
-					if (
-						usableAsToolProperty?.value.type === TSESTree.AST_NODE_TYPES.Literal &&
-						usableAsToolProperty.value.value === true
-					) {
+					if (isSetToTrue(usableAsToolProperty)) {
 						context.report({
 							node: usableAsToolProperty,
 							messageId: 'triggerUsableAsTool',
@@ -88,6 +91,14 @@ export const NodeUsableAsToolRule = createRule({
 					});
 					const isEmptyInputs = inputsProperty?.value?.elements?.length === 0;
 					if (isAiOutput && isEmptyInputs) {
+						// These nodes are only ever consumed via their AI connection type (e.g. as an
+						// Agent's memory/language model), never invoked directly like a regular tool.
+						if (isSetToTrue(usableAsToolProperty)) {
+							context.report({
+								node: usableAsToolProperty,
+								messageId: 'aiOnlyUsableAsTool',
+							});
+						}
 						return;
 					}
 				}

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
@@ -5,8 +5,18 @@ import {
 	isTriggerNodeClass,
 	findClassProperty,
 	findObjectProperty,
+	findArrayLiteralProperty,
 	createRule,
 } from '../utils/index.js';
+
+function hasTriggerGroup(descriptionValue: TSESTree.ObjectExpression): boolean {
+	const groupArray = findArrayLiteralProperty(descriptionValue, 'group');
+	return (
+		groupArray?.elements.some(
+			(element) => element?.type === TSESTree.AST_NODE_TYPES.Literal && element.value === 'trigger',
+		) ?? false
+	);
+}
 
 export const NodeUsableAsToolRule = createRule({
 	name: 'node-usable-as-tool',
@@ -30,10 +40,6 @@ export const NodeUsableAsToolRule = createRule({
 					return;
 				}
 
-				if (isTriggerNodeClass(node)) {
-					return;
-				}
-
 				const descriptionProperty = findClassProperty(node, 'description');
 				if (!descriptionProperty) {
 					return;
@@ -41,6 +47,12 @@ export const NodeUsableAsToolRule = createRule({
 
 				const descriptionValue = descriptionProperty.value;
 				if (descriptionValue?.type !== TSESTree.AST_NODE_TYPES.ObjectExpression) {
+					return;
+				}
+
+				// `group` is the authoritative signal (also catches e.g. Cron, Webhook, versioned
+				// `*TriggerV1` classes); the name suffix is kept as a fallback for dynamic `group` values.
+				if (hasTriggerGroup(descriptionValue) || isTriggerNodeClass(node)) {
 					return;
 				}
 

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
@@ -2,6 +2,7 @@ import { TSESTree } from '@typescript-eslint/utils';
 
 import {
 	isNodeTypeClass,
+	isTriggerNodeClass,
 	findClassProperty,
 	findObjectProperty,
 	createRule,
@@ -26,6 +27,10 @@ export const NodeUsableAsToolRule = createRule({
 		return {
 			ClassDeclaration(node) {
 				if (!isNodeTypeClass(node)) {
+					return;
+				}
+
+				if (isTriggerNodeClass(node)) {
 					return;
 				}
 

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/node-usable-as-tool.ts
@@ -2,21 +2,11 @@ import { TSESTree } from '@typescript-eslint/utils';
 
 import {
 	isNodeTypeClass,
-	isTriggerNodeClass,
+	isTriggerNode,
 	findClassProperty,
 	findObjectProperty,
-	findArrayLiteralProperty,
 	createRule,
 } from '../utils/index.js';
-
-function hasTriggerGroup(descriptionValue: TSESTree.ObjectExpression): boolean {
-	const groupArray = findArrayLiteralProperty(descriptionValue, 'group');
-	return (
-		groupArray?.elements.some(
-			(element) => element?.type === TSESTree.AST_NODE_TYPES.Literal && element.value === 'trigger',
-		) ?? false
-	);
-}
 
 function isSetToTrue(property: TSESTree.Property | null): property is TSESTree.Property {
 	return property?.value.type === TSESTree.AST_NODE_TYPES.Literal && property.value.value === true;
@@ -60,9 +50,7 @@ export const NodeUsableAsToolRule = createRule({
 
 				const usableAsToolProperty = findObjectProperty(descriptionValue, 'usableAsTool');
 
-				// `group` is the authoritative signal (also catches e.g. Cron, Webhook, versioned
-				// `*TriggerV1` classes); the name suffix is kept as a fallback for dynamic `group` values.
-				if (hasTriggerGroup(descriptionValue) || isTriggerNodeClass(node)) {
+				if (isTriggerNode(node, descriptionValue)) {
 					if (isSetToTrue(usableAsToolProperty)) {
 						context.report({
 							node: usableAsToolProperty,

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/trigger-node-conventions.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/trigger-node-conventions.ts
@@ -2,6 +2,7 @@ import { TSESTree } from '@typescript-eslint/utils';
 
 import {
 	isNodeTypeClass,
+	isTriggerNodeClass,
 	findClassProperty,
 	findObjectProperty,
 	getStringLiteralValue,
@@ -37,7 +38,7 @@ export const TriggerNodeConventionsRule = createRule({
 					return;
 				}
 
-				if (!node.id?.name.endsWith('Trigger')) {
+				if (!isTriggerNodeClass(node)) {
 					return;
 				}
 

--- a/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
@@ -29,6 +29,11 @@ export function isCredentialTypeClass(node: TSESTree.ClassDeclaration): boolean 
 	return implementsInterface(node, 'ICredentialType');
 }
 
+/** Matches this plugin's convention for identifying trigger nodes: class name ends with `Trigger`. */
+export function isTriggerNodeClass(node: TSESTree.ClassDeclaration): boolean {
+	return node.id?.name.endsWith('Trigger') ?? false;
+}
+
 export function findClassProperty(
 	node: TSESTree.ClassDeclaration,
 	propertyName: string,

--- a/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/utils/ast-utils.ts
@@ -34,6 +34,27 @@ export function isTriggerNodeClass(node: TSESTree.ClassDeclaration): boolean {
 	return node.id?.name.endsWith('Trigger') ?? false;
 }
 
+function hasTriggerGroup(descriptionValue: TSESTree.ObjectExpression): boolean {
+	const groupArray = findArrayLiteralProperty(descriptionValue, 'group');
+	return (
+		groupArray?.elements.some(
+			(element) => element?.type === AST_NODE_TYPES.Literal && element.value === 'trigger',
+		) ?? false
+	);
+}
+
+/**
+ * `group` is the authoritative signal for "is this a trigger node" (also catches e.g. Cron,
+ * Webhook, versioned `*TriggerV1` classes); the name suffix is kept as a fallback for dynamic
+ * `group` values.
+ */
+export function isTriggerNode(
+	node: TSESTree.ClassDeclaration,
+	descriptionValue: TSESTree.ObjectExpression,
+): boolean {
+	return hasTriggerGroup(descriptionValue) || isTriggerNodeClass(node);
+}
+
 export function findClassProperty(
 	node: TSESTree.ClassDeclaration,
 	propertyName: string,


### PR DESCRIPTION
## Summary

The `@n8n/community-nodes/node-usable-as-tool` ESLint rule required every node class to declare a `usableAsTool` property, with only a narrow exemption for AI-only nodes (non-`main` output + empty inputs). Trigger nodes (class name ending in `Trigger`) were not exempted, even though they aren't invoked as AI tools — so every trigger node had to carry a `usableAsTool` property purely to satisfy the linter.

This PR:
- Adds a trigger-node exception to `node-usable-as-tool`, reusing this plugin's existing convention for identifying trigger nodes (class name ends with `Trigger`, as already used by `trigger-node-conventions`).
- Extracts that convention into a shared `isTriggerNodeClass` helper in `ast-utils.ts` and reuses it in both rules to avoid drift.
- Adds test cases covering trigger nodes with and without `usableAsTool`.
- Updates the rule's doc page to note the exception.

TLDR:
| Node type | Can set `usableAsTool: true`? | Required to declare it? |
|---|---|---|
| Regular action node (has `main` input/output) | Yes | Yes — lint errors if missing (autofixed to `true`) |
| Trigger node (`group: ['trigger']`, or class name ends in `Trigger`) | Forbidden | No — exempt |
| AI-only node (non-`main` output, empty `inputs` — e.g. memory, embeddings, language model providers) | Forbidden | No — exempt |

## How to test

From `packages/@n8n/eslint-plugin-community-nodes`:

```bash
pnpm test node-usable-as-tool.test.ts
pnpm test trigger-node-conventions.test.ts
```

Both suites pass, including the new trigger-node cases.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-2021/bug-node-usable-as-tool-lint-rule-false-positives-on-trigger-nodes

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

