### PR TITLE
refactor(core): Move data-table package entity handling into the data-table module

### DIFF
--- a/packages/cli/src/modules/data-table/data-table.module.ts
+++ b/packages/cli/src/modules/data-table/data-table.module.ts
@@ -29,6 +29,9 @@ export class DataTableModule implements ModuleInterface {
 			},
 		});
 
+		const { registerDataTablePackageHandler } = await import('./n8n-packages/register.js');
+		registerDataTablePackageHandler();
+
 		const { DataTableAggregateService } = await import('./data-table-aggregate.service.js');
 		await Container.get(DataTableAggregateService).start();
 

--- a/packages/cli/src/modules/data-table/n8n-packages/__tests__/data-table-importer.test.ts
+++ b/packages/cli/src/modules/data-table/n8n-packages/__tests__/data-table-importer.test.ts
@@ -1,14 +1,13 @@
-import type { ModuleRegistry } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
-import type { DataTable } from '@/modules/data-table/data-table.entity';
-import type { DataTableService } from '@/modules/data-table/data-table.service';
+import type { DataTableImportRequest } from '@/modules/n8n-packages/entities/data-table/data-table.types';
+import type { ImportContext } from '@/modules/n8n-packages/n8n-packages.types';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
+import type { DataTable } from '../../data-table.entity';
+import type { DataTableService } from '../../data-table.service';
 import { DataTableImporter } from '../data-table-importer';
-import type { DataTableImportRequest } from '../data-table.types';
-import type { ImportContext } from '../../../n8n-packages.types';
 
 vi.mock('@/permissions.ee/check-access', () => ({
 	userHasScopes: vi.fn(),
@@ -24,11 +23,9 @@ const context: ImportContext = {
 
 function makeImporter() {
 	const dataTableService = mock<DataTableService>();
-	const moduleRegistry = mock<ModuleRegistry>();
-	moduleRegistry.isActive.mockReturnValue(true);
 	dataTableService.findDataTablesByIds.mockResolvedValue([]);
 	dataTableService.findDataTablesByNamesInProject.mockResolvedValue([]);
-	return { importer: new DataTableImporter(dataTableService, moduleRegistry), moduleRegistry };
+	return { importer: new DataTableImporter(dataTableService) };
 }
 
 function makeRequest(overrides: Partial<DataTableImportRequest> = {}): DataTableImportRequest {
@@ -51,22 +48,11 @@ beforeEach(() => {
 
 describe('DataTableImporter.plan', () => {
 	it('returns an empty plan when the package requires no data tables', async () => {
-		const { importer, moduleRegistry } = makeImporter();
+		const { importer } = makeImporter();
 
 		const plan = await importer.plan(context, makeRequest({ requirements: undefined }));
 
 		expect(plan).toEqual({ creations: [], failures: [], matchedCount: 0 });
-		expect(moduleRegistry.isActive).not.toHaveBeenCalled();
-	});
-
-	it('fails with module-disabled when the data-table module is inactive', async () => {
-		const { importer, moduleRegistry } = makeImporter();
-		moduleRegistry.isActive.mockReturnValue(false);
-
-		const plan = await importer.plan(context, makeRequest());
-
-		expect(plan.creations).toEqual([]);
-		expect(plan.failures).toEqual([{ kind: 'module-disabled', usedByWorkflows: ['wf-1'] }]);
 	});
 
 	it('fails with permission-denied when the user cannot create tables in the target project', async () => {
@@ -105,11 +91,9 @@ describe('DataTableImporter.plan', () => {
 			columns: [],
 		});
 		const dataTableService = mock<DataTableService>();
-		const moduleRegistry = mock<ModuleRegistry>();
-		moduleRegistry.isActive.mockReturnValue(true);
 		dataTableService.findDataTablesByIds.mockResolvedValue([foreignTable]);
 		dataTableService.findDataTablesByNamesInProject.mockResolvedValue([]);
-		const importer = new DataTableImporter(dataTableService, moduleRegistry);
+		const importer = new DataTableImporter(dataTableService);
 
 		const plan = await importer.plan(context, makeRequest());
 

--- a/packages/cli/src/modules/data-table/n8n-packages/__tests__/data-table.exporter.test.ts
+++ b/packages/cli/src/modules/data-table/n8n-packages/__tests__/data-table.exporter.test.ts
@@ -1,15 +1,14 @@
-import type { ModuleRegistry } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { jsonParse } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
-import type { DataTable } from '@/modules/data-table/data-table.entity';
-import type { DataTableService } from '@/modules/data-table/data-table.service';
+import type { WorkflowDataTableRequirement } from '@/modules/n8n-packages/entities/data-table/data-table.types';
+import { CapturingWriter } from '@/modules/n8n-packages/io/__tests__/utils/capturing-writer';
 
-import { CapturingWriter } from '../../../io/__tests__/utils/capturing-writer';
+import type { DataTable } from '../../data-table.entity';
+import type { DataTableService } from '../../data-table.service';
 import { DataTableExporter } from '../data-table.exporter';
 import { DataTableSerializer } from '../data-table.serializer';
-import type { WorkflowDataTableRequirement } from '../data-table.types';
 
 const user = mock<User>({ id: 'user-1' });
 
@@ -37,14 +36,8 @@ function makeRequirement(
 
 function makeExporter() {
 	const dataTableService = mock<DataTableService>();
-	const moduleRegistry = mock<ModuleRegistry>();
-	moduleRegistry.isActive.mockReturnValue(true);
-	const exporter = new DataTableExporter(
-		dataTableService,
-		new DataTableSerializer(),
-		moduleRegistry,
-	);
-	return { exporter, dataTableService, moduleRegistry };
+	const exporter = new DataTableExporter(dataTableService, new DataTableSerializer());
+	return { exporter, dataTableService };
 }
 
 describe('DataTableExporter', () => {
@@ -59,21 +52,6 @@ describe('DataTableExporter', () => {
 			expect(writer.files).toEqual([]);
 			expect(writer.directories).toEqual([]);
 			expect(dataTableService.findDataTablesByIdsForUser).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('module guard', () => {
-		it('throws when tables are required but the data-table module is disabled', async () => {
-			const { exporter, dataTableService, moduleRegistry } = makeExporter();
-			moduleRegistry.isActive.mockReturnValue(false);
-			const writer = new CapturingWriter();
-
-			await expect(
-				exporter.export({ user, requirements: [makeRequirement()], writer }),
-			).rejects.toThrowError(/data-table module is disabled/);
-
-			expect(dataTableService.findDataTablesByIdsForUser).not.toHaveBeenCalled();
-			expect(writer.files).toEqual([]);
 		});
 	});
 

--- a/packages/cli/src/modules/data-table/n8n-packages/__tests__/data-table.serializer.test.ts
+++ b/packages/cli/src/modules/data-table/n8n-packages/__tests__/data-table.serializer.test.ts
@@ -1,5 +1,4 @@
-import type { DataTable } from '@/modules/data-table/data-table.entity';
-
+import type { DataTable } from '../../data-table.entity';
 import { DataTableSerializer } from '../data-table.serializer';
 
 function makeDataTable(overrides: Partial<DataTable> = {}): DataTable {

--- a/packages/cli/src/modules/data-table/n8n-packages/data-table-importer.ts
+++ b/packages/cli/src/modules/data-table/n8n-packages/data-table-importer.ts
@@ -1,29 +1,28 @@
-import { ModuleRegistry } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import { UserError } from 'n8n-workflow';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import type { DataTable } from '@/modules/data-table/data-table.entity';
-import { DataTableService } from '@/modules/data-table/data-table.service';
-import { userHasScopes } from '@/permissions.ee/check-access';
-
-import { matchTargetTable } from './data-table-matching-mode';
-import { decideAbsentTable } from './data-table-missing-mode';
-import type { TableEffect } from './data-table-missing-mode';
-import { findSchemaConflict } from './data-table-schema-conflict-policy';
-import { createFailure } from './data-table.types';
+import { decideAbsentTable } from '@/modules/n8n-packages/entities/data-table/data-table-missing-mode';
+import type { TableEffect } from '@/modules/n8n-packages/entities/data-table/data-table-missing-mode';
+import { findSchemaConflict } from '@/modules/n8n-packages/entities/data-table/data-table-schema-conflict-policy';
+import { createFailure } from '@/modules/n8n-packages/entities/data-table/data-table.types';
 import type {
 	DataTableImportPlan,
 	DataTableImportRequest,
 	DataTableResolutionFailure,
-} from './data-table.types';
+} from '@/modules/n8n-packages/entities/data-table/data-table.types';
 import type {
 	DataTableMissingMode,
 	DataTableSchemaConflictPolicy,
 	ImportContext,
-} from '../../n8n-packages.types';
-import type { PackageDataTableRequirement } from '../../spec/requirements.schema';
-import type { SerializedDataTable } from '../../spec/serialized/data-table.schema';
+} from '@/modules/n8n-packages/n8n-packages.types';
+import type { PackageDataTableRequirement } from '@/modules/n8n-packages/spec/requirements.schema';
+import type { SerializedDataTable } from '@/modules/n8n-packages/spec/serialized/data-table.schema';
+import { userHasScopes } from '@/permissions.ee/check-access';
+
+import { matchTargetTable } from './data-table-matching-mode';
+import type { DataTable } from '../data-table.entity';
+import { DataTableService } from '../data-table.service';
 
 interface PlannedCreation {
 	table: SerializedDataTable;
@@ -32,10 +31,7 @@ interface PlannedCreation {
 
 @Service()
 export class DataTableImporter {
-	constructor(
-		private readonly dataTableService: DataTableService,
-		private readonly moduleRegistry: ModuleRegistry,
-	) {}
+	constructor(private readonly dataTableService: DataTableService) {}
 
 	/**
 	 * Resolves the package's data table references against the target project.
@@ -49,14 +45,6 @@ export class DataTableImporter {
 	): Promise<DataTableImportPlan> {
 		const requirements = request.requirements ?? [];
 		if (requirements.length === 0) return { creations: [], failures: [], matchedCount: 0 };
-
-		if (!this.moduleRegistry.isActive('data-table')) {
-			return {
-				creations: [],
-				failures: [{ kind: 'module-disabled', usedByWorkflows: workflowsUsing(requirements) }],
-				matchedCount: 0,
-			};
-		}
 
 		const packageTablesById = new Map(request.packageDataTables.map((table) => [table.id, table]));
 		const targets = await this.dataTableService.findDataTablesByIds(

--- a/packages/cli/src/modules/data-table/n8n-packages/data-table-matching-mode.ts
+++ b/packages/cli/src/modules/data-table/n8n-packages/data-table-matching-mode.ts
@@ -1,7 +1,7 @@
-import type { DataTable } from '@/modules/data-table/data-table.entity';
+import type { DataTableMatchingMode } from '@/modules/n8n-packages/n8n-packages.types';
+import type { PackageDataTableRequirement } from '@/modules/n8n-packages/spec/requirements.schema';
 
-import type { DataTableMatchingMode } from '../../n8n-packages.types';
-import type { PackageDataTableRequirement } from '../../spec/requirements.schema';
+import type { DataTable } from '../data-table.entity';
 
 /**
  * Lookup structures prefetched by the caller that matching modes draw on.

--- a/packages/cli/src/modules/data-table/n8n-packages/data-table.exporter.ts
+++ b/packages/cli/src/modules/data-table/n8n-packages/data-table.exporter.ts
@@ -1,47 +1,29 @@
-import { ModuleRegistry } from '@n8n/backend-common';
-import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { UserError } from 'n8n-workflow';
 
-import type { DataTable } from '@/modules/data-table/data-table.entity';
-import { DataTableService } from '@/modules/data-table/data-table.service';
+import type { WorkflowDataTableRequirement } from '@/modules/n8n-packages/entities/data-table/data-table.types';
+import { UniqueFilenameAllocator } from '@/modules/n8n-packages/io/unique-filename-allocator';
+import type {
+	DataTableExportRequest,
+	DataTableExportResult,
+} from '@/modules/n8n-packages/package-entity-handler.registry';
+import type { ManifestEntry } from '@/modules/n8n-packages/spec/manifest.schema';
+import type { PackageDataTableRequirement } from '@/modules/n8n-packages/spec/requirements.schema';
 
 import { DataTableSerializer } from './data-table.serializer';
-import type { WorkflowDataTableRequirement } from './data-table.types';
-import type { PackageWriter } from '../../io/package-writer';
-import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
-import type { ManifestEntry } from '../../spec/manifest.schema';
-import type { PackageDataTableRequirement } from '../../spec/requirements.schema';
-
-export interface DataTableExportRequest {
-	user: User;
-	requirements: WorkflowDataTableRequirement[];
-	writer: PackageWriter;
-	projectTargetsById?: Map<string, string>;
-}
-
-export interface DataTableExportResult {
-	entries: ManifestEntry[];
-	requirements: PackageDataTableRequirement[];
-}
+import type { DataTable } from '../data-table.entity';
+import { DataTableService } from '../data-table.service';
 
 @Service()
 export class DataTableExporter {
 	constructor(
 		private readonly dataTableService: DataTableService,
 		private readonly dataTableSerializer: DataTableSerializer,
-		private readonly moduleRegistry: ModuleRegistry,
 	) {}
 
 	async export(request: DataTableExportRequest): Promise<DataTableExportResult> {
 		if (request.requirements.length === 0) {
 			return { entries: [], requirements: [] };
-		}
-
-		if (!this.moduleRegistry.isActive('data-table')) {
-			throw new UserError(
-				'The exported workflows use data tables, but the data-table module is disabled on this instance.',
-			);
 		}
 
 		const usedByWorkflowsById = this.groupByDataTableId(request.requirements);

--- a/packages/cli/src/modules/data-table/n8n-packages/data-table.serializer.ts
+++ b/packages/cli/src/modules/data-table/n8n-packages/data-table.serializer.ts
@@ -1,11 +1,11 @@
 import { Service } from '@n8n/di';
 
-import type { DataTable } from '@/modules/data-table/data-table.entity';
-
 import {
 	serializedDataTableSchema,
 	type SerializedDataTable,
-} from '../../spec/serialized/data-table.schema';
+} from '@/modules/n8n-packages/spec/serialized/data-table.schema';
+
+import type { DataTable } from '../data-table.entity';
 
 @Service()
 export class DataTableSerializer {

--- a/packages/cli/src/modules/data-table/n8n-packages/register.ts
+++ b/packages/cli/src/modules/data-table/n8n-packages/register.ts
@@ -1,0 +1,22 @@
+import { Container } from '@n8n/di';
+
+import { PackageEntityHandlerRegistry } from '@/modules/n8n-packages/package-entity-handler.registry';
+
+import { DataTableImporter } from './data-table-importer';
+import { DataTableExporter } from './data-table.exporter';
+
+/**
+ * Hooks this module into n8n-packages import/export. Runs on module init, so
+ * n8n-packages sees no handler — and reports data tables as unavailable —
+ * exactly when this module is disabled.
+ */
+export function registerDataTablePackageHandler() {
+	const importer = Container.get(DataTableImporter);
+	const exporter = Container.get(DataTableExporter);
+
+	Container.get(PackageEntityHandlerRegistry).register('data-table', {
+		plan: async (context, request) => await importer.plan(context, request),
+		apply: async (context, plan) => await importer.apply(context, plan),
+		export: async (request) => await exporter.export(request),
+	});
+}

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-data-tables.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-data-tables.integration.test.ts
@@ -1,4 +1,3 @@
-import type { Project, User } from '@n8n/db';
 import {
 	createTeamProject,
 	getPersonalProject,
@@ -7,6 +6,7 @@ import {
 	testDb,
 	testModules,
 } from '@n8n/backend-test-utils';
+import type { Project, User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { jsonParse } from 'n8n-workflow';
 
@@ -14,10 +14,12 @@ import { EventService } from '@/events/event.service';
 import type { RelayEventMap } from '@/events/maps/relay.event-map';
 import { mockDataTableSizeValidator } from '@/modules/data-table/__tests__/test-helpers';
 import { DataTableService } from '@/modules/data-table/data-table.service';
+import { registerDataTablePackageHandler } from '@/modules/data-table/n8n-packages/register';
 import { createFolder } from '@test-integration/db/folders';
 import { createMember, createOwner } from '@test-integration/db/users';
 
 import { N8nPackagesService } from '../n8n-packages.service';
+import { PackageEntityHandlerRegistry } from '../package-entity-handler.registry';
 import { readExport } from './utils/tar-support';
 import {
 	buildWorkflowCallingSubWorkflow,
@@ -30,6 +32,8 @@ let dataTableService: DataTableService;
 beforeAll(async () => {
 	await testModules.loadModules(['n8n-packages', 'data-table']);
 	await testDb.init();
+	// loadModules skips module init, where this registration normally happens.
+	registerDataTablePackageHandler();
 	mockDataTableSizeValidator();
 	service = Container.get(N8nPackagesService);
 	dataTableService = Container.get(DataTableService);
@@ -514,6 +518,33 @@ describe('workflow package export — with data tables', () => {
 					workflowIds: [accessibleWf.id, forbiddenWf.id],
 				}),
 			).rejects.toThrow(/data table\(s\) not found or not accessible/i);
+		});
+	});
+
+	describe('module disabled', () => {
+		it('rejects an export whose workflows use data tables when the module is disabled', async () => {
+			const dataTable = await dataTableService.createDataTable(project.id, {
+				name: 'Customers',
+				columns: [{ name: 'email', type: 'string' }],
+			});
+			const workflow = await buildWorkflowReferencingDataTables({
+				name: 'Workflow with table',
+				project,
+				references: [{ dataTableId: dataTable.id }],
+			});
+
+			// A disabled data-table module never registers its package handler.
+			const getHandler = vi
+				.spyOn(Container.get(PackageEntityHandlerRegistry), 'get')
+				.mockReturnValue(undefined);
+
+			try {
+				await expect(
+					service.exportPackage({ user: owner, workflowIds: [workflow.id] }),
+				).rejects.toThrow(/data-table module is disabled/);
+			} finally {
+				getHandler.mockRestore();
+			}
 		});
 	});
 

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-data-tables.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-data-tables.integration.test.ts
@@ -1,4 +1,4 @@
-import { LicenseState, ModuleRegistry } from '@n8n/backend-common';
+import { LicenseState } from '@n8n/backend-common';
 import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
 import type { Project, User } from '@n8n/db';
 import { FolderRepository, WorkflowRepository } from '@n8n/db';
@@ -14,25 +14,27 @@ import { mockDataTableSizeValidator } from '@/modules/data-table/__tests__/test-
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
+import { registerDataTablePackageHandler } from '@/modules/data-table/n8n-packages/register';
 import { createFolder } from '@test-integration/db/folders';
 import { createOwner } from '@test-integration/db/users';
 import { LicenseMocker } from '@test-integration/license';
 import { initNodeTypes } from '@test-integration/utils';
 
 import { N8nPackagesService } from '../n8n-packages.service';
-import { importPackageRequest } from './fixtures/import-request';
 import type { ImportPackageRequest } from '../n8n-packages.types';
+import { PackageEntityHandlerRegistry } from '../package-entity-handler.registry';
+import { importPackageRequest } from './fixtures/import-request';
 import type { PackageDataTableRequirement } from '../spec/requirements.schema';
-import type { SerializedDataTable } from '../spec/serialized/data-table.schema';
-import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
 import {
 	buildEntityPackageBuffer,
 	dataTableRequirement,
 	serializedDataTable,
 	serializedWorkflowWithDataTable,
 } from './fixtures/package-fixtures';
-import { buildWorkflowReferencingDataTables } from './utils/test-builders';
 import { streamToBuffer } from './utils/tar-support';
+import { buildWorkflowReferencingDataTables } from './utils/test-builders';
+import type { SerializedDataTable } from '../spec/serialized/data-table.schema';
+import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
 
 let service: N8nPackagesService;
 let dataTableService: DataTableService;
@@ -44,6 +46,8 @@ const licenseMocker = new LicenseMocker();
 beforeAll(async () => {
 	await testModules.loadModules(['n8n-packages', 'data-table']);
 	await testDb.init();
+	// loadModules skips module init, where this registration normally happens.
+	registerDataTablePackageHandler();
 	// Register node types so the plan-phase missing-node-type check can resolve
 	// the node types used by the package fixtures.
 	await initNodeTypes();
@@ -524,9 +528,10 @@ describe('workflow package import — with data tables', () => {
 
 		it('blocks when the package requires data tables and the module is disabled', async () => {
 			const { packageBuffer } = await buildDataTablePackage([serializedDataTable()]);
-			const isActive = vi
-				.spyOn(Container.get(ModuleRegistry), 'isActive')
-				.mockImplementation((moduleName) => moduleName !== 'data-table');
+			// A disabled data-table module never registers its package handler.
+			const getHandler = vi
+				.spyOn(Container.get(PackageEntityHandlerRegistry), 'get')
+				.mockReturnValue(undefined);
 
 			try {
 				await expectBlocked(importPackage({ user: owner, projectId: project.id, packageBuffer }), {
@@ -534,7 +539,7 @@ describe('workflow package import — with data tables', () => {
 					kind: 'module-disabled',
 				});
 			} finally {
-				isActive.mockRestore();
+				getHandler.mockRestore();
 			}
 
 			expect(await workflowRepository.count()).toBe(0);

--- a/packages/cli/src/modules/n8n-packages/engine/import-orchestrator.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-orchestrator.ts
@@ -3,6 +3,8 @@ import { Service } from '@n8n/di';
 
 import { NodeTypes } from '@/node-types';
 
+import { toImportBlockedError } from './import-blocked.error';
+import { assertVariableWritesAllowed } from './import-gates';
 import { CredentialImporter } from '../entities/credential/credential-importer';
 import { workflowsBlockedFromPublish } from '../entities/credential/credential-missing-mode';
 import type {
@@ -11,7 +13,6 @@ import type {
 	CredentialResolution,
 	CredentialResolutionFailure,
 } from '../entities/credential/credential.types';
-import { DataTableImporter } from '../entities/data-table/data-table-importer';
 import type {
 	DataTableImportPlan,
 	DataTableImportRequest,
@@ -57,9 +58,8 @@ import type {
 	MissingNodeTypeMode,
 	PackageImportBindings,
 } from '../n8n-packages.types';
+import { PackageEntityHandlerRegistry } from '../package-entity-handler.registry';
 import type { PackageWorkflowRequirement } from '../spec/requirements.schema';
-import { toImportBlockedError } from './import-blocked.error';
-import { assertVariableWritesAllowed } from './import-gates';
 
 export interface ImportOrchestrationInput {
 	context: ImportContext;
@@ -112,7 +112,7 @@ export interface ImportPlan {
 export class ImportOrchestrator {
 	constructor(
 		private readonly credentialImporter: CredentialImporter,
-		private readonly dataTableImporter: DataTableImporter,
+		private readonly packageEntityHandlers: PackageEntityHandlerRegistry,
 		private readonly variableImporter: VariableImporter,
 		private readonly tagImporter: TagImporter,
 		private readonly folderImporter: FolderImporter,
@@ -194,7 +194,7 @@ export class ImportOrchestrator {
 		);
 
 		const credentialPlan = await this.credentialImporter.plan(context, credentialRequest);
-		const dataTablePlan = await this.dataTableImporter.plan(context, dataTableRequest);
+		const dataTablePlan = await this.planDataTables(context, dataTableRequest);
 		const variablePlan = await this.variableImporter.plan(context, variableRequest);
 		const workflowPlan = await this.workflowImporter.plan(context, workflows, options);
 		// Tags plan after workflows: only tags referenced by non-skipped workflows gate or create.
@@ -271,7 +271,8 @@ export class ImportOrchestrator {
 			credentialPlan,
 		);
 
-		await this.dataTableImporter.apply(context, dataTablePlan);
+		// Without a registered handler the plan can only be empty, so this is a no-op.
+		await this.packageEntityHandlers.get('data-table')?.apply(context, dataTablePlan);
 
 		// Which workflows the publish phase must leave inactive. Known only now, because it depends
 		// on which credentials actually ended up stubbed.
@@ -314,6 +315,35 @@ export class ImportOrchestrator {
 			variablePlan,
 			variableResult,
 			tagPlan,
+		};
+	}
+
+	/**
+	 * Data-table planning is owned by the data-table module, which registers its
+	 * handler on init. Without one (module disabled), a package that references
+	 * no data tables passes through and any other package is blocked.
+	 */
+	private async planDataTables(
+		context: ImportContext,
+		request: DataTableImportRequest,
+	): Promise<DataTableImportPlan> {
+		const handler = this.packageEntityHandlers.get('data-table');
+		if (handler) return await handler.plan(context, request);
+
+		const requirements = request.requirements ?? [];
+		if (requirements.length === 0) return { creations: [], failures: [], matchedCount: 0 };
+
+		return {
+			creations: [],
+			failures: [
+				{
+					kind: 'module-disabled',
+					usedByWorkflows: [
+						...new Set(requirements.flatMap(({ usedByWorkflows }) => usedByWorkflows)),
+					].sort(),
+				},
+			],
+			matchedCount: 0,
 		};
 	}
 

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -1,6 +1,7 @@
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
+import { UserError } from 'n8n-workflow';
 
 import { N8N_VERSION } from '@/constants';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -11,19 +12,18 @@ import { N8nPackageParser } from './engine/n8n-package-parser';
 import { ProjectPackageImporter } from './engine/project-package-importer';
 import { WorkflowPackageImporter } from './engine/workflow-package-importer';
 import { CredentialExporter } from './entities/credential/credential.exporter';
-import { DataTableExporter } from './entities/data-table/data-table.exporter';
 import { FolderExporter } from './entities/folder/folder.exporter';
 import { ProjectExporter } from './entities/project/project.exporter';
 import { mergeRequirements } from './entities/requirements.types';
 import { TagExporter } from './entities/tag/tag.exporter';
 import { VariableExporter } from './entities/variable/variable.exporter';
-import { collectNodeTypeUsage } from './entities/workflow/node-type-usage';
-import { assertStaticSubWorkflowsIncluded } from './entities/workflow/static-sub-workflow-requirements';
 import { AutoIncludedWorkflowResolver } from './entities/workflow/auto-included-workflow-resolver';
 import {
 	AutoIncludedWorkflowExporter,
 	type AutoIncludedWorkflowExportResult,
 } from './entities/workflow/auto-included-workflow.exporter';
+import { collectNodeTypeUsage } from './entities/workflow/node-type-usage';
+import { assertStaticSubWorkflowsIncluded } from './entities/workflow/static-sub-workflow-requirements';
 import { WorkflowDependencyResolver } from './entities/workflow/workflow-dependency-resolver';
 import { WorkflowRequirementExporter } from './entities/workflow/workflow-requirement.exporter';
 import { WorkflowExporter } from './entities/workflow/workflow.exporter';
@@ -38,6 +38,11 @@ import {
 	type ImportPackageRequest,
 	type ImportResult,
 } from './n8n-packages.types';
+import {
+	PackageEntityHandlerRegistry,
+	type DataTableExportRequest,
+	type DataTableExportResult,
+} from './package-entity-handler.registry';
 import { FORMAT_VERSION } from './spec/constants';
 import {
 	packageManifestSchema,
@@ -53,7 +58,7 @@ export class N8nPackagesService {
 		private readonly workflowExporter: WorkflowExporter,
 		private readonly folderExporter: FolderExporter,
 		private readonly credentialExporter: CredentialExporter,
-		private readonly dataTableExporter: DataTableExporter,
+		private readonly packageEntityHandlers: PackageEntityHandlerRegistry,
 		private readonly variableExporter: VariableExporter,
 		private readonly tagExporter: TagExporter,
 		private readonly globalConfig: GlobalConfig,
@@ -210,7 +215,7 @@ export class N8nPackagesService {
 			projectTargetsById,
 		});
 
-		const dataTableExportResult = await this.dataTableExporter.export({
+		const dataTableExportResult = await this.exportDataTables({
 			user: request.user,
 			requirements: requirements.dataTables,
 			writer,
@@ -305,6 +310,22 @@ export class N8nPackagesService {
 			return await this.projectPackageImporter.import(request, reader, manifest);
 		}
 		return await this.workflowPackageImporter.import(request, reader, manifest);
+	}
+
+	/**
+	 * Data-table export is owned by the data-table module, which registers its
+	 * handler on init. Without one (module disabled), a package that references
+	 * no data tables exports as usual and any other package is rejected.
+	 */
+	private async exportDataTables(request: DataTableExportRequest): Promise<DataTableExportResult> {
+		const handler = this.packageEntityHandlers.get('data-table');
+		if (handler) return await handler.export(request);
+
+		if (request.requirements.length === 0) return { entries: [], requirements: [] };
+
+		throw new UserError(
+			'The exported workflows use data tables, but the data-table module is disabled on this instance.',
+		);
 	}
 
 	filterWorkflowsAlreadyInFolders(workflowsInFolders: ManifestEntry[] = [], workflowIds: string[]) {

--- a/packages/cli/src/modules/n8n-packages/package-entity-handler.registry.ts
+++ b/packages/cli/src/modules/n8n-packages/package-entity-handler.registry.ts
@@ -1,0 +1,61 @@
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import type {
+	DataTableImportPlan,
+	DataTableImportRequest,
+	WorkflowDataTableRequirement,
+} from './entities/data-table/data-table.types';
+import type { PackageWriter } from './io/package-writer';
+import type { ImportContext } from './n8n-packages.types';
+import type { ManifestEntry } from './spec/manifest.schema';
+import type { PackageDataTableRequirement } from './spec/requirements.schema';
+
+export interface DataTableExportRequest {
+	user: User;
+	requirements: WorkflowDataTableRequirement[];
+	writer: PackageWriter;
+	projectTargetsById?: Map<string, string>;
+}
+
+export interface DataTableExportResult {
+	entries: ManifestEntry[];
+	requirements: PackageDataTableRequirement[];
+}
+
+export interface DataTablePackageHandler {
+	plan(context: ImportContext, request: DataTableImportRequest): Promise<DataTableImportPlan>;
+	apply(context: ImportContext, plan: DataTableImportPlan): Promise<void>;
+	export(request: DataTableExportRequest): Promise<DataTableExportResult>;
+}
+
+/* eslint-disable @typescript-eslint/naming-convention -- keys are module names */
+export interface PackageEntityHandlers {
+	'data-table': DataTablePackageHandler;
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * Modules owning a package entity type register their import/export handler
+ * here during module init, so n8n-packages never reaches into module
+ * internals. A type with no registered handler behaves exactly as if the
+ * owning module were disabled.
+ */
+@Service()
+export class PackageEntityHandlerRegistry {
+	private readonly handlers = new Map<
+		keyof PackageEntityHandlers,
+		PackageEntityHandlers[keyof PackageEntityHandlers]
+	>();
+
+	register<T extends keyof PackageEntityHandlers>(
+		entityType: T,
+		handler: PackageEntityHandlers[T],
+	) {
+		this.handlers.set(entityType, handler);
+	}
+
+	get<T extends keyof PackageEntityHandlers>(entityType: T): PackageEntityHandlers[T] | undefined {
+		return this.handlers.get(entityType);
+	}
+}


### PR DESCRIPTION
## Summary

Removes the cross-module imports from `n8n-packages` into the `data-table` module (`DataTable` entity + `DataTableService`), inverting the dependency:

- `n8n-packages` now exposes a `PackageEntityHandlerRegistry` (`@Service()`, keyed by entity type, tolerant of a type having no registered handler) as its registration point for module-owned package entity handlers.
- The four data-table handler files (`data-table-importer.ts`, `data-table.exporter.ts`, `data-table.serializer.ts`, `data-table-matching-mode.ts`) move wholesale into `packages/cli/src/modules/data-table/n8n-packages/`, where their entity/service imports become intra-module. Their unit tests move along with them.
- The data-table module registers its handler during `init()`, so the previous `moduleRegistry.isActive('data-table')` guards become redundant and are dropped from the moved code.

When no handler is registered (module disabled), `n8n-packages` behaves exactly as the old guards did: packages that reference no data tables import/export as before, imports referencing data tables are blocked with the same `module-disabled` issue, and exports referencing data tables are rejected with the same error message. Export file formats and import semantics are unchanged.

## How to test

- `pnpm test src/modules/data-table src/modules/n8n-packages` (unit) and `pnpm test:integration src/modules/data-table src/modules/n8n-packages` (integration) in `packages/cli` — all green.
- Manual: export/import an `.n8np` package referencing data tables on an instance with the module enabled (works as before), and with `N8N_DISABLED_MODULES=data-table` (export rejected / import blocked as before).

## Related Linear tickets, Github issues, and Community forum posts

Part of https://linear.app/n8n/issue/DEVP-646

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

