### PR TITLE
fix(core): Surface model discovery authentication failures to users

### DIFF
--- a/packages/@n8n/ai-utilities/src/model-discovery/__tests__/model-discovery.test.ts
+++ b/packages/@n8n/ai-utilities/src/model-discovery/__tests__/model-discovery.test.ts
@@ -1,3 +1,5 @@
+import { UserError } from 'n8n-workflow';
+
 import { isOpenAiCustomEndpoint, listModelsForProvider, MODEL_DISCOVERY_PROVIDERS } from '../index';
 
 function mockFetch(body: unknown, ok = true, status = 200) {
@@ -207,11 +209,64 @@ describe('model-discovery', () => {
 	});
 
 	describe('error handling', () => {
-		it('throws a descriptive error on a non-2xx response', async () => {
-			const fetch = mockFetch({ error: { message: 'invalid x-api-key' } }, false, 401);
+		it.each([401, 403])(
+			'throws a non-reportable user error on an authentication response with status %s',
+			async (status) => {
+				const fetch = mockFetch(
+					{ error: { message: 'provider response must not be exposed' } },
+					false,
+					status,
+				);
 
-			await expect(listModelsForProvider('anthropic', { apiKey: 'bad', fetch })).rejects.toThrow(
-				/anthropic.*401/i,
+				const error = await listModelsForProvider('anthropic', {
+					apiKey: 'bad',
+					fetch,
+				}).catch((error: unknown) => error);
+
+				expect(error).toBeInstanceOf(UserError);
+				expect(error).toMatchObject({
+					message:
+						"Models couldn't be loaded. Check that the selected credential is valid and has the required permissions, then try again.",
+					shouldReport: false,
+				});
+			},
+		);
+
+		it('keeps server errors reportable', async () => {
+			const fetch = mockFetch({ error: { message: 'provider unavailable' } }, false, 500);
+
+			const error = await listModelsForProvider('anthropic', {
+				apiKey: 'key',
+				fetch,
+			}).catch((error: unknown) => error);
+
+			expect(error).toBeInstanceOf(Error);
+			expect(error).not.toBeInstanceOf(UserError);
+			expect(error).toMatchObject({
+				message:
+					'Failed to list anthropic models (status 500): {"error":{"message":"provider unavailable"}}',
+			});
+		});
+
+		it('propagates network errors unchanged', async () => {
+			const networkError = new Error('Network unavailable');
+			const fetch = vi.fn().mockRejectedValue(networkError) as unknown as typeof globalThis.fetch;
+
+			await expect(listModelsForProvider('anthropic', { apiKey: 'key', fetch })).rejects.toBe(
+				networkError,
+			);
+		});
+
+		it('propagates malformed response errors unchanged', async () => {
+			const parseError = new SyntaxError('Unexpected token');
+			const fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				json: async () => await Promise.reject(parseError),
+			}) as unknown as typeof globalThis.fetch;
+
+			await expect(listModelsForProvider('anthropic', { apiKey: 'key', fetch })).rejects.toBe(
+				parseError,
 			);
 		});
 

--- a/packages/@n8n/ai-utilities/src/model-discovery/request.ts
+++ b/packages/@n8n/ai-utilities/src/model-discovery/request.ts
@@ -1,6 +1,8 @@
+import { UserError } from 'n8n-workflow';
+
 import type { ListModelsFn, ListModelsOptions, ProviderModel } from './types';
 
-/** GET a provider endpoint and parse JSON, throwing a descriptive error on non-2xx. */
+/** GET a provider endpoint and parse JSON, treating rejected credentials as user errors. */
 export async function getJson(
 	url: string,
 	headers: Record<string, string>,
@@ -13,6 +15,13 @@ export async function getJson(
 		headers: { ...headers, ...options.headers },
 	});
 	if (!response.ok) {
+		if (response.status === 401 || response.status === 403) {
+			throw new UserError(
+				"Models couldn't be loaded. Check that the selected credential is valid and has the required permissions, then try again.",
+				{ shouldReport: false },
+			);
+		}
+
 		const body = await response.text().catch(() => '');
 		throw new Error(
 			`Failed to list ${provider} models (status ${response.status})${body ? `: ${body.slice(0, 500)}` : ''}`,


### PR DESCRIPTION
## Summary

- Treat HTTP 401 and 403 responses during shared provider model discovery as non-reportable user errors, allowing the canvas model selector to show actionable credential guidance instead of reporting expected authentication failures to Sentry.
- Avoid exposing provider response bodies for authentication failures while preserving existing behavior for other HTTP statuses, network failures, and malformed responses.
- Keep the new Agents models.dev fallback behavior unchanged.

Screenshot showing error being exposed to user rather than bubbling up to Sentry.
<img width="958" height="514" alt="image" src="https://github.com/user-attachments/assets/d5653ea5-1e57-4149-bcad-d2e46a8934b5" />


## How to test

Automated checks run in `packages/@n8n/ai-utilities`:

- `pnpm test src/model-discovery/__tests__/model-discovery.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`

Manual verification:

1. Add an Anthropic Chat Model sub-node to a compatible canvas node.
2. Select an Anthropic credential with an invalid API key.
3. Open the Model dropdown.
4. Confirm the dropdown displays credential guidance instead of reporting the authentication failure to Sentry.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-590

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

