### PR TITLE
feat(editor): Add inline code to the markdown editor toolbar

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.test.ts
@@ -17,6 +17,7 @@ describe('components/N8nMarkdownEditorToolbar', () => {
 		expect(wrapper.getByRole('button', { name: 'Bold' })).toBeInTheDocument();
 		expect(wrapper.getByRole('button', { name: 'Italic' })).toBeInTheDocument();
 		expect(wrapper.getByRole('button', { name: 'Strikethrough' })).toBeInTheDocument();
+		expect(wrapper.getByRole('button', { name: 'Inline code' })).toBeInTheDocument();
 		expect(wrapper.getByRole('button', { name: 'Text' })).toBeInTheDocument();
 		expect(wrapper.getByRole('button', { name: 'Bullet list' })).toBeInTheDocument();
 		expect(wrapper.getByRole('button', { name: 'Task list' })).toBeInTheDocument();
@@ -84,6 +85,27 @@ describe('components/N8nMarkdownEditorToolbar', () => {
 
 		await waitFor(() => expect(wrapper.getByTestId('markdown-editor-toolbar')).toBeInTheDocument());
 		expect(wrapper.getByRole('button', { name: 'Text' })).toBeInTheDocument();
+	});
+
+	it('marks the selection as inline code and reflects the active state', async () => {
+		let editor: Editor | undefined;
+		const wrapper = render(N8nMarkdownEditor, {
+			props: {
+				modelValue: 'Content',
+				onReady: (readyEditor: Editor) => {
+					editor = readyEditor;
+				},
+			},
+		});
+
+		await waitFor(() => expect(wrapper.getByTestId('markdown-editor-toolbar')).toBeInTheDocument());
+		await waitFor(() => expect(editor).toBeDefined());
+
+		editor!.commands.selectAll();
+		await fireEvent.click(wrapper.getByRole('button', { name: 'Inline code' }));
+
+		expect(editor!.isActive('code')).toBe(true);
+		expect(editor!.getMarkdown()).toContain('`Content`');
 	});
 
 	it('disables toolbar controls when editor is disabled', async () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditorToolbar.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditorToolbar.vue
@@ -80,6 +80,12 @@ const markControls = computed<ToolbarControl[]>(() => [
 		icon: 'underline',
 		command: ({ editor }) => editor.chain().focus().toggleUnderline().run(),
 	},
+	{
+		id: 'code',
+		label: translate('markdownEditor.code'),
+		icon: 'code',
+		command: ({ editor }) => editor.chain().focus().toggleCode().run(),
+	},
 ]);
 
 const blockControls = computed<ToolbarControl[]>(() => [

--- a/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
+++ b/packages/frontend/@n8n/design-system/src/locale/lang/en.ts
@@ -197,6 +197,7 @@ export default {
 	'markdownEditor.italic': 'Italic',
 	'markdownEditor.strikethrough': 'Strikethrough',
 	'markdownEditor.underline': 'Underline',
+	'markdownEditor.code': 'Inline code',
 	'markdownEditor.link': 'Link',
 	'markdownEditor.bulletList': 'Bullet list',
 	'markdownEditor.orderedList': 'Ordered list',


### PR DESCRIPTION
## Summary

The markdown editor toolbar exposes **Bold**, **Italic**, **Strikethrough** and **Underline** as mark controls, and **Code block** as a block control — but there was no way to apply *inline* code from the toolbar. This adds it.

The plumbing was already in place: `useMarkdownEditor` registers `StarterKit`, which ships the `Code` mark, so `toggleCode()` and `isActive('code')` already worked. Only the control was missing.

Three changes:

- `MarkdownEditorToolbar.vue` — new entry in `markControls` using the `code` icon from `updatedIconSet`
- `@n8n/design-system` `en.ts` — `markdownEditor.code` label
- `MarkdownEditor.test.ts` — added to the default-toolbar assertion, plus a behaviour test

Giving the control `id: 'code'` means the active/highlight state flows through the existing `activeMarks` filter (`markControls.filter((c) => editor.isActive(c.id))`), so no extra state wiring was needed. It also inherits the existing `disabled` and `isRawMode` guards via `runControl`.

Placed last in `markControls` so the existing button order is unchanged.

## How to test

1. Open anything using the markdown editor — e.g. a workflow **Sticky Note**, or the design-system Storybook story `MarkdownEditor`.
2. Select some text and click the new **Inline code** button (`</>`).
3. The selection renders as inline code, and the button shows as active while the cursor is inside it.
4. Toggle **Raw markdown** — the text is wrapped in single backticks.
5. Click again with the selection inside the code to remove the mark.

Also worth checking: the button is disabled in raw mode and when the editor is `disabled` or `readonly`, matching the other mark controls.

## Related Linear tickets, Github issues, and Community forum posts

None — this came from noticing inline code was the one common markdown mark the toolbar could not apply. Happy to open an issue first if you would prefer that for feature work.

## Notes for the reviewer

- `pnpm vitest run src/components/N8nMarkdownEditor/MarkdownEditor.test.ts` — **17 passed**, including the new test asserting `isActive('code')` and that `editor.getMarkdown()` contains the backticked text.
- `pnpm typecheck` on `@n8n/design-system` — clean.
- `eslint` on the three changed files — 0 errors. `stylelint` on the toolbar component — clean.
- Full `@n8n/design-system` suite — 1404 passing. 20 failures in `N8nIconPicker` are pre-existing on `master`; I confirmed they reproduce with my changes stashed and left them alone.
- The `lint:styles` pre-commit hook could not run across sibling frontend packages in my environment, so it is worth letting CI confirm that step.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

