### PR TITLE
fix(HighLevel Node): Send custom fields as id and fieldValue

### DIFF
--- a/packages/nodes-base/nodes/HighLevel/v2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HighLevel/v2/GenericFunctions.ts
@@ -378,42 +378,78 @@ export async function getUsers(this: ILoadOptionsFunctions): Promise<INodeProper
 	return options;
 }
 
+type CustomFieldLocator = {
+	value?: unknown;
+	id?: unknown;
+};
+
+type RawCustomField = {
+	fieldId?: CustomFieldLocator | string;
+	id?: unknown;
+	fieldValue?: unknown;
+	field_value?: unknown;
+};
+
+function resolveCustomFieldId(field: RawCustomField): string | undefined {
+	const locator = field.fieldId;
+
+	if (typeof locator === 'string' && locator !== '') {
+		return locator;
+	}
+
+	if (typeof locator === 'object' && locator !== null) {
+		if (typeof locator.value === 'string' && locator.value !== '') {
+			return locator.value;
+		}
+		if (typeof locator.id === 'string' && locator.id !== '') {
+			return locator.id;
+		}
+	}
+
+	if (typeof field.id === 'string' && field.id !== '') {
+		return field.id;
+	}
+
+	return undefined;
+}
+
+/**
+ * HighLevel expects `{ id, fieldValue }`. The UI stores a resource locator plus
+ * `fieldValue`; older routing also emitted `{ fieldId: { id }, field_value }`.
+ */
 export async function addCustomFieldsPreSendAction(
 	this: IExecuteSingleFunctions,
 	requestOptions: IHttpRequestOptions,
 ): Promise<IHttpRequestOptions> {
 	const requestBody = requestOptions.body as IDataObject;
 
-	if (requestBody && requestBody.customFields) {
-		const rawCustomFields = requestBody.customFields as IDataObject;
-
-		// Define the structure of fieldId
-		interface FieldIdType {
-			value: unknown;
-			cachedResultName?: string;
-		}
-
-		// Ensure rawCustomFields.values is an array of objects with fieldId and fieldValue
-		if (rawCustomFields && Array.isArray(rawCustomFields.values)) {
-			const formattedCustomFields = rawCustomFields.values.map((field: unknown) => {
-				// Assert that field is of the expected shape
-				const typedField = field as { fieldId: FieldIdType; fieldValue: unknown };
-
-				const fieldId = typedField.fieldId;
-
-				if (typeof fieldId === 'object' && fieldId !== null && 'value' in fieldId) {
-					return {
-						id: fieldId.value,
-						key: fieldId.cachedResultName ?? 'default_key',
-						field_value: typedField.fieldValue,
-					};
-				} else {
-					throw new NodeOperationError(this.getNode(), 'Error processing custom fields.');
-				}
-			});
-			requestBody.customFields = formattedCustomFields;
-		}
+	if (!requestBody?.customFields) {
+		return requestOptions;
 	}
+
+	const rawCustomFields = requestBody.customFields as IDataObject | RawCustomField[];
+	const values = Array.isArray(rawCustomFields)
+		? rawCustomFields
+		: Array.isArray(rawCustomFields.values)
+			? (rawCustomFields.values as RawCustomField[])
+			: undefined;
+
+	if (!values) {
+		return requestOptions;
+	}
+
+	requestBody.customFields = values.map((field) => {
+		const id = resolveCustomFieldId(field);
+
+		if (id === undefined) {
+			throw new NodeOperationError(this.getNode(), 'Error processing custom fields.');
+		}
+
+		return {
+			id,
+			fieldValue: field.fieldValue ?? field.field_value,
+		};
+	});
 
 	return requestOptions;
 }

--- a/packages/nodes-base/nodes/HighLevel/v2/description/ContactDescription.ts
+++ b/packages/nodes-base/nodes/HighLevel/v2/description/ContactDescription.ts
@@ -116,7 +116,11 @@ export const contactOperations: INodeProperties[] = [
 						url: '=/contacts/{{$parameter.contactId}}/',
 					},
 					send: {
-						preSend: [validEmailAndPhonePreSendAction, splitTagsPreSendAction],
+						preSend: [
+							validEmailAndPhonePreSendAction,
+							splitTagsPreSendAction,
+							addCustomFieldsPreSendAction,
+						],
 					},
 					output: {
 						postReceive: [
@@ -196,14 +200,6 @@ const customFields: INodeProperties = {
 					name: 'fieldValue',
 					type: 'string',
 					default: '',
-					routing: {
-						send: {
-							type: 'body',
-							property: 'customFields',
-							value:
-								'={{ $parent.values.map(field => ({ fieldId: { id: field.fieldId.id }, field_value: field.fieldValue })) }}',
-						},
-					},
 				},
 			],
 		},

--- a/packages/nodes-base/nodes/HighLevel/v2/test/AddCustomFieldsPreSendAction.test.ts
+++ b/packages/nodes-base/nodes/HighLevel/v2/test/AddCustomFieldsPreSendAction.test.ts
@@ -1,38 +1,18 @@
 import type { IDataObject, IExecuteSingleFunctions, IHttpRequestOptions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 
 import { addCustomFieldsPreSendAction } from '../GenericFunctions';
 
 describe('addCustomFieldsPreSendAction', () => {
-	let mockThis: any;
+	let mockThis: IExecuteSingleFunctions;
 
 	beforeEach(() => {
 		mockThis = {
-			helpers: {
-				httpRequest: vi.fn(),
-				httpRequestWithAuthentication: vi.fn(),
-				requestWithAuthenticationPaginated: vi.fn(),
-				request: vi.fn(),
-				requestWithAuthentication: vi.fn(),
-				requestOAuth1: vi.fn(),
-				requestOAuth2: vi.fn(),
-				assertBinaryData: vi.fn(),
-				getBinaryDataBuffer: vi.fn(),
-				prepareBinaryData: vi.fn(),
-				setBinaryDataBuffer: vi.fn(),
-				copyBinaryFile: vi.fn(),
-				binaryToBuffer: vi.fn(),
-				binaryToString: vi.fn(),
-				getBinaryPath: vi.fn(),
-				getBinaryStream: vi.fn(),
-				getBinaryMetadata: vi.fn(),
-				createDeferredPromise: vi
-					.fn()
-					.mockReturnValue({ promise: Promise.resolve(), resolve: vi.fn(), reject: vi.fn() }),
-			},
-		};
+			getNode: vi.fn().mockReturnValue({ name: 'HighLevel' }),
+		} as unknown as IExecuteSingleFunctions;
 	});
 
-	it('should format custom fields correctly when provided', async () => {
+	it('should format custom fields as HighLevel { id, fieldValue } entries', async () => {
 		const mockRequestOptions: IHttpRequestOptions = {
 			body: {
 				customFields: {
@@ -51,14 +31,61 @@ describe('addCustomFieldsPreSendAction', () => {
 			url: '',
 		};
 
-		const result = await addCustomFieldsPreSendAction.call(
-			mockThis as IExecuteSingleFunctions,
-			mockRequestOptions,
-		);
+		const result = await addCustomFieldsPreSendAction.call(mockThis, mockRequestOptions);
 
 		expect((result.body as IDataObject).customFields).toEqual([
-			{ id: '123', key: 'FieldName', field_value: 'TestValue' },
-			{ id: '456', key: 'default_key', field_value: 'AnotherValue' },
+			{ id: '123', fieldValue: 'TestValue' },
+			{ id: '456', fieldValue: 'AnotherValue' },
+		]);
+	});
+
+	// n8n-io/n8n#35392: Update used a resource locator plus the nested routing
+	// expression, which produced `{ fieldId: { id }, field_value }` instead of
+	// the `{ id, fieldValue }` body HighLevel accepts.
+	it('should remap resource-locator and legacy field_value shapes', async () => {
+		const mockRequestOptions: IHttpRequestOptions = {
+			body: {
+				customFields: [
+					{
+						fieldId: {
+							__rl: true,
+							value: 'custom-field-id',
+							mode: 'list',
+							cachedResultName: 'Resumo',
+						},
+						fieldValue: 'teste',
+					},
+					{
+						fieldId: { id: 'legacy-field-id' },
+						field_value: 'legacy-value',
+					},
+				],
+			} as IDataObject,
+			url: '',
+		};
+
+		const result = await addCustomFieldsPreSendAction.call(mockThis, mockRequestOptions);
+
+		expect((result.body as IDataObject).customFields).toEqual([
+			{ id: 'custom-field-id', fieldValue: 'teste' },
+			{ id: 'legacy-field-id', fieldValue: 'legacy-value' },
+		]);
+	});
+
+	it('should accept a plain string field id from an expression', async () => {
+		const mockRequestOptions: IHttpRequestOptions = {
+			body: {
+				customFields: {
+					values: [{ fieldId: 'string-field-id', fieldValue: 'plain' }],
+				},
+			} as IDataObject,
+			url: '',
+		};
+
+		const result = await addCustomFieldsPreSendAction.call(mockThis, mockRequestOptions);
+
+		expect((result.body as IDataObject).customFields).toEqual([
+			{ id: 'string-field-id', fieldValue: 'plain' },
 		]);
 	});
 
@@ -70,10 +97,7 @@ describe('addCustomFieldsPreSendAction', () => {
 			url: '',
 		};
 
-		const result = await addCustomFieldsPreSendAction.call(
-			mockThis as IExecuteSingleFunctions,
-			mockRequestOptions,
-		);
+		const result = await addCustomFieldsPreSendAction.call(mockThis, mockRequestOptions);
 
 		expect(result).toEqual(mockRequestOptions);
 	});
@@ -88,11 +112,23 @@ describe('addCustomFieldsPreSendAction', () => {
 			url: '',
 		};
 
-		const result = await addCustomFieldsPreSendAction.call(
-			mockThis as IExecuteSingleFunctions,
-			mockRequestOptions,
-		);
+		const result = await addCustomFieldsPreSendAction.call(mockThis, mockRequestOptions);
 
 		expect((result.body as IDataObject).customFields).toEqual([]);
+	});
+
+	it('should throw when a custom field has no usable id', async () => {
+		const mockRequestOptions: IHttpRequestOptions = {
+			body: {
+				customFields: {
+					values: [{ fieldId: {}, fieldValue: 'missing-id' }],
+				},
+			} as IDataObject,
+			url: '',
+		};
+
+		await expect(addCustomFieldsPreSendAction.call(mockThis, mockRequestOptions)).rejects.toThrow(
+			NodeOperationError,
+		);
 	});
 });

--- a/packages/nodes-base/nodes/HighLevel/v2/test/ContactDescription.test.ts
+++ b/packages/nodes-base/nodes/HighLevel/v2/test/ContactDescription.test.ts
@@ -1,0 +1,23 @@
+import type { INodePropertyOptions } from 'n8n-workflow';
+
+import { contactOperations } from '../description/ContactDescription';
+import { addCustomFieldsPreSendAction } from '../GenericFunctions';
+
+const findContactOperation = (value: string) =>
+	(contactOperations[0].options as INodePropertyOptions[]).find((option) => option.value === value);
+
+describe('HighLevel V2 - Contact custom fields routing', () => {
+	it('formats custom fields on Contact Create', () => {
+		expect(findContactOperation('create')?.routing?.send?.preSend).toEqual(
+			expect.arrayContaining([addCustomFieldsPreSendAction]),
+		);
+	});
+
+	// n8n-io/n8n#35392: Update previously skipped this helper, so custom fields
+	// were sent as `{ fieldId, field_value }` and HighLevel rejected the request.
+	it('formats custom fields on Contact Update', () => {
+		expect(findContactOperation('update')?.routing?.send?.preSend).toEqual(
+			expect.arrayContaining([addCustomFieldsPreSendAction]),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

HighLevel Contact → Update failed whenever a custom field was included. Two things were wrong:

1. **Update never formatted custom fields.** Create already runs `addCustomFieldsPreSendAction`. Update did not, so the body kept the UI collection (or a broken routing rewrite) instead of HighLevel's `customFields` array.
2. **The payload used the wrong keys.** The helper sent `{ id, key, field_value }`, and a nested routing expression overwrote the body with `{ fieldId: { id }, field_value }`. HighLevel's Contacts API (and the working HTTP Request in #35392) expects `{ id, fieldValue }`.

This change maps the resource-locator collection — and the older `field_value` shape — to `{ id, fieldValue }`, removes the nested routing that overwrote the body, and runs the same helper on Update.

Asked to pick this up on the issue before opening the PR: https://github.com/n8n-io/n8n/issues/35392#issuecomment-5244273927

## How to test

Regression tests (no HighLevel account required):

```bash
pushd packages/nodes-base
pnpm test AddCustomFieldsPreSendAction.test.ts ContactDescription.test.ts
popd
```

The new cases fail on `master` without this change: the helper still emits `field_value` / `default_key`, and Update's `preSend` list does not include `addCustomFieldsPreSendAction`.

Manual:

1. Create a HighLevel OAuth2 credential and a contact.
2. Add a HighLevel node, **Contact → Update**, pick the contact, and set any custom field (text is enough).
3. Execute the node. It should succeed and return the contact with that custom field updated.
4. Repeat with **Contact → Create or Update** and a custom field to confirm Create still works.
5. Update only standard fields (no custom fields). That path should be unchanged.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/GHC-9164
- fixes #35392

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

