### PR TITLE
refactor(core): Tighten the data table row read scope check and its tests

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-table-proxy.service.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-proxy.service.integration.test.ts
@@ -599,6 +599,73 @@ describe('makeDataTableOperationsForUser', () => {
 		});
 	});
 
+	describe('dataTable:readRow scope on row-returning writes', () => {
+		// grants the `dataTable:writeRow` check and denies the `dataTable:readRow`
+		// one that follows it
+		const denyReadRow = () => {
+			userHasScopesSpy.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+		};
+
+		const updateOptions = {
+			filter: {
+				filters: [{ columnName: 'x', condition: 'eq' as const, value: 'y' }],
+				type: 'and' as const,
+			},
+			data: { x: 'z' },
+		};
+
+		it('should require dataTable:readRow for updateRows', async () => {
+			const ops = dataTableProxyService.makeDataTableOperationsForUser(user);
+
+			await ops.updateRows('dt-1', PROJECT_ID, updateOptions);
+
+			expect(userHasScopesSpy).toHaveBeenCalledWith(user, ['dataTable:readRow'], false, {
+				projectId: PROJECT_ID,
+			});
+		});
+
+		it('should reject updateRows when user lacks dataTable:readRow', async () => {
+			denyReadRow();
+			const ops = dataTableProxyService.makeDataTableOperationsForUser(user);
+
+			await expect(ops.updateRows('dt-1', PROJECT_ID, updateOptions)).rejects.toThrow(
+				"User does not have 'dataTable:readRow' access on project",
+			);
+
+			expect(dataTableServiceMock.updateRows).not.toHaveBeenCalled();
+		});
+
+		it('should require dataTable:readRow for deleteRows', async () => {
+			const ops = dataTableProxyService.makeDataTableOperationsForUser(user);
+
+			await ops.deleteRows('dt-1', PROJECT_ID, { filter: updateOptions.filter });
+
+			expect(userHasScopesSpy).toHaveBeenCalledWith(user, ['dataTable:readRow'], false, {
+				projectId: PROJECT_ID,
+			});
+		});
+
+		it('should reject deleteRows when user lacks dataTable:readRow', async () => {
+			denyReadRow();
+			const ops = dataTableProxyService.makeDataTableOperationsForUser(user);
+
+			await expect(
+				ops.deleteRows('dt-1', PROJECT_ID, { filter: updateOptions.filter }),
+			).rejects.toThrow("User does not have 'dataTable:readRow' access on project");
+
+			expect(dataTableServiceMock.deleteRows).not.toHaveBeenCalled();
+		});
+
+		it('should not require dataTable:readRow for insertRows', async () => {
+			denyReadRow();
+			const ops = dataTableProxyService.makeDataTableOperationsForUser(user);
+
+			await ops.insertRows('dt-1', PROJECT_ID, [{ name: 'test' }], 'count');
+
+			expect(dataTableServiceMock.insertRows).toHaveBeenCalled();
+		});
+	});
+
 	describe('read-only instance protection', () => {
 		beforeEach(() => {
 			sourceControlPreferencesServiceMock.getPreferences.mockReturnValue({

--- a/packages/cli/src/modules/data-table/__tests__/data-table.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table.controller.integration.test.ts
@@ -4370,34 +4370,44 @@ describe('row-content authorization on write endpoints', () => {
 	};
 
 	let project: Project;
+	let otherProject: Project;
+	let readWriteUser: User;
+	let writeOnlyRoleSlug: string;
 	let writerAgent: SuperAgentTest;
 	let readWriterAgent: SuperAgentTest;
 
-	const createSensitiveTable = async () => {
-		const dataTable = await createDataTable(project, {
+	const createSensitiveTable = async (owningProject: Project = project) =>
+		await createDataTable(owningProject, {
 			name: 'Sensitive Table',
 			columns: [{ name: 'secret', type: 'string' }],
+			data: [{ secret: SECRET }],
 		});
-		const columns = await dataTableColumnRepository.getColumns(dataTable.id);
-		await dataTableRowsRepository.insertRows(dataTable.id, [{ secret: SECRET }], columns, 'id');
-		return dataTable;
+
+	const readSecrets = async (dataTableId: string) => {
+		const response = await readWriterAgent
+			.get(`/projects/${project.id}/data-tables/${dataTableId}/rows`)
+			.expect(200);
+
+		return (response.body.data.data as DataTableRow[]).map((row) => row.secret);
 	};
 
 	beforeAll(async () => {
 		project = await createTeamProject('row authorization project', owner);
+		otherProject = await createTeamProject('other row authorization project', owner);
 
 		const writeOnlyRole = await createCustomRoleWithScopeSlugs(['dataTable:writeRow'], {
 			roleType: 'project',
 		});
+		writeOnlyRoleSlug = writeOnlyRole.slug;
 		const writeOnlyUser = await createMember();
-		await linkUserToProject(writeOnlyUser, project, writeOnlyRole.slug);
+		await linkUserToProject(writeOnlyUser, project, writeOnlyRoleSlug);
 		writerAgent = testServer.authAgentFor(writeOnlyUser);
 
 		const readWriteRole = await createCustomRoleWithScopeSlugs(
 			['dataTable:writeRow', 'dataTable:readRow'],
 			{ roleType: 'project' },
 		);
-		const readWriteUser = await createMember();
+		readWriteUser = await createMember();
 		await linkUserToProject(readWriteUser, project, readWriteRole.slug);
 		readWriterAgent = testServer.authAgentFor(readWriteUser);
 	});
@@ -4415,10 +4425,13 @@ describe('row-content authorization on write endpoints', () => {
 		test('rejects returnData without dataTable:readRow scope', async () => {
 			const dataTable = await createSensitiveTable();
 
-			await writerAgent
+			const response = await writerAgent
 				.patch(`/projects/${project.id}/data-tables/${dataTable.id}/rows`)
 				.send({ filter: MATCH_ALL_FILTER, data: { secret: 'overwritten' }, returnData: true })
 				.expect(403);
+
+			expect(JSON.stringify(response.body)).not.toContain(SECRET);
+			expect(await readSecrets(dataTable.id)).toEqual([SECRET]);
 		});
 
 		test('allows a plain update without dataTable:readRow scope', async () => {
@@ -4428,6 +4441,8 @@ describe('row-content authorization on write endpoints', () => {
 				.patch(`/projects/${project.id}/data-tables/${dataTable.id}/rows`)
 				.send({ filter: MATCH_ALL_FILTER, data: { secret: 'overwritten' } })
 				.expect(200);
+
+			expect(await readSecrets(dataTable.id)).toEqual(['overwritten']);
 		});
 
 		test('returns row contents with dataTable:readRow scope', async () => {
@@ -4438,7 +4453,10 @@ describe('row-content authorization on write endpoints', () => {
 				.send({ filter: MATCH_ALL_FILTER, data: { secret: 'overwritten' }, dryRun: true })
 				.expect(200);
 
-			expect(JSON.stringify(response.body)).toContain(SECRET);
+			expect(response.body.data).toMatchObject([
+				{ secret: SECRET, dryRunState: 'before' },
+				{ secret: 'overwritten', dryRunState: 'after' },
+			]);
 		});
 	});
 
@@ -4455,10 +4473,12 @@ describe('row-content authorization on write endpoints', () => {
 		test('rejects returnData without dataTable:readRow scope', async () => {
 			const dataTable = await createSensitiveTable();
 
-			await writerAgent
+			const response = await writerAgent
 				.post(`/projects/${project.id}/data-tables/${dataTable.id}/upsert`)
 				.send({ filter: MATCH_ALL_FILTER, data: { secret: 'overwritten' }, returnData: true })
 				.expect(403);
+
+			expect(JSON.stringify(response.body)).not.toContain(SECRET);
 		});
 
 		test('allows a plain upsert without dataTable:readRow scope', async () => {
@@ -4468,6 +4488,22 @@ describe('row-content authorization on write endpoints', () => {
 				.post(`/projects/${project.id}/data-tables/${dataTable.id}/upsert`)
 				.send({ filter: MATCH_ALL_FILTER, data: { secret: 'overwritten' } })
 				.expect(200);
+
+			expect(await readSecrets(dataTable.id)).toEqual(['overwritten']);
+		});
+
+		test('returns row contents with dataTable:readRow scope', async () => {
+			const dataTable = await createSensitiveTable();
+
+			const response = await readWriterAgent
+				.post(`/projects/${project.id}/data-tables/${dataTable.id}/upsert`)
+				.send({ filter: MATCH_ALL_FILTER, data: { secret: 'overwritten' }, dryRun: true })
+				.expect(200);
+
+			expect(response.body.data).toMatchObject([
+				{ secret: SECRET, dryRunState: 'before' },
+				{ secret: 'overwritten', dryRunState: 'after' },
+			]);
 		});
 	});
 
@@ -4475,10 +4511,13 @@ describe('row-content authorization on write endpoints', () => {
 		test('rejects returnData without dataTable:readRow scope', async () => {
 			const dataTable = await createSensitiveTable();
 
-			await writerAgent
+			const response = await writerAgent
 				.delete(`/projects/${project.id}/data-tables/${dataTable.id}/rows`)
 				.query({ filter: JSON.stringify(MATCH_ALL_FILTER), returnData: 'true' })
 				.expect(403);
+
+			expect(JSON.stringify(response.body)).not.toContain(SECRET);
+			expect(await readSecrets(dataTable.id)).toEqual([SECRET]);
 		});
 
 		test('allows a plain delete without dataTable:readRow scope', async () => {
@@ -4488,6 +4527,8 @@ describe('row-content authorization on write endpoints', () => {
 				.delete(`/projects/${project.id}/data-tables/${dataTable.id}/rows`)
 				.query({ filter: JSON.stringify(MATCH_ALL_FILTER) })
 				.expect(200);
+
+			expect(await readSecrets(dataTable.id)).toEqual([]);
 		});
 
 		test('returns row contents with dataTable:readRow scope', async () => {
@@ -4498,10 +4539,25 @@ describe('row-content authorization on write endpoints', () => {
 				.query({ filter: JSON.stringify(MATCH_ALL_FILTER), returnData: 'true' })
 				.expect(200);
 
-			expect(JSON.stringify(response.body)).toContain(SECRET);
+			expect(response.body.data).toMatchObject([{ secret: SECRET }]);
+		});
+	});
+
+	describe('cross-project targeting', () => {
+		test('does not accept dataTable:readRow held on the project in the URL', async () => {
+			await linkUserToProject(readWriteUser, otherProject, writeOnlyRoleSlug);
+			const dataTable = await createSensitiveTable(otherProject);
+
+			const response = await readWriterAgent
+				.patch(`/projects/${project.id}/data-tables/${dataTable.id}/rows`)
+				.send({ filter: MATCH_ALL_FILTER, data: { secret: 'overwritten' }, dryRun: true })
+				.expect(403);
+
+			expect(JSON.stringify(response.body)).not.toContain(SECRET);
 		});
 	});
 });
+
 describe('Source Control read-only mode', () => {
 	let sourceControlPreferencesService: SourceControlPreferencesService;
 	let testDataTable: DataTable;

--- a/packages/cli/src/modules/data-table/data-table-permissions.ts
+++ b/packages/cli/src/modules/data-table/data-table-permissions.ts
@@ -4,11 +4,19 @@ import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
-export async function assertRowReadAccess(
+/**
+ * The flag pair mirrors `shouldReturnData` in `DataTableRowsRepository`: a dry run
+ * returns rows whether or not `returnData` was asked for. Keyed on the data table
+ * so the check resolves the same project the `dataTable:writeRow` guard resolved.
+ */
+export async function assertRowReadAccessIfReturningRows(
 	user: User,
-	params: { projectId?: string; dataTableId?: string },
+	dataTableId: string,
+	{ dryRun, returnData }: { dryRun?: boolean; returnData?: boolean },
 ): Promise<void> {
-	if (!(await userHasScopes(user, ['dataTable:readRow'], false, params))) {
+	if (!dryRun && !returnData) return;
+
+	if (!(await userHasScopes(user, ['dataTable:readRow'], false, { dataTableId }))) {
 		throw new ForbiddenError(RESPONSE_ERROR_MESSAGES.MISSING_SCOPE);
 	}
 }

--- a/packages/cli/src/modules/data-table/data-table.controller.ts
+++ b/packages/cli/src/modules/data-table/data-table.controller.ts
@@ -38,7 +38,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { ProjectService } from '@/services/project.service.ee';
 
-import { assertRowReadAccess } from './data-table-permissions';
+import { assertRowReadAccessIfReturningRows } from './data-table-permissions';
 import { DataTableService } from './data-table.service';
 import { DataTableColumnNameConflictError } from './errors/data-table-column-name-conflict.error';
 import { FileUploadError } from './errors/data-table-file-upload.error';
@@ -417,9 +417,7 @@ export class DataTableController {
 		@Body dto: UpsertDataTableRowDto,
 	) {
 		this.checkInstanceWriteAccess();
-		if (dto.dryRun || dto.returnData) {
-			await assertRowReadAccess(req.user, req.params);
-		}
+		await assertRowReadAccessIfReturningRows(req.user, dataTableId, dto);
 		try {
 			// because of strict overloads, we need separate paths
 			const dryRun = dto.dryRun;
@@ -473,9 +471,7 @@ export class DataTableController {
 		@Body dto: UpdateDataTableRowDto,
 	) {
 		this.checkInstanceWriteAccess();
-		if (dto.dryRun || dto.returnData) {
-			await assertRowReadAccess(req.user, req.params);
-		}
+		await assertRowReadAccessIfReturningRows(req.user, dataTableId, dto);
 		try {
 			// because of strict overloads, we need separate paths
 			const dryRun = dto.dryRun;
@@ -529,9 +525,7 @@ export class DataTableController {
 		@Query dto: DeleteDataTableRowsDto,
 	) {
 		this.checkInstanceWriteAccess();
-		if (dto.dryRun || dto.returnData) {
-			await assertRowReadAccess(req.user, req.params);
-		}
+		await assertRowReadAccessIfReturningRows(req.user, dataTableId, dto);
 		try {
 			return await this.dataTableService.deleteRows(
 				dataTableId,

--- a/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/data-tables.rows.handler.ts
@@ -9,7 +9,7 @@ import { Container } from '@n8n/di';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { assertRowReadAccess } from '@/modules/data-table/data-table-permissions';
+import { assertRowReadAccessIfReturningRows } from '@/modules/data-table/data-table-permissions';
 import { DataTableService } from '@/modules/data-table/data-table.service';
 import { DataTableNotFoundError } from '@/modules/data-table/errors/data-table-not-found.error';
 import { DataTableValidationError } from '@/modules/data-table/errors/data-table-validation.error';
@@ -149,9 +149,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 				const { filter, data, returnData = false, dryRun = false } = payload.data;
 				const params = { filter, data };
 
-				if (dryRun || returnData) {
-					await assertRowReadAccess(req.user, { dataTableId });
-				}
+				await assertRowReadAccessIfReturningRows(req.user, dataTableId, { dryRun, returnData });
 
 				const result = dryRun
 					? await service.updateRows(dataTableId, projectId, params, returnData, true)
@@ -184,9 +182,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 				const { filter, data, returnData = false, dryRun = false } = payload.data;
 				const params = { filter, data };
 
-				if (dryRun || returnData) {
-					await assertRowReadAccess(req.user, { dataTableId });
-				}
+				await assertRowReadAccessIfReturningRows(req.user, dataTableId, { dryRun, returnData });
 
 				const result = dryRun
 					? await service.upsertRow(dataTableId, projectId, params, returnData, true)
@@ -238,9 +234,7 @@ const dataTableRowsHandlers: DataTableRowsHandlers = {
 				const { filter, returnData = false, dryRun = false } = payload.data;
 				const params = { filter };
 
-				if (dryRun || returnData) {
-					await assertRowReadAccess(req.user, { dataTableId });
-				}
+				await assertRowReadAccessIfReturningRows(req.user, dataTableId, { dryRun, returnData });
 
 				const result = dryRun
 					? await service.deleteRows(dataTableId, projectId, params, returnData, true)

--- a/packages/cli/test/integration/public-api/data-tables.test.ts
+++ b/packages/cli/test/integration/public-api/data-tables.test.ts
@@ -1214,7 +1214,24 @@ describe('row-content authorization on write endpoints', () => {
 
 	let project: Project;
 	let dataTable: DataTable;
+	let writeOnlyRoleSlug: string;
+	let readWriteRoleSlug: string;
 	let writerAgent: SuperAgentTest;
+	let readWriterAgent: SuperAgentTest;
+
+	beforeAll(async () => {
+		// roles survive the per-test truncation of `Project`/`ProjectRelation`
+		const writeOnlyRole = await createCustomRoleWithScopeSlugs(['dataTable:writeRow'], {
+			roleType: 'project',
+		});
+		writeOnlyRoleSlug = writeOnlyRole.slug;
+
+		const readWriteRole = await createCustomRoleWithScopeSlugs(
+			['dataTable:writeRow', 'dataTable:readRow'],
+			{ roleType: 'project' },
+		);
+		readWriteRoleSlug = readWriteRole.slug;
+	});
 
 	beforeEach(async () => {
 		project = await createTeamProject('write-only project', owner);
@@ -1223,12 +1240,13 @@ describe('row-content authorization on write endpoints', () => {
 			data: [{ secret: SECRET }],
 		});
 
-		const writeOnlyRole = await createCustomRoleWithScopeSlugs(['dataTable:writeRow'], {
-			roleType: 'project',
-		});
 		const writeOnlyUser = await createMemberWithApiKey();
-		await linkUserToProject(writeOnlyUser, project, writeOnlyRole.slug);
+		await linkUserToProject(writeOnlyUser, project, writeOnlyRoleSlug);
 		writerAgent = testServer.publicApiAgentFor(writeOnlyUser);
+
+		const readWriteUser = await createMemberWithApiKey();
+		await linkUserToProject(readWriteUser, project, readWriteRoleSlug);
+		readWriterAgent = testServer.publicApiAgentFor(readWriteUser);
 	});
 
 	test('rejects update dryRun without dataTable:readRow scope', async () => {
@@ -1250,6 +1268,21 @@ describe('row-content authorization on write endpoints', () => {
 		});
 
 		expect(response.statusCode).toBe(403);
+		expect(JSON.stringify(response.body)).not.toContain(SECRET);
+	});
+
+	test('returns update row contents with dataTable:readRow scope', async () => {
+		const response = await readWriterAgent.patch(`/data-tables/${dataTable.id}/rows/update`).send({
+			filter: MATCH_ALL_FILTER,
+			data: { secret: 'overwritten' },
+			dryRun: true,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toMatchObject([
+			{ secret: SECRET, dryRunState: 'before' },
+			{ secret: 'overwritten', dryRunState: 'after' },
+		]);
 	});
 
 	test('allows a plain update without dataTable:readRow scope', async () => {
@@ -1279,6 +1312,7 @@ describe('row-content authorization on write endpoints', () => {
 		});
 
 		expect(response.statusCode).toBe(403);
+		expect(JSON.stringify(response.body)).not.toContain(SECRET);
 	});
 
 	test('rejects delete returnData without dataTable:readRow scope', async () => {
@@ -1296,6 +1330,29 @@ describe('row-content authorization on write endpoints', () => {
 			.query({ filter: JSON.stringify(MATCH_ALL_FILTER) });
 
 		expect(response.statusCode).toBe(200);
+	});
+
+	test('returns upsert row contents with dataTable:readRow scope', async () => {
+		const response = await readWriterAgent.post(`/data-tables/${dataTable.id}/rows/upsert`).send({
+			filter: MATCH_ALL_FILTER,
+			data: { secret: 'overwritten' },
+			dryRun: true,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toMatchObject([
+			{ secret: SECRET, dryRunState: 'before' },
+			{ secret: 'overwritten', dryRunState: 'after' },
+		]);
+	});
+
+	test('returns deleted row contents with dataTable:readRow scope', async () => {
+		const response = await readWriterAgent
+			.delete(`/data-tables/${dataTable.id}/rows/delete`)
+			.query({ filter: JSON.stringify(MATCH_ALL_FILTER), returnData: 'true' });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toMatchObject([{ secret: SECRET }]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Review follow-up on #35651, stacked on its branch. Behaviour-neutral: same requests are allowed, same requests get 403.

**Code**

- Fold the `dryRun || returnData` condition into the helper (`assertRowReadAccess` -> `assertRowReadAccessIfReturningRows`). The guard was copy-pasted at six call sites, and the rule it encodes has to stay in sync with `shouldReturnData = returnData || dryRun` in `DataTableRowsRepository`. One place now.
- Pass the data table id explicitly instead of the whole `req.params`. At runtime `req.params` carries both `projectId` and `dataTableId`, and `userHasScopes` is annotated `/* only one */` and checks `dataTableId` first, so the effective key was ambiguous at the call site. Keeping `dataTableId` also means the check resolves the same project the surrounding `@ProjectScope('dataTable:writeRow')` guard resolved. It costs one lookup, which is what the original did.

**Tests**

- Reuse `createDataTable`'s `data` option instead of hand-rolling `getColumns` + `insertRows`.
- Hoist the custom roles in the public API test out of `beforeEach` (they survive the per-test truncation of `Project`/`ProjectRelation`).
- Replace `expect(JSON.stringify(body)).toContain(SECRET)` with assertions on the row shape that is actually sensitive, i.e. the `dryRunState: 'before'` row carrying the pre-update value.
- Cover the assumptions the check rests on, which were untested:
  - the rejected write does not happen (the row is read back unchanged after a 403)
  - `readRow` held on the project named in the URL does not stand in for `readRow` on the project the table actually lives in
  - the positive path on all three public API handlers, so a wrong authorization key would fail rather than pass silently
  - the proxy's unconditional `dataTable:readRow` on `updateRows`/`deleteRows`, and that `insertRows` is not affected

## Not addressed here

Three findings from the review that need a decision rather than a cleanup:

1. **The public API still has the same gap on the API key axis.** `publicApiScope('dataTableRow:update')` gates on `tokenGrant.apiKeyScopes`; the new check is RBAC. An API key granted only `dataTableRow:update`, held by any normal member, still reads full row contents via `returnData: true`, because the RBAC check passes for that user. Granular API key scopes sit behind the same enterprise gate (`isApiKeyScopesLicensed`) as custom roles, so it is the same threat model. `publicApiCompositeScope` plus a handler-side assert is the existing primitive for payload-dependent scopes (see `assertPackageExportApiKeyScopes`), and it keeps `x-required-scope` and `/discover` accurate.
2. **`DELETE /rest/projects/:projectId/data-tables/:dataTableId/rows` ignores `dryRun`.** `deleteRows(dataTableId, projectId, dto, dto.returnData)` never passes it, so `?dryRun=true` performs a real delete and returns `true`. The public API handler passes it correctly. The scope check reads `dto.dryRun` right above that call, which makes the flag look supported.
3. **The proxy hunk has no reachable caller.** Nothing in `packages/cli/src` calls `makeDataTableOperationsForUser().updateRows`/`.deleteRows`; the registered data table MCP tools are search / create / rename / add-rows / column ops. Worth adjusting the claim in #35651's description. For contrast, the live equivalent is Instance AI's adapter, which also hardcodes `returnData: true` but returns only `result.length`, so it leaks nothing and needs no `readRow`.

## How to test

Same setup as #35651. The added integration tests are the executable version of it, all green locally on sqlite (`data-table.controller` 193 passed, `data-tables` public API 132 passed, `data-table-proxy.service` 50 passed, `data-tables.handler` 26 passed), along with `tsc --noEmit`, eslint (0 errors) and biome:

```
pnpm --filter n8n test packages/cli/src/modules/data-table/__tests__/data-table.controller.integration.test.ts
pnpm --filter n8n test packages/cli/src/modules/data-table/__tests__/data-table-proxy.service.integration.test.ts
pnpm --filter n8n test packages/cli/test/integration/public-api/data-tables.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5666

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`
