### PR TITLE
test: Stabilize SSE push backend test

### DIFF
--- a/packages/testing/playwright/tests/e2e/push/sse-push-backend.spec.ts
+++ b/packages/testing/playwright/tests/e2e/push/sse-push-backend.spec.ts
@@ -2,11 +2,11 @@ import { test, expect } from '../../../fixtures/base';
 
 /**
  * The default container stack runs the `websocket` push backend, so `sse` needs a
- * container of its own. Only meaningful in container mode: the origin check this
- * covers is gated on `NODE_ENV=production`, which the image sets but a local
- * `pnpm start` does not.
+ * container of its own. `NODE_ENV` is pinned to `production` because the origin
+ * check this covers is gated on it, and the stack's base env otherwise forces
+ * `development` — without the override the connection is accepted unchecked.
  */
-test.use({ capability: { env: { N8N_PUSH_BACKEND: 'sse' } } });
+test.use({ capability: { env: { N8N_PUSH_BACKEND: 'sse', NODE_ENV: 'production' } } });
 
 test.beforeEach(({ n8nContainer }) => {
 	test.skip(!n8nContainer, 'container-only: requires the SSE backend configuration');
@@ -29,9 +29,12 @@ test.describe(
 			expect((await pushResponse).status()).toBe(200);
 
 			// Run status per node arrives over that connection, so it cannot show up unless
-			// the stream stayed open.
+			// the stream stayed open. The container is freshly booted here, so this is its
+			// first Code node run and pays the task runner's cold start — measured at 3-4s,
+			// well past the helper's 3s default.
 			await n8n.workflowComposer.executeWorkflowAndWaitForNotification(
 				'Workflow executed successfully',
+				{ timeout: 20_000 },
 			);
 			await expect(n8n.canvas.getNodeSuccessStatusIndicator('Code')).toBeVisible();
 		});


### PR DESCRIPTION
## Summary

The e2e test added in #35327 is flaky. Pin the SSE push backend E2E container to production mode so origin validation is exercised, and increase the execution notification timeout to cover the task runner's Code node cold start.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4001

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

