### PR TITLE
fix(core): Execute tools in the order the root requested them

### DIFF
--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -496,6 +496,102 @@ describe('handleRequests', () => {
 		expect(resumingNode.metadata).toHaveProperty('preservedSourceOverwrite', preservedSource);
 	});
 
+	test('enqueues actions in reverse so the LIFO stack runs them in request order', () => {
+		// ARRANGE
+		const toolA = createNodeData({ name: 'Tool A', type: types.passThrough });
+		const toolB = createNodeData({ name: 'Tool B', type: types.passThrough });
+		const toolC = createNodeData({ name: 'Tool C', type: types.passThrough });
+		const agentNode = createNodeData({ name: 'AI Agent', type: types.passThrough });
+
+		const workflow = new DirectedGraph()
+			.addNodes(toolA, toolB, toolC, agentNode)
+			.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+		const executionData: IExecuteData = {
+			data: { main: [[{ json: {} }]] },
+			source: { main: [{ previousNode: 'Trigger', previousNodeOutput: 0, previousNodeRun: 0 }] },
+			node: agentNode,
+		};
+
+		const request: EngineRequest = {
+			actions: ['Tool A', 'Tool B', 'Tool C'].map((nodeName, index) => ({
+				actionType: 'ExecutionNodeAction',
+				nodeName,
+				input: {},
+				type: 'ai_tool',
+				id: `tool_call_${index}`,
+				metadata: { itemIndex: 0 },
+			})),
+			metadata: {},
+		};
+
+		// ACT
+		const result = handleRequest({
+			workflow,
+			currentNode: agentNode,
+			request,
+			runIndex: 0,
+			executionData,
+			runData: {},
+		});
+
+		// ASSERT
+		// The requesting node is enqueued first so it ends up at the bottom of the stack,
+		// then the tools in reverse — unshifting these in turn yields [A, B, C, AI Agent].
+		expect(result.nodesToBeExecuted.map((n) => n.inputConnectionData.node)).toEqual([
+			'AI Agent',
+			'Tool C',
+			'Tool B',
+			'Tool A',
+		]);
+	});
+
+	test('keeps request order for the legacy execution order, which enqueues with push', () => {
+		// ARRANGE
+		const toolA = createNodeData({ name: 'Tool A', type: types.passThrough });
+		const toolB = createNodeData({ name: 'Tool B', type: types.passThrough });
+		const agentNode = createNodeData({ name: 'AI Agent', type: types.passThrough });
+
+		const workflow = new DirectedGraph()
+			.addNodes(toolA, toolB, agentNode)
+			.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v0' } });
+
+		const executionData: IExecuteData = {
+			data: { main: [[{ json: {} }]] },
+			source: { main: [{ previousNode: 'Trigger', previousNodeOutput: 0, previousNodeRun: 0 }] },
+			node: agentNode,
+		};
+
+		const request: EngineRequest = {
+			actions: ['Tool A', 'Tool B'].map((nodeName, index) => ({
+				actionType: 'ExecutionNodeAction',
+				nodeName,
+				input: {},
+				type: 'ai_tool',
+				id: `tool_call_${index}`,
+				metadata: { itemIndex: 0 },
+			})),
+			metadata: {},
+		};
+
+		// ACT
+		const result = handleRequest({
+			workflow,
+			currentNode: agentNode,
+			request,
+			runIndex: 0,
+			executionData,
+			runData: {},
+		});
+
+		// ASSERT
+		expect(result.nodesToBeExecuted.map((n) => n.inputConnectionData.node)).toEqual([
+			'AI Agent',
+			'Tool A',
+			'Tool B',
+		]);
+	});
+
 	test('does not add preserveSourceOverwrite metadata when not present', () => {
 		const agentNode = createNodeData({ name: 'AI Agent', type: types.passThrough });
 

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -651,6 +651,95 @@ describe('processRunExecutionData', () => {
 			});
 		});
 
+		test('executes requested tools in the order the actions were requested', async () => {
+			// ARRANGE
+			const executionOrder: string[] = [];
+			let response: EngineResponse | undefined;
+
+			const recordingTool = (name: string): INodeType => ({
+				...passThroughNode,
+				async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+					executionOrder.push(name);
+					return [this.getInputData()];
+				},
+			});
+
+			const toolNames = ['tool1', 'tool2', 'tool3'];
+			const toolNodes = toolNames.map((name) => createNodeData({ name, type: `${name}Type` }));
+
+			const nodeTypeWithRequests = modifyNode(passThroughNode)
+				.return({
+					actions: toolNames.map((nodeName, index) => ({
+						actionType: 'ExecutionNodeAction',
+						nodeName,
+						input: { query: nodeName },
+						type: 'ai_tool',
+						id: `action_${index}`,
+						metadata: { itemIndex: 0 },
+					})),
+					metadata: {},
+				})
+				.return((r) => {
+					response = r;
+					return [[{ json: { done: true } }]];
+				})
+				.done();
+
+			const nodeWithRequests = createNodeData({
+				name: 'nodeWithRequests',
+				type: 'nodeWithRequests',
+			});
+
+			const nodeTypes = NodeTypes({
+				...nodeTypeArguments,
+				nodeWithRequests: { type: nodeTypeWithRequests, sourcePath: '' },
+				...Object.fromEntries(
+					toolNames.map((name) => [`${name}Type`, { type: recordingTool(name), sourcePath: '' }]),
+				),
+			});
+
+			const graph = new DirectedGraph().addNodes(nodeWithRequests, ...toolNodes);
+			for (const toolNode of toolNodes) {
+				graph.addConnections({ from: toolNode, to: nodeWithRequests, type: 'ai_tool' });
+			}
+			const workflow = graph.toWorkflow({
+				name: '',
+				active: false,
+				nodeTypes,
+				settings: { executionOrder: 'v1' },
+			});
+
+			const executionData = createRunExecutionData({
+				startData: { startNodes: [{ name: nodeWithRequests.name, sourceData: null }] },
+				executionData: {
+					nodeExecutionStack: [
+						{
+							data: { main: [[{ json: { prompt: 'test prompt' } }]] },
+							node: nodeWithRequests,
+							source: { main: [{ previousNode: 'Start' }] },
+						},
+					],
+				},
+			});
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			// ACT
+			const result = await workflowExecute.processRunExecutionData(workflow);
+
+			// ASSERT
+			// Tools run in request order, not reversed by the LIFO execution stack
+			expect(executionOrder).toEqual(toolNames);
+
+			// The responses handed back to the requesting node stay aligned with that order
+			expect((response?.actionResponses ?? []).map((r) => r.action.nodeName)).toEqual(toolNames);
+
+			// ...and so does what the logs panel sorts on
+			const runData = result.data.resultData.runData;
+			const executionIndexes = toolNames.map((name) => runData[name][0].executionIndex);
+			expect(executionIndexes).toEqual([...executionIndexes].sort((a, b) => a - b));
+		});
+
 		test('skips waiting tools processing when parent node cannot be found', async () => {
 			// ARRANGE
 			// This test simulates the scenario where executionData.source.main[0].previousNode

--- a/packages/core/src/execution-engine/requests-response.ts
+++ b/packages/core/src/execution-engine/requests-response.ts
@@ -268,7 +268,12 @@ export function handleRequest({
 		return { nodesToBeExecuted: [] };
 	}
 
-	// 3. add current node back to the bottom of the stack
+	// 3. under executionOrder v1 reverse the actions to run the requests in the order the root requested them to run
+	if (workflow.settings.executionOrder === 'v1') {
+		nodesToBeExecuted.reverse();
+	}
+
+	// 4. add current node back to the bottom of the stack
 	nodesToBeExecuted.unshift({
 		inputConnectionData: result.connectionData,
 		parentOutputIndex: 0,


### PR DESCRIPTION
## Summary

When an agent requests several tool calls in one turn, the engine ran them in **reverse** of the order the model asked for.

`handleRequest` collects one stack entry per requested action in request order, and the caller enqueues them one at a time via `addNodeToBeExecuted`, which `unshift`s onto the execution stack under `executionOrder: 'v1'`. Since the loop consumes the stack with `shift`, the last entry enqueued is the first one executed — so actions `[A, B, C]` executed as `C, B, A`.

Two visible consequences:

- **Side effects fire in the wrong order.** For a turn like "post the message, then react to it", the tools ran in the opposite order to what the model intended.
- **The logs panel and `intermediateSteps` disagree.** The logs sort by real `startTime`/`executionIndex`, so they showed the reversed execution order. `intermediateSteps` is built from `actionResponses`, which is assembled from the request-ordered action list, so it showed the model's order. Both views were internally accurate — they were describing different orders, because the execution itself was reversed.

This reverses the tool entries before the requesting node is unshifted, cancelling out the LIFO enqueue so the tools run in request order. After the fix, execution order, `actionResponses`, and `intermediateSteps` all agree.

Notes on scope:

- Gated on `workflow.settings.executionOrder === 'v1'`, the exact condition `addNodeToBeExecuted` uses to choose `unshift` over `push`. The legacy order already resumes the requesting node *before* its own tools, so that path is left untouched rather than having a second ordering issue layered onto it.
- The two lines are order-dependent: `reverse()` runs while the array holds only tools, so the requesting node keeps its "enqueued first, therefore executed last" position. Reversing after the `unshift` would put the agent at the head of the stack and break the tool loop outright. The new enqueue-order test pins this.
- No change was needed on the LangChain side — `buildSteps` already emitted request order.

## How to test

1. Build an AI Agent (v3) workflow with two or more tools whose order is observable, and prompt it so the model requests them in a single turn (e.g. "call tool A, then tool B").
2. Run it and open the logs panel: the tool entries now appear in the order the model requested them.
3. Enable **Return Intermediate Steps** on the agent and compare the node output: `intermediateSteps` is in the same order as the logs.

Automated coverage (all three fail without the fix):

- `packages/core/src/execution-engine/__tests__/requests-response.test.ts` — enqueue order under v1 is `[AI Agent, Tool C, Tool B, Tool A]` for a 3-tool request; legacy `v0` is unchanged.
- `packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts` — end-to-end through `processRunExecutionData` with recording tools, asserting actual execution order, `actionResponses` order, and ascending `executionIndex` all match request order.

```
cd packages/core && pnpm test
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-136

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

