### PR TITLE
fix(ERPNext Node): Load DocType fields via the desk form endpoint

### DIFF
--- a/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
+++ b/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
@@ -11,7 +11,7 @@ import type {
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import { documentFields, documentOperations } from './DocumentDescription';
-import { erpNextApiRequest, erpNextApiRequestAllItems } from './GenericFunctions';
+import { erpNextApiRequest, erpNextApiRequestAllItems, getDocTypeFields } from './GenericFunctions';
 import type { DocumentProperties } from './utils';
 import { processNames, toSQL } from './utils';
 
@@ -21,7 +21,7 @@ export class ERPNext implements INodeType {
 		name: 'erpNext',
 		icon: 'file:erpnext.svg',
 		group: ['output'],
-		version: 1,
+		version: [1, 1.1],
 		subtitle: '={{$parameter["resource"] + ": " + $parameter["operation"]}}',
 		description: 'Consume ERPNext API',
 		defaults: {
@@ -73,18 +73,7 @@ export class ERPNext implements INodeType {
 			},
 			async getDocFilters(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const docType = this.getCurrentNodeParameter('docType') as string;
-				const { data } = await erpNextApiRequest.call(
-					this,
-					'GET',
-					`/api/resource/DocType/${docType}`,
-					{},
-				);
-
-				const docFields = data.fields.map(
-					({ label, fieldname }: { label: string; fieldname: string }) => {
-						return { name: label, value: fieldname };
-					},
-				);
+				const docFields = await getDocTypeFields.call(this, docType);
 
 				docFields.unshift({ name: '*', value: '*' });
 
@@ -92,18 +81,7 @@ export class ERPNext implements INodeType {
 			},
 			async getDocFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const docType = this.getCurrentNodeParameter('docType') as string;
-				const { data } = await erpNextApiRequest.call(
-					this,
-					'GET',
-					`/api/resource/DocType/${docType}`,
-					{},
-				);
-
-				const docFields = data.fields.map(
-					({ label, fieldname }: { label: string; fieldname: string }) => {
-						return { name: label, value: fieldname };
-					},
-				);
+				const docFields = await getDocTypeFields.call(this, docType);
 
 				return processNames(docFields);
 			},

--- a/packages/nodes-base/nodes/ERPNext/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ERPNext/GenericFunctions.ts
@@ -9,6 +9,8 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
+import { extractDocTypeFields } from './utils';
+
 /**
  * Return the base API URL based on the user's environment.
  */
@@ -63,6 +65,46 @@ export async function erpNextApiRequest(
 		}
 		throw error;
 	}
+}
+
+/**
+ * Fetch the field definitions of a DocType.
+ *
+ * Version 1 reads them from `/api/resource/DocType/{docType}`, which requires read
+ * access to the DocType doctype itself — in practice the System Manager role — so for
+ * an ordinary user the request 403s and the field dropdowns stay empty. From version
+ * 1.1 we call the endpoint the Frappe desk UI itself uses, which authorises against the
+ * user's access to the doctype being loaded.
+ *
+ * `docType` arrives URI-encoded from `getDocTypes`, so it is interpolated rather than
+ * passed as a query object, which would encode it a second time.
+ */
+export async function getDocTypeFields(
+	this: ILoadOptionsFunctions,
+	docType: string,
+): Promise<Array<{ name: string; value: string }>> {
+	if (this.getNode().typeVersion < 1.1) {
+		const { data } = await erpNextApiRequest.call(
+			this,
+			'GET',
+			`/api/resource/DocType/${docType}`,
+			{},
+		);
+
+		return data.fields.map(({ label, fieldname }: { label: string; fieldname: string }) => ({
+			name: label,
+			value: fieldname,
+		}));
+	}
+
+	const response = await erpNextApiRequest.call(
+		this,
+		'GET',
+		`/api/method/frappe.desk.form.load.getdoctype?doctype=${docType}`,
+		{},
+	);
+
+	return extractDocTypeFields(response, docType);
 }
 
 export async function erpNextApiRequestAllItems(

--- a/packages/nodes-base/nodes/ERPNext/test/ERPNext.node.test.ts
+++ b/packages/nodes-base/nodes/ERPNext/test/ERPNext.node.test.ts
@@ -1,0 +1,194 @@
+import type { ILoadOptionsFunctions, INode, INodePropertyOptions } from 'n8n-workflow';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { ERPNext } from '../ERPNext.node';
+
+const BASE_URL = 'https://erp.example.com';
+
+/** Shape returned by `/api/resource/DocType/{docType}` — the version 1 endpoint. */
+const RESOURCE_RESPONSE = {
+	data: {
+		fields: [
+			{ label: 'Customer Name', fieldname: 'customer_name' },
+			{ label: 'Territory', fieldname: 'territory' },
+		],
+	},
+};
+
+/**
+ * Shape returned by `frappe.desk.form.load.getdoctype` — the version 1.1 endpoint.
+ * It bundles the requested DocType with the DocTypes it links to.
+ */
+const GETDOCTYPE_RESPONSE = {
+	docs: [
+		{
+			name: 'Customer',
+			fields: [
+				{ label: 'Customer Name', fieldname: 'customer_name' },
+				{ label: 'Territory', fieldname: 'territory' },
+				// Layout breaks carry no label and are dropped, as on version 1.
+				{ label: '', fieldname: 'section_break_1' },
+			],
+		},
+		{
+			name: 'Customer Credit Limit',
+			fields: [{ label: 'Credit Limit', fieldname: 'credit_limit' }],
+		},
+	],
+};
+
+const createContext = (typeVersion: number, docType: string, response: unknown) => {
+	const ctx = mockDeep<ILoadOptionsFunctions>();
+
+	ctx.getNode.mockReturnValue({ typeVersion } as INode);
+	ctx.getCurrentNodeParameter.mockReturnValue(docType);
+	ctx.getCredentials.mockResolvedValue({
+		environment: 'selfHosted',
+		domain: BASE_URL,
+	});
+	ctx.helpers.requestWithAuthentication.mockResolvedValue(response);
+
+	return ctx;
+};
+
+/** The URI the node actually requested. */
+const requestedUri = (ctx: ReturnType<typeof createContext>) =>
+	ctx.helpers.requestWithAuthentication.mock.calls[0][1].uri;
+
+describe('ERPNext node', () => {
+	const node = new ERPNext();
+
+	describe('loadOptions.getDocFields', () => {
+		it('reads fields from the DocType resource on version 1', async () => {
+			const ctx = createContext(1, 'Customer', RESOURCE_RESPONSE);
+
+			const result = await node.methods.loadOptions.getDocFields.call(ctx);
+
+			expect(requestedUri(ctx)).toBe(`${BASE_URL}/api/resource/DocType/Customer`);
+			expect(result).toEqual<INodePropertyOptions[]>([
+				{ name: 'Customer Name', value: 'customer_name' },
+				{ name: 'Territory', value: 'territory' },
+			]);
+		});
+
+		it('reads fields from the desk form endpoint on version 1.1', async () => {
+			const ctx = createContext(1.1, 'Customer', GETDOCTYPE_RESPONSE);
+
+			const result = await node.methods.loadOptions.getDocFields.call(ctx);
+
+			expect(requestedUri(ctx)).toBe(
+				`${BASE_URL}/api/method/frappe.desk.form.load.getdoctype?doctype=Customer`,
+			);
+			expect(result).toEqual<INodePropertyOptions[]>([
+				{ name: 'Customer Name', value: 'customer_name' },
+				{ name: 'Territory', value: 'territory' },
+			]);
+		});
+
+		it('does not request the permission-restricted DocType resource on version 1.1', async () => {
+			const ctx = createContext(1.1, 'Customer', GETDOCTYPE_RESPONSE);
+
+			await node.methods.loadOptions.getDocFields.call(ctx);
+
+			expect(requestedUri(ctx)).not.toContain('/api/resource/DocType/');
+		});
+
+		it('ignores fields belonging to linked DocTypes', async () => {
+			const ctx = createContext(1.1, 'Customer', GETDOCTYPE_RESPONSE);
+
+			const result = await node.methods.loadOptions.getDocFields.call(ctx);
+
+			expect(result).not.toContainEqual({ name: 'Credit Limit', value: 'credit_limit' });
+		});
+
+		it('matches a URI-encoded DocType name against the decoded response', async () => {
+			const ctx = createContext(1.1, 'Sales%20Order', {
+				docs: [
+					{ name: 'Sales Order Item', fields: [{ label: 'Rate', fieldname: 'rate' }] },
+					{ name: 'Sales Order', fields: [{ label: 'Customer', fieldname: 'customer' }] },
+				],
+			});
+
+			const result = await node.methods.loadOptions.getDocFields.call(ctx);
+
+			expect(result).toEqual<INodePropertyOptions[]>([{ name: 'Customer', value: 'customer' }]);
+		});
+
+		it('falls back to the first document when no name matches', async () => {
+			const ctx = createContext(1.1, 'Customer', {
+				docs: [{ fields: [{ label: 'Territory', fieldname: 'territory' }] }],
+			});
+
+			const result = await node.methods.loadOptions.getDocFields.call(ctx);
+
+			expect(result).toEqual<INodePropertyOptions[]>([{ name: 'Territory', value: 'territory' }]);
+		});
+	});
+
+	describe('loadOptions.getDocFilters', () => {
+		it('reads filters from the DocType resource on version 1', async () => {
+			const ctx = createContext(1, 'Customer', RESOURCE_RESPONSE);
+
+			const result = await node.methods.loadOptions.getDocFilters.call(ctx);
+
+			expect(requestedUri(ctx)).toBe(`${BASE_URL}/api/resource/DocType/Customer`);
+			expect(result).toEqual<INodePropertyOptions[]>([
+				{ name: '*', value: '*' },
+				{ name: 'Customer Name', value: 'customer_name' },
+				{ name: 'Territory', value: 'territory' },
+			]);
+		});
+
+		it('reads filters from the desk form endpoint on version 1.1', async () => {
+			const ctx = createContext(1.1, 'Customer', GETDOCTYPE_RESPONSE);
+
+			const result = await node.methods.loadOptions.getDocFilters.call(ctx);
+
+			expect(requestedUri(ctx)).toBe(
+				`${BASE_URL}/api/method/frappe.desk.form.load.getdoctype?doctype=Customer`,
+			);
+			expect(result).toEqual<INodePropertyOptions[]>([
+				{ name: '*', value: '*' },
+				{ name: 'Customer Name', value: 'customer_name' },
+				{ name: 'Territory', value: 'territory' },
+			]);
+		});
+	});
+
+	describe('unexpected version 1.1 responses', () => {
+		it.each([
+			['no docs property', {}],
+			['docs is not an array', { docs: 'nope' }],
+			['docs is empty', { docs: [] }],
+			['document has no fields array', { docs: [{ name: 'Customer' }] }],
+			['response is null', null],
+		])('returns no options when %s', async (_label, response) => {
+			const ctx = createContext(1.1, 'Customer', response);
+
+			const result = await node.methods.loadOptions.getDocFields.call(ctx);
+
+			expect(result).toEqual([]);
+		});
+
+		it('skips malformed field entries', async () => {
+			const ctx = createContext(1.1, 'Customer', {
+				docs: [
+					{
+						name: 'Customer',
+						fields: [
+							null,
+							'not an object',
+							{ fieldname: 'no_label' },
+							{ label: 'No fieldname' },
+							{ label: 'Territory', fieldname: 'territory' },
+						],
+					},
+				],
+			});
+
+			const result = await node.methods.loadOptions.getDocFields.call(ctx);
+
+			expect(result).toEqual<INodePropertyOptions[]>([{ name: 'Territory', value: 'territory' }]);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/ERPNext/utils.ts
+++ b/packages/nodes-base/nodes/ERPNext/utils.ts
@@ -8,6 +8,47 @@ export type DocumentProperties = {
 
 type DocFields = Array<{ name: string; value: string }>;
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null;
+
+const isDocTypeField = (value: unknown): value is { label: string; fieldname: string } =>
+	isRecord(value) && typeof value.label === 'string' && typeof value.fieldname === 'string';
+
+/** DocType names reach us URI-encoded, but the API echoes them back decoded. */
+const safeDecodeUri = (value: string) => {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+};
+
+/**
+ * Pull the field definitions for `docType` out of a `frappe.desk.form.load.getdoctype`
+ * response.
+ *
+ * The endpoint returns the requested DocType alongside every DocType it links to, so
+ * select the requested one rather than merging them all — a linked DocType's fieldnames
+ * are not valid on the parent. Frappe returns the requested DocType first, which is the
+ * fallback when nothing matches by name.
+ *
+ * Every layer is checked before it is read: a shape we don't recognise yields an empty
+ * list, so an unexpected response leaves the dropdown empty instead of throwing.
+ */
+export const extractDocTypeFields = (response: unknown, docType: string): DocFields => {
+	if (!isRecord(response) || !Array.isArray(response.docs)) return [];
+
+	const wanted = safeDecodeUri(docType);
+	const doc =
+		response.docs.find((entry) => isRecord(entry) && entry.name === wanted) ?? response.docs[0];
+
+	if (!isRecord(doc) || !Array.isArray(doc.fields)) return [];
+
+	return doc.fields
+		.filter(isDocTypeField)
+		.map(({ label, fieldname }) => ({ name: label, value: fieldname }));
+};
+
 const ensureName = (docFields: DocFields) => docFields.filter((o) => o.name);
 const sortByName = (docFields: DocFields) => sortBy(docFields, ['name']);
 const uniqueByName = (docFields: DocFields) => uniqBy(docFields, (o) => o.name);


### PR DESCRIPTION
## Summary

The ERPNext node's **Field** and **Filter** dropdowns load a DocType's field
definitions from `/api/resource/DocType/{docType}`. Reading that path requires
read access to the `DocType` doctype itself — in practice the **System Manager**
role. An ordinary user who can happily read and write `Customer` records still
gets a 403 there, which the node surfaces as `DocType unavailable.`, leaving both
dropdowns empty and the node unusable without escalating that user's permissions.

From **node version 1.1** the definitions come from
`frappe.desk.form.load.getdoctype` — the endpoint the Frappe desk UI itself calls
when it opens a form. It authorises against the user's access to the doctype
being loaded rather than to the `DocType` doctype, so the dropdowns populate for
any user who can actually use the document.

Version 1 keeps the original endpoint, so existing workflows are untouched.

Two details worth calling out for review:

- `getdoctype` returns the requested DocType **together with every DocType it
  links to**. The requested one is selected by name rather than merging all of
  them, because a linked DocType's fieldnames are not valid columns on the
  parent. Frappe returns the requested DocType first, which is the fallback when
  nothing matches by name.
- The response is checked at each level before it is read, so an unrecognised
  shape yields an empty option list rather than throwing. This addresses the
  automated review comment on #17267.

**Scope note:** `getDocFilters` had the identical bug and is fixed under the same
version bump. Fixing only `getDocFields` would leave the node needing a second
version bump later for the same root cause. Happy to narrow this back to
`getDocFields` if you'd prefer the smaller diff.

This supersedes #17267 by @Mehul945, which is under a 14-day close warning. The
endpoint change is their work and the credit is theirs; this PR adds the node
version gate, the response hardening, and the tests that @michael-radency asked
for.

## How to test

Requires an ERPNext / Frappe instance.

1. In ERPNext, create a user whose roles do **not** include System Manager, but
   who does have read access to a doctype such as `Customer`. Generate an API
   key and secret for that user.
2. In n8n, create ERPNext credentials from that key/secret.
3. Add an **ERPNext** node (it will default to version 1.1), choose
   **Document → Get Many**, and set **DocType** to `Customer`.
4. Open the **Fields** dropdown. It lists `Customer`'s fields. Open **Filters** —
   it lists the same fields plus `*`.
5. To confirm the old behaviour is unchanged, pin an existing ERPNext node from a
   workflow saved before this change (it stays on version 1) and repeat step 4 —
   it still calls `/api/resource/DocType/Customer` and, with the restricted user,
   still fails as it does on master.

On `master`, step 4 shows an empty dropdown and a `DocType unavailable.` error.

Automated coverage is in
`packages/nodes-base/nodes/ERPNext/test/ERPNext.node.test.ts` — the first tests
for this node. They assert the exact URL requested on each node version, so the
version gate itself is covered rather than just the parsing.

```bash
cd packages/nodes-base && pnpm test nodes/ERPNext
```

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #35796
- Supersedes #17267 (internal reference noted there: GHC-3074)

Not related, but worth flagging while this node is open: #19271 is a separate
ERPNext bug in the execute path, where the DocType name is double-encoded and
produces `DocType Sales%20Order not found`. It is untouched here.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

