### PR TITLE
refactor(core): Simplify detailLevel plumbing in MCP get_workflow_details (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-workflow.tool.test.ts
@@ -62,9 +62,10 @@ describe('execute-workflow MCP tool', () => {
 			expect(tool.name).toBe('execute_workflow');
 			expect(tool.config).toBeDefined();
 			expect(typeof tool.config.description).toBe('string');
-			expect(tool.config.description).toBe(
-				'Execute a workflow by ID. Returns the execution ID immediately without waiting for completion. Before executing always ensure you know the input schema by first using the get_workflow_details tool and consulting workflow description',
+			expect(tool.config.description).toContain(
+				'Execute a workflow by ID. Returns the execution ID immediately without waiting for completion.',
 			);
+			expect(tool.config.description).toContain("detailLevel 'execution'");
 			expect(tool.config.inputSchema).toBeDefined();
 			expect(tool.config.inputSchema?.executionMode.safeParse(undefined).success).toBe(false);
 			expect(tool.config.outputSchema).toBeDefined();

--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
@@ -188,7 +188,8 @@ describe('get-workflow-details MCP tool', () => {
 				{ workflowId: 'wf-1', detailLevel: 'execution' },
 			);
 
-			// The active version relation stays loaded (it feeds activeVersionTriggerInfo)
+			// The published version stays loaded: its graph is omitted, but its
+			// triggers still feed activeVersionTriggerInfo
 			expect(findWorkflowForUser).toHaveBeenCalledWith(
 				'wf-1',
 				user,
@@ -200,7 +201,6 @@ describe('get-workflow-details MCP tool', () => {
 			expect(payload.workflow.connections).toBeUndefined();
 			expect(payload.workflow.nodeGroups).toBeUndefined();
 			expect(payload.workflow.activeVersion).toBeUndefined();
-			expect(payload.workflow.settings).toBeUndefined();
 			expect(payload.workflow.meta).toBeUndefined();
 
 			// Everything needed to execute is still present
@@ -210,8 +210,10 @@ describe('get-workflow-details MCP tool', () => {
 			expect(payload.workflow.scopes).toEqual(['workflow:read', 'workflow:execute']);
 			expect(payload.workflow.canExecute).toBe(true);
 			expect(payload.workflow.description).toBeUndefined();
-			// The workflow size stays reportable for telemetry despite the trimmed payload
-			expect(payload.nodeCount).toBe(2);
+			// settings carries timezone and errorWorkflow, which shape how a run behaves
+			expect(payload.workflow.settings).toEqual({ availableInMCP: true });
+			// The workflow size stays reportable despite the trimmed payload
+			expect(payload.workflow.nodeCount).toBe(2);
 		});
 
 		test("returns all graph fields when detailLevel is 'full'", async () => {
@@ -234,13 +236,12 @@ describe('get-workflow-details MCP tool', () => {
 				{ workflowId: 'wf-1', detailLevel: 'full' },
 			);
 
-			// Guards the full-mode contract: all six graph fields must be present,
+			// Guards the full-mode contract: every conditional field must be present,
 			// since the output schema marks them optional and cannot enforce this.
 			expect(payload.workflow.nodes).toBeDefined();
 			expect(payload.workflow.connections).toBeDefined();
 			expect(payload.workflow.nodeGroups).toBeDefined();
 			expect(payload.workflow.activeVersion).toBeDefined();
-			expect(payload.workflow.settings).toBeDefined();
 			expect(payload.workflow.meta).toBeDefined();
 		});
 
@@ -327,6 +328,35 @@ describe('get-workflow-details MCP tool', () => {
 				{ workflowId: 'wf-1', detailLevel: 'execution' },
 			);
 			expect(payload.activeVersionTriggerInfo).toBeUndefined();
+			// The node-level guard let this through, so the notice compare is what suppressed it
+			expect(getTriggerDetailsMock).toHaveBeenCalledTimes(2);
+		});
+
+		test('never emits activeVersionTriggerInfo when the published version is the draft', async () => {
+			// activeVersionId === versionId, so there is no divergence to report and
+			// the published triggers are never looked up.
+			getTriggerDetailsMock.mockClear();
+			const credentialsService = mockInstance(CredentialsService, {});
+			const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };
+			const workflow = createWorkflow({ activeVersionId: 'some-version-id' });
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: vi.fn().mockResolvedValue(workflow),
+			});
+
+			const payload = await getWorkflowDetails(
+				user,
+				baseWebhookUrl,
+				workflowFinderService,
+				credentialsService,
+				nodeTypes,
+				endpoints,
+				roleService,
+				projectService,
+				{ workflowId: 'wf-1', detailLevel: 'execution' },
+			);
+
+			expect(payload.activeVersionTriggerInfo).toBeUndefined();
+			expect(getTriggerDetailsMock).toHaveBeenCalledTimes(1);
 		});
 
 		test('omits activeVersion graph when the published version matches the current draft', async () => {

--- a/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-workflow.tool.ts
@@ -105,7 +105,7 @@ export const createExecuteWorkflowTool = (
 	name: 'execute_workflow',
 	config: {
 		description:
-			'Execute a workflow by ID. Returns the execution ID immediately without waiting for completion. Before executing always ensure you know the input schema by first using the get_workflow_details tool and consulting workflow description',
+			"Execute a workflow by ID. Returns the execution ID immediately without waiting for completion. Before executing always ensure you know the input schema by first using the get_workflow_details tool and consulting workflow description; pass detailLevel 'execution' to that tool when running the workflow is all you need, since the full graph is not required here.",
 		inputSchema: inputSchema.shape,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
@@ -21,7 +21,7 @@ import {
 	workflowDetailsOutputSchema,
 } from './schemas';
 import { getTriggerDetails, type WebhookEndpoints } from './webhook-utils';
-import { getMcpWorkflow } from './workflow-validation.utils';
+import { getMcpWorkflow, type FoundWorkflow } from './workflow-validation.utils';
 
 const inputSchema = {
 	workflowId: z.string().describe('The ID of the workflow to retrieve'),
@@ -33,9 +33,47 @@ const inputSchema = {
 		),
 } satisfies z.ZodRawShape;
 
-export type WorkflowDetailsLevel = z.infer<typeof inputSchema.detailLevel>;
+type WorkflowDetailsLevel = z.infer<typeof inputSchema.detailLevel>;
 
 export type WorkflowDetailsOutputSchema = typeof workflowDetailsOutputSchema;
+
+const SUPPORTED_TRIGGER_TYPES = Object.keys(SUPPORTED_MCP_TRIGGERS);
+
+/**
+ * Splits a version's nodes into the triggers MCP can execute directly and the
+ * triggers it cannot (e.g. Gmail Trigger). Keeping the unsupported ones lets the
+ * notice distinguish a workflow whose triggers MCP can't drive from one with no
+ * triggers at all. Disabled nodes are dropped, since they never fire.
+ */
+const splitTriggers = (candidates: INode[]) => {
+	const enabledNodes = candidates.filter((node) => node.disabled !== true);
+	return {
+		supported: enabledNodes.filter((node) => SUPPORTED_TRIGGER_TYPES.includes(node.type)),
+		unsupported: enabledNodes.filter(
+			(node) => isTriggerNodeType(node.type) && !SUPPORTED_TRIGGER_TYPES.includes(node.type),
+		),
+	};
+};
+
+/**
+ * The published graph, for the full payload only. Null when the workflow has no
+ * published version. A bare marker when the published snapshot is the draft:
+ * activeVersionId names the published version and any draft change to nodes,
+ * connections or node groups regenerates versionId, so equality means the two
+ * are byte-identical and repeating the graph would just double the payload.
+ */
+const toActiveVersionSummary = (workflow: FoundWorkflow) => {
+	if (!workflow.activeVersionId || !workflow.activeVersion) return null;
+	if (workflow.activeVersionId === workflow.versionId) return { sameAsDraft: true as const };
+
+	const publishedNodes = workflow.activeVersion.nodes ?? [];
+	return {
+		sameAsDraft: false as const,
+		nodes: publishedNodes.map(sanitizeNodeCredentials),
+		connections: workflow.activeVersion.connections ?? {},
+		nodeGroups: toNodeGroupSummary(workflow.activeVersion.nodeGroups ?? [], publishedNodes),
+	};
+};
 
 const outputSchema = workflowDetailsOutputSchema.shape satisfies z.ZodRawShape;
 
@@ -85,7 +123,7 @@ export const createWorkflowDetailsTool = (
 			};
 
 			try {
-				const { nodeCount, ...payload } = await getWorkflowDetails(
+				const payload = await getWorkflowDetails(
 					user,
 					baseWebhookUrl,
 					workflowFinderService,
@@ -105,7 +143,7 @@ export const createWorkflowDetailsTool = (
 						workflow_id: workflowId,
 						workflow_name: payload.workflow.name,
 						trigger_count: payload.workflow.triggerCount,
-						node_count: nodeCount,
+						node_count: payload.workflow.nodeCount,
 					},
 				};
 				telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
@@ -138,11 +176,11 @@ export async function getWorkflowDetails(
 	projectService: ProjectService,
 	{ workflowId, detailLevel = 'full' }: { workflowId: string; detailLevel?: WorkflowDetailsLevel },
 	testBaseWebhookUrl: string = baseWebhookUrl,
-): Promise<WorkflowDetailsResult & { nodeCount: number }> {
+): Promise<WorkflowDetailsResult> {
 	const includeGraph = detailLevel === 'full';
-	// The active version is loaded even in execution mode: production executions
-	// run it, so its triggers feed activeVersionTriggerInfo when they diverge
-	// from the draft's.
+	// The published version is loaded in both modes: execution mode omits its
+	// graph from the payload but still compares its triggers against the draft's
+	// to decide whether activeVersionTriggerInfo is needed.
 	const workflow = await getMcpWorkflow(
 		workflowId,
 		user,
@@ -159,55 +197,40 @@ export async function getWorkflowDetails(
 
 	const nodes = workflow.nodes ?? [];
 
-	const supportedTriggers = Object.keys(SUPPORTED_MCP_TRIGGERS);
-	const splitTriggers = (candidates: INode[]) => {
-		const enabledNodes = candidates.filter((node) => node.disabled !== true);
-		return {
-			supported: enabledNodes.filter((node) => supportedTriggers.includes(node.type)),
-			// Triggers the workflow does have but MCP can't execute directly (e.g. Gmail Trigger),
-			// so the notice can distinguish these from a workflow with no triggers at all.
-			unsupported: enabledNodes.filter(
-				(node) => isTriggerNodeType(node.type) && !supportedTriggers.includes(node.type),
-			),
-		};
-	};
+	const noticeFor = async ({ supported, unsupported }: ReturnType<typeof splitTriggers>) =>
+		await getTriggerDetails(
+			user,
+			supported,
+			unsupported,
+			baseWebhookUrl,
+			credentialsService,
+			nodeTypes,
+			endpoints,
+			workflow.id,
+			testBaseWebhookUrl,
+		);
 
 	const draftTriggers = splitTriggers(nodes);
-	const triggerNotice = await getTriggerDetails(
-		user,
-		draftTriggers.supported,
-		draftTriggers.unsupported,
-		baseWebhookUrl,
-		credentialsService,
-		nodeTypes,
-		endpoints,
-		workflow.id,
-		testBaseWebhookUrl,
-	);
+	const triggerNotice = await noticeFor(draftTriggers);
 
-	// execute_workflow runs the published (active) version in production mode, so
-	// when its triggers diverge from the draft's (edited but not republished),
-	// surface the published version's trigger info alongside the draft's. The
-	// node comparison is a cheap prefilter; only a differing notice is emitted.
+	// execute_workflow runs the published version in production mode, so when its
+	// triggers diverge from the draft's (edited but not republished), surface the
+	// published trigger info alongside the draft's. Publishing points
+	// activeVersionId at the version being published, so the relation below is
+	// that same version.
+	//
+	// Two guards keep this off the common path: an unedited draft cannot diverge,
+	// and a node-level comparison skips the second lookup when the triggers are
+	// untouched. Only a genuinely different notice is emitted, so changes that do
+	// not affect trigger info (e.g. node position) stay silent.
+	const hasDivergedPublishedVersion =
+		workflow.activeVersionId !== null && workflow.activeVersionId !== workflow.versionId;
+	const publishedNodes = hasDivergedPublishedVersion ? workflow.activeVersion?.nodes : undefined;
 	let activeVersionTriggerNotice: string | undefined;
-	if (
-		workflow.activeVersionId &&
-		workflow.activeVersion &&
-		workflow.activeVersionId !== workflow.versionId
-	) {
-		const publishedTriggers = splitTriggers(workflow.activeVersion.nodes ?? []);
+	if (publishedNodes) {
+		const publishedTriggers = splitTriggers(publishedNodes);
 		if (JSON.stringify(publishedTriggers) !== JSON.stringify(draftTriggers)) {
-			const publishedNotice = await getTriggerDetails(
-				user,
-				publishedTriggers.supported,
-				publishedTriggers.unsupported,
-				baseWebhookUrl,
-				credentialsService,
-				nodeTypes,
-				endpoints,
-				workflow.id,
-				testBaseWebhookUrl,
-			);
+			const publishedNotice = await noticeFor(publishedTriggers);
 			if (publishedNotice !== triggerNotice) {
 				activeVersionTriggerNotice = publishedNotice;
 			}
@@ -222,8 +245,12 @@ export async function getWorkflowDetails(
 		versionId: workflow.versionId,
 		activeVersionId: workflow.activeVersionId,
 		triggerCount: workflow.triggerCount,
+		// Reported in both modes so callers (and telemetry) can size the workflow
+		// without the trimmed payload having to carry the nodes.
+		nodeCount: nodes.length,
 		createdAt: workflow.createdAt.toISOString(),
 		updatedAt: workflow.updatedAt.toISOString(),
+		settings: workflow.settings ?? null,
 		tags: toTagSummary(workflow.tags),
 		parentFolderId: workflow.parentFolder?.id ?? null,
 		description: workflow.description ?? undefined,
@@ -233,27 +260,10 @@ export async function getWorkflowDetails(
 		// only needs enough to execute the workflow.
 		...(includeGraph
 			? {
-					settings: workflow.settings ?? null,
 					connections: workflow.connections ?? {},
 					nodes: nodes.map(sanitizeNodeCredentials),
 					nodeGroups: toNodeGroupSummary(workflow.nodeGroups ?? [], nodes),
-					// Publishing sets activeVersionId to the draft's versionId and every
-					// draft save regenerates versionId, so equality means the published
-					// graph is byte-identical to the draft — skip repeating it.
-					activeVersion:
-						workflow.activeVersionId && workflow.activeVersion
-							? workflow.activeVersionId === workflow.versionId
-								? { sameAsDraft: true as const }
-								: {
-										sameAsDraft: false as const,
-										nodes: (workflow.activeVersion.nodes ?? []).map(sanitizeNodeCredentials),
-										connections: workflow.activeVersion.connections ?? {},
-										nodeGroups: toNodeGroupSummary(
-											workflow.activeVersion.nodeGroups ?? [],
-											workflow.activeVersion.nodes ?? [],
-										),
-									}
-							: null,
+					activeVersion: toActiveVersionSummary(workflow),
 					meta: workflow.meta ?? null,
 				}
 			: {}),
@@ -263,8 +273,5 @@ export async function getWorkflowDetails(
 		workflow: sanitizedWorkflow,
 		triggerInfo: triggerNotice,
 		activeVersionTriggerInfo: activeVersionTriggerNotice,
-		// Not part of the MCP response; lets the handler report the workflow size
-		// in telemetry even when detailLevel omits the nodes from the payload.
-		nodeCount: nodes.length,
 	};
 }

--- a/packages/cli/src/modules/mcp/tools/schemas.ts
+++ b/packages/cli/src/modules/mcp/tools/schemas.ts
@@ -161,9 +161,12 @@ export const workflowDetailsOutputSchema = z.object({
 				.nullable()
 				.describe('The active workflow version ID, if available'),
 			triggerCount: z.number(),
+			nodeCount: z
+				.number()
+				.describe('Number of nodes in the workflow, reported even when detailLevel omits them'),
 			createdAt: z.string().nullable(),
 			updatedAt: z.string().nullable(),
-			settings: workflowSettingsSchema.optional().describe(FULL_DETAIL_ONLY_NOTE),
+			settings: workflowSettingsSchema,
 			connections: z.record(z.unknown()).optional().describe(FULL_DETAIL_ONLY_NOTE),
 			nodes: z.array(nodeSchema).optional().describe(FULL_DETAIL_ONLY_NOTE),
 			nodeGroups: z


### PR DESCRIPTION
## Summary

Stacked on #35497. Keeps that PR's behaviour intact, `detailLevel`, the `sameAsDraft` dedupe and `activeVersionTriggerInfo` all included, and tidies how the pieces are assembled.

### Response shape

- **`nodeCount` is a real response field** next to `triggerCount`, instead of riding on a `WorkflowDetailsResult & { nodeCount: number }` intersection that the handler destructured away before it reached the client. The return type stops lying about being the MCP result, and execution mode now surfaces the workflow size it was already computing, which is useful to an agent deciding whether to refetch the graph.
- **`settings` stays present in both modes.** It was grouped with the graph fields, but it is a handful of keys, and `timezone` changes how a Schedule trigger reads while `errorWorkflow` changes how a failed run should be read. Omitting it saved ~100 bytes and hid execution-relevant config in the mode named "execution". Five optional fields now instead of six.

### Discoverability

- **`execute_workflow`'s description points at `detailLevel: 'execution'`.** #35497 added cross-tool guidance toward `'full'` in two places (`list_credentials`, `mcp-instructions`) but nothing toward the cheap path, while `execute_workflow` told callers to fetch details first with no hint a cheaper level existed. Since `detailLevel` defaults to `'full'`, the saving only materialises if callers actually pass `'execution'`.

### Structure

- `splitTriggers` and the `activeVersion` summary move to module scope, and a local `noticeFor` closure removes the duplicated nine-argument `getTriggerDetails` call site.
- This puts `getWorkflowDetails` back under the repo's complexity limit. Worth flagging on #35497: master has no complexity warning on this file, #35497 takes it to **26 against a maximum of 20**, and `eslint . --quiet` hides that from CI. This branch is back to master's baseline.
- The unpublished case is guarded explicitly (`activeVersionId !== null`) rather than relying on the `activeVersion` relation happening to be null, since the previous expression conflated "unpublished" with "published and different".

## Behaviour unchanged

`activeVersionTriggerInfo` and its guards are kept exactly as #35497 has them, including the `activeVersionId !== versionId` short-circuit, the node-level prefilter and the final notice comparison. One test is added to lock in that an unedited published draft never performs the second trigger lookup.

For the record, since it came up in review: `activeVersionId` and `workflow_published_version.publishedVersionId` hold the same value by construction. `_publishViaOutbox` writes `activeVersionId` and enqueues the outbox record in one transaction, and the applier advances the mapping to that same version (`workflow-publication-applier.ts:310`); unpublish is paired the same way. So reading the published triggers off `workflow.activeVersion` agrees with what `execute_workflow` runs. They can differ only in the window between that commit and the leader draining the outbox, which predates this PR and affects `activeVersion` and `active` equally.

## Kept deliberately

- The `activeVersion` discriminated union stays as #35497 has it. `get_workflow_version` could supply the published graph on the `sameAsDraft: false` branch, but dropping it would change behaviour predating that PR.
- The full-mode contract test stays. `connections` and `meta` are asserted nowhere else in the file, so it is the only guard against a key going missing from the conditional spread.

## How to test

1. `pnpm vitest run src/modules/mcp` in `packages/cli` — 1174 passing.
2. `get_workflow_details` with `detailLevel: 'execution'`: no `nodes`/`connections`/`nodeGroups`/`activeVersion`/`meta`, but `settings`, `nodeCount` and `triggerInfo` present.
3. `get_workflow_details` with no `detailLevel`: unchanged from #35497, including `activeVersion: { sameAsDraft: true }` for a published, unedited workflow.
4. Publish a workflow, then change its trigger in the draft without republishing: `activeVersionTriggerInfo` appears, in both detail levels.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.