### PR TITLE
fix(editor): Rebuild markdown renderer when the options prop changes

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.test.ts
@@ -23,6 +23,38 @@ describe('components', () => {
 			});
 		});
 
+		it('should rebuild the renderer when the options prop changes', async () => {
+			const wrapper = render(N8nMarkdown, {
+				global: {
+					directives: {
+						n8nHtml,
+					},
+				},
+				props: {
+					content: 'Visit https://n8n.io for more',
+					options: {
+						markdown: { html: false, linkify: true, typographer: true, breaks: true },
+						linkAttributes: { attrs: { target: '_blank', rel: 'noopener' } },
+						tasklists: { enabled: true, label: true, labelAfter: false },
+						youtube: {},
+					},
+				},
+			});
+
+			expect(wrapper.container.querySelector('a')).toHaveAttribute('href', 'https://n8n.io');
+
+			await wrapper.rerender({
+				options: {
+					markdown: { html: false, linkify: false, typographer: true, breaks: true },
+					linkAttributes: { attrs: { target: '_blank', rel: 'noopener' } },
+					tasklists: { enabled: true, label: true, labelAfter: false },
+					youtube: {},
+				},
+			});
+
+			expect(wrapper.container.querySelector('a')).toBeNull();
+		});
+
 		it('should render image urls', () => {
 			const wrapper = render(N8nMarkdown, {
 				global: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -67,12 +67,15 @@ const props = withDefaults(defineProps<MarkdownProps>(), {
 
 const editor = ref<HTMLDivElement | undefined>(undefined);
 
-const { options } = props;
-const md = new Markdown(options.markdown)
-	.use(markdownLink, options.linkAttributes)
-	.use(markdownEmoji)
-	.use(markdownTaskLists, options.tasklists)
-	.use(markdownYoutubeEmbed, options.youtube);
+// Rebuild on options change — destructuring props here would capture the
+// initial value and leave the renderer on a stale config.
+const md = computed(() =>
+	new Markdown(props.options.markdown)
+		.use(markdownLink, props.options.linkAttributes)
+		.use(markdownEmoji)
+		.use(markdownTaskLists, props.options.tasklists)
+		.use(markdownYoutubeEmbed, props.options.youtube),
+);
 
 // `xss` is CJS with no `exports` map. Node's lexer cannot see `whiteList` as a
 // named export, so `import { whiteList }` throws at link time under native ESM
@@ -153,7 +156,7 @@ const htmlContent = computed(() => {
 			})
 			.join('\n');
 	}
-	const html = md.render(contentToRender);
+	const html = md.value.render(contentToRender);
 
 	const safeHtml = xss(html, {
 		onTagAttr(tag, name, value) {


### PR DESCRIPTION
## Summary

`N8nMarkdown` destructures `options` off props at setup and builds its `markdown-it` instance once from that snapshot:

```ts
const { options } = props;
const md = new Markdown(options.markdown)
	.use(markdownLink, options.linkAttributes)
	.use(markdownEmoji)
	.use(markdownTaskLists, options.tasklists)
	.use(markdownYoutubeEmbed, options.youtube);
```

Destructuring props drops reactivity, so `md` is created from the first value and never rebuilt. If a consumer changes `options`, the renderer keeps the original config — `linkify`, `typographer`, `breaks`, `html`, link attributes, task list and youtube settings all stay as they were on first render.

This builds the instance in a `computed` on `props.options` instead.

## Scope / honesty note

`options` is public API and three call sites pass it today (`RunDataParsedAiContent.vue`, `ChatMarkdownChunk.vue`, `@n8n/chat`'s `MarkdownRenderer.vue`) — but all of them pass a static object, so **nothing in the app currently hits this**. I found it while reading the component, not from a reported bug.

Happy for you to close this if you would rather keep the single-build behaviour and treat `options` as create-only. In that case it may be worth documenting the prop as non-reactive, since the current signature suggests otherwise.

## How to test

There was no coverage for the `options` prop, so I added a regression test that fails on `master`:

1. Render `N8nMarkdown` with `content: 'Visit https://n8n.io for more'` and `markdown.linkify: true` — the URL becomes an `<a>`.
2. Re-render with `markdown.linkify: false`.
3. On `master` the `<a>` is still present because `md` was never rebuilt. With this change it is gone.

## Related Linear tickets, Github issues, and Community forum posts

None — found by reading the component.

## Notes for the reviewer

- `pnpm vitest run src/components/N8nMarkdown/` — **17 passed**, including the new test.
- `pnpm typecheck` on `@n8n/design-system` — clean.
- `eslint` and `stylelint` on both changed files — 0 errors.
- Full `@n8n/design-system` suite — 1404 passing, unchanged from baseline. The 20 `N8nIconPicker` failures are pre-existing on `master`; I confirmed they reproduce with my changes stashed and left them alone.
- `md.render(...)` became `md.value.render(...)` at the single call site.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

