### PR TITLE
feat(editor): Mark instances running in E2E test mode (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/frontend-constants/src/z-indexes.ts
+++ b/packages/frontend/@n8n/frontend-constants/src/z-indexes.ts
@@ -28,5 +28,6 @@ export const APP_Z_INDEXES = {
 	DRAGGABLE: 9999999,
 	ACTIVE_STICKY: 9999999,
 	WORKFLOW_PREVIEW_NDV: 9999999,
+	E2E_TEST_MODE_MARKER: 9999999, // never takes pointer events, so it can safely sit on top of everything
 	NPS_SURVEY_MODAL: 3001,
 } as const;

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1352,6 +1352,8 @@
 	"experiments.resourceCenter.title": "Resources",
 	"experiments.resourceCenter.video.level": "Level: {level}",
 	"experiments.templatesDataQuality.modalTitle": "Featured templates",
+	"e2eTestMode.marker": "E2E MODE",
+	"e2eTestMode.markerTooltip": "This instance runs with E2E_TESTS=true. It exposes test-only reset endpoints and changes some defaults — don't use it for anything you want to keep.",
 	"error": "Error",
 	"error.goBack": "Go back",
 	"error.pageNotFound": "Oops, couldn’t find that",

--- a/packages/frontend/@n8n/stores/src/settings.store.ts
+++ b/packages/frontend/@n8n/stores/src/settings.store.ts
@@ -103,6 +103,8 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 
 	const isPreviewMode = computed(() => settings.value.previewMode);
 
+	const isE2ETestMode = computed(() => settings.value.inE2ETests);
+
 	const isCanvasOnly = computed(() => settings.value.canvasOnly);
 
 	const isCrdtCollaborationEnabled = computed(
@@ -452,6 +454,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		isPublicApiEnabled,
 		isSwaggerUIEnabled,
 		isPreviewMode,
+		isE2ETestMode,
 		isCanvasOnly,
 		isCrdtCollaborationEnabled,
 		publicApiLatestVersion,

--- a/packages/frontend/editor-ui/src/app/App.vue
+++ b/packages/frontend/editor-ui/src/app/App.vue
@@ -5,6 +5,7 @@ import AppModals from '@/app/components/app/AppModals.vue';
 import AppCommandBar from '@/app/components/app/AppCommandBar.vue';
 import AppLayout from '@/app/components/app/AppLayout.vue';
 import AppChatPanel from '@/app/components/app/AppChatPanel.vue';
+import E2ETestModeMarker from '@/app/components/app/E2ETestModeMarker.vue';
 
 import { useHistoryHelper } from '@/app/composables/useHistoryHelper';
 import { useBackendStatus } from '@/app/composables/useBackendStatus';
@@ -135,6 +136,7 @@ useExposeCssVar('--ask-assistant--floating-button--margin-bottom', askAiFloating
 		<AppCommandBar />
 		<template #overlays>
 			<div :id="CODEMIRROR_TOOLTIP_CONTAINER_ELEMENT_ID" />
+			<E2ETestModeMarker />
 		</template>
 		<template #aside>
 			<AppChatPanel v-if="layoutRef" :layout-ref="layoutRef" />

--- a/packages/frontend/editor-ui/src/app/components/app/E2ETestModeMarker.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/app/E2ETestModeMarker.test.ts
@@ -1,0 +1,33 @@
+import { createTestingPinia } from '@pinia/testing';
+import { createComponentRenderer } from '@/__tests__/render';
+import { type MockedStore, mockedStore } from '@/__tests__/utils';
+import { defaultSettings } from '@/__tests__/defaults';
+import { useSettingsStore } from '@n8n/stores/settings.store';
+import E2ETestModeMarker from './E2ETestModeMarker.vue';
+
+const renderComponent = createComponentRenderer(E2ETestModeMarker);
+
+let settingsStore: MockedStore<typeof useSettingsStore>;
+let pinia: ReturnType<typeof createTestingPinia>;
+
+describe('E2ETestModeMarker', () => {
+	beforeEach(() => {
+		pinia = createTestingPinia();
+		settingsStore = mockedStore(useSettingsStore);
+		settingsStore.settings = defaultSettings;
+	});
+
+	it('renders the marker when the instance runs in E2E test mode', () => {
+		settingsStore.settings = { ...defaultSettings, inE2ETests: true };
+
+		const { queryByTestId } = renderComponent({ pinia });
+
+		expect(queryByTestId('e2e-test-mode-marker')).toBeInTheDocument();
+	});
+
+	it('renders nothing otherwise', () => {
+		const { queryByTestId } = renderComponent({ pinia });
+
+		expect(queryByTestId('e2e-test-mode-marker')).not.toBeInTheDocument();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/components/app/E2ETestModeMarker.vue
+++ b/packages/frontend/editor-ui/src/app/components/app/E2ETestModeMarker.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { useI18n } from '@n8n/i18n';
+import { useSettingsStore } from '@n8n/stores/settings.store';
+
+const i18n = useI18n();
+const settingsStore = useSettingsStore();
+</script>
+
+<template>
+	<div
+		v-if="settingsStore.isE2ETestMode"
+		:class="$style.marker"
+		data-test-id="e2e-test-mode-marker"
+	>
+		<span :class="$style.pill" :title="i18n.baseText('e2eTestMode.markerTooltip')">
+			{{ i18n.baseText('e2eTestMode.marker') }}
+		</span>
+	</div>
+</template>
+
+<style lang="scss" module>
+.marker {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: var(--e2e-test-mode-marker--z);
+	outline: 3px solid var(--color--danger);
+	outline-offset: -3px;
+}
+
+// Top-center is the only edge that stays clear of app chrome on every view;
+// the bottom-right corner collides with the canvas logs-panel controls.
+.pill {
+	position: absolute;
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	padding: var(--spacing--4xs);
+	border-radius: 0 0 var(--radius--3xs) var(--radius--3xs);
+	background-color: var(--color--danger);
+	color: var(--color--text--tint-3);
+	font-size: var(--font-size--2xs);
+	line-height: 1;
+}
+</style>


### PR DESCRIPTION
## Summary

Add a marker when n8n is running in E2E mode

<img width="1507" height="853" alt="image" src="https://github.com/user-attachments/assets/169e212b-3469-45a9-bcb7-d3eba4909211" />

## How to test

Start n8n with `E2E_TESTS=true`


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- dev-facing marker, no user docs impact -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

