### PR TITLE
fix(GitLab Node): Make the State field work when editing an issue

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -10,6 +10,12 @@ import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import { gitlabApiRequest, gitlabApiRequestAllItems } from './GenericFunctions';
 
+/** Maps the issue `state` option to the `state_event` transition the GitLab API expects. */
+const ISSUE_STATE_EVENTS: Record<string, string> = {
+	closed: 'close',
+	open: 'reopen',
+};
+
 export class Gitlab implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'GitLab',
@@ -1450,6 +1456,13 @@ export class Gitlab implements INodeType {
 						}
 						if (body.assignee_ids !== undefined) {
 							body.assignee_ids = (body.assignee_ids as IDataObject[]).map((data) => data.assignee);
+						}
+						// The API expects the transition to apply as `state_event`, not the target
+						// `state`, so translate it here rather than renaming the field and breaking
+						// saved workflows. https://docs.gitlab.com/api/issues/#edit-an-issue
+						if (body.state !== undefined && ISSUE_STATE_EVENTS[body.state as string]) {
+							body.state_event = ISSUE_STATE_EVENTS[body.state as string];
+							delete body.state;
 						}
 
 						endpoint = `${baseEndpoint}/issues/${issueNumber}`;

--- a/packages/nodes-base/nodes/Gitlab/__tests__/Gitlab.issue.edit.test.ts
+++ b/packages/nodes-base/nodes/Gitlab/__tests__/Gitlab.issue.edit.test.ts
@@ -1,0 +1,133 @@
+import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
+import type { Mock, Mocked } from 'vitest';
+
+import * as GenericFunctions from '../GenericFunctions';
+import type * as _importType0 from '../GenericFunctions';
+import { Gitlab } from '../Gitlab.node';
+
+vi.mock('../GenericFunctions', async () => ({
+	...(await vi.importActual<typeof _importType0>('../GenericFunctions')),
+	gitlabApiRequest: vi.fn(),
+}));
+
+describe('Gitlab Node - Issue Edit Operation', () => {
+	let gitlab: Gitlab;
+	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
+
+	/** Returns the request body the node sent to the GitLab API. */
+	const sentBody = () =>
+		(GenericFunctions.gitlabApiRequest as Mock).mock.calls[0][2] as IDataObject;
+
+	const setParams = (editFields: IDataObject) => {
+		(mockExecuteFunctions.getNodeParameter as Mock).mockImplementation((paramName: string) => {
+			const params: Record<string, unknown> = {
+				authentication: 'accessToken',
+				resource: 'issue',
+				operation: 'edit',
+				owner: 'test-owner',
+				repository: 'test-repo',
+				issueNumber: '42',
+				editFields,
+			};
+			return params[paramName];
+		});
+	};
+
+	beforeEach(() => {
+		gitlab = new Gitlab();
+		vi.clearAllMocks();
+
+		(GenericFunctions.gitlabApiRequest as Mock).mockResolvedValue({ iid: 42 });
+
+		mockExecuteFunctions = {
+			getNodeParameter: vi.fn(),
+			getInputData: vi.fn().mockReturnValue([{ json: {} }]),
+			getNode: vi.fn().mockReturnValue({
+				id: 'test-node-id',
+				name: 'Gitlab',
+				type: 'n8n-nodes-base.gitlab',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			}),
+			helpers: {
+				returnJsonArray: vi.fn((data) => (Array.isArray(data) ? data : [data])),
+				constructExecutionMetaData: vi.fn((data) => data),
+			},
+			getCredentials: vi.fn().mockResolvedValue({
+				accessToken: 'test-token',
+				server: 'https://gitlab.example.com',
+			}),
+			continueOnFail: vi.fn().mockReturnValue(false),
+		} as unknown as Mocked<IExecuteFunctions>;
+	});
+
+	it('should send state_event "close" when the state is set to closed', async () => {
+		setParams({ state: 'closed' });
+
+		await gitlab.execute.call(mockExecuteFunctions);
+
+		const body = sentBody();
+		expect(body.state_event).toBe('close');
+		// `state` is not a field on GitLab's edit endpoint — sending it closes nothing.
+		expect(body).not.toHaveProperty('state');
+	});
+
+	it('should send state_event "reopen" when the state is set to open', async () => {
+		setParams({ state: 'open' });
+
+		await gitlab.execute.call(mockExecuteFunctions);
+
+		const body = sentBody();
+		expect(body.state_event).toBe('reopen');
+		expect(body).not.toHaveProperty('state');
+	});
+
+	it('should use the PUT method against the issue endpoint', async () => {
+		setParams({ state: 'closed' });
+
+		await gitlab.execute.call(mockExecuteFunctions);
+
+		const [method, endpoint] = (GenericFunctions.gitlabApiRequest as Mock).mock.calls[0];
+		expect(method).toBe('PUT');
+		expect(endpoint).toBe('/projects/test-owner%2Ftest-repo/issues/42');
+	});
+
+	it('should not add state_event when the state field is left unset', async () => {
+		setParams({ title: 'Updated title' });
+
+		await gitlab.execute.call(mockExecuteFunctions);
+
+		const body = sentBody();
+		expect(body).not.toHaveProperty('state_event');
+		expect(body.title).toBe('Updated title');
+	});
+
+	it('should leave an unrecognised state value untouched', async () => {
+		setParams({ state: 'something-else' });
+
+		await gitlab.execute.call(mockExecuteFunctions);
+
+		const body = sentBody();
+		expect(body).not.toHaveProperty('state_event');
+		expect(body.state).toBe('something-else');
+	});
+
+	it('should translate the state alongside the other edit fields', async () => {
+		setParams({
+			state: 'closed',
+			title: 'Updated title',
+			labels: [{ label: 'bug' }, { label: 'urgent' }],
+			assignee_ids: [{ assignee: 7 }],
+		});
+
+		await gitlab.execute.call(mockExecuteFunctions);
+
+		const body = sentBody();
+		expect(body.state_event).toBe('close');
+		expect(body).not.toHaveProperty('state');
+		expect(body.title).toBe('Updated title');
+		expect(body.labels).toBe('bug,urgent');
+		expect(body.assignee_ids).toEqual([7]);
+	});
+});


### PR DESCRIPTION
## Summary

The GitLab node's **Issue → Edit** operation has a **State** field offering
_Open_ and _Closed_. Selecting either currently has no effect at all.

The node puts the field into the request body as `state`:

```ts
body = this.getNodeParameter('editFields', i, {}) as IDataObject;
// ... labels and assignee_ids are transformed, `state` is passed through as-is
endpoint = `${baseEndpoint}/issues/${issueNumber}`;
```

But GitLab's [Edit issue](https://docs.gitlab.com/api/issues/#edit-an-issue)
endpoint has no `state` parameter. The state change is requested with
`state_event`, whose values are `close` and `reopen`. GitLab ignores unknown
parameters and returns `200` with the unchanged issue, so the node reports
success while the issue stays open. `state_event` appears nowhere in the
repository today.

This PR translates the value at request time:

```ts
if (body.state !== undefined && ISSUE_STATE_EVENTS[body.state as string]) {
	body.state_event = ISSUE_STATE_EVENTS[body.state as string];
	delete body.state;
}
```

### Why translate instead of renaming the parameter

This revives #16579 by @newdominic, which renamed the UI parameter from `state`
to `state_event` and changed its option values to `close` / `reopen`.
@ShireenMissi was open to that (_"This introduces a breaking change, but the
previous behaviour was incorrect, so fixing it this way seems reasonable"_), but
the cubic review raised the objection that closed the PR:

> Renaming the internal parameter key from 'state' to 'state_event' will
> invalidate existing workflows that stored the previous key, resulting in lost
> or ignored field values. Handle migration with "aliases" or keep the original
> key and map to the new API parameter programmatically.

That review comment was never addressed and the PR was closed on 2026-03-05 with
an invitation to submit a new one. This takes cubic's second suggestion. The
parameter keeps its `state` key and its `open` / `closed` values, so every saved
workflow keeps its stored value and simply starts working. Nothing needs a node
`typeVersion` bump because no behaviour that currently works is altered — the
only change is to a code path that is inert today.

An unrecognised `state` value (e.g. from an expression) is left untouched rather
than being coerced to `reopen`, so this cannot turn a no-op into a wrong action.

## How to test

1. Add a **GitLab** node, set Resource to **Issue** and Operation to **Edit**.
2. Point it at a repository and an open issue number.
3. Under **Edit Fields**, add **State** and set it to **Closed**.
4. Execute. The issue is now actually closed in GitLab. On `master` the node
   returns the issue unchanged and it stays open.
5. Repeat with **State → Open** against a closed issue to confirm the reopen path.

Covered by unit tests in
`packages/nodes-base/nodes/Gitlab/__tests__/Gitlab.issue.edit.test.ts`:

| Test | Asserts |
| --- | --- |
| State = Closed | body has `state_event: 'close'` and no `state` |
| State = Open | body has `state_event: 'reopen'` and no `state` |
| Request shape | `PUT /projects/:owner%2F:repo/issues/:iid` |
| State unset | no `state_event` is added; other fields untouched |
| Unrecognised state | left as-is, no `state_event` |
| Combined edit | state translated alongside `labels` / `assignee_ids` |

Verified locally: 22/22 tests pass across the GitLab suite (6 new, 16 existing),
`biome check` clean, `pnpm typecheck` clean. Mutation-tested — with the fix
stubbed out, the 3 tests covering the reported bug fail and the 3 covering
unchanged behaviour still pass.

## Related Linear tickets, Github issues, and Community forum posts

closes #35799

Supersedes #16579 by @newdominic, closed 2026-03-05 by @ShireenMissi with
_"Please feel free to reopen it or submit a new PR once the updates are ready."_
Credit for finding the bug and for the API reference goes to them.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Not needed: the UI is unchanged, the documented State field simply starts working. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

