### PR TITLE
fix(core): Detect workflow settings changes in source control status

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
@@ -395,6 +395,38 @@ describe('Source Control Helper', () => {
 
 			expect(isWorkflowModified(local, remote)).toBe(true);
 		});
+
+		it('should detect modifications when Available in MCP differs and version IDs match', () => {
+			const local = createWorkflowVersion({ settings: { availableInMCP: true } });
+			const remote = createWorkflowVersion({ settings: { availableInMCP: false } });
+
+			expect(isWorkflowModified(local, remote)).toBe(true);
+		});
+
+		it('should detect modifications when a settings-only field is present locally and missing remotely', () => {
+			const local = createWorkflowVersion({ settings: { availableInMCP: true } });
+			const remote = createWorkflowVersion();
+
+			expect(isWorkflowModified(local, remote)).toBe(true);
+		});
+
+		it('should not detect modifications when settings objects are deeply equal', () => {
+			const local = createWorkflowVersion({
+				settings: { availableInMCP: true, timezone: 'UTC' },
+			});
+			const remote = createWorkflowVersion({
+				settings: { timezone: 'UTC', availableInMCP: true },
+			});
+
+			expect(isWorkflowModified(local, remote)).toBe(false);
+		});
+
+		it('should treat missing settings as equal to an empty settings object', () => {
+			const local = createWorkflowVersion();
+			const remote = createWorkflowVersion({ settings: {} });
+
+			expect(isWorkflowModified(local, remote)).toBe(false);
+		});
 	});
 
 	describe('hasOwnerChanged', () => {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -163,6 +163,7 @@ describe('SourceControlImportService', () => {
 				id: 'workflow1',
 				versionId: 'v1',
 				name: 'Test Workflow',
+				settings: { availableInMCP: true },
 				owner: {
 					type: 'personal',
 					personalEmail: 'email@email.com',
@@ -180,6 +181,7 @@ describe('SourceControlImportService', () => {
 					id: 'workflow1',
 					versionId: 'v1',
 					name: 'Test Workflow',
+					settings: { availableInMCP: true },
 				}),
 			);
 		});
@@ -2744,6 +2746,30 @@ describe('SourceControlImportService', () => {
 			const result = await service.getLocalVersionIdsFromDb(globalAdminContext);
 
 			expect(result[0].updatedAt).toBe(now.toISOString());
+		});
+
+		it('should include workflow settings so settings-only edits are visible to status', async () => {
+			const mockWorkflows = [
+				{
+					id: 'workflow1',
+					name: 'Test Workflow',
+					versionId: 'v1',
+					updatedAt: now,
+					settings: { availableInMCP: true },
+					shared: [],
+				},
+			] as unknown as WorkflowEntity[];
+
+			workflowRepository.find.mockResolvedValue(mockWorkflows);
+
+			const result = await service.getLocalVersionIdsFromDb(globalAdminContext);
+
+			expect(result[0].settings).toEqual({ availableInMCP: true });
+			expect(workflowRepository.find).toHaveBeenCalledWith(
+				expect.objectContaining({
+					select: expect.objectContaining({ settings: true }),
+				}),
+			);
 		});
 	});
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -1148,6 +1148,54 @@ describe('getStatus', () => {
 				expect(result.wfModifiedInEither).toHaveLength(0);
 			});
 		});
+
+		describe('settings changes', () => {
+			it('should detect when Available in MCP is the only change', async () => {
+				const local = createWorkflow({
+					settings: { availableInMCP: true },
+				});
+				const remote = createWorkflow({
+					settings: { availableInMCP: false },
+				});
+
+				sourceControlImportService.getRemoteVersionIdsFromFiles.mockResolvedValue([remote]);
+				sourceControlImportService.getLocalVersionIdsFromDb.mockResolvedValue([local]);
+
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'push',
+					verbose: true,
+					preferLocalVersion: false,
+				});
+
+				if (Array.isArray(result)) expect.fail('Expected result to be an object.');
+				expect(result.wfModifiedInEither).toHaveLength(1);
+				expect(result.sourceControlledFiles).toEqual([
+					expect.objectContaining({
+						id: 'wf1',
+						type: 'workflow',
+						status: 'modified',
+					}),
+				]);
+			});
+
+			it('should not detect as modified when settings match', async () => {
+				const workflow = createWorkflow({
+					settings: { availableInMCP: true },
+				});
+
+				sourceControlImportService.getRemoteVersionIdsFromFiles.mockResolvedValue([workflow]);
+				sourceControlImportService.getLocalVersionIdsFromDb.mockResolvedValue([workflow]);
+
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'push',
+					verbose: true,
+					preferLocalVersion: false,
+				});
+
+				if (Array.isArray(result)) expect.fail('Expected result to be an object.');
+				expect(result.wfModifiedInEither).toHaveLength(0);
+			});
+		});
 	});
 
 	describe('credentials', () => {

--- a/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
@@ -457,8 +457,11 @@ export function hasOwnerChanged(
 }
 
 /**
- * Checks if a workflow has been modified by comparing version IDs and parent folder IDs
- * between local and remote versions
+ * Checks if a workflow has been modified by comparing version IDs, parent folder
+ * IDs, ownership, and settings between local and remote versions.
+ *
+ * Settings must be compared explicitly: a settings-only edit (for example the
+ * "Available in MCP" toggle) does not generate a new `versionId`.
  */
 export function isWorkflowModified(
 	local: SourceControlWorkflowVersionId,
@@ -468,8 +471,9 @@ export function isWorkflowModified(
 	const hasParentFolderIdChanged =
 		remote.parentFolderId !== undefined && remote.parentFolderId !== local.parentFolderId;
 	const ownerChanged = hasOwnerChanged(remote.owner, local.owner);
+	const hasSettingsChanged = !isEqual(local.settings ?? {}, remote.settings ?? {});
 
-	return hasVersionIdChanged || hasParentFolderIdChanged || ownerChanged;
+	return hasVersionIdChanged || hasParentFolderIdChanged || ownerChanged || hasSettingsChanged;
 }
 
 /**

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -203,6 +203,7 @@ export class SourceControlImportService {
 					filename: getWorkflowExportPath(remote.id, this.workflowExportFolder),
 					owner: toStatusOwner(project),
 					isRemoteArchived: remote.isArchived,
+					settings: remote.settings,
 				};
 			},
 		);
@@ -220,6 +221,7 @@ export class SourceControlImportService {
 				versionId: true,
 				name: true,
 				updatedAt: true,
+				settings: true,
 				parentFolder: {
 					id: true,
 				},
@@ -246,6 +248,7 @@ export class SourceControlImportService {
 				parentFolderId: local.parentFolder?.id ?? null,
 				filename: getWorkflowExportPath(local.id, this.workflowExportFolder),
 				updatedAt: updatedAt.toISOString(),
+				settings: local.settings,
 			};
 		}) as SourceControlWorkflowVersionId[];
 	}
@@ -265,6 +268,7 @@ export class SourceControlImportService {
 				versionId: true,
 				name: true,
 				updatedAt: true,
+				settings: true,
 				parentFolder: {
 					id: true,
 				},
@@ -305,6 +309,7 @@ export class SourceControlImportService {
 				filename: getWorkflowExportPath(local.id, this.workflowExportFolder),
 				updatedAt: updatedAt.toISOString(),
 				owner: toStatusOwner(ownerProject),
+				settings: local.settings,
 			};
 		});
 	}

--- a/packages/cli/src/modules/source-control.ee/types/source-control-workflow-version-id.ts
+++ b/packages/cli/src/modules/source-control.ee/types/source-control-workflow-version-id.ts
@@ -1,3 +1,5 @@
+import type { IWorkflowSettings } from 'n8n-workflow';
+
 import type { StatusResourceOwner } from './resource-owner';
 
 export interface SourceControlWorkflowVersionId {
@@ -11,4 +13,9 @@ export interface SourceControlWorkflowVersionId {
 	updatedAt?: string;
 	owner?: StatusResourceOwner;
 	isRemoteArchived?: boolean;
+	/**
+	 * Workflow settings from the DB / exported file. Settings-only edits (e.g.
+	 * `availableInMCP`) do not bump `versionId`, so status must compare these.
+	 */
+	settings?: IWorkflowSettings;
 }


### PR DESCRIPTION
## Summary

Source control decides whether a workflow is modified by comparing a slim status snapshot, not the exported file. That snapshot used `versionId`, `parentFolderId`, and `owner` only. `versionId` is only rotated when nodes, connections, or node groups change, so a settings-only edit never showed up in the push modal.

This PR adds `settings` to that snapshot (from the DB locally, from the exported workflow file remotely) and treats a settings diff as a modification. The **Available in MCP** toggle is the reported case; the same path covers any other `IWorkflowSettings` field that is already written to the export.

I considered rotating `versionId` on settings writes instead. That would light up the existing comparison, but `versionId` is also the workflow-history / publish identity. A settings toggle would then create a history row for an unchanged graph and could republish. Comparing settings keeps that contract intact.

## How to test

### Regression tests (fail on current `master`)

`isWorkflowModified()` on `master` only looks at `versionId`, `parentFolderId`, and `owner`. Both cases below keep those three fields identical and only change `settings`. On `master` the helper returns `false` (`expected true to be false`). On this branch it returns `true`.

**Case 1 — toggle after the workflow is already in git**

`should detect modifications when Available in MCP differs and version IDs match`

This is the bug in #34292. Local DB and remote export share `versionId: 'version1'` and `parentFolderId: 'folder1'`. Local has `{ availableInMCP: true }`, remote has `{ availableInMCP: false }` — someone turned the toggle on after the last push.

```ts
const local  = createWorkflowVersion({ settings: { availableInMCP: true } });
const remote = createWorkflowVersion({ settings: { availableInMCP: false } });
expect(isWorkflowModified(local, remote)).toBe(true);
```

On `master`: all compared fields match → `false` → push modal stays empty.
On this branch: `!isEqual({ availableInMCP: true }, { availableInMCP: false })` → `true` → listed as modified.

**Case 2 — setting present locally, absent from the export**

`should detect modifications when a settings-only field is present locally and missing remotely`

Same shared `versionId` / folder. Local has `{ availableInMCP: true }`. Remote has no `settings` at all (`undefined`), which is what an older export or a never-toggled remote looks like.

```ts
const local  = createWorkflowVersion({ settings: { availableInMCP: true } });
const remote = createWorkflowVersion(); // settings omitted
expect(isWorkflowModified(local, remote)).toBe(true);
```

On `master`: still `false` for the same reason as case 1.
On this branch: `!isEqual({ availableInMCP: true }, {})` → `true`. Missing and `{}` are treated as equal (case 4 below), but a real key vs missing is a change.

**How to see them fail**

```bash
git checkout master -- packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
pushd packages/cli
pnpm test src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts -t "Available in MCP"
pnpm test src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts -t "settings-only"
git checkout HEAD -- packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
```

Expected on `master`:

```
AssertionError: expected false to be true
```

at the `expect(isWorkflowModified(...)).toBe(true)` line in each test.

**Related cases that pass on both `master` and this branch** (they expect "not modified", which `master` already does):

- settings objects deeply equal, key order different → still not modified
- `settings` missing vs `settings: {}` → still not modified

Those are here so the new comparison does not flag every workflow that simply has an empty settings object.

The status-service test `should detect when Available in MCP is the only change` is the same as case 1 one layer up: it asserts the push-status payload contains one `workflow` file with `status: 'modified'`. It also fails on `master` because that path calls `isWorkflowModified`.

Full suite for this change:

```bash
pushd packages/cli
pnpm test src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts src/modules/source-control.ee/__tests__/source-control-status.service.test.ts src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
popd
```

### Manual (Enterprise, Environments / source control connected)

1. Push a workflow so it is already in the repo.
2. Toggle **Available in MCP** only. Save.
3. Open the source control **Push** modal. The workflow should be listed as modified.
4. Push and confirm the remote instance receives `availableInMCP`.
5. Repeat with another settings field (timezone is an easy one).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/GHC-8963
- Fixes #34292

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (no user-facing docs change; status comparison only)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Grok (xAI) helped write the patch and tests. I am keeping this as a draft until a team member confirms on #34292 that the approach is okay to take.