### PR TITLE
feat(core): Tell the assistant which services are connected and what tools they expose

### DIFF
--- a/packages/@n8n/instance-ai/docs/tools.md
+++ b/packages/@n8n/instance-ai/docs/tools.md
@@ -752,12 +752,22 @@ conversation. Creation and editing stay on `build-agent`.
 
 ### `mcp-servers` *(domain tool — conditional)*
 
-Search the MCP registry so the orchestrator can discover a hosted MCP server for
-a service the user asked about but has not connected. One action, `search`, over
-`{ queries: string[] }`; returns
-`{ results: [{ slug, title, description, tools }], hint? }`.
+Tool to interact with connected and available MCP servers.
 
-Only servers that the user has *not* connected come back. Results are capped at 5, most relevant first.
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | `'connected' \| 'details' \| 'search'` | yes | Discriminator |
+| `slug` | string | `details` | Server slug, as returned by `connected` |
+| `queries` | string[] | `search` | Free-text queries matched against server name, title, description |
+
+**`connected`** → `{ servers: [{ slug, toolCount }], hint? }`. Every connected MCP
+server, counts only — names are `details`' job.
+
+**`details`** → `{ slug, tools, hint? }`. One server's tool names. `hint` tells an
+unconnected slug apart from a connected server that loaded no tools.
+
+**`search`** → `{ results: [{ slug, title, description, tools }], hint? }`, capped
+at 5, most relevant first. Only servers the user has *not* connected come back.
 
 ## Other Domain Tools
 

--- a/packages/@n8n/instance-ai/src/agent/__tests__/instance-agent.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/instance-agent.test.ts
@@ -499,32 +499,72 @@ describe('createInstanceAgent', () => {
 		);
 	});
 
-	it('enables the MCP registry prompt section only when the host wired mcpService', async () => {
-		const baseOptions = {
-			modelId: 'test-model',
-			orchestrationContext: { runId: 'mcp-registry-prompt' },
-			memoryConfig: {},
-			mcpManager: createMcpManagerStub(new Map()),
-		};
-		const baseContext = {
-			runLabel: 'mcp-registry-prompt',
-			localGatewayStatus: undefined,
-			licenseHints: undefined,
-			localMcpServer: undefined,
+	describe('connected MCP services', () => {
+		const lastDomainToolContext = () => {
+			const calls = createOrchestratorDomainTools.mock.calls as Array<
+				[{ connectedMcpServices?: unknown }]
+			>;
+			return calls.at(-1)?.[0].connectedMcpServices;
 		};
 
-		await createInstanceAgent({ ...baseOptions, context: baseContext } as never);
-		expect(getSystemPrompt).toHaveBeenLastCalledWith(
-			expect.objectContaining({ mcpRegistrySearchEnabled: false }),
-		);
+		const mcpServers = [
+			{
+				name: 'mcp_linear',
+				url: 'https://linear.example',
+				metadata: { serverSlug: 'linear' },
+			},
+			{
+				name: 'mcp_notion',
+				url: 'https://notion.example',
+				metadata: { serverSlug: 'notion' },
+			},
+		];
 
-		await createInstanceAgent({
-			...baseOptions,
-			context: { ...baseContext, mcpService: { search: vi.fn() } },
-		} as never);
-		expect(getSystemPrompt).toHaveBeenLastCalledWith(
-			expect.objectContaining({ mcpRegistrySearchEnabled: true }),
-		);
+		const buildWith = async (toolName = 'mcp_linear_create_issue') => {
+			const linearTool = { ...mockBuiltTool(toolName), mcpServerName: 'mcp_linear' };
+
+			await createInstanceAgent({
+				modelId: 'test-model',
+				context: {
+					runLabel: 'connected-mcp',
+					logger: mockLogger,
+					mcpService: { search: vi.fn() },
+				},
+				orchestrationContext: { runId: 'connected-mcp' },
+				memoryConfig: {},
+				mcpServers,
+				mcpManager: createMcpManagerStub(new Map([[toolName, linearTool]])),
+			} as never);
+		};
+
+		// The tools capture their context by value, so the inventory has to be in place
+		// before `mcp-servers` is built — not handed to the prompt.
+		it('hands the domain tools the inventory, keyed by service', async () => {
+			await buildWith();
+
+			expect(lastDomainToolContext()).toEqual([
+				{ slug: 'linear', toolNames: ['mcp_linear_create_issue'] },
+				{ slug: 'notion', toolNames: [] },
+			]);
+		});
+
+		it('reports no tools for a service whose only tool has an unsafe name', async () => {
+			await buildWith('mcp_linear.create_issue');
+
+			expect(lastDomainToolContext()).toEqual([
+				{ slug: 'linear', toolNames: [] },
+				{ slug: 'notion', toolNames: [] },
+			]);
+		});
+
+		it('reports no tools for a service whose only tool collides with a domain tool', async () => {
+			await buildWith('workflows');
+
+			expect(lastDomainToolContext()).toEqual([
+				{ slug: 'linear', toolNames: [] },
+				{ slug: 'notion', toolNames: [] },
+			]);
+		});
 	});
 
 	it('does not enable MCP-specific tool search guidance when deferred search is disabled', async () => {

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.discovery.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.discovery.test.ts
@@ -145,25 +145,14 @@ describe('getSystemPrompt — browser/computer-use discoverability', () => {
 		});
 	});
 
-	describe('MCP registry discovery is gated on the tool being registered', () => {
-		it('nudges the orchestrator to search the registry when the tool is available', () => {
-			const prompt = getSystemPrompt({ mcpRegistrySearchEnabled: true });
+	describe('MCP server guidance belongs to the tool, not the prompt', () => {
+		// Guidance lives on `mcp-servers`, which is never deferred, so its description
+		// reaches every request the way a prompt section would — without a second copy.
+		it('says nothing about MCP servers', () => {
+			const prompt = getSystemPrompt({ toolSearchEnabled: true, mcpToolSearchEnabled: true });
 
-			expect(prompt).toContain('## Connecting Services');
-			expect(prompt).toContain('mcp-servers');
-		});
-
-		it('keeps the nudge away from workflow building', () => {
-			const prompt = getSystemPrompt({ mcpRegistrySearchEnabled: true });
-
-			expect(prompt).toContain('never call `mcp-servers` for a build request');
-		});
-
-		it('omits the section when the tool is not registered', () => {
-			const prompt = getSystemPrompt({});
-
-			expect(prompt).not.toContain('## Connecting Services');
 			expect(prompt).not.toContain('mcp-servers');
+			expect(prompt).not.toContain('## MCP Servers');
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -13,6 +13,7 @@ import {
 } from './mcp-tool-name-validation';
 import { attachRuntimeWorkspaceCapabilities } from './runtime-workspace';
 import { getSystemPrompt } from './system-prompt';
+import { listConnectedMcpServices } from '../mcp/connected-mcp-services';
 import { hasRuntimeSkills } from '../skills/runtime-skills';
 import { createToolRegistry, mergeToolRegistries, toolRegistryValues } from '../tool-registry';
 import { createAllTools, createOrchestratorDomainTools, createOrchestrationTools } from '../tools';
@@ -66,7 +67,6 @@ export async function createInstanceAgent(
 	// (e.g. verify) already get it via OrchestrationContext.
 	const domainContext: InstanceAiContext = { ...context, tracing: orchestrationContext?.tracing };
 	const domainTools = createAllTools(domainContext);
-	const orchestratorDomainTools = createOrchestratorDomainTools(domainContext);
 
 	// Load MCP tools (cached by config hash inside the manager — only spawns
 	// processes / opens connections on first call or config change). The manager
@@ -139,6 +139,11 @@ export async function createInstanceAgent(
 		warn: warnSkippedMcpTool,
 	});
 
+	const orchestratorDomainTools = createOrchestratorDomainTools({
+		...domainContext,
+		connectedMcpServices: listConnectedMcpServices(mcpServers, safeMcpTools),
+	});
+
 	const allOrchestratorTools = mergeToolRegistries(
 		orchestratorDomainTools,
 		orchestrationTools,
@@ -163,7 +168,6 @@ export async function createInstanceAgent(
 		localGateway: context.localGatewayStatus,
 		toolSearchEnabled: hasDeferrableTools,
 		mcpToolSearchEnabled: hasDeferredExternalMcpTools,
-		mcpRegistrySearchEnabled: Boolean(context.mcpService),
 		licenseHints: context.licenseHints,
 		browserAvailable: browserToolNames.size > 0,
 		branchReadOnly: context.branchReadOnly,

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -15,8 +15,6 @@ interface SystemPromptOptions {
 	localGateway?: LocalGatewayStatus;
 	toolSearchEnabled?: boolean;
 	mcpToolSearchEnabled?: boolean;
-	/** Whether the `mcp-servers` tool is registered for this run. */
-	mcpRegistrySearchEnabled?: boolean;
 	/** Human-readable hints about licensed features that are NOT available on this instance. */
 	licenseHints?: string[];
 	browserAvailable?: boolean;
@@ -68,17 +66,6 @@ ${mcpSearchGuidance}When the available tools do not cover the user's request, re
 Examples: ${mcpExamples}search "create tasks" for \`create-tasks\`, search "eval" for \`evals\`.
 
 For questions about n8n itself — how a node behaves, the shape of its output, what a parameter does, product semantics — prefer \`n8n-docs\` and the node type definitions, both already loaded and needing no search, over web search, which is for third-party services and APIs.
-`;
-}
-
-function getMcpRegistrySection(mcpRegistrySearchEnabled?: boolean): string {
-	if (!mcpRegistrySearchEnabled) return '';
-	return `
-## Connecting Services through MCP
-
-When the user wants to work with a third-party service here and no tool covers it, call \`mcp-servers\` with the service name before concluding it is unavailable. Do this proactively.
-
-This is only about tools **you** use in this conversation. It is not part of building: a workflow that talks to a service uses that service's node and credential, so never call \`mcp-servers\` for a build request, and never offer to connect a service instead of adding the node.
 `;
 }
 
@@ -137,7 +124,6 @@ export function getSystemPrompt(options: SystemPromptOptions = {}): string {
 		localGateway,
 		toolSearchEnabled,
 		mcpToolSearchEnabled,
-		mcpRegistrySearchEnabled,
 		licenseHints,
 		browserAvailable,
 		branchReadOnly,
@@ -152,7 +138,6 @@ ${workspaceRoot ? `${getSandboxWorkspaceSection(workspaceRoot)}` : ''}
 ${getProjectScopeSection(projectId)}
 ${SECRET_ASK_GUARDRAIL}
 ${getToolDiscoverySection(toolSearchEnabled, mcpToolSearchEnabled)}
-${getMcpRegistrySection(mcpRegistrySearchEnabled)}
 ## Communication Style
 
 - Be concise.

--- a/packages/@n8n/instance-ai/src/mcp/connected-mcp-services.test.ts
+++ b/packages/@n8n/instance-ai/src/mcp/connected-mcp-services.test.ts
@@ -1,0 +1,55 @@
+import type { BuiltTool } from '@n8n/agents';
+
+import { listConnectedMcpServices } from './connected-mcp-services';
+import type { InstanceAiToolRegistry, McpServerConfig } from '../types';
+
+function serverConfig(name: string, serverSlug: string): McpServerConfig {
+	return { name, url: `https://${serverSlug}.example`, metadata: { serverSlug } };
+}
+
+function toolsFrom(...entries: Array<[toolName: string, mcpServerName: string]>) {
+	const registry: InstanceAiToolRegistry = new Map();
+	for (const [toolName, mcpServerName] of entries) {
+		registry.set(toolName, {
+			name: toolName,
+			description: '',
+			handler: vi.fn(),
+			mcpTool: true,
+			mcpServerName,
+		} as unknown as BuiltTool);
+	}
+	return registry;
+}
+
+describe('listConnectedMcpServices', () => {
+	it('groups each service with the tools that reached the agent', () => {
+		const result = listConnectedMcpServices(
+			[serverConfig('mcp_linear', 'linear'), serverConfig('mcp_notion', 'notion')],
+			toolsFrom(
+				['mcp_linear_create_issue', 'mcp_linear'],
+				['mcp_notion_search', 'mcp_notion'],
+				['mcp_linear_list_issues', 'mcp_linear'],
+			),
+		);
+
+		expect(result).toEqual([
+			{ slug: 'linear', toolNames: ['mcp_linear_create_issue', 'mcp_linear_list_issues'] },
+			{ slug: 'notion', toolNames: ['mcp_notion_search'] },
+		]);
+	});
+
+	it('reports a service whose tools did not reach the agent', () => {
+		const result = listConnectedMcpServices([serverConfig('mcp_linear', 'linear')], toolsFrom());
+
+		expect(result).toEqual([{ slug: 'linear', toolNames: [] }]);
+	});
+
+	it('leaves out admin-configured servers, which carry no registry slug', () => {
+		const result = listConnectedMcpServices(
+			[serverConfig('mcp_linear', 'linear'), { name: 'internal', url: 'https://internal.example' }],
+			toolsFrom(['mcp_linear_create_issue', 'mcp_linear'], ['internal_ping', 'internal']),
+		);
+
+		expect(result).toEqual([{ slug: 'linear', toolNames: ['mcp_linear_create_issue'] }]);
+	});
+});

--- a/packages/@n8n/instance-ai/src/mcp/connected-mcp-services.ts
+++ b/packages/@n8n/instance-ai/src/mcp/connected-mcp-services.ts
@@ -1,0 +1,22 @@
+import type { ConnectedMcpService, InstanceAiToolRegistry, McpServerConfig } from '../types';
+
+/** The services the user connected themselves, each with the tools that reached the
+ *  agent. Servers the instance's administrator configured carry no registry slug and
+ *  are left out — the user cannot connect or disconnect them. */
+export function listConnectedMcpServices(
+	mcpServers: readonly McpServerConfig[],
+	mcpTools: InstanceAiToolRegistry,
+): ConnectedMcpService[] {
+	const toolNamesByServerName = new Map<string, string[]>();
+	for (const [name, tool] of mcpTools) {
+		if (tool.mcpServerName === undefined) continue;
+		const names = toolNamesByServerName.get(tool.mcpServerName);
+		if (names) names.push(name);
+		else toolNamesByServerName.set(tool.mcpServerName, [name]);
+	}
+
+	return mcpServers
+		.map((server) => ({ slug: server.metadata?.serverSlug, name: server.name }))
+		.filter((entry): entry is { slug: string; name: string } => entry.slug !== undefined)
+		.map(({ slug, name }) => ({ slug, toolNames: toolNamesByServerName.get(name) ?? [] }));
+}

--- a/packages/@n8n/instance-ai/src/tools/mcp-servers.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/mcp-servers.tool.test.ts
@@ -1,7 +1,12 @@
 import { mock } from 'vitest-mock-extended';
 
 import { executeTool } from '../__tests__/tool-test-utils';
-import type { InstanceAiContext, InstanceAiMcpService, McpRegistryServerSummary } from '../types';
+import type {
+	ConnectedMcpService,
+	InstanceAiContext,
+	InstanceAiMcpService,
+	McpRegistryServerSummary,
+} from '../types';
 import { createMcpServersTool } from './mcp-servers.tool';
 
 const notion: McpRegistryServerSummary = {
@@ -18,9 +23,13 @@ const linear: McpRegistryServerSummary = {
 	tools: ['create_issue'],
 };
 
-function makeContext(mcpService?: InstanceAiMcpService): InstanceAiContext {
+function makeContext(
+	mcpService?: InstanceAiMcpService,
+	connectedMcpServices?: ConnectedMcpService[],
+): InstanceAiContext {
 	const context = mock<InstanceAiContext>();
 	context.mcpService = mcpService;
+	context.connectedMcpServices = connectedMcpServices;
 	return context;
 }
 
@@ -50,7 +59,154 @@ async function search(
 	return await executeTool<SearchOutput>(tool, { action: 'search', queries });
 }
 
+interface ConnectedOutput {
+	servers: Array<{ slug: string; toolCount: number }>;
+	hint?: string;
+}
+
+interface DetailsOutput {
+	slug: string;
+	tools: string[];
+	hint?: string;
+}
+
+async function connected(services?: ConnectedMcpService[]): Promise<ConnectedOutput> {
+	const tool = createMcpServersTool(makeContext(makeService([]), services));
+	return await executeTool<ConnectedOutput>(tool, { action: 'connected' });
+}
+
+function toolDescription(): string {
+	return createMcpServersTool(makeContext(makeService([]))).description;
+}
+
 describe('mcp-servers tool', () => {
+	// This guidance used to live in the system prompt. `mcp-servers` is never
+	// deferred, so its description reaches every request without a second copy.
+	describe('description', () => {
+		it('names who changes a connection, so a missing server is not read as expiry', () => {
+			const description = toolDescription();
+
+			expect(description).toContain('Only the user connects or disconnects');
+			expect(description).toContain('never connected or disconnected');
+		});
+
+		it('places a connection on the account, not on the conversation', () => {
+			expect(toolDescription()).toContain('persist across conversations');
+		});
+
+		it('sends the orchestrator to the tool instead of the transcript', () => {
+			expect(toolDescription()).toContain('ask here instead of answering from the conversation');
+		});
+
+		// Distinct from a missing server: these are connections to third-party services.
+		it('explains a connected server with no tools', () => {
+			expect(toolDescription()).toContain('broken or expired connection');
+		});
+
+		it('says tool names come from `details` alone', () => {
+			expect(toolDescription()).toContain('`connected` never returns them');
+		});
+
+		it('scopes the tool against workflow building and the credentials tool', () => {
+			const description = toolDescription();
+
+			expect(description).toContain('not for building');
+			expect(description).toContain('`credentials`');
+		});
+	});
+
+	describe('connected', () => {
+		// Counts only: names are what `details` is for, and they dominate the tokens.
+		it('reports each connected server with a tool count, not tool names', async () => {
+			const output = await connected([
+				{ slug: 'notion', toolNames: ['mcp_notion_search', 'mcp_notion_fetch'] },
+				{ slug: 'linear', toolNames: ['mcp_linear_create_issue'] },
+			]);
+
+			expect(output.servers).toEqual([
+				{ slug: 'notion', toolCount: 2 },
+				{ slug: 'linear', toolCount: 1 },
+			]);
+			expect(output.hint).toBeUndefined();
+		});
+
+		it('says nothing is connected, and that only the user can fix it', async () => {
+			const output = await connected([]);
+
+			expect(output.servers).toEqual([]);
+			expect(output.hint).toContain('Nothing connected');
+			expect(output.hint).toContain('Only the user can connect');
+		});
+
+		// Same shape as an empty inventory: neither is something the agent can repair.
+		it('says nothing is connected when the host established no inventory', async () => {
+			const output = await connected(undefined);
+
+			expect(output.servers).toEqual([]);
+			expect(output.hint).toContain('Nothing connected');
+		});
+
+		it('keeps the orchestrator off the tools of a server that loaded none', async () => {
+			const output = await connected([
+				{ slug: 'notion', toolNames: ['mcp_notion_search'] },
+				{ slug: 'linear', toolNames: [] },
+			]);
+
+			expect(output.hint).toContain('broken');
+			expect(output.hint).toContain('never guess their names');
+		});
+
+		it('needs no MCP service, since the inventory rides on the context', async () => {
+			const tool = createMcpServersTool(
+				makeContext(undefined, [{ slug: 'notion', toolNames: ['mcp_notion_search'] }]),
+			);
+
+			const output = await executeTool<ConnectedOutput>(tool, { action: 'connected' });
+
+			expect(output.servers.map((server) => server.slug)).toEqual(['notion']);
+		});
+	});
+
+	describe('details', () => {
+		it('returns the full tool list that `connected` truncated', async () => {
+			const toolNames = Array.from({ length: 8 }, (_, i) => `mcp_notion_t${i}`);
+			const tool = createMcpServersTool(
+				makeContext(makeService([]), [{ slug: 'notion', toolNames }]),
+			);
+
+			const output = await executeTool<DetailsOutput>(tool, { action: 'details', slug: 'notion' });
+
+			expect(output).toEqual({ slug: 'notion', tools: toolNames });
+		});
+
+		it('reports an unconnected slug as such rather than as an empty server', async () => {
+			const tool = createMcpServersTool(
+				makeContext(makeService([]), [{ slug: 'notion', toolNames: ['mcp_notion_search'] }]),
+			);
+
+			const output = await executeTool<DetailsOutput>(tool, { action: 'details', slug: 'slack' });
+
+			expect(output.tools).toEqual([]);
+			expect(output.hint).toContain('Not connected');
+		});
+
+		it('flags a connected server that loaded no tools', async () => {
+			const tool = createMcpServersTool(
+				makeContext(makeService([]), [{ slug: 'linear', toolNames: [] }]),
+			);
+
+			const output = await executeTool<DetailsOutput>(tool, { action: 'details', slug: 'linear' });
+
+			expect(output.hint).toContain('broken');
+		});
+
+		it('rejects details without a slug', async () => {
+			const tool = createMcpServersTool(makeContext(makeService([])));
+
+			await expect(executeTool(tool, { action: 'details' })).rejects.toThrow();
+		});
+	});
+
 	it('passes the queries through and returns the matching servers', async () => {
 		const mcpService = makeService([notion, linear]);
 		const tool = createMcpServersTool(makeContext(mcpService));

--- a/packages/@n8n/instance-ai/src/tools/mcp-servers.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/mcp-servers.tool.ts
@@ -1,10 +1,22 @@
 import { Tool } from '@n8n/agents';
 import { z } from 'zod';
 
+import { sanitizeInputSchema } from '../agent/sanitize-mcp-schemas';
 import type { InstanceAiContext } from '../types';
 import { DOMAIN_TOOL_IDS } from './tool-ids';
 
-const mcpServersInputSchema = z.object({
+const MAX_RESULTS = 5;
+
+const connectedAction = z.object({
+	action: z.literal('connected').describe('List connected MCP servers and their tool counts.'),
+});
+
+const detailsAction = z.object({
+	action: z.literal('details').describe("One connected server's tool names."),
+	slug: z.string().min(1).describe('Server slug, as returned by `connected`.'),
+});
+
+const searchAction = z.object({
 	action: z
 		.literal('search')
 		.describe('Search the available MCP servers for connecting to a third party service.'),
@@ -16,7 +28,26 @@ const mcpServersInputSchema = z.object({
 		),
 });
 
-const mcpServersOutputSchema = z.object({
+const mcpServersRuntimeInputSchema = z.discriminatedUnion('action', [
+	connectedAction,
+	detailsAction,
+	searchAction,
+]);
+
+const mcpServersToolInputSchema = sanitizeInputSchema(mcpServersRuntimeInputSchema);
+
+const connectedOutputSchema = z.object({
+	servers: z.array(z.object({ slug: z.string(), toolCount: z.number() })),
+	hint: z.string().optional(),
+});
+
+const detailsOutputSchema = z.object({
+	slug: z.string(),
+	tools: z.array(z.string()),
+	hint: z.string().optional(),
+});
+
+const searchOutputSchema = z.object({
 	results: z.array(
 		z.object({
 			slug: z.string(),
@@ -28,42 +59,92 @@ const mcpServersOutputSchema = z.object({
 	hint: z.string().optional(),
 });
 
-const MAX_RESULTS = 5;
+const mcpServersOutputSchema = z.union([
+	connectedOutputSchema,
+	detailsOutputSchema,
+	searchOutputSchema,
+]);
 
-const DESCRIPTION = `Find tools you can use in this conversation to work with a third-party service (e.g. Notion, Linear, Slack).
-Use it when the user asks for a service you have no connected tool for, before saying the integration is unavailable.
-Read-only — only the user can connect one. Only services that are *not* connected yet come back. Already-connected services' tools are already available to you.`;
+const DESCRIPTION = `The user's MCP servers: connections to third-party services that persist across conversations, exposing tools you can use here. Not \`credentials\`, which only stores what a node authenticates with when a workflow runs, and not for building — a workflow that talks to a service uses that service's node and credential.
+\`connected\`: which servers are connected, and each one's tool count. Only the user connects or disconnects, so a server missing here is one they never connected or disconnected — ask here instead of answering from the conversation. A connected server with no tools has a broken or expired connection.
+\`details\`: one server's tool names; \`connected\` never returns them. \`search_tools\` finds a tool by keyword.
+\`search\`: find a server for a service nothing connected covers, before saying it is unavailable. Read-only — only the user can connect one.`;
+
+const NOTHING_CONNECTED_HINT =
+	'Nothing connected. Only the user can connect a server: `search` for it, then tell them how.';
+
+const BROKEN_CONNECTION_HINT =
+	'No tools means a broken or expired connection — its tools do not exist here, so never guess their names. Tell the user to reconnect it under "Connections".';
+
+const NOT_CONNECTED_HINT = 'Not connected. `connected` lists what is.';
 
 const CONNECT_HINT = `Not connected yet — tell the user how to connect it:
 open the right sidebar if it is hidden, then under "Connections" click the "+" button,
 find the service in the Tools dialog and click "Connect", picking an existing credential or creating one.`;
 
-const TRUNCATED_HINT =
-	'More services matched than are shown, search again with a narrower query if none of these fit.';
+const TRUNCATED_HINT = 'More matched than are shown — search again with a narrower query.';
+
+function joinHints(...lines: Array<string | false>): string | undefined {
+	const hint = lines.filter((line): line is string => typeof line === 'string').join('\n\n');
+	return hint || undefined;
+}
+
+function handleConnected(context: InstanceAiContext): z.infer<typeof connectedOutputSchema> {
+	const servers = context.connectedMcpServices ?? [];
+	return {
+		servers: servers.map(({ slug, toolNames }) => ({ slug, toolCount: toolNames.length })),
+		hint: joinHints(
+			servers.length === 0 && NOTHING_CONNECTED_HINT,
+			servers.some((service) => service.toolNames.length === 0) && BROKEN_CONNECTION_HINT,
+		),
+	};
+}
+
+function handleDetails(
+	context: InstanceAiContext,
+	slug: string,
+): z.infer<typeof detailsOutputSchema> {
+	const service = (context.connectedMcpServices ?? []).find((entry) => entry.slug === slug);
+	if (!service) return { slug, tools: [], hint: NOT_CONNECTED_HINT };
+
+	return {
+		slug,
+		tools: service.toolNames,
+		hint: service.toolNames.length === 0 ? BROKEN_CONNECTION_HINT : undefined,
+	};
+}
+
+async function handleSearch(
+	context: InstanceAiContext,
+	queries: string[],
+): Promise<z.infer<typeof searchOutputSchema>> {
+	const { mcpService } = context;
+	if (!mcpService) {
+		throw new Error('MCP server search is not available on this instance.');
+	}
+
+	const matches = await mcpService.search(queries);
+	const results = matches.slice(0, MAX_RESULTS);
+
+	return {
+		results,
+		hint: joinHints(
+			results.length > 0 && CONNECT_HINT,
+			matches.length > results.length && TRUNCATED_HINT,
+		),
+	};
+}
 
 export function createMcpServersTool(context: InstanceAiContext) {
 	return new Tool(DOMAIN_TOOL_IDS.MCP_SERVERS)
 		.description(DESCRIPTION)
-		.input(mcpServersInputSchema)
+		.input(mcpServersToolInputSchema)
 		.output(mcpServersOutputSchema)
 		.handler(async (input) => {
-			const { queries } = mcpServersInputSchema.parse(input);
-			const mcpService = context.mcpService;
-			if (!mcpService) {
-				throw new Error('MCP server search is not available on this instance.');
-			}
-
-			const matches = await mcpService.search(queries);
-			const results = matches.slice(0, MAX_RESULTS);
-
-			const hint = [
-				results.length > 0 && CONNECT_HINT,
-				matches.length > results.length && TRUNCATED_HINT,
-			]
-				.filter((line): line is string => typeof line === 'string')
-				.join('\n\n');
-
-			return { results, hint: hint || undefined };
+			const parsed = mcpServersRuntimeInputSchema.parse(input);
+			if (parsed.action === 'connected') return handleConnected(context);
+			if (parsed.action === 'details') return handleDetails(context, parsed.slug);
+			return await handleSearch(context, parsed.queries);
 		})
 		.build();
 }

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -500,6 +500,13 @@ export interface McpRegistryServerSummary {
 	tools: string[];
 }
 
+/** A service the user connected, with those of its tools that reached the agent.
+ *  Named by slug, which is also what the MCP tools accept as an argument. */
+export interface ConnectedMcpService {
+	slug: string;
+	toolNames: string[];
+}
+
 export interface InstanceAiMcpService {
 	search(queries: string[]): Promise<McpRegistryServerSummary[]>;
 }
@@ -1051,6 +1058,10 @@ export interface InstanceAiContext {
 	/** Optional — present when the host allows MCP registry discovery for this
 	 *  user. Presence gates the `mcp-servers` tool. */
 	mcpService?: InstanceAiMcpService;
+	/** Per-run inventory behind `mcp-servers`' `connected` action. Captured when the
+	 *  agent is built, which is also when its MCP tools are attached, so it always
+	 *  matches what this agent can actually call. */
+	connectedMcpServices?: ConnectedMcpService[];
 	/** The target n8n Agent being built/edited via the build-agent sub-agent tool. */
 	agentBuilderTarget?: { agentId: string; projectId: string; name?: string; ref?: string };
 	/** Narrow builder delegate for the build-agent sub-agent tool (agents module active only). */

--- a/packages/frontend/@n8n/design-system/src/components/N8nNodeIcon/IconContent.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNodeIcon/IconContent.vue
@@ -58,8 +58,6 @@ const supportedIconName = computed((): IconName | NodeIconName | undefined => {
 
 <template>
 	<div v-if="type !== 'unknown'" :class="$style.icon">
-		<!-- `src` can be a third-party URL (MCP registry icons), so never send the
-		     instance's address along with the request. -->
 		<img
 			v-if="type === 'file'"
 			:src="src"

--- a/packages/frontend/@n8n/design-system/src/components/N8nNodeIcon/IconContent.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNodeIcon/IconContent.vue
@@ -58,7 +58,14 @@ const supportedIconName = computed((): IconName | NodeIconName | undefined => {
 
 <template>
 	<div v-if="type !== 'unknown'" :class="$style.icon">
-		<img v-if="type === 'file'" :src="src" :class="$style.nodeIconImage" />
+		<!-- `src` can be a third-party URL (MCP registry icons), so never send the
+		     instance's address along with the request. -->
+		<img
+			v-if="type === 'file'"
+			:src="src"
+			referrerpolicy="no-referrer"
+			:class="$style.nodeIconImage"
+		/>
 		<N8nIcon v-else-if="supportedIconName" :icon="supportedIconName" :style="fontStyleData" />
 		<div v-else :class="$style.nodeIconPlaceholder">
 			{{ nodeTypeName ? nodeTypeName.charAt(0) : '?' }}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ConnectionRow.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ConnectionRow.vue
@@ -1,28 +1,38 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
-import { N8nDropdownMenu, N8nIcon, N8nText } from '@n8n/design-system';
+import { N8nDropdownMenu, N8nText } from '@n8n/design-system';
 import type { DropdownMenuItemProps, IconName } from '@n8n/design-system';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
+import ToolIcon from '@/features/shared/toolsConnection/ToolIcon.vue';
+import type { ToolIconSource } from '@/features/shared/toolsConnection/types';
 
 type RowAction = 'connect' | 'disconnect' | 'settings' | 'remove';
-type ConnectionStatus = 'connected' | 'waiting' | 'disconnected';
-export type ConnectionRowIcon = IconName | { type: 'file'; src: string };
+/** `none` is for rows that were never connected: there is no state to report, so
+ *  the row renders no indicator at all rather than a failure-coloured one. */
+export type ConnectionStatus = 'connected' | 'waiting' | 'disconnected' | 'none';
+export type ConnectionRowIcon = IconName | ToolIconSource;
 
-const props = defineProps<{
-	name: string;
-	subtitle: string;
-	icon: ConnectionRowIcon;
-	status: ConnectionStatus;
-	actions: RowAction[];
-	dropdownPortalTarget?: HTMLElement;
-}>();
-
-const iconSource = computed<{ type: 'icon'; name: IconName } | { type: 'file'; src: string }>(
-	() => {
-		if (typeof props.icon === 'string') return { type: 'icon', name: props.icon };
-		return props.icon;
-	},
+const props = withDefaults(
+	defineProps<{
+		name: string;
+		subtitle: string;
+		icon: ConnectionRowIcon;
+		status?: ConnectionStatus;
+		actions?: RowAction[];
+		dropdownPortalTarget?: HTMLElement;
+		clickable?: boolean;
+	}>(),
+	{ status: 'none', actions: () => [], clickable: true },
 );
+
+const iconSource = computed<ToolIconSource>(() => {
+	if (typeof props.icon === 'string') {
+		return { type: 'icon', name: props.icon, color: 'var(--color--text)' };
+	}
+	return props.icon.type === 'icon' && !props.icon.color
+		? { ...props.icon, color: 'var(--color--text)' }
+		: props.icon;
+});
 
 const emit = defineEmits<{
 	connect: [];
@@ -49,12 +59,15 @@ const menuItems = computed<Array<DropdownMenuItemProps<RowAction>>>(() =>
 	})),
 );
 
-const statusTooltip = computed(() => {
-	if (props.status === 'connected')
-		return i18n.baseText('instanceAi.connections.row.status.connected');
-	if (props.status === 'waiting') return i18n.baseText('instanceAi.connections.row.status.waiting');
-	return i18n.baseText('instanceAi.connections.row.status.disconnected');
-});
+const STATUS_LABEL_KEYS = {
+	connected: 'instanceAi.connections.row.status.connected',
+	waiting: 'instanceAi.connections.row.status.waiting',
+	disconnected: 'instanceAi.connections.row.status.disconnected',
+} satisfies Record<Exclude<ConnectionStatus, 'none'>, BaseTextKey>;
+
+const statusLabel = computed(() =>
+	props.status === 'none' ? undefined : i18n.baseText(STATUS_LABEL_KEYS[props.status]),
+);
 
 function handleSelect(action: RowAction) {
 	if (action === 'connect') emit('connect');
@@ -64,45 +77,40 @@ function handleSelect(action: RowAction) {
 }
 
 function handleRowClick() {
+	if (!props.clickable) return;
 	emit('openSettings');
 }
 </script>
 
 <template>
-	<div :class="$style.row" @click="handleRowClick">
-		<span :class="$style.iconWrap">
-			<img
-				v-if="iconSource.type === 'file'"
-				:src="iconSource.src"
-				alt=""
-				aria-hidden="true"
-				loading="lazy"
-				referrerpolicy="no-referrer"
-				:class="$style.iconImage"
-			/>
-			<N8nIcon v-else :icon="iconSource.name" size="large" :class="$style.icon" />
-		</span>
+	<div :class="[$style.row, !clickable && $style.rowStatic]" @click="handleRowClick">
+		<ToolIcon :source="iconSource" />
 		<div :class="$style.labels">
 			<N8nText bold size="small" :class="$style.name">{{ name }}</N8nText>
 			<N8nText size="xsmall" color="text-light">{{ subtitle }}</N8nText>
 		</div>
-		<span
-			:class="[
-				$style.dot,
-				status === 'connected' && $style.dotConnected,
-				status === 'waiting' && $style.dotWaiting,
-				status === 'disconnected' && $style.dotDisconnected,
-			]"
-			:title="statusTooltip"
-		/>
-		<div @click.stop>
-			<N8nDropdownMenu
-				v-if="menuItems.length > 0"
-				:items="menuItems"
-				placement="bottom-end"
-				:portal-target="dropdownPortalTarget"
-				@select="handleSelect"
-			/>
+		<div :class="$style.action" @click.stop>
+			<slot name="action">
+				<span
+					v-if="status !== 'none'"
+					:class="[
+						$style.dot,
+						status === 'connected' && $style.dotConnected,
+						status === 'waiting' && $style.dotWaiting,
+						status === 'disconnected' && $style.dotDisconnected,
+					]"
+					:title="statusLabel"
+					data-test-id="instance-ai-connection-row-status"
+				/>
+				<N8nDropdownMenu
+					v-if="menuItems.length > 0"
+					:items="menuItems"
+					placement="bottom-end"
+					:portal-target="dropdownPortalTarget"
+					data-test-id="instance-ai-connection-row-actions"
+					@select="handleSelect"
+				/>
+			</slot>
 		</div>
 	</div>
 </template>
@@ -117,25 +125,8 @@ function handleRowClick() {
 	cursor: pointer;
 }
 
-.iconWrap {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	padding: var(--spacing--4xs);
-	background: var(--color--foreground--tint-1);
-	border-radius: var(--radius);
-	flex-shrink: 0;
-}
-
-.icon {
-	color: var(--color--text);
-}
-
-.iconImage {
-	width: 20px;
-	height: 20px;
-	object-fit: contain;
-	display: block;
+.rowStatic {
+	cursor: default;
 }
 
 .labels {
@@ -150,6 +141,13 @@ function handleRowClick() {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.action {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--xs);
+	flex-shrink: 0;
 }
 
 .dot {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ConnectionsCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ConnectionsCard.vue
@@ -15,9 +15,8 @@ import { useInstanceAiComputerUseExperiment } from '@/experiments/instanceAiComp
 import { useInstanceAiSettingsStore } from '../instanceAiSettings.store';
 import { useInstanceAiMcpStore } from '../instanceAiMcp.store';
 import { useInstanceAiMcpTelemetry } from '../instanceAiMcp.telemetry';
-import ConnectionRow, { ConnectionRowIcon } from './ConnectionRow.vue';
+import ConnectionRow from './ConnectionRow.vue';
 import { iconForTool } from '../toolIcons';
-import type { McpRegistryServerIconResponse } from '@n8n/api-types';
 import {
 	BROWSER_USE_CONNECTION_TYPE,
 	COMPUTER_USE_CONNECTION_TYPE,
@@ -101,12 +100,6 @@ function getSingletonRowActions(
 }
 
 const MCP_ROW_ACTIONS: RowAction[] = ['settings', 'remove'];
-
-function getIconForConnection(icons: McpRegistryServerIconResponse[]) {
-	const icon = iconForTool(icons, uiStore.appliedTheme);
-	if (icon.type === 'icon') return icon.name as ConnectionRowIcon;
-	return icon;
-}
 
 async function openSingletonModal(type: SingletonConnectionType) {
 	if (
@@ -198,7 +191,7 @@ function openMcpSettings(connectionId: string) {
 				:key="conn.id"
 				:name="conn.serverTitle"
 				:subtitle="conn.credentialName"
-				:icon="getIconForConnection(conn.serverIcons)"
+				:icon="iconForTool(conn.serverIcons, uiStore.appliedTheme)"
 				status="connected"
 				:actions="MCP_ROW_ACTIONS"
 				:dropdown-portal-target="props.dropdownPortalTarget"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/__tests__/ConnectionRow.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/__tests__/ConnectionRow.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/vue';
+import { createComponentRenderer } from '@/__tests__/render';
+import ConnectionRow from '../ConnectionRow.vue';
+
+vi.mock('@n8n/i18n', async (importOriginal) => ({
+	...(await importOriginal()),
+	useI18n: () => ({ baseText: (key: string) => key }),
+}));
+
+const renderComponent = createComponentRenderer(ConnectionRow);
+
+const baseProps = {
+	name: 'Brave',
+	subtitle: 'Search the web',
+	icon: 'plug' as const,
+};
+
+describe('ConnectionRow', () => {
+	it('opens settings on row click', async () => {
+		const { getByText, emitted } = renderComponent({
+			props: { ...baseProps, status: 'connected' as const },
+		});
+
+		await fireEvent.click(getByText('Brave'));
+
+		expect(emitted().openSettings).toHaveLength(1);
+	});
+
+	it('stays inert when not clickable', async () => {
+		const { getByText, emitted } = renderComponent({
+			props: { ...baseProps, clickable: false },
+		});
+
+		await fireEvent.click(getByText('Brave'));
+
+		expect(emitted().openSettings).toBeUndefined();
+	});
+
+	it('reports the status through the indicator tooltip', () => {
+		const { getByTestId } = renderComponent({
+			props: { ...baseProps, status: 'disconnected' as const },
+		});
+
+		expect(getByTestId('instance-ai-connection-row-status')).toHaveAttribute(
+			'title',
+			'instanceAi.connections.row.status.disconnected',
+		);
+	});
+
+	it('renders no status indicator for a row with no status', () => {
+		const { queryByTestId } = renderComponent({ props: baseProps });
+
+		expect(queryByTestId('instance-ai-connection-row-status')).toBeNull();
+	});
+
+	it('renders no actions menu without actions', () => {
+		const { queryByTestId } = renderComponent({
+			props: { ...baseProps, status: 'connected' as const },
+		});
+
+		expect(queryByTestId('instance-ai-connection-row-actions')).toBeNull();
+	});
+
+	it.each([
+		['settings', 'openSettings'],
+		['disconnect', 'disconnect'],
+		['remove', 'remove'],
+		['connect', 'connect'],
+	] as const)('emits %s from the actions menu', async (action, event) => {
+		const { getByTestId, findByText, emitted } = renderComponent({
+			props: { ...baseProps, status: 'connected' as const, actions: [action] },
+		});
+
+		await fireEvent.click(getByTestId('instance-ai-connection-row-actions'));
+		await fireEvent.click(await findByText(`instanceAi.connections.row.${action}`));
+
+		expect(emitted()[event]).toHaveLength(1);
+	});
+
+	it('lets the action slot replace the status control', () => {
+		const { getByTestId, queryByTestId } = renderComponent({
+			props: { ...baseProps, status: 'connected' as const, actions: ['settings'] as const },
+			slots: { action: '<button data-test-id="slotted-action">Connected</button>' },
+		});
+
+		expect(getByTestId('slotted-action')).toBeVisible();
+		expect(queryByTestId('instance-ai-connection-row-status')).toBeNull();
+		expect(queryByTestId('instance-ai-connection-row-actions')).toBeNull();
+	});
+
+	it('does not open settings when interacting with the action slot', async () => {
+		const { getByTestId, emitted } = renderComponent({
+			props: { ...baseProps, status: 'connected' as const },
+			slots: { action: '<button data-test-id="slotted-action">Connected</button>' },
+		});
+
+		await fireEvent.click(getByTestId('slotted-action'));
+
+		expect(emitted().openSettings).toBeUndefined();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/InstanceAiToolsConnectionModalWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/InstanceAiToolsConnectionModalWrapper.vue
@@ -15,9 +15,7 @@ import {
 	type McpServerConnectionItem,
 	type McpServerTool,
 	type McpToolSettings,
-	type PickableCredential,
 	type ServiceConnectionItem,
-	type ToolConnectionCredentialAdapter,
 	type ToolConnectionItem,
 	type ToolConnectionSettings,
 } from '@/features/shared/toolsConnection/types';
@@ -109,7 +107,7 @@ const detailMode = computed<'detail' | 'settings'>(() =>
 
 type McpToolMetadata = McpRegistryServerToolResponse | InstanceAiMcpConnectionToolResponse;
 
-const { connectServer, connectWithCredential } = useMcpServerConnect();
+const { connectServer, connectWithCredential, createCredentialAdapter } = useMcpServerConnect();
 
 /** Reveals the settings view of the server the user just connected */
 function showConnectedServer(connectionId: string | null): void {
@@ -289,30 +287,21 @@ watch(
 	{ immediate: true },
 );
 
-const credentialAdapter: ToolConnectionCredentialAdapter = {
-	getCredentialsByType: (authType: string): readonly PickableCredential[] => {
-		const creds = credentialsStore.getCredentialsByType(authType);
-		return creds.map((c) => ({ id: c.id, name: c.name, type: c.type }));
-	},
-	openNewCredential: (authType: string) => {
+provide(
+	TOOL_CONNECTION_CREDENTIAL_ADAPTER_KEY,
+	createCredentialAdapter((authType, item) => {
 		void (async () => {
-			const item = detailItem.value;
-			const server = item?.kind === 'mcp-server' ? findServerForItem(item) : undefined;
+			const server = item.kind === 'mcp-server' ? findServerForItem(item) : undefined;
 			if (!server) {
-				// Detail view isn't open or the item isn't an MCP server — fall back
-				// to the bare modal so the user can still create a credential.
+				// Not an MCP server, or its registry entry is gone — fall back to the
+				// bare modal so the user can still create a credential.
 				uiStore.openNewCredential(authType);
 				return;
 			}
 			showConnectedServer(await connectServer(server));
 		})();
-	},
-	openExistingCredential: (credentialId: string) => {
-		uiStore.openExistingCredential(credentialId);
-	},
-};
-
-provide(TOOL_CONNECTION_CREDENTIAL_ADAPTER_KEY, credentialAdapter);
+	}),
+);
 
 function findServerForItem(item: McpServerConnectionItem): McpRegistryServerResponse | undefined {
 	const connection = mcpStore.connections.find((c) => c.id === item.id);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/InstanceAiToolsConnectionModalWrapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/InstanceAiToolsConnectionModalWrapper.test.ts
@@ -5,6 +5,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import InstanceAiToolsConnectionModalWrapper from '../InstanceAiToolsConnectionModalWrapper.vue';
 import type {
 	McpServerConnectionItem,
+	ToolConnectionCredentialAdapter,
 	ToolConnectionSettings,
 } from '@/features/shared/toolsConnection/types';
 
@@ -64,6 +65,13 @@ vi.mock('../../../composables/useMcpServerConnect', () => ({
 	useMcpServerConnect: () => ({
 		connectServer: vi.fn().mockResolvedValue(null),
 		connectWithCredential: vi.fn().mockResolvedValue(null),
+		createCredentialAdapter: (
+			openNewCredential: ToolConnectionCredentialAdapter['openNewCredential'],
+		) => ({
+			getCredentialsByType: () => [],
+			openNewCredential,
+			openExistingCredential: uiStoreMock.openExistingCredential,
+		}),
 	}),
 }));
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useMcpServerConnect.ts
@@ -8,6 +8,7 @@ import {
 } from '@/features/credentials/credentials.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import { useCredentialOAuth } from '@/features/credentials/composables/useCredentialOAuth';
+import type { ToolConnectionCredentialAdapter } from '@/features/shared/toolsConnection/types';
 import { useInstanceAiMcpStore } from '../instanceAiMcp.store';
 
 export interface McpConnectTarget {
@@ -134,5 +135,24 @@ export function useMcpServerConnect() {
 		});
 	}
 
-	return { connectServer, connectWithCredential };
+	/**
+	 * The adapter `ToolCredentialPicker` injects. Only the "create a new
+	 * credential" leg differs per surface, so callers pass just that.
+	 */
+	function createCredentialAdapter(
+		openNewCredential: ToolConnectionCredentialAdapter['openNewCredential'],
+	): ToolConnectionCredentialAdapter {
+		return {
+			getCredentialsByType: (authType) =>
+				credentialsStore.getCredentialsByType(authType).map((credential) => ({
+					id: credential.id,
+					name: credential.name,
+					type: credential.type,
+				})),
+			openNewCredential,
+			openExistingCredential: (credentialId) => uiStore.openExistingCredential(credentialId),
+		};
+	}
+
+	return { connectServer, connectWithCredential, createCredentialAdapter };
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/toolIcons.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/toolIcons.ts
@@ -1,5 +1,5 @@
-import type { ToolIconSource } from '@/features/shared/toolsConnection/types';
 import type { McpRegistryServerIconResponse } from '@n8n/api-types';
+import type { ToolIconSource } from '@/features/shared/toolsConnection/types';
 
 function pickIconForTheme(
 	icons: McpRegistryServerIconResponse[],

--- a/packages/frontend/editor-ui/src/features/shared/toolsConnection/ToolCredentialPicker.vue
+++ b/packages/frontend/editor-ui/src/features/shared/toolsConnection/ToolCredentialPicker.vue
@@ -13,9 +13,11 @@ const props = withDefaults(
 		item: ToolConnectionItem;
 		credentials: ToolCredentialRef[];
 		connectVariant?: 'solid' | 'outline';
+		teleported?: boolean;
 	}>(),
 	{
 		connectVariant: 'solid',
+		teleported: false,
 	},
 );
 
@@ -85,7 +87,7 @@ function createCredential(source: 'direct' | 'dropdown') {
 	} else {
 		emit('new-credential-connect', props.item);
 	}
-	adapter?.openNewCredential(createAuthType.value);
+	adapter?.openNewCredential(createAuthType.value, props.item);
 	isOpen.value = false;
 }
 
@@ -103,7 +105,7 @@ function editCredential(credentialId: string) {
 		align="end"
 		:side-offset="6"
 		:width="'260px'"
-		:teleported="false"
+		:teleported="teleported"
 		:z-index="2000"
 		data-test-id="tool-credential-picker"
 	>

--- a/packages/frontend/editor-ui/src/features/shared/toolsConnection/ToolIcon.vue
+++ b/packages/frontend/editor-ui/src/features/shared/toolsConnection/ToolIcon.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { N8nIcon, N8nNodeIcon } from '@n8n/design-system';
+import type { IconName } from '@n8n/design-system';
+import type { ToolIconSource } from './types';
+
+withDefaults(
+	defineProps<{
+		source?: ToolIconSource | null;
+		fallbackIcon?: IconName;
+	}>(),
+	{ source: null, fallbackIcon: 'toolbox' },
+);
+
+const INNER_SIZE = 20;
+</script>
+
+<template>
+	<span :class="$style.wrapper" aria-hidden="true">
+		<N8nNodeIcon
+			v-if="source"
+			:type="source.type"
+			:src="source.type === 'file' ? source.src : undefined"
+			:name="source.type === 'icon' ? source.name : undefined"
+			:color="source.type === 'icon' ? source.color : undefined"
+			:size="INNER_SIZE"
+		/>
+		<N8nIcon v-else :icon="fallbackIcon" :size="INNER_SIZE" :class="$style.fallback" />
+	</span>
+</template>
+
+<style lang="scss" module>
+.wrapper {
+	flex-shrink: 0;
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	background: var(--color--background--light-1);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+}
+
+.fallback {
+	color: var(--color--text--tint-1);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/shared/toolsConnection/ToolRow.vue
+++ b/packages/frontend/editor-ui/src/features/shared/toolsConnection/ToolRow.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed, inject } from 'vue';
-import { N8nButton, N8nIcon, N8nNodeIcon, N8nText, N8nTooltip } from '@n8n/design-system';
+import { N8nButton, N8nIcon, N8nText, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import ShieldIcon from 'virtual:icons/fa-solid/shield-alt';
 import ToolCredentialPicker from './ToolCredentialPicker.vue';
+import ToolIcon from './ToolIcon.vue';
 import { TOOL_CONNECTION_CREDENTIAL_ADAPTER_KEY, type ToolConnectionItem } from './types';
 import { resolveToolItemIcon } from './toolItemIcon';
 
@@ -111,17 +112,7 @@ function handleConnect() {
 			</template>
 
 			<template v-else>
-				<span :class="$style.iconWrapper" aria-hidden="true">
-					<N8nNodeIcon
-						v-if="resolvedIcon"
-						:type="resolvedIcon.type"
-						:src="resolvedIcon.type === 'file' ? resolvedIcon.src : undefined"
-						:name="resolvedIcon.type === 'icon' ? resolvedIcon.name : undefined"
-						:color="resolvedIcon.type === 'icon' ? resolvedIcon.color : undefined"
-						:size="20"
-					/>
-					<N8nIcon v-else :icon="placeholderIcon" :size="20" :class="$style.iconFallback" />
-				</span>
+				<ToolIcon :source="resolvedIcon" :fallback-icon="placeholderIcon" />
 				<span :class="$style.text">
 					<span :class="$style.titleRow">
 						<N8nText :class="$style.title" tag="span" bold>{{ item.title }}</N8nText>
@@ -243,22 +234,6 @@ function handleConnect() {
 
 .row--workflow {
 	min-height: 48px;
-}
-
-.iconWrapper {
-	flex-shrink: 0;
-	width: 40px;
-	height: 40px;
-	border-radius: 50%;
-	background: var(--color--background--light-1);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	overflow: hidden;
-}
-
-.iconFallback {
-	color: var(--color--text--tint-1);
 }
 
 .workflowIcon {

--- a/packages/frontend/editor-ui/src/features/shared/toolsConnection/types.ts
+++ b/packages/frontend/editor-ui/src/features/shared/toolsConnection/types.ts
@@ -152,7 +152,7 @@ export interface PickableCredential {
  */
 export interface ToolConnectionCredentialAdapter {
 	getCredentialsByType: (authType: string) => readonly PickableCredential[];
-	openNewCredential: (authType: string) => void;
+	openNewCredential: (authType: string, item: ToolConnectionItem) => void;
 	openExistingCredential: (credentialId: string) => void;
 }
 


### PR DESCRIPTION
## Summary

Let the instance-ai agent look up which MCP servers are connected, at any point in the conversation.

`mcp-servers` gains two read actions next to `search`:

```md
connected          → { servers: [{ slug, toolCount }], hint? }
details  { slug }  → { slug, tools, hint? }
```
`connected` returns counts only,`details` when it needs the tool names.

The system prompt points at the tool rather than listing the servers itself. A rendered list sits above the whole transcript, so the model reads it as older than a tool call that succeeded earlier and believes the transcript instead:

```md
## MCP Servers

The user connects and disconnects MCP servers between messages, so a server whose tools
worked earlier may be gone. Call `mcp-servers` with `action: "connected"` before telling
them what you can or cannot do with a service — never answer that from the conversation.
When nothing connected covers what they want, `action: "search"` before concluding it is
unavailable.
```

Also included some frontend refactoring to prepare for https://github.com/n8n-io/n8n/pull/35332

This PR was extracted from https://github.com/n8n-io/n8n/pull/35332 to make that one more easily reviewable.

## How to test

Requires MCP registry access for your user. Connect a service (e.g. Notion) from the right sidebar under **Connections**, then:

1. Ask which services or MCP Servers are connected, verify that it answers accurately.
2. **Disconnect mid-conversation**: in a thread where an MCP tool has already run successfully, disconnect the MCP server and carry on in the same conversation. Agent should realize it was disconnected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5576

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->







