### PR TITLE
test(core): Clean up invited user shells when a batch returns no accept token (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/lane-users.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/lane-users.test.ts
@@ -65,6 +65,30 @@ describe('LaneUserPool', () => {
 		expect(new Set(emails).size).toBe(emails.length);
 	});
 
+	it('records shells for cleanup and explains itself when a batch yields no accept token', async () => {
+		// Mirrors an SMTP-configured lane: the shells exist server-side, but the
+		// accept URL (and so the token) is withheld.
+		const inviteMembers = vi.fn().mockResolvedValue([
+			{ id: 'u1', email: 'a@b.invalid' },
+			{ id: 'u2', email: 'c@d.invalid' },
+		]);
+		const pool = new LaneUserPool({ inviteMembers } as unknown as N8nClient, 2);
+
+		await expect(pool.claim()).rejects.toThrow('none returned an accept token');
+		expect(pool.createdUserIds).toEqual(['u1', 'u2']);
+	});
+
+	it('serves the token-bearing invites when only some of a batch carry one', async () => {
+		const inviteMembers = vi.fn().mockResolvedValue([
+			{ id: 'u1', email: 'a@b.invalid', error: 'already invited' },
+			{ id: 'u2', email: 'c@d.invalid', acceptToken: 't2' },
+		]);
+		const pool = new LaneUserPool({ inviteMembers } as unknown as N8nClient, 2);
+
+		await expect(pool.claim()).resolves.toMatchObject({ id: 'u2' });
+		expect(pool.createdUserIds).toEqual(['u1', 'u2']);
+	});
+
 	it('rejects waiting claims when the invite fails, then recovers', async () => {
 		const inviteMembers = vi
 			.fn()
@@ -98,9 +122,8 @@ describe('provisionCaseBuildUser', () => {
 
 		const mcpApiKey = await provisionCaseBuildUser({
 			pool,
-			baseUrl: 'http://lane-1',
-			onCredentialCreated: () => {},
 			memberClient: client,
+			onCredentialCreated: () => {},
 		});
 
 		expect(member.acceptInvitation).toHaveBeenCalledTimes(1);
@@ -123,10 +146,9 @@ describe('provisionCaseBuildUser', () => {
 
 		await provisionCaseBuildUser({
 			pool,
-			baseUrl: 'http://lane-1',
+			memberClient: client,
 			credentials,
 			onCredentialCreated: (id) => reported.push(id),
-			memberClient: client,
 		});
 
 		expect(created.map((c) => c.type)).toEqual(['slackApi', 'notionApi']);
@@ -142,10 +164,9 @@ describe('provisionCaseBuildUser', () => {
 		await expect(
 			provisionCaseBuildUser({
 				pool,
-				baseUrl: 'http://lane-1',
+				memberClient: client,
 				credentials: [{ type: 'slackApi' }],
 				onCredentialCreated: () => {},
-				memberClient: client,
 			}),
 		).rejects.toThrow('credential POST failed');
 	});

--- a/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/mcp-builder.ts
@@ -62,26 +62,12 @@ export function uniqueProjectScopes(scopes: Array<string | undefined>): string[]
 }
 
 // Every staged config embeds a bearer token, so exit cleanup is intrinsic to
-// staging: each written path is registered with a single process-exit unlinker.
-// Callers that finish normally unlink eagerly via unlinkStagedMcpConfig.
+// staging: writeMcpConfig tracks each path and the exit hook unlinks whatever
+// is left. Callers that finish normally unlink eagerly via unlinkStagedMcpConfig.
 const stagedConfigPaths = new Set<string>();
-let exitCleanupInstalled = false;
-
-function registerStagedConfigForExitCleanup(path: string): void {
-	if (!exitCleanupInstalled) {
-		exitCleanupInstalled = true;
-		process.on('exit', () => {
-			for (const staged of stagedConfigPaths) {
-				try {
-					unlinkSync(staged);
-				} catch {
-					// best-effort
-				}
-			}
-		});
-	}
-	stagedConfigPaths.add(path);
-}
+process.on('exit', () => {
+	for (const staged of stagedConfigPaths) unlinkStagedMcpConfig(staged);
+});
 
 /** Eagerly remove a staged MCP config (and drop it from exit cleanup). */
 export function unlinkStagedMcpConfig(path: string): void {
@@ -101,7 +87,7 @@ function writeMcpConfig(serverName: string, block: unknown, filePrefix: string):
 		`${filePrefix}-${String(process.pid)}-${String(Date.now())}-${Math.random().toString(36).slice(2, 8)}.json`,
 	);
 	writeFileSync(tmpPath, JSON.stringify({ mcpServers: { [serverName]: block } }), { mode: 0o600 });
-	registerStagedConfigForExitCleanup(tmpPath);
+	stagedConfigPaths.add(tmpPath);
 	return tmpPath;
 }
 

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -676,14 +676,18 @@ export class N8nClient {
 	}
 
 	/**
-	 * Invite member users in one batched request and return each invitee's
-	 * accept token. Requires an owner session and an instance without SMTP —
-	 * an emailed invite omits `inviteAcceptUrl` (the token's only carrier).
+	 * Invite member users in one batched request. Requires an owner session.
+	 * Returns one row per invitee, reporting rather than throwing on failure:
+	 * n8n creates the user shells before it reports per-invite errors, so the
+	 * caller needs every id back to clean up. `acceptToken` is present only when
+	 * the invite was not emailed (`inviteAcceptUrl` is the token's only carrier,
+	 * and it is withheld when SMTP is configured or N8N_INVITE_LINKS_EMAIL_ONLY
+	 * is set).
 	 * POST /rest/invitations  body: [{ email, role: 'global:member' }, ...]
 	 */
 	async inviteMembers(
 		emails: string[],
-	): Promise<Array<{ id: string; email: string; acceptToken: string }>> {
+	): Promise<Array<{ id: string; email: string; acceptToken?: string; error?: string }>> {
 		if (emails.length === 0) return [];
 		const response = InvitedUsersEnvelope.parse(
 			await this.fetch('/rest/invitations', {
@@ -691,20 +695,14 @@ export class N8nClient {
 				body: emails.map((email) => ({ email, role: 'global:member' })),
 			}),
 		);
-		return response.data.map(({ user, error }) => {
-			if (error) {
-				throw new Error(`Invitation for ${user.email} failed: ${error}`);
-			}
-			const token = user.inviteAcceptUrl
-				? new URL(user.inviteAcceptUrl).searchParams.get('token')
-				: null;
-			if (!token) {
-				throw new Error(
-					`Invitation for ${user.email} returned no accept token — the instance likely has SMTP configured (the invite was emailed instead), which the eval user-provisioning flow cannot use`,
-				);
-			}
-			return { id: user.id, email: user.email, acceptToken: token };
-		});
+		return response.data.map(({ user, error }) => ({
+			id: user.id,
+			email: user.email,
+			acceptToken: user.inviteAcceptUrl
+				? (new URL(user.inviteAcceptUrl).searchParams.get('token') ?? undefined)
+				: undefined,
+			error: error === '' ? undefined : error,
+		}));
 	}
 
 	/**

--- a/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/build-orchestrator.ts
@@ -23,7 +23,7 @@ import {
 	type McpBuildResult,
 	type McpBuildSettings,
 } from '../cli/mcp-builder';
-import type { N8nClient } from '../clients/n8n-client';
+import { N8nClient } from '../clients/n8n-client';
 import {
 	fetchAgentScenarioContext,
 	findAgentArtifactRef,
@@ -179,7 +179,7 @@ async function buildWorkflowViaMcpOnLane(config: {
 	try {
 		mcpApiKey = await provisionCaseBuildUser({
 			pool: lane.mcpUserPool,
-			baseUrl: lane.baseUrl,
+			memberClient: new N8nClient(lane.baseUrl),
 			credentials,
 			onCredentialCreated: (id) => lane.createdCredentialIds.add(id),
 			logger,

--- a/packages/@n8n/instance-ai/evaluations/run/lane-users.ts
+++ b/packages/@n8n/instance-ai/evaluations/run/lane-users.ts
@@ -9,7 +9,7 @@
 
 import { randomBytes } from 'crypto';
 
-import { N8nClient } from '../clients/n8n-client';
+import type { N8nClient } from '../clients/n8n-client';
 import { createDeclaredCredentials } from '../credentials/seeder';
 import type { EvalLogger } from '../harness/logger';
 import type { TestCaseCredential } from '../types';
@@ -61,9 +61,19 @@ export class LaneUserPool {
 			return `eval-mcp-${this.nonce}-${String(this.seq)}@n8n-evals.invalid`;
 		});
 		const invited = await this.ownerClient.inviteMembers(emails);
-		for (const user of invited) {
-			this.createdUserIds.push(user.id);
-			this.available.push(user);
+		// Record every shell before judging usability: n8n creates them all up
+		// front, so even an unusable batch has to be deleted after the run.
+		for (const user of invited) this.createdUserIds.push(user.id);
+
+		const usable = invited.filter(
+			(user): user is InvitedCaseUser => user.acceptToken !== undefined,
+		);
+		this.available.push(...usable);
+		if (usable.length === 0) {
+			const reason = invited.map((user) => user.error).find(Boolean);
+			throw new Error(
+				`Invited ${String(invited.length)} user(s) but none returned an accept token${reason ? ` (${reason})` : ''} — the lane must run without SMTP and without N8N_INVITE_LINKS_EMAIL_ONLY for the eval build-user flow`,
+			);
 		}
 	}
 }
@@ -76,20 +86,19 @@ export class LaneUserPool {
  */
 export async function provisionCaseBuildUser(opts: {
 	pool: LaneUserPool;
-	baseUrl: string;
+	/** A fresh, logged-out client for the lane — accepting the invite logs it in. */
+	memberClient: N8nClient;
 	credentials?: TestCaseCredential[];
 	onCredentialCreated: (id: string) => void;
 	logger?: EvalLogger;
-	/** Test seam — the member's client. */
-	memberClient?: N8nClient;
 }): Promise<string> {
-	const user = await opts.pool.claim();
-	const memberClient = opts.memberClient ?? new N8nClient(opts.baseUrl);
+	const { pool, memberClient } = opts;
+	const user = await pool.claim();
 	await memberClient.acceptInvitation({
 		token: user.acceptToken,
 		firstName: 'Eval',
 		lastName: 'Builder',
-		password: opts.pool.password,
+		password: pool.password,
 	});
 	const mcpApiKey = await memberClient.rotateMcpApiKey();
 	await createDeclaredCredentials(memberClient, opts.credentials ?? [], {
@@ -110,19 +119,15 @@ export async function cleanupLaneUsers(
 	const ids = pool.createdUserIds;
 	if (ids.length === 0) return;
 	let deleted = 0;
-	// Each delete cascades server-side, so bound the concurrency to one invite
-	// chunk's worth instead of firing every delete at once.
-	for (let i = 0; i < ids.length; i += INVITE_CHUNK_SIZE) {
-		await Promise.all(
-			ids.slice(i, i + INVITE_CHUNK_SIZE).map(async (id) => {
-				try {
-					await ownerClient.deleteUser(id);
-					deleted++;
-				} catch {
-					// best-effort
-				}
-			}),
-		);
+	// Sequential, like cleanupCredentials: each delete cascades server-side and
+	// this runs after the last verdict, so nothing waits on it.
+	for (const id of ids) {
+		try {
+			await ownerClient.deleteUser(id);
+			deleted++;
+		} catch {
+			// best-effort
+		}
 	}
 	logger.verbose(`Deleted ${String(deleted)}/${String(ids.length)} MCP build user(s)`);
 }


### PR DESCRIPTION
## Summary

Stacked on #35782 (base is that PR's branch, so the diff here is just the delta).

One fix and three simplifications from reviewing the per-case build-user flow.

### Invited user shells were orphaned when a batch had no accept token

`UserService.inviteUsers` creates every user shell in a transaction *before*
`sendEmails` runs, so a response row carrying an `error` (or a withheld
`inviteAcceptUrl`) still corresponds to a user that exists on the instance.
`inviteMembers` threw inside its `.map()` on the first such row, which meant
`doRefill` never reached `createdUserIds.push` and `cleanupLaneUsers` had
nothing to delete.

Failure mode: point `--build-via-mcp` at a lane with SMTP configured and the
provisioning error is swallowed into a per-build `failure()`, so the run keeps
going and orphans a fresh chunk of user shells per build, none of which are
ever cleaned up.

`inviteMembers` now reports per row instead of throwing. The pool records every
id first, serves the token-bearing rows, and only fails the refill when the
whole batch is unusable. Two tests cover the all-unusable and partially-usable
cases.

The error message also names `N8N_INVITE_LINKS_EMAIL_ONLY`
(`user-management.config.ts`), which withholds the accept URL exactly like SMTP
does. It was previously only mentioned as SMTP.

### Simplifications

- `provisionCaseBuildUser` takes the member `N8nClient` instead of a `baseUrl`
  plus an optional `memberClient` test seam. Two params become one, the
  optional-that's-always-set goes away, and `lane-users.ts` drops to a
  type-only import.
- The staged-MCP-config exit hook is registered once at module scope instead of
  lazily behind an `exitCleanupInstalled` flag. Same single listener, same
  behaviour, 18 lines to 3.
- `cleanupLaneUsers` deletes sequentially, matching `cleanupCredentials`
  directly next to it in `cleanupLanes`. It was chunking on `INVITE_CHUNK_SIZE`,
  an unrelated constant that it also applied in preference to the pool's own
  `chunkSize`. This runs after the last verdict, so nothing waits on it.

## Not addressed here

Left for the author to decide, since they touch the shared orchestrator path or
predate this work:

- `cleanupLanes` deletes seeded credentials unconditionally, so under
  `--keep-workflows` the kept workflows come back referencing deleted
  credentials. That undercuts the stated reason for keeping the users.
- `buildWorkflowViaMcpOnLane` still documents "Never throws" while
  `stageLaneMcpConfig`, `buildWorkflowViaMcp` and `fetchPrebuiltBuild` can all
  escape. Only `provisionCaseBuildUser` is guarded.
- The README's "a build that times out can leave its workflow behind" caveat is
  now mostly obsolete, since deleting the build user cascades to their personal
  project.
- `inviteMembers` / `acceptInvitation` / `deleteUser` have no client-level
  tests. Envelope parsing and token extraction are only exercised through the
  pool's fakes.

## How to test

```
cd packages/@n8n/instance-ai
pnpm test evaluations/__tests__
pnpm typecheck && pnpm lint
```

1109 tests pass, typecheck and lint clean. No live eval run against a lane.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5733

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

