### PR TITLE
refactor(core): Trim indirection from the update_workflow steps (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -32,7 +32,6 @@ import {
 	autoPopulateNodeCredentials,
 	trackAutoassignOutcomes,
 	type AutoAssignResult,
-	type CredentialAssignment,
 } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
 import { sanitizeSkillsUsed, SKILLS_USED_PARAM_DESCRIPTION } from './skills-used';
@@ -82,9 +81,10 @@ const gatedGroupOperationTypes = [
 	'removeNodeGroup',
 	'updateNodeGroup',
 ] as const satisfies ReadonlyArray<PartialUpdateOperation['type']>;
-// Typed against the strict union rather than `string`, so renaming an operation
-// type in workflow-operations.ts fails to compile here instead of silently
-// leaving the gate unmatched.
+// The `satisfies` on both tuples above is what catches a renamed operation type
+// in workflow-operations.ts at compile time, instead of silently leaving the gate
+// unmatched or an implemented operation unreachable. The set element type is
+// narrowed to match so `.has()` only accepts a real operation type.
 const GATED_GROUP_OP_TYPES: ReadonlySet<PartialUpdateOperation['type']> = new Set(
 	gatedGroupOperationTypes,
 );
@@ -349,7 +349,7 @@ const outputSchema = {
 		.describe('Error message explaining why the update failed. Present only on failure.'),
 } satisfies z.ZodRawShape;
 /**
- * The success payload, derived from `outputSchema` so the builder cannot add a
+ * The success payload, derived from `outputSchema` so the handler cannot build a
  * field the published schema does not declare. That matters because the MCP SDK
  * validates `structuredContent` against the schema on every response, so an
  * undeclared field turns a successful update into an opaque `-32602`.
@@ -762,17 +762,10 @@ const isSettingsOperation = (op: PartialUpdateOperation) => op.type === 'setWork
  * applied. Throw order is part of the contract: gated group ops first, then
  * tag ops.
  */
-function assertOperationsSupported({
-	strictOperations,
-	hasTagOperations,
-	canvasGroupsEnabled,
-	tagsDisabled,
-}: {
-	strictOperations: PartialUpdateOperation[];
-	hasTagOperations: boolean;
-	canvasGroupsEnabled: boolean;
-	tagsDisabled: boolean;
-}): void {
+function assertOperationsSupported(
+	strictOperations: PartialUpdateOperation[],
+	{ canvasGroupsEnabled, tagsDisabled }: { canvasGroupsEnabled: boolean; tagsDisabled: boolean },
+): void {
 	// Defense in depth: with the flag off, the published schema already
 	// rejects these op types at the enum level; this guards against the
 	// loose and strict schemas drifting apart. Flag first so the scan only
@@ -783,28 +776,9 @@ function assertOperationsSupported({
 		);
 	}
 
-	if (tagsDisabled && hasTagOperations) {
+	if (tagsDisabled && strictOperations.some(isTagOperation)) {
 		throw new Error('Tag operations are not supported on this instance because tags are disabled.');
 	}
-}
-
-/**
- * Two passes, ordered by blame: an overlap between a new and an existing group
- * makes the validator flag both, so the batch's own groups go first and the
- * innocent existing one survives the re-check. `groupOperations` records which
- * groups this batch touched, not which one caused a given violation — two group
- * ops that collide take each other down.
- */
-function collectNodeGroupViolations(result: ApplyOperationsSuccess, nodeTypes: NodeTypes) {
-	const getNodeType = makeGetNodeTypeForGrouping(nodeTypes);
-
-	const ownGroups = dropInvalidNodeGroups(
-		result.workflow,
-		getNodeType,
-		(violation) => result.groupOperations[violation.groupId] !== undefined,
-	);
-
-	return [...ownGroups, ...dropInvalidNodeGroups(result.workflow, getNodeType)];
 }
 
 /**
@@ -818,14 +792,9 @@ function collectNodeGroupViolations(result: ApplyOperationsSuccess, nodeTypes: N
  * reference — cloning it makes the dropped groups silently come back.
  */
 function resolveNodeGroupViolations(
-	{
-		result,
-		canvasGroupsEnabled,
-	}: {
-		result: ApplyOperationsSuccess;
-		canvasGroupsEnabled: boolean;
-	},
-	{ nodeTypes }: { nodeTypes: NodeTypes },
+	result: ApplyOperationsSuccess,
+	canvasGroupsEnabled: boolean,
+	nodeTypes: NodeTypes,
 ): {
 	skippedOperations: SkippedOperation[];
 	removedGroups: Array<{ groupName: string; reason: string }>;
@@ -837,7 +806,22 @@ function resolveNodeGroupViolations(
 	// operation failed here, an existing group was destroyed as a side effect.
 	const removedGroups: Array<{ groupName: string; reason: string }> = [];
 
-	const violations = canvasGroupsEnabled ? collectNodeGroupViolations(result, nodeTypes) : [];
+	// Two passes, ordered by blame: an overlap between a new and an existing group
+	// makes the validator flag both, so the batch's own groups go first and the
+	// innocent existing one survives the re-check. `groupOperations` records which
+	// groups this batch touched, not which one caused a given violation — two group
+	// ops that collide take each other down.
+	const getNodeType = makeGetNodeTypeForGrouping(nodeTypes);
+	const violations = canvasGroupsEnabled
+		? [
+				...dropInvalidNodeGroups(
+					result.workflow,
+					getNodeType,
+					(violation) => result.groupOperations[violation.groupId] !== undefined,
+				),
+				...dropInvalidNodeGroups(result.workflow, getNodeType),
+			]
+		: [];
 
 	for (const violation of violations) {
 		const requestedBy = result.groupOperations[violation.groupId];
@@ -1011,14 +995,9 @@ async function autoAssignCredentialsForAddedNodes(
  * try/catch.
  */
 async function collectValidationWarnings(
-	{
-		updated,
-		existing,
-	}: {
-		updated: Pick<WorkflowEntity, 'name' | 'nodes' | 'connections'>;
-		existing: Pick<WorkflowEntity, 'name' | 'nodes' | 'connections'>;
-	},
-	{ nodeTypes }: { nodeTypes: NodeTypes },
+	updated: Pick<WorkflowEntity, 'name' | 'nodes' | 'connections'>,
+	existing: Pick<WorkflowEntity, 'name' | 'nodes' | 'connections'>,
+	nodeTypes: NodeTypes,
 ): Promise<Array<ValidationWarning & { preExisting?: boolean }>> {
 	const { ParseValidateHandler, getWarningKey } = await import('@n8n/ai-workflow-builder');
 
@@ -1069,8 +1048,9 @@ async function collectValidationWarnings(
  * every tag on the workflow.
  */
 async function resolveTagIds(
-	{ tagNames }: { tagNames: string[] | undefined },
-	{ user, tagService }: { user: User; tagService: TagService },
+	tagNames: string[] | undefined,
+	user: User,
+	tagService: TagService,
 ): Promise<string[] | undefined> {
 	if (tagNames === undefined) {
 		return undefined;
@@ -1095,54 +1075,6 @@ async function resolveTagIds(
 	}
 
 	return resolvedTags.map((t) => t.id);
-}
-
-/** Builds the tool's success payload. `structuredContent` reuses this object. */
-function buildUpdateOutput({
-	updatedWorkflow,
-	workflowUrl,
-	operationCount,
-	skippedOperations,
-	groupOperations,
-	removedGroups,
-	credentialAssignments,
-	validationWarnings,
-	skippedHttpNodes,
-	hasSettingsOperations,
-}: {
-	updatedWorkflow: Pick<WorkflowEntity, 'id' | 'name' | 'nodes' | 'settings'>;
-	workflowUrl: string;
-	operationCount: number;
-	skippedOperations: SkippedOperation[];
-	groupOperations: ApplyOperationsSuccess['groupOperations'];
-	removedGroups: Array<{ groupName: string; reason: string }>;
-	credentialAssignments: CredentialAssignment[];
-	validationWarnings: Array<ValidationWarning & { preExisting?: boolean }>;
-	skippedHttpNodes: string[];
-	hasSettingsOperations: boolean;
-}): UpdateWorkflowOutput {
-	const notAppliedCount = countOperationsWithNoEffect(skippedOperations, groupOperations);
-
-	return {
-		workflowId: updatedWorkflow.id,
-		name: updatedWorkflow.name,
-		nodeCount: updatedWorkflow.nodes.length,
-		url: workflowUrl,
-		appliedOperations: operationCount - notAppliedCount,
-		autoAssignedCredentials: credentialAssignments,
-		validationWarnings,
-		note: skippedHttpNodes.length
-			? `HTTP Request nodes (${skippedHttpNodes.join(', ')}) were skipped during credential auto-assignment. Their credentials must be configured manually.`
-			: undefined,
-		skippedOperations: skippedOperations.length > 0 ? skippedOperations : undefined,
-		removedGroups: removedGroups.length > 0 ? removedGroups : undefined,
-		// `IWorkflowSettings` is a closed interface while the published schema is an
-		// open record — server-side cleanup decides which keys survive, so the tool
-		// reports whatever came back rather than a fixed set.
-		settings: hasSettingsOperations
-			? ((updatedWorkflow.settings ?? {}) as Record<string, unknown>)
-			: undefined,
-	};
 }
 
 /**
@@ -1237,9 +1169,7 @@ export const createUpdateWorkflowTool = (
 				const hasNonTagOperations = strictOperations.some((op) => !isTagOperation(op));
 				const hasSettingsOperations = strictOperations.some(isSettingsOperation);
 
-				assertOperationsSupported({
-					strictOperations,
-					hasTagOperations,
+				assertOperationsSupported(strictOperations, {
 					canvasGroupsEnabled,
 					tagsDisabled: globalConfig.tags.disabled,
 				});
@@ -1265,7 +1195,7 @@ export const createUpdateWorkflowTool = (
 				}
 
 				const { skippedOperations, removedGroups, nodeGroupsNeedPersisting } =
-					resolveNodeGroupViolations({ result, canvasGroupsEnabled }, { nodeTypes });
+					resolveNodeGroupViolations(result, canvasGroupsEnabled, nodeTypes);
 
 				const credentialCheck = await validateCredentialReferences(
 					strictOperations,
@@ -1347,11 +1277,12 @@ export const createUpdateWorkflowTool = (
 
 				// After auto-assign, so the nodes being validated carry their credentials.
 				const validationWarnings = await collectValidationWarnings(
-					{ updated: workflowUpdateData, existing: existingWorkflow },
-					{ nodeTypes },
+					workflowUpdateData,
+					existingWorkflow,
+					nodeTypes,
 				);
 
-				const tagIds = await resolveTagIds({ tagNames: result.tagNames }, { user, tagService });
+				const tagIds = await resolveTagIds(result.tagNames, user, tagService);
 
 				// Fallback is diff-based; it only ends up persisted when the update
 				// actually produces a new history version (node/connection/group changes).
@@ -1398,18 +1329,31 @@ export const createUpdateWorkflowTool = (
 
 				telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
 
-				const output = buildUpdateOutput({
-					updatedWorkflow,
-					workflowUrl,
-					operationCount: strictOperations.length,
+				const notAppliedCount = countOperationsWithNoEffect(
 					skippedOperations,
-					groupOperations: result.groupOperations,
-					removedGroups,
-					credentialAssignments,
+					result.groupOperations,
+				);
+
+				const output: UpdateWorkflowOutput = {
+					workflowId: updatedWorkflow.id,
+					name: updatedWorkflow.name,
+					nodeCount: updatedWorkflow.nodes.length,
+					url: workflowUrl,
+					appliedOperations: strictOperations.length - notAppliedCount,
+					autoAssignedCredentials: credentialAssignments,
 					validationWarnings,
-					skippedHttpNodes,
-					hasSettingsOperations,
-				});
+					note: skippedHttpNodes.length
+						? `HTTP Request nodes (${skippedHttpNodes.join(', ')}) were skipped during credential auto-assignment. Their credentials must be configured manually.`
+						: undefined,
+					skippedOperations: skippedOperations.length > 0 ? skippedOperations : undefined,
+					removedGroups: removedGroups.length > 0 ? removedGroups : undefined,
+					// `IWorkflowSettings` is a closed interface while the published schema is an
+					// open record — server-side cleanup decides which keys survive, so the tool
+					// reports whatever came back rather than a fixed set.
+					settings: hasSettingsOperations
+						? ((updatedWorkflow.settings ?? {}) as Record<string, unknown>)
+						: undefined,
+				};
 
 				return {
 					content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],


### PR DESCRIPTION
## Summary

Stacked on #35458. That PR splits the `update_workflow` handler into named steps and takes its complexity from 44 to 9. This one removes the parts of the extraction that stopped paying for themselves once commit `7188c728d7` moved all the steps back into a single file.

Net **-56 lines** (64 insertions, 120 deletions), no behaviour change.

- **Inline `buildUpdateOutput`.** All ten of its parameters were pass-through. The real benefit it was credited with, the `UpdateWorkflowOutput` return type that stops the handler publishing a field `outputSchema` does not declare, works identically on an inline `const output: UpdateWorkflowOutput = {...}`.
- **Fold `collectNodeGroupViolations` into `resolveNodeGroupViolations`,** its only caller, so the blame-ordering comment sits next to the two passes it describes instead of one function away.
- **Drop the `(data, deps)` two-object parameter split** on the four functions with one or two dependencies. That shape arrived in `073d3545de` while the steps lived in their own module and needed explicit injection; they are file-private again now, so `resolveTagIds({ tagNames }, { user, tagService })` is ceremony. `assertWorkflowSettingsValid` keeps its dependency bundle, where six dependencies still earn it.
- **Drop the `hasTagOperations` parameter from `assertOperationsSupported`.** It was derivable from the `strictOperations` passed alongside it, so a future edit could make the two disagree.
- **Housekeeping:** remove the now-unused `CredentialAssignment` import, and correct the comment on `GATED_GROUP_OP_TYPES`. The rename protection it describes comes from the `satisfies ReadonlyArray<PartialUpdateOperation['type']>` on the two tuples, not from the set's element type.

### One trade-off to weigh

Inlining the output literal moves the handler from complexity **9 to 14**, against the repo maximum of 20, because the four `x.length ? y : undefined` presence checks are counted. Max complexity in the file is unchanged at 14 either way, since `assertErrorWorkflowIsUsable` (pre-existing, untouched by either PR) already sits there.

Four ternaries in a flat return literal are not much cognitive load, and buying 5 metric points with a ten-parameter indirection is the failure mode the `complexity` rule is meant to prevent rather than cause. But it does spend half the headroom that #35458 bought on the exact number the ticket was opened about. If you would rather keep the handler at 9, drop that one hunk and keep the other five changes; they are independent.

## How to test

Same oracle as the parent PR: `update-workflow.tool.test.ts` is untouched by both, so a green run is the check.

```bash
cd packages/cli
pnpm vitest run src/modules/mcp/__tests__/update-workflow.tool.test.ts
pnpm typecheck
npx eslint src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
```

Verified locally against the parent branch:

- `update-workflow.tool.test.ts` 121/121 passed
- whole `src/modules/mcp` module 1124 passed, 28 skipped
- `tsc --noEmit` exit 0, `eslint` exit 0 with no `complexity` warning

The one failure in the module, `mcp.settings.controller.api.test.ts`, is the pre-existing one the parent PR already documents: a DB-backed integration test that the unit config picks up because it is named `.api.test.ts` rather than `.integration.test.ts`. It fails on a `beforeAll` hook timeout with no database and is unrelated to this file.

No new tests. Every function touched here is private to this file and already covered end to end by the 121 handler tests; asserting the shape of an inlined literal would test the refactor rather than the behaviour.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5668

Stacked on #35458, so review that one first. Retarget this to `master` if #35458 lands ahead of it.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

