### PR TITLE
fix(Contentful Node): Advance pagination skip by the page size

### DIFF
--- a/packages/nodes-base/nodes/Contentful/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Contentful/GenericFunctions.ts
@@ -56,12 +56,15 @@ export async function contentfulApiRequestAllItems(
 
 	let responseData;
 
-	query.limit = 100;
+	// Contentful's `skip` is the index of the first record to return, so it
+	// has to advance by the page size to reach the next page.
+	const limit = 100;
+	query.limit = limit;
 	query.skip = 0;
 
 	do {
 		responseData = await contentfulApiRequest.call(this, method, resource, body, query);
-		query.skip = (query.skip + 1) * query.limit;
+		query.skip = (query.skip as number) + limit;
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
 	} while (returnData.length < responseData.total);
 

--- a/packages/nodes-base/nodes/Contentful/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Contentful/test/GenericFunctions.test.ts
@@ -1,0 +1,101 @@
+import type { IDataObject, IExecuteFunctions, IRequestOptions } from 'n8n-workflow';
+
+import { contentfulApiRequestAllItems } from '../GenericFunctions';
+
+describe('Contentful -> contentfulApiRequestAllItems', () => {
+	let mockExecuteFunctions: IExecuteFunctions;
+
+	const mockRequest = vi.fn();
+	/** `contentfulApiRequest` reuses the same `qs` object across calls, so snapshot it. */
+	let sentQueryStrings: IDataObject[] = [];
+
+	const TOTAL_RECORDS = 250;
+	/** Guards against a non-advancing / exploding skip spinning forever. */
+	const MAX_REQUESTS = 1000;
+
+	const setupMockFunctions = () => {
+		sentQueryStrings = [];
+		mockExecuteFunctions = {
+			getNodeParameter: vi.fn().mockReturnValue('deliveryApi'),
+			getCredentials: vi.fn().mockResolvedValue({
+				ContentDeliveryaccessToken: 'test-token',
+				ContentPreviewaccessToken: 'preview-token',
+			}),
+			helpers: {
+				request: mockRequest,
+			},
+			getNode: vi.fn().mockReturnValue({}),
+		} as unknown as IExecuteFunctions;
+		vi.clearAllMocks();
+		mockRequest.mockImplementation(async (options: IRequestOptions) => {
+			const qs = { ...options.qs } as { limit: number; skip: number };
+			sentQueryStrings.push(qs);
+			if (sentQueryStrings.length > MAX_REQUESTS) {
+				throw new Error(`Pagination did not terminate within ${MAX_REQUESTS} requests`);
+			}
+			return await Promise.resolve(buildPage(qs.skip, qs.limit));
+		});
+	};
+
+	/**
+	 * Serves records from `skip` onwards, mirroring Contentful's
+	 * `limit`/`skip`/`total` scheme where `skip` is a record index.
+	 */
+	const buildPage = (skip: number, limit: number) => ({
+		items: Array.from(
+			{ length: Math.max(0, Math.min(limit, TOTAL_RECORDS - skip)) },
+			(_, index) => ({ id: `item-${skip + index}` }),
+		),
+		total: TOTAL_RECORDS,
+	});
+
+	beforeEach(() => {
+		setupMockFunctions();
+	});
+
+	it('should advance skip by the page size (not multiply)', async () => {
+		await contentfulApiRequestAllItems.call(
+			mockExecuteFunctions,
+			'items',
+			'GET',
+			'/spaces/space/entries',
+			{},
+			{},
+		);
+
+		expect(sentQueryStrings).toEqual([
+			expect.objectContaining({ limit: 100, skip: 0 }),
+			expect.objectContaining({ limit: 100, skip: 100 }),
+			expect.objectContaining({ limit: 100, skip: 200 }),
+		]);
+	});
+
+	it('should return every record exactly once', async () => {
+		const result = await contentfulApiRequestAllItems.call(
+			mockExecuteFunctions,
+			'items',
+			'GET',
+			'/spaces/space/entries',
+			{},
+			{},
+		);
+
+		expect(result).toHaveLength(250);
+		expect(new Set(result.map((item: IDataObject) => item.id)).size).toBe(250);
+		expect(result[0]).toEqual({ id: 'item-0' });
+		expect(result[249]).toEqual({ id: 'item-249' });
+	});
+
+	it('should stop requesting once all records have been collected', async () => {
+		await contentfulApiRequestAllItems.call(
+			mockExecuteFunctions,
+			'items',
+			'GET',
+			'/spaces/space/entries',
+			{},
+			{},
+		);
+
+		expect(mockRequest).toHaveBeenCalledTimes(3);
+	});
+});


### PR DESCRIPTION
## Summary

`contentfulApiRequestAllItems` advanced Contentful's `skip` query parameter by multiplying `(skip + 1) * limit` instead of adding the page size.

In Contentful's Delivery/Preview API pagination, `skip` is the index of the *first record* to return. The buggy progression was `0 → 100 → 10100 → …`, so:

- Records past the first two pages were never fetched
- Once `skip` exceeded `total`, the API returned empty pages and the loop never terminated

```diff
-		query.skip = (query.skip + 1) * query.limit;
+		query.skip = (query.skip as number) + limit;
```

This helper backs every **Return All** path in the node (Entry, Asset, and Content Type → Get Many).

## How to test

**Unit tests**

```bash
cd packages/nodes-base
pnpm test nodes/Contentful/test/GenericFunctions.test.ts
```

**Manual (optional)**

1. Add a Contentful node → Entry → Get Many
2. Enable **Return All** against a space with **> 200** entries
3. Execute and confirm:
   - Output length equals Contentful's total
   - No duplicate IDs
   - The node terminates (does not hang)

## Related Linear tickets, Github issues, and Community forum posts

- Fixes https://github.com/n8n-io/n8n/issues/35875
- https://linear.app/n8n/issue/GHC-9238

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- N/A: bug fix, no docs change -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

