### PR TITLE
feat(core): Enable structured outputs for OpenAI-compatible providers (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -7,6 +7,8 @@ type ProviderOpts = {
 	baseURL?: string;
 	fetch?: typeof globalThis.fetch;
 	headers?: Record<string, string>;
+	includeUsage?: boolean;
+	supportsStructuredOutputs?: boolean;
 };
 
 // All providers are mocked via vi.mock so require() inside the registry entries
@@ -162,6 +164,8 @@ vi.mock('@ai-sdk/openai-compatible', () => ({
 		baseURL: opts.baseURL,
 		headers: opts.headers,
 		fetch: opts.fetch,
+		includeUsage: opts.includeUsage,
+		supportsStructuredOutputs: opts.supportsStructuredOutputs,
 		specificationVersion: 'v3',
 	}),
 }));
@@ -370,6 +374,7 @@ describe('createModel', () => {
 			expect(model.modelId).toBe('nvidia/llama-3.3-nemotron-super-49b-v1');
 			expect(model.apiKey).toBe('nv-test');
 			expect(model.baseURL).toBe('https://integrate.api.nvidia.com/v1');
+			expect(model.supportsStructuredOutputs).toBe(true);
 		});
 	});
 

--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -374,7 +374,7 @@ describe('createModel', () => {
 			expect(model.modelId).toBe('nvidia/llama-3.3-nemotron-super-49b-v1');
 			expect(model.apiKey).toBe('nv-test');
 			expect(model.baseURL).toBe('https://integrate.api.nvidia.com/v1');
-			expect(model.supportsStructuredOutputs).toBe(true);
+			expect(model.supportsStructuredOutputs).toBe(false);
 		});
 	});
 

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -96,7 +96,7 @@ function buildOpenAiCompatible(
 		headers: creds.headers,
 		fetch,
 		includeUsage: options?.includeUsage ?? true,
-		supportsStructuredOutputs: options?.supportsStructuredOutputs ?? true,
+		supportsStructuredOutputs: options?.supportsStructuredOutputs ?? false,
 	})(model);
 }
 

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -133,10 +133,7 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 		},
 	},
 	custom: {
-		build: (creds, model, fetch) =>
-			// Without includeUsage/supportsStructuredOutputs the SDK drops JSON
-			// schemas and sends json_object only.
-			buildOpenAiCompatible('custom', undefined, creds, model, fetch),
+		build: (creds, model, fetch) => buildOpenAiCompatible('custom', undefined, creds, model, fetch),
 	},
 	anthropic: {
 		build: (creds, model, fetch) => {

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -65,6 +65,53 @@ type ProviderRegistry = {
 	[P in ProviderId]: RegistryEntry<P>;
 };
 
+type OpenAiCompatibleCreds = {
+	apiKey?: string;
+	baseURL?: string;
+	headers?: Record<string, string>;
+};
+
+/**
+ * Shared builder for OpenAI-compatible HTTP providers. Prefer this over
+ * `@ai-sdk/<provider>` packages that pull optional NAPI binaries or v4-only types.
+ */
+function buildOpenAiCompatible(
+	name: string,
+	defaultBaseURL: string | undefined,
+	creds: OpenAiCompatibleCreds,
+	model: string,
+	fetch: FetchFn | undefined,
+	options?: { includeUsage?: boolean; supportsStructuredOutputs?: boolean },
+): LanguageModel {
+	const { createOpenAICompatible } =
+		require('@ai-sdk/openai-compatible') as typeof import('@ai-sdk/openai-compatible');
+	const baseURL = creds.baseURL ?? defaultBaseURL;
+	if (!baseURL) {
+		throw new Error(`baseURL is required for OpenAI-compatible provider "${name}"`);
+	}
+	return createOpenAICompatible({
+		name,
+		baseURL,
+		apiKey: creds.apiKey,
+		headers: creds.headers,
+		fetch,
+		includeUsage: options?.includeUsage ?? true,
+		supportsStructuredOutputs: options?.supportsStructuredOutputs ?? true,
+	})(model);
+}
+
+type OpenAiCompatibleProviderId = 'nvidia';
+
+function openAiCompatibleEntry<P extends OpenAiCompatibleProviderId>(
+	name: P,
+	defaultBaseURL: string,
+): RegistryEntry<P> {
+	return {
+		build: (creds, model, fetch) =>
+			buildOpenAiCompatible(name, defaultBaseURL, creds, model, fetch),
+	};
+}
+
 /**
  * Registry of language model providers.
  * Each entry maps a provider id to a builder that loads its @ai-sdk/* package
@@ -86,17 +133,10 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 		},
 	},
 	custom: {
-		build: (creds, model, fetch) => {
-			const { createOpenAICompatible } =
-				require('@ai-sdk/openai-compatible') as typeof import('@ai-sdk/openai-compatible');
-			return createOpenAICompatible({
-				name: 'custom',
-				baseURL: creds.baseURL,
-				apiKey: creds.apiKey,
-				headers: creds.headers,
-				fetch,
-			})(model);
-		},
+		build: (creds, model, fetch) =>
+			// Without includeUsage/supportsStructuredOutputs the SDK drops JSON
+			// schemas and sends json_object only.
+			buildOpenAiCompatible('custom', undefined, creds, model, fetch),
 	},
 	anthropic: {
 		build: (creds, model, fetch) => {
@@ -165,19 +205,7 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 			return createOpenRouter({ apiKey: creds.apiKey, baseURL: creds.baseURL, fetch })(model);
 		},
 	},
-	nvidia: {
-		build: (creds, model, fetch) => {
-			const { createOpenAICompatible } =
-				require('@ai-sdk/openai-compatible') as typeof import('@ai-sdk/openai-compatible');
-			return createOpenAICompatible({
-				name: 'nvidia',
-				baseURL: creds.baseURL ?? 'https://integrate.api.nvidia.com/v1',
-				apiKey: creds.apiKey,
-				headers: creds.headers,
-				fetch,
-			})(model);
-		},
-	},
+	nvidia: openAiCompatibleEntry('nvidia', 'https://integrate.api.nvidia.com/v1'),
 	'azure-openai': {
 		build: (creds, model, fetch) => {
 			const { createAzure } = require('@ai-sdk/azure') as typeof import('@ai-sdk/azure');


### PR DESCRIPTION
## Summary

Enable structured outputs (and stream usage) for OpenAI-compatible agent providers (`custom/*`, `nvidia/*`).

Without `supportsStructuredOutputs`, `@ai-sdk/openai-compatible` drops JSON schemas and falls back to `json_object`, which breaks schema-constrained agent / Instance AI output.

This PR extracts that fix from the INS-983 workstream into a focused change:
- Shared `buildOpenAiCompatible` helper defaults `supportsStructuredOutputs` and `includeUsage` to `true`
- `custom` and `nvidia` providers route through that helper
- Unit coverage asserts the structured-outputs flag is set

## How to test

1. From `packages/@n8n/agents`, run:
   `pnpm test src/runtime/__tests__/model-factory.test.ts`
2. Optionally configure a `custom/*` model with `structuredOutput` and confirm the request uses a JSON schema rather than `json_object` mode

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2718
Related: https://linear.app/n8n/issue/INS-983

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

