### PR TITLE
ci: Resolve replay stalls toward 3.x in the master sync (no-changelog)

### DIFF
--- a/.github/DEVELOPING_V3.md
+++ b/.github/DEVELOPING_V3.md
@@ -188,7 +188,9 @@ commits only).
 The next sync then makes `3.x` linear again. The plain replay stalls at that point (a fix
 recorded around a merge commit leaves no patch to replay), so it replays a second time with
 `3.x`'s side favoured, and your fix commit — which is in the queue — does the real work.
-Nothing is squashed, and the tree guard proves the result is exactly the merge of `3.x` and
+Stalls that favouring cannot settle on its own (e.g. modify/delete, when `master` touched a
+file a breaking commit deletes) are resolved toward `3.x`'s side during the replay. Nothing
+is squashed, and the tree guard proves the result is exactly the merge of `3.x` and
 `master`.
 
 **Who gets pinged.** The conflict is attributed to the authors of the `3.x` commits behind the

--- a/.github/scripts/sync-master-to-3x.mjs
+++ b/.github/scripts/sync-master-to-3x.mjs
@@ -21,7 +21,9 @@
  *   2. The replay stalls, but 3.x's content still reconciles with master → an earlier
  *      conflict was resolved in a merge, which leaves no patch to replay. Replay again
  *      favouring the 3.x side (`-X theirs`), mirroring the side the resolved merge kept;
- *      the human's fix commit is in the queue and does the real work. Tree is then proven.
+ *      the human's fix commit is in the queue and does the real work. Stalls the strategy
+ *      option cannot settle (modify/delete — `-X` never resolves those) are resolved in
+ *      place toward the queue commit's side. Tree is then proven.
  *   3. master conflicts with 3.x, but ONLY on mechanical files — tool-generated content
  *      with a deterministic resolution (the pnpm lockfile, bot-maintained data files).
  *      These are resolved in place while the replay is stopped, exactly as a human
@@ -196,10 +198,34 @@ export function resolveMechanicalPath({ git, pnpm, path, masterSha, log = consol
 }
 
 /**
+ * Resolve one stalled path by taking the side of the queue commit being replayed
+ * ("theirs" while a rebase is stopped). Exists for the stalls `-X theirs` cannot settle
+ * itself — modify/delete, which strategy options never resolve: when the queue commit
+ * deleted the file there is no stage 3, so the deletion wins. Only meaningful on the
+ * favoured replay passes, where the callers' tree guard proves the final content — a
+ * wrong pick here fails the run instead of pushing.
+ */
+export function resolveQueueSidePath({ git, path, log = console.log }) {
+	// `ls-files -u` lines are `<mode> <oid> <stage>\t<path>`; stage 3 is the queue side.
+	const stages = git(['ls-files', '-u', '--', path]);
+	const queueSideExists = stages.split('\n').some((line) => /^\S+ \S+ 3\t/.test(line));
+	if (queueSideExists) {
+		log(`Resolving ${path} with the replayed commit's version...`);
+		git(['checkout', '--theirs', '--', path]);
+		git(['add', '--', path]);
+	} else {
+		log(`Resolving ${path} with the replayed commit's deletion...`);
+		git(['rm', '--force', '--', path]);
+	}
+}
+
+/**
  * Replay the 3.x-only commits onto master, resolving stalls that involve ONLY mechanical
  * paths in place — folded into the stalled commit exactly as a human's `rebase --continue`
  * would, so no commit is added. Bails (leaving the rebase stopped, for the caller to
- * abort) as soon as a stall touches a real code path.
+ * abort) as soon as a stall touches a real code path — unless `favourQueue` is set, in
+ * which case code-path stalls are resolved with the queue commit's side too. That flag
+ * belongs only on the favoured (`-X theirs`) passes, whose tree guard proves the outcome.
  *
  * Merge commits in the range (breaking PR merges, past conflict-PR merges) are flattened;
  * commits already applied to master — or fully absorbed by a mechanical resolution — are
@@ -211,6 +237,7 @@ export function rebaseResolvingMechanical({
 	masterSha,
 	log = console.log,
 	extraArgs = [],
+	favourQueue = false,
 	maxStalls = 50,
 }) {
 	const resolved = new Set();
@@ -223,13 +250,16 @@ export function rebaseResolvingMechanical({
 		}
 		const { mechanical, code } = classifyPaths(conflictedFiles(git));
 		// No conflicted files means the rebase failed for some other reason — don't guess.
-		if (mechanical.length === 0 || code.length > 0) {
+		if (mechanical.length + code.length === 0 || (code.length > 0 && !favourQueue)) {
 			if (res.out) log(res.out);
 			return { ok: false, resolved: [...resolved], conflictedCode: code };
 		}
 		for (const path of mechanical) {
 			resolveMechanicalPath({ git, pnpm, path, masterSha, log });
 			resolved.add(path);
+		}
+		for (const path of code) {
+			resolveQueueSidePath({ git, path, log });
 		}
 		// The resolution may have absorbed the whole commit — skip it rather than
 		// letting `--continue` refuse an empty commit.
@@ -271,6 +301,42 @@ export function assertNoMarkers(git, rev = 'HEAD') {
 		throw new Error(`Refusing to continue: conflict markers present in ${rev}:\n${found.out}`);
 	if (found.out.includes('fatal:'))
 		throw new Error(`Could not scan ${rev} for conflict markers:\n${found.out}`);
+}
+
+/**
+ * Fold any residual deviation between the replayed tip and the proven merge tree into the
+ * tip commit. `-X theirs` resolves overlapping hunks toward the queue side without
+ * stalling — silently dropping master-side changes (lockfile hunks are the usual case)
+ * that no fix commit in the queue reasserts. The merge tree is the definition of the
+ * correct content, so its blobs are taken verbatim. `excludePaths` names files the merge
+ * tree itself could not resolve (marker-carrying mechanical blobs), which get their own
+ * reconciliation. Never a commit of its own, and never a rewrite of a master commit.
+ */
+export function reconcileWithMergeTreeAtTip({
+	git,
+	mergedTree,
+	masterSha,
+	excludePaths = [],
+	log = console.log,
+}) {
+	if (git(['rev-parse', 'HEAD^{tree}']) === mergedTree) return [];
+	const out = git(['diff-tree', '-r', '--name-only', '--no-renames', mergedTree, 'HEAD']);
+	const excluded = new Set(excludePaths);
+	const paths = (out ? out.split('\n') : []).filter((p) => p && !excluded.has(p));
+	if (paths.length === 0) return [];
+	if (git(['rev-parse', 'HEAD']) === masterSha) {
+		throw new Error('Merge-tree reconciliation would amend a master commit; refusing.');
+	}
+	log(`Folding the merge tree's content for ${paths.join(', ')} into the tip commit.`);
+	for (const path of paths) {
+		if (attempt(git, ['cat-file', '-e', `${mergedTree}:${path}`]).ok) {
+			git(['checkout', mergedTree, '--', path]);
+		} else {
+			git(['rm', '--force', '--', path]); // the merge deleted it
+		}
+	}
+	git(['commit', '--amend', '--no-edit', '--no-verify']);
+	return paths;
 }
 
 /**
@@ -549,9 +615,19 @@ export async function sync({
 					masterSha,
 					log,
 					extraArgs: ['-X', 'theirs'],
+					favourQueue: true,
 				});
 			}
 			if (replay.ok) {
+				// The favoured retry may have drifted from the merge tree on cleanly-merging
+				// paths; fold those back before the mechanical files get their own treatment.
+				reconcileWithMergeTreeAtTip({
+					git,
+					mergedTree: merged.tree,
+					masterSha,
+					excludePaths: mechanical,
+					log,
+				});
 				if (mechanical.includes(LOCKFILE)) reconcileLockfileAtTip({ git, pnpm, masterSha, log });
 				assertTreeMatches(git, merged.tree, mechanical);
 				assertNoMarkers(git);
@@ -607,18 +683,31 @@ export async function sync({
 	// The content reconciles but the patches no longer apply on their own: an earlier
 	// conflict was resolved in a merge, and a merge resolution leaves no patch to replay.
 	// Replay favouring the 3.x side — the same side that resolved merge kept — and let the
-	// resolver's own fix commit, which is in the queue, do the real work. Mechanical stalls
-	// the strategy cannot settle (e.g. modify/delete) are resolved in place. Nothing is
-	// squashed; the tree guard below proves the outcome exactly, since the merge was clean.
+	// resolver's own fix commit, which is in the queue, do the real work. Stalls the
+	// strategy option cannot settle (modify/delete — `-X` never resolves those) are
+	// resolved in place toward the queue commit's side. Nothing is squashed; the tree
+	// guard below proves the outcome exactly, since the merge was clean.
 	git(['rebase', '--abort']);
 	log(`Patches no longer apply individually; replaying with ${target}'s side favoured.`);
-	if (!rebaseResolvingMechanical({ git, pnpm, masterSha, log, extraArgs: ['-X', 'theirs'] }).ok) {
+	const favoured = rebaseResolvingMechanical({
+		git,
+		pnpm,
+		masterSha,
+		log,
+		extraArgs: ['-X', 'theirs'],
+		favourQueue: true,
+	});
+	if (!favoured.ok) {
 		git(['rebase', '--abort']);
 		throw new Error(
 			`Could not replay ${target} onto master even with its own side favoured; needs a human.`,
 		);
 	}
 
+	// Favouring resolves overlapping hunks toward 3.x without stalling, which can drop
+	// master-side changes no fix commit reasserts; the merge was clean, so the merge tree
+	// is the correct content — fold any drift back into the tip.
+	reconcileWithMergeTreeAtTip({ git, mergedTree: merged.tree, masterSha, log });
 	assertTreeMatches(git, merged.tree);
 	assertNoMarkers(git);
 	pushReplay(preHead);

--- a/.github/scripts/sync-master-to-3x.test.mjs
+++ b/.github/scripts/sync-master-to-3x.test.mjs
@@ -7,7 +7,9 @@ import {
 	classifyPaths,
 	blocksLockfileRegen,
 	resolveMechanicalPath,
+	resolveQueueSidePath,
 	rebaseResolvingMechanical,
+	reconcileWithMergeTreeAtTip,
 	reconcileLockfileAtTip,
 	recentAbandonedConflictPrs,
 	assertTreeMatches,
@@ -223,6 +225,53 @@ test('rebaseResolvingMechanical bails as soon as a stall touches a code path', (
 	);
 });
 
+test('resolveQueueSidePath takes the queue commit side, or its deletion when there is no stage 3', () => {
+	const FILE = 'packages/cli/x.ts';
+	const bothSides = makeStub([
+		[(a) => a[0] === 'ls-files', `100644 aaa 2\t${FILE}\n100644 bbb 3\t${FILE}`],
+	]);
+	resolveQueueSidePath({ git: bothSides, path: FILE, log: () => {} });
+	assert.ok(bothSides.calls.some((a) => a[0] === 'checkout' && a[1] === '--theirs'));
+	assert.ok(bothSides.calls.some((a) => a[0] === 'add' && a.includes(FILE)));
+
+	// modify/delete with the queue commit deleting: stages 1 and 2 only.
+	const queueDeleted = makeStub([
+		[(a) => a[0] === 'ls-files', `100644 aaa 1\t${FILE}\n100644 bbb 2\t${FILE}`],
+	]);
+	resolveQueueSidePath({ git: queueDeleted, path: FILE, log: () => {} });
+	assert.ok(queueDeleted.calls.some((a) => a[0] === 'rm' && a.includes(FILE)));
+	assert.equal(
+		queueDeleted.calls.some((a) => a[0] === 'checkout'),
+		false,
+	);
+});
+
+test('rebaseResolvingMechanical with favourQueue resolves a modify/delete code stall and continues', () => {
+	const FILE = 'packages/nodes-base/nodes/Function/Function.node.ts';
+	const git = makeStub([
+		[(a) => a[0] === 'rebase' && a[1] === '--continue', ''],
+		[isRebase, fail(`CONFLICT (modify/delete): ${FILE} deleted in 0ff923a066`)],
+		[isConflictedFiles, FILE],
+		[(a) => a[0] === 'ls-files', `100644 aaa 1\t${FILE}\n100644 bbb 2\t${FILE}`],
+		[(a) => a[0] === 'diff-index', fail()], // staged deletion -> continue, not skip
+	]);
+	const pnpm = makeStub();
+
+	const res = rebaseResolvingMechanical({
+		git,
+		pnpm,
+		masterSha: MASTER,
+		favourQueue: true,
+		log: () => {},
+	});
+
+	assert.equal(res.ok, true);
+	assert.ok(git.calls.some((a) => a[0] === 'rm' && a.includes(FILE)));
+	assert.ok(git.calls.some((a) => a[0] === 'rebase' && a[1] === '--continue'));
+	// The stall carried no mechanical file, so nothing mechanical may be touched.
+	assert.equal(pnpm.calls.length, 0);
+});
+
 test('assertTreeMatches is exact by default and scoped to the allowed paths otherwise', () => {
 	assert.doesNotThrow(() => assertTreeMatches(makeStub([[() => true, MERGE_TREE]]), MERGE_TREE));
 	assert.throws(
@@ -253,6 +302,97 @@ test('assertNoMarkers is a push guard', () => {
 	assert.throws(
 		() => assertNoMarkers(makeStub([[() => true, fail('fatal: bad object')]])),
 		/Could not scan/,
+	);
+});
+
+test('reconcileWithMergeTreeAtTip folds favoured-replay drift into the tip commit, never a master commit', () => {
+	// No drift: nothing to do.
+	const clean = makeStub([[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', MERGE_TREE]]);
+	assert.deepEqual(
+		reconcileWithMergeTreeAtTip({
+			git: clean,
+			mergedTree: MERGE_TREE,
+			masterSha: MASTER,
+			log: () => {},
+		}),
+		[],
+	);
+	assert.equal(
+		clean.calls.some((a) => a[0] === 'commit'),
+		false,
+	);
+
+	// Lockfile drift: take the merge tree's blob and amend the tip.
+	const drifted = makeStub([
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', 'OTHER'],
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD', PRE_HEAD],
+		[(a) => a[0] === 'diff-tree', LOCKFILE],
+		[(a) => a[0] === 'cat-file', ''],
+	]);
+	assert.deepEqual(
+		reconcileWithMergeTreeAtTip({
+			git: drifted,
+			mergedTree: MERGE_TREE,
+			masterSha: MASTER,
+			log: () => {},
+		}),
+		[LOCKFILE],
+	);
+	assert.ok(
+		drifted.calls.some((a) => a[0] === 'checkout' && a[1] === MERGE_TREE && a.includes(LOCKFILE)),
+	);
+	assert.ok(drifted.calls.some((a) => a[0] === 'commit' && a.includes('--amend')));
+
+	// Excluded (mechanical) paths are left to their own reconciliation.
+	const excluded = makeStub([
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', 'OTHER'],
+		[(a) => a[0] === 'diff-tree', LOCKFILE],
+	]);
+	assert.deepEqual(
+		reconcileWithMergeTreeAtTip({
+			git: excluded,
+			mergedTree: MERGE_TREE,
+			masterSha: MASTER,
+			excludePaths: [LOCKFILE],
+			log: () => {},
+		}),
+		[],
+	);
+	assert.equal(
+		excluded.calls.some((a) => a[0] === 'commit'),
+		false,
+	);
+
+	// A path the merge deleted is removed, not checked out.
+	const deleted = makeStub([
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', 'OTHER'],
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD', PRE_HEAD],
+		[(a) => a[0] === 'diff-tree', 'packages/cli/gone.ts'],
+		[(a) => a[0] === 'cat-file', fail()],
+	]);
+	reconcileWithMergeTreeAtTip({
+		git: deleted,
+		mergedTree: MERGE_TREE,
+		masterSha: MASTER,
+		log: () => {},
+	});
+	assert.ok(deleted.calls.some((a) => a[0] === 'rm' && a.includes('packages/cli/gone.ts')));
+
+	// Never rewrite a master commit.
+	const atMasterTip = makeStub([
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}', 'OTHER'],
+		[(a) => a[0] === 'rev-parse' && a[1] === 'HEAD', MASTER],
+		[(a) => a[0] === 'diff-tree', LOCKFILE],
+	]);
+	assert.throws(
+		() =>
+			reconcileWithMergeTreeAtTip({
+				git: atMasterTip,
+				mergedTree: MERGE_TREE,
+				masterSha: MASTER,
+				log: () => {},
+			}),
+		/amend a master commit/,
 	);
 });
 
@@ -441,12 +581,79 @@ test('sync replays favouring 3.x when the patches no longer apply on their own',
 	);
 });
 
+test('sync recovers when the favoured replay stalls on a modify/delete conflict', async () => {
+	// The endpoints reconcile (merge-tree is clean) because a fix commit in the queue
+	// re-deletes the file — but replaying the deleting commit itself stalls on
+	// modify/delete, which `-X theirs` never settles on its own.
+	const FILE = 'packages/nodes-base/nodes/Function/Function.node.ts';
+	const git = makeStub([
+		...baseGitRoutes,
+		[(a) => a[0] === 'rebase' && a[1] === '--continue', ''],
+		[isRebase, fail(`CONFLICT (modify/delete): ${FILE} deleted in 0ff923a066`)],
+		[isConflictedFiles, FILE],
+		[(a) => a[0] === 'ls-files', `100644 aaa 1\t${FILE}\n100644 bbb 2\t${FILE}`],
+		[(a) => a[0] === 'diff-index', fail()],
+	]);
+	const gh = makeStub(noOpenPr);
+
+	await sync({ git, gh, pnpm: makeStub(), env, log: () => {} });
+
+	assert.ok(
+		git.calls.some((a) => a[0] === 'rm' && a.includes(FILE)),
+		'expected the queue-side deletion to be taken',
+	);
+	assert.ok(
+		git.calls.some((a) => a[0] === 'push'),
+		'expected the replay to be pushed',
+	);
+	// Still no new commit and no PR — the fix commit in the queue does the real work.
+	assert.equal(
+		git.calls.some((a) => a[0] === 'commit'),
+		false,
+	);
+	assert.equal(
+		gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'),
+		false,
+	);
+});
+
+test('sync folds favoured-replay drift back to the merge tree before pushing', async () => {
+	// The favoured replay finishes but its tip drifts from the merge tree (the lockfile
+	// hunks `-X theirs` resolved toward 3.x): the drift is folded back, then pushed.
+	let treeReads = 0;
+	const git = makeStub([
+		...baseGitRoutes.filter((r) => !r[0](['rev-parse', 'HEAD^{tree}'])),
+		[
+			(a) => a[0] === 'rev-parse' && a[1] === 'HEAD^{tree}',
+			() => (treeReads++ === 0 ? 'DRIFTED' : MERGE_TREE),
+		],
+		[(a) => a[0] === 'diff-tree', LOCKFILE],
+		[(a) => a[0] === 'cat-file', ''],
+		[favouringOwnSide, ''],
+		[isRebase, fail('CONFLICT (content): packages/cli/x.ts')],
+	]);
+	const gh = makeStub(noOpenPr);
+
+	await sync({ git, gh, pnpm: makeStub(), env, log: () => {} });
+
+	assert.ok(git.calls.some((a) => a[0] === 'checkout' && a[1] === MERGE_TREE));
+	assert.ok(git.calls.some((a) => a[0] === 'commit' && a.includes('--amend')));
+	assert.ok(
+		git.calls.some((a) => a[0] === 'push'),
+		'expected the reconciled replay to be pushed',
+	);
+	assert.equal(
+		gh.calls.some((a) => a[0] === 'pr' && a[1] === 'create'),
+		false,
+	);
+});
+
 test('sync fails without pushing when even the favoured replay cannot finish', async () => {
 	const git = makeStub([
 		...baseGitRoutes,
-		[isRebase, fail('CONFLICT')],
-		// The favoured replay stalls on a real code file, so the driver must not resolve it.
-		[isConflictedFiles, 'packages/cli/x.ts'],
+		[isRebase, fail('rebase failed for a non-conflict reason')],
+		// No conflicted files: nothing the driver may resolve — don't guess.
+		[isConflictedFiles, ''],
 	]);
 	const gh = makeStub(noOpenPr);
 

--- a/.github/workflows/util-sync-master-to-3x.yml
+++ b/.github/workflows/util-sync-master-to-3x.yml
@@ -5,7 +5,9 @@
 # true by REPLAYING the 3.x-only commits onto master and force-pushing 3.x — so a clean
 # sync adds no commit at all, and every replayed commit is kept as-is (nothing squashed,
 # authors preserved). The content pushed is always verified to be exactly what a merge of
-# 3.x and master would produce.
+# 3.x and master would produce. Per-commit stalls the replay cannot settle with a strategy
+# option alone (e.g. modify/delete) are resolved toward 3.x's side, under that same
+# verification.
 #
 # Conflicts confined to mechanical, tool-generated files (the pnpm lockfile, bot-maintained
 # data files) are resolved in place during the replay — no PR, no commit, no human. When


### PR DESCRIPTION
## Summary

The favoured (`-X theirs`) replay pass could still wedge in two ways the tree guard would never let a human fix:

- modify/delete stalls: strategy options never settle them, so a breaking commit deleting a file master modified stalled the rebase on a code path and failed the run — permanently, since every future replay hits the same commit.
- silent hunk drift: `-X theirs` resolves overlapping hunks toward the queue side without stalling, dropping master-side changes (typically pnpm-lock.yaml hunks) that no fix commit in the queue reasserts; the final tree then differs from the merge tree and the guard refuses.

On the favoured passes only, resolve stalled paths with the queue commit's side (its deletion when there is no stage 3), and afterwards fold any residual deviation from the proven merge tree into the tip commit — mirroring the existing lockfile reconciliation. Both remain covered by the tree guard: the pushed content must still be exactly the tree a merge of 3.x and master produces.

Rehearsed against the live refs: the replay now reproduces the merge tree byte-for-byte and yields a linear 3.x with every commit and author preserved.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

