### PR TITLE
fix(editor): Close dropdown submenus when scrolled out of view

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.stories.ts
@@ -1,9 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 
-import N8nCheckbox from '../../v2/components/Checkbox/Checkbox.vue';
-import N8nBadge from '../N8nBadge/Badge.vue';
 import N8nButton from '../N8nButton/Button.vue';
 import N8nIcon from '../N8nIcon/Icon.vue';
 import N8nKeyboardShortcut from '../N8nKeyboardShortcut/N8nKeyboardShortcut.vue';
@@ -15,6 +13,14 @@ import DropdownMenu from './DropdownMenu.vue';
 type GenericMeta<C> = Omit<Meta<C>, 'component'> & {
 	component: Record<keyof C, unknown>;
 };
+
+type MenuItemData = {
+	shortcut?: string[];
+	shortcutType?: 'cmd' | 'ctrl' | 'alt' | 'shift';
+	tooltip?: string;
+};
+
+type MenuItem = DropdownMenuItemProps<string, MenuItemData>;
 
 const meta = {
 	title: 'Core/Dropdown Menu',
@@ -30,1043 +36,343 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu placement="bottom-start" :items="args.items" @select="handleSelect" />
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{ id: 'tags', label: 'Tags', icon: { type: 'icon', value: 'tags' } },
-			{ id: 'credentials', label: 'Credentials', icon: { type: 'icon', value: 'lock' } },
-			{ id: 'variables', label: 'Variables', icon: { type: 'icon', value: 'variable' } },
-			{ id: 'executions', label: 'Executions', icon: { type: 'icon', value: 'list' } },
-			{ id: 'created', label: 'Created', icon: { type: 'icon', value: 'calendar' } },
-			{ id: 'updated', label: 'Updated', icon: { type: 'icon', value: 'calendar' } },
-			{ id: 'dataTables', label: 'Data tables', icon: { type: 'icon', value: 'table' } },
-			{ id: 'settings', label: 'Settings', icon: { type: 'icon', value: 'settings' } },
-			{ id: 'thrash', label: 'Delete', icon: { type: 'icon', value: 'trash-2' }, divided: true },
-		] as Array<DropdownMenuItemProps<string>>,
-	},
-};
+function logSelection(action: string) {
+	console.log('Selected:', action);
+}
 
-export const WithCustomTrigger: Story = {
-	render: (args) => ({
-		components: { DropdownMenu, N8nButton },
-		setup() {
-			const isOpen = ref(false);
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, isOpen, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu
-				v-model="isOpen"
-				:items="args.items"
-				placement="bottom-end"
-				@select="handleSelect"
-			>
-				<template #trigger>
-					<N8nButton>
-						Account Menu
-					</N8nButton>
-				</template>
-			</DropdownMenu>
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{ id: 'profile', label: 'Profile', icon: { type: 'icon', value: 'user' } },
-			{ id: 'settings', label: 'Settings', icon: { type: 'icon', value: 'cog' } },
-			{
-				id: 'logout',
-				label: 'Sign out',
-				icon: { type: 'icon', value: 'sign-out-alt' },
-				divided: true,
+export const Default: Story = {
+	render: function render(args) {
+		return {
+			components: { DropdownMenu, N8nIcon, N8nKeyboardShortcut, N8nTooltip },
+			setup() {
+				return { args, logSelection };
 			},
-		] as Array<DropdownMenuItemProps<string>>,
+			template: `
+				<div style="padding: var(--spacing--xl);">
+					<DropdownMenu :items="args.items" placement="bottom-start" @select="logSelection">
+						<template #item-label="{ item, ui }">
+							<N8nTooltip
+								v-if="item.data?.tooltip"
+								:content="item.data.tooltip"
+								placement="right"
+								teleported
+								as-child
+							>
+								<span :class="ui.class">{{ item.label }}</span>
+							</N8nTooltip>
+							<span v-else :class="ui.class">{{ item.label }}</span>
+						</template>
+						<template #item-trailing="{ item, ui }">
+							<N8nKeyboardShortcut
+								v-if="item.data?.shortcut"
+								:keys="item.data.shortcut"
+								:shortcut-type="item.data.shortcutType"
+								:class="ui.class"
+							/>
+							<N8nTooltip
+								v-else-if="item.id === 'deactivate'"
+								content="Stops production executions until the workflow is activated again"
+								placement="right"
+								teleported
+								as-child
+							>
+								<N8nIcon icon="info" size="medium" :class="ui.class" />
+							</N8nTooltip>
+						</template>
+					</DropdownMenu>
+				</div>
+			`,
+		};
 	},
-};
-
-export const EmojiActivator: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu
-				:items="args.items"
-				:activator-icon="{ type: 'emoji', value: '✨' }"
-				@select="handleSelect"
-			/>
-		</div>
-		`,
-	}),
 	args: {
 		items: [
-			{ id: 'option1', label: 'Option 1' },
-			{ id: 'option2', label: 'Option 2' },
-		] as Array<DropdownMenuItemProps<string>>,
-	},
-};
-
-export const WithCheckedItems: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu :items="args.items" @select="handleSelect" />
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{ id: 'option1', label: 'Option 1', checked: true },
-			{ id: 'option2', label: 'Option 2' },
-			{ id: 'option3', label: 'Option 3' },
-		] as Array<DropdownMenuItemProps<string>>,
-	},
-};
-
-export const WithDisabledItems: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu :items="args.items" @select="handleSelect" />
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{ id: 'edit', label: 'Edit', icon: { type: 'icon', value: 'pen' } },
+			{
+				id: 'rename',
+				label: 'Rename workflow',
+				icon: { type: 'icon', value: 'pen' },
+				data: { shortcut: ['F2'] },
+			},
 			{
 				id: 'duplicate',
-				label: 'Duplicate',
+				label: 'Duplicate workflow',
 				icon: { type: 'icon', value: 'copy' },
-				disabled: true,
+				data: { shortcut: ['D'], shortcutType: 'cmd' },
 			},
-			{ id: 'delete', label: 'Delete', icon: { type: 'icon', value: 'trash' } },
-		] as Array<DropdownMenuItemProps<string>>,
+			{
+				id: 'download',
+				label: 'Download',
+				icon: { type: 'icon', value: 'download' },
+				data: { tooltip: 'Download this workflow as a JSON file' },
+			},
+			{
+				id: 'deactivate',
+				label: 'Deactivate',
+				icon: { type: 'icon', value: 'pause' },
+				data: {},
+			},
+			{
+				id: 'delete',
+				label: 'Delete workflow',
+				icon: { type: 'icon', value: 'trash-2' },
+				divided: true,
+				data: { shortcut: ['Backspace'], shortcutType: 'cmd' },
+			},
+		] as MenuItem[],
 	},
 };
 
-export const WithBadgesAndShortcuts: Story = {
-	render: (args) => ({
-		components: { DropdownMenu, N8nBadge, N8nKeyboardShortcut },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<p>Example of using custom trailing slots to render badges and keyboard shortcuts for each item.</p>
-			<DropdownMenu :items="args.items" @select="handleSelect">
-				<template #item-trailing="{ item, ui }">
-					<N8nKeyboardShortcut
-						v-if="item.id === 'save'"
-						:keys="['S']"
-						shortcut-type="cmd"
-						:class="ui.class"
-					/>
-					<N8nBadge
-						v-if="item.id === 'share'"
-						theme="success"
-						bold
-						:class="ui.class"
-					>
-						New
-					</N8nBadge>
-					<N8nBadge
-						v-if="item.id === 'pro'"
-						theme="primary"
-						:class="ui.class"
-					>
-						PRO
-					</N8nBadge>
-				</template>
-			</DropdownMenu>
-		</div>
-		`,
-	}),
+export const CustomTrigger: Story = {
+	render: function render(args) {
+		return {
+			components: { DropdownMenu, N8nButton },
+			setup() {
+				return { args, logSelection };
+			},
+			template: `
+				<div style="padding: var(--spacing--xl);">
+					<DropdownMenu :items="args.items" placement="bottom-end" @select="logSelection">
+						<template #trigger>
+							<N8nButton icon="plus">Create new</N8nButton>
+						</template>
+					</DropdownMenu>
+				</div>
+			`,
+		};
+	},
 	args: {
 		items: [
-			{ id: 'save', label: 'Save', icon: { type: 'icon', value: 'save' } },
-			{ id: 'share', label: 'Share', icon: { type: 'icon', value: 'share-alt' } },
-			{ id: 'pro', label: 'Pro Feature', icon: { type: 'icon', value: 'star' }, disabled: true },
-		] as Array<DropdownMenuItemProps<string>>,
+			{ id: 'workflow', label: 'Workflow', icon: { type: 'icon', value: 'workflow' } },
+			{ id: 'credential', label: 'Credential', icon: { type: 'icon', value: 'lock' } },
+			{ id: 'project', label: 'Project', icon: { type: 'icon', value: 'folder' } },
+		] as MenuItem[],
 	},
 };
 
-export const WithCustomLeadingSlot: Story = {
-	render: (args) => ({
-		components: { DropdownMenu, N8nCheckbox },
-		setup() {
-			const checkedItems = ref<Set<string>>(new Set(['notifications']));
-
-			const toggleItem = (id: string) => {
-				if (checkedItems.value.has(id)) {
-					checkedItems.value.delete(id);
-				} else {
-					checkedItems.value.add(id);
-				}
-				// Trigger reactivity
-				checkedItems.value = new Set(checkedItems.value);
-			};
-
-			const isChecked = (id: string) => checkedItems.value.has(id);
-
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-				toggleItem(action);
-			};
-
-			return { args, handleSelect, isChecked };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<p>Example of using a custom leading slot to render checkboxes for each item.</p>
-			<DropdownMenu :items="args.items" @select="handleSelect">
-				<template #item-leading="{ item, ui }">
-					<N8nCheckbox
-						:model-value="isChecked(item.id)"
-						:class="ui.class"
-						@click.stop
-						@change="handleSelect(item.id)"
-					/>
-				</template>
-			</DropdownMenu>
-		</div>
-		`,
-	}),
+export const CheckedItems: Story = {
+	render: function render(args) {
+		return {
+			components: { DropdownMenu },
+			setup() {
+				return { args, logSelection };
+			},
+			template: `
+				<div style="padding: var(--spacing--xl);">
+					<DropdownMenu :items="args.items" placement="bottom-start" @select="logSelection" />
+				</div>
+			`,
+		};
+	},
 	args: {
 		items: [
-			{ id: 'notifications', label: 'Enable notifications' },
-			{ id: 'sounds', label: 'Play sounds' },
-			{ id: 'desktop', label: 'Desktop alerts' },
-			{ id: 'email', label: 'Email digests', divided: true },
-		] as Array<DropdownMenuItemProps<string>>,
-	},
-};
-
-export const LoadingState: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			return { args };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu
-				:items="args.items"
-				:loading="args.loading"
-				:loading-item-count="args.loadingItemCount"
-			/>
-		</div>
-		`,
-	}),
-	args: {
-		items: [] as Array<DropdownMenuItemProps<string>>,
-		loading: true,
-		loadingItemCount: 5,
-	},
-};
-
-export const Placements: Story = {
-	render: (args) => ({
-		components: { DropdownMenu, N8nButton },
-		setup() {
-			const placements = [
-				'top',
-				'top-start',
-				'top-end',
-				'bottom',
-				'bottom-start',
-				'bottom-end',
-				'left',
-				'right',
-			];
-			return { args, placements };
-		},
-		template: `
-		<div style="padding: 200px; display: flex; flex-wrap: wrap; gap: 20px; justify-content: center;">
-			<DropdownMenu
-				v-for="placement in placements"
-				:key="placement"
-				:items="args.items"
-				:placement="placement"
-			>
-				<template #trigger>
-					<N8nButton size="small">
-						{{ placement }}
-					</N8nButton>
-				</template>
-			</DropdownMenu>
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{ id: 'option1', label: 'Option 1' },
-			{ id: 'option2', label: 'Option 2' },
-			{ id: 'option3', label: 'Option 3' },
-		] as Array<DropdownMenuItemProps<string>>,
-	},
-};
-
-export const ControlledState: Story = {
-	render: (args) => ({
-		components: { DropdownMenu, N8nButton },
-		setup() {
-			const isOpen = ref(false);
-			const toggle = () => {
-				isOpen.value = !isOpen.value;
-			};
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-				isOpen.value = false;
-			};
-			return { args, isOpen, toggle, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<p style="margin-bottom: 16px; user-select: none;">Dropdown is {{ isOpen ? 'open' : 'closed' }}</p>
-			<div style="margin-bottom: 16px;">
-				<N8nButton @click="toggle">
-					{{ isOpen ? 'Close' : 'Open' }} Dropdown
-				</N8nButton>
-			</div>
-			<DropdownMenu
-				v-model="isOpen"
-				:items="args.items"
-				@select="handleSelect"
-			/>
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{ id: 'option1', label: 'Option 1' },
-			{ id: 'option2', label: 'Option 2' },
-			{ id: 'option3', label: 'Option 3' },
-		] as Array<DropdownMenuItemProps<string>>,
+			{ id: 'name', label: 'Workflow name', checked: true },
+			{ id: 'status', label: 'Status', checked: true },
+			{ id: 'created', label: 'Date created' },
+			{ id: 'updated', label: 'Date updated', checked: true },
+			{ id: 'owner', label: 'Owner', checked: true, disabled: true },
+		] as MenuItem[],
 	},
 };
 
 export const NestedMenu: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu
-				:items="args.items"
-				placement="bottom-start"
-				:activator-icon="{ type: 'icon', value: 'plus' }"
-				@select="handleSelect"
-			/>
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{
-				id: 'workflow',
-				label: 'Workflow',
-				icon: { type: 'icon', value: 'tags' },
-				children: [
-					{ id: 'personal', label: 'Personal', icon: { type: 'icon', value: 'user' } },
-					{ id: 'adore', label: 'Adore', icon: { type: 'emoji', value: '😍' } },
-					{ id: 'assistant', label: 'AI Assistant', icon: { type: 'emoji', value: '🔮' } },
-					{ id: 'cloud', label: 'Cloud', icon: { type: 'emoji', value: '🌏' } },
-					{ id: 'Design', label: 'Design', icon: { type: 'emoji', value: '🎨' } },
-					{ id: 'studies', label: 'Diary studies', icon: { type: 'emoji', value: '📖' } },
-					{ id: 'evals', label: 'Evaluations workshop', icon: { type: 'icon', value: 'layers' } },
-				],
+	render: function render(args) {
+		return {
+			components: { DropdownMenu },
+			setup() {
+				return { args, logSelection };
 			},
-			{
-				id: 'credential',
-				label: 'Credential',
-				icon: { type: 'icon', value: 'lock' },
-				children: [
-					{ id: 'gmail', label: 'Gmail', icon: { type: 'icon', value: 'mail' } },
-					{ id: 'airtable', label: 'Airtable', icon: { type: 'icon', value: 'table' } },
-				],
-			},
-			{ id: 'project', label: 'Project', icon: { type: 'icon', value: 'layers' }, disabled: true },
-		] as Array<DropdownMenuItemProps<string>>,
+			template: `
+				<div style="padding: var(--spacing--xl);">
+					<DropdownMenu :items="args.items" placement="bottom-start" @select="logSelection" />
+				</div>
+			`,
+		};
 	},
-};
-
-export const WithTooltips: Story = {
-	render: (args) => ({
-		components: { DropdownMenu, N8nIcon, N8nTooltip },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu :items="args.items" @select="handleSelect">
-				<template #item-label="{ item, ui }">
-					<N8nTooltip
-						v-if="item.id === 'main-menu-item'"
-						:content="item.data.tooltip"
-						placement="right"
-						teleported
-						as-child
-					>
-						<span :class="ui.class">{{ item.label }}</span>
-					</N8nTooltip>
-					<span v-else :class="ui.class">{{ item.label }}</span>
-				</template>
-				<template #item-trailing="{ item, ui }">
-					<N8nTooltip
-						v-if="item.id === 'submenu-item'"
-						:content="item.data.tooltip"
-						placement="right"
-						teleported
-						as-child
-					>
-						<N8nIcon icon="info" size="medium" :class="ui.class" />
-					</N8nTooltip>
-				</template>
-			</DropdownMenu>
-		</div>
-		`,
-	}),
 	args: {
 		items: [
+			{ id: 'personal', label: 'Move to Personal', icon: { type: 'icon', value: 'user' } },
 			{
-				id: 'main-menu-item',
-				label: 'Main menu item',
-				data: { tooltip: 'Tooltip for the main menu item' },
-			},
-			{
-				id: 'submenu',
-				label: 'Open submenu',
-				data: { tooltip: '' },
+				id: 'projects',
+				label: 'Move to project',
+				icon: { type: 'icon', value: 'folder' },
 				children: [
+					{ id: 'operations', label: 'Operations', icon: { type: 'emoji', value: '⚙️' } },
 					{
-						id: 'submenu-item',
-						label: 'Submenu item',
-						data: { tooltip: 'Tooltip for the submenu item' },
-					},
-				],
-			},
-		] as Array<DropdownMenuItemProps<string, { tooltip: string }>>,
-	},
-};
-
-export const MoreLevels: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu :items="args.items" @select="handleSelect" />
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{ id: 'new', label: 'New', icon: { type: 'icon', value: 'plus' } },
-			{
-				id: 'open',
-				label: 'Open',
-				icon: { type: 'icon', value: 'folder-open' },
-				children: [
-					{ id: 'open-recent', label: 'Recent Files' },
-					{ id: 'open-folder', label: 'Open Folder...' },
-					{
-						id: 'open-workspace',
-						label: 'Open Workspace',
+						id: 'product',
+						label: 'Product',
+						icon: { type: 'emoji', value: '🧩' },
 						children: [
-							{ id: 'workspace-1', label: 'Project Alpha' },
-							{ id: 'workspace-2', label: 'Project Beta' },
-							{ id: 'workspace-3', label: 'Project Gamma' },
+							{ id: 'product-design', label: 'Design' },
+							{ id: 'product-engineering', label: 'Engineering' },
+							{
+								id: 'product-research',
+								label: 'Research',
+								children: [
+									{ id: 'research-interviews', label: 'Customer interviews' },
+									{ id: 'research-evaluations', label: 'Workflow evaluations' },
+								],
+							},
 						],
 					},
+					{ id: 'marketing', label: 'Marketing', icon: { type: 'emoji', value: '📣' } },
 				],
 			},
-			{ id: 'save', label: 'Save', icon: { type: 'icon', value: 'save' } },
-			{
-				id: 'export',
-				label: 'Export As',
-				icon: { type: 'icon', value: 'download' },
-				divided: true,
-				children: [
-					{ id: 'export-pdf', label: 'PDF', icon: { type: 'icon', value: 'file' } },
-					{ id: 'export-png', label: 'PNG', icon: { type: 'icon', value: 'file' } },
-					{ id: 'export-json', label: 'JSON', icon: { type: 'icon', value: 'file' } },
-				],
-			},
-			{ id: 'settings', label: 'Settings', icon: { type: 'icon', value: 'cog' }, divided: true },
-		] as Array<DropdownMenuItemProps<string>>,
+		] as MenuItem[],
 	},
 };
 
-export const SubMenuLoading: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu :items="args.items" @select="handleSelect" />
-		</div>
-		`,
-	}),
-	args: {
-		items: [
-			{ id: 'new', label: 'New', icon: { type: 'icon', value: 'plus' } },
-			{
-				id: 'open',
-				label: 'Open Recent',
-				icon: { type: 'icon', value: 'folder-open' },
-				loading: true,
-				loadingItemCount: 4,
-			},
-			{ id: 'save', label: 'Save', icon: { type: 'icon', value: 'save' } },
-			{
-				id: 'export',
-				label: 'Export As',
-				icon: { type: 'icon', value: 'download' },
-				children: [
-					{ id: 'export-pdf', label: 'PDF' },
+export const Searchable: Story = {
+	render: function render() {
+		return {
+			components: { DropdownMenu },
+			setup() {
+				const allItems: MenuItem[] = [
 					{
-						id: 'export-image',
-						label: 'Image',
-						loading: true,
-						loadingItemCount: 2,
+						id: 'communication',
+						label: 'Communication',
+						icon: { type: 'icon', value: 'message-circle' },
+						children: [
+							{ id: 'slack', label: 'Slack' },
+							{ id: 'gmail', label: 'Gmail' },
+							{ id: 'microsoft-teams', label: 'Microsoft Teams' },
+						],
 					},
-				],
-			},
-		] as Array<DropdownMenuItemProps<string>>,
-	},
-};
-
-export const SearchableRoot: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const allItems: Array<DropdownMenuItemProps<string>> = [
-				{ id: 'tags', label: 'Tags', icon: { type: 'icon', value: 'tags' } },
-				{ id: 'credentials', label: 'Credentials', icon: { type: 'icon', value: 'lock' } },
-				{ id: 'variables', label: 'Variables', icon: { type: 'icon', value: 'variable' } },
-				{ id: 'executions', label: 'Executions', icon: { type: 'icon', value: 'list' } },
-				{ id: 'created', label: 'Created', icon: { type: 'icon', value: 'calendar' } },
-				{ id: 'updated', label: 'Updated', icon: { type: 'icon', value: 'calendar' } },
-				{ id: 'dataTables', label: 'Data tables', icon: { type: 'icon', value: 'table' } },
-				{ id: 'settings', label: 'Settings', icon: { type: 'icon', value: 'settings' } },
-			];
-
-			const { filteredItems, handleSearch: handleDropdownSearch } = useDropdownSearch(allItems);
-
-			const handleSearch = (term: string) => {
-				console.log('Search term (debounced):', term);
-				handleDropdownSearch(term);
-			};
-
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-
-			return { args, filteredItems, handleSearch, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu
-				:items="filteredItems"
-				searchable
-				:search-placeholder="args.searchPlaceholder"
-				:search-debounce="args.searchDebounce"
-				@search="handleSearch"
-				@select="handleSelect"
-			/>
-		</div>
-		`,
-	}),
-	args: {
-		items: [] as Array<DropdownMenuItemProps<string>>,
-		searchPlaceholder: 'Search items',
-		searchDebounce: 0,
-	},
-};
-
-export const SearchableRootWithSubmenus: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const allItems: Array<DropdownMenuItemProps<string>> = [
-				{
-					id: 'fruits',
-					label: 'Fruits',
-					icon: { type: 'icon', value: 'folder' },
-					children: [
-						{ id: 'apple', label: 'Apple' },
-						{ id: 'banana', label: 'Banana' },
-						{ id: 'cherry', label: 'Cherry' },
-						...Array.from({ length: 40 }, (_, index) => ({
-							id: `long-fruit-${index + 1}`,
-							label: `Long submenu fruit ${index + 1}`,
-						})),
-					],
-				},
-				{
-					id: 'vegetables',
-					label: 'Vegetables',
-					icon: { type: 'icon', value: 'folder' },
-					children: [
-						{ id: 'carrot', label: 'Carrot' },
-						{ id: 'broccoli', label: 'Broccoli' },
-						{ id: 'spinach', label: 'Spinach' },
-					],
-				},
-				{
-					id: 'dairy',
-					label: 'Dairy',
-					icon: { type: 'icon', value: 'folder' },
-					children: [
-						{ id: 'milk', label: 'Milk' },
-						{ id: 'cheese', label: 'Cheese' },
-						{ id: 'yogurt', label: 'Yogurt' },
-					],
-				},
-				{ id: 'water', label: 'Water', divided: true },
-			];
-
-			const { filteredItems, handleSearch: handleDropdownSearch } = useDropdownSearch(allItems);
-
-			const handleSearch = (term: string) => {
-				console.log('Search term (debounced):', term);
-				handleDropdownSearch(term);
-			};
-
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-
-			return { args, filteredItems, handleSearch, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<p style="margin-bottom: 16px; color: var(--color--text--tint-1);">
-				The main menu is searchable, and the non-searchable "Fruits" submenu has enough
-				items to scroll. Use this to verify hover and keyboard focus do not cause scroll jumps.
-			</p>
-			<DropdownMenu
-				:items="filteredItems"
-				searchable
-				search-placeholder="Search all items..."
-				:search-debounce="200"
-				@search="handleSearch"
-				@select="handleSelect"
-			/>
-		</div>
-		`,
-	}),
-	args: {
-		items: [] as Array<DropdownMenuItemProps<string>>,
-	},
-};
-
-export const SearchableRootWithFlatResults: Story = {
-	render: () => ({
-		components: { DropdownMenu },
-		setup() {
-			type Item = DropdownMenuItemProps<string>;
-
-			const allItems: Item[] = [
-				{
-					id: 'fruits',
-					label: 'Fruits',
-					icon: { type: 'icon', value: 'folder' },
-					children: [
-						{ id: 'apple', label: 'Apple' },
-						{ id: 'banana', label: 'Banana' },
-						{ id: 'cherry', label: 'Cherry' },
-					],
-				},
-				{
-					id: 'vegetables',
-					label: 'Vegetables',
-					icon: { type: 'icon', value: 'folder' },
-					children: [
-						{ id: 'carrot', label: 'Carrot' },
-						{ id: 'broccoli', label: 'Broccoli' },
-						{ id: 'spinach', label: 'Spinach' },
-					],
-				},
-				{
-					id: 'dairy',
-					label: 'Dairy',
-					icon: { type: 'icon', value: 'folder' },
-					children: [
-						{ id: 'milk', label: 'Milk' },
-						{ id: 'cheese', label: 'Cheese' },
-						{ id: 'yogurt', label: 'Yogurt' },
-					],
-				},
-			];
-
-			const {
-				search,
-				filteredItems: searchResults,
-				handleSearch: handleDropdownSearch,
-			} = useDropdownSearch(allItems, {
-				flatList: true,
-				mapResult: (item, path) => ({
-					...item,
-					label: path.map((pathItem) => pathItem.label).join(' › '),
-					divided: false,
-				}),
-			});
-
-			const filteredItems = computed(() => (search.value.trim() ? searchResults.value : allItems));
-
-			const handleSearch = (term: string) => {
-				console.log('Search term (debounced):', term);
-				handleDropdownSearch(term);
-			};
-
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-
-			return { filteredItems, handleSearch, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu
-				:items="filteredItems"
-				searchable
-				search-placeholder="Search and flatten results..."
-				:search-debounce="200"
-				@search="handleSearch"
-				@select="handleSelect"
-			/>
-		</div>
-		`,
-	}),
-	args: {
-		items: [] as Array<DropdownMenuItemProps<string>>,
-	},
-};
-
-export const SearchableSubmenu: Story = {
-	render: () => ({
-		components: { DropdownMenu },
-		setup() {
-			const allProjects: Array<DropdownMenuItemProps<string>> = [
-				{ id: 'personal', label: 'Personal', icon: { type: 'icon', value: 'user' } },
-				{ id: 'adore', label: 'Adore', icon: { type: 'emoji', value: '😍' } },
-				{ id: 'assistant', label: 'AI Assistant', icon: { type: 'emoji', value: '🔮' } },
-				{ id: 'cloud', label: 'Cloud', icon: { type: 'emoji', value: '🌏' } },
-				{ id: 'Design', label: 'Design', icon: { type: 'emoji', value: '🎨' } },
-				{ id: 'studies', label: 'Diary studies', icon: { type: 'emoji', value: '📖' } },
-				{ id: 'evals', label: 'Evaluations workshop', icon: { type: 'icon', value: 'layers' } },
-			];
-
-			const { filteredItems: filteredProjects, handleSearch: handleProjectSearch } =
-				useDropdownSearch(allProjects);
-
-			const handleSearch = (term: string, itemId?: string) => {
-				console.log('Search event:', { term, itemId });
-				if (itemId === 'workflow') {
-					handleProjectSearch(term);
+					{
+						id: 'databases',
+						label: 'Databases',
+						icon: { type: 'icon', value: 'database' },
+						children: [
+							{ id: 'postgres', label: 'Postgres' },
+							{ id: 'mysql', label: 'MySQL' },
+							{ id: 'mongodb', label: 'MongoDB' },
+						],
+					},
+					{ id: 'http-request', label: 'HTTP Request', icon: { type: 'icon', value: 'globe' } },
+				];
+				function mapSearchResult(item: MenuItem, path: MenuItem[]): MenuItem {
+					return {
+						...item,
+						label: path
+							.map(function getPathLabel(pathItem) {
+								return pathItem.label;
+							})
+							.join(' › '),
+						divided: false,
+					};
 				}
-			};
 
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
+				const {
+					search,
+					filteredItems: searchResults,
+					handleSearch,
+				} = useDropdownSearch(allItems, {
+					flatList: true,
+					mapResult: mapSearchResult,
+				});
+				const filteredItems = computed<MenuItem[]>(function getFilteredItems() {
+					return search.value.trim() ? searchResults.value : allItems;
+				});
 
-			const items = computed(() => [
-				{
-					id: 'workflow',
-					label: 'Workflow',
-					icon: { type: 'icon', value: 'tags' },
-					searchable: true,
-					searchPlaceholder: 'Search projects',
-					children: filteredProjects.value,
-				},
-				{
-					id: 'credential',
-					label: 'Credential',
-					icon: { type: 'icon', value: 'lock' },
-					children: [
-						{ id: 'gmail', label: 'Gmail', icon: { type: 'icon', value: 'mail' } },
-						{ id: 'airtable', label: 'Airtable', icon: { type: 'icon', value: 'table' } },
-					],
-				},
-				{
-					id: 'project',
-					label: 'Project',
-					icon: { type: 'icon', value: 'layers' },
-					disabled: true,
-				},
-			]);
-
-			return { items, handleSearch, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu
-				:items="items"
-				:activator-icon="{ type: 'icon', value: 'plus' }"
-				placement="bottom-start"
-				@search="handleSearch"
-				@select="handleSelect"
-			/>
-		</div>
-		`,
-	}),
+				return { filteredItems, handleSearch, logSelection };
+			},
+			template: `
+				<div style="padding: var(--spacing--xl);">
+					<DropdownMenu
+						:items="filteredItems"
+						searchable
+						search-placeholder="Search nodes"
+						placement="bottom-start"
+						@search="handleSearch"
+						@select="logSelection"
+					/>
+				</div>
+			`,
+		};
+	},
 	args: {
-		items: [] as Array<DropdownMenuItemProps<string>>,
+		items: [] as MenuItem[],
 	},
 };
 
-export const LazyLoadingSubmenu: Story = {
-	render: () => ({
-		components: { DropdownMenu },
-		setup() {
-			// Define all possible children upfront (simulates API response)
-			const allRecentFiles = [
-				{ id: 'doc1', label: 'Project Proposal.docx' },
-				{ id: 'doc2', label: 'Meeting Notes.md' },
-				{ id: 'doc3', label: 'Budget 2024.xlsx' },
-				{ id: 'doc4', label: 'Presentation.pptx' },
-			];
+export const LongList: Story = {
+	render: function render() {
+		return {
+			components: { DropdownMenu },
+			setup() {
+				const recentWorkflows = Array.from({ length: 24 }, function createWorkflow(_, index) {
+					return {
+						id: `recent-workflow-${index + 1}`,
+						label: `Recent workflow ${index + 1}`,
+					};
+				});
+				const mainItems = Array.from({ length: 18 }, function createProject(_, index) {
+					return {
+						id: `project-${index + 1}`,
+						label: `Project ${index + 1}`,
+						icon: { type: 'icon' as const, value: 'folder' },
+					};
+				});
+				const items = computed<MenuItem[]>(function getItems() {
+					return [
+						{
+							id: 'recent-workflows',
+							label: 'Recent workflows',
+							icon: { type: 'icon', value: 'clock' },
+							children: recentWorkflows,
+						},
+						...mainItems.slice(0, 9),
+						{
+							id: 'shared-projects',
+							label: 'Shared projects',
+							icon: { type: 'icon', value: 'users' },
+							children: [
+								{ id: 'shared-marketing', label: 'Marketing operations' },
+								{ id: 'shared-sales', label: 'Sales automation' },
+								{ id: 'shared-support', label: 'Customer support' },
+							],
+						},
+						...mainItems.slice(9),
+					];
+				});
 
-			const allSharedFiles = [
-				{ id: 'shared1', label: 'Team Roadmap' },
-				{ id: 'shared2', label: 'Design Assets' },
-			];
-
-			// Track loading states - start as true so skeleton shows on first hover
-			const recentFilesLoading = ref(true);
-			const recentFilesChildren = ref([] as typeof allRecentFiles);
-
-			const sharedLoading = ref(true);
-			const sharedChildren = ref([] as typeof allSharedFiles);
-
-			// Simulates fetching recent files from an API
-			const fetchRecentFiles = () => {
-				console.log('Fetching recent files...');
-				setTimeout(() => {
-					recentFilesChildren.value = allRecentFiles;
-					recentFilesLoading.value = false;
-					console.log('Recent files loaded!');
-				}, 500);
-			};
-
-			// Simulates fetching shared files from an API
-			const fetchSharedFiles = () => {
-				console.log('Fetching shared files...');
-				setTimeout(() => {
-					sharedChildren.value = allSharedFiles;
-					sharedLoading.value = false;
-					console.log('Shared files loaded!');
-				}, 500);
-			};
-
-			// Reset state when dropdown closes
-			const handleOpenChange = (open: boolean) => {
-				if (!open) {
-					// Reset state when dropdown closes so loading shows again next time
-					recentFilesLoading.value = true;
-					recentFilesChildren.value = [];
-					sharedLoading.value = true;
-					sharedChildren.value = [];
-				}
-			};
-
-			// Fetch data when specific submenu opens
-			const handleSubmenuToggle = (itemId: string, open: boolean) => {
-				console.log('Submenu toggle:', itemId, open);
-				if (!open) return;
-
-				if (itemId === 'recent' && recentFilesLoading.value) {
-					fetchRecentFiles();
-				} else if (itemId === 'shared' && sharedLoading.value) {
-					fetchSharedFiles();
-				}
-			};
-
-			const items = computed(() => [
-				{ id: 'new', label: 'New File', icon: { type: 'icon', value: 'plus' } },
-				{
-					id: 'recent',
-					label: 'Recent Files',
-					icon: { type: 'icon', value: 'clock' },
-					loading: recentFilesLoading.value,
-					loadingItemCount: 4,
-					children: recentFilesChildren.value,
-				},
-				{
-					id: 'shared',
-					label: 'Shared With Me',
-					icon: { type: 'icon', value: 'users' },
-					loading: sharedLoading.value,
-					loadingItemCount: 2,
-					children: sharedChildren.value,
-				},
-				{ id: 'settings', label: 'Settings', icon: { type: 'icon', value: 'cog' }, divided: true },
-			]);
-
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-
-			return { items, handleSelect, handleOpenChange, handleSubmenuToggle };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<p style="margin-bottom: 16px; color: var(--color--text--tint-1);">
-				Open the dropdown and hover over "Recent Files" or "Shared With Me" to see lazy loading in action.
-				Each submenu fetches its content independently when hovered.
-			</p>
-			<DropdownMenu
-				:items="items"
-				@select="handleSelect"
-				@update:model-value="handleOpenChange"
-				@submenu:toggle="handleSubmenuToggle"
-			/>
-		</div>
-		`,
-	}),
-	args: {
-		items: [] as Array<DropdownMenuItemProps<string>>,
+				return { items, logSelection };
+			},
+			template: `
+				<div style="padding: var(--spacing--xl);">
+					<DropdownMenu
+						:items="items"
+						max-height="320px"
+						sub-menu-max-height="320px"
+						placement="bottom-start"
+						@select="logSelection"
+					/>
+				</div>
+			`,
+		};
 	},
-};
-
-export const TruncatedLabelsWithTooltip: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			const handleSelect = (action: string) => {
-				console.log('Selected:', action);
-			};
-			return { args, handleSelect };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<p style="margin-bottom: 16px; color: var(--color--text--tint-1);">
-				Hover over items with long labels to see the full text in a tooltip.
-				Short labels (under 20 characters) won't show a tooltip.
-			</p>
-			<DropdownMenu
-				:items="args.items"
-				show-full-label-on-hover
-				@select="handleSelect"
-			/>
-		</div>
-		`,
-	}),
 	args: {
-		items: [
-			{ id: 'short', label: 'Short label', icon: { type: 'icon', value: 'file' } },
-			{ id: 'medium', label: 'A medium-length label', icon: { type: 'icon', value: 'file' } },
-			{
-				id: 'long',
-				label: 'This is a very long workflow name that will be truncated',
-				icon: { type: 'icon', value: 'file' },
-			},
-			{
-				id: 'longer',
-				label: 'Another extremely long label that definitely exceeds the dropdown width',
-				icon: { type: 'icon', value: 'file' },
-			},
-		] as Array<DropdownMenuItemProps<string>>,
+		items: [] as MenuItem[],
 	},
 };
 
 export const EmptyState: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			return { args };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu :items="args.items" />
-		</div>
-		`,
-	}),
-	args: {
-		items: [] as Array<DropdownMenuItemProps<string>>,
+	render: function render(args) {
+		return {
+			components: { DropdownMenu },
+			setup() {
+				return { args };
+			},
+			template: `
+				<div style="padding: var(--spacing--xl);">
+					<DropdownMenu
+						:items="args.items"
+						empty-text="No workflows yet. Create a workflow to see it here."
+						placement="bottom-start"
+					/>
+				</div>
+			`,
+		};
 	},
-};
-
-export const CustomEmptyState: Story = {
-	render: (args) => ({
-		components: { DropdownMenu },
-		setup() {
-			return { args };
-		},
-		template: `
-		<div style="padding: 40px;">
-			<DropdownMenu :items="args.items">
-				<template #empty>
-					<div style="padding: 24px; text-align: center; color: var(--color--text--tint-1);">
-						<div style="font-size: 12px; margin-bottom: 8px;">🔍</div>
-						<div>Nothing here yet</div>
-					</div>
-				</template>
-			</DropdownMenu>
-		</div>
-		`,
-	}),
 	args: {
-		items: [] as Array<DropdownMenuItemProps<string>>,
+		items: [] as MenuItem[],
 	},
 };

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
@@ -13,6 +13,27 @@ const createItems = (count: number): DropdownMenuItemProps[] => {
 	}));
 };
 
+class MockIntersectionObserver {
+	static instances: MockIntersectionObserver[] = [];
+
+	readonly callback: IntersectionObserverCallback;
+
+	constructor(callback: IntersectionObserverCallback) {
+		this.callback = callback;
+		MockIntersectionObserver.instances.push(this);
+	}
+
+	observe() {}
+
+	disconnect() {}
+
+	unobserve() {}
+
+	takeRecords(): IntersectionObserverEntry[] {
+		return [];
+	}
+}
+
 async function getDropdownContent() {
 	const dropdown = await waitFor(() => {
 		const el = document.querySelector('[role="menu"]');
@@ -25,6 +46,45 @@ async function getDropdownContent() {
 
 describe('N8nDropdownMenu', () => {
 	describe('rendering', () => {
+		it('should close an open submenu when its trigger leaves the scroll container', async () => {
+			MockIntersectionObserver.instances = [];
+			vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+
+			try {
+				render(DropdownMenu, {
+					props: {
+						modelValue: true,
+						items: [{ id: 'parent', label: 'Parent', children: [{ id: 'child', label: 'Child' }] }],
+					},
+				});
+
+				const parent = await waitFor(() => {
+					const item = document.querySelector('[role="menuitem"]');
+					if (!item) throw new Error('Parent item not found');
+					return item as HTMLElement;
+				});
+
+				await userEvent.click(parent);
+				await waitFor(() => expect(parent).toHaveAttribute('aria-expanded', 'true'));
+
+				const observer = MockIntersectionObserver.instances[0];
+				expect(observer).toBeDefined();
+				observer.callback(
+					[
+						{
+							isIntersecting: false,
+							intersectionRatio: 0,
+						} as IntersectionObserverEntry,
+					],
+					observer as unknown as IntersectionObserver,
+				);
+
+				await waitFor(() => expect(parent).toHaveAttribute('aria-expanded', 'false'));
+			} finally {
+				vi.unstubAllGlobals();
+			}
+		});
+
 		it('should render default trigger button', () => {
 			const { container } = render(DropdownMenu, {
 				props: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
@@ -16,10 +16,10 @@ const createItems = (count: number): DropdownMenuItemProps[] => {
 class MockIntersectionObserver {
 	static instances: MockIntersectionObserver[] = [];
 
-	readonly callback: IntersectionObserverCallback;
+	readonly observerHandler: IntersectionObserverCallback;
 
-	constructor(callback: IntersectionObserverCallback) {
-		this.callback = callback;
+	constructor(observerHandler: IntersectionObserverCallback) {
+		this.observerHandler = observerHandler;
 		MockIntersectionObserver.instances.push(this);
 	}
 
@@ -69,7 +69,7 @@ describe('N8nDropdownMenu', () => {
 
 				const observer = MockIntersectionObserver.instances[0];
 				expect(observer).toBeDefined();
-				observer.callback(
+				observer.observerHandler(
 					[
 						{
 							isIntersecting: false,

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
@@ -7,6 +7,7 @@ import {
 } from 'reka-ui';
 import { computed, nextTick, onBeforeUnmount, provide, ref, useCssModule, watch } from 'vue';
 
+import { useCloseSubMenuOnScroll } from './composables/useCloseSubMenuOnScroll';
 import { isAlign, isSide } from './DropdownMenu.typeguards';
 import {
 	DropdownMenuPortalTargetKey,
@@ -75,6 +76,41 @@ let hoverCloseTimer: ReturnType<typeof setTimeout> | undefined;
 // DropdownMenuSearchableContent because they use virtual keyboard focus.
 const openSubMenuIndex = ref(-1);
 
+/**
+ * Gets the element that scrolls the root menu items.
+ */
+function getMenuScrollContainer() {
+	const contentEl: unknown = contentRef.value?.$el;
+	return contentEl instanceof HTMLElement ? contentEl : null;
+}
+
+/**
+ * Gets a root menu item by its index in the items collection.
+ */
+function getMenuItem(index: number) {
+	const itemsContainer = getMenuScrollContainer()?.querySelector<HTMLElement>('[data-menu-items]');
+	const itemWrapper = itemsContainer?.children.item(index);
+	return itemWrapper?.querySelector<HTMLElement>('[role="menuitem"]') ?? null;
+}
+
+/**
+ * Closes a submenu whose parent item is no longer visible without moving focus.
+ */
+function closeHiddenSubMenu(index: number) {
+	if (openSubMenuIndex.value !== index) return;
+
+	const item = props.items[index];
+	openSubMenuIndex.value = -1;
+	if (item) emit('submenu:toggle', item.id, false);
+}
+
+const { observe: observeOpenSubMenuTrigger, stopObserving: stopObservingOpenSubMenuTrigger } =
+	useCloseSubMenuOnScroll({
+		getScrollContainer: getMenuScrollContainer,
+		getItem: getMenuItem,
+		onItemHidden: closeHiddenSubMenu,
+	});
+
 const placementParts = computed(() => {
 	const [sideValue, alignValue] = props.placement.split('-');
 	return {
@@ -102,6 +138,7 @@ const handleOpenChange = (open: boolean) => {
 	emit('update:modelValue', open);
 
 	if (!open) {
+		stopObservingOpenSubMenuTrigger();
 		openSubMenuIndex.value = -1;
 	}
 };
@@ -114,13 +151,15 @@ const handleSubMenuOpenChange = (index: number, open: boolean) => {
 
 	if (open) {
 		openSubMenuIndex.value = index;
+		void observeOpenSubMenuTrigger(index);
 	} else if (openSubMenuIndex.value === index) {
+		stopObservingOpenSubMenuTrigger();
 		openSubMenuIndex.value = -1;
 		void nextTick(() => {
 			const contentEl = contentRef.value?.$el as HTMLElement | undefined;
 			const menuItems = contentEl?.querySelectorAll('[role="menuitem"]');
 			const targetItem = menuItems?.[index] as HTMLElement | undefined;
-			targetItem?.focus();
+			targetItem?.focus({ preventScroll: true });
 		});
 	}
 };
@@ -183,6 +222,7 @@ const open = () => {
 const close = () => {
 	internalOpen.value = false;
 	emit('update:modelValue', false);
+	stopObservingOpenSubMenuTrigger();
 	openSubMenuIndex.value = -1;
 };
 
@@ -192,6 +232,7 @@ watch(
 		if (newValue !== undefined) {
 			internalOpen.value = newValue;
 			if (!newValue) {
+				stopObservingOpenSubMenuTrigger();
 				openSubMenuIndex.value = -1;
 			}
 		}

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
@@ -220,7 +220,7 @@ onBeforeUnmount(() => {
 					<N8nText
 						:class="$style['item-label']"
 						:title="titleAttr"
-						size="medium"
+						step="sm"
 						:color="disabled ? 'text-xlight' : 'text-dark'"
 					>
 						{{ label }}
@@ -368,7 +368,7 @@ onBeforeUnmount(() => {
 				<N8nText
 					:class="$style['item-label']"
 					:title="titleAttr"
-					size="medium"
+					step="sm"
 					:color="disabled ? 'text-xlight' : 'text-dark'"
 				>
 					{{ label }}
@@ -404,7 +404,7 @@ onBeforeUnmount(() => {
 				<N8nText
 					:class="$style['item-label']"
 					:title="titleAttr"
-					size="medium"
+					step="sm"
 					:color="disabled ? 'text-xlight' : 'text-dark'"
 				>
 					{{ label }}
@@ -451,7 +451,7 @@ onBeforeUnmount(() => {
 }
 
 .item {
-	font-size: var(--font-size--2xs);
+	font-size: var(--font-size--sm);
 	line-height: 1;
 	border-radius: var(--radius--2xs);
 	display: flex;

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuSearchableContent.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuSearchableContent.vue
@@ -2,6 +2,7 @@
 import { useDebounceFn } from '@vueuse/core';
 import { computed, nextTick, ref, useId, watch } from 'vue';
 
+import { useCloseSubMenuOnScroll } from './composables/useCloseSubMenuOnScroll';
 import type { DropdownMenuItemProps, DropdownMenuSlots } from './DropdownMenu.types';
 import {
 	getItemDomId as getSearchableItemDomId,
@@ -57,6 +58,35 @@ const instanceId = useId();
 let searchSequence = 0;
 
 const highlightedIndex = ref(-1);
+
+/**
+ * Gets a searchable menu item by its index in the items collection.
+ */
+function getMenuItem(index: number) {
+	const itemsContainer = itemsContainerRef.value?.querySelector<HTMLElement>('[data-menu-items]');
+	const itemWrapper = itemsContainer?.children.item(index);
+	return itemWrapper?.querySelector<HTMLElement>('[role="menuitem"]') ?? null;
+}
+
+/**
+ * Closes a submenu whose parent item is no longer visible without changing the highlight.
+ */
+function closeHiddenSubMenu(index: number) {
+	if (openSubMenuIndex.value !== index) return;
+
+	const item = props.items[index];
+	openSubMenuIndex.value = -1;
+	if (item) emit('submenu:toggle', item.id, false);
+}
+
+const { observe: observeOpenSubMenuTrigger, stopObserving: stopObservingOpenSubMenuTrigger } =
+	useCloseSubMenuOnScroll({
+		getScrollContainer: function getScrollContainer() {
+			return itemsContainerRef.value;
+		},
+		getItem: getMenuItem,
+		onItemHidden: closeHiddenSubMenu,
+	});
 
 const refocusSearchInput = () => {
 	searchRef.value?.focus({ preventScroll: true });
@@ -131,6 +161,7 @@ const resetSearch = () => {
 };
 
 const resetNavigation = () => {
+	stopObservingOpenSubMenuTrigger();
 	resetHighlightedItem();
 	openSubMenuIndex.value = -1;
 };
@@ -144,7 +175,9 @@ const handleSubMenuOpenChange = (index: number, open: boolean) => {
 	if (open) {
 		openSubMenuIndex.value = index;
 		resetHighlightedItem();
+		void observeOpenSubMenuTrigger(index);
 	} else if (openSubMenuIndex.value === index) {
+		stopObservingOpenSubMenuTrigger();
 		openSubMenuIndex.value = -1;
 		void nextTick(() => {
 			highlightedIndex.value = index;

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/__snapshots__/DropdownMenuItem.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/__snapshots__/DropdownMenuItem.test.ts.snap
@@ -15,7 +15,7 @@ exports[`N8nDropdownMenuItem > rendering > should render checked item with check
   
   
   <span
-    class="n8n-text text-dark size-medium regular item-label item-label"
+    class="n8n-text text-dark step-sm regular item-label item-label"
   >
     
     Checked Item
@@ -66,7 +66,7 @@ exports[`N8nDropdownMenuItem > rendering > should render disabled item 1`] = `
   
   
   <span
-    class="n8n-text text-xlight size-medium regular item-label item-label"
+    class="n8n-text text-xlight step-sm regular item-label item-label"
   >
     
     Disabled Item
@@ -101,7 +101,7 @@ exports[`N8nDropdownMenuItem > rendering > should render item with emoji 1`] = `
   
   
   <span
-    class="n8n-text text-dark size-medium regular item-label item-label"
+    class="n8n-text text-dark step-sm regular item-label item-label"
   >
     
     With Emoji
@@ -158,7 +158,7 @@ exports[`N8nDropdownMenuItem > rendering > should render item with icon 1`] = `
   
   
   <span
-    class="n8n-text text-dark size-medium regular item-label item-label"
+    class="n8n-text text-dark step-sm regular item-label item-label"
   >
     
     With Icon
@@ -189,7 +189,7 @@ exports[`N8nDropdownMenuItem > rendering > should render item with label 1`] = `
   
   
   <span
-    class="n8n-text text-dark size-medium regular item-label item-label"
+    class="n8n-text text-dark step-sm regular item-label item-label"
   >
     
     Test Item
@@ -233,7 +233,7 @@ exports[`N8nDropdownMenuItem > rendering > should render separator when divided 
     
     
     <span
-      class="n8n-text text-dark size-medium regular item-label item-label"
+      class="n8n-text text-dark step-sm regular item-label item-label"
     >
       
       Divided Item
@@ -271,7 +271,7 @@ exports[`N8nDropdownMenuItem > rendering > should render sub-menu trigger when h
   
   
   <span
-    class="n8n-text text-dark size-medium regular item-label item-label"
+    class="n8n-text text-dark step-sm regular item-label item-label"
   >
     
     Parent Item

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/composables/useCloseSubMenuOnScroll.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/composables/useCloseSubMenuOnScroll.test.ts
@@ -1,0 +1,84 @@
+import { nextTick } from 'vue';
+
+import { useCloseSubMenuOnScroll } from './useCloseSubMenuOnScroll';
+
+type ObserverCallback = IntersectionObserverCallback;
+
+class MockIntersectionObserver {
+	static instances: MockIntersectionObserver[] = [];
+
+	readonly callback: ObserverCallback;
+	readonly root: Element | Document | null;
+
+	constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+		this.callback = callback;
+		this.root = options?.root ?? null;
+		MockIntersectionObserver.instances.push(this);
+	}
+
+	observe() {}
+
+	disconnect() {}
+
+	unobserve() {}
+
+	takeRecords(): IntersectionObserverEntry[] {
+		return [];
+	}
+}
+
+describe('useCloseSubMenuOnScroll', () => {
+	beforeEach(() => {
+		MockIntersectionObserver.instances = [];
+		vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('closes the submenu when its trigger leaves the scroll container', async () => {
+		const scrollContainer = document.createElement('div');
+		const item = document.createElement('div');
+		const onItemHidden = vi.fn();
+		const { observe } = useCloseSubMenuOnScroll({
+			getScrollContainer: function getScrollContainer() {
+				return scrollContainer;
+			},
+			getItem: function getItem() {
+				return item;
+			},
+			onItemHidden,
+		});
+
+		void observe(2);
+		await nextTick();
+
+		const observer = MockIntersectionObserver.instances[0];
+		expect(observer.root).toBe(scrollContainer);
+
+		observer.callback(
+			[
+				{
+					isIntersecting: true,
+					intersectionRatio: 1,
+				} as IntersectionObserverEntry,
+			],
+			observer as unknown as IntersectionObserver,
+		);
+		expect(onItemHidden).not.toHaveBeenCalled();
+
+		observer.callback(
+			[
+				{
+					isIntersecting: false,
+					intersectionRatio: 0,
+				} as IntersectionObserverEntry,
+			],
+			observer as unknown as IntersectionObserver,
+		);
+
+		expect(onItemHidden).toHaveBeenCalledTimes(1);
+		expect(onItemHidden).toHaveBeenCalledWith(2);
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/composables/useCloseSubMenuOnScroll.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/composables/useCloseSubMenuOnScroll.test.ts
@@ -7,11 +7,11 @@ type ObserverCallback = IntersectionObserverCallback;
 class MockIntersectionObserver {
 	static instances: MockIntersectionObserver[] = [];
 
-	readonly callback: ObserverCallback;
+	readonly observerHandler: ObserverCallback;
 	readonly root: Element | Document | null;
 
-	constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
-		this.callback = callback;
+	constructor(observerHandler: ObserverCallback, options?: IntersectionObserverInit) {
+		this.observerHandler = observerHandler;
 		this.root = options?.root ?? null;
 		MockIntersectionObserver.instances.push(this);
 	}
@@ -57,7 +57,7 @@ describe('useCloseSubMenuOnScroll', () => {
 		const observer = MockIntersectionObserver.instances[0];
 		expect(observer.root).toBe(scrollContainer);
 
-		observer.callback(
+		observer.observerHandler(
 			[
 				{
 					isIntersecting: true,
@@ -68,7 +68,7 @@ describe('useCloseSubMenuOnScroll', () => {
 		);
 		expect(onItemHidden).not.toHaveBeenCalled();
 
-		observer.callback(
+		observer.observerHandler(
 			[
 				{
 					isIntersecting: false,

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/composables/useCloseSubMenuOnScroll.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/composables/useCloseSubMenuOnScroll.ts
@@ -1,0 +1,53 @@
+import { nextTick, onBeforeUnmount } from 'vue';
+
+interface CloseSubMenuOnScrollOptions {
+	getScrollContainer: () => HTMLElement | null;
+	getItem: (index: number) => HTMLElement | null;
+	onItemHidden: (index: number) => void;
+}
+
+/**
+ * Closes an open submenu after its parent item leaves the menu scrollport.
+ * This stops sub-menus floating next to their hidden menu items and looking weird.
+ */
+export function useCloseSubMenuOnScroll(options: CloseSubMenuOnScrollOptions) {
+	let observer: IntersectionObserver | undefined;
+	let observationSequence = 0;
+
+	function stopObserving() {
+		observationSequence++;
+		observer?.disconnect();
+		observer = undefined;
+	}
+
+	async function observe(index: number) {
+		stopObserving();
+		const sequence = observationSequence;
+		await nextTick();
+
+		if (sequence !== observationSequence) return;
+
+		const scrollContainer = options.getScrollContainer();
+		const item = options.getItem(index);
+		if (!scrollContainer || !item) return;
+
+		observer = new IntersectionObserver(
+			function handleIntersection(entries) {
+				const entry = entries[0];
+				if (!entry || entry.isIntersecting) return;
+
+				stopObserving();
+				options.onItemHidden(index);
+			},
+			{
+				root: scrollContainer,
+				threshold: 0,
+			},
+		);
+		observer.observe(item);
+	}
+
+	onBeforeUnmount(stopObserving);
+
+	return { observe, stopObserving };
+}


### PR DESCRIPTION
## Summary

Closes open dropdown submenus when their parent menu item is fully scrolled out of the menu viewport. The submenu trigger is observed only while the submenu is open, so scrolling the submenu itself does not close it. This leads to weird behaviour when the trigger is out of view, making the sub-menu float.

Instead we add an observer to check if open sub-menu is open and out of view, and if so, close it.

- Added a shared `IntersectionObserver` composable for dropdown submenu triggers.
- Applied it to searchable and non-searchable dropdown menus.
- Added cleanup and focus handling for scroll-driven submenu closure.


https://github.com/user-attachments/assets/fa0b723e-2d01-49ba-9f64-d9602157e543

## How to test

1. Open an n8n dropdown menu with enough items to scroll (AI Model select is a good candidate)
2. Open a submenu near the top or bottom of the menu.
3. Scroll the parent menu until the submenu's parent item is fully outside the menu viewport.
4. Confirm that the submenu closes and the menu remains at the new scroll position.
5. Confirm that scrolling while the parent item remains visible does not close the submenu.
6. Repeat with a searchable dropdown menu.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-608

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
