### PR TITLE
feat(MiniMax Node): Add M3 and H3 model support

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/LmChatMinimax.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/LmChatMinimax.node.ts
@@ -7,6 +7,7 @@ import {
 } from '@n8n/ai-utilities';
 import {
 	NodeConnectionTypes,
+	type INodePropertyOptions,
 	type INodeType,
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
@@ -16,6 +17,16 @@ import {
 import type { OpenAICompatibleCredential } from '../../../types/types';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
 
+const legacyModelOptions: INodePropertyOptions[] = [
+	{ name: 'MiniMax-M2', value: 'MiniMax-M2' },
+	{ name: 'MiniMax-M2.1', value: 'MiniMax-M2.1' },
+	{ name: 'MiniMax-M2.1-Highspeed', value: 'MiniMax-M2.1-highspeed' },
+	{ name: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
+	{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
+	{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
+	{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
+];
+
 export class LmChatMinimax implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'MiniMax Chat Model',
@@ -23,7 +34,8 @@ export class LmChatMinimax implements INodeType {
 		name: 'lmChatMinimax',
 		icon: 'file:minimax.svg',
 		group: ['transform'],
-		version: [1],
+		version: [1, 1.1],
+		defaultVersion: 1.1,
 		description: 'For advanced usage with an AI chain',
 		defaults: {
 			name: 'MiniMax Chat Model',
@@ -66,19 +78,29 @@ export class LmChatMinimax implements INodeType {
 				type: 'options',
 				description:
 					'The model which will generate the completion. <a href="https://platform.minimax.io/docs/api-reference/text-openai-api">Learn more</a>.',
-				options: [
-					{ name: 'MiniMax-M2', value: 'MiniMax-M2' },
-					{ name: 'MiniMax-M2.1', value: 'MiniMax-M2.1' },
-					{ name: 'MiniMax-M2.1-Highspeed', value: 'MiniMax-M2.1-highspeed' },
-					{ name: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
-					{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
-					{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
-					{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
-					{ name: 'MiniMax-M3', value: 'MiniMax-M3' },
-				],
+				options: legacyModelOptions,
+				default: 'MiniMax-M2.7',
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
+				displayName: 'Model',
+				name: 'model',
+				type: 'options',
+				description:
+					'The model which will generate the completion. <a href="https://platform.minimax.io/docs/api-reference/text-openai-api">Learn more</a>.',
+				options: [...legacyModelOptions, { name: 'MiniMax-M3', value: 'MiniMax-M3' }],
 				default: 'MiniMax-M3',
 				builderHint: {
 					propertyHint: 'Default to the latest MiniMax flagship model (MiniMax-M3).',
+				},
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.1 } }],
+					},
 				},
 			},
 			{

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/LmChatMinimax.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/LmChatMinimax.node.ts
@@ -7,7 +7,6 @@ import {
 } from '@n8n/ai-utilities';
 import {
 	NodeConnectionTypes,
-	type INodePropertyOptions,
 	type INodeType,
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
@@ -15,17 +14,8 @@ import {
 } from 'n8n-workflow';
 
 import type { OpenAICompatibleCredential } from '../../../types/types';
+import { minimaxTextModelOptions } from '../../vendors/MiniMax/helpers/modelOptions';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
-
-const legacyModelOptions: INodePropertyOptions[] = [
-	{ name: 'MiniMax-M2', value: 'MiniMax-M2' },
-	{ name: 'MiniMax-M2.1', value: 'MiniMax-M2.1' },
-	{ name: 'MiniMax-M2.1-Highspeed', value: 'MiniMax-M2.1-highspeed' },
-	{ name: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
-	{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
-	{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
-	{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
-];
 
 export class LmChatMinimax implements INodeType {
 	description: INodeTypeDescription = {
@@ -78,7 +68,7 @@ export class LmChatMinimax implements INodeType {
 				type: 'options',
 				description:
 					'The model which will generate the completion. <a href="https://platform.minimax.io/docs/api-reference/text-openai-api">Learn more</a>.',
-				options: legacyModelOptions,
+				options: minimaxTextModelOptions.v1,
 				default: 'MiniMax-M2.7',
 				displayOptions: {
 					show: {
@@ -92,7 +82,7 @@ export class LmChatMinimax implements INodeType {
 				type: 'options',
 				description:
 					'The model which will generate the completion. <a href="https://platform.minimax.io/docs/api-reference/text-openai-api">Learn more</a>.',
-				options: [...legacyModelOptions, { name: 'MiniMax-M3', value: 'MiniMax-M3' }],
+				options: minimaxTextModelOptions.v1_1,
 				default: 'MiniMax-M3',
 				builderHint: {
 					propertyHint: 'Default to the latest MiniMax flagship model (MiniMax-M3).',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/LmChatMinimax.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/LmChatMinimax.node.ts
@@ -74,11 +74,11 @@ export class LmChatMinimax implements INodeType {
 					{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
 					{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
 					{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
+					{ name: 'MiniMax-M3', value: 'MiniMax-M3' },
 				],
-				default: 'MiniMax-M2.7',
+				default: 'MiniMax-M3',
 				builderHint: {
-					propertyHint:
-						'Default to the latest MiniMax-M2.x flagship (MiniMax-M2.7). Avoid MiniMax-M2 and earlier.',
+					propertyHint: 'Default to the latest MiniMax flagship model (MiniMax-M3).',
 				},
 			},
 			{

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/test/LmChatMinimax.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/test/LmChatMinimax.test.ts
@@ -92,6 +92,10 @@ describe('LmChatMinimax', () => {
 				default: 'MiniMax-M2.7',
 				displayOptions: { show: { '@version': [1] } },
 			});
+			expect(legacyModelProperty?.options).not.toContainEqual({
+				name: 'MiniMax-M3',
+				value: 'MiniMax-M3',
+			});
 			expect(currentModelProperty).toMatchObject({
 				default: 'MiniMax-M3',
 				options: expect.arrayContaining([{ name: 'MiniMax-M3', value: 'MiniMax-M3' }]),

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/test/LmChatMinimax.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/test/LmChatMinimax.test.ts
@@ -66,7 +66,8 @@ describe('LmChatMinimax', () => {
 				displayName: 'MiniMax Chat Model',
 				name: 'lmChatMinimax',
 				group: ['transform'],
-				version: [1],
+				version: [1, 1.1],
+				defaultVersion: 1.1,
 			});
 		});
 
@@ -79,14 +80,22 @@ describe('LmChatMinimax', () => {
 			expect(node.description.outputNames).toEqual(['Model']);
 		});
 
-		it('should default to MiniMax-M3', () => {
-			const modelProperty = node.description.properties.find(
-				(property) => property?.name === 'model',
+		it('should preserve the M2.7 default for version 1 and use M3 for version 1.1', () => {
+			const legacyModelProperty = node.description.properties.find(
+				(property) => property?.name === 'model' && property.default === 'MiniMax-M2.7',
+			);
+			const currentModelProperty = node.description.properties.find(
+				(property) => property?.name === 'model' && property.default === 'MiniMax-M3',
 			);
 
-			expect(modelProperty).toMatchObject({
+			expect(legacyModelProperty).toMatchObject({
+				default: 'MiniMax-M2.7',
+				displayOptions: { show: { '@version': [1] } },
+			});
+			expect(currentModelProperty).toMatchObject({
 				default: 'MiniMax-M3',
 				options: expect.arrayContaining([{ name: 'MiniMax-M3', value: 'MiniMax-M3' }]),
+				displayOptions: { show: { '@version': [{ _cnd: { gte: 1.1 } }] } },
 			});
 		});
 	});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/test/LmChatMinimax.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatMinimax/test/LmChatMinimax.test.ts
@@ -42,7 +42,7 @@ describe('LmChatMinimax', () => {
 		});
 		ctx.getNode = vi.fn().mockReturnValue(nodeDef);
 		ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
-			if (paramName === 'model') return 'MiniMax-M2.7';
+			if (paramName === 'model') return 'MiniMax-M3';
 			if (paramName === 'options') return {};
 			return undefined;
 		});
@@ -78,6 +78,17 @@ describe('LmChatMinimax', () => {
 			expect(node.description.outputs).toEqual(['ai_languageModel']);
 			expect(node.description.outputNames).toEqual(['Model']);
 		});
+
+		it('should default to MiniMax-M3', () => {
+			const modelProperty = node.description.properties.find(
+				(property) => property?.name === 'model',
+			);
+
+			expect(modelProperty).toMatchObject({
+				default: 'MiniMax-M3',
+				options: expect.arrayContaining([{ name: 'MiniMax-M3', value: 'MiniMax-M3' }]),
+			});
+		});
 	});
 
 	describe('supplyData', () => {
@@ -90,7 +101,7 @@ describe('LmChatMinimax', () => {
 			expect(MockedChatOpenAI).toHaveBeenCalledWith(
 				expect.objectContaining({
 					apiKey: 'test-minimax-key',
-					model: 'MiniMax-M2.7',
+					model: 'MiniMax-M3',
 					maxRetries: 2,
 					callbacks: expect.arrayContaining([expect.any(Object)]),
 					onFailedAttempt: expect.any(Function),

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/audio/tts.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/audio/tts.operation.ts
@@ -226,7 +226,7 @@ export async function execute(
 		body.language_boost = options.languageBoost;
 	}
 
-	const response = (await apiRequest.call(this, 'POST', '/t2a_v2', {
+	const response = (await apiRequest.call(this, 'POST', '/v1/t2a_v2', {
 		body,
 	})) as T2AResponse;
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/image/generate.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/image/generate.operation.ts
@@ -134,7 +134,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		body.seed = options.seed;
 	}
 
-	const response = (await apiRequest.call(this, 'POST', '/image_generation', {
+	const response = (await apiRequest.call(this, 'POST', '/v1/image_generation', {
 		body,
 	})) as ImageGenerationResponse;
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/text/message.operation.ts
@@ -3,7 +3,6 @@ import type {
 	IDataObject,
 	IExecuteFunctions,
 	INodeExecutionData,
-	INodePropertyOptions,
 	INodeProperties,
 } from 'n8n-workflow';
 import { accumulateTokenUsage, jsonParse, updateDisplayOptions } from 'n8n-workflow';
@@ -17,24 +16,15 @@ import type {
 	ToolCall,
 	ToolFunction,
 } from '../../helpers/interfaces';
+import { minimaxTextModelOptions } from '../../helpers/modelOptions';
 import { apiRequest } from '../../transport';
-
-const legacyModelOptions: INodePropertyOptions[] = [
-	{ name: 'MiniMax-M2', value: 'MiniMax-M2' },
-	{ name: 'MiniMax-M2.1', value: 'MiniMax-M2.1' },
-	{ name: 'MiniMax-M2.1-Highspeed', value: 'MiniMax-M2.1-highspeed' },
-	{ name: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
-	{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
-	{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
-	{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
-];
 
 const properties: INodeProperties[] = [
 	{
 		displayName: 'Model',
 		name: 'modelId',
 		type: 'options',
-		options: legacyModelOptions,
+		options: minimaxTextModelOptions.v1,
 		default: 'MiniMax-M2.7',
 		description: 'The model to use for generating the response',
 		displayOptions: {
@@ -47,7 +37,7 @@ const properties: INodeProperties[] = [
 		displayName: 'Model',
 		name: 'modelId',
 		type: 'options',
-		options: [...legacyModelOptions, { name: 'MiniMax-M3', value: 'MiniMax-M3' }],
+		options: minimaxTextModelOptions.v1_1,
 		default: 'MiniMax-M3',
 		description: 'The model to use for generating the response',
 		displayOptions: {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/text/message.operation.ts
@@ -3,6 +3,7 @@ import type {
 	IDataObject,
 	IExecuteFunctions,
 	INodeExecutionData,
+	INodePropertyOptions,
 	INodeProperties,
 } from 'n8n-workflow';
 import { accumulateTokenUsage, jsonParse, updateDisplayOptions } from 'n8n-workflow';
@@ -18,23 +19,42 @@ import type {
 } from '../../helpers/interfaces';
 import { apiRequest } from '../../transport';
 
+const legacyModelOptions: INodePropertyOptions[] = [
+	{ name: 'MiniMax-M2', value: 'MiniMax-M2' },
+	{ name: 'MiniMax-M2.1', value: 'MiniMax-M2.1' },
+	{ name: 'MiniMax-M2.1-Highspeed', value: 'MiniMax-M2.1-highspeed' },
+	{ name: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
+	{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
+	{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
+	{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
+];
+
 const properties: INodeProperties[] = [
 	{
 		displayName: 'Model',
 		name: 'modelId',
 		type: 'options',
-		options: [
-			{ name: 'MiniMax-M2', value: 'MiniMax-M2' },
-			{ name: 'MiniMax-M2.1', value: 'MiniMax-M2.1' },
-			{ name: 'MiniMax-M2.1-Highspeed', value: 'MiniMax-M2.1-highspeed' },
-			{ name: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
-			{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
-			{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
-			{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
-			{ name: 'MiniMax-M3', value: 'MiniMax-M3' },
-		],
+		options: legacyModelOptions,
+		default: 'MiniMax-M2.7',
+		description: 'The model to use for generating the response',
+		displayOptions: {
+			show: {
+				'@version': [1],
+			},
+		},
+	},
+	{
+		displayName: 'Model',
+		name: 'modelId',
+		type: 'options',
+		options: [...legacyModelOptions, { name: 'MiniMax-M3', value: 'MiniMax-M3' }],
 		default: 'MiniMax-M3',
 		description: 'The model to use for generating the response',
+		displayOptions: {
+			show: {
+				'@version': [{ _cnd: { gte: 1.1 } }],
+			},
+		},
 	},
 	{
 		displayName: 'Messages',

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/text/message.operation.ts
@@ -31,8 +31,9 @@ const properties: INodeProperties[] = [
 			{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
 			{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
 			{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
+			{ name: 'MiniMax-M3', value: 'MiniMax-M3' },
 		],
-		default: 'MiniMax-M2.7',
+		default: 'MiniMax-M3',
 		description: 'The model to use for generating the response',
 	},
 	{
@@ -223,7 +224,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		body.tools = tools;
 	}
 
-	let response = (await apiRequest.call(this, 'POST', '/chat/completions', {
+	let response = (await apiRequest.call(this, 'POST', '/v1/chat/completions', {
 		body,
 	})) as ChatCompletionResponse;
 
@@ -267,7 +268,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		await handleToolUse.call(this, choice.message.tool_calls, messages, connectedTools);
 		currentIteration++;
 
-		response = (await apiRequest.call(this, 'POST', '/chat/completions', {
+		response = (await apiRequest.call(this, 'POST', '/v1/chat/completions', {
 			body,
 		})) as ChatCompletionResponse;
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/versionDescription.ts
@@ -11,7 +11,8 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'minimax',
 	icon: 'file:minimax.svg',
 	group: ['transform'],
-	version: 1,
+	version: [1, 1.1],
+	defaultVersion: 1.1,
 	subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
 	description: 'Message MiniMax, generate speech, images, and video',
 	defaults: {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.i2v.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.i2v.operation.ts
@@ -2,6 +2,7 @@ import type {
 	IDataObject,
 	IExecuteFunctions,
 	INodeExecutionData,
+	INodePropertyOptions,
 	INodeProperties,
 } from 'n8n-workflow';
 import { updateDisplayOptions } from 'n8n-workflow';
@@ -9,7 +10,53 @@ import { updateDisplayOptions } from 'n8n-workflow';
 import { generateVideo } from '../../transport';
 import { assertH3Prompt, H3_MODEL, h3VideoProperties, prepareVideoOutput } from './helpers';
 
+const legacyModelOptions: INodePropertyOptions[] = [
+	{
+		name: 'I2V-01',
+		value: 'I2V-01',
+		description: 'Standard image-to-video model',
+	},
+	{
+		name: 'I2V-01-Director',
+		value: 'I2V-01-Director',
+		description: 'Image-to-video with camera control commands',
+	},
+	{
+		name: 'I2V-01-Live',
+		value: 'I2V-01-live',
+		description: 'Image-to-video live model',
+	},
+	{
+		name: 'MiniMax-Hailuo-02',
+		value: 'MiniMax-Hailuo-02',
+		description: 'Model supporting higher resolution and longer duration',
+	},
+	{
+		name: 'MiniMax-Hailuo-2.3',
+		value: 'MiniMax-Hailuo-2.3',
+		description: 'Hailuo 2.3 model with enhanced realism',
+	},
+	{
+		name: 'MiniMax-Hailuo-2.3-Fast',
+		value: 'MiniMax-Hailuo-2.3-Fast',
+		description: 'Faster image-to-video model for value and efficiency',
+	},
+];
+
 const properties: INodeProperties[] = [
+	{
+		displayName: 'Model',
+		name: 'modelId',
+		type: 'options',
+		options: legacyModelOptions,
+		default: 'MiniMax-Hailuo-2.3',
+		description: 'The model to use for video generation',
+		displayOptions: {
+			show: {
+				'@version': [1],
+			},
+		},
+	},
 	{
 		displayName: 'Model',
 		name: 'modelId',
@@ -20,39 +67,15 @@ const properties: INodeProperties[] = [
 				value: H3_MODEL,
 				description: 'Latest multimodal video generation model',
 			},
-			{
-				name: 'I2V-01',
-				value: 'I2V-01',
-				description: 'Standard image-to-video model',
-			},
-			{
-				name: 'I2V-01-Director',
-				value: 'I2V-01-Director',
-				description: 'Image-to-video with camera control commands',
-			},
-			{
-				name: 'I2V-01-Live',
-				value: 'I2V-01-live',
-				description: 'Image-to-video live model',
-			},
-			{
-				name: 'MiniMax-Hailuo-02',
-				value: 'MiniMax-Hailuo-02',
-				description: 'Model supporting higher resolution and longer duration',
-			},
-			{
-				name: 'MiniMax-Hailuo-2.3',
-				value: 'MiniMax-Hailuo-2.3',
-				description: 'Hailuo 2.3 model with enhanced realism',
-			},
-			{
-				name: 'MiniMax-Hailuo-2.3-Fast',
-				value: 'MiniMax-Hailuo-2.3-Fast',
-				description: 'Faster image-to-video model for value and efficiency',
-			},
+			...legacyModelOptions,
 		],
 		default: H3_MODEL,
 		description: 'The model to use for video generation',
+		displayOptions: {
+			show: {
+				'@version': [{ _cnd: { gte: 1.1 } }],
+			},
+		},
 	},
 	{
 		displayName: 'Image Input Type',

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.i2v.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.i2v.operation.ts
@@ -10,7 +10,7 @@ import { updateDisplayOptions } from 'n8n-workflow';
 import { generateVideo } from '../../transport';
 import { assertH3Prompt, H3_MODEL, h3VideoProperties, prepareVideoOutput } from './helpers';
 
-const legacyModelOptions: INodePropertyOptions[] = [
+const modelOptionsV1: INodePropertyOptions[] = [
 	{
 		name: 'I2V-01',
 		value: 'I2V-01',
@@ -43,12 +43,21 @@ const legacyModelOptions: INodePropertyOptions[] = [
 	},
 ];
 
+const modelOptionsV1_1: INodePropertyOptions[] = [
+	{
+		name: H3_MODEL,
+		value: H3_MODEL,
+		description: 'Latest multimodal video generation model',
+	},
+	...modelOptionsV1,
+];
+
 const properties: INodeProperties[] = [
 	{
 		displayName: 'Model',
 		name: 'modelId',
 		type: 'options',
-		options: legacyModelOptions,
+		options: modelOptionsV1,
 		default: 'MiniMax-Hailuo-2.3',
 		description: 'The model to use for video generation',
 		displayOptions: {
@@ -61,14 +70,7 @@ const properties: INodeProperties[] = [
 		displayName: 'Model',
 		name: 'modelId',
 		type: 'options',
-		options: [
-			{
-				name: H3_MODEL,
-				value: H3_MODEL,
-				description: 'Latest multimodal video generation model',
-			},
-			...legacyModelOptions,
-		],
+		options: modelOptionsV1_1,
 		default: H3_MODEL,
 		description: 'The model to use for video generation',
 		displayOptions: {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.i2v.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.i2v.operation.ts
@@ -4,10 +4,10 @@ import type {
 	INodeExecutionData,
 	INodeProperties,
 } from 'n8n-workflow';
-import { NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
+import { updateDisplayOptions } from 'n8n-workflow';
 
-import type { VideoGenerationResponse } from '../../helpers/interfaces';
-import { apiRequest, getVideoDownloadUrl, pollVideoTask } from '../../transport';
+import { generateVideo } from '../../transport';
+import { assertH3Prompt, H3_MODEL, h3VideoProperties, prepareVideoOutput } from './helpers';
 
 const properties: INodeProperties[] = [
 	{
@@ -15,6 +15,11 @@ const properties: INodeProperties[] = [
 		name: 'modelId',
 		type: 'options',
 		options: [
+			{
+				name: H3_MODEL,
+				value: H3_MODEL,
+				description: 'Latest multimodal video generation model',
+			},
 			{
 				name: 'I2V-01',
 				value: 'I2V-01',
@@ -38,7 +43,7 @@ const properties: INodeProperties[] = [
 			{
 				name: 'MiniMax-Hailuo-2.3',
 				value: 'MiniMax-Hailuo-2.3',
-				description: 'Latest model with enhanced realism',
+				description: 'Hailuo 2.3 model with enhanced realism',
 			},
 			{
 				name: 'MiniMax-Hailuo-2.3-Fast',
@@ -46,7 +51,7 @@ const properties: INodeProperties[] = [
 				description: 'Faster image-to-video model for value and efficiency',
 			},
 		],
-		default: 'MiniMax-Hailuo-2.3',
+		default: H3_MODEL,
 		description: 'The model to use for video generation',
 	},
 	{
@@ -102,7 +107,13 @@ const properties: INodeProperties[] = [
 		description:
 			'Optional text description of the video (max 2000 characters). Camera movements can be controlled using [command] syntax.',
 		placeholder: 'e.g. The subject smiles and waves at the camera [Zoom in]',
+		displayOptions: {
+			hide: {
+				modelId: [H3_MODEL],
+			},
+		},
 	},
+	...h3VideoProperties,
 	{
 		displayName: 'Duration (Seconds)',
 		name: 'duration',
@@ -113,6 +124,11 @@ const properties: INodeProperties[] = [
 		],
 		default: 6,
 		description: 'Duration of the generated video',
+		displayOptions: {
+			hide: {
+				modelId: [H3_MODEL],
+			},
+		},
 	},
 	{
 		displayName: 'Resolution',
@@ -126,6 +142,11 @@ const properties: INodeProperties[] = [
 		],
 		default: '768P',
 		description: 'Resolution of the generated video. Available options depend on the model.',
+		displayOptions: {
+			hide: {
+				modelId: [H3_MODEL],
+			},
+		},
 	},
 	{
 		displayName: 'Download Video',
@@ -148,6 +169,11 @@ const properties: INodeProperties[] = [
 				type: 'boolean',
 				default: true,
 				description: 'Whether to automatically optimize the prompt',
+				displayOptions: {
+					hide: {
+						modelId: [H3_MODEL],
+					},
+				},
 			},
 			{
 				displayName: 'Last Frame Image Input Type',
@@ -160,7 +186,7 @@ const properties: INodeProperties[] = [
 				],
 				default: 'none',
 				description:
-					'Provide a last frame image to generate a first-and-last-frame video. Only supported by MiniMax-Hailuo-2.3 and MiniMax-Hailuo-02.',
+					'Provide a last frame image to generate a first-and-last-frame video. Available only for supported models.',
 			},
 			{
 				displayName: 'Last Frame Image URL',
@@ -201,6 +227,11 @@ const properties: INodeProperties[] = [
 				default: 'none',
 				description:
 					'Provide a face photo for facial consistency in the generated video. Only supported by MiniMax-Hailuo-2.3.',
+				displayOptions: {
+					hide: {
+						modelId: [H3_MODEL],
+					},
+				},
 			},
 			{
 				displayName: 'Subject Reference Image URL',
@@ -211,6 +242,9 @@ const properties: INodeProperties[] = [
 				displayOptions: {
 					show: {
 						subjectReferenceInputType: ['url'],
+					},
+					hide: {
+						modelId: [H3_MODEL],
 					},
 				},
 			},
@@ -226,6 +260,9 @@ const properties: INodeProperties[] = [
 				displayOptions: {
 					show: {
 						subjectReferenceInputType: ['binary'],
+					},
+					hide: {
+						modelId: [H3_MODEL],
 					},
 				},
 			},
@@ -267,10 +304,9 @@ export async function execute(
 	const model = this.getNodeParameter('modelId', itemIndex) as string;
 	const imageInputType = this.getNodeParameter('imageInputType', itemIndex) as string;
 	const prompt = this.getNodeParameter('prompt', itemIndex, '') as string;
-	const duration = this.getNodeParameter('duration', itemIndex) as number;
-	const resolution = this.getNodeParameter('resolution', itemIndex) as string;
 	const downloadVideo = this.getNodeParameter('downloadVideo', itemIndex, true) as boolean;
 	const options = this.getNodeParameter('options', itemIndex, {}) as IDataObject;
+	const isH3 = model === H3_MODEL;
 
 	let firstFrameImage: string;
 	if (imageInputType === 'binary') {
@@ -281,24 +317,10 @@ export async function execute(
 		firstFrameImage = imageUrl;
 	}
 
-	const body: IDataObject = {
-		model,
-		first_frame_image: firstFrameImage,
-		duration,
-		resolution,
-	};
-
-	if (prompt) {
-		body.prompt = prompt;
-	}
-
-	if (options.promptOptimizer !== undefined) {
-		body.prompt_optimizer = options.promptOptimizer;
-	}
-
 	const lastFrameInputType = (options.lastFrameInputType as string) || 'none';
+	let lastFrameImage: string | undefined;
 	if (lastFrameInputType !== 'none') {
-		body.last_frame_image = await resolveImageInput(
+		lastFrameImage = await resolveImageInput(
 			this,
 			itemIndex,
 			lastFrameInputType,
@@ -307,74 +329,68 @@ export async function execute(
 		);
 	}
 
-	const subjectRefInputType = (options.subjectReferenceInputType as string) || 'none';
-	if (subjectRefInputType !== 'none') {
-		body.subject_reference = [
+	let body: IDataObject;
+	if (isH3) {
+		assertH3Prompt(this, prompt);
+		const content: IDataObject[] = [
+			{ type: 'text', text: prompt },
 			{
-				image: await resolveImageInput(
-					this,
-					itemIndex,
-					subjectRefInputType,
-					(options.subjectReferenceImageUrl as string) || '',
-					(options.subjectReferenceBinaryPropertyName as string) || 'subjectReference',
-				),
+				type: 'image_url',
+				image_url: { url: firstFrameImage },
+				role: 'first_frame',
 			},
 		];
+		if (lastFrameImage) {
+			content.push({
+				type: 'image_url',
+				image_url: { url: lastFrameImage },
+				role: 'last_frame',
+			});
+		}
+
+		body = {
+			model,
+			content,
+			duration: this.getNodeParameter('h3Duration', itemIndex) as number,
+			resolution: this.getNodeParameter('h3Resolution', itemIndex) as string,
+			ratio: 'adaptive',
+		};
+	} else {
+		body = {
+			model,
+			first_frame_image: firstFrameImage,
+			duration: this.getNodeParameter('duration', itemIndex) as number,
+			resolution: this.getNodeParameter('resolution', itemIndex) as string,
+		};
+
+		if (prompt) {
+			body.prompt = prompt;
+		}
+
+		if (options.promptOptimizer !== undefined) {
+			body.prompt_optimizer = options.promptOptimizer;
+		}
+
+		if (lastFrameImage) {
+			body.last_frame_image = lastFrameImage;
+		}
+
+		const subjectRefInputType = (options.subjectReferenceInputType as string) || 'none';
+		if (subjectRefInputType !== 'none') {
+			body.subject_reference = [
+				{
+					image: await resolveImageInput(
+						this,
+						itemIndex,
+						subjectRefInputType,
+						(options.subjectReferenceImageUrl as string) || '',
+						(options.subjectReferenceBinaryPropertyName as string) || 'subjectReference',
+					),
+				},
+			];
+		}
 	}
 
-	const createResponse = (await apiRequest.call(this, 'POST', '/video_generation', {
-		body,
-	})) as VideoGenerationResponse;
-
-	if (createResponse.base_resp?.status_code !== 0) {
-		throw new NodeOperationError(
-			this.getNode(),
-			`Failed to create video task: ${createResponse.base_resp?.status_msg || 'Unknown error'}`,
-		);
-	}
-
-	const taskId = createResponse.task_id;
-	if (!taskId) {
-		throw new NodeOperationError(
-			this.getNode(),
-			'No task_id returned from video generation request',
-		);
-	}
-
-	const { fileId } = await pollVideoTask.call(this, taskId);
-	const videoUrl = await getVideoDownloadUrl.call(this, fileId);
-
-	const jsonData: IDataObject = {
-		videoUrl,
-		taskId,
-		fileId,
-	};
-
-	if (downloadVideo && videoUrl) {
-		const videoResponse = await this.helpers.httpRequest({
-			method: 'GET',
-			url: videoUrl,
-			encoding: 'arraybuffer',
-			returnFullResponse: true,
-		});
-
-		const contentType = (videoResponse.headers?.['content-type'] as string) || 'video/mp4';
-		const fileContent = Buffer.from(videoResponse.body as ArrayBuffer);
-		const binaryData = await this.helpers.prepareBinaryData(fileContent, 'video.mp4', contentType);
-
-		return [
-			{
-				binary: { data: binaryData },
-				json: jsonData,
-				pairedItem: { item: itemIndex },
-			},
-		];
-	}
-
-	return [
-		{
-			json: jsonData,
-			pairedItem: { item: itemIndex },
-		},
-	];
+	const result = await generateVideo.call(this, isH3 ? 'v2' : 'v1', body);
+	return await prepareVideoOutput(this, itemIndex, result, downloadVideo);
 }

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.t2v.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.t2v.operation.ts
@@ -4,10 +4,10 @@ import type {
 	INodeExecutionData,
 	INodeProperties,
 } from 'n8n-workflow';
-import { NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
+import { updateDisplayOptions } from 'n8n-workflow';
 
-import type { VideoGenerationResponse } from '../../helpers/interfaces';
-import { apiRequest, getVideoDownloadUrl, pollVideoTask } from '../../transport';
+import { generateVideo } from '../../transport';
+import { assertH3Prompt, H3_MODEL, h3VideoProperties, prepareVideoOutput } from './helpers';
 
 const properties: INodeProperties[] = [
 	{
@@ -16,9 +16,14 @@ const properties: INodeProperties[] = [
 		type: 'options',
 		options: [
 			{
+				name: H3_MODEL,
+				value: H3_MODEL,
+				description: 'Latest multimodal video generation model',
+			},
+			{
 				name: 'MiniMax-Hailuo-2.3',
 				value: 'MiniMax-Hailuo-2.3',
-				description: 'Latest video generation model with enhanced realism',
+				description: 'Hailuo 2.3 video generation model with enhanced realism',
 			},
 			{
 				name: 'MiniMax-Hailuo-02',
@@ -36,7 +41,7 @@ const properties: INodeProperties[] = [
 				description: 'Standard text-to-video model',
 			},
 		],
-		default: 'MiniMax-Hailuo-2.3',
+		default: H3_MODEL,
 		description: 'The model to use for video generation',
 	},
 	{
@@ -51,7 +56,13 @@ const properties: INodeProperties[] = [
 		description:
 			'Text description of the video (max 2000 characters). Camera movements can be controlled using [command] syntax, e.g. [Push in], [Pan left].',
 		placeholder: 'e.g. A cat playing with a ball of yarn [Static shot]',
+		displayOptions: {
+			hide: {
+				modelId: [H3_MODEL],
+			},
+		},
 	},
+	...h3VideoProperties,
 	{
 		displayName: 'Duration (Seconds)',
 		name: 'duration',
@@ -62,6 +73,11 @@ const properties: INodeProperties[] = [
 		],
 		default: 6,
 		description: 'Duration of the generated video',
+		displayOptions: {
+			hide: {
+				modelId: [H3_MODEL],
+			},
+		},
 	},
 	{
 		displayName: 'Resolution',
@@ -74,6 +90,31 @@ const properties: INodeProperties[] = [
 		],
 		default: '768P',
 		description: 'Resolution of the generated video. Available options depend on the model.',
+		displayOptions: {
+			hide: {
+				modelId: [H3_MODEL],
+			},
+		},
+	},
+	{
+		displayName: 'Aspect Ratio',
+		name: 'ratio',
+		type: 'options',
+		options: [
+			{ name: '1:1', value: '1:1' },
+			{ name: '16:9', value: '16:9' },
+			{ name: '21:9', value: '21:9' },
+			{ name: '3:4', value: '3:4' },
+			{ name: '4:3', value: '4:3' },
+			{ name: '9:16', value: '9:16' },
+		],
+		default: '16:9',
+		description: 'Aspect ratio of the generated video',
+		displayOptions: {
+			show: {
+				modelId: [H3_MODEL],
+			},
+		},
 	},
 	{
 		displayName: 'Download Video',
@@ -89,6 +130,11 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add Option',
 		type: 'collection',
 		default: {},
+		displayOptions: {
+			hide: {
+				modelId: [H3_MODEL],
+			},
+		},
 		options: [
 			{
 				displayName: 'Prompt Optimizer',
@@ -116,77 +162,36 @@ export async function execute(
 ): Promise<INodeExecutionData[]> {
 	const model = this.getNodeParameter('modelId', itemIndex) as string;
 	const prompt = this.getNodeParameter('prompt', itemIndex) as string;
-	const duration = this.getNodeParameter('duration', itemIndex) as number;
-	const resolution = this.getNodeParameter('resolution', itemIndex) as string;
 	const downloadVideo = this.getNodeParameter('downloadVideo', itemIndex, true) as boolean;
-	const options = this.getNodeParameter('options', itemIndex, {}) as {
-		promptOptimizer?: boolean;
-	};
+	const isH3 = model === H3_MODEL;
 
-	const body: IDataObject = {
-		model,
-		prompt,
-		duration,
-		resolution,
-	};
+	let body: IDataObject;
+	if (isH3) {
+		assertH3Prompt(this, prompt);
+		const ratio = this.getNodeParameter('ratio', itemIndex) as string;
+		body = {
+			model,
+			content: [{ type: 'text', text: prompt }],
+			duration: this.getNodeParameter('h3Duration', itemIndex) as number,
+			resolution: this.getNodeParameter('h3Resolution', itemIndex) as string,
+			ratio,
+		};
+	} else {
+		const options = this.getNodeParameter('options', itemIndex, {}) as {
+			promptOptimizer?: boolean;
+		};
+		body = {
+			model,
+			prompt,
+			duration: this.getNodeParameter('duration', itemIndex) as number,
+			resolution: this.getNodeParameter('resolution', itemIndex) as string,
+		};
 
-	if (options.promptOptimizer !== undefined) {
-		body.prompt_optimizer = options.promptOptimizer;
+		if (options.promptOptimizer !== undefined) {
+			body.prompt_optimizer = options.promptOptimizer;
+		}
 	}
 
-	const createResponse = (await apiRequest.call(this, 'POST', '/video_generation', {
-		body,
-	})) as VideoGenerationResponse;
-
-	if (createResponse.base_resp?.status_code !== 0) {
-		throw new NodeOperationError(
-			this.getNode(),
-			`Failed to create video task: ${createResponse.base_resp?.status_msg || 'Unknown error'}`,
-		);
-	}
-
-	const taskId = createResponse.task_id;
-	if (!taskId) {
-		throw new NodeOperationError(
-			this.getNode(),
-			'No task_id returned from video generation request',
-		);
-	}
-
-	const { fileId } = await pollVideoTask.call(this, taskId);
-	const videoUrl = await getVideoDownloadUrl.call(this, fileId);
-
-	const jsonData: IDataObject = {
-		videoUrl,
-		taskId,
-		fileId,
-	};
-
-	if (downloadVideo && videoUrl) {
-		const videoResponse = await this.helpers.httpRequest({
-			method: 'GET',
-			url: videoUrl,
-			encoding: 'arraybuffer',
-			returnFullResponse: true,
-		});
-
-		const contentType = (videoResponse.headers?.['content-type'] as string) || 'video/mp4';
-		const fileContent = Buffer.from(videoResponse.body as ArrayBuffer);
-		const binaryData = await this.helpers.prepareBinaryData(fileContent, 'video.mp4', contentType);
-
-		return [
-			{
-				binary: { data: binaryData },
-				json: jsonData,
-				pairedItem: { item: itemIndex },
-			},
-		];
-	}
-
-	return [
-		{
-			json: jsonData,
-			pairedItem: { item: itemIndex },
-		},
-	];
+	const result = await generateVideo.call(this, isH3 ? 'v2' : 'v1', body);
+	return await prepareVideoOutput(this, itemIndex, result, downloadVideo);
 }

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.t2v.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.t2v.operation.ts
@@ -10,7 +10,7 @@ import { updateDisplayOptions } from 'n8n-workflow';
 import { generateVideo } from '../../transport';
 import { assertH3Prompt, H3_MODEL, h3VideoProperties, prepareVideoOutput } from './helpers';
 
-const legacyModelOptions: INodePropertyOptions[] = [
+const modelOptionsV1: INodePropertyOptions[] = [
 	{
 		name: 'MiniMax-Hailuo-2.3',
 		value: 'MiniMax-Hailuo-2.3',
@@ -33,12 +33,21 @@ const legacyModelOptions: INodePropertyOptions[] = [
 	},
 ];
 
+const modelOptionsV1_1: INodePropertyOptions[] = [
+	{
+		name: H3_MODEL,
+		value: H3_MODEL,
+		description: 'Latest multimodal video generation model',
+	},
+	...modelOptionsV1,
+];
+
 const properties: INodeProperties[] = [
 	{
 		displayName: 'Model',
 		name: 'modelId',
 		type: 'options',
-		options: legacyModelOptions,
+		options: modelOptionsV1,
 		default: 'MiniMax-Hailuo-2.3',
 		description: 'The model to use for video generation',
 		displayOptions: {
@@ -51,14 +60,7 @@ const properties: INodeProperties[] = [
 		displayName: 'Model',
 		name: 'modelId',
 		type: 'options',
-		options: [
-			{
-				name: H3_MODEL,
-				value: H3_MODEL,
-				description: 'Latest multimodal video generation model',
-			},
-			...legacyModelOptions,
-		],
+		options: modelOptionsV1_1,
 		default: H3_MODEL,
 		description: 'The model to use for video generation',
 		displayOptions: {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.t2v.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/generate.t2v.operation.ts
@@ -2,6 +2,7 @@ import type {
 	IDataObject,
 	IExecuteFunctions,
 	INodeExecutionData,
+	INodePropertyOptions,
 	INodeProperties,
 } from 'n8n-workflow';
 import { updateDisplayOptions } from 'n8n-workflow';
@@ -9,7 +10,43 @@ import { updateDisplayOptions } from 'n8n-workflow';
 import { generateVideo } from '../../transport';
 import { assertH3Prompt, H3_MODEL, h3VideoProperties, prepareVideoOutput } from './helpers';
 
+const legacyModelOptions: INodePropertyOptions[] = [
+	{
+		name: 'MiniMax-Hailuo-2.3',
+		value: 'MiniMax-Hailuo-2.3',
+		description: 'Hailuo 2.3 video generation model with enhanced realism',
+	},
+	{
+		name: 'MiniMax-Hailuo-02',
+		value: 'MiniMax-Hailuo-02',
+		description: 'Video model supporting higher resolution and longer duration',
+	},
+	{
+		name: 'T2V-01-Director',
+		value: 'T2V-01-Director',
+		description: 'Text-to-video model with camera control commands',
+	},
+	{
+		name: 'T2V-01',
+		value: 'T2V-01',
+		description: 'Standard text-to-video model',
+	},
+];
+
 const properties: INodeProperties[] = [
+	{
+		displayName: 'Model',
+		name: 'modelId',
+		type: 'options',
+		options: legacyModelOptions,
+		default: 'MiniMax-Hailuo-2.3',
+		description: 'The model to use for video generation',
+		displayOptions: {
+			show: {
+				'@version': [1],
+			},
+		},
+	},
 	{
 		displayName: 'Model',
 		name: 'modelId',
@@ -20,29 +57,15 @@ const properties: INodeProperties[] = [
 				value: H3_MODEL,
 				description: 'Latest multimodal video generation model',
 			},
-			{
-				name: 'MiniMax-Hailuo-2.3',
-				value: 'MiniMax-Hailuo-2.3',
-				description: 'Hailuo 2.3 video generation model with enhanced realism',
-			},
-			{
-				name: 'MiniMax-Hailuo-02',
-				value: 'MiniMax-Hailuo-02',
-				description: 'Video model supporting higher resolution and longer duration',
-			},
-			{
-				name: 'T2V-01-Director',
-				value: 'T2V-01-Director',
-				description: 'Text-to-video model with camera control commands',
-			},
-			{
-				name: 'T2V-01',
-				value: 'T2V-01',
-				description: 'Standard text-to-video model',
-			},
+			...legacyModelOptions,
 		],
 		default: H3_MODEL,
 		description: 'The model to use for video generation',
+		displayOptions: {
+			show: {
+				'@version': [{ _cnd: { gte: 1.1 } }],
+			},
+		},
 	},
 	{
 		displayName: 'Prompt',
@@ -113,6 +136,7 @@ const properties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				modelId: [H3_MODEL],
+				'@version': [{ _cnd: { gte: 1.1 } }],
 			},
 		},
 	},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/helpers.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/helpers.ts
@@ -23,6 +23,7 @@ export const h3VideoProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				modelId: [H3_MODEL],
+				'@version': [{ _cnd: { gte: 1.1 } }],
 			},
 		},
 	},
@@ -39,6 +40,7 @@ export const h3VideoProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				modelId: [H3_MODEL],
+				'@version': [{ _cnd: { gte: 1.1 } }],
 			},
 		},
 	},
@@ -55,6 +57,7 @@ export const h3VideoProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				modelId: [H3_MODEL],
+				'@version': [{ _cnd: { gte: 1.1 } }],
 			},
 		},
 	},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/helpers.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/actions/video/helpers.ts
@@ -1,0 +1,109 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+export const H3_MODEL = 'MiniMax-H3';
+
+export const h3VideoProperties: INodeProperties[] = [
+	{
+		displayName: 'Prompt',
+		name: 'prompt',
+		type: 'string',
+		typeOptions: {
+			rows: 4,
+		},
+		default: '',
+		required: true,
+		description: 'Text description of the video (max 7000 characters)',
+		placeholder: 'A subject moves naturally through the scene',
+		displayOptions: {
+			show: {
+				modelId: [H3_MODEL],
+			},
+		},
+	},
+	{
+		displayName: 'Duration (Seconds)',
+		name: 'h3Duration',
+		type: 'options',
+		options: Array.from({ length: 12 }, (_, index) => {
+			const duration = index + 4;
+			return { name: `${duration} Seconds`, value: duration };
+		}),
+		default: 5,
+		description: 'Duration of the generated video',
+		displayOptions: {
+			show: {
+				modelId: [H3_MODEL],
+			},
+		},
+	},
+	{
+		displayName: 'Resolution',
+		name: 'h3Resolution',
+		type: 'options',
+		options: [
+			{ name: '768P', value: '768P' },
+			{ name: '2K', value: '2K' },
+		],
+		default: '2K',
+		description: 'Resolution of the generated video',
+		displayOptions: {
+			show: {
+				modelId: [H3_MODEL],
+			},
+		},
+	},
+];
+
+export function assertH3Prompt(executeFunctions: IExecuteFunctions, prompt: string) {
+	if (!prompt.trim()) {
+		throw new NodeOperationError(
+			executeFunctions.getNode(),
+			'Prompt is required for MiniMax-H3 video generation',
+		);
+	}
+}
+
+export async function prepareVideoOutput(
+	executeFunctions: IExecuteFunctions,
+	itemIndex: number,
+	result: { videoUrl: string; taskId: string; fileId?: string },
+	downloadVideo: boolean,
+): Promise<INodeExecutionData[]> {
+	const json: IDataObject = {
+		videoUrl: result.videoUrl,
+		taskId: result.taskId,
+	};
+	if (result.fileId) json.fileId = result.fileId;
+
+	if (!downloadVideo) {
+		return [{ json, pairedItem: { item: itemIndex } }];
+	}
+
+	const response = await executeFunctions.helpers.httpRequest({
+		method: 'GET',
+		url: result.videoUrl,
+		encoding: 'arraybuffer',
+		returnFullResponse: true,
+	});
+	const contentType = (response.headers?.['content-type'] as string) || 'video/mp4';
+	const fileContent = Buffer.from(response.body as ArrayBuffer);
+	const binaryData = await executeFunctions.helpers.prepareBinaryData(
+		fileContent,
+		'video.mp4',
+		contentType,
+	);
+
+	return [
+		{
+			binary: { data: binaryData },
+			json,
+			pairedItem: { item: itemIndex },
+		},
+	];
+}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/helpers/interfaces.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/helpers/interfaces.ts
@@ -72,6 +72,23 @@ export interface VideoGenerationResponse {
 	};
 }
 
+export interface VideoGenerationV2Response {
+	task_id?: string;
+}
+
+export interface VideoTaskV2QueryResponse {
+	task?: {
+		status?: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+		content?: {
+			url?: string;
+		};
+		error?: {
+			code?: string;
+			message?: string;
+		};
+	};
+}
+
 export interface T2AResponse {
 	data: {
 		audio: string;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/helpers/modelOptions.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/helpers/modelOptions.ts
@@ -1,0 +1,16 @@
+import type { INodePropertyOptions } from 'n8n-workflow';
+
+const modelOptionsV1: INodePropertyOptions[] = [
+	{ name: 'MiniMax-M2', value: 'MiniMax-M2' },
+	{ name: 'MiniMax-M2.1', value: 'MiniMax-M2.1' },
+	{ name: 'MiniMax-M2.1-Highspeed', value: 'MiniMax-M2.1-highspeed' },
+	{ name: 'MiniMax-M2.5', value: 'MiniMax-M2.5' },
+	{ name: 'MiniMax-M2.5-Highspeed', value: 'MiniMax-M2.5-highspeed' },
+	{ name: 'MiniMax-M2.7', value: 'MiniMax-M2.7' },
+	{ name: 'MiniMax-M2.7-Highspeed', value: 'MiniMax-M2.7-highspeed' },
+];
+
+export const minimaxTextModelOptions = {
+	v1: modelOptionsV1,
+	v1_1: [...modelOptionsV1, { name: 'MiniMax-M3', value: 'MiniMax-M3' }],
+} satisfies Record<'v1' | 'v1_1', INodePropertyOptions[]>;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/operations.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/operations.test.ts
@@ -37,6 +37,7 @@ import {
 	description as videoT2VDescription,
 	execute as videoT2VExecute,
 } from '../actions/video/generate.t2v.operation';
+import { versionDescription } from '../actions/versionDescription';
 import { apiRequest, generateVideo } from '../transport';
 
 import type { Mock } from 'vitest';
@@ -65,13 +66,34 @@ describe('MiniMax Operations', () => {
 		vi.clearAllMocks();
 	});
 
-	describe('Text: message', () => {
-		it('should default to MiniMax-M3', () => {
-			const modelProperty = textMessageDescription.find(({ name }) => name === 'modelId');
+	it('should use version 1.1 for newly added nodes', () => {
+		expect(versionDescription).toMatchObject({
+			version: [1, 1.1],
+			defaultVersion: 1.1,
+		});
+	});
 
-			expect(modelProperty).toMatchObject({
+	describe('Text: message', () => {
+		it('should preserve the M2.7 default for version 1 and use M3 for version 1.1', () => {
+			const legacyModelProperty = textMessageDescription.find(
+				({ name, default: defaultValue }) => name === 'modelId' && defaultValue === 'MiniMax-M2.7',
+			);
+			const currentModelProperty = textMessageDescription.find(
+				({ name, default: defaultValue }) => name === 'modelId' && defaultValue === 'MiniMax-M3',
+			);
+
+			expect(legacyModelProperty).toMatchObject({
+				default: 'MiniMax-M2.7',
+				displayOptions: {
+					show: expect.objectContaining({ '@version': [1] }),
+				},
+			});
+			expect(currentModelProperty).toMatchObject({
 				default: 'MiniMax-M3',
 				options: expect.arrayContaining([{ name: 'MiniMax-M3', value: 'MiniMax-M3' }]),
+				displayOptions: {
+					show: expect.objectContaining({ '@version': [{ _cnd: { gte: 1.1 } }] }),
+				},
 			});
 		});
 
@@ -261,13 +283,28 @@ describe('MiniMax Operations', () => {
 
 	describe('Video: textToVideo', () => {
 		it('should keep H3 parameters separate from legacy parameters', () => {
-			const modelProperty = videoT2VDescription.find(({ name }) => name === 'modelId');
+			const legacyModelProperty = videoT2VDescription.find(
+				({ name, default: defaultValue }) =>
+					name === 'modelId' && defaultValue === 'MiniMax-Hailuo-2.3',
+			);
+			const currentModelProperty = videoT2VDescription.find(
+				({ name, default: defaultValue }) => name === 'modelId' && defaultValue === 'MiniMax-H3',
+			);
 			const h3Duration = videoT2VDescription.find(({ name }) => name === 'h3Duration');
 			const legacyDuration = videoT2VDescription.find(({ name }) => name === 'duration');
 			const h3Resolution = videoT2VDescription.find(({ name }) => name === 'h3Resolution');
 			const legacyResolution = videoT2VDescription.find(({ name }) => name === 'resolution');
 
-			expect(modelProperty).toMatchObject({ default: 'MiniMax-H3' });
+			expect(legacyModelProperty).toMatchObject({
+				default: 'MiniMax-Hailuo-2.3',
+				displayOptions: { show: expect.objectContaining({ '@version': [1] }) },
+			});
+			expect(currentModelProperty).toMatchObject({
+				default: 'MiniMax-H3',
+				displayOptions: {
+					show: expect.objectContaining({ '@version': [{ _cnd: { gte: 1.1 } }] }),
+				},
+			});
 			expect(h3Duration).toMatchObject({ default: 5 });
 			expect(legacyDuration).toMatchObject({ default: 6 });
 			expect(h3Resolution).toMatchObject({ default: '2K' });
@@ -369,13 +406,28 @@ describe('MiniMax Operations', () => {
 
 	describe('Video: imageToVideo', () => {
 		it('should keep H3 parameters separate from legacy parameters', () => {
-			const modelProperty = videoI2VDescription.find(({ name }) => name === 'modelId');
+			const legacyModelProperty = videoI2VDescription.find(
+				({ name, default: defaultValue }) =>
+					name === 'modelId' && defaultValue === 'MiniMax-Hailuo-2.3',
+			);
+			const currentModelProperty = videoI2VDescription.find(
+				({ name, default: defaultValue }) => name === 'modelId' && defaultValue === 'MiniMax-H3',
+			);
 			const h3Duration = videoI2VDescription.find(({ name }) => name === 'h3Duration');
 			const legacyDuration = videoI2VDescription.find(({ name }) => name === 'duration');
 			const h3Resolution = videoI2VDescription.find(({ name }) => name === 'h3Resolution');
 			const legacyResolution = videoI2VDescription.find(({ name }) => name === 'resolution');
 
-			expect(modelProperty).toMatchObject({ default: 'MiniMax-H3' });
+			expect(legacyModelProperty).toMatchObject({
+				default: 'MiniMax-Hailuo-2.3',
+				displayOptions: { show: expect.objectContaining({ '@version': [1] }) },
+			});
+			expect(currentModelProperty).toMatchObject({
+				default: 'MiniMax-H3',
+				displayOptions: {
+					show: expect.objectContaining({ '@version': [{ _cnd: { gte: 1.1 } }] }),
+				},
+			});
 			expect(h3Duration).toMatchObject({ default: 5 });
 			expect(legacyDuration).toMatchObject({ default: 6 });
 			expect(h3Resolution).toMatchObject({ default: '2K' });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/operations.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/operations.test.ts
@@ -3,8 +3,7 @@ import { mock, mockDeep } from 'vitest-mock-extended';
 
 vi.mock('../transport', () => ({
 	apiRequest: vi.fn(),
-	pollVideoTask: vi.fn(),
-	getVideoDownloadUrl: vi.fn(),
+	generateVideo: vi.fn(),
 }));
 
 vi.mock('@utils/helpers', () => ({
@@ -26,16 +25,24 @@ vi.mock('n8n-workflow', async () => {
 
 import { execute as audioTTSExecute } from '../actions/audio/tts.operation';
 import { execute as imageGenerateExecute } from '../actions/image/generate.operation';
-import { execute as textMessageExecute } from '../actions/text/message.operation';
-import { execute as videoI2VExecute } from '../actions/video/generate.i2v.operation';
-import { execute as videoT2VExecute } from '../actions/video/generate.t2v.operation';
-import { apiRequest, pollVideoTask, getVideoDownloadUrl } from '../transport';
+import {
+	description as textMessageDescription,
+	execute as textMessageExecute,
+} from '../actions/text/message.operation';
+import {
+	description as videoI2VDescription,
+	execute as videoI2VExecute,
+} from '../actions/video/generate.i2v.operation';
+import {
+	description as videoT2VDescription,
+	execute as videoT2VExecute,
+} from '../actions/video/generate.t2v.operation';
+import { apiRequest, generateVideo } from '../transport';
 
 import type { Mock } from 'vitest';
 
 const mockApiRequest = apiRequest as Mock;
-const mockPollVideoTask = pollVideoTask as Mock;
-const mockGetVideoDownloadUrl = getVideoDownloadUrl as Mock;
+const mockGenerateVideo = generateVideo as Mock;
 
 describe('MiniMax Operations', () => {
 	let mockExecuteFunctions: ReturnType<typeof mock<IExecuteFunctions>>;
@@ -44,6 +51,14 @@ describe('MiniMax Operations', () => {
 		mockExecuteFunctions = mock<IExecuteFunctions>();
 		mockExecuteFunctions.getNodeInputs.mockReturnValue([{ type: 'main' }]);
 		mockExecuteFunctions.getExecutionCancelSignal.mockReturnValue(undefined);
+		mockExecuteFunctions.getNode.mockReturnValue({
+			id: 'test-node-id',
+			name: 'MiniMax',
+			type: '@n8n/n8n-nodes-langchain.minimax',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		});
 	});
 
 	afterEach(() => {
@@ -51,11 +66,20 @@ describe('MiniMax Operations', () => {
 	});
 
 	describe('Text: message', () => {
+		it('should default to MiniMax-M3', () => {
+			const modelProperty = textMessageDescription.find(({ name }) => name === 'modelId');
+
+			expect(modelProperty).toMatchObject({
+				default: 'MiniMax-M3',
+				options: expect.arrayContaining([{ name: 'MiniMax-M3', value: 'MiniMax-M3' }]),
+			});
+		});
+
 		it('should send correct request body and return simplified response', async () => {
 			mockExecuteFunctions.getNodeParameter.mockImplementation(
 				(param: string, _index: number, fallback?: any) => {
 					const params: Record<string, unknown> = {
-						modelId: 'MiniMax-M2.7',
+						modelId: 'MiniMax-M3',
 						'messages.values': [{ role: 'user', content: 'Hello' }],
 						options: { temperature: 0.7 },
 						simplify: true,
@@ -73,9 +97,9 @@ describe('MiniMax Operations', () => {
 
 			const result = await textMessageExecute.call(mockExecuteFunctions, 0);
 
-			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/chat/completions', {
+			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/v1/chat/completions', {
 				body: expect.objectContaining({
-					model: 'MiniMax-M2.7',
+					model: 'MiniMax-M3',
 					messages: [{ role: 'user', content: 'Hello' }],
 					reasoning_split: true,
 				}),
@@ -135,7 +159,7 @@ describe('MiniMax Operations', () => {
 
 			await textMessageExecute.call(mockExecuteFunctions, 0);
 
-			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/chat/completions', {
+			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/v1/chat/completions', {
 				body: expect.objectContaining({
 					messages: expect.arrayContaining([
 						{ role: 'system', content: 'You are a helpful assistant' },
@@ -170,7 +194,7 @@ describe('MiniMax Operations', () => {
 
 			const result = await imageGenerateExecute.call(mockExecuteFunctions, 0);
 
-			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/image_generation', {
+			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/v1/image_generation', {
 				body: expect.objectContaining({
 					model: 'image-01',
 					prompt: 'A sunset over mountains',
@@ -236,6 +260,74 @@ describe('MiniMax Operations', () => {
 	});
 
 	describe('Video: textToVideo', () => {
+		it('should keep H3 parameters separate from legacy parameters', () => {
+			const modelProperty = videoT2VDescription.find(({ name }) => name === 'modelId');
+			const h3Duration = videoT2VDescription.find(({ name }) => name === 'h3Duration');
+			const legacyDuration = videoT2VDescription.find(({ name }) => name === 'duration');
+			const h3Resolution = videoT2VDescription.find(({ name }) => name === 'h3Resolution');
+			const legacyResolution = videoT2VDescription.find(({ name }) => name === 'resolution');
+
+			expect(modelProperty).toMatchObject({ default: 'MiniMax-H3' });
+			expect(h3Duration).toMatchObject({ default: 5 });
+			expect(legacyDuration).toMatchObject({ default: 6 });
+			expect(h3Resolution).toMatchObject({ default: '2K' });
+			expect(legacyResolution).toMatchObject({ default: '768P' });
+		});
+
+		it('should create an H3 task through the V2 API', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'MiniMax-H3',
+						prompt: 'A cat playing with yarn',
+						h3Duration: 5,
+						h3Resolution: '2K',
+						duration: 10,
+						resolution: '1080P',
+						ratio: '16:9',
+						downloadVideo: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+			mockGenerateVideo.mockResolvedValue({
+				videoUrl: 'https://cdn.minimax.io/h3-video.mp4',
+				taskId: 'h3-task-1',
+			});
+
+			const result = await videoT2VExecute.call(mockExecuteFunctions, 0);
+
+			expect(mockGenerateVideo).toHaveBeenCalledWith('v2', {
+				model: 'MiniMax-H3',
+				content: [{ type: 'text', text: 'A cat playing with yarn' }],
+				duration: 5,
+				resolution: '2K',
+				ratio: '16:9',
+			});
+			expect(result[0].json).toEqual({
+				videoUrl: 'https://cdn.minimax.io/h3-video.mp4',
+				taskId: 'h3-task-1',
+			});
+		});
+
+		it('should reject an empty H3 prompt before making a request', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'MiniMax-H3',
+						prompt: ' ',
+						downloadVideo: false,
+					};
+					return params[param] ?? fallback;
+				},
+			);
+
+			await expect(videoT2VExecute.call(mockExecuteFunctions, 0)).rejects.toThrow(
+				'Prompt is required for MiniMax-H3 video generation',
+			);
+			expect(mockGenerateVideo).not.toHaveBeenCalled();
+		});
+
 		it('should create task, poll until success, and return video URL', async () => {
 			mockExecuteFunctions.getNodeParameter.mockImplementation(
 				(param: string, _index: number, fallback?: any) => {
@@ -251,25 +343,20 @@ describe('MiniMax Operations', () => {
 				},
 			);
 
-			mockApiRequest.mockResolvedValue({
-				task_id: 'video-task-1',
-				base_resp: { status_code: 0, status_msg: 'success' },
+			mockGenerateVideo.mockResolvedValue({
+				videoUrl: 'https://cdn.minimax.io/video.mp4',
+				taskId: 'video-task-1',
+				fileId: 'file-abc',
 			});
-
-			mockPollVideoTask.mockResolvedValue({ fileId: 'file-abc', status: 'Success' });
-			mockGetVideoDownloadUrl.mockResolvedValue('https://cdn.minimax.io/video.mp4');
 
 			const result = await videoT2VExecute.call(mockExecuteFunctions, 0);
 
-			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/video_generation', {
-				body: expect.objectContaining({
-					model: 'MiniMax-Hailuo-2.3',
-					prompt: 'A cat playing with yarn',
-					duration: 6,
-					resolution: '768P',
-				}),
+			expect(mockGenerateVideo).toHaveBeenCalledWith('v1', {
+				model: 'MiniMax-Hailuo-2.3',
+				prompt: 'A cat playing with yarn',
+				duration: 6,
+				resolution: '768P',
 			});
-			expect(mockPollVideoTask).toHaveBeenCalledWith('video-task-1');
 			expect(result[0].json).toEqual(
 				expect.objectContaining({
 					videoUrl: 'https://cdn.minimax.io/video.mp4',
@@ -281,6 +368,134 @@ describe('MiniMax Operations', () => {
 	});
 
 	describe('Video: imageToVideo', () => {
+		it('should keep H3 parameters separate from legacy parameters', () => {
+			const modelProperty = videoI2VDescription.find(({ name }) => name === 'modelId');
+			const h3Duration = videoI2VDescription.find(({ name }) => name === 'h3Duration');
+			const legacyDuration = videoI2VDescription.find(({ name }) => name === 'duration');
+			const h3Resolution = videoI2VDescription.find(({ name }) => name === 'h3Resolution');
+			const legacyResolution = videoI2VDescription.find(({ name }) => name === 'resolution');
+
+			expect(modelProperty).toMatchObject({ default: 'MiniMax-H3' });
+			expect(h3Duration).toMatchObject({ default: 5 });
+			expect(legacyDuration).toMatchObject({ default: 6 });
+			expect(h3Resolution).toMatchObject({ default: '2K' });
+			expect(legacyResolution).toMatchObject({ default: '768P' });
+		});
+
+		it('should create an H3 task with first and last frames through the V2 API', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'MiniMax-H3',
+						imageInputType: 'url',
+						imageUrl: 'https://example.com/first.png',
+						prompt: 'A bird taking flight',
+						h3Duration: 5,
+						h3Resolution: '2K',
+						downloadVideo: false,
+						options: {
+							lastFrameInputType: 'url',
+							lastFrameImageUrl: 'https://example.com/last.png',
+						},
+					};
+					return params[param] ?? fallback;
+				},
+			);
+			mockGenerateVideo.mockResolvedValue({
+				videoUrl: 'https://cdn.minimax.io/h3-i2v-video.mp4',
+				taskId: 'h3-i2v-task-1',
+			});
+
+			const result = await videoI2VExecute.call(mockExecuteFunctions, 0);
+
+			expect(mockGenerateVideo).toHaveBeenCalledWith('v2', {
+				model: 'MiniMax-H3',
+				content: [
+					{ type: 'text', text: 'A bird taking flight' },
+					{
+						type: 'image_url',
+						image_url: { url: 'https://example.com/first.png' },
+						role: 'first_frame',
+					},
+					{
+						type: 'image_url',
+						image_url: { url: 'https://example.com/last.png' },
+						role: 'last_frame',
+					},
+				],
+				duration: 5,
+				resolution: '2K',
+				ratio: 'adaptive',
+			});
+			expect(result[0].json).toEqual({
+				videoUrl: 'https://cdn.minimax.io/h3-i2v-video.mp4',
+				taskId: 'h3-i2v-task-1',
+			});
+		});
+
+		it('should reject an empty H3 prompt inherited from a legacy workflow', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'MiniMax-H3',
+						imageInputType: 'url',
+						imageUrl: 'https://example.com/first.png',
+						prompt: '',
+						downloadVideo: false,
+						options: {},
+					};
+					return params[param] ?? fallback;
+				},
+			);
+
+			await expect(videoI2VExecute.call(mockExecuteFunctions, 0)).rejects.toThrow(
+				'Prompt is required for MiniMax-H3 video generation',
+			);
+			expect(mockGenerateVideo).not.toHaveBeenCalled();
+		});
+
+		it('should send H3 binary image input as a data URL', async () => {
+			const deepMock = mockDeep<IExecuteFunctions>();
+			deepMock.getNodeParameter.mockImplementation(
+				(param: string, _index: number, fallback?: any) => {
+					const params: Record<string, unknown> = {
+						modelId: 'MiniMax-H3',
+						imageInputType: 'binary',
+						binaryPropertyName: 'data',
+						prompt: 'A bird taking flight',
+						h3Duration: 5,
+						h3Resolution: '2K',
+						downloadVideo: false,
+						options: {},
+					};
+					return params[param] ?? fallback;
+				},
+			);
+			deepMock.helpers.assertBinaryData.mockReturnValue(
+				mock<IBinaryData>({ mimeType: 'image/png', data: '' }),
+			);
+			deepMock.helpers.getBinaryDataBuffer.mockResolvedValue(Buffer.from('image'));
+			mockGenerateVideo.mockResolvedValue({
+				videoUrl: 'https://cdn.minimax.io/h3-i2v-video.mp4',
+				taskId: 'h3-i2v-task-1',
+			});
+
+			await videoI2VExecute.call(deepMock, 0);
+
+			expect(mockGenerateVideo).toHaveBeenCalledWith(
+				'v2',
+				expect.objectContaining({
+					content: expect.arrayContaining([
+						{
+							type: 'image_url',
+							image_url: { url: 'data:image/png;base64,aW1hZ2U=' },
+							role: 'first_frame',
+						},
+					]),
+				}),
+			);
+		});
+
 		it('should create task with image URL input and return video URL', async () => {
 			mockExecuteFunctions.getNodeParameter.mockImplementation(
 				(param: string, _index: number, fallback?: any) => {
@@ -298,22 +513,20 @@ describe('MiniMax Operations', () => {
 				},
 			);
 
-			mockApiRequest.mockResolvedValue({
-				task_id: 'i2v-task-1',
-				base_resp: { status_code: 0, status_msg: 'success' },
+			mockGenerateVideo.mockResolvedValue({
+				videoUrl: 'https://cdn.minimax.io/i2v-video.mp4',
+				taskId: 'i2v-task-1',
+				fileId: 'file-i2v',
 			});
-
-			mockPollVideoTask.mockResolvedValue({ fileId: 'file-i2v', status: 'Success' });
-			mockGetVideoDownloadUrl.mockResolvedValue('https://cdn.minimax.io/i2v-video.mp4');
 
 			const result = await videoI2VExecute.call(mockExecuteFunctions, 0);
 
-			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/video_generation', {
-				body: expect.objectContaining({
-					model: 'MiniMax-Hailuo-2.3',
-					first_frame_image: 'https://example.com/frame.png',
-					prompt: 'A bird taking flight',
-				}),
+			expect(mockGenerateVideo).toHaveBeenCalledWith('v1', {
+				model: 'MiniMax-Hailuo-2.3',
+				first_frame_image: 'https://example.com/frame.png',
+				prompt: 'A bird taking flight',
+				duration: 6,
+				resolution: '768P',
 			});
 			expect(result[0].json).toEqual(
 				expect.objectContaining({
@@ -353,7 +566,7 @@ describe('MiniMax Operations', () => {
 
 			const result = await audioTTSExecute.call(mockExecuteFunctions, 0);
 
-			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/t2a_v2', {
+			expect(mockApiRequest).toHaveBeenCalledWith('POST', '/v1/t2a_v2', {
 				body: expect.objectContaining({
 					model: 'speech-2.8-hd',
 					text: 'Hello world',

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/operations.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/operations.test.ts
@@ -88,6 +88,10 @@ describe('MiniMax Operations', () => {
 					show: expect.objectContaining({ '@version': [1] }),
 				},
 			});
+			expect(legacyModelProperty?.options).not.toContainEqual({
+				name: 'MiniMax-M3',
+				value: 'MiniMax-M3',
+			});
 			expect(currentModelProperty).toMatchObject({
 				default: 'MiniMax-M3',
 				options: expect.arrayContaining([{ name: 'MiniMax-M3', value: 'MiniMax-M3' }]),

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/operations.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/operations.test.ts
@@ -37,6 +37,7 @@ import {
 	description as videoT2VDescription,
 	execute as videoT2VExecute,
 } from '../actions/video/generate.t2v.operation';
+import { prepareVideoOutput } from '../actions/video/helpers';
 import { versionDescription } from '../actions/versionDescription';
 import { apiRequest, generateVideo } from '../transport';
 
@@ -71,6 +72,57 @@ describe('MiniMax Operations', () => {
 			version: [1, 1.1],
 			defaultVersion: 1.1,
 		});
+	});
+
+	it('should preserve downloaded V1 video output', async () => {
+		const executeFunctions = mockDeep<IExecuteFunctions>();
+		const videoBuffer = Buffer.from('fake-video-data');
+		const binaryData: IBinaryData = {
+			mimeType: 'video/mp4',
+			fileType: 'video',
+			fileExtension: 'mp4',
+			data: '',
+			fileName: 'video.mp4',
+		};
+		executeFunctions.helpers.httpRequest.mockResolvedValue({
+			body: videoBuffer,
+			headers: { 'content-type': 'video/mp4' },
+		});
+		executeFunctions.helpers.prepareBinaryData.mockResolvedValue(binaryData);
+
+		const result = await prepareVideoOutput(
+			executeFunctions,
+			0,
+			{
+				videoUrl: 'https://cdn.minimax.io/video.mp4',
+				taskId: 'task-v1',
+				fileId: 'file-v1',
+			},
+			true,
+		);
+
+		expect(executeFunctions.helpers.httpRequest).toHaveBeenCalledWith({
+			method: 'GET',
+			url: 'https://cdn.minimax.io/video.mp4',
+			encoding: 'arraybuffer',
+			returnFullResponse: true,
+		});
+		expect(executeFunctions.helpers.prepareBinaryData).toHaveBeenCalledWith(
+			videoBuffer,
+			'video.mp4',
+			'video/mp4',
+		);
+		expect(result).toEqual([
+			{
+				binary: { data: binaryData },
+				json: {
+					videoUrl: 'https://cdn.minimax.io/video.mp4',
+					taskId: 'task-v1',
+					fileId: 'file-v1',
+				},
+				pairedItem: { item: 0 },
+			},
+		]);
 	});
 
 	describe('Text: message', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/transport.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/transport.test.ts
@@ -2,7 +2,13 @@ import { mockDeep } from 'vitest-mock-extended';
 import type { IExecuteFunctions } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-import { apiRequest, pollVideoTask, getVideoDownloadUrl } from '../transport';
+import {
+	apiRequest,
+	generateVideo,
+	pollVideoTask,
+	pollVideoTaskV2,
+	getVideoDownloadUrl,
+} from '../transport';
 
 vi.mock('@n8n/utils/sleep', () => ({
 	sleep: vi.fn(),
@@ -36,7 +42,7 @@ describe('MiniMax Transport', () => {
 			const mockResponse = { choices: [{ message: { content: 'hello' } }] };
 			mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue(mockResponse);
 
-			const result = await apiRequest.call(mockExecuteFunctions, 'POST', '/chat/completions', {
+			const result = await apiRequest.call(mockExecuteFunctions, 'POST', '/v1/chat/completions', {
 				body: { model: 'MiniMax-M2.7', messages: [] },
 			});
 
@@ -55,7 +61,7 @@ describe('MiniMax Transport', () => {
 		it('should pass through query string parameters', async () => {
 			mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue({});
 
-			await apiRequest.call(mockExecuteFunctions, 'GET', '/query/video_generation', {
+			await apiRequest.call(mockExecuteFunctions, 'GET', '/v1/query/video_generation', {
 				qs: { task_id: 'task-123' },
 			});
 
@@ -76,12 +82,38 @@ describe('MiniMax Transport', () => {
 			});
 			mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue({});
 
-			await apiRequest.call(mockExecuteFunctions, 'GET', '/files/retrieve');
+			await apiRequest.call(mockExecuteFunctions, 'GET', '/v1/files/retrieve');
 
 			expect(mockExecuteFunctions.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
 				'minimaxApi',
 				expect.objectContaining({
 					url: 'https://api.minimaxi.com/v1/files/retrieve',
+				}),
+			);
+		});
+	});
+
+	describe('versioned API URLs', () => {
+		it.each([
+			['https://api.minimax.io/v1', 'https://api.minimax.io/v2/video_generation'],
+			['https://api.minimaxi.com/v1', 'https://api.minimaxi.com/v2/video_generation'],
+		])('should derive the V2 URL from %s', async (credentialUrl, expectedUrl) => {
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				apiKey: 'test-key',
+				url: credentialUrl,
+			});
+			mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue({});
+
+			await apiRequest.call(mockExecuteFunctions, 'POST', '/v2/video_generation', {
+				body: { model: 'MiniMax-H3' },
+			});
+
+			expect(mockExecuteFunctions.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+				'minimaxApi',
+				expect.objectContaining({
+					method: 'POST',
+					url: expectedUrl,
+					body: { model: 'MiniMax-H3' },
 				}),
 			);
 		});
@@ -129,6 +161,98 @@ describe('MiniMax Transport', () => {
 			await expect(pollVideoTask.call(mockExecuteFunctions, 'task-timeout', 0)).rejects.toThrow(
 				/did not complete within the maximum polling time/,
 			);
+		});
+	});
+
+	describe('pollVideoTaskV2', () => {
+		it('should return video URL when task status is succeeded', async () => {
+			mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue({
+				task: {
+					status: 'succeeded',
+					content: { url: 'https://cdn.minimax.io/videos/h3.mp4' },
+				},
+			});
+
+			const result = await pollVideoTaskV2.call(mockExecuteFunctions, 'task-h3', 0);
+
+			expect(result).toEqual({
+				videoUrl: 'https://cdn.minimax.io/videos/h3.mp4',
+				status: 'succeeded',
+			});
+			expect(mockExecuteFunctions.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+				'minimaxApi',
+				expect.objectContaining({
+					method: 'GET',
+					url: 'https://api.minimax.io/v2/query/video_generation/task-h3',
+				}),
+			);
+		});
+
+		it('should throw NodeOperationError when task status is failed', async () => {
+			mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue({
+				task: {
+					status: 'failed',
+					error: { code: '1026', message: 'Content rejected' },
+				},
+			});
+
+			await expect(pollVideoTaskV2.call(mockExecuteFunctions, 'task-h3', 0)).rejects.toThrow(
+				'Task failed: [1026] Content rejected',
+			);
+		});
+
+		it('should throw timeout error when max poll attempts are exceeded', async () => {
+			mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue({
+				task: { status: 'running' },
+			});
+
+			await expect(pollVideoTaskV2.call(mockExecuteFunctions, 'task-timeout', 0)).rejects.toThrow(
+				/did not complete within the maximum polling time/,
+			);
+		});
+	});
+
+	describe('generateVideo', () => {
+		it('should create and resolve a V2 video task', async () => {
+			mockExecuteFunctions.helpers.httpRequestWithAuthentication
+				.mockResolvedValueOnce({ task_id: 'task-h3' })
+				.mockResolvedValueOnce({
+					task: {
+						status: 'succeeded',
+						content: { url: 'https://cdn.minimax.io/videos/h3.mp4' },
+					},
+				});
+
+			const result = await generateVideo.call(mockExecuteFunctions, 'v2', {
+				model: 'MiniMax-H3',
+			});
+
+			expect(result).toEqual({
+				videoUrl: 'https://cdn.minimax.io/videos/h3.mp4',
+				taskId: 'task-h3',
+			});
+		});
+
+		it('should preserve the V1 file ID output', async () => {
+			mockExecuteFunctions.helpers.httpRequestWithAuthentication
+				.mockResolvedValueOnce({
+					task_id: 'task-v1',
+					base_resp: { status_code: 0, status_msg: 'success' },
+				})
+				.mockResolvedValueOnce({ status: 'Success', file_id: 'file-v1' })
+				.mockResolvedValueOnce({
+					file: { download_url: 'https://cdn.minimax.io/videos/v1.mp4' },
+				});
+
+			const result = await generateVideo.call(mockExecuteFunctions, 'v1', {
+				model: 'MiniMax-Hailuo-2.3',
+			});
+
+			expect(result).toEqual({
+				videoUrl: 'https://cdn.minimax.io/videos/v1.mp4',
+				taskId: 'task-v1',
+				fileId: 'file-v1',
+			});
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/transport.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/test/transport.test.ts
@@ -201,6 +201,15 @@ describe('MiniMax Transport', () => {
 			);
 		});
 
+		it('should stop polling when execution is cancelled', async () => {
+			const abortController = new AbortController();
+			abortController.abort();
+			mockExecuteFunctions.getExecutionCancelSignal.mockReturnValue(abortController.signal);
+
+			await expect(pollVideoTaskV2.call(mockExecuteFunctions, 'task-h3', 0)).rejects.toThrow();
+			expect(mockExecuteFunctions.helpers.httpRequestWithAuthentication).not.toHaveBeenCalled();
+		});
+
 		it('should throw timeout error when max poll attempts are exceeded', async () => {
 			mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue({
 				task: { status: 'running' },

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/transport/index.ts
@@ -7,6 +7,12 @@ import type {
 import { sleep } from '@n8n/utils/sleep';
 import { NodeOperationError } from 'n8n-workflow';
 
+import type {
+	VideoGenerationResponse,
+	VideoGenerationV2Response,
+	VideoTaskV2QueryResponse,
+} from '../helpers/interfaces';
+
 type RequestParameters = {
 	headers?: IDataObject;
 	body?: IDataObject;
@@ -23,7 +29,8 @@ export async function apiRequest(
 	const { body, qs, option, headers } = parameters ?? {};
 
 	const credentials = await this.getCredentials('minimaxApi');
-	const baseUrl = (credentials.url as string) ?? 'https://api.minimax.io/v1';
+	const versionedBaseUrl = (credentials.url as string) ?? 'https://api.minimax.io/v1';
+	const baseUrl = versionedBaseUrl.replace(/\/v1\/?$/, '');
 	const url = `${baseUrl}${endpoint}`;
 
 	const options = {
@@ -43,6 +50,7 @@ export async function apiRequest(
 }
 
 const VIDEO_TERMINAL_STATUSES = ['Success', 'Fail'];
+const VIDEO_V2_TERMINAL_STATUSES = ['succeeded', 'failed', 'cancelled'];
 const DEFAULT_POLL_INTERVAL_MS = 15_000;
 const MAX_POLL_ATTEMPTS = 60;
 
@@ -52,7 +60,7 @@ export async function pollVideoTask(
 	pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
 ): Promise<{ fileId: string; status: string }> {
 	for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
-		const response = await apiRequest.call(this, 'GET', '/query/video_generation', {
+		const response = await apiRequest.call(this, 'GET', '/v1/query/video_generation', {
 			qs: { task_id: taskId },
 		});
 
@@ -85,11 +93,52 @@ export async function pollVideoTask(
 	);
 }
 
+export async function pollVideoTaskV2(
+	this: IExecuteFunctions,
+	taskId: string,
+	pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
+): Promise<{ videoUrl: string; status: string }> {
+	for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+		const response = (await apiRequest.call(
+			this,
+			'GET',
+			`/v2/query/video_generation/${taskId}`,
+		)) as VideoTaskV2QueryResponse;
+		const task = response.task;
+		const status = task?.status;
+
+		if (status && VIDEO_V2_TERMINAL_STATUSES.includes(status)) {
+			if (status !== 'succeeded') {
+				const errorCode = task.error?.code ?? 'UNKNOWN';
+				const errorMessage = task.error?.message ?? `Video generation task was ${status}`;
+				throw new NodeOperationError(this.getNode(), `Task failed: [${errorCode}] ${errorMessage}`);
+			}
+
+			const videoUrl = task.content?.url;
+			if (!videoUrl) {
+				throw new NodeOperationError(
+					this.getNode(),
+					'Video generation succeeded but no video URL was returned',
+				);
+			}
+
+			return { videoUrl, status };
+		}
+
+		await sleep(pollIntervalMs);
+	}
+
+	throw new NodeOperationError(
+		this.getNode(),
+		`Video task ${taskId} did not complete within the maximum polling time. You can query the task manually using the task ID.`,
+	);
+}
+
 export async function getVideoDownloadUrl(
 	this: IExecuteFunctions,
 	fileId: string,
 ): Promise<string> {
-	const response = await apiRequest.call(this, 'GET', '/files/retrieve', {
+	const response = await apiRequest.call(this, 'GET', '/v1/files/retrieve', {
 		qs: { file_id: fileId },
 	});
 
@@ -102,4 +151,48 @@ export async function getVideoDownloadUrl(
 	}
 
 	return downloadUrl;
+}
+
+export async function generateVideo(
+	this: IExecuteFunctions,
+	apiVersion: 'v1' | 'v2',
+	body: IDataObject,
+): Promise<{ videoUrl: string; taskId: string; fileId?: string }> {
+	if (apiVersion === 'v2') {
+		const response = (await apiRequest.call(this, 'POST', '/v2/video_generation', {
+			body,
+		})) as VideoGenerationV2Response;
+		const taskId = response.task_id;
+		if (!taskId) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'No task_id returned from video generation request',
+			);
+		}
+
+		const { videoUrl } = await pollVideoTaskV2.call(this, taskId);
+		return { videoUrl, taskId };
+	}
+
+	const response = (await apiRequest.call(this, 'POST', '/v1/video_generation', {
+		body,
+	})) as VideoGenerationResponse;
+	if (response.base_resp?.status_code !== 0) {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Failed to create video task: ${response.base_resp?.status_msg || 'Unknown error'}`,
+		);
+	}
+
+	const taskId = response.task_id;
+	if (!taskId) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'No task_id returned from video generation request',
+		);
+	}
+
+	const { fileId } = await pollVideoTask.call(this, taskId);
+	const videoUrl = await getVideoDownloadUrl.call(this, fileId);
+	return { videoUrl, taskId, fileId };
 }

--- a/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/MiniMax/transport/index.ts
@@ -98,7 +98,11 @@ export async function pollVideoTaskV2(
 	taskId: string,
 	pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
 ): Promise<{ videoUrl: string; status: string }> {
+	const abortSignal = this.getExecutionCancelSignal();
+
 	for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+		abortSignal?.throwIfAborted();
+
 		const response = (await apiRequest.call(
 			this,
 			'GET',
@@ -125,7 +129,7 @@ export async function pollVideoTaskV2(
 			return { videoUrl, status };
 		}
 
-		await sleep(pollIntervalMs);
+		await sleep(pollIntervalMs, abortSignal);
 	}
 
 	throw new NodeOperationError(


### PR DESCRIPTION
## Summary

- Add `MiniMax-M3` to both MiniMax language-model surfaces and make it the default for new nodes
- Add `MiniMax-H3` text-to-video and image-to-video support through the V2 video API while preserving existing V1 workflows
- Keep H3-specific parameters isolated from legacy model parameters and share video request, polling, and output handling
- Keep the model options as a hardcoded list, which is expected for the node today; migrate to API-driven model discovery if MiniMax provides a stable, suitable endpoint in the future

## Testing

Fully tested locally (both `1` and `1.1`):
<img width="336" height="394" alt="Screenshot 2026-08-10 at 12 50 39" src="https://github.com/user-attachments/assets/17246987-18de-44fe-9b9c-e7a23e463690" />

<img width="704" height="423" alt="Screenshot 2026-08-10 at 12 53 42" src="https://github.com/user-attachments/assets/e0fe588a-5c8d-413d-bcca-a6b497de193a" />

Workflow:

<details>
<summary>Importable M3/H3 test workflow</summary>

Configure MiniMax credentials on the three MiniMax nodes after importing.

```json
{
  "nodes": [
    {
      "parameters": {},
      "id": "3cb4ea92-3ac6-4842-9dd6-517093948f60",
      "name": "Run Latest Model Tests",
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [-560, 320]
    },
    {
      "parameters": {
        "modelId": "MiniMax-M3",
        "messages": {
          "values": [
            {
              "content": "What is the capital of France? Answer in one sentence."
            }
          ]
        },
        "options": {
          "hideThinking": true,
          "maxTokens": 256,
          "temperature": 0.7
        }
      },
      "id": "2a8284d8-dabe-4d73-9e49-245050aff907",
      "name": "Text: MiniMax M3",
      "type": "@n8n/n8n-nodes-langchain.minimax",
      "typeVersion": 1.1,
      "position": [-280, 160]
    },
    {
      "parameters": {
        "resource": "video",
        "modelId": "MiniMax-H3",
        "prompt": "A cat stretching and yawning on a sunny windowsill, camera slowly zooms in",
        "h3Duration": 5,
        "h3Resolution": "2K",
        "ratio": "16:9",
        "downloadVideo": false
      },
      "id": "cd542007-8266-45b5-a0d2-d1ee760d60f2",
      "name": "Video T2V: MiniMax H3",
      "type": "@n8n/n8n-nodes-langchain.minimax",
      "typeVersion": 1.1,
      "position": [-280, 320]
    },
    {
      "parameters": {
        "resource": "video",
        "operation": "imageToVideo",
        "modelId": "MiniMax-H3",
        "imageInputType": "url",
        "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg",
        "prompt": "The cat looks toward the camera and blinks naturally",
        "h3Duration": 5,
        "h3Resolution": "2K",
        "downloadVideo": false,
        "options": {}
      },
      "id": "ff86d05f-b5d4-4cb9-a4c3-bdb97d67ec60",
      "name": "Video I2V: MiniMax H3",
      "type": "@n8n/n8n-nodes-langchain.minimax",
      "typeVersion": 1.1,
      "position": [-280, 480]
    }
  ],
  "connections": {
    "Run Latest Model Tests": {
      "main": [
        [
          {
            "node": "Text: MiniMax M3",
            "type": "main",
            "index": 0
          },
          {
            "node": "Video T2V: MiniMax H3",
            "type": "main",
            "index": 0
          },
          {
            "node": "Video I2V: MiniMax H3",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {}
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-227

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->