### PR TITLE
refactor(core): Invert SSO to provisioning coupling via login hooks

### DIFF
--- a/packages/cli/src/modules/provisioning.ee/__tests__/sso-provisioning.handler.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/sso-provisioning.handler.ee.test.ts
@@ -1,0 +1,153 @@
+import type { User } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { ProvisioningService } from '../provisioning.service.ee';
+import { SsoProvisioningHandlerService } from '../sso-provisioning.handler.ee';
+
+describe('SsoProvisioningHandlerService', () => {
+	let provisioningService: ProvisioningService;
+	let handler: SsoProvisioningHandlerService;
+
+	const user = mock<User>({ id: 'user-1' });
+	const samlLogin = {
+		provider: 'saml' as const,
+		rawAttributes: { groups: ['engineering'] },
+		instanceRole: 'global:admin',
+		projectRoles: ['project-1:viewer'],
+	};
+	const oidcLogin = {
+		provider: 'oidc' as const,
+		claims: {
+			sub: 'sub-1',
+			n8n_instance_role: 'global:member',
+			n8n_projects: ['project-1:viewer'],
+		},
+		userInfo: { email: 'test@example.com' },
+	};
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		provisioningService = mock<ProvisioningService>();
+		provisioningService.getConfig = vi.fn().mockResolvedValue({
+			scopesProvisionInstanceRole: false,
+			scopesProvisionProjectRoles: false,
+			scopesName: 'n8n',
+			scopesInstanceRoleClaimName: 'n8n_instance_role',
+			scopesProjectsRolesClaimName: 'n8n_projects',
+		});
+		provisioningService.isExpressionMappingEnabled = vi.fn().mockResolvedValue(false);
+		handler = new SsoProvisioningHandlerService(provisioningService);
+	});
+
+	describe('getSamlRoleClaimNames', () => {
+		it('returns the claim names from the provisioning service', async () => {
+			provisioningService.getInstanceRoleClaimName = vi.fn().mockResolvedValue('instance-claim');
+			provisioningService.getProjectsRolesClaimName = vi.fn().mockResolvedValue(null);
+
+			await expect(handler.getSamlRoleClaimNames()).resolves.toEqual({
+				instanceRole: 'instance-claim',
+				projectRoles: null,
+			});
+		});
+	});
+
+	describe('getOidcScope', () => {
+		it('returns the configured scope name when role provisioning is enabled', async () => {
+			provisioningService.getConfig = vi.fn().mockResolvedValue({
+				scopesProvisionInstanceRole: true,
+				scopesProvisionProjectRoles: false,
+				scopesName: 'n8n',
+			});
+
+			await expect(handler.getOidcScope()).resolves.toBe('n8n');
+		});
+
+		it('returns undefined when role provisioning is disabled', async () => {
+			await expect(handler.getOidcScope()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('assertLoginAllowed', () => {
+		it('builds a SAML claims context and passes the mapped instance role', async () => {
+			await handler.assertLoginAllowed(samlLogin);
+
+			expect(provisioningService.assertSsoLoginAllowed).toHaveBeenCalledWith(
+				expect.objectContaining({
+					$provider: 'saml',
+					$claims: samlLogin.rawAttributes,
+					$saml: { attributes: samlLogin.rawAttributes },
+				}),
+				'global:admin',
+			);
+		});
+
+		it('builds an OIDC claims context and extracts the configured instance role claim', async () => {
+			await handler.assertLoginAllowed(oidcLogin);
+
+			expect(provisioningService.assertSsoLoginAllowed).toHaveBeenCalledWith(
+				expect.objectContaining({
+					$provider: 'oidc',
+					$claims: expect.objectContaining({ sub: 'sub-1', email: 'test@example.com' }),
+				}),
+				'global:member',
+			);
+		});
+
+		it('propagates a denial from the provisioning service', async () => {
+			const error = new Error('Access denied by SSO role mapping configuration');
+			provisioningService.assertSsoLoginAllowed = vi.fn().mockRejectedValue(error);
+
+			await expect(handler.assertLoginAllowed(samlLogin)).rejects.toThrow(error);
+		});
+	});
+
+	describe('provisionRoles', () => {
+		it('provisions expression-mapped roles when expression mapping is enabled', async () => {
+			provisioningService.isExpressionMappingEnabled = vi.fn().mockResolvedValue(true);
+
+			await handler.provisionRoles(user, samlLogin);
+
+			expect(provisioningService.provisionExpressionMappedRolesForUser).toHaveBeenCalledWith(
+				user,
+				expect.objectContaining({ $provider: 'saml' }),
+			);
+			expect(provisioningService.provisionInstanceRoleForUser).not.toHaveBeenCalled();
+			expect(provisioningService.provisionProjectRolesForUser).not.toHaveBeenCalled();
+		});
+
+		it('provisions direct SAML claims when expression mapping is disabled', async () => {
+			await handler.provisionRoles(user, samlLogin);
+
+			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
+				user,
+				'global:admin',
+			);
+			expect(provisioningService.provisionProjectRolesForUser).toHaveBeenCalledWith(user.id, [
+				'project-1:viewer',
+			]);
+			expect(provisioningService.provisionExpressionMappedRolesForUser).not.toHaveBeenCalled();
+		});
+
+		it('still provisions the instance role when the SAML claims are missing, so the default condition applies', async () => {
+			await handler.provisionRoles(user, { provider: 'saml', rawAttributes: {} });
+
+			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
+				user,
+				undefined,
+			);
+			expect(provisioningService.provisionProjectRolesForUser).not.toHaveBeenCalled();
+		});
+
+		it('extracts OIDC claims by the configured claim names', async () => {
+			await handler.provisionRoles(user, oidcLogin);
+
+			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
+				user,
+				'global:member',
+			);
+			expect(provisioningService.provisionProjectRolesForUser).toHaveBeenCalledWith(user.id, [
+				'project-1:viewer',
+			]);
+		});
+	});
+});

--- a/packages/cli/src/modules/provisioning.ee/provisioning.module.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.module.ts
@@ -25,10 +25,7 @@ export class ProvisioningModule implements ModuleInterface {
 
 		// Register the SSO login hooks so SAML/OIDC logins trigger role
 		// provisioning without those modules importing this one.
-		const { SsoProvisioningHooks } = await import('@/sso.ee/sso-provisioning-hooks.js');
-		const { SsoProvisioningHandlerService } = await import('./sso-provisioning.handler.ee.js');
-		Container.get(SsoProvisioningHooks).registerHandler(
-			Container.get(SsoProvisioningHandlerService),
-		);
+		const { registerSsoProvisioningHandler } = await import('./register.js');
+		registerSsoProvisioningHandler();
 	}
 }

--- a/packages/cli/src/modules/provisioning.ee/provisioning.module.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.module.ts
@@ -22,5 +22,13 @@ export class ProvisioningModule implements ModuleInterface {
 		Container.get(RoleDeletionCheckProxy).registerProvider(
 			Container.get(ProvisioningRoleDeletionChecker),
 		);
+
+		// Register the SSO login hooks so SAML/OIDC logins trigger role
+		// provisioning without those modules importing this one.
+		const { SsoProvisioningHooks } = await import('@/sso.ee/sso-provisioning-hooks.js');
+		const { SsoProvisioningHandlerService } = await import('./sso-provisioning.handler.ee.js');
+		Container.get(SsoProvisioningHooks).registerHandler(
+			Container.get(SsoProvisioningHandlerService),
+		);
 	}
 }

--- a/packages/cli/src/modules/provisioning.ee/register.ts
+++ b/packages/cli/src/modules/provisioning.ee/register.ts
@@ -1,0 +1,14 @@
+import { Container } from '@n8n/di';
+
+import { SsoProvisioningHooks } from '@/sso.ee/sso-provisioning-hooks';
+
+import { SsoProvisioningHandlerService } from './sso-provisioning.handler.ee';
+
+/**
+ * Hooks this module into SAML/OIDC logins. Runs on module init, so the SSO
+ * hooks no-op — matching provisioning's default all-disabled configuration —
+ * exactly when this module is disabled.
+ */
+export function registerSsoProvisioningHandler() {
+	Container.get(SsoProvisioningHooks).registerHandler(Container.get(SsoProvisioningHandlerService));
+}

--- a/packages/cli/src/modules/provisioning.ee/sso-provisioning.handler.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/sso-provisioning.handler.ee.ts
@@ -1,0 +1,76 @@
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import type { SsoLoginClaims, SsoProvisioningHandler } from '@/sso.ee/sso-provisioning-hooks';
+
+import { buildOidcClaimsContext, buildSamlClaimsContext } from './claims-context.builder';
+import { ProvisioningService } from './provisioning.service.ee';
+import type { RoleResolverContext } from './role-resolver-types';
+
+/**
+ * Implements the SSO login hooks so provisioning runs on SAML/OIDC logins.
+ * Registered with `SsoProvisioningHooks` when the module inits.
+ */
+@Service()
+export class SsoProvisioningHandlerService implements SsoProvisioningHandler {
+	constructor(private readonly provisioningService: ProvisioningService) {}
+
+	async getSamlRoleClaimNames() {
+		return {
+			instanceRole: await this.provisioningService.getInstanceRoleClaimName(),
+			projectRoles: await this.provisioningService.getProjectsRolesClaimName(),
+		};
+	}
+
+	async getOidcScope() {
+		const config = await this.provisioningService.getConfig();
+		const enabled = config.scopesProvisionInstanceRole || config.scopesProvisionProjectRoles;
+		return enabled ? config.scopesName : undefined;
+	}
+
+	async assertLoginAllowed(login: SsoLoginClaims) {
+		await this.provisioningService.assertSsoLoginAllowed(
+			this.buildContext(login),
+			await this.getInstanceRoleClaim(login),
+		);
+	}
+
+	async provisionRoles(user: User, login: SsoLoginClaims) {
+		if (await this.provisioningService.isExpressionMappingEnabled()) {
+			await this.provisioningService.provisionExpressionMappedRolesForUser(
+				user,
+				this.buildContext(login),
+			);
+			return;
+		}
+
+		// Called even when the claim is missing so the configured default condition applies
+		await this.provisioningService.provisionInstanceRoleForUser(
+			user,
+			await this.getInstanceRoleClaim(login),
+		);
+
+		const projectRolesClaim = await this.getProjectRolesClaim(login);
+		if (projectRolesClaim) {
+			await this.provisioningService.provisionProjectRolesForUser(user.id, projectRolesClaim);
+		}
+	}
+
+	private buildContext(login: SsoLoginClaims): RoleResolverContext {
+		return login.provider === 'saml'
+			? buildSamlClaimsContext(login.rawAttributes)
+			: buildOidcClaimsContext(login.claims, login.userInfo);
+	}
+
+	private async getInstanceRoleClaim(login: SsoLoginClaims): Promise<unknown> {
+		if (login.provider === 'saml') return login.instanceRole;
+		const config = await this.provisioningService.getConfig();
+		return login.claims[config.scopesInstanceRoleClaimName];
+	}
+
+	private async getProjectRolesClaim(login: SsoLoginClaims): Promise<unknown> {
+		if (login.provider === 'saml') return login.projectRoles;
+		const config = await this.provisioningService.getConfig();
+		return login.claims[config.scopesProjectsRolesClaimName];
+	}
+}

--- a/packages/cli/src/modules/sso-oidc/__tests__/oidc.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-oidc/__tests__/oidc.service.ee.test.ts
@@ -24,11 +24,11 @@ vi.mock('openid-client', async (importOriginal) => {
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { type ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { JwtService } from '@/services/jwt.service';
 import type { UrlService } from '@/services/url.service';
 import * as ssoHelpers from '@/sso.ee/sso-helpers';
+import type { SsoProvisioningHooks } from '@/sso.ee/sso-provisioning-hooks';
 
 import { OIDC_PREFERENCES_DB_KEY } from '../constants';
 import { OidcService } from '../oidc.service.ee';
@@ -41,7 +41,7 @@ describe('OidcService', () => {
 	let cipher: Cipher;
 	let logger: Logger;
 	let jwtService: JwtService;
-	let provisioningService: ProvisioningService;
+	let provisioningHooks: Mocked<SsoProvisioningHooks>;
 	let userRepository: UserRepository;
 	let authIdentityRepository: AuthIdentityRepository;
 	let outboundHttp: Mocked<OutboundHttp>;
@@ -77,12 +77,7 @@ describe('OidcService', () => {
 		cipher = mock<Cipher>();
 		logger = mockLogger();
 		jwtService = mock<JwtService>();
-		provisioningService = mock<ProvisioningService>();
-		// loginUser reads the provisioning config to extract the instance role claim
-		provisioningService.getConfig = vi.fn().mockResolvedValue({
-			scopesInstanceRoleClaimName: 'n8n_instance_role',
-			scopesProjectsRolesClaimName: 'n8n_projects',
-		});
+		provisioningHooks = mock<SsoProvisioningHooks>();
 		userRepository = mock<UserRepository>();
 		authIdentityRepository = mock<AuthIdentityRepository>();
 		customFetch = vi.fn();
@@ -104,7 +99,7 @@ describe('OidcService', () => {
 			logger,
 			jwtService,
 			instanceSettings,
-			provisioningService,
+			provisioningHooks,
 			outboundHttp,
 		);
 
@@ -666,9 +661,9 @@ describe('OidcService', () => {
 			oidcService.verifyNonce = vi.fn().mockReturnValue('valid-nonce');
 			// @ts-expect-error - getOidcConfiguration is private and only accessible within class 'OidcService'
 			oidcService.getOidcConfiguration = vi.fn().mockResolvedValue({} as client.Configuration);
-			provisioningService.assertSsoLoginAllowed = vi
-				.fn()
-				.mockRejectedValue(new ForbiddenError('Access denied by SSO role mapping configuration'));
+			provisioningHooks.assertLoginAllowed.mockRejectedValue(
+				new ForbiddenError('Access denied by SSO role mapping configuration'),
+			);
 			authIdentityRepository.findOne = vi.fn().mockResolvedValue(null);
 			userRepository.findOne = vi.fn().mockResolvedValue(null);
 			userRepository.manager.transaction = vi.fn();
@@ -692,13 +687,14 @@ describe('OidcService', () => {
 				ForbiddenError,
 			);
 
-			expect(provisioningService.assertSsoLoginAllowed).toHaveBeenCalledWith(
-				expect.objectContaining({ $provider: 'oidc' }),
-				'global:unknown',
-			);
+			expect(provisioningHooks.assertLoginAllowed).toHaveBeenCalledWith({
+				provider: 'oidc',
+				claims: expect.objectContaining({ n8n_instance_role: 'global:unknown' }),
+				userInfo: expect.objectContaining({ email: 'john.doe@test.com' }),
+			});
 			// No account creation, no provisioning
 			expect(userRepository.manager.transaction).not.toHaveBeenCalled();
-			expect(provisioningService.provisionInstanceRoleForUser).not.toHaveBeenCalled();
+			expect(provisioningHooks.provisionRoles).not.toHaveBeenCalled();
 		});
 
 		it('should deny an existing user without touching their account when role mapping blocks access', async () => {
@@ -706,9 +702,9 @@ describe('OidcService', () => {
 			oidcService.verifyNonce = vi.fn().mockReturnValue('valid-nonce');
 			// @ts-expect-error - getOidcConfiguration is private and only accessible within class 'OidcService'
 			oidcService.getOidcConfiguration = vi.fn().mockResolvedValue({} as client.Configuration);
-			provisioningService.assertSsoLoginAllowed = vi
-				.fn()
-				.mockRejectedValue(new ForbiddenError('Access denied by SSO role mapping configuration'));
+			provisioningHooks.assertLoginAllowed.mockRejectedValue(
+				new ForbiddenError('Access denied by SSO role mapping configuration'),
+			);
 			authIdentityRepository.findOne = vi
 				.fn()
 				.mockResolvedValue({ user: { email: 'john.doe@test.com' } as any });
@@ -733,8 +729,7 @@ describe('OidcService', () => {
 			);
 
 			// The account is left untouched — no role changes, no deactivation
-			expect(provisioningService.provisionInstanceRoleForUser).not.toHaveBeenCalled();
-			expect(provisioningService.provisionExpressionMappedRolesForUser).not.toHaveBeenCalled();
+			expect(provisioningHooks.provisionRoles).not.toHaveBeenCalled();
 			expect(userRepository.save).not.toHaveBeenCalled();
 		});
 	});
@@ -757,11 +752,7 @@ describe('OidcService', () => {
 			vi.mocked(client.fetchUserInfo).mockResolvedValue(userInfo as any);
 		});
 
-		it('calls provisionExpressionMappedRolesForUser when expression mapping is enabled', async () => {
-			provisioningService.isExpressionMappingEnabled = vi.fn().mockResolvedValue(true);
-			provisioningService.provisionExpressionMappedRolesForUser = vi
-				.fn()
-				.mockResolvedValue(undefined);
+		it('forwards claims and user info to the provisioning hook', async () => {
 			authIdentityRepository.findOne = vi.fn().mockResolvedValue({ user });
 
 			const callbackUrl = new URL('https://example.com/callback');
@@ -769,33 +760,11 @@ describe('OidcService', () => {
 			const storedNonce = oidcService.generateNonce().signed;
 			await oidcService.loginUser(callbackUrl, storedState, storedNonce);
 
-			expect(provisioningService.provisionExpressionMappedRolesForUser).toHaveBeenCalledWith(
-				user,
-				expect.objectContaining({ $provider: 'oidc' }),
-			);
-			expect(provisioningService.provisionInstanceRoleForUser).not.toHaveBeenCalled();
-			expect(provisioningService.provisionProjectRolesForUser).not.toHaveBeenCalled();
-		});
-
-		it('falls through to direct-claim provisioning when expression mapping is disabled', async () => {
-			provisioningService.isExpressionMappingEnabled = vi.fn().mockResolvedValue(false);
-			provisioningService.getConfig = vi.fn().mockResolvedValue({
-				scopesInstanceRoleClaimName: 'n8n_instance_role',
-				scopesProjectsRolesClaimName: 'n8n_projects',
+			expect(provisioningHooks.provisionRoles).toHaveBeenCalledWith(user, {
+				provider: 'oidc',
+				claims,
+				userInfo,
 			});
-			provisioningService.provisionInstanceRoleForUser = vi.fn().mockResolvedValue(undefined);
-			authIdentityRepository.findOne = vi.fn().mockResolvedValue({ user });
-
-			const callbackUrl = new URL('https://example.com/callback');
-			const storedState = oidcService.generateState().signed;
-			const storedNonce = oidcService.generateNonce().signed;
-			await oidcService.loginUser(callbackUrl, storedState, storedNonce);
-
-			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
-				user,
-				'global:member',
-			);
-			expect(provisioningService.provisionExpressionMappedRolesForUser).not.toHaveBeenCalled();
 		});
 	});
 
@@ -879,7 +848,7 @@ describe('OidcService', () => {
 				logger,
 				jwtService,
 				instanceSettings,
-				provisioningService,
+				provisioningHooks,
 				realOutboundHttp,
 			);
 		});

--- a/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
+++ b/packages/cli/src/modules/sso-oidc/oidc.service.ee.ts
@@ -21,8 +21,6 @@ import { inspect } from 'util';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { buildOidcClaimsContext } from '@/modules/provisioning.ee/claims-context.builder';
-import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { JwtService } from '@/services/jwt.service';
 import { UrlService } from '@/services/url.service';
 import {
@@ -32,6 +30,7 @@ import {
 	reloadAuthenticationMethod,
 	setCurrentAuthenticationMethod,
 } from '@/sso.ee/sso-helpers';
+import { SsoProvisioningHooks } from '@/sso.ee/sso-provisioning-hooks';
 
 import { OIDC_CLIENT_SECRET_REDACTED_VALUE, OIDC_PREFERENCES_DB_KEY } from './constants';
 
@@ -100,7 +99,7 @@ export class OidcService {
 		private readonly logger: Logger,
 		private readonly jwtService: JwtService,
 		private readonly instanceSettings: InstanceSettings,
-		private readonly provisioningService: ProvisioningService,
+		private readonly provisioningHooks: SsoProvisioningHooks,
 		private readonly outboundHttp: OutboundHttp,
 	) {}
 
@@ -229,14 +228,10 @@ export class OidcService {
 		const prompt = this.oidcConfig.prompt;
 		const authenticationContextClassReference = this.oidcConfig.authenticationContextClassReference;
 
-		const provisioningConfig = await this.provisioningService.getConfig();
-		const provisioningEnabled =
-			provisioningConfig.scopesProvisionInstanceRole ||
-			provisioningConfig.scopesProvisionProjectRoles;
-
 		// Include the custom n8n scope if provisioning is enabled
-		const baseScope = provisioningEnabled
-			? `openid email profile ${provisioningConfig.scopesName}`
+		const provisioningScope = await this.provisioningHooks.getOidcScope();
+		const baseScope = provisioningScope
+			? `openid email profile ${provisioningScope}`
 			: 'openid email profile';
 
 		const additionalScopes = this.oidcConfig.additionalScopes.trim();
@@ -482,13 +477,9 @@ export class OidcService {
 		const state = this.generateState(true);
 		const nonce = this.generateNonce();
 
-		const provisioningConfig = await this.provisioningService.getConfig();
-		const provisioningEnabled =
-			provisioningConfig.scopesProvisionInstanceRole ||
-			provisioningConfig.scopesProvisionProjectRoles;
-
-		const baseScope = provisioningEnabled
-			? `openid email profile ${provisioningConfig.scopesName}`
+		const provisioningScope = await this.provisioningHooks.getOidcScope();
+		const baseScope = provisioningScope
+			? `openid email profile ${provisioningScope}`
 			: 'openid email profile';
 
 		const additionalScopes = config.additionalScopes.trim();
@@ -593,20 +584,7 @@ export class OidcService {
 		claims: Record<string, unknown>,
 		userInfo: Record<string, unknown>,
 	) {
-		if (await this.provisioningService.isExpressionMappingEnabled()) {
-			const context = buildOidcClaimsContext(claims, userInfo);
-			await this.provisioningService.provisionExpressionMappedRolesForUser(user, context);
-			return;
-		}
-
-		const provisioningConfig = await this.provisioningService.getConfig();
-		const projectRoleMapping = claims[provisioningConfig.scopesProjectsRolesClaimName];
-		const instanceRole = claims[provisioningConfig.scopesInstanceRoleClaimName];
-		// Called even when the claim is missing so the configured default condition applies
-		await this.provisioningService.provisionInstanceRoleForUser(user, instanceRole);
-		if (projectRoleMapping) {
-			await this.provisioningService.provisionProjectRolesForUser(user.id, projectRoleMapping);
-		}
+		await this.provisioningHooks.provisionRoles(user, { provider: 'oidc', claims, userInfo });
 	}
 
 	/**
@@ -617,11 +595,7 @@ export class OidcService {
 		claims: Record<string, unknown>,
 		userInfo: Record<string, unknown>,
 	) {
-		const provisioningConfig = await this.provisioningService.getConfig();
-		await this.provisioningService.assertSsoLoginAllowed(
-			buildOidcClaimsContext(claims, userInfo),
-			claims[provisioningConfig.scopesInstanceRoleClaimName],
-		);
+		await this.provisioningHooks.assertLoginAllowed({ provider: 'oidc', claims, userInfo });
 	}
 
 	private async broadcastReloadOIDCConfigurationCommand(): Promise<void> {

--- a/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
@@ -14,11 +14,11 @@ import type { IdentityProviderInstance, ServiceProviderInstance } from 'samlify'
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import type { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { CacheService } from '@/services/cache/cache.service';
 import type { UrlService } from '@/services/url.service';
 import * as ssoHelpers from '@/sso.ee/sso-helpers';
+import type { SsoProvisioningHooks } from '@/sso.ee/sso-provisioning-hooks';
 
 import { SAML_PREFERENCES_DB_KEY } from '../constants';
 import { InvalidSamlMetadataUrlError } from '../errors/invalid-saml-metadata-url.error';
@@ -162,7 +162,7 @@ describe('SamlService', () => {
 	let instanceSettings: InstanceSettings;
 	let globalConfig: GlobalConfig;
 	let userRepository: UserRepository;
-	let provisioningService: ProvisioningService;
+	let provisioningHooks: Mocked<SsoProvisioningHooks>;
 	let cipher: Cipher;
 	let cacheService: Mocked<CacheService>;
 	let outboundHttp: Mocked<OutboundHttp>;
@@ -208,12 +208,15 @@ describe('SamlService', () => {
 		instanceSettings = mock<InstanceSettings>({
 			isMultiMain: true,
 		});
-		provisioningService = mock<ProvisioningService>();
+		provisioningHooks = mock<SsoProvisioningHooks>();
+		provisioningHooks.getSamlRoleClaimNames.mockResolvedValue({
+			instanceRole: null,
+			projectRoles: null,
+		});
 		userRepository = mock<UserRepository>();
 		globalConfig = mock<GlobalConfig>({
 			sso: { saml: { loginEnabled: false } },
 		});
-		provisioningService = mock<ProvisioningService>();
 		cipher = mock<Cipher>();
 		cipher.encryptV2 = vi.fn(async (data: string) => `encrypted:${data}`) as Cipher['encryptV2'];
 		cipher.decryptV2 = vi.fn(async (data: string) =>
@@ -236,7 +239,7 @@ describe('SamlService', () => {
 			userRepository,
 			settingsRepository,
 			instanceSettings,
-			provisioningService,
+			provisioningHooks,
 			cipher,
 			cacheService,
 			outboundHttp,
@@ -432,26 +435,24 @@ describe('SamlService', () => {
 				mapped: samlAttributes,
 				raw: { groups: ['contractors'] },
 			});
-			provisioningService.assertSsoLoginAllowed = vi
-				.fn()
-				.mockRejectedValue(new ForbiddenError('Access denied by SSO role mapping configuration'));
+			provisioningHooks.assertLoginAllowed.mockRejectedValue(
+				new ForbiddenError('Access denied by SSO role mapping configuration'),
+			);
 			const createUserSpy = vi.spyOn(samlHelpers, 'createUserFromSamlAttributes');
 
 			await expect(samlService.handleSamlLogin(mock<express.Request>(), 'post')).rejects.toThrow(
 				ForbiddenError,
 			);
 
-			expect(provisioningService.assertSsoLoginAllowed).toHaveBeenCalledWith(
-				expect.objectContaining({
-					$provider: 'saml',
-					$claims: { groups: ['contractors'] },
-				}),
-				'global:unknown',
-			);
+			expect(provisioningHooks.assertLoginAllowed).toHaveBeenCalledWith({
+				provider: 'saml',
+				rawAttributes: { groups: ['contractors'] },
+				instanceRole: 'global:unknown',
+			});
 			// Denied before any account lookup, creation, or provisioning
 			expect(userRepository.findOne).not.toHaveBeenCalled();
 			expect(createUserSpy).not.toHaveBeenCalled();
-			expect(provisioningService.provisionInstanceRoleForUser).not.toHaveBeenCalled();
+			expect(provisioningHooks.provisionRoles).not.toHaveBeenCalled();
 		});
 
 		it('throws error for invalid email', async () => {
@@ -632,17 +633,15 @@ describe('SamlService', () => {
 
 			await samlService.handleSamlLogin(mock<express.Request>(), 'post');
 
-			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
-				mockUser,
-				samlAttributes.n8nInstanceRole,
-			);
-			expect(provisioningService.provisionProjectRolesForUser).toHaveBeenCalledWith(
-				mockUser.id,
-				samlAttributes.n8nProjectRoles,
-			);
+			expect(provisioningHooks.provisionRoles).toHaveBeenCalledWith(mockUser, {
+				provider: 'saml',
+				rawAttributes: {},
+				instanceRole: samlAttributes.n8nInstanceRole,
+				projectRoles: samlAttributes.n8nProjectRoles,
+			});
 		});
 
-		it('calls provisionExpressionMappedRolesForUser when expression mapping is enabled', async () => {
+		it('forwards the raw attributes to the provisioning hook', async () => {
 			const samlAttributes = {
 				email: 'foo@bar.com',
 				firstName: 'Foo',
@@ -658,10 +657,6 @@ describe('SamlService', () => {
 				],
 			} as any;
 
-			provisioningService.isExpressionMappingEnabled = vi.fn().mockResolvedValue(true);
-			provisioningService.provisionExpressionMappedRolesForUser = vi
-				.fn()
-				.mockResolvedValue(undefined);
 			vi.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
 				mapped: samlAttributes,
 				raw: rawAttributes,
@@ -670,44 +665,12 @@ describe('SamlService', () => {
 
 			await samlService.handleSamlLogin(mock<express.Request>(), 'post');
 
-			expect(provisioningService.provisionExpressionMappedRolesForUser).toHaveBeenCalledWith(
-				mockUser,
-				expect.objectContaining({ $provider: 'saml', $saml: { attributes: rawAttributes } }),
-			);
-			expect(provisioningService.provisionInstanceRoleForUser).not.toHaveBeenCalled();
-			expect(provisioningService.provisionProjectRolesForUser).not.toHaveBeenCalled();
-		});
-
-		it('falls through to direct-claim provisioning when expression mapping is disabled', async () => {
-			const samlAttributes = {
-				email: 'foo@bar.com',
-				firstName: '',
-				lastName: '',
-				userPrincipalName: 'foo@bar.com',
-				n8nInstanceRole: 'global:admin',
-			};
-			const mockUser = {
-				id: '123',
-				email: samlAttributes.email,
-				authIdentities: [
-					{ providerType: 'saml', providerId: samlAttributes.userPrincipalName } as any,
-				],
-			} as any;
-
-			provisioningService.isExpressionMappingEnabled = vi.fn().mockResolvedValue(false);
-			vi.spyOn(samlService, 'getAttributesFromLoginResponse').mockResolvedValue({
-				mapped: samlAttributes,
-				raw: {},
+			expect(provisioningHooks.provisionRoles).toHaveBeenCalledWith(mockUser, {
+				provider: 'saml',
+				rawAttributes,
+				instanceRole: undefined,
+				projectRoles: undefined,
 			});
-			vi.mocked(userRepository.findOne).mockResolvedValue(mockUser);
-
-			await samlService.handleSamlLogin(mock<express.Request>(), 'post');
-
-			expect(provisioningService.provisionInstanceRoleForUser).toHaveBeenCalledWith(
-				mockUser,
-				'global:admin',
-			);
-			expect(provisioningService.provisionExpressionMappedRolesForUser).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/sso-saml/saml.service.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.service.ee.ts
@@ -19,8 +19,6 @@ import type {
 
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { buildSamlClaimsContext } from '@/modules/provisioning.ee/claims-context.builder';
-import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { CacheService } from '@/services/cache/cache.service';
 import { UrlService } from '@/services/url.service';
 import {
@@ -30,6 +28,7 @@ import {
 	isSsoJustInTimeProvisioningEnabled,
 	reloadAuthenticationMethod,
 } from '@/sso.ee/sso-helpers';
+import { SsoProvisioningHooks } from '@/sso.ee/sso-provisioning-hooks';
 
 import { SAML_PREFERENCES_DB_KEY } from './constants';
 import { InvalidSamlMetadataUrlError } from './errors/invalid-saml-metadata-url.error';
@@ -99,7 +98,7 @@ export class SamlService {
 		private readonly userRepository: UserRepository,
 		private readonly settingsRepository: SettingsRepository,
 		private readonly instanceSettings: InstanceSettings,
-		private readonly provisioningService: ProvisioningService,
+		private readonly provisioningHooks: SsoProvisioningHooks,
 		private readonly cipher: Cipher,
 		private readonly cacheService: CacheService,
 		private readonly outboundHttp: OutboundHttp,
@@ -377,10 +376,11 @@ export class SamlService {
 		);
 
 		// Deny a blocked login before any account is created or session issued
-		await this.provisioningService.assertSsoLoginAllowed(
-			buildSamlClaimsContext(rawAttributes),
-			attributes.n8nInstanceRole,
-		);
+		await this.provisioningHooks.assertLoginAllowed({
+			provider: 'saml',
+			rawAttributes,
+			instanceRole: attributes.n8nInstanceRole,
+		});
 
 		if (attributes.email) {
 			const lowerCasedEmail = attributes.email.toLowerCase();
@@ -447,19 +447,12 @@ export class SamlService {
 		attributes: SamlPreferencesAttributeMapping,
 		rawAttributes: Record<string, unknown>,
 	): Promise<void> {
-		if (await this.provisioningService.isExpressionMappingEnabled()) {
-			const context = buildSamlClaimsContext(rawAttributes);
-			await this.provisioningService.provisionExpressionMappedRolesForUser(user, context);
-			return;
-		}
-		// Called even when the attribute is missing so the configured default condition applies
-		await this.provisioningService.provisionInstanceRoleForUser(user, attributes?.n8nInstanceRole);
-		if (attributes?.n8nProjectRoles) {
-			await this.provisioningService.provisionProjectRolesForUser(
-				user.id,
-				attributes.n8nProjectRoles,
-			);
-		}
+		await this.provisioningHooks.provisionRoles(user, {
+			provider: 'saml',
+			rawAttributes,
+			instanceRole: attributes?.n8nInstanceRole,
+			projectRoles: attributes?.n8nProjectRoles,
+		});
 	}
 
 	private async broadcastReloadSAMLConfigurationCommand(): Promise<void> {
@@ -764,10 +757,7 @@ export class SamlService {
 		const { attributes, missingAttributes, rawAttributes } = getMappedSamlAttributesFromFlowResult(
 			parsedSamlResponse,
 			this._samlPreferences.mapping,
-			{
-				instanceRole: await this.provisioningService.getInstanceRoleClaimName(),
-				projectRoles: await this.provisioningService.getProjectsRolesClaimName(),
-			},
+			await this.provisioningHooks.getSamlRoleClaimNames(),
 		);
 		if (!attributes) {
 			throw new AuthError('SAML Authentication failed. Invalid SAML response.');

--- a/packages/cli/src/sso.ee/__tests__/sso-provisioning-hooks.test.ts
+++ b/packages/cli/src/sso.ee/__tests__/sso-provisioning-hooks.test.ts
@@ -1,0 +1,43 @@
+import type { User } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { SsoLoginClaims, SsoProvisioningHandler } from '../sso-provisioning-hooks';
+import { SsoProvisioningHooks } from '../sso-provisioning-hooks';
+
+describe('SsoProvisioningHooks', () => {
+	describe('without a registered handler', () => {
+		const hooks = new SsoProvisioningHooks();
+		const login: SsoLoginClaims = { provider: 'saml', rawAttributes: {} };
+
+		it('getSamlRoleClaimNames returns disabled claim names', async () => {
+			await expect(hooks.getSamlRoleClaimNames()).resolves.toEqual({
+				instanceRole: null,
+				projectRoles: null,
+			});
+		});
+
+		it('getOidcScope returns no scope', async () => {
+			await expect(hooks.getOidcScope()).resolves.toBeUndefined();
+		});
+
+		it('assertLoginAllowed does not throw', async () => {
+			await expect(hooks.assertLoginAllowed(login)).resolves.toBeUndefined();
+		});
+
+		it('provisionRoles no-ops', async () => {
+			await expect(hooks.provisionRoles(mock<User>(), login)).resolves.toBeUndefined();
+		});
+	});
+
+	it('delegates to the registered handler', async () => {
+		const hooks = new SsoProvisioningHooks();
+		const handler = mock<SsoProvisioningHandler>();
+		handler.getSamlRoleClaimNames.mockResolvedValue({ instanceRole: 'role', projectRoles: 'pr' });
+		hooks.registerHandler(handler);
+
+		await expect(hooks.getSamlRoleClaimNames()).resolves.toEqual({
+			instanceRole: 'role',
+			projectRoles: 'pr',
+		});
+	});
+});

--- a/packages/cli/src/sso.ee/sso-provisioning-hooks.ts
+++ b/packages/cli/src/sso.ee/sso-provisioning-hooks.ts
@@ -1,0 +1,71 @@
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+/** Claims an SSO login carries, in the shape the protocol delivered them. */
+export type SsoLoginClaims =
+	| {
+			provider: 'saml';
+			rawAttributes: Record<string, unknown>;
+			/** Instance role attribute, already mapped via the configured claim name. */
+			instanceRole?: string;
+			/** Project role attributes, already mapped via the configured claim name. */
+			projectRoles?: string[];
+	  }
+	| {
+			provider: 'oidc';
+			claims: Record<string, unknown>;
+			userInfo: Record<string, unknown>;
+	  };
+
+export interface SsoProvisioningHandler {
+	/** SAML attribute names carrying role claims; `null` when that scope's provisioning is disabled. */
+	getSamlRoleClaimNames(): Promise<{ instanceRole: string | null; projectRoles: string | null }>;
+
+	/** Extra OAuth scope to request on OIDC logins; `undefined` when role provisioning is disabled. */
+	getOidcScope(): Promise<string | undefined>;
+
+	/** Throws when role mapping denies the login. Runs before any account is created or session issued. */
+	assertLoginAllowed(login: SsoLoginClaims): Promise<void>;
+
+	/** Provisions instance/project roles for the logged-in user. */
+	provisionRoles(user: User, login: SsoLoginClaims): Promise<void>;
+}
+
+/**
+ * Login hooks through which the provisioning module plugs into SSO logins
+ * without the SSO modules importing it.
+ *
+ * The module registers its handler on init — same pattern as
+ * `RoleDeletionCheckProxy`. Until a handler is registered (e.g. the module is
+ * unlicensed), every hook no-ops, which matches the provisioning behavior
+ * with its default (all-disabled) configuration.
+ */
+@Service()
+export class SsoProvisioningHooks implements SsoProvisioningHandler {
+	private handler: SsoProvisioningHandler | undefined;
+
+	registerHandler(handler: SsoProvisioningHandler): void {
+		this.handler = handler;
+	}
+
+	async getSamlRoleClaimNames(): Promise<{
+		instanceRole: string | null;
+		projectRoles: string | null;
+	}> {
+		return (
+			(await this.handler?.getSamlRoleClaimNames()) ?? { instanceRole: null, projectRoles: null }
+		);
+	}
+
+	async getOidcScope(): Promise<string | undefined> {
+		return await this.handler?.getOidcScope();
+	}
+
+	async assertLoginAllowed(login: SsoLoginClaims): Promise<void> {
+		await this.handler?.assertLoginAllowed(login);
+	}
+
+	async provisionRoles(user: User, login: SsoLoginClaims): Promise<void> {
+		await this.handler?.provisionRoles(user, login);
+	}
+}

--- a/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
+++ b/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
@@ -27,6 +27,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { License } from '@/license';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
+import { registerSsoProvisioningHandler } from '@/modules/provisioning.ee/register';
 import { OIDC_CLIENT_SECRET_REDACTED_VALUE } from '@/modules/sso-oidc/constants';
 import { OidcService } from '@/modules/sso-oidc/oidc.service.ee';
 import { JwtService } from '@/services/jwt.service';
@@ -35,6 +36,8 @@ import { createUser } from '@test-integration/db/users';
 
 beforeAll(async () => {
 	await testDb.init();
+	// The provisioning module registers this on init, which tests don't run.
+	registerSsoProvisioningHandler();
 });
 
 afterAll(async () => {

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -29,6 +29,7 @@ import { TEMPLATES_DIR } from '@/constants';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
+import { registerSsoProvisioningHandler } from '@/modules/provisioning.ee/register';
 import {
 	EC_TEST_CERTIFICATE,
 	EC_TEST_PRIVATE_KEY,
@@ -73,6 +74,8 @@ const memberPassword = randomValidPassword();
 const samlUserPassword = randomValidPassword();
 
 beforeAll(async () => {
+	// The provisioning module registers this on init, which tests don't run.
+	registerSsoProvisioningHandler();
 	owner = await createOwner();
 	someUser = await createUser({ password: memberPassword });
 	samlUser = await createUser({ password: samlUserPassword });


### PR DESCRIPTION
## Summary

Removes the cross-module imports from `sso-saml` and `sso-oidc` into the `provisioning.ee` module, as part of decoupling backend modules from each other.

- Adds `SsoProvisioningHooks` in core (`packages/cli/src/sso.ee/`): a small hook holder the SSO services call at login time (assert login allowed, provision roles, SAML role claim names, extra OIDC scope). Same pattern as `RoleDeletionCheckProxy`.
- The provisioning module registers its handler (`SsoProvisioningHandlerService`) during module `init()`. The protocol-specific claims-context building and claim-name extraction now live entirely inside the provisioning module — SSO services pass raw claims/attributes.
- When the provisioning module is unlicensed/disabled, no handler is registered and every hook no-ops, which matches provisioning's behavior with its default (all-disabled) configuration. Error propagation from a blocked login (`ForbiddenError` before any account is created) is unchanged.

No runtime behavior change for licensed instances with the module enabled (see behavior note below for the explicitly-disabled-module case).

## Behavior note

When the provisioning module is explicitly disabled via `N8N_DISABLED_MODULES`, provisioning enforcement — including block-access login rules — is off even if provisioning env config is present. This differs from master, where the SSO services called the provisioning service directly and applied its config regardless of module state. This is a deliberate consequence of the module inversion: a disabled module registers no handler, so its policies do not apply.

## How to test

- `pnpm test src/modules/sso-saml src/modules/sso-oidc src/modules/provisioning.ee` in `packages/cli` (401 tests pass).
- With a licensed instance: configure SAML or OIDC with role provisioning enabled, log in, and verify instance/project roles are still provisioned and a Block-access mapping still denies the login.

## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/DEVP-646

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



