### PR TITLE
fix(core): Steer Instance AI off full WorkflowJSON rewrites that hang…

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -623,7 +623,30 @@ describe('workflows tool', () => {
 			);
 
 			expect(context.workflowService.getAsWorkflowJSON).toHaveBeenCalledWith('wf1', undefined);
-			expect(result).toEqual(workflow);
+			expect(result).toEqual({
+				...workflow,
+				editingGuidance: expect.stringContaining('get-as-code'),
+			});
+		});
+
+		it('should steer edits away from full JSON rewrites', async () => {
+			const context = createMockContext();
+			(context.workflowService.getAsWorkflowJSON as Mock).mockResolvedValue({
+				id: 'wf1',
+				name: 'Test WF',
+				nodes: [],
+				connections: {},
+			});
+
+			const tool = createWorkflowsTool(context, 'full');
+			const result = (await executeTool(
+				tool,
+				{ action: 'get-json', workflowId: 'wf1' },
+				{} as never,
+			)) as { editingGuidance: string };
+
+			expect(result.editingGuidance).toContain('workspace_write_file');
+			expect(result.editingGuidance).toContain('get-as-code');
 		});
 
 		it('should forward versionId to the full fetches', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -33,6 +33,7 @@ import {
 import { validateWorkflowConfig } from './workflows/validate-workflow.service';
 import { refreshWorkflowSourceFileBindingFromWorkflow } from './workflows/workflow-file-bindings';
 import { getReferencedWorkflowIds } from './workflows/workflow-json-utils';
+import { GET_JSON_EDITING_GUIDANCE } from '../workspace/guard-workflow-json-write';
 
 // ── Action schemas ──────────────────────────────────────────────────────────
 
@@ -74,7 +75,7 @@ const getJsonAction = z.object({
 	action: z
 		.literal('get-json')
 		.describe(
-			'Get full WorkflowJSON for workspace-file workflow edits. Write it to a .workflow.json file, edit the file, then save with build-workflow. Pass versionId for a past version instead of the current draft.',
+			'Inspect full WorkflowJSON (read-only). Do not use this for edits — rewriting the JSON with workspace_write_file hangs on large workflows. Prefer get-as-code for edits. Pass versionId for a past version instead of the current draft.',
 		),
 	workflowId: z.string().describe('ID of the workflow'),
 	versionId: z.string().optional().describe('Version ID'),
@@ -84,7 +85,7 @@ const getAsCodeAction = z.object({
 	action: z
 		.literal('get-as-code')
 		.describe(
-			'Convert an existing workflow to TypeScript SDK code. Call before precise patches when you need the current code. Pass versionId for a past version instead of the current draft.',
+			'Preferred path for existing-workflow edits: convert the workflow to TypeScript SDK code, apply the smallest change, write or patch a .workflow.ts file (prefer workspace_str_replace_file), then call build-workflow. Pass versionId for a past version instead of the current draft.',
 		),
 	workflowId: z.string().describe('ID of the workflow'),
 	versionId: z.string().optional().describe('Version ID'),
@@ -293,8 +294,8 @@ const WORKFLOW_ACTION_ORDER = [
 const WORKFLOW_ACTION_LABELS = {
 	list: 'list',
 	get: 'inspect',
-	'get-json': 'inspect full WorkflowJSON',
-	'get-as-code': 'convert existing workflows to TypeScript SDK code',
+	'get-json': 'inspect full WorkflowJSON (read-only)',
+	'get-as-code': 'edit existing workflows via TypeScript SDK code',
 	delete: 'archive',
 	unarchive: 'restore archived workflows',
 	setup: 'set up credentials and parameters',
@@ -456,7 +457,14 @@ async function handleGetJson(
 	input: Extract<Input, { action: 'get-json' }>,
 ) {
 	try {
-		return await context.workflowService.getAsWorkflowJSON(input.workflowId, input.versionId);
+		const workflow = await context.workflowService.getAsWorkflowJSON(
+			input.workflowId,
+			input.versionId,
+		);
+		return {
+			...workflow,
+			editingGuidance: GET_JSON_EDITING_GUIDANCE,
+		};
 	} catch (error) {
 		return {
 			workflowId: input.workflowId,

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -304,7 +304,9 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 			'Build and save a workflow from workflow source. ' +
 				'Load `workflow-builder` via `load_skill` before calling this tool. ' +
 				'When the workflow creates or writes Data Tables, also load `data-table-manager` first. ' +
-				'Use TypeScript SDK source for new workflows, or WorkflowJSON .json source for existing workflow edits. ' +
+				'Prefer TypeScript SDK `.workflow.ts` source for new workflows and existing-workflow edits ' +
+				'(get-as-code → targeted file edits → build-workflow). Avoid full WorkflowJSON rewrites via ' +
+				'workspace_write_file — they hang on large workflows. ' +
 				'Prefer writing the file with `workspace_write_file` / `workspace_str_replace_file` so `workflow-sdk validate` can run on it, then call this tool with filePath. ' +
 				'For a one-shot create/rewrite you may pass `sourceCode` instead (the tool writes filePath and builds).',
 		)

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/guard-workflow-json-write.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/guard-workflow-json-write.test.ts
@@ -1,0 +1,65 @@
+import {
+	GET_JSON_EDITING_GUIDANCE,
+	MAX_WORKFLOW_JSON_WRITE_CHARS,
+	WORKFLOW_JSON_WRITE_GUIDANCE,
+	guardWorkspaceWriteFileTool,
+	isOversizedWorkflowJsonWrite,
+} from '../guard-workflow-json-write';
+
+describe('guard-workflow-json-write', () => {
+	it('flags oversized .workflow.json writes only', () => {
+		const oversized = 'x'.repeat(MAX_WORKFLOW_JSON_WRITE_CHARS + 1);
+		expect(isOversizedWorkflowJsonWrite('src/workflows/dash.workflow.json', oversized)).toBe(true);
+		expect(isOversizedWorkflowJsonWrite('src/workflows/dash.workflow.ts', oversized)).toBe(false);
+		expect(isOversizedWorkflowJsonWrite('src/workflows/dash.workflow.json', '{}\n')).toBe(false);
+	});
+
+	it('rejects oversized workspace_write_file calls with remediation', async () => {
+		const writeFile = vi.fn(async () => ({ success: true }));
+		const tool = guardWorkspaceWriteFileTool({
+			name: 'workspace_write_file',
+			description: 'Write content to a file in the workspace',
+			handler: writeFile,
+		});
+
+		await expect(
+			tool.handler?.(
+				{
+					path: 'src/workflows/dashboard.workflow.json',
+					content: 'x'.repeat(MAX_WORKFLOW_JSON_WRITE_CHARS + 1),
+				},
+				{},
+			),
+		).rejects.toThrow(WORKFLOW_JSON_WRITE_GUIDANCE);
+		expect(writeFile).not.toHaveBeenCalled();
+		expect(tool.systemInstruction).toContain('get-as-code');
+	});
+
+	it('allows small .workflow.json writes and non-json paths', async () => {
+		const writeFile = vi.fn(async () => ({ success: true }));
+		const tool = guardWorkspaceWriteFileTool({
+			name: 'workspace_write_file',
+			description: 'Write content to a file in the workspace',
+			handler: writeFile,
+		});
+
+		await expect(
+			tool.handler?.({ path: 'src/workflows/small.workflow.json', content: '{"name":"ok"}' }, {}),
+		).resolves.toEqual({ success: true });
+		await expect(
+			tool.handler?.(
+				{
+					path: 'src/workflows/large.workflow.ts',
+					content: 'x'.repeat(MAX_WORKFLOW_JSON_WRITE_CHARS + 1),
+				},
+				{},
+			),
+		).resolves.toEqual({ success: true });
+		expect(writeFile).toHaveBeenCalledTimes(2);
+	});
+
+	it('exposes editing guidance for get-json results', () => {
+		expect(GET_JSON_EDITING_GUIDANCE).toContain('get-as-code');
+		expect(GET_JSON_EDITING_GUIDANCE).toContain('workspace_write_file');
+	});
+});

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/lazy-runtime-workspace.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/lazy-runtime-workspace.test.ts
@@ -97,6 +97,9 @@ describe('createLazyRuntimeWorkspace', () => {
 		expect(tools.some((tool) => tool.name === 'workspace_list_files')).toBe(false);
 		expect(tools.some((tool) => tool.name === 'workspace_append_file')).toBe(false);
 
+		const writeFile = tools.find((tool) => tool.name === 'workspace_write_file');
+		expect(writeFile?.systemInstruction).toContain('get-as-code');
+
 		const readFile = tools.find((tool) => tool.name === 'workspace_read_file');
 		await readFile?.handler?.({ path: '/workspace/report.md' }, {});
 

--- a/packages/@n8n/instance-ai/src/workspace/guard-workflow-json-write.ts
+++ b/packages/@n8n/instance-ai/src/workspace/guard-workflow-json-write.ts
@@ -1,0 +1,67 @@
+/**
+ * Full `.workflow.json` rewrites via `workspace_write_file` force the model to
+ * stream the entire WorkflowJSON as a tool argument. On large workflows that
+ * hangs the assistant on "Writing file" and can leave Stop ineffective until
+ * the stream finishes (see GitHub #35862).
+ */
+export const MAX_WORKFLOW_JSON_WRITE_CHARS = 8_192;
+
+export const WORKFLOW_JSON_WRITE_GUIDANCE =
+	'Refusing to overwrite a large .workflow.json file via workspace_write_file. ' +
+	'For edits, call workflows(action="get-as-code", workflowId), apply the smallest ' +
+	'TypeScript change to a .workflow.ts file (prefer workspace_str_replace_file), then ' +
+	'build-workflow with that filePath. Targeted JSON patches must use workspace_str_replace_file ' +
+	'(or build-workflow sourceCode), never a full JSON rewrite.';
+
+export const GET_JSON_EDITING_GUIDANCE =
+	'For workflow edits, call workflows(action="get-as-code", workflowId), apply the smallest ' +
+	'TypeScript change, write or patch a .workflow.ts file (prefer workspace_str_replace_file), ' +
+	'then build-workflow. Do not rewrite the full WorkflowJSON with workspace_write_file — ' +
+	'large JSON rewrites hang the assistant.';
+
+const WORKFLOW_JSON_PATH = /\.workflow\.json$/i;
+
+export function isOversizedWorkflowJsonWrite(path: string, content: string): boolean {
+	return WORKFLOW_JSON_PATH.test(path) && content.length > MAX_WORKFLOW_JSON_WRITE_CHARS;
+}
+
+interface WritableWorkspaceTool {
+	name: string;
+	description?: string;
+	systemInstruction?: string;
+	handler?: (input: unknown, ctx: unknown) => Promise<unknown>;
+}
+
+/**
+ * Wraps `workspace_write_file` so oversized `.workflow.json` full rewrites fail
+ * fast with remediation instead of hanging the chat.
+ */
+export function guardWorkspaceWriteFileTool<T extends WritableWorkspaceTool>(tool: T): T {
+	if (tool.name !== 'workspace_write_file' || !tool.handler) return tool;
+
+	const inner = tool.handler;
+	const priorInstruction = tool.systemInstruction?.trim();
+	const systemInstruction = [
+		priorInstruction,
+		'Never rewrite an entire .workflow.json with workspace_write_file. Prefer get-as-code + .workflow.ts + workspace_str_replace_file, then build-workflow.',
+	]
+		.filter(Boolean)
+		.join('\n');
+
+	return {
+		...tool,
+		systemInstruction,
+		handler: async (input: unknown, ctx: unknown) => {
+			if (isRecord(input) && typeof input.path === 'string' && typeof input.content === 'string') {
+				if (isOversizedWorkflowJsonWrite(input.path, input.content)) {
+					throw new Error(WORKFLOW_JSON_WRITE_GUIDANCE);
+				}
+			}
+			return await inner(input, ctx);
+		},
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}

--- a/packages/@n8n/instance-ai/src/workspace/lazy-runtime-workspace.ts
+++ b/packages/@n8n/instance-ai/src/workspace/lazy-runtime-workspace.ts
@@ -21,6 +21,8 @@ import {
 	type WriteOptions,
 } from '@n8n/agents';
 
+import { guardWorkspaceWriteFileTool } from './guard-workflow-json-write';
+
 export type RuntimeWorkspaceResolver = () => Promise<Workspace | undefined>;
 
 /** Workspace tools exposed to Instance AI agents — read/write/replace/execute only. */
@@ -69,7 +71,9 @@ export function createLazyRuntimeWorkspace({
 
 	const baseGetTools = workspace.getTools.bind(workspace);
 	workspace.getTools = () =>
-		baseGetTools().filter((tool) => INSTANCE_AI_WORKSPACE_TOOL_ALLOWLIST.has(tool.name));
+		baseGetTools()
+			.filter((tool) => INSTANCE_AI_WORKSPACE_TOOL_ALLOWLIST.has(tool.name))
+			.map(guardWorkspaceWriteFileTool);
 
 	return workspace;
 }


### PR DESCRIPTION
## Summary

Stops the AI assistant from getting stuck on "Writing file" / "Generating workflow" when editing an existing workflow.

**Cause:** `workflows(action="get-json")` instructed the model to rewrite full WorkflowJSON into a `.workflow.json` file via `workspace_write_file`, then call `build-workflow`. On large workflows that forces the model to stream the entire JSON as a tool argument, which looks like an infinite loop and leaves the chat hard to stop.

**Fix:**

* Treat `get-json` as read-only inspection; prefer `get-as-code` + TypeScript + targeted file edits for changes
* Return `editingGuidance` from `get-json` steering away from full JSON rewrites
* Update `build-workflow` description to prefer `.workflow.ts` over full JSON rewrites
* Guard `workspace_write_file` so oversized `.workflow.json` overwrites fail fast with remediation

## How to test

1. Open Instance AI on a large existing workflow (many nodes / parameters).
2. Ask for several edits (e.g. "make 4 small changes to this workflow").
3. Confirm the agent uses `get-as-code` (or targeted `workspace_str_replace_file`), not a full `workspace_write_file` of `.workflow.json`.
4. Confirm it does not hang on "Writing file" / "Generating workflow".
5. If a large `.workflow.json` rewrite is still attempted, confirm the write fails fast with guidance to use `get-as-code`.

Unit tests:

```
cd packages/@n8n/instance-ai
pnpm test -- src/workspace/__tests__/guard-workflow-json-write.test.ts src/workspace/__tests__/lazy-runtime-workspace.test.ts src/tools/__tests__/workflows.tool.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

* fixes [https://github.com/n8n-io/n8n/issues/35862](<https://github.com/n8n-io/n8n/issues/35862>)
* [INS-1118](https://linear.app/n8n/issue/INS-1118)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)