### PR TITLE
chore: Update codespace scope if missing on pnpm session

### DIFF
--- a/scripts/cloud-session.mjs
+++ b/scripts/cloud-session.mjs
@@ -19,9 +19,23 @@ const FALLBACK_MACHINE = 'standardLinux32gb'; // 4-core/16GB, until org policy a
 const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8' }).trim();
 const ghTty = (...args) => spawnSync('gh', args, { stdio: 'inherit' });
 
-function findCodespace() {
-	const list = JSON.parse(gh('codespace', 'list', '-R', REPO, '--json', 'name,state'));
-	return list[0];
+function findCodespace(retry = false) {
+	try {
+		const list = JSON.parse(gh('codespace', 'list', '-R', REPO, '--json', 'name,state'));
+		return list[0];
+	} catch (ex) {
+		if (ex.message.includes('This API operation needs the "codespace" scope') && !retry) {
+			requestCodespaceScope();
+			return findCodespace(true);
+		} else {
+			throw new Error(ex.message);
+		}
+	}
+}
+
+function requestCodespaceScope() {
+	console.log("Requesting codespace scope");
+	ghTty("auth", "refresh", "-h", "github.com", "-s", "codespace")
 }
 
 function ensureCodespace() {


### PR DESCRIPTION
## Summary

Fixes a small DX issue in codespace setup when scopes are missing. Makes the command truly one-line setup instead of having the user configure and run commands to fix issues.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

