### PR TITLE
fix(editor): Localize the filter button tooltip

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.test.ts
@@ -1,0 +1,60 @@
+import { createTestingPinia } from '@pinia/testing';
+import { i18n, i18nInstance } from '@n8n/i18n';
+
+import { createComponentRenderer } from '@/__tests__/render';
+import ResourceFiltersDropdown from '@/app/components/forms/ResourceFiltersDropdown.vue';
+
+const TEST_LOCALE = 'test-locale';
+const TRANSLATED_FILTERS = 'Translated filters label';
+
+/**
+ * `N8nTooltip` teleports its content into a popper on hover, so stub it to render
+ * the content slot inline. The popover renders only its trigger, since the
+ * dropdown body is not under test and pulls in router-dependent stores.
+ */
+const renderComponent = createComponentRenderer(ResourceFiltersDropdown, {
+	global: {
+		stubs: {
+			N8nPopover: {
+				template: '<div><slot name="trigger" /></div>',
+			},
+			N8nTooltip: {
+				template:
+					'<div><span data-test-id="filters-tooltip-content"><slot name="content" /></span><slot /></div>',
+			},
+		},
+	},
+});
+
+describe('ResourceFiltersDropdown', () => {
+	const originalLocale = i18nInstance.global.locale.value;
+
+	beforeEach(() => {
+		createTestingPinia();
+		i18nInstance.global.setLocaleMessage(TEST_LOCALE, {
+			'forms.resourceFiltersDropdown.filters': TRANSLATED_FILTERS,
+		});
+		i18nInstance.global.locale.value = TEST_LOCALE;
+		i18n.clearCache();
+	});
+
+	afterEach(() => {
+		i18nInstance.global.locale.value = originalLocale;
+		i18n.clearCache();
+	});
+
+	it('should localize the filter button tooltip', () => {
+		const { getByTestId } = renderComponent();
+
+		expect(getByTestId('filters-tooltip-content')).toHaveTextContent(TRANSLATED_FILTERS);
+	});
+
+	it('should use the same localized label for the tooltip and the aria-label', () => {
+		const { getByTestId } = renderComponent();
+
+		const trigger = getByTestId('resources-list-filters-trigger');
+
+		expect(trigger).toHaveAttribute('aria-label', TRANSLATED_FILTERS);
+		expect(getByTestId('filters-tooltip-content')).toHaveTextContent(TRANSLATED_FILTERS);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
@@ -126,7 +126,9 @@ watch(filtersLength, (value) => {
 		<template #trigger>
 			<span :class="$style['trigger-wrapper']">
 				<N8nTooltip>
-					<template #content> Filters </template>
+					<template #content>
+						{{ i18n.baseText('forms.resourceFiltersDropdown.filters') }}
+					</template>
 					<N8nButton
 						variant="outline"
 						icon="funnel"


### PR DESCRIPTION
## Summary

`ResourceFiltersDropdown` rendered its tooltip as a hardcoded English literal, while the `aria-label` and the visible button text on the **same element** both went through i18n.

```diff
 <N8nTooltip>
-  <template #content> Filters </template>
+  <template #content>
+    {{ i18n.baseText('forms.resourceFiltersDropdown.filters') }}
+  </template>
   <N8nButton
     ...
     :aria-label="i18n.baseText('forms.resourceFiltersDropdown.filters')"
```

The key `forms.resourceFiltersDropdown.filters` already existed in `en.json` and the `i18n` instance was already in scope, so nothing new was needed — the literal was simply the only hardcoded user-facing string left in the component.

This is the tooltip that matters most on narrow viewports. Below 480px the visible label is hidden (`text-indent: -10000px`), so the tooltip becomes the *only* text explaining the button — and that is exactly the case where it stayed untranslated.

The component is rendered by `ResourcesListLayout` (Workflows, Credentials, Variables, Data Tables, Agents) and by `MigrationRuleDetail`, so this affects every resource list.

## How to test

**Automated** — new colocated test, fails on `master` and passes with this change:

```bash
cd packages/frontend/editor-ui
pnpm test src/app/components/forms/ResourceFiltersDropdown.test.ts
```

The test registers a throwaway locale with a distinct translation for the key and switches to it, so it distinguishes a translated tooltip from the hardcoded literal — against the real English locale both render "Filters" and the bug would be invisible. To see it fail against `master`:

```bash
git stash push -- src/app/components/forms/ResourceFiltersDropdown.vue   # keep the test, drop the fix
pnpm test src/app/components/forms/ResourceFiltersDropdown.test.ts
git stash pop
```

Both tests go red — the tooltip renders the untranslated literal while the `aria-label` next to it renders the translation.

**Manual**

1. Switch the instance UI to a non-English language.
2. Open **Workflows** (or Credentials / Variables / Data Tables / Agents).
3. Hover the filter button in the list header.
4. Before: the tooltip reads "Filters" in English while the button's own label beside it is translated. After: both are translated.
5. Narrow the window below 480px to see the case where the tooltip is the only label present.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #35777

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- No user-facing behaviour change beyond the string now being localized. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

*Disclosure, per the "Using AI Tools" section of the contributing guide: I used Claude Code to help locate this and draft the test. I have reviewed and run everything here and can explain each line.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

