### PR TITLE
fix(core): Fix non existent workflow id pathway for AIA

### DIFF
--- a/packages/@n8n/instance-ai/src/errors/__tests__/workflow-not-found.error.test.ts
+++ b/packages/@n8n/instance-ai/src/errors/__tests__/workflow-not-found.error.test.ts
@@ -1,0 +1,26 @@
+import { isWorkflowNotFoundError, WorkflowNotFoundError } from '../workflow-not-found.error';
+
+describe('WorkflowNotFoundError', () => {
+	// The eval harness classifies transient aborts by matching this text
+	// (`isTransientExecutionAbort`), so the wording is a contract, not cosmetic.
+	it('uses a stable message that includes the workflow id', () => {
+		expect(new WorkflowNotFoundError('abc123').message).toBe(
+			'Workflow abc123 not found or not accessible',
+		);
+	});
+
+	it('is detected directly and when wrapped as a cause', () => {
+		const root = new WorkflowNotFoundError('abc123');
+		const wrapped = new Error('Failed to load existing workflow', { cause: root });
+
+		expect(isWorkflowNotFoundError(root)).toBe(true);
+		expect(isWorkflowNotFoundError(wrapped)).toBe(true);
+	});
+
+	it('does not match look-alike messages or non-errors', () => {
+		expect(isWorkflowNotFoundError(new Error('Workflow abc123 not found or not accessible'))).toBe(
+			false,
+		);
+		expect(isWorkflowNotFoundError('Workflow abc123 not found or not accessible')).toBe(false);
+	});
+});

--- a/packages/@n8n/instance-ai/src/errors/workflow-not-found.error.ts
+++ b/packages/@n8n/instance-ai/src/errors/workflow-not-found.error.ts
@@ -1,8 +1,8 @@
-import { UnexpectedError } from 'n8n-workflow';
+import { OperationalError } from 'n8n-workflow';
 
-export class WorkflowNotFoundError extends UnexpectedError {
+export class WorkflowNotFoundError extends OperationalError {
 	constructor(readonly workflowId: string) {
-		super(`Workflow ${workflowId} not found or not accessible`);
+		super(`Workflow ${workflowId} not found or not accessible`, { level: 'warning' });
 	}
 }
 

--- a/packages/@n8n/instance-ai/src/errors/workflow-not-found.error.ts
+++ b/packages/@n8n/instance-ai/src/errors/workflow-not-found.error.ts
@@ -1,0 +1,12 @@
+import { UnexpectedError } from 'n8n-workflow';
+
+export class WorkflowNotFoundError extends UnexpectedError {
+	constructor(readonly workflowId: string) {
+		super(`Workflow ${workflowId} not found or not accessible`);
+	}
+}
+
+export function isWorkflowNotFoundError(error: unknown): boolean {
+	if (error instanceof WorkflowNotFoundError) return true;
+	return error instanceof Error && error.cause instanceof WorkflowNotFoundError;
+}

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -187,10 +187,7 @@ const loadValidateAttachments = lazyModule(
 
 export { MAX_STEPS } from './constants/max-steps';
 export { WorkflowSaveConflictError } from './errors/workflow-save-conflict.error';
-export {
-	WorkflowNotFoundError,
-	isWorkflowNotFoundError,
-} from './errors/workflow-not-found.error';
+export { WorkflowNotFoundError } from './errors/workflow-not-found.error';
 export {
 	LEGACY_PLANNED_TASK_KINDS,
 	PLANNED_TASK_KINDS,

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -188,6 +188,10 @@ const loadValidateAttachments = lazyModule(
 export { MAX_STEPS } from './constants/max-steps';
 export { WorkflowSaveConflictError } from './errors/workflow-save-conflict.error';
 export {
+	WorkflowNotFoundError,
+	isWorkflowNotFoundError,
+} from './errors/workflow-not-found.error';
+export {
 	LEGACY_PLANNED_TASK_KINDS,
 	PLANNED_TASK_KINDS,
 	STORED_PLANNED_TASK_KINDS,

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -1,4 +1,5 @@
 import { executeTool } from '../../../__tests__/tool-test-utils';
+import { WorkflowNotFoundError } from '../../../errors/workflow-not-found.error';
 import { WorkflowSaveConflictError } from '../../../errors/workflow-save-conflict.error';
 import { emitTraceOnlyChildRun } from '../../../tracing/langsmith-tracing';
 import type { InstanceAiContext } from '../../../types';
@@ -114,6 +115,7 @@ type BuildToolOutput = {
 		category: string;
 		shouldEdit: boolean;
 		reason?: string;
+		guidance?: string;
 	};
 };
 
@@ -963,7 +965,7 @@ describe('createBuildWorkflowTool', () => {
 	it('returns blocked remediation when the bound workflow no longer exists', async () => {
 		const { context, filePath } = makeContext({ source: 'workflow source' });
 		vi.mocked(context.workflowService.updateFromWorkflowJSON).mockRejectedValue(
-			new Error('Workflow not found'),
+			new WorkflowNotFoundError('wf-deleted'),
 		);
 
 		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
@@ -987,9 +989,9 @@ describe('createBuildWorkflowTool', () => {
 	it('returns a structured save failure when preserving existing webhook IDs fails', async () => {
 		const { context, filePath } = makeContext({ source: 'workflow source' });
 		vi.mocked(ensureWebhookIds).mockRejectedValueOnce(
-			new Error(
-				'Failed to load existing workflow wf-bound to preserve webhook IDs: Workflow not found',
-			),
+			new Error('Failed to load existing workflow wf-bound to preserve webhook IDs', {
+				cause: new WorkflowNotFoundError('wf-bound'),
+			}),
 		);
 
 		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
@@ -1009,6 +1011,34 @@ describe('createBuildWorkflowTool', () => {
 		});
 		expect(result.errors?.[0]).toContain('preserve webhook IDs');
 		expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+	});
+
+	it('returns blocked remediation when binding to a missing workflow id fails', async () => {
+		const { context, filePath } = makeContext({ source: 'workflow source' });
+		vi.mocked(context.workflowService.get).mockRejectedValue(
+			new WorkflowNotFoundError('wf-deleted'),
+		);
+
+		const result = await executeTool<BuildToolOutput>(createBuildWorkflowTool(context), {
+			filePath,
+			workflowId: 'wf-deleted',
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			filePath,
+			remediation: {
+				category: 'blocked',
+				shouldEdit: false,
+				reason: 'workflow_id_not_found',
+			},
+		});
+		expect(result.errors?.[0]).toContain('Failed to bind source file');
+		expect(result.remediation?.guidance).toContain(
+			'Call build-workflow again with the same filePath and omit workflowId',
+		);
+		expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+		expect(context.workflowService.createFromWorkflowJSON).not.toHaveBeenCalled();
 	});
 
 	it('returns blocked remediation when create permission is blocked', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-build-remediation.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-build-remediation.test.ts
@@ -1,3 +1,4 @@
+import { WorkflowNotFoundError } from '../../../errors/workflow-not-found.error';
 import { WorkflowSaveConflictError } from '../../../errors/workflow-save-conflict.error';
 import { createSaveFailureRemediation } from '../workflow-build-remediation';
 
@@ -11,5 +12,46 @@ describe('createSaveFailureRemediation', () => {
 			reason: 'workflow_modified_externally',
 		});
 		expect(remediation.guidance).toContain('get-as-code');
+	});
+
+	it('returns bound_workflow_not_found for WorkflowNotFoundError', () => {
+		const remediation = createSaveFailureRemediation(
+			new WorkflowNotFoundError('invoice-processing'),
+			true,
+		);
+
+		expect(remediation).toMatchObject({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'bound_workflow_not_found',
+		});
+	});
+
+	it('returns bound_workflow_not_found when WorkflowNotFoundError is nested as cause', () => {
+		const remediation = createSaveFailureRemediation(
+			new Error('Failed to load existing workflow invoice-processing to preserve setup values', {
+				cause: new WorkflowNotFoundError('invoice-processing'),
+			}),
+			true,
+		);
+
+		expect(remediation).toMatchObject({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'bound_workflow_not_found',
+		});
+	});
+
+	it('keeps workflow_save_failed when no workflow id was bound', () => {
+		const remediation = createSaveFailureRemediation(
+			new WorkflowNotFoundError('invoice-processing'),
+			false,
+		);
+
+		expect(remediation).toMatchObject({
+			category: 'code_fixable',
+			shouldEdit: true,
+			reason: 'workflow_save_failed',
+		});
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-build-remediation.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/workflow-build-remediation.test.ts
@@ -42,16 +42,18 @@ describe('createSaveFailureRemediation', () => {
 		});
 	});
 
-	it('keeps workflow_save_failed when no workflow id was bound', () => {
+	it('returns workflow_id_not_found when no workflow id was bound', () => {
 		const remediation = createSaveFailureRemediation(
 			new WorkflowNotFoundError('invoice-processing'),
 			false,
 		);
 
 		expect(remediation).toMatchObject({
-			category: 'code_fixable',
-			shouldEdit: true,
-			reason: 'workflow_save_failed',
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'workflow_id_not_found',
 		});
+		expect(remediation.guidance).toContain('omit workflowId');
+		expect(remediation.guidance).toContain('workflows()');
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -113,11 +113,6 @@ function isStructurallyValidWorkflowSourceFilePath(value: string): boolean {
 	}
 }
 
-const INVALID_WORKFLOW_ID_GUIDANCE =
-	'Call build-workflow again with the same filePath and omit workflowId to create a new workflow. ' +
-	'workflowId must be a real n8n workflow id from a prior build-workflow or workflows() tool result — ' +
-	'never the first argument of workflow(slug, name).';
-
 export const buildWorkflowInputSchema = z
 	.object({
 		filePath: z
@@ -144,7 +139,7 @@ export const buildWorkflowInputSchema = z
 			.describe(
 				'Real n8n workflow id from a prior build-workflow or workflows() tool result, used to bind this file on the first update. ' +
 					'Never pass the first argument of workflow(slug, name). Once bound, omit this on retries. ' +
-					'Omit to create a new workflow.',
+					'Omit to create a new workflow. Missing and inaccessible ids look the same — confirm with workflows() before inventing one.',
 			),
 		projectId: z
 			.string()
@@ -402,24 +397,15 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 					binding = await bindSourceFileToExistingWorkflow(context, binding, input.workflowId);
 				} catch (error) {
 					const message = error instanceof Error ? error.message : String(error);
-					const remediation = createSaveFailureRemediation(error, true);
-
-					const bindRemediation =
-						remediation.reason === 'bound_workflow_not_found'
-							? createRemediation({
-									category: 'blocked',
-									shouldEdit: false,
-									reason: 'workflow_id_not_found',
-									guidance: INVALID_WORKFLOW_ID_GUIDANCE,
-								})
-							: remediation;
+					// File is not bound yet, so not-found maps to workflow_id_not_found (not bound_*).
+					const remediation = createSaveFailureRemediation(error, false);
 
 					trackWorkflowSourceBuild(context, {
 						result: 'blocked',
 						stage: 'save',
 						binding,
 						targetWorkflowId: input.workflowId,
-						remediation: bindRemediation,
+						remediation,
 						errorCount: 1,
 					});
 
@@ -427,7 +413,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						success: false,
 						...sourceResponseBase(binding),
 						errors: [`Failed to bind source file to workflow ${input.workflowId}: ${message}`],
-						remediation: bindRemediation,
+						remediation,
 					};
 				}
 			}

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -113,6 +113,11 @@ function isStructurallyValidWorkflowSourceFilePath(value: string): boolean {
 	}
 }
 
+const INVALID_WORKFLOW_ID_GUIDANCE =
+	'Call build-workflow again with the same filePath and omit workflowId to create a new workflow. ' +
+	'workflowId must be a real n8n workflow id from a prior build-workflow or workflows() tool result — ' +
+	'never the first argument of workflow(slug, name).';
+
 export const buildWorkflowInputSchema = z
 	.object({
 		filePath: z
@@ -137,7 +142,9 @@ export const buildWorkflowInputSchema = z
 			.string()
 			.optional()
 			.describe(
-				'Existing workflow ID to bind this file to on the first update. Once bound, omit this on retries.',
+				'Real n8n workflow id from a prior build-workflow or workflows() tool result, used to bind this file on the first update. ' +
+					'Never pass the first argument of workflow(slug, name). Once bound, omit this on retries. ' +
+					'Omit to create a new workflow.',
 			),
 		projectId: z
 			.string()
@@ -391,7 +398,38 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 			}
 
 			if (input.workflowId && !binding.workflowId) {
-				binding = await bindSourceFileToExistingWorkflow(context, binding, input.workflowId);
+				try {
+					binding = await bindSourceFileToExistingWorkflow(context, binding, input.workflowId);
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					const remediation = createSaveFailureRemediation(error, true);
+
+					const bindRemediation =
+						remediation.reason === 'bound_workflow_not_found'
+							? createRemediation({
+									category: 'blocked',
+									shouldEdit: false,
+									reason: 'workflow_id_not_found',
+									guidance: INVALID_WORKFLOW_ID_GUIDANCE,
+								})
+							: remediation;
+
+					trackWorkflowSourceBuild(context, {
+						result: 'blocked',
+						stage: 'save',
+						binding,
+						targetWorkflowId: input.workflowId,
+						remediation: bindRemediation,
+						errorCount: 1,
+					});
+
+					return {
+						success: false,
+						...sourceResponseBase(binding),
+						errors: [`Failed to bind source file to workflow ${input.workflowId}: ${message}`],
+						remediation: bindRemediation,
+					};
+				}
 			}
 
 			const targetWorkflowId = binding.workflowId;

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-remediation.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-remediation.ts
@@ -4,6 +4,11 @@ import { WorkflowSaveConflictError } from '../../errors/workflow-save-conflict.e
 import { createRemediation } from '../../workflow-loop/remediation';
 import type { RemediationMetadata } from '../../workflow-loop/workflow-loop-state';
 
+export const INVALID_WORKFLOW_ID_GUIDANCE =
+	'Call build-workflow again with the same filePath and omit workflowId to create a new workflow only if that value was never a real n8n workflow id (for example an SDK slug). ' +
+	'If you meant an existing workflow, confirm the id with workflows() first — missing and inaccessible look the same. ' +
+	'workflowId must be a real n8n workflow id from a prior build-workflow or workflows() tool result — never the first argument of workflow(slug, name).';
+
 function getFailureText(error: unknown): string {
 	return (error instanceof Error ? error.message : String(error)).toLowerCase();
 }
@@ -73,13 +78,22 @@ export function createSaveFailureRemediation(
 		});
 	}
 
-	if (hasBoundWorkflowId && isWorkflowNotFoundError(error)) {
+	if (isWorkflowNotFoundError(error)) {
+		if (hasBoundWorkflowId) {
+			return createRemediation({
+				category: 'blocked',
+				shouldEdit: false,
+				reason: 'bound_workflow_not_found',
+				guidance:
+					'The saved workflow bound to this source file no longer exists. Stop editing this source and explain that the workflow must be restored or a new build started.',
+			});
+		}
+
 		return createRemediation({
 			category: 'blocked',
 			shouldEdit: false,
-			reason: 'bound_workflow_not_found',
-			guidance:
-				'The saved workflow bound to this source file no longer exists. Stop editing this source and explain that the workflow must be restored or a new build started.',
+			reason: 'workflow_id_not_found',
+			guidance: INVALID_WORKFLOW_ID_GUIDANCE,
 		});
 	}
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-remediation.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-build-remediation.ts
@@ -1,12 +1,8 @@
 import type { WorkflowSourceCompileFailureReason } from './workflow-source-compiler';
+import { isWorkflowNotFoundError } from '../../errors/workflow-not-found.error';
 import { WorkflowSaveConflictError } from '../../errors/workflow-save-conflict.error';
 import { createRemediation } from '../../workflow-loop/remediation';
 import type { RemediationMetadata } from '../../workflow-loop/workflow-loop-state';
-
-function isWorkflowNotFoundError(error: unknown): boolean {
-	const message = error instanceof Error ? error.message : String(error);
-	return /workflow not found/i.test(message);
-}
 
 function getFailureText(error: unknown): string {
 	return (error instanceof Error ? error.message : String(error)).toLowerCase();

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
@@ -1,22 +1,32 @@
 // Mock the barrel import so these adapter tests only exercise local formatting helpers.
-vi.mock('@n8n/instance-ai', () => ({
-	wrapUntrustedData(content: string, source: string, label?: string): string {
-		const esc = (s: string) =>
-			s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-		const safeLabel = label ? ` label="${esc(label)}"` : '';
-		const safeContent = content.replace(/<\/untrusted_data/gi, '&lt;/untrusted_data');
-		return `<untrusted_data source="${esc(source)}"${safeLabel}>\n${safeContent}\n</untrusted_data>`;
-	},
-	builderTemplatesOptionsFromEnv: () => ({}),
-	BuilderTemplatesService: class {
-		async getBundle() {
-			return { files: [], indexTxt: '', version: null };
-		}
-		getVersion() {
-			return null;
-		}
-	},
-}));
+vi.mock('@n8n/instance-ai', async () => {
+	const { WorkflowNotFoundError } = await import(
+		'../../../../../@n8n/instance-ai/src/errors/workflow-not-found.error.js'
+	);
+	return {
+		WorkflowNotFoundError,
+		wrapUntrustedData(content: string, source: string, label?: string): string {
+			const esc = (s: string) =>
+				s
+					.replace(/&/g, '&amp;')
+					.replace(/"/g, '&quot;')
+					.replace(/</g, '&lt;')
+					.replace(/>/g, '&gt;');
+			const safeLabel = label ? ` label="${esc(label)}"` : '';
+			const safeContent = content.replace(/<\/untrusted_data/gi, '&lt;/untrusted_data');
+			return `<untrusted_data source="${esc(source)}"${safeLabel}>\n${safeContent}\n</untrusted_data>`;
+		},
+		builderTemplatesOptionsFromEnv: () => ({}),
+		BuilderTemplatesService: class {
+			async getBundle() {
+				return { files: [], indexTxt: '', version: null };
+			}
+			getVersion() {
+				return null;
+			}
+		},
+	};
+});
 
 import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -3,8 +3,12 @@ vi.mock('@n8n/instance-ai', async () => {
 	const { WorkflowSaveConflictError } = await import(
 		'../../../../../@n8n/instance-ai/src/errors/workflow-save-conflict.error.js'
 	);
+	const { WorkflowNotFoundError } = await import(
+		'../../../../../@n8n/instance-ai/src/errors/workflow-not-found.error.js'
+	);
 	return {
 		WorkflowSaveConflictError,
+		WorkflowNotFoundError,
 		wrapUntrustedData(content: string, source: string, label?: string): string {
 			const esc = (s: string) =>
 				s
@@ -1233,9 +1237,11 @@ import type { DataTableRepository } from '@/modules/data-table/data-table.reposi
 import type { DataTableService } from '@/modules/data-table/data-table.service';
 import type { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import { WorkflowNotFoundError } from '../../../../../@n8n/instance-ai/src/errors/workflow-not-found.error';
 import { WorkflowSaveConflictError } from '../../../../../@n8n/instance-ai/src/errors/workflow-save-conflict.error';
 import type { WorkflowService } from '@/workflows/workflow.service';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { License } from '@/license';
 import type { RoleService } from '@/services/role.service';
 
@@ -2544,6 +2550,19 @@ describe('createWorkflowAdapter', () => {
 				expectedChecksum: 'stale-checksum',
 			}),
 		).rejects.toBeInstanceOf(WorkflowSaveConflictError);
+	});
+
+	it('throws WorkflowNotFoundError when workflowService.update cannot find the workflow', async () => {
+		const { adapter, mockWorkflowService } = createWorkflowAdapterForTests();
+		mockWorkflowService.update.mockRejectedValueOnce(
+			new NotFoundError(
+				'You do not have permission to update this workflow. Ask the owner to share it with you.',
+			),
+		);
+
+		await expect(
+			adapter.updateFromWorkflowJSON('wf-missing', minimalWorkflowJSON),
+		).rejects.toBeInstanceOf(WorkflowNotFoundError);
 	});
 
 	it('returns a checksum on create and update saves', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -53,6 +53,7 @@ import {
 	wrapUntrustedData,
 	deriveCredentialHosts,
 	WorkflowSaveConflictError,
+	WorkflowNotFoundError,
 } from '@n8n/instance-ai';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
 import {
@@ -126,6 +127,7 @@ import {
 
 import { ActiveExecutions } from '@/active-executions';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { EvaluationConfigService } from '@/evaluation.ee/evaluation-config.service';
@@ -642,7 +644,7 @@ export class InstanceAiAdapterService {
 				]);
 
 				if (!workflow) {
-					throw new Error(`Workflow ${workflowId} not found or not accessible`);
+					throw new WorkflowNotFoundError(workflowId);
 				}
 
 				return await toWorkflowDetailWithChecksum(workflow, { redactParameters });
@@ -652,7 +654,7 @@ export class InstanceAiAdapterService {
 				assertNotReadOnly();
 				const result = await workflowService.archive(user, workflowId, { skipArchived: true });
 				if (!result) {
-					throw new Error(`Workflow ${workflowId} not found or not accessible`);
+					throw new WorkflowNotFoundError(workflowId);
 				}
 			},
 
@@ -660,7 +662,7 @@ export class InstanceAiAdapterService {
 				assertNotReadOnly();
 				const result = await workflowService.unarchive(user, workflowId);
 				if (!result) {
-					throw new Error(`Workflow ${workflowId} not found or not accessible`);
+					throw new WorkflowNotFoundError(workflowId);
 				}
 			},
 
@@ -730,7 +732,7 @@ export class InstanceAiAdapterService {
 				const wf = await workflowFinderService.findWorkflowForUser(workflowId, user, [
 					'workflow:read',
 				]);
-				if (!wf) throw new Error(`Workflow ${workflowId} not found or not accessible`);
+				if (!wf) throw new WorkflowNotFoundError(workflowId);
 				if (!versionId) return toWorkflowJSON(wf, { redactParameters });
 				const version = await workflowHistoryService.getVersion(user, workflowId, versionId);
 				return toWorkflowJSON(wf, { redactParameters, graph: version });
@@ -740,7 +742,7 @@ export class InstanceAiAdapterService {
 				const head = await workflowFinderService.findWorkflowHeadForUser(workflowId, user, [
 					'workflow:read',
 				]);
-				if (!head) throw new Error(`Workflow ${workflowId} not found or not accessible`);
+				if (!head) throw new WorkflowNotFoundError(workflowId);
 				return { versionId: head.versionId, updatedAt: head.updatedAt.getTime() };
 			},
 
@@ -748,7 +750,7 @@ export class InstanceAiAdapterService {
 				const wf = await workflowFinderService.findWorkflowForUser(workflowId, user, [
 					'workflow:read',
 				]);
-				if (!wf) throw new Error(`Workflow ${workflowId} not found or not accessible`);
+				if (!wf) throw new WorkflowNotFoundError(workflowId);
 				return {
 					json: toWorkflowJSON(wf, { redactParameters }),
 					versionId: wf.versionId,
@@ -961,6 +963,9 @@ export class InstanceAiAdapterService {
 				} catch (error) {
 					if (error instanceof ConflictError) {
 						throw new WorkflowSaveConflictError(workflowId);
+					}
+					if (error instanceof NotFoundError) {
+						throw new WorkflowNotFoundError(workflowId);
 					}
 					logger.warn('AI-builder workflow save failed', {
 						threadId,
@@ -1175,7 +1180,7 @@ export class InstanceAiAdapterService {
 				]);
 
 				if (!workflow) {
-					throw new Error(`Workflow ${workflowId} not found or not accessible`);
+					throw new WorkflowNotFoundError(workflowId);
 				}
 
 				const nodes = workflow.nodes ?? [];
@@ -1923,7 +1928,7 @@ export class InstanceAiAdapterService {
 		): Promise<WorkflowEntity> => {
 			const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, [scope]);
 			if (!workflow) {
-				throw new Error(`Workflow ${workflowId} not found or not accessible`);
+				throw new WorkflowNotFoundError(workflowId);
 			}
 			return workflow;
 		};
@@ -2916,7 +2921,7 @@ export class InstanceAiAdapterService {
 								'workflow:update',
 							]);
 							if (!workflow) {
-								throw new Error(`Workflow ${workflowId} not found or not accessible`);
+								throw new WorkflowNotFoundError(workflowId);
 							}
 							await workflowService.update(user, workflow, workflowId, {
 								parentFolderId: folderId,
@@ -2932,7 +2937,7 @@ export class InstanceAiAdapterService {
 					'workflow:update',
 				]);
 				if (!workflow) {
-					throw new Error(`Workflow ${workflowId} not found or not accessible`);
+					throw new WorkflowNotFoundError(workflowId);
 				}
 
 				// Resolve tag names to IDs, creating missing tags
@@ -2988,7 +2993,7 @@ export class InstanceAiAdapterService {
 					'workflow:execute',
 				]);
 				if (!workflow) {
-					throw new Error(`Workflow ${workflowId} not found or not accessible`);
+					throw new WorkflowNotFoundError(workflowId);
 				}
 
 				const olderThanHours = options?.olderThanHours ?? 1;

--- a/packages/cli/test/integration/api-keys.api.test.ts
+++ b/packages/cli/test/integration/api-keys.api.test.ts
@@ -335,7 +335,9 @@ describe('Owner shell', () => {
 			apiKey: publicApiKeyService.redactApiKey(apiKeyWithExpiration.body.data.rawApiKey),
 			createdAt: expect.any(String),
 			updatedAt: expect.any(String),
-			expiresAt: expirationDateInTheFuture,
+			// GET returns JWT `exp`, which can drift 1s from the request value when
+			// sign-time `iat` crosses a second boundary vs generateApiKey's now.
+			expiresAt: publicApiKeyService.getApiKeyExpiration(apiKeyWithExpiration.body.data.rawApiKey),
 			scopes: ['workflow:create'],
 			audience: 'public-api',
 			lastUsedAt: null,
@@ -541,7 +543,9 @@ describe('Member', () => {
 			apiKey: publicApiKeyService.redactApiKey(apiKeyWithExpiration.body.data.rawApiKey),
 			createdAt: expect.any(String),
 			updatedAt: expect.any(String),
-			expiresAt: expirationDateInTheFuture,
+			// GET returns JWT `exp`, which can drift 1s from the request value when
+			// sign-time `iat` crosses a second boundary vs generateApiKey's now.
+			expiresAt: publicApiKeyService.getApiKeyExpiration(apiKeyWithExpiration.body.data.rawApiKey),
 			scopes: ['workflow:create'],
 			audience: 'public-api',
 			lastUsedAt: null,


### PR DESCRIPTION
## Summary

When `build-workflow` is given a non-existent `workflowId` (commonly an SDK slug like `invoice-processing` after a failed first save), the agent used to get `code_fixable` / `shouldEdit: true` — or, on current master, a bare bind throw with no remediation. That pushed it into edit/retry loops and sometimes duplicate workflows.

This PR:

- Introduces typed `WorkflowNotFoundError` and throws it from the Instance AI workflow adapter (including mapping `NotFoundError` from `workflowService.update`)
- Detects not-found via the typed error / `cause` instead of a message regex that never matched production (`Workflow ${id} not found or not accessible`)
- Catches failures from `bindSourceFileToExistingWorkflow` and returns structured remediation with `reason: workflow_id_not_found`
- Guides the agent to **retry with the same `filePath` and omit `workflowId`**, and clarifies the `workflowId` input description so SDK slugs are not treated as n8n ids

## How to test

1. Build a new multi-node workflow build.
2. After a validation failure on the first save (`workflowId` still unset), have the agent retry `build-workflow` with an invented id / SDK slug (e.g. `invoice-processing`).
3. Expect a failed tool result with:
   - `remediation.reason: workflow_id_not_found`
   - `shouldEdit: false`
   - guidance to call `build-workflow` again with the same `filePath` and **omit** `workflowId`
4. Confirm a retry without `workflowId` creates the workflow successfully (no duplicate source file workaround).

Unit coverage:
- `packages/@n8n/instance-ai` — `build-workflow.tool`, `workflow-build-remediation`, `workflow-not-found.error`
- `packages/cli` — adapter maps `NotFoundError` → `WorkflowNotFoundError` on update

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-865

Related: https://linear.app/n8n/issue/INS-436

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

