### PR TITLE
fix(core): Stop scheduled poll ticks from releasing the activation's expression isolate

### DIFF
--- a/packages/@n8n/expression-runtime/src/evaluator/__tests__/expression-evaluator.test.ts
+++ b/packages/@n8n/expression-runtime/src/evaluator/__tests__/expression-evaluator.test.ts
@@ -47,4 +47,22 @@ describe('ExpressionEvaluator', () => {
 		await evaluator.release(caller);
 		await evaluator.dispose();
 	});
+
+	it('should report whether a bridge was newly acquired', async () => {
+		const evaluator = new ExpressionEvaluator({
+			createBridge: createMockBridge,
+			maxCodeCacheSize: 100,
+		});
+		await evaluator.initialize();
+
+		const caller = {};
+		await expect(evaluator.acquire(caller)).resolves.toBe(true);
+		await expect(evaluator.acquire(caller)).resolves.toBe(false);
+
+		await evaluator.release(caller);
+		await expect(evaluator.acquire(caller)).resolves.toBe(true);
+
+		await evaluator.release(caller);
+		await evaluator.dispose();
+	});
 });

--- a/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
@@ -83,8 +83,14 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 		await this.pool.initialize();
 	}
 
-	async acquire(caller: object): Promise<void> {
-		if (this.bridgesByCaller.has(caller)) return;
+	/**
+	 * Acquire a bridge for the caller. Returns whether a bridge was newly
+	 * acquired: `false` means the caller already held one, so the current
+	 * scope must not release it (release is not reference-counted and would
+	 * return the caller's bridge to the pool mid-use).
+	 */
+	async acquire(caller: object): Promise<boolean> {
+		if (this.bridgesByCaller.has(caller)) return false;
 		let bridge: RuntimeBridge;
 		try {
 			bridge = this.pool.acquire();
@@ -95,6 +101,7 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 		}
 		this.config.observability?.metrics.counter(EXPRESSION_METRICS.poolAcquired.name, 1);
 		this.bridgesByCaller.set(caller, bridge);
+		return true;
 	}
 
 	evaluate(

--- a/packages/@n8n/expression-runtime/src/types/evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/types/evaluator.ts
@@ -81,8 +81,12 @@ export interface IExpressionEvaluator {
 	 * Acquire a bridge for an owner object (e.g. an Expression instance).
 	 * Must be called before evaluate(). The same object must be passed as
 	 * the caller argument to evaluate().
+	 *
+	 * Returns whether a bridge was newly acquired: `false` means the owner
+	 * already held one, so the current scope must not release it (release is
+	 * not reference-counted).
 	 */
-	acquire(owner: object): Promise<void>;
+	acquire(owner: object): Promise<boolean>;
 
 	/**
 	 * Release the bridge held for an owner object.

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -118,7 +118,7 @@ describe('DynamicNodeParametersService', () => {
 		it('should resolve routing from the node definition and run it', async () => {
 			const runNode = jest.fn().mockResolvedValue([[{ json: { name: 'opt', value: 'v' } }]]);
 			(RoutingNode as unknown as jest.Mock).mockImplementation(() => ({ runNode }));
-			jest.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			jest.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(true);
 			jest.spyOn(Expression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
 
 			const nodeRouting = { request: { url: '/v1/models', method: 'GET' as const } };

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -131,10 +131,10 @@ export async function withExpressionIsolate<T>(
 	workflow: Workflow,
 	fn: () => Promise<T>,
 ): Promise<T> {
-	await workflow.expression.acquireIsolate();
+	const acquired = await workflow.expression.acquireIsolate();
 	try {
 		return await fn();
 	} finally {
-		await workflow.expression.releaseIsolate();
+		if (acquired) await workflow.expression.releaseIsolate();
 	}
 }

--- a/packages/core/src/execution-engine/__tests__/active-workflows.test.ts
+++ b/packages/core/src/execution-engine/__tests__/active-workflows.test.ts
@@ -45,7 +45,7 @@ describe('ActiveWorkflows', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		acquireIsolate = jest.fn().mockResolvedValue(undefined);
+		acquireIsolate = jest.fn().mockResolvedValue(true);
 		releaseIsolate = jest.fn().mockResolvedValue(undefined);
 		// @ts-expect-error -- assign minimal expression stub for isolate-acquisition tests
 		workflow.expression = { acquireIsolate, releaseIsolate };
@@ -210,6 +210,38 @@ describe('ActiveWorkflows', () => {
 				expect(triggersAndPollers.runPoll).toHaveBeenCalledTimes(2);
 				expect(pollFunctions.__emit).not.toHaveBeenCalled();
 				expect(pollFunctions.__emitError).toHaveBeenCalledWith(error);
+			});
+
+			it('should not acquire or release the isolate for the initial test poll', async () => {
+				await addWorkflow({ pollNodes: [pollNode] });
+
+				expect(acquireIsolate).not.toHaveBeenCalled();
+				expect(releaseIsolate).not.toHaveBeenCalled();
+			});
+
+			it('should acquire and release the isolate per scheduled poll tick', async () => {
+				await addWorkflow({ pollNodes: [pollNode] });
+
+				const executeTrigger = scheduledTaskManager.registerCron.mock
+					.calls[0][1] as () => Promise<void>;
+				await executeTrigger();
+
+				expect(acquireIsolate).toHaveBeenCalledTimes(1);
+				expect(releaseIsolate).toHaveBeenCalledTimes(1);
+			});
+
+			it('should not release an isolate it did not newly acquire', async () => {
+				await addWorkflow({ pollNodes: [pollNode] });
+
+				// Simulate a scheduled tick firing while the activation's outer
+				// isolate window still holds the bridge: acquire reports "already held"
+				acquireIsolate.mockResolvedValue(false);
+				const executeTrigger = scheduledTaskManager.registerCron.mock
+					.calls[0][1] as () => Promise<void>;
+				await executeTrigger();
+
+				expect(acquireIsolate).toHaveBeenCalledTimes(1);
+				expect(releaseIsolate).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/core/src/execution-engine/active-workflows.ts
+++ b/packages/core/src/execution-engine/active-workflows.ts
@@ -164,10 +164,10 @@ export class ActiveWorkflows {
 			// (acquire is idempotent per caller; release deletes it). Scheduled
 			// polls fire from the cron scheduler's own async context outside
 			// that window and must acquire/release per tick — see CAT-3147.
-			const ownsIsolate = !testingTrigger;
+			let ownsIsolate = false;
 
 			try {
-				if (ownsIsolate) await workflow.expression.acquireIsolate();
+				if (!testingTrigger) ownsIsolate = await workflow.expression.acquireIsolate();
 
 				const pollResponse = await this.triggersAndPollers.runPoll(workflow, node, pollFunctions);
 

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -292,8 +292,10 @@ export class Expression {
 		}
 	}
 
-	async acquireIsolate(): Promise<void> {
-		if (Expression.vmEvaluator) await Expression.vmEvaluator.acquire(this);
+	/** Returns whether an isolate was newly acquired; `false` means this caller already held one and must not release it. */
+	async acquireIsolate(): Promise<boolean> {
+		if (Expression.vmEvaluator) return await Expression.vmEvaluator.acquire(this);
+		return false;
 	}
 
 	async releaseIsolate(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes `IsolateError: No bridge acquired for this context. Call acquire() first.` thrown during workflow activation on 1.x with `N8N_EXPRESSION_ENGINE=vm` (Sentry INSTANCE-BACKEND-267F, 1125 events / 44 users).

**What's happening:** `acquire()` does nothing if the caller already holds a bridge, and `release()` always drops it. So if a workflow has two or more polling nodes, poller #1's cron can fire while activation is still testing poller #2. That tick "acquires" (a no-op), polls, then releases — throwing away the bridge the activation was still using. When activation then counts triggers, evaluating the webhook's `path` expression fails, and the workflow gets stuck in an endless retry loop.

**The fix** (ported from #33492, which never made it to 1.x — most of that diff touches files that only exist on master):

- `acquire()` now reports whether it *newly* acquired a bridge. `false` means someone else holds it — don't release it.
- Scheduled poll ticks only release the isolate when they actually own it.
- Same guard for `withExpressionIsolate` in `packages/cli/src/utils.ts` (matches master).

**How to test:** workflow with a Webhook node + two RSS Feed Trigger pollers set to "every minute", where the second poller's feed URL takes ~55s to respond. Start n8n with `N8N_EXPRESSION_ENGINE=vm` and activate the workflow a few seconds past a minute boundary. Without this fix, poller #1's tick kills the activation; with it, activation succeeds. Unit tests cover the acquire contract and the don't-release-what-you-don't-own behavior.

**Reviewer note:** master's `poll-trigger-executor.ts` still decides ownership from `!testingTrigger` rather than the acquire result, so it likely carries the same latent race — follow-up forward-port worth a ticket.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-4021

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (N/A — internal engine fix)
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
