### PR TITLE
feat(MatrixNode): add room ban/unban actions

### DIFF
--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -107,6 +107,13 @@ export async function handleMatrixCall(
 				reason,
 			};
 			return await matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/ban`, body);
+		} else if (operation === 'unban') {
+			const roomId = this.getNodeParameter('roomId', index) as string;
+			const userId = this.getNodeParameter('userId', index) as string;
+			const body: IDataObject = {
+				user_id: userId,
+			};
+			return await matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/unban`, body);
 		}
 	} else if (resource === 'message') {
 		if (operation === 'create') {

--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -98,6 +98,15 @@ export async function handleMatrixCall(
 				reason,
 			};
 			return await matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/kick`, body);
+		} else if (operation === 'ban') {
+			const roomId = this.getNodeParameter('roomId', index) as string;
+			const userId = this.getNodeParameter('userId', index) as string;
+			const reason = this.getNodeParameter('reason', index) as string;
+			const body: IDataObject = {
+				user_id: userId,
+				reason,
+			};
+			return await matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/ban`, body);
 		}
 	} else if (resource === 'message') {
 		if (operation === 'create') {

--- a/packages/nodes-base/nodes/Matrix/RoomDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/RoomDescription.ts
@@ -43,6 +43,12 @@ export const roomOperations: INodeProperties[] = [
 				action: 'Ban a user from a room',
 			},
 			{
+				name: 'Unban',
+				value: 'unban',
+				description: 'Unban a user from a room',
+				action: 'Unban a user from a room',
+			},
+			{
 				name: 'Leave',
 				value: 'leave',
 				description: 'Leave a room',
@@ -287,5 +293,42 @@ export const roomFields: INodeProperties[] = [
 		default: '',
 		description: 'Reason for ban',
 		placeholder: 'Telling unfunny jokes',
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                                 room:unban                                 */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Room Name or ID',
+		name: 'roomId',
+		type: 'options',
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: {
+			loadOptionsMethod: 'getChannels',
+		},
+		displayOptions: {
+			show: {
+				resource: ['room'],
+				operation: ['unban'],
+			},
+		},
+		default: '',
+		required: true,
+	},
+	{
+		displayName: 'User ID',
+		name: 'userId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['room'],
+				operation: ['unban'],
+			},
+		},
+		default: '',
+		description: 'The fully qualified user ID',
+		placeholder: '@cheeky_monkey:matrix.org',
+		required: true,
 	},
 ];

--- a/packages/nodes-base/nodes/Matrix/RoomDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/RoomDescription.ts
@@ -37,6 +37,12 @@ export const roomOperations: INodeProperties[] = [
 				action: 'Kick a user from a room',
 			},
 			{
+				name: 'Ban',
+				value: 'ban',
+				description: 'Ban a user from a room',
+				action: 'Ban a user from a room',
+			},
+			{
 				name: 'Leave',
 				value: 'leave',
 				description: 'Leave a room',
@@ -229,6 +235,57 @@ export const roomFields: INodeProperties[] = [
 		},
 		default: '',
 		description: 'Reason for kick',
+		placeholder: 'Telling unfunny jokes',
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                                  room:ban                                  */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Room Name or ID',
+		name: 'roomId',
+		type: 'options',
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+		typeOptions: {
+			loadOptionsMethod: 'getChannels',
+		},
+		displayOptions: {
+			show: {
+				resource: ['room'],
+				operation: ['ban'],
+			},
+		},
+		default: '',
+		required: true,
+	},
+	{
+		displayName: 'User ID',
+		name: 'userId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['room'],
+				operation: ['ban'],
+			},
+		},
+		default: '',
+		description: 'The fully qualified user ID',
+		placeholder: '@cheeky_monkey:matrix.org',
+		required: true,
+	},
+	{
+		displayName: 'Reason',
+		name: 'reason',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['room'],
+				operation: ['ban'],
+			},
+		},
+		default: '',
+		description: 'Reason for ban',
 		placeholder: 'Telling unfunny jokes',
 	},
 ];


### PR DESCRIPTION
## Summary

Add ban/unban actions for the matrix node.

This allow better control of memberships when automating matrix rooms.

I tested the API endpoints directly and checked with the matrix documentation.

Just kicking the users is sometimes not enough because they can join again anytime, banning them ensure they cannot join again with the same user unless unbanned.

## How to test

- A matrix Room will display a different message when user is kicked or banned.
- Testable live with a matrix client

## Related Linear tickets, Github issues, and Community forum posts

-

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

