### PR TITLE
fix(core): Route HTTP errors with details to the error output

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -1789,6 +1789,44 @@ describe('WorkflowExecute', () => {
 			]);
 		});
 
+		test('should route HTTP Request errors with details to the error output', () => {
+			const nodeSuccessData: INodeExecutionData[][] = [
+				[
+					{
+						json: {
+							error: 'Request failed with status code 500',
+							details: {
+								message: 'The service failed to process the request',
+								httpCode: '500',
+								body: { error: 'Internal Server Error' },
+								context: { itemIndex: 0 },
+							},
+						},
+						pairedItem: { item: 0, input: 0 },
+					},
+				],
+			];
+
+			workflowExecute.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, 0);
+
+			expect(nodeSuccessData[0]).toEqual([]);
+			expect(nodeSuccessData[1]).toEqual([
+				{
+					json: {
+						someData: 'test',
+						error: 'Request failed with status code 500',
+						details: {
+							message: 'The service failed to process the request',
+							httpCode: '500',
+							body: { error: 'Internal Server Error' },
+							context: { itemIndex: 0 },
+						},
+					},
+					pairedItem: { item: 0, input: 0 },
+				},
+			]);
+		});
+
 		test('should preserve pairedItem data when routing errors', () => {
 			const nodeSuccessData: INodeExecutionData[][] = [
 				[

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2759,6 +2759,12 @@ export class WorkflowExecute {
 					errorData = item.json.error;
 				} else if (item.json.error && item.json.message && Object.keys(item.json).length === 2) {
 					errorData = item.json.error;
+				} else if (
+					item.json.error &&
+					Object.hasOwn(item.json, 'details') &&
+					Object.keys(item.json).length === 2
+				) {
+					errorData = item.json.error;
 				}
 
 				if (errorData) {


### PR DESCRIPTION
## Summary

Routes HTTP Request failures shaped as `error + details` through the error output when the node uses **Continue (using error output)**.

Previously, this response shape stayed on the success output because `handleNodeErrorOutput` only recognized an Error instance and two older JSON shapes. This change recognizes the existing `error + details` shape while preserving the original item data and adds regression coverage.

## How to test

1. Run the focused `WorkflowExecute` tests.
2. Execute an HTTP Request node that returns HTTP 500 with **Continue (using error output)**.
3. Verify the success output contains 0 items and the error output contains 1 item with the original JSON plus `error` and `details`.

Validation completed locally:

- Routing tests: 9/9 passed
- Typecheck: passed
- Biome: passed
- ESLint: passed

## Related Linear tickets, Github issues, and Community forum posts

Fixes https://github.com/n8n-io/n8n/issues/35899


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs update is not required for this internal routing fix.
- [x] Tests included.
- [ ] PR labeled with a backport label if maintainers determine an urgent backport is needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

