### PR TITLE
fix(editor): Show dependency pills on views listing more than 100 resources

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useDependencies.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDependencies.test.ts
@@ -1,0 +1,102 @@
+import { createPinia, setActivePinia } from 'pinia';
+import type { DependencyTypeCounts } from '@n8n/api-types';
+
+import * as workflowDependenciesApi from '@/app/api/workflow-dependencies';
+import { useDependencies } from '@/app/composables/useDependencies';
+
+vi.mock('@/app/api/workflow-dependencies', () => ({
+	getResourceDependencyCounts: vi.fn(),
+	getResourceDependencies: vi.fn(),
+}));
+
+const getResourceDependencyCountsMock = vi.mocked(
+	workflowDependenciesApi.getResourceDependencyCounts,
+);
+const getResourceDependenciesMock = vi.mocked(workflowDependenciesApi.getResourceDependencies);
+
+const countsFor = (ids: string[]): Record<string, DependencyTypeCounts> =>
+	Object.fromEntries(
+		ids.map((id) => [
+			id,
+			{
+				agentUsage: 0,
+				credentialId: 0,
+				dataTableId: 0,
+				errorWorkflow: 0,
+				errorWorkflowParent: 0,
+				workflowCall: 0,
+				workflowParent: 1,
+			},
+		]),
+	);
+
+describe('useDependencies', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		vi.clearAllMocks();
+		useDependencies().clearCache();
+	});
+
+	describe('fetchDependencyCounts', () => {
+		it('does not send a request for an empty id list', async () => {
+			await useDependencies().fetchDependencyCounts([], 'credential');
+
+			expect(getResourceDependencyCountsMock).not.toHaveBeenCalled();
+		});
+
+		it('splits requests into batches of 100 ids and merges the results', async () => {
+			const ids = Array.from({ length: 250 }, (_, i) => `cred-${i}`);
+			getResourceDependencyCountsMock.mockImplementation(async (_context, resourceIds) =>
+				countsFor(resourceIds),
+			);
+
+			const dependencies = useDependencies();
+			await dependencies.fetchDependencyCounts(ids, 'credential');
+
+			expect(getResourceDependencyCountsMock).toHaveBeenCalledTimes(3);
+			const batchSizes = getResourceDependencyCountsMock.mock.calls.map(
+				([, resourceIds]) => resourceIds.length,
+			);
+			expect(batchSizes).toEqual([100, 100, 50]);
+			expect(dependencies.hasDependencies('cred-0')).toBe(true);
+			expect(dependencies.hasDependencies('cred-249')).toBe(true);
+		});
+
+		it('keeps results from successful batches when another batch fails', async () => {
+			const ids = Array.from({ length: 150 }, (_, i) => `cred-${i}`);
+			getResourceDependencyCountsMock
+				.mockRejectedValueOnce(new Error('request failed'))
+				.mockImplementation(async (_context, resourceIds) => countsFor(resourceIds));
+
+			const dependencies = useDependencies();
+			await dependencies.fetchDependencyCounts(ids, 'credential');
+
+			expect(dependencies.hasDependencies('cred-0')).toBe(false);
+			expect(dependencies.hasDependencies('cred-149')).toBe(true);
+		});
+	});
+
+	describe('fetchDependencies', () => {
+		it('splits requests into batches of 100 ids and merges the results', async () => {
+			const ids = Array.from({ length: 101 }, (_, i) => `wf-${i}`);
+			getResourceDependenciesMock.mockImplementation(async (_context, resourceIds) =>
+				Object.fromEntries(
+					resourceIds.map((id) => [id, { dependencies: [], inaccessibleCount: 1 }]),
+				),
+			);
+
+			const dependencies = useDependencies();
+			await dependencies.fetchDependencies(ids, 'workflow');
+
+			expect(getResourceDependenciesMock).toHaveBeenCalledTimes(2);
+			expect(dependencies.getDependencies('wf-0')).toEqual({
+				dependencies: [],
+				inaccessibleCount: 1,
+			});
+			expect(dependencies.getDependencies('wf-100')).toEqual({
+				dependencies: [],
+				inaccessibleCount: 1,
+			});
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/useDependencies.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDependencies.ts
@@ -11,6 +11,18 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 const dependenciesMap = ref<Record<string, ResolvedDependenciesResult>>({});
 const countsMap = ref<Record<string, DependencyTypeCounts>>({});
 
+// The backend rejects requests with more than 100 resource ids
+// (see GetResourceDependencyCountsDto), so batch larger id lists.
+const BATCH_SIZE = 100;
+
+function toBatches(resourceIds: string[]): string[][] {
+	const batches: string[][] = [];
+	for (let i = 0; i < resourceIds.length; i += BATCH_SIZE) {
+		batches.push(resourceIds.slice(i, i + BATCH_SIZE));
+	}
+	return batches;
+}
+
 export function useDependencies() {
 	const rootStore = useRootStore();
 
@@ -19,20 +31,22 @@ export function useDependencies() {
 		resourceIds: string[],
 		resourceType: DependencyResourceType,
 	): Promise<void> {
-		if (resourceIds.length === 0) return;
-
-		try {
-			const result = await workflowDependenciesApi.getResourceDependencyCounts(
-				rootStore.restApiContext,
-				resourceIds,
-				resourceType,
-			);
-			for (const [id, counts] of Object.entries(result)) {
-				countsMap.value[id] = counts;
-			}
-		} catch {
-			// Counts are supplementary — silently ignore errors
-		}
+		await Promise.all(
+			toBatches(resourceIds).map(async (batch) => {
+				try {
+					const result = await workflowDependenciesApi.getResourceDependencyCounts(
+						rootStore.restApiContext,
+						batch,
+						resourceType,
+					);
+					for (const [id, counts] of Object.entries(result)) {
+						countsMap.value[id] = counts;
+					}
+				} catch {
+					// Counts are supplementary — silently ignore errors
+				}
+			}),
+		);
 	}
 
 	/** Fetch full resolved dependencies for any resource type. */
@@ -40,20 +54,22 @@ export function useDependencies() {
 		resourceIds: string[],
 		resourceType: DependencyResourceType,
 	): Promise<void> {
-		if (resourceIds.length === 0) return;
-
-		try {
-			const result = await workflowDependenciesApi.getResourceDependencies(
-				rootStore.restApiContext,
-				resourceIds,
-				resourceType,
-			);
-			for (const [id, entry] of Object.entries(result)) {
-				dependenciesMap.value[id] = entry;
-			}
-		} catch {
-			// Dependencies are supplementary — silently ignore errors
-		}
+		await Promise.all(
+			toBatches(resourceIds).map(async (batch) => {
+				try {
+					const result = await workflowDependenciesApi.getResourceDependencies(
+						rootStore.restApiContext,
+						batch,
+						resourceType,
+					);
+					for (const [id, entry] of Object.entries(result)) {
+						dependenciesMap.value[id] = entry;
+					}
+				} catch {
+					// Dependencies are supplementary — silently ignore errors
+				}
+			}),
+		);
 	}
 
 	function getDependencies(resourceId: string): ResolvedDependenciesResult | undefined {


### PR DESCRIPTION
## Summary

Workflow dependency pills were missing on credential cards in any view listing more than 100 credentials (large projects, admin Overview). `CredentialsView` requested dependency counts for every credential in the view in a single `POST /workflow-dependencies/counts` call; the backend DTO caps `resourceIds` at 100 and rejected the request with a 400, which the frontend silently swallowed — so the whole view lost its pills.

This batches the ids into chunks of 100 in the shared `useDependencies` composable (`fetchDependencyCounts` and `fetchDependencies`), fixing all callers (`CredentialsView`, `DataTableView`, `DependencyPill`) in one place. Batches run in parallel and each keeps its own error handling, so one failing batch no longer discards results from the others. `WorkflowsView` was unaffected since it already fetches per page (≤ 100).

Permissions were ruled out as the cause: a non-member global admin gets identical counts to a project member at both the service and HTTP level.

## How to test

1. Create a project with more than 100 credentials, at least one of them used by a workflow.
2. Open the project's Credentials tab.
3. Before this change no cards show the dependency pill; with it, the used credential shows its pill.
4. Unit tests: `pnpm test src/app/composables/useDependencies.test.ts` in `packages/frontend/editor-ui`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5750

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

