### PR TITLE
feat(core): Add telemetry for Simplified Custom Auth templated credentials

### DIFF
--- a/packages/@n8n/telemetry/src/events/credentials.ts
+++ b/packages/@n8n/telemetry/src/events/credentials.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod/v4';
+
+import { defineTelemetryEvents } from '../define';
+
+export const CREDENTIALS_TELEMETRY = defineTelemetryEvents({
+	USER_PROBED_CREDENTIAL: {
+		name: 'User probed credential',
+		description:
+			"A stored credential was auth-probed against its own persisted test URL (POST /credentials/:id/probe) — the test path for generic credential types that declare no test, currently Simplified Custom Auth. Fires once per probe, including retries. The outcome is the probe's three-state verdict; joins to 'User created credentials' on credential_id.",
+		properties: z.object({
+			user_id: z.string(),
+			credential_id: z.string(),
+			outcome: z
+				.enum(['accepted', 'rejected', 'unverified'])
+				.describe(
+					"'accepted' = the service took the credential (2xx, or a service-declared accepted status code); 'rejected' = explicit 401/403 auth rejection; 'unverified' = anything else (wrong test URL, unreachable service) — proves nothing about the credential",
+				),
+		}),
+	},
+});

--- a/packages/@n8n/telemetry/src/events/instance-ai.ts
+++ b/packages/@n8n/telemetry/src/events/instance-ai.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod/v4';
+
+import { defineTelemetryEvents } from '../define';
+
+export const INSTANCE_AI_TELEMETRY = defineTelemetryEvents({
+	BUILDER_SPECCED_TEMPLATED_CRED: {
+		name: 'Builder specced templated cred',
+		description:
+			'The Instance AI workflow builder composed a Simplified Custom Auth recipe (credentialHints) and suspended to show its setup card. Captures the recipe fields so template and link quality are observable in production — one event per recipe in the suspension. Contains no secrets by construction: recipes are agent-authored before any user input.',
+		properties: z.object({
+			thread_id: z.string(),
+			input_thread_id: z
+				.string()
+				.describe("Joins with 'Builder asked for input' / 'User finished providing input'"),
+			template: z
+				.record(z.string(), z.unknown())
+				.describe('Auth request parts with {{placeholder}} markers, never real values'),
+			placeholders: z
+				.array(z.record(z.string(), z.unknown()))
+				.describe('Placeholder defs (name, title, info, type, optional)'),
+			test_url: z.string().optional(),
+			docs_url: z
+				.string()
+				.optional()
+				.describe('Provider key page the credential help thread directs the user to'),
+			service_host: z
+				.string()
+				.optional()
+				.describe('API host the recipe targets (server-derived) — groups events by service'),
+			accepted_status_codes: z
+				.array(z.number())
+				.optional()
+				.describe('No longer model-suppliable; expected absent — presence flags a regression'),
+		}),
+	},
+});

--- a/packages/@n8n/telemetry/src/telemetry-events.ts
+++ b/packages/@n8n/telemetry/src/telemetry-events.ts
@@ -1,10 +1,12 @@
 import type { TelemetryEventRegistry } from './define';
 import { AGENTS_TELEMETRY } from './events/agents';
 import { INSTANCE_TELEMETRY } from './events/instance';
+import { INSTANCE_AI_TELEMETRY } from './events/instance-ai';
 import { PLATFORM_TELEMETRY } from './events/platform';
 
 export const TELEMETRY_EVENT = {
 	PLATFORM: PLATFORM_TELEMETRY,
 	AGENTS: AGENTS_TELEMETRY,
 	INSTANCE: INSTANCE_TELEMETRY,
+	INSTANCE_AI: INSTANCE_AI_TELEMETRY,
 } satisfies TelemetryEventRegistry;

--- a/packages/@n8n/telemetry/src/telemetry-events.ts
+++ b/packages/@n8n/telemetry/src/telemetry-events.ts
@@ -1,5 +1,6 @@
 import type { TelemetryEventRegistry } from './define';
 import { AGENTS_TELEMETRY } from './events/agents';
+import { CREDENTIALS_TELEMETRY } from './events/credentials';
 import { INSTANCE_TELEMETRY } from './events/instance';
 import { INSTANCE_AI_TELEMETRY } from './events/instance-ai';
 import { PLATFORM_TELEMETRY } from './events/platform';
@@ -7,6 +8,7 @@ import { PLATFORM_TELEMETRY } from './events/platform';
 export const TELEMETRY_EVENT = {
 	PLATFORM: PLATFORM_TELEMETRY,
 	AGENTS: AGENTS_TELEMETRY,
+	CREDENTIALS: CREDENTIALS_TELEMETRY,
 	INSTANCE: INSTANCE_TELEMETRY,
 	INSTANCE_AI: INSTANCE_AI_TELEMETRY,
 } satisfies TelemetryEventRegistry;

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -3885,7 +3885,11 @@ describe('CredentialsService', () => {
 				acceptedStatusCodes: '[401]',
 			};
 			mockDecryptedData(data);
-			const verdict = { status: 'OK' as const, message: 'Connection successful!' };
+			const verdict = {
+				status: 'OK' as const,
+				message: 'Connection successful!',
+				outcome: 'accepted' as const,
+			};
 			credentialsTester.probeCredentialAuth.mockResolvedValue(verdict);
 
 			await expect(service.probeById(ownerUser, 'cred-id')).resolves.toEqual(verdict);
@@ -3904,6 +3908,7 @@ describe('CredentialsService', () => {
 			credentialsTester.probeCredentialAuth.mockResolvedValue({
 				status: 'OK',
 				message: 'Connection successful!',
+				outcome: 'accepted',
 			});
 
 			await service.probeById(ownerUser, 'cred-id');

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -170,7 +170,15 @@ export class CredentialsController {
 		@Param('credentialId') credentialId: string,
 	) {
 		try {
-			return await this.credentialsService.probeById(req.user, credentialId);
+			const result = await this.credentialsService.probeById(req.user, credentialId);
+
+			this.eventService.emit('credentials-probed', {
+				user: req.user,
+				credentialId,
+				outcome: result.outcome,
+			});
+
+			return result;
 		} catch (error) {
 			if (error instanceof CredentialNotFoundError) {
 				throw new ForbiddenError();

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1085,6 +1085,35 @@ describe('TelemetryEventRelay', () => {
 			});
 		});
 
+		it('should track on `credentials-probed` event', () => {
+			const event: RelayEventMap['credentials-probed'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				credentialId: 'cred123',
+				outcome: 'rejected',
+			};
+
+			eventService.emit('credentials-probed', event);
+
+			const payload = {
+				user_id: 'user123',
+				credential_id: 'cred123',
+				outcome: 'rejected',
+			};
+			expect(telemetry.track).toHaveBeenCalledWith(
+				TELEMETRY_EVENT.CREDENTIALS.USER_PROBED_CREDENTIAL,
+				payload,
+			);
+			expect(
+				TELEMETRY_EVENT.CREDENTIALS.USER_PROBED_CREDENTIAL.getValidationError(payload),
+			).toBeNull();
+		});
+
 		it('should track on `private-credential-created` event', () => {
 			const event: RelayEventMap['private-credential-created'] = {
 				user: {

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -13,6 +13,7 @@ import type {
 } from 'n8n-workflow';
 
 import type { ConcurrencyQueueType } from '@/concurrency/concurrency-control.service';
+import type { CredentialAuthProbeOutcome } from '@/services/credentials-tester.service';
 import type {
 	ExportPackageEventCounts,
 	ImportAuditCredentialIds,
@@ -486,6 +487,12 @@ export type RelayEventMap = {
 		user: UserLike;
 		credentialType: string;
 		credentialId: string;
+	};
+
+	'credentials-probed': {
+		user: UserLike;
+		credentialId: string;
+		outcome: CredentialAuthProbeOutcome;
 	};
 
 	'oauth-callback-binding-rejected': {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -147,6 +147,7 @@ export class TelemetryEventRelay extends EventRelay {
 			'credentials-updated': (event) => this.credentialsUpdated(event),
 			'credentials-deleted': (event) => this.credentialsDeleted(event),
 			'credentials-user-disconnected': (event) => this.credentialsUserDisconnected(event),
+			'credentials-probed': (event) => this.credentialsProbed(event),
 			'private-credential-created': (event) => this.privateCredentialCreated(event),
 			'private-credential-toggled-to-private': (event) =>
 				this.privateCredentialToggledToPrivate(event),
@@ -734,6 +735,14 @@ export class TelemetryEventRelay extends EventRelay {
 			user_role: user.role?.slug,
 			credential_type: credentialType,
 			credential_id: credentialId,
+		});
+	}
+
+	private credentialsProbed({ user, credentialId, outcome }: RelayEventMap['credentials-probed']) {
+		this.telemetry.track(TELEMETRY_EVENT.CREDENTIALS.USER_PROBED_CREDENTIAL, {
+			user_id: user.id,
+			credential_id: credentialId,
+			outcome,
 		});
 	}
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
@@ -27,6 +27,8 @@ vi.mock('@n8n/instance-ai', async () => {
 	};
 });
 
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
+
 import { InstanceAiService } from '../instance-ai.service';
 
 /**
@@ -168,6 +170,65 @@ describe('InstanceAiService — "Builder asked for input" telemetry', () => {
 		expect(service.telemetry.track).toHaveBeenCalledWith(
 			'Builder asked for input',
 			expect.objectContaining({ type: 'credential-setup', contains_templated_cred: false }),
+		);
+	});
+
+	it("emits 'Builder specced templated cred' with the recipe fields, once per recipe", () => {
+		const service = makeService();
+		const setupHint = {
+			template: { headers: { Authorization: 'Key {{api_key}}' } },
+			placeholders: [{ name: 'api_key', title: 'fal.ai API key', type: 'password' }],
+			testUrl: 'https://api.fal.ai/v1/models/usage',
+			docsUrl: 'https://fal.ai/dashboard/keys',
+			serviceHost: 'fal.run',
+		};
+
+		service.trackConfirmationRequest('user-1', 'thread-a', {
+			payload: {
+				credentialRequests: [
+					{ credentialType: 'httpHeaderAuth' },
+					{ credentialType: 'httpTemplatedCustomAuth', setupHint },
+				],
+			},
+		});
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			TELEMETRY_EVENT.INSTANCE_AI.BUILDER_SPECCED_TEMPLATED_CRED,
+			{
+				thread_id: 'thread-a',
+				// a fresh nanoid, shared with the paired 'Builder asked for input' event
+				input_thread_id: expect.any(String),
+				template: setupHint.template,
+				placeholders: setupHint.placeholders,
+				test_url: setupHint.testUrl,
+				docs_url: setupHint.docsUrl,
+				service_host: setupHint.serviceHost,
+				accepted_status_codes: undefined,
+			},
+		);
+		expect(
+			service.telemetry.track.mock.calls.filter(
+				([event]) => event === TELEMETRY_EVENT.INSTANCE_AI.BUILDER_SPECCED_TEMPLATED_CRED,
+			),
+		).toHaveLength(1);
+	});
+
+	it('does not emit the specced event for requests without a parseable recipe', () => {
+		const service = makeService();
+
+		service.trackConfirmationRequest('user-1', 'thread-a', {
+			payload: {
+				credentialRequests: [
+					{ credentialType: 'httpHeaderAuth' },
+					// malformed: placeholders must have at least one entry
+					{ credentialType: 'httpTemplatedCustomAuth', setupHint: { template: {} } },
+				],
+			},
+		});
+
+		expect(service.telemetry.track).not.toHaveBeenCalledWith(
+			TELEMETRY_EVENT.INSTANCE_AI.BUILDER_SPECCED_TEMPLATED_CRED,
+			expect.anything(),
 		);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
@@ -132,7 +132,42 @@ describe('InstanceAiService — "Builder asked for input" telemetry', () => {
 
 		expect(service.telemetry.track).toHaveBeenCalledWith(
 			'Builder asked for input',
-			expect.objectContaining({ type: 'setup', num_steps: 3 }),
+			expect.objectContaining({ type: 'setup', num_steps: 3, contains_templated_cred: false }),
+		);
+	});
+
+	it('flags credential setups that include a Templated Custom Auth request', () => {
+		const service = makeService();
+
+		service.trackConfirmationRequest('user-1', 'thread-a', {
+			payload: {
+				credentialRequests: [
+					{ credentialType: 'httpHeaderAuth' },
+					{ credentialType: 'httpTemplatedCustomAuth', setupHint: { template: {} } },
+				],
+			},
+		});
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Builder asked for input',
+			expect.objectContaining({
+				type: 'credential-setup',
+				num_steps: 2,
+				contains_templated_cred: true,
+			}),
+		);
+	});
+
+	it('does not flag credential setups with only plain credential requests', () => {
+		const service = makeService();
+
+		service.trackConfirmationRequest('user-1', 'thread-a', {
+			payload: { credentialRequests: [{ credentialType: 'httpHeaderAuth' }] },
+		});
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Builder asked for input',
+			expect.objectContaining({ type: 'credential-setup', contains_templated_cred: false }),
 		);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
@@ -206,11 +206,17 @@ describe('InstanceAiService — "Builder asked for input" telemetry', () => {
 				accepted_status_codes: undefined,
 			},
 		);
+		const speccedCalls = service.telemetry.track.mock.calls.filter(
+			([event]) => event === TELEMETRY_EVENT.INSTANCE_AI.BUILDER_SPECCED_TEMPLATED_CRED,
+		);
+		expect(speccedCalls).toHaveLength(1);
+		// The emitted payload must satisfy the registry schema — the transport
+		// only logs a warning on mismatch in production.
 		expect(
-			service.telemetry.track.mock.calls.filter(
-				([event]) => event === TELEMETRY_EVENT.INSTANCE_AI.BUILDER_SPECCED_TEMPLATED_CRED,
+			TELEMETRY_EVENT.INSTANCE_AI.BUILDER_SPECCED_TEMPLATED_CRED.getValidationError(
+				speccedCalls[0][1],
 			),
-		).toHaveLength(1);
+		).toBeNull();
 	});
 
 	it('does not emit the specced event for requests without a parseable recipe', () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -9,6 +9,7 @@ import type {
 import {
 	applyBranchReadOnlyOverrides,
 	buildProxyHeaders,
+	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
 	type InstanceAiAttachment,
 	type InstanceAiHandoffContext,
 	type InstanceAiAgentAttachment,
@@ -5838,12 +5839,29 @@ export class InstanceAiService {
 			}
 		}
 
+		// Whether any requested credential is a recipe-driven Templated Custom Auth
+		// one (recipe-seeded modal), to compare completion against plain types.
+		const credentialRequests: unknown[] = Array.isArray(payload.credentialRequests)
+			? payload.credentialRequests
+			: [];
+		const containsTemplatedCred = credentialRequests.some(
+			(request) =>
+				typeof request === 'object' &&
+				request !== null &&
+				(('credentialType' in request &&
+					request.credentialType === TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE) ||
+					('setupHint' in request &&
+						request.setupHint !== null &&
+						request.setupHint !== undefined)),
+		);
+
 		this.telemetry.track('Builder asked for input', {
 			user_id: userId,
 			thread_id: threadId,
 			input_thread_id: inputThreadId,
 			type,
 			num_steps: numSteps,
+			contains_templated_cred: containsTemplatedCred,
 		});
 	}
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -9,6 +9,7 @@ import type {
 import {
 	applyBranchReadOnlyOverrides,
 	buildProxyHeaders,
+	credentialSetupHintSchema,
 	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
 	type InstanceAiAttachment,
 	type InstanceAiHandoffContext,
@@ -107,6 +108,7 @@ import {
 	ThreadTaskStorage,
 } from '@n8n/instance-ai';
 import type { Scope } from '@n8n/permissions';
+import { TELEMETRY_EVENT } from '@n8n/telemetry';
 import { lazyImport } from '@n8n/utils/lazy-import';
 import { setSchemaBaseDirs } from '@n8n/workflow-sdk';
 import { ErrorReporter, InstanceSettings } from 'n8n-core';
@@ -5863,6 +5865,27 @@ export class InstanceAiService {
 			num_steps: numSteps,
 			contains_templated_cred: containsTemplatedCred,
 		});
+
+		// Recipe content at spec time — production visibility into template and
+		// link quality (the offline eval suite grades the same fields). One event
+		// per recipe; secret-free by construction: recipes are agent-authored
+		// before any user input.
+		for (const request of credentialRequests) {
+			if (typeof request !== 'object' || request === null || !('setupHint' in request)) continue;
+			const parsedHint = credentialSetupHintSchema.safeParse(request.setupHint);
+			if (!parsedHint.success) continue;
+			const hint = parsedHint.data;
+			this.telemetry.track(TELEMETRY_EVENT.INSTANCE_AI.BUILDER_SPECCED_TEMPLATED_CRED, {
+				thread_id: threadId,
+				input_thread_id: inputThreadId,
+				template: hint.template,
+				placeholders: hint.placeholders,
+				test_url: hint.testUrl,
+				docs_url: hint.docsUrl,
+				service_host: hint.serviceHost,
+				accepted_status_codes: hint.acceptedStatusCodes,
+			});
+		}
 	}
 
 	private async finalizeCancelledSuspendedRun(

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -5841,20 +5841,19 @@ export class InstanceAiService {
 			}
 		}
 
+		const credentialRequests = (
+			Array.isArray(payload.credentialRequests) ? payload.credentialRequests : []
+		).filter(
+			(request): request is { credentialType?: unknown; setupHint?: unknown } =>
+				typeof request === 'object' && request !== null,
+		);
+
 		// Whether any requested credential is a recipe-driven Templated Custom Auth
 		// one (recipe-seeded modal), to compare completion against plain types.
-		const credentialRequests: unknown[] = Array.isArray(payload.credentialRequests)
-			? payload.credentialRequests
-			: [];
 		const containsTemplatedCred = credentialRequests.some(
 			(request) =>
-				typeof request === 'object' &&
-				request !== null &&
-				(('credentialType' in request &&
-					request.credentialType === TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE) ||
-					('setupHint' in request &&
-						request.setupHint !== null &&
-						request.setupHint !== undefined)),
+				request.credentialType === TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE ||
+				(request.setupHint !== null && request.setupHint !== undefined),
 		);
 
 		this.telemetry.track('Builder asked for input', {
@@ -5871,7 +5870,6 @@ export class InstanceAiService {
 		// per recipe; secret-free by construction: recipes are agent-authored
 		// before any user input.
 		for (const request of credentialRequests) {
-			if (typeof request !== 'object' || request === null || !('setupHint' in request)) continue;
 			const parsedHint = credentialSetupHintSchema.safeParse(request.setupHint);
 			if (!parsedHint.success) continue;
 			const hint = parsedHint.data;

--- a/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
+++ b/packages/cli/src/services/__tests__/credentials-tester.service.test.ts
@@ -307,6 +307,7 @@ describe('CredentialsTester', () => {
 			// Some services answer 2xx regardless of the credential, so the green
 			// verdict states what happened instead of claiming verification.
 			expect(result.message).toBe(AUTH_PROBE_ACCEPTED_MESSAGE);
+			expect(result.outcome).toBe('accepted');
 			const nodeTypeArg = (RoutingNode as unknown as Mock).mock.calls[0][1] as INodeType;
 			expect(nodeTypeArg.description.properties[0].routing?.request).toEqual({
 				url: targetUrl,
@@ -326,6 +327,7 @@ describe('CredentialsTester', () => {
 
 			expect(result.status).toBe('Error');
 			expect(result.message).toContain('401');
+			expect(result.outcome).toBe('rejected');
 		});
 
 		it('reports a non-auth error response as unverifiable instead of success', async () => {
@@ -341,6 +343,7 @@ describe('CredentialsTester', () => {
 			expect(result.status).toBe('Error');
 			expect(result.message).toContain('405');
 			expect(result.message).toContain('could not be verified');
+			expect(result.outcome).toBe('unverified');
 		});
 
 		it('accepts a declared service-specific status code instead of rejecting on it', async () => {
@@ -355,6 +358,7 @@ describe('CredentialsTester', () => {
 			);
 
 			expect(result.status).toBe('OK');
+			expect(result.outcome).toBe('accepted');
 		});
 
 		// The routing engine wraps HTTP failures in NodeApiError: the status is
@@ -390,6 +394,7 @@ describe('CredentialsTester', () => {
 
 			expect(result.status).toBe('Error');
 			expect(result.message).toContain('401');
+			expect(result.outcome).toBe('rejected');
 		});
 
 		it('reports a NodeApiError-wrapped non-auth status as unverifiable', async () => {
@@ -404,6 +409,7 @@ describe('CredentialsTester', () => {
 
 			expect(result.status).toBe('Error');
 			expect(result.message).toContain('405');
+			expect(result.outcome).toBe('unverified');
 		});
 
 		it('accepts a declared code on the NodeApiError shape too', async () => {
@@ -418,6 +424,7 @@ describe('CredentialsTester', () => {
 			);
 
 			expect(result.status).toBe('OK');
+			expect(result.outcome).toBe('accepted');
 		});
 
 		it('reports an unreachable service as unverifiable rather than success', async () => {
@@ -434,6 +441,7 @@ describe('CredentialsTester', () => {
 
 			expect(result.status).toBe('Error');
 			expect(result.message).toContain('Could not reach');
+			expect(result.outcome).toBe('unverified');
 		});
 
 		it('preserves credential configuration errors', async () => {
@@ -451,6 +459,7 @@ describe('CredentialsTester', () => {
 			expect(result).toEqual({
 				status: 'Error',
 				message: 'No value set for placeholder {{api_key}}',
+				outcome: 'unverified',
 			});
 		});
 	});

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -49,6 +49,17 @@ const { OAUTH2_CREDENTIAL_TEST_SUCCEEDED, OAUTH2_CREDENTIAL_TEST_FAILED } = RESP
  *  key was verified — some services answer 2xx regardless of the credential. */
 export const AUTH_PROBE_ACCEPTED_MESSAGE = 'The service accepted the credential.';
 
+/**
+ * The three-state auth-probe verdict: 'accepted' (the service took the
+ * credential), 'rejected' (explicit 401/403 auth rejection), 'unverified'
+ * (anything else proves nothing about the credential).
+ */
+export type CredentialAuthProbeOutcome = 'accepted' | 'rejected' | 'unverified';
+
+export type CredentialAuthProbeResult = INodeCredentialTestResult & {
+	outcome: CredentialAuthProbeOutcome;
+};
+
 const mockNodesData: INodeTypeData = {
 	mock: {
 		sourcePath: '',
@@ -238,7 +249,7 @@ export class CredentialsTester {
 		credentialsDecrypted: ICredentialsDecrypted,
 		targetUrl: string,
 		options: { acceptedStatusCodes?: number[] } = {},
-	): Promise<INodeCredentialTestResult> {
+	): Promise<CredentialAuthProbeResult> {
 		try {
 			await this.prepareCredentialsForTest(userId, credentialType, credentialsDecrypted);
 		} catch (error) {
@@ -246,6 +257,7 @@ export class CredentialsTester {
 			return {
 				status: 'Error',
 				message: error.message.toString(),
+				outcome: 'unverified',
 			};
 		}
 
@@ -338,7 +350,7 @@ export class CredentialsTester {
 			cause?: { response?: { status?: unknown }; code?: unknown };
 		},
 		acceptedStatusCodes?: number[],
-	): INodeCredentialTestResult {
+	): CredentialAuthProbeResult {
 		const statusCode =
 			Number(error.httpCode) ||
 			Number(error.context?.data?.status) ||
@@ -350,28 +362,31 @@ export class CredentialsTester {
 				return {
 					status: 'Error',
 					message: `The service rejected the credential (HTTP ${statusCode}). Check the key and try again.`,
+					outcome: 'rejected',
 				};
 			}
 			// The service is documented to answer this code to a valid GET — the
 			// probe can't tell valid from invalid here, so don't overclaim.
-			return { status: 'OK', message: AUTH_PROBE_ACCEPTED_MESSAGE };
+			return { status: 'OK', message: AUTH_PROBE_ACCEPTED_MESSAGE, outcome: 'accepted' };
 		}
 
 		if (statusCode) {
 			return {
 				status: 'Error',
 				message: `The test URL answered HTTP ${statusCode}, so the credential could not be verified. The test URL may be wrong — it must be a read-only endpoint that answers an authenticated GET.`,
+				outcome: 'unverified',
 			};
 		}
 
 		if (typeof error.message === 'string' && !error.cause?.code) {
-			return { status: 'Error', message: error.message };
+			return { status: 'Error', message: error.message, outcome: 'unverified' };
 		}
 
 		this.logger.debug('Credential auth probe inconclusive', error);
 		return {
 			status: 'Error',
 			message: 'Could not reach the test URL to verify the credential.',
+			outcome: 'unverified',
 		};
 	}
 
@@ -380,8 +395,25 @@ export class CredentialsTester {
 	 * engine. The `authProbe` verdict treats 401/403 as rejection, 2xx as
 	 * success, and everything else (wrong test URL, unreachable service) as
 	 * unverifiable — used for ad-hoc probes of generic credentials against a
-	 * known endpoint.
+	 * known endpoint. Probe requests carry no test rules, so every `authProbe`
+	 * return path stamps a probe outcome — which is what lets the first
+	 * overload narrow the result.
 	 */
+	private async runRequestTest(
+		userId: User['id'],
+		credentialType: string,
+		credentialsDecrypted: ICredentialsDecrypted,
+		credentialTestFunction: ICredentialTestRequestData,
+		verdict: 'authProbe',
+		acceptedStatusCodes?: number[],
+	): Promise<CredentialAuthProbeResult>;
+	private async runRequestTest(
+		userId: User['id'],
+		credentialType: string,
+		credentialsDecrypted: ICredentialsDecrypted,
+		credentialTestFunction: ICredentialTestRequestData,
+		verdict: 'default',
+	): Promise<INodeCredentialTestResult>;
 	// eslint-disable-next-line complexity
 	private async runRequestTest(
 		userId: User['id'],
@@ -567,10 +599,12 @@ export class CredentialsTester {
 			// answer 2xx regardless (no auth required, or errors signalled in the
 			// body) it is not — the probe can't tell them apart, so the copy states
 			// what happened instead of claiming the key was verified.
-			return {
+			const result: CredentialAuthProbeResult = {
 				status: 'OK',
 				message: AUTH_PROBE_ACCEPTED_MESSAGE,
+				outcome: 'accepted',
 			};
+			return result;
 		}
 
 		return {

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -261,7 +261,7 @@ export class CredentialsTester {
 			};
 		}
 
-		return await this.runRequestTest(
+		const result = await this.runRequestTest(
 			userId,
 			credentialType,
 			credentialsDecrypted,
@@ -269,6 +269,9 @@ export class CredentialsTester {
 			'authProbe',
 			options.acceptedStatusCodes,
 		);
+		// Probe requests carry no test rules, so every reachable path stamps an
+		// outcome — the fallback makes the required field structural, not asserted.
+		return { ...result, outcome: result.outcome ?? 'unverified' };
 	}
 
 	async testCredentials(
@@ -395,25 +398,9 @@ export class CredentialsTester {
 	 * engine. The `authProbe` verdict treats 401/403 as rejection, 2xx as
 	 * success, and everything else (wrong test URL, unreachable service) as
 	 * unverifiable — used for ad-hoc probes of generic credentials against a
-	 * known endpoint. Probe requests carry no test rules, so every `authProbe`
-	 * return path stamps a probe outcome — which is what lets the first
-	 * overload narrow the result.
+	 * known endpoint. Only the rules-driven return paths skip the `outcome`
+	 * stamp; `probeCredentialAuth` defaults those to 'unverified'.
 	 */
-	private async runRequestTest(
-		userId: User['id'],
-		credentialType: string,
-		credentialsDecrypted: ICredentialsDecrypted,
-		credentialTestFunction: ICredentialTestRequestData,
-		verdict: 'authProbe',
-		acceptedStatusCodes?: number[],
-	): Promise<CredentialAuthProbeResult>;
-	private async runRequestTest(
-		userId: User['id'],
-		credentialType: string,
-		credentialsDecrypted: ICredentialsDecrypted,
-		credentialTestFunction: ICredentialTestRequestData,
-		verdict: 'default',
-	): Promise<INodeCredentialTestResult>;
 	// eslint-disable-next-line complexity
 	private async runRequestTest(
 		userId: User['id'],
@@ -422,7 +409,7 @@ export class CredentialsTester {
 		credentialTestFunction: ICredentialTestRequestData,
 		verdict: 'default' | 'authProbe',
 		acceptedStatusCodes?: number[],
-	): Promise<INodeCredentialTestResult> {
+	): Promise<INodeCredentialTestResult & { outcome?: CredentialAuthProbeOutcome }> {
 		// TODO: Temp workflows get created at multiple locations (for example also LoadNodeParameterOptions),
 		//       check if some of them are identical enough that it can be combined
 
@@ -599,12 +586,11 @@ export class CredentialsTester {
 			// answer 2xx regardless (no auth required, or errors signalled in the
 			// body) it is not — the probe can't tell them apart, so the copy states
 			// what happened instead of claiming the key was verified.
-			const result: CredentialAuthProbeResult = {
+			return {
 				status: 'OK',
 				message: AUTH_PROBE_ACCEPTED_MESSAGE,
 				outcome: 'accepted',
 			};
-			return result;
 		}
 
 		return {


### PR DESCRIPTION
## Summary

Follow-up to [#35056](https://github.com/n8n-io/n8n/pull/35056). Adds the telemetry that shows whether the Simplified Custom Auth credential flow works for users, step by step: the AI builder proposes a pre-filled credential (a "recipe"), the user saves it, n8n tests it against the service.

Three additions:

1. **`Builder specced templated cred`** (new event). Fires when the builder shows a setup card with a recipe, once per recipe. Records what the builder generated: the auth template, the placeholder list, the test URL, the docs link, the service host. This shows in production whether the generated templates and links are any good. The user has not typed anything at this point, so the payload cannot contain secrets.
2. **`contains_templated_cred`** (new true/false property on the existing `Builder asked for input` event). True when the requested credentials include a recipe-driven one. Lets us compare setup completion between recipe-driven and plain credential types.
3. **`User probed credential`** (new event). Fires each time `POST /credentials/:id/probe` tests a saved credential, retries included. Its `outcome` property has three values: `accepted` (the service took the key), `rejected` (the service answered 401/403), `unverified` (anything else, which says nothing about the key). To support this, the credential tester now returns the verdict as an explicit `outcome` field instead of only wording it into the user-facing message. This endpoint has no thread id; join to `User created credentials` on `credential_id`.

The remaining steps of the flow (`User created credentials`, workflow execution) already have events. No changes there.

Both new events are registered in `@n8n/telemetry`: reshaping a property without updating the schema fails typecheck, and tests validate the emitted payloads against the registry schemas.

## How to test

Unit tests:

1. `packages/@n8n/telemetry`: `pnpm test` (covers both new registry entries); `pnpm catalog` lists them.
2. `packages/cli`: `pnpm test src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts src/services/__tests__/credentials-tester.service.test.ts src/credentials/__tests__/credentials.service.test.ts src/events/__tests__/telemetry-event-relay.test.ts`

Manual:

1. Enable telemetry and ask the AI Assistant to build a workflow against a keyed HTTP API (for example Replicate).
2. When the setup card appears, expect one `Builder asked for input` with `contains_templated_cred: true`, plus one `Builder specced templated cred` per recipe.
3. Save the credential from the pre-filled modal. The test runs and emits `User probed credential` with the same verdict the modal banner shows: `rejected` for a bad key, `accepted` for a valid one, `unverified` when the test URL is unusable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1064

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
