### PR TITLE
fix(ai-builder): Surface existing LLM-provider credentials when a filtered lookup finds none

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -303,6 +303,12 @@ decision after testing.
 - Call `credentials(action="list")` early when the task touches external
   services; note each credential's `id`, `name`, and `type` (the credential
   key, e.g. `slackApi`, comes from the node type definition).
+- When the workflow needs an LLM/chat-model provider and the user hasn't named
+  one, pick it from that unfiltered list: one stored LLM-provider credential →
+  build with that provider bound to it; several → ask which to use; none →
+  keep the default provider. Never probe a single provider's type (e.g.
+  `openAiApi`) to confirm a default — an empty filtered result does not mean
+  the user has no LLM credential.
 - Use `newCredential('Credential Name', 'credential-id')` only when the user
   selected a specific credential, exactly one unambiguous match exists, or the
   workflow already had it. Otherwise use `newCredential('Suggested Credential

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -303,12 +303,6 @@ decision after testing.
 - Call `credentials(action="list")` early when the task touches external
   services; note each credential's `id`, `name`, and `type` (the credential
   key, e.g. `slackApi`, comes from the node type definition).
-- When the workflow needs an LLM/chat-model provider and the user hasn't named
-  one, pick it from that unfiltered list: one stored LLM-provider credential →
-  build with that provider bound to it; several → ask which to use; none →
-  keep the default provider. Never probe a single provider's type (e.g.
-  `openAiApi`) to confirm a default — an empty filtered result does not mean
-  the user has no LLM credential.
 - Use `newCredential('Credential Name', 'credential-id')` only when the user
   selected a specific credential, exactly one unambiguous match exists, or the
   workflow already had it. Otherwise use `newCredential('Suggested Credential

--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -403,6 +403,117 @@ describe('credentials tool', () => {
 		});
 	});
 
+	// ── list steering toward existing LLM-provider credentials ─────────────
+
+	describe('list action — existing LLM-provider credential hint', () => {
+		const gemini: CredentialSummary = {
+			id: 'g1',
+			name: 'Google Gemini account',
+			type: 'googlePalmApi',
+		};
+		const slack: CredentialSummary = { id: 's1', name: 'Slack token', type: 'slackApi' };
+
+		function makeContextWithStored(stored: CredentialSummary[]) {
+			const context = createMockContext();
+			(context.credentialService.list as Mock).mockImplementation((options?: { type?: string }) =>
+				options?.type ? stored.filter((c) => c.type === options.type) : stored,
+			);
+			return context;
+		}
+
+		it('hints at stored LLM credentials when a filtered LLM-type lookup finds none', async () => {
+			const context = makeContextWithStored([gemini, slack]);
+			const tool = createCredentialsTool(context);
+
+			const result = await executeTool(
+				tool,
+				{ action: 'list' as const, type: 'openAiApi' },
+				noSuspendCtx(),
+			);
+
+			expect(result.credentials).toEqual([]);
+			expect(result.hint).toContain('"Google Gemini account" (googlePalmApi, id: g1)');
+		});
+
+		it('does not hint when a stored credential of the requested type exists', async () => {
+			const openAi: CredentialSummary = { id: 'o1', name: 'My OpenAI', type: 'openAiApi' };
+			const context = makeContextWithStored([openAi, gemini]);
+			const tool = createCredentialsTool(context);
+
+			const result = await executeTool(
+				tool,
+				{ action: 'list' as const, type: 'openAiApi' },
+				noSuspendCtx(),
+			);
+
+			expect(result.hint).toBeUndefined();
+			expect(context.credentialService.list).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not hint or re-list for an empty non-LLM type lookup', async () => {
+			const context = makeContextWithStored([gemini]);
+			const tool = createCredentialsTool(context);
+
+			const result = await executeTool(
+				tool,
+				{ action: 'list' as const, type: 'notionApi' },
+				noSuspendCtx(),
+			);
+
+			expect(result.hint).toBeUndefined();
+			expect(context.credentialService.list).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not hint when the user has no LLM credential for another provider', async () => {
+			const context = makeContextWithStored([slack]);
+			const tool = createCredentialsTool(context);
+
+			const result = await executeTool(
+				tool,
+				{ action: 'list' as const, type: 'openAiApi' },
+				noSuspendCtx(),
+			);
+
+			expect(result.hint).toBeUndefined();
+		});
+
+		it('still hints when the requested type only has the synthetic n8n Connect entry', async () => {
+			const context = makeContextWithStored([gemini]);
+			(
+				context.credentialService as unknown as { isAiGatewayCredentialType: Mock }
+			).isAiGatewayCredentialType = vi.fn().mockResolvedValue(true);
+			const tool = createCredentialsTool(context);
+
+			const result = await executeTool(
+				tool,
+				{ action: 'list' as const, type: 'openAiApi' },
+				noSuspendCtx(),
+			);
+
+			expect(result.credentials).toEqual([
+				expect.objectContaining({ id: null, type: 'openAiApi', __aiGatewayManaged: true }),
+			]);
+			expect(result.hint).toContain('googlePalmApi');
+		});
+
+		it('returns the empty listing without a hint when the unfiltered lookup fails', async () => {
+			const context = createMockContext();
+			(context.credentialService.list as Mock).mockImplementation((options?: { type?: string }) => {
+				if (!options?.type) throw new Error('boom');
+				return [];
+			});
+			const tool = createCredentialsTool(context);
+
+			const result = await executeTool(
+				tool,
+				{ action: 'list' as const, type: 'openAiApi' },
+				noSuspendCtx(),
+			);
+
+			expect(result).toEqual({ credentials: [], total: 0, hasMore: false });
+		});
+	});
+
 	// ── get ─────────────────────────────────────────────────────────────────
 
 	describe('get action', () => {

--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -464,19 +464,6 @@ describe('credentials tool', () => {
 			expect(context.credentialService.list).toHaveBeenCalledTimes(1);
 		});
 
-		it('does not hint when the user has no LLM credential for another provider', async () => {
-			const context = makeContextWithStored([slack]);
-			const tool = createCredentialsTool(context);
-
-			const result = await executeTool(
-				tool,
-				{ action: 'list' as const, type: 'openAiApi' },
-				noSuspendCtx(),
-			);
-
-			expect(result.hint).toBeUndefined();
-		});
-
 		it('still hints when the requested type only has the synthetic n8n Connect entry', async () => {
 			const context = makeContextWithStored([gemini]);
 			(

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -13,6 +13,10 @@ import { z } from 'zod';
 
 import { sanitizeInputSchema } from '../agent/sanitize-mcp-schemas';
 import type { InstanceAiContext } from '../types';
+import {
+	buildChatModelProviderHint,
+	isChatModelProviderCredentialType,
+} from './nodes/preferred-chat-model';
 import { CREDENTIALS_TOOL_ID } from './tool-ids';
 import { extractServiceHost, N8N_CONNECT_DISPLAY_NAME } from './workflows/credential-utils';
 
@@ -467,6 +471,23 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 		type: input.type,
 	});
 
+	// An empty LLM-provider lookup is the moment the builder locks in a default
+	// provider — surface the LLM credentials the user does have so it prefers
+	// those (or asks) instead.
+	let chatModelProviderHint: string | undefined;
+	if (
+		input.type &&
+		storedCredentials.length === 0 &&
+		isChatModelProviderCredentialType(input.type)
+	) {
+		try {
+			const allStored = await context.credentialService.list({});
+			chatModelProviderHint = buildChatModelProviderHint(input.type, allStored);
+		} catch {
+			// Soft signal — the primary (empty) listing still returns.
+		}
+	}
+
 	// When the caller filters by type, prepend the synthetic n8n Connect
 	// managed entry if the AI Gateway covers that credential type. This is
 	// the LLM's primary awareness signal that a zero-config credential is
@@ -503,6 +524,14 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 
 	const truncatedWithoutNarrowing = hasMore && !input.name && !input.type;
 
+	// Mutually exclusive: the provider hint requires a type filter, the
+	// truncation hint requires none.
+	const hint =
+		chatModelProviderHint ??
+		(truncatedWithoutNarrowing
+			? `Showing ${page.length} of ${total} credentials. Pass \`name\` (substring) or \`type\` to narrow the search before concluding a user-named credential doesn't exist, or use \`offset\` to paginate.`
+			: undefined);
+
 	return {
 		credentials: page.map((c) =>
 			c.id === null
@@ -511,11 +540,7 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 		),
 		total,
 		hasMore,
-		...(truncatedWithoutNarrowing
-			? {
-					hint: `Showing ${page.length} of ${total} credentials. Pass \`name\` (substring) or \`type\` to narrow the search before concluding a user-named credential doesn't exist, or use \`offset\` to paginate.`,
-				}
-			: {}),
+		...(hint ? { hint } : {}),
 	};
 }
 

--- a/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
@@ -104,4 +104,12 @@ describe('buildChatModelProviderMismatchWarnings', () => {
 		expect(warnings).toHaveLength(1);
 		expect(warnings[0]).toContain('"OpenAI Chat Model"');
 	});
+
+	it('does not warn when the node already runs on the n8n credits managed credential', () => {
+		const warnings = buildChatModelProviderMismatchWarnings([openAiNode], [gemini], {
+			'OpenAI Chat Model': [{ type: 'openAiApi', __aiGatewayManaged: true }],
+		});
+
+		expect(warnings).toEqual([]);
+	});
 });

--- a/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
@@ -105,6 +105,15 @@ describe('buildChatModelProviderMismatchWarnings', () => {
 		expect(warnings[0]).toContain('"OpenAI Chat Model"');
 	});
 
+	it('still warns for nodes named after Object.prototype members', () => {
+		const protoNode = { name: 'constructor', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' };
+
+		const warnings = buildChatModelProviderMismatchWarnings([protoNode], [gemini], {});
+
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('"constructor"');
+	});
+
 	it('does not warn when the node already runs on the n8n credits managed credential', () => {
 		const warnings = buildChatModelProviderMismatchWarnings([openAiNode], [gemini], {
 			'OpenAI Chat Model': [{ type: 'openAiApi', __aiGatewayManaged: true }],

--- a/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
@@ -1,8 +1,4 @@
-import {
-	buildChatModelProviderHint,
-	isChatModelProviderCredentialType,
-	pickPreferredChatModelNode,
-} from '../preferred-chat-model';
+import { buildChatModelProviderHint, pickPreferredChatModelNode } from '../preferred-chat-model';
 
 describe('pickPreferredChatModelNode', () => {
 	it('returns the matching chat model for a single provider credential', () => {
@@ -23,18 +19,6 @@ describe('pickPreferredChatModelNode', () => {
 	it('returns undefined when no credential maps to a chat model', () => {
 		expect(pickPreferredChatModelNode([])).toBeUndefined();
 		expect(pickPreferredChatModelNode(['slackApi', 'notionApi'])).toBeUndefined();
-	});
-});
-
-describe('isChatModelProviderCredentialType', () => {
-	it('recognizes LLM-provider credential types', () => {
-		expect(isChatModelProviderCredentialType('openAiApi')).toBe(true);
-		expect(isChatModelProviderCredentialType('googlePalmApi')).toBe(true);
-	});
-
-	it('rejects non-LLM credential types', () => {
-		expect(isChatModelProviderCredentialType('notionApi')).toBe(false);
-		expect(isChatModelProviderCredentialType('slackApi')).toBe(false);
 	});
 });
 

--- a/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
@@ -1,4 +1,8 @@
-import { buildChatModelProviderHint, pickPreferredChatModelNode } from '../preferred-chat-model';
+import {
+	buildChatModelProviderHint,
+	buildChatModelProviderMismatchWarnings,
+	pickPreferredChatModelNode,
+} from '../preferred-chat-model';
 
 describe('pickPreferredChatModelNode', () => {
 	it('returns the matching chat model for a single provider credential', () => {
@@ -54,5 +58,50 @@ describe('buildChatModelProviderHint', () => {
 	it('returns undefined when the user has no LLM credential for another provider', () => {
 		expect(buildChatModelProviderHint('openAiApi', [slack])).toBeUndefined();
 		expect(buildChatModelProviderHint('openAiApi', [])).toBeUndefined();
+	});
+});
+
+describe('buildChatModelProviderMismatchWarnings', () => {
+	const gemini = { id: 'g1', name: 'Google Gemini account', type: 'googlePalmApi' };
+	const anthropic = { id: 'a1', name: 'Anthropic key', type: 'anthropicApi' };
+	const openAiNode = { name: 'OpenAI Chat Model', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' };
+	const webhookNode = { name: 'Webhook', type: 'n8n-nodes-base.webhook' };
+
+	it('warns for a chat-model node whose provider has no stored credential', () => {
+		const warnings = buildChatModelProviderMismatchWarnings([webhookNode, openAiNode], [gemini]);
+
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('"OpenAI Chat Model"');
+		expect(warnings[0]).toContain('openAiApi');
+		expect(warnings[0]).toContain('"Google Gemini account" (googlePalmApi, id: g1)');
+	});
+
+	it('lists alternatives in provider recommendation precedence order', () => {
+		const warnings = buildChatModelProviderMismatchWarnings([openAiNode], [gemini, anthropic]);
+
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0].indexOf('anthropicApi')).toBeLessThan(warnings[0].indexOf('googlePalmApi'));
+	});
+
+	it('does not warn when the provider credential is stored', () => {
+		const openAi = { id: 'o1', name: 'My OpenAI', type: 'openAiApi' };
+		expect(buildChatModelProviderMismatchWarnings([openAiNode], [openAi, gemini])).toEqual([]);
+	});
+
+	it('does not warn when the user has no LLM credential for another provider', () => {
+		const slack = { id: 's1', name: 'Slack token', type: 'slackApi' };
+		expect(buildChatModelProviderMismatchWarnings([openAiNode], [slack])).toEqual([]);
+		expect(buildChatModelProviderMismatchWarnings([openAiNode], [])).toEqual([]);
+	});
+
+	it('only warns for the mismatched nodes in a multi-model workflow', () => {
+		const anthropicNode = { name: 'Claude', type: '@n8n/n8n-nodes-langchain.lmChatAnthropic' };
+		const warnings = buildChatModelProviderMismatchWarnings(
+			[openAiNode, anthropicNode],
+			[anthropic],
+		);
+
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain('"OpenAI Chat Model"');
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
@@ -1,4 +1,8 @@
-import { pickPreferredChatModelNode } from '../preferred-chat-model';
+import {
+	buildChatModelProviderHint,
+	isChatModelProviderCredentialType,
+	pickPreferredChatModelNode,
+} from '../preferred-chat-model';
 
 describe('pickPreferredChatModelNode', () => {
 	it('returns the matching chat model for a single provider credential', () => {
@@ -19,5 +23,52 @@ describe('pickPreferredChatModelNode', () => {
 	it('returns undefined when no credential maps to a chat model', () => {
 		expect(pickPreferredChatModelNode([])).toBeUndefined();
 		expect(pickPreferredChatModelNode(['slackApi', 'notionApi'])).toBeUndefined();
+	});
+});
+
+describe('isChatModelProviderCredentialType', () => {
+	it('recognizes LLM-provider credential types', () => {
+		expect(isChatModelProviderCredentialType('openAiApi')).toBe(true);
+		expect(isChatModelProviderCredentialType('googlePalmApi')).toBe(true);
+	});
+
+	it('rejects non-LLM credential types', () => {
+		expect(isChatModelProviderCredentialType('notionApi')).toBe(false);
+		expect(isChatModelProviderCredentialType('slackApi')).toBe(false);
+	});
+});
+
+describe('buildChatModelProviderHint', () => {
+	const gemini = { id: 'g1', name: 'Google Gemini account', type: 'googlePalmApi' };
+	const anthropic = { id: 'a1', name: 'Anthropic key', type: 'anthropicApi' };
+	const slack = { id: 's1', name: 'Slack token', type: 'slackApi' };
+
+	it('names the LLM credentials the user does have when the requested type has none', () => {
+		const hint = buildChatModelProviderHint('openAiApi', [slack, gemini]);
+
+		expect(hint).toContain('openAiApi');
+		expect(hint).toContain('"Google Gemini account" (googlePalmApi, id: g1)');
+		expect(hint).not.toContain('slackApi');
+	});
+
+	it('lists several alternatives in provider recommendation precedence order', () => {
+		const hint = buildChatModelProviderHint('openAiApi', [gemini, anthropic]);
+
+		expect(hint).toBeDefined();
+		expect(hint!.indexOf('anthropicApi')).toBeLessThan(hint!.indexOf('googlePalmApi'));
+	});
+
+	it('returns undefined when a stored credential of the requested type exists', () => {
+		const openAi = { id: 'o1', name: 'My OpenAI', type: 'openAiApi' };
+		expect(buildChatModelProviderHint('openAiApi', [openAi, gemini])).toBeUndefined();
+	});
+
+	it('returns undefined when the requested type is not an LLM provider', () => {
+		expect(buildChatModelProviderHint('notionApi', [gemini])).toBeUndefined();
+	});
+
+	it('returns undefined when the user has no LLM credential for another provider', () => {
+		expect(buildChatModelProviderHint('openAiApi', [slack])).toBeUndefined();
+		expect(buildChatModelProviderHint('openAiApi', [])).toBeUndefined();
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
@@ -1,7 +1,14 @@
+import type { CredentialSummary } from '../../types';
+
 /**
  * Maps an LLM-provider credential type to its chat model node, ordered by the
  * provider recommendation precedence. When the user has credentials for several
  * providers, the first match wins; with none, the builder keeps its own default.
+ *
+ * Deliberately scoped to the recommended providers: chat-model nodes outside
+ * this table (Azure OpenAI, OpenRouter, Groq, DeepSeek, Cohere, Ollama,
+ * Bedrock, ...) get no steering, hints, or mismatch warnings. Extending it is
+ * a recommendation decision, not just a lookup fix — keep the precedence order.
  */
 const CHAT_MODEL_BY_CREDENTIAL_TYPE: ReadonlyArray<[credentialType: string, nodeType: string]> = [
 	['anthropicApi', '@n8n/n8n-nodes-langchain.lmChatAnthropic'],
@@ -31,12 +38,6 @@ export function isChatModelProviderCredentialType(credentialType: string): boole
 	return CHAT_MODEL_BY_CREDENTIAL_TYPE.some(([type]) => type === credentialType);
 }
 
-interface StoredCredentialRef {
-	id: string;
-	name: string;
-	type: string;
-}
-
 /**
  * Stored credentials of chat-model providers other than `excludedType`,
  * rendered `"name" (type, id: ...)` in recommendation precedence order.
@@ -44,7 +45,7 @@ interface StoredCredentialRef {
  */
 function listStoredChatModelAlternatives(
 	excludedType: string,
-	storedCredentials: readonly StoredCredentialRef[],
+	storedCredentials: readonly CredentialSummary[],
 ): string | undefined {
 	const alternatives = CHAT_MODEL_BY_CREDENTIAL_TYPE.flatMap(([credentialType]) =>
 		credentialType === excludedType
@@ -64,7 +65,7 @@ function listStoredChatModelAlternatives(
  */
 export function buildChatModelProviderHint(
 	requestedType: string,
-	storedCredentials: readonly StoredCredentialRef[],
+	storedCredentials: readonly CredentialSummary[],
 ): string | undefined {
 	if (!isChatModelProviderCredentialType(requestedType)) return undefined;
 	if (storedCredentials.some((cred) => cred.type === requestedType)) return undefined;
@@ -81,18 +82,27 @@ export function buildChatModelProviderHint(
  * Deterministic post-build counterpart of `buildChatModelProviderHint` for
  * builders that never consult the credential list: one warning per chat-model
  * node whose provider has no stored credential while the user has one for
- * another provider. The decision to switch (or keep an explicitly requested
- * provider and ask) stays with the agent — only it can see the user's intent.
+ * another provider. Nodes the resolver already covered with the n8n credits
+ * managed credential are skipped — they run as built, so a rebuild directive
+ * would be a false alarm. The decision to switch (or keep an explicitly
+ * requested provider and ask) stays with the agent — only it can see the
+ * user's intent.
  */
 export function buildChatModelProviderMismatchWarnings(
 	nodes: ReadonlyArray<{ name?: string; type?: string }>,
-	storedCredentials: readonly StoredCredentialRef[],
+	storedCredentials: readonly CredentialSummary[],
+	resolvedCredentialsByNode: Record<
+		string,
+		ReadonlyArray<{ type: string; __aiGatewayManaged?: boolean }>
+	> = {},
 ): string[] {
 	const storedTypes = new Set(storedCredentials.map((cred) => cred.type));
 	const warnings: string[] = [];
 	for (const node of nodes) {
 		const entry = CHAT_MODEL_BY_CREDENTIAL_TYPE.find(([, nodeType]) => nodeType === node.type);
 		if (!entry) continue;
+		const resolved = node.name ? resolvedCredentialsByNode[node.name] : undefined;
+		if (resolved?.some((cred) => cred.__aiGatewayManaged)) continue;
 		const [credentialType] = entry;
 		if (storedTypes.has(credentialType)) continue;
 		const listed = listStoredChatModelAlternatives(credentialType, storedCredentials);

--- a/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
@@ -101,7 +101,12 @@ export function buildChatModelProviderMismatchWarnings(
 	for (const node of nodes) {
 		const entry = CHAT_MODEL_BY_CREDENTIAL_TYPE.find(([, nodeType]) => nodeType === node.type);
 		if (!entry) continue;
-		const resolved = node.name ? resolvedCredentialsByNode[node.name] : undefined;
+		// Own-key check: a node named "constructor" or "__proto__" must not
+		// resolve to an inherited Object.prototype member.
+		const resolved =
+			node.name && Object.hasOwn(resolvedCredentialsByNode, node.name)
+				? resolvedCredentialsByNode[node.name]
+				: undefined;
 		if (resolved?.some((cred) => cred.__aiGatewayManaged)) continue;
 		const [credentialType] = entry;
 		if (storedTypes.has(credentialType)) continue;

--- a/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
@@ -31,6 +31,30 @@ export function isChatModelProviderCredentialType(credentialType: string): boole
 	return CHAT_MODEL_BY_CREDENTIAL_TYPE.some(([type]) => type === credentialType);
 }
 
+interface StoredCredentialRef {
+	id: string;
+	name: string;
+	type: string;
+}
+
+/**
+ * Stored credentials of chat-model providers other than `excludedType`,
+ * rendered `"name" (type, id: ...)` in recommendation precedence order.
+ * Undefined when there is none.
+ */
+function listStoredChatModelAlternatives(
+	excludedType: string,
+	storedCredentials: readonly StoredCredentialRef[],
+): string | undefined {
+	const alternatives = CHAT_MODEL_BY_CREDENTIAL_TYPE.flatMap(([credentialType]) =>
+		credentialType === excludedType
+			? []
+			: storedCredentials.filter((cred) => cred.type === credentialType),
+	);
+	if (alternatives.length === 0) return undefined;
+	return alternatives.map((cred) => `"${cred.name}" (${cred.type}, id: ${cred.id})`).join(', ');
+}
+
 /**
  * Hint for a credential listing filtered to an LLM-provider type that found no
  * stored credential: names the LLM-provider credentials the user does have, so
@@ -40,23 +64,44 @@ export function isChatModelProviderCredentialType(credentialType: string): boole
  */
 export function buildChatModelProviderHint(
 	requestedType: string,
-	storedCredentials: ReadonlyArray<{ id: string; name: string; type: string }>,
+	storedCredentials: readonly StoredCredentialRef[],
 ): string | undefined {
 	if (!isChatModelProviderCredentialType(requestedType)) return undefined;
 	if (storedCredentials.some((cred) => cred.type === requestedType)) return undefined;
 
-	const alternatives = CHAT_MODEL_BY_CREDENTIAL_TYPE.flatMap(([credentialType]) =>
-		credentialType === requestedType
-			? []
-			: storedCredentials.filter((cred) => cred.type === credentialType),
-	);
-	if (alternatives.length === 0) return undefined;
-
-	const listed = alternatives
-		.map((cred) => `"${cred.name}" (${cred.type}, id: ${cred.id})`)
-		.join(', ');
+	const listed = listStoredChatModelAlternatives(requestedType, storedCredentials);
+	if (!listed) return undefined;
 	return (
 		`No stored ${requestedType} credential exists, but the user already has LLM-provider credential(s): ${listed}. ` +
 		`Unless the user explicitly asked for ${requestedType}, use a chat model from a provider they already have a credential for — or ask which provider to use.`
 	);
+}
+
+/**
+ * Deterministic post-build counterpart of `buildChatModelProviderHint` for
+ * builders that never consult the credential list: one warning per chat-model
+ * node whose provider has no stored credential while the user has one for
+ * another provider. The decision to switch (or keep an explicitly requested
+ * provider and ask) stays with the agent — only it can see the user's intent.
+ */
+export function buildChatModelProviderMismatchWarnings(
+	nodes: ReadonlyArray<{ name?: string; type?: string }>,
+	storedCredentials: readonly StoredCredentialRef[],
+): string[] {
+	const storedTypes = new Set(storedCredentials.map((cred) => cred.type));
+	const warnings: string[] = [];
+	for (const node of nodes) {
+		const entry = CHAT_MODEL_BY_CREDENTIAL_TYPE.find(([, nodeType]) => nodeType === node.type);
+		if (!entry) continue;
+		const [credentialType] = entry;
+		if (storedTypes.has(credentialType)) continue;
+		const listed = listStoredChatModelAlternatives(credentialType, storedCredentials);
+		if (!listed) continue;
+		warnings.push(
+			`Node "${node.name ?? node.type}" uses ${node.type}, but no stored ${credentialType} credential exists. ` +
+				`The user already has LLM-provider credential(s): ${listed}. ` +
+				`Unless the user explicitly asked for ${credentialType}, rebuild with a chat model for a provider they already have a credential for — or ask which provider to use.`,
+		);
+	}
+	return warnings;
 }

--- a/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
@@ -25,3 +25,38 @@ export function pickPreferredChatModelNode(
 	}
 	return undefined;
 }
+
+/** Whether a credential type belongs to an LLM provider with a chat model node. */
+export function isChatModelProviderCredentialType(credentialType: string): boolean {
+	return CHAT_MODEL_BY_CREDENTIAL_TYPE.some(([type]) => type === credentialType);
+}
+
+/**
+ * Hint for a credential listing filtered to an LLM-provider type that found no
+ * stored credential: names the LLM-provider credentials the user does have, so
+ * the builder prefers one of those providers (or asks) instead of locking in
+ * its own default. Undefined when the requested type is not an LLM provider,
+ * a stored credential of it exists, or there is no alternative to prefer.
+ */
+export function buildChatModelProviderHint(
+	requestedType: string,
+	storedCredentials: ReadonlyArray<{ id: string; name: string; type: string }>,
+): string | undefined {
+	if (!isChatModelProviderCredentialType(requestedType)) return undefined;
+	if (storedCredentials.some((cred) => cred.type === requestedType)) return undefined;
+
+	const alternatives = CHAT_MODEL_BY_CREDENTIAL_TYPE.flatMap(([credentialType]) =>
+		credentialType === requestedType
+			? []
+			: storedCredentials.filter((cred) => cred.type === credentialType),
+	);
+	if (alternatives.length === 0) return undefined;
+
+	const listed = alternatives
+		.map((cred) => `"${cred.name}" (${cred.type}, id: ${cred.id})`)
+		.join(', ');
+	return (
+		`No stored ${requestedType} credential exists, but the user already has LLM-provider credential(s): ${listed}. ` +
+		`Unless the user explicitly asked for ${requestedType}, use a chat model from a provider they already have a credential for — or ask which provider to use.`
+	);
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -8,7 +8,7 @@ import {
 	buildWorkflowInputSchema,
 	createBuildWorkflowTool,
 } from '../build-workflow.tool';
-import { buildCredentialMap } from '../resolve-credentials';
+import { buildCredentialMap, resolveCredentials } from '../resolve-credentials';
 import type { SetupRequest } from '../setup-workflow.schema';
 import { analyzeWorkflow } from '../setup-workflow.service';
 import { getWorkflowSourceFileBinding, hashWorkflowSource } from '../workflow-file-bindings';
@@ -1197,6 +1197,51 @@ describe('createBuildWorkflowTool', () => {
 		const warningText = (result.warnings ?? []).join('\n');
 		expect(warningText).toContain('[chat_model_provider_mismatch]');
 		expect(warningText).toContain('"Google Gemini account" (googlePalmApi, id: g1)');
+	});
+
+	it('does not warn about the provider when the resolver attached the n8n Connect managed credential', async () => {
+		const { context, filePath } = makeContext({ source: 'workflow source' });
+		vi.mocked(compileWorkflowSource).mockResolvedValueOnce({
+			success: true,
+			workflow: {
+				name: 'Generated workflow',
+				nodes: [
+					{
+						id: 'model-1',
+						name: 'OpenAI Chat Model',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						typeVersion: 1,
+						position: [0, 0] as [number, number],
+						parameters: {},
+					},
+				],
+				connections: {},
+			},
+			warnings: [],
+			compiler: 'sandbox-tsx',
+		});
+		vi.mocked(buildCredentialMap).mockResolvedValueOnce(
+			new Map([
+				['googlePalmApi', [{ id: 'g1', name: 'Google Gemini account', type: 'googlePalmApi' }]],
+			]),
+		);
+		vi.mocked(resolveCredentials).mockResolvedValueOnce({
+			mockedNodeNames: ['OpenAI Chat Model'],
+			mockedCredentialTypes: [],
+			mockedCredentialsByNode: {},
+			resolvedCredentialsByNode: {
+				'OpenAI Chat Model': [
+					{ type: 'openAiApi', id: null, name: 'n8n Connect', __aiGatewayManaged: true },
+				],
+			},
+		});
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+		});
+
+		expect(result.success).toBe(true);
+		expect((result.warnings ?? []).join('\n')).not.toContain('chat_model_provider_mismatch');
 	});
 
 	it('returns source file metadata on validation failures', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -8,6 +8,7 @@ import {
 	buildWorkflowInputSchema,
 	createBuildWorkflowTool,
 } from '../build-workflow.tool';
+import { buildCredentialMap } from '../resolve-credentials';
 import type { SetupRequest } from '../setup-workflow.schema';
 import { analyzeWorkflow } from '../setup-workflow.service';
 import { getWorkflowSourceFileBinding, hashWorkflowSource } from '../workflow-file-bindings';
@@ -1159,6 +1160,43 @@ describe('createBuildWorkflowTool', () => {
 		});
 		expect(outcome?.simulationFixtures).toEqual({ 'Get Berlin Weather': rainyOutput });
 		expect(outcome?.verificationPinData).toBeUndefined();
+	});
+
+	it('warns when a chat-model node uses a provider without a stored credential while another LLM credential exists', async () => {
+		const { context, filePath } = makeContext({ source: 'workflow source' });
+		vi.mocked(compileWorkflowSource).mockResolvedValueOnce({
+			success: true,
+			workflow: {
+				name: 'Generated workflow',
+				nodes: [
+					{
+						id: 'model-1',
+						name: 'OpenAI Chat Model',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						typeVersion: 1,
+						position: [0, 0] as [number, number],
+						parameters: {},
+					},
+				],
+				connections: {},
+			},
+			warnings: [],
+			compiler: 'sandbox-tsx',
+		});
+		vi.mocked(buildCredentialMap).mockResolvedValueOnce(
+			new Map([
+				['googlePalmApi', [{ id: 'g1', name: 'Google Gemini account', type: 'googlePalmApi' }]],
+			]),
+		);
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+		});
+
+		expect(result.success).toBe(true);
+		const warningText = (result.warnings ?? []).join('\n');
+		expect(warningText).toContain('[chat_model_provider_mismatch]');
+		expect(warningText).toContain('"Google Gemini account" (googlePalmApi, id: g1)');
 	});
 
 	it('returns source file metadata on validation failures', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -746,10 +746,12 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 
 			// Deterministic backstop for a builder that never checked credentials:
 			// a chat-model node for a provider the user has no credential for gets
-			// flagged with the LLM credentials they do have.
+			// flagged with the LLM credentials they do have. Nodes the resolver
+			// covered with n8n credits are exempt — they run as built.
 			for (const message of buildChatModelProviderMismatchWarnings(
 				json.nodes ?? [],
 				[...credentialMap.values()].flat(),
+				mockResult.resolvedCredentialsByNode,
 			)) {
 				informational.push({
 					code: 'chat_model_provider_mismatch',

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -67,6 +67,7 @@ import { BuildFailureTracker } from '../../workflow-builder/build-failure-tracke
 import { createRemediation } from '../../workflow-loop/remediation';
 import { remediationMetadataSchema } from '../../workflow-loop/workflow-loop-state';
 import { writeWorkspaceFile } from '../../workspace/workspace-files';
+import { buildChatModelProviderMismatchWarnings } from '../nodes/preferred-chat-model';
 import { COMPILED_WORKFLOW_TRACE_RUN_NAME } from '../tool-ids';
 
 /** Over this serialized length only a `truncated` marker is emitted; the seed
@@ -742,6 +743,20 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 
 			const credentialMap = await buildCredentialMap(context.credentialService);
 			const mockResult = await resolveCredentials(json, targetWorkflowId, context, credentialMap);
+
+			// Deterministic backstop for a builder that never checked credentials:
+			// a chat-model node for a provider the user has no credential for gets
+			// flagged with the LLM credentials they do have.
+			for (const message of buildChatModelProviderMismatchWarnings(
+				json.nodes ?? [],
+				[...credentialMap.values()].flat(),
+			)) {
+				informational.push({
+					code: 'chat_model_provider_mismatch',
+					message,
+					severity: 'informational',
+				});
+			}
 
 			await stripStaleCredentialsFromWorkflow(context, json);
 


### PR DESCRIPTION
## Summary

When a workflow needs a chat model and the user has not picked a provider, the assistant tends to assume OpenAI. It checks only for OpenAI credentials, finds none, and builds an OpenAI node anyway. A user whose only credential is Google Gemini ends up with a workflow they cannot run. This happened in 4 out of 5 runs of the eval case `gemini-model-hint-compliance`.

Two code changes, no prompt changes:

1. When the assistant lists credentials for one LLM provider and finds none, the response now also names the LLM credentials the user does have, and tells it to prefer those or ask.
2. If it still builds a chat-model node for a provider the user has no credential for, the build result includes a warning naming the credential to switch to.

The assistant keeps the final decision. The user may have asked for that provider on purpose, and switching the node also means choosing a valid model name, which code should not guess.

## How to test

Unit tests cover both changes (`preferred-chat-model.test.ts`, `credentials.tool.test.ts`, `build-workflow.tool.test.ts`).

Manual: create only a Gemini credential, then ask the assistant to add a model to an AI Agent workflow without naming a provider. The result should use Gemini with that credential.

Ran the eval case locally on this branch: 5 out of 5 runs now build Gemini bound to the existing credential.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-912

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
