### PR TITLE
chore(editor): Derive dev REST base URL from N8N_PORT (no-changelog)

### DIFF
--- a/.github/workflows/test-dev-server-smoke-reusable.yml
+++ b/.github/workflows/test-dev-server-smoke-reusable.yml
@@ -38,9 +38,10 @@ jobs:
         # correctly. cd-ing into the playwright package double-nests it.
         run: pnpm --filter=n8n-playwright test:dev-server-smoke --reporter=list
 
-      - name: Run dev-server smoke spec (backend on non-default port)
-        # Same spec, backend on 5699: verifies the dev frontend derives its
-        # backend URL from N8N_PORT instead of assuming 5678.
+      - name: Run dev-server smoke spec (non-default ports)
+        # Same spec, backend on 5699 and editor on 8082: verifies the dev
+        # frontend derives its backend URL from N8N_PORT and its own port
+        # from N8N_EDITOR_PORT instead of assuming 5678/8080.
         run: pnpm --filter=n8n-playwright test:dev-server-smoke:alt-port --reporter=list
 
       - name: Upload Failure Artifacts

--- a/.github/workflows/test-dev-server-smoke-reusable.yml
+++ b/.github/workflows/test-dev-server-smoke-reusable.yml
@@ -16,7 +16,7 @@ jobs:
   smoke:
     name: Dev-server smoke
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -36,15 +36,15 @@ jobs:
       # Both steps run from repo root so PLAYWRIGHT_BROWSERS_PATH (relative)
       # resolves correctly. cd-ing into the playwright package double-nests it.
       - name: Run dev-server smoke spec (non-default ports)
-        # Same spec, backend on 5699, editor on 8082, task-runner broker on
-        # 5701: verifies the dev frontend derives its backend URL from
-        # N8N_PORT and its own port from N8N_EDITOR_PORT instead of assuming
-        # 5678/8080. Runs FIRST, while nothing has ever listened on 5678, so
-        # a regression to the 5678 fallback fails with a connection error
-        # instead of being satisfied by a server leaked from the default run.
+        # Runs FIRST, while nothing has ever listened on 5678, so a regression
+        # to the 5678 fallback fails with a connection error instead of being
+        # satisfied by a server leaked from the default run. The broker moves
+        # too, so it cannot squat on 5679 for the run below.
         run: pnpm --filter=n8n-playwright test:dev-server-smoke:alt-port --reporter=list
 
       - name: Run dev-server smoke spec
+        # Always run: a flake above must not cost the default-port signal.
+        if: ${{ !cancelled() }}
         run: pnpm --filter=n8n-playwright test:dev-server-smoke --reporter=list
 
       - name: Upload Failure Artifacts

--- a/.github/workflows/test-dev-server-smoke-reusable.yml
+++ b/.github/workflows/test-dev-server-smoke-reusable.yml
@@ -38,6 +38,11 @@ jobs:
         # correctly. cd-ing into the playwright package double-nests it.
         run: pnpm --filter=n8n-playwright test:dev-server-smoke --reporter=list
 
+      - name: Run dev-server smoke spec (backend on non-default port)
+        # Same spec, backend on 5699: verifies the dev frontend derives its
+        # backend URL from N8N_PORT instead of assuming 5678.
+        run: pnpm --filter=n8n-playwright test:dev-server-smoke:alt-port --reporter=list
+
       - name: Upload Failure Artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/test-dev-server-smoke-reusable.yml
+++ b/.github/workflows/test-dev-server-smoke-reusable.yml
@@ -33,16 +33,19 @@ jobs:
       - name: Install Browsers
         run: pnpm turbo run install-browsers --filter=n8n-playwright
 
-      - name: Run dev-server smoke spec
-        # Run from repo root so PLAYWRIGHT_BROWSERS_PATH (relative) resolves
-        # correctly. cd-ing into the playwright package double-nests it.
-        run: pnpm --filter=n8n-playwright test:dev-server-smoke --reporter=list
-
+      # Both steps run from repo root so PLAYWRIGHT_BROWSERS_PATH (relative)
+      # resolves correctly. cd-ing into the playwright package double-nests it.
       - name: Run dev-server smoke spec (non-default ports)
-        # Same spec, backend on 5699 and editor on 8082: verifies the dev
-        # frontend derives its backend URL from N8N_PORT and its own port
-        # from N8N_EDITOR_PORT instead of assuming 5678/8080.
+        # Same spec, backend on 5699, editor on 8082, task-runner broker on
+        # 5701: verifies the dev frontend derives its backend URL from
+        # N8N_PORT and its own port from N8N_EDITOR_PORT instead of assuming
+        # 5678/8080. Runs FIRST, while nothing has ever listened on 5678, so
+        # a regression to the 5678 fallback fails with a connection error
+        # instead of being satisfied by a server leaked from the default run.
         run: pnpm --filter=n8n-playwright test:dev-server-smoke:alt-port --reporter=list
+
+      - name: Run dev-server smoke spec
+        run: pnpm --filter=n8n-playwright test:dev-server-smoke --reporter=list
 
       - name: Upload Failure Artifacts
         if: ${{ failure() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,16 @@ does not exist: it prints a notice and exits with code 0.
 Given the size of the code base and the number of modules, we recommend only watching the modules you're
 actively working on.
 
+The dev servers default to 5678 (backend) and 8080 (editor). Set `N8N_PORT` and
+`N8N_EDITOR_PORT` to relocate them, for example to run a second instance beside
+your main one. The editor derives its REST base URL from `N8N_PORT`, so pass it
+to both commands:
+
+```bash
+N8N_PORT=5699 pnpm dev:be
+N8N_PORT=5699 N8N_EDITOR_PORT=8082 pnpm dev:fe:editor
+```
+
 ### Basic Development Workflow Example (most used within n8n)
 
 If you're working on API and FE, a lot of team members run the following steps:

--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -18,7 +18,7 @@
     "lint:styles:fix": "stylelint \"src/**/*.{scss,sass,vue}\" --fix --cache",
     "format": "biome format --write . && prettier --write . --ignore-path ../../../.prettierignore",
     "format:check": "biome ci . && prettier --check . --ignore-path ../../../.prettierignore",
-    "serve": "cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 --strictPort dev",
+    "serve": "vite --host 0.0.0.0 --port 8080 --strictPort dev",
     "test": "vitest run",
     "test:changed": "janitor test-scoped",
     "test:dev": "vitest --silent=false"

--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -18,7 +18,7 @@
     "lint:styles:fix": "stylelint \"src/**/*.{scss,sass,vue}\" --fix --cache",
     "format": "biome format --write . && prettier --write . --ignore-path ../../../.prettierignore",
     "format:check": "biome ci . && prettier --check . --ignore-path ../../../.prettierignore",
-    "serve": "vite --host 0.0.0.0 --port 8080 --strictPort dev",
+    "serve": "vite dev",
     "test": "vitest run",
     "test:changed": "janitor test-scoped",
     "test:dev": "vitest --silent=false"

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -23,19 +23,12 @@ const { NODE_ENV } = process.env;
 
 // Dev backend URL. N8N_PORT (the backend's own listen-port var) moves both
 // the injected BASE_PATH and the REST base URL, so one var configures a
-// second instance running next to the default one. Dev-server only: in
-// builds VUE_APP_URL_BASE_API must stay unset so the app falls back to
-// window.BASE_PATH.
-const devBackendPort = process.env.N8N_PORT ?? '5678';
-if (NODE_ENV === 'development') {
-	process.env.VUE_APP_URL_BASE_API ??= `http://localhost:${devBackendPort}/`;
-}
+// second instance running next to the default one. `||` on purpose: an
+// explicitly empty env var must fall back like an unset one.
+const devBackendPort = process.env.N8N_PORT || '5678';
 
-// Fail fast on a malformed port rather than silently starting on 8080.
-const editorPort = Number(process.env.N8N_EDITOR_PORT ?? 8080);
-if (!Number.isInteger(editorPort) || editorPort < 1 || editorPort > 65535) {
-	throw new Error(`N8N_EDITOR_PORT must be a port number, got: ${process.env.N8N_EDITOR_PORT}`);
-}
+// The editor's own dev port; N8N_PORT above is where the backend lives.
+const editorPort = Number(process.env.N8N_EDITOR_PORT || '8080');
 
 const browsers = browserslist.loadConfig({ path: process.cwd() });
 
@@ -170,47 +163,70 @@ const plugins: UserConfig['plugins'] = [
 
 const target = browserslistToEsbuild(browsers);
 
-export default defineConfig({
-	server: {
-		host: '0.0.0.0',
-		// The editor's own dev port; N8N_PORT above is where the backend lives.
-		port: editorPort,
-		strictPort: true,
-	},
-	define: {
-		// This causes test to fail but is required for actually running it
-		// ...(NODE_ENV !== 'test' ? { 'global': 'globalThis' } : {}),
-		...(NODE_ENV === 'development' ? { 'process.env': {} } : {}),
-		BASE_PATH: `'${publicPath}'`,
-	},
-	plugins,
-	resolve: { alias, dedupe: singleInstanceDedupe },
-	base: publicPath,
-	envPrefix: ['VUE', 'N8N_ENV_FEAT'],
-	css: {
-		preprocessorMaxWorkers: 2,
-		preprocessorOptions: {
-			scss: {
-				additionalData: [
-					'',
-					'@use "@/app/css/_variables.scss" as *;',
-					'@use "@n8n/design-system/css/mixins" as mixins;',
-				].join('\n'),
+export default defineConfig(({ command, mode }) => {
+	// `vite dev` only. command/mode identify the dev server precisely where
+	// process.env.NODE_ENV can't: a shell-exported NODE_ENV would leak the
+	// localhost URL into builds (or silently skip it in dev), while build,
+	// preview (serve/production) and vitest (serve/test) all resolve to a
+	// different command/mode pair. Builds must keep VUE_APP_URL_BASE_API
+	// unset so the app falls back to window.BASE_PATH.
+	if (command === 'serve' && mode === 'development') {
+		// Fail fast on a malformed port rather than an obscure vite crash.
+		for (const [name, port] of [
+			['N8N_PORT', Number(devBackendPort)],
+			['N8N_EDITOR_PORT', editorPort],
+		] as const) {
+			if (!Number.isInteger(port) || port < 1 || port > 65535) {
+				throw new Error(`${name} must be a port number, got: ${process.env[name]}`);
+			}
+		}
+		// Truthiness check, not ??=: an explicitly empty value counts as unset.
+		if (!process.env.VUE_APP_URL_BASE_API) {
+			process.env.VUE_APP_URL_BASE_API = `http://localhost:${devBackendPort}/`;
+		}
+	}
+
+	return {
+		server: {
+			host: '0.0.0.0',
+			port: editorPort,
+			strictPort: true,
+		},
+		define: {
+			// This causes test to fail but is required for actually running it
+			// ...(NODE_ENV !== 'test' ? { 'global': 'globalThis' } : {}),
+			...(NODE_ENV === 'development' ? { 'process.env': {} } : {}),
+			BASE_PATH: `'${publicPath}'`,
+		},
+		plugins,
+		resolve: { alias, dedupe: singleInstanceDedupe },
+		base: publicPath,
+		envPrefix: ['VUE', 'N8N_ENV_FEAT'],
+		css: {
+			preprocessorMaxWorkers: 2,
+			preprocessorOptions: {
+				scss: {
+					additionalData: [
+						'',
+						'@use "@/app/css/_variables.scss" as *;',
+						'@use "@n8n/design-system/css/mixins" as mixins;',
+					].join('\n'),
+				},
 			},
 		},
-	},
-	build: {
-		minify: !!release,
-		// Coverage builds emit INLINE maps so browser V8 coverage carries the
-		// map in the script source and monocart resolves offsets back to src.
-		sourcemap: process.env.BUILD_WITH_COVERAGE === 'true' ? 'inline' : !!release,
-		target,
-	},
-	optimizeDeps: {
-		exclude: ['wa-sqlite'],
-		rolldownOptions: {},
-	},
-	worker: {
-		format: 'es',
-	},
+		build: {
+			minify: !!release,
+			// Coverage builds emit INLINE maps so browser V8 coverage carries the
+			// map in the script source and monocart resolves offsets back to src.
+			sourcemap: process.env.BUILD_WITH_COVERAGE === 'true' ? 'inline' : !!release,
+			target,
+		},
+		optimizeDeps: {
+			exclude: ['wa-sqlite'],
+			rolldownOptions: {},
+		},
+		worker: {
+			format: 'es',
+		},
+	};
 });

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -31,6 +31,12 @@ if (NODE_ENV === 'development') {
 	process.env.VUE_APP_URL_BASE_API ??= `http://localhost:${devBackendPort}/`;
 }
 
+// Fail fast on a malformed port rather than silently starting on 8080.
+const editorPort = Number(process.env.N8N_EDITOR_PORT ?? 8080);
+if (!Number.isInteger(editorPort) || editorPort < 1 || editorPort > 65535) {
+	throw new Error(`N8N_EDITOR_PORT must be a port number, got: ${process.env.N8N_EDITOR_PORT}`);
+}
+
 const browsers = browserslist.loadConfig({ path: process.cwd() });
 
 const packagesDir = resolve(__dirname, '..', '..');
@@ -168,7 +174,7 @@ export default defineConfig({
 	server: {
 		host: '0.0.0.0',
 		// The editor's own dev port; N8N_PORT above is where the backend lives.
-		port: Number(process.env.N8N_EDITOR_PORT ?? 8080),
+		port: editorPort,
 		strictPort: true,
 	},
 	define: {

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -21,6 +21,16 @@ const publicPath = process.env.VUE_APP_PUBLIC_PATH || '/';
 
 const { NODE_ENV } = process.env;
 
+// Dev backend URL. N8N_PORT (the backend's own listen-port var) moves both
+// the injected BASE_PATH and the REST base URL, so one var configures a
+// second instance running next to the default one. Dev-server only: in
+// builds VUE_APP_URL_BASE_API must stay unset so the app falls back to
+// window.BASE_PATH.
+const devBackendPort = process.env.N8N_PORT ?? '5678';
+if (NODE_ENV === 'development') {
+	process.env.VUE_APP_URL_BASE_API ??= `http://localhost:${devBackendPort}/`;
+}
+
 const browsers = browserslist.loadConfig({ path: process.cwd() });
 
 const packagesDir = resolve(__dirname, '..', '..');
@@ -96,7 +106,7 @@ const plugins: UserConfig['plugins'] = [
 			return ctx.server
 				? html
 						.replace('%CONFIG_TAGS%', '')
-						.replaceAll('/{{BASE_PATH}}', `//localhost:${process.env.N8N_PORT ?? '5678'}`)
+						.replaceAll('/{{BASE_PATH}}', `//localhost:${devBackendPort}`)
 						.replaceAll('/{{REST_ENDPOINT}}', '/rest')
 				: html;
 		},

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -165,6 +165,12 @@ const plugins: UserConfig['plugins'] = [
 const target = browserslistToEsbuild(browsers);
 
 export default defineConfig({
+	server: {
+		host: '0.0.0.0',
+		// The editor's own dev port; N8N_PORT above is where the backend lives.
+		port: Number(process.env.N8N_EDITOR_PORT ?? 8080),
+		strictPort: true,
+	},
 	define: {
 		// This causes test to fail but is required for actually running it
 		// ...(NODE_ENV !== 'test' ? { 'global': 'globalThis' } : {}),

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -16,19 +16,15 @@ import browserslist from 'browserslist';
 import { isLocaleFile, sendLocaleUpdate } from './vite/i18n-locales-hmr-helpers';
 import { nodePopularityPlugin } from './vite/vite-plugin-node-popularity.mjs';
 import { editorUiAliases } from './vite/aliases.mjs';
+import { DEFAULT_BACKEND_PORT, devServerPlugin, readDevPort } from './vite/dev-ports.mjs';
 
 const publicPath = process.env.VUE_APP_PUBLIC_PATH || '/';
 
 const { NODE_ENV } = process.env;
 
-// Dev backend URL. N8N_PORT (the backend's own listen-port var) moves both
-// the injected BASE_PATH and the REST base URL, so one var configures a
-// second instance running next to the default one. `||` on purpose: an
-// explicitly empty env var must fall back like an unset one.
-const devBackendPort = Number(process.env.N8N_PORT || '5678');
-
-// The editor's own dev port; N8N_PORT above is where the backend lives.
-const editorPort = Number(process.env.N8N_EDITOR_PORT || '8080');
+// Only reachable through the dev server (see the `ctx.server` guard below),
+// which `devServerPlugin` has already validated by the time it runs.
+const devBackendPort = readDevPort(process.env, 'N8N_PORT', DEFAULT_BACKEND_PORT);
 
 const browsers = browserslist.loadConfig({ path: process.cwd() });
 
@@ -43,6 +39,7 @@ const alias = editorUiAliases(__dirname, packagesDir);
 const { RELEASE: release } = process.env;
 
 const plugins: UserConfig['plugins'] = [
+	devServerPlugin(process.env),
 	nodePopularityPlugin(),
 	lucideIconsPlugin(),
 	icons({
@@ -163,70 +160,41 @@ const plugins: UserConfig['plugins'] = [
 
 const target = browserslistToEsbuild(browsers);
 
-export default defineConfig(({ command, mode }) => {
-	// `vite dev` only. command/mode identify the dev server precisely where
-	// process.env.NODE_ENV can't: a shell-exported NODE_ENV would leak the
-	// localhost URL into builds (or silently skip it in dev), while build,
-	// preview (serve/production) and vitest (serve/test) all resolve to a
-	// different command/mode pair. Builds must keep VUE_APP_URL_BASE_API
-	// unset so the app falls back to window.BASE_PATH.
-	if (command === 'serve' && mode === 'development') {
-		// Fail fast on a malformed port rather than an obscure vite crash.
-		for (const [name, port] of [
-			['N8N_PORT', devBackendPort],
-			['N8N_EDITOR_PORT', editorPort],
-		] as const) {
-			if (!Number.isInteger(port) || port < 1 || port > 65535) {
-				throw new Error(`${name} must be a port number, got: ${process.env[name]}`);
-			}
-		}
-		// Truthiness check, not ??=: an explicitly empty value counts as unset.
-		if (!process.env.VUE_APP_URL_BASE_API) {
-			process.env.VUE_APP_URL_BASE_API = `http://localhost:${devBackendPort}/`;
-		}
-	}
-
-	return {
-		server: {
-			host: '0.0.0.0',
-			port: editorPort,
-			strictPort: true,
-		},
-		define: {
-			// This causes test to fail but is required for actually running it
-			// ...(NODE_ENV !== 'test' ? { 'global': 'globalThis' } : {}),
-			...(NODE_ENV === 'development' ? { 'process.env': {} } : {}),
-			BASE_PATH: `'${publicPath}'`,
-		},
-		plugins,
-		resolve: { alias, dedupe: singleInstanceDedupe },
-		base: publicPath,
-		envPrefix: ['VUE', 'N8N_ENV_FEAT'],
-		css: {
-			preprocessorMaxWorkers: 2,
-			preprocessorOptions: {
-				scss: {
-					additionalData: [
-						'',
-						'@use "@/app/css/_variables.scss" as *;',
-						'@use "@n8n/design-system/css/mixins" as mixins;',
-					].join('\n'),
-				},
+export default defineConfig({
+	define: {
+		// This causes test to fail but is required for actually running it
+		// ...(NODE_ENV !== 'test' ? { 'global': 'globalThis' } : {}),
+		...(NODE_ENV === 'development' ? { 'process.env': {} } : {}),
+		BASE_PATH: `'${publicPath}'`,
+	},
+	plugins,
+	resolve: { alias, dedupe: singleInstanceDedupe },
+	base: publicPath,
+	envPrefix: ['VUE', 'N8N_ENV_FEAT'],
+	css: {
+		preprocessorMaxWorkers: 2,
+		preprocessorOptions: {
+			scss: {
+				additionalData: [
+					'',
+					'@use "@/app/css/_variables.scss" as *;',
+					'@use "@n8n/design-system/css/mixins" as mixins;',
+				].join('\n'),
 			},
 		},
-		build: {
-			minify: !!release,
-			// Coverage builds emit INLINE maps so browser V8 coverage carries the
-			// map in the script source and monocart resolves offsets back to src.
-			sourcemap: process.env.BUILD_WITH_COVERAGE === 'true' ? 'inline' : !!release,
-			target,
-		},
-		optimizeDeps: {
-			exclude: ['wa-sqlite'],
-			rolldownOptions: {},
-		},
-		worker: {
-			format: 'es',
-		},
-	};
+	},
+	build: {
+		minify: !!release,
+		// Coverage builds emit INLINE maps so browser V8 coverage carries the
+		// map in the script source and monocart resolves offsets back to src.
+		sourcemap: process.env.BUILD_WITH_COVERAGE === 'true' ? 'inline' : !!release,
+		target,
+	},
+	optimizeDeps: {
+		exclude: ['wa-sqlite'],
+		rolldownOptions: {},
+	},
+	worker: {
+		format: 'es',
+	},
 });

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -25,7 +25,7 @@ const { NODE_ENV } = process.env;
 // the injected BASE_PATH and the REST base URL, so one var configures a
 // second instance running next to the default one. `||` on purpose: an
 // explicitly empty env var must fall back like an unset one.
-const devBackendPort = process.env.N8N_PORT || '5678';
+const devBackendPort = Number(process.env.N8N_PORT || '5678');
 
 // The editor's own dev port; N8N_PORT above is where the backend lives.
 const editorPort = Number(process.env.N8N_EDITOR_PORT || '8080');
@@ -173,7 +173,7 @@ export default defineConfig(({ command, mode }) => {
 	if (command === 'serve' && mode === 'development') {
 		// Fail fast on a malformed port rather than an obscure vite crash.
 		for (const [name, port] of [
-			['N8N_PORT', Number(devBackendPort)],
+			['N8N_PORT', devBackendPort],
 			['N8N_EDITOR_PORT', editorPort],
 		] as const) {
 			if (!Number.isInteger(port) || port < 1 || port > 65535) {

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -29,6 +29,12 @@ if (NODE_ENV === 'development') {
 	process.env.VUE_APP_URL_BASE_API ??= `http://localhost:${devBackendPort}/`;
 }
 
+// Fail fast on a malformed port rather than silently starting on 8080.
+const editorPort = Number(process.env.N8N_EDITOR_PORT ?? 8080);
+if (!Number.isInteger(editorPort) || editorPort < 1 || editorPort > 65535) {
+	throw new Error(`N8N_EDITOR_PORT must be a port number, got: ${process.env.N8N_EDITOR_PORT}`);
+}
+
 const browsers = browserslist.loadConfig({ path: process.cwd() });
 
 const packagesDir = resolve(__dirname, '..', '..');
@@ -240,7 +246,7 @@ export default mergeConfig(
 		server: {
 			host: '0.0.0.0',
 			// The editor's own dev port; N8N_PORT above is where the backend lives.
-			port: Number(process.env.N8N_EDITOR_PORT ?? 8080),
+			port: editorPort,
 			strictPort: true,
 		},
 		define: {

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -23,7 +23,7 @@ const { NODE_ENV } = process.env;
 // the injected BASE_PATH and the REST base URL, so one var configures a
 // second instance running next to the default one. `||` on purpose: an
 // explicitly empty env var must fall back like an unset one.
-const devBackendPort = process.env.N8N_PORT || '5678';
+const devBackendPort = Number(process.env.N8N_PORT || '5678');
 
 // The editor's own dev port; N8N_PORT above is where the backend lives.
 const editorPort = Number(process.env.N8N_EDITOR_PORT || '8080');
@@ -244,7 +244,7 @@ export default defineConfig(({ command, mode }) => {
 	if (command === 'serve' && mode === 'development') {
 		// Fail fast on a malformed port rather than an obscure vite crash.
 		for (const [name, port] of [
-			['N8N_PORT', Number(devBackendPort)],
+			['N8N_PORT', devBackendPort],
 			['N8N_EDITOR_PORT', editorPort],
 		] as const) {
 			if (!Number.isInteger(port) || port < 1 || port > 65535) {

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -19,6 +19,16 @@ const publicPath = process.env.VUE_APP_PUBLIC_PATH || '/';
 
 const { NODE_ENV } = process.env;
 
+// Dev backend URL. N8N_PORT (the backend's own listen-port var) moves both
+// the injected BASE_PATH and the REST base URL, so one var configures a
+// second instance running next to the default one. Dev-server only: in
+// builds VUE_APP_URL_BASE_API must stay unset so the app falls back to
+// window.BASE_PATH.
+const devBackendPort = process.env.N8N_PORT ?? '5678';
+if (NODE_ENV === 'development') {
+	process.env.VUE_APP_URL_BASE_API ??= `http://localhost:${devBackendPort}/`;
+}
+
 const browsers = browserslist.loadConfig({ path: process.cwd() });
 
 const packagesDir = resolve(__dirname, '..', '..');
@@ -167,7 +177,7 @@ const plugins: UserConfig['plugins'] = [
 			return ctx.server
 				? html
 						.replace('%CONFIG_TAGS%', '')
-						.replaceAll('/{{BASE_PATH}}', `//localhost:${process.env.N8N_PORT ?? '5678'}`)
+						.replaceAll('/{{BASE_PATH}}', `//localhost:${devBackendPort}`)
 						.replaceAll('/{{REST_ENDPOINT}}', '/rest')
 				: html;
 		},

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -21,19 +21,12 @@ const { NODE_ENV } = process.env;
 
 // Dev backend URL. N8N_PORT (the backend's own listen-port var) moves both
 // the injected BASE_PATH and the REST base URL, so one var configures a
-// second instance running next to the default one. Dev-server only: in
-// builds VUE_APP_URL_BASE_API must stay unset so the app falls back to
-// window.BASE_PATH.
-const devBackendPort = process.env.N8N_PORT ?? '5678';
-if (NODE_ENV === 'development') {
-	process.env.VUE_APP_URL_BASE_API ??= `http://localhost:${devBackendPort}/`;
-}
+// second instance running next to the default one. `||` on purpose: an
+// explicitly empty env var must fall back like an unset one.
+const devBackendPort = process.env.N8N_PORT || '5678';
 
-// Fail fast on a malformed port rather than silently starting on 8080.
-const editorPort = Number(process.env.N8N_EDITOR_PORT ?? 8080);
-if (!Number.isInteger(editorPort) || editorPort < 1 || editorPort > 65535) {
-	throw new Error(`N8N_EDITOR_PORT must be a port number, got: ${process.env.N8N_EDITOR_PORT}`);
-}
+// The editor's own dev port; N8N_PORT above is where the backend lives.
+const editorPort = Number(process.env.N8N_EDITOR_PORT || '8080');
 
 const browsers = browserslist.loadConfig({ path: process.cwd() });
 
@@ -241,50 +234,73 @@ const plugins: UserConfig['plugins'] = [
 
 const target = browserslistToEsbuild(browsers);
 
-export default mergeConfig(
-	defineConfig({
-		server: {
-			host: '0.0.0.0',
-			// The editor's own dev port; N8N_PORT above is where the backend lives.
-			port: editorPort,
-			strictPort: true,
-		},
-		define: {
-			// This causes test to fail but is required for actually running it
-			// ...(NODE_ENV !== 'test' ? { 'global': 'globalThis' } : {}),
-			...(NODE_ENV === 'development' ? { 'process.env': {} } : {}),
-			BASE_PATH: `'${publicPath}'`,
-		},
-		plugins,
-		resolve: { alias },
-		base: publicPath,
-		envPrefix: ['VUE', 'N8N_ENV_FEAT'],
-		css: {
-			preprocessorMaxWorkers: 2,
-			preprocessorOptions: {
-				scss: {
-					additionalData: [
-						'',
-						'@use "@/app/css/_variables.scss" as *;',
-						'@use "@n8n/design-system/css/mixins" as mixins;',
-					].join('\n'),
+export default defineConfig(({ command, mode }) => {
+	// `vite dev` only. command/mode identify the dev server precisely where
+	// process.env.NODE_ENV can't: a shell-exported NODE_ENV would leak the
+	// localhost URL into builds (or silently skip it in dev), while build,
+	// preview (serve/production) and vitest (serve/test) all resolve to a
+	// different command/mode pair. Builds must keep VUE_APP_URL_BASE_API
+	// unset so the app falls back to window.BASE_PATH.
+	if (command === 'serve' && mode === 'development') {
+		// Fail fast on a malformed port rather than an obscure vite crash.
+		for (const [name, port] of [
+			['N8N_PORT', Number(devBackendPort)],
+			['N8N_EDITOR_PORT', editorPort],
+		] as const) {
+			if (!Number.isInteger(port) || port < 1 || port > 65535) {
+				throw new Error(`${name} must be a port number, got: ${process.env[name]}`);
+			}
+		}
+		// Truthiness check, not ??=: an explicitly empty value counts as unset.
+		if (!process.env.VUE_APP_URL_BASE_API) {
+			process.env.VUE_APP_URL_BASE_API = `http://localhost:${devBackendPort}/`;
+		}
+	}
+
+	return mergeConfig(
+		{
+			server: {
+				host: '0.0.0.0',
+				port: editorPort,
+				strictPort: true,
+			},
+			define: {
+				// This causes test to fail but is required for actually running it
+				// ...(NODE_ENV !== 'test' ? { 'global': 'globalThis' } : {}),
+				...(NODE_ENV === 'development' ? { 'process.env': {} } : {}),
+				BASE_PATH: `'${publicPath}'`,
+			},
+			plugins,
+			resolve: { alias },
+			base: publicPath,
+			envPrefix: ['VUE', 'N8N_ENV_FEAT'],
+			css: {
+				preprocessorMaxWorkers: 2,
+				preprocessorOptions: {
+					scss: {
+						additionalData: [
+							'',
+							'@use "@/app/css/_variables.scss" as *;',
+							'@use "@n8n/design-system/css/mixins" as mixins;',
+						].join('\n'),
+					},
 				},
 			},
+			build: {
+				minify: !!release,
+				// Coverage builds emit INLINE maps so browser V8 coverage carries the
+				// map in the script source and monocart resolves offsets back to src.
+				sourcemap: process.env.BUILD_WITH_COVERAGE === 'true' ? 'inline' : !!release,
+				target,
+			},
+			optimizeDeps: {
+				exclude: ['wa-sqlite'],
+				rolldownOptions: {},
+			},
+			worker: {
+				format: 'es',
+			},
 		},
-		build: {
-			minify: !!release,
-			// Coverage builds emit INLINE maps so browser V8 coverage carries the
-			// map in the script source and monocart resolves offsets back to src.
-			sourcemap: process.env.BUILD_WITH_COVERAGE === 'true' ? 'inline' : !!release,
-			target,
-		},
-		optimizeDeps: {
-			exclude: ['wa-sqlite'],
-			rolldownOptions: {},
-		},
-		worker: {
-			format: 'es',
-		},
-	}),
-	vitestConfig,
-);
+		vitestConfig,
+	);
+});

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -237,6 +237,12 @@ const target = browserslistToEsbuild(browsers);
 
 export default mergeConfig(
 	defineConfig({
+		server: {
+			host: '0.0.0.0',
+			// The editor's own dev port; N8N_PORT above is where the backend lives.
+			port: Number(process.env.N8N_EDITOR_PORT ?? 8080),
+			strictPort: true,
+		},
 		define: {
 			// This causes test to fail but is required for actually running it
 			// ...(NODE_ENV !== 'test' ? { 'global': 'globalThis' } : {}),

--- a/packages/frontend/editor-ui/vite/dev-ports.mts
+++ b/packages/frontend/editor-ui/vite/dev-ports.mts
@@ -1,0 +1,55 @@
+import type { Plugin } from 'vite';
+
+export const DEFAULT_BACKEND_PORT = 5678;
+export const DEFAULT_EDITOR_PORT = 8080;
+
+// `||` not `??`: an explicitly empty env var must fall back like an unset one.
+export const readDevPort = (env: NodeJS.ProcessEnv, name: string, fallback: number): number =>
+	Number(env[name] || fallback);
+
+const assertDevPort = (env: NodeJS.ProcessEnv, name: string, fallback: number): number => {
+	const port = readDevPort(env, name, fallback);
+	// Vite silently boots on its own default 5173 when handed NaN, so an
+	// unvalidated typo surfaces as a connection timeout minutes later.
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		throw new Error(`${name} must be a port number, got: ${env[name]}`);
+	}
+	return port;
+};
+
+/**
+ * N8N_PORT is the backend's own listen-port var. It moves both the injected
+ * BASE_PATH and the REST base URL, so the pair relocates a whole dev instance
+ * next to the default one.
+ */
+export const resolveDevPorts = (env: NodeJS.ProcessEnv) => ({
+	backendPort: assertDevPort(env, 'N8N_PORT', DEFAULT_BACKEND_PORT),
+	editorPort: assertDevPort(env, 'N8N_EDITOR_PORT', DEFAULT_EDITOR_PORT),
+});
+
+/**
+ * Dev-server topology, kept out of the `serve` script so the env vars work on
+ * Windows too (`cross-env` cannot expand `${N8N_PORT:-5678}`).
+ *
+ * `apply: 'serve'` skips builds; the mode/isPreview check skips `vite preview`
+ * (serve/production) and vitest (serve/test). Builds must leave
+ * VUE_APP_URL_BASE_API unset so the app falls back to window.BASE_PATH.
+ */
+export const devServerPlugin = (env: NodeJS.ProcessEnv): Plugin => ({
+	name: 'n8n-dev-server-topology',
+	apply: 'serve',
+	config: (_config, { mode, isPreview }) => {
+		if (mode !== 'development' || isPreview) return;
+
+		const { backendPort, editorPort } = resolveDevPorts(env);
+
+		// Vite's loadEnv reads VUE_* straight out of process.env and runs after
+		// this hook, so the assignment still reaches import.meta.env.
+		// Truthiness, not ??=: an explicitly empty value counts as unset.
+		if (!env.VUE_APP_URL_BASE_API) {
+			env.VUE_APP_URL_BASE_API = `http://localhost:${backendPort}/`;
+		}
+
+		return { server: { host: '0.0.0.0', port: editorPort, strictPort: true } };
+	},
+});

--- a/packages/frontend/editor-ui/vite/dev-ports.test.ts
+++ b/packages/frontend/editor-ui/vite/dev-ports.test.ts
@@ -1,0 +1,88 @@
+import type { ConfigEnv, UserConfig } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+import { devServerPlugin, resolveDevPorts } from './dev-ports.mjs';
+
+const runConfigHook = (env: NodeJS.ProcessEnv, configEnv: ConfigEnv) => {
+	const plugin = devServerPlugin(env);
+	const hook = plugin.config as (c: UserConfig, e: ConfigEnv) => UserConfig | undefined;
+	return hook({}, configEnv);
+};
+
+const DEV: ConfigEnv = { command: 'serve', mode: 'development' };
+const VITEST: ConfigEnv = { command: 'serve', mode: 'test' };
+const PREVIEW: ConfigEnv = { command: 'serve', mode: 'production', isPreview: true };
+
+describe('resolveDevPorts', () => {
+	it.each([
+		['unset', {}, 5678, 8080],
+		['empty', { N8N_PORT: '', N8N_EDITOR_PORT: '' }, 5678, 8080],
+		['set', { N8N_PORT: '5699', N8N_EDITOR_PORT: '8082' }, 5699, 8082],
+	])('resolves %s ports', (_label, env, backendPort, editorPort) => {
+		expect(resolveDevPorts(env)).toEqual({ backendPort, editorPort });
+	});
+
+	it.each(['abc', '0', '70000', '5699.5', '-1'])('rejects the malformed port %s', (value) => {
+		expect(() => resolveDevPorts({ N8N_EDITOR_PORT: value })).toThrow(
+			`N8N_EDITOR_PORT must be a port number, got: ${value}`,
+		);
+	});
+
+	it('names the offending variable', () => {
+		expect(() => resolveDevPorts({ N8N_PORT: 'abc' })).toThrow(/^N8N_PORT must be/);
+	});
+});
+
+describe('devServerPlugin', () => {
+	it('never applies to builds', () => {
+		expect(devServerPlugin({}).apply).toBe('serve');
+	});
+
+	it('binds the editor port and derives the REST base from N8N_PORT', () => {
+		const env: NodeJS.ProcessEnv = { N8N_PORT: '5699', N8N_EDITOR_PORT: '8082' };
+
+		expect(runConfigHook(env, DEV)).toEqual({
+			server: { host: '0.0.0.0', port: 8082, strictPort: true },
+		});
+		expect(env.VUE_APP_URL_BASE_API).toBe('http://localhost:5699/');
+	});
+
+	it('falls back to the default ports', () => {
+		const env: NodeJS.ProcessEnv = {};
+
+		expect(runConfigHook(env, DEV)?.server).toMatchObject({ port: 8080 });
+		expect(env.VUE_APP_URL_BASE_API).toBe('http://localhost:5678/');
+	});
+
+	it('keeps an explicitly set REST base URL', () => {
+		const env: NodeJS.ProcessEnv = { VUE_APP_URL_BASE_API: 'https://tunnel.example/' };
+
+		runConfigHook(env, DEV);
+
+		expect(env.VUE_APP_URL_BASE_API).toBe('https://tunnel.example/');
+	});
+
+	it('treats an empty REST base URL as unset', () => {
+		const env: NodeJS.ProcessEnv = { VUE_APP_URL_BASE_API: '' };
+
+		runConfigHook(env, DEV);
+
+		expect(env.VUE_APP_URL_BASE_API).toBe('http://localhost:5678/');
+	});
+
+	// A build that inherits VUE_APP_URL_BASE_API would ship a localhost REST base
+	// instead of falling back to window.BASE_PATH, and vitest must not bind a port.
+	it.each([
+		['vitest', VITEST],
+		['preview', PREVIEW],
+	])('stays out of the way of %s', (_label, configEnv) => {
+		const env: NodeJS.ProcessEnv = { N8N_EDITOR_PORT: '8082' };
+
+		expect(runConfigHook(env, configEnv)).toBeUndefined();
+		expect(env.VUE_APP_URL_BASE_API).toBeUndefined();
+	});
+
+	it('does not validate ports outside the dev server', () => {
+		expect(() => runConfigHook({ N8N_EDITOR_PORT: 'abc' }, VITEST)).not.toThrow();
+	});
+});

--- a/packages/frontend/editor-ui/vitest.config.mts
+++ b/packages/frontend/editor-ui/vitest.config.mts
@@ -1,8 +1,10 @@
 import { vitestConfig } from '@n8n/vitest-config/frontend';
-import { mergeConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 
 import viteConfig from './vite.config.mjs';
 
 // This file is separate from `vite.config.mts`, because `@n8n/vitest-config` resolves to its
 // `dist`. Only `test` always has that `dist`, because turbo builds the dependencies before `test`.
-export default mergeConfig(viteConfig, vitestConfig);
+// `vite.config.mts` exports a callback (it reads `command`/`mode`) and `mergeConfig` rejects
+// callbacks, so resolve it against this run's env first.
+export default defineConfig((env) => mergeConfig(viteConfig(env), vitestConfig));

--- a/packages/frontend/editor-ui/vitest.config.mts
+++ b/packages/frontend/editor-ui/vitest.config.mts
@@ -1,10 +1,8 @@
 import { vitestConfig } from '@n8n/vitest-config/frontend';
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { mergeConfig } from 'vitest/config';
 
 import viteConfig from './vite.config.mjs';
 
 // This file is separate from `vite.config.mts`, because `@n8n/vitest-config` resolves to its
 // `dist`. Only `test` always has that `dist`, because turbo builds the dependencies before `test`.
-// `vite.config.mts` exports a callback (it reads `command`/`mode`) and `mergeConfig` rejects
-// callbacks, so resolve it against this run's env first.
-export default defineConfig((env) => mergeConfig(viteConfig(env), vitestConfig));
+export default mergeConfig(viteConfig, vitestConfig);

--- a/packages/testing/playwright/README.md
+++ b/packages/testing/playwright/README.md
@@ -108,7 +108,8 @@ situations where `test:local`'s defaults aren't enough:
   Pin a port with `N8N_BASE_URL=http://localhost:5680 …` when you need a
   stable URL for browser inspection.
 - **Throwaway `N8N_USER_FOLDER`** under the OS temp dir (cleaned up on exit).
-  Its `database.sqlite` is fully isolated from your local `~/.n8n` install.
+  n8n creates `.n8n/` (sqlite DB, encryption key) inside it, fully isolated
+  from your local `~/.n8n` install.
 - **Container-only tests included.** `@capability:*` / `@licensed` /
   `@db:reset` tests are picked up by the local `e2e` project. Their fixtures
   are responsible for detecting the missing container and skipping or falling

--- a/packages/testing/playwright/README.md
+++ b/packages/testing/playwright/README.md
@@ -107,7 +107,8 @@ situations where `test:local`'s defaults aren't enough:
   Pin a port with `N8N_BASE_URL=http://localhost:5680 …` when you need a
   stable URL for browser inspection.
 - **Throwaway `N8N_USER_FOLDER`** under the OS temp dir (cleaned up on exit).
-  Its `database.sqlite` is fully isolated from your local `~/.n8n` install.
+  n8n creates `.n8n/` (sqlite DB, encryption key) inside it, fully isolated
+  from your local `~/.n8n` install.
 - **Container-only tests included.** `@capability:*` / `@licensed` /
   `@db:reset` tests are picked up by the local `e2e` project. Their fixtures
   are responsible for detecting the missing container and skipping or falling

--- a/packages/testing/playwright/global-teardown.ts
+++ b/packages/testing/playwright/global-teardown.ts
@@ -1,19 +1,32 @@
 import { execSync } from 'child_process';
 
-import { getBackendUrl, getFrontendUrl, getPortFromUrl } from './utils/url-helper';
+import { getBackendUrl, getFrontendUrl } from './utils/url-helper';
+
+// Ports this run actually used (they may differ from the defaults, e.g. the
+// alt-port dev-server smoke runs the backend on 5699). Only URLs with an
+// explicit port count: a portless URL means 80/443, never a dev server this
+// run started. An unparseable URL falls back to the default dev ports
+// instead of aborting teardown.
+function getRunPorts(): number[] {
+	try {
+		return [
+			...new Set(
+				[getBackendUrl(), getFrontendUrl()]
+					.filter((url): url is string => !!url)
+					.map((url) => new URL(url).port)
+					.filter((port) => port !== '')
+					.map(Number),
+			),
+		];
+	} catch {
+		return [5678, 8080];
+	}
+}
 
 function globalTeardown() {
 	console.log('🧹 Starting global teardown...');
 
-	// Kill the ports this run actually used (they may differ from the
-	// defaults, e.g. the alt-port dev-server smoke runs the backend on 5699).
-	const ports = [
-		...new Set(
-			[getBackendUrl(), getFrontendUrl()]
-				.filter((url): url is string => !!url)
-				.map((url) => Number(getPortFromUrl(url))),
-		),
-	];
+	const ports = getRunPorts();
 
 	for (const port of ports) {
 		try {

--- a/packages/testing/playwright/global-teardown.ts
+++ b/packages/testing/playwright/global-teardown.ts
@@ -2,31 +2,21 @@ import { execSync } from 'child_process';
 
 import { getBackendUrl, getFrontendUrl } from './utils/url-helper';
 
-// Ports this run actually used (they may differ from the defaults, e.g. the
-// alt-port dev-server smoke runs the backend on 5699). Only URLs with an
-// explicit port count: a portless URL means 80/443, never a dev server this
-// run started. An unparseable URL falls back to the default dev ports
-// instead of aborting teardown.
-function getRunPorts(): number[] {
-	try {
-		return [
-			...new Set(
-				[getBackendUrl(), getFrontendUrl()]
-					.filter((url): url is string => !!url)
-					.map((url) => new URL(url).port)
-					.filter((port) => port !== '')
-					.map(Number),
-			),
-		];
-	} catch {
-		return [5678, 8080];
-	}
-}
-
 function globalTeardown() {
 	console.log('🧹 Starting global teardown...');
 
-	const ports = getRunPorts();
+	// Ports this run actually used (they may differ from the defaults, e.g. the
+	// alt-port dev-server smoke runs the backend on 5699). A portless URL means
+	// 80/443, never a dev server this run started. Killing nothing beats falling
+	// back to the defaults, which are most likely the developer's own servers.
+	const ports = [
+		...new Set(
+			[getBackendUrl(), getFrontendUrl()]
+				.filter((url): url is string => !!url && URL.canParse(url))
+				.map((url) => new URL(url).port)
+				.filter(Boolean),
+		),
+	];
 
 	for (const port of ports) {
 		try {

--- a/packages/testing/playwright/global-teardown.ts
+++ b/packages/testing/playwright/global-teardown.ts
@@ -1,9 +1,19 @@
 import { execSync } from 'child_process';
 
+import { getBackendUrl, getFrontendUrl, getPortFromUrl } from './utils/url-helper';
+
 function globalTeardown() {
 	console.log('🧹 Starting global teardown...');
 
-	const ports = [5678, 8080];
+	// Kill the ports this run actually used (they may differ from the
+	// defaults, e.g. the alt-port dev-server smoke runs the backend on 5699).
+	const ports = [
+		...new Set(
+			[getBackendUrl(), getFrontendUrl()]
+				.filter((url): url is string => !!url)
+				.map((url) => Number(getPortFromUrl(url))),
+		),
+	];
 
 	for (const port of ports) {
 		try {

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "N8N_BASE_URL=http://localhost:5678 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=e2e",
     "test:dev-server-smoke": "N8N_BASE_URL=http://localhost:5678 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=dev-server-smoke",
-    "test:dev-server-smoke:alt-port": "N8N_BASE_URL=http://localhost:5699 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=dev-server-smoke",
+    "test:dev-server-smoke:alt-port": "N8N_BASE_URL=http://localhost:5699 N8N_EDITOR_URL=http://localhost:8082 RESET_E2E_DB=true playwright test --project=dev-server-smoke",
     "test:all": "playwright test",
     "test:local": "N8N_BASE_URL=http://localhost:5680 RESET_E2E_DB=true playwright test --project=e2e",
     "test:local:isolated": "node scripts/run-local-isolated.mjs",

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "N8N_BASE_URL=http://localhost:5678 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=e2e",
     "test:dev-server-smoke": "N8N_BASE_URL=http://localhost:5678 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=dev-server-smoke",
+    "test:dev-server-smoke:alt-port": "N8N_BASE_URL=http://localhost:5699 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=dev-server-smoke",
     "test:all": "playwright test",
     "test:local": "N8N_BASE_URL=http://localhost:5680 RESET_E2E_DB=true playwright test --project=e2e",
     "test:local:isolated": "node scripts/run-local-isolated.mjs",

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "N8N_BASE_URL=http://localhost:5678 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=e2e",
     "test:dev-server-smoke": "N8N_BASE_URL=http://localhost:5678 N8N_EDITOR_URL=http://localhost:8080 RESET_E2E_DB=true playwright test --project=dev-server-smoke",
-    "test:dev-server-smoke:alt-port": "N8N_BASE_URL=http://localhost:5699 N8N_EDITOR_URL=http://localhost:8082 RESET_E2E_DB=true playwright test --project=dev-server-smoke",
+    "test:dev-server-smoke:alt-port": "N8N_BASE_URL=http://localhost:5699 N8N_EDITOR_URL=http://localhost:8082 N8N_TEST_ENV='{\"N8N_RUNNERS_BROKER_PORT\":\"5701\"}' RESET_E2E_DB=true playwright test --project=dev-server-smoke",
     "test:all": "playwright test",
     "test:local": "N8N_BASE_URL=http://localhost:5680 RESET_E2E_DB=true playwright test --project=e2e",
     "test:local:isolated": "node scripts/run-local-isolated.mjs",

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -81,7 +81,9 @@ if (IS_DEV && FRONTEND_URL) {
 		reuseExistingServer: IS_DEV ? false : true,
 		env: {
 			E2E_TESTS: 'true',
-			N8N_PORT: getPortFromUrl(FRONTEND_URL),
+			// The dev frontend derives its backend URL (BASE_PATH + REST base)
+			// from N8N_PORT, so pass the backend's port, not the frontend's.
+			...(BACKEND_URL ? { N8N_PORT: getPortFromUrl(BACKEND_URL) } : {}),
 			...getTestEnv(),
 		},
 	});

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -15,7 +15,10 @@ const IS_DEV = !!process.env.N8N_EDITOR_URL;
 
 const MACBOOK_WINDOW_SIZE = { width: 1536, height: 960 };
 
-const USER_FOLDER = path.join(os.tmpdir(), `n8n-main-${Date.now()}`);
+// Sticky across processes: workers re-import this config, and Date.now()
+// would give each of them a different path than the one the webServer got.
+const USER_FOLDER =
+	process.env.N8N_TEST_USER_FOLDER ?? path.join(os.tmpdir(), `n8n-main-${Date.now()}`);
 
 // Helper to get environment variables from N8N_TEST_ENV
 const getTestEnv = () => {
@@ -52,6 +55,9 @@ const webServer: PlaywrightTestConfig['webServer'] = [];
 const SKIP_WEB_SERVER = process.env.PLAYWRIGHT_SKIP_WEBSERVER === 'true';
 
 if (BACKEND_URL && !SKIP_WEB_SERVER) {
+	// Expose the user folder to specs (the dev-server smoke asserts the sqlite
+	// DB is created inside it). Only set when this run manages the webServer.
+	process.env.N8N_TEST_USER_FOLDER = USER_FOLDER;
 	webServer.push({
 		command: 'cd .. && pnpm start',
 		url: `${BACKEND_URL}/favicon.ico`,

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -58,13 +58,16 @@ const webServer: PlaywrightTestConfig['webServer'] = [];
 const SKIP_WEB_SERVER = process.env.PLAYWRIGHT_SKIP_WEBSERVER === 'true';
 
 if (BACKEND_URL && !SKIP_WEB_SERVER) {
-	// Expose the user folder to specs (the dev-server smoke asserts the sqlite
-	// DB is created inside it). Only set when this run manages the webServer.
+	// Expose the user folder to specs (the dev-server smoke asserts the sqlite DB
+	// is created inside it). Only meaningful when this run starts the backend
+	// itself; a reused server writes to wherever it was already pointed.
 	// N8N_TEST_ENV may override N8N_USER_FOLDER (spread below wins), so export
 	// the folder the backend will actually use.
-	const envUserFolder: unknown = getTestEnv().N8N_USER_FOLDER;
-	process.env.N8N_TEST_USER_FOLDER =
-		typeof envUserFolder === 'string' ? envUserFolder : USER_FOLDER;
+	if (IS_DEV) {
+		const envUserFolder: unknown = getTestEnv().N8N_USER_FOLDER;
+		process.env.N8N_TEST_USER_FOLDER =
+			typeof envUserFolder === 'string' ? envUserFolder : USER_FOLDER;
+	}
 	webServer.push({
 		command: 'cd .. && pnpm start',
 		url: `${BACKEND_URL}/favicon.ico`,

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -17,8 +17,11 @@ const MACBOOK_WINDOW_SIZE = { width: 1536, height: 960 };
 
 // Sticky across processes: workers re-import this config, and Date.now()
 // would give each of them a different path than the one the webServer got.
+// Only workers honor the inherited value; the main process always mints a
+// fresh folder so a stale shell-exported variable can't leak in.
 const USER_FOLDER =
-	process.env.N8N_TEST_USER_FOLDER ?? path.join(os.tmpdir(), `n8n-main-${Date.now()}`);
+	(process.env.TEST_WORKER_INDEX !== undefined ? process.env.N8N_TEST_USER_FOLDER : undefined) ??
+	path.join(os.tmpdir(), `n8n-main-${Date.now()}`);
 
 // Helper to get environment variables from N8N_TEST_ENV
 const getTestEnv = () => {
@@ -57,7 +60,10 @@ const SKIP_WEB_SERVER = process.env.PLAYWRIGHT_SKIP_WEBSERVER === 'true';
 if (BACKEND_URL && !SKIP_WEB_SERVER) {
 	// Expose the user folder to specs (the dev-server smoke asserts the sqlite
 	// DB is created inside it). Only set when this run manages the webServer.
-	process.env.N8N_TEST_USER_FOLDER = USER_FOLDER;
+	// N8N_TEST_ENV may override N8N_USER_FOLDER (spread below wins), so export
+	// the folder the backend will actually use.
+	const envUserFolder: unknown = getTestEnv().N8N_USER_FOLDER;
+	process.env.N8N_TEST_USER_FOLDER = typeof envUserFolder === 'string' ? envUserFolder : USER_FOLDER;
 	webServer.push({
 		command: 'cd .. && pnpm start',
 		url: `${BACKEND_URL}/favicon.ico`,

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -84,6 +84,7 @@ if (IS_DEV && FRONTEND_URL) {
 			// The dev frontend derives its backend URL (BASE_PATH + REST base)
 			// from N8N_PORT, so pass the backend's port, not the frontend's.
 			...(BACKEND_URL ? { N8N_PORT: getPortFromUrl(BACKEND_URL) } : {}),
+			N8N_EDITOR_PORT: getPortFromUrl(FRONTEND_URL),
 			...getTestEnv(),
 		},
 	});

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -63,7 +63,8 @@ if (BACKEND_URL && !SKIP_WEB_SERVER) {
 	// N8N_TEST_ENV may override N8N_USER_FOLDER (spread below wins), so export
 	// the folder the backend will actually use.
 	const envUserFolder: unknown = getTestEnv().N8N_USER_FOLDER;
-	process.env.N8N_TEST_USER_FOLDER = typeof envUserFolder === 'string' ? envUserFolder : USER_FOLDER;
+	process.env.N8N_TEST_USER_FOLDER =
+		typeof envUserFolder === 'string' ? envUserFolder : USER_FOLDER;
 	webServer.push({
 		command: 'cd .. && pnpm start',
 		url: `${BACKEND_URL}/favicon.ico`,

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -82,7 +82,9 @@ if (IS_DEV && FRONTEND_URL) {
 		reuseExistingServer: IS_DEV ? false : true,
 		env: {
 			E2E_TESTS: 'true',
-			N8N_PORT: getPortFromUrl(FRONTEND_URL),
+			// The dev frontend derives its backend URL (BASE_PATH + REST base)
+			// from N8N_PORT, so pass the backend's port, not the frontend's.
+			...(BACKEND_URL ? { N8N_PORT: getPortFromUrl(BACKEND_URL) } : {}),
 			...getTestEnv(),
 		},
 	});

--- a/packages/testing/playwright/playwright.config.ts
+++ b/packages/testing/playwright/playwright.config.ts
@@ -85,6 +85,7 @@ if (IS_DEV && FRONTEND_URL) {
 			// The dev frontend derives its backend URL (BASE_PATH + REST base)
 			// from N8N_PORT, so pass the backend's port, not the frontend's.
 			...(BACKEND_URL ? { N8N_PORT: getPortFromUrl(BACKEND_URL) } : {}),
+			N8N_EDITOR_PORT: getPortFromUrl(FRONTEND_URL),
 			...getTestEnv(),
 		},
 	});

--- a/packages/testing/playwright/scripts/run-local-isolated.mjs
+++ b/packages/testing/playwright/scripts/run-local-isolated.mjs
@@ -76,8 +76,9 @@ if (process.env.N8N_BASE_URL) {
 	backendUrl = `http://localhost:${port}`;
 }
 
-// Throwaway `~/.n8n`-equivalent. SQLite lives at `${userFolder}/database.sqlite`,
-// so this also isolates the DB from any local n8n install.
+// Throwaway home-dir stand-in. n8n creates `${userFolder}/.n8n/` inside it
+// (SQLite DB, encryption key), so this also isolates the DB from any local
+// n8n install.
 const userFolder = mkdtempSync(path.join(os.tmpdir(), 'n8n-test-isolated-'));
 
 // Caller-supplied n8n env (same convention as `pnpm test:local`).

--- a/packages/testing/playwright/scripts/run-local-isolated.mjs
+++ b/packages/testing/playwright/scripts/run-local-isolated.mjs
@@ -9,8 +9,8 @@
  *     `5678`/`5679`. Pin a port with `N8N_BASE_URL=http://localhost:5680 …`
  *     when you need a stable URL for browser inspection.
  *   - **Throwaway `N8N_USER_FOLDER`** under the OS temp dir (cleaned up on
- *     exit). Its `database.sqlite` is fully isolated from your local
- *     `~/.n8n` install.
+ *     exit). n8n creates `.n8n/` (sqlite DB, encryption key) inside it, fully
+ *     isolated from your local `~/.n8n` install.
  *   - **Self-managed n8n process** with a real readiness check against
  *     `/rest/e2e/reset` (Playwright's default `webServer` favicon check is
  *     racy with slower module startups). Sets `PLAYWRIGHT_SKIP_WEBSERVER=true`
@@ -76,9 +76,8 @@ if (process.env.N8N_BASE_URL) {
 	backendUrl = `http://localhost:${port}`;
 }
 
-// Throwaway home-dir stand-in. n8n creates `${userFolder}/.n8n/` inside it
-// (SQLite DB, encryption key), so this also isolates the DB from any local
-// n8n install.
+// Throwaway home-dir stand-in. n8n creates `.n8n/` (sqlite DB, encryption
+// key) inside it, so this also isolates the DB from any local n8n install.
 const userFolder = mkdtempSync(path.join(os.tmpdir(), 'n8n-test-isolated-'));
 
 // Caller-supplied n8n env (same convention as `pnpm test:local`).

--- a/packages/testing/playwright/tests/dev-server-smoke/dev-server-boots.spec.ts
+++ b/packages/testing/playwright/tests/dev-server-smoke/dev-server-boots.spec.ts
@@ -1,6 +1,6 @@
 import type { ConsoleMessage, Page } from '@playwright/test';
 
-import { test } from '../../fixtures/base';
+import { expect, test } from '../../fixtures/base';
 
 /**
  * Smoke tests that catch app-wide regressions where the editor-ui fails to boot —
@@ -123,6 +123,22 @@ test.describe(
 			await navigateAndAssertNoErrors(n8n.page, 'home', async () => {
 				await n8n.start.fromHome();
 			});
+		});
+
+		// The dev frontend derives its REST base from N8N_PORT. "Boots cleanly" is
+		// not enough on its own: on the default ports a hardcoded 5678 would be
+		// indistinguishable from correct derivation, so assert the origin directly.
+		test('REST calls go to the configured backend', async ({ n8n }) => {
+			const restOrigins = new Set<string>();
+			n8n.page.on('request', (request) => {
+				const url = new URL(request.url());
+				if (url.pathname.startsWith('/rest/')) restOrigins.add(url.origin);
+			});
+
+			await n8n.start.fromHome();
+
+			const backendOrigin = new URL(process.env.N8N_BASE_URL!).origin;
+			expect([...restOrigins]).toEqual([backendOrigin]);
 		});
 
 		test('blank canvas boots cleanly', async ({ n8n }) => {

--- a/packages/testing/playwright/tests/dev-server-smoke/user-folder.spec.ts
+++ b/packages/testing/playwright/tests/dev-server-smoke/user-folder.spec.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { expect, test } from '../../fixtures/base';
 
 /**
- * Asserts that the backend started by this run respects N8N_USER_FOLDER —
+ * Asserts that the backend started by this run respects N8N_USER_FOLDER:
  * the sqlite database must be created inside the run's generated user folder
  * (see USER_FOLDER in playwright.config.ts), not in the default ~/.n8n.
  * Together with the non-default-port smoke variant this covers the full
@@ -25,16 +25,23 @@ test.describe(
 	},
 	() => {
 		test('sqlite database is created in the configured user folder', async ({ n8n }) => {
+			// The config only exports the folder when it manages the webServer.
+			test.skip(
+				process.env.PLAYWRIGHT_SKIP_WEBSERVER === 'true',
+				'this run does not manage the webServer',
+			);
+
 			// The smoke scripts always manage the webServer, so a missing value
-			// means the env did not propagate to the worker: fail, don't skip.
+			// means the config did not export the user folder: fail, don't skip.
 			const userFolder = process.env.N8N_TEST_USER_FOLDER;
-			expect(userFolder, 'N8N_TEST_USER_FOLDER must propagate to workers').toBeTruthy();
+			expect(userFolder, 'playwright.config.ts must export N8N_TEST_USER_FOLDER').toBeTruthy();
 
 			// Visiting the app guarantees the backend has fully booted.
 			await n8n.start.fromHome();
 
 			// n8n creates `.n8n/` inside N8N_USER_FOLDER (see getN8nFolder in @n8n/config).
-			expect(existsSync(path.join(userFolder!, '.n8n', 'database.sqlite'))).toBe(true);
+			const dbPath = path.join(userFolder!, '.n8n', 'database.sqlite');
+			expect(existsSync(dbPath), `expected sqlite DB at ${dbPath}`).toBe(true);
 		});
 	},
 );

--- a/packages/testing/playwright/tests/dev-server-smoke/user-folder.spec.ts
+++ b/packages/testing/playwright/tests/dev-server-smoke/user-folder.spec.ts
@@ -25,12 +25,15 @@ test.describe(
 	},
 	() => {
 		test('sqlite database is created in the configured user folder', async ({ n8n }) => {
+			// The smoke scripts always manage the webServer, so a missing value
+			// means the env did not propagate to the worker: fail, don't skip.
 			const userFolder = process.env.N8N_TEST_USER_FOLDER;
-			test.skip(!userFolder, 'This run does not manage the n8n webServer');
+			expect(userFolder, 'N8N_TEST_USER_FOLDER must propagate to workers').toBeTruthy();
 
 			// Visiting the app guarantees the backend has fully booted.
 			await n8n.start.fromHome();
 
+			// n8n creates `.n8n/` inside N8N_USER_FOLDER (see getN8nFolder in @n8n/config).
 			expect(existsSync(path.join(userFolder!, '.n8n', 'database.sqlite'))).toBe(true);
 		});
 	},

--- a/packages/testing/playwright/tests/dev-server-smoke/user-folder.spec.ts
+++ b/packages/testing/playwright/tests/dev-server-smoke/user-folder.spec.ts
@@ -1,0 +1,37 @@
+import { existsSync } from 'fs';
+import path from 'path';
+
+import { expect, test } from '../../fixtures/base';
+
+/**
+ * Asserts that the backend started by this run respects N8N_USER_FOLDER —
+ * the sqlite database must be created inside the run's generated user folder
+ * (see USER_FOLDER in playwright.config.ts), not in the default ~/.n8n.
+ * Together with the non-default-port smoke variant this covers the full
+ * "relocated dev instance" setup: custom ports and a custom data folder.
+ */
+
+test.describe(
+	'Dev-server user folder',
+	{
+		annotation: [
+			{ type: 'owner', description: 'Catalysts' },
+			{
+				type: 'description',
+				description:
+					'Verifies the dev backend creates its sqlite database inside the N8N_USER_FOLDER configured for the run.',
+			},
+		],
+	},
+	() => {
+		test('sqlite database is created in the configured user folder', async ({ n8n }) => {
+			const userFolder = process.env.N8N_TEST_USER_FOLDER;
+			test.skip(!userFolder, 'This run does not manage the n8n webServer');
+
+			// Visiting the app guarantees the backend has fully booted.
+			await n8n.start.fromHome();
+
+			expect(existsSync(path.join(userFolder!, '.n8n', 'database.sqlite'))).toBe(true);
+		});
+	},
+);

--- a/packages/testing/playwright/tests/dev-server-smoke/user-folder.spec.ts
+++ b/packages/testing/playwright/tests/dev-server-smoke/user-folder.spec.ts
@@ -4,13 +4,14 @@ import path from 'path';
 import { expect, test } from '../../fixtures/base';
 
 /**
- * Asserts that the backend started by this run respects N8N_USER_FOLDER:
- * the sqlite database must be created inside the run's generated user folder
- * (see USER_FOLDER in playwright.config.ts), not in the default ~/.n8n.
- * Together with the non-default-port smoke variant this covers the full
- * "relocated dev instance" setup: custom ports and a custom data folder.
+ * Asserts that the backend started by this run respects N8N_USER_FOLDER: the
+ * sqlite database must be created inside the run's generated user folder (see
+ * USER_FOLDER in playwright.config.ts), not in the default ~/.n8n. Guards the
+ * smoke suite against silently polluting the developer's own install.
+ *
+ * Playwright polls the backend's favicon and global-setup resets its database
+ * before any test runs, so the file exists by now without visiting the app.
  */
-
 test.describe(
 	'Dev-server user folder',
 	{
@@ -24,20 +25,11 @@ test.describe(
 		],
 	},
 	() => {
-		test('sqlite database is created in the configured user folder', async ({ n8n }) => {
-			// The config only exports the folder when it manages the webServer.
-			test.skip(
-				process.env.PLAYWRIGHT_SKIP_WEBSERVER === 'true',
-				'this run does not manage the webServer',
-			);
-
+		test('sqlite database is created in the configured user folder', () => {
 			// The smoke scripts always manage the webServer, so a missing value
 			// means the config did not export the user folder: fail, don't skip.
 			const userFolder = process.env.N8N_TEST_USER_FOLDER;
 			expect(userFolder, 'playwright.config.ts must export N8N_TEST_USER_FOLDER').toBeTruthy();
-
-			// Visiting the app guarantees the backend has fully booted.
-			await n8n.start.fromHome();
 
 			// n8n creates `.n8n/` inside N8N_USER_FOLDER (see getN8nFolder in @n8n/config).
 			const dbPath = path.join(userFolder!, '.n8n', 'database.sqlite');


### PR DESCRIPTION
## Summary

Follow-up to #35724, completing configurable ports for the dev servers. Two remaining hardcodes:

1. The `serve` script hardcoded `VUE_APP_URL_BASE_API=http://localhost:5678/` (the REST base URL used by `useRootStore`), so a dev frontend pointed at a backend on another port loaded assets from the right place but sent API calls to 5678.
2. The `serve` script hardcoded the editor's own port (`--port 8080`).

Changes:

- Default `VUE_APP_URL_BASE_API` from `N8N_PORT` and read the editor's own dev port from `N8N_EDITOR_PORT` (default 8080), both in a new `vite/dev-ports.mts` plugin, and drop the hardcoded values and flags from the `serve` script (`host`/`strictPort` behavior preserved). The plugin is `apply: 'serve'` plus a mode/isPreview check, so only `vite dev` gets any of it: builds, `vite preview` and vitest keep `VUE_APP_URL_BASE_API` unset (the app falls back to `window.BASE_PATH`) and keep vite's own server defaults. Malformed ports fail fast with a clear error, again dev server only. Unit tested in `vite/dev-ports.test.ts`.
- **Small behavior change:** if you already have `VUE_APP_URL_BASE_API` exported in your shell, it now wins for `pnpm dev`. Before, `cross-env` in the `serve` script always overwrote it with `http://localhost:5678/`. This is on purpose, it's the escape hatch for pointing the dev editor at a tunnelled or remote backend, but it means a stale exported value has an effect now where it had none.
- Fix the dev-server smoke webServer env to pass the backend's port as `N8N_PORT` (it passed the frontend's own port, which the vite BASE_PATH replacement has consumed since #35724, pointing window.BASE_PATH at the vite server itself; the hardcoded REST base URL masked it).
- Add a second dev-server smoke run on non-default ports (backend 5699, editor 8082, task-runner broker 5701) so CI exercises the relocated-instance path. It runs before the default-port run, so a regression to the 5678 fallback fails with a connection error instead of being satisfied by a leaked server. Global-teardown kill ports derive from the run's URLs instead of hardcoding 5678/8080 (explicit ports only, and it kills nothing if nothing parses, so a typo can't take down your own dev servers). The smoke suite also asserts that every `/rest/*` call goes to the configured backend origin, because "the app boots without console errors" passes on the default ports even if the port is hardcoded. A second new spec asserts the backend creates its sqlite DB inside the run's `N8N_USER_FOLDER` (the folder is now sticky across Playwright config re-imports, since `Date.now()` gave workers a different path than the webServer).

With `N8N_PORT` + `N8N_EDITOR_PORT`, a plain `pnpm dev` in `packages/cli` and `packages/frontend/editor-ui` runs a fully relocated dev instance (e.g. a second isolated n8n for PR testing next to the main dev servers). No behavior change for anyone not setting the variables.

## How to test

1. Backend: `N8N_PORT=5699 pnpm dev` from `packages/cli` (add `N8N_RUNNERS_BROKER_PORT` if 5679 is taken).
2. Frontend: `N8N_PORT=5699 N8N_EDITOR_PORT=8082 pnpm dev` from `packages/frontend/editor-ui`.
3. The editor at http://localhost:8082 loads, signs in, and every `/rest/*` and `/static/*` request goes to port 5699.
4. Without the variables set, `pnpm dev` works as before on 8080 against 5678.

CI: the dev-server smoke job now runs the suite twice, first on non-default ports (5699/8082, task-runner broker 5701), then on the defaults. Both variants pass locally (5/5 specs each). The default-port step runs even if the alt-port step fails, so one flake doesn't cost both signals.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-331

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




