### PR TITLE
fix(core): Stop auto-selecting the only generic auth credential

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -317,6 +317,7 @@ export {
 	credentialRequestSchema,
 	credentialSetupHintSchema,
 	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
+	GENERIC_AUTH_CREDENTIAL_TYPES,
 	workflowSetupNodeSchema,
 	errorPayloadSchema,
 	filesystemRequestPayloadSchema,

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -293,6 +293,21 @@ export const toolErrorPayloadSchema = z.object({
 /** The generic credential type that agent-supplied setup recipes create. */
 export const TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE = 'httpTemplatedCustomAuth';
 
+/**
+ * Auth types where one credential serves many services.
+ */
+export const GENERIC_AUTH_CREDENTIAL_TYPES: ReadonlySet<string> = new Set([
+	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
+	'httpHeaderAuth',
+	'httpBearerAuth',
+	'httpQueryAuth',
+	'httpBasicAuth',
+	'httpDigestAuth',
+	'httpCustomAuth',
+	'oAuth1Api',
+	'oAuth2Api',
+]);
+
 /** One user-provided input of a Templated Custom Auth credential. */
 export const credentialPlaceholderDefSchema = z.object({
 	/** Marker name referenced by the template as `{{name}}`. */

--- a/packages/@n8n/instance-ai/docs/tools.md
+++ b/packages/@n8n/instance-ai/docs/tools.md
@@ -480,10 +480,12 @@ The LLM never sees secrets — the user interacts with the n8n frontend directly
 **Returns**: `{ credentialId, credentialType, needsBrowserSetup? }`
 
 **HITL**: Suspends execution and renders the credential setup UI. When a single
-matching credential already exists, the card auto-selects it and resolves
-without user input — a `success` result with a credentials map means setup is
-already complete, and the card is never open once a result is returned. When
-`needsBrowserSetup=true`, the orchestrator should load the
+matching *service-scoped* credential already exists, the card auto-selects it
+and resolves without user input — a `success` result with a credentials map
+means setup is already complete, and the card is never open once a result is
+returned. Generic auth types (bearer/header/query/basic/etc.) stay preselected
+but always require an explicit Continue, since the type alone does not identify
+a service. When `needsBrowserSetup=true`, the orchestrator should load the
 `credential-setup-with-computer-use` skill, use Computer Use `browser_*` tools
 directly, then call `setup-credentials` again to finalize.
 

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -279,7 +279,7 @@ const setupAction = z.object({
 	action: z
 		.literal('setup')
 		.describe(
-			'Open the credential setup card for the user to create or select credentials. The card is only visible while this call is pending — any returned result means the interaction already finished. A `success` result with a `credentials` map means setup is complete (an existing credential may have been auto-selected with no user action): confirm the credentials are ready and do not tell the user a card is open or that they must authorize.',
+			'Open the credential setup card for the user to create or select credentials. The card is only visible while this call is pending — any returned result means the interaction already finished. A `success` result with a `credentials` map means setup is complete (a sole service-scoped credential may have been auto-selected with no user action; generic auth types always need an explicit Continue): confirm the credentials are ready and do not tell the user a card is open or that they must authorize.',
 		),
 	credentials: z
 		.array(

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/resolve-credentials.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/resolve-credentials.test.ts
@@ -1298,6 +1298,64 @@ describe('resolveCredentials', () => {
 			expect(result.mockedNodeNames).toContain('HTTP Request');
 		});
 	});
+
+	// Bearer/header/query/basic/digest/custom/OAuth all share one type across
+	// every service, so the sole-candidate fallback must not wire them either —
+	// otherwise a build silently sends the user's only key to the node's URL.
+	describe('generic auth types', () => {
+		const bearerNode = () => ({
+			id: '1',
+			name: 'MCP Client',
+			type: '@n8n/n8n-nodes-langchain.mcpClientTool',
+			typeVersion: 1,
+			position: [0, 0] as [number, number],
+			parameters: { endpointUrl: 'http://localhost:5678/mcp-server/http' },
+			credentials: { httpBearerAuth: null as unknown as { id: string; name: string } },
+		});
+
+		it('skips the sole-candidate fallback for a bearer auth credential', async () => {
+			const json = makeWorkflow({ nodes: [bearerNode()] });
+
+			const result = await resolveCredentials(
+				json,
+				undefined,
+				createMockContext(),
+				makeCredentialMap([
+					{ id: 'cred-bearer', name: 'Bearer Auth account', type: 'httpBearerAuth' },
+				]),
+			);
+
+			expect(json.nodes[0].credentials).toEqual({});
+			expect(result.mockedNodeNames).toContain('MCP Client');
+			expect(result.resolvedCredentialsByNode).toEqual({});
+		});
+
+		it('still auto-binds the sole candidate of a service-scoped type', async () => {
+			const json = makeWorkflow({
+				nodes: [
+					{
+						id: '1',
+						name: 'Slack',
+						type: 'n8n-nodes-base.slack',
+						typeVersion: 2,
+						position: [0, 0],
+						credentials: { slackApi: null as unknown as { id: string; name: string } },
+					},
+				],
+			});
+
+			await resolveCredentials(
+				json,
+				undefined,
+				createMockContext(),
+				makeCredentialMap([{ id: 'cred-slack', name: 'My Slack', type: 'slackApi' }]),
+			);
+
+			expect(json.nodes[0].credentials).toEqual({
+				slackApi: { id: 'cred-slack', name: 'My Slack' },
+			});
+		});
+	});
 });
 
 describe('buildCredentialResolutionNote', () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/setup-workflow.service.test.ts
@@ -494,6 +494,34 @@ describe('buildSetupRequests', () => {
 		expect(result[0].existingCredentials?.[0].id).toBe('cred-1');
 	});
 
+	it('does not auto-apply a sole generic auth credential', async () => {
+		(context.nodeService.getDescription as Mock).mockResolvedValue({
+			group: [],
+			credentials: [{ name: 'httpBearerAuth' }],
+		});
+		(context.credentialService.list as Mock).mockResolvedValue([
+			{ id: 'cred-bearer', name: 'Bearer Auth account', updatedAt: '2025-01-01T00:00:00.000Z' },
+		]);
+
+		const node = makeNode({
+			name: 'MCP Client',
+			type: '@n8n/n8n-nodes-langchain.mcpClientTool',
+			parameters: {
+				authentication: 'bearerAuth',
+			},
+		});
+		const result = await buildSetupRequests(context, node);
+
+		expect(result[0].isAutoApplied).toBeFalsy();
+		expect(result[0].node.credentials?.httpBearerAuth).toBeUndefined();
+		expect(result[0].existingCredentials).toEqual([
+			{ id: 'cred-bearer', name: 'Bearer Auth account' },
+		]);
+		expect(result[0].needsAction).toBe(true);
+		// No credential was bound, so no test was run either.
+		expect(context.credentialService.test).not.toHaveBeenCalled();
+	});
+
 	it('does not auto-apply when multiple credentials of the same type exist', async () => {
 		(context.credentialService.list as Mock).mockResolvedValue([
 			{ id: 'cred-2', name: 'Newer Slack', updatedAt: '2025-06-01T00:00:00.000Z' },
@@ -1375,6 +1403,39 @@ describe('applyNodeChanges', () => {
 		expect(track).toHaveBeenCalledWith('Node credential assigned', {
 			credential_type: 'slackApi',
 			node_type: 'n8n-nodes-base.slack',
+			workflow_id: 'wf-1',
+			credential_kind: 'own',
+			source: 'instance-ai-confirmed',
+		});
+	});
+
+	it('keeps source instance-ai-confirmed when a sole generic auth credential is applied', async () => {
+		const track = vi.fn();
+		(context as unknown as { trackTelemetry: Mock }).trackTelemetry = track;
+		const wfJson = makeWorkflowJSON([
+			makeNode({
+				name: 'HTTP Request',
+				id: 'n1',
+				type: 'n8n-nodes-base.httpRequest',
+			}),
+		]);
+		(context.workflowService.getAsWorkflowJSON as Mock).mockResolvedValue(wfJson);
+		(context.credentialService.get as Mock).mockResolvedValue({
+			id: 'cred-bearer',
+			name: 'Bearer Auth account',
+		});
+		(context.credentialService.list as Mock).mockResolvedValue([
+			{ id: 'cred-bearer', name: 'Bearer Auth account' },
+		]);
+		(context.workflowService.updateFromWorkflowJSON as Mock).mockResolvedValue(undefined);
+
+		await applyNodeChanges(context, 'wf-1', {
+			'HTTP Request': { httpBearerAuth: 'cred-bearer' },
+		});
+
+		expect(track).toHaveBeenCalledWith('Node credential assigned', {
+			credential_type: 'httpBearerAuth',
+			node_type: 'n8n-nodes-base.httpRequest',
 			workflow_id: 'wf-1',
 			credential_kind: 'own',
 			source: 'instance-ai-confirmed',

--- a/packages/@n8n/instance-ai/src/tools/workflows/credential-utils.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/credential-utils.ts
@@ -1,24 +1,8 @@
-import { AI_GATEWAY_MANAGED_TAG, TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE } from '@n8n/api-types';
+import { AI_GATEWAY_MANAGED_TAG, GENERIC_AUTH_CREDENTIAL_TYPES } from '@n8n/api-types';
 import type { NodeJSON } from '@n8n/workflow-sdk';
 
 import type { InstanceAiContext } from '../../types';
-
-/**
- * The HTTP Request node's generic auth family: one credential type serves many
- * services, so the type alone never identifies a service. Kept out of
- * search-by-service results and out of cross-node credential reuse.
- */
-export const GENERIC_AUTH_CREDENTIAL_TYPES: ReadonlySet<string> = new Set([
-	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
-	'httpHeaderAuth',
-	'httpBearerAuth',
-	'httpQueryAuth',
-	'httpBasicAuth',
-	'httpDigestAuth',
-	'httpCustomAuth',
-	'oAuth1Api',
-	'oAuth2Api',
-]);
+export { GENERIC_AUTH_CREDENTIAL_TYPES };
 
 export interface AiGatewayCredential {
 	id: null;

--- a/packages/@n8n/instance-ai/src/tools/workflows/resolve-credentials.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/resolve-credentials.ts
@@ -374,11 +374,12 @@ export async function resolveCredentials(
 				continue;
 			}
 
-			// The sole-credential fallback is skipped for Templated Custom Auth: the
-			// type is shared by every service, so "the only stored credential" may
-			// belong to a different service — mock instead so setup asks.
+			// The sole-credential fallback is skipped for generic auth types: one
+			// type serves every service, so "the only stored credential" may belong
+			// to a different service and must not be sent to this node's URL — mock
+			// instead so setup asks.
 			const credentialsForType = availableCredentials?.get(key);
-			if (credentialsForType?.length === 1 && key !== TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE) {
+			if (credentialsForType?.length === 1 && !GENERIC_AUTH_CREDENTIAL_TYPES.has(key)) {
 				const [credential] = credentialsForType;
 				creds[key] = { id: credential.id, name: credential.name };
 				registerSiblingBinding(key, creds[key]);

--- a/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/setup-workflow.service.ts
@@ -6,6 +6,7 @@
  * state machine, and this logic is testable independently.
  */
 import {
+	GENERIC_AUTH_CREDENTIAL_TYPES,
 	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
 	type InstanceAiCredentialSetupHint,
 } from '@n8n/api-types';
@@ -534,9 +535,10 @@ async function resolveCredentialState(
 	// Fall back to auto-applying the sole stored credential when n8n credits
 	// is not available. With multiple candidates, picking the first is a
 	// silent guess — surface the list so the setup wizard can prompt.
-	// Templated Custom Auth never auto-applies: even host-filtered candidates
-	// of the shared type need the user's click (a sole match arrives preselected).
-	if (!isAutoApplied && credentialType !== TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE) {
+	// Generic auth types never auto-apply: the type alone does not identify a
+	// service, so a sole bearer/header/etc. key must not be attached to an
+	// arbitrary URL without the user's click (a sole match arrives preselected).
+	if (!isAutoApplied && !GENERIC_AUTH_CREDENTIAL_TYPES.has(credentialType)) {
 		isAutoApplied = !hasExistingOnNode && existingCredentials.length === 1;
 	}
 
@@ -1138,9 +1140,9 @@ export async function applyNodeParameters(
  * `instance-ai-auto` mirrors the auto-apply rules in `buildSetupRequests`: Instance
  * AI defaults a credential unprompted only when the node had none and the user did
  * not have to choose — n8n Connect when the user has no stored credential of the
- * type (rule 3), or their sole stored credential (rule 2). Anything else — a
- * credential picked among several, or n8n Connect chosen despite having stored keys
- * — is a user-confirmed choice.
+ * type (rule 3), or their sole stored non-generic credential (rule 2). Anything
+ * else — a credential picked among several, a generic auth type, or n8n Connect
+ * chosen despite having stored keys — is a user-confirmed choice.
  */
 async function trackCredentialAssignment(
 	context: InstanceAiContext,
@@ -1160,8 +1162,11 @@ async function trackCredentialAssignment(
 			.list({ type: opts.credType, ...(opts.workflowId ? { workflowId: opts.workflowId } : {}) })
 			.catch(() => []);
 		// Gateway auto-applies when no stored key exists; a BYOK key auto-applies
-		// when it is the user's only one for the type.
-		if (isGateway ? stored.length === 0 : stored.length === 1) source = 'instance-ai-auto';
+		// when it is the user's only one for a service-scoped type. Generic auth
+		// never auto-applies — the type alone does not identify a service.
+		const soleByokAutoApplied =
+			!isGateway && stored.length === 1 && !GENERIC_AUTH_CREDENTIAL_TYPES.has(opts.credType);
+		if (isGateway ? stored.length === 0 : soleByokAutoApplied) source = 'instance-ai-auto';
 	}
 	context.trackTelemetry('Node credential assigned', {
 		credential_type: opts.credType,

--- a/packages/cli/src/modules/agents/builder/interactive/__tests__/ask-credential.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/__tests__/ask-credential.tool.test.ts
@@ -64,6 +64,35 @@ describe('ask_credential tool', () => {
 		});
 	});
 
+	it('suspends instead of auto-resolving when the sole credential is a generic auth type', async () => {
+		// One credential type serves every service, so the user must pick it —
+		// otherwise their only bearer token is attached to an arbitrary endpoint.
+		const credentialProvider = makeProvider([
+			{ id: 'c1', name: 'Bearer Auth account', type: 'httpBearerAuth' },
+		]);
+		const tool = askCredentialTool({ credentialProvider });
+		const ctx = makeCtx();
+
+		await tool.handler!(
+			{ purpose: 'Authenticate the MCP server', credentialType: 'httpBearerAuth' },
+			ctx as never,
+		);
+
+		expect(ctx.suspend).toHaveBeenCalledWith(
+			expect.objectContaining({
+				credentialRequests: [
+					expect.objectContaining({
+						credentialType: 'httpBearerAuth',
+						existingCredentials: [{ id: 'c1', name: 'Bearer Auth account' }],
+					}),
+				],
+			}),
+		);
+		expect(track).toHaveBeenCalledWith(TELEMETRY_EVENT.AGENTS.BUILDER_REQUESTED_CREDENTIAL, {
+			credential_type: 'httpBearerAuth',
+		});
+	});
+
 	it('returns a node credentials map keyed by the requested credential slot when auto-resolving', async () => {
 		const credentialProvider = makeProvider([
 			{ id: 'c1', name: 'My Linear', type: 'linearOAuth2Api' },

--- a/packages/cli/src/modules/agents/builder/interactive/ask-credential.tool.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/ask-credential.tool.ts
@@ -3,6 +3,7 @@ import { Tool } from '@n8n/agents/tool';
 import {
 	ASK_CREDENTIAL_TOOL_NAME,
 	ASK_EMBEDDING_CREDENTIAL_TOOL_NAME,
+	GENERIC_AUTH_CREDENTIAL_TYPES,
 	MANAGED_CREDENTIAL_TOKEN,
 	askCredentialInputSchema,
 	credentialResumeSchema,
@@ -133,8 +134,13 @@ async function resolveCredentialSelection(
 
 	// If the user has exactly one credential of the requested type the
 	// picker has nothing to ask — auto-resolve so the LLM doesn't render
-	// a card the user can only confirm.
-	if (existingCredentials.length === 1) {
+	// a card the user can only confirm. Generic auth types are excluded: the
+	// type alone does not identify a service, so the sole credential must not
+	// be attached to an arbitrary destination without the user picking it.
+	if (
+		existingCredentials.length === 1 &&
+		!GENERIC_AUTH_CREDENTIAL_TYPES.has(input.credentialType)
+	) {
 		return withNodeCredentialMap(input, existingCredentials[0].id, existingCredentials[0].name);
 	}
 
@@ -169,7 +175,8 @@ export function buildAskCredentialTool(deps: AskCredentialToolDeps): BuiltTool {
 				'without credentials. For node tools, copy the returned `credentials` object into `node.credentials`. Auto-resolves without ' +
 				'rendering a card when the agent has a chat channel configured whose credential matches the ' +
 				'requested type (the channel credential is reused so tools act through the same connection), ' +
-				'or when the user has exactly one credential of the requested type.',
+				'or when the user has exactly one credential of the requested type — except for generic ' +
+				'auth types (bearer, header, query, basic, digest, custom, OAuth), which always render the card.',
 		)
 		.input(askCredentialInputSchema)
 		.suspend(credentialSuspendPayloadSchema)

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
@@ -534,8 +534,77 @@ describe('InstanceAiCredentialSetup', () => {
 				},
 			});
 
+			// Give the immediate watcher a tick — it must not resolve the card.
 			await nextTick();
 			await nextTick();
+			expect(confirmSpy).not.toHaveBeenCalled();
+
+			// User confirms the preselected credential explicitly.
+			await userEvent.click(getByTestId('instance-ai-credential-continue-button'));
+			expect(confirmSpy).toHaveBeenCalledWith('req-1', {
+				kind: 'credentialSelection',
+				credentials: { httpBearerAuth: 'existing-bearer' },
+			});
+		});
+
+		it('does not auto-submit a generic auth credential picked after the initial render', async () => {
+			const requests: InstanceAiCredentialRequest[] = [
+				{
+					credentialType: 'httpBearerAuth',
+					reason: 'Authenticate the MCP server',
+					existingCredentials: [
+						{ id: 'existing-bearer', name: 'Bearer Auth account' },
+						{ id: 'existing-bearer-b', name: 'Other Bearer account' },
+					],
+				},
+			];
+			const confirmSpy = vi.spyOn(thread, 'confirmAction').mockResolvedValue(true);
+
+			const { getByTestId } = renderComponent({
+				props: {
+					requestId: 'req-1',
+					credentialRequests: requests,
+					message: 'Set up credentials',
+				},
+			});
+
+			// Two candidates, so nothing is preselected — picking one must not submit.
+			await userEvent.click(getByTestId('credential-picker'));
+			expect(confirmSpy).not.toHaveBeenCalled();
+
+			await userEvent.click(getByTestId('instance-ai-credential-continue-button'));
+			expect(confirmSpy).toHaveBeenCalledWith('req-1', {
+				kind: 'credentialSelection',
+				credentials: { httpBearerAuth: 'cred-123' },
+			});
+		});
+
+		it('does not submit a preselected generic auth credential when the other step is skipped', async () => {
+			const requests: InstanceAiCredentialRequest[] = [
+				{
+					credentialType: 'slackApi',
+					reason: 'Post the message',
+					existingCredentials: [],
+				},
+				{
+					credentialType: 'httpBearerAuth',
+					reason: 'Authenticate the MCP server',
+					existingCredentials: [{ id: 'existing-bearer', name: 'Bearer Auth account' }],
+				},
+			];
+			const confirmSpy = vi.spyOn(thread, 'confirmAction').mockResolvedValue(true);
+
+			const { getByText, getByTestId } = renderComponent({
+				props: {
+					requestId: 'req-1',
+					credentialRequests: requests,
+					message: 'Set up credentials',
+				},
+			});
+
+			// Skipping the only open step leaves the bearer credential selected — it
+			// must still wait for Continue rather than being submitted here.
+			await userEvent.click(getByText('instanceAi.credential.deny'));
 			expect(confirmSpy).not.toHaveBeenCalled();
 
 			await userEvent.click(getByTestId('instance-ai-credential-continue-button'));

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
@@ -516,6 +516,35 @@ describe('InstanceAiCredentialSetup', () => {
 			expect(getByText('instanceAi.credential.allSelected')).toBeTruthy();
 		});
 
+		it('keeps a sole generic auth credential preselected but does not auto-submit', async () => {
+			const requests: InstanceAiCredentialRequest[] = [
+				{
+					credentialType: 'httpBearerAuth',
+					reason: 'Authenticate the MCP server',
+					existingCredentials: [{ id: 'existing-bearer', name: 'Bearer Auth account' }],
+				},
+			];
+			const confirmSpy = vi.spyOn(thread, 'confirmAction').mockResolvedValue(true);
+
+			const { getByTestId } = renderComponent({
+				props: {
+					requestId: 'req-1',
+					credentialRequests: requests,
+					message: 'Set up credentials',
+				},
+			});
+
+			await nextTick();
+			await nextTick();
+			expect(confirmSpy).not.toHaveBeenCalled();
+
+			await userEvent.click(getByTestId('instance-ai-credential-continue-button'));
+			expect(confirmSpy).toHaveBeenCalledWith('req-1', {
+				kind: 'credentialSelection',
+				credentials: { httpBearerAuth: 'existing-bearer' },
+			});
+		});
+
 		it('shows deferred state after skip', async () => {
 			const requests = makeCredentialRequests(1);
 			vi.spyOn(thread, 'confirmAction').mockResolvedValue(true);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -12,6 +12,7 @@ import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useQuickConnect } from '@/features/credentials/quickConnect/composables/useQuickConnect';
 import type { INodeUi, INodeUpdatePropertiesInformation } from '@/Interface';
 import {
+	GENERIC_AUTH_CREDENTIAL_TYPES,
 	TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE,
 	type InstanceAiCredentialFlow,
 	type InstanceAiCredentialRequest,
@@ -188,15 +189,24 @@ watch(
 	},
 );
 
+const hasGenericAuthRequest = computed(() =>
+	props.credentialRequests.some((request) =>
+		GENERIC_AUTH_CREDENTIAL_TYPES.has(request.credentialType),
+	),
+);
+
 // Auto-continue once every step is handled (selected or skipped) and at
 // least one credential was provided. Runs immediately so a single existing
-// credential auto-selected on init resolves the card without user input, as
-// the setup tool describes. The per-step skip path submits directly instead
-// of relying on this watcher (see handleLater).
+// service-scoped credential auto-selected on init resolves the card without
+// user input, as the setup tool describes. Generic auth types stay
+// preselected but need an explicit Continue — the type alone never identifies
+// a service. The per-step skip path submits directly instead of relying on
+// this watcher (see handleLater).
 watch(
 	() => allHandled.value && anySelected.value,
 	async (nowReady, wasReady) => {
 		if (nowReady && !wasReady) {
+			if (wasReady === undefined && hasGenericAuthRequest.value) return;
 			await nextTick();
 			await handleContinue();
 		}
@@ -601,9 +611,7 @@ async function handleSetupAutomatically() {
 							standalone
 							hide-issues
 							:instance-ai-credential-help="instanceAiCredentialHelp"
-							:skip-auto-select="
-								currentRequest.credentialType === TEMPLATED_CUSTOM_AUTH_CREDENTIAL_TYPE
-							"
+							:skip-auto-select="GENERIC_AUTH_CREDENTIAL_TYPES.has(currentRequest.credentialType)"
 							:credential-setup-hint="currentRequest.setupHint"
 							:credentials-field-label="credentialsFieldLabel"
 							@credential-selected="onCredentialSelected(currentRequest.credentialType, $event)"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -189,7 +189,13 @@ watch(
 	},
 );
 
-const hasGenericAuthRequest = computed(() =>
+/**
+ * A generic auth type (bearer, header, query, basic, digest, custom, OAuth) never
+ * identifies a service, so its credential must not be attached to whatever URL the
+ * workflow points at unless the user says so. Whenever the card carries one, the
+ * Continue button is the only path that may submit — every automatic path bails out.
+ */
+const requiresExplicitContinue = computed(() =>
 	props.credentialRequests.some((request) =>
 		GENERIC_AUTH_CREDENTIAL_TYPES.has(request.credentialType),
 	),
@@ -198,15 +204,13 @@ const hasGenericAuthRequest = computed(() =>
 // Auto-continue once every step is handled (selected or skipped) and at
 // least one credential was provided. Runs immediately so a single existing
 // service-scoped credential auto-selected on init resolves the card without
-// user input, as the setup tool describes. Generic auth types stay
-// preselected but need an explicit Continue — the type alone never identifies
-// a service. The per-step skip path submits directly instead of relying on
-// this watcher (see handleLater).
+// user input, as the setup tool describes. The per-step skip path submits
+// directly instead of relying on this watcher (see handleLater).
 watch(
 	() => allHandled.value && anySelected.value,
 	async (nowReady, wasReady) => {
 		if (nowReady && !wasReady) {
-			if (wasReady === undefined && hasGenericAuthRequest.value) return;
+			if (requiresExplicitContinue.value) return;
 			await nextTick();
 			await handleContinue();
 		}
@@ -477,6 +481,18 @@ async function handleLater() {
 	// Every step is now handled: submit the mixed selected/skipped result if
 	// anything was selected, otherwise defer the whole card as before.
 	if (anySelected.value) {
+		// Skipping the last open step must not submit a generic auth credential on
+		// the user's behalf — park on the step still awaiting confirmation instead.
+		if (requiresExplicitContinue.value) {
+			const awaitingConfirmation = props.credentialRequests.findIndex((r) =>
+				isStepComplete(r.credentialType),
+			);
+			if (awaitingConfirmation >= 0) {
+				userNavigated.value = false;
+				goToStep(awaitingConfirmation);
+			}
+			return;
+		}
 		await handleContinue();
 		return;
 	}


### PR DESCRIPTION
## Summary

Instance AI applied a stored credential without asking whenever it was the only one of its type. For generic auth types (bearer, header, query, basic, digest, custom, OAuth) the credential type does not identify a service, so the sole credential could be attached to an arbitrary URL — and the setup card auto-resolved itself before the user ever saw it.

Generic auth types are now excluded from sole-credential auto-apply, and the setup card keeps them preselected but requires an explicit **Continue**. Service-scoped types such as `slackApi` keep the existing frictionless behaviour.

- `GENERIC_AUTH_CREDENTIAL_TYPES` moved to `@n8n/api-types` so backend and editor share one definition
- Assignment telemetry reports these as `instance-ai-confirmed` instead of `instance-ai-auto`

## How to test

1. In a project, create exactly **one** Bearer Auth credential and no other credential of that type.
2. Ask the AI Assistant: `Create a workflow that uses an agent node that connects to this MCP http://localhost:5678/mcp-server/http`
3. The credential setup card appears with the existing Bearer Auth credential preselected, and waits for **Continue** — previously it resolved silently and the credential was attached with no prompt.
4. Repeat with a service-scoped credential (e.g. a single Slack credential on a Slack node) — that one still auto-applies without a prompt.

Unit tests:

```bash
cd packages/@n8n/instance-ai && pnpm test src/tools/workflows/__tests__/setup-workflow.service.test.ts
cd packages/frontend/editor-ui && pnpm test src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-932

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

