### PR TITLE
test: Pin Instance AI off for the legacy AI Assistant e2e suites

### DIFF
--- a/packages/testing/playwright/Types.ts
+++ b/packages/testing/playwright/Types.ts
@@ -1,4 +1,10 @@
-import type { FrontendSettings } from '@n8n/api-types';
+import type { FrontendModuleSettings, FrontendSettings } from '@n8n/api-types';
+
+type DeepPartial<T> = T extends Array<infer U>
+	? Array<DeepPartial<U>>
+	: T extends object
+		? { [K in keyof T]?: DeepPartial<T[K]> }
+		: T;
 
 export class TestError extends Error {
 	constructor(message: string) {
@@ -47,6 +53,9 @@ export interface TestRequirements {
 	config?: {
 		/** Frontend settings to override (merged with default settings) */
 		settings?: Partial<FrontendSettings>;
+
+		/** Backend module settings to override (merged with the ones the instance reports) */
+		moduleSettings?: DeepPartial<FrontendModuleSettings>;
 
 		/** Feature flags to enable/disable for the test */
 		features?: Record<string, boolean>;

--- a/packages/testing/playwright/config/ai-assistant-fixtures.ts
+++ b/packages/testing/playwright/config/ai-assistant-fixtures.ts
@@ -107,11 +107,22 @@ export const codeSnippetAssistantResponse = {
 
 // #region Test Requirements for different scenarios
 
+/**
+ * The legacy AI Assistant entry points (canvas action button, node error view
+ * button, credential help) only render while Instance AI is off, so these
+ * suites pin the module off. Instance AI's own entry points are covered by
+ * `tests/e2e/instance-ai`.
+ */
+export const INSTANCE_AI_DISABLED: NonNullable<TestRequirements['config']>['moduleSettings'] = {
+	'instance-ai': { enabled: false },
+};
+
 export const aiDisabledRequirements: TestRequirements = {
 	config: {
 		settings: {
 			aiAssistant: { enabled: false, setup: false },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: false },
 	},
 };
@@ -121,6 +132,7 @@ export const aiEnabledRequirements: TestRequirements = {
 		settings: {
 			aiAssistant: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: true, setup: true },
 	},
 };
@@ -130,6 +142,7 @@ export const aiEnabledWithWorkflowRequirements: TestRequirements = {
 		settings: {
 			aiAssistant: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: true, setup: true },
 	},
 	workflow: {
@@ -148,6 +161,7 @@ export const aiEnabledWithQuickRepliesRequirements: TestRequirements = {
 		settings: {
 			aiAssistant: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: true },
 	},
 	workflow: {
@@ -185,6 +199,7 @@ export const aiEnabledWithEndSessionRequirements: TestRequirements = {
 		settings: {
 			aiAssistant: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: true },
 	},
 	workflow: {
@@ -218,6 +233,7 @@ export const aiEnabledWorkflowBaseRequirements: TestRequirements = {
 		settings: {
 			aiAssistant: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: true, setup: true },
 	},
 	workflow: {
@@ -240,6 +256,7 @@ export const aiEnabledWithSimpleChatRequirements: TestRequirements = {
 		settings: {
 			aiAssistant: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: true, setup: true },
 	},
 	intercepts: {
@@ -255,6 +272,7 @@ export const aiEnabledWithCodeSnippetRequirements: TestRequirements = {
 		settings: {
 			aiAssistant: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: true, setup: true },
 	},
 	intercepts: {
@@ -270,6 +288,7 @@ export const aiEnabledWithHttpWorkflowRequirements: TestRequirements = {
 		settings: {
 			aiAssistant: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: { aiAssistant: true, setup: true },
 	},
 	workflow: {

--- a/packages/testing/playwright/config/ai-builder-fixtures.ts
+++ b/packages/testing/playwright/config/ai-builder-fixtures.ts
@@ -1,3 +1,4 @@
+import { INSTANCE_AI_DISABLED } from './ai-assistant-fixtures';
 import type { TestRequirements } from '../Types';
 
 /**
@@ -11,6 +12,7 @@ export const workflowBuilderEnabledRequirements: TestRequirements = {
 			aiAssistant: { enabled: true, setup: true },
 			aiBuilder: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: {
 			aiAssistant: true,
 			aiBuilder: true,

--- a/packages/testing/playwright/config/ai-builder-wizard-fixtures.ts
+++ b/packages/testing/playwright/config/ai-builder-wizard-fixtures.ts
@@ -1,3 +1,4 @@
+import { INSTANCE_AI_DISABLED } from './ai-assistant-fixtures';
 import type { TestRequirements } from '../Types';
 
 // #region Mock Builder Responses
@@ -441,6 +442,7 @@ export const builderWizardRequirements: TestRequirements = {
 			aiAssistant: { enabled: true, setup: true },
 			aiBuilder: { enabled: true, setup: true },
 		},
+		moduleSettings: INSTANCE_AI_DISABLED,
 		features: {
 			aiAssistant: true,
 			aiBuilder: true,

--- a/packages/testing/playwright/config/intercepts.ts
+++ b/packages/testing/playwright/config/intercepts.ts
@@ -3,6 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 
 const contextSettings = new Map<BrowserContext, Partial<Record<string, unknown>>>();
+const contextModuleSettings = new Map<BrowserContext, Partial<Record<string, unknown>>>();
 
 export function setContextSettings(
 	context: BrowserContext,
@@ -13,6 +14,17 @@ export function setContextSettings(
 
 export function getContextSettings(context: BrowserContext) {
 	return contextSettings.get(context);
+}
+
+export function setContextModuleSettings(
+	context: BrowserContext,
+	moduleSettings: Partial<Record<string, unknown>>,
+) {
+	contextModuleSettings.set(context, moduleSettings);
+}
+
+export function getContextModuleSettings(context: BrowserContext) {
+	return contextModuleSettings.get(context);
 }
 
 export async function setupDefaultInterceptors(target: BrowserContext) {
@@ -42,6 +54,34 @@ export async function setupDefaultInterceptors(target: BrowserContext) {
 			});
 		} catch (error) {
 			console.error('Error in /rest/settings intercept:', error);
+			await route.continue();
+		}
+	});
+
+	// Global /rest/module-settings intercept - lets a test pin a backend module's
+	// client settings (e.g. turn `instance-ai` off) without changing the instance.
+	await target.route('**/rest/module-settings', async (route: Route) => {
+		try {
+			const originalResponse = await route.fetch();
+			const originalJson = await originalResponse.json();
+
+			const testModuleSettings = getContextModuleSettings(target);
+
+			const modifiedData = {
+				data:
+					testModuleSettings && Object.keys(testModuleSettings).length > 0
+						? merge(cloneDeep(originalJson.data), testModuleSettings)
+						: originalJson.data,
+			};
+
+			await route.fulfill({
+				status: originalResponse.status(),
+				headers: originalResponse.headers(),
+				contentType: 'application/json',
+				body: JSON.stringify(modifiedData),
+			});
+		} catch (error) {
+			console.error('Error in /rest/module-settings intercept:', error);
 			await route.continue();
 		}
 	});

--- a/packages/testing/playwright/tests/e2e/auth/authenticated.spec.ts
+++ b/packages/testing/playwright/tests/e2e/auth/authenticated.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../../fixtures/base';
+import type { TestRequirements } from '../../../Types';
 
 test.describe(
 	'Authentication',
@@ -6,18 +7,38 @@ test.describe(
 		annotation: [{ type: 'owner', description: 'Identity & Access' }],
 	},
 	() => {
-		// Every signed-in role holds `instanceAi:message`, so the root route lands
-		// them on the AI Assistant while the `instance-ai` module is active.
+		// The root route lands users on the AI Assistant while the `instance-ai`
+		// module is active — but only if they may manage it, or setup is complete.
+		// Owner and admin hold `instanceAi:manage`; members only hold
+		// `instanceAi:message`, so they land there once Instance AI is set up.
+		// The module's `setupCompleted` flag is pinned per case so the expectation
+		// doesn't depend on how the instance under test happens to be configured.
+		const instanceAiSetup = (setupCompleted: boolean): TestRequirements => ({
+			config: { moduleSettings: { 'instance-ai': { setupCompleted } } },
+		});
+
 		const testCases = [
-			{ role: 'default', expectedUrl: /\/assistant/, auth: '' },
-			{ role: 'owner', expectedUrl: /\/assistant/, auth: '@auth:owner' },
-			{ role: 'admin', expectedUrl: /\/assistant/, auth: '@auth:admin' },
-			{ role: 'member', expectedUrl: /\/assistant/, auth: '@auth:member' },
-			{ role: 'none', expectedUrl: /\/signin/, auth: '@auth:none' },
+			{ role: 'default', expectedUrl: /\/assistant/, auth: '', requirements: {} },
+			{ role: 'owner', expectedUrl: /\/assistant/, auth: '@auth:owner', requirements: {} },
+			{ role: 'admin', expectedUrl: /\/assistant/, auth: '@auth:admin', requirements: {} },
+			{
+				role: 'member without Instance AI set up',
+				expectedUrl: /\/home\/workflows/,
+				auth: '@auth:member',
+				requirements: instanceAiSetup(false),
+			},
+			{
+				role: 'member with Instance AI set up',
+				expectedUrl: /\/assistant/,
+				auth: '@auth:member',
+				requirements: instanceAiSetup(true),
+			},
+			{ role: 'none', expectedUrl: /\/signin/, auth: '@auth:none', requirements: {} },
 		];
 
-		for (const { role, expectedUrl, auth } of testCases) {
-			test(`${role} authentication ${auth}`, async ({ n8n }) => {
+		for (const { role, expectedUrl, auth, requirements } of testCases) {
+			test(`${role} authentication ${auth}`, async ({ n8n, setupRequirements }) => {
+				await setupRequirements(requirements);
 				await n8n.goToRoot();
 				await expect(n8n.page).toHaveURL(expectedUrl);
 			});

--- a/packages/testing/playwright/utils/requirements.ts
+++ b/packages/testing/playwright/utils/requirements.ts
@@ -1,6 +1,6 @@
 import type { BrowserContext } from '@playwright/test';
 
-import { setContextSettings } from '../config/intercepts';
+import { setContextModuleSettings, setContextSettings } from '../config/intercepts';
 import type { n8nPage } from '../pages/n8nPage';
 import { TestError, type TestRequirements } from '../Types';
 
@@ -23,6 +23,11 @@ export async function setupTestRequirements(
 	if (requirements.config?.settings) {
 		// Store settings for this context
 		setContextSettings(context, requirements.config.settings);
+	}
+
+	// 1b. Setup module settings override
+	if (requirements.config?.moduleSettings) {
+		setContextModuleSettings(context, requirements.config.moduleSettings);
 	}
 
 	// 2. Setup feature flags


### PR DESCRIPTION
## Summary

Follow-up to #35670 (`instance-ai` enabled by default). The legacy AI Assistant / Builder entry points are gated behind `!instanceAi`, so with the module on by default they are replaced by their `instance-ai-*` variants and the legacy suites can no longer find them:

| Legacy testId the suites target | Rendered instead when Instance AI is on |
|---|---|
| `canvas-build-with-ai-button` | `canvas-instance-ai-build-with-ai-button` |
| `ask-assistant-canvas-action-button` | `instance-ai-canvas-action-button` |
| `node-error-view-ask-assistant-button` | `node-error-view-instance-ai-button` |

Retargeting these specs at the `instance-ai-*` testIds would change what they cover (those buttons hand off to an Instance AI thread, not the legacy assistant chat), and the legacy assistant is still the experience on instances where Instance AI is off. So instead the legacy suites now pin the module off:

- `TestRequirements` gains `config.moduleSettings`, deep-merged into `/rest/module-settings` exactly the way `config.settings` is already merged into `/rest/settings`.
- The AI assistant / builder / builder-wizard fixtures set `moduleSettings: { 'instance-ai': { enabled: false } }`.

This is frontend-only and per browser context, so it needs no container env change, works in local and container mode alike, and doesn't touch instance-wide state that parallel workers share. Instance AI's own entry points stay covered by `tests/e2e/instance-ai`.

## How to test

```bash
pnpm --filter=n8n-playwright test:local tests/e2e/ai/assistant-basic.spec.ts tests/e2e/ai/assistant-credential-help.spec.ts tests/e2e/ai/builder-setup-wizard.spec.ts tests/e2e/ai/assistant-code-help.spec.ts tests/e2e/ai/assistant-support-chat.spec.ts
```

Run locally on this branch: 28 passed, 1 skipped. On `master` the same specs fail deterministically (e.g. `assistant-basic.spec.ts:40 renders placeholder UI` times out waiting for `ask-assistant-canvas-action-button`).

`tests/e2e/ai/workflow-builder.spec.ts` uses the same canvas button and gets the same fix, but is `@capability:proxy` so it only runs in container mode.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #35670.

https://n8nio.slack.com/archives/C035KBDA917/p1786352346796409

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

