### PR TITLE
feat: Track AI created credentials success signals

### DIFF
--- a/packages/@n8n/api-types/src/dto/instance-ai/__tests__/instance-ai-confirm-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/instance-ai/__tests__/instance-ai-confirm-request.dto.test.ts
@@ -59,6 +59,10 @@ describe('InstanceAiConfirmRequestDto', () => {
 				'credentialAutoSetup with credential type',
 				{ kind: 'credentialAutoSetup', credentialType: 'firecrawlApi' },
 			],
+			[
+				'credentialAutoSetup with attempt id',
+				{ kind: 'credentialAutoSetup', credentialType: 'firecrawlApi', attemptId: 'attempt-1' },
+			],
 			// DomainAccessApproval: handleAction (primary path — with action)
 			[
 				'domainAccessApprove with allow_domain',

--- a/packages/@n8n/api-types/src/dto/instance-ai/__tests__/instance-ai-confirm-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/instance-ai/__tests__/instance-ai-confirm-request.dto.test.ts
@@ -156,6 +156,15 @@ describe('InstanceAiConfirmRequestDto', () => {
 			expect(result.success).toBe(false);
 		});
 
+		test('credentialAutoSetup with empty attemptId', () => {
+			const result = InstanceAiConfirmRequestDto.safeParse({
+				kind: 'credentialAutoSetup',
+				credentialType: 'slackApi',
+				attemptId: '  ',
+			});
+			expect(result.success).toBe(false);
+		});
+
 		test('resourceDecision without decision', () => {
 			const result = InstanceAiConfirmRequestDto.safeParse({ kind: 'resourceDecision' });
 			expect(result.success).toBe(false);

--- a/packages/@n8n/api-types/src/dto/instance-ai/instance-ai-confirm-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/instance-ai/instance-ai-confirm-request.dto.ts
@@ -46,7 +46,7 @@ const credentialAutoSetupConfirmSchema = z.object({
 	credentialType: z.string(),
 	/** Client-generated id shared by the setup-choice telemetry events and the
 	 *  terminal setup-completed event, so retries can be told apart in the funnel. */
-	attemptId: z.string().max(64).optional(),
+	attemptId: z.string().trim().min(1).max(64).optional(),
 });
 
 /** Domain-access approval — `domainAccessAction` carries which scope the user picked. */

--- a/packages/@n8n/api-types/src/dto/instance-ai/instance-ai-confirm-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/instance-ai/instance-ai-confirm-request.dto.ts
@@ -44,6 +44,9 @@ const credentialSelectionConfirmSchema = z.object({
 const credentialAutoSetupConfirmSchema = z.object({
 	kind: z.literal('credentialAutoSetup'),
 	credentialType: z.string(),
+	/** Client-generated id shared by the setup-choice telemetry events and the
+	 *  terminal setup-completed event, so retries can be told apart in the funnel. */
+	attemptId: z.string().max(64).optional(),
 });
 
 /** Domain-access approval — `domainAccessAction` carries which scope the user picked. */

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -86,15 +86,16 @@ export async function createInstanceAgent(
 	}));
 	const browserCredentialSetup = context.browserCredentialSetup;
 	const rawLocalMcpTools = context.localMcpServer
-		? createToolsFromLocalMcpServer(
-				context.localMcpServer,
-				context.logger,
-				browserCredentialSetup &&
-					((credentialType, outcome) => {
-						if (outcome.ok) browserCredentialSetup.markCreated(credentialType);
-						else browserCredentialSetup.markCreateFailed(credentialType, outcome.errorCode);
-					}),
-			)
+		? createToolsFromLocalMcpServer({
+				server: context.localMcpServer,
+				logger: context.logger,
+				onCredentialCreateResult: browserCredentialSetup
+					? (credentialType, outcome) => {
+							if (outcome.ok) browserCredentialSetup.markCreated(credentialType);
+							else browserCredentialSetup.markCreateFailed(credentialType, outcome.errorCode);
+						}
+					: undefined,
+			})
 		: createToolRegistry();
 
 	const browserToolNames = new Set(

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -84,8 +84,17 @@ export async function createInstanceAgent(
 		server: f.server.name,
 		error: f.error,
 	}));
+	const browserCredentialSetup = context.browserCredentialSetup;
 	const rawLocalMcpTools = context.localMcpServer
-		? createToolsFromLocalMcpServer(context.localMcpServer, context.logger)
+		? createToolsFromLocalMcpServer(
+				context.localMcpServer,
+				context.logger,
+				browserCredentialSetup &&
+					((credentialType, outcome) => {
+						if (outcome.ok) browserCredentialSetup.markCreated(credentialType);
+						else browserCredentialSetup.markCreateFailed(credentialType, outcome.errorCode);
+					}),
+			)
 		: createToolRegistry();
 
 	const browserToolNames = new Set(

--- a/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
+++ b/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
@@ -81,7 +81,7 @@ export interface ConfirmationData {
 	/** `'session'` means the user chose "always allow": the resuming tool should
 	 *  persist a thread-level grant so the same action isn't re-asked. */
 	scope?: 'once' | 'session';
-	autoSetup?: { credentialType: string };
+	autoSetup?: { credentialType: string; attemptId?: string };
 }
 
 export interface PendingConfirmation {

--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -46,7 +46,7 @@ function suspendCtx(suspendFn: Mock = vi.fn()) {
 function resumeCtx(resumeData: {
 	approved: boolean;
 	credentials?: Record<string, string>;
-	autoSetup?: { credentialType: string };
+	autoSetup?: { credentialType: string; attemptId?: string };
 }) {
 	const suspend = vi.fn();
 	return { resumeData, suspend } as never;
@@ -937,6 +937,31 @@ describe('credentials tool', () => {
 					{ name: 'apiKey', displayName: 'API Key', type: 'string', required: true },
 				],
 			});
+		});
+
+		it('should mark browser credential setup pending when autoSetup is present', async () => {
+			const context = createMockContext();
+			const markPending = vi.fn();
+			context.browserCredentialSetup = {
+				markPending,
+				markCreated: vi.fn(),
+				markCreateFailed: vi.fn(),
+			};
+
+			const tool = createCredentialsTool(context);
+			await executeTool(
+				tool,
+				{
+					action: 'setup' as const,
+					credentials: [{ credentialType: 'slackApi' }],
+				},
+				resumeCtx({
+					approved: true,
+					autoSetup: { credentialType: 'slackApi', attemptId: 'attempt-1' },
+				}),
+			);
+
+			expect(markPending).toHaveBeenCalledWith('slackApi', 'attempt-1');
 		});
 
 		it('should handle autoSetup when getDocumentationUrl is not available', async () => {

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -258,7 +258,7 @@ const suspendSchema = z.object({
 const resumeSchema = z.object({
 	approved: z.boolean(),
 	credentials: z.record(z.string()).optional(),
-	autoSetup: z.object({ credentialType: z.string() }).optional(),
+	autoSetup: z.object({ credentialType: z.string(), attemptId: z.string().optional() }).optional(),
 });
 
 interface CredentialToolContext {
@@ -467,7 +467,8 @@ async function handleSetup(
 
 	// State 4: User requested automatic browser-assisted setup
 	if (resumeData.autoSetup) {
-		const { credentialType } = resumeData.autoSetup;
+		const { credentialType, attemptId } = resumeData.autoSetup;
+		context.browserCredentialSetup?.markPending(credentialType, attemptId);
 		const docsUrl =
 			(await context.credentialService.getDocumentationUrl?.(credentialType)) ?? undefined;
 		const requiredFields =

--- a/packages/@n8n/instance-ai/src/tools/filesystem/__tests__/create-tools-from-mcp-server.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/filesystem/__tests__/create-tools-from-mcp-server.test.ts
@@ -470,4 +470,78 @@ describe('createToolsFromLocalMcpServer', () => {
 			expect(server.callTool).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('onCredentialCreateResult', () => {
+		const CREATE_CREDENTIAL_TOOL: McpTool = {
+			name: 'browser_create_credential',
+			description: 'Create a credential',
+			inputSchema: { type: 'object', properties: {} },
+		};
+
+		const CREATE_CREDENTIAL_ARGS = {
+			credentialsKey: 'slack-setup',
+			type: 'slackApi',
+			name: 'Slack account',
+		};
+
+		function getExecuteWithCallback(server: LocalMcpServer, toolName: string) {
+			const onCredentialCreateResult = vi.fn();
+			const tools = createToolsFromLocalMcpServer(server, mockLogger, onCredentialCreateResult);
+			const tool = tools.get(toolName);
+			if (!tool) throw new Error(`Tool '${toolName}' was not created`);
+			const execute = async (args: Record<string, unknown>, ctx: unknown) =>
+				await executeTool<McpToolCallResult>(tool, args, ctx);
+			return { execute, onCredentialCreateResult };
+		}
+
+		it('reports success when browser_create_credential succeeds', async () => {
+			const server = makeMockServer([CREATE_CREDENTIAL_TOOL]);
+			server.callTool.mockResolvedValue(SUCCESS_RESULT);
+			const { execute, onCredentialCreateResult } = getExecuteWithCallback(
+				server,
+				'browser_create_credential',
+			);
+
+			await execute(CREATE_CREDENTIAL_ARGS, makeCtx({}));
+
+			expect(onCredentialCreateResult).toHaveBeenCalledExactlyOnceWith('slackApi', { ok: true });
+		});
+
+		it.each([
+			['No captured fields found for credentialsKey "slack-setup"', 'missing_captured_fields'],
+			['resolveData references field "apiKey" which was not captured', 'unresolved_field'],
+			[
+				'This tool is only available when running inside the n8n gateway context.',
+				'gateway_context_missing',
+			],
+			['Something else went wrong', 'credential_create_failed'],
+		])('classifies failure %s as %s', async (errorText, expectedCode) => {
+			const server = makeMockServer([CREATE_CREDENTIAL_TOOL]);
+			server.callTool.mockResolvedValue({
+				content: [{ type: 'text', text: errorText }],
+				isError: true,
+			});
+			const { execute, onCredentialCreateResult } = getExecuteWithCallback(
+				server,
+				'browser_create_credential',
+			);
+
+			await execute(CREATE_CREDENTIAL_ARGS, makeCtx({}));
+
+			expect(onCredentialCreateResult).toHaveBeenCalledExactlyOnceWith('slackApi', {
+				ok: false,
+				errorCode: expectedCode,
+			});
+		});
+
+		it('does not notify for other tools', async () => {
+			const server = makeMockServer();
+			server.callTool.mockResolvedValue(SUCCESS_RESULT);
+			const { execute, onCredentialCreateResult } = getExecuteWithCallback(server, 'write_file');
+
+			await execute({ filePath: 'test.ts' }, makeCtx({}));
+
+			expect(onCredentialCreateResult).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/@n8n/instance-ai/src/tools/filesystem/__tests__/create-tools-from-mcp-server.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/filesystem/__tests__/create-tools-from-mcp-server.test.ts
@@ -534,6 +534,38 @@ describe('createToolsFromLocalMcpServer', () => {
 			});
 		});
 
+		it('reports user_denied when the user denies the resource confirmation', async () => {
+			const server = makeMockServer([CREATE_CREDENTIAL_TOOL]);
+			const { execute, onCredentialCreateResult } = getExecuteWithCallback(
+				server,
+				'browser_create_credential',
+			);
+
+			await execute(CREATE_CREDENTIAL_ARGS, makeCtx({ resumeData: { approved: false } }));
+
+			expect(onCredentialCreateResult).toHaveBeenCalledExactlyOnceWith('slackApi', {
+				ok: false,
+				errorCode: 'user_denied',
+			});
+			expect(server.callTool).not.toHaveBeenCalled();
+		});
+
+		it('reports failure and rethrows when the call rejects', async () => {
+			const server = makeMockServer([CREATE_CREDENTIAL_TOOL]);
+			server.callTool.mockRejectedValue(new Error('connection lost'));
+			const { execute, onCredentialCreateResult } = getExecuteWithCallback(
+				server,
+				'browser_create_credential',
+			);
+
+			await expect(execute(CREATE_CREDENTIAL_ARGS, makeCtx({}))).rejects.toThrow('connection lost');
+
+			expect(onCredentialCreateResult).toHaveBeenCalledExactlyOnceWith('slackApi', {
+				ok: false,
+				errorCode: 'credential_create_failed',
+			});
+		});
+
 		it('does not notify for other tools', async () => {
 			const server = makeMockServer();
 			server.callTool.mockResolvedValue(SUCCESS_RESULT);

--- a/packages/@n8n/instance-ai/src/tools/filesystem/__tests__/create-tools-from-mcp-server.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/filesystem/__tests__/create-tools-from-mcp-server.test.ts
@@ -107,7 +107,7 @@ function makeMockServer(tools: McpTool[] = [SAMPLE_TOOL]): Mocked<LocalMcpServer
 
 /** Build the tool and return its execute function. */
 function getExecute(server: LocalMcpServer, toolName = 'write_file') {
-	const tools = createToolsFromLocalMcpServer(server, mockLogger);
+	const tools = createToolsFromLocalMcpServer({ server, logger: mockLogger });
 	const tool = tools.get(toolName);
 	if (!tool) throw new Error(`Tool '${toolName}' was not created`);
 	return async (args: Record<string, unknown>, ctx: unknown) =>
@@ -130,7 +130,7 @@ describe('createToolsFromLocalMcpServer', () => {
 	describe('tool creation', () => {
 		it('creates a tool for each advertised tool', () => {
 			const server = makeMockServer([SAMPLE_TOOL, { ...SAMPLE_TOOL, name: 'read_file' }]);
-			const tools = createToolsFromLocalMcpServer(server, mockLogger);
+			const tools = createToolsFromLocalMcpServer({ server, logger: mockLogger });
 			expect(tools.has('write_file')).toBe(true);
 			expect(tools.has('read_file')).toBe(true);
 		});
@@ -144,8 +144,10 @@ describe('createToolsFromLocalMcpServer', () => {
 				},
 			]);
 			// Should not throw — the tool must be created even with a bad schema
-			expect(() => createToolsFromLocalMcpServer(server, mockLogger)).not.toThrow();
-			expect(createToolsFromLocalMcpServer(server, mockLogger).get('bad_tool')).toBeDefined();
+			expect(() => createToolsFromLocalMcpServer({ server, logger: mockLogger })).not.toThrow();
+			expect(
+				createToolsFromLocalMcpServer({ server, logger: mockLogger }).get('bad_tool'),
+			).toBeDefined();
 		});
 
 		it('skips tools with invalid names', () => {
@@ -155,7 +157,7 @@ describe('createToolsFromLocalMcpServer', () => {
 				{ ...SAMPLE_TOOL, name: 'read_file' },
 			]);
 
-			const tools = createToolsFromLocalMcpServer(server, logger as never);
+			const tools = createToolsFromLocalMcpServer({ server, logger: logger as never });
 
 			expect(tools.get('bad tool')).toBeUndefined();
 			expect(tools.get('read_file')).toBeDefined();
@@ -175,7 +177,7 @@ describe('createToolsFromLocalMcpServer', () => {
 				{ ...SAMPLE_TOOL, name: 'read_file' },
 			]);
 
-			const tools = createToolsFromLocalMcpServer(server, logger as never);
+			const tools = createToolsFromLocalMcpServer({ server, logger: logger as never });
 
 			expect(tools.has('constructor')).toBe(false);
 			expect(tools.get('read_file')).toBeDefined();
@@ -195,7 +197,7 @@ describe('createToolsFromLocalMcpServer', () => {
 				{ ...SAMPLE_TOOL, name: 'custom-tool' },
 			]);
 
-			const tools = createToolsFromLocalMcpServer(server, logger as never);
+			const tools = createToolsFromLocalMcpServer({ server, logger: logger as never });
 
 			expect(tools.get('custom_tool')).toBeDefined();
 			expect(tools.get('custom-tool')).toBeUndefined();
@@ -215,7 +217,7 @@ describe('createToolsFromLocalMcpServer', () => {
 				{ ...SAMPLE_TOOL, name: 'read_file' },
 			]);
 
-			const tools = createToolsFromLocalMcpServer(server, logger as never);
+			const tools = createToolsFromLocalMcpServer({ server, logger: logger as never });
 
 			expect(tools.get('ＴＯＯＬ')).toBeUndefined();
 			expect(tools.get('read_file')).toBeDefined();
@@ -242,7 +244,7 @@ describe('createToolsFromLocalMcpServer', () => {
 				{ ...SAMPLE_TOOL, name: 'read_file' },
 			]);
 
-			const tools = createToolsFromLocalMcpServer(server, logger as never);
+			const tools = createToolsFromLocalMcpServer({ server, logger: logger as never });
 
 			expect(tools.get('huge_tool')).toBeUndefined();
 			expect(tools.get('read_file')).toBeDefined();
@@ -260,7 +262,7 @@ describe('createToolsFromLocalMcpServer', () => {
 	describe('media output', () => {
 		it('returns native file parts from toMessage for gateway image results', () => {
 			const server = makeMockServer();
-			const tool = createToolsFromLocalMcpServer(server, mockLogger).get('write_file');
+			const tool = createToolsFromLocalMcpServer({ server, logger: mockLogger }).get('write_file');
 
 			const message = tool?.toMessage?.(SCREENSHOT_RESULT);
 
@@ -275,14 +277,14 @@ describe('createToolsFromLocalMcpServer', () => {
 
 		it('does not create an extra message for text-only results', () => {
 			const server = makeMockServer();
-			const tool = createToolsFromLocalMcpServer(server, mockLogger).get('write_file');
+			const tool = createToolsFromLocalMcpServer({ server, logger: mockLogger }).get('write_file');
 
 			expect(tool?.toMessage?.(SUCCESS_RESULT)).toBeUndefined();
 		});
 
 		it('returns AI SDK content output for gateway image results', () => {
 			const server = makeMockServer();
-			const tool = createToolsFromLocalMcpServer(server, mockLogger).get('write_file');
+			const tool = createToolsFromLocalMcpServer({ server, logger: mockLogger }).get('write_file');
 
 			expect(tool?.toModelOutput?.(SCREENSHOT_RESULT)).toEqual({
 				type: 'content',
@@ -295,7 +297,7 @@ describe('createToolsFromLocalMcpServer', () => {
 
 		it('returns a native file part from toMessage for gateway resource results', () => {
 			const server = makeMockServer();
-			const tool = createToolsFromLocalMcpServer(server, mockLogger).get('write_file');
+			const tool = createToolsFromLocalMcpServer({ server, logger: mockLogger }).get('write_file');
 
 			expect(tool?.toMessage?.(PDF_RESULT)).toEqual({
 				role: 'assistant',
@@ -305,7 +307,7 @@ describe('createToolsFromLocalMcpServer', () => {
 
 		it('falls back to application/octet-stream when resource has no mimeType', () => {
 			const server = makeMockServer();
-			const tool = createToolsFromLocalMcpServer(server, mockLogger).get('write_file');
+			const tool = createToolsFromLocalMcpServer({ server, logger: mockLogger }).get('write_file');
 
 			const result: McpToolCallResult = {
 				content: [{ type: 'resource', resource: { uri: 'file:///x', blob: 'base64-bytes' } }],
@@ -319,7 +321,7 @@ describe('createToolsFromLocalMcpServer', () => {
 
 		it('returns AI SDK content output for gateway resource results', () => {
 			const server = makeMockServer();
-			const tool = createToolsFromLocalMcpServer(server, mockLogger).get('write_file');
+			const tool = createToolsFromLocalMcpServer({ server, logger: mockLogger }).get('write_file');
 
 			expect(tool?.toModelOutput?.(PDF_RESULT)).toEqual({
 				type: 'content',
@@ -486,7 +488,11 @@ describe('createToolsFromLocalMcpServer', () => {
 
 		function getExecuteWithCallback(server: LocalMcpServer, toolName: string) {
 			const onCredentialCreateResult = vi.fn();
-			const tools = createToolsFromLocalMcpServer(server, mockLogger, onCredentialCreateResult);
+			const tools = createToolsFromLocalMcpServer({
+				server,
+				logger: mockLogger,
+				onCredentialCreateResult,
+			});
 			const tool = tools.get(toolName);
 			if (!tool) throw new Error(`Tool '${toolName}' was not created`);
 			const execute = async (args: Record<string, unknown>, ctx: unknown) =>

--- a/packages/@n8n/instance-ai/src/tools/filesystem/create-tools-from-mcp-server.ts
+++ b/packages/@n8n/instance-ai/src/tools/filesystem/create-tools-from-mcp-server.ts
@@ -222,6 +222,7 @@ function classifyCredentialCreateError(result: McpToolCallResult): string {
 		return 'missing_captured_fields';
 	}
 	if (text.includes('gateway context')) return 'gateway_context_missing';
+	if (text.includes('Access denied by user')) return 'user_denied';
 	return 'credential_create_failed';
 }
 
@@ -364,35 +365,47 @@ export function createToolsFromLocalMcpServer(
 					}
 					return result;
 				};
+				// A rejected call must reach the observer too — otherwise a thrown
+				// credential-create leaves no failure outcome. Skip on abort: the run's
+				// terminal status reports user cancellation more accurately.
+				const callServer = async (callArgs: Record<string, unknown>) => {
+					try {
+						return await server.callTool(
+							{ name: toolName, arguments: callArgs },
+							{ abortSignal: ctx.abortSignal },
+						);
+					} catch (error) {
+						if (!ctx.abortSignal?.aborted) {
+							observeResult({
+								content: [
+									{ type: 'text', text: error instanceof Error ? error.message : String(error) },
+								],
+								isError: true,
+							});
+						}
+						throw error;
+					}
+				};
 
 				// Resume path: user has made a resource-access decision
 				if (resumeData !== undefined && resumeData !== null) {
 					if (!resumeData.resourceDecision) {
 						// User denied — no decision provided
-						return {
+						return observeResult({
 							content: [{ type: 'text', text: JSON.stringify({ error: 'Access denied by user' }) }],
 							isError: true,
-						};
+						});
 					}
 					// Re-call the daemon with the user's decision
 					return observeResult(
-						await server.callTool(
-							{
-								name: toolName,
-								arguments: { ...args, _confirmation: resumeData.resourceDecision },
-							},
-							{ abortSignal: ctx.abortSignal },
-						),
+						await callServer({ ...args, _confirmation: resumeData.resourceDecision }),
 					);
 				}
 
 				// First-call path: strip any LLM-provided _confirmation key so the agent
 				// cannot bypass the human confirmation flow by supplying its own token.
 				const { _confirmation: _stripped, ...safeArgs } = args;
-				const result = await server.callTool(
-					{ name: toolName, arguments: safeArgs },
-					{ abortSignal: ctx.abortSignal },
-				);
+				const result = await callServer(safeArgs);
 
 				// If the daemon requires a resource-access confirmation, suspend the agent
 				if (result.isError) {

--- a/packages/@n8n/instance-ai/src/tools/filesystem/create-tools-from-mcp-server.ts
+++ b/packages/@n8n/instance-ai/src/tools/filesystem/create-tools-from-mcp-server.ts
@@ -286,14 +286,18 @@ function warnSkippedLocalMcpTool(logger: Logger) {
  * The `toModelOutput` callback converts MCP image blocks into AI SDK content
  * output parts so the LLM receives gateway screenshots as real multimodal input.
  */
-export function createToolsFromLocalMcpServer(
-	server: LocalMcpServer,
-	logger: Logger,
+export function createToolsFromLocalMcpServer({
+	server,
+	logger,
+	onCredentialCreateResult,
+}: {
+	server: LocalMcpServer;
+	logger: Logger;
 	onCredentialCreateResult?: (
 		credentialType: string,
 		outcome: BrowserCredentialCreateOutcome,
-	) => void,
-): InstanceAiToolRegistry {
+	) => void;
+}): InstanceAiToolRegistry {
 	const tools = createToolRegistry();
 	const claimedToolNames = createClaimedToolNames([]);
 	const warnTool = warnSkippedLocalMcpTool(logger);

--- a/packages/@n8n/instance-ai/src/tools/filesystem/create-tools-from-mcp-server.ts
+++ b/packages/@n8n/instance-ai/src/tools/filesystem/create-tools-from-mcp-server.ts
@@ -203,6 +203,28 @@ function isMcpMediaBlock(block: McpContentBlock): boolean {
 	return block.type === 'image' || block.type === 'resource';
 }
 
+export type BrowserCredentialCreateOutcome = { ok: true } | { ok: false; errorCode: string };
+
+/**
+ * Map a failed `browser_create_credential` result to a stable, non-sensitive
+ * error code. The matched substrings are the error messages thrown by
+ * `@n8n/mcp-browser`'s credential tool before it reaches credential
+ * persistence; anything else means the host's create-credential call failed.
+ */
+function classifyCredentialCreateError(result: McpToolCallResult): string {
+	const text = result.content
+		.filter((block) => block.type === 'text')
+		.map((block) => block.text ?? '')
+		.join(' ');
+	if (text.includes('No captured fields found')) return 'missing_captured_fields';
+	if (text.includes('resolveData')) return 'unresolved_field';
+	if (text.includes('was not found') || text.includes('Secret capturing failed')) {
+		return 'missing_captured_fields';
+	}
+	if (text.includes('gateway context')) return 'gateway_context_missing';
+	return 'credential_create_failed';
+}
+
 function buildNativeMcpMediaMessage(result: unknown): AgentMessage | undefined {
 	const raw = unwrapMcpToolResult(result);
 	if (!raw?.content.some(isMcpMediaBlock)) return undefined;
@@ -266,6 +288,10 @@ function warnSkippedLocalMcpTool(logger: Logger) {
 export function createToolsFromLocalMcpServer(
 	server: LocalMcpServer,
 	logger: Logger,
+	onCredentialCreateResult?: (
+		credentialType: string,
+		outcome: BrowserCredentialCreateOutcome,
+	) => void,
 ): InstanceAiToolRegistry {
 	const tools = createToolRegistry();
 	const claimedToolNames = createClaimedToolNames([]);
@@ -327,6 +353,17 @@ export function createToolsFromLocalMcpServer(
 			.resume(gatewayConfirmationResumeSchema)
 			.handler(async (args: Record<string, unknown>, ctx) => {
 				const resumeData = ctx.resumeData;
+				const observeResult = (result: McpToolCallResult): McpToolCallResult => {
+					if (toolName === 'browser_create_credential' && typeof args.type === 'string') {
+						onCredentialCreateResult?.(
+							args.type,
+							result.isError
+								? { ok: false, errorCode: classifyCredentialCreateError(result) }
+								: { ok: true },
+						);
+					}
+					return result;
+				};
 
 				// Resume path: user has made a resource-access decision
 				if (resumeData !== undefined && resumeData !== null) {
@@ -338,12 +375,14 @@ export function createToolsFromLocalMcpServer(
 						};
 					}
 					// Re-call the daemon with the user's decision
-					return await server.callTool(
-						{
-							name: toolName,
-							arguments: { ...args, _confirmation: resumeData.resourceDecision },
-						},
-						{ abortSignal: ctx.abortSignal },
+					return observeResult(
+						await server.callTool(
+							{
+								name: toolName,
+								arguments: { ...args, _confirmation: resumeData.resourceDecision },
+							},
+							{ abortSignal: ctx.abortSignal },
+						),
 					);
 				}
 
@@ -369,7 +408,7 @@ export function createToolsFromLocalMcpServer(
 					}
 				}
 
-				return result;
+				return observeResult(result);
 			})
 			.toModelOutput((result: unknown) => {
 				const raw = unwrapMcpToolResult(result);

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -1051,6 +1051,18 @@ export interface InstanceAiContext {
 	domainAccessTracker?: DomainAccessTracker;
 	/** Current run ID — used for transient (allow_once) domain approvals. */
 	runId?: string;
+	/**
+	 * Run-scoped outcome tracking for browser-assisted credential setup. The
+	 * credentials tool marks an attempt pending when it hands off to the LLM
+	 * with `needsBrowserSetup`; the browser tool wrapper reports each
+	 * `browser_create_credential` outcome. The host resolves the terminal
+	 * success/failure telemetry when the run finishes.
+	 */
+	browserCredentialSetup?: {
+		markPending: (credentialType: string, attemptId?: string) => void;
+		markCreated: (credentialType: string) => void;
+		markCreateFailed: (credentialType: string, errorCode: string) => void;
+	};
 	/** Records workflow code snapshots for the run debug buffer (dev tooling). */
 	recordWorkflowCodeSnapshot?: (snapshot: WorkflowCodeSnapshotInput) => void;
 	/**

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -685,6 +685,18 @@ type TerminalGuardOrderServiceInternals = {
 		markCreated: (credentialType: string) => void;
 		markCreateFailed: (credentialType: string, errorCode: string) => void;
 	};
+	emitBrowserCredentialSetupOutcomes: (
+		threadId: string,
+		runId: string,
+		runStatus: 'completed' | 'cancelled' | 'errored',
+		runFinishReason?: string,
+	) => void;
+	publishRunFinish: (
+		threadId: string,
+		runId: string,
+		status: 'completed' | 'cancelled' | 'errored',
+		reason?: string,
+	) => void;
 	saveAgentTreeSnapshot: Mock;
 	backgroundTasks: { getRunningTasks: Mock; getRunningTasksByParentCheckpoint?: Mock };
 	temporaryWorkflowService: { reapForRun: Mock };
@@ -3561,6 +3573,154 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			vi.mocked(resumeAgentRun).mock.invocationCallOrder[0],
 		);
 		expect(tracing.withActiveSpan).toHaveBeenCalledWith(tracing.actorRun, expect.any(Function));
+	});
+});
+
+describe('InstanceAiService — emitBrowserCredentialSetupOutcomes', () => {
+	const CREDENTIAL_SETUP_EVENT = 'Instance AI Browser Use credential setup completed';
+
+	function seedAttempts(
+		service: TerminalGuardOrderServiceInternals,
+		attempts: Array<{
+			credentialType: string;
+			setupMethod: 'setup_card' | 'conversation';
+			attemptId?: string;
+			startedAt: number;
+			created: boolean;
+			errorCode?: string;
+		}>,
+	) {
+		service.pendingBrowserCredentialSetups.set('run-1', { userId: 'user-1', attempts });
+	}
+
+	it('emits nothing when the run has no pending setups', () => {
+		const service = createTerminalGuardOrderService();
+
+		service.emitBrowserCredentialSetupOutcomes('thread-a', 'run-1', 'completed');
+
+		expect(service.telemetry.track).not.toHaveBeenCalled();
+	});
+
+	it('emits one event per attempt and consumes the record', () => {
+		const service = createTerminalGuardOrderService();
+		seedAttempts(service, [
+			{
+				credentialType: 'slackApi',
+				setupMethod: 'setup_card',
+				attemptId: 'attempt-1',
+				startedAt: 1000,
+				created: true,
+			},
+			{
+				credentialType: 'notionApi',
+				setupMethod: 'conversation',
+				startedAt: 2000,
+				created: false,
+				errorCode: 'unresolved_field',
+			},
+		]);
+
+		service.emitBrowserCredentialSetupOutcomes('thread-a', 'run-1', 'completed');
+
+		expect(service.telemetry.track).toHaveBeenCalledTimes(2);
+		expect(service.telemetry.track).toHaveBeenCalledWith(CREDENTIAL_SETUP_EVENT, {
+			user_id: 'user-1',
+			credential_type: 'slackApi',
+			status: 'success',
+			is_valid: null,
+			is_new: true,
+			setup_method: 'setup_card',
+			thread_id: 'thread-a',
+			run_id: 'run-1',
+			credential_setup_attempt_id: 'attempt-1',
+			duration_ms: expect.any(Number),
+		});
+		expect(service.telemetry.track).toHaveBeenCalledWith(CREDENTIAL_SETUP_EVENT, {
+			user_id: 'user-1',
+			credential_type: 'notionApi',
+			status: 'failure',
+			failure_stage: 'generation',
+			error_code: 'unresolved_field',
+			is_valid: null,
+			is_new: true,
+			setup_method: 'conversation',
+			thread_id: 'thread-a',
+			run_id: 'run-1',
+			duration_ms: expect.any(Number),
+		});
+		expect(service.pendingBrowserCredentialSetups.size).toBe(0);
+
+		service.telemetry.track.mockClear();
+		service.emitBrowserCredentialSetupOutcomes('thread-a', 'run-1', 'completed');
+		expect(service.telemetry.track).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['completed', undefined, 'not_attempted'],
+		['cancelled', undefined, 'run_cancelled'],
+		['cancelled', 'timeout', 'run_timed_out'],
+		['errored', 'stream_error', 'run_errored'],
+	] as const)(
+		'maps a %s run (reason %s) without flow error to error code %s',
+		(runStatus, reason, errorCode) => {
+			const service = createTerminalGuardOrderService();
+			seedAttempts(service, [
+				{ credentialType: 'slackApi', setupMethod: 'setup_card', startedAt: 1000, created: false },
+			]);
+
+			service.emitBrowserCredentialSetupOutcomes('thread-a', 'run-1', runStatus, reason);
+
+			expect(service.telemetry.track).toHaveBeenCalledWith(
+				CREDENTIAL_SETUP_EVENT,
+				expect.objectContaining({
+					status: 'failure',
+					failure_stage: 'unknown',
+					error_code: errorCode,
+				}),
+			);
+		},
+	);
+
+	it('prefers the flow error code over the run termination code', () => {
+		const service = createTerminalGuardOrderService();
+		seedAttempts(service, [
+			{
+				credentialType: 'slackApi',
+				setupMethod: 'setup_card',
+				startedAt: 1000,
+				created: false,
+				errorCode: 'missing_captured_fields',
+			},
+		]);
+
+		service.emitBrowserCredentialSetupOutcomes('thread-a', 'run-1', 'cancelled');
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			CREDENTIAL_SETUP_EVENT,
+			expect.objectContaining({
+				failure_stage: 'generation',
+				error_code: 'missing_captured_fields',
+			}),
+		);
+	});
+
+	it('is invoked by publishRunFinish with the run status and reason', () => {
+		const service = createTerminalGuardOrderService();
+		seedAttempts(service, [
+			{ credentialType: 'slackApi', setupMethod: 'setup_card', startedAt: 1000, created: false },
+		]);
+
+		service.publishRunFinish('thread-a', 'run-1', 'cancelled', 'timeout');
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			CREDENTIAL_SETUP_EVENT,
+			expect.objectContaining({
+				credential_type: 'slackApi',
+				status: 'failure',
+				error_code: 'run_timed_out',
+			}),
+		);
+		expect(service.pendingBrowserCredentialSetups.size).toBe(0);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3041,6 +3041,46 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		expect(service.pendingBrowserCredentialSetups.size).toBe(0);
 	});
 
+	it('reports the run termination as error code when the user stops a pending credential setup', async () => {
+		const service = createTerminalGuardOrderService();
+		const abortController = new AbortController();
+		mockClaimedResumeResult({
+			status: 'cancelled',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve(''),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+		});
+		service.pendingBrowserCredentialSetups.set('run-1', {
+			userId: 'user-1',
+			attempts: [{ credentialType: 'slackApi', startedAt: 1000, created: false }],
+		});
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: {},
+			},
+		);
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Instance AI Browser Use credential setup completed',
+			expect.objectContaining({
+				credential_type: 'slackApi',
+				status: 'failure',
+				failure_stage: 'unknown',
+				error_code: 'run_cancelled',
+			}),
+		);
+	});
+
 	it('claims credits for the consumed segment when a resumed run suspends again', async () => {
 		const service = createTerminalGuardOrderService();
 		vi.spyOn(service.terminalOutcome, 'evaluateWaitingResponse').mockResolvedValue(undefined);

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -663,6 +663,19 @@ type TerminalGuardOrderServiceInternals = {
 		registerTraceContext: Mock;
 	};
 	threadPushRef: Map<string, string>;
+	pendingBrowserCredentialSetups: Map<
+		string,
+		{
+			userId: string;
+			attempts: Array<{
+				credentialType: string;
+				attemptId?: string;
+				startedAt: number;
+				created: boolean;
+				errorCode?: string;
+			}>;
+		}
+	>;
 	saveAgentTreeSnapshot: Mock;
 	backgroundTasks: { getRunningTasks: Mock; getRunningTasksByParentCheckpoint?: Mock };
 	temporaryWorkflowService: { reapForRun: Mock };
@@ -771,6 +784,7 @@ function createTerminalGuardOrderService(): TerminalGuardOrderServiceInternals {
 		registerTraceContext: vi.fn(),
 	};
 	service.threadPushRef = new Map();
+	service.pendingBrowserCredentialSetups = new Map();
 	service.saveAgentTreeSnapshot = vi.fn(async () => {});
 	service.backgroundTasks = { getRunningTasks: vi.fn(() => []) };
 	service.temporaryWorkflowService = { reapForRun: vi.fn(async () => []) };
@@ -2935,6 +2949,96 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			status: 'completed',
 			user_id: 'user-1',
 		});
+	});
+
+	it('tracks browser credential setup outcome per attempt when the run finishes', async () => {
+		const service = createTerminalGuardOrderService();
+		const abortController = new AbortController();
+		mockClaimedResumeResult({
+			status: 'completed',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve('done'),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+		});
+		service.pendingBrowserCredentialSetups.set('run-1', {
+			userId: 'user-1',
+			attempts: [
+				{ credentialType: 'slackApi', attemptId: 'attempt-1', startedAt: 1000, created: true },
+				{
+					credentialType: 'notionApi',
+					attemptId: 'attempt-2',
+					startedAt: 2000,
+					created: false,
+					errorCode: 'missing_captured_fields',
+				},
+				{ credentialType: 'githubApi', startedAt: 3000, created: false },
+			],
+		});
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: {},
+			},
+		);
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Instance AI Browser Use credential setup completed',
+			{
+				user_id: 'user-1',
+				credential_type: 'slackApi',
+				status: 'success',
+				is_valid: null,
+				is_new: true,
+				setup_method: 'ai',
+				thread_id: 'thread-a',
+				run_id: 'run-1',
+				credential_setup_attempt_id: 'attempt-1',
+				duration_ms: expect.any(Number),
+			},
+		);
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Instance AI Browser Use credential setup completed',
+			{
+				user_id: 'user-1',
+				credential_type: 'notionApi',
+				status: 'failure',
+				failure_stage: 'generation',
+				error_code: 'missing_captured_fields',
+				is_valid: null,
+				is_new: true,
+				setup_method: 'ai',
+				thread_id: 'thread-a',
+				run_id: 'run-1',
+				credential_setup_attempt_id: 'attempt-2',
+				duration_ms: expect.any(Number),
+			},
+		);
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Instance AI Browser Use credential setup completed',
+			{
+				user_id: 'user-1',
+				credential_type: 'githubApi',
+				status: 'failure',
+				failure_stage: 'unknown',
+				error_code: 'not_attempted',
+				is_valid: null,
+				is_new: true,
+				setup_method: 'ai',
+				thread_id: 'thread-a',
+				run_id: 'run-1',
+				duration_ms: expect.any(Number),
+			},
+		);
+		expect(service.pendingBrowserCredentialSetups.size).toBe(0);
 	});
 
 	it('claims credits for the consumed segment when a resumed run suspends again', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -669,6 +669,7 @@ type TerminalGuardOrderServiceInternals = {
 			userId: string;
 			attempts: Array<{
 				credentialType: string;
+				setupMethod: 'setup_card' | 'conversation';
 				attemptId?: string;
 				startedAt: number;
 				created: boolean;
@@ -676,6 +677,14 @@ type TerminalGuardOrderServiceInternals = {
 			}>;
 		}
 	>;
+	createBrowserCredentialSetupTracker: (
+		runId: string,
+		userId: string,
+	) => {
+		markPending: (credentialType: string, attemptId?: string) => void;
+		markCreated: (credentialType: string) => void;
+		markCreateFailed: (credentialType: string, errorCode: string) => void;
+	};
 	saveAgentTreeSnapshot: Mock;
 	backgroundTasks: { getRunningTasks: Mock; getRunningTasksByParentCheckpoint?: Mock };
 	temporaryWorkflowService: { reapForRun: Mock };
@@ -2963,15 +2972,27 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		service.pendingBrowserCredentialSetups.set('run-1', {
 			userId: 'user-1',
 			attempts: [
-				{ credentialType: 'slackApi', attemptId: 'attempt-1', startedAt: 1000, created: true },
+				{
+					credentialType: 'slackApi',
+					setupMethod: 'setup_card' as const,
+					attemptId: 'attempt-1',
+					startedAt: 1000,
+					created: true,
+				},
 				{
 					credentialType: 'notionApi',
+					setupMethod: 'setup_card' as const,
 					attemptId: 'attempt-2',
 					startedAt: 2000,
 					created: false,
 					errorCode: 'missing_captured_fields',
 				},
-				{ credentialType: 'githubApi', startedAt: 3000, created: false },
+				{
+					credentialType: 'githubApi',
+					setupMethod: 'setup_card' as const,
+					startedAt: 3000,
+					created: false,
+				},
 			],
 		});
 
@@ -2998,7 +3019,7 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 				status: 'success',
 				is_valid: null,
 				is_new: true,
-				setup_method: 'ai',
+				setup_method: 'setup_card',
 				thread_id: 'thread-a',
 				run_id: 'run-1',
 				credential_setup_attempt_id: 'attempt-1',
@@ -3015,7 +3036,7 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 				error_code: 'missing_captured_fields',
 				is_valid: null,
 				is_new: true,
-				setup_method: 'ai',
+				setup_method: 'setup_card',
 				thread_id: 'thread-a',
 				run_id: 'run-1',
 				credential_setup_attempt_id: 'attempt-2',
@@ -3032,7 +3053,7 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 				error_code: 'not_attempted',
 				is_valid: null,
 				is_new: true,
-				setup_method: 'ai',
+				setup_method: 'setup_card',
 				thread_id: 'thread-a',
 				run_id: 'run-1',
 				duration_ms: expect.any(Number),
@@ -3052,7 +3073,14 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 		});
 		service.pendingBrowserCredentialSetups.set('run-1', {
 			userId: 'user-1',
-			attempts: [{ credentialType: 'slackApi', startedAt: 1000, created: false }],
+			attempts: [
+				{
+					credentialType: 'slackApi',
+					setupMethod: 'setup_card' as const,
+					startedAt: 1000,
+					created: false,
+				},
+			],
 		});
 
 		await service.processResumedStream(
@@ -3079,6 +3107,63 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 				error_code: 'run_cancelled',
 			}),
 		);
+	});
+
+	it('tracks a conversation-driven attempt when the LLM creates a credential without a setup card', async () => {
+		const service = createTerminalGuardOrderService();
+		const abortController = new AbortController();
+		mockClaimedResumeResult({
+			status: 'completed',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve('done'),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+		});
+
+		const tracker = service.createBrowserCredentialSetupTracker('run-1', 'user-1');
+		// No markPending — the user asked in chat, no setup card was shown.
+		tracker.markCreateFailed('slackApi', 'missing_captured_fields');
+		tracker.markCreated('slackApi');
+		tracker.markCreateFailed('notionApi', 'credential_create_failed');
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: {},
+			},
+		);
+
+		// The failed-then-retried slack attempt resolves as one success.
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Instance AI Browser Use credential setup completed',
+			expect.objectContaining({
+				user_id: 'user-1',
+				credential_type: 'slackApi',
+				status: 'success',
+				setup_method: 'conversation',
+			}),
+		);
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Instance AI Browser Use credential setup completed',
+			expect.objectContaining({
+				credential_type: 'notionApi',
+				status: 'failure',
+				failure_stage: 'persistence',
+				error_code: 'credential_create_failed',
+				setup_method: 'conversation',
+			}),
+		);
+		const setupEvents = service.telemetry.track.mock.calls.filter(
+			([eventName]) => eventName === 'Instance AI Browser Use credential setup completed',
+		);
+		expect(setupEvents).toHaveLength(2);
 	});
 
 	it('claims credits for the consumed segment when a resumed run suspends again', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -392,9 +392,9 @@ const GENERATION_STAGE_ERROR_CODES = new Set([
 function failureStageForErrorCode(
 	errorCode: string | undefined,
 ): 'generation' | 'persistence' | 'unknown' {
-	if (!errorCode) return 'unknown';
-	if (GENERATION_STAGE_ERROR_CODES.has(errorCode)) return 'generation';
-	return 'persistence';
+	if (errorCode && GENERATION_STAGE_ERROR_CODES.has(errorCode)) return 'generation';
+	if (errorCode === 'credential_create_failed') return 'persistence';
+	return 'unknown';
 }
 
 /**

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -5940,7 +5940,7 @@ export class InstanceAiService {
 			status: effectiveStatus,
 			...(userId ? { user_id: userId } : {}),
 		});
-		this.emitBrowserCredentialSetupOutcomes(threadId, runId);
+		this.emitBrowserCredentialSetupOutcomes(threadId, runId, status, reason);
 		if (status === 'errored') {
 			this.telemetry.track('Builder generation errored', {
 				thread_id: threadId,
@@ -5955,12 +5955,28 @@ export class InstanceAiService {
 	/**
 	 * Emit one terminal telemetry event per browser-assisted credential setup
 	 * attempt of the finished run (NODE-5511). Consumes the pending record so
-	 * every attempt yields exactly one success or failure event.
+	 * every attempt yields exactly one success or failure event. When the flow
+	 * itself never failed, the run's own termination (user stop, timeout,
+	 * stream error) is reported as the error code so aborts aren't counted as
+	 * flow failures.
 	 */
-	private emitBrowserCredentialSetupOutcomes(threadId: string, runId: string): void {
+	private emitBrowserCredentialSetupOutcomes(
+		threadId: string,
+		runId: string,
+		runStatus: 'completed' | 'cancelled' | 'errored',
+		runFinishReason?: string,
+	): void {
 		const browserSetup = this.pendingBrowserCredentialSetups.get(runId);
 		if (!browserSetup) return;
 		this.pendingBrowserCredentialSetups.delete(runId);
+		const terminalErrorCode =
+			runStatus === 'completed'
+				? 'not_attempted'
+				: runStatus === 'errored'
+					? 'run_errored'
+					: runFinishReason === INSTANCE_AI_RUN_TIMEOUT_REASON
+						? 'run_timed_out'
+						: 'run_cancelled';
 		for (const attempt of browserSetup.attempts) {
 			this.telemetry.track('Instance AI Browser Use credential setup completed', {
 				user_id: browserSetup.userId,
@@ -5970,7 +5986,7 @@ export class InstanceAiService {
 					? {}
 					: {
 							failure_stage: failureStageForErrorCode(attempt.errorCode),
-							error_code: attempt.errorCode ?? 'not_attempted',
+							error_code: attempt.errorCode ?? terminalErrorCode,
 						}),
 				// The flow never runs a credential test, so validation support is unknown.
 				is_valid: null,

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -380,6 +380,22 @@ export function isMaskedStreamFailure(error: unknown): error is Error {
 	return error.name === 'TypeError' && error.message === 'terminated';
 }
 
+/** Error codes reported by the browser tool wrapper for failures that happen
+ *  before credential persistence (capturing/resolving secrets in the browser). */
+const GENERATION_STAGE_ERROR_CODES = new Set([
+	'missing_captured_fields',
+	'unresolved_field',
+	'gateway_context_missing',
+]);
+
+function failureStageForErrorCode(
+	errorCode: string | undefined,
+): 'generation' | 'persistence' | 'unknown' {
+	if (!errorCode) return 'unknown';
+	if (GENERATION_STAGE_ERROR_CODES.has(errorCode)) return 'generation';
+	return 'persistence';
+}
+
 /**
  * Substituted for a masked stream failure once the credit re-check confirms
  * the user is out of credits. Carries the machine-readable quota code so the
@@ -457,7 +473,10 @@ function toConfirmationData(request: InstanceAiConfirmRequest): ConfirmationData
 		case 'credentialSelection':
 			return { approved: true, credentials: request.credentials };
 		case 'credentialAutoSetup':
-			return { approved: true, autoSetup: { credentialType: request.credentialType } };
+			return {
+				approved: true,
+				autoSetup: { credentialType: request.credentialType, attemptId: request.attemptId },
+			};
 		case 'resourceDecision':
 			return { approved: true, resourceDecision: request.resourceDecision };
 		case 'setupWorkflowApply':
@@ -523,6 +542,27 @@ export class InstanceAiService {
 
 	/** Tracks the iframe pushRef per thread for live execution push events. */
 	private readonly threadPushRef = new Map<string, string>();
+
+	/**
+	 * Runs where the credentials tool handed off to browser-assisted credential
+	 * setup (`needsBrowserSetup`), keyed by runId with one record per setup
+	 * attempt (a run can attempt several). Resolved to one terminal
+	 * success/failure telemetry event per attempt in `publishRunFinish`.
+	 * Entries exist only between the hand-off and the run's terminal event.
+	 */
+	private readonly pendingBrowserCredentialSetups = new Map<
+		string,
+		{
+			userId: string;
+			attempts: Array<{
+				credentialType: string;
+				attemptId?: string;
+				startedAt: number;
+				created: boolean;
+				errorCode?: string;
+			}>;
+		}
+	>();
 
 	/** Counts plan-review confirmations per thread, to tell the first plan apart from later revisions. */
 	private readonly planRequestsByThread = new Map<string, number>();
@@ -2153,6 +2193,37 @@ export class InstanceAiService {
 		}
 
 		context.runId = runId;
+
+		const findOpenAttempt = (credentialType: string) => {
+			const attempts = this.pendingBrowserCredentialSetups.get(runId)?.attempts ?? [];
+			return attempts.findLast(
+				(attempt) => attempt.credentialType === credentialType && !attempt.created,
+			);
+		};
+		context.browserCredentialSetup = {
+			markPending: (credentialType: string, attemptId?: string) => {
+				let pending = this.pendingBrowserCredentialSetups.get(runId);
+				if (!pending) {
+					pending = { userId: user.id, attempts: [] };
+					this.pendingBrowserCredentialSetups.set(runId, pending);
+				}
+				if (attemptId && pending.attempts.some((attempt) => attempt.attemptId === attemptId)) {
+					return;
+				}
+				pending.attempts.push({ credentialType, attemptId, startedAt: Date.now(), created: false });
+			},
+			markCreated: (credentialType: string) => {
+				const attempt = findOpenAttempt(credentialType);
+				if (attempt) {
+					attempt.created = true;
+					attempt.errorCode = undefined;
+				}
+			},
+			markCreateFailed: (credentialType: string, errorCode: string) => {
+				const attempt = findOpenAttempt(credentialType);
+				if (attempt) attempt.errorCode = errorCode;
+			},
+		};
 
 		// Per-user, thread-level "always allow" grants are persisted in the DB so they survive
 		// reload/navigation and are visible across mains. Load once per run; a tool resuming
@@ -5869,6 +5940,7 @@ export class InstanceAiService {
 			status: effectiveStatus,
 			...(userId ? { user_id: userId } : {}),
 		});
+		this.emitBrowserCredentialSetupOutcomes(threadId, runId);
 		if (status === 'errored') {
 			this.telemetry.track('Builder generation errored', {
 				thread_id: threadId,
@@ -5876,6 +5948,38 @@ export class InstanceAiService {
 				error_message: errorInfo?.errorMessage ?? reason ?? 'unknown',
 				...(errorInfo?.errorSource ? { error_source: errorInfo.errorSource } : {}),
 				...(userId ? { user_id: userId } : {}),
+			});
+		}
+	}
+
+	/**
+	 * Emit one terminal telemetry event per browser-assisted credential setup
+	 * attempt of the finished run (NODE-5511). Consumes the pending record so
+	 * every attempt yields exactly one success or failure event.
+	 */
+	private emitBrowserCredentialSetupOutcomes(threadId: string, runId: string): void {
+		const browserSetup = this.pendingBrowserCredentialSetups.get(runId);
+		if (!browserSetup) return;
+		this.pendingBrowserCredentialSetups.delete(runId);
+		for (const attempt of browserSetup.attempts) {
+			this.telemetry.track('Instance AI Browser Use credential setup completed', {
+				user_id: browserSetup.userId,
+				credential_type: attempt.credentialType,
+				status: attempt.created ? 'success' : 'failure',
+				...(attempt.created
+					? {}
+					: {
+							failure_stage: failureStageForErrorCode(attempt.errorCode),
+							error_code: attempt.errorCode ?? 'not_attempted',
+						}),
+				// The flow never runs a credential test, so validation support is unknown.
+				is_valid: null,
+				is_new: true,
+				setup_method: 'ai',
+				thread_id: threadId,
+				run_id: runId,
+				...(attempt.attemptId ? { credential_setup_attempt_id: attempt.attemptId } : {}),
+				duration_ms: Date.now() - attempt.startedAt,
 			});
 		}
 	}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -74,6 +74,7 @@ import {
 	saveAgentBuilderTarget,
 	type ConfirmationData,
 	type DomainAccessTracker,
+	type InstanceAiContext,
 	type ManagedBackgroundTask,
 	type McpServerConfig,
 	type ModelConfig,
@@ -556,6 +557,7 @@ export class InstanceAiService {
 			userId: string;
 			attempts: Array<{
 				credentialType: string;
+				setupMethod: 'setup_card' | 'conversation';
 				attemptId?: string;
 				startedAt: number;
 				created: boolean;
@@ -2194,36 +2196,7 @@ export class InstanceAiService {
 
 		context.runId = runId;
 
-		const findOpenAttempt = (credentialType: string) => {
-			const attempts = this.pendingBrowserCredentialSetups.get(runId)?.attempts ?? [];
-			return attempts.findLast(
-				(attempt) => attempt.credentialType === credentialType && !attempt.created,
-			);
-		};
-		context.browserCredentialSetup = {
-			markPending: (credentialType: string, attemptId?: string) => {
-				let pending = this.pendingBrowserCredentialSetups.get(runId);
-				if (!pending) {
-					pending = { userId: user.id, attempts: [] };
-					this.pendingBrowserCredentialSetups.set(runId, pending);
-				}
-				if (attemptId && pending.attempts.some((attempt) => attempt.attemptId === attemptId)) {
-					return;
-				}
-				pending.attempts.push({ credentialType, attemptId, startedAt: Date.now(), created: false });
-			},
-			markCreated: (credentialType: string) => {
-				const attempt = findOpenAttempt(credentialType);
-				if (attempt) {
-					attempt.created = true;
-					attempt.errorCode = undefined;
-				}
-			},
-			markCreateFailed: (credentialType: string, errorCode: string) => {
-				const attempt = findOpenAttempt(credentialType);
-				if (attempt) attempt.errorCode = errorCode;
-			},
-		};
+		context.browserCredentialSetup = this.createBrowserCredentialSetupTracker(runId, user.id);
 
 		// Per-user, thread-level "always allow" grants are persisted in the DB so they survive
 		// reload/navigation and are visible across mains. Load once per run; a tool resuming
@@ -5953,6 +5926,65 @@ export class InstanceAiService {
 	}
 
 	/**
+	 * Per-run bookkeeping behind `context.browserCredentialSetup` (NODE-5511).
+	 * `markPending` opens an attempt when the user clicks auto-setup on the
+	 * credential card; `markCreated`/`markCreateFailed` resolve the latest open
+	 * attempt for the type — or open an implicit `'conversation'` attempt when
+	 * there is none, so LLM-initiated creations (user asked directly in chat,
+	 * no setup card involved) still produce a terminal telemetry event.
+	 */
+	private createBrowserCredentialSetupTracker(
+		runId: string,
+		userId: string,
+	): NonNullable<InstanceAiContext['browserCredentialSetup']> {
+		const getOrCreateAttempts = () => {
+			let pending = this.pendingBrowserCredentialSetups.get(runId);
+			if (!pending) {
+				pending = { userId, attempts: [] };
+				this.pendingBrowserCredentialSetups.set(runId, pending);
+			}
+			return pending.attempts;
+		};
+		const resolveOpenAttempt = (credentialType: string) => {
+			const attempts = getOrCreateAttempts();
+			let attempt = attempts.findLast((a) => a.credentialType === credentialType && !a.created);
+			if (!attempt) {
+				attempt = {
+					credentialType,
+					setupMethod: 'conversation',
+					startedAt: Date.now(),
+					created: false,
+				};
+				attempts.push(attempt);
+			}
+			return attempt;
+		};
+		return {
+			markPending: (credentialType: string, attemptId?: string) => {
+				const attempts = getOrCreateAttempts();
+				if (attemptId && attempts.some((attempt) => attempt.attemptId === attemptId)) {
+					return;
+				}
+				attempts.push({
+					credentialType,
+					setupMethod: 'setup_card',
+					attemptId,
+					startedAt: Date.now(),
+					created: false,
+				});
+			},
+			markCreated: (credentialType: string) => {
+				const attempt = resolveOpenAttempt(credentialType);
+				attempt.created = true;
+				attempt.errorCode = undefined;
+			},
+			markCreateFailed: (credentialType: string, errorCode: string) => {
+				resolveOpenAttempt(credentialType).errorCode = errorCode;
+			},
+		};
+	}
+
+	/**
 	 * Emit one terminal telemetry event per browser-assisted credential setup
 	 * attempt of the finished run (NODE-5511). Consumes the pending record so
 	 * every attempt yields exactly one success or failure event. When the flow
@@ -5991,7 +6023,7 @@ export class InstanceAiService {
 				// The flow never runs a credential test, so validation support is unknown.
 				is_valid: null,
 				is_new: true,
-				setup_method: 'ai',
+				setup_method: attempt.setupMethod,
 				thread_id: threadId,
 				run_id: runId,
 				...(attempt.attemptId ? { credential_setup_attempt_id: attempt.attemptId } : {}),

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
@@ -598,12 +598,15 @@ describe('InstanceAiCredentialSetup', () => {
 				attemptId: expect.any(String),
 			});
 			expect(resolveSpy).toHaveBeenCalledWith('req-1', 'approved');
+			const confirmedAttemptId = (
+				confirmSpy.mock.calls[0][1] as { kind: string; attemptId: string }
+			).attemptId;
 			expect(mockTelemetryTrack).toHaveBeenCalledWith(
 				'Instance AI Browser Use User clicked credential setup option',
 				expect.objectContaining({
 					credential_type: 'type1',
 					choice: 'ai',
-					credential_setup_attempt_id: expect.any(String),
+					credential_setup_attempt_id: confirmedAttemptId,
 				}),
 			);
 		});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
@@ -595,11 +595,16 @@ describe('InstanceAiCredentialSetup', () => {
 			expect(confirmSpy).toHaveBeenCalledWith('req-1', {
 				kind: 'credentialAutoSetup',
 				credentialType: 'type1',
+				attemptId: expect.any(String),
 			});
 			expect(resolveSpy).toHaveBeenCalledWith('req-1', 'approved');
 			expect(mockTelemetryTrack).toHaveBeenCalledWith(
 				'Instance AI Browser Use User clicked credential setup option',
-				expect.objectContaining({ credential_type: 'type1', choice: 'ai' }),
+				expect.objectContaining({
+					credential_type: 'type1',
+					choice: 'ai',
+					credential_setup_attempt_id: expect.any(String),
+				}),
 			);
 		});
 
@@ -624,6 +629,7 @@ describe('InstanceAiCredentialSetup', () => {
 				expect(confirmSpy).toHaveBeenCalledWith('req-1', {
 					kind: 'credentialAutoSetup',
 					credentialType: 'type1',
+					attemptId: expect.any(String),
 				});
 			});
 			expect(closeModalSpy).toHaveBeenCalledWith(INSTANCE_AI_BROWSER_USE_SETUP_MODAL_KEY);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -15,6 +15,7 @@ import { N8nActionDropdown, N8nButton, N8nIcon, N8nText } from '@n8n/design-syst
 import type { ActionDropdownItem } from '@n8n/design-system/types';
 import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
+import { v4 as uuidv4 } from 'uuid';
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useInstanceAiSettingsStore } from '../instanceAiSettings.store';
@@ -435,10 +436,11 @@ async function handleLater() {
 	await deferWholeCard();
 }
 
-function trackSetupChoiceClicked(choice: CredentialSetupChoice | 'skip') {
+function trackSetupChoiceClicked(choice: CredentialSetupChoice | 'skip', attemptId?: string) {
 	telemetry.track('Instance AI Browser Use User clicked credential setup option', {
 		credential_type: currentRequest.value?.credentialType,
 		choice,
+		...(attemptId ? { credential_setup_attempt_id: attemptId } : {}),
 	});
 }
 
@@ -484,11 +486,12 @@ function handleSetupManually() {
 	openNewCredentialModal();
 }
 
-async function submitAutoSetup(credentialType: string) {
+async function submitAutoSetup(credentialType: string, attemptId: string) {
 	isSubmitted.value = true;
 	const success = await thread.confirmAction(props.requestId, {
 		kind: 'credentialAutoSetup',
 		credentialType,
+		attemptId,
 	});
 	if (success) {
 		thread.resolveConfirmation(props.requestId, 'approved');
@@ -501,10 +504,11 @@ async function handleSetupAutomatically() {
 	const credentialType = currentRequest.value?.credentialType;
 	if (!credentialType) return;
 
-	trackSetupChoiceClicked('ai');
+	const attemptId = uuidv4();
+	trackSetupChoiceClicked('ai', attemptId);
 
 	if (settingsStore.browserConnected) {
-		await submitAutoSetup(credentialType);
+		await submitAutoSetup(credentialType, attemptId);
 		return;
 	}
 
@@ -516,7 +520,7 @@ async function handleSetupAutomatically() {
 			if (!connected) return;
 			stopWatchingBrowserConnect();
 			uiStore.closeModal(INSTANCE_AI_BROWSER_USE_SETUP_MODAL_KEY);
-			await submitAutoSetup(credentialType);
+			await submitAutoSetup(credentialType, attemptId);
 		},
 	);
 }


### PR DESCRIPTION
## Summary

Adds telemetry events for the outcome of browser use credential setup in AI Assistant. For this to work we first need to capture the intent to create credentials, which is done in two places:
1. AI calls `setup credentials tool` and user clicks on "Setup automatically" - this is the clear signal/intent
2. User can instruct the AI to just create some app in external service and setup credentials, in this case AI will often omit the  `setup credentials tool` and directly work on the task. For this case only successful credential creation telemetry event is fired because we don't have any functionality to reliably determine the intent of AI to create credentials on this path (without adding too much refactoring or special logic)

## How to test

1. Run the branch locally with AI assistant set up
2. Ensure that feature flags for browser use and AI-based credential creation are enabled via `featureFlags.override('090_instance_ai_browser_use', 'variant')` and `featureFlags.override('094_instance_ai_browser_credential_setup', 'variant')`
3. Add a breakpoint at https://github.com/n8n-io/n8n/blob/NODE-5511-ai-created-credentials-emit-success-signal/packages/cli/src/modules/instance-ai/instance-ai.service.ts#L6002
4. Ask AI to setup specific credentials for you (ask it to call setup credentials tool explicitly if it tries something else) and follow the instructions to connect the browser
5. After AI started browser control stop the run by pressing the stop button
6. Observe at the breakpoint that the `track('Instance AI Browser Use credential setup completed'` path is fired with a failure (attempt.created is false)
7. Do the same again but let the AI successfully create credentials
8. Observe at the breakpoint that the track path is fired with a success

Alternatively you can check big query for these events but depending on the access these will come in after some time (f.e. in metabase or ruderstack they arrive later)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5511/ai-created-credentials-emit-no-success-signal


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

