### PR TITLE
fix: Stop browser_clicks timing out in background browser tabs (no-changelog)

### DIFF
--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
@@ -393,6 +393,41 @@ describe('RelayConnection', () => {
 			);
 		});
 
+		it('should keep the tab usable when focus emulation is rejected', async () => {
+			chrome.debugger.getTargets.mockResolvedValueOnce([mockTarget(123)]);
+			await relay.registerSelectedTabs([123]);
+			const tabId = relay.getControlledIds()[0].targetId;
+			ws.sent.length = 0;
+
+			// Focus emulation is the first command sent after attaching
+			chrome.debugger.sendCommand.mockRejectedValueOnce(
+				new Error('Emulation.setFocusEmulationEnabled is not allowed'),
+			);
+
+			ws.onmessage?.({
+				data: JSON.stringify({
+					id: 1,
+					method: 'forwardCDPCommand',
+					params: { method: 'Runtime.evaluate', params: {}, id: tabId },
+				}),
+			});
+			await tick();
+
+			expect(chrome.debugger.sendCommand).toHaveBeenNthCalledWith(
+				1,
+				{ tabId: 123 },
+				'Emulation.setFocusEmulationEnabled',
+				{ enabled: true },
+			);
+			expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+				{ tabId: 123 },
+				'Runtime.evaluate',
+				{},
+			);
+			expect(parseSent(ws)).toEqual(expect.objectContaining({ id: 1 }));
+			expect(parseSent(ws)).not.toHaveProperty('error');
+		});
+
 		it('should route CDP commands to specific tab by CDP targetId', async () => {
 			chrome.debugger.getTargets.mockResolvedValueOnce([mockTarget(10), mockTarget(20)]);
 			await relay.registerSelectedTabs([10, 20]);

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
@@ -428,6 +428,46 @@ describe('RelayConnection', () => {
 			expect(parseSent(ws)).not.toHaveProperty('error');
 		});
 
+		it('should re-apply focus emulation when a tab is re-registered after a detach', async () => {
+			const forward = (id: string, method: string) =>
+				ws.onmessage?.({
+					data: JSON.stringify({
+						id: 1,
+						method: 'forwardCDPCommand',
+						params: { method, params: {}, id },
+					}),
+				});
+
+			// A second tab keeps the relay alive once the first one detaches
+			chrome.debugger.getTargets.mockResolvedValue([mockTarget(42), mockTarget(43)]);
+			await relay.registerSelectedTabs([42, 43]);
+
+			forward(targetIdForTab(42), 'Runtime.evaluate');
+			await tick();
+			expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+				{ tabId: 42 },
+				'Emulation.setFocusEmulationEnabled',
+				{ enabled: true },
+			);
+
+			// Detach drops the tab entirely, so recovery goes through re-registration
+			fireDebuggerDetach({ tabId: 42 }, 'target_closed');
+			expect(ws.closed).toBe(false);
+			chrome.debugger.sendCommand.mockClear();
+			chrome.debugger.attach.mockClear();
+
+			await relay.registerSelectedTabs([42]);
+			forward(targetIdForTab(42), 'DOM.getDocument');
+			await tick();
+
+			expect(chrome.debugger.attach).toHaveBeenCalledWith({ tabId: 42 }, '1.3');
+			expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+				{ tabId: 42 },
+				'Emulation.setFocusEmulationEnabled',
+				{ enabled: true },
+			);
+		});
+
 		it('should route CDP commands to specific tab by CDP targetId', async () => {
 			chrome.debugger.getTargets.mockResolvedValueOnce([mockTarget(10), mockTarget(20)]);
 			await relay.registerSelectedTabs([10, 20]);

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
@@ -360,7 +360,37 @@ describe('RelayConnection', () => {
 			await tick();
 
 			expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
-			expect(chrome.debugger.sendCommand).toHaveBeenCalledTimes(2);
+			expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+				{ tabId: 123 },
+				'Runtime.evaluate',
+				{},
+			);
+			expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+				{ tabId: 123 },
+				'DOM.getDocument',
+				{},
+			);
+		});
+
+		it('should enable focus emulation on attach so hidden tabs keep rendering', async () => {
+			chrome.debugger.getTargets.mockResolvedValueOnce([mockTarget(123)]);
+			await relay.registerSelectedTabs([123]);
+			const tabId = relay.getControlledIds()[0].targetId;
+
+			ws.onmessage?.({
+				data: JSON.stringify({
+					id: 1,
+					method: 'forwardCDPCommand',
+					params: { method: 'Runtime.evaluate', params: {}, id: tabId },
+				}),
+			});
+			await tick();
+
+			expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+				{ tabId: 123 },
+				'Emulation.setFocusEmulationEnabled',
+				{ enabled: true },
+			);
 		});
 
 		it('should route CDP commands to specific tab by CDP targetId', async () => {
@@ -433,6 +463,11 @@ describe('RelayConnection', () => {
 			expect(relay.isAgentCreatedTab(999)).toBe(true);
 			// Agent-created tabs ARE eagerly attached
 			expect(chrome.debugger.attach).toHaveBeenCalledWith({ tabId: 999 }, '1.3');
+			expect(chrome.debugger.sendCommand).toHaveBeenCalledWith(
+				{ tabId: 999 },
+				'Emulation.setFocusEmulationEnabled',
+				{ enabled: true },
+			);
 
 			// Response should have CDP targetId, not chromeTabId
 			expect(parseSent(ws)).toEqual(

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.ts
@@ -303,9 +303,31 @@ export class RelayConnection {
 			'Target.getTargetInfo',
 		)) as { targetInfo: { targetId: string } };
 
+		await this.applyFocusEmulation(chromeTabId);
+
 		const targetId = result.targetInfo.targetId;
 		log.debug(`attached: chromeTabId=${chromeTabId} → targetId=${targetId}`);
 		return targetId;
+	}
+
+	/**
+	 * Playwright's "stable" actionability check only resolves from a requestAnimationFrame
+	 * callback, and Chrome gives a backgrounded tab no frames — so clicks hang. Re-applied
+	 * on every attach because Playwright's own init-time call is lost on re-attach.
+	 */
+	private async applyFocusEmulation(chromeTabId: number): Promise<void> {
+		try {
+			await chrome.debugger.sendCommand(
+				{ tabId: chromeTabId },
+				'Emulation.setFocusEmulationEnabled',
+				{
+					enabled: true,
+				},
+			);
+			log.debug(`focus emulation enabled (chromeTabId=${chromeTabId})`);
+		} catch (e) {
+			log.warn('Failed to enable focus emulation:', e);
+		}
 	}
 
 	/** Lazily attach debugger to a tab. Deduplicates concurrent calls. */
@@ -335,6 +357,8 @@ export class RelayConnection {
 			]);
 			entry.attached = true;
 			log.debug(`ensureAttached: attached ${id}`);
+
+			await this.applyFocusEmulation(entry.chromeTabId);
 
 			// Reapply cached auto-attach so new tabs report iframes immediately
 			if (this.autoAttachParams) {


### PR DESCRIPTION
## Summary

`browser_click` timed out after 30s on any tab the agent controlled, stalling at
`waiting for element to be visible, enabled and stable` — even though the element
reference was correct. The agent would then fall back to snapshots and other
selectors, and nothing was clicked until the tab was manually brought to the front.

Playwright's `stable` actionability check only ever resolves from a
`requestAnimationFrame` callback (no timeout, no fallback), and Chrome produces no
animation frames for a tab that isn't in front. Agent tabs are created with
`active: false` and never activated, so the check never settled.

`Emulation.setFocusEmulationEnabled` is what normally makes this harmless —
Playwright sends it itself once per page at init — but it does not survive a
`chrome.debugger` re-attach, and nothing re-asserted it. This applies it after both
attach paths in `relayConnection.ts`: the eager one used by `createTab`, and the lazy
`ensureAttached()`. Since a detach removes the tab outright, the second path covers a
tab that is registered again later. The command is idempotent, so it covers both
"never set" and "set, then lost".

Two adjacent issues found while debugging this, deliberately **not** included here:

- `configureLogger()` is never called in the extension, so the level stays at the
  `info` default and every `log.debug` in it is silently dropped.
- `CDP_COMMAND_TIMEOUT_MS` (30s) exactly ties Playwright's default action timeout, so
  the two race on every hang and the relay's own error never surfaces.

## How to test

1. Build the extension: `pnpm --filter @n8n/mcp-browser-extension build`
2. `chrome://extensions` → Load unpacked → `packages/@n8n/mcp-browser-extension/dist`
   (remove any older unpacked entry pointing at a different checkout first — the
   manifest has a fixed `key`, so the extension ID is unchanged)
3. Start a browser-use run that clicks something — e.g. the Anthropic credential
   setup flow that surfaced this
4. **Leave the agent's tab in the background for the whole run. Do not click it.**

Before this change the first `browser_click` hangs for 30s and fails; foregrounding
the tab mid-hang completes the pending click immediately. After it, clicks land while
the tab stays in the background and is never foregrounded.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5724

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI