### PR TITLE
chore: Add Codespaces devcontainer variant for cloud agent sessions (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/Dockerfile
+++ b/.devcontainer/codespaces/Dockerfile
@@ -1,0 +1,27 @@
+ARG NODE_VERSION=24
+
+# Debian, not Alpine: Playwright browsers and the agent CLIs need glibc
+FROM node:${NODE_VERSION}-bookworm
+
+ARG PLAYWRIGHT_VERSION=1.60.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tmux sudo less jq ripgrep postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Chromium system libs baked into the image; browser binaries install per-user in onCreate
+RUN npx -y playwright@${PLAYWRIGHT_VERSION} install-deps chromium
+
+# Agent harnesses. Self-update is off: the image is the update mechanism
+ENV DISABLE_AUTOUPDATER=1
+RUN npm install -g @anthropic-ai/claude-code opencode-ai
+
+RUN echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node && chmod 0440 /etc/sudoers.d/node
+RUN mkdir -p /workspaces && chown node:node /workspaces
+RUN corepack enable
+
+ENV PNPM_HOME=/home/node/.local/share/pnpm
+ENV PATH=$PNPM_HOME/bin:$PATH
+
+USER node
+RUN mkdir -p $PNPM_HOME ~/.pnpm-store && pnpm config set store-dir ~/.pnpm-store --global

--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -1,0 +1,25 @@
+{
+	"name": "n8n (Codespaces agent sessions)",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "n8n",
+	"workspaceFolder": "/workspaces",
+	"hostRequirements": {
+		"cpus": 8,
+		"memory": "32gb",
+		"storage": "64gb"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+	"forwardPorts": [8080, 5678],
+	// Runs in prebuilds, so a fresh codespace starts with deps installed and the build warm
+	"onCreateCommand": "corepack install && pnpm install && (pnpm build > /tmp/build.log 2>&1 || tail -n 50 /tmp/build.log) && pnpm --filter=n8n-playwright exec playwright install chromium",
+	"secrets": {
+		"ANTHROPIC_API_KEY": {
+			"description": "Anthropic API key for Claude Code / OpenCode sessions"
+		},
+		"CLAUDE_CODE_OAUTH_TOKEN": {
+			"description": "Alternative to an API key: token from `claude setup-token` (Max subscription)"
+		}
+	}
+}

--- a/.devcontainer/codespaces/docker-compose.yml
+++ b/.devcontainer/codespaces/docker-compose.yml
@@ -1,0 +1,26 @@
+volumes:
+  postgres-data:
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=n8n
+      - POSTGRES_PASSWORD=password
+
+  n8n:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    depends_on:
+      - postgres
+    environment:
+      DB_POSTGRESDB_HOST: postgres
+      DB_TYPE: postgresdb
+      DB_POSTGRESDB_PASSWORD: password


### PR DESCRIPTION
## Summary

POC for the cloud-agent-sessions build baseline: a second devcontainer config at `.devcontainer/codespaces/` for running human-steered agent sessions (Claude Code / OpenCode) in GitHub Codespaces. The existing `.devcontainer/` laptop config is untouched — Codespaces shows a config picker when multiple exist.

What's in the variant vs the existing devcontainer:
- **Debian (`node:24-bookworm`) instead of Alpine** — Playwright browsers and the agent CLIs need glibc
- **Both agent harnesses preinstalled** (`@anthropic-ai/claude-code`, `opencode-ai`, self-update disabled — the image is the update mechanism) plus `tmux` for detach/resume session persistence
- **Playwright Chromium system deps** pinned to the repo's Playwright version (1.60.0); browser binaries install per-user in `onCreateCommand`
- **Prebuild-friendly lifecycle**: `pnpm install` + `pnpm build` run in `onCreateCommand` so Codespaces prebuilds bake a warm build into new codespaces
- **Declared Codespaces secrets** (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`) so users get prompted once and every codespace gets them injected
- **No `localEnv:HOME` bind mounts** — those are laptop-only and break in Codespaces
- Same Postgres 16 sidecar, user/sudo/pnpm-store conventions as the existing config

## How to test

```bash
# once per user
gh secret set ANTHROPIC_API_KEY --app codespaces

gh codespace create -R n8n-io/n8n -b devp-711-evaluate-build-baseline-codespacescoder-claude-code-for \
  --devcontainer-path .devcontainer/codespaces/devcontainer.json -m largePremiumLinux

# interactive session that survives closing your laptop
gh codespace ssh -- -t 'tmux new -As agent claude'
# detach: Ctrl-b d — reattach later with the same command; after an idle-stop, resume with: claude --resume
```

Local verification done: image builds clean; `claude`, `opencode`, `tmux`, node 24 and pnpm all smoke-tested inside the container.

Not included (repo-settings, not files): Codespaces prebuild configuration for this devcontainer path.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-711

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

