### PR TITLE
fix: prevent smartDecimal from crashing on exponential-notation numbers

### DIFF
--- a/packages/@n8n/utils/src/number/smart-decimal.test.ts
+++ b/packages/@n8n/utils/src/number/smart-decimal.test.ts
@@ -32,4 +32,10 @@ describe('smartDecimal', () => {
 	it('should round to two decimal if it is smaller than the given one', () => {
 		expect(smartDecimal(42.56, 3)).toBe(42.56);
 	});
+
+	it('should not throw for numbers that serialize in exponential notation', () => {
+		// (0.0000001).toString() === '1e-7', which has no decimal point
+		expect(smartDecimal(0.0000001)).toBe(0);
+		expect(smartDecimal(5e-8, 3)).toBe(0);
+	});
 });

--- a/packages/@n8n/utils/src/number/smart-decimal.ts
+++ b/packages/@n8n/utils/src/number/smart-decimal.ts
@@ -4,8 +4,10 @@ export const smartDecimal = (value: number, decimals = 2): number => {
 		return value;
 	}
 
-	// Check if it has only one decimal place
-	if (value.toString().split('.')[1].length <= decimals) {
+	// Numbers small enough to serialize in exponential notation (e.g. 1e-7)
+	// have no '.' in their string form, so guard the missing decimal segment.
+	const decimalPart = value.toString().split('.')[1];
+	if (decimalPart !== undefined && decimalPart.length <= decimals) {
 		return value;
 	}
 


### PR DESCRIPTION
## Summary

`smartDecimal` (in `@n8n/utils`) throws a `TypeError` for non-integer numbers that JavaScript serializes in exponential notation, e.g. `0.0000001` → `"1e-7"`. It works out how many decimal places a value has with `value.toString().split('.')[1].length`, but an exponential string has no `.`, so `split('.')[1]` is `undefined` and reading `.length` on it throws.

This change stores the decimal segment first and guards the `undefined` case, so a value whose string form has no decimal part falls through to `Number(value.toFixed(decimals))` and rounds as intended. `smartDecimal(0.0000001)` now returns `0` (rounded to the default 2 decimals) instead of crashing. All existing behaviour is unchanged.

`smartDecimal` is used by the Insights views (failure rate, time saved, average run time) in the editor UI, so a small enough value coming from those transforms could otherwise crash the rendering.

## How to test

From `packages/@n8n/utils`:

```
pnpm test smart-decimal
```

The added regression test (`should not throw for numbers that serialize in exponential notation`) fails on `master` with `TypeError: Cannot read properties of undefined (reading 'length')` and passes with this change.

Manual check:

```ts
import { smartDecimal } from '@n8n/utils/number/smart-decimal';
smartDecimal(0.0000001); // before: throws TypeError; after: 0
```

## Related Linear tickets, Github issues, and Community forum posts

closes #35923

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

