### PR TITLE
fix(editor): Name the AI Assistant browser tab after the conversation

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useDocumentTitle.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDocumentTitle.test.ts
@@ -1,7 +1,8 @@
 import { mock } from 'vitest-mock-extended';
 import { describe, it, expect } from 'vitest';
+import { effectScope } from 'vue';
 import type { FrontendSettings } from '@n8n/api-types';
-import { useDocumentTitle } from './useDocumentTitle';
+import { claimDocumentTitle, useDocumentTitle } from './useDocumentTitle';
 
 const settings = mock<FrontendSettings>({ releaseChannel: 'stable' });
 vi.mock('@n8n/stores/settings.store', () => ({
@@ -108,6 +109,50 @@ describe('useDocumentTitle', () => {
 
 			reset();
 			expect(getDocumentState()).toBeUndefined();
+		});
+	});
+
+	describe('claimDocumentTitle', () => {
+		beforeEach(() => {
+			settings.releaseChannel = 'stable';
+		});
+
+		it('should ignore workflow title updates while a host owns the title', () => {
+			const scope = effectScope();
+			scope.run(() => claimDocumentTitle());
+
+			const { set, setDocumentTitle } = useDocumentTitle();
+			set('My conversation');
+			setDocumentTitle('My Workflow', 'IDLE');
+
+			expect(document.title).toBe('My conversation - n8n');
+			scope.stop();
+		});
+
+		it('should apply workflow title updates again once the host releases the title', () => {
+			const scope = effectScope();
+			scope.run(() => claimDocumentTitle());
+			scope.stop();
+
+			useDocumentTitle().setDocumentTitle('My Workflow', 'IDLE');
+
+			expect(document.title).toBe('▶️ My Workflow - n8n');
+		});
+
+		it('should keep the title owned while a second host instance still holds it', () => {
+			// A transient remount claims from the new instance before the old one disposes
+			const outgoing = effectScope();
+			outgoing.run(() => claimDocumentTitle());
+			const incoming = effectScope();
+			incoming.run(() => claimDocumentTitle());
+			outgoing.stop();
+
+			const { set, setDocumentTitle } = useDocumentTitle();
+			set('My conversation');
+			setDocumentTitle('My Workflow', 'IDLE');
+
+			expect(document.title).toBe('My conversation - n8n');
+			incoming.stop();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useDocumentTitle.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useDocumentTitle.ts
@@ -3,12 +3,33 @@ import {
 	type WorkflowTitleStatus,
 } from '@n8n/composables/useDocumentTitle';
 import { useSettingsStore } from '@n8n/stores/settings.store';
-import type { Ref } from 'vue';
+import { onScopeDispose, ref, type Ref } from 'vue';
 
 export type { WorkflowTitleStatus };
+
+// Hosts that embed a workflow canvas but name the tab after something else
+// (Instance AI names it after the conversation, not the previewed workflow)
+// claim the title while mounted, which turns `setDocumentTitle` into a no-op —
+// the workflow-flavoured setter the canvas and its execution handlers call.
+// Counted, not a boolean: a transient remount claims from the new instance
+// before the outgoing one disposes.
+const titleClaims = ref(0);
+
+export function claimDocumentTitle() {
+	titleClaims.value++;
+	onScopeDispose(() => titleClaims.value--);
+}
 
 export function useDocumentTitle(windowRef?: Ref<Window | undefined>) {
 	const settingsStore = useSettingsStore();
 	const { releaseChannel } = settingsStore.settings;
-	return useDocumentTitleBase({ releaseChannel, windowRef });
+	const base = useDocumentTitleBase({ releaseChannel, windowRef });
+
+	return {
+		...base,
+		setDocumentTitle: (workflowName: string, status: WorkflowTitleStatus) => {
+			if (titleClaims.value > 0) return;
+			base.setDocumentTitle(workflowName, status);
+		},
+	};
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -10,6 +10,7 @@ import { useChatInputAutoFocus } from '@n8n/design-system';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useToast } from '@n8n/composables/useToast';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
+import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 import { getExperimentTelemetryPayload } from '@/experiments/utils';
 import {
@@ -122,6 +123,9 @@ const rootStore = useRootStore();
 const toast = useToast();
 const telemetry = useTelemetry();
 const i18n = useI18n();
+// Opening a new conversation drops the tab title of the thread we came from —
+// this view mounts on every entry to the empty route, the parent layout doesn't.
+useDocumentTitle().set(i18n.baseText('instanceAi.view.title'));
 const { goToUpgrade } = usePageRedirectionHelper();
 const creditBanner = useCreditWarningBanner(isLowCredits);
 const { isFeatureEnabled: isProactiveAgentExperimentEnabled } =

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -29,6 +29,7 @@ import type {
 	InstanceAiHandoffContext,
 } from '@n8n/api-types';
 import { useRootStore } from '@n8n/stores/useRootStore';
+import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 import { COLLAPSED_MAIN_SIDEBAR_WIDTH, useSidebarLayout } from '@/app/composables/useSidebarLayout';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
@@ -244,6 +245,15 @@ const currentThreadTitle = computed<string | undefined>(() => {
 	}
 	return undefined;
 });
+
+// The tab names the conversation, not the workflow previewed inside it — the
+// parent view claims the title so the embedded canvas can't overwrite this.
+const documentTitle = useDocumentTitle();
+watch(
+	currentThreadTitle,
+	(title) => documentTitle.set(title ?? i18n.baseText('instanceAi.view.title')),
+	{ immediate: true },
+);
 
 // --- Canvas / data table preview ---
 const preview = useCanvasPreview({

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -5,7 +5,7 @@ import { N8nResizeWrapper } from '@n8n/design-system';
 import { useEventListener, useSessionStorage } from '@vueuse/core';
 import { useI18n } from '@n8n/i18n';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
-import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
+import { claimDocumentTitle, useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useTelemetry } from '@n8n/composables/useTelemetry';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -61,6 +61,10 @@ watch(setupCompletionState, (setupCompleted) => {
 	}
 });
 
+// The tab is named after the conversation, by whichever inner view is mounted
+// (thread → its title, empty → the default below). Claiming the title keeps the
+// workflow canvas embedded in a thread from renaming the tab after its workflow.
+claimDocumentTitle();
 documentTitle.set(i18n.baseText('instanceAi.view.title'));
 
 // --- Sidebar collapse & resize ---

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
@@ -83,6 +83,7 @@ const {
 	},
 	appSettingsStoreMock: {
 		isCloudDeployment: false,
+		settings: { releaseChannel: 'stable' },
 	},
 	promptSuggestionsV2: Array.from({ length: 12 }, (_, index) => ({
 		type: 'prompt',
@@ -459,6 +460,14 @@ describe('InstanceAiEmptyView', () => {
 		vi.useRealTimers();
 		vi.clearAllMocks();
 		vi.unstubAllGlobals();
+	});
+
+	it('resets the browser tab title left behind by the previous thread', () => {
+		document.title = 'Previous thread - n8n';
+
+		renderView();
+
+		expect(document.title).toBe('AI Assistant - n8n');
 	});
 
 	it('passes the fixed suggestions to the empty-state composer', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -11,6 +11,7 @@ import type { PlanEditContext } from '../instanceAi.threadRuntime';
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { SidebarStateKey } from '../instanceAiLayout';
+import { NEW_CONVERSATION_TITLE } from '../constants';
 import type { WorkflowFailuresReport } from '../components/InstanceAiWorkflowPreview.vue';
 import type {
 	FrontendModuleSettings,
@@ -426,6 +427,33 @@ describe('InstanceAiThreadView', () => {
 	it('does not pass suggestions to its composer', () => {
 		const { getByTestId } = renderView({ props: { threadId: 'thread-1' } });
 		expect(getByTestId('instance-ai-input-stub')).toHaveTextContent('unset');
+	});
+
+	describe('browser tab title', () => {
+		it('names the tab after the thread it opens', () => {
+			renderView({ props: { threadId: 'thread-1' } });
+			expect(document.title).toBe('Test thread - n8n');
+		});
+
+		it('falls back to the feature title for a thread without a title', () => {
+			store.threads = [
+				{ ...store.threads[0], title: NEW_CONVERSATION_TITLE },
+			] as typeof store.threads;
+
+			renderView({ props: { threadId: 'thread-1' } });
+
+			expect(document.title).toBe('AI Assistant - n8n');
+		});
+
+		it('renames the tab when the thread gets a title', async () => {
+			renderView({ props: { threadId: 'thread-1' } });
+
+			store.threads = [{ ...store.threads[0], title: 'Renamed thread' }] as typeof store.threads;
+
+			await vi.waitFor(() => {
+				expect(document.title).toBe('Renamed thread - n8n');
+			});
+		});
 	});
 
 	it('reconnects on same-thread re-entry when SSE is disconnected', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
@@ -7,6 +7,7 @@ import { useInstanceAiSettingsStore } from '../instanceAiSettings.store';
 import { INSTANCE_AI_VIEW } from '../constants';
 import { useSettingsStore } from '@n8n/stores/settings.store';
 import { hasPermission } from '@/app/utils/rbac/permissions';
+import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 
 const TEST_INSTANCE_ID = 'test-instance-id';
 
@@ -74,6 +75,20 @@ describe('InstanceAiView', () => {
 		routerHistoryState.back = null;
 		routeState.name = INSTANCE_AI_VIEW;
 		sessionStorage.clear();
+	});
+
+	it('keeps the tab title off the workflow previewed inside a thread', () => {
+		const { unmount } = renderView({ pinia });
+		const { set, setDocumentTitle } = useDocumentTitle();
+		set('My conversation');
+
+		setDocumentTitle('Previewed workflow', 'IDLE');
+		expect(document.title).toBe('My conversation - n8n');
+
+		// Leaving the feature hands the tab title back to the workflow editor
+		unmount();
+		setDocumentTitle('Previewed workflow', 'IDLE');
+		expect(document.title).toBe('▶️ Previewed workflow - n8n');
 	});
 
 	it('opens a new thread with Ctrl/Cmd+Shift+O', () => {


### PR DESCRIPTION
## Summary

The AI Assistant browser tab title never followed the conversation:

- `InstanceAiView.vue` (the persistent layout) set the title once in `setup()`. Route changes between threads only remount the keyed inner view, so it never re-ran — the tab kept the title from first entry.
- Worse, the workflow canvas embedded in a thread renamed the tab after the workflow it previewed: `useWorkflowInitialization` sets the document title on load, and `useRunWorkflow` / the `executionFinished` push handlers set it on every run. All are route-agnostic, so they won over whatever the assistant had set.

https://github.com/user-attachments/assets/f87ae63b-d97d-47f7-b2a0-d89f756a36ba


Now each inner view owns the tab title — the thread view names it after the thread (reactively, so it also follows auto-renames), the empty view resets it to the default. The layout claims the title via a new `claimDocumentTitle()`, which turns the workflow-flavoured `setDocumentTitle()` into a no-op while a conversation is open, so the embedded canvas can't rename the tab. The claim is released when the user leaves the feature, handing the title back to the workflow editor. It's counted rather than a boolean because a transient remount claims from the new instance before the outgoing one disposes.

## How to test

1. Open the AI Assistant and start two conversations with different titles.
2. Switch between them in the sidebar — the browser tab title follows the conversation each time.
3. Start a new conversation — the tab title resets to `AI Assistant`.
4. In a conversation where the agent built a workflow, open the workflow preview and run it — the tab keeps naming the conversation instead of switching to the workflow name / `▶️` status.
5. Navigate out to a workflow in the editor — the tab titles the workflow with its execution status as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-890

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

