### PR TITLE
feat(core): Hide feature request link for nodes in canvas-only mode (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.test.ts
@@ -14,6 +14,7 @@ import { NdvAgentConfigKey } from '@/features/ndv/agents/composables/useNdvAgent
 import type { UseNdvAgentConfigReturn } from '@/features/ndv/agents/composables/useNdvAgentConfig';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useSettingsStore } from '@n8n/stores/settings.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createWorkflowDocumentId,
@@ -110,16 +111,26 @@ interface RenderOptions {
 	nodeType?: INodeTypeDescription;
 	provide?: Record<symbol, unknown>;
 	stubs?: Record<string, unknown>;
+	canvasOnly?: boolean;
 }
 
 const renderNodeSettings = (options: RenderOptions = {}) => {
-	const { runData, node = httpNode, nodeType = httpNodeType, provide = {}, stubs = {} } = options;
+	const {
+		runData,
+		node = httpNode,
+		nodeType = httpNodeType,
+		provide = {},
+		stubs = {},
+		canvasOnly = false,
+	} = options;
 	const pinia = createTestingPinia({ stubActions: false });
 	setActivePinia(pinia);
 
 	const workflow = createTestWorkflow({ nodes: [node], connections: {} });
 	const workflowsStore = useWorkflowsStore();
 	const nodeTypesStore = useNodeTypesStore();
+	const settingsStore = useSettingsStore();
+	settingsStore.settings = { ...settingsStore.settings, canvasOnly };
 	workflowsStore.setWorkflowId(workflow.id);
 	const ndvStore = useNDVStore(createWorkflowDocumentId(workflow.id));
 	const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id));
@@ -228,6 +239,21 @@ describe('NodeSettings', () => {
 		await waitFor(() => {
 			expect(settingsTab.querySelector('.tab')?.className).toContain('activeTab');
 			expect(paramsTab.querySelector('.tab')?.className).not.toContain('activeTab');
+		});
+	});
+
+	describe('feature request link', () => {
+		it('renders the feature request link by default', async () => {
+			const { findByTestId } = renderNodeSettings({});
+
+			expect(await findByTestId('node-feature-request')).toBeInTheDocument();
+		});
+
+		it('hides the feature request link when in canvas-only mode', async () => {
+			const { findByTestId, queryByTestId } = renderNodeSettings({ canvasOnly: true });
+
+			await findByTestId('tab-params');
+			expect(queryByTestId('node-feature-request')).not.toBeInTheDocument();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -305,7 +305,7 @@ const credentialOwnerName = computed(() => {
 });
 
 const featureRequestUrl = computed(() => {
-	if (!nodeType.value) {
+	if (!nodeType.value || settingsStore.isCanvasOnly) {
 		return '';
 	}
 	return `${BASE_NODE_SURVEY_URL}${nodeType.value.name}`;
@@ -845,7 +845,11 @@ function handleSelectAction(params: INodeParameters) {
 					<span>({{ nodeVersionTag }})</span>
 				</div>
 			</div>
-			<div v-if="featureRequestUrl && !isEmbeddedInCanvas" :class="$style.featureRequest">
+			<div
+				v-if="featureRequestUrl && !isEmbeddedInCanvas"
+				data-test-id="node-feature-request"
+				:class="$style.featureRequest"
+			>
 				<a target="_blank" @click="onFeatureRequestClick">
 					<N8nIcon icon="lightbulb" />
 					{{ i18n.baseText('ndv.featureRequest') }}


### PR DESCRIPTION
## Summary

Nodes show a link at the bottom to provide feedback to n8n. This should not be visible in canvas only mode.

| Before | After |
| ------------- | ------------- |
|  <img width="1589" height="832" alt="Screenshot 2026-08-11 at 00 04 00" src="https://github.com/user-attachments/assets/e7bfd857-fde8-4372-9aa9-59801df499df" /> |  <img width="1593" height="836" alt="Screenshot 2026-08-11 at 00 05 11" src="https://github.com/user-attachments/assets/bbf27102-9a10-46f5-acd7-219c378f038b" /> |

### How to test

Start n8n with `N8N_CANVAS_ONLY=true pnpm run dev`.
Start the frontend if not built yet -> open a "Set" node, see that "I wish this node would" link is no longer shown.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-160/


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

