### PR TITLE
fix(RabbitMQ Node): await queue bindings before returning the channel

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -77,9 +77,12 @@ export async function rabbitmqConnectQueue(
 			}
 
 			if ('binding' in options && options.binding?.bindings.length) {
-				options.binding.bindings.forEach(async (binding) => {
+				// `forEach` does not await its callback: the promises returned by
+				// bindQueue were dropped, so the channel was resolved before the
+				// bindings existed and a rejection surfaced as an unhandled one.
+				for (const binding of options.binding.bindings) {
 					await channel.bindQueue(queue, binding.exchange, binding.routingKey);
-				});
+				}
 			}
 
 			resolve(channel);

--- a/packages/nodes-base/nodes/RabbitMQ/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/GenericFunctions.test.ts
@@ -144,6 +144,46 @@ describe('RabbitMQ GenericFunctions', () => {
 			expect(mockChannel.checkQueue).toHaveBeenCalledWith('queue');
 			expect(mockChannel.bindQueue).not.toHaveBeenCalled();
 		});
+
+		it('should not resolve until every binding is established', async () => {
+			context.getCredentials.mockResolvedValue(credentials);
+			const options = mock<TriggerOptions>({
+				assertQueue: true,
+				binding: {
+					bindings: [
+						{ exchange: 'ex1', routingKey: 'rk1' },
+						{ exchange: 'ex2', routingKey: 'rk2' },
+					],
+				},
+			});
+
+			let settled = 0;
+			mockChannel.bindQueue.mockImplementation(async () => {
+				await new Promise((r) => setImmediate(r));
+				settled += 1;
+				return {} as never;
+			});
+
+			await rabbitmqConnectQueue.call(context, 'queue', options);
+
+			expect(settled).toBe(2);
+			expect(mockChannel.bindQueue).toHaveBeenNthCalledWith(1, 'queue', 'ex1', 'rk1');
+			expect(mockChannel.bindQueue).toHaveBeenNthCalledWith(2, 'queue', 'ex2', 'rk2');
+		});
+
+		it('should reject when a binding fails', async () => {
+			context.getCredentials.mockResolvedValue(credentials);
+			const options = mock<TriggerOptions>({
+				assertQueue: true,
+				binding: { bindings: [{ exchange: 'ex1', routingKey: 'rk1' }] },
+			});
+
+			mockChannel.bindQueue.mockRejectedValueOnce(new Error('no such exchange'));
+
+			await expect(rabbitmqConnectQueue.call(context, 'queue', options)).rejects.toThrow(
+				'no such exchange',
+			);
+		});
 	});
 
 	describe('rabbitmqConnectExchange', () => {


### PR DESCRIPTION
## Problem

`rabbitmqConnectQueue` binds the queue to its exchanges like this:

```ts
if ('binding' in options && options.binding?.bindings.length) {
    options.binding.bindings.forEach(async (binding) => {
        await channel.bindQueue(queue, binding.exchange, binding.routingKey);
    });
}

resolve(channel);
```

`Array.prototype.forEach` ignores the promise its callback returns. The `await`
inside only suspends that callback — `forEach` returns immediately and
`resolve(channel)` runs while every `bindQueue` is still in flight.

Two consequences:

1. **The channel is handed back before the bindings exist.** A trigger that
   starts consuming right away can miss messages published in that window.
2. **A failed bind never rejects.** The `try/catch` around `resolve` cannot see
   it, because the rejection belongs to a detached callback promise. It becomes
   an unhandled rejection.

Reduced to plain node, same shape:

```
forEach : bindings established when channel returned = []
for..of : bindings established when channel returned = ["ex1/rk1","ex2/rk2"]

forEach : bindQueue error swallowed, channel returned anyway
for..of : rejected with "no such exchange"
   !! unhandledRejection: no such exchange
```

The last line is the `forEach` version's error arriving after the promise had
already resolved.

## Fix

A `for..of` loop, so each `bindQueue` is actually awaited and a rejection
propagates into the surrounding `try/catch`.

Binding is sequential rather than concurrent. That is what the code already
read as, the counts here are small, and `bindQueue` on one channel is cheap;
`Promise.all` would work too if you prefer concurrency, happy to switch.

`rabbitmqConnectExchange` does not have this pattern — this is the only
`forEach(async …)` in the file.

## Tests

Two added to the existing `describe('rabbitmqConnectQueue')` in
`nodes/RabbitMQ/test/GenericFunctions.test.ts`:

- `should not resolve until every binding is established` — `bindQueue` yields
  to the event loop before recording; asserts both have settled by the time
  `rabbitmqConnectQueue` returns, and that they ran in order.
- `should reject when a binding fails` — asserts a rejecting `bindQueue`
  surfaces as a rejection rather than an unhandled one.

Both fail on `master`: the first sees `settled === 0`, the second sees the
promise resolve.

**I could not run vitest locally** — `pnpm --filter n8n-nodes-base` leaves
`test/globalSetup.ts` unable to resolve its tsconfig on my machine, which looks
like a workspace-install issue on my side rather than anything to do with this
change. Please let CI run them.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

