### PR TITLE
feat(HITLStackAgent Node): Add async register-and-resume node

### DIFF
--- a/packages/nodes-base/nodes/HitlStackAgent/HitlStackAgent.node.json
+++ b/packages/nodes-base/nodes/HitlStackAgent/HitlStackAgent.node.json
@@ -1,0 +1,15 @@
+{
+	"node": "n8n-nodes-base.hitlStackAgent",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": ["Development"],
+	"alias": ["HITL", "Human in the Loop", "HTTP", "Webhook", "Agent"],
+	"resources": {
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.hitlstackagent/"
+			}
+		],
+		"generic": []
+	}
+}

--- a/packages/nodes-base/nodes/HitlStackAgent/HitlStackAgent.node.ts
+++ b/packages/nodes-base/nodes/HitlStackAgent/HitlStackAgent.node.ts
@@ -209,10 +209,18 @@ export class HitlStackAgent implements INodeType {
 			allowUnauthorizedCerts?: boolean;
 		};
 
+		const workflow = this.getWorkflow();
+		const node = this.getNode();
+
 		const body: IDataObject = {
 			executionId: this.getExecutionId(),
-			workflowId: this.getWorkflow().id ?? 'unknown',
-			nodeName: this.getNode().name,
+			workflowId: workflow.id ?? 'unknown',
+			// A reviewer managing several workflows needs a name, not just an id
+			workflowName: workflow.name ?? '',
+			nodeName: node.name,
+			// Distinguishes two HITL nodes in the same workflow
+			nodeId: node.id,
+			registeredAt: new Date().toISOString(),
 			resumeUrl: this.getSignedResumeUrl(),
 			data: items[0].json,
 		};

--- a/packages/nodes-base/nodes/HitlStackAgent/HitlStackAgent.node.ts
+++ b/packages/nodes-base/nodes/HitlStackAgent/HitlStackAgent.node.ts
@@ -124,6 +124,26 @@ export class HitlStackAgent implements INodeType {
 				],
 			},
 			{
+				displayName: 'Include Upstream Context',
+				name: 'includeContext',
+				type: 'boolean',
+				default: true,
+				description:
+					'Whether to also send what the preceding nodes produced. A reviewer needs the question, not just the answer — and a revise round needs the original input to compose from.',
+			},
+			{
+				displayName: 'Context Depth',
+				name: 'contextDepth',
+				type: 'number',
+				typeOptions: { minValue: 1 },
+				default: 2,
+				displayOptions: {
+					show: { includeContext: [true] },
+				},
+				description:
+					'How many nodes back to walk. 2 covers an AI Agent and whatever fed it. Raising this grows the payload and sends more of the workflow to the endpoint.',
+			},
+			{
 				displayName: 'Limit Wait Time',
 				name: 'limitWaitTime',
 				type: 'boolean',
@@ -189,19 +209,25 @@ export class HitlStackAgent implements INodeType {
 			allowUnauthorizedCerts?: boolean;
 		};
 
+		const body: IDataObject = {
+			executionId: this.getExecutionId(),
+			workflowId: this.getWorkflow().id ?? 'unknown',
+			nodeName: this.getNode().name,
+			resumeUrl: this.getSignedResumeUrl(),
+			data: items[0].json,
+		};
+
+		if (this.getNodeParameter('includeContext', 0, true) as boolean) {
+			body.trail = buildTrail(this, this.getNodeParameter('contextDepth', 0, 2) as number);
+		}
+
 		const requestOptions: IHttpRequestOptions = {
 			url,
 			method: 'POST',
 			json: true,
 			timeout: options.timeout ?? 10000,
 			skipSslCertificateValidation: options.allowUnauthorizedCerts ?? false,
-			body: {
-				executionId: this.getExecutionId(),
-				workflowId: this.getWorkflow().id ?? 'unknown',
-				nodeName: this.getNode().name,
-				resumeUrl: this.getSignedResumeUrl(),
-				data: items[0].json,
-			} as IDataObject,
+			body,
 		};
 
 		if (this.getNodeParameter('sendHeaders', 0, false) as boolean) {
@@ -251,4 +277,30 @@ export class HitlStackAgent implements INodeType {
 			workflowData: [[{ json: body }]],
 		};
 	}
+}
+
+/**
+ * Walks back from the HITL node and records what each ancestor produced, nearest
+ * first. The reviewer needs the question alongside the answer, and a revise round
+ * needs the agent's original input to compose the next prompt from.
+ */
+function buildTrail(ctx: IExecuteFunctions, depth: number): IDataObject[] {
+	const proxy = ctx.getWorkflowDataProxy(0);
+	const parents = ctx.getParentNodes(ctx.getNode().name, {
+		connectionType: NodeConnectionTypes.Main,
+		depth,
+	});
+
+	return parents.map(({ name, type, disabled }) => {
+		const entry: IDataObject = { node: name, type, executed: !disabled };
+		try {
+			// A node that never ran on this branch throws rather than returning []
+			const items = proxy.$items(name);
+			entry.output = items[0]?.json ?? null;
+		} catch {
+			entry.executed = false;
+			entry.output = null;
+		}
+		return entry;
+	});
 }

--- a/packages/nodes-base/nodes/HitlStackAgent/HitlStackAgent.node.ts
+++ b/packages/nodes-base/nodes/HitlStackAgent/HitlStackAgent.node.ts
@@ -1,0 +1,254 @@
+import {
+	NodeApiError,
+	NodeConnectionTypes,
+	NodeOperationError,
+	SEND_AND_WAIT_OPERATION,
+	WAIT_INDEFINITELY,
+	isSafeObjectProperty,
+	setSafeObjectProperty,
+	type IDataObject,
+	type IExecuteFunctions,
+	type IHttpRequestOptions,
+	type INodeExecutionData,
+	type INodeType,
+	type INodeTypeDescription,
+	type IWebhookFunctions,
+	type IWebhookResponseData,
+	type JsonObject,
+} from 'n8n-workflow';
+
+type HeaderParameter = { name: string; value: string };
+
+/**
+ * Registers work with an external service, then parks the execution until that
+ * service calls back. The wait is persisted by n8n, so it survives restarts and
+ * can span days — which a held-open HTTP request cannot.
+ */
+export class HitlStackAgent implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'HITLStackAgent',
+		name: 'hitlStackAgent',
+		icon: 'fa:user-check',
+		iconColor: 'blue',
+		group: ['transform'],
+		version: 1,
+		subtitle: '={{"register: " + $parameter["url"]}}',
+		description: 'Register an item with an external service and wait for its callback',
+		defaults: {
+			name: 'HITLStackAgent',
+		},
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
+		// `restartWebhook` marks these as execution-resumers rather than triggers.
+		webhooks: [
+			{
+				name: 'default',
+				httpMethod: 'GET',
+				responseMode: 'onReceived',
+				responseData: '',
+				path: '={{ $nodeId }}',
+				restartWebhook: true,
+				isFullPath: true,
+			},
+			{
+				name: 'default',
+				httpMethod: 'POST',
+				responseMode: 'onReceived',
+				responseData: '',
+				path: '={{ $nodeId }}',
+				restartWebhook: true,
+				isFullPath: true,
+			},
+		],
+		properties: [
+			{
+				displayName:
+					'This node registers the item with your service, then waits for that service to call the resume URL back. The execution is paused and persisted meanwhile.',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+			},
+			// n8n's waiting-webhook handler only HMAC-validates a resume URL when the
+			// node declares this operation; otherwise it expects a plain resumeToken
+			// and rejects a signed URL with 401.
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'hidden',
+				default: SEND_AND_WAIT_OPERATION,
+			},
+			{
+				displayName: 'URL',
+				name: 'url',
+				type: 'string',
+				default: 'http://localhost:3100/hitl',
+				required: true,
+				placeholder: 'http://localhost:3100/hitl',
+				description: 'Registration endpoint. Must acknowledge quickly, then call back when done.',
+			},
+			{
+				displayName: 'Send Headers',
+				name: 'sendHeaders',
+				type: 'boolean',
+				default: false,
+			},
+			{
+				displayName: 'Headers',
+				name: 'headerParameters',
+				type: 'fixedCollection',
+				typeOptions: { multipleValues: true },
+				default: {},
+				placeholder: 'Add Header',
+				displayOptions: {
+					show: { sendHeaders: [true] },
+				},
+				options: [
+					{
+						name: 'parameters',
+						displayName: 'Parameters',
+						values: [
+							{
+								displayName: 'Name',
+								name: 'name',
+								type: 'string',
+								default: '',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+							},
+						],
+					},
+				],
+			},
+			{
+				displayName: 'Limit Wait Time',
+				name: 'limitWaitTime',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to give up after a set time. By default the execution waits indefinitely.',
+			},
+			{
+				displayName: 'Max Wait (Minutes)',
+				name: 'maxWaitMinutes',
+				type: 'number',
+				typeOptions: { minValue: 1 },
+				default: 60,
+				displayOptions: {
+					show: { limitWaitTime: [true] },
+				},
+				description: 'Resume anyway once this many minutes have passed without a callback',
+			},
+			{
+				displayName: 'Options',
+				name: 'options',
+				type: 'collection',
+				placeholder: 'Add option',
+				default: {},
+				options: [
+					{
+						displayName: 'Registration Timeout',
+						name: 'timeout',
+						type: 'number',
+						typeOptions: { minValue: 1 },
+						default: 10000,
+						description:
+							'Time in ms to wait for the registration acknowledgement. Unrelated to how long the service may then take.',
+					},
+					{
+						displayName: 'Ignore SSL Issues',
+						name: 'allowUnauthorizedCerts',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to connect even if SSL certificate validation is not possible',
+					},
+				],
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+
+		// putExecutionToWait pauses the whole execution, so a per-item loop is not
+		// expressible. Callers batch with a Loop Over Items node upstream.
+		if (items.length !== 1) {
+			throw new NodeOperationError(
+				this.getNode(),
+				`This node handles exactly one item at a time, but received ${items.length}`,
+				{ description: 'Add a "Loop Over Items" node upstream to split the batch.' },
+			);
+		}
+
+		const url = this.getNodeParameter('url', 0) as string;
+		const options = this.getNodeParameter('options', 0, {}) as {
+			timeout?: number;
+			allowUnauthorizedCerts?: boolean;
+		};
+
+		const requestOptions: IHttpRequestOptions = {
+			url,
+			method: 'POST',
+			json: true,
+			timeout: options.timeout ?? 10000,
+			skipSslCertificateValidation: options.allowUnauthorizedCerts ?? false,
+			body: {
+				executionId: this.getExecutionId(),
+				workflowId: this.getWorkflow().id ?? 'unknown',
+				nodeName: this.getNode().name,
+				resumeUrl: this.getSignedResumeUrl(),
+				data: items[0].json,
+			} as IDataObject,
+		};
+
+		if (this.getNodeParameter('sendHeaders', 0, false) as boolean) {
+			const { parameters = [] } = this.getNodeParameter('headerParameters', 0, {}) as {
+				parameters?: HeaderParameter[];
+			};
+
+			// Header names come from the workflow author, so they are untrusted keys
+			const headers: IDataObject = {};
+			for (const { name, value } of parameters) {
+				if (name && isSafeObjectProperty(name)) {
+					setSafeObjectProperty(headers, name, value);
+				}
+			}
+			requestOptions.headers = headers;
+		}
+
+		// Register first. Parking the execution after a failed registration would
+		// strand it forever, since nothing would exist to call the resume URL.
+		try {
+			await this.helpers.httpRequest(requestOptions);
+		} catch (error) {
+			throw new NodeApiError(this.getNode(), error as JsonObject, {
+				itemIndex: 0,
+				message: 'Could not register with the service',
+				description: 'The execution was not paused, so no callback is expected.',
+			});
+		}
+
+		let waitTill = WAIT_INDEFINITELY;
+		if (this.getNodeParameter('limitWaitTime', 0, false) as boolean) {
+			const maxWaitMinutes = this.getNodeParameter('maxWaitMinutes', 0, 60) as number;
+			waitTill = new Date(Date.now() + maxWaitMinutes * 60 * 1000);
+		}
+
+		await this.putExecutionToWait(waitTill);
+
+		// Returned only if the wait times out; a callback replaces this via webhook()
+		return [items];
+	}
+
+	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const body = this.getBodyData();
+
+		return {
+			webhookResponse: { received: true },
+			workflowData: [[{ json: body }]],
+		};
+	}
+}

--- a/packages/nodes-base/nodes/HitlStackAgent/test/HitlStackAgent.node.test.ts
+++ b/packages/nodes-base/nodes/HitlStackAgent/test/HitlStackAgent.node.test.ts
@@ -59,7 +59,10 @@ describe('HITLStackAgent Node — registration', () => {
 				body: {
 					executionId: '1042',
 					workflowId: 'wf-1',
+					workflowName: 'wf',
 					nodeName: 'HITLStackAgent',
+					nodeId: 'hitl-node',
+					registeredAt: expect.any(String),
 					resumeUrl: RESUME_URL,
 					data: { customer: 'acme' },
 				},

--- a/packages/nodes-base/nodes/HitlStackAgent/test/HitlStackAgent.node.test.ts
+++ b/packages/nodes-base/nodes/HitlStackAgent/test/HitlStackAgent.node.test.ts
@@ -40,6 +40,7 @@ const baseParams = {
 	url: 'http://localhost:3100/hitl',
 	sendHeaders: false,
 	limitWaitTime: false,
+	includeContext: false,
 	options: {},
 };
 
@@ -67,6 +68,59 @@ describe('HITLStackAgent Node — registration', () => {
 		expect(ctx.putExecutionToWait).toHaveBeenCalledWith(WAIT_INDEFINITELY);
 		// Only surfaces if the wait times out; a callback replaces it via webhook()
 		expect(result[0]).toEqual([{ json: { customer: 'acme' } }]);
+	});
+
+	it('captures what upstream nodes produced when context is enabled', async () => {
+		const ctx = setupExecuteFunctions({ ...baseParams, includeContext: true, contextDepth: 2 });
+		ctx.getParentNodes.mockReturnValue([
+			{ name: 'AI Agent', type: 'n8n-nodes-base.agent', typeVersion: 1, disabled: false },
+			{ name: 'Chat Trigger', type: 'n8n-nodes-base.chatTrigger', typeVersion: 1, disabled: false },
+		]);
+		ctx.getWorkflowDataProxy.mockReturnValue({
+			$items: (name: string) =>
+				name === 'AI Agent'
+					? [{ json: { output: 'draft A' } }]
+					: [{ json: { chatInput: 'summarise this' } }],
+		} as never);
+		ctx.helpers.httpRequest.mockResolvedValue({});
+
+		await new HitlStackAgent().execute.call(ctx);
+
+		const body = ctx.helpers.httpRequest.mock.calls[0][0].body as IDataObject;
+		expect(body.trail).toEqual([
+			{
+				node: 'AI Agent',
+				type: 'n8n-nodes-base.agent',
+				executed: true,
+				output: { output: 'draft A' },
+			},
+			{
+				node: 'Chat Trigger',
+				type: 'n8n-nodes-base.chatTrigger',
+				executed: true,
+				output: { chatInput: 'summarise this' },
+			},
+		]);
+	});
+
+	it('marks an upstream node that never ran, without failing the registration', async () => {
+		const ctx = setupExecuteFunctions({ ...baseParams, includeContext: true, contextDepth: 2 });
+		ctx.getParentNodes.mockReturnValue([
+			{ name: 'Skipped Branch', type: 'n8n-nodes-base.set', typeVersion: 1, disabled: false },
+		]);
+		ctx.getWorkflowDataProxy.mockReturnValue({
+			$items: () => {
+				throw new Error("Node 'Skipped Branch' hasn't been executed");
+			},
+		} as never);
+		ctx.helpers.httpRequest.mockResolvedValue({});
+
+		await new HitlStackAgent().execute.call(ctx);
+
+		const body = ctx.helpers.httpRequest.mock.calls[0][0].body as IDataObject;
+		expect(body.trail).toEqual([
+			{ node: 'Skipped Branch', type: 'n8n-nodes-base.set', executed: false, output: null },
+		]);
 	});
 
 	it('rejects more than one input item before making any call', async () => {

--- a/packages/nodes-base/nodes/HitlStackAgent/test/HitlStackAgent.node.test.ts
+++ b/packages/nodes-base/nodes/HitlStackAgent/test/HitlStackAgent.node.test.ts
@@ -1,0 +1,143 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	IWebhookFunctions,
+} from 'n8n-workflow';
+import { NodeApiError, NodeOperationError, WAIT_INDEFINITELY } from 'n8n-workflow';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { HitlStackAgent } from '../HitlStackAgent.node';
+
+const RESUME_URL = 'http://localhost:5678/webhook-waiting/1042?token=abc';
+
+const setupExecuteFunctions = (
+	params: Record<string, unknown>,
+	items: INodeExecutionData[] = [{ json: { customer: 'acme' } }],
+) => {
+	const ctx = mockDeep<IExecuteFunctions>();
+
+	ctx.getInputData.mockReturnValue(items);
+	ctx.getExecutionId.mockReturnValue('1042');
+	ctx.getWorkflow.mockReturnValue({ id: 'wf-1', name: 'wf', active: false });
+	ctx.getSignedResumeUrl.mockReturnValue(RESUME_URL);
+	ctx.getNode.mockReturnValue({
+		id: 'hitl-node',
+		name: 'HITLStackAgent',
+		type: 'n8n-nodes-base.hitlStackAgent',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	});
+	ctx.getNodeParameter.mockImplementation(
+		(name: string, _itemIndex?: number, fallback?: unknown) => (params[name] ?? fallback) as never,
+	);
+
+	return ctx;
+};
+
+const baseParams = {
+	url: 'http://localhost:3100/hitl',
+	sendHeaders: false,
+	limitWaitTime: false,
+	options: {},
+};
+
+describe('HITLStackAgent Node — registration', () => {
+	it('registers the item with a signed resume URL, then parks the execution', async () => {
+		const ctx = setupExecuteFunctions(baseParams);
+		ctx.helpers.httpRequest.mockResolvedValue({ requestId: 'r1', status: 'registered' });
+
+		const result = await new HitlStackAgent().execute.call(ctx);
+
+		expect(ctx.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'http://localhost:3100/hitl',
+				method: 'POST',
+				json: true,
+				body: {
+					executionId: '1042',
+					workflowId: 'wf-1',
+					nodeName: 'HITLStackAgent',
+					resumeUrl: RESUME_URL,
+					data: { customer: 'acme' },
+				},
+			}),
+		);
+		expect(ctx.putExecutionToWait).toHaveBeenCalledWith(WAIT_INDEFINITELY);
+		// Only surfaces if the wait times out; a callback replaces it via webhook()
+		expect(result[0]).toEqual([{ json: { customer: 'acme' } }]);
+	});
+
+	it('rejects more than one input item before making any call', async () => {
+		const ctx = setupExecuteFunctions(baseParams, [{ json: { a: 1 } }, { json: { b: 2 } }]);
+
+		await expect(new HitlStackAgent().execute.call(ctx)).rejects.toThrow(NodeOperationError);
+		expect(ctx.helpers.httpRequest).not.toHaveBeenCalled();
+		expect(ctx.putExecutionToWait).not.toHaveBeenCalled();
+	});
+
+	it('does NOT park the execution when registration fails', async () => {
+		const ctx = setupExecuteFunctions(baseParams);
+		ctx.helpers.httpRequest.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+		await expect(new HitlStackAgent().execute.call(ctx)).rejects.toThrow(NodeApiError);
+		// Parking here would strand the execution forever with nothing able to resume it
+		expect(ctx.putExecutionToWait).not.toHaveBeenCalled();
+	});
+
+	it('honours a bounded wait time', async () => {
+		const ctx = setupExecuteFunctions({
+			...baseParams,
+			limitWaitTime: true,
+			maxWaitMinutes: 30,
+		});
+		ctx.helpers.httpRequest.mockResolvedValue({});
+
+		const before = Date.now();
+		await new HitlStackAgent().execute.call(ctx);
+
+		const waitTill = ctx.putExecutionToWait.mock.calls[0][0];
+		expect(waitTill).not.toEqual(WAIT_INDEFINITELY);
+		const deltaMinutes = (waitTill.getTime() - before) / 60000;
+		expect(deltaMinutes).toBeGreaterThan(29);
+		expect(deltaMinutes).toBeLessThanOrEqual(30);
+	});
+
+	it('skips header names that would pollute the prototype', async () => {
+		const ctx = setupExecuteFunctions({
+			...baseParams,
+			sendHeaders: true,
+			headerParameters: {
+				parameters: [
+					{ name: 'X-Token', value: 'abc' },
+					// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased -- header fixture, not a node display name
+					{ name: '__proto__', value: 'polluted' },
+				],
+			},
+		});
+		ctx.helpers.httpRequest.mockResolvedValue({});
+
+		await new HitlStackAgent().execute.call(ctx);
+
+		const { headers } = ctx.helpers.httpRequest.mock.calls[0][0];
+		expect(headers).toEqual({ 'X-Token': 'abc' });
+		expect({}.constructor.prototype.polluted).toBeUndefined();
+	});
+});
+
+describe('HITLStackAgent Node — resume', () => {
+	it('turns the callback body into the node output', async () => {
+		const ctx = mockDeep<IWebhookFunctions>();
+		const callback: IDataObject = {
+			requestId: 'r1',
+			status: 'processed',
+			data: { customer: 'ACME' },
+		};
+		ctx.getBodyData.mockReturnValue(callback);
+
+		const result = await new HitlStackAgent().webhook.call(ctx);
+
+		expect(result.workflowData).toEqual([[{ json: callback }]]);
+	});
+});

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -620,6 +620,7 @@
       "dist/nodes/HelpScout/HelpScout.node.js",
       "dist/nodes/HelpScout/HelpScoutTrigger.node.js",
       "dist/nodes/HighLevel/HighLevel.node.js",
+      "dist/nodes/HitlStackAgent/HitlStackAgent.node.js",
       "dist/nodes/HomeAssistant/HomeAssistant.node.js",
       "dist/nodes/HtmlExtract/HtmlExtract.node.js",
       "dist/nodes/Html/Html.node.js",


### PR DESCRIPTION
Registers a work item with an external HTTP service, then parks the execution until that service calls back. The wait is persisted by n8n, so it survives restarts and can span days — which a held-open HTTP request cannot.

- execute() registers, confirms a 2xx ack, then putExecutionToWait. Parking before a successful ack would strand the execution with nothing able to resume it, so the order is load-bearing.
- webhook() turns the callback body into the node's output.
- Declares operation: sendAndWait. WaitingWebhooks only HMAC-validates a resume URL for nodes carrying that operation; without it n8n falls back to plain resumeToken comparison and rejects every callback.
- Handles exactly one input item, since putExecutionToWait pauses the whole execution. Batch upstream with Loop Over Items.

## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

