### PR TITLE
fix(core): Normalize MCP registry server tags from the registry API

### DIFF
--- a/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-api.client.test.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/__tests__/mcp-registry-api.client.test.ts
@@ -274,4 +274,48 @@ describe('McpRegistryApiClient', () => {
 			expect(result).toEqual([...batch1, ...batch2]);
 		});
 	});
+
+	describe('tags normalization', () => {
+		const rawServer = (tags: unknown) => ({ slug: 'notion', name: 'Notion', tags });
+
+		it('should unwrap the Strapi relation wrapper into a flat array', async () => {
+			mockPaginatedRequest.mockResolvedValue([rawServer({ data: ['productivity', 'docs'] })]);
+
+			const [server] = await client.fetchAllServers();
+
+			expect(server.tags).toEqual(['productivity', 'docs']);
+		});
+
+		it('should pass an already flat array through unchanged', async () => {
+			mockPaginatedRequest.mockResolvedValue([rawServer(['productivity', 'docs'])]);
+
+			const [server] = await client.fetchAllServers();
+
+			expect(server.tags).toEqual(['productivity', 'docs']);
+		});
+
+		it('should treat a wrapper with no data as an empty list', async () => {
+			mockPaginatedRequest.mockResolvedValue([rawServer({})]);
+
+			const [server] = await client.fetchAllServers();
+
+			expect(server.tags).toEqual([]);
+		});
+
+		it('should leave a server without tags untouched', async () => {
+			mockPaginatedRequest.mockResolvedValue([{ slug: 'notion', name: 'Notion' }]);
+
+			const [server] = await client.fetchAllServers();
+
+			expect(server).not.toHaveProperty('tags');
+		});
+
+		it('should normalize tags fetched by slug as well', async () => {
+			mockPaginatedRequest.mockResolvedValue([rawServer({ data: ['issue-tracking'] })]);
+
+			const [server] = await client.fetchServersBySlugs(['linear']);
+
+			expect(server.tags).toEqual(['issue-tracking']);
+		});
+	});
 });

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry-api.client.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry-api.client.ts
@@ -13,10 +13,27 @@ const MCP_SERVERS_PRODUCTION_URL = 'https://api.n8n.io/api/mcp-servers';
 /** Strapi's qs parser has an arrayLimit of 100 */
 const STRAPI_ARRAY_LIMIT = 100;
 
+/**
+ * `tags` is a Strapi relation, so the API wraps it in `{ data }`. `paginatedRequest`
+ * only unwraps the top-level entity, not nested relations, so it arrives wrapped
+ * and has to be flattened here before it reaches the entity and the DTO.
+ */
+type RawMcpRegistryServer = Omit<McpRegistryServer, 'tags'> & {
+	tags?: string[] | { data?: string[] };
+};
+
+function normalizeServer(server: RawMcpRegistryServer): McpRegistryServer {
+	const { tags, ...rest } = server;
+
+	if (tags === undefined || tags === null) return rest;
+
+	return { ...rest, tags: Array.isArray(tags) ? tags : (tags.data ?? []) };
+}
+
 @Service()
 export class McpRegistryApiClient {
 	async fetchAllServers(): Promise<McpRegistryServer[]> {
-		return await paginatedRequest<McpRegistryServer>(
+		const servers = await paginatedRequest<RawMcpRegistryServer>(
 			this.getUrl(),
 			{
 				pagination: { page: 1, pageSize: 25 },
@@ -25,6 +42,8 @@ export class McpRegistryApiClient {
 				throwOnError: true,
 			},
 		);
+
+		return servers.map(normalizeServer);
 	}
 
 	async fetchServersMetadata(): Promise<McpRegistryServerMetadata[]> {
@@ -44,7 +63,7 @@ export class McpRegistryApiClient {
 		const data: McpRegistryServer[] = [];
 		for (let i = 0; i < slugs.length; i += STRAPI_ARRAY_LIMIT) {
 			const batch = slugs.slice(i, i + STRAPI_ARRAY_LIMIT);
-			const batchData = await paginatedRequest<McpRegistryServer>(
+			const batchData = await paginatedRequest<RawMcpRegistryServer>(
 				this.getUrl(),
 				{
 					filters: {
@@ -58,7 +77,7 @@ export class McpRegistryApiClient {
 					throwOnError: true,
 				},
 			);
-			data.push(...batchData);
+			data.push(...batchData.map(normalizeServer));
 		}
 
 		return data;

--- a/packages/cli/src/modules/mcp-registry/registry/mcp-registry.types.ts
+++ b/packages/cli/src/modules/mcp-registry/registry/mcp-registry.types.ts
@@ -49,7 +49,7 @@ export type McpRegistryServer = {
 	isOfficial: boolean;
 	origin: 'registry';
 	status: McpRegistryServerStatus;
-	// FIXME: api returns {data?: string[]} not string[]
+	/** Normalized from the registry API's Strapi relation wrapper by `McpRegistryApiClient`. */
 	tags?: string[];
 	extendsCredential?: McpRegistryExtendsCredential;
 };


### PR DESCRIPTION
## Summary

`tags` is a Strapi relation, so the MCP registry API returns it wrapped as `{ data?: string[] }`. `paginatedRequest` only unwraps the top-level entity's `attributes`, not nested relation fields, and there is no validation on this path — so the wrapper flowed straight through the module:

1. Persisted verbatim by `toEntity` (spread into the JSON column typed `tags?: string[]`).
2. Read back through the `as McpRegistryServer` cast in `fromEntity`, which suppressed the very error that would have caught it.
3. Served verbatim by `mcp-registry.controller.ts`.

Net effect: `GET /rest/mcp-registry/servers` returned `tags: { data: [...] }` while `McpRegistryServerResponse` declares `tags?: string[]`. The mismatch was flagged in-code with `// FIXME: api returns {data?: string[]} not string[]`.

It has not surfaced in practice yet **only because nothing reads `tags` today** — no frontend consumer touches it, and `mcp-registry-search.ts` matches on slug/title/description/tagline. The first consumer to write `server.tags.map(...)` would have hit a runtime crash against green types. Fixing it now rather than at the first call site.

I normalized at the **ingest boundary** rather than at the DTO, so the declared type becomes true from the API client onwards and the entity, controller and `@n8n/api-types` schema need no changes. Already-flat arrays pass through untouched, so this keeps working if the upstream API ever drops the wrapper.

```ts
type RawMcpRegistryServer = Omit<McpRegistryServer, 'tags'> & {
	tags?: string[] | { data?: string[] };
};

function normalizeServer(server: RawMcpRegistryServer): McpRegistryServer {
	const { tags, ...rest } = server;
	if (tags === undefined || tags === null) return rest;
	return { ...rest, tags: Array.isArray(tags) ? tags : (tags.data ?? []) };
}
```

## How to test

**Automated** — five new cases in the existing API-client suite:

```bash
cd packages/cli
pnpm test src/modules/mcp-registry/registry/__tests__/mcp-registry-api.client.test.ts
```

All 20 pass. To see the new ones fail against `master`:

```bash
git stash push -- src/modules/mcp-registry/registry/mcp-registry-api.client.ts
pnpm test src/modules/mcp-registry/registry/__tests__/mcp-registry-api.client.test.ts
git stash pop
```

Exactly the three wrapper cases go red, and the two pass-through cases stay green on both sides — which is the point, since the fix must not change behaviour for flat input:

```
× should unwrap the Strapi relation wrapper into a flat array
    expected { data: [ 'productivity', 'docs' ] } to deeply equal [ 'productivity', 'docs' ]
✓ should pass an already flat array through unchanged
× should treat a wrapper with no data as an empty list
    expected {} to deeply equal []
✓ should leave a server without tags untouched
× should normalize tags fetched by slug as well
```

`pnpm typecheck` and `pnpm lint` are clean in `packages/cli`.

**Manual** — with the registry reachable, call `GET /rest/mcp-registry/servers` and confirm each server's `tags` is a flat array of strings rather than `{ "data": [...] }`.

Note the existing fixtures in `mock-servers.ts` hardcode the already-correct `string[]` shape, which is why the mismatch was never caught — the new tests feed the raw API shape instead.

## Related Linear tickets, Github issues, and Community forum posts

Related to #35413 (third of the three bugs reported there)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Internal REST response now matches its already-documented type. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

**On process:** #35413 was filed by @pufuki and reports three separate bugs. I commented there asking whether I could pick them up and have not heard back yet, so this is a **draft** — if the team has this in flight internally, say the word and I'll close it. I've kept it to one of the three bugs so each stays independently reviewable; the other two (the `canBeCancelled` inversion and the double DB fetch in the test-run endpoint) are untouched here.

*Disclosure, per the "Using AI Tools" section of the contributing guide: I used Claude Code to help trace this through the module and draft the tests. I have reviewed and run everything here and can explain each line.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

