### PR TITLE
fix(core): Deduplicate OAuth2 authorization URL query parameters

### DIFF
--- a/packages/@n8n/client-oauth2/src/code-flow.ts
+++ b/packages/@n8n/client-oauth2/src/code-flow.ts
@@ -16,6 +16,21 @@ interface CodeFlowBody {
 	client_assertion?: string;
 }
 
+// Sent exactly once with the flow's value — a stale copy baked into the
+// authorization URL would break the callback or PKCE validation.
+const FLOW_OWNED_PARAMS = new Set([
+	'client_id',
+	'redirect_uri',
+	'response_type',
+	'state',
+	'scope',
+	'code_challenge',
+	'code_challenge_method',
+]);
+
+// May legitimately repeat (RFC 8707 resource indicators), so never deduplicated.
+const REPEATABLE_PARAMS = new Set(['resource']);
+
 /**
  * Support authorization code OAuth 2.0 grant.
  *
@@ -35,7 +50,7 @@ export class CodeFlow {
 
 		const url = new URL(options.authorizationUri);
 
-		const queryParams = {
+		const queryParams: Record<string, string | string[] | undefined> = {
 			...options.query,
 			client_id: options.clientId,
 			redirect_uri: options.redirectUri,
@@ -46,8 +61,21 @@ export class CodeFlow {
 		};
 
 		for (const [key, value] of Object.entries(queryParams)) {
-			if (value !== null && value !== undefined) {
-				url.searchParams.append(key, value);
+			if (value === null || value === undefined) continue;
+			if (REPEATABLE_PARAMS.has(key)) {
+				for (const entry of Array.isArray(value) ? value : [value]) {
+					url.searchParams.append(key, entry);
+				}
+				continue;
+			}
+			const param = Array.isArray(value) ? value.join(',') : value;
+			if (FLOW_OWNED_PARAMS.has(key)) {
+				// An empty flow value (e.g. a blank scope) must not evict a URL-carried value.
+				if (param === '' && url.searchParams.has(key)) continue;
+				url.searchParams.set(key, param);
+			} else if (!url.searchParams.has(key)) {
+				// A key already on the URL is the user's explicit choice; our default falls back.
+				url.searchParams.append(key, param);
 			}
 		}
 

--- a/packages/@n8n/client-oauth2/test/code-flow.test.ts
+++ b/packages/@n8n/client-oauth2/test/code-flow.test.ts
@@ -107,6 +107,115 @@ describe('CodeFlow', () => {
 						'response_type=code&scope=notifications',
 				);
 			});
+
+			it('should keep the URL value and drop the default when a query param key exists in both', () => {
+				const authWithPromptInUrl = new ClientOAuth2({
+					clientId: config.clientId,
+					clientSecret: config.clientSecret,
+					accessTokenUri: config.accessTokenUri,
+					authorizationUri: `${config.authorizationUri}?prompt=consent`,
+					authorizationGrants: ['code'],
+					redirectUri: config.redirectUri,
+					scopes: ['notifications'],
+					query: { prompt: 'select_account', response_mode: 'query' },
+				});
+				expect(authWithPromptInUrl.code.getUri()).toEqual(
+					`${config.authorizationUri}?prompt=consent&response_mode=query&client_id=abc&` +
+						`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
+						'response_type=code&scope=notifications',
+				);
+			});
+
+			it('should replace flow-owned params carried by the URL with the flow values', () => {
+				const authWithStaleFlowParams = new ClientOAuth2({
+					clientId: config.clientId,
+					clientSecret: config.clientSecret,
+					accessTokenUri: config.accessTokenUri,
+					authorizationUri: `${config.authorizationUri}?client_id=stale&state=stale`,
+					authorizationGrants: ['code'],
+					redirectUri: config.redirectUri,
+					scopes: ['notifications'],
+				});
+				expect(authWithStaleFlowParams.code.getUri({ state: config.state })).toEqual(
+					`${config.authorizationUri}?client_id=abc&state=${config.state}&` +
+						`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
+						'response_type=code&scope=notifications',
+				);
+			});
+
+			it('should replace a PKCE challenge carried by the URL with the generated one', () => {
+				const authWithStaleChallenge = new ClientOAuth2({
+					clientId: config.clientId,
+					clientSecret: config.clientSecret,
+					accessTokenUri: config.accessTokenUri,
+					authorizationUri: `${config.authorizationUri}?code_challenge=stale&code_challenge_method=plain`,
+					authorizationGrants: ['code'],
+					redirectUri: config.redirectUri,
+					scopes: ['notifications'],
+					query: { code_challenge: 'abc123', code_challenge_method: 'S256' },
+				});
+				expect(authWithStaleChallenge.code.getUri()).toEqual(
+					`${config.authorizationUri}?code_challenge=abc123&code_challenge_method=S256&client_id=abc&` +
+						`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
+						'response_type=code&scope=notifications',
+				);
+			});
+
+			it('should keep a URL-carried scope when the flow scope is empty', () => {
+				const authWithBlankScope = new ClientOAuth2({
+					clientId: config.clientId,
+					clientSecret: config.clientSecret,
+					accessTokenUri: config.accessTokenUri,
+					authorizationUri: `${config.authorizationUri}?scope=custom.read`,
+					authorizationGrants: ['code'],
+					redirectUri: config.redirectUri,
+					// A blank Scope field reaches this package as [''] via the oauth service.
+					scopes: [''],
+				});
+				expect(authWithBlankScope.code.getUri()).toEqual(
+					`${config.authorizationUri}?scope=custom.read&client_id=abc&` +
+						`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
+						'response_type=code',
+				);
+			});
+
+			it('should emit repeated resource params from an array value separately', () => {
+				const authWithResourceArray = new ClientOAuth2({
+					clientId: config.clientId,
+					clientSecret: config.clientSecret,
+					accessTokenUri: config.accessTokenUri,
+					authorizationUri: config.authorizationUri,
+					authorizationGrants: ['code'],
+					redirectUri: config.redirectUri,
+					scopes: ['notifications'],
+					query: { resource: ['https://a.example.com', 'https://b.example.com'] },
+				});
+				expect(authWithResourceArray.code.getUri()).toEqual(
+					`${config.authorizationUri}?resource=${encodeURIComponent('https://a.example.com')}&` +
+						`resource=${encodeURIComponent('https://b.example.com')}&client_id=abc&` +
+						`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
+						'response_type=code&scope=notifications',
+				);
+			});
+
+			it('should not deduplicate the repeatable resource param', () => {
+				const authWithResourceInUrl = new ClientOAuth2({
+					clientId: config.clientId,
+					clientSecret: config.clientSecret,
+					accessTokenUri: config.accessTokenUri,
+					authorizationUri: `${config.authorizationUri}?resource=${encodeURIComponent('https://a.example.com')}`,
+					authorizationGrants: ['code'],
+					redirectUri: config.redirectUri,
+					scopes: ['notifications'],
+					resource: 'https://b.example.com',
+				});
+				expect(authWithResourceInUrl.code.getUri()).toEqual(
+					`${config.authorizationUri}?resource=${encodeURIComponent('https://a.example.com')}&client_id=abc&` +
+						`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
+						'response_type=code&' +
+						`resource=${encodeURIComponent('https://b.example.com')}&scope=notifications`,
+				);
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

Since 2.31.5, connecting a Microsoft credential fails with `AADSTS9000411: The parameter 'prompt' is duplicated` when the credential's Authorization URL already contains a query parameter that also appears in Auth URI Query Parameters. The URL builder in `CodeFlow.getUri()` appended every parameter with `searchParams.append()`, so a key present in both places was sent twice. This surfaced when #32015 gave all Microsoft credentials a default `prompt=select_account`, colliding with auth URLs that already carry a `prompt`.

The builder now sends each single-valued parameter once, with these rules:

- A key that is already on the Authorization URL wins over our `authQueryParameters` defaults. The user's explicit value is kept and our default is dropped. Removing it from the URL makes the default apply again.
- Parameters that n8n generates for the flow (`client_id`, `redirect_uri`, `response_type`, `state`, `scope`, `code_challenge`, `code_challenge_method`) always win, because a stale copy baked into the URL would break the callback or PKCE validation. An empty flow value (for example a blank Scope field) never removes a value the user put in the URL.
- `resource` is never deduplicated, since it may legitimately appear multiple times (RFC 8707). Array values now also produce separate `resource=` parameters instead of one comma-joined value.

One behavioural note for reviewers: external `oauth2.authenticate` hooks that add query parameters now follow the same rule — a key already on the auth URL wins. There are no such hooks in the repo.

## How to test

1. Create a Microsoft Outlook OAuth2 credential.
2. Add `?prompt=consent` (or any `prompt` value) to the credential's Authorization URL and leave Auth URI Query Parameters at its default.
3. Click Connect. Before this fix, Microsoft rejects the request with `AADSTS9000411`. With the fix, the consent screen opens and the URL contains a single `prompt` with the value from the Authorization URL.
4. Remove the `prompt` from the Authorization URL and connect again — the default `prompt=select_account` applies.

Unit tests cover the duplicated-key case, stale flow parameters in the URL, PKCE challenge replacement, the blank-scope case, and repeated `resource` parameters (`packages/@n8n/client-oauth2/test/code-flow.test.ts`).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-330

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

