### PR TITLE
fix: Preserve Agent build intent and refresh artifact names

### DIFF
--- a/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/agent-builder/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: agent-builder
+description: >-
+  Load before calling build-agent for a new or existing n8n Agent. Governs
+  prerequisite creation, faithful handoff of the user's request, agent
+  targeting across turns, builder questions, testing, and publishing. Use
+  directly for routine follow-ups when the conversation already targets an
+  Agent; rerun intent-recognition only when the requested artifact is no
+  longer clear.
+recommended_tools:
+  - build-agent
+  - build-workflow
+  - data-tables
+---
+
+# Agent Builder
+
+## Routing
+
+Use this skill after `intent-recognition` chooses an agent-anchored design, or
+when the conversation already targets an Agent and the user is continuing that
+build. Do not rerun intent recognition for routine Agent edits or extensions.
+Use `build-agent` only for Agent artifacts.
+
+## Faithful handoff
+
+Treat `message` as a faithful handoff of the user's request, not an Agent build
+specification authored by you. Forward the user's wording as close to verbatim
+as possible. Include only:
+
+- Requirements, constraints, and implementation choices the user explicitly
+  stated.
+- Explicit answers or decisions from earlier turns that are necessary for the
+  current request.
+- Prerequisite workflows or data tables you created for this Agent.
+
+Never infer, invent, expand, recommend, or prescribe implementation details the
+user did not request, and never present your assumptions as user requirements.
+In particular, do not choose or tell the builder which model, instructions,
+tools, tool types, integrations, channels, MCP servers, workflows, skills,
+tasks, memory, credentials, triggers, schedules, approvals, or test strategy to
+use.
+
+Do not translate an outcome or named service into a specific implementation.
+For example, forward "a Slack agent that says hello to me" without turning it
+into a request for a Slack node tool. Preserve unspecified and ambiguous
+implementation details so the builder can resolve them with its own guidance
+and interactive tools.
+
+## Prerequisites
+
+Before the first `build-agent` call, create every prerequisite the builder
+cannot create:
+
+- Create a workflow tool only when one Agent tool call must run an ordered
+  multi-node procedure, or when the user explicitly needs that workflow to be
+  reusable, manually callable, or usable outside the Agent. Follow
+  `workflow-builder`, then pass the built workflow in `workflowContext`.
+- When the Agent will store or query tabular data, follow `data-table-manager`
+  and create the required tables via `data-tables`. The builder cannot create
+  tables.
+
+List prerequisite names and schemas in `message`. Let the builder gather the
+remaining Agent-specific requirements, including model, credentials,
+integrations, and direct tools.
+
+If a `builderReply` lists missing workflows or tables, create them and call
+`build-agent` again. Never ask the user to create them manually.
+
+## Targeting across turns
+
+Address Agents in this conversation with `agentRef`, a short stable key similar
+to a workflow `filePath`.
+
+- For the first Agent, pass a fresh `agentRef` and `name`.
+- Reuse that `agentRef` on later calls. Calls with neither `agentRef` nor
+  `agentId` continue editing the current Agent.
+- To build an additional Agent, pass `createNew: true` with a different
+  `agentRef` and `name`.
+- To edit an Agent not built in this conversation, pass its `agentId` once,
+  optionally with an `agentRef`, then prefer the returned `agentRef`.
+
+Naming or renaming the current Agent never silently creates another one.
+
+## Builder-owned interactions
+
+When the user asks to test, run, publish, activate, make usable, unpublish, or
+otherwise change the Agent, forward that intent in `message`. The builder owns
+its internal testing tools; do not conclude testing is unavailable because
+those tools do not appear in your toolset.
+
+When the builder needs a user choice, credential, chat channel, or approval, it
+surfaces an interactive card in this chat. Do not relay the question yourself;
+the `build-agent` call resumes with the user's answer.

--- a/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/intent-recognition/SKILL.md
@@ -5,24 +5,25 @@ description: >-
   owns the top-level control flow — workflow-anchored, agent-anchored,
   needs-clarification, or out-of-scope) and embeds_other (whether the other
   primitive appears embedded inside — an agent step inside a workflow, or a
-  workflow invoked as an agent tool). Must be used before deciding the intent
-  of any automation request, including compound requests with multiple
-  independent automations, mid-build extensions to an existing workflow or
-  agent, one-off questions or reports that need external systems you cannot
-  query directly, and requests that need clarification before an anchor can
-  be chosen, before choosing workflow-builder, planning, or an agent-oriented
-  design.
+  workflow invoked as an agent tool). Must be used whenever the current turn
+  requires choosing or reconsidering the intent of an automation request,
+  including compound requests, independent automations introduced mid-build,
+  one-off questions or reports that need external systems you cannot query
+  directly, and requests that need clarification before an anchor can be
+  chosen. Do not load for routine edits or extensions when the conversation
+  already targets a workflow or Agent.
 ---
 
 # Intent recognition
 
 ## Purpose
 
-Use this skill to classify an automation request before designing or building
-it. This skill must be used before deciding whether a request is
-workflow-anchored, agent-anchored, needs clarification, or out of scope, and
-before deciding whether the other primitive is embedded inside it. The
-deciding question is not a single "workflow or agent" label — it is two
+Use this skill when an automation request still needs to be classified before
+designing or building it, or when a new turn may require reconsidering the
+current artifact. Do not load it again for a routine edit or extension when the
+conversation already targets a workflow or Agent, unless the user introduces
+an independent automation or the new request carries its own anchor signal.
+The deciding question is not a single "workflow or agent" label — it is two
 questions: who owns the top-level control flow, and does the other primitive
 show up inside that flow.
 
@@ -76,8 +77,8 @@ Two orthogonal decisions per request, or per part for compound requests:
 
 - workflow-anchored + `true`: an agent embedded as a workflow step (e.g. a
   scheduled pipeline whose middle step is open-ended investigation).
-- agent-anchored + `true`: workflows invoked as tools of the agent; see Adding
-  tools to an agent to distinguish them from direct tools.
+- agent-anchored + `true`: workflows invoked as tools of the agent; see Agent
+  tool shape to distinguish them from direct tools.
 - `n/a` for needs-clarification and out-of-scope.
 
 **Migration from the old taxonomy**: old **hybrid** → workflow-anchored,
@@ -87,36 +88,28 @@ only when the user wants a persistent, triggerable automation. Old
 **ambiguous** → needs-clarification. Old **workflow** and **agent** map
 directly onto the matching anchor value.
 
-## Adding tools to an agent
+## Agent tool shape
 
 After choosing an agent-anchored design, decide whether each capability should
 be a direct agent tool or a workflow tool:
 
-- **Direct agent tools are the default.** Forward requests to add capabilities
-  to `build-agent` near-verbatim so the delegated builder can choose MCP,
-  node-backed, provider, or custom tools. One node-backed capability or
-  multiple independent node tools stay on the agent build path with
+- **Direct agent tools are the default.** One node-backed capability or multiple
+  independent node tools stay on the Agent build path with
   `embeds_other: false`.
 - Use a **workflow tool** only when one agent tool call must run an ordered
   multi-node procedure, or when the user explicitly needs that workflow
   reusable, manually callable, or usable outside the agent. Build the workflow
   first, pass it to `build-agent` via `workflowContext`, and set
   `embeds_other: true`.
-- Create required **data tables** via `data-table-manager` → `data-tables`
-  before `build-agent` when the agent will store or query tabular data — the
-  builder cannot create tables.
-- Before the first `build-agent` call, create every prerequisite the builder
-  cannot: required data tables and any workflow tools the agent will invoke.
-  Pass built workflows in `workflowContext` and list every prerequisite
-  name/schema in `message`. Then let the builder gather remaining agent-specific
-  requirements (model, credentials, integrations).
-- If a `builderReply` lists missing workflows or tables, create them and call
-  `build-agent` again — never ask the user to create them manually.
 
 Count the nodes required inside one tool invocation, not the total number of
 tools on the agent. For example, looking up and inserting Data Table rows are
 two direct node tools; an atomic lookup-transform-write procedure is one
 workflow tool.
+
+After choosing an agent-anchored design, load `agent-builder` before calling
+`build-agent`. It owns prerequisite creation and the handoff to the delegated
+builder.
 
 ## Decision Steps
 
@@ -224,7 +217,7 @@ that agent, never a spawned workflow.
   that drafts a tailored renewal pitch for each account from its usage
   history embeds an agent; a nightly job that condenses each ticket into a
   two-sentence summary does not.
-- For an agent with workflow tools, apply Adding tools to an agent.
+- For an agent with workflow tools, apply Agent tool shape.
 
 **Context continuity** (step 0): inside a workflow build, a request to insert
 a scoring step stays a bounded LLM step, not a new agent. Inside an agent

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -6,6 +6,7 @@ import { INSTANCE_AI_SKILLS_DIR, loadInstanceAiRuntimeSkillSource } from '../run
 import { CONFIG_EVALS_SKILL_ID, disabledInstanceAiSkillIds } from '../skill-gates';
 
 const ORIGINAL_ENABLED_MODULES = process.env.N8N_ENABLED_MODULES;
+const AGENTS_MODULE_SKILL_IDS = ['agent-builder', 'intent-recognition'] as const;
 
 describe('Instance AI runtime skills', () => {
 	afterEach(() => {
@@ -136,61 +137,26 @@ describe('Instance AI runtime skills', () => {
 		expect(configEvals?.id).toBe(CONFIG_EVALS_SKILL_ID);
 	});
 
-	it('excludes the bundled intent-recognition skill unless the agents module is enabled', async () => {
+	it('excludes bundled Agents module skills unless the module is enabled', async () => {
 		const source = await loadRuntimeSkillSourceWithEnabledModules('instance-ai');
 
-		expect(source.registry.skills).not.toContainEqual(
-			expect.objectContaining({ id: 'intent-recognition' }),
-		);
-		await expect(source.loadSkill('intent-recognition')).resolves.toBeNull();
+		for (const skillId of AGENTS_MODULE_SKILL_IDS) {
+			expect(source.registry.skills).not.toContainEqual(expect.objectContaining({ id: skillId }));
+			await expect(source.loadSkill(skillId)).resolves.toBeNull();
+		}
 	});
 
-	it('loads the bundled intent-recognition skill when the agents module is enabled', async () => {
+	it('loads bundled Agents module skills when the module is enabled', async () => {
 		const source = await loadRuntimeSkillSourceWithEnabledModules('instance-ai, agents');
-
-		expect(source.registry.skills).toContainEqual(
-			expect.objectContaining({ id: 'intent-recognition' }),
-		);
-		expect(
-			source.registry.skills.find((entry) => entry.id === 'intent-recognition')?.description,
-		).toContain('Must be used before deciding the intent of any automation request');
-		const skill = await source.loadSkill('intent-recognition');
-		expect(skill?.name).toBe('intent-recognition');
-		expect(skill?.instructions).toContain('This skill must be used before deciding');
-
 		const loadTool = createSkillLoadTool(source);
-		const loadResult = await loadTool.handler?.({ skillId: 'intent-recognition' }, {});
-		const loadedText = skillLoadText(loadResult);
-		expect(loadedText).toContain('[Skill: "intent-recognition"]');
-		expect(loadedText).toContain(
-			'workflow-anchored | agent-anchored | needs-clarification | out-of-scope',
-		);
-	});
 
-	it('keeps agent tool routing in one dedicated section', () => {
-		const skill = readFileSync(
-			join(INSTANCE_AI_SKILLS_DIR, 'intent-recognition', 'SKILL.md'),
-			'utf-8',
-		);
+		for (const skillId of AGENTS_MODULE_SKILL_IDS) {
+			expect(source.registry.skills).toContainEqual(expect.objectContaining({ id: skillId }));
+			await expect(source.loadSkill(skillId)).resolves.toMatchObject({ name: skillId });
 
-		expect(skill).toContain('## Adding tools to an agent');
-		expect(skill).toContain('Direct agent tools are the default');
-		expect(skill.match(/multiple independent node tools/g)).toHaveLength(1);
-		expect(
-			skill.match(/one agent tool call must run an ordered\s+multi-node procedure/g),
-		).toHaveLength(1);
-	});
-
-	it('requires agent prerequisites before build-agent and retries when the builder reports missing assets', () => {
-		const skill = readFileSync(
-			join(INSTANCE_AI_SKILLS_DIR, 'intent-recognition', 'SKILL.md'),
-			'utf-8',
-		);
-
-		expect(skill).toContain('Before the first `build-agent` call, create every prerequisite');
-		expect(skill).toContain('builder cannot create tables');
-		expect(skill).toContain('If a `builderReply` lists missing workflows or tables');
-		expect(skill).toContain('never ask the user to create them manually');
+			const loadResult = await loadTool.handler?.({ skillId }, {});
+			expect(skillLoadText(loadResult)).toContain(`[Skill: "${skillId}"]`);
+		}
 	});
 
 	it('loads the bundled Computer Use credential setup skill', async () => {

--- a/packages/@n8n/instance-ai/src/skills/runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/runtime-skills.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 import { isAgentFeatureEnabled } from '@/utils/agent-feature-enabled';
 
 export const INSTANCE_AI_SKILLS_DIR = resolve(__dirname, '..', '..', 'skills');
-const AGENTS_MODULE_RUNTIME_SKILLS = new Set(['intent-recognition']);
+const AGENTS_MODULE_RUNTIME_SKILLS = new Set(['agent-builder', 'intent-recognition']);
 
 let cachedRuntimeSkillSource: RuntimeSkillSource | undefined;
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -148,9 +148,9 @@ const buildAgentInputSchema = z.object({
 		.string()
 		.min(1)
 		.describe(
-			'The instruction or user message to forward to the agent builder. The builder cannot ' +
-				'see this chat — include every requirement, decision, and user answer already ' +
-				'gathered in this conversation, not just the latest message.',
+			'A faithful handoff to the agent builder, which cannot see this chat. Include the ' +
+				'user’s explicit requirements, decisions, and relevant prior answers, but never infer ' +
+				'or prescribe implementation details the user did not request.',
 		),
 	agentRef: z
 		.string()
@@ -931,32 +931,20 @@ export function createBuildAgentTool(context: OrchestrationContext) {
 		.description(
 			'Builds and edits n8n **Agent** artifacts (instructions, model, tools, skills, tasks, ' +
 				'integrations, sub-agents) and delegates draft agent test runs to the agents-module ' +
-				'builder. When the user asks to test or run an agent, call this tool and forward that ' +
-				'intent in `message`. The builder owns the internal `call_agent` tool, so it will not ' +
-				'appear in your toolset or tool search; never conclude agent testing is unavailable ' +
-				'because you cannot see it. This tool is only for Agent artifacts. When the request ' +
-				'is workflow-anchored (via the intent gate / ' +
+				'builder. Load `agent-builder` via `load_skill` before calling this tool and follow it ' +
+				'for prerequisite creation, faithful handoff, targeting, interactive questions, ' +
+				'testing, and publishing. In `message`, forward only the user’s explicit requirements ' +
+				'and relevant prior decisions; never infer, invent, expand, recommend, or prescribe ' +
+				'implementation details. Do not translate a named outcome or service into an ' +
+				'implementation choice — for example, do not turn “a Slack agent” into a Slack node ' +
+				'tool. This tool is only for Agent artifacts. When the request is workflow-anchored ' +
+				'(via the intent gate / ' +
 				'`intent-recognition`), stay on the `workflow-builder` path and do not call this tool ' +
 				'at all — not to inspect nodes, not to list workflows, and not to compile custom ' +
 				'tools. If a workflow build seems to need a utility tool the workspace does not ' +
 				'provide, ask the user or use a placeholder; do not route around that by calling ' +
-				'`build-agent`. ' +
-				'Address agents in this conversation with `agentRef` (a short stable key you choose, ' +
-				'like a workflow `filePath`). Pass `name` with a fresh key to create the first agent; ' +
-				'repeat the same key to continue. Calls with neither key nor `agentId` keep editing ' +
-				'the current agent, and so does a fresh key once an agent is bound — naming an agent ' +
-				'never silently creates a second one. To build ANOTHER agent in the same ' +
-				'conversation, pass `createNew: true` with a different `agentRef` and `name`. To edit ' +
-				'an agent that was not built here, pass `agentId` (optionally with `agentRef`) once ' +
-				'to adopt it. The builder can also publish or unpublish the target ' +
-				'agent when the user asks to publish, activate, make it live/usable, or unpublish — ' +
-				'forward that intent in `message`; never tell the user to open the agent editor and ' +
-				'click Publish. When the builder needs user input (a choice, a ' +
-				'credential, a chat channel, or approval for a target-agent tool), it surfaces automatically as an interactive card in ' +
-				'this chat — do not relay those questions yourself; this tool call resumes with the ' +
-				'user’s answer and returns the builder’s reply. Returns the builder’s reply, the ' +
-				'target `agentRef`/`agentId`, and whether it updated the agent config. Prefer the ' +
-				'returned `agentRef` on later calls for that agent.',
+				'`build-agent`. Returns the builder’s reply, the target `agentRef`/`agentId`, and ' +
+				'whether it updated the Agent config.',
 		)
 		.input(buildAgentInputSchema)
 		.output(buildAgentOutputSchema)

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMessage.vue
@@ -82,7 +82,13 @@ const formattedTechnicalDetails = computed(() => {
 	}
 });
 
-const attachments = computed(() => props.message.attachments ?? []);
+const attachments = computed(() =>
+	(props.message.attachments ?? []).map((attachment) => {
+		if (attachment.type !== 'agent') return attachment;
+		const name = thread.producedArtifacts.get(attachment.id)?.name;
+		return name && name !== attachment.name ? { ...attachment, name } : attachment;
+	}),
+);
 
 /** Transient status message from the backend (e.g. "Recalling conversation..."). */
 const statusMessage = computed(() => {


### PR DESCRIPTION
## Summary

- Add an `agent-builder` skill that gives `build-agent` the same skill-first contract as workflow builds and preserves the user's explicit requirements during delegation.
- Keep intent recognition focused on choosing the artifact while moving Agent build prerequisites and continuation guidance into the dedicated builder skill.
- Resolve Agent message attachment names from the canonical produced-artifact registry so builder-driven renames update the attachment chip.

## How to test

1. Start n8n with `N8N_ENABLED_MODULES=agents,instance-ai`.
2. Open a new unsaved Agent and start an Instance AI conversation from it.
3. Ask: “Build me a Slack agent that says hello to me.”
4. Confirm Instance AI loads the Agent builder guidance and forwards the request without prescribing a Slack node tool.
5. Confirm the attachment chip updates from “New Agent” when the builder names the Agent.

Automated checks:

- `pnpm test src/skills/__tests__/runtime-skills.test.ts` in `packages/@n8n/instance-ai`
- Package-scoped lint and type checks for `@n8n/instance-ai` and `n8n-editor-ui`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-595

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

