### PR TITLE
chore: Align dev environments to Postgres 18 (no-changelog)

### DIFF
--- a/.devcontainer/codespaces/docker-compose.yml
+++ b/.devcontainer/codespaces/docker-compose.yml
@@ -3,10 +3,10 @@ volumes:
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=n8n
       - POSTGRES_PASSWORD=password

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,10 +3,10 @@ volumes:
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=n8n
       - POSTGRES_PASSWORD=password

--- a/packages/@n8n/benchmark/scripts/n8n-setups/postgres/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/postgres/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${MOCK_API_DATA_PATH}/mappings:/home/wiremock/mappings
 
   postgres:
-    image: postgres:16.4
+    image: postgres:18.4
     restart: always
     user: root:root
     environment:

--- a/packages/@n8n/benchmark/scripts/n8n-setups/scaling-multi-main/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/scaling-multi-main/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       timeout: 3s
 
   postgres:
-    image: postgres:16.4
+    image: postgres:18.4
     restart: always
     environment:
       - POSTGRES_DB=n8n

--- a/packages/@n8n/benchmark/scripts/n8n-setups/scaling-single-main/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8n-setups/scaling-single-main/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       timeout: 3s
 
   postgres:
-    image: postgres:16.4
+    image: postgres:18.4
     user: root:root
     restart: always
     environment:


### PR DESCRIPTION
## Summary

Aligns the dev environments to the newest supported Postgres major (18), per the Postgres version policy:

- **Devcontainer** and **Codespaces** composes: `postgres:16-alpine` → `postgres:18-alpine`
- **Benchmark setups** (`postgres`, `scaling-single-main`, `scaling-multi-main`): `postgres:16.4` → `postgres:18.4`

The devcontainer/Codespaces volume mount moves from `/var/lib/postgresql/data` to `/var/lib/postgresql`: the `postgres:18` image keeps `PGDATA` under `/var/lib/postgresql/<major>` and declares its volume at the parent, so mounting the old data path would silently stop persisting data. The benchmark setups set `PGDATA` explicitly, which 18 still honors, so they only needed the tag bump.

⚠️ Existing devcontainer volumes hold PG16 data, which PG18 cannot open — rebuilding the devcontainer starts with a fresh database (dev-only data). New Codespaces are unaffected.

## How to test

Verified locally with real container boots:

- Devcontainer compose (throwaway project): PG 18.4 healthy, wrote a marker row, restarted the container, row persisted, cluster located at `/var/lib/postgresql/18` on the named volume (confirms the mount fix).
- Benchmark `postgres` setup with a temp `RUN_DIR`: PG 18.4 initializes into the explicit `PGDATA` bind mount with no entrypoint errors.

To reproduce: `docker compose -f .devcontainer/docker-compose.yml up postgres`, then `psql -U postgres -d n8n -c 'select version()'`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-692

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

