### PR TITLE
fix(editor): Keep agent nodes inside canvas group borders

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/agentNodeCanvasGeometry.store.ts
+++ b/packages/frontend/editor-ui/src/features/agents/agentNodeCanvasGeometry.store.ts
@@ -1,13 +1,14 @@
 import { defineStore } from 'pinia';
+import { shallowReactive } from 'vue';
 
 export const useAgentNodeCanvasGeometryStore = defineStore('agentNodeCanvasGeometry', () => {
-	const nodeHeightsByCanvas = new Map<string, Map<string, number>>();
+	const nodeHeightsByCanvas = shallowReactive(new Map<string, Map<string, number>>());
 	const pendingCenterYByCanvas = new Map<string, Map<string, number>>();
 
 	function setNodeHeight(canvasId: string, nodeId: string, height: number) {
 		let heightsByNode = nodeHeightsByCanvas.get(canvasId);
 		if (!heightsByNode) {
-			heightsByNode = new Map();
+			heightsByNode = shallowReactive(new Map<string, number>());
 			nodeHeightsByCanvas.set(canvasId, heightsByNode);
 		}
 		heightsByNode.set(nodeId, height);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -36,6 +36,7 @@ import Canvas from './Canvas.vue';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useWorkflowDocumentRenderData } from '@/app/stores/workflowDocument/useWorkflowDocumentRenderData';
 import { useExperimentalNdvStore } from '../experimental/experimentalNdv.store';
+import { useAgentNodeCanvasGeometryStore } from '@/features/agents/agentNodeCanvasGeometry.store';
 
 defineOptions({
 	inheritAttrs: false,
@@ -130,6 +131,7 @@ const suppressInteractionRef = computed(() => props.suppressInteraction ?? false
 
 const experimentalNdvStore = useExperimentalNdvStore();
 const isExperimentalNdvActive = computed(() => experimentalNdvStore.isActive(viewport.value.zoom));
+const agentNodeGeometryStore = useAgentNodeCanvasGeometryStore();
 
 const {
 	nodes: mappedWorkflowNodes,
@@ -143,6 +145,7 @@ const {
 	allGroups,
 	nodeGroupView,
 	isExperimentalNdvActive,
+	getAgentNodeHeight: (id) => agentNodeGeometryStore.getNodeHeight(props.id, id),
 });
 
 const groupIdsToExpand = computed(() => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
@@ -23,6 +23,7 @@ import { createTestNode } from '@/__tests__/mocks';
 import type { INodeUi } from '@/Interface';
 import { CanvasNodeRenderType, type CanvasNodeData } from '../canvas.types';
 import { MarkerType } from '@vue-flow/core';
+import { AGENT_NODE_SIZE } from '@/app/utils/nodeViewUtils';
 
 vi.mock('@n8n/i18n', async (importOriginal) => ({
 	...(await importOriginal()),
@@ -273,6 +274,45 @@ describe('useCanvasMapping — mapped nodes', () => {
 		const betaMapped = nodes.value.find((n) => n.id === 'b');
 		expect(alphaMapped?.data?.connections.outputs.main?.[0]?.[0]?.node).toBe('Beta');
 		expect(betaMapped?.data?.connections.inputs.main?.[0]?.[0]?.node).toBe('Alpha');
+	});
+});
+
+describe('useCanvasMapping — node display sizes', () => {
+	it('uses the agent card width and measured height for Message an Agent nodes', () => {
+		const agent = createTestNode({
+			id: 'agent',
+			name: 'Message an Agent',
+			type: CanvasNodeRenderType.Agent,
+		}) as INodeUi;
+		const measuredHeight = ref<number | undefined>();
+		const rd = createEmptyCanvasRenderData();
+		const render: CanvasNodeData['render'] = {
+			type: CanvasNodeRenderType.Agent,
+			options: {},
+		};
+		rd.renderTypeByNodeId.set(
+			agent.id,
+			computed(() => render),
+		);
+
+		const { nodeDisplaySizeById } = useCanvasMapping({
+			nodes: ref([agent]),
+			connections: ref({}),
+			renderData: shallowRef(rd),
+			getAgentNodeHeight: () => measuredHeight.value,
+		});
+
+		expect(nodeDisplaySizeById.value[agent.id]).toEqual({
+			width: AGENT_NODE_SIZE[0],
+			height: AGENT_NODE_SIZE[1],
+		});
+
+		measuredHeight.value = 224;
+
+		expect(nodeDisplaySizeById.value[agent.id]).toEqual({
+			width: AGENT_NODE_SIZE[0],
+			height: 224,
+		});
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -26,6 +26,7 @@ import {
 	mapLegacyConnectionsToCanvasConnections,
 	parseCanvasConnectionHandleString,
 } from '../canvas.utils';
+import { AGENT_NODE_SIZE } from '@/app/utils/nodeViewUtils';
 import type { IConnections, ITaskData, IWorkflowGroup } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import type { INodeUi } from '@/Interface';
@@ -52,6 +53,7 @@ export function useCanvasMapping({
 	allGroups = ref([]),
 	nodeGroupView,
 	isExperimentalNdvActive = ref(false),
+	getAgentNodeHeight,
 }: {
 	nodes: Ref<INodeUi[]>;
 	connections: Ref<IConnections>;
@@ -59,6 +61,7 @@ export function useCanvasMapping({
 	allGroups?: Ref<IWorkflowGroup[]>;
 	nodeGroupView?: CanvasNodeGroupView;
 	isExperimentalNdvActive?: Ref<boolean>;
+	getAgentNodeHeight?: (id: string) => number | undefined;
 }) {
 	const i18n = useI18n();
 
@@ -123,14 +126,19 @@ export function useCanvasMapping({
 		for (const node of nodes.value) {
 			const render = rd.renderTypeByNodeId.get(node.id)?.value;
 
-			if (render?.type !== CanvasNodeRenderType.Default) continue;
-
-			dimensionsById[node.id] = computeNodeDisplaySize(
-				node.id,
-				render.options,
-				rd,
-				isExperimentalNdvActive.value,
-			);
+			if (render?.type === CanvasNodeRenderType.Default) {
+				dimensionsById[node.id] = computeNodeDisplaySize(
+					node.id,
+					render.options,
+					rd,
+					isExperimentalNdvActive.value,
+				);
+			} else if (render?.type === CanvasNodeRenderType.Agent) {
+				dimensionsById[node.id] = {
+					width: AGENT_NODE_SIZE[0],
+					height: getAgentNodeHeight?.(node.id) ?? AGENT_NODE_SIZE[1],
+				};
+			}
 		}
 		return dimensionsById;
 	});


### PR DESCRIPTION
## Summary

Updates canvas group bounds to account for Message an Agent cards, whose rendered width and height can exceed the default node dimensions.

Before:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/d2d8cf4f-89cc-4d82-b288-c2894fe5ddac" />

After:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/2344be06-2eb6-4cc7-a58d-d6c4900fc600" />


## How to test

1. Open a workflow with a Message an Agent node:
<details>
<summary>Workflow with an inline agent</summary>

```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        -176,
        48
      ],
      "id": "e5593f5a-5c61-4ab7-b789-5427d445df02",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.noOp",
      "typeVersion": 1,
      "position": [
        48,
        48
      ],
      "id": "678a225c-41a6-4c54-9374-966a5538dec2",
      "name": "No Operation, do nothing"
    },
    {
      "parameters": {
        "agentSource": "inline",
        "inlineAgent": {
          "config": {
            "name": "Wide Load Analyst",
            "model": "anthropic/claude-sonnet-4-5",
            "instructions": "You are a helpful agent",
            "tools": [
              {
                "type": "node",
                "name": "search_customer_records",
                "node": {
                  "nodeType": "n8n-nodes-base.googleSheetsTool",
                  "nodeTypeVersion": 4.5,
                  "nodeParameters": {}
                }
              },
              {
                "type": "node",
                "name": "send_status_email",
                "node": {
                  "nodeType": "n8n-nodes-base.gmailTool",
                  "nodeTypeVersion": 2.1,
                  "nodeParameters": {}
                }
              },
              {
                "type": "node",
                "name": "post_to_team_channel",
                "node": {
                  "nodeType": "n8n-nodes-base.slackTool",
                  "nodeTypeVersion": 2.3,
                  "nodeParameters": {}
                }
              },
              {
                "type": "node",
                "name": "update_project_page",
                "node": {
                  "nodeType": "n8n-nodes-base.notionTool",
                  "nodeTypeVersion": 2.2,
                  "nodeParameters": {}
                }
              },
              {
                "type": "node",
                "name": "log_to_airtable_base",
                "node": {
                  "nodeType": "n8n-nodes-base.airtableTool",
                  "nodeTypeVersion": 2.1,
                  "nodeParameters": {}
                }
              },
              {
                "type": "node",
                "name": "fetch_external_report",
                "node": {
                  "nodeType": "n8n-nodes-base.httpRequestTool",
                  "nodeTypeVersion": 4.2,
                  "nodeParameters": {}
                }
              }
            ],
            "mcpServers": [
              {
                "name": "competitor_intel_server",
                "url": "https://example.invalid/mcp",
                "authentication": "none"
              }
            ],
            "skills": [
              {
                "type": "skill",
                "id": "skill_build_competitor_report"
              }
            ]
          },
          "skills": {
            "skill_build_competitor_report": {
              "name": "Build competitor report"
            }
          }
        },
        "message": "Stress the card height with many capabilities.",
        "advanced": {}
      },
      "id": "701cfb0c-cf38-41e5-b3ca-f418b5edd5c6",
      "name": "Tall Inline Agent",
      "type": "n8n-nodes-base.messageAnAgent",
      "typeVersion": 3,
      "position": [
        272,
        -120
      ]
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "No Operation, do nothing",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "No Operation, do nothing": {
      "main": [
        [
          {
            "node": "Tall Inline Agent",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "nodeGroups": [
    {
      "id": "cbf4c8f5-92e0-457c-abee-3d87504e7cf2",
      "name": "Group with an agent",
      "nodeIds": [
        "678a225c-41a6-4c54-9374-966a5538dec2",
        "701cfb0c-cf38-41e5-b3ca-f418b5edd5c6"
      ]
    }
  ]
}
```

</details>

2. Verify the expanded group border wraps the full agent card.

4. Verify dragging/group layout still works as expected.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5757](https://linear.app/n8n/issue/ADO-5757/bug-agent-node-overlaps-the-canvas-group-border)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

