### PR TITLE
chore: Move instance MCP ownership to Adore

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -100,7 +100,7 @@ packages/cli/src/evaluation.ee/                         @n8n-io/ai
 packages/cli/src/chat/                                  @n8n-io/ai
 packages/cli/src/tool-generation/                       @n8n-io/ai
 packages/cli/src/modules/workflow-builder/              @n8n-io/ai
-packages/cli/src/modules/mcp/                           @n8n-io/ai
+packages/cli/src/modules/mcp/                           @n8n-io/adore
 packages/cli/src/modules/quick-connect/                 @n8n-io/ai
 packages/cli/src/modules/chat-hub/                      @n8n-io/ai
 packages/cli/src/modules/instance-ai/                   @n8n-io/instance-ai


### PR DESCRIPTION
## Summary

Reassign ownership of `packages/cli/src/modules/mcp/` in `.github/OWNERS` from `@n8n-io/ai` to `@n8n-io/adore`. The Adore team now owns the instance MCP server, so CODEOWNERS routing should reflect that.

## How to test

No functional change. Verify the `OWNERS` diff reassigns the `mcp/` module path to the correct team.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ADO-5747

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

