### PR TITLE
fix(core): Resolve expressions in ephemeral agent tools

### DIFF
--- a/packages/cli/src/node-execution/__tests__/ephemeral-node-executor.test.ts
+++ b/packages/cli/src/node-execution/__tests__/ephemeral-node-executor.test.ts
@@ -9,11 +9,13 @@ import {
 } from '@n8n/db';
 import { StructuredToolkit } from 'n8n-core';
 import {
+	Expression,
 	NodeConnectionTypes,
 	type IExecuteFunctions,
 	type INodeCredentialsDetails,
 	type INodeType,
 	type INodeTypeDescription,
+	type ISupplyDataFunctions,
 	type IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
@@ -835,5 +837,56 @@ describe('EphemeralNodeExecutor', () => {
 			expect(executedNodeName).toBe('Target Node');
 			expect(base.evalLlmMockHandler).toBeUndefined();
 		});
+	});
+
+	it('resolves expressions when invoking a supplyData tool with the VM engine', async () => {
+		await Expression.initExpressionEngine({
+			engine: 'vm',
+			bridgeTimeout: 1000,
+			bridgeMemoryLimit: 128,
+			poolSize: 1,
+			maxCodeCacheSize: 10,
+		});
+
+		try {
+			nodeTypes.getByNameAndVersion.mockReturnValue(
+				mockNodeType({
+					description: {
+						...toolDescription,
+						properties: [
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+							},
+						],
+					},
+					async supplyData(this: ISupplyDataFunctions) {
+						const resolvedValue = this.getNodeParameter('value', 0);
+						return {
+							response: {
+								invoke: async () => resolvedValue,
+							},
+						};
+					},
+				}),
+			);
+
+			const result = await executor.executeInline({
+				nodeType: '@n8n/n8n-nodes-langchain.toolHttpRequest',
+				nodeTypeVersion: 1,
+				nodeParameters: { value: '={{ 1 + 1 }}' },
+				inputData: [{ json: {} }],
+				projectId: 'p-1',
+			});
+
+			expect(result).toEqual({
+				status: 'success',
+				data: [{ json: { response: 2 } }],
+			});
+		} finally {
+			await Expression.disposeExpressionEngine();
+		}
 	});
 });

--- a/packages/cli/src/node-execution/ephemeral-node-executor.ts
+++ b/packages/cli/src/node-execution/ephemeral-node-executor.ts
@@ -482,27 +482,30 @@ export class EphemeralNodeExecutor {
 		);
 
 		const nodeType = this.nodeTypes.getByNameAndVersion(tool.nodeType, tool.nodeTypeVersion);
-		if (typeof nodeType.supplyData !== 'function') {
+		const supplyData = nodeType.supplyData;
+		if (typeof supplyData !== 'function') {
 			return { ok: false, error: 'Node does not implement supplyData' };
 		}
 
 		try {
-			const supplyDataResult = await nodeType.supplyData.call(context, 0);
-			const response = supplyDataResult.response as
-				| LangChainToolType
-				| StructuredToolkit
-				| undefined;
+			return await withExpressionIsolate(parts.workflow, async () => {
+				const supplyDataResult = await supplyData.call(context, 0);
+				const response = supplyDataResult.response as
+					| LangChainToolType
+					| StructuredToolkit
+					| undefined;
 
-			if (response instanceof StructuredToolkit) {
-				return { ok: true, value: await onTool(response) };
-			}
-			if (response && typeof response.invoke === 'function') {
-				return { ok: true, value: await onTool(response) };
-			}
-			return {
-				ok: false,
-				error: `Node "${tool.nodeType}" did not return a valid LangChain tool or toolkit`,
-			};
+				if (response instanceof StructuredToolkit) {
+					return { ok: true, value: await onTool(response) };
+				}
+				if (response && typeof response.invoke === 'function') {
+					return { ok: true, value: await onTool(response) };
+				}
+				return {
+					ok: false,
+					error: `Node "${tool.nodeType}" did not return a valid LangChain tool or toolkit`,
+				};
+			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			return { ok: false, error: message };


### PR DESCRIPTION
## Summary

- Acquire the VM expression isolate while creating and invoking ephemeral `supplyData` tools
- Allow native Agent tools such as HTTP Request Tool to resolve expressions and credentials
- Add regression coverage for expression resolution through the `supplyData` execution path

## How to test

Run the focused regression test from `packages/cli`:

```bash
N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite pnpm vitest run src/node-execution/__tests__/ephemeral-node-executor.test.ts -t "resolves expressions when invoking a supplyData tool with the VM engine"
```

For a manual smoke test, start n8n with `N8N_ENABLED_MODULES=agents` and `N8N_EXPRESSION_ENGINE=vm`, create an Agent with an HTTP Request Tool whose URL is an expression, and confirm the tool call succeeds.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-607

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

