### PR TITLE
fix(Contentful Node): Advance skip by page size in Return All pagination

### DIFF
--- a/packages/nodes-base/nodes/Contentful/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Contentful/GenericFunctions.ts
@@ -61,7 +61,7 @@ export async function contentfulApiRequestAllItems(
 
 	do {
 		responseData = await contentfulApiRequest.call(this, method, resource, body, query);
-		query.skip = (query.skip + 1) * query.limit;
+		query.skip = (query.skip as number) + (query.limit as number);
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
 	} while (returnData.length < responseData.total);
 

--- a/packages/nodes-base/nodes/Contentful/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Contentful/test/GenericFunctions.test.ts
@@ -1,0 +1,76 @@
+import type { IDataObject, IExecuteFunctions, IRequestOptions } from 'n8n-workflow';
+
+import { contentfulApiRequestAllItems } from '../GenericFunctions';
+
+describe('Contentful -> contentfulApiRequestAllItems', () => {
+	let executeFunctions: IExecuteFunctions;
+	const mockRequest = vi.fn();
+	/** The function mutates its `qs` argument across calls, so capture a copy per request. */
+	const sentQueryStrings: IDataObject[] = [];
+
+	const TOTAL_RECORDS = 250;
+	/** Guards against a non-advancing skip spinning forever. */
+	const MAX_REQUESTS = 1000;
+
+	const buildPage = (skip: number, limit: number) => ({
+		items: Array.from(
+			{ length: Math.max(0, Math.min(limit, TOTAL_RECORDS - skip)) },
+			(_, index) => ({ id: `item-${skip + index}` }),
+		),
+		total: TOTAL_RECORDS,
+	});
+
+	beforeEach(() => {
+		sentQueryStrings.length = 0;
+		vi.clearAllMocks();
+		mockRequest.mockImplementation(async (options: IRequestOptions) => {
+			const qs = options.qs as { limit: number; skip: number };
+			sentQueryStrings.push({ ...qs });
+			if (sentQueryStrings.length > MAX_REQUESTS) {
+				throw new Error(`Pagination did not terminate within ${MAX_REQUESTS} requests`);
+			}
+			return buildPage(qs.skip, qs.limit);
+		});
+		executeFunctions = {
+			getNodeParameter: vi.fn().mockReturnValue('deliveryApi'),
+			getCredentials: vi.fn().mockResolvedValue({
+				ContentDeliveryaccessToken: 'test-token',
+				ContentPreviewaccessToken: 'preview-token',
+			}),
+			helpers: { request: mockRequest },
+			getNode: vi.fn().mockReturnValue({}),
+		} as unknown as IExecuteFunctions;
+	});
+
+	it('should advance skip by the page size on every request', async () => {
+		await contentfulApiRequestAllItems.call(executeFunctions, 'items', 'GET', '/spaces/space/entries', {}, {});
+
+		expect(sentQueryStrings).toEqual([
+			expect.objectContaining({ limit: 100, skip: 0 }),
+			expect.objectContaining({ limit: 100, skip: 100 }),
+			expect.objectContaining({ limit: 100, skip: 200 }),
+		]);
+	});
+
+	it('should return every record exactly once', async () => {
+		const result = await contentfulApiRequestAllItems.call(
+			executeFunctions,
+			'items',
+			'GET',
+			'/spaces/space/entries',
+			{},
+			{},
+		);
+
+		expect(result).toHaveLength(TOTAL_RECORDS);
+		expect(new Set(result.map((item: IDataObject) => item.id)).size).toBe(TOTAL_RECORDS);
+		expect(result[0]).toEqual({ id: 'item-0' });
+		expect(result[TOTAL_RECORDS - 1]).toEqual({ id: 'item-249' });
+	});
+
+	it('should stop requesting once all records have been collected', async () => {
+		await contentfulApiRequestAllItems.call(executeFunctions, 'items', 'GET', '/spaces/space/entries', {}, {});
+
+		expect(mockRequest).toHaveBeenCalledTimes(3);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #35875. Contentful "Return All" skipped records after the first two pages and could loop forever.

`contentfulApiRequestAllItems` advanced `skip` as `(skip + 1) * limit`, so the offsets went 0, 100, 10100, 2020100... Records between page 2 and the end were never fetched, and once `skip` passed `total`, the loop could never collect enough records to stop.

The fix advances `skip` by the page size (`skip += limit`), matching Contentful's record-index pagination, so pages are fetched in order until every record is collected.

## How to test

The new unit tests cover the three things that matter:
- pagination offsets are 0, 100, 200 (page size progression, not multiplication)
- all 250 records come back exactly once with no duplicates
- the loop terminates after 3 requests

## Related Linear tickets, Github issues, and Community forum posts

closes #35875

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created (bug fix, no docs change needed).
- [x] Tests included.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

