### PR TITLE
fix(editor): Remove misleading reset zoom control

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -1918,7 +1918,6 @@ defineExpose({
 			@zoom-to-fit="onFitView"
 			@zoom-in="onZoomIn"
 			@zoom-out="onZoomOut"
-			@reset-zoom="onResetZoom"
 			@tidy-up="onTidyUp({ source: 'canvas-button' })"
 			@toggle-zoom-mode="onToggleZoomMode"
 		/>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.test.ts
@@ -28,26 +28,6 @@ describe('CanvasControlButtons', () => {
 		expect(wrapper.html()).toMatchSnapshot();
 	});
 
-	it('should show reset zoom button when zoom is not equal to 1', () => {
-		const wrapper = renderComponent({
-			props: {
-				zoom: 1.5,
-			},
-		});
-
-		expect(wrapper.getByTestId('reset-zoom-button')).toBeVisible();
-	});
-
-	it('should hide the reset zoom button when zoom is equal to 1', () => {
-		const wrapper = renderComponent({
-			props: {
-				zoom: 1,
-			},
-		});
-
-		expect(wrapper.queryByTestId('reset-zoom-button')).not.toBeInTheDocument();
-	});
-
 	it('should hide the tidy up button when canvas is read-only', () => {
 		const wrapper = renderComponent({
 			props: {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
@@ -38,12 +38,6 @@ const isExperimentalNdvActive = computed(() => experimentalNdvStore.isActive(pro
 
 const isToggleZoomVisible = computed(() => experimentalNdvStore.isZoomedViewEnabled);
 
-const isResetZoomVisible = computed(() => !isToggleZoomVisible.value && props.zoom !== 1);
-
-function onResetZoom() {
-	emit('reset-zoom');
-}
-
 function onZoomIn() {
 	emit('zoom-in');
 }
@@ -127,20 +121,6 @@ function handleClickCollapseAll() {
 						)
 					"
 					@click="emit('toggle-zoom-mode')"
-				/>
-			</KeyboardShortcutTooltip>
-			<KeyboardShortcutTooltip
-				v-if="isResetZoomVisible"
-				:label="i18n.baseText('nodeView.resetZoom')"
-				:shortcut="{ keys: ['0'] }"
-			>
-				<N8nIconButton
-					variant="subtle"
-					size="large"
-					icon="undo-2"
-					:aria-label="i18n.baseText('nodeView.resetZoom')"
-					data-test-id="reset-zoom-button"
-					@click="onResetZoom"
 				/>
 			</KeyboardShortcutTooltip>
 			<KeyboardShortcutTooltip

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
@@ -20,7 +20,6 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-	'reset-zoom': [];
 	'zoom-in': [];
 	'zoom-out': [];
 	'zoom-to-fit': [];

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/__snapshots__/CanvasControlButtons.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/__snapshots__/CanvasControlButtons.test.ts.snap
@@ -12,7 +12,6 @@ exports[`CanvasControlButtons > should render correctly 1`] = `
     <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-icon-button-stub variant="subtle" icon="zoom-in" size="large" loading="false" icononly="true" disabled="false" class="" aria-label="Zoom In" data-test-id="zoom-in-button"></n8n-icon-button-stub></span>
     <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-icon-button-stub variant="subtle" icon="zoom-out" size="large" loading="false" icononly="true" disabled="false" class="" aria-label="Zoom Out" data-test-id="zoom-out-button"></n8n-icon-button-stub></span>
     <!--v-if-->
-    <!--v-if-->
     <!--v-if--><span class="" data-state="closed" data-grace-area-trigger=""><n8n-button-stub variant="subtle" size="large" loading="false" icononly="true" disabled="false" class="iconButton" aria-label="Tidy Up" data-test-id="tidy-up-button"></n8n-button-stub></span>
     <!--v-if-->
     <!--v-if-->

--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -896,10 +896,6 @@ export class CanvasPage extends BasePage {
 		return this.page.getByTestId('zoom-in-button');
 	}
 
-	getResetZoomButton(): Locator {
-		return this.page.getByTestId('reset-zoom-button');
-	}
-
 	async clickZoomInButton(): Promise<void> {
 		await this.clickByTestId('zoom-in-button');
 	}

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts
@@ -55,13 +55,9 @@ test.describe(
 			expect(finalZoom).toBeLessThanOrEqual(ZOOM_OUT_X2_FACTOR + ZOOM_TOLERANCE);
 		});
 
-		test('should reset zoom', async ({ n8n }) => {
-			await expect(n8n.canvas.getResetZoomButton()).not.toBeAttached();
-
+		test('should reset zoom on keyboard shortcut', async ({ n8n }) => {
 			await n8n.canvas.clickZoomInButton();
-
-			await expect(n8n.canvas.getResetZoomButton()).toBeVisible();
-			await n8n.canvas.getResetZoomButton().click();
+			await n8n.page.keyboard.press('0');
 
 			await expectZoomLevel(n8n, DEFAULT_ZOOM_FACTOR);
 		});


### PR DESCRIPTION
## Summary

Remove the reset zoom button from the AI Assistant Builder canvas because its undo-style icon does not clearly represent its function.

The existing Zoom to fit control provides similar canvas navigation. The `0` keyboard shortcut remains available so existing keyboard workflows continue to work.

<img src="https://github.com/user-attachments/assets/064b4e11-bab5-40e4-9a5a-113a0fb59cb7 " alt="CleanShot 2026-08-07 at 12 02 36@2x" width="676" data-linear-height="254" />

## How to test

1. Open the AI Assistant Builder canvas.
2. Change the canvas zoom level.
3. Confirm that the reset zoom button with the left-facing arrow is not shown.
4. Confirm that Zoom to fit remains available.
5. Press `0` and confirm that the canvas zoom resets.

## Related Linear tickets, Github issues, and Community forum posts

[DS-612](https://linear.app/n8n/issue/DS-612)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)