### PR TITLE
docs: fix typos and duplicated words in comments/descriptions

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -192,7 +192,7 @@ If you are using Prometheus metrics from these categories and are using a non-em
 
 ### What changed?
 
-Calling `$(...).last()` (or `$(...).first()` or `$(...).all()` respectively) without arguments is returning the the last item (or first or all items) of the output that connects the two nodes. Before it was returning the item/items of the first output of that node.
+Calling `$(...).last()` (or `$(...).first()` or `$(...).all()` respectively) without arguments is returning the last item (or first or all items) of the output that connects the two nodes. Before it was returning the item/items of the first output of that node.
 
 ### When is action necessary?
 

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -132,7 +132,7 @@ export class CredentialsTester {
 
 			// Check each of the node versions for credential tests
 			for (const nodeType of allNodeTypes) {
-				// Check each of teh credentials
+				// Check each of the credentials
 				for (const { name, testedBy } of nodeType.description.credentials ?? []) {
 					if (
 						name === credentialType &&

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -205,7 +205,7 @@ export class GitlabTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 

--- a/packages/nodes-base/nodes/If/V1/IfV1.node.ts
+++ b/packages/nodes-base/nodes/If/V1/IfV1.node.ts
@@ -461,7 +461,7 @@ export class IfV1 implements INodeType {
 				// so it passes.
 				returnDataTrue.push(item);
 			} else {
-				// If the operation is "any" it means the the item did not match any condition.
+				// If the operation is "any" it means the item did not match any condition.
 				returnDataFalse.push(item);
 			}
 		}

--- a/packages/nodes-base/nodes/Medium/Medium.node.ts
+++ b/packages/nodes-base/nodes/Medium/Medium.node.ts
@@ -426,7 +426,7 @@ export class Medium implements INodeType {
 								if (returnValue.length > 25) {
 									throw new NodeOperationError(
 										this.getNode(),
-										`The tag "${returnValue}" is to long. Maximum lenght of a tag is 25 characters.`,
+										`The tag "${returnValue}" is too long. Maximum length of a tag is 25 characters.`,
 										{ itemIndex: i },
 									);
 								}

--- a/packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts
+++ b/packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts
@@ -455,7 +455,7 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to assign the the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to assign the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Backlog Order',

--- a/scripts/backend-module/backend-module-guide.md
+++ b/scripts/backend-module/backend-module-guide.md
@@ -309,7 +309,7 @@ As an exception, migrations remain centralized at `@n8n/db/src/migrations`, beca
 
 ## Configuration
 
-Module-specific configuration is defined in the the `.config.ts` file:
+Module-specific configuration is defined in the `.config.ts` file:
 
 ```ts
 @Config


### PR DESCRIPTION
### WHY

Several comments and node descriptions contain typos (`teh`, `occured`, `to long`, `lenght`) and duplicated words (`the the`). Trivial text fixes.

### WHAT

| File | Before | After |
|------|--------|-------|
| `cli/src/services/credentials-tester.service.ts` | `each of teh credentials` | `each of the credentials` |
| `nodes-base/nodes/Gitlab/GitlabTrigger.node.ts` | `Some error occured` | `Some error occurred` |
| `nodes-base/nodes/If/V1/IfV1.node.ts` | `the the item` | `the item` |
| `nodes-base/nodes/Medium/Medium.node.ts` | `is to long. Maximum lenght` | `is too long. Maximum length` |
| `nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts` | `the the user story` | `the user story` |
| `scripts/backend-module/backend-module-guide.md` | `in the the `.config.ts`` | `in the `.config.ts`` |
| `cli/BREAKING-CHANGES.md` | `the the last item` | `the last item` |

Comments/descriptions only; no code behavior change. The Medium.node.ts fix also corrects a user-facing error message.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

