### PR TITLE
test(core): Pin that workflow `tags` are dropped from the executions filter (no-changelog)

### DIFF
--- a/packages/cli/src/executions/__tests__/parse-range-query.middleware.test.ts
+++ b/packages/cli/src/executions/__tests__/parse-range-query.middleware.test.ts
@@ -141,6 +141,27 @@ describe('`parseRangeQuery` middleware', () => {
 			expect('test' in req.rangeQuery).toBe(false);
 			expect(nextFn).toBeCalledTimes(1);
 		});
+
+		// Workflow `tags` are not an executions filter — only `annotationTags` are.
+		// Pinned because the editor once mapped `tags` into this filter and it was
+		// silently dropped here; adding `tags` to the schema would revive a
+		// user-facing filter with no UI behind it.
+		test('should delete workflow `tags` while keeping `annotationTags`', () => {
+			const req = mock<ExecutionRequest.GetMany>({
+				query: {
+					filter: '{ "tags": ["t1"], "annotationTags": ["a1"] }',
+					limit: undefined,
+					firstId: undefined,
+					lastId: undefined,
+				},
+			});
+
+			parseRangeQuery(req, res, nextFn);
+
+			expect('tags' in req.rangeQuery).toBe(false);
+			expect(req.rangeQuery.annotationTags).toEqual(['a1']);
+			expect(nextFn).toBeCalledTimes(1);
+		});
 	});
 
 	describe('range', () => {


### PR DESCRIPTION
## Summary

Adds one test case to `parse-range-query.middleware.test.ts` pinning that workflow `tags` are dropped from the executions filter while `annotationTags` survive.

Test-only, no production change.

`parseRangeQuery` deletes any filter key outside `allowedExecutionsQueryFilterFields`, which is derived from `Object.keys(schemaGetExecutionsQueryFilter.properties)`. `tags` is not among them, so a `tags` key in `GET /executions?filter=…` never reaches the query.

That invariant is currently only covered incidentally, by a generic unknown-field case using a placeholder key (`"test": "789"`). #35618 removes the editor's `tags` → query mapping and rests on this behaviour, so it is worth a named case: if `tags` is ever added to the schema, this test fails and points at the missing editor half rather than shipping a filter with no UI behind it.

## How to test

```bash
cd packages/cli
pnpm vitest run src/executions/__tests__/parse-range-query.middleware.test.ts
```

11 passed. The new case was checked for teeth: adding `tags: { type: 'array', items: { type: 'string' } }` to `schemaGetExecutionsQueryFilter` turns it red (`expected true to be false`), and removing it again turns it green.

## Related Linear tickets, Github issues, and Community forum posts

Companion to #35618 (executions tag filter removal) — independent of it, and not a prerequisite for merging it.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

