### PR TITLE
fix(editor): Derive workflow home project from shared relation when absent

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -8,7 +8,7 @@ import type {
 import type { ILogInStatus } from '@/features/settings/users/users.types';
 import type { NodeViewItemSection } from '@/features/shared/nodeCreator/views/viewsData';
 import type { IUsedCredential } from '@/features/credentials/credentials.types';
-import type { Scope } from '@n8n/permissions';
+import type { Scope, WorkflowSharingRole } from '@n8n/permissions';
 import type { NodeCreatorTag, IconName, BinaryMetadata } from '@n8n/design-system';
 import type { ModalState } from '@n8n/frontend-module-sdk';
 import type {
@@ -259,6 +259,11 @@ export interface IWorkflowDb {
 	pinData?: IPinData;
 	sharedWithProjects?: ProjectSharingData[];
 	homeProject?: ProjectSharingData;
+	// Raw ownership relation returned by `GET /workflows/:id` only when the
+	// sharing license is inactive (the licensed path assembles `homeProject`
+	// instead). Kept so the client can derive `homeProject` from it — see the
+	// workflowDocument store hydration.
+	shared?: Array<{ role: WorkflowSharingRole; project: ProjectSharingData }>;
 	scopes?: Scope[];
 	versionId: string;
 	activeVersionId: string | null;

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
@@ -435,6 +435,54 @@ describe('workflowDocument.store orchestration', () => {
 			expect(store.pinnedDataByNodeName).toEqual({});
 		});
 
+		it('derives homeProject from the shared owner relation when homeProject is absent', () => {
+			// `GET /workflows/:id` omits the assembled `homeProject` when the sharing
+			// license is inactive, returning the raw `shared` relation instead.
+			const store = useWorkflowDocumentStore(createWorkflowDocumentId('wf-shared'));
+			const ownerProject = { id: 'p-owner' } as ProjectSharingData;
+
+			store.hydrate({
+				id: 'wf-shared',
+				name: 'FromShared',
+				active: false,
+				isArchived: false,
+				createdAt: -1,
+				updatedAt: -1,
+				nodes: [],
+				connections: {},
+				versionId: '',
+				activeVersionId: null,
+				shared: [
+					{ role: 'workflow:editor', project: { id: 'p-editor' } as ProjectSharingData },
+					{ role: 'workflow:owner', project: ownerProject },
+				],
+			});
+
+			expect(store.homeProject).toEqual(ownerProject);
+		});
+
+		it('prefers an assembled homeProject over the shared owner relation', () => {
+			const store = useWorkflowDocumentStore(createWorkflowDocumentId('wf-both'));
+			const homeProject = { id: 'p-home' } as ProjectSharingData;
+
+			store.hydrate({
+				id: 'wf-both',
+				name: 'Both',
+				active: false,
+				isArchived: false,
+				createdAt: -1,
+				updatedAt: -1,
+				nodes: [],
+				connections: {},
+				versionId: '',
+				activeVersionId: null,
+				homeProject,
+				shared: [{ role: 'workflow:owner', project: { id: 'p-owner' } as ProjectSharingData }],
+			});
+
+			expect(store.homeProject).toEqual(homeProject);
+		});
+
 		it('normalizes ITag[] tags to string[]', () => {
 			const store = useWorkflowDocumentStore(createWorkflowDocumentId('wf-tag'));
 			const itags: ITag[] = [

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -319,7 +319,15 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 				activeVersion: workflow.activeVersion ?? null,
 			});
 			workflowDocumentIsArchived.setIsArchived(workflow.isArchived ?? false);
-			workflowDocumentHomeProject.setHomeProject(workflow.homeProject ?? null);
+			// `GET /workflows/:id` only assembles `homeProject` when the sharing
+			// license is active; otherwise it returns the raw `shared` relation.
+			// Derive the owning project from `shared` so features that depend on it
+			// (e.g. the evaluations wizard) work regardless of the sharing license.
+			const homeProject =
+				workflow.homeProject ??
+				workflow.shared?.find((share) => share.role === 'workflow:owner')?.project ??
+				null;
+			workflowDocumentHomeProject.setHomeProject(homeProject);
 			workflowDocumentSharedWithProjects.setSharedWithProjects(workflow.sharedWithProjects ?? []);
 			workflowDocumentScopes.setScopes(workflow.scopes ?? []);
 			workflowDocumentTags.setTags(workflow.tags ?? []);


### PR DESCRIPTION
## Summary

The metric-based evaluations wizard (now the **Evaluations** side-panel) fails to save a test case with a client-side toast **"Missing project or workflow context"** on instances where the sharing license is inactive. No request reaches the backend.

**Root cause:** the persistence guards read `workflowDocumentStore.value.homeProject?.id`, but `GET /rest/workflows/:id` only assembles `homeProject` on the sharing-enabled branch. When sharing is inactive it returns the raw `shared` relation (owner + project) with **no** `homeProject`, so the frontend hydrates `homeProject = null` and the guard throws. Evaluations should not depend on the sharing feature.

**Fix (frontend-only, per the constraint of not changing the API for now):** during `workflowDocument` store hydration, derive `homeProject` from the `workflow:owner` entry in `shared` when the assembled `homeProject` is absent — the client-side mirror of the backend's `addOwnedByAndSharedWith`. This is the single point that populates the document store, so it fixes every consumer (the new Tests panel and the legacy wizard) at once. The `shared` relation is already eager-loaded on both API branches, so the data is always present client-side; we just weren't using it.

## How to test

1. Run a self-hosted instance where the sharing license is inactive (default community edition — no license activation).
2. Create a workflow with an AI node (LLMChain, AIAgent).
3. Open the **Evaluations** side-panel → add a test case → **Save / Run**.
4. Before: toast "Couldn't save your test case… Missing project or workflow context", no backend request. After: the case saves and runs normally.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/TRUST-257
- fixes #33855

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
