### PR TITLE
test: Pin system time for all workflow history compaction tests

### DIFF
--- a/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
@@ -27,6 +27,16 @@ describe('WorkflowHistoryCompactionService', () => {
 		},
 	});
 
+	beforeEach(() => {
+		// Set the system to a time that isn't 3 AM to avoid hitting the "trim once a day" window
+		const mockDate = new Date(2026, 10, 10, 1, 0, 0);
+		vi.setSystemTime(mockDate);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	describe('init', () => {
 		it('should start compacting on main instance that is the leader', () => {
 			const compactingService = new WorkflowHistoryCompactionService(
@@ -64,16 +74,6 @@ describe('WorkflowHistoryCompactionService', () => {
 	});
 
 	describe('startCompacting', () => {
-		beforeEach(() => {
-			// Set the system to a time that isn't 3 AM to avoid hitting the "trim once a day" window
-			const mockDate = new Date(2026, 10, 10, 1, 0, 0);
-			vi.setSystemTime(mockDate);
-		});
-
-		afterEach(() => {
-			vi.useRealTimers();
-		});
-
 		it('should start compacting if service is enabled and DB is migrated', () => {
 			const compactingService = new WorkflowHistoryCompactionService(
 				config,


### PR DESCRIPTION
## Summary

Completes the fix from #35573: the clock-pinning `beforeEach`/`afterEach` was added only inside `describe('startCompacting')`, but four tests — including `should compact on start up` — sit outside that block and still ran on the real wall clock. Any test run whose runner-local hour is 3 (e.g. nightly CI between 03:00 and 04:00 UTC) made `scheduleTrimming()`'s immediate `trimOnceADay()` call fire `trimLongRunningHistories()`, failing the `not.toHaveBeenCalled()` assertion.

This hoists the hooks to the top-level `describe` so every test runs with the system time pinned to 1 AM. The two tests that deliberately exercise the 3 AM / 5 AM windows still set their own time, which overrides the hook.

## How to test

```bash
pushd packages/cli
pnpm vitest run src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
# reproduce the old failure mode: pick a TZ where the current hour is 3
TZ=Etc/GMT+1 pnpm vitest run src/services/pruning/__tests__/workflow-history-compaction.service.test.ts
```

Before this change the second command fails on `should compact on start up` whenever the chosen TZ puts local time in the 3 o'clock hour; now both pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-684

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

