### PR TITLE
build(editor): Resolve @n8n/tournament from source via the n8n:source condition (no-changelog)

### DIFF
--- a/packages/@n8n/tournament/package.json
+++ b/packages/@n8n/tournament/package.json
@@ -7,6 +7,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "n8n:source": "./src/index.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -14,7 +14,7 @@ import legacy from '@vitejs/plugin-legacy';
 import browserslist from 'browserslist';
 import { isLocaleFile, sendLocaleUpdate } from './vite/i18n-locales-hmr-helpers';
 import { nodePopularityPlugin } from './vite/vite-plugin-node-popularity.mjs';
-import { editorUiAliases } from './vite/aliases.mjs';
+import { editorUiAliases, resolveConditions } from './vite/aliases.mjs';
 
 const publicPath = process.env.VUE_APP_PUBLIC_PATH || '/';
 
@@ -158,7 +158,7 @@ export default mergeConfig(
 			BASE_PATH: `'${publicPath}'`,
 		},
 		plugins,
-		resolve: { alias },
+		resolve: { alias, conditions: resolveConditions },
 		base: publicPath,
 		envPrefix: ['VUE', 'N8N_ENV_FEAT'],
 		css: {

--- a/packages/frontend/editor-ui/vite/aliases.mts
+++ b/packages/frontend/editor-ui/vite/aliases.mts
@@ -1,12 +1,24 @@
 import { resolve } from 'path';
-import type { Alias } from 'vite';
+import { defaultClientConditions, type Alias } from 'vite';
+
+/**
+ * Export conditions editor-ui resolves with. `@n8n/tournament` declares an `n8n:source` condition
+ * pointing at its TypeScript source, and opting in here is what makes the browser graph reach that
+ * source instead of its CJS `dist` — which the dev server serves verbatim (the browser then fails
+ * to parse a named export out of it) and which costs the build ~397 kB in defeated tree-shaking.
+ * Resolution lives in that package's own `package.json`, so there is no list here to keep in sync.
+ *
+ * Spreading vite's defaults is mandatory: `conditions` replaces them rather than appending, so
+ * dropping the spread would silently change how every third-party package in the graph resolves.
+ */
+export const resolveConditions = ['n8n:source', ...defaultClientConditions];
 
 /**
  * Aliases that belong to editor-ui itself: its own `@/` root and the fixes for transitive
  * dependencies that misbehave in a browser graph. These packages are reached through
  * `n8n-workflow`, not imported by editor-ui directly.
  */
-export const appAliases = (editorUiDir: string, packagesDir: string): Alias[] => [
+export const appAliases = (editorUiDir: string): Alias[] => [
 	{ find: '@', replacement: resolve(editorUiDir, 'src') },
 	{ find: 'stream', replacement: 'stream-browserify' },
 	// Stub out @n8n/expression-runtime for browser build (it pulls in isolated-vm, a Node.js-only native module)
@@ -14,11 +26,6 @@ export const appAliases = (editorUiDir: string, packagesDir: string): Alias[] =>
 		find: '@n8n/expression-runtime',
 		replacement: resolve(editorUiDir, 'vite/expression-runtime-stub.ts'),
 	},
-	// `n8n-workflow`'s expression-sandboxing imports `astVisit` from @n8n/tournament, whose dist is
-	// CJS. Linked workspace packages skip optimizeDeps, so the dev server serves that file verbatim
-	// and the browser fails to parse a named export out of it; the build survives because rolldown
-	// interops CJS, but pays ~397 kB in defeated tree-shaking. Resolving to src avoids both.
-	{ find: '@n8n/tournament', replacement: resolve(packagesDir, '@n8n', 'tournament', 'src') },
 ];
 
 /**
@@ -89,7 +96,7 @@ export const vendorAliases = (editorUiDir: string): Alias[] => [
 ];
 
 export const editorUiAliases = (editorUiDir: string, packagesDir: string): Alias[] => [
-	...appAliases(editorUiDir, packagesDir),
+	...appAliases(editorUiDir),
 	...frontendSourceAliases(packagesDir),
 	...vendorAliases(editorUiDir),
 ];

--- a/packages/frontend/editor-ui/vite/aliases.test.ts
+++ b/packages/frontend/editor-ui/vite/aliases.test.ts
@@ -1,9 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
-import type { Alias } from 'vite';
+import { createServer, defaultClientConditions, type Alias } from 'vite';
 import { describe, expect, it } from 'vitest';
 
-import { editorUiAliases, sourcePackages } from './aliases.mjs';
+import { editorUiAliases, resolveConditions, sourcePackages } from './aliases.mjs';
 
 // vitest runs with the package root as cwd; `import.meta.url` is not a file URL under jsdom.
 const editorUiDir = process.cwd();
@@ -96,18 +96,6 @@ describe('editor-ui vite aliases', () => {
 		}
 	});
 
-	it('resolves @n8n/tournament from source', () => {
-		// Reached transitively via `n8n-workflow`, so it is not a declared dependency and is not in
-		// `sourcePackages`. Its dist is CJS: on `dist` the dev server fails to parse a named export
-		// out of it and the build loses ~397 kB to defeated tree-shaking.
-		expect(resolveSpecifier('@n8n/tournament', aliases)).toBe(
-			'packages/@n8n/tournament/src/index.ts',
-		);
-		expect(resolveSpecifier('@n8n/tournament/ast', aliases)).toBe(
-			'packages/@n8n/tournament/src/ast',
-		);
-	});
-
 	it('resolves a package and its subpaths independently of entry order', () => {
 		// An open-ended `^@n8n/chat(.+)$` also matches `@n8n/chat-hub/…`, so a list carrying both
 		// only resolves correctly while the more specific entry happens to come first.
@@ -115,5 +103,54 @@ describe('editor-ui vite aliases', () => {
 		expect(resolveSpecifier('@n8n/chat-hub/api', [...aliases].reverse())).toBe(
 			'packages/@n8n/chat-hub/src/api',
 		);
+	});
+});
+
+describe('editor-ui resolve conditions', () => {
+	// `@n8n/tournament` is reached transitively through `n8n-workflow`'s built ESM, so it is not a
+	// declared dependency of editor-ui and resolves relative to that file, not to editor-ui's root.
+	const importer = join(repoRoot, 'packages/workflow/dist/esm/extensions/expression-parser.js');
+
+	/** Real vite resolution — the same code path the dev server and the build take. */
+	const resolveThroughVite = async (conditions: string[]) => {
+		const server = await createServer({
+			configFile: false,
+			root: editorUiDir,
+			logLevel: 'silent',
+			server: { middlewareMode: true, ws: false },
+			resolve: { conditions },
+		});
+
+		try {
+			const resolved = await server.environments.client.pluginContainer.resolveId(
+				'@n8n/tournament',
+				importer,
+			);
+			return resolved && relative(repoRoot, resolved.id);
+		} finally {
+			await server.close();
+		}
+	};
+
+	it('resolves @n8n/tournament to src through the n8n:source condition', async () => {
+		expect(await resolveThroughVite(resolveConditions)).toBe(
+			'packages/@n8n/tournament/src/index.ts',
+		);
+	});
+
+	it('falls back to the CJS dist when the condition is absent', async () => {
+		// The negative control, and the reason this test exists: a wrong condition does not error,
+		// it silently lands on `dist` — where the dev server serves CJS the browser cannot parse a
+		// named export out of, and the build loses ~397 kB to defeated tree-shaking. Without this
+		// case, the assertion above would still pass if `n8n:source` stopped doing any work.
+		expect(await resolveThroughVite([...defaultClientConditions])).toBe(
+			'packages/@n8n/tournament/dist/index.js',
+		);
+	});
+
+	it('keeps vite defaults active alongside the custom condition', () => {
+		// `conditions` replaces vite's defaults instead of appending to them, so a missing spread
+		// would change third-party resolution across the whole graph rather than fail loudly.
+		expect(resolveConditions).toEqual(['n8n:source', ...defaultClientConditions]);
 	});
 });


### PR DESCRIPTION
## Summary

`@n8n/tournament` now declares its own frontend resolution in its `package.json`, and editor-ui's
hand-maintained alias for it is gone.

```jsonc
// packages/@n8n/tournament/package.json
"exports": { ".": { "n8n:source": "./src/index.ts", /* …unchanged… */ } }
```

```ts
// packages/frontend/editor-ui/vite.config.mts
resolve: { alias, conditions: resolveConditions }   // ['n8n:source', ...defaultClientConditions]
```

Why this package first: it is the one entry in editor-ui's alias list that exists purely to fix a
**transitive** dependency. `n8n-workflow`'s built ESM imports `astVisit` from tournament, whose
`dist` is CJS — linked workspace packages skip `optimizeDeps`, so the dev server serves that file
verbatim and the browser cannot parse a named export out of it, while the production build survives
only because rolldown interops CJS, at a cost of ~397 kB in defeated tree-shaking. An alias in
editor-ui cannot express that, because editor-ui never imports the package: it is a false negative
for any consumer-side mapping, generated or hand-written. Declaring the source entry on the package
itself puts the fact where the fact belongs, and any Vite context that opts into the condition
inherits the fix.

The spread in `resolveConditions` is load-bearing: `conditions` **replaces** Vite's defaults rather
than appending to them, so dropping it would silently change third-party resolution across the whole
graph. A test pins the exact array for that reason.

### Verification

Typecheck-green and build-green are known-insufficient for this package — the ~397 kB regression was
invisible to both — so every claim below has a negative control that fires.

| Check | Result |
| --- | --- |
| Vite **dev server** in Chromium | Serves `tournament/src/index.ts` + 7 more `src/*.ts`, all 200, zero `dist` requests; `astVisit` is a live `function`; `expression-sandboxing.js` loads clean |
| ↳ negative control (condition removed) | App fails to boot: `The requested module '…/tournament/dist/index.js' does not provide an export named 'astVisit'` — verbatim the documented failure |
| Production bundle | 45,110,584 B with the condition vs **45,507,890 B** with no resolution config → **−397,306 B**, matching the previously measured regression byte-for-byte |
| ↳ attribution | With the condition, `astVisit` is tree-shaken out entirely (0 chunks) and 3 chunks reference `tournament/src`; without it, 3 chunks reference `tournament/dist` |
| `vue-tsc` honours `customConditions`? | **Yes** — 2.2.8 / TS 6.0.2, in `.ts` and inside a `.vue` SFC alike; control without the option resolves `dist` and errors (exit 2). See "Not changed" below for why none is added here |
| Backend resolution | Unchanged and structurally so: default Node ESM `import.meta.resolve` and CJS `require.resolve` both still land on `dist`; only an explicit opt-in reaches `src` |
| editor-ui typecheck / build / unit suite | Green |

The two repo assertions in `vite/aliases.test.ts` resolve `@n8n/tournament` through a **real Vite
server**, not a model of one, and were mutation-tested: deleting the condition from the package
fails the positive case with `expected 'packages/@n8n/tournament/dist/index.js' to be
'packages/@n8n/tournament/src/index.ts'`, and dropping the spread fails the defaults case. This
matters because the failure mode is silent by construction — a wrong condition falls back to `dist`
instead of erroring.

The old alias-based `resolves @n8n/tournament from source` case is replaced by those two, since the
alias it asserted on no longer exists. Its second half also asserted a subpath (`@n8n/tournament/ast`)
that nothing imports — all five importers in the repo use the bare specifier — so a `"."` entry is
the whole requirement here and no extension-specific `"./src/*.ts"` pattern is needed.

### Not changed, deliberately

- **No `customConditions` on any tsconfig, and no `paths` key was deleted — there was none.** No
  frontend TypeScript context resolves this package: `vue-tsc --listFiles` puts 8,008 files in
  editor-ui's program and tournament is not among them, because the `.d.ts` chain reachable from
  `n8n-workflow`'s entry never references it (only `expression-sandboxing.d.ts` does, and nothing
  imports that subpath). Adding a global resolution option whose effect is unobservable would be
  scaffolding, not safety. When the six frontend-only packages gain the condition they *are* in that
  program, and that is when editor-ui's tsconfig needs `customConditions` — testably.
- **Storybook.** `@n8n/storybook`'s Vite context has no equivalent alias, so this chain breaks its
  dev server today — see the comment at `ToolsConnectionModal.stories.ts:108`. Pre-existing, not
  touched here; it is a candidate beneficiary of the condition and belongs with the deferred-consumer
  work rather than this PR.
- The four other frontend packages that declare `n8n-workflow` (`@n8n/composables`, `@n8n/stores`,
  `@n8n/rest-api-client`, `@n8n/i18n`) — their suites pass as-is; no opt-in added without a
  demonstrated need.

## How to test

```bash
pnpm --filter n8n-editor-ui vitest run vite/aliases.test.ts   # 20 passing
pnpm --filter n8n-editor-ui typecheck
pnpm --filter n8n-editor-ui build
pnpm --filter n8n-editor-ui dev                               # then load the editor
```

To see the mechanism doing the work, delete `"n8n:source"` from
`packages/@n8n/tournament/package.json` and reload the dev server: the app stops booting with
`does not provide an export named 'astVisit'`, and the tests go red.

## Sequencing

**Branched from #35642, not from `master`** — that PR introduces `vite/aliases.mts` and
`aliases.test.ts`, the single source of alias truth this change edits, and it is still open with
`CHANGES_REQUESTED`. Basing on `master` would mean re-landing a conflicting version of that mapping.
This PR should land after it; the diff against #35642 is the four files above.

This is the first, smallest step of the direction agreed for frontend source resolution: resolution
truth moves into each package's own `package.json` instead of being mirrored in consumer-side lists.
It changes no published artifact — tournament already ships `src/` in `files`, and `n8n:source` is
inert unless a consumer opts in.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

