### PR TITLE
fix(core): Fail stalled Instance AI model streams fast instead of hanging

### DIFF
--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -120,6 +120,7 @@ export {
 	throwIfAborted,
 } from './sdk/abort';
 export {
+	DEFAULT_MODEL_STREAM_FIRST_OUTPUT_TIMEOUT_MS,
 	DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS,
 	ModelStreamStallError,
 } from './runtime/streaming/stream-stall';

--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -120,6 +120,10 @@ export {
 	throwIfAborted,
 } from './sdk/abort';
 export {
+	DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS,
+	ModelStreamStallError,
+} from './runtime/streaming/stream-stall';
+export {
 	APPROVAL_RESUME_SCHEMA,
 	APPROVAL_SUSPEND_SCHEMA,
 	Tool,

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -7756,7 +7756,10 @@ describe('AgentRuntime — model stream stall handling', () => {
 			.mockReturnValueOnce(makeStreamSuccess('Recovered'));
 		const { runtime } = createRuntime();
 
-		const result = await runtime.stream('hi', { modelStreamIdleTimeoutMs: 50 });
+		const result = await runtime.stream('hi', {
+			modelStreamIdleTimeoutMs: 50,
+			modelStreamFirstOutputTimeoutMs: 50,
+		});
 		const chunks = await collectChunks(result.stream);
 
 		expect(streamText).toHaveBeenCalledTimes(2);
@@ -7783,7 +7786,10 @@ describe('AgentRuntime — model stream stall handling', () => {
 			.mockReturnValue(makeStreamSuccess('should-not-run'));
 		const { runtime } = createRuntime();
 
-		const result = await runtime.stream('hi', { modelStreamIdleTimeoutMs: 50 });
+		const result = await runtime.stream('hi', {
+			modelStreamIdleTimeoutMs: 50,
+			modelStreamFirstOutputTimeoutMs: 50,
+		});
 		const chunks = await collectChunks(result.stream);
 
 		expect(streamText).toHaveBeenCalledTimes(1);
@@ -7798,7 +7804,10 @@ describe('AgentRuntime — model stream stall handling', () => {
 		streamText.mockReturnValueOnce(makeStalledStream()).mockReturnValueOnce(makeStalledStream());
 		const { runtime } = createRuntime();
 
-		const result = await runtime.stream('hi', { modelStreamIdleTimeoutMs: 50 });
+		const result = await runtime.stream('hi', {
+			modelStreamIdleTimeoutMs: 50,
+			modelStreamFirstOutputTimeoutMs: 50,
+		});
 		const chunks = await collectChunks(result.stream);
 
 		expect(streamText).toHaveBeenCalledTimes(2);

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -7726,3 +7726,86 @@ describe('AgentRuntime — oversized tool results', () => {
 		expect(fileBlock).toMatchObject({ type: 'file', mediaType: 'text/plain', data: fileData });
 	});
 });
+
+// ---------------------------------------------------------------------------
+// model stream stall handling
+// ---------------------------------------------------------------------------
+
+describe('AgentRuntime — model stream stall handling', () => {
+	beforeEach(() => {
+		streamText.mockReset();
+	});
+
+	/** streamText response that emits `chunks` then goes silent — a dead connection. */
+	function makeStalledStream(chunks: Array<Record<string, unknown>> = []) {
+		return {
+			stream: (async function* () {
+				for (const c of chunks) yield await Promise.resolve(c);
+				await new Promise(() => {});
+			})(),
+			finishReason: new Promise(() => {}),
+			usage: new Promise(() => {}),
+			response: new Promise(() => {}),
+			toolCalls: new Promise(() => {}),
+		};
+	}
+
+	it('silently retries a turn that stalls before any content and completes', async () => {
+		streamText
+			.mockReturnValueOnce(makeStalledStream())
+			.mockReturnValueOnce(makeStreamSuccess('Recovered'));
+		const { runtime } = createRuntime();
+
+		const result = await runtime.stream('hi', { modelStreamIdleTimeoutMs: 50 });
+		const chunks = await collectChunks(result.stream);
+
+		expect(streamText).toHaveBeenCalledTimes(2);
+		const finish = chunks.filter((c) => c.type === 'finish').at(-1) as
+			| (StreamChunk & { type: 'finish'; finishReason: string })
+			| undefined;
+		expect(finish?.finishReason).toBe('stop');
+		const text = chunks
+			.filter(
+				(c): c is StreamChunk & { type: 'text-delta'; delta: string } => c.type === 'text-delta',
+			)
+			.map((c) => c.delta)
+			.join('');
+		expect(text).toBe('Recovered');
+		expect(runtime.getState().status).toBe('success');
+	});
+
+	it('fails without retry when the stalled turn already streamed content', async () => {
+		streamText
+			.mockReturnValueOnce(
+				makeStalledStream([{ type: 'text-delta', id: 'text-1', text: 'partial' }]),
+			)
+			// A wrongly-taken retry completes loudly instead of hanging the test.
+			.mockReturnValue(makeStreamSuccess('should-not-run'));
+		const { runtime } = createRuntime();
+
+		const result = await runtime.stream('hi', { modelStreamIdleTimeoutMs: 50 });
+		const chunks = await collectChunks(result.stream);
+
+		expect(streamText).toHaveBeenCalledTimes(1);
+		const errorChunk = chunks.find((c) => c.type === 'error') as
+			| (StreamChunk & { type: 'error'; error: unknown })
+			| undefined;
+		expect(String(errorChunk?.error)).toContain('stalled');
+		expect(runtime.getState().status).toBe('failed');
+	});
+
+	it('surfaces the stall error when the retry stalls too', async () => {
+		streamText.mockReturnValueOnce(makeStalledStream()).mockReturnValueOnce(makeStalledStream());
+		const { runtime } = createRuntime();
+
+		const result = await runtime.stream('hi', { modelStreamIdleTimeoutMs: 50 });
+		const chunks = await collectChunks(result.stream);
+
+		expect(streamText).toHaveBeenCalledTimes(2);
+		const errorChunk = chunks.find((c) => c.type === 'error') as
+			| (StreamChunk & { type: 'error'; error: unknown })
+			| undefined;
+		expect(String(errorChunk?.error)).toContain('stalled');
+		expect(runtime.getState().status).toBe('failed');
+	});
+});

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -7736,8 +7736,13 @@ describe('AgentRuntime — model stream stall handling', () => {
 		streamText.mockReset();
 	});
 
-	/** streamText response that emits `chunks` then goes silent — a dead connection. */
+	/**
+	 * streamText response that emits `chunks` then goes silent — a dead
+	 * connection. Always leads with the SDK's synthetic `start` lifecycle chunk,
+	 * which arrives before any provider byte and must not count as content.
+	 */
 	function makeStalledStream(chunks: Array<Record<string, unknown>> = []) {
+		chunks = [{ type: 'start' }, ...chunks];
 		return {
 			stream: (async function* () {
 				for (const c of chunks) yield await Promise.resolve(c);

--- a/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
@@ -14,6 +14,11 @@ import { fromAiFinishReason, fromAiMessages } from '../model/messages';
 import { createRawErrorReader, type RawErrorReader } from '../model/raw-error';
 import { createRawUsageReader, type RawUsageReader } from '../model/raw-usage';
 import { convertChunk, toTokenUsage } from '../streaming/stream';
+import {
+	DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS,
+	raceWithStallDeadline,
+	withChunkIdleTimeout,
+} from '../streaming/stream-stall';
 import type { StreamWriterGuard } from '../streaming/stream-writer-guard';
 import type { ToolCallBatchResult } from '../tools/tool-call-executor';
 
@@ -111,13 +116,33 @@ export class StreamSink implements RunOutputSink<void> {
 		// raw stream — no error, no content — so raw chunks are required to
 		// explain an otherwise silent empty response.
 		this.rawErrorReader = createRawErrorReader(this.services.modelId);
+		const idleMs = this.options?.modelStreamIdleTimeoutMs ?? DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS;
+		// Per-turn controller chained to the run signal: a stall must be able to
+		// cancel this turn's fetch (releasing the socket the 1h network timeout
+		// would otherwise hold) without touching the run-level signal.
+		const turnAbort = new AbortController();
+		const onRunAbort = () => turnAbort.abort();
+		if (ctx.abortSignal.aborted) turnAbort.abort();
+		else ctx.abortSignal.addEventListener('abort', onRunAbort, { once: true });
+		try {
+			return await this.streamModelTurn(ctx, turnAbort, idleMs);
+		} finally {
+			ctx.abortSignal.removeEventListener('abort', onRunAbort);
+		}
+	}
+
+	private async streamModelTurn(
+		ctx: ModelCallContext,
+		turnAbort: AbortController,
+		idleMs: number,
+	): Promise<ModelTurnResult> {
 		const { streamText } = loadAi();
 		const result = streamText({
 			model: ctx.model,
 			instructions: ctx.system,
 			messages: ctx.messages,
 			allowSystemInMessages: true,
-			abortSignal: ctx.abortSignal,
+			abortSignal: turnAbort.signal,
 			...(ctx.reasoning ? { reasoning: ctx.reasoning } : {}),
 			// Surface the provider's raw message_start/message_delta events so an
 			// aborted run can recover its usage — the SDK reports none on abort.
@@ -131,10 +156,18 @@ export class StreamSink implements RunOutputSink<void> {
 			...this.buildSmoothStreamTransformOptions(),
 		});
 
+		// A healthy streaming response emits chunks continuously (raw provider
+		// events included), so prolonged silence means the connection or provider
+		// is wedged — fail the turn instead of hanging until the network timeout.
+		const chunkStream =
+			idleMs > 0
+				? withChunkIdleTimeout(result.stream, idleMs, () => turnAbort.abort())
+				: result.stream;
+
 		// Consume the stream. When the AbortSignal fires mid-stream the AI SDK
 		// cancels the underlying fetch and the async iterator throws; the error
 		// propagates to the StreamSession which closes the consumer stream.
-		for await (const chunk of result.stream) {
+		for await (const chunk of chunkStream) {
 			// Track usage from raw provider events so an aborted turn (which never
 			// reaches the post-loop awaits) can still be billed via getTerminalFinish.
 			if (chunk.type === 'raw') {
@@ -179,10 +212,18 @@ export class StreamSink implements RunOutputSink<void> {
 			}
 		}
 
-		const aiFinishReason = await result.finishReason;
-		const usage = await result.usage;
-		const providerMetadata = await result.providerMetadata;
-		const response = await result.response;
+		// The result promises settle as part of stream close on a healthy turn;
+		// guard them with the same stall deadline so an SDK-internal promise that
+		// never settles cannot hang the turn after the chunk loop ended.
+		const settle = async <T>(promise: PromiseLike<T>): Promise<T> =>
+			idleMs > 0
+				? await raceWithStallDeadline(promise, idleMs, () => turnAbort.abort())
+				: await promise;
+
+		const aiFinishReason = await settle(result.finishReason);
+		const usage = await settle(result.usage);
+		const providerMetadata = await settle(result.providerMetadata);
+		const response = await settle(result.response);
 		const newMessages = fromAiMessages(response.messages);
 		const errorReason = classifyModelTurnError({
 			aiFinishReason,
@@ -195,9 +236,9 @@ export class StreamSink implements RunOutputSink<void> {
 			finishReason: fromAiFinishReason(aiFinishReason),
 			usage: toTokenUsage(usage, providerMetadata),
 			newMessages,
-			toolCalls: await result.toolCalls,
+			toolCalls: await settle(result.toolCalls),
 			structuredOutput:
-				ctx.outputSpec && aiFinishReason !== 'tool-calls' ? await result.output : undefined,
+				ctx.outputSpec && aiFinishReason !== 'tool-calls' ? await settle(result.output) : undefined,
 			...(errorReason && { errorReason }),
 		};
 	}

--- a/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
@@ -16,11 +16,26 @@ import { createRawUsageReader, type RawUsageReader } from '../model/raw-usage';
 import { convertChunk, toTokenUsage } from '../streaming/stream';
 import {
 	DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS,
+	MAX_MODEL_STREAM_STALL_RETRIES,
+	ModelStreamStallError,
 	raceWithStallDeadline,
 	withChunkIdleTimeout,
 } from '../streaming/stream-stall';
 import type { StreamWriterGuard } from '../streaming/stream-writer-guard';
 import type { ToolCallBatchResult } from '../tools/tool-call-executor';
+
+/**
+ * Chunk types that are pure transport bookkeeping: an attempt that stalled
+ * having emitted only these produced nothing user-visible or persisted, so it
+ * can be silently re-issued. Everything else (text, reasoning, tool activity)
+ * marks the attempt as streamed — unknown future types err on the safe side.
+ */
+const STALL_RETRY_SAFE_CHUNK_TYPES = new Set<string>([
+	'raw',
+	'start-step',
+	'finish-step',
+	'finish',
+]);
 
 /**
  * Streaming output sink: drives the loop with `streamText`, forwards text /
@@ -43,6 +58,10 @@ export class StreamSink implements RunOutputSink<void> {
 	// implementations live behind `RawErrorReader`; undefined when the run's
 	// provider has no reader.
 	private rawErrorReader: RawErrorReader | undefined;
+	// Usage captured from attempts abandoned to a pre-content stall retry.
+	// Folded into the eventual turn usage (or the terminal finish on abort) so
+	// prompt processing the provider already billed is never dropped.
+	private stallAbandonedUsage: TokenUsage | undefined;
 
 	constructor(
 		private readonly guard: StreamWriterGuard,
@@ -54,7 +73,9 @@ export class StreamSink implements RunOutputSink<void> {
 		this.lastUsage = usage;
 		// The just-completed turn is now folded into `usage`; its raw capture is
 		// stale and must not be re-added to a later between-turns abort total.
+		// Same for stall-abandoned usage: the turn result already included it.
 		this.rawUsageReader = undefined;
+		this.stallAbandonedUsage = undefined;
 	}
 
 	/**
@@ -80,7 +101,10 @@ export class StreamSink implements RunOutputSink<void> {
 	 */
 	getTerminalFinish(): { usage?: TokenUsage; model: string } {
 		const usage = this.services.applyCost(
-			mergeUsage(this.lastUsage, this.rawUsageReader?.getUsage()),
+			mergeUsage(
+				this.lastUsage,
+				mergeUsage(this.stallAbandonedUsage, this.rawUsageReader?.getUsage()),
+			),
 		);
 		return { ...(usage && { usage }), model: this.services.modelId };
 	}
@@ -106,28 +130,51 @@ export class StreamSink implements RunOutputSink<void> {
 	}
 
 	async callModel(ctx: ModelCallContext): Promise<ModelTurnResult> {
-		// Opt-in: only build the reader (and request raw chunks) when the host bills
-		// stopped runs. Also requires a reader for the provider, so an unsupported
-		// provider never pays the cost even with the option on.
-		this.rawUsageReader = this.options?.recoverUsageOnAbort
-			? createRawUsageReader(this.services.modelId)
-			: undefined;
-		// Some providers report failures (e.g. prompt safety blocks) only on the
-		// raw stream — no error, no content — so raw chunks are required to
-		// explain an otherwise silent empty response.
-		this.rawErrorReader = createRawErrorReader(this.services.modelId);
 		const idleMs = this.options?.modelStreamIdleTimeoutMs ?? DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS;
-		// Per-turn controller chained to the run signal: a stall must be able to
-		// cancel this turn's fetch (releasing the socket the 1h network timeout
-		// would otherwise hold) without touching the run-level signal.
-		const turnAbort = new AbortController();
-		const onRunAbort = () => turnAbort.abort();
-		if (ctx.abortSignal.aborted) turnAbort.abort();
-		else ctx.abortSignal.addEventListener('abort', onRunAbort, { once: true });
-		try {
-			return await this.streamModelTurn(ctx, turnAbort, idleMs);
-		} finally {
-			ctx.abortSignal.removeEventListener('abort', onRunAbort);
+		this.stallAbandonedUsage = undefined;
+		for (let attempt = 0; ; attempt++) {
+			// Opt-in: only build the reader (and request raw chunks) when the host bills
+			// stopped runs. Also requires a reader for the provider, so an unsupported
+			// provider never pays the cost even with the option on. Re-created per
+			// attempt so a retried turn starts from a clean raw capture.
+			this.rawUsageReader = this.options?.recoverUsageOnAbort
+				? createRawUsageReader(this.services.modelId)
+				: undefined;
+			// Some providers report failures (e.g. prompt safety blocks) only on the
+			// raw stream — no error, no content — so raw chunks are required to
+			// explain an otherwise silent empty response.
+			this.rawErrorReader = createRawErrorReader(this.services.modelId);
+			// Per-attempt controller chained to the run signal: a stall must be able
+			// to cancel this attempt's fetch (releasing the socket the 1h network
+			// timeout would otherwise hold) without touching the run-level signal.
+			const turnAbort = new AbortController();
+			const onRunAbort = () => turnAbort.abort();
+			if (ctx.abortSignal.aborted) turnAbort.abort();
+			else ctx.abortSignal.addEventListener('abort', onRunAbort, { once: true });
+			const attemptState = { streamedContent: false };
+			try {
+				return await this.streamModelTurn(ctx, turnAbort, idleMs, attemptState);
+			} catch (error) {
+				// A stall before any content is invisible to the user (and to the
+				// host's persistence) — re-issue the request instead of failing the
+				// run for what is usually a dead connection at request time. Once
+				// content has streamed, a retry would duplicate segments and orphan
+				// already-persisted tool-call facts, so the error surfaces instead.
+				const retryable =
+					error instanceof ModelStreamStallError &&
+					attempt < MAX_MODEL_STREAM_STALL_RETRIES &&
+					!attemptState.streamedContent &&
+					!ctx.abortSignal.aborted;
+				if (!retryable) throw error;
+				// The stalled attempt may still have billed prompt processing (raw
+				// message_start) — fold its capture so the turn's usage stays honest.
+				this.stallAbandonedUsage = mergeUsage(
+					this.stallAbandonedUsage,
+					this.rawUsageReader?.getUsage(),
+				);
+			} finally {
+				ctx.abortSignal.removeEventListener('abort', onRunAbort);
+			}
 		}
 	}
 
@@ -135,6 +182,7 @@ export class StreamSink implements RunOutputSink<void> {
 		ctx: ModelCallContext,
 		turnAbort: AbortController,
 		idleMs: number,
+		attemptState: { streamedContent: boolean },
 	): Promise<ModelTurnResult> {
 		const { streamText } = loadAi();
 		const result = streamText({
@@ -168,6 +216,9 @@ export class StreamSink implements RunOutputSink<void> {
 		// cancels the underlying fetch and the async iterator throws; the error
 		// propagates to the StreamSession which closes the consumer stream.
 		for await (const chunk of chunkStream) {
+			// Anything beyond transport bookkeeping counts as content: once seen,
+			// a stalled attempt is no longer silently retryable (see callModel).
+			if (!STALL_RETRY_SAFE_CHUNK_TYPES.has(chunk.type)) attemptState.streamedContent = true;
 			// Track usage from raw provider events so an aborted turn (which never
 			// reaches the post-loop awaits) can still be billed via getTerminalFinish.
 			if (chunk.type === 'raw') {
@@ -234,7 +285,9 @@ export class StreamSink implements RunOutputSink<void> {
 		return {
 			aiFinishReason,
 			finishReason: fromAiFinishReason(aiFinishReason),
-			usage: toTokenUsage(usage, providerMetadata),
+			// Include usage billed by attempts abandoned to a pre-content stall
+			// retry, so the turn reports everything the provider actually charged.
+			usage: mergeUsage(this.stallAbandonedUsage, toTokenUsage(usage, providerMetadata)),
 			newMessages,
 			toolCalls: await settle(result.toolCalls),
 			structuredOutput:

--- a/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
@@ -15,6 +15,7 @@ import { createRawErrorReader, type RawErrorReader } from '../model/raw-error';
 import { createRawUsageReader, type RawUsageReader } from '../model/raw-usage';
 import { convertChunk, toTokenUsage } from '../streaming/stream';
 import {
+	DEFAULT_MODEL_STREAM_FIRST_OUTPUT_TIMEOUT_MS,
 	DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS,
 	MAX_MODEL_STREAM_STALL_RETRIES,
 	ModelStreamStallError,
@@ -131,6 +132,12 @@ export class StreamSink implements RunOutputSink<void> {
 
 	async callModel(ctx: ModelCallContext): Promise<ModelTurnResult> {
 		const idleMs = this.options?.modelStreamIdleTimeoutMs ?? DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS;
+		// Pre-first-output silence tolerates prompt processing (large cache-miss
+		// prompts send nothing for minutes); never let it undercut the idle limit.
+		const firstOutputMs = Math.max(
+			idleMs,
+			this.options?.modelStreamFirstOutputTimeoutMs ?? DEFAULT_MODEL_STREAM_FIRST_OUTPUT_TIMEOUT_MS,
+		);
 		this.stallAbandonedUsage = undefined;
 		for (let attempt = 0; ; attempt++) {
 			// Opt-in: only build the reader (and request raw chunks) when the host bills
@@ -153,7 +160,7 @@ export class StreamSink implements RunOutputSink<void> {
 			else ctx.abortSignal.addEventListener('abort', onRunAbort, { once: true });
 			const attemptState = { streamedContent: false };
 			try {
-				return await this.streamModelTurn(ctx, turnAbort, idleMs, attemptState);
+				return await this.streamModelTurn(ctx, turnAbort, { idleMs, firstOutputMs }, attemptState);
 			} catch (error) {
 				// A stall before any content is invisible to the user (and to the
 				// host's persistence) — re-issue the request instead of failing the
@@ -181,9 +188,10 @@ export class StreamSink implements RunOutputSink<void> {
 	private async streamModelTurn(
 		ctx: ModelCallContext,
 		turnAbort: AbortController,
-		idleMs: number,
+		deadlines: { idleMs: number; firstOutputMs: number },
 		attemptState: { streamedContent: boolean },
 	): Promise<ModelTurnResult> {
+		const { idleMs, firstOutputMs } = deadlines;
 		const { streamText } = loadAi();
 		const result = streamText({
 			model: ctx.model,
@@ -207,9 +215,16 @@ export class StreamSink implements RunOutputSink<void> {
 		// A healthy streaming response emits chunks continuously (raw provider
 		// events included), so prolonged silence means the connection or provider
 		// is wedged — fail the turn instead of hanging until the network timeout.
+		// Pre-first-output silence gets the longer deadline (prompt processing on
+		// large cache-miss prompts sends nothing for minutes); once content has
+		// streamed, the tighter idle limit applies.
 		const chunkStream =
 			idleMs > 0
-				? withChunkIdleTimeout(result.stream, idleMs, () => turnAbort.abort())
+				? withChunkIdleTimeout(
+						result.stream,
+						() => (attemptState.streamedContent ? idleMs : firstOutputMs),
+						() => turnAbort.abort(),
+					)
 				: result.stream;
 
 		// Consume the stream. When the AbortSignal fires mid-stream the AI SDK

--- a/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
@@ -62,11 +62,6 @@ export class StreamSink implements RunOutputSink<void> {
 	// implementations live behind `RawErrorReader`; undefined when the run's
 	// provider has no reader.
 	private rawErrorReader: RawErrorReader | undefined;
-	// Usage captured from attempts abandoned to a pre-content stall retry.
-	// Folded into the eventual turn usage (or the terminal finish on abort) so
-	// prompt processing the provider already billed is never dropped.
-	private stallAbandonedUsage: TokenUsage | undefined;
-
 	constructor(
 		private readonly guard: StreamWriterGuard,
 		private readonly services: RunServices,
@@ -77,9 +72,7 @@ export class StreamSink implements RunOutputSink<void> {
 		this.lastUsage = usage;
 		// The just-completed turn is now folded into `usage`; its raw capture is
 		// stale and must not be re-added to a later between-turns abort total.
-		// Same for stall-abandoned usage: the turn result already included it.
 		this.rawUsageReader = undefined;
-		this.stallAbandonedUsage = undefined;
 	}
 
 	/**
@@ -105,10 +98,7 @@ export class StreamSink implements RunOutputSink<void> {
 	 */
 	getTerminalFinish(): { usage?: TokenUsage; model: string } {
 		const usage = this.services.applyCost(
-			mergeUsage(
-				this.lastUsage,
-				mergeUsage(this.stallAbandonedUsage, this.rawUsageReader?.getUsage()),
-			),
+			mergeUsage(this.lastUsage, this.rawUsageReader?.getUsage()),
 		);
 		return { ...(usage && { usage }), model: this.services.modelId };
 	}
@@ -141,7 +131,6 @@ export class StreamSink implements RunOutputSink<void> {
 			idleMs,
 			this.options?.modelStreamFirstOutputTimeoutMs ?? DEFAULT_MODEL_STREAM_FIRST_OUTPUT_TIMEOUT_MS,
 		);
-		this.stallAbandonedUsage = undefined;
 		for (let attempt = 0; ; attempt++) {
 			// Opt-in: only build the reader (and request raw chunks) when the host bills
 			// stopped runs. Also requires a reader for the provider, so an unsupported
@@ -154,13 +143,10 @@ export class StreamSink implements RunOutputSink<void> {
 			// raw stream — no error, no content — so raw chunks are required to
 			// explain an otherwise silent empty response.
 			this.rawErrorReader = createRawErrorReader(this.services.modelId);
-			// Per-attempt controller chained to the run signal: a stall must be able
-			// to cancel this attempt's fetch (releasing the socket the 1h network
-			// timeout would otherwise hold) without touching the run-level signal.
+			// Per-attempt controller: a stall must be able to cancel this attempt's
+			// fetch (releasing the socket the 1h network timeout would otherwise
+			// hold) without touching the run-level signal.
 			const turnAbort = new AbortController();
-			const onRunAbort = () => turnAbort.abort();
-			if (ctx.abortSignal.aborted) turnAbort.abort();
-			else ctx.abortSignal.addEventListener('abort', onRunAbort, { once: true });
 			const attemptState = { streamedContent: false };
 			try {
 				return await this.streamModelTurn(ctx, turnAbort, { idleMs, firstOutputMs }, attemptState);
@@ -170,20 +156,15 @@ export class StreamSink implements RunOutputSink<void> {
 				// run for what is usually a dead connection at request time. Once
 				// content has streamed, a retry would duplicate segments and orphan
 				// already-persisted tool-call facts, so the error surfaces instead.
+				// The abandoned attempt's prompt processing goes unbilled — accepted:
+				// it only has usage at all when the stream died between message_start
+				// and the first content chunk.
 				const retryable =
 					error instanceof ModelStreamStallError &&
 					attempt < MAX_MODEL_STREAM_STALL_RETRIES &&
 					!attemptState.streamedContent &&
 					!ctx.abortSignal.aborted;
 				if (!retryable) throw error;
-				// The stalled attempt may still have billed prompt processing (raw
-				// message_start) — fold its capture so the turn's usage stays honest.
-				this.stallAbandonedUsage = mergeUsage(
-					this.stallAbandonedUsage,
-					this.rawUsageReader?.getUsage(),
-				);
-			} finally {
-				ctx.abortSignal.removeEventListener('abort', onRunAbort);
 			}
 		}
 	}
@@ -201,7 +182,9 @@ export class StreamSink implements RunOutputSink<void> {
 			instructions: ctx.system,
 			messages: ctx.messages,
 			allowSystemInMessages: true,
-			abortSignal: turnAbort.signal,
+			// Run abort (user stop) and turn abort (stall watchdog) both cancel
+			// this attempt's fetch.
+			abortSignal: AbortSignal.any([ctx.abortSignal, turnAbort.signal]),
 			...(ctx.reasoning ? { reasoning: ctx.reasoning } : {}),
 			// Surface the provider's raw message_start/message_delta events so an
 			// aborted run can recover its usage — the SDK reports none on abort.
@@ -303,9 +286,7 @@ export class StreamSink implements RunOutputSink<void> {
 		return {
 			aiFinishReason,
 			finishReason: fromAiFinishReason(aiFinishReason),
-			// Include usage billed by attempts abandoned to a pre-content stall
-			// retry, so the turn reports everything the provider actually charged.
-			usage: mergeUsage(this.stallAbandonedUsage, toTokenUsage(usage, providerMetadata)),
+			usage: toTokenUsage(usage, providerMetadata),
 			newMessages,
 			toolCalls: await settle(result.toolCalls),
 			structuredOutput:

--- a/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/stream-sink.ts
@@ -33,9 +33,12 @@ import type { ToolCallBatchResult } from '../tools/tool-call-executor';
  */
 const STALL_RETRY_SAFE_CHUNK_TYPES = new Set<string>([
 	'raw',
+	'start',
+	'stream-start',
 	'start-step',
 	'finish-step',
 	'finish',
+	'abort',
 ]);
 
 /**

--- a/packages/@n8n/agents/src/runtime/streaming/__tests__/stream-stall.test.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/__tests__/stream-stall.test.ts
@@ -21,7 +21,11 @@ describe('withChunkIdleTimeout', () => {
 		}
 		const seen: number[] = [];
 
-		for await (const chunk of withChunkIdleTimeout(source(), 60_000, () => {})) {
+		for await (const chunk of withChunkIdleTimeout(
+			source(),
+			() => 60_000,
+			() => {},
+		)) {
 			seen.push(chunk);
 		}
 
@@ -35,7 +39,11 @@ describe('withChunkIdleTimeout', () => {
 		}
 		const seen: string[] = [];
 
-		for await (const chunk of withChunkIdleTimeout(source(), 60_000, () => {})) {
+		for await (const chunk of withChunkIdleTimeout(
+			source(),
+			() => 60_000,
+			() => {},
+		)) {
 			seen.push(chunk);
 		}
 
@@ -49,7 +57,7 @@ describe('withChunkIdleTimeout', () => {
 			yield 1;
 			yield await gate;
 		}
-		const iterator = withChunkIdleTimeout(source(), 60_000, onStall);
+		const iterator = withChunkIdleTimeout(source(), () => 60_000, onStall);
 
 		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
 
@@ -76,7 +84,11 @@ describe('withChunkIdleTimeout', () => {
 			});
 			yield 3;
 		}
-		const iterator = withChunkIdleTimeout(source(), 60_000, () => {});
+		const iterator = withChunkIdleTimeout(
+			source(),
+			() => 60_000,
+			() => {},
+		);
 
 		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
 
@@ -97,7 +109,11 @@ describe('withChunkIdleTimeout', () => {
 			yield await Promise.resolve(1);
 			throw new Error('provider exploded');
 		}
-		const iterator = withChunkIdleTimeout(source(), 60_000, () => {});
+		const iterator = withChunkIdleTimeout(
+			source(),
+			() => 60_000,
+			() => {},
+		);
 
 		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
 		await expect(iterator.next()).rejects.toThrow('provider exploded');

--- a/packages/@n8n/agents/src/runtime/streaming/__tests__/stream-stall.test.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/__tests__/stream-stall.test.ts
@@ -1,0 +1,134 @@
+import {
+	ModelStreamStallError,
+	raceWithStallDeadline,
+	withChunkIdleTimeout,
+} from '../stream-stall';
+
+describe('withChunkIdleTimeout', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('passes chunks through and completes with the source', async () => {
+		async function* source() {
+			yield await Promise.resolve(1);
+			yield 2;
+			yield 3;
+		}
+		const seen: number[] = [];
+
+		for await (const chunk of withChunkIdleTimeout(source(), 60_000, () => {})) {
+			seen.push(chunk);
+		}
+
+		expect(seen).toEqual([1, 2, 3]);
+	});
+
+	it('accepts sync iterables, mirroring for-await semantics', async () => {
+		function* source() {
+			yield 'a';
+			yield 'b';
+		}
+		const seen: string[] = [];
+
+		for await (const chunk of withChunkIdleTimeout(source(), 60_000, () => {})) {
+			seen.push(chunk);
+		}
+
+		expect(seen).toEqual(['a', 'b']);
+	});
+
+	it('fails with a stall error and aborts the source when a chunk never arrives', async () => {
+		const onStall = vi.fn();
+		const gate = new Promise<number>(() => {});
+		async function* source() {
+			yield 1;
+			yield await gate;
+		}
+		const iterator = withChunkIdleTimeout(source(), 60_000, onStall);
+
+		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
+
+		// Capture the outcome with a synchronously attached handler so the
+		// rejection is never unhandled while the fake timers advance.
+		const stalled = iterator.next().then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+		await vi.advanceTimersByTimeAsync(59_999);
+		expect(onStall).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+
+		await expect(stalled).resolves.toBeInstanceOf(ModelStreamStallError);
+		expect(onStall).toHaveBeenCalledTimes(1);
+	});
+
+	it('resets the idle window on every chunk', async () => {
+		let release!: (value: number) => void;
+		async function* source() {
+			yield 1;
+			yield await new Promise<number>((resolve) => {
+				release = resolve;
+			});
+			yield 3;
+		}
+		const iterator = withChunkIdleTimeout(source(), 60_000, () => {});
+
+		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
+
+		const pending = iterator.next();
+		// Just under the deadline the read is still allowed to settle…
+		await vi.advanceTimersByTimeAsync(59_000);
+		release(2);
+		await expect(pending).resolves.toEqual({ done: false, value: 2 });
+
+		// …and the next read gets a fresh window rather than the stale timer.
+		const after = iterator.next();
+		await vi.advanceTimersByTimeAsync(59_000);
+		await expect(after).resolves.toEqual({ done: false, value: 3 });
+	});
+
+	it('propagates source errors unchanged', async () => {
+		async function* source(): AsyncGenerator<number> {
+			yield await Promise.resolve(1);
+			throw new Error('provider exploded');
+		}
+		const iterator = withChunkIdleTimeout(source(), 60_000, () => {});
+
+		await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
+		await expect(iterator.next()).rejects.toThrow('provider exploded');
+	});
+});
+
+describe('raceWithStallDeadline', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('resolves with the promise when it settles in time', async () => {
+		await expect(raceWithStallDeadline(Promise.resolve('ok'), 60_000)).resolves.toBe('ok');
+	});
+
+	it('rejects with a stall error and notifies when the promise never settles', async () => {
+		const onStall = vi.fn();
+		// Capture the outcome with a synchronously attached handler so the
+		// rejection is never unhandled while the fake timers advance.
+		const settled = raceWithStallDeadline(new Promise<never>(() => {}), 60_000, onStall).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		await expect(settled).resolves.toBeInstanceOf(ModelStreamStallError);
+		expect(onStall).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
@@ -1,0 +1,92 @@
+/**
+ * Chunk-idle stall detection for model streams.
+ *
+ * The AI transport raises undici's network idle timeouts to one hour so long
+ * completions and slow non-streaming calls are not cut off — which means a
+ * dead connection (half-open socket, a proxy that keeps the wire warm without
+ * forwarding data) can hang a streaming turn for that long. Streaming
+ * responses emit deltas continuously, so extended silence *between chunks* is
+ * the reliable liveness signal the network layer cannot see. These helpers
+ * fail the turn fast with a typed, user-explainable error instead.
+ */
+
+export const DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS = 5 * 60_000;
+
+export class ModelStreamStallError extends Error {
+	constructor(idleMs: number) {
+		super(
+			`The model stream stalled: no data received for ${Math.round(idleMs / 1000)} seconds. ` +
+				'This is usually a transient connection issue — please try again.',
+		);
+		this.name = 'ModelStreamStallError';
+	}
+}
+
+/** Resolve the iterator the way `for await` would: async first, sync fallback. */
+function getChunkIterator<T>(
+	source: AsyncIterable<T> | Iterable<T>,
+): AsyncIterator<T> | Iterator<T> {
+	if (Symbol.asyncIterator in source) return source[Symbol.asyncIterator]();
+	return source[Symbol.iterator]();
+}
+
+/**
+ * Yield chunks from `source`, throwing {@link ModelStreamStallError} when no
+ * chunk arrives within `idleMs`. `onStall` fires first so the caller can abort
+ * the underlying request (releasing the socket and settling the abandoned
+ * read). The abandoned read's eventual rejection is swallowed — the stall
+ * error is the one the caller reports.
+ */
+export async function* withChunkIdleTimeout<T>(
+	source: AsyncIterable<T> | Iterable<T>,
+	idleMs: number,
+	onStall: () => void,
+): AsyncGenerator<T> {
+	const iterator = getChunkIterator(source);
+	try {
+		while (true) {
+			const next = Promise.resolve(iterator.next());
+			// If the deadline wins, the losing read settles later — without a
+			// handler its rejection would surface as an unhandled rejection.
+			next.catch(() => undefined);
+			const result = await raceWithStallDeadline(next, idleMs, onStall);
+			if (result.done) return;
+			yield result.value;
+		}
+	} finally {
+		// Fire-and-forget: a wedged source's teardown may itself never settle,
+		// and awaiting it here would block the stall error on the very hang this
+		// wrapper exists to break. `onStall` already aborted the underlying
+		// request, which is what actually reclaims the socket.
+		void Promise.resolve()
+			.then(async () => await iterator.return?.())
+			.catch(() => undefined);
+	}
+}
+
+/**
+ * Await `promise` with the same stall deadline. Used for the SDK's post-stream
+ * result promises (`finishReason`, `usage`, `response`, …), which settle
+ * instantly on a healthy stream but would otherwise be an unguarded await.
+ */
+export async function raceWithStallDeadline<T>(
+	promise: PromiseLike<T>,
+	idleMs: number,
+	onStall?: () => void,
+): Promise<T> {
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => {
+					onStall?.();
+					reject(new ModelStreamStallError(idleMs));
+				}, idleMs);
+				timer.unref?.();
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
@@ -60,18 +60,17 @@ function getChunkIterator<T>(
  */
 export async function* withChunkIdleTimeout<T>(
 	source: AsyncIterable<T> | Iterable<T>,
-	idleMs: number | (() => number),
+	getIdleMs: () => number,
 	onStall: () => void,
 ): AsyncGenerator<T> {
 	const iterator = getChunkIterator(source);
-	const resolveIdleMs = typeof idleMs === 'function' ? idleMs : () => idleMs;
 	try {
 		while (true) {
 			const next = Promise.resolve(iterator.next());
 			// If the deadline wins, the losing read settles later — without a
 			// handler its rejection would surface as an unhandled rejection.
 			next.catch(() => undefined);
-			const result = await raceWithStallDeadline(next, resolveIdleMs(), onStall);
+			const result = await raceWithStallDeadline(next, getIdleMs(), onStall);
 			if (result.done) return;
 			yield result.value;
 		}

--- a/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
@@ -12,6 +12,14 @@
 
 export const DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS = 5 * 60_000;
 
+/**
+ * How many times a stalled turn is silently re-issued before the stall error
+ * surfaces. Only applies while the stalled attempt has streamed no content
+ * (see `StreamSink.callModel`) — retrying an attempt the user already saw
+ * would duplicate segments and orphan persisted tool-call facts.
+ */
+export const MAX_MODEL_STREAM_STALL_RETRIES = 1;
+
 export class ModelStreamStallError extends Error {
 	constructor(idleMs: number) {
 		super(

--- a/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
+++ b/packages/@n8n/agents/src/runtime/streaming/stream-stall.ts
@@ -10,7 +10,20 @@
  * fail the turn fast with a typed, user-explainable error instead.
  */
 
-export const DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS = 5 * 60_000;
+/**
+ * Max silence between chunks once the turn has streamed content. Bytes were
+ * flowing and stopped — beyond this the connection is dead for all practical
+ * purposes, and the user is staring at a frozen response.
+ */
+export const DEFAULT_MODEL_STREAM_IDLE_TIMEOUT_MS = 90_000;
+
+/**
+ * Max silence before the turn's first content chunk. Deliberately longer than
+ * the post-content limit: a large cache-miss prompt legitimately spends 1-3
+ * minutes in prompt processing before the provider sends anything, and a trip
+ * here is recovered by a silent retry rather than a user-facing error.
+ */
+export const DEFAULT_MODEL_STREAM_FIRST_OUTPUT_TIMEOUT_MS = 3 * 60_000;
 
 /**
  * How many times a stalled turn is silently re-issued before the stall error
@@ -47,17 +60,18 @@ function getChunkIterator<T>(
  */
 export async function* withChunkIdleTimeout<T>(
 	source: AsyncIterable<T> | Iterable<T>,
-	idleMs: number,
+	idleMs: number | (() => number),
 	onStall: () => void,
 ): AsyncGenerator<T> {
 	const iterator = getChunkIterator(source);
+	const resolveIdleMs = typeof idleMs === 'function' ? idleMs : () => idleMs;
 	try {
 		while (true) {
 			const next = Promise.resolve(iterator.next());
 			// If the deadline wins, the losing read settles later — without a
 			// handler its rejection would surface as an unhandled rejection.
 			next.catch(() => undefined);
-			const result = await raceWithStallDeadline(next, idleMs, onStall);
+			const result = await raceWithStallDeadline(next, resolveIdleMs(), onStall);
 			if (result.done) return;
 			yield result.value;
 		}

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -189,13 +189,22 @@ export interface ExecutionOptions {
 	 */
 	recoverUsageOnAbort?: boolean;
 	/**
-	 * Max silence in milliseconds between model stream chunks before the turn
-	 * fails with a stall error. Healthy streaming responses emit chunks
-	 * continuously, so prolonged chunk silence means a dead connection that the
-	 * long AI network timeouts (raised to 1h for slow non-streaming calls) would
-	 * otherwise keep open. 0 disables. Defaults to 5 minutes.
+	 * Max silence in milliseconds between model stream chunks (after the turn
+	 * has streamed content) before the turn fails with a stall error. Healthy
+	 * streaming responses emit chunks continuously, so prolonged chunk silence
+	 * means a dead connection that the long AI network timeouts (raised to 1h
+	 * for slow non-streaming calls) would otherwise keep open. 0 disables the
+	 * stall watchdog entirely. Defaults to 90 seconds.
 	 */
 	modelStreamIdleTimeoutMs?: number;
+	/**
+	 * Max silence in milliseconds before the turn's first content chunk.
+	 * Longer than the idle limit by design — large cache-miss prompts spend
+	 * minutes in prompt processing before the provider sends anything — and a
+	 * trip here is recovered by a silent retry instead of a user-facing error.
+	 * Clamped to at least `modelStreamIdleTimeoutMs`. Defaults to 3 minutes.
+	 */
+	modelStreamFirstOutputTimeoutMs?: number;
 	/** Inherited telemetry from a host runtime. */
 	telemetry?: BuiltTelemetry;
 	/** Inherited execution counter from the host runtime. Used for aggregate heartbeat telemetry. */

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -188,6 +188,14 @@ export interface ExecutionOptions {
 	 * streaming raw provider events that nothing consumes.
 	 */
 	recoverUsageOnAbort?: boolean;
+	/**
+	 * Max silence in milliseconds between model stream chunks before the turn
+	 * fails with a stall error. Healthy streaming responses emit chunks
+	 * continuously, so prolonged chunk silence means a dead connection that the
+	 * long AI network timeouts (raised to 1h for slow non-streaming calls) would
+	 * otherwise keep open. 0 disables. Defaults to 5 minutes.
+	 */
+	modelStreamIdleTimeoutMs?: number;
 	/** Inherited telemetry from a host runtime. */
 	telemetry?: BuiltTelemetry;
 	/** Inherited execution counter from the host runtime. Used for aggregate heartbeat telemetry. */


### PR DESCRIPTION
## Summary

Fixes AI Assistant chats getting stuck forever on a task like "Loading node schema", with no way to recover (reloading only reset the timer).

**Why it happened:** when the connection to the model dies quietly mid-response, nothing on our side notices. The network timeout for AI calls is 1 hour on cloud, so the chat just sits there.

**What this PR does:** watch the response stream itself.

- If the reply stops arriving for 90 seconds, cancel it and show "The model stream stalled. This is usually a transient connection issue, please try again." The chat is immediately usable again.
- If the connection dies before anything was shown to the user, retry once silently. The user just gets a slower answer. This case gets 3 minutes of grace, because large prompts genuinely take a couple of minutes before the first word arrives.
- Nothing else changes: the stop button works as before, and both timeouts are configurable (0 disables).

This is the standard approach for agent tooling. OpenAI's Codex CLI ships the same two knobs: an idle timeout on the response stream (`stream_idle_timeout_ms`, default 5 minutes) and automatic retries for interrupted streams (`stream_max_retries`, default 5). See the [Codex configuration reference](https://developers.openai.com/codex/config-reference).

**Verified live** by killing the connection mid-response against the real Anthropic API:

- Without the fix: stuck until the network layer gives up (5 minutes locally with a cryptic "terminated" error, up to an hour or forever on cloud).
- With the fix: clear error after 90 seconds, or invisible recovery when nothing was shown yet.

## How to test

Unit tests cover the stall and retry scenarios (`stream-stall.test.ts`, `agent-runtime.test.ts`). To see it by hand: run n8n behind a proxy that stops forwarding the model response mid-stream, then send a chat message.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1096
