### PR TITLE
fix(Telegram Node): don't force Markdown when attribution is off

### DIFF
--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -89,7 +89,11 @@ export function addAdditionalFields(
 			additionalFields.appendAttribution = true;
 		}
 
-		if (!additionalFields.parse_mode) {
+		// Only force Markdown when attribution needs it. Forcing Markdown while
+		// attribution is off makes Telegram parse the whole message as entities,
+		// so unescaped characters like "_" in {{ $workflow.name }} fail with
+		// "can't parse entities" (see n8n-io/n8n#35386).
+		if (additionalFields.appendAttribution && !additionalFields.parse_mode) {
 			additionalFields.parse_mode = 'Markdown';
 		}
 
@@ -273,20 +277,23 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions, chatApp
 
 	const config = getSendAndWaitConfig(context);
 	let text = config.message;
+	const appendAttribution = config.appendAttribution !== false;
 
-	if (config.appendAttribution !== false) {
+	if (appendAttribution) {
 		const instanceId = context.getInstanceId();
 		const attributionText = 'This message was sent automatically with ';
 		const link = createUtmCampaignLink('n8n-nodes-base.telegram', instanceId);
 		text = `${text}\n\n_${attributionText}_[n8n](${link})`;
 	}
 
-	const body = {
+	const body: IDataObject = {
 		chat_id,
 		text,
 
 		disable_web_page_preview: true,
-		parse_mode: 'Markdown',
+		// Only set Markdown when attribution formatting requires it; otherwise
+		// plain text so underscores etc. in the message are not treated as entities.
+		...(appendAttribution ? { parse_mode: 'Markdown' } : {}),
 		reply_markup: {
 			inline_keyboard: [
 				config.options.map((option) => {

--- a/packages/nodes-base/nodes/Telegram/tests/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/GenericFunctions.test.ts
@@ -195,7 +195,6 @@ describe('Telegram > GenericFunctions', () => {
 			expect(body).toEqual({
 				text: 'Hello, world!',
 				disable_web_page_preview: true,
-				parse_mode: 'Markdown',
 				reply_markup: {
 					inline_keyboard: [
 						[{ text: 'Button 1', url: 'https://example.com' }, { text: 'Button 2' }],
@@ -228,7 +227,6 @@ describe('Telegram > GenericFunctions', () => {
 			expect(body).toEqual({
 				text: 'Hello, world!',
 				disable_web_page_preview: true,
-				parse_mode: 'Markdown',
 				reply_markup: { force_reply: true },
 			});
 		});
@@ -257,8 +255,61 @@ describe('Telegram > GenericFunctions', () => {
 			expect(body).toEqual({
 				text: 'Hello, world!',
 				disable_web_page_preview: true,
-				parse_mode: 'Markdown',
 				reply_markup: { remove_keyboard: true },
+			});
+		});
+
+		it('should not force Markdown parse_mode when attribution is disabled (issue #35386)', () => {
+			const body: IDataObject = { text: 'Workflow: My_Workflow' };
+			const index = 0;
+			const nodeVersion = 1.2;
+
+			(mockThis.getNodeParameter as Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'operation':
+						return 'sendMessage';
+					case 'additionalFields':
+						return { appendAttribution: false };
+					case 'replyMarkup':
+						return 'none';
+					default:
+						return '';
+				}
+			});
+
+			addAdditionalFields.call(mockThis, body, index, nodeVersion);
+
+			expect(body).toEqual({
+				text: 'Workflow: My_Workflow',
+				disable_web_page_preview: true,
+			});
+			expect(body).not.toHaveProperty('parse_mode');
+		});
+
+		it('should preserve explicit parse_mode when attribution is disabled', () => {
+			const body: IDataObject = { text: '*bold* and My_Workflow' };
+			const index = 0;
+			const nodeVersion = 1.2;
+
+			(mockThis.getNodeParameter as Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'operation':
+						return 'sendMessage';
+					case 'additionalFields':
+						return { appendAttribution: false, parse_mode: 'HTML' };
+					case 'replyMarkup':
+						return 'none';
+					default:
+						return '';
+				}
+			});
+
+			addAdditionalFields.call(mockThis, body, index, nodeVersion);
+
+			expect(body).toEqual({
+				text: '*bold* and My_Workflow',
+				disable_web_page_preview: true,
+				parse_mode: 'HTML',
 			});
 		});
 

--- a/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/sendAndWait.operation.test.ts
@@ -84,6 +84,60 @@ describe('Test Telegram, message => sendAndWait', () => {
 		});
 	});
 
+	it('should omit parse_mode and attribution footer when appendAttribution is false', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(SEND_AND_WAIT_OPERATION);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('message');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false);
+		mockExecuteFunctions.getNode.mockReturnValue(mock<INode>());
+		mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(false); // chatApproval
+
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('chatID');
+
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('Workflow: My_Workflow');
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('my subject');
+		mockExecuteFunctions.getSignedResumeUrl.mockReturnValue(
+			'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+		);
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // approvalOptions
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({ appendAttribution: false }); // options
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('approval');
+
+		mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({}); // options.limitWaitTime.values
+
+		const result = await telegram.execute.call(mockExecuteFunctions);
+
+		expect(result).toEqual([items]);
+		expect(genericFunctions.apiRequest).toHaveBeenCalledTimes(1);
+		expect(mockExecuteFunctions.putExecutionToWait).toHaveBeenCalledTimes(1);
+
+		expect(genericFunctions.apiRequest).toHaveBeenCalledWith('POST', 'sendMessage', {
+			chat_id: 'chatID',
+			disable_web_page_preview: true,
+			reply_markup: {
+				inline_keyboard: [
+					[
+						{
+							text: 'Approve',
+							url: 'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+						},
+					],
+				],
+			},
+			text: 'Workflow: My_Workflow',
+		});
+
+		const [, , body] = (genericFunctions.apiRequest as Mock).mock.calls[0] as [
+			string,
+			string,
+			Record<string, unknown>,
+		];
+		expect(body).not.toHaveProperty('parse_mode');
+		expect(body.text).not.toContain('This message was sent automatically with');
+	});
+
 	it('should route API errors to error output when continueOnFail is true', async () => {
 		const items = [{ json: { data: 'test' } }];
 		mockExecuteFunctions.getInputData.mockReturnValue(items);
@@ -186,5 +240,35 @@ describe('createSendAndWaitMessageBody - chat approval callback references', () 
 
 		expect(decisionForLabel('Approve')).toBe('a');
 		expect(decisionForLabel('Decline')).toBe('d');
+	});
+
+	it('omits parse_mode and attribution footer when appendAttribution is false', () => {
+		const context = mock<IExecuteFunctions>();
+		context.getInstanceId.mockReturnValue('instanceId');
+		context.getSignedResumeUrl.mockReturnValue(
+			'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+		);
+		context.getNodeParameter.mockImplementation((name: string) => {
+			switch (name) {
+				case 'chatId':
+					return 'chatID';
+				case 'message':
+					return 'Workflow: My_Workflow';
+				case 'subject':
+					return 'my subject';
+				case 'options':
+					return { appendAttribution: false };
+				case 'responseType':
+					return 'approval';
+				default:
+					return {};
+			}
+		});
+
+		const body = genericFunctions.createSendAndWaitMessageBody(context);
+
+		expect(body.text).toBe('Workflow: My_Workflow');
+		expect(body).not.toHaveProperty('parse_mode');
+		expect(body.text).not.toContain('This message was sent automatically with');
 	});
 });


### PR DESCRIPTION
## Summary

When **Append n8n Attribution** is disabled and `parse_mode` is not set, the Telegram node no longer forces `parse_mode: Markdown`.

Previously, Markdown was always forced for `sendMessage`. That made Telegram treat `_` in values like `{{ $workflow.name }}` (`My_Workflow`) as italic markers, causing:

`400 Bad Request: can't parse entities: Can't find end of the entity...`

Enabling attribution appeared to “fix” it because the attribution footer’s closing `_..._` accidentally balanced the unclosed entity.

**Fix:** only default to Markdown when attribution is enabled (it needs Markdown for the footer). With attribution off and no explicit parse mode, send plain text. Explicit `parse_mode` (HTML / Markdown / MarkdownV2) is preserved.

Also applies the same rule to `sendAndWait`.

## How to test

1. Create a workflow named `My_Workflow`.
2. Add Telegram **Send Message** with text `Workflow: {{ $workflow.name }}`.
3. Disable **Append n8n Attribution**.
4. Do **not** set Parse Mode.
5. Execute — message should send successfully.

Unit coverage added in `GenericFunctions.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #35386

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. *(N/A — bugfix)*
- [x] Tests included.
- [ ] PR Labeled with backport label if needed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

