### PR TITLE
refactor(core): Decouple agents builder from instance-ai credit service

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents-builder.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-builder.service.test.ts
@@ -5,10 +5,10 @@ import { mock } from 'vitest-mock-extended';
 
 import type { NodeCatalogService } from '@/node-catalog';
 
-import type { InstanceAiCreditService } from '../../instance-ai/instance-ai-credit.service';
 import type { AgentsService } from '../agents.service';
 import type { AgentsBuilderToolsService } from '../builder/agents-builder-tools.service';
 import { AgentsBuilderService } from '../builder/agents-builder.service';
+import type { BuilderCreditProviderRegistry } from '../builder/builder-credit-provider';
 import type { AgentCheckpoint } from '../entities/agent-checkpoint.entity';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
 import type { N8nMemory } from '../integrations/n8n-memory';
@@ -39,7 +39,7 @@ function makeService(agentCheckpointRepository: Mocked<AgentCheckpointRepository
 		mock<NodeCatalogService>(),
 		mock<AgentsBuilderToolsService>(),
 		mock<N8nMemory>(),
-		mock<InstanceAiCreditService>(),
+		mock<BuilderCreditProviderRegistry>(),
 		mock<N8NCheckpointStorage>(),
 		agentCheckpointRepository,
 	);

--- a/packages/cli/src/modules/agents/builder/__tests__/agents-builder.service.session.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/agents-builder.service.session.test.ts
@@ -5,7 +5,6 @@ import { mock } from 'vitest-mock-extended';
 
 import type { NodeCatalogService } from '@/node-catalog';
 
-import type { InstanceAiCreditService } from '../../../instance-ai/instance-ai-credit.service';
 import type { AgentsService } from '../../agents.service';
 import type { Agent as AgentEntity } from '../../entities/agent.entity';
 import type { N8NCheckpointStorage } from '../../integrations/n8n-checkpoint-storage';
@@ -13,6 +12,7 @@ import type { N8nMemory, N8nMemoryImpl } from '../../integrations/n8n-memory';
 import type { AgentCheckpointRepository } from '../../repositories/agent-checkpoint.repository';
 import type { AgentsBuilderToolsService } from '../agents-builder-tools.service';
 import { AgentsBuilderService } from '../agents-builder.service';
+import type { BuilderCreditProviderRegistry } from '../builder-credit-provider';
 
 // The `Agent`/`Memory` SDK classes and observational-memory factories are
 // imported inside `agents-builder.service.ts` from `@n8n/agents`. Stubbing
@@ -176,7 +176,7 @@ function setup(
 	const nodeCatalogService = mock<NodeCatalogService>();
 	const agentsBuilderToolsService = mock<AgentsBuilderToolsService>();
 	const n8nMemory = mock<N8nMemory>();
-	const instanceAiCreditService = mock<InstanceAiCreditService>();
+	const builderCreditProvider = mock<BuilderCreditProviderRegistry>();
 	const n8nCheckpointStorage = mock<N8NCheckpointStorage>();
 	const agentCheckpointRepository = mock<AgentCheckpointRepository>();
 
@@ -202,7 +202,7 @@ function setup(
 		nodeCatalogService,
 		agentsBuilderToolsService,
 		n8nMemory,
-		instanceAiCreditService,
+		builderCreditProvider,
 		n8nCheckpointStorage,
 		agentCheckpointRepository,
 	);
@@ -217,7 +217,7 @@ function setup(
 		user,
 		credentialProvider,
 		agentsBuilderToolsService,
-		instanceAiCreditService,
+		builderCreditProvider,
 		n8nCheckpointStorage,
 	};
 }
@@ -422,7 +422,7 @@ describe('AgentsBuilderService session isolation', () => {
 	});
 
 	it('constructs observer/reflector callbacks on the builder model and claims usage under the host thread/run/target-agent dedupe key', async () => {
-		const { service, user, credentialProvider, instanceAiCreditService } = setup();
+		const { service, user, credentialProvider, builderCreditProvider } = setup();
 
 		await drain(
 			service.buildAgent('agent-1', 'project-1', 'hi', credentialProvider, user, baseSession),
@@ -440,7 +440,7 @@ describe('AgentsBuilderService session isolation', () => {
 			reportId: 'report-1',
 		});
 
-		expect(instanceAiCreditService.claimRunUsage).toHaveBeenCalledWith(
+		expect(builderCreditProvider.claimRunUsage).toHaveBeenCalledWith(
 			user,
 			'instance-thread-1',
 			'run-1:agent-builder:agent-1:memory:observer:report-1',

--- a/packages/cli/src/modules/agents/builder/__tests__/builder-credit-provider.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/builder-credit-provider.test.ts
@@ -1,0 +1,47 @@
+import type { User } from '@n8n/db';
+import type { BuilderUsageItem } from '@n8n/instance-ai';
+import { mock } from 'vitest-mock-extended';
+
+import type { BuilderCreditProvider } from '../builder-credit-provider';
+import { BuilderCreditProviderRegistry } from '../builder-credit-provider';
+
+describe('BuilderCreditProviderRegistry', () => {
+	const user = mock<User>({ id: 'user-1' });
+	const usage: BuilderUsageItem[] = [
+		{
+			type: 'llmTokens',
+			model: 'model-1',
+			uncachedInput: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			output: 2,
+		},
+	];
+
+	it('is a no-op when no provider is registered', async () => {
+		const registry = new BuilderCreditProviderRegistry();
+
+		await expect(
+			registry.claimRunUsage(user, 'thread-1', 'dedupe-1', usage, 'completed'),
+		).resolves.toBeUndefined();
+	});
+
+	it('forwards claims to the registered provider', async () => {
+		const registry = new BuilderCreditProviderRegistry();
+		const provider = mock<BuilderCreditProvider>();
+		provider.claimRunUsage.mockResolvedValue(3);
+
+		registry.register(provider);
+
+		await expect(
+			registry.claimRunUsage(user, 'thread-1', 'dedupe-1', usage, 'completed'),
+		).resolves.toBe(3);
+		expect(provider.claimRunUsage).toHaveBeenCalledWith(
+			user,
+			'thread-1',
+			'dedupe-1',
+			usage,
+			'completed',
+		);
+	});
+});

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -20,12 +20,12 @@ import { jsonParse } from 'n8n-workflow';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { NodeCatalogService } from '@/node-catalog';
 
-import { InstanceAiCreditService } from '../../instance-ai/instance-ai-credit.service';
 import { AgentsService } from '../agents.service';
 import { buildAgentPreviewPath } from './agent-builder-preview-path';
 import { getModelRecommendationsSection } from './agents-builder-model-recommendations';
 import { buildBuilderPrompt } from './agents-builder-prompts';
 import { AgentsBuilderToolsService } from './agents-builder-tools.service';
+import { BuilderCreditProviderRegistry } from './builder-credit-provider';
 import { BuilderCheckpointUnavailableError } from './errors';
 import {
 	BUILDER_PLANNER_TODOS_DESCRIPTION,
@@ -80,7 +80,7 @@ export class AgentsBuilderService {
 		private readonly nodeCatalogService: NodeCatalogService,
 		private readonly agentsBuilderToolsService: AgentsBuilderToolsService,
 		private readonly n8nMemory: N8nMemory,
-		private readonly instanceAiCreditService: InstanceAiCreditService,
+		private readonly builderCreditProvider: BuilderCreditProviderRegistry,
 		private readonly n8nCheckpointStorage: N8NCheckpointStorage,
 		private readonly agentCheckpointRepository: AgentCheckpointRepository,
 	) {}
@@ -243,7 +243,7 @@ export class AgentsBuilderService {
 			try {
 				const items = tokenUsageToBuilderUsageItems(report.model, report.usage);
 				if (items.length === 0) return;
-				await this.instanceAiCreditService.claimRunUsage(
+				await this.builderCreditProvider.claimRunUsage(
 					user,
 					session.hostThreadId,
 					`${session.runId}:agent-builder:${agentId}:memory:${report.task}:${report.reportId}`,

--- a/packages/cli/src/modules/agents/builder/builder-credit-provider.ts
+++ b/packages/cli/src/modules/agents/builder/builder-credit-provider.ts
@@ -1,0 +1,40 @@
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { BuilderUsageItem, TraceStatus } from '@n8n/instance-ai';
+
+/** The slice of credit accounting the agent builder needs from its host. */
+export interface BuilderCreditProvider {
+	claimRunUsage(
+		user: User,
+		threadId: string,
+		dedupeId: string,
+		usage: BuilderUsageItem[],
+		status: TraceStatus,
+	): Promise<number | undefined>;
+}
+
+/**
+ * Seam through which the instance-ai module supplies credit accounting to the
+ * agent builder without the agents module importing instance-ai. Instance-ai
+ * registers its credit service during module `init()`. With no provider
+ * registered (instance-ai module disabled) claims are no-ops, which is safe:
+ * builder runs are only started through instance-ai's build-agent tool.
+ */
+@Service()
+export class BuilderCreditProviderRegistry implements BuilderCreditProvider {
+	private provider: BuilderCreditProvider | undefined;
+
+	register(provider: BuilderCreditProvider) {
+		this.provider = provider;
+	}
+
+	async claimRunUsage(
+		user: User,
+		threadId: string,
+		dedupeId: string,
+		usage: BuilderUsageItem[],
+		status: TraceStatus,
+	): Promise<number | undefined> {
+		return await this.provider?.claimRunUsage(user, threadId, dedupeId, usage, status);
+	}
+}

--- a/packages/cli/src/modules/instance-ai/instance-ai.module.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.module.ts
@@ -36,6 +36,14 @@ export class InstanceAiModule implements ModuleInterface {
 		await import('./instance-ai.controller.js');
 		await import('./mcp/instance-ai-mcp-connection.controller.js');
 
+		// Supply credit accounting to the agent builder through the agents-module
+		// seam, so the agents module never imports instance-ai.
+		const { BuilderCreditProviderRegistry } = await import(
+			'../agents/builder/builder-credit-provider.js'
+		);
+		const { InstanceAiCreditService } = await import('./instance-ai-credit.service.js');
+		Container.get(BuilderCreditProviderRegistry).register(Container.get(InstanceAiCreditService));
+
 		// Instantiating the relay registers its `user-deleted` listener, which
 		// cleans up Instance AI data owned by the deleted user.
 		const { InstanceAiEventRelay } = await import('./instance-ai-event-relay.service.js');


### PR DESCRIPTION
## Summary

Removes the runtime `agents` → `instance-ai` service edge: `AgentsBuilderService` no longer imports `InstanceAiCreditService` from the instance-ai module.

- Adds a minimal credit-provider seam owned by the agents module (`BuilderCreditProviderRegistry` in `packages/cli/src/modules/agents/builder/builder-credit-provider.ts`) with just the one method the builder uses (`claimRunUsage`).
- `AgentsBuilderService` now injects the registry instead of the credit service.
- The instance-ai module registers `InstanceAiCreditService` on the registry during its `init()` (instance-ai → agents is the accepted dependency direction and already exists).

**Behavior:** identical when the instance-ai module is enabled — the same `InstanceAiCreditService.claimRunUsage` call runs with the same arguments. When the instance-ai module is disabled, the registry is a no-op (no credit claim); this is unreachable in practice because `buildAgent`/`resumeBuild` are only invoked through instance-ai's build-agent tool delegate, and it is strictly safer than today's behavior, where DI would still construct the disabled module's credit service and let it call out to the AI proxy.

Note: one non-service edge remains (`agents/utils/node-tool-validation.ts` imports `node-definition-resolver` from instance-ai); it is out of scope here and tracked by the umbrella ticket.

## How to test

1. Run the agents builder unit tests: `cd packages/cli && pnpm test src/modules/agents/builder src/modules/agents/__tests__/agents-builder.service.test.ts`.
2. With instance-ai enabled (`N8N_ENABLED_MODULES=agents,instance-ai`), build an agent via the AI assistant's build-agent flow and confirm credit claims/telemetry behave as before.

## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/DEVP-646

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

