### PR TITLE
fix(editor): Open OAuth sign-in popup before network calls and report blocked pop-ups clearly

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1129,6 +1129,8 @@
 	"credentialEdit.credentialEdit.showError.invalidOAuthUrl.message": "Authorization URL must use HTTP or HTTPS protocol.",
 	"credentialEdit.credentialEdit.showError.invalidOAuthUrl.title": "Invalid OAuth URL",
 	"credentialEdit.credentialEdit.showError.loadCredential.title": "Problem loading credential",
+	"credentialEdit.credentialEdit.showError.oauthPopupBlocked.message": "Your browser blocked the sign-in window. Allow pop-ups for this site and try again.",
+	"credentialEdit.credentialEdit.showError.oauthPopupBlocked.title": "Sign-in window was blocked",
 	"credentialEdit.credentialEdit.showError.updateCredential.title": "Problem updating credential",
 	"credentialEdit.credentialEdit.showMessage.title": "Credential deleted",
 	"credentialEdit.credentialEdit.showMessage.disconnected.title": "Account disconnected",

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -1266,7 +1266,7 @@ describe('CredentialEdit', () => {
 			vi.stubGlobal('BroadcastChannel', BroadcastChannelMock);
 			vi.stubGlobal(
 				'open',
-				vi.fn(() => ({ close: vi.fn() })),
+				vi.fn(() => ({ close: vi.fn(), closed: false, location: { href: '' } })),
 			);
 
 			const pinia = createPiniaForSaveTest(credentialModalState);

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1025,6 +1025,22 @@ async function oAuthCredentialAuthorize() {
 
 	credentialsStore.pendingOAuthRefresh = true;
 
+	// window.open must run within the click's transient user activation:
+	// opening after the save/authorize round trips below gets the popup blocked
+	// on slow connections (Chrome expires activation after ~5s) and in stricter
+	// browsers (Safari) regardless of timing. Open a blank window now and
+	// navigate it once the authorization URL is known.
+	const params =
+		'scrollbars=no,resizable=yes,status=no,titlebar=noe,location=no,toolbar=no,menubar=no,width=500,height=700';
+	const oauthPopup = window.open('about:blank', 'OAuth Authorization', params);
+	if (!oauthPopup) {
+		toast.showError(
+			new Error(i18n.baseText('credentialEdit.credentialEdit.showError.oauthPopupBlocked.message')),
+			i18n.baseText('credentialEdit.credentialEdit.showError.oauthPopupBlocked.title'),
+		);
+		return;
+	}
+
 	// Editors persist any blueprint changes before connecting. Connect-only users
 	// (e.g. on a private credential they can't edit) have nothing to save, so
 	// connecting through saveCredential would be a no-op that returns null and
@@ -1032,6 +1048,7 @@ async function oAuthCredentialAuthorize() {
 	const canEditBlueprint = credentialPermissions.value.update || credentialPermissions.value.create;
 	const credential = canEditBlueprint ? await saveCredential() : currentCredential.value;
 	if (!credential) {
+		oauthPopup.close();
 		return;
 	}
 
@@ -1053,6 +1070,7 @@ async function oAuthCredentialAuthorize() {
 			}
 		}
 	} catch (error) {
+		oauthPopup.close();
 		toast.showError(
 			error,
 			i18n.baseText('credentialEdit.credentialEdit.showError.generateAuthorizationUrl.title'),
@@ -1067,6 +1085,7 @@ async function oAuthCredentialAuthorize() {
 	}
 
 	if (url === undefined || url === '') {
+		oauthPopup.close();
 		toast.showError(
 			new Error(i18n.baseText('credentialEdit.credentialEdit.showError.invalidOAuthUrl.message')),
 			i18n.baseText('credentialEdit.credentialEdit.showError.invalidOAuthUrl.title'),
@@ -1079,6 +1098,7 @@ async function oAuthCredentialAuthorize() {
 	try {
 		const parsedUrl = new URL(url);
 		if (!allowedOAuthUrlProtocols.includes(parsedUrl.protocol)) {
+			oauthPopup.close();
 			toast.showError(
 				new Error(i18n.baseText('credentialEdit.credentialEdit.showError.invalidOAuthUrl.message')),
 				i18n.baseText('credentialEdit.credentialEdit.showError.invalidOAuthUrl.title'),
@@ -1086,6 +1106,7 @@ async function oAuthCredentialAuthorize() {
 			return;
 		}
 	} catch {
+		oauthPopup.close();
 		toast.showError(
 			new Error(i18n.baseText('credentialEdit.credentialEdit.showError.invalidOAuthUrl.message')),
 			i18n.baseText('credentialEdit.credentialEdit.showError.invalidOAuthUrl.title'),
@@ -1093,9 +1114,7 @@ async function oAuthCredentialAuthorize() {
 		return;
 	}
 
-	const params =
-		'scrollbars=no,resizable=yes,status=no,titlebar=noe,location=no,toolbar=no,menubar=no,width=500,height=700';
-	const oauthPopup = window.open(url, 'OAuth Authorization', params);
+	oauthPopup.location.href = url;
 
 	// Token presence in credential data can only confirm the flow when there was
 	// no token yet (a reconnect's old token would read as an immediate false
@@ -1141,20 +1160,13 @@ async function oAuthCredentialAuthorize() {
 			});
 
 			// Close the window
-			if (oauthPopup) {
-				oauthPopup.close();
-			}
+			oauthPopup.close();
 
 			if (closeOnSave.value) {
 				closeDialog();
 			}
 		}
 	};
-
-	if (!oauthPopup) {
-		handleOAuthResult(false);
-		return;
-	}
 
 	// Supersede any previous pending flow so a re-click doesn't leave a second
 	// set of listeners alive; unmounting the modal aborts too (onBeforeUnmount).

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialOAuth.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialOAuth.test.ts
@@ -392,7 +392,11 @@ describe('useCredentialOAuth', () => {
 			isManaged: false,
 		};
 
-		let mockPopup: { closed: boolean; close: ReturnType<typeof vi.fn> };
+		let mockPopup: {
+			closed: boolean;
+			close: ReturnType<typeof vi.fn>;
+			location: { href: string };
+		};
 		class MockBroadcastChannel {
 			static failOauth = false;
 
@@ -432,7 +436,7 @@ describe('useCredentialOAuth', () => {
 		}
 
 		beforeEach(() => {
-			mockPopup = { closed: false, close: vi.fn() };
+			mockPopup = { closed: false, close: vi.fn(), location: { href: '' } };
 
 			vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
 			vi.stubGlobal('open', vi.fn().mockReturnValue(mockPopup));
@@ -456,6 +460,29 @@ describe('useCredentialOAuth', () => {
 			expect(result).toBe(true);
 		});
 
+		it('should open the popup before any request and navigate it to the fetched URL', async () => {
+			const credentialsStore = mockedStore(useCredentialsStore);
+			const openSpy = vi.fn().mockReturnValue(mockPopup);
+			vi.stubGlobal('open', openSpy);
+			// The popup must already exist by the time the authorization URL is
+			// requested — opening it later falls outside the click's transient
+			// user activation and gets blocked.
+			credentialsStore.oAuth2Authorize.mockImplementation(async () => {
+				expect(openSpy).toHaveBeenCalledWith(
+					'about:blank',
+					'OAuth Authorization',
+					expect.any(String),
+				);
+				return await Promise.resolve('https://oauth.example.com/auth');
+			});
+
+			const { authorize } = useCredentialOAuth();
+			const result = await authorize(mockCredential);
+
+			expect(result).toBe(true);
+			expect(mockPopup.location.href).toBe('https://oauth.example.com/auth');
+		});
+
 		it('should call oAuth1Authorize for OAuth1 types', async () => {
 			const credentialsStore = mockedStore(useCredentialsStore);
 			const oauth1Credential: ICredentialsResponse = {
@@ -471,7 +498,7 @@ describe('useCredentialOAuth', () => {
 			expect(result).toBe(true);
 		});
 
-		it('should return false when API call fails', async () => {
+		it('should return false and close the popup when API call fails', async () => {
 			const credentialsStore = mockedStore(useCredentialsStore);
 			credentialsStore.oAuth2Authorize.mockRejectedValue(new Error('API error'));
 
@@ -480,9 +507,10 @@ describe('useCredentialOAuth', () => {
 
 			expect(result).toBe(false);
 			expect(mockShowError).toHaveBeenCalled();
+			expect(mockPopup.close).toHaveBeenCalled();
 		});
 
-		it('should return false for invalid URL protocol', async () => {
+		it('should return false and close the popup for invalid URL protocol', async () => {
 			const credentialsStore = mockedStore(useCredentialsStore);
 			credentialsStore.oAuth2Authorize.mockResolvedValue('ftp://bad-protocol.com');
 
@@ -490,10 +518,11 @@ describe('useCredentialOAuth', () => {
 			const result = await authorize(mockCredential);
 
 			expect(result).toBe(false);
-			expect(mockShowError).toHaveBeenCalled();
+			expect(mockShowError).toHaveBeenCalledWith(expect.any(Error), 'Invalid OAuth URL');
+			expect(mockPopup.close).toHaveBeenCalled();
 		});
 
-		it('should return false when popup is blocked', async () => {
+		it('should show the popup-blocked error and skip the URL request when the popup is blocked', async () => {
 			const credentialsStore = mockedStore(useCredentialsStore);
 			credentialsStore.oAuth2Authorize.mockResolvedValue('https://oauth.example.com/auth');
 			vi.stubGlobal('open', vi.fn().mockReturnValue(null));
@@ -502,6 +531,8 @@ describe('useCredentialOAuth', () => {
 			const result = await authorize(mockCredential);
 
 			expect(result).toBe(false);
+			expect(credentialsStore.oAuth2Authorize).not.toHaveBeenCalled();
+			expect(mockShowError).toHaveBeenCalledWith(expect.any(Error), 'Sign-in window was blocked');
 		});
 
 		it('should return false on non-success BroadcastChannel message', async () => {
@@ -779,7 +810,11 @@ describe('useCredentialOAuth', () => {
 			isManaged: false,
 		};
 
-		let mockPopup: { closed: boolean; close: ReturnType<typeof vi.fn> };
+		let mockPopup: {
+			closed: boolean;
+			close: ReturnType<typeof vi.fn>;
+			location: { href: string };
+		};
 
 		class MockBroadcastChannel {
 			static failOauth = false;
@@ -811,7 +846,8 @@ describe('useCredentialOAuth', () => {
 
 		beforeEach(() => {
 			mockTrack.mockClear();
-			mockPopup = { closed: false, close: vi.fn() };
+			mockShowError.mockClear();
+			mockPopup = { closed: false, close: vi.fn(), location: { href: '' } };
 			MockBroadcastChannel.silent = false;
 			vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
 			vi.stubGlobal('open', vi.fn().mockReturnValue(mockPopup));
@@ -948,6 +984,29 @@ describe('useCredentialOAuth', () => {
 
 			const savedCall = mockTrack.mock.calls.find((call) => call[0] === 'User saved credentials');
 			expect(savedCall?.[1]).not.toHaveProperty('node_type');
+		});
+
+		it('should not create a credential when the popup is blocked', async () => {
+			const credentialsStore = setupSuccessfulOAuthFlow();
+			vi.stubGlobal('open', vi.fn().mockReturnValue(null));
+
+			const { createAndAuthorize } = useCredentialOAuth();
+			const credential = await createAndAuthorize('slackOAuth2Api');
+
+			expect(credential).toBeNull();
+			expect(credentialsStore.createNewCredential).not.toHaveBeenCalled();
+			expect(mockShowError).toHaveBeenCalledWith(expect.any(Error), 'Sign-in window was blocked');
+		});
+
+		it('should close the popup when credential creation fails', async () => {
+			const credentialsStore = setupSuccessfulOAuthFlow();
+			credentialsStore.createNewCredential.mockRejectedValue(new Error('creation failed'));
+
+			const { createAndAuthorize } = useCredentialOAuth();
+			const credential = await createAndAuthorize('slackOAuth2Api');
+
+			expect(credential).toBeNull();
+			expect(mockPopup.close).toHaveBeenCalled();
 		});
 
 		it('should keep the credential when OAuth succeeds via backend verification (COOP)', async () => {

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialOAuth.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialOAuth.ts
@@ -194,6 +194,13 @@ export function useCredentialOAuth() {
 		);
 	}
 
+	function showPopupBlockedError(): void {
+		toast.showError(
+			new Error(i18n.baseText('credentialEdit.credentialEdit.showError.oauthPopupBlocked.message')),
+			i18n.baseText('credentialEdit.credentialEdit.showError.oauthPopupBlocked.title'),
+		);
+	}
+
 	function openOAuthPopup(url: string, signal?: AbortSignal): Window | null {
 		const params =
 			'scrollbars=no,resizable=yes,status=no,titlebar=no,location=no,toolbar=no,menubar=no,width=500,height=700';
@@ -217,11 +224,26 @@ export function useCredentialOAuth() {
 	/**
 	 * Authorize OAuth credentials by opening a popup and listening for callback.
 	 * Returns true if OAuth was successful, false if cancelled or failed.
+	 *
+	 * Must be called synchronously from the click handler (or be given a popup
+	 * that was opened synchronously from it, see `preopenedPopup`).
 	 */
 	async function authorize(
 		credential: ICredentialsResponse,
 		signal?: AbortSignal,
+		preopenedPopup?: Window,
 	): Promise<boolean> {
+		// window.open must run within the click's transient user activation:
+		// opening after the network round trips below gets the popup blocked on
+		// slow connections (Chrome expires activation after ~5s) and in stricter
+		// browsers (Safari) regardless of timing. Open a blank window now and
+		// navigate it once the authorization URL is known.
+		const popup = preopenedPopup ?? openOAuthPopup('about:blank', signal);
+		if (!popup) {
+			showPopupBlockedError();
+			return false;
+		}
+
 		// Token presence in credential data can only confirm the flow for fixed
 		// credentials that had no token before the popup opened: a reconnect's old
 		// token would read as an immediate false success, and end-user
@@ -231,20 +253,18 @@ export function useCredentialOAuth() {
 
 		const urlResult = await getOAuthAuthorizationUrl(credential);
 		if (!urlResult.ok) {
+			popup.close();
 			if (urlResult.error === 'no-url') showOAuthUrlError();
 			return false;
 		}
 
 		if (!isValidHttpUrl(urlResult.result)) {
+			popup.close();
 			showOAuthUrlError();
 			return false;
 		}
 
-		const popup = openOAuthPopup(urlResult.result, signal);
-		if (!popup) {
-			showOAuthUrlError();
-			return false;
-		}
+		popup.location.href = urlResult.result;
 
 		let outcome = await waitForOAuthCallback({
 			popup,
@@ -301,6 +321,18 @@ export function useCredentialOAuth() {
 			return null;
 		}
 
+		const controller = new AbortController();
+		oauthAbortController.value = controller;
+
+		// Opened before the credential-creation round trips so it stays within
+		// the click's transient user activation (see authorize).
+		const popup = openOAuthPopup('about:blank', controller.signal);
+		if (!popup) {
+			showPopupBlockedError();
+			oauthAbortController.value = null;
+			return null;
+		}
+
 		const data: ICredentialDataDecryptedObject = {};
 		const allowedHttpRequestDomainsProperty = credentialType.properties.find(
 			(prop) => prop.name === 'allowedHttpRequestDomains',
@@ -333,15 +365,15 @@ export function useCredentialOAuth() {
 				workflow_id: workflowsStore.workflowId,
 			});
 		} catch (error) {
+			popup.close();
+			oauthAbortController.value = null;
 			toast.showError(error, i18n.baseText('nodeCredentials.showMessage.title'));
 			return null;
 		}
 
-		const controller = new AbortController();
-		oauthAbortController.value = controller;
 		pendingCredentialId.value = credential.id;
 
-		const success = await authorize(credential, controller.signal);
+		const success = await authorize(credential, controller.signal, popup);
 
 		oauthAbortController.value = null;
 		pendingCredentialId.value = null;

--- a/packages/testing/playwright/tests/e2e/credentials/oauth.spec.ts
+++ b/packages/testing/playwright/tests/e2e/credentials/oauth.spec.ts
@@ -22,8 +22,11 @@ test.describe(
 			const popupPromise = n8n.page.waitForEvent('popup');
 			await n8n.credentials.credentialModal.oauthConnectButton.click();
 
+			// The window opens blank within the click gesture and is navigated to the
+			// authorization URL once the backend returns it — wait for that request.
 			const popup = await popupPromise;
-			const popupUrl = popup.url();
+			const authRequest = await popup.waitForRequest(/accounts\.google\.com/);
+			const popupUrl = authRequest.url();
 			expect(popupUrl).toContain('accounts.google.com');
 			expect(popupUrl).toContain('client_id=test-key');
 


### PR DESCRIPTION
## Summary

Clicking "Sign in with Google" sometimes failed with a confusing "Invalid OAuth URL" error and the user got stuck.

The real problem: we only opened the sign-in window after several server calls. Browsers only allow a new window right after a click, so on slow connections (and often on Safari) the window got blocked, and we wrongly reported that as an invalid URL. Each failed attempt also created and deleted a credential behind the scenes.

The fix: the sign-in window now opens immediately on click and loads the Google page once it is ready, so browsers no longer block it. If something still blocks it (e.g. an ad blocker), the user now sees a clear message: "Sign-in window was blocked. Allow pop-ups for this site and try again." This applies to all one-click connect buttons and the credential modal.

| Before | After |
| --- | --- |
|  <img width="3024" height="1432" alt="01-toast-popup-blocked-fast-network" src="https://github.com/user-attachments/assets/5ad58cc6-1fdd-4513-b969-9016e41a8bf2" /> | <img width="3024" height="1432" alt="02-after-fix-blocked-popup-toast" src="https://github.com/user-attachments/assets/925d6c58-c96d-4e5f-93a6-afd20c810bd8" /> |

## How to test

1. Start n8n with a managed OAuth client for Google, e.g. `CREDENTIALS_OVERWRITE_DATA='{"googleOAuth2Api":{"clientId":"...","clientSecret":"..."}}'`.
2. Add a Google Sheets node, open it, and click "Sign in with Google". The window must open right away, even with DevTools network throttling set to Slow 3G.
3. Run `window.open = () => null` in the console and click again. You should see the "Sign-in window was blocked" message, and no new credential in the credentials list.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-1074

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
