### PR TITLE
test(core): Add engine M1 acceptance test suite

### DIFF
--- a/packages/@n8n/engine/src/database/create-stores.ts
+++ b/packages/@n8n/engine/src/database/create-stores.ts
@@ -1,0 +1,17 @@
+import type { DataSource } from '@n8n/typeorm';
+
+import { WorkflowExecution, WorkflowStepExecution } from './entities';
+import { TypeOrmExecutionStore } from './typeorm-execution-store';
+import { TypeOrmStepStore } from './typeorm-step-store';
+import type { ExecutionStore } from '../execution/execution-store';
+import type { StepStore } from '../execution/step-store';
+
+export function createStores(dataSource: DataSource): {
+	executionStore: ExecutionStore;
+	stepStore: StepStore;
+} {
+	return {
+		executionStore: new TypeOrmExecutionStore(dataSource.getRepository(WorkflowExecution)),
+		stepStore: new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution)),
+	};
+}

--- a/packages/@n8n/engine/src/database/index.ts
+++ b/packages/@n8n/engine/src/database/index.ts
@@ -1,4 +1,5 @@
 export { createDataSource } from './data-source';
+export { createStores } from './create-stores';
 export { WorkflowExecution, WorkflowStepExecution } from './entities';
 export { TypeOrmExecutionStore } from './typeorm-execution-store';
 export { TypeOrmStepStore } from './typeorm-step-store';

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -64,8 +64,7 @@ export type {
 
 export {
 	createDataSource,
-	TypeOrmExecutionStore,
-	TypeOrmStepStore,
+	createStores,
 	WorkflowExecution,
 	WorkflowStepExecution,
 } from './database';

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -40,6 +40,7 @@ export {
 	ExecutionNotFoundError,
 	ExecutionStartHandler,
 	OrchestrationWorker,
+	StartExecutionService,
 	StepCompletedHandler,
 	StepNotFoundError,
 	StepReadyHandler,
@@ -52,6 +53,8 @@ export type {
 	ExecutionStore,
 	NewExecutionRecord,
 	NewStepRecord,
+	StartExecutionRequest,
+	StartExecutionResult,
 	StepError,
 	StepRecord,
 	StepSlots,
@@ -59,4 +62,10 @@ export type {
 	StepStore,
 } from './execution';
 
-export { createDataSource, TypeOrmExecutionStore, TypeOrmStepStore } from './database';
+export {
+	createDataSource,
+	TypeOrmExecutionStore,
+	TypeOrmStepStore,
+	WorkflowExecution,
+	WorkflowStepExecution,
+} from './database';

--- a/packages/@n8n/engine/src/serve.ts
+++ b/packages/@n8n/engine/src/serve.ts
@@ -3,13 +3,7 @@ import { Container } from '@n8n/di';
 import type { DataSource } from '@n8n/typeorm';
 
 import { AllowAllAdmittance } from './admittance';
-import {
-	createDataSource,
-	TypeOrmExecutionStore,
-	TypeOrmStepStore,
-	WorkflowExecution,
-	WorkflowStepExecution,
-} from './database';
+import { createDataSource, createStores } from './database';
 import {
 	ExecutionStartHandler,
 	OrchestrationWorker,
@@ -41,8 +35,7 @@ async function main(): Promise<void> {
 	let orchestrationWorker: OrchestrationWorker | undefined;
 	let stepWorker: StepWorker | undefined;
 	if (dataSource) {
-		const executionStore = new TypeOrmExecutionStore(dataSource.getRepository(WorkflowExecution));
-		const stepStore = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { executionStore, stepStore } = createStores(dataSource);
 		orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),

--- a/packages/@n8n/node-engine-compatibility/eslint.config.mjs
+++ b/packages/@n8n/node-engine-compatibility/eslint.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'eslint/config';
 import { nodeConfig } from '@n8n/eslint-config/node';
 
-export default defineConfig({ ignores: ['dist/**'] }, nodeConfig, {
+export default defineConfig({ ignores: ['dist/**', 'vitest.integration.config.ts'] }, nodeConfig, {
 	files: ['src/__tests__/**'],
 	rules: {
 		// Workflow fixtures key connections by node name, e.g. "When clicking Execute"

--- a/packages/@n8n/node-engine-compatibility/package.json
+++ b/packages/@n8n/node-engine-compatibility/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest run --passWithNoTests",
     "test:dev": "vitest --watch",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "watch": "tsc -p tsconfig.build.json --watch"
   },
   "main": "dist/index.js",
@@ -28,7 +29,9 @@
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
+    "@testcontainers/postgresql": "catalog:",
     "n8n-nodes-base": "workspace:*",
+    "testcontainers": "catalog:",
     "typescript": "catalog:typescript",
     "vitest": "catalog:"
   },

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/acceptance-fixtures.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/acceptance-fixtures.ts
@@ -1,0 +1,158 @@
+import type {
+	createDataSource,
+	JsonObject,
+	OrchestrationMessage,
+	StepMessage,
+	WorkflowGraph,
+} from '@n8n/engine';
+import {
+	AllowAllAdmittance,
+	ExecutionStartHandler,
+	InMemoryWorkQueue,
+	OrchestrationWorker,
+	StartExecutionService,
+	StepCompletedHandler,
+	StepReadyHandler,
+	StepWorker,
+	TypeOrmExecutionStore,
+	TypeOrmStepStore,
+	WorkflowExecution,
+	WorkflowStepExecution,
+} from '@n8n/engine';
+import { UnrecognizedNodeTypeError } from 'n8n-core';
+/* The Set node's source files predate strict mode and would fail this
+package's strict typecheck if pulled into the program. */
+import { Set as SetNode } from 'n8n-nodes-base/dist/nodes/Set/Set.node';
+import { NoOp } from 'n8n-nodes-base/nodes/NoOp/NoOp.node';
+import { SplitOut } from 'n8n-nodes-base/nodes/Transform/SplitOut/SplitOut.node';
+import type { IDataObject, INodeType, INodeTypes, IVersionedNodeType } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
+import { vi } from 'vitest';
+
+import { createEngineStepDataLoader } from '../engine-step-data-loader';
+import { V1StepExecutor } from '../v1-step-executor';
+import { V1WorkflowConverter } from '../v1-workflow-converter';
+import { testAdditionalDataFactory, v1Workflow } from './fixtures';
+
+const registry = new Map<string, INodeType | IVersionedNodeType>([
+	['n8n-nodes-base.set', new SetNode()],
+	['n8n-nodes-base.noOp', new NoOp()],
+	['n8n-nodes-base.splitOut', new SplitOut()],
+]);
+
+export const realNodeTypes: INodeTypes = {
+	getByName: (type) => {
+		const found = registry.get(type);
+		if (!found) throw new UnrecognizedNodeTypeError('e2e', type);
+		return found;
+	},
+	getByNameAndVersion: (type, version) => {
+		const found = registry.get(type);
+		if (!found) throw new UnrecognizedNodeTypeError('e2e', type);
+		return NodeHelpers.getVersionedNodeType(found, version);
+	},
+	getKnownTypes: (): IDataObject => ({}),
+};
+
+export const converter = new V1WorkflowConverter();
+
+export type Assignment = { name: string; value: string | number; type: string };
+
+/** A Set node definition applying `assignments`, wired by the caller. */
+export function setNode(id: string, name: string, assignments: Assignment[]) {
+	return {
+		id,
+		name,
+		type: 'n8n-nodes-base.set',
+		typeVersion: 3.4,
+		parameters: {
+			mode: 'manual',
+			assignments: {
+				assignments: assignments.map((assignment, i) => ({ id: String(i), ...assignment })),
+			},
+			options: {},
+		},
+	};
+}
+
+export const TRIGGER = {
+	id: 'trigger',
+	name: 'When clicking Execute',
+	type: 'n8n-nodes-base.manualTrigger',
+};
+
+export const mainTo = (target: string) => ({
+	main: [[{ node: target, type: 'main' as const, index: 0 }]],
+});
+
+export function setWorkflow(assignments: Assignment[]) {
+	return converter.convert(
+		v1Workflow([TRIGGER, setNode('set-node', 'Edit Fields', assignments)], {
+			'When clicking Execute': mainTo('Edit Fields'),
+		}),
+	);
+}
+
+type EngineDataSource = ReturnType<typeof createDataSource>;
+
+export function makeRunWorkflow(getDataSource: () => EngineDataSource) {
+	return async function runWorkflow(graph: WorkflowGraph, triggerPayload: JsonObject | null) {
+		const dataSource = getDataSource();
+		const executionStore = new TypeOrmExecutionStore(dataSource.getRepository(WorkflowExecution));
+		const stepStore = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const orchestrationQueue = new InMemoryWorkQueue<OrchestrationMessage>();
+		const stepQueue = new InMemoryWorkQueue<StepMessage>();
+
+		let done!: () => void;
+		const finished = new Promise<void>((resolve) => (done = resolve));
+		const finishExecution = executionStore.finishExecution.bind(executionStore);
+		vi.spyOn(executionStore, 'finishExecution').mockImplementation(async (id, status) => {
+			const recorded = await finishExecution(id, status);
+			done();
+			return recorded;
+		});
+
+		const executor = new V1StepExecutor({
+			nodeTypes: realNodeTypes,
+			additionalDataFactory: testAdditionalDataFactory,
+			loadStepData: createEngineStepDataLoader(executionStore, stepStore),
+		});
+
+		const orchestrationWorker = new OrchestrationWorker(
+			orchestrationQueue,
+			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
+			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+		);
+		const stepWorker = new StepWorker(
+			stepQueue,
+			new StepReadyHandler(executionStore, stepStore, orchestrationQueue, {
+				v1StepExecutor: executor,
+			}),
+		);
+		orchestrationWorker.start();
+		stepWorker.start();
+
+		const { executionId } = await new StartExecutionService(
+			new AllowAllAdmittance(),
+			executionStore,
+			orchestrationQueue,
+		).start({ workflowId: 'wf-m1', graph, triggerPayload });
+		await finished;
+
+		await stepWorker.stop();
+		await orchestrationWorker.stop();
+
+		const steps = await dataSource
+			.getRepository(WorkflowStepExecution)
+			.find({ where: { executionId } });
+		const execution = await dataSource
+			.getRepository(WorkflowExecution)
+			.findOneOrFail({ where: { id: executionId } });
+		return {
+			execution,
+			steps,
+			byNode: (nodeId: string) =>
+				steps.find((step: WorkflowStepExecution) => step.nodeId === nodeId),
+		};
+	};
+}

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/acceptance-fixtures.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/acceptance-fixtures.ts
@@ -7,6 +7,7 @@ import type {
 } from '@n8n/engine';
 import {
 	AllowAllAdmittance,
+	createStores,
 	ExecutionStartHandler,
 	InMemoryWorkQueue,
 	OrchestrationWorker,
@@ -14,8 +15,6 @@ import {
 	StepCompletedHandler,
 	StepReadyHandler,
 	StepWorker,
-	TypeOrmExecutionStore,
-	TypeOrmStepStore,
 	WorkflowExecution,
 	WorkflowStepExecution,
 } from '@n8n/engine';
@@ -98,8 +97,7 @@ type EngineDataSource = ReturnType<typeof createDataSource>;
 export function makeRunWorkflow(getDataSource: () => EngineDataSource) {
 	return async function runWorkflow(graph: WorkflowGraph, triggerPayload: JsonObject | null) {
 		const dataSource = getDataSource();
-		const executionStore = new TypeOrmExecutionStore(dataSource.getRepository(WorkflowExecution));
-		const stepStore = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { executionStore, stepStore } = createStores(dataSource);
 		const orchestrationQueue = new InMemoryWorkQueue<OrchestrationMessage>();
 		const stepQueue = new InMemoryWorkQueue<StepMessage>();
 

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/acceptance-fixtures.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/acceptance-fixtures.ts
@@ -137,10 +137,24 @@ export function makeRunWorkflow(getDataSource: () => EngineDataSource) {
 			executionStore,
 			orchestrationQueue,
 		).start({ workflowId: 'wf-m1', graph, triggerPayload });
-		await finished;
 
-		await stepWorker.stop();
-		await orchestrationWorker.stop();
+		try {
+			await Promise.race([
+				finished,
+				new Promise((_, reject) => {
+					setTimeout(() => {
+						reject(
+							new Error(
+								`execution ${executionId} never recorded an outcome: the engine stalled without calling finishExecution`,
+							),
+						);
+					}, 10_000).unref();
+				}),
+			]);
+		} finally {
+			await stepWorker.stop();
+			await orchestrationWorker.stop();
+		}
 
 		const steps = await dataSource
 			.getRepository(WorkflowStepExecution)

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/engine-step-data-loader.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/engine-step-data-loader.test.ts
@@ -1,0 +1,52 @@
+import type { ExecutionStore, StepStore, WorkflowGraph } from '@n8n/engine';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createEngineStepDataLoader } from '../engine-step-data-loader';
+
+const graph: WorkflowGraph = {
+	nodes: [
+		{ id: 't', name: 'Trigger', type: 'trigger' },
+		{ id: 'a', name: 'A', type: 'v1-node' },
+		{ id: 'b', name: 'B', type: 'v1-node' },
+	],
+	edges: [
+		{ from: 't', to: 'a', outputIndex: 0, inputIndex: 0 },
+		{ from: 'a', to: 'b', outputIndex: 0, inputIndex: 0 },
+	],
+};
+
+const context = {
+	executionId: 'exec-1',
+	stepId: 'step-b',
+	workflowId: 'wf-1',
+	mode: 'production',
+} as const;
+
+describe('createEngineStepDataLoader', () => {
+	it('loads the graph and the outputs of every completed step', async () => {
+		const executionStore = {
+			loadExecution: vi.fn().mockResolvedValue({ id: 'exec-1', graph }),
+		} as unknown as ExecutionStore;
+		const stepStore = {
+			// the trigger's completed row carries its payload as output slot 0
+			loadStepOutputs: vi.fn().mockResolvedValue({
+				t: [{ body: { hello: 'world' } }],
+				a: [[{ json: { from: 'a' } }]],
+				b: null,
+			}),
+		} as unknown as StepStore;
+
+		const loadStepData = createEngineStepDataLoader(executionStore, stepStore);
+		const stepData = await loadStepData(context);
+
+		expect(executionStore.loadExecution).toHaveBeenCalledWith('exec-1');
+		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['t', 'a', 'b']);
+		expect(stepData.graph).toBe(graph);
+		// incomplete steps are omitted, not mapped to null, so expressions
+		// referencing them fail as "hasn't been executed"
+		expect(stepData.outputsByNodeId).toEqual({
+			t: [{ body: { hello: 'world' } }],
+			a: [[{ json: { from: 'a' } }]],
+		});
+	});
+});

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/fixtures.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/fixtures.ts
@@ -255,12 +255,12 @@ export const stepRequest = (
 
 export const testStepExecutor = (
 	graph: WorkflowGraph,
-	outputsByStepId: Record<string, StepSlots> = {},
+	outputsByNodeId: Record<string, StepSlots> = {},
 ): V1StepExecutor =>
 	new V1StepExecutor({
 		nodeTypes: testNodeTypes,
 		additionalDataFactory: testAdditionalDataFactory,
-		loadStepData: async () => await Promise.resolve({ graph, outputsByStepId }),
+		loadStepData: async () => await Promise.resolve({ graph, outputsByNodeId }),
 	});
 
 export const items = (...objects: JsonObject[]): StepSlots => [objects.map((json) => ({ json }))];

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
@@ -36,8 +36,11 @@ describe('fromStepInputs', () => {
 		expect(fromStepInputs([null])).toEqual([[]]);
 	});
 
+	it('wraps a bare object slot as a single item (trigger payload shape)', () => {
+		expect(fromStepInputs([{ name: 'ada' }])).toEqual([[{ json: { name: 'ada' } }]]);
+	});
+
 	it('yields an empty item list for a slot not carrying items', () => {
-		// e.g. the trigger's raw payload rides in slot 0 as a bare object
 		expect(fromStepInputs(['nope'])).toEqual([[]]);
 	});
 });

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/m1-acceptance.integration.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/m1-acceptance.integration.test.ts
@@ -1,0 +1,183 @@
+import { createDataSource } from '@n8n/engine';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+	converter,
+	mainTo,
+	makeRunWorkflow,
+	setNode,
+	setWorkflow,
+	TRIGGER,
+} from './acceptance-fixtures';
+import { v1Workflow } from './fixtures';
+
+describe('M1 acceptance (integration)', () => {
+	let container: StartedPostgreSqlContainer;
+	let dataSource: ReturnType<typeof createDataSource>;
+
+	beforeAll(async () => {
+		container = await new PostgreSqlContainer('postgres:18-alpine').start();
+		dataSource = createDataSource(container.getConnectionUri());
+		await dataSource.initialize();
+		await dataSource.runMigrations();
+	}, 120_000);
+
+	afterAll(async () => {
+		if (dataSource?.isInitialized) await dataSource.destroy();
+		if (container) await container.stop();
+	});
+
+	const runWorkflow = makeRunWorkflow(() => dataSource);
+
+	it('runs a single v1 node (Set) workflow to completion with correct rows', async () => {
+		const graph = setWorkflow([{ name: 'greeting', value: 'hello', type: 'string' }]);
+		const { execution, steps, byNode } = await runWorkflow(graph, { name: 'ada' });
+
+		expect(steps).toHaveLength(2);
+		expect(byNode('trigger')?.status).toBe('completed');
+		expect(byNode('set-node')?.status).toBe('completed');
+		expect(byNode('set-node')?.error).toBeNull();
+		expect(byNode('set-node')?.outputs).toEqual([
+			[expect.objectContaining({ json: { greeting: 'hello' } })],
+		]);
+		expect(execution.status).toBe('completed');
+		expect(execution.finishedAt).toBeInstanceOf(Date);
+	});
+
+	it('runs a multi-step linear pipeline of 3 nodes, feeding each output forward', async () => {
+		const graph = converter.convert(
+			v1Workflow(
+				[
+					TRIGGER,
+					setNode('node-a', 'A', [{ name: 'a', value: '={{ $json.seed }}-a', type: 'string' }]),
+					setNode('node-b', 'B', [{ name: 'b', value: '={{ $json.a }}-b', type: 'string' }]),
+					setNode('node-c', 'C', [
+						{ name: 'c', value: '={{ $json.b }}-c', type: 'string' },
+						{ name: 'fromA', value: "={{ $('A').first().json.a }}", type: 'string' },
+					]),
+				],
+				{
+					'When clicking Execute': mainTo('A'),
+					A: mainTo('B'),
+					B: mainTo('C'),
+				},
+			),
+		);
+
+		const { execution, steps, byNode } = await runWorkflow(graph, { seed: 's' });
+
+		expect(steps).toHaveLength(4);
+		for (const nodeId of ['trigger', 'node-a', 'node-b', 'node-c']) {
+			expect(byNode(nodeId)?.status).toBe('completed');
+		}
+		const chained = expect.objectContaining({ c: 's-a-b-c', fromA: 's-a' }) as unknown;
+		expect(byNode('node-c')?.outputs).toEqual([[expect.objectContaining({ json: chained })]]);
+		expect(execution.status).toBe('completed');
+	});
+
+	it('processes an n-item input into an n-item output, serially and in order', async () => {
+		const graph = converter.convert(
+			v1Workflow(
+				[
+					TRIGGER,
+					{
+						id: 'split',
+						name: 'Split Out',
+						type: 'n8n-nodes-base.splitOut',
+						typeVersion: 1,
+						parameters: { fieldToSplitOut: 'orders', options: {} },
+					},
+					setNode('mark', 'Mark', [{ name: 'marked', value: '={{ $json.n }}!', type: 'string' }]),
+				],
+				{
+					'When clicking Execute': mainTo('Split Out'),
+					'Split Out': mainTo('Mark'),
+				},
+			),
+		);
+
+		const { execution, byNode } = await runWorkflow(graph, {
+			orders: [{ n: 1 }, { n: 2 }, { n: 3 }],
+		});
+
+		expect(byNode('mark')?.outputs).toEqual([
+			[
+				expect.objectContaining({ json: { marked: '1!' } }),
+				expect.objectContaining({ json: { marked: '2!' } }),
+				expect.objectContaining({ json: { marked: '3!' } }),
+			],
+		]);
+		expect(execution.status).toBe('completed');
+	});
+
+	it('resolves expressions against upstream data, by reference and by input', async () => {
+		const graph = setWorkflow([
+			{ name: 'byInput', value: '={{ $json.name }}!', type: 'string' },
+			{
+				name: 'byReference',
+				value: "={{ $('When clicking Execute').first().json.name }}?",
+				type: 'string',
+			},
+		]);
+		const { set } = { set: (await runWorkflow(graph, { name: 'ada' })).byNode('set-node') };
+
+		expect(set?.outputs).toEqual([
+			[expect.objectContaining({ json: { byInput: 'ada!', byReference: 'ada?' } })],
+		]);
+	});
+
+	it('fails the execution when a node errors, leaving no orphan step rows', async () => {
+		const graph = setWorkflow([
+			{ name: 'boom', value: "={{ $('Ghost').first().json.x }}", type: 'string' },
+		]);
+		const { execution, steps, byNode } = await runWorkflow(graph, { name: 'ada' });
+
+		expect(steps).toHaveLength(2);
+		expect(byNode('set-node')?.status).toBe('failed');
+		expect(byNode('set-node')?.outputs).toBeNull();
+		expect(byNode('set-node')?.error).toMatchObject({
+			name: 'NodeOperationError',
+			message: "Referenced node doesn't exist",
+		});
+		expect(execution.status).toBe('failed');
+		expect(execution.finishedAt).toBeInstanceOf(Date);
+	});
+
+	it('fails the execution mid-pipeline and plans nothing downstream of the failure', async () => {
+		const graph = converter.convert(
+			v1Workflow(
+				[
+					TRIGGER,
+					setNode('node-a', 'A', [
+						{ name: 'boom', value: "={{ $('Ghost').first().json.x }}", type: 'string' },
+					]),
+					setNode('node-b', 'B', [{ name: 'b', value: 'never', type: 'string' }]),
+				],
+				{
+					'When clicking Execute': mainTo('A'),
+					A: mainTo('B'),
+				},
+			),
+		);
+
+		const { execution, steps, byNode } = await runWorkflow(graph, {});
+
+		expect(byNode('node-a')?.status).toBe('failed');
+		expect(byNode('node-b')).toBeUndefined();
+		expect(steps).toHaveLength(2);
+		expect(execution.status).toBe('failed');
+	});
+
+	// TODO(CAT-2874): slot-shaped IO and branching land as a PR series (#35672
+	// first); If/Merge routing is asserted once input slots beyond 0 exist.
+	it.todo('routes items through an If node and consolidates with Merge');
+
+	// TODO(CAT-2875): loop iteration, back-edge graphs are rejected at the start
+	// boundary until then.
+	it.todo('executes a fixed-count loop via a back-edge');
+
+	// No cancellation mechanism exists yet (discussed during CAT-2905, needs an
+	// API to request it and a hard-stop story for in-flight steps).
+	it.todo('stops cleanly on a cancel request mid-flight');
+});

--- a/packages/@n8n/node-engine-compatibility/src/engine-step-data-loader.ts
+++ b/packages/@n8n/node-engine-compatibility/src/engine-step-data-loader.ts
@@ -1,0 +1,32 @@
+import type { ExecutionStore, StepSlots, StepStore } from '@n8n/engine';
+
+import type { StepData, StepDataLoader } from './types';
+
+/**
+ * A `StepDataLoader` backed by the engine's own stores: the graph off the
+ * execution row, the outputs of every completed step off the step rows.
+ * Loads everything. TODO(CAT-3017): load selectively, based on what the
+ * step's expressions actually reference.
+ *
+ * Steps that haven't completed are omitted rather than mapped to null, so
+ * expressions referencing them fail with the standard "hasn't been executed"
+ * error.
+ */
+export function createEngineStepDataLoader(
+	executionStore: ExecutionStore,
+	stepStore: StepStore,
+): StepDataLoader {
+	return async (context): Promise<StepData> => {
+		const execution = await executionStore.loadExecution(context.executionId);
+
+		const nodeIds = execution.graph.nodes.map((node) => node.id);
+		const stored = await stepStore.loadStepOutputs(context.executionId, nodeIds);
+
+		const outputsByNodeId: Record<string, StepSlots> = {};
+		for (const [nodeId, outputs] of Object.entries(stored)) {
+			if (outputs !== null) outputsByNodeId[nodeId] = outputs;
+		}
+
+		return { graph: execution.graph, outputsByNodeId };
+	};
+}

--- a/packages/@n8n/node-engine-compatibility/src/index.ts
+++ b/packages/@n8n/node-engine-compatibility/src/index.ts
@@ -1,4 +1,5 @@
 export { V1WorkflowConverter } from './v1-workflow-converter';
 export { V1StepExecutor } from './v1-step-executor';
+export { createEngineStepDataLoader } from './engine-step-data-loader';
 export { UnsupportedTriggerError, UnsupportedWorkflowError } from './errors';
 export type { StepData, StepDataLoader, V1StepExecutorDeps } from './types';

--- a/packages/@n8n/node-engine-compatibility/src/io.ts
+++ b/packages/@n8n/node-engine-compatibility/src/io.ts
@@ -5,6 +5,9 @@ import { isRecord } from './guards';
 
 export function fromStepInputs(value: StepSlots): INodeExecutionData[][] {
 	return value.map((items) => {
+		// a bare object in a slot is a single item: the shape of a trigger
+		// payload, until proper trigger handling decides its shape
+		if (isRecord(items)) return [{ json: items as IDataObject }];
 		if (!Array.isArray(items)) return [];
 		return items.map((item): INodeExecutionData => {
 			if (isRecord(item) && isRecord(item.json)) return item as unknown as INodeExecutionData;

--- a/packages/@n8n/node-engine-compatibility/src/types.ts
+++ b/packages/@n8n/node-engine-compatibility/src/types.ts
@@ -26,7 +26,7 @@ export interface V1Execution extends Pick<IWorkflowBase, 'nodes' | 'connections'
 
 export interface StepData {
 	graph: WorkflowGraph;
-	outputsByStepId: Record<string, StepSlots>;
+	outputsByNodeId: Record<string, StepSlots>;
 }
 
 export type StepDataLoader = (context: StepExecutionContext) => Promise<StepData>;

--- a/packages/@n8n/node-engine-compatibility/src/v1-adapters.ts
+++ b/packages/@n8n/node-engine-compatibility/src/v1-adapters.ts
@@ -25,12 +25,12 @@ import type { CreateExecuteContextParams, V1Execution, V1NodeStepConfig } from '
 
 export function toV1Execution(
 	graph: WorkflowGraph,
-	outputsByStepId: Record<string, StepSlots>,
+	outputsByNodeId: Record<string, StepSlots>,
 ): V1Execution {
 	return {
 		nodes: toV1Nodes(graph),
 		connections: toV1Connections(graph),
-		runData: toV1RunData(graph, outputsByStepId),
+		runData: toV1RunData(graph, outputsByNodeId),
 	};
 }
 
@@ -79,13 +79,13 @@ function toV1Connections(graph: WorkflowGraph): IConnections {
 	return connections;
 }
 
-function toV1RunData(graph: WorkflowGraph, outputsByStepId: Record<string, StepSlots>): IRunData {
+function toV1RunData(graph: WorkflowGraph, outputsByNodeId: Record<string, StepSlots>): IRunData {
 	const namesById = new Map(graph.nodes.map((node) => [node.id, node.name]));
-	const sourcesByStepId = toV1Sources(graph);
+	const sourcesByNodeId = toV1Sources(graph);
 
 	const runData: IRunData = {};
-	for (const [completedStepId, outputs] of Object.entries(outputsByStepId)) {
-		const nodeName = namesById.get(completedStepId);
+	for (const [completedNodeId, outputs] of Object.entries(outputsByNodeId)) {
+		const nodeName = namesById.get(completedNodeId);
 		if (nodeName === undefined) continue;
 
 		runData[nodeName] = [
@@ -93,7 +93,7 @@ function toV1RunData(graph: WorkflowGraph, outputsByStepId: Record<string, StepS
 				startTime: 0,
 				executionTime: 0,
 				executionIndex: 0,
-				source: sourcesByStepId.get(completedStepId) ?? [],
+				source: sourcesByNodeId.get(completedNodeId) ?? [],
 				data: { [MAIN_CONNECTION_TYPE]: fromStepInputs(outputs) },
 			},
 		];
@@ -105,19 +105,19 @@ function toV1RunData(graph: WorkflowGraph, outputsByStepId: Record<string, StepS
 export function toV1Sources(graph: WorkflowGraph): Map<string, Array<ISourceData | null>> {
 	const namesById = new Map(graph.nodes.map((node) => [node.id, node.name]));
 
-	const sourcesByStepId = new Map<string, Array<ISourceData | null>>();
+	const sourcesByNodeId = new Map<string, Array<ISourceData | null>>();
 	for (const edge of graph.edges) {
 		if (edge.isBackEdge === true) continue;
 		const fromName = namesById.get(edge.from);
 		if (fromName === undefined) continue;
 
-		const source = sourcesByStepId.get(edge.to) ?? [];
+		const source = sourcesByNodeId.get(edge.to) ?? [];
 		const inputIndex = edge.inputIndex ?? 0;
 		while (source.length <= inputIndex) source.push(null);
 		source[inputIndex] ??= { previousNode: fromName, previousNodeOutput: edge.outputIndex };
-		sourcesByStepId.set(edge.to, source);
+		sourcesByNodeId.set(edge.to, source);
 	}
-	return sourcesByStepId;
+	return sourcesByNodeId;
 }
 
 export function toV1Workflow(

--- a/packages/@n8n/node-engine-compatibility/src/v1-step-executor.ts
+++ b/packages/@n8n/node-engine-compatibility/src/v1-step-executor.ts
@@ -49,7 +49,7 @@ export class V1StepExecutor implements IStepExecutor {
 		const stepData = await this.deps.loadStepData(request.context);
 
 		const node = toV1Node(request.node, stepConfig);
-		const execution = toV1Execution(stepData.graph, stepData.outputsByStepId);
+		const execution = toV1Execution(stepData.graph, stepData.outputsByNodeId);
 		const workflow = toV1Workflow(request.context.workflowId, node, execution, this.deps.nodeTypes);
 
 		const additionalData = await this.deps.additionalDataFactory(request.context.executionId);

--- a/packages/@n8n/node-engine-compatibility/vitest.integration.config.ts
+++ b/packages/@n8n/node-engine-compatibility/vitest.integration.config.ts
@@ -3,4 +3,6 @@ import { createVitestConfig } from '@n8n/vitest-config/node';
 export default createVitestConfig({
 	include: ['**/*.integration.test.ts'],
 	setupFiles: ['./src/__tests__/setup-vm-evaluator.ts'],
+	// must exceed the harness's 10s outcome deadline
+	testTimeout: 30_000,
 });

--- a/packages/@n8n/node-engine-compatibility/vitest.integration.config.ts
+++ b/packages/@n8n/node-engine-compatibility/vitest.integration.config.ts
@@ -1,6 +1,6 @@
 import { createVitestConfig } from '@n8n/vitest-config/node';
 
 export default createVitestConfig({
-	exclude: ['**/node_modules/**', '**/dist/**', '**/*.integration.test.ts'],
+	include: ['**/*.integration.test.ts'],
 	setupFiles: ['./src/__tests__/setup-vm-evaluator.ts'],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3110,9 +3110,15 @@ importers:
       '@n8n/vitest-config':
         specifier: workspace:*
         version: link:../vitest-config
+      '@testcontainers/postgresql':
+        specifier: 'catalog:'
+        version: 11.13.0
       n8n-nodes-base:
         specifier: workspace:*
         version: link:../../nodes-base
+      testcontainers:
+        specifier: 'catalog:'
+        version: 11.13.0
       typescript:
         specifier: catalog:typescript
         version: 7.0.2


### PR DESCRIPTION
## Summary

M1 acceptance tests. Each test converts a v1 workflow, runs it through the engine end to end with nodes-base nodes (Set, Split Out), and asserts the resulting execution and step rows in the data plane DB.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2870

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.