### PR TITLE
feat(core): Support branch settlement in @n8n/engine (no-changelog)

### DIFF
--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -119,25 +119,37 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(await store.createSteps('00000000-0000-7000-8000-000000000000', [])).toEqual([]);
 	});
 
-	it('TypeOrmStepStore.createSteps rejects outputs mismatched with status at runtime', async () => {
+	it.each([
+		{
+			violation: 'a transition-only status',
+			record: { nodeId: 'x', status: 'failed' },
+			message: 'transition method',
+		},
+		{
+			violation: 'outputs on a non-completed step',
+			record: { nodeId: 'x', status: 'queued', outputs: [{}] },
+			message: 'with outputs',
+		},
+		{
+			violation: 'a completed step without outputs',
+			record: { nodeId: 'x', status: 'completed' },
+			message: 'without a slot list',
+		},
+		{
+			violation: 'a completed step with null outputs',
+			record: { nodeId: 'x', status: 'completed', outputs: null },
+			message: 'without a slot list',
+		},
+	])('TypeOrmStepStore.createSteps rejects $violation at runtime', async ({ record, message }) => {
 		// the casts simulate a caller outside the type system
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
-		const queuedWithOutputs = { nodeId: 'x', status: 'queued', outputs: [{}] };
 		await expect(
-			store.createSteps(executionId, [queuedWithOutputs as unknown as NewStepRecord]),
+			store.createSteps(executionId, [record as unknown as NewStepRecord]),
 		).rejects.toMatchObject({
 			name: 'UnexpectedError',
-			message: expect.stringContaining('with outputs') as string,
-		});
-
-		const completedWithoutOutputs = { nodeId: 'x', status: 'completed' };
-		await expect(
-			store.createSteps(executionId, [completedWithoutOutputs as unknown as NewStepRecord]),
-		).rejects.toMatchObject({
-			name: 'UnexpectedError',
-			message: expect.stringContaining('without outputs') as string,
+			message: expect.stringContaining(message) as string,
 		});
 	});
 

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -51,11 +51,7 @@ describe('workflow_step_execution table (integration)', () => {
 		return step;
 	}
 
-	/**
-	 * Seeds a row in a status the creation contract forbids (`running`,
-	 * `failed`, `cancelled`), straight through the repository. Fixture-only:
-	 * production rows reach these states via their transitions.
-	 */
+	/** Fixture-only: seeds a row in a status the creation contract forbids. */
 	async function seedStep(record: {
 		executionId: string;
 		nodeId: string;
@@ -124,8 +120,7 @@ describe('workflow_step_execution table (integration)', () => {
 	});
 
 	it('TypeOrmStepStore.createSteps rejects outputs mismatched with status at runtime', async () => {
-		// both shapes are unrepresentable in NewStepRecord; the casts simulate a
-		// caller outside the type system reaching the runtime guard
+		// the casts simulate a caller outside the type system
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
@@ -134,7 +129,7 @@ describe('workflow_step_execution table (integration)', () => {
 			store.createSteps(executionId, [queuedWithOutputs as unknown as NewStepRecord]),
 		).rejects.toMatchObject({
 			name: 'UnexpectedError',
-			message: expect.stringContaining('carries outputs') as string,
+			message: expect.stringContaining('with outputs') as string,
 		});
 
 		const completedWithoutOutputs = { nodeId: 'x', status: 'completed' };
@@ -211,8 +206,6 @@ describe('workflow_step_execution table (integration)', () => {
 		const { id } = await createStep(store, executionId, { nodeId: 'b', status: 'queued' });
 		await seedStep({ executionId, nodeId: 'a', status: 'failed' });
 
-		// the fence in the claim statement keeps b from starting work in a
-		// doomed execution
 		expect(await store.claimStep(id)).toBeNull();
 		expect((await store.loadStep(id)).status).toBe('queued');
 
@@ -227,8 +220,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		await seedStep({ executionId, nodeId: 'a', status: 'failed' });
 
-		// planned after the failure's cancellation sweep, these rows would be
-		// unclaimable and stuck queued forever, so they must not exist at all
+		// rows planned after the cancellation sweep would be stuck queued forever
 		const created = await store.createSteps(executionId, [{ nodeId: 'b', status: 'queued' }]);
 
 		expect(created).toEqual([]);

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -3,7 +3,7 @@ import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testconta
 import postgresVersions from 'n8n-containers/postgres-versions.json';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import type { StepStatus } from '../../execution/execution.types';
+import type { StepSlots, StepStatus } from '../../execution/execution.types';
 import { StepNotFoundError, type NewStepRecord } from '../../execution/step-store';
 import { createDataSource } from '../data-source';
 import { WorkflowExecution } from '../entities/workflow-execution.entity';
@@ -48,6 +48,22 @@ describe('workflow_step_execution table (integration)', () => {
 	): Promise<{ id: string }> {
 		const [step] = await store.createSteps([record]);
 		return step;
+	}
+
+	/**
+	 * Seeds a row in a status the creation contract forbids (`running`,
+	 * `failed`, `cancelled`), straight through the repository. Fixture-only:
+	 * production rows reach these states via their transitions.
+	 */
+	async function seedStep(record: {
+		executionId: string;
+		nodeId: string;
+		status: StepStatus;
+		outputs?: StepSlots;
+	}): Promise<{ id: string }> {
+		const repo = dataSource.getRepository(WorkflowStepExecution);
+		const row = await repo.save(repo.create(record));
+		return { id: row.id };
 	}
 
 	it('persists and retrieves a step row', async () => {
@@ -185,7 +201,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		// b is planned first; a's failure lands before b's step:ready is claimed
 		const { id } = await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
-		await createStep(store, { executionId, nodeId: 'a', status: 'failed' });
+		await seedStep({ executionId, nodeId: 'a', status: 'failed' });
 
 		// the fence in the claim statement keeps b from starting work in a
 		// doomed execution
@@ -205,7 +221,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.createSteps creates nothing once any step in the execution failed', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		await createStep(store, { executionId, nodeId: 'a', status: 'failed' });
+		await seedStep({ executionId, nodeId: 'a', status: 'failed' });
 
 		// planned after the failure's cancellation sweep, these rows would be
 		// unclaimable and stuck queued forever, so they must not exist at all
@@ -219,7 +235,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.createSteps waits out a concurrently committing failure and creates nothing', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const failing = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		const failing = await seedStep({ executionId, nodeId: 'a', status: 'running' });
 
 		const failure = dataSource.createQueryRunner();
 		await failure.connect();
@@ -243,7 +259,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.claimStep waits out a concurrently committing failure and refuses', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const failing = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		const failing = await seedStep({ executionId, nodeId: 'a', status: 'running' });
 		const { id } = await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
 
 		// An in-flight failStep: execution lock held, failed row written, commit
@@ -271,7 +287,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.completeStep persists outputs and marks the step completed', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		const { id } = await seedStep({ executionId, nodeId: 'a', status: 'running' });
 
 		expect(await store.completeStep(id, [[{ json: { ok: true } }]])).toBe(true);
 
@@ -306,7 +322,7 @@ describe('workflow_step_execution table (integration)', () => {
 			nodeId: 'a',
 			status: 'queued',
 		});
-		const { id: runningId } = await createStep(store, {
+		const { id: runningId } = await seedStep({
 			executionId,
 			nodeId: 'b',
 			status: 'running',
@@ -334,7 +350,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.failStep persists the error and marks the step failed', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		const { id } = await seedStep({ executionId, nodeId: 'a', status: 'running' });
 
 		const error = {
 			name: 'Error',
@@ -366,7 +382,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.loadStepsByNodeIds returns rows keyed by node id, omitting absent nodes', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		const { id: aId } = await seedStep({ executionId, nodeId: 'a', status: 'running' });
 		// a multi-slot output with a dead slot round-trips as stored
 		await store.completeStep(aId, [[{ json: { from: 'a' } }], null]);
 		const { id: bId } = await createStep(store, { executionId, nodeId: 'b', status: 'skipped' });
@@ -391,7 +407,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.loadStepSummaries reports per-slot liveness without payloads', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		const { id: aId } = await seedStep({ executionId, nodeId: 'a', status: 'running' });
 		// slot 0 has data, slot 1 was never fired, slot 2 ran but produced zero
 		// items — [] is live, only JSON null marks a dead slot
 		await store.completeStep(aId, [[{ json: { big: 'payload' } }], null, []]);
@@ -435,11 +451,11 @@ describe('workflow_step_execution table (integration)', () => {
 		await store.createSteps([
 			{ executionId, nodeId: 'trigger', status: 'completed' },
 			{ executionId, nodeId: 'a', status: 'skipped' },
-			{ executionId, nodeId: 'b', status: 'cancelled' },
 			{ executionId, nodeId: 'c', status: 'queued' },
-			{ executionId, nodeId: 'd', status: 'running' },
 		]);
-		const { id: eId } = await createStep(store, { executionId, nodeId: 'e', status: 'running' });
+		await seedStep({ executionId, nodeId: 'b', status: 'cancelled' });
+		await seedStep({ executionId, nodeId: 'd', status: 'running' });
+		const { id: eId } = await seedStep({ executionId, nodeId: 'e', status: 'running' });
 		await store.failStep(eId, { name: 'Error', message: 'node blew up' });
 		// a sibling execution's settled rows must not count
 		const otherExecutionId = await createExecution();

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -183,11 +183,12 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.claimStep refuses once any step in the execution failed', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		await createStep(store, { executionId, nodeId: 'a', status: 'failed' });
+		// b is planned first; a's failure lands before b's step:ready is claimed
 		const { id } = await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
+		await createStep(store, { executionId, nodeId: 'a', status: 'failed' });
 
-		// b's step:ready was published before a's failure landed; the fence in
-		// the claim statement keeps it from starting work in a doomed execution
+		// the fence in the claim statement keeps b from starting work in a
+		// doomed execution
 		expect(await store.claimStep(id)).toBeNull();
 		expect((await store.loadStep(id)).status).toBe('queued');
 
@@ -199,6 +200,44 @@ describe('workflow_step_execution table (integration)', () => {
 			status: 'queued',
 		});
 		expect(await store.claimStep(other.id)).not.toBeNull();
+	});
+
+	it('TypeOrmStepStore.createSteps creates nothing once any step in the execution failed', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		await createStep(store, { executionId, nodeId: 'a', status: 'failed' });
+
+		// planned after the failure's cancellation sweep, these rows would be
+		// unclaimable and stuck queued forever, so they must not exist at all
+		const created = await store.createSteps([{ executionId, nodeId: 'b', status: 'queued' }]);
+
+		expect(created).toEqual([]);
+		const stepRepo = dataSource.getRepository(WorkflowStepExecution);
+		expect(await stepRepo.count({ where: { executionId } })).toBe(1);
+	});
+
+	it('TypeOrmStepStore.createSteps waits out a concurrently committing failure and creates nothing', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const failing = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+
+		const failure = dataSource.createQueryRunner();
+		await failure.connect();
+		await failure.startTransaction();
+		await failure.query('SELECT id FROM workflow_execution WHERE id = $1 FOR NO KEY UPDATE', [
+			executionId,
+		]);
+		await failure.query("UPDATE workflow_step_execution SET status = 'failed' WHERE id = $1", [
+			failing.id,
+		]);
+
+		// the insert must park on the execution lock until the failure commits
+		const create = store.createSteps([{ executionId, nodeId: 'b', status: 'queued' }]);
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		await failure.commitTransaction();
+		await failure.release();
+
+		expect(await create).toEqual([]);
 	});
 
 	it('TypeOrmStepStore.claimStep waits out a concurrently committing failure and refuses', async () => {

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -202,14 +202,14 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.claimStep refuses once any step in the execution failed', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		// b is planned first; a's failure lands before b's step:ready is claimed
+		// b is planned first, then a's failure lands before b's step:ready is claimed
 		const { id } = await createStep(store, executionId, { nodeId: 'b', status: 'queued' });
 		await seedStep({ executionId, nodeId: 'a', status: 'failed' });
 
 		expect(await store.claimStep(id)).toBeNull();
 		expect((await store.loadStep(id)).status).toBe('queued');
 
-		// a failure in one execution doesn't fence claims in another
+		// a failure in one execution doesn't block claims in another
 		const otherExecutionId = await createExecution();
 		const other = await createStep(store, otherExecutionId, { nodeId: 'a', status: 'queued' });
 		expect(await store.claimStep(other.id)).not.toBeNull();
@@ -258,8 +258,8 @@ describe('workflow_step_execution table (integration)', () => {
 		const failing = await seedStep({ executionId, nodeId: 'a', status: 'running' });
 		const { id } = await createStep(store, executionId, { nodeId: 'b', status: 'queued' });
 
-		// An in-flight failStep: execution lock held, failed row written, commit
-		// pending. A snapshot-only claim would see no failure and go through.
+		// A failStep mid-transaction, with the lock held and the failed row
+		// uncommitted. Without the lock, the claim would see no failure and succeed.
 		const failure = dataSource.createQueryRunner();
 		await failure.connect();
 		await failure.startTransaction();

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -99,7 +99,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
 		const ids = await store.createSteps(executionId, [
-			{ nodeId: 'trigger', status: 'completed' },
+			{ nodeId: 'trigger', status: 'completed', outputs: [{}] },
 			{ nodeId: 'a', status: 'queued' },
 			{ nodeId: 'b', status: 'queued' },
 		]);
@@ -123,15 +123,26 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(await store.createSteps('00000000-0000-7000-8000-000000000000', [])).toEqual([]);
 	});
 
-	it('TypeOrmStepStore.createSteps rejects a step created with outputs but not completed', async () => {
+	it('TypeOrmStepStore.createSteps rejects outputs mismatched with status at runtime', async () => {
+		// both shapes are unrepresentable in NewStepRecord; the casts simulate a
+		// caller outside the type system reaching the runtime guard
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
+		const queuedWithOutputs = { nodeId: 'x', status: 'queued', outputs: [{}] };
 		await expect(
-			store.createSteps(executionId, [{ nodeId: 'x', status: 'queued', outputs: [{}] }]),
+			store.createSteps(executionId, [queuedWithOutputs as unknown as NewStepRecord]),
 		).rejects.toMatchObject({
 			name: 'UnexpectedError',
-			message: expect.stringContaining('completed') as string,
+			message: expect.stringContaining('carries outputs') as string,
+		});
+
+		const completedWithoutOutputs = { nodeId: 'x', status: 'completed' };
+		await expect(
+			store.createSteps(executionId, [completedWithoutOutputs as unknown as NewStepRecord]),
+		).rejects.toMatchObject({
+			name: 'UnexpectedError',
+			message: expect.stringContaining('without outputs') as string,
 		});
 	});
 
@@ -322,6 +333,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const { id: completedId } = await createStep(store, executionId, {
 			nodeId: 'c',
 			status: 'completed',
+			outputs: [{}],
 		});
 		// scoped to the execution: a sibling execution's queued work is untouched
 		const { id: otherId } = await createStep(store, otherExecutionId, {
@@ -439,7 +451,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		await store.createSteps(executionId, [
-			{ nodeId: 'trigger', status: 'completed' },
+			{ nodeId: 'trigger', status: 'completed', outputs: [{}] },
 			{ nodeId: 'a', status: 'skipped' },
 			{ nodeId: 'c', status: 'queued' },
 		]);
@@ -449,7 +461,7 @@ describe('workflow_step_execution table (integration)', () => {
 		await store.failStep(eId, { name: 'Error', message: 'node blew up' });
 		// a sibling execution's settled rows must not count
 		const otherExecutionId = await createExecution();
-		await createStep(store, otherExecutionId, { nodeId: 'x', status: 'completed' });
+		await createStep(store, otherExecutionId, { nodeId: 'x', status: 'completed', outputs: [{}] });
 
 		// trigger, a, b, e — not c (queued) or d (running)
 		expect(await store.countSettledSteps(executionId)).toBe(4);

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -180,6 +180,55 @@ describe('workflow_step_execution table (integration)', () => {
 		expect((await store.loadStep(id)).status).toBe('running');
 	});
 
+	it('TypeOrmStepStore.claimStep refuses once any step in the execution failed', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		await createStep(store, { executionId, nodeId: 'a', status: 'failed' });
+		const { id } = await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
+
+		// b's step:ready was published before a's failure landed; the fence in
+		// the claim statement keeps it from starting work in a doomed execution
+		expect(await store.claimStep(id)).toBeNull();
+		expect((await store.loadStep(id)).status).toBe('queued');
+
+		// a failure in one execution doesn't fence claims in another
+		const otherExecutionId = await createExecution();
+		const other = await createStep(store, {
+			executionId: otherExecutionId,
+			nodeId: 'a',
+			status: 'queued',
+		});
+		expect(await store.claimStep(other.id)).not.toBeNull();
+	});
+
+	it('TypeOrmStepStore.claimStep waits out a concurrently committing failure and refuses', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const failing = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		const { id } = await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
+
+		// An in-flight failStep: execution lock held, failed row written, commit
+		// pending. A snapshot-only claim would see no failure and go through.
+		const failure = dataSource.createQueryRunner();
+		await failure.connect();
+		await failure.startTransaction();
+		await failure.query('SELECT id FROM workflow_execution WHERE id = $1 FOR NO KEY UPDATE', [
+			executionId,
+		]);
+		await failure.query("UPDATE workflow_step_execution SET status = 'failed' WHERE id = $1", [
+			failing.id,
+		]);
+
+		// the claim must park on the execution lock until the failure commits
+		const claim = store.claimStep(id);
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		await failure.commitTransaction();
+		await failure.release();
+
+		expect(await claim).toBeNull();
+		expect((await store.loadStep(id)).status).toBe('queued');
+	});
+
 	it('TypeOrmStepStore.completeStep persists outputs and marks the step completed', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -377,6 +377,26 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(await store.loadStepsByNodeIds('00000000-0000-7000-8000-000000000000', [])).toEqual({});
 	});
 
+	it('TypeOrmStepStore.countSettledSteps counts terminal rows only, per execution', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		await store.createSteps([
+			{ executionId, nodeId: 'trigger', status: 'completed' },
+			{ executionId, nodeId: 'a', status: 'skipped' },
+			{ executionId, nodeId: 'b', status: 'cancelled' },
+			{ executionId, nodeId: 'c', status: 'queued' },
+			{ executionId, nodeId: 'd', status: 'running' },
+		]);
+		const { id: eId } = await createStep(store, { executionId, nodeId: 'e', status: 'running' });
+		await store.failStep(eId, { name: 'Error', message: 'node blew up' });
+		// a sibling execution's settled rows must not count
+		const otherExecutionId = await createExecution();
+		await createStep(store, { executionId: otherExecutionId, nodeId: 'x', status: 'completed' });
+
+		// trigger, a, b, e — not c (queued) or d (running)
+		expect(await store.countSettledSteps(executionId)).toBe(4);
+	});
+
 	it('rejects an invalid status (check constraint)', async () => {
 		const executionId = await createExecution();
 		const repo = dataSource.getRepository(WorkflowStepExecution);

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -263,42 +263,6 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(found.error).toEqual(error);
 	});
 
-	it('TypeOrmStepStore.loadStepOutputs returns only completed outputs, keyed by node id', async () => {
-		const executionId = await createExecution();
-		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
-		await store.completeStep(aId, [[{ json: { from: 'a' } }]]);
-		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
-		const { id: cId } = await createStep(store, { executionId, nodeId: 'c', status: 'running' });
-		await store.failStep(cId, { name: 'Error', message: 'node blew up' });
-
-		const outputs = await store.loadStepOutputs(executionId, ['a', 'b', 'c', 'd']);
-
-		expect(outputs).toEqual({
-			a: [[{ json: { from: 'a' } }]],
-			b: null, // queued
-			c: null, // failed
-			d: null, // no step row
-		});
-	});
-
-	it('TypeOrmStepStore.loadCompletedNodeIds returns only the completed ones', async () => {
-		const executionId = await createExecution();
-		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
-		// completed without firing its slot — readiness must not depend on what
-		// the outputs contain, which is why it has its own method
-		await store.completeStep(aId, [null]);
-		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
-		const { id: cId } = await createStep(store, { executionId, nodeId: 'c', status: 'running' });
-		await store.failStep(cId, { name: 'Error', message: 'node blew up' });
-
-		const completed = await store.loadCompletedNodeIds(executionId, ['a', 'b', 'c', 'd']);
-
-		// b queued, c failed, d has no row at all
-		expect(completed).toEqual(new Set(['a']));
-	});
-
 	it('TypeOrmStepStore.createSteps persists a skipped step (settled at birth)', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -44,9 +44,10 @@ describe('workflow_step_execution table (integration)', () => {
 	/** Most cases need one step; the store's API is the batch `createSteps`. */
 	async function createStep(
 		store: TypeOrmStepStore,
+		executionId: string,
 		record: NewStepRecord,
 	): Promise<{ id: string }> {
-		const [step] = await store.createSteps([record]);
+		const [step] = await store.createSteps(executionId, [record]);
 		return step;
 	}
 
@@ -84,7 +85,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
-		const { id } = await createStep(store, { executionId, nodeId: 'x', status: 'queued' });
+		const { id } = await createStep(store, executionId, { nodeId: 'x', status: 'queued' });
 
 		const found = await dataSource
 			.getRepository(WorkflowStepExecution)
@@ -97,10 +98,10 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
-		const ids = await store.createSteps([
-			{ executionId, nodeId: 'trigger', status: 'completed' },
-			{ executionId, nodeId: 'a', status: 'queued' },
-			{ executionId, nodeId: 'b', status: 'queued' },
+		const ids = await store.createSteps(executionId, [
+			{ nodeId: 'trigger', status: 'completed' },
+			{ nodeId: 'a', status: 'queued' },
+			{ nodeId: 'b', status: 'queued' },
 		]);
 
 		expect(ids).toHaveLength(3);
@@ -119,7 +120,7 @@ describe('workflow_step_execution table (integration)', () => {
 
 	it('TypeOrmStepStore.createSteps is a no-op for an empty batch', async () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		expect(await store.createSteps([])).toEqual([]);
+		expect(await store.createSteps('00000000-0000-7000-8000-000000000000', [])).toEqual([]);
 	});
 
 	it('TypeOrmStepStore.createSteps rejects a step created with outputs but not completed', async () => {
@@ -127,7 +128,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
 		await expect(
-			store.createSteps([{ executionId, nodeId: 'x', status: 'queued', outputs: [{}] }]),
+			store.createSteps(executionId, [{ nodeId: 'x', status: 'queued', outputs: [{}] }]),
 		).rejects.toMatchObject({
 			name: 'UnexpectedError',
 			message: expect.stringContaining('completed') as string,
@@ -147,18 +148,14 @@ describe('workflow_step_execution table (integration)', () => {
 	it('rejects a step referencing a non-existent execution (foreign key)', async () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		await expect(
-			createStep(store, {
-				executionId: '00000000-0000-7000-8000-000000000000',
-				nodeId: 'a',
-				status: 'queued',
-			}),
+			createStep(store, '00000000-0000-7000-8000-000000000000', { nodeId: 'a', status: 'queued' }),
 		).rejects.toThrow();
 	});
 
 	it('TypeOrmStepStore.loadStep returns the step, or throws when absent', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await createStep(store, { executionId, nodeId: 'node-a', status: 'queued' });
+		const { id } = await createStep(store, executionId, { nodeId: 'node-a', status: 'queued' });
 
 		const step = await store.loadStep(id);
 
@@ -180,7 +177,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.claimStep only claims a queued step', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
+		const { id } = await createStep(store, executionId, { nodeId: 'a', status: 'queued' });
 
 		// the winning claim gets the step back, already `running`
 		expect(await store.claimStep(id)).toEqual({
@@ -200,7 +197,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		// b is planned first; a's failure lands before b's step:ready is claimed
-		const { id } = await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
+		const { id } = await createStep(store, executionId, { nodeId: 'b', status: 'queued' });
 		await seedStep({ executionId, nodeId: 'a', status: 'failed' });
 
 		// the fence in the claim statement keeps b from starting work in a
@@ -210,11 +207,7 @@ describe('workflow_step_execution table (integration)', () => {
 
 		// a failure in one execution doesn't fence claims in another
 		const otherExecutionId = await createExecution();
-		const other = await createStep(store, {
-			executionId: otherExecutionId,
-			nodeId: 'a',
-			status: 'queued',
-		});
+		const other = await createStep(store, otherExecutionId, { nodeId: 'a', status: 'queued' });
 		expect(await store.claimStep(other.id)).not.toBeNull();
 	});
 
@@ -225,7 +218,7 @@ describe('workflow_step_execution table (integration)', () => {
 
 		// planned after the failure's cancellation sweep, these rows would be
 		// unclaimable and stuck queued forever, so they must not exist at all
-		const created = await store.createSteps([{ executionId, nodeId: 'b', status: 'queued' }]);
+		const created = await store.createSteps(executionId, [{ nodeId: 'b', status: 'queued' }]);
 
 		expect(created).toEqual([]);
 		const stepRepo = dataSource.getRepository(WorkflowStepExecution);
@@ -248,7 +241,7 @@ describe('workflow_step_execution table (integration)', () => {
 		]);
 
 		// the insert must park on the execution lock until the failure commits
-		const create = store.createSteps([{ executionId, nodeId: 'b', status: 'queued' }]);
+		const create = store.createSteps(executionId, [{ nodeId: 'b', status: 'queued' }]);
 		await new Promise((resolve) => setTimeout(resolve, 150));
 		await failure.commitTransaction();
 		await failure.release();
@@ -260,7 +253,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		const failing = await seedStep({ executionId, nodeId: 'a', status: 'running' });
-		const { id } = await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
+		const { id } = await createStep(store, executionId, { nodeId: 'b', status: 'queued' });
 
 		// An in-flight failStep: execution lock held, failed row written, commit
 		// pending. A snapshot-only claim would see no failure and go through.
@@ -299,7 +292,7 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.completeStep and failStep only record a step that is running', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id } = await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
+		const { id } = await createStep(store, executionId, { nodeId: 'a', status: 'queued' });
 
 		expect(await store.completeStep(id, [[{ json: { ok: true } }]])).toBe(false);
 		expect(await store.failStep(id, { name: 'Error', message: 'node blew up' })).toBe(false);
@@ -317,8 +310,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const otherExecutionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id: queuedId } = await createStep(store, {
-			executionId,
+		const { id: queuedId } = await createStep(store, executionId, {
 			nodeId: 'a',
 			status: 'queued',
 		});
@@ -327,14 +319,12 @@ describe('workflow_step_execution table (integration)', () => {
 			nodeId: 'b',
 			status: 'running',
 		});
-		const { id: completedId } = await createStep(store, {
-			executionId,
+		const { id: completedId } = await createStep(store, executionId, {
 			nodeId: 'c',
 			status: 'completed',
 		});
 		// scoped to the execution: a sibling execution's queued work is untouched
-		const { id: otherId } = await createStep(store, {
-			executionId: otherExecutionId,
+		const { id: otherId } = await createStep(store, otherExecutionId, {
 			nodeId: 'a',
 			status: 'queued',
 		});
@@ -371,7 +361,7 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 
-		const { id } = await createStep(store, { executionId, nodeId: 'x', status: 'skipped' });
+		const { id } = await createStep(store, executionId, { nodeId: 'x', status: 'skipped' });
 
 		const step = await store.loadStep(id);
 		expect(step.status).toBe('skipped');
@@ -385,11 +375,11 @@ describe('workflow_step_execution table (integration)', () => {
 		const { id: aId } = await seedStep({ executionId, nodeId: 'a', status: 'running' });
 		// a multi-slot output with a dead slot round-trips as stored
 		await store.completeStep(aId, [[{ json: { from: 'a' } }], null]);
-		const { id: bId } = await createStep(store, { executionId, nodeId: 'b', status: 'skipped' });
-		await createStep(store, { executionId, nodeId: 'c', status: 'queued' });
+		const { id: bId } = await createStep(store, executionId, { nodeId: 'b', status: 'skipped' });
+		await createStep(store, executionId, { nodeId: 'c', status: 'queued' });
 		// scoped to the execution: a sibling execution's row for 'a' must not leak in
 		const otherExecutionId = await createExecution();
-		await createStep(store, { executionId: otherExecutionId, nodeId: 'a', status: 'queued' });
+		await createStep(store, otherExecutionId, { nodeId: 'a', status: 'queued' });
 
 		const steps = await store.loadStepsByNodeIds(executionId, ['a', 'b', 'c', 'd']);
 
@@ -411,11 +401,11 @@ describe('workflow_step_execution table (integration)', () => {
 		// slot 0 has data, slot 1 was never fired, slot 2 ran but produced zero
 		// items — [] is live, only JSON null marks a dead slot
 		await store.completeStep(aId, [[{ json: { big: 'payload' } }], null, []]);
-		const { id: bId } = await createStep(store, { executionId, nodeId: 'b', status: 'skipped' });
-		await createStep(store, { executionId, nodeId: 'c', status: 'queued' });
+		const { id: bId } = await createStep(store, executionId, { nodeId: 'b', status: 'skipped' });
+		await createStep(store, executionId, { nodeId: 'c', status: 'queued' });
 		// scoped to the execution: a sibling execution's row for 'a' must not leak in
 		const otherExecutionId = await createExecution();
-		await createStep(store, { executionId: otherExecutionId, nodeId: 'a', status: 'queued' });
+		await createStep(store, otherExecutionId, { nodeId: 'a', status: 'queued' });
 
 		const summaries = await store.loadStepSummaries(executionId, ['a', 'b', 'c', 'd']);
 
@@ -448,10 +438,10 @@ describe('workflow_step_execution table (integration)', () => {
 	it('TypeOrmStepStore.countSettledSteps counts terminal rows only, per execution', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		await store.createSteps([
-			{ executionId, nodeId: 'trigger', status: 'completed' },
-			{ executionId, nodeId: 'a', status: 'skipped' },
-			{ executionId, nodeId: 'c', status: 'queued' },
+		await store.createSteps(executionId, [
+			{ nodeId: 'trigger', status: 'completed' },
+			{ nodeId: 'a', status: 'skipped' },
+			{ nodeId: 'c', status: 'queued' },
 		]);
 		await seedStep({ executionId, nodeId: 'b', status: 'cancelled' });
 		await seedStep({ executionId, nodeId: 'd', status: 'running' });
@@ -459,7 +449,7 @@ describe('workflow_step_execution table (integration)', () => {
 		await store.failStep(eId, { name: 'Error', message: 'node blew up' });
 		// a sibling execution's settled rows must not count
 		const otherExecutionId = await createExecution();
-		await createStep(store, { executionId: otherExecutionId, nodeId: 'x', status: 'completed' });
+		await createStep(store, otherExecutionId, { nodeId: 'x', status: 'completed' });
 
 		// trigger, a, b, e — not c (queued) or d (running)
 		expect(await store.countSettledSteps(executionId)).toBe(4);
@@ -479,13 +469,13 @@ describe('workflow_step_execution table (integration)', () => {
 		const executionId = await createExecution();
 		const repo = dataSource.getRepository(WorkflowStepExecution);
 		const store = new TypeOrmStepStore(repo);
-		await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
+		await createStep(store, executionId, { nodeId: 'a', status: 'queued' });
 
 		// 'a' is taken; 'b' is not, and must still land — the whole point of skipping
 		// the conflict rather than failing the statement
-		const created = await store.createSteps([
-			{ executionId, nodeId: 'a', status: 'queued' },
-			{ executionId, nodeId: 'b', status: 'queued' },
+		const created = await store.createSteps(executionId, [
+			{ nodeId: 'a', status: 'queued' },
+			{ nodeId: 'b', status: 'queued' },
 		]);
 
 		expect(created).toEqual([{ id: expect.any(String) as string, nodeId: 'b' }]);
@@ -498,11 +488,9 @@ describe('workflow_step_execution table (integration)', () => {
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
 		const executionId = await createExecution();
 		const otherExecutionId = await createExecution();
-		await createStep(store, { executionId, nodeId: 'a', status: 'queued' });
+		await createStep(store, executionId, { nodeId: 'a', status: 'queued' });
 
-		const created = await store.createSteps([
-			{ executionId: otherExecutionId, nodeId: 'a', status: 'queued' },
-		]);
+		const created = await store.createSteps(otherExecutionId, [{ nodeId: 'a', status: 'queued' }]);
 
 		expect(created).toEqual([{ id: expect.any(String) as string, nodeId: 'a' }]);
 	});

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -299,6 +299,84 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(completed).toEqual(new Set(['a']));
 	});
 
+	it('TypeOrmStepStore.createSteps persists a skipped step (settled at birth)', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+
+		const { id } = await createStep(store, { executionId, nodeId: 'x', status: 'skipped' });
+
+		const step = await store.loadStep(id);
+		expect(step.status).toBe('skipped');
+		expect(step.outputs).toBeNull();
+		expect(step.error).toBeNull();
+	});
+
+	it('TypeOrmStepStore.loadStepsByNodeIds returns rows keyed by node id, omitting absent nodes', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		// a multi-slot output with a dead slot round-trips as stored
+		await store.completeStep(aId, [[{ json: { from: 'a' } }], null]);
+		const { id: bId } = await createStep(store, { executionId, nodeId: 'b', status: 'skipped' });
+		await createStep(store, { executionId, nodeId: 'c', status: 'queued' });
+		// scoped to the execution: a sibling execution's row for 'a' must not leak in
+		const otherExecutionId = await createExecution();
+		await createStep(store, { executionId: otherExecutionId, nodeId: 'a', status: 'queued' });
+
+		const steps = await store.loadStepsByNodeIds(executionId, ['a', 'b', 'c', 'd']);
+
+		// 'd' has no row, so it has no key — absence means "not planned yet"
+		expect(Object.keys(steps).sort()).toEqual(['a', 'b', 'c']);
+		expect(steps.a).toMatchObject({
+			id: aId,
+			status: 'completed',
+			outputs: [[{ json: { from: 'a' } }], null],
+		});
+		expect(steps.b).toMatchObject({ id: bId, status: 'skipped', outputs: null });
+		expect(steps.c).toMatchObject({ status: 'queued', outputs: null });
+	});
+
+	it('TypeOrmStepStore.loadStepSummaries reports per-slot liveness without payloads', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		// slot 0 has data, slot 1 was never fired, slot 2 ran but produced zero
+		// items — [] is live, only JSON null marks a dead slot
+		await store.completeStep(aId, [[{ json: { big: 'payload' } }], null, []]);
+		const { id: bId } = await createStep(store, { executionId, nodeId: 'b', status: 'skipped' });
+		await createStep(store, { executionId, nodeId: 'c', status: 'queued' });
+		// scoped to the execution: a sibling execution's row for 'a' must not leak in
+		const otherExecutionId = await createExecution();
+		await createStep(store, { executionId: otherExecutionId, nodeId: 'a', status: 'queued' });
+
+		const summaries = await store.loadStepSummaries(executionId, ['a', 'b', 'c', 'd']);
+
+		expect(Object.keys(summaries).sort()).toEqual(['a', 'b', 'c']);
+		expect(summaries.a).toEqual({
+			id: aId,
+			nodeId: 'a',
+			status: 'completed',
+			filledOutputSlots: [true, false, true],
+		});
+		expect(summaries.b).toEqual({
+			id: bId,
+			nodeId: 'b',
+			status: 'skipped',
+			filledOutputSlots: [],
+		});
+		expect(summaries.c).toMatchObject({ status: 'queued', filledOutputSlots: [] });
+	});
+
+	it('TypeOrmStepStore.loadStepSummaries is a no-op for no node ids', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		expect(await store.loadStepSummaries('00000000-0000-7000-8000-000000000000', [])).toEqual({});
+	});
+
+	it('TypeOrmStepStore.loadStepsByNodeIds is a no-op for no node ids', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		expect(await store.loadStepsByNodeIds('00000000-0000-7000-8000-000000000000', [])).toEqual({});
+	});
+
 	it('rejects an invalid status (check constraint)', async () => {
 		const executionId = await createExecution();
 		const repo = dataSource.getRepository(WorkflowStepExecution);

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -298,6 +298,84 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(completed).toEqual(new Set(['a']));
 	});
 
+	it('TypeOrmStepStore.createSteps persists a skipped step (settled at birth)', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+
+		const { id } = await createStep(store, { executionId, nodeId: 'x', status: 'skipped' });
+
+		const step = await store.loadStep(id);
+		expect(step.status).toBe('skipped');
+		expect(step.outputs).toBeNull();
+		expect(step.error).toBeNull();
+	});
+
+	it('TypeOrmStepStore.loadStepsByNodeIds returns rows keyed by node id, omitting absent nodes', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		// a multi-slot output with a dead slot round-trips as stored
+		await store.completeStep(aId, [[{ json: { from: 'a' } }], null]);
+		const { id: bId } = await createStep(store, { executionId, nodeId: 'b', status: 'skipped' });
+		await createStep(store, { executionId, nodeId: 'c', status: 'queued' });
+		// scoped to the execution: a sibling execution's row for 'a' must not leak in
+		const otherExecutionId = await createExecution();
+		await createStep(store, { executionId: otherExecutionId, nodeId: 'a', status: 'queued' });
+
+		const steps = await store.loadStepsByNodeIds(executionId, ['a', 'b', 'c', 'd']);
+
+		// 'd' has no row, so it has no key — absence means "not planned yet"
+		expect(Object.keys(steps).sort()).toEqual(['a', 'b', 'c']);
+		expect(steps.a).toMatchObject({
+			id: aId,
+			status: 'completed',
+			outputs: [[{ json: { from: 'a' } }], null],
+		});
+		expect(steps.b).toMatchObject({ id: bId, status: 'skipped', outputs: null });
+		expect(steps.c).toMatchObject({ status: 'queued', outputs: null });
+	});
+
+	it('TypeOrmStepStore.loadStepSummaries reports per-slot liveness without payloads', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
+		// slot 0 has data, slot 1 was never fired, slot 2 ran but produced zero
+		// items — [] is live, only JSON null marks a dead slot
+		await store.completeStep(aId, [[{ json: { big: 'payload' } }], null, []]);
+		const { id: bId } = await createStep(store, { executionId, nodeId: 'b', status: 'skipped' });
+		await createStep(store, { executionId, nodeId: 'c', status: 'queued' });
+		// scoped to the execution: a sibling execution's row for 'a' must not leak in
+		const otherExecutionId = await createExecution();
+		await createStep(store, { executionId: otherExecutionId, nodeId: 'a', status: 'queued' });
+
+		const summaries = await store.loadStepSummaries(executionId, ['a', 'b', 'c', 'd']);
+
+		expect(Object.keys(summaries).sort()).toEqual(['a', 'b', 'c']);
+		expect(summaries.a).toEqual({
+			id: aId,
+			nodeId: 'a',
+			status: 'completed',
+			filledOutputSlots: [true, false, true],
+		});
+		expect(summaries.b).toEqual({
+			id: bId,
+			nodeId: 'b',
+			status: 'skipped',
+			filledOutputSlots: [],
+		});
+		expect(summaries.c).toMatchObject({ status: 'queued', filledOutputSlots: [] });
+	});
+
+	it('TypeOrmStepStore.loadStepSummaries is a no-op for no node ids', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		expect(await store.loadStepSummaries('00000000-0000-7000-8000-000000000000', [])).toEqual({});
+	});
+
+	it('TypeOrmStepStore.loadStepsByNodeIds is a no-op for no node ids', async () => {
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		expect(await store.loadStepsByNodeIds('00000000-0000-7000-8000-000000000000', [])).toEqual({});
+	});
+
 	it('rejects an invalid status (check constraint)', async () => {
 		const executionId = await createExecution();
 		const repo = dataSource.getRepository(WorkflowStepExecution);

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -376,6 +376,26 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(await store.loadStepsByNodeIds('00000000-0000-7000-8000-000000000000', [])).toEqual({});
 	});
 
+	it('TypeOrmStepStore.countSettledSteps counts terminal rows only, per execution', async () => {
+		const executionId = await createExecution();
+		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
+		await store.createSteps([
+			{ executionId, nodeId: 'trigger', status: 'completed' },
+			{ executionId, nodeId: 'a', status: 'skipped' },
+			{ executionId, nodeId: 'b', status: 'cancelled' },
+			{ executionId, nodeId: 'c', status: 'queued' },
+			{ executionId, nodeId: 'd', status: 'running' },
+		]);
+		const { id: eId } = await createStep(store, { executionId, nodeId: 'e', status: 'running' });
+		await store.failStep(eId, { name: 'Error', message: 'node blew up' });
+		// a sibling execution's settled rows must not count
+		const otherExecutionId = await createExecution();
+		await createStep(store, { executionId: otherExecutionId, nodeId: 'x', status: 'completed' });
+
+		// trigger, a, b, e — not c (queued) or d (running)
+		expect(await store.countSettledSteps(executionId)).toBe(4);
+	});
+
 	it('rejects an invalid status (check constraint)', async () => {
 		const executionId = await createExecution();
 		const repo = dataSource.getRepository(WorkflowStepExecution);

--- a/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/database/__tests__/workflow-step-execution.integration.test.ts
@@ -262,42 +262,6 @@ describe('workflow_step_execution table (integration)', () => {
 		expect(found.error).toEqual(error);
 	});
 
-	it('TypeOrmStepStore.loadStepOutputs returns only completed outputs, keyed by node id', async () => {
-		const executionId = await createExecution();
-		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
-		await store.completeStep(aId, [[{ json: { from: 'a' } }]]);
-		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
-		const { id: cId } = await createStep(store, { executionId, nodeId: 'c', status: 'running' });
-		await store.failStep(cId, { name: 'Error', message: 'node blew up' });
-
-		const outputs = await store.loadStepOutputs(executionId, ['a', 'b', 'c', 'd']);
-
-		expect(outputs).toEqual({
-			a: [[{ json: { from: 'a' } }]],
-			b: null, // queued
-			c: null, // failed
-			d: null, // no step row
-		});
-	});
-
-	it('TypeOrmStepStore.loadCompletedNodeIds returns only the completed ones', async () => {
-		const executionId = await createExecution();
-		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));
-		const { id: aId } = await createStep(store, { executionId, nodeId: 'a', status: 'running' });
-		// completed without firing its slot — readiness must not depend on what
-		// the outputs contain, which is why it has its own method
-		await store.completeStep(aId, [null]);
-		await createStep(store, { executionId, nodeId: 'b', status: 'queued' });
-		const { id: cId } = await createStep(store, { executionId, nodeId: 'c', status: 'running' });
-		await store.failStep(cId, { name: 'Error', message: 'node blew up' });
-
-		const completed = await store.loadCompletedNodeIds(executionId, ['a', 'b', 'c', 'd']);
-
-		// b queued, c failed, d has no row at all
-		expect(completed).toEqual(new Set(['a']));
-	});
-
 	it('TypeOrmStepStore.createSteps persists a skipped step (settled at birth)', async () => {
 		const executionId = await createExecution();
 		const store = new TypeOrmStepStore(dataSource.getRepository(WorkflowStepExecution));

--- a/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
+++ b/packages/@n8n/engine/src/database/migrations/1784890100000-CreateWorkflowStepExecution.ts
@@ -60,7 +60,8 @@ export class CreateWorkflowStepExecution1784890100000 implements MigrationInterf
 				checks: [
 					{
 						name: 'chk_workflow_step_execution_status',
-						expression: "status IN ('queued', 'running', 'completed', 'failed', 'cancelled')",
+						expression:
+							"status IN ('queued', 'running', 'completed', 'failed', 'skipped', 'cancelled')",
 					},
 				],
 			}),

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -33,11 +33,9 @@ export class TypeOrmStepStore implements StepStore {
 		// instances, and these are plain values.
 		const rows = records.map((record) => ({ ...record, executionId, id: generateId() }));
 
-		// Shared side of the failure fence (see `claimStep`): a concurrent
-		// `failStep` either committed before the check below, which then creates
-		// nothing, or waits for this insert to commit, whereupon the failure's
-		// cancellation sweep sees the new rows. Without it, an insert landing
-		// after the sweep would strand rows `queued` forever.
+		// Shared side of the failure fence (see `claimStep`): rows either commit
+		// before a failure (whose sweep then cancels them) or are never created.
+		// Unfenced, a late insert would strand rows `queued` forever.
 		return await this.repo.manager.transaction(async (manager) => {
 			await manager.query('SELECT id FROM workflow_execution WHERE id = $1 FOR SHARE', [
 				executionId,
@@ -82,10 +80,9 @@ export class TypeOrmStepStore implements StepStore {
 		// only the identity columns: a step claimed out of `queued` can't have
 		// an outcome yet, so `outputs`/`error` are `null` by the lifecycle.
 		//
-		// The failure fence: the claim and `failStep` contend on the execution
-		// row (shared vs exclusive lock), so the failed-sibling check cannot
-		// miss a concurrently committing failure — the claim either waits it
-		// out and sees it, or committed strictly before it.
+		// The failure fence: the claim contends with `failStep` on the execution
+		// row (shared vs exclusive lock), so it either waits out a committing
+		// failure and sees it, or committed strictly before it.
 		return await this.repo.manager.transaction(async (manager) => {
 			const [execution] = await manager.query<Array<{ id: string }>>(
 				`SELECT id FROM workflow_execution
@@ -230,12 +227,12 @@ function assertOutputsMatchStatus(record: {
 }): void {
 	if (record.outputs !== undefined && record.status !== 'completed') {
 		throw new UnexpectedError(
-			`step for node ${record.nodeId} carries outputs but is created ${record.status}; only a step created completed may carry outputs`,
+			`step for node ${record.nodeId} is created ${record.status} with outputs, which only a step created completed may carry`,
 		);
 	}
 	if (record.status === 'completed' && record.outputs === undefined) {
 		throw new UnexpectedError(
-			`step for node ${record.nodeId} is created completed without outputs; a NULL outputs column reads as every slot dead — pass [] for a step that fired nothing`,
+			`step for node ${record.nodeId} is created completed without outputs, which persists as NULL and reads as every slot dead (pass [] for a step that fired nothing)`,
 		);
 	}
 }

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -181,8 +181,9 @@ export class TypeOrmStepStore implements StepStore {
 	): Promise<Record<string, StepSummary>> {
 		if (nodeIds.length === 0) return {};
 
-		// Slot liveness is projected in SQL so the jsonb payloads never leave the
-		// database: a slot is filled unless it holds JSON null.
+		// The per-slot booleans are computed inside the query, so the potentially
+		// large outputs payloads are never transferred. A slot counts as filled
+		// unless it holds JSON null.
 		const rows: Array<{
 			id: string;
 			nodeId: string;

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -17,6 +17,10 @@ import {
 	type StepSummary,
 } from '../execution/step-store';
 
+/** RETURNING rows come back keyed by database column name (snake_case). */
+type InsertedStepRow = { id: string; node_id: string };
+type ClaimedStepRow = { id: string; execution_id: string; node_id: string };
+
 /** TypeORM-backed `StepStore` adapter. */
 export class TypeOrmStepStore implements StepStore {
 	constructor(private readonly repo: Repository<WorkflowStepExecution>) {}
@@ -60,9 +64,7 @@ export class TypeOrmStepStore implements StepStore {
 				.returning(['id', 'nodeId'])
 				.execute();
 
-			return (result.raw as Array<{ id: string; node_id: string }>).map(
-				({ id, node_id: nodeId }) => ({ id, nodeId }),
-			);
+			return (result.raw as InsertedStepRow[]).map(({ id, node_id: nodeId }) => ({ id, nodeId }));
 		});
 	}
 
@@ -107,7 +109,7 @@ export class TypeOrmStepStore implements StepStore {
 				.returning(['id', 'executionId', 'nodeId'])
 				.execute();
 
-			const [row] = result.raw as Array<{ id: string; execution_id: string; node_id: string }>;
+			const [row] = result.raw as ClaimedStepRow[];
 			if (!row) return null;
 
 			return {

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -3,7 +3,11 @@ import { In, type Repository } from '@n8n/typeorm';
 import type { WorkflowStepExecution } from './entities';
 import { generateId } from './generate-id';
 import { UnexpectedError } from '../common';
-import type { StepSlots, StepStatus } from '../execution/execution.types';
+import {
+	SETTLED_STEP_STATUSES,
+	type StepSlots,
+	type StepStatus,
+} from '../execution/execution.types';
 import {
 	StepNotFoundError,
 	type NewStepRecord,
@@ -179,6 +183,12 @@ export class TypeOrmStepStore implements StepStore {
 		});
 
 		return new Set(rows.map((row) => row.nodeId));
+	}
+
+	async countSettledSteps(executionId: string): Promise<number> {
+		return await this.repo.count({
+			where: { executionId, status: In([...SETTLED_STEP_STATUSES]) },
+		});
 	}
 
 	async hasActiveSteps(executionId: string): Promise<boolean> {

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -36,20 +36,40 @@ export class TypeOrmStepStore implements StepStore {
 		// instances, and these are plain values.
 		const rows = records.map((record) => ({ ...record, id: generateId() }));
 
-		// `orIgnore` is the unique key doing its job: a node another planner already
-		// queued is skipped, leaving the rest of the batch to land. RETURNING emits
-		// exactly the rows that were inserted, keyed by database column name.
-		const result = await this.repo
-			.createQueryBuilder()
-			.insert()
-			.values(rows)
-			.orIgnore()
-			.returning(['id', 'nodeId'])
-			.execute();
+		// Shared side of the failure fence (see `claimStep`): a concurrent
+		// `failStep` either committed before the check below, which then creates
+		// nothing, or waits for this insert to commit, whereupon the failure's
+		// cancellation sweep sees the new rows. Without it, an insert landing
+		// after the sweep would strand rows `queued` forever.
+		const executionIds = [...new Set(records.map((record) => record.executionId))];
+		return await this.repo.manager.transaction(async (manager) => {
+			await manager.query('SELECT id FROM workflow_execution WHERE id = ANY($1) FOR SHARE', [
+				executionIds,
+			]);
+			const [failed] = await manager.query<Array<{ id: string }>>(
+				`SELECT id FROM workflow_step_execution
+				 WHERE execution_id = ANY($1) AND status = 'failed'
+				 LIMIT 1`,
+				[executionIds],
+			);
+			if (failed) return [];
 
-		return (result.raw as Array<{ id: string; node_id: string }>).map(
-			({ id, node_id: nodeId }) => ({ id, nodeId }),
-		);
+			// `orIgnore` is the unique key doing its job: a node another planner already
+			// queued is skipped, leaving the rest of the batch to land. RETURNING emits
+			// exactly the rows that were inserted, keyed by database column name.
+			const result = await manager
+				.createQueryBuilder()
+				.insert()
+				.into(WorkflowStepExecution)
+				.values(rows)
+				.orIgnore()
+				.returning(['id', 'nodeId'])
+				.execute();
+
+			return (result.raw as Array<{ id: string; node_id: string }>).map(
+				({ id, node_id: nodeId }) => ({ id, nodeId }),
+			);
+		});
 	}
 
 	async loadStep(id: string): Promise<StepRecord> {

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -1,6 +1,6 @@
 import { In, type Repository } from '@n8n/typeorm';
 
-import type { WorkflowStepExecution } from './entities';
+import { WorkflowStepExecution } from './entities';
 import { generateId } from './generate-id';
 import { UnexpectedError } from '../common';
 import {
@@ -65,25 +65,47 @@ export class TypeOrmStepStore implements StepStore {
 		// need a second query to learn which node it now runs. RETURNING covers
 		// only the identity columns: a step claimed out of `queued` can't have
 		// an outcome yet, so `outputs`/`error` are `null` by the lifecycle.
-		const result = await this.repo
-			.createQueryBuilder()
-			.update()
-			.set({ status: 'running' })
-			.where({ id, status: 'queued' })
-			.returning(['id', 'executionId', 'nodeId'])
-			.execute();
+		//
+		// The failure fence: the claim and `failStep` contend on the execution
+		// row (shared vs exclusive lock), so the failed-sibling check cannot
+		// miss a concurrently committing failure — the claim either waits it
+		// out and sees it, or committed strictly before it.
+		return await this.repo.manager.transaction(async (manager) => {
+			const [execution] = (await manager.query(
+				`SELECT id FROM workflow_execution
+				 WHERE id = (SELECT execution_id FROM workflow_step_execution WHERE id = $1)
+				 FOR SHARE`,
+				[id],
+			)) as Array<{ id: string }>;
+			if (!execution) return null;
 
-		const [row] = result.raw as Array<{ id: string; execution_id: string; node_id: string }>;
-		if (!row) return null;
+			const result = await manager
+				.createQueryBuilder()
+				.update(WorkflowStepExecution)
+				.set({ status: 'running' })
+				.where({ id, status: 'queued' })
+				.andWhere(
+					`NOT EXISTS (
+						SELECT 1 FROM workflow_step_execution sibling
+						WHERE sibling.execution_id = :executionId AND sibling.status = 'failed'
+					)`,
+					{ executionId: execution.id },
+				)
+				.returning(['id', 'executionId', 'nodeId'])
+				.execute();
 
-		return {
-			id: row.id,
-			executionId: row.execution_id,
-			nodeId: row.node_id,
-			status: 'running',
-			outputs: null,
-			error: null,
-		};
+			const [row] = result.raw as Array<{ id: string; execution_id: string; node_id: string }>;
+			if (!row) return null;
+
+			return {
+				id: row.id,
+				executionId: row.execution_id,
+				nodeId: row.node_id,
+				status: 'running',
+				outputs: null,
+				error: null,
+			};
+		});
 	}
 
 	async completeStep(id: string, outputs: StepSlots): Promise<boolean> {
@@ -95,7 +117,22 @@ export class TypeOrmStepStore implements StepStore {
 	}
 
 	async failStep(id: string, error: StepError): Promise<boolean> {
-		return await this.transition(id, 'running', 'failed', { error });
+		// Exclusive side of the claim fence (see `claimStep`). NO KEY UPDATE
+		// rather than UPDATE so FK-checked step inserts don't queue behind it.
+		return await this.repo.manager.transaction(async (manager) => {
+			await manager.query(
+				`SELECT id FROM workflow_execution
+				 WHERE id = (SELECT execution_id FROM workflow_step_execution WHERE id = $1)
+				 FOR NO KEY UPDATE`,
+				[id],
+			);
+			const result = await manager.update(
+				WorkflowStepExecution,
+				{ id, status: 'running' },
+				{ error, status: 'failed' },
+			);
+			return result.affected === 1;
+		});
 	}
 
 	/**

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -155,46 +155,9 @@ export class TypeOrmStepStore implements StepStore {
 		return Object.fromEntries(rows.map((row) => [row.nodeId, row]));
 	}
 
-	async loadStepOutputs(
-		executionId: string,
-		nodeIds: string[],
-	): Promise<Record<string, StepSlots | null>> {
-		const outputsByNodeId: Record<string, StepSlots | null> = {};
-		for (const nodeId of nodeIds) outputsByNodeId[nodeId] = null;
-		if (nodeIds.length === 0) return outputsByNodeId;
-
-		// Filter on `completed` rather than relying on non-completed rows having a
-		// null `outputs` column, so the contract holds however writes are ordered.
-		const rows = await this.repo.find({
-			where: { executionId, nodeId: In(nodeIds), status: 'completed' },
-			select: ['nodeId', 'outputs'],
-		});
-		for (const row of rows) outputsByNodeId[row.nodeId] = row.outputs;
-
-		return outputsByNodeId;
-	}
-
-	async loadCompletedNodeIds(executionId: string, nodeIds: string[]): Promise<Set<string>> {
-		if (nodeIds.length === 0) return new Set();
-
-		const rows = await this.repo.find({
-			where: { executionId, nodeId: In(nodeIds), status: 'completed' },
-			select: ['nodeId'],
-		});
-
-		return new Set(rows.map((row) => row.nodeId));
-	}
-
 	async countSettledSteps(executionId: string): Promise<number> {
 		return await this.repo.count({
 			where: { executionId, status: In([...SETTLED_STEP_STATUSES]) },
-		});
-	}
-
-	async hasActiveSteps(executionId: string): Promise<boolean> {
-		// `exists({ where })`, not `existsBy`, for the reason given in `loadStep`.
-		return await this.repo.exists({
-			where: { executionId, status: In<StepStatus>(['queued', 'running']) },
 		});
 	}
 

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -27,7 +27,7 @@ export class TypeOrmStepStore implements StepStore {
 	): Promise<Array<{ id: string; nodeId: string }>> {
 		if (records.length === 0) return [];
 
-		for (const record of records) assertOutputsMatchStatus(record);
+		for (const record of records) assertCreatableRecord(record);
 
 		// Ids are assigned here because the entity's insert hook only runs on class
 		// instances, and these are plain values.
@@ -217,23 +217,30 @@ export class TypeOrmStepStore implements StepStore {
 	}
 }
 
+const CREATION_STATUSES: readonly StepStatus[] = ['queued', 'completed', 'skipped'];
+
 /**
  * Re-checks `NewStepRecord`'s union at runtime for callers outside the type
  * system. The widened parameter keeps the checks from narrowing to `never`.
  */
-function assertOutputsMatchStatus(record: {
+function assertCreatableRecord(record: {
 	nodeId: string;
 	status: StepStatus;
 	outputs?: StepSlots;
 }): void {
+	if (!CREATION_STATUSES.includes(record.status)) {
+		throw new UnexpectedError(
+			`step for node ${record.nodeId} is created ${record.status}, a status only reachable through its transition method`,
+		);
+	}
 	if (record.outputs !== undefined && record.status !== 'completed') {
 		throw new UnexpectedError(
 			`step for node ${record.nodeId} is created ${record.status} with outputs, which only a step created completed may carry`,
 		);
 	}
-	if (record.status === 'completed' && record.outputs === undefined) {
+	if (record.status === 'completed' && !Array.isArray(record.outputs)) {
 		throw new UnexpectedError(
-			`step for node ${record.nodeId} is created completed without outputs, which persists as NULL and reads as every slot dead (pass [] for a step that fired nothing)`,
+			`step for node ${record.nodeId} is created completed without a slot list, which persists as NULL and reads as every slot dead (pass [] for a step that fired nothing)`,
 		);
 	}
 }

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -21,7 +21,10 @@ import {
 export class TypeOrmStepStore implements StepStore {
 	constructor(private readonly repo: Repository<WorkflowStepExecution>) {}
 
-	async createSteps(records: NewStepRecord[]): Promise<Array<{ id: string; nodeId: string }>> {
+	async createSteps(
+		executionId: string,
+		records: NewStepRecord[],
+	): Promise<Array<{ id: string; nodeId: string }>> {
 		if (records.length === 0) return [];
 
 		for (const record of records) {
@@ -34,23 +37,22 @@ export class TypeOrmStepStore implements StepStore {
 
 		// Ids are assigned here because the entity's insert hook only runs on class
 		// instances, and these are plain values.
-		const rows = records.map((record) => ({ ...record, id: generateId() }));
+		const rows = records.map((record) => ({ ...record, executionId, id: generateId() }));
 
 		// Shared side of the failure fence (see `claimStep`): a concurrent
 		// `failStep` either committed before the check below, which then creates
 		// nothing, or waits for this insert to commit, whereupon the failure's
 		// cancellation sweep sees the new rows. Without it, an insert landing
 		// after the sweep would strand rows `queued` forever.
-		const executionIds = [...new Set(records.map((record) => record.executionId))];
 		return await this.repo.manager.transaction(async (manager) => {
-			await manager.query('SELECT id FROM workflow_execution WHERE id = ANY($1) FOR SHARE', [
-				executionIds,
+			await manager.query('SELECT id FROM workflow_execution WHERE id = $1 FOR SHARE', [
+				executionId,
 			]);
 			const [failed] = await manager.query<Array<{ id: string }>>(
 				`SELECT id FROM workflow_step_execution
-				 WHERE execution_id = ANY($1) AND status = 'failed'
+				 WHERE execution_id = $1 AND status = 'failed'
 				 LIMIT 1`,
-				[executionIds],
+				[executionId],
 			);
 			if (failed) return [];
 

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -27,13 +27,7 @@ export class TypeOrmStepStore implements StepStore {
 	): Promise<Array<{ id: string; nodeId: string }>> {
 		if (records.length === 0) return [];
 
-		for (const record of records) {
-			if (record.outputs && record.status !== 'completed') {
-				throw new UnexpectedError(
-					`step for node ${record.nodeId} carries outputs but is created ${record.status}; only a step created completed may carry outputs`,
-				);
-			}
-		}
+		for (const record of records) assertOutputsMatchStatus(record);
 
 		// Ids are assigned here because the entity's insert hook only runs on class
 		// instances, and these are plain values.
@@ -222,5 +216,26 @@ export class TypeOrmStepStore implements StepStore {
 
 	async hasFailedSteps(executionId: string): Promise<boolean> {
 		return await this.repo.exists({ where: { executionId, status: 'failed' } });
+	}
+}
+
+/**
+ * Runtime mirror of `NewStepRecord`'s union for callers outside the type
+ * system, widened so the checks don't narrow the union to `never`.
+ */
+function assertOutputsMatchStatus(record: {
+	nodeId: string;
+	status: StepStatus;
+	outputs?: StepSlots;
+}): void {
+	if (record.outputs !== undefined && record.status !== 'completed') {
+		throw new UnexpectedError(
+			`step for node ${record.nodeId} carries outputs but is created ${record.status}; only a step created completed may carry outputs`,
+		);
+	}
+	if (record.status === 'completed' && record.outputs === undefined) {
+		throw new UnexpectedError(
+			`step for node ${record.nodeId} is created completed without outputs; a NULL outputs column reads as every slot dead — pass [] for a step that fired nothing`,
+		);
 	}
 }

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -71,12 +71,12 @@ export class TypeOrmStepStore implements StepStore {
 		// miss a concurrently committing failure — the claim either waits it
 		// out and sees it, or committed strictly before it.
 		return await this.repo.manager.transaction(async (manager) => {
-			const [execution] = (await manager.query(
+			const [execution] = await manager.query<Array<{ id: string }>>(
 				`SELECT id FROM workflow_execution
 				 WHERE id = (SELECT execution_id FROM workflow_step_execution WHERE id = $1)
 				 FOR SHARE`,
 				[id],
-			)) as Array<{ id: string }>;
+			);
 			if (!execution) return null;
 
 			const result = await manager

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -33,9 +33,9 @@ export class TypeOrmStepStore implements StepStore {
 		// instances, and these are plain values.
 		const rows = records.map((record) => ({ ...record, executionId, id: generateId() }));
 
-		// Shared side of the failure fence (see `claimStep`): rows either commit
-		// before a failure (whose sweep then cancels them) or are never created.
-		// Unfenced, a late insert would strand rows `queued` forever.
+		// The execution-row lock serializes this insert with `failStep`, so rows
+		// land before the failure (its sweep cancels them) or not at all.
+		// Otherwise rows inserted after the sweep would stay `queued` forever.
 		return await this.repo.manager.transaction(async (manager) => {
 			await manager.query('SELECT id FROM workflow_execution WHERE id = $1 FOR SHARE', [
 				executionId,
@@ -80,9 +80,9 @@ export class TypeOrmStepStore implements StepStore {
 		// only the identity columns: a step claimed out of `queued` can't have
 		// an outcome yet, so `outputs`/`error` are `null` by the lifecycle.
 		//
-		// The failure fence: the claim contends with `failStep` on the execution
-		// row (shared vs exclusive lock), so it either waits out a committing
-		// failure and sees it, or committed strictly before it.
+		// The execution-row lock serializes the claim with `failStep`, so no
+		// step starts running once its execution has a failed step. Claims
+		// don't block each other (shared lock).
 		return await this.repo.manager.transaction(async (manager) => {
 			const [execution] = await manager.query<Array<{ id: string }>>(
 				`SELECT id FROM workflow_execution
@@ -130,8 +130,9 @@ export class TypeOrmStepStore implements StepStore {
 	}
 
 	async failStep(id: string, error: StepError): Promise<boolean> {
-		// Exclusive side of the claim fence (see `claimStep`). NO KEY UPDATE
-		// rather than UPDATE so FK-checked step inserts don't queue behind it.
+		// Locking the execution row makes concurrent claims and planning inserts
+		// wait for this failure to commit (see `claimStep` and `createSteps`).
+		// NO KEY UPDATE, not UPDATE, so plain FK checks don't queue behind it.
 		return await this.repo.manager.transaction(async (manager) => {
 			await manager.query(
 				`SELECT id FROM workflow_execution
@@ -217,8 +218,8 @@ export class TypeOrmStepStore implements StepStore {
 }
 
 /**
- * Runtime mirror of `NewStepRecord`'s union for callers outside the type
- * system, widened so the checks don't narrow the union to `never`.
+ * Re-checks `NewStepRecord`'s union at runtime for callers outside the type
+ * system. The widened parameter keeps the checks from narrowing to `never`.
  */
 function assertOutputsMatchStatus(record: {
 	nodeId: string;

--- a/packages/@n8n/engine/src/database/typeorm-step-store.ts
+++ b/packages/@n8n/engine/src/database/typeorm-step-store.ts
@@ -10,6 +10,7 @@ import {
 	type StepError,
 	type StepRecord,
 	type StepStore,
+	type StepSummary,
 } from '../execution/step-store';
 
 /** TypeORM-backed `StepStore` adapter. */
@@ -105,6 +106,49 @@ export class TypeOrmStepStore implements StepStore {
 	): Promise<boolean> {
 		const result = await this.repo.update({ id, status: from }, { ...fields, status: to });
 		return result.affected === 1;
+	}
+
+	async loadStepsByNodeIds(
+		executionId: string,
+		nodeIds: string[],
+	): Promise<Record<string, StepRecord>> {
+		if (nodeIds.length === 0) return {};
+
+		const rows = await this.repo.find({ where: { executionId, nodeId: In(nodeIds) } });
+		return Object.fromEntries(rows.map((row) => [row.nodeId, row]));
+	}
+
+	async loadStepSummaries(
+		executionId: string,
+		nodeIds: string[],
+	): Promise<Record<string, StepSummary>> {
+		if (nodeIds.length === 0) return {};
+
+		// Slot liveness is projected in SQL so the jsonb payloads never leave the
+		// database: a slot is filled unless it holds JSON null.
+		const rows: Array<{
+			id: string;
+			nodeId: string;
+			status: StepStatus;
+			filledOutputSlots: boolean[];
+		}> = await this.repo
+			.createQueryBuilder('step')
+			.select('step.id', 'id')
+			.addSelect('step.node_id', 'nodeId')
+			.addSelect('step.status', 'status')
+			.addSelect(
+				`COALESCE(
+					(SELECT array_agg(jsonb_typeof(slot.value) <> 'null' ORDER BY slot.ordinality)
+					 FROM jsonb_array_elements(step.outputs) WITH ORDINALITY AS slot),
+					'{}'
+				)`,
+				'filledOutputSlots',
+			)
+			.where('step.execution_id = :executionId', { executionId })
+			.andWhere('step.node_id IN (:...nodeIds)', { nodeIds })
+			.getRawMany();
+
+		return Object.fromEntries(rows.map((row) => [row.nodeId, row]));
 	}
 
 	async loadStepOutputs(

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -29,6 +29,8 @@ function makeStepStore(createSteps = vi.fn()): StepStore {
 		completeStep: vi.fn(),
 		failStep: vi.fn(),
 		cancelQueuedSteps: vi.fn(),
+		loadStepsByNodeIds: vi.fn().mockResolvedValue({}),
+		loadStepSummaries: vi.fn().mockResolvedValue({}),
 		loadStepOutputs: vi.fn(),
 		loadCompletedNodeIds: vi.fn(),
 		hasActiveSteps: vi.fn(),

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -34,6 +34,7 @@ function makeStepStore(createSteps = vi.fn()): StepStore {
 		loadStepOutputs: vi.fn(),
 		loadCompletedNodeIds: vi.fn(),
 		hasActiveSteps: vi.fn(),
+		countSettledSteps: vi.fn(),
 		hasFailedSteps: vi.fn(),
 	};
 }

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -70,7 +70,7 @@ describe('ExecutionStartHandler', () => {
 		await handler.handle({ type: 'execution:enqueued', executionId: 'exec-1' });
 
 		expect(executionStore.transitionStatus).toHaveBeenCalledWith('exec-1', 'queued', 'running');
-		// only the trigger's row — planning is the step:completed handler's job.
+		// only the trigger's row — planning is the step:settled handler's job.
 		// Its payload rides along as output slot 0, read downstream like any
 		// other predecessor's outputs.
 		expect(createSteps).toHaveBeenCalledExactlyOnceWith([
@@ -82,7 +82,7 @@ describe('ExecutionStartHandler', () => {
 			},
 		]);
 		expect(queue.publish).toHaveBeenCalledExactlyOnceWith({
-			type: 'step:completed',
+			type: 'step:settled',
 			executionId: 'exec-1',
 			stepId: 'step-trigger',
 		});

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -73,9 +73,8 @@ describe('ExecutionStartHandler', () => {
 		// only the trigger's row — planning is the step:settled handler's job.
 		// Its payload rides along as output slot 0, read downstream like any
 		// other predecessor's outputs.
-		expect(createSteps).toHaveBeenCalledExactlyOnceWith([
+		expect(createSteps).toHaveBeenCalledExactlyOnceWith('exec-1', [
 			{
-				executionId: 'exec-1',
 				nodeId: 'trigger',
 				status: 'completed',
 				outputs: [{ webhook: 'data' }],
@@ -104,8 +103,8 @@ describe('ExecutionStartHandler', () => {
 
 		await handler.handle({ type: 'execution:enqueued', executionId: 'exec-1' });
 
-		expect(createSteps).toHaveBeenCalledExactlyOnceWith([
-			{ executionId: 'exec-1', nodeId: 'trigger', status: 'completed', outputs: [{}] },
+		expect(createSteps).toHaveBeenCalledExactlyOnceWith('exec-1', [
+			{ nodeId: 'trigger', status: 'completed', outputs: [{}] },
 		]);
 	});
 

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start-handler.test.ts
@@ -31,9 +31,6 @@ function makeStepStore(createSteps = vi.fn()): StepStore {
 		cancelQueuedSteps: vi.fn(),
 		loadStepsByNodeIds: vi.fn().mockResolvedValue({}),
 		loadStepSummaries: vi.fn().mockResolvedValue({}),
-		loadStepOutputs: vi.fn(),
-		loadCompletedNodeIds: vi.fn(),
-		hasActiveSteps: vi.fn(),
 		countSettledSteps: vi.fn(),
 		hasFailedSteps: vi.fn(),
 	};

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
@@ -21,7 +21,7 @@ import {
 import { ExecutionStartHandler } from '../execution-start-handler';
 import { OrchestrationWorker } from '../orchestration-worker';
 import { StartExecutionService } from '../start-execution.service';
-import { StepCompletedHandler } from '../step-completed-handler';
+import { StepSettledHandler } from '../step-settled-handler';
 
 const graph: WorkflowGraph = {
 	nodes: [
@@ -61,7 +61,7 @@ describe('execution start (integration)', () => {
 		const worker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue),
 		);
 		worker.start();
 		const startExecution = new StartExecutionService(

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
@@ -61,7 +61,7 @@ describe('execution start (integration)', () => {
 		const worker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepSettledHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue, orchestrationQueue),
 		);
 		worker.start();
 		const startExecution = new StartExecutionService(

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
@@ -60,7 +60,7 @@ describe('execution start (integration)', () => {
 		const worker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepSettledHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue, orchestrationQueue),
 		);
 		worker.start();
 		const startExecution = new StartExecutionService(

--- a/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/execution-start.integration.test.ts
@@ -20,7 +20,7 @@ import {
 import { ExecutionStartHandler } from '../execution-start-handler';
 import { OrchestrationWorker } from '../orchestration-worker';
 import { StartExecutionService } from '../start-execution.service';
-import { StepCompletedHandler } from '../step-completed-handler';
+import { StepSettledHandler } from '../step-settled-handler';
 
 const graph: WorkflowGraph = {
 	nodes: [
@@ -60,7 +60,7 @@ describe('execution start (integration)', () => {
 		const worker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue),
 		);
 		worker.start();
 		const startExecution = new StartExecutionService(

--- a/packages/@n8n/engine/src/execution/__tests__/settlement.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/settlement.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GraphEdge, WorkflowGraph } from '../../graph';
+import { getDescendantNodeIds } from '../../graph';
+import type { StepStatus } from '../execution.types';
+import { decideSuccessors } from '../settlement';
+import type { StepSummary } from '../step-store';
+
+function summary(
+	nodeId: string,
+	status: StepStatus,
+	filledOutputSlots: boolean[] = [],
+): StepSummary {
+	return { id: `step-${nodeId}`, nodeId, status, filledOutputSlots };
+}
+
+function makeSteps(...summaries: StepSummary[]): Record<string, StepSummary> {
+	return Object.fromEntries(summaries.map((s) => [s.nodeId, s]));
+}
+
+function makeGraph(
+	edges: Array<Partial<GraphEdge> & Pick<GraphEdge, 'from' | 'to'>>,
+): WorkflowGraph {
+	const nodeIds = [...new Set(edges.flatMap(({ from, to }) => [from, to]))];
+	return {
+		nodes: nodeIds.map((id) => ({
+			id,
+			name: id.toUpperCase(),
+			type: id === 'trigger' ? 'trigger' : 'v1-node',
+		})),
+		edges: edges.map((edge) => ({ outputIndex: 0, inputIndex: 0, ...edge })),
+	};
+}
+
+/** trigger → if → {a (out 0), b (out 1)} → m: the conditional diamond. */
+const diamond = makeGraph([
+	{ from: 'trigger', to: 'if' },
+	{ from: 'if', to: 'a', outputIndex: 0 },
+	{ from: 'if', to: 'b', outputIndex: 1 },
+	{ from: 'a', to: 'm', inputIndex: 0 },
+	{ from: 'b', to: 'm', inputIndex: 1 },
+]);
+
+describe('decideSuccessors', () => {
+	it('queues the live branch and skips the dead one', () => {
+		// if fired only output slot 0; m is not a direct successor, so it is
+		// not considered — b's own settled event will examine it.
+		const decisions = decideSuccessors(
+			diamond,
+			'if',
+			makeSteps(summary('trigger', 'completed', [true]), summary('if', 'completed', [true, false])),
+		);
+
+		expect(decisions).toEqual({ toQueue: ['a'], toSkip: ['b'] });
+	});
+
+	it('decides a merge once its last predecessor settles', () => {
+		// b was skipped earlier; a just completed. m has one live and one dead
+		// edge, so it runs on the live data.
+		const decisions = decideSuccessors(
+			diamond,
+			'a',
+			makeSteps(
+				summary('trigger', 'completed', [true]),
+				summary('if', 'completed', [true, false]),
+				summary('a', 'completed', [true]),
+				summary('b', 'skipped'),
+			),
+		);
+
+		expect(decisions).toEqual({ toQueue: ['m'], toSkip: [] });
+	});
+
+	it('leaves a merge undecided while a predecessor is still unsettled', () => {
+		// b's settled event fires while a is still queued: m is not decidable
+		// yet, and a's own settlement will decide it later.
+		const decisions = decideSuccessors(
+			diamond,
+			'b',
+			makeSteps(
+				summary('trigger', 'completed', [true]),
+				summary('if', 'completed', [true, false]),
+				summary('a', 'queued'),
+				summary('b', 'skipped'),
+			),
+		);
+
+		expect(decisions).toEqual({ toQueue: [], toSkip: [] });
+	});
+
+	it('cascades a skip one hop at a time through the event loop', () => {
+		// dead chain b → c → d: each settled event plans exactly the next hop.
+		const graph = makeGraph([
+			{ from: 'trigger', to: 'if' },
+			{ from: 'if', to: 'a', outputIndex: 0 },
+			{ from: 'if', to: 'b', outputIndex: 1 },
+			{ from: 'b', to: 'c' },
+			{ from: 'c', to: 'd' },
+		]);
+		const steps = makeSteps(
+			summary('trigger', 'completed', [true]),
+			summary('if', 'completed', [true, false]),
+		);
+
+		expect(decideSuccessors(graph, 'if', steps)).toEqual({ toQueue: ['a'], toSkip: ['b'] });
+
+		steps.b = summary('b', 'skipped');
+		expect(decideSuccessors(graph, 'b', steps)).toEqual({ toQueue: [], toSkip: ['c'] });
+
+		steps.c = summary('c', 'skipped');
+		expect(decideSuccessors(graph, 'c', steps)).toEqual({ toQueue: [], toSkip: ['d'] });
+	});
+
+	it('skips a node only when every predecessor has settled dead', () => {
+		// d sits behind both b and c. When b's skip settles first, d must wait
+		// for c rather than being skipped early.
+		const graph = makeGraph([
+			{ from: 'trigger', to: 'if' },
+			{ from: 'if', to: 'a', outputIndex: 0 },
+			{ from: 'if', to: 'b', outputIndex: 1 },
+			{ from: 'if', to: 'c', outputIndex: 1 },
+			{ from: 'b', to: 'd', inputIndex: 0 },
+			{ from: 'c', to: 'd', inputIndex: 1 },
+		]);
+		const steps = makeSteps(
+			summary('trigger', 'completed', [true]),
+			summary('if', 'completed', [true, false]),
+			summary('b', 'skipped'),
+		);
+
+		expect(decideSuccessors(graph, 'b', steps)).toEqual({ toQueue: [], toSkip: [] });
+
+		steps.c = summary('c', 'skipped');
+		expect(decideSuccessors(graph, 'c', steps)).toEqual({ toQueue: [], toSkip: ['d'] });
+	});
+
+	it('does not re-decide a successor that already has a row', () => {
+		// duplicate delivery: both successors were planned by the first run.
+		// Nothing is created, so nothing is announced — a lost announcement is
+		// reconciliation's job (CAT-2938), not this planner's.
+		const decisions = decideSuccessors(
+			diamond,
+			'if',
+			makeSteps(
+				summary('trigger', 'completed', [true]),
+				summary('if', 'completed', [true, false]),
+				summary('a', 'queued'),
+				summary('b', 'skipped'),
+			),
+		);
+
+		expect(decisions).toEqual({ toQueue: [], toSkip: [] });
+	});
+
+	it('routes an N-output fan-out per slot', () => {
+		const graph = makeGraph([
+			{ from: 'trigger', to: 'switch' },
+			{ from: 'switch', to: 'a', outputIndex: 0 },
+			{ from: 'switch', to: 'b', outputIndex: 1 },
+			{ from: 'switch', to: 'c', outputIndex: 2 },
+		]);
+
+		const decisions = decideSuccessors(
+			graph,
+			'switch',
+			makeSteps(
+				summary('trigger', 'completed', [true]),
+				summary('switch', 'completed', [true, false, true]),
+			),
+		);
+
+		expect(decisions).toEqual({ toQueue: ['a', 'c'], toSkip: ['b'] });
+	});
+
+	it('treats an output slot beyond the produced list as dead', () => {
+		const graph = makeGraph([
+			{ from: 'trigger', to: 'a' },
+			{ from: 'a', to: 'b', outputIndex: 1 },
+		]);
+
+		const decisions = decideSuccessors(
+			graph,
+			'a',
+			makeSteps(summary('trigger', 'completed', [true]), summary('a', 'completed', [true])),
+		);
+
+		expect(decisions).toEqual({ toQueue: [], toSkip: ['b'] });
+	});
+});
+
+/**
+ * Property test: the cascade is the event loop, so correctness is a property
+ * of the whole loop, not one call. The simulation below models the engine —
+ * a FIFO settlement queue, steps completing in arbitrary order relative to
+ * event handling — using `decideSuccessors` as the only decision logic. Its
+ * terminal state must match an independent whole-graph evaluation of the
+ * three-rule spec, and must satisfy rule 1: every reachable node settled.
+ */
+
+/** Deterministic PRNG so failures reproduce from the logged seed. */
+function lcg(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (state * 1664525 + 1013904223) >>> 0;
+		return state / 2 ** 32;
+	};
+}
+
+function randomInt(rand: () => number, bound: number): number {
+	return Math.floor(rand() * bound);
+}
+
+function randomDag(rand: () => number): WorkflowGraph {
+	const count = 3 + randomInt(rand, 6);
+	const edges: GraphEdge[] = [];
+	for (let i = 0; i < count; i++) {
+		const to = `n${i}`;
+		const candidates = ['trigger', ...Array.from({ length: i }, (_, j) => `n${j}`)];
+		const predecessorCount = Math.min(candidates.length, 1 + randomInt(rand, 2));
+		// distinct predecessors, one edge per input slot (the validated shape)
+		const shuffled = [...candidates].sort(() => rand() - 0.5);
+		for (let slot = 0; slot < predecessorCount; slot++) {
+			edges.push({
+				from: shuffled[slot],
+				to,
+				outputIndex: randomInt(rand, 2),
+				inputIndex: slot,
+			});
+		}
+	}
+	return makeGraph(edges);
+}
+
+/** Fixed per-node outputs so the simulation and the reference agree on data. */
+function makeOutputs(graph: WorkflowGraph, rand: () => number): Record<string, boolean[]> {
+	return Object.fromEntries(
+		graph.nodes.map(({ id }) => [id, id === 'trigger' ? [true] : [rand() < 0.7, rand() < 0.3]]),
+	);
+}
+
+/**
+ * Runs the engine's event loop in miniature: settled events are handled FIFO
+ * (the orchestration queue is a single sequential consumer), while queued
+ * steps complete at arbitrary points in between (the step workers).
+ */
+function simulateExecution(
+	graph: WorkflowGraph,
+	outputs: Record<string, boolean[]>,
+	rand: () => number,
+): Record<string, StepSummary> {
+	const steps = makeSteps(summary('trigger', 'completed', outputs.trigger));
+	const settledEvents = ['trigger'];
+	const queuedNodes: string[] = [];
+
+	while (settledEvents.length > 0 || queuedNodes.length > 0) {
+		const handleEvent = settledEvents.length > 0 && (queuedNodes.length === 0 || rand() < 0.5);
+		if (handleEvent) {
+			const nodeId = settledEvents[0];
+			settledEvents.shift();
+			const { toQueue, toSkip } = decideSuccessors(graph, nodeId, steps);
+			for (const id of toQueue) {
+				steps[id] = summary(id, 'queued');
+				queuedNodes.push(id);
+			}
+			for (const id of toSkip) {
+				steps[id] = summary(id, 'skipped');
+				settledEvents.push(id);
+			}
+		} else {
+			const [nodeId] = queuedNodes.splice(randomInt(rand, queuedNodes.length), 1);
+			steps[nodeId] = summary(nodeId, 'completed', outputs[nodeId]);
+			settledEvents.push(nodeId);
+		}
+	}
+	return steps;
+}
+
+/** The three-rule spec, evaluated by whole-graph fixpoint over `outputs`. */
+function referenceTerminalState(
+	graph: WorkflowGraph,
+	outputs: Record<string, boolean[]>,
+): Record<string, StepStatus> {
+	const statuses: Record<string, StepStatus> = { trigger: 'completed' };
+	const isLive = (edge: GraphEdge): boolean =>
+		statuses[edge.from] === 'completed' && Boolean(outputs[edge.from][edge.outputIndex]);
+
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const node of graph.nodes) {
+			if (statuses[node.id]) continue;
+			const incoming = graph.edges.filter((edge) => edge.to === node.id && !edge.isBackEdge);
+			if (incoming.length === 0) continue;
+			if (!incoming.every(({ from }) => statuses[from])) continue;
+			statuses[node.id] = incoming.some(isLive) ? 'completed' : 'skipped';
+			changed = true;
+		}
+	}
+	return statuses;
+}
+
+describe('the event loop over decideSuccessors matches the reference evaluator', () => {
+	it('settles every reachable node with the spec fate, on 200 random DAGs', () => {
+		for (let seed = 1; seed <= 200; seed++) {
+			const rand = lcg(seed);
+			const graph = randomDag(rand);
+			const outputs = makeOutputs(graph, rand);
+
+			const terminal = simulateExecution(graph, outputs, rand);
+			const expected = referenceTerminalState(graph, outputs);
+
+			const reachable = ['trigger', ...getDescendantNodeIds(graph, 'trigger')];
+			const actual = Object.fromEntries(
+				reachable.map((id) => [id, terminal[id]?.status ?? 'missing']),
+			);
+			// rule 1 (the finish predicate): every reachable node settled, and
+			// with exactly the fate the spec assigns
+			expect({ seed, statuses: actual }).toEqual({ seed, statuses: expected });
+		}
+	});
+});

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -79,7 +79,7 @@ describe('step execution (integration)', () => {
 		const orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepSettledHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue, orchestrationQueue),
 		);
 		const stepWorker = new StepWorker(
 			stepQueue,

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -18,7 +18,7 @@ import { InMemoryWorkQueue, type OrchestrationMessage, type StepMessage } from '
 import { ExecutionStartHandler } from '../execution-start-handler';
 import { OrchestrationWorker } from '../orchestration-worker';
 import { StartExecutionService } from '../start-execution.service';
-import { StepCompletedHandler } from '../step-completed-handler';
+import { StepSettledHandler } from '../step-settled-handler';
 import { StepReadyHandler } from '../step-ready-handler';
 import { StepWorker } from '../step-worker';
 
@@ -79,7 +79,7 @@ describe('step execution (integration)', () => {
 		const orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue),
 		);
 		const stepWorker = new StepWorker(
 			stepQueue,

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -242,6 +242,70 @@ describe('step execution (integration)', () => {
 		expect(execution.finishedAt).toBeInstanceOf(Date);
 	});
 
+	it('settles a conditional diamond: dead chain skipped, merge runs on the live side', async () => {
+		// trigger → if → {a (out 0), b (out 1) → c} → m: the not-taken branch is
+		// two nodes long, so its skips must cascade through the event loop
+		// before the merge can settle and the execution can finish.
+		const branchingGraph: WorkflowGraph = {
+			nodes: [
+				{ id: 'trigger', name: 'Webhook', type: 'trigger' },
+				{ id: 'node-if', name: 'If', type: 'v1-node' },
+				{ id: 'node-a', name: 'A', type: 'v1-node' },
+				{ id: 'node-b', name: 'B', type: 'v1-node' },
+				{ id: 'node-c', name: 'C', type: 'v1-node' },
+				{ id: 'node-m', name: 'M', type: 'v1-node' },
+			],
+			edges: [
+				{ from: 'trigger', to: 'node-if', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-if', to: 'node-a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-if', to: 'node-b', outputIndex: 1, inputIndex: 0 },
+				{ from: 'node-b', to: 'node-c', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-a', to: 'node-m', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-c', to: 'node-m', outputIndex: 0, inputIndex: 1 },
+			],
+		};
+		const requests: StepExecutionRequest[] = [];
+		const executor: IStepExecutor = {
+			execute: async (request) => {
+				requests.push(request);
+				await Promise.resolve();
+				if (request.node.id === 'node-if') {
+					// everything went down the taken branch; output slot 1 is dead
+					return { outputs: [[{ json: { taken: true } }], null] };
+				}
+				return { outputs: [[{ json: { ran: request.node.id } }]] };
+			},
+		};
+
+		const { execution, steps } = await runWorkflow(
+			executor,
+			{},
+			{ workflowId: 'wf-branch', graph: branchingGraph },
+		);
+
+		// the dead branch never ran a node
+		expect(requests.map(({ node }) => node.id).sort()).toEqual(['node-a', 'node-if', 'node-m']);
+
+		// the merge ran once, on the live slot, with the dead slot explicitly null
+		const merge = requests.filter(({ node }) => node.id === 'node-m');
+		expect(merge).toHaveLength(1);
+		expect(merge[0].inputs).toEqual([[{ json: { ran: 'node-a' } }], null]);
+
+		// every reachable node settled, with exactly one row each
+		expect(steps.map(({ nodeId, status }) => [nodeId, status]).sort()).toEqual([
+			['node-a', 'completed'],
+			['node-b', 'skipped'],
+			['node-c', 'skipped'],
+			['node-if', 'completed'],
+			['node-m', 'completed'],
+			['trigger', 'completed'],
+		]);
+		expect(steps.find(({ nodeId }) => nodeId === 'node-b')?.outputs).toBeNull();
+
+		expect(execution.status).toBe('completed');
+		expect(execution.finishedAt).toBeInstanceOf(Date);
+	});
+
 	it('is idempotent across duplicate step:ready deliveries', async () => {
 		const { executionStore, stepStore } = stores();
 		const execute = vi.fn().mockResolvedValue({ outputs: [[{ json: { n: 1 } }]] });

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -321,10 +321,10 @@ describe('step execution (integration)', () => {
 			graph,
 			triggerPayload: null,
 		});
-		const created = await stepStore.createSteps([
+		const created = await stepStore.createSteps(executionId, [
 			// completed steps always carry outputs, as the start handler writes them
-			{ executionId, nodeId: 'trigger', status: 'completed', outputs: [{}] },
-			{ executionId, nodeId: 'node-a', status: 'queued' },
+			{ nodeId: 'trigger', status: 'completed', outputs: [{}] },
+			{ nodeId: 'node-a', status: 'queued' },
 		]);
 		const stepId = created.find(({ nodeId }) => nodeId === 'node-a')!.id;
 

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -18,8 +18,8 @@ import { InMemoryWorkQueue, type OrchestrationMessage, type StepMessage } from '
 import { ExecutionStartHandler } from '../execution-start-handler';
 import { OrchestrationWorker } from '../orchestration-worker';
 import { StartExecutionService } from '../start-execution.service';
-import { StepSettledHandler } from '../step-settled-handler';
 import { StepReadyHandler } from '../step-ready-handler';
+import { StepSettledHandler } from '../step-settled-handler';
 import { StepWorker } from '../step-worker';
 
 const graph: WorkflowGraph = {

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -202,6 +202,45 @@ describe('step execution (integration)', () => {
 		expect(execution.finishedAt).toBeInstanceOf(Date);
 	});
 
+	it('runs a fan-in once, with each input slot fed by its branch', async () => {
+		const diamondGraph: WorkflowGraph = {
+			nodes: [
+				{ id: 'trigger', name: 'Webhook', type: 'trigger' },
+				{ id: 'node-a', name: 'A', type: 'v1-node' },
+				{ id: 'node-b', name: 'B', type: 'v1-node' },
+				{ id: 'node-m', name: 'M', type: 'v1-node' },
+			],
+			edges: [
+				{ from: 'trigger', to: 'node-a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'trigger', to: 'node-b', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-a', to: 'node-m', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-b', to: 'node-m', outputIndex: 0, inputIndex: 1 },
+			],
+		};
+		const requests: StepExecutionRequest[] = [];
+		const executor: IStepExecutor = {
+			execute: async (request) => {
+				requests.push(request);
+				await Promise.resolve();
+				return { outputs: [[{ json: { ran: request.node.id } }]] };
+			},
+		};
+
+		const { execution } = await runWorkflow(
+			executor,
+			{ body: { name: 'ada' } },
+			{ workflowId: 'wf-diamond', graph: diamondGraph },
+		);
+
+		// the merge ran exactly once, after both branches, one slot per branch
+		const merge = requests.filter(({ node }) => node.id === 'node-m');
+		expect(merge).toHaveLength(1);
+		expect(merge[0].inputs).toEqual([[{ json: { ran: 'node-a' } }], [{ json: { ran: 'node-b' } }]]);
+
+		expect(execution.status).toBe('completed');
+		expect(execution.finishedAt).toBeInstanceOf(Date);
+	});
+
 	it('is idempotent across duplicate step:ready deliveries', async () => {
 		const { executionStore, stepStore } = stores();
 		const execute = vi.fn().mockResolvedValue({ outputs: [[{ json: { n: 1 } }]] });

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -78,7 +78,7 @@ describe('step execution (integration)', () => {
 		const orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepSettledHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue, orchestrationQueue),
 		);
 		const stepWorker = new StepWorker(
 			stepQueue,

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -17,7 +17,7 @@ import { InMemoryWorkQueue, type OrchestrationMessage, type StepMessage } from '
 import { ExecutionStartHandler } from '../execution-start-handler';
 import { OrchestrationWorker } from '../orchestration-worker';
 import { StartExecutionService } from '../start-execution.service';
-import { StepCompletedHandler } from '../step-completed-handler';
+import { StepSettledHandler } from '../step-settled-handler';
 import { StepReadyHandler } from '../step-ready-handler';
 import { StepWorker } from '../step-worker';
 
@@ -78,7 +78,7 @@ describe('step execution (integration)', () => {
 		const orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue),
 		);
 		const stepWorker = new StepWorker(
 			stepQueue,

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -17,8 +17,8 @@ import { InMemoryWorkQueue, type OrchestrationMessage, type StepMessage } from '
 import { ExecutionStartHandler } from '../execution-start-handler';
 import { OrchestrationWorker } from '../orchestration-worker';
 import { StartExecutionService } from '../start-execution.service';
-import { StepSettledHandler } from '../step-settled-handler';
 import { StepReadyHandler } from '../step-ready-handler';
+import { StepSettledHandler } from '../step-settled-handler';
 import { StepWorker } from '../step-worker';
 
 const graph: WorkflowGraph = {

--- a/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-execution.integration.test.ts
@@ -241,6 +241,70 @@ describe('step execution (integration)', () => {
 		expect(execution.finishedAt).toBeInstanceOf(Date);
 	});
 
+	it('settles a conditional diamond: dead chain skipped, merge runs on the live side', async () => {
+		// trigger → if → {a (out 0), b (out 1) → c} → m: the not-taken branch is
+		// two nodes long, so its skips must cascade through the event loop
+		// before the merge can settle and the execution can finish.
+		const branchingGraph: WorkflowGraph = {
+			nodes: [
+				{ id: 'trigger', name: 'Webhook', type: 'trigger' },
+				{ id: 'node-if', name: 'If', type: 'v1-node' },
+				{ id: 'node-a', name: 'A', type: 'v1-node' },
+				{ id: 'node-b', name: 'B', type: 'v1-node' },
+				{ id: 'node-c', name: 'C', type: 'v1-node' },
+				{ id: 'node-m', name: 'M', type: 'v1-node' },
+			],
+			edges: [
+				{ from: 'trigger', to: 'node-if', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-if', to: 'node-a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-if', to: 'node-b', outputIndex: 1, inputIndex: 0 },
+				{ from: 'node-b', to: 'node-c', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-a', to: 'node-m', outputIndex: 0, inputIndex: 0 },
+				{ from: 'node-c', to: 'node-m', outputIndex: 0, inputIndex: 1 },
+			],
+		};
+		const requests: StepExecutionRequest[] = [];
+		const executor: IStepExecutor = {
+			execute: async (request) => {
+				requests.push(request);
+				await Promise.resolve();
+				if (request.node.id === 'node-if') {
+					// everything went down the taken branch; output slot 1 is dead
+					return { outputs: [[{ json: { taken: true } }], null] };
+				}
+				return { outputs: [[{ json: { ran: request.node.id } }]] };
+			},
+		};
+
+		const { execution, steps } = await runWorkflow(
+			executor,
+			{},
+			{ workflowId: 'wf-branch', graph: branchingGraph },
+		);
+
+		// the dead branch never ran a node
+		expect(requests.map(({ node }) => node.id).sort()).toEqual(['node-a', 'node-if', 'node-m']);
+
+		// the merge ran once, on the live slot, with the dead slot explicitly null
+		const merge = requests.filter(({ node }) => node.id === 'node-m');
+		expect(merge).toHaveLength(1);
+		expect(merge[0].inputs).toEqual([[{ json: { ran: 'node-a' } }], null]);
+
+		// every reachable node settled, with exactly one row each
+		expect(steps.map(({ nodeId, status }) => [nodeId, status]).sort()).toEqual([
+			['node-a', 'completed'],
+			['node-b', 'skipped'],
+			['node-c', 'skipped'],
+			['node-if', 'completed'],
+			['node-m', 'completed'],
+			['trigger', 'completed'],
+		]);
+		expect(steps.find(({ nodeId }) => nodeId === 'node-b')?.outputs).toBeNull();
+
+		expect(execution.status).toBe('completed');
+		expect(execution.finishedAt).toBeInstanceOf(Date);
+	});
+
 	it('is idempotent across duplicate step:ready deliveries', async () => {
 		const { executionStore, stepStore } = stores();
 		const execute = vi.fn().mockResolvedValue({ outputs: [[{ json: { n: 1 } }]] });

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -133,6 +133,111 @@ describe('StepReadyHandler', () => {
 		);
 	});
 
+	it('gathers a fan-in: each input slot from its predecessor', async () => {
+		// trigger fans out to a and b, which converge on m's two input slots
+		const diamond: WorkflowGraph = {
+			nodes: [...graph.nodes, { id: 'm', name: 'M', type: 'v1-node' }],
+			edges: [
+				{ from: 'trigger', to: 'a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 0 },
+				{ from: 'a', to: 'm', outputIndex: 0, inputIndex: 0 },
+				{ from: 'b', to: 'm', outputIndex: 0, inputIndex: 1 },
+			],
+		};
+		const stepStore = makeStepStore(
+			{ id: 'step-m', nodeId: 'm' },
+			{
+				loadStepOutputs: vi.fn().mockResolvedValue({
+					a: [[{ json: { from: 'a' } }]],
+					b: [[{ json: { from: 'b' } }]],
+				}),
+			},
+		);
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(
+			makeExecutionStore({ graph: diamond }),
+			stepStore,
+			makeQueue(),
+			{ v1StepExecutor: executor },
+		);
+
+		await handler.handle({ ...event, stepId: 'step-m' });
+
+		// one round trip for all predecessors
+		expect(stepStore.loadStepOutputs).toHaveBeenCalledTimes(1);
+		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['a', 'b']);
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({ inputs: [[{ json: { from: 'a' } }], [{ json: { from: 'b' } }]] }),
+		);
+	});
+
+	it('leaves an input slot no edge feeds null', async () => {
+		const gapped: WorkflowGraph = {
+			nodes: [...graph.nodes, { id: 'm', name: 'M', type: 'v1-node' }],
+			edges: [
+				{ from: 'trigger', to: 'a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 0 },
+				{ from: 'a', to: 'm', outputIndex: 0, inputIndex: 0 },
+				{ from: 'b', to: 'm', outputIndex: 0, inputIndex: 2 },
+			],
+		};
+		const stepStore = makeStepStore(
+			{ id: 'step-m', nodeId: 'm' },
+			{
+				loadStepOutputs: vi.fn().mockResolvedValue({
+					a: [[{ json: { from: 'a' } }]],
+					b: [[{ json: { from: 'b' } }]],
+				}),
+			},
+		);
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(
+			makeExecutionStore({ graph: gapped }),
+			stepStore,
+			makeQueue(),
+			{ v1StepExecutor: executor },
+		);
+
+		await handler.handle({ ...event, stepId: 'step-m' });
+
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({
+				inputs: [[{ json: { from: 'a' } }], null, [{ json: { from: 'b' } }]],
+			}),
+		);
+	});
+
+	it('feeds two input slots from one predecessor wired to both', async () => {
+		const doubled: WorkflowGraph = {
+			nodes: [...graph.nodes, { id: 'm', name: 'M', type: 'v1-node' }],
+			edges: [
+				{ from: 'trigger', to: 'a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'a', to: 'm', outputIndex: 0, inputIndex: 0 },
+				{ from: 'a', to: 'm', outputIndex: 0, inputIndex: 1 },
+			],
+		};
+		const stepStore = makeStepStore(
+			{ id: 'step-m', nodeId: 'm' },
+			{ loadStepOutputs: vi.fn().mockResolvedValue({ a: [[{ json: { from: 'a' } }]] }) },
+		);
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(
+			makeExecutionStore({ graph: doubled }),
+			stepStore,
+			makeQueue(),
+			{ v1StepExecutor: executor },
+		);
+
+		await handler.handle({ ...event, stepId: 'step-m' });
+
+		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['a']);
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({
+				inputs: [[{ json: { from: 'a' } }], [{ json: { from: 'a' } }]],
+			}),
+		);
+	});
+
 	it('fails the step when the executor produces more than one output slot', async () => {
 		// A single-wired If passes graph validation but still emits two slots —
 		// this guard is where branch selection gets rejected until it exists.
@@ -200,26 +305,27 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.completeStep).toHaveBeenCalledWith('step-b', [null]);
 	});
 
-	it('throws when a predecessor row carries more than one output slot', async () => {
-		// the write-time guard makes this unreachable; reaching it means the store
-		// and this handler disagree, so nothing is recorded
+	it('reads the slot the edge names from a predecessor row carrying more slots', async () => {
+		// write-time guards keep rows single-slot today; the read side doesn't
+		// re-enforce that, it just takes the edge's slot
 		const stepStore = makeStepStore(
 			{ id: 'step-b', nodeId: 'b' },
-			{ loadStepOutputs: vi.fn().mockResolvedValue({ a: [[{ json: {} }], [{ json: {} }]] }) },
+			{
+				loadStepOutputs: vi
+					.fn()
+					.mockResolvedValue({ a: [[{ json: { slot: 0 } }], [{ json: { slot: 1 } }]] }),
+			},
 		);
 		const executor = makeExecutor();
 		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
 			v1StepExecutor: executor,
 		});
 
-		await expect(handler.handle({ ...event, stepId: 'step-b' })).rejects.toMatchObject({
-			name: 'UnexpectedError',
-			message: expect.stringContaining('more than one output slot') as string,
-		});
+		await handler.handle({ ...event, stepId: 'step-b' });
 
-		expect(executor.execute).not.toHaveBeenCalled();
-		expect(stepStore.completeStep).not.toHaveBeenCalled();
-		expect(stepStore.failStep).not.toHaveBeenCalled();
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({ inputs: [[{ json: { slot: 0 } }]] }),
+		);
 	});
 
 	it('throws, running nothing, when the predecessor step has no completed outputs', async () => {
@@ -440,34 +546,19 @@ describe('StepReadyHandler', () => {
 	 */
 	it.each([
 		{
-			reason: 'more than one edge feeds it (fan-in)',
+			reason: 'two edges feed the same input slot',
 			stepId: 'step-b',
 			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
 			execution: () =>
 				makeExecutionStore({
 					graph: {
 						nodes: graph.nodes,
-						// second input into b makes it a fan-in
-						edges: [...graph.edges, { from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 1 }],
+						// both a and the trigger feed b's slot 0
+						edges: [...graph.edges, { from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 0 }],
 					},
 				}),
 			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
-			expected: { name: 'UnexpectedError', message: 'incoming edges' },
-		},
-		{
-			reason: 'one node feeds it through two edges',
-			stepId: 'step-b',
-			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
-			execution: () =>
-				makeExecutionStore({
-					graph: {
-						nodes: graph.nodes,
-						// 'a' connected to b twice still counts per edge, not per node
-						edges: [...graph.edges, { from: 'a', to: 'b', outputIndex: 1, inputIndex: 1 }],
-					},
-				}),
-			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
-			expected: { name: 'UnexpectedError', message: 'incoming edges' },
+			expected: { name: 'UnexpectedError', message: 'input slot' },
 		},
 		{
 			reason: "its edge leaves the predecessor's second output",
@@ -479,13 +570,13 @@ describe('StepReadyHandler', () => {
 						nodes: graph.nodes,
 						edges: [
 							graph.edges[0],
-							// slot routing beyond 0→0 is rejected at graph validation
+							// output slots beyond 0 are rejected at graph validation
 							{ from: 'a', to: 'b', outputIndex: 1, inputIndex: 0 },
 						],
 					},
 				}),
 			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
-			expected: { name: 'UnexpectedError', message: 'slot 0' },
+			expected: { name: 'UnexpectedError', message: 'output slot' },
 		},
 		{
 			reason: 'its node has no predecessor in the graph',

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -65,9 +65,6 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 			.fn()
 			.mockResolvedValue({ trigger: stepRow('trigger', 'completed', [{}]) }),
 		loadStepSummaries: vi.fn().mockResolvedValue({}),
-		loadStepOutputs: vi.fn(),
-		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set()),
-		hasActiveSteps: vi.fn().mockResolvedValue(false),
 		countSettledSteps: vi.fn().mockResolvedValue(0),
 		hasFailedSteps: vi.fn().mockResolvedValue(false),
 		...overrides,
@@ -89,11 +86,9 @@ describe('StepReadyHandler', () => {
 		const stepStore = makeStepStore(
 			{},
 			{
-				loadStepsByNodeIds: vi
-					.fn()
-					.mockResolvedValue({
-						trigger: stepRow('trigger', 'completed', [{ body: { hello: 'world' } }]),
-					}),
+				loadStepsByNodeIds: vi.fn().mockResolvedValue({
+					trigger: stepRow('trigger', 'completed', [{ body: { hello: 'world' } }]),
+				}),
 			},
 		);
 		const queue = makeQueue();

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -4,8 +4,14 @@ import type { ExternalDependencies, IStepExecutor } from '../../dependencies';
 import type { WorkflowGraph } from '../../graph';
 import type { OrchestrationMessage, WorkQueue } from '../../queue';
 import type { ExecutionRecord, ExecutionStore } from '../execution-store';
+import type { StepSlots, StepStatus } from '../execution.types';
 import { StepReadyHandler } from '../step-ready-handler';
 import type { StepRecord, StepStore } from '../step-store';
+
+/** A predecessor row as `loadStepsByNodeIds` returns it. */
+function stepRow(nodeId: string, status: StepStatus, outputs: StepSlots | null = null): StepRecord {
+	return { id: `step-${nodeId}`, executionId: 'exec-1', nodeId, status, outputs, error: null };
+}
 
 /** trigger -> a -> b, so `a` has the trigger as its only predecessor. */
 const graph: WorkflowGraph = {
@@ -55,9 +61,11 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		completeStep: vi.fn().mockResolvedValue(true),
 		failStep: vi.fn().mockResolvedValue(true),
 		cancelQueuedSteps: vi.fn(),
-		loadStepsByNodeIds: vi.fn().mockResolvedValue({}),
+		loadStepsByNodeIds: vi
+			.fn()
+			.mockResolvedValue({ trigger: stepRow('trigger', 'completed', [{}]) }),
 		loadStepSummaries: vi.fn().mockResolvedValue({}),
-		loadStepOutputs: vi.fn().mockResolvedValue({ trigger: [{}] }),
+		loadStepOutputs: vi.fn(),
 		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set()),
 		hasActiveSteps: vi.fn().mockResolvedValue(false),
 		countSettledSteps: vi.fn().mockResolvedValue(0),
@@ -81,7 +89,11 @@ describe('StepReadyHandler', () => {
 		const stepStore = makeStepStore(
 			{},
 			{
-				loadStepOutputs: vi.fn().mockResolvedValue({ trigger: [{ body: { hello: 'world' } }] }),
+				loadStepsByNodeIds: vi
+					.fn()
+					.mockResolvedValue({
+						trigger: stepRow('trigger', 'completed', [{ body: { hello: 'world' } }]),
+					}),
 			},
 		);
 		const queue = makeQueue();
@@ -97,7 +109,7 @@ describe('StepReadyHandler', () => {
 
 		expect(stepStore.claimStep).toHaveBeenCalledWith('step-a');
 		// 'a' sits behind the trigger; its input slot 0 is the trigger's output slot 0
-		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['trigger']);
+		expect(stepStore.loadStepsByNodeIds).toHaveBeenCalledWith('exec-1', ['trigger']);
 		expect(executor.execute).toHaveBeenCalledWith({
 			node: { id: 'a', name: 'A', type: 'v1-node', config: { some: 'config' } },
 			inputs: [{ body: { hello: 'world' } }],
@@ -122,7 +134,11 @@ describe('StepReadyHandler', () => {
 		// step 'b', whose only predecessor is 'a'
 		const stepStore = makeStepStore(
 			{ id: 'step-b', nodeId: 'b' },
-			{ loadStepOutputs: vi.fn().mockResolvedValue({ a: [[{ json: { from: 'a' } }]] }) },
+			{
+				loadStepsByNodeIds: vi
+					.fn()
+					.mockResolvedValue({ a: stepRow('a', 'completed', [[{ json: { from: 'a' } }]]) }),
+			},
 		);
 		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
 			v1StepExecutor: executor,
@@ -130,7 +146,7 @@ describe('StepReadyHandler', () => {
 
 		await handler.handle({ ...event, stepId: 'step-b' });
 
-		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['a']);
+		expect(stepStore.loadStepsByNodeIds).toHaveBeenCalledWith('exec-1', ['a']);
 		expect(executor.execute).toHaveBeenCalledWith(
 			expect.objectContaining({ inputs: [[{ json: { from: 'a' } }]] }),
 		);
@@ -150,9 +166,9 @@ describe('StepReadyHandler', () => {
 		const stepStore = makeStepStore(
 			{ id: 'step-m', nodeId: 'm' },
 			{
-				loadStepOutputs: vi.fn().mockResolvedValue({
-					a: [[{ json: { from: 'a' } }]],
-					b: [[{ json: { from: 'b' } }]],
+				loadStepsByNodeIds: vi.fn().mockResolvedValue({
+					a: stepRow('a', 'completed', [[{ json: { from: 'a' } }]]),
+					b: stepRow('b', 'completed', [[{ json: { from: 'b' } }]]),
 				}),
 			},
 		);
@@ -167,8 +183,8 @@ describe('StepReadyHandler', () => {
 		await handler.handle({ ...event, stepId: 'step-m' });
 
 		// one round trip for all predecessors
-		expect(stepStore.loadStepOutputs).toHaveBeenCalledTimes(1);
-		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['a', 'b']);
+		expect(stepStore.loadStepsByNodeIds).toHaveBeenCalledTimes(1);
+		expect(stepStore.loadStepsByNodeIds).toHaveBeenCalledWith('exec-1', ['a', 'b']);
 		expect(executor.execute).toHaveBeenCalledWith(
 			expect.objectContaining({ inputs: [[{ json: { from: 'a' } }], [{ json: { from: 'b' } }]] }),
 		);
@@ -187,9 +203,9 @@ describe('StepReadyHandler', () => {
 		const stepStore = makeStepStore(
 			{ id: 'step-m', nodeId: 'm' },
 			{
-				loadStepOutputs: vi.fn().mockResolvedValue({
-					a: [[{ json: { from: 'a' } }]],
-					b: [[{ json: { from: 'b' } }]],
+				loadStepsByNodeIds: vi.fn().mockResolvedValue({
+					a: stepRow('a', 'completed', [[{ json: { from: 'a' } }]]),
+					b: stepRow('b', 'completed', [[{ json: { from: 'b' } }]]),
 				}),
 			},
 		);
@@ -221,7 +237,11 @@ describe('StepReadyHandler', () => {
 		};
 		const stepStore = makeStepStore(
 			{ id: 'step-m', nodeId: 'm' },
-			{ loadStepOutputs: vi.fn().mockResolvedValue({ a: [[{ json: { from: 'a' } }]] }) },
+			{
+				loadStepsByNodeIds: vi
+					.fn()
+					.mockResolvedValue({ a: stepRow('a', 'completed', [[{ json: { from: 'a' } }]]) }),
+			},
 		);
 		const executor = makeExecutor();
 		const handler = new StepReadyHandler(
@@ -233,7 +253,7 @@ describe('StepReadyHandler', () => {
 
 		await handler.handle({ ...event, stepId: 'step-m' });
 
-		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['a']);
+		expect(stepStore.loadStepsByNodeIds).toHaveBeenCalledWith('exec-1', ['a']);
 		expect(executor.execute).toHaveBeenCalledWith(
 			expect.objectContaining({
 				inputs: [[{ json: { from: 'a' } }], [{ json: { from: 'a' } }]],
@@ -241,27 +261,24 @@ describe('StepReadyHandler', () => {
 		);
 	});
 
-	it('fails the step when the executor produces more than one output slot', async () => {
-		// A single-wired If passes graph validation but still emits two slots —
-		// this guard is where branch selection gets rejected until it exists.
-		const stepStore = makeStepStore(
-			{},
-			{ loadStepOutputs: vi.fn().mockResolvedValue({ trigger: [{}] }) },
-		);
+	it('records multi-slot outputs verbatim', async () => {
+		// An If that routed everything to the taken branch: slot 0 has items,
+		// slot 1 is dead. Recording is shape-agnostic; planning reads the
+		// slots to decide which branches live.
+		const stepStore = makeStepStore();
 		const queue = makeQueue();
-		const executor = makeExecutor({ outputs: [[{ json: { taken: true } }], []] });
+		const executor = makeExecutor({ outputs: [[{ json: { taken: true } }], null] });
 		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, queue, {
 			v1StepExecutor: executor,
 		});
 
 		await handler.handle(event);
 
-		expect(stepStore.completeStep).not.toHaveBeenCalled();
-		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
-			name: 'UnimplementedError',
-			message: expect.stringContaining('output slot') as string,
-			stack: expect.any(String) as string,
-		});
+		expect(stepStore.failStep).not.toHaveBeenCalled();
+		expect(stepStore.completeStep).toHaveBeenCalledWith('step-a', [
+			[{ json: { taken: true } }],
+			null,
+		]);
 		expect(queue.publish).toHaveBeenCalledWith({
 			type: 'step:settled',
 			executionId: 'exec-1',
@@ -269,13 +286,10 @@ describe('StepReadyHandler', () => {
 		});
 	});
 
-	it('fails the step when it leaves its connected output slot unfilled', async () => {
-		// 'a' has a successor, so an empty slot 0 means a branch was not taken —
-		// unrepresentable until settlement lands
-		const stepStore = makeStepStore(
-			{},
-			{ loadStepOutputs: vi.fn().mockResolvedValue({ trigger: [{}] }) },
-		);
+	it('completes a step that fires nothing despite having successors', async () => {
+		// a dead output is a legal outcome now: the settlement handler skips the
+		// successors instead of this step failing
+		const stepStore = makeStepStore();
 		const executor = makeExecutor({ outputs: [] });
 		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
 			v1StepExecutor: executor,
@@ -283,19 +297,19 @@ describe('StepReadyHandler', () => {
 
 		await handler.handle(event);
 
-		expect(stepStore.completeStep).not.toHaveBeenCalled();
-		expect(stepStore.failStep).toHaveBeenCalledWith('step-a', {
-			name: 'UnimplementedError',
-			message: expect.stringContaining('did not fire output slot 0') as string,
-			stack: expect.any(String) as string,
-		});
+		expect(stepStore.failStep).not.toHaveBeenCalled();
+		expect(stepStore.completeStep).toHaveBeenCalledWith('step-a', []);
 	});
 
 	it('completes a terminal step that leaves its output slot unfilled', async () => {
 		// nothing is connected to b's output, so declining to fire it means nothing
 		const stepStore = makeStepStore(
 			{ id: 'step-b', nodeId: 'b' },
-			{ loadStepOutputs: vi.fn().mockResolvedValue({ a: [[{ json: { from: 'a' } }]] }) },
+			{
+				loadStepsByNodeIds: vi
+					.fn()
+					.mockResolvedValue({ a: stepRow('a', 'completed', [[{ json: { from: 'a' } }]]) }),
+			},
 		);
 		const executor = makeExecutor({ outputs: [null] });
 		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
@@ -308,37 +322,92 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.completeStep).toHaveBeenCalledWith('step-b', [null]);
 	});
 
-	it('reads the slot the edge names from a predecessor row carrying more slots', async () => {
-		// write-time guards keep rows single-slot today; the read side doesn't
-		// re-enforce that, it just takes the edge's slot
+	it('routes from the output slot the edge names', async () => {
+		// b reads a's second output slot: exactly the If/Switch shape
+		const routed: WorkflowGraph = {
+			nodes: graph.nodes,
+			edges: [graph.edges[0], { from: 'a', to: 'b', outputIndex: 1, inputIndex: 0 }],
+		};
 		const stepStore = makeStepStore(
 			{ id: 'step-b', nodeId: 'b' },
 			{
-				loadStepOutputs: vi
-					.fn()
-					.mockResolvedValue({ a: [[{ json: { slot: 0 } }], [{ json: { slot: 1 } }]] }),
+				loadStepsByNodeIds: vi.fn().mockResolvedValue({
+					a: stepRow('a', 'completed', [[{ json: { slot: 0 } }], [{ json: { slot: 1 } }]]),
+				}),
 			},
 		);
 		const executor = makeExecutor();
-		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
-			v1StepExecutor: executor,
-		});
+		const handler = new StepReadyHandler(
+			makeExecutionStore({ graph: routed }),
+			stepStore,
+			makeQueue(),
+			{
+				v1StepExecutor: executor,
+			},
+		);
 
 		await handler.handle({ ...event, stepId: 'step-b' });
 
 		expect(executor.execute).toHaveBeenCalledWith(
-			expect.objectContaining({ inputs: [[{ json: { slot: 0 } }]] }),
+			expect.objectContaining({ inputs: [[{ json: { slot: 1 } }]] }),
 		);
 	});
 
-	it('throws, running nothing, when the predecessor step has no completed outputs', async () => {
-		// a step is planned only once every predecessor completed, so a null entry
-		// means the planner and the store disagree — running on a fabricated empty
-		// input would mask that
+	it('reads null from an input slot fed by a skipped predecessor', async () => {
+		// m runs on b's live edge; its other input came from skipped c and reads
+		// null — dead edges carry explicitly no data, not fabricated items
+		const merged: WorkflowGraph = {
+			nodes: [
+				...graph.nodes,
+				{ id: 'c', name: 'C', type: 'v1-node' },
+				{ id: 'm', name: 'M', type: 'v1-node' },
+			],
+			edges: [
+				...graph.edges,
+				{ from: 'b', to: 'm', outputIndex: 0, inputIndex: 0 },
+				{ from: 'c', to: 'm', outputIndex: 0, inputIndex: 1 },
+			],
+		};
 		const stepStore = makeStepStore(
-			{},
-			{ loadStepOutputs: vi.fn().mockResolvedValue({ trigger: null }) },
+			{ id: 'step-m', nodeId: 'm' },
+			{
+				loadStepsByNodeIds: vi.fn().mockResolvedValue({
+					b: stepRow('b', 'completed', [[{ json: { from: 'b' } }]]),
+					c: stepRow('c', 'skipped'),
+				}),
+			},
 		);
+		const executor = makeExecutor();
+		const handler = new StepReadyHandler(
+			makeExecutionStore({ graph: merged }),
+			stepStore,
+			makeQueue(),
+			{
+				v1StepExecutor: executor,
+			},
+		);
+
+		await handler.handle({ ...event, stepId: 'step-m' });
+
+		expect(executor.execute).toHaveBeenCalledWith(
+			expect.objectContaining({ inputs: [[{ json: { from: 'b' } }], null] }),
+		);
+	});
+
+	it.each([
+		{
+			reason: 'the predecessor row is still unsettled',
+			rows: () => ({ trigger: stepRow('trigger', 'running') }),
+		},
+		{
+			reason: 'the predecessor has no row at all',
+			rows: () => ({}),
+		},
+	])('throws, running nothing, when $reason', async ({ rows }) => {
+		// a step is planned only once every predecessor settled, so anything else
+		// means the planner and the store disagree — running on a fabricated
+		// empty input would mask that
+		const stepStore = makeStepStore({}, { loadStepsByNodeIds: vi.fn().mockResolvedValue(rows()) });
 		const executor = makeExecutor();
 		const handler = new StepReadyHandler(makeExecutionStore(), stepStore, makeQueue(), {
 			v1StepExecutor: executor,
@@ -346,7 +415,7 @@ describe('StepReadyHandler', () => {
 
 		await expect(handler.handle(event)).rejects.toMatchObject({
 			name: 'UnexpectedError',
-			message: expect.stringContaining('not completed') as string,
+			message: expect.stringContaining('not settled') as string,
 		});
 
 		expect(executor.execute).not.toHaveBeenCalled();
@@ -562,24 +631,6 @@ describe('StepReadyHandler', () => {
 				}),
 			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
 			expected: { name: 'UnexpectedError', message: 'input slot' },
-		},
-		{
-			reason: "its edge leaves the predecessor's second output",
-			stepId: 'step-b',
-			steps: () => makeStepStore({ id: 'step-b', nodeId: 'b' }),
-			execution: () =>
-				makeExecutionStore({
-					graph: {
-						nodes: graph.nodes,
-						edges: [
-							graph.edges[0],
-							// output slots beyond 0 are rejected at graph validation
-							{ from: 'a', to: 'b', outputIndex: 1, inputIndex: 0 },
-						],
-					},
-				}),
-			deps: (executor: IStepExecutor): ExternalDependencies => ({ v1StepExecutor: executor }),
-			expected: { name: 'UnexpectedError', message: 'output slot' },
 		},
 		{
 			reason: 'its node has no predecessor in the graph',

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -55,6 +55,8 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		completeStep: vi.fn().mockResolvedValue(true),
 		failStep: vi.fn().mockResolvedValue(true),
 		cancelQueuedSteps: vi.fn(),
+		loadStepsByNodeIds: vi.fn().mockResolvedValue({}),
+		loadStepSummaries: vi.fn().mockResolvedValue({}),
 		loadStepOutputs: vi.fn().mockResolvedValue({ trigger: [{}] }),
 		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set()),
 		hasActiveSteps: vi.fn().mockResolvedValue(false),

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -60,6 +60,7 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		loadStepOutputs: vi.fn().mockResolvedValue({ trigger: [{}] }),
 		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set()),
 		hasActiveSteps: vi.fn().mockResolvedValue(false),
+		countSettledSteps: vi.fn().mockResolvedValue(0),
 		hasFailedSteps: vi.fn().mockResolvedValue(false),
 		...overrides,
 	} satisfies StepStore;

--- a/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-ready-handler.test.ts
@@ -108,7 +108,7 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.completeStep).toHaveBeenCalledWith('step-a', [[{ json: { ok: true } }]]);
 		expect(stepStore.failStep).not.toHaveBeenCalled();
 		expect(queue.publish).toHaveBeenCalledWith({
-			type: 'step:completed',
+			type: 'step:settled',
 			executionId: 'exec-1',
 			stepId: 'step-a',
 		});
@@ -260,7 +260,7 @@ describe('StepReadyHandler', () => {
 			stack: expect.any(String) as string,
 		});
 		expect(queue.publish).toHaveBeenCalledWith({
-			type: 'step:completed',
+			type: 'step:settled',
 			executionId: 'exec-1',
 			stepId: 'step-a',
 		});
@@ -463,7 +463,7 @@ describe('StepReadyHandler', () => {
 		expect(stepStore.completeStep).not.toHaveBeenCalled();
 		// the orchestrator still has to hear about it
 		expect(queue.publish).toHaveBeenCalledWith({
-			type: 'step:completed',
+			type: 'step:settled',
 			executionId: 'exec-1',
 			stepId: 'step-a',
 		});
@@ -487,7 +487,7 @@ describe('StepReadyHandler', () => {
 		});
 		expect(stepStore.completeStep).not.toHaveBeenCalled();
 		expect(queue.publish).toHaveBeenCalledWith({
-			type: 'step:completed',
+			type: 'step:settled',
 			executionId: 'exec-1',
 			stepId: 'step-a',
 		});

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -177,18 +177,21 @@ describe('StepSettledHandler', () => {
 		});
 	});
 
-	it("fails the execution when a sibling's settlement sees a failed predecessor", async () => {
-		const stepStore = makeStepStore({ id: 'step-c', nodeId: 'c' }, {}, [
-			...defaultSummaries,
-			summary('b', 'failed'),
-			summary('c', 'completed', [true]),
-		]);
+	it('fails the execution before planning when any step has failed', async () => {
+		// b failed while c completed, and settled(c) is handled first: m must not
+		// be planned off c's live edge. The check is execution-wide, so it also
+		// covers failures in branches this settlement's snapshot never sees.
+		const stepStore = makeStepStore(
+			{ id: 'step-c', nodeId: 'c' },
+			{ hasFailedSteps: vi.fn().mockResolvedValue(true) },
+		);
 		const { handler, executionStore, stepQueue, orchestrationQueue } = makeHandler(stepStore);
 
 		await handler.handle({ ...event, stepId: 'step-c' });
 
 		expect(executionStore.finishExecution).toHaveBeenCalledExactlyOnceWith('exec-1', 'failed');
 		expect(stepStore.cancelQueuedSteps).toHaveBeenCalledExactlyOnceWith('exec-1');
+		expect(stepStore.loadStepSummaries).not.toHaveBeenCalled();
 		expect(stepStore.createSteps).not.toHaveBeenCalled();
 		expect(stepQueue.publish).not.toHaveBeenCalled();
 		expect(orchestrationQueue.publish).not.toHaveBeenCalled();
@@ -391,7 +394,6 @@ describe('StepSettledHandler', () => {
 		await handler.handle({ ...event, stepId: 'step-m' });
 
 		expect(executionStore.finishExecution).not.toHaveBeenCalled();
-		expect(stepStore.hasFailedSteps).not.toHaveBeenCalled();
 	});
 
 	it('fails the execution and cancels queued steps the moment a step fails', async () => {

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -178,8 +178,8 @@ describe('StepSettledHandler', () => {
 	});
 
 	it('fails the execution before planning when any step has failed', async () => {
-		// b failed but settled(c) is handled first: m must not be planned off
-		// c's live edge
+		// b failed but settled(c) is handled first, so m must not be planned
+		// off c's live edge
 		const stepStore = makeStepStore(
 			{ id: 'step-c', nodeId: 'c' },
 			{ hasFailedSteps: vi.fn().mockResolvedValue(true) },

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { WorkflowGraph } from '../../graph';
 import type { StepMessage, WorkQueue } from '../../queue';
 import type { ExecutionRecord, ExecutionStore } from '../execution-store';
-import { StepCompletedHandler } from '../step-completed-handler';
+import { StepSettledHandler } from '../step-settled-handler';
 import type { NewStepRecord, StepRecord, StepStore } from '../step-store';
 
 /**
@@ -83,13 +83,13 @@ function makeQueue(): WorkQueue<StepMessage> {
 	return { publish: vi.fn(), start: vi.fn(), stop: vi.fn() };
 }
 
-const event = { type: 'step:completed', executionId: 'exec-1', stepId: 'step-a' } as const;
+const event = { type: 'step:settled', executionId: 'exec-1', stepId: 'step-a' } as const;
 
-describe('StepCompletedHandler', () => {
+describe('StepSettledHandler', () => {
 	it('plans every ready successor in one batch and publishes step:ready for each', async () => {
 		const stepStore = makeStepStore();
 		const queue = makeQueue();
-		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
+		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, queue);
 
 		await handler.handle(event);
 
@@ -115,7 +115,7 @@ describe('StepCompletedHandler', () => {
 		// steps are planned here, through the same readiness rule as the rest
 		const stepStore = makeStepStore({ id: 'step-trigger', nodeId: 'trigger' });
 		const queue = makeQueue();
-		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
+		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, queue);
 
 		await handler.handle({ ...event, stepId: 'step-trigger' });
 
@@ -131,7 +131,7 @@ describe('StepCompletedHandler', () => {
 
 	it("asks readiness in one query, for the successors' other predecessors", async () => {
 		const stepStore = makeStepStore({ id: 'step-b', nodeId: 'b' });
-		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, makeQueue());
+		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, makeQueue());
 
 		await handler.handle({ ...event, stepId: 'step-b' });
 
@@ -143,7 +143,7 @@ describe('StepCompletedHandler', () => {
 	it('skips the readiness query when the completed node is every predecessor', async () => {
 		// a is the sole predecessor of both b and c, and a just completed
 		const stepStore = makeStepStore();
-		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, makeQueue());
+		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, makeQueue());
 
 		await handler.handle(event);
 
@@ -158,7 +158,7 @@ describe('StepCompletedHandler', () => {
 		const stepStore = makeStepStore({ executionId: 'exec-2' });
 		const executionStore = makeExecutionStore();
 		const queue = makeQueue();
-		const handler = new StepCompletedHandler(executionStore, stepStore, queue);
+		const handler = new StepSettledHandler(executionStore, stepStore, queue);
 
 		await expect(handler.handle(event)).rejects.toMatchObject({
 			name: 'UnexpectedError',
@@ -176,7 +176,7 @@ describe('StepCompletedHandler', () => {
 		const stepStore = makeStepStore({ nodeId: 'ghost' });
 		const executionStore = makeExecutionStore();
 		const queue = makeQueue();
-		const handler = new StepCompletedHandler(executionStore, stepStore, queue);
+		const handler = new StepSettledHandler(executionStore, stepStore, queue);
 
 		await expect(handler.handle(event)).rejects.toMatchObject({
 			name: 'UnexpectedError',
@@ -213,7 +213,7 @@ describe('StepCompletedHandler', () => {
 	it.each(notPlanned)('plans nothing when $reason', async ({ stepId, step, overrides }) => {
 		const stepStore = makeStepStore(step, overrides);
 		const queue = makeQueue();
-		const handler = new StepCompletedHandler(makeExecutionStore(), stepStore, queue);
+		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, queue);
 
 		await handler.handle({ ...event, stepId });
 
@@ -234,7 +234,7 @@ describe('StepCompletedHandler', () => {
 		);
 		const executionStore = makeExecutionStore();
 		const queue = makeQueue();
-		const handler = new StepCompletedHandler(executionStore, stepStore, queue);
+		const handler = new StepSettledHandler(executionStore, stepStore, queue);
 
 		await handler.handle(event);
 
@@ -246,7 +246,7 @@ describe('StepCompletedHandler', () => {
 		// 'm' is terminal, and nothing else is left running
 		const stepStore = makeStepStore({ id: 'step-m', nodeId: 'm' });
 		const executionStore = makeExecutionStore();
-		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
 
 		await handler.handle({ ...event, stepId: 'step-m' });
 
@@ -259,7 +259,7 @@ describe('StepCompletedHandler', () => {
 			{ hasFailedSteps: vi.fn().mockResolvedValue(true) },
 		);
 		const executionStore = makeExecutionStore();
-		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
 
 		await handler.handle({ ...event, stepId: 'step-m' });
 
@@ -276,7 +276,7 @@ describe('StepCompletedHandler', () => {
 			},
 		);
 		const executionStore = makeExecutionStore();
-		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
 
 		await handler.handle({ ...event, stepId: 'step-b' });
 
@@ -287,7 +287,7 @@ describe('StepCompletedHandler', () => {
 		const stepStore = makeStepStore({ status: 'failed' });
 		const executionStore = makeExecutionStore();
 		const queue = makeQueue();
-		const handler = new StepCompletedHandler(executionStore, stepStore, queue);
+		const handler = new StepSettledHandler(executionStore, stepStore, queue);
 
 		await handler.handle(event);
 
@@ -306,7 +306,7 @@ describe('StepCompletedHandler', () => {
 			{},
 			{ finishExecution: vi.fn().mockResolvedValue(false) },
 		);
-		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
 
 		await handler.handle(event);
 
@@ -317,7 +317,7 @@ describe('StepCompletedHandler', () => {
 		const stepStore = makeStepStore();
 		const executionStore = makeExecutionStore({ status: 'failed' });
 		const queue = makeQueue();
-		const handler = new StepCompletedHandler(executionStore, stepStore, queue);
+		const handler = new StepSettledHandler(executionStore, stepStore, queue);
 
 		await handler.handle(event);
 
@@ -329,7 +329,7 @@ describe('StepCompletedHandler', () => {
 	it('does not test for completion when it just queued work', async () => {
 		const stepStore = makeStepStore();
 		const executionStore = makeExecutionStore();
-		const handler = new StepCompletedHandler(executionStore, stepStore, makeQueue());
+		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
 
 		await handler.handle(event);
 

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -178,9 +178,8 @@ describe('StepSettledHandler', () => {
 	});
 
 	it('fails the execution before planning when any step has failed', async () => {
-		// b failed while c completed, and settled(c) is handled first: m must not
-		// be planned off c's live edge. The check is execution-wide, so it also
-		// covers failures in branches this settlement's snapshot never sees.
+		// b failed but settled(c) is handled first: m must not be planned off
+		// c's live edge
 		const stepStore = makeStepStore(
 			{ id: 'step-c', nodeId: 'c' },
 			{ hasFailedSteps: vi.fn().mockResolvedValue(true) },

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -177,6 +177,23 @@ describe('StepSettledHandler', () => {
 		});
 	});
 
+	it("fails the execution when a sibling's settlement sees a failed predecessor", async () => {
+		const stepStore = makeStepStore({ id: 'step-c', nodeId: 'c' }, {}, [
+			...defaultSummaries,
+			summary('b', 'failed'),
+			summary('c', 'completed', [true]),
+		]);
+		const { handler, executionStore, stepQueue, orchestrationQueue } = makeHandler(stepStore);
+
+		await handler.handle({ ...event, stepId: 'step-c' });
+
+		expect(executionStore.finishExecution).toHaveBeenCalledExactlyOnceWith('exec-1', 'failed');
+		expect(stepStore.cancelQueuedSteps).toHaveBeenCalledExactlyOnceWith('exec-1');
+		expect(stepStore.createSteps).not.toHaveBeenCalled();
+		expect(stepQueue.publish).not.toHaveBeenCalled();
+		expect(orchestrationQueue.publish).not.toHaveBeenCalled();
+	});
+
 	it('loads the decision rows in one query: the successors and their predecessors', async () => {
 		const stepStore = makeStepStore({ id: 'step-b', nodeId: 'b' }, {}, [
 			...defaultSummaries,

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -99,9 +99,6 @@ function makeStepStore(
 			);
 		}),
 		loadStepsByNodeIds: vi.fn().mockResolvedValue({}),
-		loadStepOutputs: vi.fn(),
-		loadCompletedNodeIds: vi.fn(),
-		hasActiveSteps: vi.fn(),
 		// far from settled, so finish tests opt in explicitly
 		countSettledSteps: vi.fn().mockResolvedValue(0),
 		hasFailedSteps: vi.fn().mockResolvedValue(false),

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { WorkflowGraph } from '../../graph';
-import type { StepMessage, WorkQueue } from '../../queue';
+import type { OrchestrationMessage, StepMessage, WorkQueue } from '../../queue';
 import type { ExecutionRecord, ExecutionStore } from '../execution-store';
+import type { StepStatus } from '../execution.types';
 import { StepSettledHandler } from '../step-settled-handler';
-import type { NewStepRecord, StepRecord, StepStore } from '../step-store';
+import type { NewStepRecord, StepRecord, StepStore, StepSummary } from '../step-store';
 
 /**
- * trigger → a → {b, c} → m. So `a` fans out, `m` fans in behind both `b` and
- * `c`, and `m` is terminal.
+ * trigger → a → {b (out 0), c (out 1)} → m. So `a` fans out across two output
+ * slots, `m` fans in behind both `b` and `c`, and `m` is terminal. Five
+ * reachable nodes in total, which the finish tests count against.
  */
 const graph: WorkflowGraph = {
 	nodes: [
@@ -26,6 +28,20 @@ const graph: WorkflowGraph = {
 		{ from: 'c', to: 'm', outputIndex: 0, inputIndex: 1 },
 	],
 };
+
+function summary(
+	nodeId: string,
+	status: StepStatus,
+	filledOutputSlots: boolean[] = [],
+): StepSummary {
+	return { id: `step-${nodeId}`, nodeId, status, filledOutputSlots };
+}
+
+/** Both of a's output slots fired, so both branches are live by default. */
+const defaultSummaries = [
+	summary('trigger', 'completed', [true]),
+	summary('a', 'completed', [true, true]),
+];
 
 function makeExecutionStore(
 	overrides: Partial<ExecutionRecord> = {},
@@ -49,7 +65,11 @@ function makeExecutionStore(
 	};
 }
 
-function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepStore> = {}) {
+function makeStepStore(
+	step: Partial<StepRecord> = {},
+	overrides: Partial<StepStore> = {},
+	summaries: StepSummary[] = defaultSummaries,
+) {
 	const record: StepRecord = {
 		id: 'step-a',
 		executionId: 'exec-1',
@@ -59,6 +79,7 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		error: null,
 		...step,
 	};
+	const summariesByNodeId = Object.fromEntries(summaries.map((s) => [s.nodeId, s]));
 	return {
 		// ids derived from the node, so assertions can name the step they expect
 		createSteps: vi.fn().mockImplementation(async (records: NewStepRecord[]) => {
@@ -70,97 +91,224 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		completeStep: vi.fn(),
 		failStep: vi.fn(),
 		cancelQueuedSteps: vi.fn(),
+		// like the store: only requested nodes that have rows appear
+		loadStepSummaries: vi.fn().mockImplementation(async (_: string, nodeIds: string[]) => {
+			await Promise.resolve();
+			return Object.fromEntries(
+				nodeIds.filter((id) => summariesByNodeId[id]).map((id) => [id, summariesByNodeId[id]]),
+			);
+		}),
 		loadStepsByNodeIds: vi.fn().mockResolvedValue({}),
-		loadStepSummaries: vi.fn().mockResolvedValue({}),
 		loadStepOutputs: vi.fn(),
-		// every node completed, so a case has to opt out to be unready
-		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set(graph.nodes.map(({ id }) => id))),
-		hasActiveSteps: vi.fn().mockResolvedValue(false),
+		loadCompletedNodeIds: vi.fn(),
+		hasActiveSteps: vi.fn(),
+		// far from settled, so finish tests opt in explicitly
+		countSettledSteps: vi.fn().mockResolvedValue(0),
 		hasFailedSteps: vi.fn().mockResolvedValue(false),
 		...overrides,
 	} satisfies StepStore;
 }
 
-function makeQueue(): WorkQueue<StepMessage> {
+function makeStepQueue(): WorkQueue<StepMessage> {
 	return { publish: vi.fn(), start: vi.fn(), stop: vi.fn() };
+}
+
+function makeOrchestrationQueue(): WorkQueue<OrchestrationMessage> {
+	return { publish: vi.fn(), start: vi.fn(), stop: vi.fn() };
+}
+
+function makeHandler(
+	stepStore: StepStore,
+	{
+		executionStore = makeExecutionStore(),
+		stepQueue = makeStepQueue(),
+		orchestrationQueue = makeOrchestrationQueue(),
+	} = {},
+) {
+	return {
+		handler: new StepSettledHandler(executionStore, stepStore, stepQueue, orchestrationQueue),
+		executionStore,
+		stepQueue,
+		orchestrationQueue,
+	};
 }
 
 const event = { type: 'step:settled', executionId: 'exec-1', stepId: 'step-a' } as const;
 
 describe('StepSettledHandler', () => {
-	it('plans every ready successor in one batch and publishes step:ready for each', async () => {
+	it('plans every live successor in one batch and publishes step:ready for each', async () => {
 		const stepStore = makeStepStore();
-		const queue = makeQueue();
-		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, queue);
+		const { handler, stepQueue, orchestrationQueue } = makeHandler(stepStore);
 
 		await handler.handle(event);
 
-		expect(stepStore.createSteps).toHaveBeenCalledWith([
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
 			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
 			{ executionId: 'exec-1', nodeId: 'c', status: 'queued' },
 		]);
-		expect(queue.publish).toHaveBeenCalledTimes(2);
-		expect(queue.publish).toHaveBeenCalledWith({
+		expect(stepQueue.publish).toHaveBeenCalledTimes(2);
+		expect(stepQueue.publish).toHaveBeenCalledWith({
 			type: 'step:ready',
 			executionId: 'exec-1',
 			stepId: 'step-b',
 		});
-		expect(queue.publish).toHaveBeenCalledWith({
+		expect(stepQueue.publish).toHaveBeenCalledWith({
 			type: 'step:ready',
 			executionId: 'exec-1',
 			stepId: 'step-c',
 		});
+		expect(orchestrationQueue.publish).not.toHaveBeenCalled();
 	});
 
 	it("plans the trigger's successors like any other node's", async () => {
-		// execution start only announces the trigger's completion; the first
-		// steps are planned here, through the same readiness rule as the rest
-		const stepStore = makeStepStore({ id: 'step-trigger', nodeId: 'trigger' });
-		const queue = makeQueue();
-		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, queue);
+		// execution start only announces the trigger's settlement; the first
+		// steps are planned here, through the same rules as the rest
+		const stepStore = makeStepStore({ id: 'step-trigger', nodeId: 'trigger' }, {}, [
+			summary('trigger', 'completed', [true]),
+		]);
+		const { handler, stepQueue } = makeHandler(stepStore);
 
 		await handler.handle({ ...event, stepId: 'step-trigger' });
 
-		expect(stepStore.createSteps).toHaveBeenCalledWith([
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
 			{ executionId: 'exec-1', nodeId: 'a', status: 'queued' },
 		]);
-		expect(queue.publish).toHaveBeenCalledExactlyOnceWith({
+		expect(stepQueue.publish).toHaveBeenCalledExactlyOnceWith({
 			type: 'step:ready',
 			executionId: 'exec-1',
 			stepId: 'step-a',
 		});
 	});
 
-	it("asks readiness in one query, for the successors' other predecessors", async () => {
-		const stepStore = makeStepStore({ id: 'step-b', nodeId: 'b' });
-		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, makeQueue());
+	it('loads the decision rows in one query: the successors and their predecessors', async () => {
+		const stepStore = makeStepStore({ id: 'step-b', nodeId: 'b' }, {}, [
+			...defaultSummaries,
+			summary('b', 'completed', [true]),
+		]);
+		const { handler } = makeHandler(stepStore);
 
 		await handler.handle({ ...event, stepId: 'step-b' });
 
-		// b's only successor is m, which sits behind both b and c — but b just
-		// completed, so only c is in question
-		expect(stepStore.loadCompletedNodeIds).toHaveBeenCalledExactlyOnceWith('exec-1', ['c']);
+		// b's only successor is m; m reads from both b and c
+		expect(stepStore.loadStepSummaries).toHaveBeenCalledExactlyOnceWith('exec-1', ['m', 'b', 'c']);
 	});
 
-	it('skips the readiness query when the completed node is every predecessor', async () => {
-		// a is the sole predecessor of both b and c, and a just completed
-		const stepStore = makeStepStore();
-		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, makeQueue());
+	it('skips a dead branch and announces its settlement', async () => {
+		// a fired only output slot 0: b is live, c is dead. The skip is a
+		// settlement, so it is announced on the orchestration queue — its own
+		// handler decides the next hop (the cascade is the event loop).
+		const stepStore = makeStepStore({}, {}, [
+			summary('trigger', 'completed', [true]),
+			summary('a', 'completed', [true, false]),
+		]);
+		const { handler, stepQueue, orchestrationQueue } = makeHandler(stepStore);
 
 		await handler.handle(event);
 
-		expect(stepStore.loadCompletedNodeIds).not.toHaveBeenCalled();
-		expect(stepStore.createSteps).toHaveBeenCalledWith([
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
 			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
-			{ executionId: 'exec-1', nodeId: 'c', status: 'queued' },
+			{ executionId: 'exec-1', nodeId: 'c', status: 'skipped' },
 		]);
+		expect(stepQueue.publish).toHaveBeenCalledExactlyOnceWith({
+			type: 'step:ready',
+			executionId: 'exec-1',
+			stepId: 'step-b',
+		});
+		expect(orchestrationQueue.publish).toHaveBeenCalledExactlyOnceWith({
+			type: 'step:settled',
+			executionId: 'exec-1',
+			stepId: 'step-c',
+		});
+	});
+
+	it("plans a skipped step's successors like a completed step's", async () => {
+		// c was skipped; its settlement event arrives. m is now decidable: b's
+		// edge is live, c's is dead — m runs on the live data.
+		const stepStore = makeStepStore({ id: 'step-c', nodeId: 'c', status: 'skipped' }, {}, [
+			summary('trigger', 'completed', [true]),
+			summary('a', 'completed', [true, false]),
+			summary('b', 'completed', [true]),
+			summary('c', 'skipped'),
+		]);
+		const { handler, stepQueue } = makeHandler(stepStore);
+
+		await handler.handle({ ...event, stepId: 'step-c' });
+
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
+			{ executionId: 'exec-1', nodeId: 'm', status: 'queued' },
+		]);
+		expect(stepQueue.publish).toHaveBeenCalledExactlyOnceWith({
+			type: 'step:ready',
+			executionId: 'exec-1',
+			stepId: 'step-m',
+		});
+	});
+
+	it('announces only the rows the insert actually created', async () => {
+		// Another planner won both rows: RETURNING is empty, so nothing is
+		// announced here — the winner announces, and lost announcements are
+		// reconciliation's job (CAT-2938).
+		const stepStore = makeStepStore({}, { createSteps: vi.fn().mockResolvedValue([]) }, [
+			summary('trigger', 'completed', [true]),
+			summary('a', 'completed', [true, false]),
+		]);
+		const { handler, stepQueue, orchestrationQueue, executionStore } = makeHandler(stepStore);
+
+		await handler.handle(event);
+
+		expect(stepQueue.publish).not.toHaveBeenCalled();
+		expect(orchestrationQueue.publish).not.toHaveBeenCalled();
+		// nothing queued by us and the count says work remains → no finish
+		expect(executionStore.finishExecution).not.toHaveBeenCalled();
+	});
+
+	const notPlanned: Array<{
+		reason: string;
+		stepId: string;
+		step: Partial<StepRecord>;
+		summaries: StepSummary[];
+	}> = [
+		{
+			reason: 'a successor still has an unsettled predecessor',
+			stepId: 'step-b',
+			step: { id: 'step-b', nodeId: 'b' },
+			// m sits behind b and c; c is still running
+			summaries: [...defaultSummaries, summary('b', 'completed', [true]), summary('c', 'running')],
+		},
+		{
+			reason: "a successor's predecessor has no row at all",
+			stepId: 'step-b',
+			step: { id: 'step-b', nodeId: 'b' },
+			summaries: [...defaultSummaries, summary('b', 'completed', [true])],
+		},
+		{
+			reason: 'the settled node has no successors',
+			stepId: 'step-m',
+			step: { id: 'step-m', nodeId: 'm' },
+			summaries: defaultSummaries,
+		},
+		{
+			reason: 'every successor already has a row (duplicate delivery)',
+			stepId: 'step-a',
+			step: {},
+			summaries: [...defaultSummaries, summary('b', 'queued'), summary('c', 'queued')],
+		},
+	];
+
+	it.each(notPlanned)('plans nothing when $reason', async ({ stepId, step, summaries }) => {
+		const stepStore = makeStepStore(step, {}, summaries);
+		const { handler, stepQueue, orchestrationQueue } = makeHandler(stepStore);
+
+		await handler.handle({ ...event, stepId });
+
+		expect(stepStore.createSteps).not.toHaveBeenCalled();
+		expect(stepQueue.publish).not.toHaveBeenCalled();
+		expect(orchestrationQueue.publish).not.toHaveBeenCalled();
 	});
 
 	it('rejects an event whose step belongs to another execution', async () => {
 		const stepStore = makeStepStore({ executionId: 'exec-2' });
-		const executionStore = makeExecutionStore();
-		const queue = makeQueue();
-		const handler = new StepSettledHandler(executionStore, stepStore, queue);
+		const { handler, stepQueue, executionStore } = makeHandler(stepStore);
 
 		await expect(handler.handle(event)).rejects.toMatchObject({
 			name: 'UnexpectedError',
@@ -170,15 +318,13 @@ describe('StepSettledHandler', () => {
 		// Node ids are workflow-scoped, so 'a' resolves against exec-1's graph too:
 		// unguarded, a sibling execution's step would plan and announce real work here.
 		expect(stepStore.createSteps).not.toHaveBeenCalled();
-		expect(queue.publish).not.toHaveBeenCalled();
+		expect(stepQueue.publish).not.toHaveBeenCalled();
 		expect(executionStore.finishExecution).not.toHaveBeenCalled();
 	});
 
 	it('rejects an event whose step references a node absent from the graph', async () => {
 		const stepStore = makeStepStore({ nodeId: 'ghost' });
-		const executionStore = makeExecutionStore();
-		const queue = makeQueue();
-		const handler = new StepSettledHandler(executionStore, stepStore, queue);
+		const { handler, stepQueue, executionStore } = makeHandler(stepStore);
 
 		await expect(handler.handle(event)).rejects.toMatchObject({
 			name: 'UnexpectedError',
@@ -187,118 +333,64 @@ describe('StepSettledHandler', () => {
 
 		// Unguarded, an unknown node has no successors, so this would silently
 		// finish the execution on a corrupted row.
-		expect(queue.publish).not.toHaveBeenCalled();
+		expect(stepQueue.publish).not.toHaveBeenCalled();
 		expect(executionStore.finishExecution).not.toHaveBeenCalled();
 	});
 
-	const notPlanned: Array<{
-		reason: string;
-		stepId: string;
-		step: Partial<StepRecord>;
-		overrides: Partial<StepStore>;
-	}> = [
-		{
-			reason: 'a successor still has an incomplete predecessor',
-			stepId: 'step-b',
-			step: { id: 'step-b', nodeId: 'b' },
-			// m sits behind b and c; c hasn't completed
-			overrides: { loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set()) },
-		},
-		{
-			reason: 'the completed node has no successors',
-			stepId: 'step-m',
-			step: { id: 'step-m', nodeId: 'm' },
-			overrides: {},
-		},
-	];
-
-	it.each(notPlanned)('plans nothing when $reason', async ({ stepId, step, overrides }) => {
-		const stepStore = makeStepStore(step, overrides);
-		const queue = makeQueue();
-		const handler = new StepSettledHandler(makeExecutionStore(), stepStore, queue);
-
-		await handler.handle({ ...event, stepId });
-
-		expect(stepStore.createSteps).not.toHaveBeenCalled();
-		expect(queue.publish).not.toHaveBeenCalled();
-	});
-
-	it('re-announces nothing and finishes nothing on duplicate delivery', async () => {
-		// Redelivered completion for 'a': its successors are already planned, so
-		// the insert's RETURNING is empty, and they're still active, so the
-		// execution must not be finished early.
+	it('finishes the execution once every reachable node has settled', async () => {
+		// 'm' is terminal; with its row settled all five reachable nodes are done
 		const stepStore = makeStepStore(
-			{},
-			{
-				createSteps: vi.fn().mockResolvedValue([]),
-				hasActiveSteps: vi.fn().mockResolvedValue(true),
-			},
+			{ id: 'step-m', nodeId: 'm' },
+			{ countSettledSteps: vi.fn().mockResolvedValue(5) },
 		);
-		const executionStore = makeExecutionStore();
-		const queue = makeQueue();
-		const handler = new StepSettledHandler(executionStore, stepStore, queue);
-
-		await handler.handle(event);
-
-		expect(queue.publish).not.toHaveBeenCalled();
-		expect(executionStore.finishExecution).not.toHaveBeenCalled();
-	});
-
-	it('finishes the execution once the last step is done', async () => {
-		// 'm' is terminal, and nothing else is left running
-		const stepStore = makeStepStore({ id: 'step-m', nodeId: 'm' });
-		const executionStore = makeExecutionStore();
-		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
+		const { handler, executionStore } = makeHandler(stepStore);
 
 		await handler.handle({ ...event, stepId: 'step-m' });
 
+		expect(stepStore.countSettledSteps).toHaveBeenCalledExactlyOnceWith('exec-1');
 		expect(executionStore.finishExecution).toHaveBeenCalledWith('exec-1', 'completed');
 	});
 
 	it('finishes the execution as failed when any step failed', async () => {
 		const stepStore = makeStepStore(
 			{ id: 'step-m', nodeId: 'm' },
-			{ hasFailedSteps: vi.fn().mockResolvedValue(true) },
+			{
+				countSettledSteps: vi.fn().mockResolvedValue(5),
+				hasFailedSteps: vi.fn().mockResolvedValue(true),
+			},
 		);
-		const executionStore = makeExecutionStore();
-		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
+		const { handler, executionStore } = makeHandler(stepStore);
 
 		await handler.handle({ ...event, stepId: 'step-m' });
 
 		expect(executionStore.finishExecution).toHaveBeenCalledWith('exec-1', 'failed');
 	});
 
-	it('leaves the execution running while another step is still outstanding', async () => {
-		// 'b' completed but 'm' still waits on 'c', which is still going
+	it('leaves the execution running while any reachable node is unsettled', async () => {
+		// four of five settled: a dead-branch cascade or a running step remains
 		const stepStore = makeStepStore(
-			{ id: 'step-b', nodeId: 'b' },
-			{
-				loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set()),
-				hasActiveSteps: vi.fn().mockResolvedValue(true),
-			},
+			{ id: 'step-m', nodeId: 'm' },
+			{ countSettledSteps: vi.fn().mockResolvedValue(4) },
 		);
-		const executionStore = makeExecutionStore();
-		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
+		const { handler, executionStore } = makeHandler(stepStore);
 
-		await handler.handle({ ...event, stepId: 'step-b' });
+		await handler.handle({ ...event, stepId: 'step-m' });
 
 		expect(executionStore.finishExecution).not.toHaveBeenCalled();
+		expect(stepStore.hasFailedSteps).not.toHaveBeenCalled();
 	});
 
 	it('fails the execution and cancels queued steps the moment a step fails', async () => {
 		const stepStore = makeStepStore({ status: 'failed' });
-		const executionStore = makeExecutionStore();
-		const queue = makeQueue();
-		const handler = new StepSettledHandler(executionStore, stepStore, queue);
+		const { handler, stepQueue, executionStore } = makeHandler(stepStore);
 
 		await handler.handle(event);
 
 		expect(executionStore.finishExecution).toHaveBeenCalledExactlyOnceWith('exec-1', 'failed');
 		expect(stepStore.cancelQueuedSteps).toHaveBeenCalledExactlyOnceWith('exec-1');
 		expect(stepStore.createSteps).not.toHaveBeenCalled();
-		expect(queue.publish).not.toHaveBeenCalled();
-		expect(stepStore.hasActiveSteps).not.toHaveBeenCalled();
-		expect(stepStore.hasFailedSteps).not.toHaveBeenCalled();
+		expect(stepQueue.publish).not.toHaveBeenCalled();
+		expect(stepStore.countSettledSteps).not.toHaveBeenCalled();
 	});
 
 	it('cancels queued steps again on a redelivered failure event', async () => {
@@ -308,7 +400,7 @@ describe('StepSettledHandler', () => {
 			{},
 			{ finishExecution: vi.fn().mockResolvedValue(false) },
 		);
-		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
+		const { handler } = makeHandler(stepStore, { executionStore });
 
 		await handler.handle(event);
 
@@ -318,25 +410,23 @@ describe('StepSettledHandler', () => {
 	it('plans nothing more once the execution is finished', async () => {
 		const stepStore = makeStepStore();
 		const executionStore = makeExecutionStore({ status: 'failed' });
-		const queue = makeQueue();
-		const handler = new StepSettledHandler(executionStore, stepStore, queue);
+		const { handler, stepQueue } = makeHandler(stepStore, { executionStore });
 
 		await handler.handle(event);
 
 		expect(stepStore.createSteps).not.toHaveBeenCalled();
-		expect(queue.publish).not.toHaveBeenCalled();
+		expect(stepQueue.publish).not.toHaveBeenCalled();
 		expect(executionStore.finishExecution).not.toHaveBeenCalled();
 	});
 
 	it('does not test for completion when it just queued work', async () => {
 		const stepStore = makeStepStore();
-		const executionStore = makeExecutionStore();
-		const handler = new StepSettledHandler(executionStore, stepStore, makeQueue());
+		const { handler, executionStore } = makeHandler(stepStore);
 
 		await handler.handle(event);
 
 		// 'a' fanned out to b and c, so the execution is provably unfinished
-		expect(stepStore.hasActiveSteps).not.toHaveBeenCalled();
+		expect(stepStore.countSettledSteps).not.toHaveBeenCalled();
 		expect(executionStore.finishExecution).not.toHaveBeenCalled();
 	});
 });

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -82,7 +82,7 @@ function makeStepStore(
 	const summariesByNodeId = Object.fromEntries(summaries.map((s) => [s.nodeId, s]));
 	return {
 		// ids derived from the node, so assertions can name the step they expect
-		createSteps: vi.fn().mockImplementation(async (records: NewStepRecord[]) => {
+		createSteps: vi.fn().mockImplementation(async (_: string, records: NewStepRecord[]) => {
 			await Promise.resolve();
 			return records.map(({ nodeId }) => ({ id: `step-${nodeId}`, nodeId }));
 		}),
@@ -139,9 +139,9 @@ describe('StepSettledHandler', () => {
 
 		await handler.handle(event);
 
-		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
-			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
-			{ executionId: 'exec-1', nodeId: 'c', status: 'queued' },
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith('exec-1', [
+			{ nodeId: 'b', status: 'queued' },
+			{ nodeId: 'c', status: 'queued' },
 		]);
 		expect(stepQueue.publish).toHaveBeenCalledTimes(2);
 		expect(stepQueue.publish).toHaveBeenCalledWith({
@@ -167,8 +167,8 @@ describe('StepSettledHandler', () => {
 
 		await handler.handle({ ...event, stepId: 'step-trigger' });
 
-		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
-			{ executionId: 'exec-1', nodeId: 'a', status: 'queued' },
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith('exec-1', [
+			{ nodeId: 'a', status: 'queued' },
 		]);
 		expect(stepQueue.publish).toHaveBeenCalledExactlyOnceWith({
 			type: 'step:ready',
@@ -222,9 +222,9 @@ describe('StepSettledHandler', () => {
 
 		await handler.handle(event);
 
-		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
-			{ executionId: 'exec-1', nodeId: 'b', status: 'queued' },
-			{ executionId: 'exec-1', nodeId: 'c', status: 'skipped' },
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith('exec-1', [
+			{ nodeId: 'b', status: 'queued' },
+			{ nodeId: 'c', status: 'skipped' },
 		]);
 		expect(stepQueue.publish).toHaveBeenCalledExactlyOnceWith({
 			type: 'step:ready',
@@ -251,8 +251,8 @@ describe('StepSettledHandler', () => {
 
 		await handler.handle({ ...event, stepId: 'step-c' });
 
-		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith([
-			{ executionId: 'exec-1', nodeId: 'm', status: 'queued' },
+		expect(stepStore.createSteps).toHaveBeenCalledExactlyOnceWith('exec-1', [
+			{ nodeId: 'm', status: 'queued' },
 		]);
 		expect(stepQueue.publish).toHaveBeenCalledExactlyOnceWith({
 			type: 'step:ready',

--- a/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
+++ b/packages/@n8n/engine/src/execution/__tests__/step-settled-handler.test.ts
@@ -70,6 +70,8 @@ function makeStepStore(step: Partial<StepRecord> = {}, overrides: Partial<StepSt
 		completeStep: vi.fn(),
 		failStep: vi.fn(),
 		cancelQueuedSteps: vi.fn(),
+		loadStepsByNodeIds: vi.fn().mockResolvedValue({}),
+		loadStepSummaries: vi.fn().mockResolvedValue({}),
 		loadStepOutputs: vi.fn(),
 		// every node completed, so a case has to opt out to be unready
 		loadCompletedNodeIds: vi.fn().mockResolvedValue(new Set(graph.nodes.map(({ id }) => id))),

--- a/packages/@n8n/engine/src/execution/execution-start-handler.ts
+++ b/packages/@n8n/engine/src/execution/execution-start-handler.ts
@@ -43,9 +43,8 @@ export class ExecutionStartHandler {
 		// NOTE: trigger payloads are not really supported yet — the raw payload is
 		// not item-shaped, so the v1 shim coerces it to zero items. Proper trigger
 		// handling will decide its shape.
-		const [triggerStep] = await this.stepStore.createSteps([
+		const [triggerStep] = await this.stepStore.createSteps(event.executionId, [
 			{
-				executionId: event.executionId,
 				nodeId: trigger.id,
 				status: 'completed',
 				outputs: [execution.triggerPayload ?? {}],

--- a/packages/@n8n/engine/src/execution/execution-start-handler.ts
+++ b/packages/@n8n/engine/src/execution/execution-start-handler.ts
@@ -59,7 +59,7 @@ export class ExecutionStartHandler {
 
 		// Published only after the row exists, so the consumer can always load it.
 		await this.orchestrationQueue.publish({
-			type: 'step:completed',
+			type: 'step:settled',
 			executionId: event.executionId,
 			stepId: triggerStep.id,
 		});

--- a/packages/@n8n/engine/src/execution/execution.types.ts
+++ b/packages/@n8n/engine/src/execution/execution.types.ts
@@ -15,7 +15,7 @@ export type StepStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancel
  * input slot; the engine understands the slot structure and nothing below it —
  * a slot's contents are opaque and step-type-specific.
  *
- * TODO(CAT-2874): only slot 0 is populated until multi-slot routing lands;
- * graph validation rejects edges that use any other slot.
+ * TODO(CAT-2874): outputs currently only support slot 0 (graph validation rejects edges with `outputIndex !== 0`).
+ * Inputs may populate multiple slots; an unfilled slot is represented as `null`.
  */
 export type StepSlots = JsonValue[];

--- a/packages/@n8n/engine/src/execution/execution.types.ts
+++ b/packages/@n8n/engine/src/execution/execution.types.ts
@@ -18,15 +18,15 @@ export type StepStatus = 'queued' | 'running' | 'completed' | 'failed' | 'skippe
  * immutable, and it will never produce more data. Planning decisions are made
  * over settled predecessors only, so they hold no matter when they're computed.
  */
-const SETTLED_STEP_STATUSES: ReadonlySet<StepStatus> = new Set([
+export const SETTLED_STEP_STATUSES: readonly StepStatus[] = [
 	'completed',
 	'failed',
 	'skipped',
 	'cancelled',
-]);
+];
 
 export function isSettledStatus(status: StepStatus): boolean {
-	return SETTLED_STEP_STATUSES.has(status);
+	return SETTLED_STEP_STATUSES.includes(status);
 }
 
 /**

--- a/packages/@n8n/engine/src/execution/execution.types.ts
+++ b/packages/@n8n/engine/src/execution/execution.types.ts
@@ -6,8 +6,28 @@ export type ExecutionStatus = 'queued' | 'running' | 'completed' | 'failed' | 'c
 /** How an execution was initiated. */
 export type ExecutionMode = 'production' | 'manual';
 
-/** Lifecycle status of a single step within an execution. */
-export type StepStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+/**
+ * Lifecycle status of a single step within an execution. `skipped` is terminal
+ * at birth: the step was considered and decided against (no live input), so it
+ * never runs.
+ */
+export type StepStatus = 'queued' | 'running' | 'completed' | 'failed' | 'skipped' | 'cancelled';
+
+/**
+ * A settled step has reached a terminal state: its status and outputs are
+ * immutable, and it will never produce more data. Planning decisions are made
+ * over settled predecessors only, so they hold no matter when they're computed.
+ */
+const SETTLED_STEP_STATUSES: ReadonlySet<StepStatus> = new Set([
+	'completed',
+	'failed',
+	'skipped',
+	'cancelled',
+]);
+
+export function isSettledStatus(status: StepStatus): boolean {
+	return SETTLED_STEP_STATUSES.has(status);
+}
 
 /**
  * A step's data on one side of a connection, indexed by slot: outputs by

--- a/packages/@n8n/engine/src/execution/execution.types.ts
+++ b/packages/@n8n/engine/src/execution/execution.types.ts
@@ -35,7 +35,8 @@ export function isSettledStatus(status: StepStatus): boolean {
  * input slot; the engine understands the slot structure and nothing below it —
  * a slot's contents are opaque and step-type-specific.
  *
- * TODO(CAT-2874): outputs currently only support slot 0 (graph validation rejects edges with `outputIndex !== 0`).
- * Inputs may populate multiple slots; an unfilled slot is represented as `null`.
+ * `null` marks a slot without data: on outputs, the step didn't fire the slot
+ * (a branch not taken); on inputs, nothing arrived (a dead edge). `[]` is not
+ * the same thing — a step that ran and produced zero items is still live.
  */
 export type StepSlots = JsonValue[];

--- a/packages/@n8n/engine/src/execution/index.ts
+++ b/packages/@n8n/engine/src/execution/index.ts
@@ -10,6 +10,6 @@ export { StepNotFoundError } from './step-store';
 export type { NewStepRecord, StepError, StepRecord, StepStore } from './step-store';
 export { ExecutionStartHandler } from './execution-start-handler';
 export { OrchestrationWorker } from './orchestration-worker';
-export { StepCompletedHandler } from './step-completed-handler';
+export { StepSettledHandler } from './step-settled-handler';
 export { StepReadyHandler } from './step-ready-handler';
 export { StepWorker } from './step-worker';

--- a/packages/@n8n/engine/src/execution/orchestration-worker.ts
+++ b/packages/@n8n/engine/src/execution/orchestration-worker.ts
@@ -1,7 +1,7 @@
 import { UnimplementedError } from '../common';
 import type { OrchestrationMessage, WorkQueue } from '../queue';
 import type { ExecutionStartHandler } from './execution-start-handler';
-import type { StepCompletedHandler } from './step-completed-handler';
+import type { StepSettledHandler } from './step-settled-handler';
 
 /**
  * Consumes the orchestration queue and routes each message to its handler.
@@ -10,7 +10,7 @@ export class OrchestrationWorker {
 	constructor(
 		private readonly orchestrationQueue: WorkQueue<OrchestrationMessage>,
 		private readonly startHandler: ExecutionStartHandler,
-		private readonly completedHandler: StepCompletedHandler,
+		private readonly settledHandler: StepSettledHandler,
 	) {}
 
 	start(): void {
@@ -19,8 +19,8 @@ export class OrchestrationWorker {
 				case 'execution:enqueued':
 					await this.startHandler.handle(message);
 					break;
-				case 'step:completed':
-					await this.completedHandler.handle(message);
+				case 'step:settled':
+					await this.settledHandler.handle(message);
 					break;
 				default: {
 					// Exhaustive today; the throw guards an off-contract message at runtime.

--- a/packages/@n8n/engine/src/execution/settlement.ts
+++ b/packages/@n8n/engine/src/execution/settlement.ts
@@ -1,0 +1,78 @@
+import { getSuccessorNodeIds, type GraphEdge, type WorkflowGraph } from '../graph';
+import { isSettledStatus } from './execution.types';
+import type { StepSummary } from './step-store';
+
+/**
+ * Settlement rules (design: CAT-2874):
+ *
+ * 1. Every node the execution considers eventually settles: completed,
+ *    failed, skipped, or cancelled. Settled fates are immutable. The
+ *    execution is finished exactly when every reachable node has settled.
+ * 2. An edge is live iff its source completed and filled the edge's output
+ *    slot; it is dead if the source settled any other way, or left the slot
+ *    null. An edge whose source is unsettled is neither yet.
+ * 3. A node is decidable once every predecessor is settled. Decidable with at
+ *    least one live incoming edge → it runs (queued). Decidable with none →
+ *    it is skipped: settled at birth, its own out-edges all dead.
+ * 4. A settlement decides only its direct successors; the cascade is the
+ *    event loop. A skip is announced as settled like any other settlement,
+ *    and its handler decides the next hop.
+ * 5. A planner commits its decisions in one batch, then announces only the
+ *    rows it created. A settlement whose announcement is lost is detectable
+ *    from rows alone — a settled row with decidable but rowless successors —
+ *    and re-announced by reconciliation (CAT-2938).
+ *
+ * Fates are pure functions of settled rows, so any planner, at any time,
+ * recomputes the same decisions; duplicates and races converge instead of
+ * corrupting.
+ */
+
+export interface SuccessorDecisions {
+	/** Successors with a live input, to enqueue — in edge order. */
+	toQueue: string[];
+	/** Successors with settled but all-dead inputs, to record as skipped. */
+	toSkip: string[];
+}
+
+/**
+ * Decides the direct successors of `settledNodeId` (rules 2–4). `steps` holds
+ * the existing rows for those successors and their predecessors, including
+ * `settledNodeId` itself.
+ */
+export function decideSuccessors(
+	graph: WorkflowGraph,
+	settledNodeId: string,
+	steps: Record<string, StepSummary>,
+): SuccessorDecisions {
+	const decisions: SuccessorDecisions = { toQueue: [], toSkip: [] };
+	for (const successor of getSuccessorNodeIds(graph, settledNodeId)) {
+		// An existing row was decided by an earlier settlement, which announced it.
+		if (steps[successor]) continue;
+		const fate = decideNodeFate(graph, successor, steps);
+		if (fate === 'queued') decisions.toQueue.push(successor);
+		else if (fate === 'skipped') decisions.toSkip.push(successor);
+	}
+	return decisions;
+}
+
+/** One node's fate under rules 2–3; undecidable while a predecessor is unsettled. */
+function decideNodeFate(
+	graph: WorkflowGraph,
+	nodeId: string,
+	steps: Record<string, StepSummary>,
+): 'queued' | 'skipped' | 'undecidable' {
+	// Back-edges aside: loop iteration is CAT-2875.
+	const incoming = graph.edges.filter((edge) => edge.to === nodeId && !edge.isBackEdge);
+	const predecessors = [...new Set(incoming.map((edge) => edge.from))];
+	const settled = predecessors.every(
+		(id) => steps[id] !== undefined && isSettledStatus(steps[id].status),
+	);
+	if (!settled) return 'undecidable';
+	return incoming.some((edge) => isLiveEdge(edge, steps)) ? 'queued' : 'skipped';
+}
+
+/** Rule 2. A slot beyond the produced list reads undefined — dead, like null. */
+function isLiveEdge(edge: GraphEdge, steps: Record<string, StepSummary>): boolean {
+	const source = steps[edge.from];
+	return source?.status === 'completed' && Boolean(source.filledOutputSlots[edge.outputIndex]);
+}

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -87,9 +87,8 @@ export class StepReadyHandler {
 		inputs: StepSlots,
 		executor: IStepExecutor,
 	): Promise<StepSlots> {
-		// Outputs are recorded shape-agnostically: which slots fired (including
-		// none) is planning's concern — the settlement handler reads the slots
-		// to queue live branches and skip dead ones.
+		// Outputs are stored without inspection. Which slots fired (including
+		// none) is the settlement handler's concern when it plans successors.
 		const { outputs } = await executor.execute({
 			node,
 			inputs,

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -1,9 +1,9 @@
-import { UnexpectedError, UnimplementedError } from '../common';
+import { UnexpectedError, UnimplementedError, type JsonValue } from '../common';
 import type { ExternalDependencies, IStepExecutor } from '../dependencies';
 import type { GraphEdge, GraphNode } from '../graph';
 import type { OrchestrationMessage, StepReadyEvent, WorkQueue } from '../queue';
 import type { ExecutionRecord, ExecutionStore } from './execution-store';
-import type { StepSlots } from './execution.types';
+import { isSettledStatus, type StepSlots } from './execution.types';
 import type { StepError, StepRecord, StepStore } from './step-store';
 import { validateStepContext } from './validate-step-context';
 
@@ -87,6 +87,9 @@ export class StepReadyHandler {
 		inputs: StepSlots,
 		executor: IStepExecutor,
 	): Promise<StepSlots> {
+		// Outputs are recorded shape-agnostically: which slots fired (including
+		// none) is planning's concern — the settlement handler reads the slots
+		// to queue live branches and skip dead ones.
 		const { outputs } = await executor.execute({
 			node,
 			inputs,
@@ -97,36 +100,7 @@ export class StepReadyHandler {
 				mode: execution.mode,
 			},
 		});
-
-		// TODO(CAT-2874): support multi-slot outputs.
-		if (outputs.length > 1) {
-			throw new UnimplementedError(
-				`step ${step.id} runs node ${step.nodeId}, which produced ${outputs.length} output slots; only output slot 0 is supported yet`,
-			);
-		}
-		// TODO(CAT-2874): support stopping on empty outputs.
-		this.assertOutputFiredForSuccessors(step, execution, outputs);
-
 		return outputs;
-	}
-
-	/**
-	 * We don't support stopping the execution on null outputs yet: planning is
-	 * status-based, so successors run even when this step fired nothing — on an
-	 * empty input slot, instead of not at all. Fail loudly until then.
-	 */
-	private assertOutputFiredForSuccessors(
-		step: StepRecord,
-		execution: ExecutionRecord,
-		outputs: StepSlots,
-	): void {
-		// NOTE: we check hasSuccessors because we DO support empty outputs for the last node.
-		const hasSuccessors = execution.graph.edges.some((edge) => edge.from === step.nodeId);
-		if (hasSuccessors && (outputs.length === 0 || outputs[0] === null)) {
-			throw new UnimplementedError(
-				`step ${step.id} runs node ${step.nodeId}, which did not fire output slot 0 despite having successors; branch selection is not supported yet`,
-			);
-		}
 	}
 
 	/** Inputs for `node`, each slot taken from its predecessor's output. */
@@ -134,7 +108,7 @@ export class StepReadyHandler {
 		// These are all the edges that feed into the node this step runs.
 		const incomingEdges = execution.graph.edges.filter((edge) => edge.to === step.nodeId);
 		if (incomingEdges.length === 0) {
-			// Steps are planned only for a completed step's successors, so a step
+			// Steps are planned only for a settled step's successors, so a step
 			// without a predecessor means the graph and the step rows disagree.
 			throw new UnexpectedError(
 				`step ${step.id} runs node ${step.nodeId}, which has no predecessor in the execution graph`,
@@ -143,7 +117,11 @@ export class StepReadyHandler {
 
 		validateIncomingEdges(incomingEdges, step);
 
-		const incomingOutputsByNodeId = await this.loadIncomingOutputs(execution.id, incomingEdges);
+		const predecessorNodeIds = [...new Set(incomingEdges.map((edge) => edge.from))];
+		const predecessorSteps = await this.stepStore.loadStepsByNodeIds(
+			execution.id,
+			predecessorNodeIds,
+		);
 
 		// Array of length equal to the highest input slot plus one.
 		// The entries are `null` placeholders filled by the loop immediately below.
@@ -153,7 +131,7 @@ export class StepReadyHandler {
 		);
 
 		for (const edge of incomingEdges) {
-			populateInputFromPredecessor(edge, step, incomingOutputsByNodeId, inputs);
+			inputs[edge.inputIndex] = readEdgeValue(edge, predecessorSteps, step);
 		}
 
 		return inputs;
@@ -176,37 +154,16 @@ export class StepReadyHandler {
 
 		throw new UnimplementedError(`step ${step.id}: no executor for step type ${node.type}`);
 	}
-
-	/**
-	 * Loads the outputs of all the source steps of `incomingEdges`, keyed by the source node ID.
-	 * The source steps must have completed.
-	 * @param executionId to gather the predecessor outputs
-	 * @param incomingEdges to know which predecessor nodes to gather outputs from
-	 * @returns
-	 */
-	private async loadIncomingOutputs(
-		executionId: string,
-		incomingEdges: GraphEdge[],
-	): Promise<Record<string, StepSlots | null>> {
-		const predecessorNodeIds = [...new Set(incomingEdges.map((edge) => edge.from))];
-		return await this.stepStore.loadStepOutputs(executionId, predecessorNodeIds);
-	}
 }
 
-// Validate that the incoming edge meets our constraints. filledSlots tracks the filled
+// Validate that the incoming edges meet our constraints. filledSlots tracks the filled
 // input slots so we can detect multiple edges into the same slot.
 function validateIncomingEdges(incomingEdges: GraphEdge[], step: StepRecord): void {
 	const filledSlots: Set<number> = new Set();
 	for (const edge of incomingEdges) {
-		// TODO(CAT-2874): route from non-zero output slots. We should have
-		// rejected this graph at validation time.
-		if (edge.outputIndex !== 0) {
-			throw new UnexpectedError(
-				`step ${step.id} runs node ${step.nodeId}, fed from output slot ${edge.outputIndex} of node ${edge.from}; validated graphs only use output slot 0`,
-			);
-		}
 		if (filledSlots.has(edge.inputIndex)) {
-			// We should have rejected this graph at validation time.
+			// TODO(CAT-3982): same-slot convergence gets a defined meaning. We
+			// should have rejected this graph at validation time.
 			throw new UnexpectedError(
 				`step ${step.id} runs node ${step.nodeId}, which has more than one edge into input slot ${edge.inputIndex}; validated graphs have at most one edge per input slot`,
 			);
@@ -215,21 +172,26 @@ function validateIncomingEdges(incomingEdges: GraphEdge[], step: StepRecord): vo
 	}
 }
 
-function populateInputFromPredecessor(
+/**
+ * The value an edge delivers: the source's output slot for a completed
+ * predecessor, `null` for a dead edge (predecessor settled without completing,
+ * or left the slot unfilled).
+ */
+function readEdgeValue(
 	edge: GraphEdge,
+	predecessorSteps: Record<string, StepRecord>,
 	step: StepRecord,
-	incomingOutputsByNodeId: Record<string, StepSlots | null>,
-	inputs: StepSlots,
-): void {
-	const predecessorOutputs = incomingOutputsByNodeId[edge.from];
-	if (!predecessorOutputs) {
-		// A step is planned only once every predecessor completed, so running on
+): JsonValue {
+	const row = predecessorSteps[edge.from];
+	if (!row || !isSettledStatus(row.status)) {
+		// A step is planned only once every predecessor settled, so running on
 		// a fabricated empty input would mask a planner/store inconsistency.
 		throw new UnexpectedError(
-			`step ${step.id} reads node ${edge.from}, whose step has not completed`,
+			`step ${step.id} reads node ${edge.from}, whose step has not settled`,
 		);
 	}
-	inputs[edge.inputIndex] = predecessorOutputs[edge.outputIndex] ?? null;
+	if (row.status !== 'completed') return null;
+	return row.outputs?.[edge.outputIndex] ?? null;
 }
 
 function toStepError(error: unknown): StepError {

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -10,7 +10,7 @@ import { validateStepContext } from './validate-step-context';
 /**
  * Handles the `step:ready` step event: claims the step (`queued → running`),
  * runs it through the executor for its step type, records the outcome, and
- * reports back to the orchestration worker with `step:completed`.
+ * reports back to the orchestration worker with `step:settled`.
  *
  * A step that cannot run — no executor, an input shape we don't support yet —
  * makes the handler throw, leaving the step `running` for reconciliation
@@ -74,7 +74,7 @@ export class StepReadyHandler {
 		if (!recorded) return;
 
 		await this.orchestrationQueue.publish({
-			type: 'step:completed',
+			type: 'step:settled',
 			executionId: event.executionId,
 			stepId: event.stepId,
 		});

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -141,16 +141,12 @@ export class StepReadyHandler {
 			);
 		}
 
-		// All the filled input slots.
-		const filledSlots = new Set<number>();
-		for (const edge of incomingEdges) {
-			validateIncomingEdge(edge, step, filledSlots);
-			filledSlots.add(edge.inputIndex);
-		}
+		validateIncomingEdges(incomingEdges, step);
 
 		const incomingOutputsByNodeId = await this.loadIncomingOutputs(execution.id, incomingEdges);
 
 		// Array of length equal to the highest input slot. All empty for now.
+		// TODO(CAT-3042): enforce data size limits.
 		const inputs: StepSlots = Array.from(
 			{ length: Math.max(...incomingEdges.map((edge) => edge.inputIndex)) + 1 },
 			() => null,
@@ -184,8 +180,8 @@ export class StepReadyHandler {
 	/**
 	 * Loads the outputs of all the source steps of `incomingEdges`, keyed by the source node ID.
 	 * The source steps must have completed.
-	 * @param executionId
-	 * @param incomingEdges
+	 * @param executionId to gather the predecessor outputs
+	 * @param incomingEdges to know which predecessor nodes to gather outputs from
 	 * @returns
 	 */
 	private async loadIncomingOutputs(
@@ -199,19 +195,23 @@ export class StepReadyHandler {
 
 // Validate that the incoming edge meets our constraints. filledSlots tracks the filled
 // input slots so we can detect multiple edges into the same slot.
-function validateIncomingEdge(edge: GraphEdge, step: StepRecord, filledSlots: Set<number>): void {
-	// TODO(CAT-2874): route from non-zero output slots. We should have
-	// rejected this graph at validation time.
-	if (edge.outputIndex !== 0) {
-		throw new UnexpectedError(
-			`step ${step.id} runs node ${step.nodeId}, fed from output slot ${edge.outputIndex} of node ${edge.from}; validated graphs only use output slot 0`,
-		);
-	}
-	if (filledSlots.has(edge.inputIndex)) {
-		// We should have rejected this graph at validation time.
-		throw new UnexpectedError(
-			`step ${step.id} runs node ${step.nodeId}, which has more than one edge into input slot ${edge.inputIndex}; validated graphs have at most one edge per input slot`,
-		);
+function validateIncomingEdges(incomingEdges: GraphEdge[], step: StepRecord): void {
+	const filledSlots: Set<number> = new Set();
+	for (const edge of incomingEdges) {
+		// TODO(CAT-2874): route from non-zero output slots. We should have
+		// rejected this graph at validation time.
+		if (edge.outputIndex !== 0) {
+			throw new UnexpectedError(
+				`step ${step.id} runs node ${step.nodeId}, fed from output slot ${edge.outputIndex} of node ${edge.from}; validated graphs only use output slot 0`,
+			);
+		}
+		if (filledSlots.has(edge.inputIndex)) {
+			// We should have rejected this graph at validation time.
+			throw new UnexpectedError(
+				`step ${step.id} runs node ${step.nodeId}, which has more than one edge into input slot ${edge.inputIndex}; validated graphs have at most one edge per input slot`,
+			);
+		}
+		filledSlots.add(edge.inputIndex);
 	}
 }
 

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -1,6 +1,6 @@
 import { UnexpectedError, UnimplementedError } from '../common';
 import type { ExternalDependencies, IStepExecutor } from '../dependencies';
-import type { GraphNode } from '../graph';
+import type { GraphEdge, GraphNode } from '../graph';
 import type { OrchestrationMessage, StepReadyEvent, WorkQueue } from '../queue';
 import type { ExecutionRecord, ExecutionStore } from './execution-store';
 import type { StepSlots } from './execution.types';
@@ -129,48 +129,38 @@ export class StepReadyHandler {
 		}
 	}
 
-	/** Inputs for `node`, taken from its predecessor's output. */
+	/** Inputs for `node`, each slot taken from its predecessor's output. */
 	private async gatherInputs(execution: ExecutionRecord, step: StepRecord): Promise<StepSlots> {
-		const incoming = execution.graph.edges.filter((edge) => edge.to === step.nodeId);
-		if (incoming.length === 0) {
+		// These are all the edges that feed into the node this step runs.
+		const incomingEdges = execution.graph.edges.filter((edge) => edge.to === step.nodeId);
+		if (incomingEdges.length === 0) {
 			// Steps are planned only for a completed step's successors, so a step
 			// without a predecessor means the graph and the step rows disagree.
 			throw new UnexpectedError(
 				`step ${step.id} runs node ${step.nodeId}, which has no predecessor in the execution graph`,
 			);
 		}
-		// TODO(CAT-2874): support multiple inputs. We should have rejected this
-		// graph at validation time.
-		if (incoming.length > 1) {
-			throw new UnexpectedError(
-				`step ${step.id} runs node ${step.nodeId}, which has ${incoming.length} incoming edges; validated graphs have at most one edge per input slot`,
-			);
-		}
-		const [edge] = incoming;
-		// TODO(CAT-2874): route by slot indices. We should have rejected this
-		// graph at validation time.
-		if (edge.outputIndex !== 0 || edge.inputIndex !== 0) {
-			throw new UnexpectedError(
-				`step ${step.id} runs node ${step.nodeId} through edge slots ${edge.outputIndex} → ${edge.inputIndex}; validated graphs only use slot 0`,
-			);
+
+		// All the filled input slots.
+		const filledSlots = new Set<number>();
+		for (const edge of incomingEdges) {
+			validateIncomingEdge(edge, step, filledSlots);
+			filledSlots.add(edge.inputIndex);
 		}
 
-		const outputsByNodeId = await this.stepStore.loadStepOutputs(execution.id, [edge.from]);
-		const predecessorOutputs = outputsByNodeId[edge.from];
-		if (!predecessorOutputs) {
-			// A step is planned only once every predecessor completed, so running on
-			// a fabricated empty input would mask a planner/store inconsistency.
-			throw new UnexpectedError(
-				`step ${step.id} reads node ${edge.from}, whose step has not completed`,
-			);
-		}
-		if (predecessorOutputs.length > 1) {
-			throw new UnexpectedError(
-				`step ${step.id} reads node ${edge.from}, whose step recorded more than one output slot; the write-time guard admits only slot 0`,
-			);
+		const incomingOutputsByNodeId = await this.loadIncomingOutputs(execution.id, incomingEdges);
+
+		// Array of length equal to the highest input slot. All empty for now.
+		const inputs: StepSlots = Array.from(
+			{ length: Math.max(...incomingEdges.map((edge) => edge.inputIndex)) + 1 },
+			() => null,
+		);
+
+		for (const edge of incomingEdges) {
+			populateInputFromPredecessor(edge, step, incomingOutputsByNodeId, inputs);
 		}
 
-		return [predecessorOutputs[0] ?? null];
+		return inputs;
 	}
 
 	/**
@@ -190,6 +180,56 @@ export class StepReadyHandler {
 
 		throw new UnimplementedError(`step ${step.id}: no executor for step type ${node.type}`);
 	}
+
+	/**
+	 * Loads the outputs of all the source steps of `incomingEdges`, keyed by the source node ID.
+	 * The source steps must have completed.
+	 * @param executionId
+	 * @param incomingEdges
+	 * @returns
+	 */
+	private async loadIncomingOutputs(
+		executionId: string,
+		incomingEdges: GraphEdge[],
+	): Promise<Record<string, StepSlots | null>> {
+		const predecessorNodeIds = [...new Set(incomingEdges.map((edge) => edge.from))];
+		return await this.stepStore.loadStepOutputs(executionId, predecessorNodeIds);
+	}
+}
+
+// Validate that the incoming edge meets our constraints. filledSlots tracks the filled
+// input slots so we can detect multiple edges into the same slot.
+function validateIncomingEdge(edge: GraphEdge, step: StepRecord, filledSlots: Set<number>): void {
+	// TODO(CAT-2874): route from non-zero output slots. We should have
+	// rejected this graph at validation time.
+	if (edge.outputIndex !== 0) {
+		throw new UnexpectedError(
+			`step ${step.id} runs node ${step.nodeId}, fed from output slot ${edge.outputIndex} of node ${edge.from}; validated graphs only use output slot 0`,
+		);
+	}
+	if (filledSlots.has(edge.inputIndex)) {
+		// We should have rejected this graph at validation time.
+		throw new UnexpectedError(
+			`step ${step.id} runs node ${step.nodeId}, which has more than one edge into input slot ${edge.inputIndex}; validated graphs have at most one edge per input slot`,
+		);
+	}
+}
+
+function populateInputFromPredecessor(
+	edge: GraphEdge,
+	step: StepRecord,
+	incomingOutputsByNodeId: Record<string, StepSlots | null>,
+	inputs: StepSlots,
+): void {
+	const predecessorOutputs = incomingOutputsByNodeId[edge.from];
+	if (!predecessorOutputs) {
+		// A step is planned only once every predecessor completed, so running on
+		// a fabricated empty input would mask a planner/store inconsistency.
+		throw new UnexpectedError(
+			`step ${step.id} reads node ${edge.from}, whose step has not completed`,
+		);
+	}
+	inputs[edge.inputIndex] = predecessorOutputs[edge.outputIndex] ?? null;
 }
 
 function toStepError(error: unknown): StepError {

--- a/packages/@n8n/engine/src/execution/step-ready-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-ready-handler.ts
@@ -1,9 +1,9 @@
-import { UnexpectedError, UnimplementedError } from '../common';
+import { UnexpectedError, UnimplementedError, type JsonValue } from '../common';
 import type { ExternalDependencies, IStepExecutor } from '../dependencies';
 import type { GraphEdge, GraphNode } from '../graph';
 import type { OrchestrationMessage, StepReadyEvent, WorkQueue } from '../queue';
 import type { ExecutionRecord, ExecutionStore } from './execution-store';
-import type { StepSlots } from './execution.types';
+import { isSettledStatus, type StepSlots } from './execution.types';
 import type { StepError, StepRecord, StepStore } from './step-store';
 import { validateStepContext } from './validate-step-context';
 
@@ -87,6 +87,9 @@ export class StepReadyHandler {
 		inputs: StepSlots,
 		executor: IStepExecutor,
 	): Promise<StepSlots> {
+		// Outputs are recorded shape-agnostically: which slots fired (including
+		// none) is planning's concern — the settlement handler reads the slots
+		// to queue live branches and skip dead ones.
 		const { outputs } = await executor.execute({
 			node,
 			inputs,
@@ -97,36 +100,7 @@ export class StepReadyHandler {
 				mode: execution.mode,
 			},
 		});
-
-		// TODO(CAT-2874): support multi-slot outputs.
-		if (outputs.length > 1) {
-			throw new UnimplementedError(
-				`step ${step.id} runs node ${step.nodeId}, which produced ${outputs.length} output slots; only output slot 0 is supported yet`,
-			);
-		}
-		// TODO(CAT-2874): support stopping on empty outputs.
-		this.assertOutputFiredForSuccessors(step, execution, outputs);
-
 		return outputs;
-	}
-
-	/**
-	 * We don't support stopping the execution on null outputs yet: planning is
-	 * status-based, so successors run even when this step fired nothing — on an
-	 * empty input slot, instead of not at all. Fail loudly until then.
-	 */
-	private assertOutputFiredForSuccessors(
-		step: StepRecord,
-		execution: ExecutionRecord,
-		outputs: StepSlots,
-	): void {
-		// NOTE: we check hasSuccessors because we DO support empty outputs for the last node.
-		const hasSuccessors = execution.graph.edges.some((edge) => edge.from === step.nodeId);
-		if (hasSuccessors && (outputs.length === 0 || outputs[0] === null)) {
-			throw new UnimplementedError(
-				`step ${step.id} runs node ${step.nodeId}, which did not fire output slot 0 despite having successors; branch selection is not supported yet`,
-			);
-		}
 	}
 
 	/** Inputs for `node`, each slot taken from its predecessor's output. */
@@ -134,7 +108,7 @@ export class StepReadyHandler {
 		// These are all the edges that feed into the node this step runs.
 		const incomingEdges = execution.graph.edges.filter((edge) => edge.to === step.nodeId);
 		if (incomingEdges.length === 0) {
-			// Steps are planned only for a completed step's successors, so a step
+			// Steps are planned only for a settled step's successors, so a step
 			// without a predecessor means the graph and the step rows disagree.
 			throw new UnexpectedError(
 				`step ${step.id} runs node ${step.nodeId}, which has no predecessor in the execution graph`,
@@ -143,7 +117,11 @@ export class StepReadyHandler {
 
 		validateIncomingEdges(incomingEdges, step);
 
-		const incomingOutputsByNodeId = await this.loadIncomingOutputs(execution.id, incomingEdges);
+		const predecessorNodeIds = [...new Set(incomingEdges.map((edge) => edge.from))];
+		const predecessorSteps = await this.stepStore.loadStepsByNodeIds(
+			execution.id,
+			predecessorNodeIds,
+		);
 
 		// Array of length equal to the highest input slot. All empty for now.
 		// TODO(CAT-3042): enforce data size limits.
@@ -153,7 +131,7 @@ export class StepReadyHandler {
 		);
 
 		for (const edge of incomingEdges) {
-			populateInputFromPredecessor(edge, step, incomingOutputsByNodeId, inputs);
+			inputs[edge.inputIndex] = readEdgeValue(edge, predecessorSteps, step);
 		}
 
 		return inputs;
@@ -176,37 +154,16 @@ export class StepReadyHandler {
 
 		throw new UnimplementedError(`step ${step.id}: no executor for step type ${node.type}`);
 	}
-
-	/**
-	 * Loads the outputs of all the source steps of `incomingEdges`, keyed by the source node ID.
-	 * The source steps must have completed.
-	 * @param executionId to gather the predecessor outputs
-	 * @param incomingEdges to know which predecessor nodes to gather outputs from
-	 * @returns
-	 */
-	private async loadIncomingOutputs(
-		executionId: string,
-		incomingEdges: GraphEdge[],
-	): Promise<Record<string, StepSlots | null>> {
-		const predecessorNodeIds = [...new Set(incomingEdges.map((edge) => edge.from))];
-		return await this.stepStore.loadStepOutputs(executionId, predecessorNodeIds);
-	}
 }
 
-// Validate that the incoming edge meets our constraints. filledSlots tracks the filled
+// Validate that the incoming edges meet our constraints. filledSlots tracks the filled
 // input slots so we can detect multiple edges into the same slot.
 function validateIncomingEdges(incomingEdges: GraphEdge[], step: StepRecord): void {
 	const filledSlots: Set<number> = new Set();
 	for (const edge of incomingEdges) {
-		// TODO(CAT-2874): route from non-zero output slots. We should have
-		// rejected this graph at validation time.
-		if (edge.outputIndex !== 0) {
-			throw new UnexpectedError(
-				`step ${step.id} runs node ${step.nodeId}, fed from output slot ${edge.outputIndex} of node ${edge.from}; validated graphs only use output slot 0`,
-			);
-		}
 		if (filledSlots.has(edge.inputIndex)) {
-			// We should have rejected this graph at validation time.
+			// TODO(CAT-3982): same-slot convergence gets a defined meaning. We
+			// should have rejected this graph at validation time.
 			throw new UnexpectedError(
 				`step ${step.id} runs node ${step.nodeId}, which has more than one edge into input slot ${edge.inputIndex}; validated graphs have at most one edge per input slot`,
 			);
@@ -215,21 +172,26 @@ function validateIncomingEdges(incomingEdges: GraphEdge[], step: StepRecord): vo
 	}
 }
 
-function populateInputFromPredecessor(
+/**
+ * The value an edge delivers: the source's output slot for a completed
+ * predecessor, `null` for a dead edge (predecessor settled without completing,
+ * or left the slot unfilled).
+ */
+function readEdgeValue(
 	edge: GraphEdge,
+	predecessorSteps: Record<string, StepRecord>,
 	step: StepRecord,
-	incomingOutputsByNodeId: Record<string, StepSlots | null>,
-	inputs: StepSlots,
-): void {
-	const predecessorOutputs = incomingOutputsByNodeId[edge.from];
-	if (!predecessorOutputs) {
-		// A step is planned only once every predecessor completed, so running on
+): JsonValue {
+	const row = predecessorSteps[edge.from];
+	if (!row || !isSettledStatus(row.status)) {
+		// A step is planned only once every predecessor settled, so running on
 		// a fabricated empty input would mask a planner/store inconsistency.
 		throw new UnexpectedError(
-			`step ${step.id} reads node ${edge.from}, whose step has not completed`,
+			`step ${step.id} reads node ${edge.from}, whose step has not settled`,
 		);
 	}
-	inputs[edge.inputIndex] = predecessorOutputs[edge.outputIndex] ?? null;
+	if (row.status !== 'completed') return null;
+	return row.outputs?.[edge.outputIndex] ?? null;
 }
 
 function toStepError(error: unknown): StepError {

--- a/packages/@n8n/engine/src/execution/step-settled-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-settled-handler.ts
@@ -1,17 +1,24 @@
-import { getPredecessorNodeIds, getSuccessorNodeIds } from '../graph';
-import type { StepSettledEvent, StepMessage, WorkQueue } from '../queue';
+import { UnexpectedError } from '../common';
+import {
+	findTriggerNode,
+	getDescendantNodeIds,
+	getPredecessorNodeIds,
+	getSuccessorNodeIds,
+} from '../graph';
+import type { OrchestrationMessage, StepMessage, StepSettledEvent, WorkQueue } from '../queue';
 import type { ExecutionRecord, ExecutionStore } from './execution-store';
-import type { StepStore } from './step-store';
+import { decideSuccessors } from './settlement';
+import type { StepStore, StepSummary } from './step-store';
 import { validateStepContext } from './validate-step-context';
 
 /**
- * Handles the `step:settled` orchestration event: plans the successors of the
- * finished step and publishes `step:ready` for each, or records the execution's
- * outcome when there is nothing left to run.
- *
- * A successor is planned once, when every predecessor has completed — never
- * planned early and held back at run time — so a step row exists only for work
- * whose inputs are all available.
+ * Handles the `step:settled` orchestration event: decides the fate of the
+ * settled step's direct successors — queued when a live edge feeds them,
+ * skipped when every input is settled dead (see the rules in `settlement.ts`)
+ * — and records the execution's outcome once every reachable node has
+ * settled. Skips are settlements too: each one is announced back onto the
+ * orchestration queue, and handling it here decides the next hop, so a dead
+ * region cascades through the event loop one settlement at a time.
  *
  * An event whose step and execution disagree is rejected before anything is
  * planned, leaving both executions untouched.
@@ -21,6 +28,7 @@ export class StepSettledHandler {
 		private readonly executionStore: ExecutionStore,
 		private readonly stepStore: StepStore,
 		private readonly stepQueue: WorkQueue<StepMessage>,
+		private readonly orchestrationQueue: WorkQueue<OrchestrationMessage>,
 	) {}
 
 	async handle(event: StepSettledEvent): Promise<void> {
@@ -40,97 +48,109 @@ export class StepSettledHandler {
 
 		if (execution.status !== 'running') return;
 
-		const planned =
-			step.status === 'completed' ? await this.planSuccessors(execution, step.nodeId) : 0;
+		const queued =
+			step.status === 'completed' || step.status === 'skipped'
+				? await this.planSuccessors(execution, step.nodeId)
+				: 0;
 
-		// If we've planned steps, we know the execution isn't done yet, so we definitely don't need
-		// to mark it finished.
-		if (planned > 0) return;
+		// If we've queued steps, we know the execution isn't done yet, so we
+		// definitely don't need to mark it finished.
+		if (queued > 0) return;
 
-		await this.finishExecutionIfDone(execution.id);
+		await this.finishExecutionIfDone(execution);
 	}
 
-	/**
-	 * Records the execution's outcome once no step is left to run: `failed` if any
-	 * step failed, `completed` otherwise. A no-op while work is still outstanding.
-	 *
-	 * TODO(CAT-3910): there's a possible race condition with two branches, where
-	 * one branch finishes and the other is still running. If we check while the
-	 * still-running branch has finished a step but not yet planned its successors,
-	 * it will look like there are no active steps and we'll mark the execution
-	 * finished. There are a few possible approaches to close this race e.g.,
-	 * distinguish between "completed" and "completed AND possible next steps planned".
-	 */
-	private async finishExecutionIfDone(executionId: string): Promise<void> {
-		if (await this.stepStore.hasActiveSteps(executionId)) return;
-
-		const failed = await this.stepStore.hasFailedSteps(executionId);
-		await this.executionStore.finishExecution(executionId, failed ? 'failed' : 'completed');
-	}
-
-	/** Plans the ready successors of `nodeId`, returning how many were queued. */
+	/** Plans the direct successors of `nodeId`, returning how many were queued. */
 	private async planSuccessors(execution: ExecutionRecord, nodeId: string): Promise<number> {
-		const readyNodeIds = await this.readySuccessorNodeIds(execution, nodeId);
-		if (readyNodeIds.length === 0) return 0;
+		const steps = await this.loadDecisionSteps(execution, nodeId);
+		const { toQueue, toSkip } = decideSuccessors(execution.graph, nodeId, steps);
+		if (toQueue.length === 0 && toSkip.length === 0) return 0;
 
-		// Planned together so a fan-out is one round trip, and published only after
-		// the rows exist, so a consumer can always load the step. A step another
-		// planner got to first isn't returned, so it isn't announced twice either.
-		// TODO(CAT-2938): a crash between the insert and the publishes strands the
-		// rows `queued` forever; the reconciler re-announces stale queued steps.
-		const created = await this.stepStore.createSteps(
-			readyNodeIds.map((readyNodeId) => ({
+		// One batch, so a settlement's consequence lands atomically and a fan-out
+		// costs one round trip. A row another planner got to first isn't
+		// returned, so it isn't announced twice either.
+		// TODO(CAT-2938): a crash between the insert and the publishes strands
+		// the rows forever; the reconciler re-announces stale queued steps and
+		// settled steps whose decidable successors have no rows.
+		const created = await this.stepStore.createSteps([
+			...toQueue.map((id) => ({
 				executionId: execution.id,
-				nodeId: readyNodeId,
+				nodeId: id,
 				status: 'queued' as const,
 			})),
-		);
-
-		for (const { id: stepId } of created) {
-			await this.stepQueue.publish({
-				type: 'step:ready',
+			...toSkip.map((id) => ({
 				executionId: execution.id,
-				stepId,
-			});
-		}
+				nodeId: id,
+				status: 'skipped' as const,
+			})),
+		]);
 
-		return created.length;
+		return await this.announceCreatedSteps(execution.id, created, new Set(toQueue));
 	}
 
 	/**
-	 * Successors of `nodeId` whose every predecessor has completed.
-	 * We get the successors straight from the graph, while we check
-	 * for predecessors completion in a single query to the step store,
-	 * so a fan-out costs one round trip.
-	 *
-	 * NOTE: we exclude `nodeId` itself from the check, since we know it's complete.
-	 * This also lets us skip a database trip when there's no merging happening,
-	 * which is the common case.
+	 * The rows a successor decision reads: the successors themselves (an
+	 * existing row means already decided) and their predecessors (settledness
+	 * and slot liveness), which include the settled node itself.
 	 */
-	private async readySuccessorNodeIds(
+	private async loadDecisionSteps(
 		execution: ExecutionRecord,
 		nodeId: string,
-	): Promise<string[]> {
-		const successors = getSuccessorNodeIds(execution.graph, nodeId).map((id) => ({
-			id,
-			predecessorIds: getPredecessorNodeIds(execution.graph, id),
-		}));
+	): Promise<Record<string, StepSummary>> {
+		const successors = getSuccessorNodeIds(execution.graph, nodeId);
+		const nodeIds = [
+			...new Set([
+				...successors,
+				...successors.flatMap((id) => getPredecessorNodeIds(execution.graph, id)),
+			]),
+		];
+		return await this.stepStore.loadStepSummaries(execution.id, nodeIds);
+	}
 
-		// We get all the predecessors of our successors, for possible merging.
-		const predecessorsToCheck = successors
-			.flatMap(({ predecessorIds }) => predecessorIds)
-			// NOTE: we exclude ourselves, since we know we're complete.
-			.filter((id) => id !== nodeId);
+	/**
+	 * Announces the created rows — `step:ready` for queued ones, `step:settled`
+	 * for skips, which settle at birth — and returns how many were queued.
+	 * Published only after the rows exist, so a consumer can always load them.
+	 */
+	private async announceCreatedSteps(
+		executionId: string,
+		created: Array<{ id: string; nodeId: string }>,
+		queuedNodeIds: Set<string>,
+	): Promise<number> {
+		let queued = 0;
+		for (const { id: stepId, nodeId } of created) {
+			if (queuedNodeIds.has(nodeId)) {
+				queued += 1;
+				await this.stepQueue.publish({ type: 'step:ready', executionId, stepId });
+			} else {
+				await this.orchestrationQueue.publish({ type: 'step:settled', executionId, stepId });
+			}
+		}
+		return queued;
+	}
 
-		const completed =
-			predecessorsToCheck.length === 0
-				? new Set<string>()
-				: await this.stepStore.loadCompletedNodeIds(execution.id, predecessorsToCheck);
+	/**
+	 * Records the execution's outcome once every reachable node has settled:
+	 * `failed` if any step failed, `completed` otherwise. Settled rows are
+	 * unique per node, only exist for reachable nodes, and never unsettle, so
+	 * the count comparison cannot pass early — in-flight events and unplanned
+	 * successors both leave reachable nodes unsettled.
+	 */
+	private async finishExecutionIfDone(execution: ExecutionRecord): Promise<void> {
+		const settled = await this.stepStore.countSettledSteps(execution.id);
+		if (settled < this.reachableNodeCount(execution)) return;
 
-		return successors
-			.filter(({ predecessorIds }) =>
-				predecessorIds.every((id) => id === nodeId || completed.has(id)),
-			)
-			.map(({ id }) => id);
+		const failed = await this.stepStore.hasFailedSteps(execution.id);
+		await this.executionStore.finishExecution(execution.id, failed ? 'failed' : 'completed');
+	}
+
+	private reachableNodeCount(execution: ExecutionRecord): number {
+		const trigger = findTriggerNode(execution.graph);
+		if (!trigger) {
+			// The start boundary rejects triggerless graphs, so this execution
+			// should never have been created.
+			throw new UnexpectedError(`Execution ${execution.id} has no trigger node in its graph`);
+		}
+		return 1 + getDescendantNodeIds(execution.graph, trigger.id).length;
 	}
 }

--- a/packages/@n8n/engine/src/execution/step-settled-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-settled-handler.ts
@@ -1,11 +1,11 @@
 import { getPredecessorNodeIds, getSuccessorNodeIds } from '../graph';
-import type { StepCompletedEvent, StepMessage, WorkQueue } from '../queue';
+import type { StepSettledEvent, StepMessage, WorkQueue } from '../queue';
 import type { ExecutionRecord, ExecutionStore } from './execution-store';
 import type { StepStore } from './step-store';
 import { validateStepContext } from './validate-step-context';
 
 /**
- * Handles the `step:completed` orchestration event: plans the successors of the
+ * Handles the `step:settled` orchestration event: plans the successors of the
  * finished step and publishes `step:ready` for each, or records the execution's
  * outcome when there is nothing left to run.
  *
@@ -16,14 +16,14 @@ import { validateStepContext } from './validate-step-context';
  * An event whose step and execution disagree is rejected before anything is
  * planned, leaving both executions untouched.
  */
-export class StepCompletedHandler {
+export class StepSettledHandler {
 	constructor(
 		private readonly executionStore: ExecutionStore,
 		private readonly stepStore: StepStore,
 		private readonly stepQueue: WorkQueue<StepMessage>,
 	) {}
 
-	async handle(event: StepCompletedEvent): Promise<void> {
+	async handle(event: StepSettledEvent): Promise<void> {
 		const [step, execution] = await Promise.all([
 			this.stepStore.loadStep(event.stepId),
 			this.executionStore.loadExecution(event.executionId),

--- a/packages/@n8n/engine/src/execution/step-settled-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-settled-handler.ts
@@ -89,17 +89,9 @@ export class StepSettledHandler {
 		// TODO(CAT-2938): a crash between the insert and the publishes strands
 		// the rows forever; the reconciler re-announces stale queued steps and
 		// settled steps whose decidable successors have no rows.
-		const created = await this.stepStore.createSteps([
-			...toQueue.map((id) => ({
-				executionId: execution.id,
-				nodeId: id,
-				status: 'queued' as const,
-			})),
-			...toSkip.map((id) => ({
-				executionId: execution.id,
-				nodeId: id,
-				status: 'skipped' as const,
-			})),
+		const created = await this.stepStore.createSteps(execution.id, [
+			...toQueue.map((id) => ({ nodeId: id, status: 'queued' as const })),
+			...toSkip.map((id) => ({ nodeId: id, status: 'skipped' as const })),
 		]);
 
 		return await this.announceCreatedSteps(execution.id, created, new Set(toQueue));

--- a/packages/@n8n/engine/src/execution/step-settled-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-settled-handler.ts
@@ -49,8 +49,8 @@ export class StepSettledHandler {
 
 		let queued = 0;
 		if (step.status === 'completed' || step.status === 'skipped') {
-			// Fail-fast: a failure recorded anywhere ends the run before more work
-			// is planned, even while its own settled event is still queued.
+			// a failure elsewhere may still have its settled event queued behind
+			// this one, so it must end the execution here, before planning
 			if (await this.stepStore.hasFailedSteps(execution.id)) {
 				await this.failExecution(execution.id);
 				return;

--- a/packages/@n8n/engine/src/execution/step-settled-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-settled-handler.ts
@@ -49,9 +49,8 @@ export class StepSettledHandler {
 
 		let queued = 0;
 		if (step.status === 'completed' || step.status === 'skipped') {
-			// Fail-fast is execution-wide: a failure recorded anywhere ends the
-			// run before more work is planned, even when its own settled event is
-			// still queued behind this one.
+			// Fail-fast: a failure recorded anywhere ends the run before more work
+			// is planned, even while its own settled event is still queued.
 			if (await this.stepStore.hasFailedSteps(execution.id)) {
 				await this.failExecution(execution.id);
 				return;
@@ -68,7 +67,6 @@ export class StepSettledHandler {
 		await this.finishExecutionIfDone(execution);
 	}
 
-	/** Fail-fast: record the execution as failed and cancel work not yet claimed. */
 	private async failExecution(executionId: string): Promise<void> {
 		await this.executionStore.finishExecution(executionId, 'failed');
 		await this.stepStore.cancelQueuedSteps(executionId);

--- a/packages/@n8n/engine/src/execution/step-settled-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-settled-handler.ts
@@ -49,13 +49,15 @@ export class StepSettledHandler {
 
 		let queued = 0;
 		if (step.status === 'completed' || step.status === 'skipped') {
-			const steps = await this.loadDecisionSteps(execution, step.nodeId);
-
-			if (Object.values(steps).some((summary) => summary.status === 'failed')) {
+			// Fail-fast is execution-wide: a failure recorded anywhere ends the
+			// run before more work is planned, even when its own settled event is
+			// still queued behind this one.
+			if (await this.stepStore.hasFailedSteps(execution.id)) {
 				await this.failExecution(execution.id);
 				return;
 			}
 
+			const steps = await this.loadDecisionSteps(execution, step.nodeId);
 			queued = await this.planSuccessors(execution, step.nodeId, steps);
 		}
 

--- a/packages/@n8n/engine/src/execution/step-settled-handler.ts
+++ b/packages/@n8n/engine/src/execution/step-settled-handler.ts
@@ -41,17 +41,23 @@ export class StepSettledHandler {
 		// v1 parity: an error that escapes a node ends the whole execution, not
 		// just its branch.
 		if (step.status === 'failed') {
-			await this.executionStore.finishExecution(execution.id, 'failed');
-			await this.stepStore.cancelQueuedSteps(execution.id);
+			await this.failExecution(execution.id);
 			return;
 		}
 
 		if (execution.status !== 'running') return;
 
-		const queued =
-			step.status === 'completed' || step.status === 'skipped'
-				? await this.planSuccessors(execution, step.nodeId)
-				: 0;
+		let queued = 0;
+		if (step.status === 'completed' || step.status === 'skipped') {
+			const steps = await this.loadDecisionSteps(execution, step.nodeId);
+
+			if (Object.values(steps).some((summary) => summary.status === 'failed')) {
+				await this.failExecution(execution.id);
+				return;
+			}
+
+			queued = await this.planSuccessors(execution, step.nodeId, steps);
+		}
 
 		// If we've queued steps, we know the execution isn't done yet, so we
 		// definitely don't need to mark it finished.
@@ -60,9 +66,18 @@ export class StepSettledHandler {
 		await this.finishExecutionIfDone(execution);
 	}
 
+	/** Fail-fast: record the execution as failed and cancel work not yet claimed. */
+	private async failExecution(executionId: string): Promise<void> {
+		await this.executionStore.finishExecution(executionId, 'failed');
+		await this.stepStore.cancelQueuedSteps(executionId);
+	}
+
 	/** Plans the direct successors of `nodeId`, returning how many were queued. */
-	private async planSuccessors(execution: ExecutionRecord, nodeId: string): Promise<number> {
-		const steps = await this.loadDecisionSteps(execution, nodeId);
+	private async planSuccessors(
+		execution: ExecutionRecord,
+		nodeId: string,
+		steps: Record<string, StepSummary>,
+	): Promise<number> {
 		const { toQueue, toSkip } = decideSuccessors(execution.graph, nodeId, steps);
 		if (toQueue.length === 0 && toSkip.length === 0) return 0;
 

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -77,6 +77,12 @@ export interface StepStore {
 	 * so it returns the claimed step for at most one caller — `null` means the
 	 * claim was lost and duplicate/redelivered events are handled idempotently.
 	 *
+	 * The claim also refuses once any step in the execution has failed, so
+	 * fail-fast holds even for a `step:ready` published before the failure
+	 * landed. This holds under concurrency: the claim serializes with
+	 * `failStep` on the execution, so it never succeeds after a failure is
+	 * recorded.
+	 *
 	 * Transitions are exposed one named method at a time rather than as a generic
 	 * `(from, to)` pair, so the interface can't express a transition the
 	 * lifecycle doesn't allow.

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -3,7 +3,6 @@ import type { StepSlots, StepStatus } from './execution.types';
 
 /** A new step to persist. `id` and timestamps are assigned by the store. */
 export interface NewStepRecord {
-	executionId: string;
 	nodeId: string;
 	/**
 	 * Creation statuses only. The rest are reachable solely through their
@@ -66,8 +65,8 @@ export class StepNotFoundError extends Error {
 /** Persistence interface for step records. */
 export interface StepStore {
 	/**
-	 * Persist new step records, batched so planning a fan-out costs a single round
-	 * trip. Returns the rows actually created.
+	 * Persist new step records for one execution, batched so planning a fan-out
+	 * costs a single round trip. Returns the rows actually created.
 	 *
 	 * If a step for a given `(executionId, nodeId)` already exists, it is skipped
 	 * and not returned. This allows multiple planners to race to enqueue the same
@@ -78,7 +77,10 @@ export interface StepStore {
 	 * `failStep` like `claimStep`, so a planning insert cannot land after the
 	 * failure's cancellation sweep and strand rows `queued` forever.
 	 */
-	createSteps(records: NewStepRecord[]): Promise<Array<{ id: string; nodeId: string }>>;
+	createSteps(
+		executionId: string,
+		records: NewStepRecord[],
+	): Promise<Array<{ id: string; nodeId: string }>>;
 
 	/** Load a single step by id. Throws `StepNotFoundError` if absent. */
 	loadStep(id: string): Promise<StepRecord>;

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -4,15 +4,14 @@ import type { StepSlots, StepStatus } from './execution.types';
 /**
  * A new step to persist. `id` and timestamps are assigned by the store.
  *
- * Creation statuses only. The rest are reachable solely through their
- * transitions — `running` via `claimStep`, `failed` via `failStep`,
- * `cancelled` via `cancelQueuedSteps` — so a row can't enter a state
- * without passing that transition's guarantees (the failure fence above
- * all: a `failed` row created here would bypass its exclusive lock).
+ * Creation statuses only: the rest are reachable solely through their
+ * transitions (`claimStep`, `failStep`, `cancelQueuedSteps`), so a row can't
+ * enter a state without passing that transition's guarantees, the failure
+ * fence above all.
  *
  * A step created `completed` (the trigger) must carry its slot list, even
  * `[]`: a missing one persists as SQL NULL, which liveness reads as every
- * output slot dead. The other statuses have no outputs by definition.
+ * output slot dead.
  */
 export type NewStepRecord = { nodeId: string } & (
 	| { status: Extract<StepStatus, 'queued' | 'skipped'>; outputs?: never }
@@ -76,9 +75,9 @@ export interface StepStore {
 	 * node without erroring or duplicating work. We return the actually created rows
 	 * so the caller knows which step creations it needs to publish.
 	 *
-	 * Creates nothing once any step in the execution has failed, serialized with
-	 * `failStep` like `claimStep`, so a planning insert cannot land after the
-	 * failure's cancellation sweep and strand rows `queued` forever.
+	 * Creates nothing once any step in the execution has failed (serialized with
+	 * `failStep`), so a planning insert cannot land after the failure's
+	 * cancellation sweep and strand rows `queued` forever.
 	 */
 	createSteps(
 		executionId: string,
@@ -93,11 +92,9 @@ export interface StepStore {
 	 * so it returns the claimed step for at most one caller — `null` means the
 	 * claim was lost and duplicate/redelivered events are handled idempotently.
 	 *
-	 * The claim also refuses once any step in the execution has failed, so
-	 * fail-fast holds even for a `step:ready` published before the failure
-	 * landed. This holds under concurrency: the claim serializes with
-	 * `failStep` on the execution, so it never succeeds after a failure is
-	 * recorded.
+	 * The claim also refuses once any step in the execution has failed
+	 * (serialized with `failStep`), so fail-fast holds even for a `step:ready`
+	 * published before the failure landed.
 	 *
 	 * Transitions are exposed one named method at a time rather than as a generic
 	 * `(from, to)` pair, so the interface can't express a transition the

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -35,6 +35,19 @@ export interface StepRecord {
 	error: StepError | null;
 }
 
+/**
+ * Planning view of a step row: everything a settlement decision needs, and no
+ * payloads — outputs can dominate row size, and planning only ever asks
+ * whether a slot holds data, not what.
+ */
+export interface StepSummary {
+	id: string;
+	nodeId: string;
+	status: StepStatus;
+	/** Per output slot: whether the completed step put data there. Empty unless completed. */
+	filledOutputSlots: boolean[];
+}
+
 /** Thrown by `loadStep` when no step exists for the given id. */
 export class StepNotFoundError extends Error {
 	constructor(readonly stepId: string) {
@@ -83,6 +96,23 @@ export interface StepStore {
 
 	/** Cancel every step of the execution still `queued` (`queued → cancelled`). */
 	cancelQueuedSteps(executionId: string): Promise<void>;
+
+	/**
+	 * Step rows of the given nodes within an execution, keyed by node id. A node
+	 * with no row yet is absent from the result — absence always means "not
+	 * planned yet", never "forgotten".
+	 *
+	 * Full rows, outputs included — for gathering a ready step's inputs from its
+	 * direct predecessors. Planning reads `loadStepSummaries` instead.
+	 */
+	loadStepsByNodeIds(executionId: string, nodeIds: string[]): Promise<Record<string, StepRecord>>;
+
+	/**
+	 * Planning view of the given nodes' rows, keyed by node id; absent as in
+	 * `loadStepsByNodeIds`. Slot liveness is computed in the database so
+	 * settlement decisions never pull output payloads over the wire.
+	 */
+	loadStepSummaries(executionId: string, nodeIds: string[]): Promise<Record<string, StepSummary>>;
 
 	/**
 	 * Outputs of the given nodes' *completed* steps within an execution, keyed by

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -137,6 +137,14 @@ export interface StepStore {
 	/** Whether the execution has any step still `queued` or `running`. */
 	hasActiveSteps(executionId: string): Promise<boolean>;
 
+	/**
+	 * How many of the execution's steps have settled (completed, failed,
+	 * skipped, or cancelled). Rows are unique per node and only exist for
+	 * reachable nodes, so comparing this against the graph's reachable node
+	 * count answers "has everything settled?" exactly.
+	 */
+	countSettledSteps(executionId: string): Promise<number>;
+
 	/** Whether any of the execution's steps failed. */
 	hasFailedSteps(executionId: string): Promise<boolean>;
 }

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -1,20 +1,23 @@
 import type { JsonValue } from '../common';
 import type { StepSlots, StepStatus } from './execution.types';
 
-/** A new step to persist. `id` and timestamps are assigned by the store. */
-export interface NewStepRecord {
-	nodeId: string;
-	/**
-	 * Creation statuses only. The rest are reachable solely through their
-	 * transitions — `running` via `claimStep`, `failed` via `failStep`,
-	 * `cancelled` via `cancelQueuedSteps` — so a row can't enter a state
-	 * without passing that transition's guarantees (the failure fence above
-	 * all: a `failed` row created here would bypass its exclusive lock).
-	 */
-	status: Extract<StepStatus, 'queued' | 'completed' | 'skipped'>;
-	/** Only for a step recorded already-completed, such as the trigger. */
-	outputs?: StepSlots;
-}
+/**
+ * A new step to persist. `id` and timestamps are assigned by the store.
+ *
+ * Creation statuses only. The rest are reachable solely through their
+ * transitions — `running` via `claimStep`, `failed` via `failStep`,
+ * `cancelled` via `cancelQueuedSteps` — so a row can't enter a state
+ * without passing that transition's guarantees (the failure fence above
+ * all: a `failed` row created here would bypass its exclusive lock).
+ *
+ * A step created `completed` (the trigger) must carry its slot list, even
+ * `[]`: a missing one persists as SQL NULL, which liveness reads as every
+ * output slot dead. The other statuses have no outputs by definition.
+ */
+export type NewStepRecord = { nodeId: string } & (
+	| { status: Extract<StepStatus, 'queued' | 'skipped'>; outputs?: never }
+	| { status: Extract<StepStatus, 'completed'>; outputs: StepSlots }
+);
 
 /** The error that failed a step, as persisted on its row. */
 export interface StepError {

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -4,10 +4,9 @@ import type { StepSlots, StepStatus } from './execution.types';
 /**
  * A new step to persist. `id` and timestamps are assigned by the store.
  *
- * Creation statuses only: the rest are reachable solely through their
- * transitions (`claimStep`, `failStep`, `cancelQueuedSteps`), so a row can't
- * enter a state without passing that transition's guarantees, the failure
- * fence above all.
+ * Creation statuses only: a row becomes `running`, `failed`, or `cancelled`
+ * solely through `claimStep`, `failStep`, or `cancelQueuedSteps`, so it
+ * cannot bypass the checks and locking those transitions enforce.
  *
  * A step created `completed` (the trigger) must carry its slot list, even
  * `[]`: a missing one persists as SQL NULL, which liveness reads as every

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -5,7 +5,14 @@ import type { StepSlots, StepStatus } from './execution.types';
 export interface NewStepRecord {
 	executionId: string;
 	nodeId: string;
-	status: StepStatus;
+	/**
+	 * Creation statuses only. The rest are reachable solely through their
+	 * transitions — `running` via `claimStep`, `failed` via `failStep`,
+	 * `cancelled` via `cancelQueuedSteps` — so a row can't enter a state
+	 * without passing that transition's guarantees (the failure fence above
+	 * all: a `failed` row created here would bypass its exclusive lock).
+	 */
+	status: Extract<StepStatus, 'queued' | 'completed' | 'skipped'>;
 	/** Only for a step recorded already-completed, such as the trigger. */
 	outputs?: StepSlots;
 }

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -66,6 +66,10 @@ export interface StepStore {
 	 * and not returned. This allows multiple planners to race to enqueue the same
 	 * node without erroring or duplicating work. We return the actually created rows
 	 * so the caller knows which step creations it needs to publish.
+	 *
+	 * Creates nothing once any step in the execution has failed, serialized with
+	 * `failStep` like `claimStep`, so a planning insert cannot land after the
+	 * failure's cancellation sweep and strand rows `queued` forever.
 	 */
 	createSteps(records: NewStepRecord[]): Promise<Array<{ id: string; nodeId: string }>>;
 

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -115,29 +115,6 @@ export interface StepStore {
 	loadStepSummaries(executionId: string, nodeIds: string[]): Promise<Record<string, StepSummary>>;
 
 	/**
-	 * Outputs of the given nodes' *completed* steps within an execution, keyed by
-	 * node id. A node whose step is absent or hasn't completed maps to `null`.
-	 *
-	 * This is for gathering a step's inputs, so it deliberately can't answer
-	 * "have all predecessors completed?" — the two are indistinguishable from a
-	 * `null` here. Use `loadCompletedNodeIds` for that.
-	 */
-	loadStepOutputs(
-		executionId: string,
-		nodeIds: string[],
-	): Promise<Record<string, StepSlots | null>>;
-
-	/**
-	 * Which of `nodeIds` have a completed step in the execution. Returns the
-	 * subset rather than a yes/no so one query can answer readiness for several
-	 * candidate steps at once.
-	 */
-	loadCompletedNodeIds(executionId: string, nodeIds: string[]): Promise<Set<string>>;
-
-	/** Whether the execution has any step still `queued` or `running`. */
-	hasActiveSteps(executionId: string): Promise<boolean>;
-
-	/**
 	 * How many of the execution's steps have settled (completed, failed,
 	 * skipped, or cancelled). Rows are unique per node and only exist for
 	 * reachable nodes, so comparing this against the graph's reachable node

--- a/packages/@n8n/engine/src/execution/step-store.ts
+++ b/packages/@n8n/engine/src/execution/step-store.ts
@@ -127,8 +127,8 @@ export interface StepStore {
 
 	/**
 	 * Planning view of the given nodes' rows, keyed by node id; absent as in
-	 * `loadStepsByNodeIds`. Slot liveness is computed in the database so
-	 * settlement decisions never pull output payloads over the wire.
+	 * `loadStepsByNodeIds`. The per-slot booleans are computed in the database,
+	 * so planning never pulls the potentially large outputs over the wire.
 	 */
 	loadStepSummaries(executionId: string, nodeIds: string[]): Promise<Record<string, StepSummary>>;
 

--- a/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
@@ -68,14 +68,13 @@ describe('validateExecutableGraph', () => {
 		expect(() => validateExecutableGraph(graph)).toThrow('above 100');
 	});
 
-	it('rejects an edge leaving an output slot other than 0 as unimplemented', () => {
+	it('accepts a fan-out across output slots (If/Switch shape)', () => {
 		const graph: WorkflowGraph = {
 			nodes: [...validGraph.nodes, { id: 'b', name: 'B', type: 'v1-node' }],
 			edges: [...validGraph.edges, { from: 'a', to: 'b', outputIndex: 1, inputIndex: 0 }],
 		};
 
-		expect(() => validateExecutableGraph(graph)).toThrow(UnimplementedError);
-		expect(() => validateExecutableGraph(graph)).toThrow('output slot');
+		expect(() => validateExecutableGraph(graph)).not.toThrow();
 	});
 
 	it('accepts a fan-in: edges into distinct input slots of one node', () => {

--- a/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
@@ -37,6 +37,33 @@ describe('validateExecutableGraph', () => {
 		expect(() => validateExecutableGraph(graph)).toThrow('one trigger node');
 	});
 
+	it('rejects an edge feeding a reachable node from one the trigger cannot reach', () => {
+		// r would never settle (nothing ever reaches it), leaving a waiting on it
+		// forever and the execution hanging as running
+		const graph: WorkflowGraph = {
+			nodes: [...validGraph.nodes, { id: 'r', name: 'R', type: 'v1-node' }],
+			edges: [...validGraph.edges, { from: 'r', to: 'a', outputIndex: 0, inputIndex: 1 }],
+		};
+
+		expect(() => validateExecutableGraph(graph)).toThrow(GraphValidationError);
+		expect(() => validateExecutableGraph(graph)).toThrow('would wait on r forever');
+	});
+
+	it('accepts a disconnected island that feeds nothing reachable', () => {
+		// parked nodes are v1-legal; they are never considered, so they cannot
+		// block anything
+		const graph: WorkflowGraph = {
+			nodes: [
+				...validGraph.nodes,
+				{ id: 'r', name: 'R', type: 'v1-node' },
+				{ id: 's', name: 'S', type: 'v1-node' },
+			],
+			edges: [...validGraph.edges, { from: 'r', to: 's', outputIndex: 0, inputIndex: 0 }],
+		};
+
+		expect(() => validateExecutableGraph(graph)).not.toThrow();
+	});
+
 	it('accepts a fan-out: several edges leaving one output slot', () => {
 		const graph: WorkflowGraph = {
 			nodes: [...validGraph.nodes, { id: 'b', name: 'B', type: 'v1-node' }],

--- a/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
@@ -38,8 +38,7 @@ describe('validateExecutableGraph', () => {
 	});
 
 	it('rejects an edge feeding a reachable node from one the trigger cannot reach', () => {
-		// r would never settle (nothing ever reaches it), leaving a waiting on it
-		// forever and the execution hanging as running
+		// r would never settle, leaving a waiting on it forever
 		const graph: WorkflowGraph = {
 			nodes: [...validGraph.nodes, { id: 'r', name: 'R', type: 'v1-node' }],
 			edges: [...validGraph.edges, { from: 'r', to: 'a', outputIndex: 0, inputIndex: 1 }],
@@ -50,8 +49,7 @@ describe('validateExecutableGraph', () => {
 	});
 
 	it('accepts a disconnected island that feeds nothing reachable', () => {
-		// parked nodes are v1-legal; they are never considered, so they cannot
-		// block anything
+		// parked nodes are v1-legal and never considered
 		const graph: WorkflowGraph = {
 			nodes: [
 				...validGraph.nodes,

--- a/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
@@ -38,7 +38,7 @@ describe('validateExecutableGraph', () => {
 	});
 
 	it('rejects an edge feeding a reachable node from one the trigger cannot reach', () => {
-		// r would never settle, leaving a waiting on it forever
+		// nothing ever reaches r, so it never settles and a would wait forever
 		const graph: WorkflowGraph = {
 			nodes: [...validGraph.nodes, { id: 'r', name: 'R', type: 'v1-node' }],
 			edges: [...validGraph.edges, { from: 'r', to: 'a', outputIndex: 0, inputIndex: 1 }],

--- a/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
@@ -56,14 +56,22 @@ describe('validateExecutableGraph', () => {
 		expect(() => validateExecutableGraph(graph)).toThrow('output slot');
 	});
 
-	it('rejects an edge arriving at an input slot other than 0 as unimplemented', () => {
+	it('accepts a fan-in: edges into distinct input slots of one node', () => {
 		const graph: WorkflowGraph = {
-			nodes: [...validGraph.nodes, { id: 'b', name: 'B', type: 'v1-node' }],
-			edges: [...validGraph.edges, { from: 'a', to: 'b', outputIndex: 0, inputIndex: 1 }],
+			nodes: [
+				...validGraph.nodes,
+				{ id: 'b', name: 'B', type: 'v1-node' },
+				{ id: 'm', name: 'M', type: 'v1-node' },
+			],
+			edges: [
+				...validGraph.edges,
+				{ from: 'trigger', to: 'b', outputIndex: 0, inputIndex: 0 },
+				{ from: 'a', to: 'm', outputIndex: 0, inputIndex: 0 },
+				{ from: 'b', to: 'm', outputIndex: 0, inputIndex: 1 },
+			],
 		};
 
-		expect(() => validateExecutableGraph(graph)).toThrow(UnimplementedError);
-		expect(() => validateExecutableGraph(graph)).toThrow('input slot');
+		expect(() => validateExecutableGraph(graph)).not.toThrow();
 	});
 
 	it('rejects two edges into the same input slot of one node as unimplemented', () => {

--- a/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
@@ -46,6 +46,18 @@ describe('validateExecutableGraph', () => {
 		expect(() => validateExecutableGraph(graph)).not.toThrow();
 	});
 
+	it.each([
+		{ slot: 'input', edge: { from: 'trigger', to: 'a', outputIndex: 0, inputIndex: -1 } },
+		{ slot: 'input', edge: { from: 'trigger', to: 'a', outputIndex: 0, inputIndex: 1.5 } },
+		{ slot: 'input', edge: { from: 'trigger', to: 'a', outputIndex: 0, inputIndex: NaN } },
+		{ slot: 'output', edge: { from: 'trigger', to: 'a', outputIndex: NaN, inputIndex: 0 } },
+	])('rejects an edge whose $slot slot index is $edge', ({ edge }) => {
+		const graph: WorkflowGraph = { nodes: validGraph.nodes, edges: [edge] };
+
+		expect(() => validateExecutableGraph(graph)).toThrow(GraphValidationError);
+		expect(() => validateExecutableGraph(graph)).toThrow('non-negative integer');
+	});
+
 	it('rejects an edge leaving an output slot other than 0 as unimplemented', () => {
 		const graph: WorkflowGraph = {
 			nodes: [...validGraph.nodes, { id: 'b', name: 'B', type: 'v1-node' }],

--- a/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/validate-executable-graph.test.ts
@@ -58,14 +58,13 @@ describe('validateExecutableGraph', () => {
 		expect(() => validateExecutableGraph(graph)).toThrow('non-negative integer');
 	});
 
-	it('rejects an edge leaving an output slot other than 0 as unimplemented', () => {
+	it('accepts a fan-out across output slots (If/Switch shape)', () => {
 		const graph: WorkflowGraph = {
 			nodes: [...validGraph.nodes, { id: 'b', name: 'B', type: 'v1-node' }],
 			edges: [...validGraph.edges, { from: 'a', to: 'b', outputIndex: 1, inputIndex: 0 }],
 		};
 
-		expect(() => validateExecutableGraph(graph)).toThrow(UnimplementedError);
-		expect(() => validateExecutableGraph(graph)).toThrow('output slot');
+		expect(() => validateExecutableGraph(graph)).not.toThrow();
 	});
 
 	it('accepts a fan-in: edges into distinct input slots of one node', () => {

--- a/packages/@n8n/engine/src/graph/__tests__/workflow-graph-queries.test.ts
+++ b/packages/@n8n/engine/src/graph/__tests__/workflow-graph-queries.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { WorkflowGraph } from '../workflow-graph';
 import {
 	findTriggerNode,
+	getDescendantNodeIds,
 	getPredecessorNodeIds,
 	getSuccessorNodeIds,
 } from '../workflow-graph-queries';
@@ -77,5 +78,33 @@ describe('getPredecessorNodeIds', () => {
 			],
 		};
 		expect(getPredecessorNodeIds(looping, 'a')).toEqual(['b']);
+	});
+});
+
+describe('getDescendantNodeIds', () => {
+	it('returns all transitive successors, excluding the node itself', () => {
+		expect(getDescendantNodeIds(graph, 'trigger')).toEqual(['a', 'b']);
+	});
+
+	it('reports a diamond reconvergence once', () => {
+		const diamond: WorkflowGraph = {
+			nodes: [
+				{ id: 'if', name: 'If', type: 'v1-node' },
+				{ id: 'a', name: 'A', type: 'v1-node' },
+				{ id: 'b', name: 'B', type: 'v1-node' },
+				{ id: 'm', name: 'M', type: 'v1-node' },
+			],
+			edges: [
+				{ from: 'if', to: 'a', outputIndex: 0, inputIndex: 0 },
+				{ from: 'if', to: 'b', outputIndex: 1, inputIndex: 0 },
+				{ from: 'a', to: 'm', outputIndex: 0, inputIndex: 0 },
+				{ from: 'b', to: 'm', outputIndex: 0, inputIndex: 1 },
+			],
+		};
+		expect(getDescendantNodeIds(diamond, 'if')).toEqual(['a', 'b', 'm']);
+	});
+
+	it('returns an empty array for a terminal node', () => {
+		expect(getDescendantNodeIds(graph, 'b')).toEqual([]);
 	});
 });

--- a/packages/@n8n/engine/src/graph/index.ts
+++ b/packages/@n8n/engine/src/graph/index.ts
@@ -7,6 +7,7 @@ export type {
 } from './workflow-graph';
 export {
 	findTriggerNode,
+	getDescendantNodeIds,
 	getPredecessorNodeIds,
 	getSuccessorNodeIds,
 } from './workflow-graph-queries';

--- a/packages/@n8n/engine/src/graph/validate-executable-graph.ts
+++ b/packages/@n8n/engine/src/graph/validate-executable-graph.ts
@@ -51,16 +51,6 @@ export function validateExecutableGraph(graph: WorkflowGraph): void {
 		}
 	}
 
-	// TODO(CAT-2874): multi-slot outputs arrive with branching; until then only
-	// output slot 0 fires, and the runtime can assume single-slot outputs.
-	for (const edge of graph.edges) {
-		if (edge.outputIndex !== 0) {
-			throw new UnimplementedError(
-				`Edge ${edge.from} → ${edge.to} leaves output slot ${edge.outputIndex}; only output slot 0 is supported yet`,
-			);
-		}
-	}
-
 	// TODO(CAT-3982): same-slot convergence gets a defined meaning (concatenation);
 	// until then it is rejected rather than given accidental semantics.
 	const seenInputSlots = new Set<string>();

--- a/packages/@n8n/engine/src/graph/validate-executable-graph.ts
+++ b/packages/@n8n/engine/src/graph/validate-executable-graph.ts
@@ -1,5 +1,6 @@
 import { UnimplementedError } from '../common';
 import type { WorkflowGraph } from './workflow-graph';
+import { getDescendantNodeIds } from './workflow-graph-queries';
 
 const MAX_SLOT_INDEX = 100;
 
@@ -32,6 +33,16 @@ export function validateExecutableGraph(graph: WorkflowGraph): void {
 	// graphs with back-edges are rejected outright rather than deadlocking.
 	if (graph.edges.some((edge) => edge.isBackEdge)) {
 		throw new UnimplementedError('Graphs with back-edges (loops) are not supported yet');
+	}
+
+	const [trigger] = triggers;
+	const reachable = new Set([trigger.id, ...getDescendantNodeIds(graph, trigger.id)]);
+	for (const edge of graph.edges) {
+		if (reachable.has(edge.to) && !reachable.has(edge.from)) {
+			throw new GraphValidationError(
+				`Edge ${edge.from} → ${edge.to} feeds a node the trigger reaches from one it cannot reach; ${edge.to} would wait on ${edge.from} forever`,
+			);
+		}
 	}
 
 	// Slot indices are structural, so they're enforced here rather than left to

--- a/packages/@n8n/engine/src/graph/validate-executable-graph.ts
+++ b/packages/@n8n/engine/src/graph/validate-executable-graph.ts
@@ -40,7 +40,7 @@ export function validateExecutableGraph(graph: WorkflowGraph): void {
 	for (const edge of graph.edges) {
 		if (reachable.has(edge.to) && !reachable.has(edge.from)) {
 			throw new GraphValidationError(
-				`Edge ${edge.from} → ${edge.to} feeds a node the trigger reaches from one it cannot reach; ${edge.to} would wait on ${edge.from} forever`,
+				`Edge ${edge.from} → ${edge.to} feeds a node the trigger reaches from one it cannot reach, so ${edge.to} would wait on ${edge.from} forever`,
 			);
 		}
 	}

--- a/packages/@n8n/engine/src/graph/validate-executable-graph.ts
+++ b/packages/@n8n/engine/src/graph/validate-executable-graph.ts
@@ -32,17 +32,12 @@ export function validateExecutableGraph(graph: WorkflowGraph): void {
 		throw new UnimplementedError('Graphs with back-edges (loops) are not supported yet');
 	}
 
-	// TODO(CAT-2874): multi-slot routing arrives with branching; until then only
-	// slot 0 → slot 0 edges run, and the runtime can assume single-slot IO.
+	// TODO(CAT-2874): multi-slot outputs arrive with branching; until then only
+	// output slot 0 fires, and the runtime can assume single-slot outputs.
 	for (const edge of graph.edges) {
 		if (edge.outputIndex !== 0) {
 			throw new UnimplementedError(
 				`Edge ${edge.from} → ${edge.to} leaves output slot ${edge.outputIndex}; only output slot 0 is supported yet`,
-			);
-		}
-		if (edge.inputIndex !== 0) {
-			throw new UnimplementedError(
-				`Edge ${edge.from} → ${edge.to} arrives at input slot ${edge.inputIndex}; only input slot 0 is supported yet`,
 			);
 		}
 	}

--- a/packages/@n8n/engine/src/graph/validate-executable-graph.ts
+++ b/packages/@n8n/engine/src/graph/validate-executable-graph.ts
@@ -32,6 +32,18 @@ export function validateExecutableGraph(graph: WorkflowGraph): void {
 		throw new UnimplementedError('Graphs with back-edges (loops) are not supported yet');
 	}
 
+	// Slot indices are structural, so they're enforced here rather than left to
+	// the transport boundary. TODO(CAT-3042): enforce an upper bound too.
+	for (const edge of graph.edges) {
+		for (const index of [edge.outputIndex, edge.inputIndex]) {
+			if (!Number.isInteger(index) || index < 0) {
+				throw new GraphValidationError(
+					`Edge ${edge.from} → ${edge.to} has slot index ${index}; slot indices are non-negative integers`,
+				);
+			}
+		}
+	}
+
 	// TODO(CAT-2874): multi-slot outputs arrive with branching; until then only
 	// output slot 0 fires, and the runtime can assume single-slot outputs.
 	for (const edge of graph.edges) {

--- a/packages/@n8n/engine/src/graph/validate-executable-graph.ts
+++ b/packages/@n8n/engine/src/graph/validate-executable-graph.ts
@@ -44,16 +44,6 @@ export function validateExecutableGraph(graph: WorkflowGraph): void {
 		}
 	}
 
-	// TODO(CAT-2874): multi-slot outputs arrive with branching; until then only
-	// output slot 0 fires, and the runtime can assume single-slot outputs.
-	for (const edge of graph.edges) {
-		if (edge.outputIndex !== 0) {
-			throw new UnimplementedError(
-				`Edge ${edge.from} → ${edge.to} leaves output slot ${edge.outputIndex}; only output slot 0 is supported yet`,
-			);
-		}
-	}
-
 	// TODO(CAT-3982): same-slot convergence gets a defined meaning (concatenation);
 	// until then it is rejected rather than given accidental semantics.
 	const seenInputSlots = new Set<string>();

--- a/packages/@n8n/engine/src/graph/workflow-graph-queries.ts
+++ b/packages/@n8n/engine/src/graph/workflow-graph-queries.ts
@@ -22,9 +22,9 @@ export function getSuccessorNodeIds(graph: WorkflowGraph, nodeId: string): strin
 
 /**
  * Ids of every node reachable downstream of `nodeId` (transitive successors),
- * de-duplicated, in BFS order, excluding `nodeId` itself. Bounds the region a
- * settlement can decide: nothing outside a settled step's descendants changes
- * when it settles.
+ * de-duplicated, in BFS order, excluding `nodeId` itself. The completion
+ * check counts these against settled rows, and validation uses them to
+ * reject unreachable predecessors.
  */
 export function getDescendantNodeIds(graph: WorkflowGraph, nodeId: string): string[] {
 	// BFS where the queue doubles as the result: every id is appended exactly

--- a/packages/@n8n/engine/src/graph/workflow-graph-queries.ts
+++ b/packages/@n8n/engine/src/graph/workflow-graph-queries.ts
@@ -21,6 +21,27 @@ export function getSuccessorNodeIds(graph: WorkflowGraph, nodeId: string): strin
 }
 
 /**
+ * Ids of every node reachable downstream of `nodeId` (transitive successors),
+ * de-duplicated, in BFS order, excluding `nodeId` itself. Bounds the region a
+ * settlement can decide: nothing outside a settled step's descendants changes
+ * when it settles.
+ */
+export function getDescendantNodeIds(graph: WorkflowGraph, nodeId: string): string[] {
+	// BFS where the queue doubles as the result: every id is appended exactly
+	// once, and the index only moves forward.
+	const descendants = getSuccessorNodeIds(graph, nodeId);
+	const visited = new Set(descendants);
+	for (let i = 0; i < descendants.length; i++) {
+		for (const successor of getSuccessorNodeIds(graph, descendants[i])) {
+			if (visited.has(successor)) continue;
+			visited.add(successor);
+			descendants.push(successor);
+		}
+	}
+	return descendants;
+}
+
+/**
  * Ids of the nodes directly upstream of `nodeId`, de-duplicated, in edge order.
  *
  * TODO(CAT-3854): validate edge endpoints against `nodes`.

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -30,7 +30,7 @@ export { InMemoryWorkQueue } from './queue';
 export type {
 	ExecutionEnqueuedEvent,
 	OrchestrationMessage,
-	StepCompletedEvent,
+	StepSettledEvent,
 	StepMessage,
 	StepReadyEvent,
 	WorkQueue,
@@ -41,9 +41,9 @@ export {
 	ExecutionStartHandler,
 	OrchestrationWorker,
 	StartExecutionService,
-	StepCompletedHandler,
 	StepNotFoundError,
 	StepReadyHandler,
+	StepSettledHandler,
 	StepWorker,
 } from './execution';
 export type {

--- a/packages/@n8n/engine/src/index.ts
+++ b/packages/@n8n/engine/src/index.ts
@@ -30,7 +30,7 @@ export { InMemoryWorkQueue } from './queue';
 export type {
 	ExecutionEnqueuedEvent,
 	OrchestrationMessage,
-	StepCompletedEvent,
+	StepSettledEvent,
 	StepMessage,
 	StepReadyEvent,
 	WorkQueue,
@@ -40,7 +40,7 @@ export {
 	ExecutionNotFoundError,
 	ExecutionStartHandler,
 	OrchestrationWorker,
-	StepCompletedHandler,
+	StepSettledHandler,
 	StepNotFoundError,
 	StepReadyHandler,
 	StepWorker,

--- a/packages/@n8n/engine/src/queue/index.ts
+++ b/packages/@n8n/engine/src/queue/index.ts
@@ -1,7 +1,7 @@
 export type {
 	ExecutionEnqueuedEvent,
 	OrchestrationMessage,
-	StepCompletedEvent,
+	StepSettledEvent,
 	StepMessage,
 	StepReadyEvent,
 	WorkQueue,

--- a/packages/@n8n/engine/src/queue/work-queue.types.ts
+++ b/packages/@n8n/engine/src/queue/work-queue.types.ts
@@ -13,17 +13,18 @@ export interface ExecutionEnqueuedEvent {
 }
 
 /**
- * A step has finished, successfully or not. Carries ids only, like
- * `step:ready` — the consumer reads the step row for the outcome.
+ * A step has reached a terminal state — completed, failed, or skipped.
+ * Carries ids only, like `step:ready` — the consumer reads the step row
+ * for the outcome.
  */
-export interface StepCompletedEvent {
-	type: 'step:completed';
+export interface StepSettledEvent {
+	type: 'step:settled';
 	executionId: string;
 	stepId: string;
 }
 
 /** Messages consumed by the orchestration worker. */
-export type OrchestrationMessage = ExecutionEnqueuedEvent | StepCompletedEvent;
+export type OrchestrationMessage = ExecutionEnqueuedEvent | StepSettledEvent;
 
 export interface StepReadyEvent {
 	type: 'step:ready';

--- a/packages/@n8n/engine/src/serve.ts
+++ b/packages/@n8n/engine/src/serve.ts
@@ -39,7 +39,7 @@ async function main(): Promise<void> {
 		orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepSettledHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue, orchestrationQueue),
 		);
 		// No executors here: the v1 one lives in `@n8n/node-engine-compatibility`,
 		// which depends on this package, so only an integrated host can supply it.

--- a/packages/@n8n/engine/src/serve.ts
+++ b/packages/@n8n/engine/src/serve.ts
@@ -7,7 +7,7 @@ import { createDataSource, createStores } from './database';
 import {
 	ExecutionStartHandler,
 	OrchestrationWorker,
-	StepCompletedHandler,
+	StepSettledHandler,
 	StepReadyHandler,
 	StepWorker,
 } from './execution';
@@ -39,7 +39,7 @@ async function main(): Promise<void> {
 		orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue),
 		);
 		// No executors here: the v1 one lives in `@n8n/node-engine-compatibility`,
 		// which depends on this package, so only an integrated host can supply it.

--- a/packages/@n8n/engine/src/serve.ts
+++ b/packages/@n8n/engine/src/serve.ts
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
 		orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepSettledHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue, orchestrationQueue),
 		);
 		// No executors here: the v1 one lives in `@n8n/node-engine-compatibility`,
 		// which depends on this package, so only an integrated host can supply it.

--- a/packages/@n8n/engine/src/serve.ts
+++ b/packages/@n8n/engine/src/serve.ts
@@ -13,7 +13,7 @@ import {
 import {
 	ExecutionStartHandler,
 	OrchestrationWorker,
-	StepCompletedHandler,
+	StepSettledHandler,
 	StepReadyHandler,
 	StepWorker,
 } from './execution';
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
 		orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue),
 		);
 		// No executors here: the v1 one lives in `@n8n/node-engine-compatibility`,
 		// which depends on this package, so only an integrated host can supply it.

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/acceptance-fixtures.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/acceptance-fixtures.ts
@@ -12,8 +12,8 @@ import {
 	InMemoryWorkQueue,
 	OrchestrationWorker,
 	StartExecutionService,
-	StepCompletedHandler,
 	StepReadyHandler,
+	StepSettledHandler,
 	StepWorker,
 	WorkflowExecution,
 	WorkflowStepExecution,
@@ -119,7 +119,7 @@ export function makeRunWorkflow(getDataSource: () => EngineDataSource) {
 		const orchestrationWorker = new OrchestrationWorker(
 			orchestrationQueue,
 			new ExecutionStartHandler(executionStore, stepStore, orchestrationQueue),
-			new StepCompletedHandler(executionStore, stepStore, stepQueue),
+			new StepSettledHandler(executionStore, stepStore, stepQueue, orchestrationQueue),
 		);
 		const stepWorker = new StepWorker(
 			stepQueue,

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/engine-step-data-loader.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/engine-step-data-loader.test.ts
@@ -29,10 +29,10 @@ describe('createEngineStepDataLoader', () => {
 		} as unknown as ExecutionStore;
 		const stepStore = {
 			// the trigger's completed row carries its payload as output slot 0
-			loadStepOutputs: vi.fn().mockResolvedValue({
-				t: [{ body: { hello: 'world' } }],
-				a: [[{ json: { from: 'a' } }]],
-				b: null,
+			loadStepsByNodeIds: vi.fn().mockResolvedValue({
+				t: { nodeId: 't', status: 'completed', outputs: [{ body: { hello: 'world' } }] },
+				a: { nodeId: 'a', status: 'completed', outputs: [[{ json: { from: 'a' } }]] },
+				b: { nodeId: 'b', status: 'running', outputs: null },
 			}),
 		} as unknown as StepStore;
 
@@ -40,7 +40,7 @@ describe('createEngineStepDataLoader', () => {
 		const stepData = await loadStepData(context);
 
 		expect(executionStore.loadExecution).toHaveBeenCalledWith('exec-1');
-		expect(stepStore.loadStepOutputs).toHaveBeenCalledWith('exec-1', ['t', 'a', 'b']);
+		expect(stepStore.loadStepsByNodeIds).toHaveBeenCalledWith('exec-1', ['t', 'a', 'b']);
 		expect(stepData.graph).toBe(graph);
 		// incomplete steps are omitted, not mapped to null, so expressions
 		// referencing them fail as "hasn't been executed"

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
@@ -46,8 +46,16 @@ describe('fromStepInputs', () => {
 });
 
 describe('toStepOutputs', () => {
+	it('collapses a zero-item slot to null (v1: branch not taken)', () => {
+		expect(toStepOutputs([[{ json: { x: 1 } }], []])).toEqual([[{ json: { x: 1 } }], null]);
+	});
+
+	it('collapses a lone empty slot', () => {
+		expect(toStepOutputs([[]])).toEqual([null]);
+	});
+
 	it('survives a JSON round-trip', () => {
-		const outputs: INodeExecutionData[][] = [[{ json: { x: 1 } }], []];
+		const outputs: INodeExecutionData[][] = [[{ json: { x: 1 } }], [{ json: { y: 2 } }]];
 		const payload = toStepOutputs(outputs);
 		expect(payload).toEqual(outputs);
 

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/io.test.ts
@@ -43,8 +43,16 @@ describe('fromStepInputs', () => {
 });
 
 describe('toStepOutputs', () => {
+	it('collapses a zero-item slot to null (v1: branch not taken)', () => {
+		expect(toStepOutputs([[{ json: { x: 1 } }], []])).toEqual([[{ json: { x: 1 } }], null]);
+	});
+
+	it('collapses a lone empty slot', () => {
+		expect(toStepOutputs([[]])).toEqual([null]);
+	});
+
 	it('survives a JSON round-trip', () => {
-		const outputs: INodeExecutionData[][] = [[{ json: { x: 1 } }], []];
+		const outputs: INodeExecutionData[][] = [[{ json: { x: 1 } }], [{ json: { y: 2 } }]];
 		const payload = toStepOutputs(outputs);
 		expect(payload).toEqual(outputs);
 

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/v1-workflow-converter.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/v1-workflow-converter.test.ts
@@ -6,6 +6,7 @@ import {
 	UnsupportedCycleError,
 	UnsupportedTriggerError,
 	UnsupportedLoopEntryError,
+	UnsupportedWorkflowError,
 } from '../errors';
 import { V1WorkflowConverter } from '../v1-workflow-converter';
 
@@ -168,6 +169,45 @@ describe('V1WorkflowConverter', () => {
 					}),
 				),
 			).toThrow(UnsupportedTriggerError);
+		});
+
+		const mergeNode = (parameters: INode['parameters']): INode =>
+			node('merge-uuid', 'Merge', { type: 'n8n-nodes-base.merge', typeVersion: 3.2, parameters });
+
+		it('rejects a Merge in chooseBranch mode', () => {
+			expect(() =>
+				converter.convert(
+					workflow({ nodes: [manualTrigger, mergeNode({ mode: 'chooseBranch' })] }),
+				),
+			).toThrow(UnsupportedWorkflowError);
+		});
+
+		it.each([2.1, 3.2])('rejects a Merge v%s whose mode is an expression', (typeVersion) => {
+			// unknowable at conversion time; v3's noDataExpression only binds the
+			// UI, so a hand-authored workflow can still carry one
+			expect(() =>
+				converter.convert(
+					workflow({
+						nodes: [manualTrigger, { ...mergeNode({ mode: '={{ $json.mode }}' }), typeVersion }],
+					}),
+				),
+			).toThrow(UnsupportedWorkflowError);
+		});
+
+		it('accepts a Merge in a literal non-chooseBranch mode', () => {
+			expect(() =>
+				converter.convert(workflow({ nodes: [manualTrigger, mergeNode({ mode: 'append' })] })),
+			).not.toThrow();
+		});
+
+		it('accepts an expression mode on Merge v1, which predates chooseBranch', () => {
+			expect(() =>
+				converter.convert(
+					workflow({
+						nodes: [manualTrigger, { ...mergeNode({ mode: "={{ 'append' }}" }), typeVersion: 1 }],
+					}),
+				),
+			).not.toThrow();
 		});
 	});
 

--- a/packages/@n8n/node-engine-compatibility/src/constants.ts
+++ b/packages/@n8n/node-engine-compatibility/src/constants.ts
@@ -1,3 +1,4 @@
 export const MANUAL_TRIGGER_TYPE = 'n8n-nodes-base.manualTrigger';
+export const MERGE_TYPE = 'n8n-nodes-base.merge';
 export const SPLIT_IN_BATCHES_TYPE = 'n8n-nodes-base.splitInBatches';
 export const MAIN_CONNECTION_TYPE = 'main';

--- a/packages/@n8n/node-engine-compatibility/src/engine-step-data-loader.ts
+++ b/packages/@n8n/node-engine-compatibility/src/engine-step-data-loader.ts
@@ -20,11 +20,11 @@ export function createEngineStepDataLoader(
 		const execution = await executionStore.loadExecution(context.executionId);
 
 		const nodeIds = execution.graph.nodes.map((node) => node.id);
-		const stored = await stepStore.loadStepOutputs(context.executionId, nodeIds);
+		const stored = await stepStore.loadStepsByNodeIds(context.executionId, nodeIds);
 
 		const outputsByNodeId: Record<string, StepSlots> = {};
-		for (const [nodeId, outputs] of Object.entries(stored)) {
-			if (outputs !== null) outputsByNodeId[nodeId] = outputs;
+		for (const [nodeId, row] of Object.entries(stored)) {
+			if (row.status === 'completed' && row.outputs !== null) outputsByNodeId[nodeId] = row.outputs;
 		}
 
 		return { graph: execution.graph, outputsByNodeId };

--- a/packages/@n8n/node-engine-compatibility/src/io.ts
+++ b/packages/@n8n/node-engine-compatibility/src/io.ts
@@ -15,5 +15,9 @@ export function fromStepInputs(value: StepSlots): INodeExecutionData[][] {
 }
 
 export function toStepOutputs(outputs: INodeExecutionData[][]): StepSlots {
-	return outputs as unknown as StepSlots;
+	// v1 marks a branch "not taken" by producing zero items; the engine marks it
+	// with a null slot (dead edge), which is what makes skip propagation see the
+	// branch as dead. The collapse is v1 policy applied at the boundary — []
+	// stays representable inside the engine.
+	return outputs.map((slot) => (slot.length === 0 ? null : slot)) as unknown as StepSlots;
 }

--- a/packages/@n8n/node-engine-compatibility/src/io.ts
+++ b/packages/@n8n/node-engine-compatibility/src/io.ts
@@ -18,5 +18,9 @@ export function fromStepInputs(value: StepSlots): INodeExecutionData[][] {
 }
 
 export function toStepOutputs(outputs: INodeExecutionData[][]): StepSlots {
-	return outputs as unknown as StepSlots;
+	// v1 marks a branch "not taken" by producing zero items; the engine marks it
+	// with a null slot (dead edge), which is what makes skip propagation see the
+	// branch as dead. The collapse is v1 policy applied at the boundary — []
+	// stays representable inside the engine.
+	return outputs.map((slot) => (slot.length === 0 ? null : slot)) as unknown as StepSlots;
 }

--- a/packages/@n8n/node-engine-compatibility/src/v1-workflow-converter.ts
+++ b/packages/@n8n/node-engine-compatibility/src/v1-workflow-converter.ts
@@ -1,7 +1,12 @@
 import type { GraphEdge, GraphNode, WorkflowGraph } from '@n8n/engine';
 import type { INode, INodeConnections, IWorkflowBase } from 'n8n-workflow';
 
-import { MAIN_CONNECTION_TYPE, MANUAL_TRIGGER_TYPE, SPLIT_IN_BATCHES_TYPE } from './constants';
+import {
+	MAIN_CONNECTION_TYPE,
+	MANUAL_TRIGGER_TYPE,
+	MERGE_TYPE,
+	SPLIT_IN_BATCHES_TYPE,
+} from './constants';
 import {
 	UnsupportedConnectionTypeError,
 	UnsupportedCycleError,
@@ -81,6 +86,8 @@ export class V1WorkflowConverter {
 			);
 		}
 
+		if (node.type === MERGE_TYPE) this.assertSupportedMergeMode(node);
+
 		const config: V1NodeStepConfig = {
 			nodeType: node.type,
 			typeVersion: node.typeVersion,
@@ -91,6 +98,26 @@ export class V1WorkflowConverter {
 		const type = node.type === SPLIT_IN_BATCHES_TYPE ? 'batch' : 'v1-node';
 
 		return { id: node.id, name: node.name, type, config };
+	}
+
+	/**
+	 * chooseBranch waits for data on every input, but the engine runs a node
+	 * once any input is live. An expression-valued mode could resolve to
+	 * chooseBranch at run time (`noDataExpression` only binds the UI), so it
+	 * is rejected too, except on Merge v1, which predates chooseBranch.
+	 */
+	private assertSupportedMergeMode(node: INode): void {
+		const mode = node.parameters.mode;
+		if (mode === 'chooseBranch') {
+			throw new UnsupportedWorkflowError(
+				`Node "${node.name}" uses Merge mode "chooseBranch", which is not supported yet.`,
+			);
+		}
+		if (node.typeVersion >= 2 && typeof mode === 'string' && mode.startsWith('=')) {
+			throw new UnsupportedWorkflowError(
+				`Node "${node.name}" sets its Merge mode with an expression, which cannot be checked at conversion time. Use a literal mode.`,
+			);
+		}
 	}
 
 	/** Heuristic trigger detection — see {@link KNOWN_TRIGGER_TYPES}. */


### PR DESCRIPTION
## Summary

This is PR 3 of the CAT-2874 series. It makes the engine execute graphs that branch: If, Switch, and Merge shapes. The engine now supports all output slots, and it can skip the branches that a node does not take.

### The settlement model

The rules are in the header of `settlement.ts`. In short:

1. Every node that the execution considers reaches a terminal status: `completed`, `failed`, `skipped`, or `cancelled`. We call such a node **settled**.
2. An edge is **live** when its source completed and put data in the edge's output slot. In all other cases, the edge is **dead**. A slot that holds JSON `null` has no data.
3. When all predecessors of a node are settled, the engine decides the node. If one input edge is live, the node runs. If no input edge is live, the engine writes a `skipped` row. A skipped node is settled at birth.
4. A settlement decides only its direct successors. Each new skip gets its own `step:settled` event. The handler of that event decides the next hop. Thus a dead region cascades through the event loop, one settlement at a time. There is no explicit graph walk.
5. The execution is complete when every reachable node is settled. The handler compares a count of settled rows with the count of reachable nodes. This count cannot pass early, because settled rows are unique per node and do not change.

### Context a reviewer needs

- **Announcements**: a planner announces only the rows that its own insert created. If a crash loses an announcement, the rows show it: a settled row with decidable successors that have no rows. The reconciler (CAT-2938, future work) re-announces from that state. The engine does not depend on queue redelivery.
- **Failure stays fail-fast** (v1 parity): a failed step ends the whole execution. Failed-step propagation through dead edges is a deliberate non-goal here.
- **Event rename**: `step:completed` is now `step:settled`. The old event already fired for failed steps, and it now also fires for skipped steps. The old name collided with the `completed` status value.
- **The count-based completion check closes the CAT-3910 race**: unplanned successors keep the count short, so the execution cannot complete while work is in flight. Add a note to that ticket after merge.
- **The v1 boundary**: v1 marks a branch "not taken" with zero items. The shim converts `[]` to a `null` slot at the boundary. Inside the engine, `[]` stays a legal, live value.
- Out of scope: same-slot convergence (CAT-3982), loops (CAT-2875), converter rejection of Merge in `chooseBranch` mode (PR 4 of this series).

### Commits

Each commit builds and tests green on its own:

1. `refactor`: rename `step:completed` to `step:settled` (mechanical).
2. `skipped` status, `StepSummary`, and payload-free planning queries. A SQL projection computes slot liveness, so planning does not pull output payloads.
3. `getDescendantNodeIds` graph query (used by the completion check).
4. The settlement decision rules as a pure function (`decideSuccessors`). The property test simulates the full event loop on 200 random DAGs and compares the result with a reference evaluator. This test is the main correctness evidence.
5. The `StepSettledHandler` rewrite: one-hop planning, skip announcements, count-based completion.
6. The `StepReadyHandler`: record multi-slot outputs, read `null` from dead input edges.
7. Graph validation accepts `outputIndex > 0`. An end-to-end test runs a conditional diamond with a two-node dead chain against Postgres.
8. The shim collapse (`[]` to `null`) and removal of the three superseded store queries.

## How to test

Run in `packages/@n8n/engine`: `pnpm test` and `pnpm test:integration` (needs Docker). Run `pnpm test` in `packages/@n8n/node-engine-compatibility`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

