### PR TITLE
fix(core): Persist Header Auth values instead of redaction placeholders

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -120,6 +120,52 @@ describe('CredentialsHelper', () => {
 	});
 
 	describe('applyDefaultsAndOverwrites', () => {
+		// GHC-9252 / https://github.com/n8n-io/n8n/issues/35966
+		// Header Auth stores the header name in a field also called `name`, which
+		// must not be replaced by the credential's display name when defaults are applied.
+		test('keeps Header Auth header name and value distinct from the credential display name', async () => {
+			const credentialType: ICredentialType = {
+				name: 'httpHeaderAuth',
+				displayName: 'Header Auth',
+				properties: [
+					{ displayName: 'Name', name: 'name', type: 'string', default: '' },
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+						typeOptions: { password: true },
+					},
+				],
+			};
+			mockNodesAndCredentials.getCredential.calledWith(credentialType.name).mockReturnValue({
+				type: credentialType,
+				sourcePath: '',
+			});
+			const credentialsOverwrites = mock<CredentialsOverwrites>();
+			credentialsOverwrites.applyOverwrite.mockImplementation((_type, data) => data);
+			const helper = new CredentialsHelper(
+				new CredentialTypes(mockNodesAndCredentials),
+				credentialsOverwrites,
+				credentialsRepository,
+				dynamicCredentialProxy,
+				secretsProviderRepository,
+				licenseState,
+				externalSecretsConfig,
+				mock<AiGatewayService>(),
+			);
+
+			const result = await helper.applyDefaultsAndOverwrites(
+				mock<IWorkflowExecuteAdditionalData>({ variables: {} }),
+				{ name: 'Authorization', value: 'newer-secret' },
+				credentialType.name,
+				'webhook',
+			);
+
+			expect(result).toEqual({ name: 'Authorization', value: 'newer-secret' });
+			expect(result.name).not.toBe('Header Auth');
+		});
+
 		test('omits marked credential fields that cannot resolve without execution context', async () => {
 			const credentialType: ICredentialType = {
 				name: 'openAiApi',
@@ -1841,6 +1887,81 @@ describe('CredentialsHelper', () => {
 				true,
 			);
 			expect(resultB.apiKey).toBe('key_account_B_UPDATED');
+		});
+	});
+
+	// GHC-9252 / https://github.com/n8n-io/n8n/issues/35966
+	describe('Header Auth credential isolation', () => {
+		const credentialType = 'httpHeaderAuth';
+		const olderData = { name: 'Authorization', value: 'older-secret' };
+		const newerData = { name: 'Authorization', value: 'newer-secret' };
+
+		const olderEntity = {
+			id: 'header-old',
+			name: 'Older Header Auth',
+			type: credentialType,
+			data: cipher.encrypt(olderData),
+			isResolvable: false,
+			resolverId: null,
+			usageScope: 'project',
+		} as CredentialsEntity;
+
+		const newerEntity = {
+			id: 'header-new',
+			name: 'Newer Header Auth',
+			type: credentialType,
+			data: cipher.encrypt(newerData),
+			isResolvable: false,
+			resolverId: null,
+			usageScope: 'project',
+		} as CredentialsEntity;
+
+		const additionalData = {
+			executionContext: undefined,
+			workflowSettings: undefined,
+			rootExecutionMode: 'webhook',
+		} as any;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			dynamicCredentialProxy.setResolverProvider(undefined as any);
+
+			credentialsRepository.findOneByOrFail.mockImplementation(async (query: any) => {
+				if (query.id === 'header-old' && query.type === credentialType) return olderEntity;
+				if (query.id === 'header-new' && query.type === credentialType) return newerEntity;
+				throw new EntityNotFoundError(CredentialsEntity, query);
+			});
+		});
+
+		test('decrypts a new Header Auth credential to its own value, not an older one', async () => {
+			const result = await credentialsHelper.getDecrypted(
+				additionalData,
+				{ id: 'header-new', name: 'Newer Header Auth' },
+				credentialType,
+				'webhook',
+				undefined,
+				true,
+			);
+
+			expect(result).toEqual(newerData);
+			expect(result.value).toBe('newer-secret');
+			expect(result.value).not.toBe('older-secret');
+		});
+
+		test('looks up Header Auth credentials by id, not by header name or display name', async () => {
+			await credentialsHelper.getDecrypted(
+				additionalData,
+				{ id: 'header-new', name: 'Older Header Auth' },
+				credentialType,
+				'webhook',
+				undefined,
+				true,
+			);
+
+			expect(credentialsRepository.findOneByOrFail).toHaveBeenCalledWith({
+				id: 'header-new',
+				type: credentialType,
+			});
 		});
 	});
 

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -2820,6 +2820,49 @@ describe('CredentialsService', () => {
 			expect(savedCredential.isGlobal).toBeUndefined();
 		});
 
+		// GHC-9252 / https://github.com/n8n-io/n8n/issues/35966
+		it('should not persist a redaction sentinel as a Header Auth value on create', async () => {
+			mockTransactionManager();
+			const createEncryptedDataSpy = vi.spyOn(service, 'createEncryptedData');
+
+			await service.createUnmanagedCredential(
+				{
+					name: 'Newer Header Auth',
+					type: 'httpHeaderAuth',
+					data: { name: 'Authorization', value: CREDENTIAL_BLANKING_VALUE },
+					projectId: 'project-1',
+				},
+				ownerUser,
+			);
+
+			expect(createEncryptedDataSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: { name: 'Authorization', value: '' },
+				}),
+			);
+		});
+
+		it('should not persist an expression-prefixed redaction sentinel on create', async () => {
+			mockTransactionManager();
+			const createEncryptedDataSpy = vi.spyOn(service, 'createEncryptedData');
+
+			await service.createUnmanagedCredential(
+				{
+					name: 'Newer Header Auth',
+					type: 'httpHeaderAuth',
+					data: { name: 'Authorization', value: `=${CREDENTIAL_BLANKING_VALUE}` },
+					projectId: 'project-1',
+				},
+				ownerUser,
+			);
+
+			expect(createEncryptedDataSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: { name: 'Authorization', value: '' },
+				}),
+			);
+		});
+
 		it('should allow member to create non-global credential', async () => {
 			// ARRANGE
 			const payload = { ...credentialData, isGlobal: false };

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -43,11 +43,13 @@ import {
 	CREDENTIAL_EMPTY_VALUE,
 	deepCopy,
 	displayParameter,
+	isCredentialSentinelValue,
 	isExpression,
 	isINodePropertyCollection,
 	jsonParse,
 	jsonStringify,
 	NodeHelpers,
+	stripCredentialSentinels,
 } from 'n8n-workflow';
 
 import { CredentialTypes } from '@/credential-types';
@@ -1430,11 +1432,9 @@ export class CredentialsService {
 	private unredactRestoreValues(unmerged: any, replacement: any) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		for (const [key, value] of Object.entries(unmerged)) {
-			// Strip a leading `=`: switching a redacted field to expression mode
-			// prepends it to the sentinel, which would otherwise defeat the match
-			// and persist the sentinel as the real value.
-			const sentinel = typeof value === 'string' && value.startsWith('=') ? value.slice(1) : value;
-			if (sentinel === CREDENTIAL_BLANKING_VALUE || sentinel === CREDENTIAL_EMPTY_VALUE) {
+			// Expression-toggle prepends `=` to the displayed sentinel; treat that
+			// the same as the bare sentinel so we restore the saved secret.
+			if (isCredentialSentinelValue(value)) {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 				unmerged[key] = replacement[key];
 			} else if (
@@ -1837,8 +1837,13 @@ export class CredentialsService {
 	}
 
 	private async createCredential(opts: CreateCredentialOptions, user: User) {
+		// Create has no saved secret to restore from, so a redaction sentinel
+		// (or `=`+sentinel from toggling a password field to expression) must
+		// not be persisted as the real value. GHC-9252 / n8n-io/n8n#35966
+		const data = stripCredentialSentinels((opts.data ?? {}) as ICredentialDataDecryptedObject);
+
 		if (opts.usageScope === 'instance') {
-			const savedCredential = await this.persistInstanceCredential(opts, user, {});
+			const savedCredential = await this.persistInstanceCredential({ ...opts, data }, user, {});
 			const scopes = await this.getCredentialScopes(user, savedCredential.id);
 			const { shared, ...credential } = savedCredential;
 			return { ...credential, scopes };
@@ -1850,16 +1855,11 @@ export class CredentialsService {
 			await this.ensureCanManageEndUserCredential(user, targetProjectId);
 		}
 
-		await this.checkCredentialData(
-			opts.type,
-			opts.data as ICredentialDataDecryptedObject,
-			user,
-			targetProjectId,
-		);
+		await this.checkCredentialData(opts.type, data, user, targetProjectId);
 		if (this.externalSecretsConfig.externalSecretsForProjects) {
 			await validateAccessToReferencedSecretProviders(
 				targetProjectId,
-				opts.data as ICredentialDataDecryptedObject,
+				data,
 				this.externalSecretsProviderAccessCheckService,
 				'create',
 			);
@@ -1868,7 +1868,7 @@ export class CredentialsService {
 			id: null,
 			name: opts.name,
 			type: opts.type,
-			data: opts.data as ICredentialDataDecryptedObject,
+			data,
 		});
 
 		// Set isGlobal if provided in the payload and user has permission
@@ -1894,7 +1894,7 @@ export class CredentialsService {
 			encryptedCredential,
 			user,
 			targetProjectId,
-			opts.data as ICredentialDataDecryptedObject,
+			data,
 		);
 
 		const scopes = await this.getCredentialScopes(user, credential.id);
@@ -1917,7 +1917,7 @@ export class CredentialsService {
 		if (opts.isResolvable === true || opts.isManaged) {
 			throw new BadRequestError('Provider connections cannot be end-user or managed credentials');
 		}
-		const data = opts.data as ICredentialDataDecryptedObject;
+		const data = stripCredentialSentinels(opts.data as ICredentialDataDecryptedObject);
 		this.validateInstanceCredentialData(data);
 
 		this.validateCredentialData(opts.type, data);

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -931,6 +931,39 @@ describe('POST /credentials', () => {
 		}
 	});
 
+	// GHC-9252 / https://github.com/n8n-io/n8n/issues/35966
+	// A newly created Header Auth credential must persist its own value, not
+	// silently reuse the secret of an older Header Auth credential.
+	test('should persist Header Auth values independently of an older Header Auth credential', async () => {
+		const older = {
+			name: 'Older Header Auth',
+			type: 'httpHeaderAuth',
+			data: { name: 'Authorization', value: 'older-secret' },
+		};
+		const newer = {
+			name: 'Newer Header Auth',
+			type: 'httpHeaderAuth',
+			data: { name: 'Authorization', value: 'newer-secret' },
+		};
+
+		const olderResponse = await authOwnerAgent.post('/credentials').send(older);
+		expect(olderResponse.statusCode).toBe(200);
+
+		const newerResponse = await authOwnerAgent.post('/credentials').send(newer);
+		expect(newerResponse.statusCode).toBe(200);
+
+		const olderCredential = await getCredentialById(olderResponse.body.data.id);
+		const newerCredential = await getCredentialById(newerResponse.body.data.id);
+		a.ok(olderCredential);
+		a.ok(newerCredential);
+
+		expect(await decryptCredentialData(olderCredential)).toStrictEqual(older.data);
+		expect(await decryptCredentialData(newerCredential)).toStrictEqual(newer.data);
+		expect(await decryptCredentialData(newerCredential)).not.toEqual(
+			await decryptCredentialData(olderCredential),
+		);
+	});
+
 	test('should ignore ID in payload', async () => {
 		const firstResponse = await authOwnerAgent
 			.post('/credentials')
@@ -1296,6 +1329,30 @@ describe('PATCH /credentials/:id', () => {
 		});
 
 		expect(sharedCredential.credentials.name).toBe(patchPayload.name); // updated
+	});
+
+	// GHC-9252 / https://github.com/n8n-io/n8n/issues/35966
+	test('should persist an updated Header Auth value instead of keeping an older secret', async () => {
+		const created = await authOwnerAgent.post('/credentials').send({
+			name: 'Header Auth',
+			type: 'httpHeaderAuth',
+			data: { name: 'Authorization', value: 'original-secret' },
+		});
+		expect(created.statusCode).toBe(200);
+
+		const response = await authOwnerAgent.patch(`/credentials/${created.body.data.id}`).send({
+			name: 'Header Auth',
+			type: 'httpHeaderAuth',
+			data: { name: 'Authorization', value: 'rotated-secret' },
+		});
+		expect(response.statusCode).toBe(200);
+
+		const credential = await getCredentialById(created.body.data.id);
+		a.ok(credential);
+		expect(await decryptCredentialData(credential)).toStrictEqual({
+			name: 'Authorization',
+			value: 'rotated-secret',
+		});
 	});
 
 	test('should update non-owned cred for owner', async () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -12,7 +12,7 @@ import type {
 	INodeParameters,
 	ITelemetryTrackProperties,
 } from 'n8n-workflow';
-import { NodeHelpers } from 'n8n-workflow';
+import { NodeHelpers, stripCredentialSentinels } from 'n8n-workflow';
 import CredentialIcon from '../CredentialIcon.vue';
 
 import CredentialConfig from './CredentialConfig.vue';
@@ -646,7 +646,7 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 
 	// Save only the none default data
 	assert(credentialType.value);
-	const data = NodeHelpers.getNodeParameters(
+	let data = NodeHelpers.getNodeParameters(
 		credentialType.value.properties,
 		credentialData.value as INodeParameters,
 		false,
@@ -654,6 +654,12 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 		null,
 		null,
 	);
+
+	const isNewCredential = props.mode === 'new' && !credentialId.value;
+	// Create cannot restore a redacted secret — never send the placeholder as the value.
+	if (isNewCredential && data) {
+		data = stripCredentialSentinels(data as ICredentialDataDecryptedObject) as INodeParameters;
+	}
 
 	assert(credentialTypeName.value);
 	const credentialDetails: ICredentialsDecrypted = {
@@ -688,8 +694,6 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 	}
 
 	let credential: ICredentialsResponse | null = null;
-
-	const isNewCredential = props.mode === 'new' && !credentialId.value;
 
 	if (isNewCredential) {
 		if (presetUsageScope.value) {

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
-import type { ICredentialType, INode, INodeTypeDescription } from 'n8n-workflow';
+import {
+	CREDENTIAL_BLANKING_VALUE,
+	type ICredentialType,
+	type INode,
+	type INodeTypeDescription,
+} from 'n8n-workflow';
 
 import { mockedStore } from '@/__tests__/utils';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
@@ -30,6 +35,22 @@ const httpBasicAuth: ICredentialType = {
 	properties: [
 		{ displayName: 'User', name: 'user', type: 'string', default: '' },
 		{ displayName: 'Password', name: 'password', type: 'string', default: '' },
+	],
+};
+
+const httpHeaderAuth: ICredentialType = {
+	name: 'httpHeaderAuth',
+	displayName: 'Header Auth',
+	properties: [
+		{ displayName: 'Name', name: 'name', type: 'string', default: '', required: true },
+		{
+			displayName: 'Value',
+			name: 'value',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			required: true,
+		},
 	],
 };
 
@@ -104,6 +125,7 @@ const betaApi: ICredentialType = {
 
 const typesByName: Record<string, ICredentialType> = {
 	httpBasicAuth,
+	httpHeaderAuth,
 	acmeOAuth2Api: managedOAuth,
 	privateOAuth2Api: privateOAuth,
 	skipOAuth2Api: skipManagedOAuth,
@@ -494,6 +516,74 @@ describe('useCredentialForm', () => {
 			const form = useCredentialForm({ mode: 'new', activeId: 'skipOAuth2Api' });
 
 			expect(form.managedOAuthAvailable.value).toBe(false);
+		});
+	});
+
+	// GHC-9252 / https://github.com/n8n-io/n8n/issues/35966
+	describe('Header Auth new-credential isolation', () => {
+		it('does not seed a new Header Auth form from an older Header Auth credential', async () => {
+			credentialsStore.state.credentials = {
+				'older-header-auth': {
+					id: 'older-header-auth',
+					name: 'Older Header Auth',
+					type: 'httpHeaderAuth',
+					createdAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+					isManaged: false,
+				},
+			};
+			credentialsStore.getCredentialData.mockResolvedValue({
+				id: 'older-header-auth',
+				name: 'Older Header Auth',
+				type: 'httpHeaderAuth',
+				data: { name: 'Authorization', value: 'older-secret' },
+			} as unknown as ICredentialsDecryptedResponse);
+
+			const form = useCredentialForm({ mode: 'new', activeId: 'httpHeaderAuth' });
+			await form.initialize();
+
+			expect(form.credentialData.value).toMatchObject({ name: '', value: '' });
+			expect(form.credentialData.value.value).not.toBe('older-secret');
+			expect(credentialsStore.getCredentialData).not.toHaveBeenCalled();
+		});
+
+		it('keeps the typed Header Auth value when the user fills a new credential', async () => {
+			const form = useCredentialForm({ mode: 'new', activeId: 'httpHeaderAuth' });
+			await form.initialize();
+
+			form.onDataChange({ name: 'name', value: 'Authorization' });
+			form.onDataChange({ name: 'value', value: 'newer-secret' });
+
+			expect(form.credentialData.value).toMatchObject({
+				name: 'Authorization',
+				value: 'newer-secret',
+			});
+		});
+
+		it('does not treat a redaction sentinel as a filled required value on create', async () => {
+			const form = useCredentialForm({ mode: 'new', activeId: 'httpHeaderAuth' });
+			await form.initialize();
+			form.onDataChange({ name: 'name', value: 'Authorization' });
+			form.onDataChange({ name: 'value', value: CREDENTIAL_BLANKING_VALUE });
+
+			expect(form.requiredPropertiesFilled.value).toBe(false);
+
+			form.onDataChange({ name: 'value', value: 'newer-secret' });
+			expect(form.requiredPropertiesFilled.value).toBe(true);
+		});
+
+		it('still treats a redaction sentinel as filled when editing an existing credential', async () => {
+			credentialsStore.getCredentialData.mockResolvedValue({
+				id: 'older-header-auth',
+				name: 'Older Header Auth',
+				type: 'httpHeaderAuth',
+				data: { name: 'Authorization', value: CREDENTIAL_BLANKING_VALUE },
+			} as unknown as ICredentialsDecryptedResponse);
+
+			const form = useCredentialForm({ mode: 'edit', activeId: 'older-header-auth' });
+			await form.initialize();
+
+			expect(form.requiredPropertiesFilled.value).toBe(true);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
@@ -13,7 +13,12 @@ import type {
 	INodeParameters,
 	INodeProperties,
 } from 'n8n-workflow';
-import { CREDENTIAL_EMPTY_VALUE, deepCopy, NodeHelpers } from 'n8n-workflow';
+import {
+	CREDENTIAL_EMPTY_VALUE,
+	deepCopy,
+	isCredentialSentinelValue,
+	NodeHelpers,
+} from 'n8n-workflow';
 import { getResourcePermissions } from '@n8n/permissions';
 import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
@@ -273,7 +278,10 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 			if (property.required !== true) continue;
 			const value = credentialData.value[property.name];
 
-			if (property.type === 'string' && !value) return false;
+			if (property.type === 'string') {
+				// On create a redaction sentinel is not a real secret — treat it as empty.
+				if (!value || (isNewCredential.value && isCredentialSentinelValue(value))) return false;
+			}
 
 			if (property.type === 'number') {
 				const containsExpression = typeof value === 'string' && value.startsWith('=');

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -1551,7 +1551,9 @@ describe('ParameterInput.vue', () => {
 			});
 
 			await nextTick();
-			expect(container.querySelector('input[type="password"]')).toBeInTheDocument();
+			const input = container.querySelector('input[type="password"]');
+			expect(input).toBeInTheDocument();
+			expect(input).toHaveAttribute('autocomplete', 'new-password');
 			expect(container.querySelector('textarea')).not.toBeInTheDocument();
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -1855,6 +1855,7 @@ onUpdated(async () => {
 					:class="{ 'input-with-opener': true, 'ph-no-capture': shouldRedactValue }"
 					:size="parameterInputSize"
 					:type="getStringInputType"
+					:autocomplete="getTypeOption('password') === true ? 'new-password' : 'off'"
 					:masked="isMaskedTextarea"
 					:rows="editorRows"
 					:disabled="

--- a/packages/nodes-base/nodes/Webhook/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/utils.test.ts
@@ -679,6 +679,47 @@ describe('Webhook Utils', () => {
 			).rejects.toThrowError('Authorization data is wrong!');
 		});
 
+		// GHC-9252 / https://github.com/n8n-io/n8n/issues/35966
+		// A webhook assigned a newly created Header Auth credential must accept
+		// that credential's value and reject an older Header Auth credential's value.
+		it('should accept only the assigned Header Auth credential value, not an older one', async () => {
+			const assignedAuth = {
+				name: 'Authorization',
+				value: 'newer-secret',
+			};
+			const successHeaders = {
+				authorization: 'newer-secret',
+			};
+			const successCtx: Partial<IWebhookFunctions> = {
+				getNodeParameter: vi.fn().mockReturnValue('headerAuth'),
+				getCredentials: vi.fn().mockResolvedValue(assignedAuth),
+				getRequestObject: vi.fn().mockReturnValue({
+					headers: successHeaders,
+				}),
+				getHeaderData: vi.fn().mockReturnValue(successHeaders),
+			};
+
+			await expect(
+				validateWebhookAuthentication(successCtx as IWebhookFunctions, 'authentication'),
+			).resolves.toBeUndefined();
+
+			const olderHeaders = {
+				authorization: 'older-secret',
+			};
+			const olderCtx: Partial<IWebhookFunctions> = {
+				getNodeParameter: vi.fn().mockReturnValue('headerAuth'),
+				getCredentials: vi.fn().mockResolvedValue(assignedAuth),
+				getRequestObject: vi.fn().mockReturnValue({
+					headers: olderHeaders,
+				}),
+				getHeaderData: vi.fn().mockReturnValue(olderHeaders),
+			};
+
+			await expect(
+				validateWebhookAuthentication(olderCtx as IWebhookFunctions, 'authentication'),
+			).rejects.toThrowError('Authorization data is wrong!');
+		});
+
 		it('should throw an error if jwtAuth is enabled but no authentication data is defined on the node', async () => {
 			const ctx: Partial<IWebhookFunctions> = {
 				getNodeParameter: vi.fn().mockReturnValue('jwtAuth'),

--- a/packages/workflow/src/credential-sentinels.ts
+++ b/packages/workflow/src/credential-sentinels.ts
@@ -1,0 +1,34 @@
+import { CREDENTIAL_BLANKING_VALUE, CREDENTIAL_EMPTY_VALUE } from './constants';
+import type { ICredentialDataDecryptedObject } from './interfaces';
+
+/**
+ * True when `value` is a credential redaction sentinel, including the
+ * `=`-prefixed form produced by toggling a redacted password field into
+ * expression mode.
+ */
+export function isCredentialSentinelValue(value: unknown): boolean {
+	if (typeof value !== 'string') return false;
+	const bare = value.startsWith('=') ? value.slice(1) : value;
+	return bare === CREDENTIAL_BLANKING_VALUE || bare === CREDENTIAL_EMPTY_VALUE;
+}
+
+/**
+ * Replace redaction sentinels with empty strings so they cannot be persisted
+ * as the real secret (create has no saved value to restore from).
+ */
+export function stripCredentialSentinels(
+	data: ICredentialDataDecryptedObject,
+): ICredentialDataDecryptedObject {
+	return stripSentinelValue(data) as ICredentialDataDecryptedObject;
+}
+
+function stripSentinelValue(value: unknown): unknown {
+	if (isCredentialSentinelValue(value)) return '';
+	if (Array.isArray(value)) return value.map(stripSentinelValue);
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, nested]) => [key, stripSentinelValue(nested)]),
+		);
+	}
+	return value;
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -5,6 +5,7 @@ import * as TelemetryHelpers from './telemetry-helpers';
 
 export * from './errors';
 export * from './constants';
+export * from './credential-sentinels';
 export * from './common';
 export * from './cron';
 export * from './data-table.types';

--- a/packages/workflow/test/credential-sentinels.test.ts
+++ b/packages/workflow/test/credential-sentinels.test.ts
@@ -1,0 +1,49 @@
+import {
+	CREDENTIAL_BLANKING_VALUE,
+	CREDENTIAL_EMPTY_VALUE,
+	isCredentialSentinelValue,
+	stripCredentialSentinels,
+} from '../src';
+
+describe('isCredentialSentinelValue', () => {
+	it.each([
+		CREDENTIAL_BLANKING_VALUE,
+		CREDENTIAL_EMPTY_VALUE,
+		`=${CREDENTIAL_BLANKING_VALUE}`,
+		`=${CREDENTIAL_EMPTY_VALUE}`,
+	])('returns true for %s', (value) => {
+		expect(isCredentialSentinelValue(value)).toBe(true);
+	});
+
+	it.each(['secret', '=', '={{ $secrets.key }}', '', 1, null, undefined, { value: 'x' }])(
+		'returns false for %j',
+		(value) => {
+			expect(isCredentialSentinelValue(value)).toBe(false);
+		},
+	);
+});
+
+describe('stripCredentialSentinels', () => {
+	it('replaces sentinels with empty strings, including expression-prefixed ones', () => {
+		expect(
+			stripCredentialSentinels({
+				name: 'Authorization',
+				value: CREDENTIAL_BLANKING_VALUE,
+				extra: `=${CREDENTIAL_EMPTY_VALUE}`,
+				nested: { token: CREDENTIAL_BLANKING_VALUE, keep: 'ok' },
+				list: [CREDENTIAL_BLANKING_VALUE, 'keep'],
+			}),
+		).toEqual({
+			name: 'Authorization',
+			value: '',
+			extra: '',
+			nested: { token: '', keep: 'ok' },
+			list: ['', 'keep'],
+		});
+	});
+
+	it('leaves a real secret unchanged', () => {
+		const data = { name: 'Authorization', value: 'newer-secret' };
+		expect(stripCredentialSentinels(data)).toEqual(data);
+	});
+});


### PR DESCRIPTION
## Summary

When creating a Header Auth credential, the Value field could be saved as the client redaction sentinel (`__n8n_BLANK_VALUE_…`, including the `=`-prefixed form after toggling the field to expression) instead of the secret the user entered. Create has no stored secret to restore from, so that placeholder became the real credential value. Incoming webhook header auth then rejected the new secret and could still accept an older Header Auth value (browser autofill of the password field, or the node still using the previous credential).

This change:

- Strips redaction sentinels on credential **create** so they are never persisted as secrets
- Treats sentinels as empty when checking required fields on **new** credentials (edit still treats them as filled)
- Strips sentinels from the create payload in the credential editor
- Sets `autocomplete="new-password"` on password inputs so the browser does not fill an older Header Auth secret

## How to test

1. Create a Header Auth credential (Credentials page or from a Webhook node): Name `Authorization`, Value `older-secret`. Save.
2. Create a **second** Header Auth credential with a new name: Name `Authorization`, Value `newer-secret`. Save.
3. Re-open the second credential — Value should show as a hidden/redacted field (expected), not as the literal sentinel.
4. Attach the second credential to a Webhook node (Header Auth) and publish.
5. Call the webhook with `Authorization: newer-secret` → accepted.
6. Call with `Authorization: older-secret` → rejected (403).
7. Optional: on the new credential form, toggle Value to expression and back, then enter `newer-secret` and save — the stored secret should still be `newer-secret`, not the blanking placeholder.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/GHC-9252
- fixes #35966

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

