### PR TITLE
feat(core): Hide AI templates link in "Add nodes" panel in canvas-only mode (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
@@ -132,6 +132,21 @@ describe('viewsData', () => {
 			expect(messageAgentItem).toBeUndefined();
 		});
 
+		test('should include the AI templates callout by default', () => {
+			const result = AIView([]);
+
+			expect(result.items.some((item) => item.key === 'ai_templates_root')).toBe(true);
+		});
+
+		test('should not include the AI templates callout in canvas-only mode', () => {
+			const settingsStore = useSettingsStore();
+			vi.spyOn(settingsStore, 'isCanvasOnly', 'get').mockReturnValue(true);
+
+			const result = AIView([]);
+
+			expect(result.items.some((item) => item.key === 'ai_templates_root')).toBe(false);
+		});
+
 		test('should not mutate the shared template repository parameters', () => {
 			const templatesStore = useTemplatesStore();
 			const sharedParams = new URLSearchParams({ test: 'value' });

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
@@ -207,7 +207,9 @@ export function AIView(_nodes: SimplifiedNodeType[]): NodeView {
 		TEMPLATE_CATEGORY_AI,
 	);
 
-	const callouts: NodeViewItem[] = [getAiTemplatesCallout(aiTemplatesURL)];
+	const callouts: NodeViewItem[] = settingsStore.isCanvasOnly
+		? []
+		: [getAiTemplatesCallout(aiTemplatesURL)];
 
 	return {
 		value: AI_NODE_CREATOR_VIEW,


### PR DESCRIPTION
## Summary

<img width="1595" height="884" alt="image" src="https://github.com/user-attachments/assets/9f487d85-5371-42e8-98d9-5e53bf33185a" />


## How to test

Start n8n with `N8N_CANVAS_ONLY=true pnpm run dev`.
Start the frontend if not built yet -> see that AI Templates section is not shown.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/35999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

