### PR TITLE
fix(editor): Keep NDV panels spanning the full container width

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/panel/composables/useNdvLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/composables/useNdvLayout.test.ts
@@ -51,8 +51,9 @@ describe('useNdvLayout', () => {
 		localStorage.setItem(key, JSON.stringify({ left: 0, main: 5, right: 0 }));
 
 		const { panelWidthPercentage } = useNdvLayout({ container, hasInputPanel, paneType });
-		expect(panelWidthPercentage.value.left).toBeCloseTo(12);
-		expect(panelWidthPercentage.value.right).toBeCloseTo(12);
+		expect(panelWidthPercentage.value.left).toBeGreaterThanOrEqual(12);
+		expect(panelWidthPercentage.value.right).toBeGreaterThanOrEqual(12);
+		expect(panelWidthPercentage.value.main).toBeCloseTo(36.8);
 	});
 
 	it('updates layout on resize (left)', () => {
@@ -108,5 +109,68 @@ describe('useNdvLayout', () => {
 		expect(panelWidthPercentage.value.left).toBeCloseTo(29);
 		expect(panelWidthPercentage.value.main).toBeCloseTo(42);
 		expect(panelWidthPercentage.value.right).toBeCloseTo(29);
+	});
+
+	describe('when the stored layout cannot be used as-is', () => {
+		const totalOf = ({ left, main, right }: { left: number; main: number; right: number }) =>
+			left + main + right;
+
+		it('spans the full container when stored values fall below the minimums', () => {
+			containerWidth.value = 1317;
+			const key = `${LOCAL_STORAGE_NDV_PANEL_WIDTH}_REGULAR`;
+			localStorage.setItem(key, JSON.stringify({ left: 1, main: 1, right: 1 }));
+
+			const { panelWidthPercentage } = useNdvLayout({ container, hasInputPanel, paneType });
+
+			// Minimums alone only add up to 46% of the container, leaving the canvas visible behind.
+			expect(totalOf(panelWidthPercentage.value)).toBeCloseTo(100);
+			expect(panelWidthPercentage.value.left).toBeGreaterThanOrEqual((120 / 1317) * 100);
+			expect(panelWidthPercentage.value.right).toBeGreaterThanOrEqual((120 / 1317) * 100);
+			expect(panelWidthPercentage.value.main).toBeGreaterThanOrEqual((368 / 1317) * 100);
+		});
+
+		it('falls back to the defaults when the stored value is not usable', () => {
+			containerWidth.value = 1317;
+			const key = `${LOCAL_STORAGE_NDV_PANEL_WIDTH}_REGULAR`;
+			localStorage.setItem(key, JSON.stringify({ left: null, main: null, right: null }));
+
+			const { panelWidthPercentage } = useNdvLayout({ container, hasInputPanel, paneType });
+
+			expect(panelWidthPercentage.value.main).toBeCloseTo((420 / 1317) * 100);
+			expect(totalOf(panelWidthPercentage.value)).toBeCloseTo(100);
+		});
+
+		it('keeps a usable layout while the container is unmeasured', () => {
+			containerWidth.value = 0;
+
+			const { panelWidthPercentage } = useNdvLayout({ container, hasInputPanel, paneType });
+
+			expect(Object.values(panelWidthPercentage.value).every(Number.isFinite)).toBe(true);
+			expect(totalOf(panelWidthPercentage.value)).toBeCloseTo(100);
+		});
+
+		it('does not persist while the container is unmeasured', () => {
+			containerWidth.value = 0;
+			const spy = vi.spyOn(Storage.prototype, 'setItem');
+
+			const { onResizeEnd } = useNdvLayout({ container, hasInputPanel, paneType });
+			onResizeEnd();
+
+			expect(spy).not.toHaveBeenCalled();
+			spy.mockRestore();
+		});
+
+		it('keeps the left panel collapsed for "inputless" layouts', () => {
+			containerWidth.value = 1317;
+			hasInputPanel.value = false;
+			paneType.value = 'inputless';
+			const key = `${LOCAL_STORAGE_NDV_PANEL_WIDTH}_INPUTLESS`;
+			localStorage.setItem(key, JSON.stringify({ left: 0, main: 1, right: 1 }));
+
+			const { panelWidthPercentage } = useNdvLayout({ container, hasInputPanel, paneType });
+
+			expect(panelWidthPercentage.value.left).toBe(0);
+			expect(totalOf(panelWidthPercentage.value)).toBeCloseTo(100);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ndv/panel/composables/useNdvLayout.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/composables/useNdvLayout.ts
@@ -72,6 +72,12 @@ export function useNdvLayout(options: UseNdvLayoutOptions) {
 		}
 	});
 
+	const isUsablePanelSize = (size: NdvPanelsSize | null | undefined): size is NdvPanelsSize =>
+		!!size &&
+		Number.isFinite(size.left) &&
+		Number.isFinite(size.main) &&
+		Number.isFinite(size.right);
+
 	const safePanelWidth = ({ left, main, right }: { left: number; main: number; right: number }) => {
 		const hasInput = toValue(options.hasInputPanel);
 		const minLeft = hasInput ? minPanelWidthPercentage.value : 0;
@@ -85,32 +91,41 @@ export function useNdvLayout(options: UseNdvLayoutOptions) {
 		};
 
 		const total = newPanelWidth.left + newPanelWidth.main + newPanelWidth.right;
+		const sides = newPanelWidth.left + newPanelWidth.right;
 
-		if (total > 100) {
-			const overflow = total - 100;
+		// Panels must always span the container: distribute any difference across the
+		// side panels, otherwise a short total leaves the canvas showing through.
+		if (total !== 100 && sides > 0) {
+			const diff = 100 - total;
+			const leftShare = newPanelWidth.left / sides;
 
-			const trimLeft = (newPanelWidth.left / (newPanelWidth.left + newPanelWidth.right)) * overflow;
-			const trimRight = overflow - trimLeft;
-
-			newPanelWidth.left = Math.max(minLeft, newPanelWidth.left - trimLeft);
-			newPanelWidth.right = Math.max(minRight, newPanelWidth.right - trimRight);
+			newPanelWidth.left = Math.max(minLeft, newPanelWidth.left + diff * leftShare);
+			newPanelWidth.right = Math.max(minRight, newPanelWidth.right + diff * (1 - leftShare));
 		}
 
 		return newPanelWidth;
 	};
 
 	const persistPanelSize = () => {
+		// Before the container is measured the sizes are placeholders, not something
+		// the user chose — persisting them would overwrite their actual layout.
+		if (!containerWidth.value || !isUsablePanelSize(panelWidthPercentage.value)) return;
+
 		localStorage.setItem(localStorageKey.value, JSON.stringify(panelWidthPercentage.value));
 	};
 
 	const loadPanelSize = () => {
+		if (!containerWidth.value) return;
+
 		const storedPanelSizeString = localStorage.getItem(localStorageKey.value);
 		const defaultSize = defaultPanelSize.value;
 		if (storedPanelSizeString) {
 			const storedPanelSize = jsonParse<NdvPanelsSize>(storedPanelSizeString, {
 				fallbackValue: defaultSize,
 			});
-			panelWidthPercentage.value = safePanelWidth(storedPanelSize ?? defaultSize);
+			panelWidthPercentage.value = safePanelWidth(
+				isUsablePanelSize(storedPanelSize) ? storedPanelSize : defaultSize,
+			);
 		} else {
 			panelWidthPercentage.value = safePanelWidth(defaultSize);
 		}


### PR DESCRIPTION
## Summary

The node details view remembers how you've sized its three panels (input, parameters, output) in browser local storage, with a separate entry per layout type. Those sizes are restored every time you open a node.

If a stored entry ever described panels that don't add up to the full width, they were restored exactly as stored — too narrow, leaving an empty strip where the workflow canvas shows through, with the input and output content clipped:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/cbe96fb8-5cb0-4452-8182-6f81c36b4dd9" />

Reloading didn't help, because the same entry is read back each time. The layout only recovered if the user cleared their browser storage, or happened to drag the centre handle — dragging a panel edge kept it broken.

### What changed

- A restored layout that doesn't fill the available width now has the leftover space distributed across the side panels. This also repairs anyone already affected — their layout corrects itself the next time they open a node, with nothing to clear.
- The layout is no longer calculated before the panel area has been measured, which is where unusable values originated.
- Unusable stored entries are ignored in favor of the defaults and are never written.

### What we know, and what we don't

The reporter of #34756 confirmed that clearing the stored layout entry resolved it for them, which places the cause in the stored value. They didn't share the values they had, so the exact sequence that produced a bad entry is still unconfirmed. The fix therefore targets the whole class — any stored layout that can't be used as-is — rather than one specific bad value.

## How to test

1. Open any workflow, then in the DevTools console:

```js
localStorage.setItem('N8N_NDV_PANEL_WIDTH_REGULAR', '{"left":13.4,"main":41.3,"right":13.4}');
```

2. Open any ordinary node (e.g. No Operation node)
   - On master: the panels don't span the width, the canvas shows through on the right, and the input/output content is clipped.
   - On this branch: the panels fill the width.

3. Resize a panel and reopen the node — the new size is remembered, and the stored entry is now healthy.

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/ADO-5744
Closes https://github.com/n8n-io/n8n/issues/35682 and https://github.com/n8n-io/n8n/issues/34756

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

