### PR TITLE
feat: Graduate Codespaces agent-session config with POC fixes and session script (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/Dockerfile
+++ b/.devcontainer/codespaces/Dockerfile
@@ -16,6 +16,8 @@ RUN npx -y playwright@${PLAYWRIGHT_VERSION} install-deps chromium
 ENV DISABLE_AUTOUPDATER=1
 RUN npm install -g @anthropic-ai/claude-code opencode-ai
 
+COPY codespaces-secrets.sh /etc/profile.d/codespaces-secrets.sh
+
 RUN echo node ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/node && chmod 0440 /etc/sudoers.d/node
 RUN mkdir -p /workspaces && chown node:node /workspaces
 RUN corepack enable

--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -84,13 +84,16 @@ After a stop, `pnpm session <name>` restarts the codespace (~30–60 s); run
   agent injects them into VS Code sessions only; they're delivered
   base64-encoded to `/workspaces/.codespaces/shared/.env-secrets`. The image's
   profile shim exports them for ssh/tmux sessions.
-- Codespaces on this repo (public) bill to **your personal account** by
-  default — the free tier is 120 core-hours/month. Org billing, bigger
-  machines, and prebuilds (which remove the ~20 min cold start) require org
-  admin enablement.
+- Codespaces created by org members on this repo are **org-owned and
+  org-billed** (organization ownership + a monthly Codespaces budget are
+  enabled for n8n-io). Codespaces created before that change, or by
+  non-members, bill to the personal account (free tier: 120 core-hours/month).
+  If creation unexpectedly falls back to personal billing, the org budget is
+  exhausted for the period.
 
 ## Costs
 
-You pay only while the codespace runs: ~$0.36/hr (4-core) / ~$0.72/hr
-(8-core), ~nothing stopped. `pnpm session stop` when you leave; the idle
-timeout is the backstop, not the plan.
+Compute bills only while the codespace runs: ~$0.36/hr (4-core) / ~$0.72/hr
+(8-core), ~nothing stopped. Usage draws from a shared monthly org budget, so
+`pnpm session stop` when you leave; the idle timeout is the backstop, not the
+plan.

--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -1,0 +1,74 @@
+# Cloud agent sessions (Codespaces)
+
+Run long-lived, human-steered agent sessions (Claude Code / OpenCode) on a
+GitHub Codespace instead of your laptop: start a task, close the lid, steer it
+from anywhere with a terminal, resume tomorrow.
+
+This is a separate devcontainer config from the laptop one in
+`.devcontainer/` — it ships both agent CLIs, `tmux` for session persistence,
+and Playwright system deps, on the same Postgres sidecar setup.
+
+## One-time setup (~5 min)
+
+1. Add your key at [github.com/settings/codespaces](https://github.com/settings/codespaces)
+   → **New secret** → name `ANTHROPIC_API_KEY`, repository access `n8n-io/n8n`.
+   (Alternative for Max subscriptions: `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`.)
+2. Give the GitHub CLI the codespace scope:
+
+   ```bash
+   gh auth refresh -h github.com -s codespace
+   ```
+
+## Daily flow
+
+```bash
+pnpm session              # attach the default agent session (creates everything on first run)
+pnpm session fix-flaky    # a second, parallel agent in its own git worktree
+pnpm session ls           # what's running
+pnpm session stop         # end of day: billing stops, disk survives
+pnpm session rm           # delete the codespace
+```
+
+- **Detach** with `Ctrl-b d` — the agent keeps working without you.
+- **Reattach** by running the same `pnpm session <name>` from any machine.
+- Each named session gets its own worktree (`/workspaces/wt-<name>`, branch
+  `session/<name>`), so parallel agents never touch each other's tree. Builds
+  in fresh worktrees are cache-hits via a shared turbo cache.
+- First codespace creation takes ~20 min uncached (image + full build). After
+  that, sessions attach instantly; new worktrees cost a `pnpm install` (~1–2 min).
+
+## What survives what
+
+| Event | Running processes | Disk (checkout, worktrees, chat history) |
+|---|---|---|
+| Detach / close laptop / network drop | ✅ keep running | ✅ |
+| Stop, or idle timeout (default 30 min, max 4 h) | ❌ killed | ✅ |
+| Delete (`pnpm session rm`) | ❌ | ❌ (push your branches first) |
+
+After a stop, `pnpm session <name>` restarts the codespace (~30–60 s); run
+`claude --resume` (or `--continue`) inside to restore the conversation from disk.
+
+## Gotchas (learned the hard way)
+
+- **Codespaces clones the repo to `/workspaces/n8n`**, not `/workspaces` —
+  `workspaceFolder` here differs from the laptop config on purpose.
+- **A failing `onCreateCommand` is fatal**: Codespaces discards the container
+  and drops you into a minimal recovery container (no node, no CLIs). If your
+  codespace has nothing installed, check
+  `/workspaces/.codespaces/.persistedshare/creation.log`.
+- **`gh codespace ssh` needs sshd inside the container** — provided by the
+  `sshd` devcontainer feature, don't remove it.
+- **User secrets aren't visible in ssh shells by default**: the codespace
+  agent injects them into VS Code sessions only; they're delivered
+  base64-encoded to `/workspaces/.codespaces/shared/.env-secrets`. The image's
+  profile shim exports them for ssh/tmux sessions.
+- Codespaces on this repo (public) bill to **your personal account** by
+  default — the free tier is 120 core-hours/month. Org billing, bigger
+  machines, and prebuilds (which remove the ~20 min cold start) require org
+  admin enablement.
+
+## Costs
+
+You pay only while the codespace runs: ~$0.36/hr (4-core) / ~$0.72/hr
+(8-core), ~nothing stopped. `pnpm session stop` when you leave; the idle
+timeout is the backstop, not the plan.

--- a/.devcontainer/codespaces/README.md
+++ b/.devcontainer/codespaces/README.md
@@ -25,6 +25,7 @@ and Playwright system deps, on the same Postgres sidecar setup.
 pnpm session              # attach the default agent session (creates everything on first run)
 pnpm session fix-flaky    # a second, parallel agent in its own git worktree
 pnpm session ls           # what's running
+pnpm session tunnel       # forward n8n ports (default 5678, 8080) to localhost; Ctrl-C to stop
 pnpm session stop         # end of day: billing stops, disk survives
 pnpm session rm           # delete the codespace
 ```
@@ -36,6 +37,27 @@ pnpm session rm           # delete the codespace
   in fresh worktrees are cache-hits via a shared turbo cache.
 - First codespace creation takes ~20 min uncached (image + full build). After
   that, sessions attach instantly; new worktrees cost a `pnpm install` (~1–2 min).
+
+## Viewing the dev UI locally
+
+Two terminal windows:
+
+```bash
+pnpm session          # window 1: attach the agent session
+pnpm session tunnel   # window 2: forward 5678 + 8080 to localhost
+```
+
+Attaching lands you in the agent (Claude), not a shell — open a shell in a
+new tmux window with `Ctrl-b c` (or ask the agent) and run `pnpm dev` there.
+Then open http://localhost:8080.
+
+The tunnel prints nothing while forwarding — that's normal. `Connection
+refused` means nothing is listening on that port in the codespace yet; it
+starts serving as soon as `pnpm dev` is up, no restart needed. Pass ports to
+override the defaults (`pnpm session tunnel 5678 8080 5679`), but always
+forward the pair together with matching numbers: the Vite dev UI points its
+API base at `localhost:5678` (the `N8N_PORT` default), so an asymmetric or
+partial mapping breaks it.
 
 ## What survives what
 

--- a/.devcontainer/codespaces/codespaces-secrets.sh
+++ b/.devcontainer/codespaces/codespaces-secrets.sh
@@ -1,0 +1,8 @@
+# Codespaces delivers user secrets base64-encoded to a shared env file and only
+# injects them into VS Code sessions; ssh/tmux login shells must source them here.
+if [ -f /workspaces/.codespaces/shared/.env-secrets ]; then
+	while IFS='=' read -r key val; do
+		case "$key" in '' | *[!A-Za-z0-9_]*) continue ;; esac
+		dec=$(printf %s "$val" | base64 -d 2>/dev/null) && export "$key=$dec"
+	done </workspaces/.codespaces/shared/.env-secrets
+fi

--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -2,14 +2,17 @@
 	"name": "n8n (Codespaces agent sessions)",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "n8n",
-	"workspaceFolder": "/workspaces",
+	// Codespaces clones the repo into /workspaces/<repo>, unlike the laptop config
+	"workspaceFolder": "/workspaces/n8n",
 	"hostRequirements": {
 		"cpus": 8,
 		"memory": "32gb",
 		"storage": "64gb"
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		// gh codespace ssh needs an SSH server inside the container
+		"ghcr.io/devcontainers/features/sshd:1": {}
 	},
 	"forwardPorts": [8080, 5678],
 	// Runs in prebuilds, so a fresh codespace starts with deps installed and the build warm

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -70,8 +70,10 @@ jobs:
               !**/*.spec.ts
               !packages/testing/playwright/**
               !packages/frontend/@n8n/storybook/**
+              !.devcontainer/**
               !scripts/agent-setup.mjs
               !scripts/backend-module/**
+              !scripts/cloud-session.mjs
               !scripts/licenses/**
               !scripts/mutation-health/**
               !scripts/sync-agent-skill-links.mjs
@@ -83,8 +85,10 @@ jobs:
               !**/*.md
               !**/LICENSE
               !**/CHANGELOG.md
+              !.devcontainer/**
               !scripts/agent-setup.mjs
               !scripts/backend-module/**
+              !scripts/cloud-session.mjs
               !scripts/licenses/**
               !scripts/mutation-health/**
               !scripts/sync-agent-skill-links.mjs

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev-metrics:status": "node scripts/dev-metrics/setup.mjs --status",
     "dev-metrics:reset": "node scripts/dev-metrics/setup.mjs --reset",
     "clean": "turbo run clean",
+    "session": "node scripts/cloud-session.mjs",
     "reset": "node scripts/ensure-zx.mjs && zx scripts/reset.mjs",
     "format": "turbo run format && node scripts/format.mjs",
     "grind": "node scripts/grind.mjs",

--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Manage cloud agent sessions: one Codespace per developer, one tmux session +
+// git worktree per agent, so parallel sessions never trample each other's tree.
+// Requires `gh` with the codespace scope (gh auth refresh -s codespace).
+//
+//   pnpm session            attach the default session (main checkout, /workspaces/n8n)
+//   pnpm session <name>     attach a named session in its own worktree (/workspaces/wt-<name>)
+//   pnpm session ls         list codespaces and the tmux sessions inside
+//   pnpm session stop       stop the codespace (compute billing stops; disk survives)
+//   pnpm session rm         delete the codespace
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const REPO = 'n8n-io/n8n';
+const DEVCONTAINER = '.devcontainer/codespaces/devcontainer.json';
+const MACHINE = process.env.CODESPACE_MACHINE ?? 'premiumLinux'; // 8-core/32GB
+const FALLBACK_MACHINE = 'standardLinux32gb'; // 4-core/16GB, until org policy allows bigger
+
+const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8' }).trim();
+const ghTty = (...args) => spawnSync('gh', args, { stdio: 'inherit' });
+
+function findCodespace() {
+	const list = JSON.parse(gh('codespace', 'list', '-R', REPO, '--json', 'name,state'));
+	return list[0];
+}
+
+function ensureCodespace() {
+	let cs = findCodespace();
+	if (!cs) {
+		console.log(`No codespace on ${REPO} — creating one (first build takes a while)…`);
+		const create = (machine) =>
+			gh('codespace', 'create', '-R', REPO, '--devcontainer-path', DEVCONTAINER, '-m', machine);
+		let name;
+		try {
+			name = create(MACHINE);
+		} catch {
+			console.log(`Machine type ${MACHINE} unavailable — falling back to ${FALLBACK_MACHINE}`);
+			name = create(FALLBACK_MACHINE);
+		}
+		cs = { name };
+	}
+	return cs.name;
+}
+
+// Worktrees share the pnpm store but not the turbo cache; a shared TURBO_CACHE_DIR
+// (seeded from the main checkout) keeps new-worktree builds at cache-hit speed.
+// No single quotes allowed here: the whole prelude rides inside tmux's '…' arg.
+const CACHE = 'export TURBO_CACHE_DIR=/workspaces/.turbo-cache; [ -d "$TURBO_CACHE_DIR" ] || cp -r /workspaces/n8n/.turbo/cache "$TURBO_CACHE_DIR" 2>/dev/null || mkdir -p "$TURBO_CACHE_DIR"';
+
+function remoteCommand(session, extraArgs) {
+	const claude = `claude ${extraArgs}`.trim();
+	if (session === 'agent') return `${CACHE}; cd /workspaces/n8n && ${claude}`;
+	const wt = `/workspaces/wt-${session}`;
+	const branch = `session/${session}`;
+	return [
+		CACHE,
+		`if [ ! -d "${wt}" ]; then echo "Setting up worktree ${wt}…"`,
+		`git -C /workspaces/n8n worktree add "${wt}" -b "${branch}" 2>/dev/null || git -C /workspaces/n8n worktree add "${wt}" "${branch}"`,
+		`(cd "${wt}" && pnpm install); fi`,
+		`cd "${wt}" && ${claude}`,
+	].join('; ');
+}
+
+const [cmd = 'agent', ...rest] = process.argv.slice(2);
+
+switch (cmd) {
+	case 'ls': {
+		const cs = findCodespace();
+		if (!cs) {
+			console.log(`No codespace on ${REPO}. Run \`pnpm session\` to create one.`);
+			break;
+		}
+		console.log(`${cs.name} [${cs.state}]`);
+		if (cs.state === 'Available') {
+			ghTty('codespace', 'ssh', '-c', cs.name, '--', 'tmux ls 2>/dev/null || echo "  no active sessions"');
+		}
+		break;
+	}
+	case 'stop':
+	case 'rm': {
+		const cs = findCodespace();
+		if (!cs) break;
+		if (cmd === 'stop') gh('codespace', 'stop', '-c', cs.name);
+		else ghTty('codespace', 'delete', '-c', cs.name, '--force');
+		console.log(`${cmd === 'stop' ? 'Stopped' : 'Deleted'} ${cs.name}`);
+		break;
+	}
+	default: {
+		// treat cmd as the session name; each name = an independent agent in its own worktree
+		if (!/^[\w-]+$/.test(cmd)) {
+			console.error(`Invalid session name '${cmd}' — use letters, digits, - or _`);
+			process.exit(1);
+		}
+		const name = ensureCodespace();
+		console.log(`Attaching to session '${cmd}' on ${name} (detach: Ctrl-b d)…`);
+		ghTty(
+			'codespace', 'ssh', '-c', name, '--', '-t',
+			`tmux new -As ${cmd} '${remoteCommand(cmd, rest.join(' '))}'`,
+		);
+	}
+}

--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -108,8 +108,12 @@ switch (cmd) {
 	case 'rm': {
 		const cs = findCodespace();
 		if (!cs) break;
-		if (cmd === 'stop') gh('codespace', 'stop', '-c', cs.name);
-		else ghTty('codespace', 'delete', '-c', cs.name, '--force');
+		if (cmd === 'stop') {
+			gh('codespace', 'stop', '-c', cs.name);
+		} else {
+			const { status } = ghTty('codespace', 'delete', '-c', cs.name, '--force');
+			if (status !== 0) process.exit(status ?? 1);
+		}
 		console.log(`${cmd === 'stop' ? 'Stopped' : 'Deleted'} ${cs.name}`);
 		break;
 	}
@@ -121,9 +125,10 @@ switch (cmd) {
 		}
 		const name = ensureCodespace();
 		console.log(`Attaching to session '${cmd}' on ${name} (detach: Ctrl-b d)…`);
-		ghTty(
+		const { status } = ghTty(
 			'codespace', 'ssh', '-c', name, '--', '-t',
 			`tmux new -As ${cmd} '${remoteCommand(cmd, rest.join(' '))}'`,
 		);
+		process.exitCode = status ?? 1;
 	}
 }

--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -6,6 +6,7 @@
 //   pnpm session            attach the default session (main checkout, /workspaces/n8n)
 //   pnpm session <name>     attach a named session in its own worktree (/workspaces/wt-<name>)
 //   pnpm session ls         list codespaces and the tmux sessions inside
+//   pnpm session tunnel [port…]  forward ports (default 5678, 8080) to localhost; Ctrl-C to stop
 //   pnpm session stop       stop the codespace (compute billing stops; disk survives)
 //   pnpm session rm         delete the codespace
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -73,6 +74,34 @@ switch (cmd) {
 		if (cs.state === 'Available') {
 			ghTty('codespace', 'ssh', '-c', cs.name, '--', 'tmux ls 2>/dev/null || echo "  no active sessions"');
 		}
+		break;
+	}
+	case 'tunnel': {
+		// Local ports must match remote ones: the Vite dev UI (8080) points its API
+		// base at localhost:5678 (N8N_PORT's default), so an asymmetric or partial
+		// mapping breaks it.
+		const ports = rest.length ? rest : ['5678', '8080'];
+		if (ports.some((p) => !/^\d+$/.test(p) || +p < 1 || +p > 65535)) {
+			console.error(`Ports must be 1-65535, got: ${ports.join(' ')}`);
+			process.exit(1);
+		}
+		const cs = findCodespace();
+		if (!cs) {
+			console.log(`No codespace on ${REPO}. Run \`pnpm session\` first.`);
+			break;
+		}
+		if (cs.state !== 'Available') {
+			console.error(`${cs.name} is ${cs.state} — run \`pnpm session\` to start it first.`);
+			process.exit(1);
+		}
+		console.log(`Forwarding ${ports.map((p) => `localhost:${p}`).join(', ')} from ${cs.name} — Ctrl-C to stop…`);
+		// ssh -L over `gh codespace ports forward`: gh binds all interfaces (LAN-exposed),
+		// ssh binds loopback only. ExitOnForwardFailure fails fast if a port is taken.
+		const { status } = ghTty(
+			'codespace', 'ssh', '-c', cs.name, '--', '-N', '-o', 'ExitOnForwardFailure=yes',
+			...ports.flatMap((p) => ['-L', `${p}:localhost:${p}`]),
+		);
+		process.exitCode = status ?? 1;
 		break;
 	}
 	case 'stop':


### PR DESCRIPTION
## Summary

Follow-up to #35855, folding in everything learned from the live POC (verified on a real codespace end to end):

**Config fixes (all bite-tested — without them the codespace lands in a recovery container or is unreachable):**
- `workspaceFolder` → `/workspaces/n8n`: Codespaces clones into `/workspaces/<repo>`, unlike the laptop compose mount. A failing `onCreateCommand` is fatal (recovery container), so this fix is what makes the config work at all.
- `sshd` devcontainer feature: `gh codespace ssh` requires an SSH server inside the container.
- `/etc/profile.d/codespaces-secrets.sh`: Codespaces delivers user secrets base64-encoded and only injects them into VS Code sessions; this shim exports them for ssh/tmux login shells. Parser skips malformed lines silently (tested with hostile input).

**`pnpm session` — the DX wrapper:**
- `pnpm session` / `pnpm session <name>` / `ls` / `tunnel` / `stop` / `rm`
- One codespace per developer; each named session = its own tmux session + git worktree (`/workspaces/wt-<name>`, branch `session/<name>`) so parallel agents never trample each other
- Shared `TURBO_CACHE_DIR` seeded from the main checkout: fresh-worktree builds verified at FULL TURBO (69/69 cached, 6.9s)
- Defaults to 8-core `premiumLinux` with automatic fallback to `standardLinux32gb` until org policy allows bigger machines

**`pnpm session tunnel [port…]` — view the dev UI locally (second commit):**
- Forwards 5678 + 8080 (or given ports) from the codespace to localhost over `gh codespace ssh -N -L`, so `pnpm dev` in the codespace is browsable at `localhost:8080`
- Deliberately ssh `-L` rather than `gh codespace ports forward`: gh binds all interfaces (LAN-exposed, verified via lsof), ssh binds loopback only
- Fails fast instead of degrading silently: `ExitOnForwardFailure=yes` (port already in use → immediate error), refuses to run against a non-`Available` codespace (won't silently boot a stopped one and resume billing), propagates the ssh/gh exit status, validates ports 1–65535
- Local and remote port numbers must match — the Vite dev UI points its API base at `localhost:5678` (the `N8N_PORT` default), so an asymmetric mapping breaks it; documented in the script and README

**CI (third commit):** `.devcontainer/**` and `scripts/cloud-session.mjs` are now excluded from the `runtime`/`unit` change filters in `ci-pull-requests.yml` (same convention as the other dev-only scripts), so codespaces-config-only PRs no longer trigger the full E2E + unit suites — verified by simulating the filter against this PR's file list. This PR still runs E2E once because it also touches root `package.json`, which stays a trigger deliberately.

**Docs:** `.devcontainer/codespaces/README.md` — setup, daily flow, two-window tunnel flow, persistence semantics, gotchas, costs.

POC measurements (4-core, uncached): create → Available ~22 min, of which ~9.5 min is the cold `pnpm install` + full build (no remote cache). Stop/restart + `claude --continue` conversation restore verified. Prebuilds on this config (repo settings, blocked on org spending limit) remove the cold start for users.

## How to test

```bash
gh auth refresh -h github.com -s codespace   # once
# secret: github.com/settings/codespaces → ANTHROPIC_API_KEY, access to n8n-io/n8n
pnpm session          # creates codespace on this branch's config, attaches Claude Code in tmux
pnpm session second   # parallel session in its own worktree
pnpm session ls && pnpm session stop
```

Detach with `Ctrl-b d`; reattach with the same command from any machine.

Tunnel (two terminal windows):

```bash
pnpm session          # window 1: attach, open a shell (Ctrl-b c), run `pnpm dev`
pnpm session tunnel   # window 2: forward 5678 + 8080, then open http://localhost:8080
```

Failure paths verified live: port already bound locally → immediate `bind: Address already in use` + exit 1; stopped codespace → refusal with hint instead of a silent boot.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-711

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated (README in this PR).
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

