### PR TITLE
ci: Auto-resolve mechanical master→3.x sync conflicts (no-changelog)

### DIFF
--- a/.github/DEVELOPING_V3.md
+++ b/.github/DEVELOPING_V3.md
@@ -133,14 +133,26 @@ of the breaking removal on `3.x`.
    original message and author. Nothing is ever squashed. Merge commits in the range (breaking
    PRs merged into `3.x`) are flattened away, and a breaking commit that also landed on
    `master` is dropped as empty.
-3. On a **conflict**, `3.x` is left **untouched** and a **draft conflict PR** (labeled
-   `automation:v3-sync`) carrying the conflict markers is opened on `sync/master-to-3x`, plus a
-   post to the **`#alerts-v3-sync`** Slack channel. **Syncs pause until that PR is merged** —
-   so conflicts never pile up silently.
+3. Conflicts confined to **mechanical files** — tool-generated content with a deterministic
+   resolution (`pnpm-lock.yaml`, `packages/frontend/editor-ui/data/node-popularity.json`,
+   `.github/test-metrics/e2e-impact-map.json`) — are **auto-resolved during the replay**,
+   exactly as a human resolver would: the lockfile is regenerated with
+   `pnpm install --lockfile-only` (pnpm merges its own conflict markers), bot-maintained data
+   files take `master`'s side. The resolution is folded into the stalled commit, so this
+   still adds **no commit and no PR**. The list lives in `MECHANICAL_PATHS` in
+   [`sync-master-to-3x.mjs`](./scripts/sync-master-to-3x.mjs).
+4. On a **real code conflict**, `3.x` is left **untouched** and a **draft conflict PR**
+   (labeled `automation:v3-sync`) carrying the conflict markers is opened on
+   `sync/master-to-3x` — with the mechanical files already pre-resolved — plus a post to the
+   **`#alerts-v3-sync`** Slack channel. **Syncs pause until that PR is merged** — so
+   conflicts never pile up silently.
 
 Whatever route it takes, the sync verifies that the content it is about to push is **exactly
 the tree a merge of `3.x` and `master` produces** (`git merge-tree`), and that no conflict
-markers are present. Either check failing fails the run instead of rewriting `3.x`.
+markers are present. When mechanical files had to be regenerated, the exactness check applies
+to every path **except** those files, and a regenerated lockfile must additionally be
+consistent with the manifests in the pushed tree. Any check failing fails the run instead of
+rewriting `3.x`.
 
 > **`3.x` is force-pushed daily.** Branch breaking-change PRs off **`master`** and target
 > `3.x` — then your merge-base is a `master` commit that survives every rewrite and your
@@ -152,7 +164,8 @@ markers are present. Either check failing fails the run instead of rewriting `3.
 
 The conflict branch is `master` merged into `3.x` with the **conflict markers committed**, so
 you see exactly what clashed — and the required checks stay red until they're gone, so the PR
-can't be merged half-resolved:
+can't be merged half-resolved. Mechanical files arrive **pre-resolved** (listed in the PR
+under "Auto-resolved for you"), so only the real code conflicts need you:
 
 ```bash
 git fetch origin sync/master-to-3x && git switch sync/master-to-3x
@@ -160,8 +173,13 @@ git fetch origin sync/master-to-3x && git switch sync/master-to-3x
 git push origin sync/master-to-3x
 ```
 
+If the PR says the lockfile was **deferred** (a `package.json` / `pnpm-workspace.yaml` is
+conflicted too), resolve the manifests first, then regenerate it with
+`pnpm install --lockfile-only` and include the result in your fix commit.
+
 Then **merge the PR with the normal merge button.** `master`'s commits arrive as-is and your
-fix stays its own commit.
+fix stays its own commit. **Never close a conflict PR unmerged** — closing resolves nothing,
+the same conflict reopens on the next sync, and the new PR will call out the abandoned one.
 
 `3.x` never holds markers at its tip, so nightly images keep building; the merge commit that
 carries them drops out of `3.x`'s history at the next sync (the replay takes the queue's

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -425,11 +425,14 @@ During the v3 release window, `master` carries normal feature work (behind opt-i
 flags) and the long-lived `3.x` branch carries breaking changes. `util-sync-master-to-3x.yml`
 syncs daily by **replaying the `3.x`-only commits onto `master` and force-pushing `3.x`**, so a
 clean sync adds no commit and nothing is squashed. What it pushes is always verified to be
-exactly the tree a merge of `3.x` and `master` produces, and marker-free. On a real conflict
-`3.x` is left untouched and a draft PR carrying the conflict markers (labeled
-`automation:v3-sync`) is opened on `sync/master-to-3x`, requesting the breaking-commit authors
-as reviewers via `sync-conflict-owners.mjs`, posting to `#alerts-v3-sync` and pausing further
-syncs until it is resolved and merged normally.
+exactly the tree a merge of `3.x` and `master` produces, and marker-free. Conflicts confined
+to mechanical, tool-generated files (the pnpm lockfile, bot-maintained data files — see
+`MECHANICAL_PATHS` in `sync-master-to-3x.mjs`) are auto-resolved during the replay; the tree
+check then applies to every path except those files. On a real code conflict `3.x` is left
+untouched and a draft PR carrying the conflict markers (labeled `automation:v3-sync`, with
+mechanical files pre-resolved) is opened on `sync/master-to-3x`, requesting the
+breaking-commit authors as reviewers via `sync-conflict-owners.mjs`, posting to
+`#alerts-v3-sync` and pausing further syncs until it is resolved and merged normally.
 `build-v3-nightly.yml` publishes `n8nio/n8n:v3-nightly[-<date>]` images from `3.x`
 by calling `docker-build-push.yml` with `ref: 3.x` + `date_tag`.
 

--- a/.github/scripts/sync-conflict-owners.mjs
+++ b/.github/scripts/sync-conflict-owners.mjs
@@ -80,16 +80,35 @@ export async function resolveLogins(repo, shas, token, fetchFn = fetch) {
 }
 
 // Build the conflict-PR body, reviewer CSV, and Slack owner line.
-export function buildOutputs({ syncBranch, targetBranch = '3.x', files, owners }) {
+export function buildOutputs({
+	syncBranch,
+	targetBranch = '3.x',
+	files,
+	owners,
+	preResolved = [],
+	lockfileDeferred = false,
+	abandoned = [],
+}) {
 	const filesMd = files.map((f) => `- \`${f}\``).join('\n') || '_none detected_';
 	const ownersMd = owners.length
 		? owners.map((o) => `- @${o}`).join('\n')
 		: '_Could not auto-attribute — review the conflicted files manually._';
-	const slack = owners.length
-		? `Likely owners (GitHub): ${owners.map((o) => `@${o}`).join(' ')}`
-		: 'Could not auto-attribute owners.';
+	const abandonedWarning = abandoned.length
+		? `A previous PR for this recurring conflict (${abandoned.map((pr) => `#${pr.number}`).join(', ')}) was closed without being merged. Closing resolves nothing — the conflict comes back on the next sync. **Merge, don't close.**`
+		: '';
+	const slack = [
+		owners.length
+			? `Likely owners (GitHub): ${owners.map((o) => `@${o}`).join(' ')}`
+			: 'Could not auto-attribute owners.',
+		abandoned.length
+			? `⚠️ ${abandoned.map((pr) => `<${pr.url}|#${pr.number}>`).join(', ')} was closed without merging and the conflict is back — merge this one, don't close it.`
+			: '',
+	]
+		.filter(Boolean)
+		.join(' ');
 	const body = [
 		`Automated \`master\`→\`${targetBranch}\` sync hit a conflict.`,
+		...(abandonedWarning ? ['', '> [!WARNING]', `> ${abandonedWarning}`] : []),
 		'',
 		`**\`${targetBranch}\` was not touched.** This branch is \`master\` merged into \`${targetBranch}\` with the **conflict markers committed**, so you can see exactly what clashed. The required checks stay red until they are resolved, so this PR cannot be merged half-done.`,
 		'',
@@ -97,12 +116,27 @@ export function buildOutputs({ syncBranch, targetBranch = '3.x', files, owners }
 		`1. \`git fetch origin ${syncBranch} && git switch ${syncBranch}\``,
 		'2. Fix the conflict markers and commit them **in one commit of your own** (rather than amending the merge).',
 		`3. \`git push origin ${syncBranch}\``,
-		`4. **Merge this PR with the normal merge button.** \`master\`'s commits come in as-is and your fix stays its own commit — nothing is squashed.`,
+		`4. **Merge this PR with the normal merge button.** \`master\`'s commits come in as-is and your fix stays its own commit — nothing is squashed. Never close this PR unmerged: closing resolves nothing and the same conflict reopens on the next sync.`,
 		'',
 		`**Daily syncs are paused until this PR is merged.** The next sync then replays \`${targetBranch}\` onto master linearly again — which also drops this merge commit and its markers out of \`${targetBranch}\`'s history — and verifies the result is exactly what a merge would produce.`,
 		'',
 		'### Conflicted files',
 		filesMd,
+		...(preResolved.length
+			? [
+					'',
+					'### Auto-resolved for you',
+					'These tool-generated files also conflicted and were resolved mechanically — no action needed:',
+					preResolved.map((f) => `- \`${f}\``).join('\n'),
+				]
+			: []),
+		...(lockfileDeferred
+			? [
+					'',
+					'> [!NOTE]',
+					'> `pnpm-lock.yaml` still carries its conflict markers because a manifest (`package.json` / `pnpm-workspace.yaml`) is conflicted too, or its regeneration failed. After resolving the manifests, regenerate it with `pnpm install --lockfile-only` and commit the result.',
+				]
+			: []),
 		'',
 		'### Likely owners',
 		`Authors of the ${targetBranch} commits behind the conflicted files, requested as reviewers:`,

--- a/.github/scripts/sync-conflict-owners.test.mjs
+++ b/.github/scripts/sync-conflict-owners.test.mjs
@@ -93,8 +93,51 @@ test('buildOutputs formats reviewers, slack line, and PR body with owners', () =
 });
 
 test('buildOutputs degrades gracefully when nothing could be attributed', () => {
-	const out = buildOutputs({ syncBranch: 'sync/master-to-3x', syncBase: 'abc1234', files: ['x.ts'], owners: [] });
+	const out = buildOutputs({
+		syncBranch: 'sync/master-to-3x',
+		syncBase: 'abc1234',
+		files: ['x.ts'],
+		owners: [],
+	});
 	assert.equal(out.ownersCsv, '');
 	assert.equal(out.slack, 'Could not auto-attribute owners.');
 	assert.match(out.body, /Could not auto-attribute/);
+});
+
+test('buildOutputs lists mechanically pre-resolved files apart from the code conflicts', () => {
+	const out = buildOutputs({
+		syncBranch: 'sync/master-to-3x',
+		files: ['packages/cli/x.ts'],
+		owners: ['alice'],
+		preResolved: ['pnpm-lock.yaml'],
+	});
+	assert.match(out.body, /### Conflicted files\n- `packages\/cli\/x\.ts`/);
+	assert.match(out.body, /### Auto-resolved for you/);
+	assert.match(out.body, /resolved mechanically — no action needed/);
+	assert.ok(out.body.indexOf('pnpm-lock.yaml') > out.body.indexOf('Auto-resolved'));
+});
+
+test('buildOutputs carries the regen instruction when the lockfile was deferred', () => {
+	const out = buildOutputs({
+		syncBranch: 'sync/master-to-3x',
+		files: ['packages/cli/package.json'],
+		owners: [],
+		lockfileDeferred: true,
+	});
+	assert.match(out.body, /still carries its conflict markers/);
+	assert.match(out.body, /pnpm install --lockfile-only/);
+});
+
+test('buildOutputs warns about conflict PRs that were closed without merging', () => {
+	const abandoned = [{ number: 42, url: 'https://github.com/n8n-io/n8n/pull/42' }];
+	const out = buildOutputs({
+		syncBranch: 'sync/master-to-3x',
+		files: ['x.ts'],
+		owners: ['alice'],
+		abandoned,
+	});
+	assert.match(out.body, /#42\) was closed without being merged/);
+	assert.match(out.body, /Merge, don't close/);
+	assert.match(out.slack, /<https:\/\/github\.com\/n8n-io\/n8n\/pull\/42\|#42>/);
+	assert.match(out.slack, /merge this one, don't close it/);
 });

--- a/.github/scripts/sync-master-to-3x.mjs
+++ b/.github/scripts/sync-master-to-3x.mjs
@@ -11,24 +11,37 @@
  *
  * Whatever route it takes, the content 3.x receives is verified to be exactly the tree that
  * merging 3.x with master produces (`git merge-tree`); a mismatch fails the run instead of
- * pushing. That invariant is what makes the rewrite safe.
+ * pushing. That invariant is what makes the rewrite safe. When MECHANICAL files (see
+ * `MECHANICAL_PATHS`) had to be regenerated, the verification demands exactness everywhere
+ * BUT those files, which get their own checks instead (no markers, lockfile consistent
+ * with the pushed tree's manifests).
  *
- * Three cases:
+ * Four cases:
  *   1. The replay is clean            → force-push. No commit.
  *   2. The replay stalls, but 3.x's content still reconciles with master → an earlier
  *      conflict was resolved in a merge, which leaves no patch to replay. Replay again
  *      favouring the 3.x side (`-X theirs`), mirroring the side the resolved merge kept;
  *      the human's fix commit is in the queue and does the real work. Tree is then proven.
- *   3. The content does NOT reconcile → a genuinely new conflict. 3.x is left UNTOUCHED and a
- *      draft PR is opened on the sync branch carrying the conflict markers, attributed to the
- *      authors of the breaking commits behind the conflicted files. Syncs pause until it is
- *      merged.
+ *   3. master conflicts with 3.x, but ONLY on mechanical files — tool-generated content
+ *      with a deterministic resolution (the pnpm lockfile, bot-maintained data files).
+ *      These are resolved in place while the replay is stopped, exactly as a human
+ *      resolver would (regenerate the lockfile, take master's blob), and folded into the
+ *      stalled commit — still no commit of its own and no PR. When the `-X theirs` route
+ *      resolves lockfile hunks without stalling, the lockfile is reconciled at the tip
+ *      instead (folded into the tip commit by amending — never a commit of its own).
+ *   4. The content does NOT reconcile on a real code path → a genuinely new conflict. 3.x
+ *      is left UNTOUCHED and a draft PR is opened on the sync branch carrying the conflict
+ *      markers — with the mechanical files pre-resolved, so the resolver only deals with
+ *      real code — attributed to the authors of the breaking commits behind the conflicted
+ *      files. Syncs pause until it is merged.
  *
  * The conflict branch carries the conflict markers, so the resolver sees exactly what clashed
  * and the required checks stay red until they fix it in a commit of their own. That PR is
  * merged with the normal GitHub merge button — master's commits arrive as-is and the fix stays
- * its own commit. 3.x itself never has markers at its tip (nightly images build from it), and
- * the merge commit holding them is dropped from its history by the next replay.
+ * its own commit. NEVER close a conflict PR unmerged: closing resolves nothing and the same
+ * conflict reopens on the next sync. 3.x itself never has markers at its tip (nightly images
+ * build from it), and the merge commit holding them is dropped from its history by the next
+ * replay.
  *
  * Runs from a checkout of the target branch (fetch-depth 0). Assumes credentials are NOT
  * persisted by checkout — pushes go through an explicit token URL.
@@ -39,7 +52,8 @@
  * Env: GH_TOKEN (installation token with contents/pull-requests/issues write),
  *      GITHUB_REPOSITORY (owner/repo, auto-provided by Actions),
  *      SYNC_TARGET_BRANCH (optional — override 3.x to rehearse against a scratch branch).
- * Requires Node 18+ (global fetch), git 2.38+ (`merge-tree --write-tree`) and `gh` on PATH.
+ * Requires Node 18+ (global fetch), git 2.38+ (`merge-tree --write-tree`), `gh` on PATH,
+ * and `pnpm` on PATH (lockfile conflict resolution).
  *
  * See .github/DEVELOPING_V3.md for the full v3 development model.
  */
@@ -47,11 +61,32 @@
 import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
-import { conflictedFiles, breakingShas, resolveLogins, buildOutputs } from './sync-conflict-owners.mjs';
+import {
+	conflictedFiles,
+	breakingShas,
+	resolveLogins,
+	buildOutputs,
+} from './sync-conflict-owners.mjs';
 
 export const TARGET_BRANCH = '3.x';
 export const SYNC_BRANCH = 'sync/master-to-3x';
 export const CONFLICT_LABEL = 'automation:v3-sync';
+
+export const LOCKFILE = 'pnpm-lock.yaml';
+
+/**
+ * Paths whose conflicts are MECHANICAL: tool-generated files with a deterministic
+ * resolution, so no human judgement is lost by resolving them automatically.
+ * Keys are exact repo-relative paths; values pick the resolution strategy:
+ *   - 'pnpm-regen':  pnpm natively merges a conflicted lockfile when regenerating
+ *                    (`pnpm install --lockfile-only`).
+ *   - 'take-master': bots regenerate the file on master, so master's side wins.
+ */
+export const MECHANICAL_PATHS = {
+	[LOCKFILE]: 'pnpm-regen',
+	'packages/frontend/editor-ui/data/node-popularity.json': 'take-master',
+	'.github/test-metrics/e2e-impact-map.json': 'take-master',
+};
 
 const BOT_NAME = 'n8n-assistant[bot]';
 const BOT_EMAIL = 'n8n-assistant[bot]@users.noreply.github.com';
@@ -60,6 +95,8 @@ const BOT_EMAIL = 'n8n-assistant[bot]@users.noreply.github.com';
 // throwing on a non-zero exit (mirrors `set -e`). Injectable for tests.
 const runGit = (args, opts = {}) => execFileSync('git', args, { encoding: 'utf8', ...opts }).trim();
 const runGh = (args, opts = {}) => execFileSync('gh', args, { encoding: 'utf8', ...opts }).trim();
+const runPnpm = (args, opts = {}) =>
+	execFileSync('pnpm', args, { encoding: 'utf8', ...opts }).trim();
 
 // The branch to sync into. Overridable so the whole flow can be rehearsed end-to-end
 // against a throwaway branch before it is pointed at the real 3.x.
@@ -93,29 +130,136 @@ export function isAncestor(git, maybeAncestor, descendant) {
  * The tree a merge of the two commits would produce — the definition of the content 3.x
  * should end up with, computed without touching the working tree.
  *
- * `ok: false` means the two sides genuinely conflict: there is a new conflict that no
- * existing commit on 3.x resolves.
+ * `ok: false` means the two sides genuinely conflict; `conflictedPaths` then names the
+ * clashing files, and `tree` is still written (conflicted blobs carry their markers) —
+ * it is the comparison baseline for the relaxed tree guard.
  */
 export function mergeTree(git, a, b) {
-	const res = attempt(git, ['merge-tree', '--write-tree', a, b]);
-	return { ok: res.ok, tree: res.ok ? res.out.split('\n')[0].trim() : '', out: res.out };
+	const res = attempt(git, ['merge-tree', '--write-tree', '--name-only', a, b]);
+	// Line 0 is the toplevel tree OID (written even on conflict); the lines up to the
+	// first blank line are the conflicted filenames (`--name-only`). Informational
+	// messages follow the blank line, but `attempt` folds stderr in too — filter both.
+	const lines = res.out.split('\n');
+	const tree = lines[0]?.trim() ?? '';
+	let conflictedPaths = [];
+	if (!res.ok) {
+		const blank = lines.indexOf('', 1);
+		const section = lines.slice(1, blank === -1 ? undefined : blank);
+		conflictedPaths = [
+			...new Set(section.filter((l) => l && !/^(CONFLICT|Auto-merging|warning)/.test(l))),
+		];
+	}
+	return {
+		ok: res.ok,
+		tree: res.ok || conflictedPaths.length ? tree : '',
+		conflictedPaths,
+		out: res.out,
+	};
 }
 
-// Replay the 3.x-only commits onto master. Merge commits in the range (breaking PR merges,
-// past sync merges) are flattened; commits already applied to master are dropped as empty.
-// Individual commits, messages and authors are preserved — nothing is squashed.
-export function tryRebase(git, masterSha, log = console.log, extraArgs = []) {
-	const { ok, out } = attempt(git, ['rebase', ...extraArgs, masterSha]);
-	if (!ok && out) log(out);
-	return ok;
+// Split conflicted paths into mechanically-resolvable ones and real code conflicts.
+export function classifyPaths(paths) {
+	const mechanical = [];
+	const code = [];
+	for (const p of paths) (MECHANICAL_PATHS[p] ? mechanical : code).push(p);
+	return { mechanical, code };
 }
 
-// The content guard for every push: whichever route produced HEAD, its tree must be exactly
-// what merging 3.x with master yields.
-export function assertTree(git, expectedTree) {
+// A conflicted manifest makes lockfile regeneration meaningless until it is resolved
+// (catalogs live in pnpm-workspace.yaml, so it counts as a manifest too).
+export function blocksLockfileRegen(codePaths) {
+	return codePaths.some(
+		(p) => p === 'package.json' || p.endsWith('/package.json') || p === 'pnpm-workspace.yaml',
+	);
+}
+
+/**
+ * Resolve one mechanical path in the working tree (valid mid-merge and mid-rebase alike)
+ * and stage the result.
+ */
+export function resolveMechanicalPath({ git, pnpm, path, masterSha, log = console.log }) {
+	const strategy = MECHANICAL_PATHS[path];
+	if (strategy === 'pnpm-regen') {
+		// pnpm merges the conflict markers itself while regenerating. `--no-frozen-lockfile`
+		// is required: pnpm flips `--frozen-lockfile` on by default when CI=true.
+		log(`Regenerating ${path} with pnpm...`);
+		pnpm(['install', '--lockfile-only', '--no-frozen-lockfile']);
+		git(['add', '--', path]);
+		return;
+	}
+	log(`Resolving ${path} with master's version...`);
+	if (attempt(git, ['cat-file', '-e', `${masterSha}:${path}`]).ok) {
+		git(['checkout', masterSha, '--', path]);
+	} else {
+		git(['rm', '--force', '--', path]); // master deleted it
+	}
+}
+
+/**
+ * Replay the 3.x-only commits onto master, resolving stalls that involve ONLY mechanical
+ * paths in place — folded into the stalled commit exactly as a human's `rebase --continue`
+ * would, so no commit is added. Bails (leaving the rebase stopped, for the caller to
+ * abort) as soon as a stall touches a real code path.
+ *
+ * Merge commits in the range (breaking PR merges, past conflict-PR merges) are flattened;
+ * commits already applied to master — or fully absorbed by a mechanical resolution — are
+ * dropped as empty. Individual commits, messages and authors are preserved.
+ */
+export function rebaseResolvingMechanical({
+	git,
+	pnpm,
+	masterSha,
+	log = console.log,
+	extraArgs = [],
+	maxStalls = 50,
+}) {
+	const resolved = new Set();
+	let res = attempt(git, ['rebase', ...extraArgs, masterSha]);
+	let stalls = 0;
+	while (!res.ok) {
+		if (++stalls > maxStalls) {
+			log(`Giving up after ${maxStalls} rebase stalls.`);
+			return { ok: false, resolved: [...resolved] };
+		}
+		const { mechanical, code } = classifyPaths(conflictedFiles(git));
+		// No conflicted files means the rebase failed for some other reason — don't guess.
+		if (mechanical.length === 0 || code.length > 0) {
+			if (res.out) log(res.out);
+			return { ok: false, resolved: [...resolved], conflictedCode: code };
+		}
+		for (const path of mechanical) {
+			resolveMechanicalPath({ git, pnpm, path, masterSha, log });
+			resolved.add(path);
+		}
+		// The resolution may have absorbed the whole commit — skip it rather than
+		// letting `--continue` refuse an empty commit.
+		const empty = attempt(git, ['diff-index', '--cached', '--quiet', 'HEAD']).ok;
+		res = attempt(git, empty ? ['rebase', '--skip'] : ['rebase', '--continue']);
+	}
+	return { ok: true, resolved: [...resolved] };
+}
+
+/**
+ * The content guard for every push: whichever route produced HEAD, its tree must be exactly
+ * what merging 3.x with master yields — except on `allowedPaths`, the mechanical files the
+ * merge itself could not resolve (always derived from the merge-tree conflict list, never
+ * from what the run happened to touch). With no `allowedPaths` this is exact equality.
+ */
+export function assertTreeMatches(git, expectedTree, allowedPaths = []) {
 	const actual = git(['rev-parse', 'HEAD^{tree}']);
-	if (actual !== expectedTree) {
-		throw new Error(`Replayed tree ${actual} does not match the merge tree ${expectedTree}; refusing to push.`);
+	if (actual === expectedTree) return;
+	if (allowedPaths.length === 0) {
+		throw new Error(
+			`Replayed tree ${actual} does not match the merge tree ${expectedTree}; refusing to push.`,
+		);
+	}
+	const out = git(['diff-tree', '-r', '--name-only', '--no-renames', expectedTree, actual]);
+	const allowed = new Set(allowedPaths);
+	const violations = (out ? out.split('\n') : []).filter((p) => p && !allowed.has(p));
+	if (violations.length > 0) {
+		throw new Error(
+			`Replayed tree deviates from the merge tree on non-mechanical paths:\n${violations.join('\n')}\nrefusing to push.`,
+		);
 	}
 }
 
@@ -123,8 +267,27 @@ export function assertTree(git, expectedTree) {
 // with matches, 1 with none and >1 on error, so an error must not be read as "clean".
 export function assertNoMarkers(git, rev = 'HEAD') {
 	const found = attempt(git, ['grep', '-I', '-l', '-e', '^<<<<<<< ', '-e', '^>>>>>>> ', rev]);
-	if (found.ok) throw new Error(`Refusing to continue: conflict markers present in ${rev}:\n${found.out}`);
-	if (found.out.includes('fatal:')) throw new Error(`Could not scan ${rev} for conflict markers:\n${found.out}`);
+	if (found.ok)
+		throw new Error(`Refusing to continue: conflict markers present in ${rev}:\n${found.out}`);
+	if (found.out.includes('fatal:'))
+		throw new Error(`Could not scan ${rev} for conflict markers:\n${found.out}`);
+}
+
+/**
+ * Make the lockfile at the replayed tip consistent with the tip's own manifests. A regen
+ * at a stall usually already did this, but the `-X theirs` route resolves lockfile hunks
+ * without stalling — so the reconciliation happens here, folded into the tip commit by
+ * amending. Never a commit of its own, and never a rewrite of a master commit.
+ */
+export function reconcileLockfileAtTip({ git, pnpm, masterSha, log = console.log }) {
+	pnpm(['install', '--lockfile-only', '--no-frozen-lockfile']);
+	if (attempt(git, ['diff', '--quiet', '--', LOCKFILE]).ok) return;
+	if (git(['rev-parse', 'HEAD']) === masterSha) {
+		throw new Error('Lockfile reconciliation would amend a master commit; refusing.');
+	}
+	log('Folding a lockfile reconciliation into the tip commit.');
+	git(['add', '--', LOCKFILE]);
+	git(['commit', '--amend', '--no-edit', '--no-verify']);
 }
 
 // Append key=value lines to $GITHUB_OUTPUT (no-op when running outside Actions).
@@ -139,32 +302,86 @@ export function writeGithubOutput(obj, env = process.env) {
 
 /**
  * Build the conflict branch: master merged into 3.x with the conflict markers committed as
- * they are. The markers are the review surface — the resolver sees exactly what clashed, and
- * the required checks stay red until they fix it, so the PR cannot be merged half-resolved
- * (an auto-resolved branch would be green with master's change silently dropped).
+ * they are — except mechanical files, which are pre-resolved so the resolver only deals
+ * with real code conflicts. The remaining markers are the review surface: the resolver sees
+ * exactly what clashed, and the required checks stay red until they fix it, so the PR
+ * cannot be merged half-resolved (an auto-resolved branch would be green with master's
+ * change silently dropped).
  *
- * 3.x never carries them at its tip, and not for long in its history either: this merge
- * commit is dropped by the next replay, which takes the queue's commits only.
+ * The lockfile is left with its markers when a manifest is among the code conflicts
+ * (regenerating is meaningless until the manifests are resolved) or when the regen fails
+ * transiently — flagged via `lockfileDeferred` so the PR body carries the instruction.
  *
- * @returns {string[]} the conflicted files
+ * 3.x never carries the markers at its tip, and not for long in its history either: this
+ * merge commit is dropped by the next replay, which takes the queue's commits only.
+ *
+ * @returns {{ files: string[], preResolved: string[], lockfileDeferred: boolean }}
+ *   `files` is the list the PR reports and attributes owners for: the code conflicts,
+ *   or every conflict when none are code (a fallback after a failed auto-resolution).
  */
-export function buildConflictBranch({ git, masterSha, log = console.log }) {
+export function buildConflictBranch({ git, pnpm, masterSha, log = console.log }) {
 	const merge = attempt(git, ['merge', '--no-edit', masterSha]);
 	if (merge.ok) {
 		// merge-tree said these conflict; if a real merge disagrees, don't guess.
-		throw new Error('Expected a merge conflict but the merge succeeded; aborting to avoid guessing.');
+		throw new Error(
+			'Expected a merge conflict but the merge succeeded; aborting to avoid guessing.',
+		);
 	}
 	if (merge.out) log(merge.out);
 
-	const files = conflictedFiles(git);
+	const all = conflictedFiles(git);
+	const { mechanical, code } = classifyPaths(all);
+
+	const preResolved = [];
+	let lockfileDeferred = false;
+	for (const path of mechanical) {
+		const needsManifests = MECHANICAL_PATHS[path] === 'pnpm-regen' && blocksLockfileRegen(code);
+		if (needsManifests) {
+			lockfileDeferred = true;
+			continue;
+		}
+		try {
+			resolveMechanicalPath({ git, pnpm, path, masterSha, log });
+			preResolved.push(path);
+		} catch (error) {
+			// Degrade gracefully (e.g. a transient registry failure): leave the markers
+			// for the resolver rather than failing the PR-opening path.
+			log(`warning: could not pre-resolve ${path}: ${error.message}`);
+			if (MECHANICAL_PATHS[path] === 'pnpm-regen') lockfileDeferred = true;
+		}
+	}
+
 	git(['add', '-A']);
 	git(['commit', '--no-edit', '--no-verify']);
-	return files;
+	return { files: code.length > 0 ? code : all, preResolved, lockfileDeferred };
+}
+
+// Conflict PRs that were recently closed WITHOUT being merged — closing resolves nothing,
+// so the same conflict is about to come back; the new PR and Slack message call it out.
+export function recentAbandonedConflictPrs(
+	gh,
+	{ label = CONFLICT_LABEL, sinceDays = 14, now = Date.now() } = {},
+) {
+	const out = gh([
+		'pr',
+		'list',
+		'--state',
+		'closed',
+		'--label',
+		label,
+		'--json',
+		'number,url,mergedAt,closedAt',
+		'--limit',
+		'10',
+	]);
+	return JSON.parse(out || '[]').filter(
+		(pr) => !pr.mergedAt && pr.closedAt && now - Date.parse(pr.closedAt) < sinceDays * 86_400_000,
+	);
 }
 
 /**
- * Push the marker-free conflict branch and open a draft PR, attributing it to the authors of
- * the breaking commits behind the conflicted files. 3.x is left untouched.
+ * Push the marker-carrying conflict branch and open a draft PR, attributing it to the
+ * authors of the breaking commits behind the conflicted files. 3.x is left untouched.
  *
  * @returns {Promise<{ prUrl: string, ownersSlack: string }>}
  */
@@ -178,6 +395,8 @@ export async function openConflictPr({
 	pushUrl,
 	target = TARGET_BRANCH,
 	files = [],
+	preResolved = [],
+	lockfileDeferred = false,
 	fetchFn = fetch,
 	log = console.log,
 }) {
@@ -193,24 +412,50 @@ export async function openConflictPr({
 		log(`warning: could not resolve owners: ${error.message}`);
 	}
 
+	let abandoned = [];
+	try {
+		abandoned = recentAbandonedConflictPrs(gh);
+	} catch (error) {
+		log(`warning: could not check for abandoned conflict PRs: ${error.message}`);
+	}
+
 	const { ownersCsv, slack, body } = buildOutputs({
 		syncBranch: SYNC_BRANCH,
 		targetBranch: target,
 		files,
 		owners,
+		preResolved,
+		lockfileDeferred,
+		abandoned,
 	});
 
 	git(['push', '--force', pushUrl, `HEAD:refs/heads/${SYNC_BRANCH}`]);
 
 	// Ensure the label exists (idempotent), then open the draft conflict PR.
-	gh(['label', 'create', CONFLICT_LABEL, '--color', 'B60205', '--description', 'master→3.x sync conflict', '--force']);
+	gh([
+		'label',
+		'create',
+		CONFLICT_LABEL,
+		'--color',
+		'B60205',
+		'--description',
+		'master→3.x sync conflict',
+		'--force',
+	]);
 	const prUrl = gh([
-		'pr', 'create', '--draft',
-		'--base', target,
-		'--head', SYNC_BRANCH,
-		'--label', CONFLICT_LABEL,
-		'--title', 'chore: Resolve master→3.x sync conflict',
-		'--body', body,
+		'pr',
+		'create',
+		'--draft',
+		'--base',
+		target,
+		'--head',
+		SYNC_BRANCH,
+		'--label',
+		CONFLICT_LABEL,
+		'--title',
+		'chore: Resolve master→3.x sync conflict',
+		'--body',
+		body,
 	]);
 
 	// Request owners as reviewers (best-effort: the API rejects the PR author
@@ -229,6 +474,7 @@ export async function openConflictPr({
 export async function sync({
 	git = runGit,
 	gh = runGh,
+	pnpm = runPnpm,
 	env = process.env,
 	fetchFn = fetch,
 	log = console.log,
@@ -244,7 +490,12 @@ export async function sync({
 	const pushUrl = `https://x-access-token:${token}@github.com/${repo}.git`;
 	// The lease pins the tip we replayed from, so a concurrent push is never overwritten.
 	const pushReplay = (from) =>
-		git(['push', `--force-with-lease=refs/heads/${target}:${from}`, pushUrl, `HEAD:refs/heads/${target}`]);
+		git([
+			'push',
+			`--force-with-lease=refs/heads/${target}:${from}`,
+			pushUrl,
+			`HEAD:refs/heads/${target}`,
+		]);
 
 	// Halt gate: if a previous conflict PR is still open, do nothing until it is merged.
 	if (hasOpenConflictPr(gh)) {
@@ -254,6 +505,8 @@ export async function sync({
 
 	git(['config', 'user.name', BOT_NAME]);
 	git(['config', 'user.email', BOT_EMAIL]);
+	// `rebase --continue` insists on an editor for the commit message; keep it headless.
+	git(['config', 'core.editor', 'true']);
 
 	git(['fetch', 'origin', 'master']);
 	// Pin to the fetched SHA — a command-line refspec doesn't reliably update the
@@ -266,43 +519,107 @@ export async function sync({
 		return;
 	}
 
-	const queue = git(['log', '--no-merges', '--reverse', '--format=%h %s', `${masterSha}..${preHead}`]);
+	const queue = git([
+		'log',
+		'--no-merges',
+		'--reverse',
+		'--format=%h %s',
+		`${masterSha}..${preHead}`,
+	]);
 	log(`Replaying onto master ${masterSha}:\n${queue || '(none)'}`);
 
 	// What the content must end up as, and whether a new conflict exists at all.
 	const merged = mergeTree(git, preHead, masterSha);
 
 	if (!merged.ok) {
-		log(`master conflicts with ${target} — leaving ${target} untouched and opening a conflict PR.`);
-		const files = buildConflictBranch({ git, masterSha, log });
+		const { mechanical, code } = classifyPaths(merged.conflictedPaths);
+
+		if (code.length === 0 && mechanical.length > 0) {
+			log(
+				`master conflicts with ${target} only on mechanical files (${mechanical.join(', ')}); auto-resolving.`,
+			);
+			let replay = rebaseResolvingMechanical({ git, pnpm, masterSha, log });
+			if (!replay.ok) {
+				// An intermediate stall on a code file whose endpoints still reconcile —
+				// same "resolved in a merge" situation as the clean-tree second pass.
+				attempt(git, ['rebase', '--abort']);
+				replay = rebaseResolvingMechanical({
+					git,
+					pnpm,
+					masterSha,
+					log,
+					extraArgs: ['-X', 'theirs'],
+				});
+			}
+			if (replay.ok) {
+				if (mechanical.includes(LOCKFILE)) reconcileLockfileAtTip({ git, pnpm, masterSha, log });
+				assertTreeMatches(git, merged.tree, mechanical);
+				assertNoMarkers(git);
+				pushReplay(preHead);
+				log(
+					`Replayed ${target} onto master, auto-resolving ${mechanical.join(', ')} — no PR, no sync commit.`,
+				);
+				return;
+			}
+			attempt(git, ['rebase', '--abort']);
+			log('Mechanical auto-resolution did not complete; falling back to a conflict PR.');
+		} else {
+			log(
+				`master conflicts with ${target} — leaving ${target} untouched and opening a conflict PR.`,
+			);
+		}
+
+		const { files, preResolved, lockfileDeferred } = buildConflictBranch({
+			git,
+			pnpm,
+			masterSha,
+			log,
+		});
 		const { prUrl, ownersSlack } = await openConflictPr({
-			git, gh, repo, token, masterSha, preHead, pushUrl, target, files, fetchFn, log,
+			git,
+			gh,
+			repo,
+			token,
+			masterSha,
+			preHead,
+			pushUrl,
+			target,
+			files,
+			preResolved,
+			lockfileDeferred,
+			fetchFn,
+			log,
 		});
 		writeGithubOutput({ conflict_pr: prUrl, conflict_owners: ownersSlack }, env);
 		return;
 	}
 
-	if (tryRebase(git, masterSha, log)) {
-		assertTree(git, merged.tree);
+	const plainReplay = attempt(git, ['rebase', masterSha]);
+	if (plainReplay.ok) {
+		assertTreeMatches(git, merged.tree);
 		assertNoMarkers(git);
 		pushReplay(preHead);
 		log(`Replayed ${target} onto master — no sync commit created.`);
 		return;
 	}
+	if (plainReplay.out) log(plainReplay.out);
 
 	// The content reconciles but the patches no longer apply on their own: an earlier
 	// conflict was resolved in a merge, and a merge resolution leaves no patch to replay.
 	// Replay favouring the 3.x side — the same side that resolved merge kept — and let the
-	// resolver's own fix commit, which is in the queue, do the real work. Nothing is
-	// squashed; the tree guard below proves the outcome.
+	// resolver's own fix commit, which is in the queue, do the real work. Mechanical stalls
+	// the strategy cannot settle (e.g. modify/delete) are resolved in place. Nothing is
+	// squashed; the tree guard below proves the outcome exactly, since the merge was clean.
 	git(['rebase', '--abort']);
 	log(`Patches no longer apply individually; replaying with ${target}'s side favoured.`);
-	if (!tryRebase(git, masterSha, log, ['-X', 'theirs'])) {
+	if (!rebaseResolvingMechanical({ git, pnpm, masterSha, log, extraArgs: ['-X', 'theirs'] }).ok) {
 		git(['rebase', '--abort']);
-		throw new Error(`Could not replay ${target} onto master even with its own side favoured; needs a human.`);
+		throw new Error(
+			`Could not replay ${target} onto master even with its own side favoured; needs a human.`,
+		);
 	}
 
-	assertTree(git, merged.tree);
+	assertTreeMatches(git, merged.tree);
 	assertNoMarkers(git);
 	pushReplay(preHead);
 	log(`Replayed ${target} onto master — no sync commit created.`);

--- a/.github/scripts/sync-master-to-3x.test.mjs
+++ b/.github/scripts/sync-master-to-3x.test.mjs
@@ -4,8 +4,13 @@ import { test } from 'node:test';
 import {
 	hasOpenConflictPr,
 	mergeTree,
-	tryRebase,
-	assertTree,
+	classifyPaths,
+	blocksLockfileRegen,
+	resolveMechanicalPath,
+	rebaseResolvingMechanical,
+	reconcileLockfileAtTip,
+	recentAbandonedConflictPrs,
+	assertTreeMatches,
 	assertNoMarkers,
 	buildConflictBranch,
 	openConflictPr,
@@ -14,9 +19,10 @@ import {
 	CONFLICT_LABEL,
 	SYNC_BRANCH,
 	TARGET_BRANCH,
+	LOCKFILE,
 } from './sync-master-to-3x.mjs';
 
-// A git/gh stub: routes calls by a matcher, records every invocation.
+// A git/gh/pnpm stub: routes calls by a matcher, records every invocation.
 function makeStub(routes = []) {
 	const calls = [];
 	const fn = (args) => {
@@ -30,24 +36,39 @@ function makeStub(routes = []) {
 	return fn;
 }
 
-const fail = (stdout = '') => () => {
-	const err = new Error('command failed');
-	err.status = 1;
-	err.stdout = stdout;
-	throw err;
-};
+const fail =
+	(stdout = '') =>
+	() => {
+		const err = new Error('command failed');
+		err.status = 1;
+		err.stdout = stdout;
+		throw err;
+	};
 
 const okFetch = (logins) => async () => ({
 	ok: true,
-	json: async () => ({ data: { repository: Object.fromEntries(logins.map((l, i) => [`c${i}`, { author: { user: { login: l } } }])) } }),
+	json: async () => ({
+		data: {
+			repository: Object.fromEntries(
+				logins.map((l, i) => [`c${i}`, { author: { user: { login: l } } }]),
+			),
+		},
+	}),
 });
 
 const PRE_HEAD = 'PREHEAD';
 const MASTER = 'MASTERSHA';
 const MERGE_TREE = 'MERGETREEOID';
+const POPULARITY = 'packages/frontend/editor-ui/data/node-popularity.json';
 
 const isRebase = (a) => a[0] === 'rebase' && a[1] !== '--abort';
 const favouringOwnSide = (a) => a[0] === 'rebase' && a.includes('-X') && a.includes('theirs');
+const isConflictedFiles = (a) => a[0] === 'diff' && a.includes('--diff-filter=U');
+
+// What `git merge-tree --write-tree --name-only` emits on a conflict: the (marker-carrying)
+// tree OID, the conflicted paths, a blank line, then informational messages.
+const conflictedMergeTree = (...paths) =>
+	fail(`${MERGE_TREE}\n${paths.join('\n')}\n\nCONFLICT (content): Merge conflict in ${paths[0]}`);
 
 // Routes shared by every sync path: master fetched, 3.x hasn't absorbed it yet, and the
 // merge tree is computable (no new conflict). git grep exits non-zero => no markers.
@@ -71,45 +92,235 @@ test('targetBranch defaults to 3.x and honours the rehearsal override', () => {
 test('hasOpenConflictPr reflects the open-PR count from gh', () => {
 	const empty = makeStub([[() => true, '[]']]);
 	assert.equal(hasOpenConflictPr(empty), false);
-	assert.deepEqual(empty.calls[0], ['pr', 'list', '--state', 'open', '--label', CONFLICT_LABEL, '--json', 'number']);
+	assert.deepEqual(empty.calls[0], [
+		'pr',
+		'list',
+		'--state',
+		'open',
+		'--label',
+		CONFLICT_LABEL,
+		'--json',
+		'number',
+	]);
 
 	const one = makeStub([[() => true, JSON.stringify([{ number: 42 }])]]);
 	assert.equal(hasOpenConflictPr(one), true);
 });
 
-test('mergeTree reports the tree when clean and not-ok when the sides conflict', () => {
+test('mergeTree reports the tree when clean, and the conflicted paths when the sides conflict', () => {
 	const clean = makeStub([[() => true, `${MERGE_TREE}\nsome extra output`]]);
-	assert.deepEqual(mergeTree(clean, 'A', 'B'), { ok: true, tree: MERGE_TREE, out: `${MERGE_TREE}\nsome extra output` });
-	assert.deepEqual(clean.calls[0], ['merge-tree', '--write-tree', 'A', 'B']);
+	assert.deepEqual(mergeTree(clean, 'A', 'B'), {
+		ok: true,
+		tree: MERGE_TREE,
+		conflictedPaths: [],
+		out: `${MERGE_TREE}\nsome extra output`,
+	});
+	assert.deepEqual(clean.calls[0], ['merge-tree', '--write-tree', '--name-only', 'A', 'B']);
 
-	const conflicting = makeStub([[() => true, fail('CONFLICT (content): x.ts')]]);
-	assert.equal(mergeTree(conflicting, 'A', 'B').ok, false);
+	const conflicting = makeStub([
+		[
+			() => true,
+			fail(
+				`${MERGE_TREE}\n${LOCKFILE}\npackages/cli/x.ts\n\nAuto-merging ${LOCKFILE}\nCONFLICT (content): Merge conflict in ${LOCKFILE}`,
+			),
+		],
+	]);
+	const res = mergeTree(conflicting, 'A', 'B');
+	assert.equal(res.ok, false);
+	// The conflicted tree is still written — it is the baseline for the relaxed guard.
+	assert.equal(res.tree, MERGE_TREE);
+	assert.deepEqual(res.conflictedPaths, [LOCKFILE, 'packages/cli/x.ts']);
 });
 
-test('tryRebase replays onto master and can favour a side', () => {
-	const git = makeStub([[(a) => a[0] === 'rebase', '']]);
-	assert.equal(tryRebase(git, MASTER, () => {}), true);
-	assert.deepEqual(git.calls[0], ['rebase', MASTER]);
+test('classifyPaths and blocksLockfileRegen split mechanical from code conflicts', () => {
+	const { mechanical, code } = classifyPaths([
+		LOCKFILE,
+		'packages/cli/x.ts',
+		'.github/test-metrics/e2e-impact-map.json',
+	]);
+	assert.deepEqual(mechanical, [LOCKFILE, '.github/test-metrics/e2e-impact-map.json']);
+	assert.deepEqual(code, ['packages/cli/x.ts']);
 
-	assert.equal(tryRebase(git, MASTER, () => {}, ['-X', 'theirs']), true);
-	assert.deepEqual(git.calls[1], ['rebase', '-X', 'theirs', MASTER]);
+	assert.equal(blocksLockfileRegen(['packages/cli/package.json']), true);
+	assert.equal(blocksLockfileRegen(['package.json']), true);
+	assert.equal(blocksLockfileRegen(['pnpm-workspace.yaml']), true);
+	assert.equal(blocksLockfileRegen(['packages/cli/x.ts']), false);
 });
 
-test('assertTree and assertNoMarkers are the push guards', () => {
-	assert.doesNotThrow(() => assertTree(makeStub([[() => true, MERGE_TREE]]), MERGE_TREE));
-	assert.throws(() => assertTree(makeStub([[() => true, 'OTHER']]), MERGE_TREE), /does not match the merge tree/);
+test('resolveMechanicalPath takes the blob from master, or the deletion when master removed the file', () => {
+	const present = makeStub([[(a) => a[0] === 'cat-file', '']]);
+	resolveMechanicalPath({
+		git: present,
+		pnpm: makeStub(),
+		path: POPULARITY,
+		masterSha: MASTER,
+		log: () => {},
+	});
+	assert.ok(
+		present.calls.some((a) => a[0] === 'checkout' && a[1] === MASTER && a.includes(POPULARITY)),
+	);
 
+	const deleted = makeStub([[(a) => a[0] === 'cat-file', fail()]]);
+	resolveMechanicalPath({
+		git: deleted,
+		pnpm: makeStub(),
+		path: POPULARITY,
+		masterSha: MASTER,
+		log: () => {},
+	});
+	assert.ok(
+		deleted.calls.some((a) => a[0] === 'rm' && a.includes('--force') && a.includes(POPULARITY)),
+	);
+});
+
+test('resolveMechanicalPath regenerates the lockfile with pnpm and stages it', () => {
+	const git = makeStub();
+	const pnpm = makeStub();
+	resolveMechanicalPath({ git, pnpm, path: LOCKFILE, masterSha: MASTER, log: () => {} });
+	// `--no-frozen-lockfile` is load-bearing: pnpm defaults to frozen when CI=true.
+	assert.deepEqual(pnpm.calls[0], ['install', '--lockfile-only', '--no-frozen-lockfile']);
+	assert.ok(git.calls.some((a) => a[0] === 'add' && a.includes(LOCKFILE)));
+});
+
+test('rebaseResolvingMechanical resolves mechanical stalls in place and skips emptied commits', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'rebase' && a[1] === '--skip', ''],
+		[isRebase, fail(`CONFLICT (content): Merge conflict in ${POPULARITY}`)],
+		[isConflictedFiles, POPULARITY],
+		[(a) => a[0] === 'cat-file', ''],
+		[(a) => a[0] === 'diff-index', ''], // resolution emptied the commit
+	]);
+
+	const res = rebaseResolvingMechanical({
+		git,
+		pnpm: makeStub(),
+		masterSha: MASTER,
+		log: () => {},
+	});
+
+	assert.equal(res.ok, true);
+	assert.deepEqual(res.resolved, [POPULARITY]);
+	assert.ok(git.calls.some((a) => a[0] === 'checkout' && a[1] === MASTER));
+	assert.ok(git.calls.some((a) => a[0] === 'rebase' && a[1] === '--skip'));
+});
+
+test('rebaseResolvingMechanical bails as soon as a stall touches a code path', () => {
+	const git = makeStub([
+		[isRebase, fail('CONFLICT (content): Merge conflict in packages/cli/x.ts')],
+		[isConflictedFiles, `packages/cli/x.ts\n${LOCKFILE}`],
+	]);
+	const pnpm = makeStub();
+
+	const res = rebaseResolvingMechanical({ git, pnpm, masterSha: MASTER, log: () => {} });
+
+	assert.equal(res.ok, false);
+	assert.deepEqual(res.conflictedCode, ['packages/cli/x.ts']);
+	// Nothing may be auto-resolved when human judgement is needed for the same stall.
+	assert.equal(pnpm.calls.length, 0);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'checkout'),
+		false,
+	);
+});
+
+test('assertTreeMatches is exact by default and scoped to the allowed paths otherwise', () => {
+	assert.doesNotThrow(() => assertTreeMatches(makeStub([[() => true, MERGE_TREE]]), MERGE_TREE));
+	assert.throws(
+		() => assertTreeMatches(makeStub([[() => true, 'OTHER']]), MERGE_TREE),
+		/does not match the merge tree/,
+	);
+
+	const onlyLockfile = makeStub([
+		[(a) => a[0] === 'rev-parse', 'OTHER'],
+		[(a) => a[0] === 'diff-tree', LOCKFILE],
+	]);
+	assert.doesNotThrow(() => assertTreeMatches(onlyLockfile, MERGE_TREE, [LOCKFILE]));
+
+	const alsoCode = makeStub([
+		[(a) => a[0] === 'rev-parse', 'OTHER'],
+		[(a) => a[0] === 'diff-tree', `${LOCKFILE}\npackages/cli/x.ts`],
+	]);
+	assert.throws(() => assertTreeMatches(alsoCode, MERGE_TREE, [LOCKFILE]), /non-mechanical paths/);
+});
+
+test('assertNoMarkers is a push guard', () => {
 	assert.doesNotThrow(() => assertNoMarkers(makeStub([[() => true, fail()]])));
-	assert.throws(() => assertNoMarkers(makeStub([[() => true, 'packages/cli/x.ts']])), /conflict markers present/);
+	assert.throws(
+		() => assertNoMarkers(makeStub([[() => true, 'packages/cli/x.ts']])),
+		/conflict markers present/,
+	);
 	// git grep failing for any other reason must not read as "clean".
-	assert.throws(() => assertNoMarkers(makeStub([[() => true, fail('fatal: bad object')]])), /Could not scan/);
+	assert.throws(
+		() => assertNoMarkers(makeStub([[() => true, fail('fatal: bad object')]])),
+		/Could not scan/,
+	);
+});
+
+test('reconcileLockfileAtTip folds an inconsistent lockfile into the tip commit, never a master commit', () => {
+	const consistent = makeStub([[(a) => a[0] === 'diff', '']]);
+	reconcileLockfileAtTip({ git: consistent, pnpm: makeStub(), masterSha: MASTER, log: () => {} });
+	assert.equal(
+		consistent.calls.some((a) => a[0] === 'commit'),
+		false,
+	);
+
+	const inconsistent = makeStub([
+		[(a) => a[0] === 'diff', fail()],
+		[(a) => a[0] === 'rev-parse', PRE_HEAD],
+	]);
+	const pnpm = makeStub();
+	reconcileLockfileAtTip({ git: inconsistent, pnpm, masterSha: MASTER, log: () => {} });
+	assert.deepEqual(pnpm.calls[0], ['install', '--lockfile-only', '--no-frozen-lockfile']);
+	assert.ok(inconsistent.calls.some((a) => a[0] === 'commit' && a.includes('--amend')));
+
+	const atMasterTip = makeStub([
+		[(a) => a[0] === 'diff', fail()],
+		[(a) => a[0] === 'rev-parse', MASTER],
+	]);
+	assert.throws(
+		() =>
+			reconcileLockfileAtTip({
+				git: atMasterTip,
+				pnpm: makeStub(),
+				masterSha: MASTER,
+				log: () => {},
+			}),
+		/amend a master commit/,
+	);
+});
+
+test('recentAbandonedConflictPrs keeps only recently closed-unmerged conflict PRs', () => {
+	const now = Date.parse('2026-08-10T00:00:00Z');
+	const gh = makeStub([
+		[
+			() => true,
+			JSON.stringify([
+				{
+					number: 1,
+					url: 'u1',
+					mergedAt: '2026-08-01T00:00:00Z',
+					closedAt: '2026-08-01T00:00:00Z',
+				},
+				{ number: 2, url: 'u2', mergedAt: null, closedAt: '2026-07-01T00:00:00Z' }, // too old
+				{ number: 3, url: 'u3', mergedAt: null, closedAt: '2026-08-08T00:00:00Z' },
+			]),
+		],
+	]);
+
+	const abandoned = recentAbandonedConflictPrs(gh, { now });
+
+	assert.deepEqual(
+		abandoned.map((pr) => pr.number),
+		[3],
+	);
+	assert.equal(gh.calls[0][gh.calls[0].indexOf('--state') + 1], 'closed');
 });
 
 test('sync replays and force-pushes with a lease, creating no commit', async () => {
 	const git = makeStub([...baseGitRoutes, [isRebase, '']]);
 	const gh = makeStub(noOpenPr);
 
-	await sync({ git, gh, env, log: () => {} });
+	await sync({ git, gh, pnpm: makeStub(), env, log: () => {} });
 
 	const push = git.calls.find((a) => a[0] === 'push');
 	assert.deepEqual(push, [
@@ -119,16 +330,31 @@ test('sync replays and force-pushes with a lease, creating no commit', async () 
 		`HEAD:refs/heads/${TARGET_BRANCH}`,
 	]);
 	// The point of the change: no merge, no squash, no PR on the clean path.
-	assert.equal(git.calls.some((a) => a[0] === 'merge'), false);
-	assert.equal(git.calls.some((a) => a[0] === 'commit'), false);
-	assert.equal(gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'), false);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'merge'),
+		false,
+	);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'commit'),
+		false,
+	);
+	assert.equal(
+		gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'),
+		false,
+	);
 });
 
 test('sync targets the rehearsal branch when SYNC_TARGET_BRANCH is set', async () => {
 	const git = makeStub([...baseGitRoutes, [isRebase, '']]);
 	const gh = makeStub(noOpenPr);
 
-	await sync({ git, gh, env: { ...env, SYNC_TARGET_BRANCH: '3x-sync-test' }, log: () => {} });
+	await sync({
+		git,
+		gh,
+		pnpm: makeStub(),
+		env: { ...env, SYNC_TARGET_BRANCH: '3x-sync-test' },
+		log: () => {},
+	});
 
 	assert.equal(git.calls.find((a) => a[0] === 'push').at(-1), 'HEAD:refs/heads/3x-sync-test');
 });
@@ -141,10 +367,18 @@ test('sync does nothing when 3.x already contains master', async () => {
 	]);
 	const gh = makeStub(noOpenPr);
 
-	await sync({ git, gh, env, log: () => {} });
+	await sync({ git, gh, pnpm: makeStub(), env, log: () => {} });
 
-	assert.equal(git.calls.some((a) => a[0] === 'rebase'), false, 'must not rebase');
-	assert.equal(git.calls.some((a) => a[0] === 'push'), false, 'must not push');
+	assert.equal(
+		git.calls.some((a) => a[0] === 'rebase'),
+		false,
+		'must not rebase',
+	);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'push'),
+		false,
+		'must not push',
+	);
 });
 
 test('sync refuses to push when the replayed tree is not the merge tree', async () => {
@@ -155,15 +389,22 @@ test('sync refuses to push when the replayed tree is not the merge tree', async 
 	]);
 	const gh = makeStub(noOpenPr);
 
-	await assert.rejects(() => sync({ git, gh, env, log: () => {} }), /does not match the merge tree/);
-	assert.equal(git.calls.some((a) => a[0] === 'push'), false, 'must not push a suspect rewrite');
+	await assert.rejects(
+		() => sync({ git, gh, pnpm: makeStub(), env, log: () => {} }),
+		/does not match the merge tree/,
+	);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'push'),
+		false,
+		'must not push a suspect rewrite',
+	);
 });
 
 test('sync halts (no fetch/rebase) when a conflict PR is already open', async () => {
 	const git = makeStub();
 	const gh = makeStub([[(a) => a[0] === 'pr' && a[1] === 'list', JSON.stringify([{ number: 7 }])]]);
 
-	await sync({ git, gh, env, log: () => {} });
+	await sync({ git, gh, pnpm: makeStub(), env, log: () => {} });
 
 	assert.equal(git.calls.length, 0, 'must not touch git while halted');
 });
@@ -178,55 +419,93 @@ test('sync replays favouring 3.x when the patches no longer apply on their own',
 	]);
 	const gh = makeStub(noOpenPr);
 
-	await sync({ git, gh, env, log: () => {} });
+	await sync({ git, gh, pnpm: makeStub(), env, log: () => {} });
 
-	assert.ok(git.calls.some((a) => a[0] === 'rebase' && a[1] === '--abort'), 'stalled rebase must be aborted');
+	assert.ok(
+		git.calls.some((a) => a[0] === 'rebase' && a[1] === '--abort'),
+		'stalled rebase must be aborted',
+	);
 	assert.ok(git.calls.some(favouringOwnSide), 'expected the second replay to favour 3.x');
-	assert.ok(git.calls.some((a) => a[0] === 'push'), 'expected the replay to be pushed');
+	assert.ok(
+		git.calls.some((a) => a[0] === 'push'),
+		'expected the replay to be pushed',
+	);
 	// Still no new commit and no PR: the resolver's own fix commit is already in the queue.
-	assert.equal(git.calls.some((a) => a[0] === 'commit'), false);
-	assert.equal(gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'), false);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'commit'),
+		false,
+	);
+	assert.equal(
+		gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'),
+		false,
+	);
 });
 
 test('sync fails without pushing when even the favoured replay cannot finish', async () => {
-	const git = makeStub([...baseGitRoutes, [isRebase, fail('CONFLICT')]]);
+	const git = makeStub([
+		...baseGitRoutes,
+		[isRebase, fail('CONFLICT')],
+		// The favoured replay stalls on a real code file, so the driver must not resolve it.
+		[isConflictedFiles, 'packages/cli/x.ts'],
+	]);
 	const gh = makeStub(noOpenPr);
 
-	await assert.rejects(() => sync({ git, gh, env, log: () => {} }), /needs a human/);
-	assert.equal(git.calls.some((a) => a[0] === 'push'), false);
+	await assert.rejects(
+		() => sync({ git, gh, pnpm: makeStub(), env, log: () => {} }),
+		/needs a human/,
+	);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'push'),
+		false,
+	);
 	assert.equal(git.calls.filter((a) => a[0] === 'rebase' && a[1] === '--abort').length, 2);
 });
 
-test('buildConflictBranch commits the conflicted state, markers and all', () => {
-	const git = makeStub([
-		[(a) => a[0] === 'merge', fail('CONFLICT (content): packages/cli/x.ts')],
-		[(a) => a[0] === 'diff', 'packages/cli/x.ts'],
-	]);
-
-	const files = buildConflictBranch({ git, masterSha: MASTER, log: () => {} });
-
-	assert.deepEqual(files, ['packages/cli/x.ts']);
-	assert.deepEqual(git.calls[0], ['merge', '--no-edit', MASTER]);
-	assert.ok(git.calls.some((a) => a[0] === 'add' && a[1] === '-A'));
-	assert.ok(git.calls.some((a) => a[0] === 'commit' && a.includes('--no-edit')));
-	// The markers ARE the review surface here, so nothing may auto-resolve them.
-	assert.equal(git.calls.some((a) => a.includes('-X')), false);
-	assert.equal(git.calls.some((a) => a[0] === 'merge' && a[1] === '--abort'), false);
-});
-
-test('buildConflictBranch refuses to guess when the merge unexpectedly succeeds', () => {
-	const git = makeStub([[(a) => a[0] === 'merge', '']]);
-
-	assert.throws(() => buildConflictBranch({ git, masterSha: MASTER, log: () => {} }), /Expected a merge conflict/);
-	assert.equal(git.calls.some((a) => a[0] === 'commit'), false);
-});
-
-test('sync opens a draft conflict PR and leaves 3.x untouched on a real conflict', async () => {
+test('sync auto-resolves a lockfile-only conflict during the replay — no PR, no commit', async () => {
 	const git = makeStub([
 		...baseGitRoutes.filter((r) => !r[0](['merge-tree'])),
-		[(a) => a[0] === 'merge-tree', fail('CONFLICT (content): packages/cli/x.ts')],
-		[(a) => a[0] === 'merge', fail('CONFLICT (content): packages/cli/x.ts')],
-		[(a) => a[0] === 'diff', 'packages/cli/x.ts'],
+		[(a) => a[0] === 'merge-tree', conflictedMergeTree(LOCKFILE)],
+		[(a) => a[0] === 'rebase' && a[1] === '--continue', ''],
+		[isRebase, fail(`CONFLICT (content): Merge conflict in ${LOCKFILE}`)],
+		[isConflictedFiles, LOCKFILE],
+		[(a) => a[0] === 'diff' && a.includes('--quiet'), ''], // tip lockfile already consistent
+		[(a) => a[0] === 'diff-index', fail()], // staged resolution -> continue, not skip
+	]);
+	const gh = makeStub(noOpenPr);
+	const pnpm = makeStub();
+
+	await sync({ git, gh, pnpm, env, log: () => {} });
+
+	// The stall regen plus the tip reconciliation check.
+	assert.deepEqual(pnpm.calls[0], ['install', '--lockfile-only', '--no-frozen-lockfile']);
+	assert.equal(pnpm.calls.length, 2);
+	assert.ok(git.calls.some((a) => a[0] === 'add' && a.includes(LOCKFILE)));
+	assert.ok(git.calls.some((a) => a[0] === 'rebase' && a[1] === '--continue'));
+	const push = git.calls.find((a) => a[0] === 'push');
+	assert.equal(push[1], `--force-with-lease=refs/heads/${TARGET_BRANCH}:${PRE_HEAD}`);
+	// No human surface: no merge commit, no amend, no conflict PR.
+	assert.equal(
+		git.calls.some((a) => a[0] === 'merge'),
+		false,
+	);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'commit'),
+		false,
+	);
+	assert.equal(
+		gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'),
+		false,
+	);
+});
+
+test('sync falls back to a conflict PR when mechanical auto-resolution cannot complete', async () => {
+	const git = makeStub([
+		...baseGitRoutes.filter((r) => !r[0](['merge-tree'])),
+		[(a) => a[0] === 'merge-tree', conflictedMergeTree(LOCKFILE)],
+		[isRebase, fail('CONFLICT')],
+		// Both replay attempts stall on a code file the endpoints do not reconcile.
+		[isConflictedFiles, 'packages/cli/x.ts'],
+		[(a) => a[0] === 'merge', fail('CONFLICT (content): Merge conflict in packages/cli/x.ts')],
 		[(a) => a[0] === 'log', 'breaking-sha'],
 	]);
 	const gh = makeStub([
@@ -234,7 +513,142 @@ test('sync opens a draft conflict PR and leaves 3.x untouched on a real conflict
 		[(a) => a[0] === 'pr' && a[1] === 'create', 'https://github.com/n8n-io/n8n/pull/99'],
 	]);
 
-	await sync({ git, gh, env, fetchFn: okFetch(['alice']), log: () => {} });
+	await sync({ git, gh, pnpm: makeStub(), env, fetchFn: okFetch(['alice']), log: () => {} });
+
+	assert.ok(
+		gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'),
+		'expected the fallback conflict PR',
+	);
+	// Only the sync branch is pushed — 3.x must not move after a failed auto-resolution.
+	const pushes = git.calls.filter((a) => a[0] === 'push');
+	assert.equal(pushes.length, 1);
+	assert.equal(pushes[0].at(-1), `HEAD:refs/heads/${SYNC_BRANCH}`);
+});
+
+test('buildConflictBranch commits the conflicted state, markers and all', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge', fail('CONFLICT (content): packages/cli/x.ts')],
+		[isConflictedFiles, 'packages/cli/x.ts'],
+	]);
+
+	const { files, preResolved, lockfileDeferred } = buildConflictBranch({
+		git,
+		pnpm: makeStub(),
+		masterSha: MASTER,
+		log: () => {},
+	});
+
+	assert.deepEqual(files, ['packages/cli/x.ts']);
+	assert.deepEqual(preResolved, []);
+	assert.equal(lockfileDeferred, false);
+	assert.deepEqual(git.calls[0], ['merge', '--no-edit', MASTER]);
+	assert.ok(git.calls.some((a) => a[0] === 'add' && a[1] === '-A'));
+	assert.ok(git.calls.some((a) => a[0] === 'commit' && a.includes('--no-edit')));
+	// The markers ARE the review surface here, so nothing may auto-resolve them.
+	assert.equal(
+		git.calls.some((a) => a.includes('-X')),
+		false,
+	);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'merge' && a[1] === '--abort'),
+		false,
+	);
+});
+
+test('buildConflictBranch pre-resolves mechanical files so only code conflicts remain', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge', fail('CONFLICT')],
+		[isConflictedFiles, `packages/cli/x.ts\n${LOCKFILE}\n${POPULARITY}`],
+		[(a) => a[0] === 'cat-file', ''],
+	]);
+	const pnpm = makeStub();
+
+	const { files, preResolved, lockfileDeferred } = buildConflictBranch({
+		git,
+		pnpm,
+		masterSha: MASTER,
+		log: () => {},
+	});
+
+	assert.deepEqual(files, ['packages/cli/x.ts']);
+	assert.deepEqual(preResolved, [LOCKFILE, POPULARITY]);
+	assert.equal(lockfileDeferred, false);
+	assert.deepEqual(pnpm.calls[0], ['install', '--lockfile-only', '--no-frozen-lockfile']);
+	assert.ok(
+		git.calls.some((a) => a[0] === 'checkout' && a[1] === MASTER && a.includes(POPULARITY)),
+	);
+});
+
+test('buildConflictBranch defers the lockfile when a manifest is conflicted too', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge', fail('CONFLICT')],
+		[isConflictedFiles, `packages/cli/package.json\n${LOCKFILE}`],
+	]);
+	const pnpm = makeStub();
+
+	const { files, preResolved, lockfileDeferred } = buildConflictBranch({
+		git,
+		pnpm,
+		masterSha: MASTER,
+		log: () => {},
+	});
+
+	assert.deepEqual(files, ['packages/cli/package.json']);
+	assert.deepEqual(preResolved, []);
+	assert.equal(lockfileDeferred, true);
+	assert.equal(pnpm.calls.length, 0, 'regen is meaningless until the manifests are resolved');
+});
+
+test('buildConflictBranch degrades to a deferred lockfile when the regen fails', () => {
+	const git = makeStub([
+		[(a) => a[0] === 'merge', fail('CONFLICT')],
+		[isConflictedFiles, `packages/cli/x.ts\n${LOCKFILE}`],
+	]);
+	const pnpm = makeStub([[() => true, fail('ERR_PNPM_REGISTRY unreachable')]]);
+
+	const { files, preResolved, lockfileDeferred } = buildConflictBranch({
+		git,
+		pnpm,
+		masterSha: MASTER,
+		log: () => {},
+	});
+
+	assert.deepEqual(files, ['packages/cli/x.ts']);
+	assert.deepEqual(preResolved, []);
+	assert.equal(lockfileDeferred, true);
+	assert.ok(
+		git.calls.some((a) => a[0] === 'commit'),
+		'the conflict branch must still be committed',
+	);
+});
+
+test('buildConflictBranch refuses to guess when the merge unexpectedly succeeds', () => {
+	const git = makeStub([[(a) => a[0] === 'merge', '']]);
+
+	assert.throws(
+		() => buildConflictBranch({ git, pnpm: makeStub(), masterSha: MASTER, log: () => {} }),
+		/Expected a merge conflict/,
+	);
+	assert.equal(
+		git.calls.some((a) => a[0] === 'commit'),
+		false,
+	);
+});
+
+test('sync opens a draft conflict PR and leaves 3.x untouched on a real conflict', async () => {
+	const git = makeStub([
+		...baseGitRoutes.filter((r) => !r[0](['merge-tree'])),
+		[(a) => a[0] === 'merge-tree', conflictedMergeTree('packages/cli/x.ts')],
+		[(a) => a[0] === 'merge', fail('CONFLICT (content): packages/cli/x.ts')],
+		[isConflictedFiles, 'packages/cli/x.ts'],
+		[(a) => a[0] === 'log', 'breaking-sha'],
+	]);
+	const gh = makeStub([
+		...noOpenPr,
+		[(a) => a[0] === 'pr' && a[1] === 'create', 'https://github.com/n8n-io/n8n/pull/99'],
+	]);
+
+	await sync({ git, gh, pnpm: makeStub(), env, fetchFn: okFetch(['alice']), log: () => {} });
 
 	const create = gh.calls.find((a) => a[0] === 'pr' && a[1] === 'create');
 	assert.ok(create.includes('--draft'));
@@ -253,12 +667,52 @@ test('sync opens a draft conflict PR and leaves 3.x untouched on a real conflict
 	const pushes = git.calls.filter((a) => a[0] === 'push');
 	assert.equal(pushes.length, 1);
 	assert.equal(pushes[0].at(-1), `HEAD:refs/heads/${SYNC_BRANCH}`);
-	assert.equal(git.calls.some((a) => a[0] === 'rebase'), false, 'no replay attempt while a conflict is unresolved');
+	assert.equal(
+		git.calls.some((a) => a[0] === 'rebase'),
+		false,
+		'no replay attempt while a code conflict is unresolved',
+	);
+});
+
+test('sync reports only the code conflicts on a mixed conflict, with mechanical files pre-resolved', async () => {
+	const git = makeStub([
+		...baseGitRoutes.filter((r) => !r[0](['merge-tree'])),
+		[(a) => a[0] === 'merge-tree', conflictedMergeTree(LOCKFILE, 'packages/cli/x.ts')],
+		[(a) => a[0] === 'merge', fail('CONFLICT')],
+		[isConflictedFiles, `packages/cli/x.ts\n${LOCKFILE}`],
+		[(a) => a[0] === 'log' && a.includes('--format=%H'), 'breaking-sha'],
+	]);
+	const gh = makeStub([
+		...noOpenPr,
+		[(a) => a[0] === 'pr' && a[1] === 'create', 'https://github.com/n8n-io/n8n/pull/99'],
+	]);
+	const pnpm = makeStub();
+
+	await sync({ git, gh, pnpm, env, fetchFn: okFetch(['alice']), log: () => {} });
+
+	assert.equal(pnpm.calls.length, 1, 'the lockfile is regenerated for the conflict branch');
+
+	const create = gh.calls.find((a) => a[0] === 'pr' && a[1] === 'create');
+	const body = create[create.indexOf('--body') + 1];
+	assert.match(body, /### Conflicted files\n- `packages\/cli\/x\.ts`/);
+	assert.match(body, /### Auto-resolved for you/);
+	assert.ok(
+		body.indexOf(LOCKFILE) > body.indexOf('Auto-resolved'),
+		'the lockfile belongs to the auto-resolved section',
+	);
+
+	// Owner attribution is scoped to the real code conflicts only.
+	const attributions = git.calls.filter((a) => a[0] === 'log' && a.includes('--format=%H'));
+	assert.equal(attributions.length, 1);
+	assert.equal(attributions[0].at(-1), 'packages/cli/x.ts');
 });
 
 test('openConflictPr degrades gracefully when owner resolution fails', async () => {
 	const git = makeStub([[(a) => a[0] === 'log', 'sha1']]);
-	const gh = makeStub([[(a) => a[0] === 'pr' && a[1] === 'create', 'https://github.com/n8n-io/n8n/pull/1']]);
+	const gh = makeStub([
+		[(a) => a[0] === 'pr' && a[1] === 'list', '[]'],
+		[(a) => a[0] === 'pr' && a[1] === 'create', 'https://github.com/n8n-io/n8n/pull/1'],
+	]);
 	const failingFetch = async () => ({ ok: false, status: 500, json: async () => ({}) });
 
 	const { prUrl, ownersSlack } = await openConflictPr({
@@ -277,5 +731,41 @@ test('openConflictPr degrades gracefully when owner resolution fails', async () 
 	assert.equal(prUrl, 'https://github.com/n8n-io/n8n/pull/1');
 	assert.equal(ownersSlack, 'Could not auto-attribute owners.');
 	// No reviewer request when there are no owners.
-	assert.equal(gh.calls.some((a) => a[0] === 'pr' && a[1] === 'edit'), false);
+	assert.equal(
+		gh.calls.some((a) => a[0] === 'pr' && a[1] === 'edit'),
+		false,
+	);
+});
+
+test('openConflictPr calls out a recently abandoned conflict PR', async () => {
+	const git = makeStub([[(a) => a[0] === 'log', 'sha1']]);
+	const closedAt = new Date(Date.now() - 2 * 86_400_000).toISOString();
+	const gh = makeStub([
+		[
+			(a) => a[0] === 'pr' && a[1] === 'list' && a.includes('closed'),
+			JSON.stringify([
+				{ number: 42, url: 'https://github.com/n8n-io/n8n/pull/42', mergedAt: null, closedAt },
+			]),
+		],
+		[(a) => a[0] === 'pr' && a[1] === 'create', 'https://github.com/n8n-io/n8n/pull/43'],
+	]);
+
+	const { ownersSlack } = await openConflictPr({
+		git,
+		gh,
+		repo: 'n8n-io/n8n',
+		token: 't',
+		masterSha: MASTER,
+		preHead: PRE_HEAD,
+		pushUrl: 'https://push',
+		files: ['x.ts'],
+		fetchFn: okFetch(['alice']),
+		log: () => {},
+	});
+
+	const create = gh.calls.find((a) => a[0] === 'pr' && a[1] === 'create');
+	const body = create[create.indexOf('--body') + 1];
+	assert.match(body, /#42\) was closed without being merged/);
+	assert.match(body, /Merge, don't close/);
+	assert.match(ownersSlack, /<https:\/\/github\.com\/n8n-io\/n8n\/pull\/42\|#42>/);
 });

--- a/.github/workflows/util-sync-master-to-3x.yml
+++ b/.github/workflows/util-sync-master-to-3x.yml
@@ -7,12 +7,15 @@
 # authors preserved). The content pushed is always verified to be exactly what a merge of
 # 3.x and master would produce.
 #
-# When master genuinely conflicts with 3.x, 3.x is left untouched: a draft conflict PR
-# carrying the conflict markers is opened on the sync branch and #alerts-v3-sync is notified.
-# The resolver fixes the markers in a commit of their own and merges that PR with the normal
-# merge button. No further syncs run until it is merged. 3.x itself never has markers at its
-# tip (nightly images build from it) and the merge commit holding them drops out of its
-# history at the next replay.
+# Conflicts confined to mechanical, tool-generated files (the pnpm lockfile, bot-maintained
+# data files) are resolved in place during the replay — no PR, no commit, no human. When
+# master genuinely conflicts with 3.x on real code, 3.x is left untouched: a draft conflict
+# PR carrying the conflict markers (mechanical files pre-resolved) is opened on the sync
+# branch and #alerts-v3-sync is notified. The resolver fixes the markers in a commit of their
+# own and merges that PR with the normal merge button — never closes it, since closing
+# resolves nothing and the conflict returns. No further syncs run until it is merged. 3.x
+# itself never has markers at its tip (nightly images build from it) and the merge commit
+# holding them drops out of its history at the next replay.
 #
 # See .github/DEVELOPING_V3.md for the full v3 development model.
 
@@ -60,6 +63,14 @@ jobs:
           ref: 3.x
           fetch-depth: 0
           persist-credentials: false # we push with an explicit token URL instead
+
+      # Node + pnpm toolchain for the mechanical lockfile resolution
+      # (`pnpm install --lockfile-only`). No dependency install, no build.
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          install-command: ''
+          build-command: ''
 
       - name: Sync master into 3.x
         id: sync


### PR DESCRIPTION
## Summary

The daily master→3.x sync opened a conflict PR almost every day (8 in the last ~3 weeks). Analysis of the recent conflict PRs showed most are **mechanical**: `pnpm-lock.yaml` conflicted in 4 of the last 5 (3.x removed dependencies, master churns the lockfile daily), plus bot-generated data files (`node-popularity.json`, `e2e-impact-map.json`). Real code conflicts are only ~1–2/week.

This PR teaches the sync to resolve mechanical conflicts itself, so those days need no human and open no PR:

- **New `MECHANICAL_PATHS` config** in `sync-master-to-3x.mjs` (exact paths → strategy, easy to extend):
  - `pnpm-lock.yaml` → regenerated with `pnpm install --lockfile-only --no-frozen-lockfile` (pnpm natively merges its own conflicted lockfile; the explicit `--no-frozen-lockfile` matters because pnpm defaults to frozen when `CI=true`).
  - `node-popularity.json`, `e2e-impact-map.json` → take master's side (bots regenerate them on master).
- **In-place resolution during the replay**: when the rebase stalls and every conflicted path is mechanical, the resolution is folded into the stalled commit via `rebase --continue` — exactly what a human resolver would do. Still **no commit of its own and no PR**; "3.x = master + breaking commits" stays literally true.
- **Guards preserved**: the pushed tree must equal the `git merge-tree` result on every path *except* the mechanical paths the merge itself could not resolve (derived from the merge contract, never from what the run touched); no conflict markers may be present anywhere; and a regenerated lockfile must be consistent with the pushed tree's manifests (reconciled at the tip — folded into the tip commit by amending — when the `-X theirs` route settled lockfile hunks without stalling). Any check failing fails the run instead of rewriting 3.x.
- **Real code conflicts keep today's conflict-PR flow**, but mechanical files now arrive pre-resolved so only actual code carries markers. When a `package.json`/`pnpm-workspace.yaml` is itself conflicted, the lockfile is left with its markers and the PR body carries the regen instruction.
- **"Merge, don't close" hygiene**: 3 of the 8 recent conflict PRs were closed unmerged, which guarantees the same conflict returns (why `ParameterInputList.vue` conflicted twice in 3 days). New conflict PRs and the Slack ping now call out recently closed-unmerged conflict PRs.
- Workflow gains a `setup-nodejs` step with empty install/build commands (pnpm on PATH, no dependency install, no build); permissions unchanged.
- Docs updated: `DEVELOPING_V3.md` (sync cases, conflict-PR resolution guidance) and `WORKFLOWS.md`.

## How to test

- Unit tests: `cd .github/scripts && node --test sync-master-to-3x.test.mjs sync-conflict-owners.test.mjs` (40 tests, all green — covers the auto-resolve path, mixed-conflict pre-resolution, the deferred-lockfile case, the relaxed tree guard, and the abandoned-PR warning).
- End-to-end rehearsal (the one behavior not exercisable in unit tests is pnpm's conflicted-lockfile auto-merge on lockfileVersion 9.0 + catalogs): use the script's built-in `SYNC_TARGET_BRANCH` override — create a scratch branch off current `3.x`, commit a dependency removal to it so its lockfile diverges, wait for a master lockfile change, then `workflow_dispatch` the sync with `SYNC_TARGET_BRANCH` pointing at the scratch branch and verify it force-pushes with the lockfile resolved and opens no PR.

## Related Linear tickets, Github issues, and Community forum posts

<!-- none -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

