### PR TITLE
fix(core): Time out and recover stalled Instance AI runs

### DIFF
--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -120,6 +120,10 @@ export {
 	throwIfAborted,
 } from './sdk/abort';
 export {
+	DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS,
+	ModelStreamStallError,
+} from './runtime/streaming/stream-stall';
+export {
 	APPROVAL_RESUME_SCHEMA,
 	APPROVAL_SUSPEND_SCHEMA,
 	Tool,

--- a/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
@@ -14,6 +14,11 @@ import { fromAiFinishReason, fromAiMessages } from '../model/messages';
 import { createRawErrorReader, type RawErrorReader } from '../model/raw-error';
 import { createRawUsageReader, type RawUsageReader } from '../model/raw-usage';
 import { convertChunk, toTokenUsage } from '../streaming/stream';
+import {
+	DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS,
+	raceWithStallDeadline,
+	withChunkIdleTimeout,
+} from '../streaming/stream-stall';
 import type { StreamWriterGuard } from '../streaming/stream-writer-guard';
 import type { ToolCallBatchResult } from '../tools/tool-call-executor';
 
@@ -111,13 +116,33 @@ export class StreamSink implements RunOutputSink<void> {
 		// raw stream — no error, no content — so raw chunks are required to
 		// explain an otherwise silent empty response.
 		this.rawErrorReader = createRawErrorReader(this.services.modelId);
+		const idleMs = this.options?.modelStreamIdleTimeoutMs ?? DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS;
+		// Per-turn controller chained to the run signal: a stall must be able to
+		// cancel this turn's fetch (releasing the socket the 1h network timeout
+		// would otherwise hold) without touching the run-level signal.
+		const turnAbort = new AbortController();
+		const onRunAbort = () => turnAbort.abort();
+		if (ctx.abortSignal.aborted) turnAbort.abort();
+		else ctx.abortSignal.addEventListener('abort', onRunAbort, { once: true });
+		try {
+			return await this.streamModelTurn(ctx, turnAbort, idleMs);
+		} finally {
+			ctx.abortSignal.removeEventListener('abort', onRunAbort);
+		}
+	}
+
+	private async streamModelTurn(
+		ctx: ModelCallContext,
+		turnAbort: AbortController,
+		idleMs: number,
+	): Promise<ModelTurnResult> {
 		const { streamText } = loadAi();
 		const result = streamText({
 			model: ctx.model,
 			instructions: ctx.system,
 			messages: ctx.messages,
 			allowSystemInMessages: true,
-			abortSignal: ctx.abortSignal,
+			abortSignal: turnAbort.signal,
 			...(ctx.reasoning ? { reasoning: ctx.reasoning } : {}),
 			// Surface the provider's raw message_start/message_delta events so an
 			// aborted run can recover its usage — the SDK reports none on abort.
@@ -131,10 +156,18 @@ export class StreamSink implements RunOutputSink<void> {
 			...this.buildSmoothStreamTransformOptions(),
 		});
 
+		// A healthy streaming response emits chunks continuously (raw provider
+		// events included), so prolonged silence means the connection or provider
+		// is wedged — fail the turn instead of hanging until the network timeout.
+		const chunkStream =
+			idleMs > 0
+				? withChunkIdleTimeout(result.stream, idleMs, () => turnAbort.abort())
+				: result.stream;
+
 		// Consume the stream. When the AbortSignal fires mid-stream the AI SDK
 		// cancels the underlying fetch and the async iterator throws; the error
 		// propagates to the StreamSession which closes the consumer stream.
-		for await (const chunk of result.stream) {
+		for await (const chunk of chunkStream) {
 			// Track usage from raw provider events so an aborted turn (which never
 			// reaches the post-loop awaits) can still be billed via getTerminalFinish.
 			if (chunk.type === 'raw') {
@@ -179,10 +212,18 @@ export class StreamSink implements RunOutputSink<void> {
 			}
 		}
 
-		const aiFinishReason = await result.finishReason;
-		const usage = await result.usage;
-		const providerMetadata = await result.providerMetadata;
-		const response = await result.response;
+		// The result promises settle as part of stream close on a healthy turn;
+		// guard them with the same stall deadline so an SDK-internal promise that
+		// never settles cannot hang the turn after the chunk loop ended.
+		const settle = async <T>(promise: PromiseLike<T>): Promise<T> =>
+			idleMs > 0
+				? await raceWithStallDeadline(promise, idleMs, () => turnAbort.abort())
+				: await promise;
+
+		const aiFinishReason = await settle(result.finishReason);
+		const usage = await settle(result.usage);
+		const providerMetadata = await settle(result.providerMetadata);
+		const response = await settle(result.response);
 		const newMessages = fromAiMessages(response.messages);
 		const errorReason = classifyModelTurnError({
 			aiFinishReason,
@@ -195,9 +236,9 @@ export class StreamSink implements RunOutputSink<void> {
 			finishReason: fromAiFinishReason(aiFinishReason),
 			usage: toTokenUsage(usage, providerMetadata),
 			newMessages,
-			toolCalls: await result.toolCalls,
+			toolCalls: await settle(result.toolCalls),
 			structuredOutput:
-				ctx.outputSpec && aiFinishReason !== 'tool-calls' ? await result.output : undefined,
+				ctx.outputSpec && aiFinishReason !== 'tool-calls' ? await settle(result.output) : undefined,
 			...(errorReason && { errorReason }),
 		};
 	}

--- a/packages/@n8n/agents/src/runtime/streaming/__tests__/stream-stall.test.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/__tests__/stream-stall.test.ts
@@ -1,0 +1,134 @@
+import {
+	ModelStreamStallError,
+	raceWithStallDeadline,
+	withChunkIdleTimeout,
+} from '../stream-stall';
+
+describe('withChunkIdleTimeout', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('passes chunks through and completes with the source', async () => {
+		async function* source() {
+			yield await Promise.resolve(1);
+			yield 2;
+			yield 3;
+		}
+		const seen: number[] = [];
+
+		for await (const chunk of withChunkIdleTimeout(source(), 60_000, () => {})) {
+			seen.push(chunk);
+		}
+
+		expect(seen).toEqual([1, 2, 3]);
+	});
+
+	it('accepts sync iterables, mirroring for-await semantics', async () => {
+		function* source() {
+			yield 'a';
+			yield 'b';
+		}
+		const seen: string[] = [];
+
+		for await (const chunk of withChunkIdleTimeout(source(), 60_000, () => {})) {
+			seen.push(chunk);
+		}
+
+		expect(seen).toEqual(['a', 'b']);
+	});
+
+	it('fails with a stall error and aborts the source when a chunk never arrives', async () => {
+		const onStall = vi.fn();
+		const gate = new Promise<number>(() => {});
+		async function* source() {
+			yield 1;
+			yield await gate;
+		}
+		const iterator = withChunkIdleTimeout(source(), 60_000, onStall);
+
+		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
+
+		// Capture the outcome with a synchronously attached handler so the
+		// rejection is never unhandled while the fake timers advance.
+		const stalled = iterator.next().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		await vi.advanceTimersByTimeAsync(59_999);
+		expect(onStall).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+
+		await expect(stalled).resolves.toBeInstanceOf(ModelStreamStallError);
+		expect(onStall).toHaveBeenCalledTimes(1);
+	});
+
+	it('resets the idle window on every chunk', async () => {
+		let release!: (value: number) => void;
+		async function* source() {
+			yield 1;
+			yield await new Promise<number>((resolve) => {
+				release = resolve;
+			});
+			yield 3;
+		}
+		const iterator = withChunkIdleTimeout(source(), 60_000, () => {});
+
+		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
+
+		const pending = iterator.next();
+		// Just under the deadline the read is still allowed to settle…
+		await vi.advanceTimersByTimeAsync(59_000);
+		release(2);
+		await expect(pending).resolves.toEqual({ done: false, value: 2 });
+
+		// …and the next read gets a fresh window rather than the stale timer.
+		const after = iterator.next();
+		await vi.advanceTimersByTimeAsync(59_000);
+		await expect(after).resolves.toEqual({ done: false, value: 3 });
+	});
+
+	it('propagates source errors unchanged', async () => {
+		async function* source(): AsyncGenerator<number> {
+			yield await Promise.resolve(1);
+			throw new Error('provider exploded');
+		}
+		const iterator = withChunkIdleTimeout(source(), 60_000, () => {});
+
+		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
+		await expect(iterator.next()).rejects.toThrow('provider exploded');
+	});
+});
+
+describe('raceWithStallDeadline', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('resolves with the promise when it settles in time', async () => {
+		await expect(raceWithStallDeadline(Promise.resolve('ok'), 60_000)).resolves.toBe('ok');
+	});
+
+	it('rejects with a stall error and notifies when the promise never settles', async () => {
+		const onStall = vi.fn();
+		// Capture the outcome with a synchronously attached handler so the
+		// rejection is never unhandled while the fake timers advance.
+		const settled = raceWithStallDeadline(new Promise<never>(() => {}), 60_000, onStall).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		await expect(settled).resolves.toBeInstanceOf(ModelStreamStallError);
+		expect(onStall).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
@@ -1,0 +1,92 @@
+/**
+ * Chunk-idle stall detection for model streams.
+ *
+ * The AI transport raises undici's network idle timeouts to one hour so long
+ * completions and slow non-streaming calls are not cut off — which means a
+ * dead connection (half-open socket, a proxy that keeps the wire warm without
+ * forwarding data) can hang a streaming turn for that long. Streaming
+ * responses emit deltas continuously, so extended silence *between chunks* is
+ * the reliable liveness signal the network layer cannot see. These helpers
+ * fail the turn fast with a typed, user-explainable error instead.
+ */
+
+export const DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS = 5 * 60_000;
+
+export class ModelStreamStallError extends Error {
+	constructor(idleMs: number) {
+		super(
+			`The model stream stalled: no data received for ${Math.round(idleMs / 1000)} seconds. ` +
+				'This is usually a transient connection issue — please try again.',
+		);
+		this.name = 'ModelStreamStallError';
+	}
+}
+
+/** Resolve the iterator the way `for await` would: async first, sync fallback. */
+function getChunkIterator<T>(
+	source: AsyncIterable<T> | Iterable<T>,
+): AsyncIterator<T> | Iterator<T> {
+	if (Symbol.asyncIterator in source) return source[Symbol.asyncIterator]();
+	return source[Symbol.iterator]();
+}
+
+/**
+ * Yield chunks from `source`, throwing {@link ModelStreamStallError} when no
+ * chunk arrives within `idleMs`. `onStall` fires first so the caller can abort
+ * the underlying request (releasing the socket and settling the abandoned
+ * read). The abandoned read's eventual rejection is swallowed — the stall
+ * error is the one the caller reports.
+ */
+export async function* withChunkIdleTimeout<T>(
+	source: AsyncIterable<T> | Iterable<T>,
+	idleMs: number,
+	onStall: () => void,
+): AsyncGenerator<T> {
+	const iterator = getChunkIterator(source);
+	try {
+		while (true) {
+			const next = Promise.resolve(iterator.next());
+			// If the deadline wins, the losing read settles later — without a
+			// handler its rejection would surface as an unhandled rejection.
+			next.catch(() => undefined);
+			const result = await raceWithStallDeadline(next, idleMs, onStall);
+			if (result.done) return;
+			yield result.value;
+		}
+	} finally {
+		// Fire-and-forget: a wedged source's teardown may itself never settle,
+		// and awaiting it here would block the stall error on the very hang this
+		// wrapper exists to break. `onStall` already aborted the underlying
+		// request, which is what actually reclaims the socket.
+		void Promise.resolve()
+			.then(async () => await iterator.return?.())
+			.catch(() => undefined);
+	}
+}
+
+/**
+ * Await `promise` with the same stall deadline. Used for the SDK's post-stream
+ * result promises (`finishReason`, `usage`, `response`, …), which settle
+ * instantly on a healthy stream but would otherwise be an unguarded await.
+ */
+export async function raceWithStallDeadline<T>(
+	promise: PromiseLike<T>,
+	idleMs: number,
+	onStall?: () => void,
+): Promise<T> {
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => {
+					onStall?.();
+					reject(new ModelStreamStallError(idleMs));
+				}, idleMs);
+				timer.unref?.();
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -188,6 +188,14 @@ export interface ExecutionOptions {
 	 * streaming raw provider events that nothing consumes.
 	 */
 	recoverUsageOnAbort?: boolean;
+	/**
+	 * Max silence in milliseconds between model stream chunks before the turn
+	 * fails with a stall error. Healthy streaming responses emit chunks
+	 * continuously, so prolonged chunk silence means a dead connection that the
+	 * long AI network timeouts (raised to 1h for slow non-streaming calls) would
+	 * otherwise keep open. 0 disables. Defaults to 5 minutes.
+	 */
+	modelStreamIdleTimeoutMs?: number;
 	/** Inherited telemetry from a host runtime. */
 	telemetry?: BuiltTelemetry;
 	/** Inherited execution counter from the host runtime. Used for aggregate heartbeat telemetry. */

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -152,6 +152,10 @@ export class InstanceAiConfig {
 	@Env('N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT')
 	confirmationTimeout: number = 24 * Time.hours.toMilliseconds;
 
+	/** Idle timeout in milliseconds for active runs. A run that produces no stream chunks and publishes no thread events for this long is treated as stalled and cancelled. 0 = no idle timeout. */
+	@Env('N8N_INSTANCE_AI_ACTIVE_RUN_IDLE_TIMEOUT')
+	activeRunIdleTimeout: number = 10 * Time.minutes.toMilliseconds;
+
 	/** Scan and redact secrets/PII from agent output before it reaches the user. */
 	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_ENABLED')
 	outputRedactionEnabled: boolean = true;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -351,6 +351,7 @@ describe('GlobalConfig', () => {
 			snapshotRetention: 86_400_000,
 			checkpointGcRetention: 604_800_000,
 			confirmationTimeout: 86_400_000,
+			activeRunIdleTimeout: 600_000,
 			outputRedactionEnabled: true,
 			outputRedactionSecrets: true,
 			outputRedactionPii: 'credit-card',

--- a/packages/@n8n/instance-ai/src/runtime/__tests__/liveness-policy.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/liveness-policy.test.ts
@@ -12,7 +12,7 @@ function createPolicy() {
 }
 
 describe('InstanceAiLivenessPolicy', () => {
-	it('keeps default liveness limits centralized and allows the existing confirmation override', () => {
+	it('keeps default liveness limits centralized and allows the supported overrides', () => {
 		expect(INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG).toEqual({
 			confirmationTimeoutMs: day,
 			backgroundTaskIdleTimeoutMs: 10 * minute,
@@ -24,6 +24,11 @@ describe('InstanceAiLivenessPolicy', () => {
 		expect(createInstanceAiLivenessPolicyConfig({ confirmationTimeoutMs: 42_000 })).toEqual({
 			...INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG,
 			confirmationTimeoutMs: 42_000,
+		});
+
+		expect(createInstanceAiLivenessPolicyConfig({ activeRunIdleTimeoutMs: 10 * minute })).toEqual({
+			...INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG,
+			activeRunIdleTimeoutMs: 10 * minute,
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/runtime/__tests__/run-state-registry.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/run-state-registry.test.ts
@@ -1117,6 +1117,26 @@ describe('RunStateRegistry', () => {
 		});
 	});
 
+	// ── touchActiveRunForRun ──────────────────────────────────────────────────
+
+	describe('touchActiveRunForRun', () => {
+		it('touches activity only when the event belongs to the active run', () => {
+			const { runId } = registry.startRun({ threadId: 'thread-1', user: { id: 'u1', name: 'A' } });
+			registry.touchActiveRun('thread-1', 0);
+
+			// Another run's events (e.g. a background task) must not mask a stall.
+			expect(registry.touchActiveRunForRun('thread-1', 'run_other', 20_000)).toBe(false);
+			expect(registry.sweepTimedOut(policy, 30_000).activeThreadIds).toEqual(['thread-1']);
+
+			expect(registry.touchActiveRunForRun('thread-1', runId, 20_000)).toBe(true);
+			expect(registry.sweepTimedOut(policy, 30_000).activeThreadIds).toEqual([]);
+		});
+
+		it('returns false when the thread has no active run', () => {
+			expect(registry.touchActiveRunForRun('thread-1', 'run_abc')).toBe(false);
+		});
+	});
+
 	// ── sweepTimedOut ─────────────────────────────────────────────────────────
 
 	describe('sweepTimedOut', () => {

--- a/packages/@n8n/instance-ai/src/runtime/liveness-policy.ts
+++ b/packages/@n8n/instance-ai/src/runtime/liveness-policy.ts
@@ -26,7 +26,9 @@ export const INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG = {
 } satisfies InstanceAiLivenessPolicyConfig;
 
 export function createInstanceAiLivenessPolicyConfig(
-	overrides: Partial<Pick<InstanceAiLivenessPolicyConfig, 'confirmationTimeoutMs'>> = {},
+	overrides: Partial<
+		Pick<InstanceAiLivenessPolicyConfig, 'confirmationTimeoutMs' | 'activeRunIdleTimeoutMs'>
+	> = {},
 ): InstanceAiLivenessPolicyConfig {
 	return {
 		...INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG,

--- a/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
+++ b/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
@@ -372,6 +372,20 @@ export class RunStateRegistry<TUser = unknown> {
 		return true;
 	}
 
+	/**
+	 * Touch activity only when the given run is the thread's active run. Used by
+	 * the event-bus publish tap: tool bodies (builders, sub-agents) publish
+	 * progress events directly without streaming chunks, and those must count as
+	 * liveness — but events from other runs on the thread (e.g. a background
+	 * task) must not keep a wedged foreground run alive.
+	 */
+	touchActiveRunForRun(threadId: string, runId: string, at = Date.now()): boolean {
+		const active = this.activeRuns.get(threadId);
+		if (!active || active.runId !== runId) return false;
+		active.lastActivityAt = at;
+		return true;
+	}
+
 	touchSuspendedRun(threadId: string, at = Date.now()): boolean {
 		const suspended = this.suspendedRuns.get(threadId);
 		if (!suspended) return false;

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts
@@ -81,6 +81,7 @@ function createLivenessService() {
 		(_suspended: TestSuspendedRun, _reason: string) => {},
 	);
 	const onPendingConfirmationRejected = vi.fn((_requestId: string) => {});
+	const onActiveRunTimedOut = vi.fn((_threadId: string) => {});
 	const logger = mock<Logger>();
 
 	const service = new InstanceAiLivenessService<TestSuspendedRun>({
@@ -91,6 +92,7 @@ function createLivenessService() {
 		eventBus,
 		finalizeCancelledSuspendedRun,
 		onPendingConfirmationRejected,
+		onActiveRunTimedOut,
 		logger,
 	});
 
@@ -102,6 +104,7 @@ function createLivenessService() {
 		eventBus,
 		finalizeCancelledSuspendedRun,
 		onPendingConfirmationRejected,
+		onActiveRunTimedOut,
 		logger,
 	};
 }
@@ -116,6 +119,7 @@ describe('InstanceAiLivenessService', () => {
 			eventBus,
 			finalizeCancelledSuspendedRun,
 			onPendingConfirmationRejected,
+			onActiveRunTimedOut,
 		} = createLivenessService();
 		const activeAbortController = new AbortController();
 		const suspendedAbortController = new AbortController();
@@ -169,6 +173,10 @@ describe('InstanceAiLivenessService', () => {
 		expect(runState.cancelSuspendedRun).toHaveBeenCalledWith('thread-suspended');
 		expect(activeAbortController.signal.aborted).toBe(true);
 		expect(suspendedAbortController.signal.aborted).toBe(true);
+		// Abort-immune runs need the deferred terminalization scheduled — but only
+		// for active runs; suspended runs settle via finalizeCancelledSuspendedRun.
+		expect(onActiveRunTimedOut).toHaveBeenCalledWith('thread-active');
+		expect(onActiveRunTimedOut).not.toHaveBeenCalledWith('thread-suspended');
 		expect(finalizeCancelledSuspendedRun).toHaveBeenCalledWith(
 			suspended,
 			INSTANCE_AI_RUN_TIMEOUT_REASON,

--- a/packages/cli/src/modules/instance-ai/event-bus/__tests__/in-process-event-bus.test.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/__tests__/in-process-event-bus.test.ts
@@ -142,6 +142,27 @@ describe('InProcessEventBus', () => {
 		});
 	});
 
+	describe('onPublish', () => {
+		it('notifies listeners for every published event and survives listener throws', () => {
+			const seen: Array<{ threadId: string; runId: string }> = [];
+			bus.onPublish(() => {
+				throw new Error('listener boom');
+			});
+			bus.onPublish((threadId, event) => seen.push({ threadId, runId: event.runId }));
+
+			bus.publish('thread-1', makeEvent('a', 'run_1'));
+			bus.publish('thread-2', makeEvent('b', 'run_2'));
+
+			expect(seen).toEqual([
+				{ threadId: 'thread-1', runId: 'run_1' },
+				{ threadId: 'thread-2', runId: 'run_2' },
+			]);
+			// The throwing listener must not break publishing itself.
+			expect(bus.getEventsAfter('thread-1', 0)).toHaveLength(1);
+			expect(bus.getEventsAfter('thread-2', 0)).toHaveLength(1);
+		});
+	});
+
 	describe('publish (multi-main, shared sequence)', () => {
 		beforeEach(() => {
 			instanceSettings = { isMultiMain: true };

--- a/packages/cli/src/modules/instance-ai/event-bus/__tests__/interrupted-run-sweeper.test.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/__tests__/interrupted-run-sweeper.test.ts
@@ -351,6 +351,16 @@ describe('InterruptedRunSweeper.cancelUnfinishedRuns', () => {
 		expect(metrics.sweep.runsCrashResumed).toBe(0);
 	});
 
+	it('stamps a caller-provided finish reason (liveness-timeout fallback)', async () => {
+		const { sweeper, published } = buildSweeper({ events: [runStart()] });
+
+		expect(await sweeper.cancelUnfinishedRuns(THREAD, 'timeout')).toBe(1);
+
+		const finish = published.at(-1);
+		expect(finish?.type === 'run-finish' && finish.payload.status).toBe('cancelled');
+		expect(finish?.type === 'run-finish' && finish.payload.reason).toBe('timeout');
+	});
+
 	it('terminalizes orphaned spawned children as cancelled without an error', async () => {
 		const { sweeper, published } = buildSweeper({
 			events: [runStart(), agentSpawned('child-orphaned')],

--- a/packages/cli/src/modules/instance-ai/event-bus/in-process-event-bus.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/in-process-event-bus.ts
@@ -63,6 +63,9 @@ export class InProcessEventBus implements InstanceAiEventBus {
 
 	private readonly drainingThreads = new Set<string>();
 
+	/** Synchronous observers of every locally published event (see `onPublish`). */
+	private readonly publishListeners: Array<(threadId: string, event: InstanceAiEvent) => void> = [];
+
 	private readonly seqKeyPrefix: string;
 
 	private readonly durableLogEnabled: boolean;
@@ -110,6 +113,13 @@ export class InProcessEventBus implements InstanceAiEventBus {
 		// it too.
 		if (event.ts === undefined) {
 			event = { ...event, ts: Date.now() };
+		}
+		for (const listener of this.publishListeners) {
+			try {
+				listener(threadId, event);
+			} catch (error) {
+				this.logger.warn('Instance AI event publish listener failed', { threadId, error });
+			}
 		}
 		if (this.durableLogEnabled) {
 			this.eventLog.publish(threadId, event, (drained) => this.onDrained(threadId, drained));
@@ -348,6 +358,16 @@ export class InProcessEventBus implements InstanceAiEventBus {
 			return;
 		}
 		this.storeAndEmit(threadId, { id: storedEvent.id, event: storedEvent.event });
+	}
+
+	/**
+	 * Observe every event published on this main, before sequencing/persistence.
+	 * Unlike `subscribe`, this is not thread-scoped and never sees relayed
+	 * sibling events — it exists for local liveness tracking (any event a run
+	 * body publishes proves the run is making progress).
+	 */
+	onPublish(listener: (threadId: string, event: InstanceAiEvent) => void): void {
+		this.publishListeners.push(listener);
 	}
 
 	subscribe(threadId: string, handler: (storedEvent: StoredEvent) => void): () => void {

--- a/packages/cli/src/modules/instance-ai/event-bus/interrupted-run-sweeper.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/interrupted-run-sweeper.ts
@@ -152,8 +152,11 @@ export class InterruptedRunSweeper {
 	 * run-finish moments later. Both facts carry `cancelled`, the fold is
 	 * idempotent on repeats, and the terminal-fact recheck below narrows the
 	 * window — a per-run claim would need the lease table this design avoids.
+	 *
+	 * Also invoked (with reason `timeout`) as the deferred fallback after the
+	 * liveness sweep aborts an idle-timed-out run whose body never settled.
 	 */
-	async cancelUnfinishedRuns(threadId: string): Promise<number> {
+	async cancelUnfinishedRuns(threadId: string, reason = 'user_cancelled'): Promise<number> {
 		if (!this.durableLogEnabled) return 0;
 
 		let unfinished;
@@ -169,7 +172,7 @@ export class InterruptedRunSweeper {
 			try {
 				const inFlightToolCalls = await this.resolveZombieRun(threadId, run.runId, {
 					status: 'cancelled',
-					reason: 'user_cancelled',
+					reason,
 				});
 				if (inFlightToolCalls === null) continue;
 				resolved++;

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -681,6 +681,7 @@ export class InstanceAiService {
 		});
 		const livenessPolicyConfig = createInstanceAiLivenessPolicyConfig({
 			confirmationTimeoutMs: this.instanceAiConfig.confirmationTimeout,
+			activeRunIdleTimeoutMs: this.instanceAiConfig.activeRunIdleTimeout,
 		});
 		this.liveness = new InstanceAiLivenessService<SuspendedRunState<User>>({
 			policy: new InstanceAiLivenessPolicy(livenessPolicyConfig),
@@ -695,6 +696,15 @@ export class InstanceAiService {
 			onPendingConfirmationRejected: (requestId) => {
 				void this.suspendedThreads.dropPendingConfirmation(requestId);
 			},
+			onActiveRunTimedOut: (threadId) => this.scheduleTimedOutRunResolution(threadId),
+		});
+		// Liveness for active runs is chunk-driven (`onActivity` in the stream
+		// options), but tool bodies — builders, sub-agents — publish progress
+		// events directly without streaming chunks. Count those as activity too,
+		// scoped to the active run's own events, so a 15-minute build isn't
+		// mistaken for a stall while a genuinely wedged run stays silent.
+		this.eventBus.onPublish((threadId, event) => {
+			this.runState.touchActiveRunForRun(threadId, event.runId);
 		});
 		this.tracing = new InstanceAiTracingService({
 			logger: this.logger,
@@ -1194,6 +1204,37 @@ export class InstanceAiService {
 		}
 
 		void this.suspendedThreads.dropPendingConfirmationsForThread(threadId);
+	}
+
+	/**
+	 * Fallback terminalization for a timed-out active run whose abort never
+	 * lands. The abort normally makes the run body publish its own `run-finish`
+	 * within seconds; a run wedged in an await that ignores the signal never
+	 * does, and the durable log would then keep rendering it as running on
+	 * every reload. After a settle window, append terminal facts for whatever
+	 * is still unfinished on the thread. The delay exceeds the sweeper's
+	 * multi-main activity grace so the timeout notice published at abort time
+	 * doesn't read as sibling liveness.
+	 */
+	private scheduleTimedOutRunResolution(threadId: string): void {
+		const settleWindowMs = InterruptedRunSweeper.LIVENESS_GRACE_MS + 30_000;
+		const timer = setTimeout(() => {
+			void (async () => {
+				// Settle the drain first so a run that finalized during the window
+				// cannot be misread as unfinished and given a second terminal fact.
+				await this.eventLog.flush(threadId);
+				await this.interruptedRunSweeper.cancelUnfinishedRuns(
+					threadId,
+					INSTANCE_AI_RUN_TIMEOUT_REASON,
+				);
+			})().catch((error) => {
+				this.logger.warn('Failed to terminalize a timed-out Instance AI run', {
+					threadId,
+					error: getErrorMessage(error),
+				});
+			});
+		}, settleWindowMs);
+		timer.unref();
 	}
 
 	/** Send a correction message to a running background task. */

--- a/packages/cli/src/modules/instance-ai/liveness/instance-ai-liveness.service.ts
+++ b/packages/cli/src/modules/instance-ai/liveness/instance-ai-liveness.service.ts
@@ -91,6 +91,13 @@ export type InstanceAiLivenessServiceOptions<
 	eventBus: InstanceAiLivenessEventBus;
 	finalizeCancelledSuspendedRun: (suspended: TSuspendedRun, reason: string) => void;
 	onPendingConfirmationRejected?: (requestId: string) => void;
+	/**
+	 * Invoked after a timed-out active run has been aborted. The abort normally
+	 * makes the run body publish its own terminal facts, but a run wedged in an
+	 * await that ignores the signal never does — the callback schedules the
+	 * fallback terminalization for that case.
+	 */
+	onActiveRunTimedOut?: (threadId: string) => void;
 	logger: Logger;
 };
 
@@ -221,6 +228,7 @@ export class InstanceAiLivenessService<
 		this.timedOutActiveRunThreads.add(threadId);
 		this.publishRunTimeoutNotice(threadId, active.runId);
 		active.abortController.abort();
+		this.options.onActiveRunTimedOut?.(threadId);
 	}
 
 	cancelTimedOutSuspendedRun(threadId: string, details?: InstanceAiRunTimeoutDetails): void {


### PR DESCRIPTION
## Summary

Fixes the "AI Assistant session stuck indefinitely" class of hangs (e.g. wedged on a "Loading node schema" task) in two layers: prevent the hang at its source, and guarantee recovery for anything that still wedges.

### Root cause

`createAiProxyFetch` raises undici's network idle timeouts (`headersTimeout`/`bodyTimeout`) from the 5-minute default to **one hour** so slow non-streaming AI calls are not cut off. For a *streaming* turn this is the bug: `bodyTimeout` is idle-time-between-bytes, and healthy streams emit continuously — so a dead connection (half-open socket, or a proxy that keeps the wire warm without forwarding data) hangs the turn for an hour, or indefinitely. Nothing above the socket had a timeout either: active runs had `activeRunIdleTimeoutMs: 0`, stop could not reach an await that ignores the signal, and reload faithfully rebuilt the open task card from the durable log with a reset frontend timer.

### Layer 1 — prevention (`@n8n/agents`)

- Chunk-idle watchdog around model stream consumption (default 5 min, `ExecutionOptions.modelStreamIdleTimeoutMs`, `0` = off): prolonged chunk silence aborts the turn's fetch and fails the turn with a typed `ModelStreamStallError` ("…usually a transient connection issue — please try again") instead of hanging. This also catches the case network timeouts can never see: a proxy trickling keepalive bytes over a dead upstream.
- The SDK's post-stream result awaits (`finishReason`, `usage`, `response`, …) are guarded by the same deadline, so an unsettled internal promise cannot hang a turn after the chunk loop ends.
- Each turn runs on a per-turn `AbortController` chained to the run signal, so a stall cancels its own fetch without touching the run scope.

### Layer 2 — recovery (`packages/cli` instance-ai)

- Enable the dormant idle timeout for active runs (default 10 min, `N8N_INSTANCE_AI_ACTIVE_RUN_IDLE_TIMEOUT`, `0` = off). The per-minute liveness sweep already knew how to abort, notify ("run stopped making progress"), and skip HITL-waiting threads — the limit was just hard-coded to 0.
- Count tool-body event publishes as run activity via a new `onPublish` tap, scoped to the active run's own events: builders and sub-agents publish progress without streaming chunks, so a legitimate 15-minute build is not mistaken for a stall, while a background task cannot keep a wedged foreground run alive.
- After a timeout abort, if the run body never settles (abort-immune wedge), the interrupted-run sweeper's zombie resolution appends the terminal facts (reason `timeout`) after a settle window — the durable log converges and reloads stop rendering a running task card.

Layer 1 turns the known hang into a fast, retryable, user-visible error; layer 2 bounds every hang class — including ones not discovered yet — at ~10 minutes with a guaranteed terminal state.

Not covered here (own tickets): stop-button delivery reliability (INS-1090); the non-streaming `generateText` path still relies on the 1h network timeout plus the run/background-task liveness nets.

## How to test

Unit coverage: `stream-stall` (new, incl. sync-iterable parity and stall abort), `agent-runtime`/`crash-resume`/`provider-quirks`/`stream` regression suites (752 tests), `liveness-policy`, `run-state-registry`, `instance-ai-liveness.service`, `in-process-event-bus`, `interrupted-run-sweeper`, `config` defaults.

Manual: start an assistant run and suspend the outbound LLM connection mid-stream (drop the network after the first tool call streams). Within 5 minutes the run fails with "The model stream stalled…" and the thread is immediately usable; with `N8N_INSTANCE_AI_ACTIVE_RUN_IDLE_TIMEOUT=60000` and the watchdog disabled (`modelStreamIdleTimeoutMs: 0`), the liveness net cancels the run instead. Reloading shows a settled run in both cases, not a running card with a reset timer.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1096

Related (not closed by this PR): INS-1090 (stop reliability), INS-1072 (same missing-timeout shape).