### PR TITLE
fix(core): Handle out-of-scope display option dependencies

### DIFF
--- a/packages/nodes-base/nodes/Baserow/OperationDescription.ts
+++ b/packages/nodes-base/nodes/Baserow/OperationDescription.ts
@@ -716,7 +716,7 @@ export const operationFields: INodeProperties[] = [
 								default: 'UTC',
 								displayOptions: {
 									show: {
-										'../operator': [
+										operator: [
 											...MULTI_STEP_DATE_OPERATORS,
 											...DEPRECATED_TIMEZONE_NUMBER_OPERATORS,
 											...DEPRECATED_TIMEZONE_ONLY_OPERATORS,

--- a/packages/nodes-base/nodes/Baserow/__tests__/OperationDescription.test.ts
+++ b/packages/nodes-base/nodes/Baserow/__tests__/OperationDescription.test.ts
@@ -1,0 +1,101 @@
+import { getNodeParameters, type INodeParameters } from 'n8n-workflow';
+
+import { Baserow } from '../Baserow.node';
+import { MULTI_STEP_DATE_OPERATORS } from '../GenericFunctions';
+
+// Regression test for CAT-3999 / NODE-5693 (GH #35788, #35783):
+// the `timezone` filter child gated on a sibling via an unsupported `'../'`
+// prefix, so loading a workflow with a populated Filters collection threw
+// "Could not resolve parameter dependencies. Max iterations reached!".
+
+const properties = new Baserow().description.properties;
+
+const resolve = (values: INodeParameters) =>
+	getNodeParameters(properties, values, true, false, null, null);
+
+/** Stored parameters as reported, with a single populated filter. */
+const withFilter = (operator: string, value: string): INodeParameters => ({
+	resource: 'row',
+	operation: 'getAll',
+	authentication: 'databaseToken',
+	tableId: '1110755',
+	returnAll: false,
+	limit: 1,
+	additionalOptions: {
+		filters: { fields: [{ field: '9882393', operator, value }] },
+	},
+});
+
+describe('Baserow filter description', () => {
+	it('resolves a workflow with a populated filters collection', () => {
+		expect(() =>
+			resolve(
+				withFilter('equal', "={{ $('Webhook Trigger').item.json.body.author_id || 'fallback' }}"),
+			),
+		).not.toThrow();
+	});
+
+	it('shows Timezone for a date operator', () => {
+		const resolved = resolve(withFilter('date_is', '2026-06-17')) as INodeParameters;
+		const [filter] = (resolved.additionalOptions as { filters: { fields: INodeParameters[] } })
+			.filters.fields;
+
+		expect(filter).toEqual({
+			field: '9882393',
+			operator: 'date_is',
+			timezone: 'UTC',
+			value: '2026-06-17',
+		});
+	});
+
+	it('hides Timezone for a non-date operator', () => {
+		const resolved = resolve(withFilter('equal', 'abc')) as INodeParameters;
+		const [filter] = (resolved.additionalOptions as { filters: { fields: INodeParameters[] } })
+			.filters.fields;
+
+		expect(filter).not.toHaveProperty('timezone');
+	});
+
+	it('shows Timezone for every multi-step date operator', () => {
+		for (const operator of MULTI_STEP_DATE_OPERATORS) {
+			const resolved = resolve(withFilter(operator, '2026-06-17')) as INodeParameters;
+			const [filter] = (resolved.additionalOptions as { filters: { fields: INodeParameters[] } })
+				.filters.fields;
+
+			expect(filter).toHaveProperty('timezone', 'UTC');
+		}
+	});
+
+	it('preserves a stored non-default Timezone', () => {
+		const stored: INodeParameters = {
+			resource: 'row',
+			operation: 'getAll',
+			tableId: '1110755',
+			additionalOptions: {
+				filters: {
+					fields: [
+						{
+							field: '9882393',
+							operator: 'date_is',
+							timezone: 'Europe/Berlin',
+							value: '2026-06-17',
+						},
+					],
+				},
+			},
+		};
+
+		const resolved = getNodeParameters(
+			properties,
+			stored,
+			false,
+			false,
+			null,
+			null,
+		) as INodeParameters;
+		const [filter] = (resolved.additionalOptions as { filters: { fields: INodeParameters[] } })
+			.filters.fields;
+
+		expect(filter).toHaveProperty('timezone', 'Europe/Berlin');
+	});
+});

--- a/packages/nodes-base/nodes/Baserow/__tests__/OperationDescription.test.ts
+++ b/packages/nodes-base/nodes/Baserow/__tests__/OperationDescription.test.ts
@@ -10,92 +10,53 @@ import { MULTI_STEP_DATE_OPERATORS } from '../GenericFunctions';
 
 const properties = new Baserow().description.properties;
 
-const resolve = (values: INodeParameters) =>
-	getNodeParameters(properties, values, true, false, null, null);
-
-/** Stored parameters as reported, with a single populated filter. */
-const withFilter = (operator: string, value: string): INodeParameters => ({
+/** Stored parameters for a Get Many with a single populated filter. */
+const withFilter = (filter: INodeParameters): INodeParameters => ({
 	resource: 'row',
 	operation: 'getAll',
-	authentication: 'databaseToken',
 	tableId: '1110755',
-	returnAll: false,
-	limit: 1,
-	additionalOptions: {
-		filters: { fields: [{ field: '9882393', operator, value }] },
-	},
+	additionalOptions: { filters: { fields: [{ field: '9882393', ...filter }] } },
 });
+
+const firstFilter = (values: INodeParameters, returnDefaults = true) => {
+	const resolved = getNodeParameters(properties, values, returnDefaults, false, null, null);
+
+	return (resolved?.additionalOptions as { filters: { fields: INodeParameters[] } }).filters
+		.fields[0];
+};
 
 describe('Baserow filter description', () => {
 	it('resolves a workflow with a populated filters collection', () => {
-		expect(() =>
-			resolve(
-				withFilter('equal', "={{ $('Webhook Trigger').item.json.body.author_id || 'fallback' }}"),
-			),
-		).not.toThrow();
+		const values = withFilter({
+			operator: 'equal',
+			value: "={{ $('Webhook Trigger').item.json.body.author_id || 'fallback' }}",
+		});
+
+		expect(() => firstFilter(values)).not.toThrow();
 	});
 
-	it('shows Timezone for a date operator', () => {
-		const resolved = resolve(withFilter('date_is', '2026-06-17')) as INodeParameters;
-		const [filter] = (resolved.additionalOptions as { filters: { fields: INodeParameters[] } })
-			.filters.fields;
-
-		expect(filter).toEqual({
+	it.each([...MULTI_STEP_DATE_OPERATORS])('shows Timezone for operator %s', (operator) => {
+		expect(firstFilter(withFilter({ operator, value: '2026-06-17' }))).toEqual({
 			field: '9882393',
-			operator: 'date_is',
+			operator,
 			timezone: 'UTC',
 			value: '2026-06-17',
 		});
 	});
 
 	it('hides Timezone for a non-date operator', () => {
-		const resolved = resolve(withFilter('equal', 'abc')) as INodeParameters;
-		const [filter] = (resolved.additionalOptions as { filters: { fields: INodeParameters[] } })
-			.filters.fields;
-
-		expect(filter).not.toHaveProperty('timezone');
-	});
-
-	it('shows Timezone for every multi-step date operator', () => {
-		for (const operator of MULTI_STEP_DATE_OPERATORS) {
-			const resolved = resolve(withFilter(operator, '2026-06-17')) as INodeParameters;
-			const [filter] = (resolved.additionalOptions as { filters: { fields: INodeParameters[] } })
-				.filters.fields;
-
-			expect(filter).toHaveProperty('timezone', 'UTC');
-		}
+		expect(firstFilter(withFilter({ operator: 'equal', value: 'abc' }))).not.toHaveProperty(
+			'timezone',
+		);
 	});
 
 	it('preserves a stored non-default Timezone', () => {
-		const stored: INodeParameters = {
-			resource: 'row',
-			operation: 'getAll',
-			tableId: '1110755',
-			additionalOptions: {
-				filters: {
-					fields: [
-						{
-							field: '9882393',
-							operator: 'date_is',
-							timezone: 'Europe/Berlin',
-							value: '2026-06-17',
-						},
-					],
-				},
-			},
-		};
+		const stored = withFilter({
+			operator: 'date_is',
+			timezone: 'Europe/Berlin',
+			value: '2026-06-17',
+		});
 
-		const resolved = getNodeParameters(
-			properties,
-			stored,
-			false,
-			false,
-			null,
-			null,
-		) as INodeParameters;
-		const [filter] = (resolved.additionalOptions as { filters: { fields: INodeParameters[] } })
-			.filters.fields;
-
-		expect(filter).toHaveProperty('timezone', 'Europe/Berlin');
+		expect(firstFilter(stored, false)).toHaveProperty('timezone', 'Europe/Berlin');
 	});
 });

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -601,6 +601,10 @@ function getParameterResolveOrder(
 	const executionOrder: number[] = [];
 	const indexToResolve = Array.from({ length: nodePropertiesArray.length }, (_, k) => k);
 	const resolvedParameters: string[] = [];
+	// Only these names can ever be resolved here. A dependency on anything else
+	// (e.g. a parameter of an enclosing level) is out of scope at this level, so
+	// waiting for it would loop until the iteration guard below trips.
+	const namesAtThisLevel = new Set(nodePropertiesArray.map((property) => property.name));
 
 	let index: number;
 	let property: INodeProperties;
@@ -626,8 +630,10 @@ function getParameterResolveOrder(
 		// Parameter has dependencies
 		for (const dependency of parameterDependencies[property.name]) {
 			if (!resolvedParameters.includes(dependency)) {
-				if (dependency.charAt(0) === '/') {
-					// Assume that root level dependencies are resolved
+				if (dependency.charAt(0) === '/' || !namesAtThisLevel.has(dependency)) {
+					// Assume that root level and out-of-scope dependencies are resolved.
+					// `displayParameter` resolves the value later and hides the parameter
+					// if it cannot, which beats aborting the whole node's resolution.
 					continue;
 				}
 				// Dependencies for that parameter are still missing so

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -601,10 +601,6 @@ function getParameterResolveOrder(
 	const executionOrder: number[] = [];
 	const indexToResolve = Array.from({ length: nodePropertiesArray.length }, (_, k) => k);
 	const resolvedParameters: string[] = [];
-	// Only these names can ever be resolved here. A dependency on anything else
-	// (e.g. a parameter of an enclosing level) is out of scope at this level, so
-	// waiting for it would loop until the iteration guard below trips.
-	const namesAtThisLevel = new Set(nodePropertiesArray.map((property) => property.name));
 
 	let index: number;
 	let property: INodeProperties;
@@ -630,10 +626,10 @@ function getParameterResolveOrder(
 		// Parameter has dependencies
 		for (const dependency of parameterDependencies[property.name]) {
 			if (!resolvedParameters.includes(dependency)) {
-				if (dependency.charAt(0) === '/' || !namesAtThisLevel.has(dependency)) {
-					// Assume that root level and out-of-scope dependencies are resolved.
-					// `displayParameter` resolves the value later and hides the parameter
-					// if it cannot, which beats aborting the whole node's resolution.
+				if (!Object.hasOwn(parameterDependencies, dependency)) {
+					// Not a parameter of this level (e.g. a `/root.path`), so it cannot be
+					// resolved here. `displayParameter` looks the value up later and hides
+					// the parameter if it is missing.
 					continue;
 				}
 				// Dependencies for that parameter are still missing so

--- a/packages/workflow/test/node-helpers.parameter-dependencies.test.ts
+++ b/packages/workflow/test/node-helpers.parameter-dependencies.test.ts
@@ -78,22 +78,15 @@ const resolve = (props: INodeProperties[], values: INodeParameters) =>
 	getNodeParameters(props, values, true, false, null, null);
 
 describe('getNodeParameters dependency resolution', () => {
+	// Each of these names nothing at the `timezone` parameter's own level, so it
+	// is unsatisfiable there: `timezone` is hidden rather than throwing.
 	test.each([
 		['a relative-path reference', '../operator'],
 		['a dot-notation reference', 'filters.fields.operator'],
 		['a name only present at an enclosing level', 'operation'],
 		['a name that exists nowhere', 'nonExistentParameter'],
-	])('does not throw on %s', (_label, dep) => {
-		expect(() => resolve(withChildDependency(dep), populated)).not.toThrow();
-	});
-
-	test('hides a parameter whose dependency cannot be resolved at its level', () => {
-		// The dependency is unsatisfiable, so `timezone` is not displayed and its
-		// default is not applied — previously this threw instead.
-		expect(resolve(withChildDependency('../operator'), populated)).toEqual({
-			operation: 'getAll',
-			additionalOptions: { filters: { fields: [{ field: '9882393', operator: 'date_is' }] } },
-		});
+	])('hides the parameter instead of throwing for %s', (_label, dep) => {
+		expect(resolve(withChildDependency(dep), populated)).toEqual(populated);
 	});
 
 	test('resolves a sibling reference and applies the default when displayed', () => {
@@ -111,19 +104,11 @@ describe('getNodeParameters dependency resolution', () => {
 			additionalOptions: { filters: { fields: [{ field: '9882393', operator: 'equal' }] } },
 		};
 
-		expect(resolve(withChildDependency('operator'), values)).toEqual({
-			operation: 'getAll',
-			additionalOptions: { filters: { fields: [{ field: '9882393', operator: 'equal' }] } },
-		});
+		expect(resolve(withChildDependency('operator'), values)).toEqual(values);
 	});
 
 	test('resolves a root-level reference from inside a fixedCollection', () => {
-		expect(resolve(withChildDependency('/operation'), populated)).toEqual({
-			operation: 'getAll',
-			additionalOptions: {
-				filters: { fields: [{ field: '9882393', operator: 'date_is' }] },
-			},
-		});
+		expect(resolve(withChildDependency('/operation'), populated)).toEqual(populated);
 	});
 
 	test('leaves an empty fixedCollection untouched', () => {

--- a/packages/workflow/test/node-helpers.unresolvable-display-options.test.ts
+++ b/packages/workflow/test/node-helpers.unresolvable-display-options.test.ts
@@ -1,0 +1,158 @@
+import type { INodeParameters, INodeProperties } from '../src/interfaces';
+import { getNodeParameters } from '../src/node-helpers';
+
+// Regression test for CAT-3999 / NODE-5693 (GH #35788, #35783):
+// A `displayOptions` key that names no parameter at its own level used to make
+// getNodeParameters throw "Could not resolve parameter dependencies. Max
+// iterations reached!", aborting workflow load/activation/publish and leaving a
+// blank canvas. Such a dependency can never be satisfied at that level, so the
+// resolver now treats it as external and lets `displayParameter` decide
+// visibility instead.
+
+/** A `fixedCollection` whose child gates on `dep`, mirroring the Baserow filters shape. */
+const withChildDependency = (dep: string): INodeProperties[] => [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		default: 'getAll',
+		options: [{ name: 'Get Many', value: 'getAll' }],
+	},
+	{
+		displayName: 'Additional Options',
+		name: 'additionalOptions',
+		type: 'collection',
+		placeholder: 'Add option',
+		default: {},
+		options: [
+			{
+				displayName: 'Filters',
+				name: 'filters',
+				type: 'fixedCollection',
+				typeOptions: { multipleValues: true },
+				default: {},
+				options: [
+					{
+						name: 'fields',
+						displayName: 'Field',
+						values: [
+							{
+								displayName: 'Field Name or ID',
+								name: 'field',
+								type: 'string',
+								default: '',
+							},
+							{
+								displayName: 'Filter',
+								name: 'operator',
+								type: 'options',
+								default: 'equal',
+								options: [
+									{ name: 'Is', value: 'equal' },
+									{ name: 'Is Date', value: 'date_is' },
+								],
+							},
+							{
+								displayName: 'Timezone',
+								name: 'timezone',
+								type: 'string',
+								default: 'UTC',
+								displayOptions: { show: { [dep]: ['date_is'] } },
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+];
+
+const populated: INodeParameters = {
+	operation: 'getAll',
+	additionalOptions: {
+		filters: { fields: [{ field: '9882393', operator: 'date_is' }] },
+	},
+};
+
+const resolve = (props: INodeProperties[], values: INodeParameters) =>
+	getNodeParameters(props, values, true, false, null, null);
+
+describe('getNodeParameters dependency resolution', () => {
+	test.each([
+		['a relative-path reference', '../operator'],
+		['a dot-notation reference', 'filters.fields.operator'],
+		['a name only present at an enclosing level', 'operation'],
+		['a name that exists nowhere', 'nonExistentParameter'],
+	])('does not throw on %s', (_label, dep) => {
+		expect(() => resolve(withChildDependency(dep), populated)).not.toThrow();
+	});
+
+	test('hides a parameter whose dependency cannot be resolved at its level', () => {
+		// The dependency is unsatisfiable, so `timezone` is not displayed and its
+		// default is not applied — previously this threw instead.
+		expect(resolve(withChildDependency('../operator'), populated)).toEqual({
+			operation: 'getAll',
+			additionalOptions: { filters: { fields: [{ field: '9882393', operator: 'date_is' }] } },
+		});
+	});
+
+	test('resolves a sibling reference and applies the default when displayed', () => {
+		expect(resolve(withChildDependency('operator'), populated)).toEqual({
+			operation: 'getAll',
+			additionalOptions: {
+				filters: { fields: [{ field: '9882393', operator: 'date_is', timezone: 'UTC' }] },
+			},
+		});
+	});
+
+	test('hides a sibling-gated parameter when the sibling does not match', () => {
+		const values: INodeParameters = {
+			operation: 'getAll',
+			additionalOptions: { filters: { fields: [{ field: '9882393', operator: 'equal' }] } },
+		};
+
+		expect(resolve(withChildDependency('operator'), values)).toEqual({
+			operation: 'getAll',
+			additionalOptions: { filters: { fields: [{ field: '9882393', operator: 'equal' }] } },
+		});
+	});
+
+	test('resolves a root-level reference from inside a fixedCollection', () => {
+		expect(resolve(withChildDependency('/operation'), populated)).toEqual({
+			operation: 'getAll',
+			additionalOptions: {
+				filters: { fields: [{ field: '9882393', operator: 'date_is' }] },
+			},
+		});
+	});
+
+	test('leaves an empty fixedCollection untouched', () => {
+		expect(resolve(withChildDependency('../operator'), { additionalOptions: {} })).toEqual({
+			operation: 'getAll',
+			additionalOptions: {},
+		});
+	});
+
+	test('still resolves parameters that depend on each other in a cycle', () => {
+		// Mutually dependent siblings are tolerated rather than reported as
+		// unresolvable; this guards that behaviour against resolver changes.
+		const cyclic: INodeProperties[] = [
+			{
+				displayName: 'X',
+				name: 'x',
+				type: 'string',
+				default: '',
+				displayOptions: { show: { y: ['1'] } },
+			},
+			{
+				displayName: 'Y',
+				name: 'y',
+				type: 'string',
+				default: '',
+				displayOptions: { show: { x: ['1'] } },
+			},
+		];
+
+		expect(resolve(cyclic, { x: '1', y: '1' })).toEqual({ x: '1', y: '1' });
+	});
+});


### PR DESCRIPTION
## Summary

Baserow's `timezone` filter field gated on a sibling using an unsupported `'../operator'` prefix. The resolver took that as a dependency it could never satisfy and threw `Max iterations reached!`, so workflows with a populated Baserow **Filters** collection couldn't open, activate or publish. All 2.33.x affected.

- **Baserow**: `'../operator'` → `operator` (bare names already resolve against the collection item).
- **Resolver**: a dependency naming nothing at its own level is now treated as external, like `/root` paths, so one bad key can't abort workflow loading. Audited all 689 built-in nodes; Baserow was the only one.

## How to test

Baserow → *Get Many* → add a **Filters** row → save → reload. Blank canvas plus the error on `master`; loads here. **Timezone** should appear only for date operators.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3999
- https://linear.app/n8n/issue/NODE-5693
- closes #35788
- closes #35783

CAT-3956 blames `RespondToWebhook`, which resolves fine; not closed here.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI