### PR TITLE
fix(core): Explain Browser Use failures caused by other browser extensions

### DIFF
--- a/packages/@n8n/mcp-browser-extension/src/foreignFrames.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/foreignFrames.test.ts
@@ -1,0 +1,164 @@
+import { ForeignFrames } from './foreignFrames';
+
+const OURS = 'ourextensionid';
+const OFFENDING = 'offendingextensionid';
+
+const chrome = {
+	runtime: { id: OURS },
+	webNavigation: { getAllFrames: vi.fn().mockResolvedValue([]) },
+};
+Object.assign(globalThis, { chrome });
+
+const menuUrl = (id = OFFENDING) => `chrome-extension://${id}/inline/menu/menu.html`;
+
+let frames: ForeignFrames;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	chrome.webNavigation.getAllFrames.mockReset().mockResolvedValue([]);
+	frames = new ForeignFrames();
+});
+
+describe('ForeignFrames.isDenial', () => {
+	it.each([
+		'Detached while handling command.',
+		'Cannot access a chrome-extension:// URL of a different extension',
+		'Cannot attach to this target.',
+	])('recognises %s', (message) => {
+		expect(ForeignFrames.isDenial(new Error(message))).toBe(true);
+	});
+
+	it('leaves ordinary failures alone', () => {
+		expect(ForeignFrames.isDenial(new Error('No node with given id'))).toBe(false);
+	});
+
+	it('is safe on a non-Error', () => {
+		expect(ForeignFrames.isDenial('Detached while handling command.')).toBe(false);
+	});
+});
+
+describe('ForeignFrames tracking', () => {
+	// All three carry the URL, and which one Chrome emits varies by navigation.
+	it.each([
+		['Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() }],
+		['Page.frameStartedNavigating', { frameId: 'f1', url: menuUrl() }],
+		['Page.frameNavigated', { frame: { id: 'f1', url: menuUrl() } }],
+	])('records a foreign frame from %s', async (method, params) => {
+		frames.track(1, method, params);
+
+		await expect(frames.owners(1)).resolves.toEqual([OFFENDING]);
+	});
+
+	it('ignores frames belonging to us', async () => {
+		frames.track(1, 'Page.frameNavigated', { frame: { id: 'f1', url: menuUrl(OURS) } });
+
+		await expect(frames.owners(1)).resolves.toEqual([]);
+	});
+
+	it('ignores ordinary page frames', async () => {
+		frames.track(1, 'Page.frameNavigated', {
+			frame: { id: 'f1', url: 'https://console.anthropic.com' },
+		});
+
+		await expect(frames.owners(1)).resolves.toEqual([]);
+	});
+
+	it('forgets a frame that detaches', async () => {
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+		frames.track(1, 'Page.frameDetached', { frameId: 'f1' });
+
+		await expect(frames.owners(1)).resolves.toEqual([]);
+	});
+
+	it('forgets a frame that navigates off the extension origin', async () => {
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+		frames.track(1, 'Page.frameNavigated', {
+			frame: { id: 'f1', url: 'https://console.anthropic.com' },
+		});
+
+		await expect(frames.owners(1)).resolves.toEqual([]);
+	});
+
+	it('keeps a second frame when only the first detaches', async () => {
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f2', url: menuUrl() });
+		frames.track(1, 'Page.frameDetached', { frameId: 'f1' });
+
+		await expect(frames.owners(1)).resolves.toEqual([OFFENDING]);
+	});
+
+	it('keeps tabs apart', async () => {
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+
+		await expect(frames.owners(2)).resolves.toEqual([]);
+	});
+
+	it('keeps a frame that passes through about:blank on its way to the real URL', async () => {
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+		frames.track(1, 'Page.frameNavigated', { frame: { id: 'f1', url: 'about:blank' } });
+
+		await expect(frames.owners(1)).resolves.toEqual([OFFENDING]);
+	});
+
+	it('forgets every tab on clear', async () => {
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+		frames.track(2, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+		frames.clear();
+
+		await expect(frames.owners(1)).resolves.toEqual([]);
+		await expect(frames.owners(2)).resolves.toEqual([]);
+	});
+
+	it('forgets everything for a tab on request', async () => {
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+		frames.forget(1);
+
+		await expect(frames.owners(1)).resolves.toEqual([]);
+	});
+});
+
+describe('ForeignFrames.owners', () => {
+	it('falls back to the frame tree when no event was seen', async () => {
+		// A frame already open before we attached emits no navigation event, but is
+		// committed and therefore readable.
+		chrome.webNavigation.getAllFrames.mockResolvedValueOnce([
+			{ frameId: 0, url: 'https://console.anthropic.com' },
+			{ frameId: 1, url: menuUrl() },
+		]);
+
+		await expect(frames.owners(1)).resolves.toEqual([OFFENDING]);
+	});
+
+	it('prefers tracked frames over the frame tree', async () => {
+		// The tree reports about:blank for a frame that is still committing, which
+		// is exactly when the menu opens under us.
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+		chrome.webNavigation.getAllFrames.mockResolvedValueOnce([{ frameId: 1, url: 'about:blank' }]);
+
+		await expect(frames.owners(1)).resolves.toEqual([OFFENDING]);
+		expect(chrome.webNavigation.getAllFrames).not.toHaveBeenCalled();
+	});
+
+	it('reports nothing when the tab is gone', async () => {
+		chrome.webNavigation.getAllFrames.mockRejectedValueOnce(new Error('No tab with id: 1'));
+
+		await expect(frames.owners(1)).resolves.toEqual([]);
+	});
+});
+
+describe('ForeignFrames.describeDenial', () => {
+	it('names the extension and keeps the original message', async () => {
+		frames.track(1, 'Page.frameRequestedNavigation', { frameId: 'f1', url: menuUrl() });
+
+		const described = await frames.describeDenial(1, new Error('Detached while handling command.'));
+
+		expect(described.message).toContain(OFFENDING);
+		expect(described.message).toContain('Detached while handling command.');
+	});
+
+	it('returns the original untouched when nothing can be named', async () => {
+		const original = new Error('Detached while handling command.');
+
+		expect(await frames.describeDenial(1, original)).toBe(original);
+	});
+});

--- a/packages/@n8n/mcp-browser-extension/src/foreignFrames.ts
+++ b/packages/@n8n/mcp-browser-extension/src/foreignFrames.ts
@@ -1,0 +1,105 @@
+/**
+ * Chromium refuses `chrome.debugger` access to a tab while any frame in it belongs
+ * to a different extension, rechecked on every command, and never names the
+ * culprit. Two sources because they cover different windows: `Page.*` events see
+ * the URL while the frame is committing, `getAllFrames` sees it once committed.
+ */
+
+import { createLogger } from './logger';
+
+const log = createLogger('foreign-frames');
+
+const EXTENSION_SCHEME = 'chrome-extension://';
+
+const DENIAL_MESSAGE =
+	/Detached while handling command|Cannot access a chrome-extension|Cannot attach to this target/i;
+
+function foreignExtensionId(url: string | undefined): string | undefined {
+	if (!url?.startsWith(EXTENSION_SCHEME)) return undefined;
+	// Sliced, not parsed: this runs on every forwarded CDP event, and slicing
+	// allocates nothing until a chrome-extension:// URL actually shows up.
+	const id = url.slice(EXTENSION_SCHEME.length).split('/', 1)[0];
+	return id && id !== chrome.runtime.id ? id : undefined;
+}
+
+function frameNavigation(
+	method: string,
+	params?: object,
+): { frameId: string; url: string } | undefined {
+	if (method === 'Page.frameRequestedNavigation' || method === 'Page.frameStartedNavigating') {
+		const p = params as { frameId?: string; url?: string } | undefined;
+		return p?.frameId && p.url ? { frameId: p.frameId, url: p.url } : undefined;
+	}
+	if (method === 'Page.frameNavigated') {
+		const frame = (params as { frame?: { id?: string; url?: string } } | undefined)?.frame;
+		return frame?.id && frame.url ? { frameId: frame.id, url: frame.url } : undefined;
+	}
+	return undefined;
+}
+
+export class ForeignFrames {
+	/** chromeTabId → frameId → owning extension id. */
+	private readonly byTab = new Map<number, Map<string, string>>();
+
+	/** Chrome refused because of the tab's frame tree. */
+	static isDenial(error: unknown): error is Error {
+		return error instanceof Error && DENIAL_MESSAGE.test(error.message);
+	}
+
+	/** Forgets frames that detach or navigate away, so a closed menu is not blamed later. */
+	track(chromeTabId: number, method: string, params?: object): void {
+		if (method === 'Page.frameDetached') {
+			const frameId = (params as { frameId?: string } | undefined)?.frameId;
+			if (frameId) this.byTab.get(chromeTabId)?.delete(frameId);
+			return;
+		}
+
+		const nav = frameNavigation(method, params);
+		if (!nav) return;
+
+		const owner = foreignExtensionId(nav.url);
+		if (!owner) {
+			// about:blank is a step on the way to the real URL, not a navigation away
+			// from it — dropping the frame here would lose the only record we get.
+			if (nav.url !== 'about:blank') this.byTab.get(chromeTabId)?.delete(nav.frameId);
+			return;
+		}
+
+		const frames = this.byTab.get(chromeTabId);
+		if (frames) frames.set(nav.frameId, owner);
+		else this.byTab.set(chromeTabId, new Map([[nav.frameId, owner]]));
+		log.debug(`foreign extension frame in tab ${chromeTabId}:`, owner);
+	}
+
+	forget(chromeTabId: number): void {
+		this.byTab.delete(chromeTabId);
+	}
+
+	clear(): void {
+		this.byTab.clear();
+	}
+
+	/** Tracked frames first: the frame tree cannot read one that is still committing. */
+	async owners(chromeTabId: number): Promise<string[]> {
+		const tracked = this.byTab.get(chromeTabId);
+		if (tracked?.size) return [...new Set(tracked.values())];
+
+		try {
+			const frames = await chrome.webNavigation.getAllFrames({ tabId: chromeTabId });
+			const ids = (frames ?? []).map((frame) => foreignExtensionId(frame.url));
+			return [...new Set(ids.filter((id): id is string => id !== undefined))];
+		} catch (e) {
+			log.debug('failed to enumerate frames:', e);
+			return [];
+		}
+	}
+
+	async describeDenial(chromeTabId: number, original: Error): Promise<Error> {
+		const owners = await this.owners(chromeTabId);
+		if (owners.length === 0) return original;
+
+		return new Error(
+			`Browser automation was blocked by another browser extension (${owners.join(', ')}): ${original.message}`,
+		);
+	}
+}

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.test.ts
@@ -47,6 +47,12 @@ const chrome = {
 			set: vi.fn().mockResolvedValue(undefined),
 		},
 	},
+	runtime: {
+		id: 'ourextensionid',
+	},
+	webNavigation: {
+		getAllFrames: vi.fn().mockResolvedValue([]),
+	},
 };
 Object.assign(globalThis, { chrome });
 
@@ -109,6 +115,12 @@ function parseSent(ws: MockWebSocket, index = 0): unknown {
 	return JSON.parse(ws.sent[index]);
 }
 
+function findSent(ws: MockWebSocket, method: string) {
+	return ws.sent
+		.map((frame) => JSON.parse(frame) as { method?: string; params?: Record<string, unknown> })
+		.find((frame) => frame.method === method);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -119,6 +131,9 @@ describe('RelayConnection', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// clearAllMocks leaves `mockResolvedValueOnce` queues intact, so an
+		// unconsumed frame tree would surface in whichever test runs next.
+		chrome.webNavigation.getAllFrames.mockReset().mockResolvedValue([]);
 
 		ws = new MockWebSocket();
 		relay = new RelayConnection(ws as unknown as WebSocket);
@@ -626,8 +641,10 @@ describe('RelayConnection', () => {
 		relay.onclose = onclose;
 
 		fireDebuggerDetach({ tabId: 42 }, 'target_closed');
-
+		// The tab leaves the registry at once; the close follows the frame-tree probe.
 		expect(relay.getControlledIds()).toEqual([]);
+		await tick();
+
 		expect(ws.closed).toBe(true);
 		expect(onclose).toHaveBeenCalled();
 	});
@@ -791,6 +808,124 @@ describe('RelayConnection', () => {
 					}),
 				}),
 			);
+		});
+	});
+
+	describe('attributing a lost session to another extension', () => {
+		const OFFENDING_ID = 'offendingextensionid';
+
+		const frames = (...urls: string[]) => urls.map((url, frameId) => ({ frameId, url }));
+
+		/** What a password manager opening its autofill menu looks like on the wire. */
+		const openAutofillMenu = (frameId = 'f1') =>
+			fireDebuggerEvent({ tabId: 42 }, 'Page.frameRequestedNavigation', {
+				frameId,
+				disposition: 'currentTab',
+				url: `chrome-extension://${OFFENDING_ID}/inline/menu/menu.html`,
+			});
+
+		it('names the extension whose frame is in the tab when the session dies', async () => {
+			await registerAndAttach(42);
+			openAutofillMenu();
+			// By now Chrome has revoked us, so the probe sees the frame as about:blank
+			// and cannot help — the frame events are the only record of the URL.
+			chrome.webNavigation.getAllFrames.mockResolvedValueOnce(frames('about:blank'));
+
+			fireDebuggerDetach({ tabId: 42 }, 'target_closed');
+			await tick();
+
+			expect(findSent(ws, 'tabClosed')?.params).toEqual(
+				expect.objectContaining({
+					id: targetIdForTab(42),
+					reason: 'blocked_by_extension',
+					blockingExtensionIds: [OFFENDING_ID],
+				}),
+			);
+		});
+
+		it('attributes a command that fails because the session was revoked', async () => {
+			await registerAndAttach(42);
+			openAutofillMenu();
+			chrome.debugger.sendCommand.mockRejectedValueOnce(
+				new Error('Detached while handling command.'),
+			);
+
+			ws.onmessage?.({
+				data: JSON.stringify({
+					id: 7,
+					method: 'forwardCDPCommand',
+					params: { method: 'Input.insertText', params: { text: 'n8n-integration' } },
+				}),
+			});
+			await tick();
+
+			const response = ws.sent
+				.map((frame) => JSON.parse(frame) as { id?: number; error?: string })
+				.find((frame) => frame.id === 7);
+
+			expect(response?.error).toContain(OFFENDING_ID);
+		});
+
+		it('leaves an ordinary failure unattributed', async () => {
+			await registerAndAttach(42);
+			chrome.debugger.sendCommand.mockRejectedValueOnce(new Error('No node with given id'));
+
+			ws.onmessage?.({
+				data: JSON.stringify({
+					id: 8,
+					method: 'forwardCDPCommand',
+					params: { method: 'DOM.focus', params: {} },
+				}),
+			});
+			await tick();
+
+			const response = ws.sent
+				.map((frame) => JSON.parse(frame) as { id?: number; error?: string })
+				.find((frame) => frame.id === 8);
+
+			expect(response?.error).toContain('No node with given id');
+			expect(chrome.webNavigation.getAllFrames).not.toHaveBeenCalled();
+		});
+
+		it('attributes a denial that happens at attach time', async () => {
+			chrome.debugger.getTargets.mockResolvedValueOnce([mockTarget(42)]);
+			await relay.registerSelectedTabs([42]);
+			chrome.debugger.attach.mockRejectedValueOnce(new Error('Cannot attach to this target.'));
+			chrome.webNavigation.getAllFrames.mockResolvedValueOnce(
+				frames('https://example.com', `chrome-extension://${OFFENDING_ID}/inline/menu.html`),
+			);
+
+			ws.onmessage?.({
+				data: JSON.stringify({
+					id: 9,
+					method: 'forwardCDPCommand',
+					params: { method: 'Runtime.evaluate', params: {} },
+				}),
+			});
+			await tick();
+
+			const response = ws.sent
+				.map((frame) => JSON.parse(frame) as { id?: number; error?: string })
+				.find((frame) => frame.id === 9);
+
+			expect(response?.error).toContain(OFFENDING_ID);
+		});
+
+		it('reports every tab detaching in the same turn before closing', async () => {
+			await registerAndAttach(42);
+			await registerAndAttach(43);
+
+			fireDebuggerDetach({ tabId: 42 }, 'target_closed');
+			fireDebuggerDetach({ tabId: 43 }, 'target_closed');
+			await tick();
+
+			// Closing on the first probe to resolve would drop the second frame.
+			const closed = ws.sent
+				.map((frame) => JSON.parse(frame) as { method?: string; params?: { id?: string } })
+				.filter((frame) => frame.method === 'tabClosed')
+				.map((frame) => frame.params?.id);
+			expect(closed).toEqual([targetIdForTab(42), targetIdForTab(43)]);
+			expect(ws.closed).toBe(true);
 		});
 	});
 
@@ -968,6 +1103,8 @@ describe('RelayConnection', () => {
 			await relay.addTab(42, 'Test', 'https://test.com');
 
 			fireDebuggerDetach({ tabId: 42 }, 'target_closed');
+			await tick();
+
 			expect(ws.closeReason).toBe('debugger_detached');
 		});
 

--- a/packages/@n8n/mcp-browser-extension/src/relayConnection.ts
+++ b/packages/@n8n/mcp-browser-extension/src/relayConnection.ts
@@ -7,6 +7,7 @@
  * All communication with the relay uses these CDP target IDs.
  */
 
+import { ForeignFrames } from './foreignFrames';
 import { createLogger } from './logger';
 import type { TabManagementSettings } from './types';
 
@@ -76,6 +77,9 @@ export class RelayConnection {
 	private readonly pendingAttaches = new Map<string, Promise<void>>();
 	/** Set of chrome tab IDs created by the AI agent */
 	private readonly agentCreatedChromeTabIds = new Set<number>();
+	/** Detach reports still waiting on a frame-tree probe. */
+	private pendingDetachReports = 0;
+	private readonly foreignFrames = new ForeignFrames();
 	/** The primary tab ID (first registered), used as default target */
 	private primaryId: string | undefined;
 	/** Cached Target.setAutoAttach params — reapplied to newly attached tabs for iframe support. */
@@ -169,6 +173,7 @@ export class RelayConnection {
 		this.tabs.delete(id);
 		this.chromeTabIdToId.delete(chromeTabId);
 		this.agentCreatedChromeTabIds.delete(chromeTabId);
+		this.foreignFrames.forget(chromeTabId);
 
 		// Update primary
 		if (id === this.primaryId) {
@@ -179,9 +184,7 @@ export class RelayConnection {
 		log.debug(`removeTab: ${id} (chromeTabId=${chromeTabId})`);
 		this.sendMessage({ method: 'tabClosed', params: { id } });
 
-		if (this.tabs.size === 0) {
-			this.close('extension_disconnected');
-		}
+		this.closeIfIdle('extension_disconnected');
 	}
 
 	setSettings(settings: TabManagementSettings): void {
@@ -211,6 +214,11 @@ export class RelayConnection {
 
 	markAsAgentCreated(chromeTabId: number): void {
 		this.agentCreatedChromeTabIds.add(chromeTabId);
+	}
+
+	/** Close once the last tab is gone, but not before in-flight detaches have reported. */
+	private closeIfIdle(reason: string): void {
+		if (this.tabs.size === 0 && this.pendingDetachReports === 0) this.close(reason);
 	}
 
 	close(message: string): void {
@@ -255,6 +263,7 @@ export class RelayConnection {
 		this.chromeTabIdToId.clear();
 		this.pendingAttaches.clear();
 		this.agentCreatedChromeTabIds.clear();
+		this.foreignFrames.clear();
 		this.onclose?.();
 	}
 
@@ -412,6 +421,8 @@ export class RelayConnection {
 			}
 		}
 
+		this.foreignFrames.track(source.tabId, method, params);
+
 		this.sendMessage({
 			method: 'forwardCDPEvent',
 			params: { method, params, id },
@@ -419,16 +430,17 @@ export class RelayConnection {
 	}
 
 	private onDebuggerDetach(source: chrome.debugger.Debuggee, reason: string): void {
-		if (!source.tabId) return;
-		const id = this.chromeTabIdToId.get(source.tabId);
+		const chromeTabId = source.tabId;
+		if (!chromeTabId) return;
+		const id = this.chromeTabIdToId.get(chromeTabId);
 		if (!id) return;
 
 		const entry = this.tabs.get(id);
 		if (entry) entry.attached = false;
 
 		this.tabs.delete(id);
-		this.chromeTabIdToId.delete(source.tabId);
-		this.agentCreatedChromeTabIds.delete(source.tabId);
+		this.chromeTabIdToId.delete(chromeTabId);
+		this.agentCreatedChromeTabIds.delete(chromeTabId);
 
 		if (id === this.primaryId) {
 			const remaining = [...this.tabs.keys()];
@@ -436,11 +448,32 @@ export class RelayConnection {
 		}
 
 		log.debug(`debuggerDetach: ${id} reason=${reason}`);
-		this.sendMessage({ method: 'tabClosed', params: { id } });
+		// Chrome's reason never names an extension, and only a frame that is live now
+		// can have caused this detach.
+		void this.reportDetached(chromeTabId, id).catch((e) =>
+			log.debug('failed to report detach:', e),
+		);
+	}
 
-		if (this.tabs.size === 0) {
-			this.close('debugger_detached');
+	private async reportDetached(chromeTabId: number, id: string): Promise<void> {
+		this.pendingDetachReports++;
+		try {
+			const blockingExtensionIds = await this.foreignFrames.owners(chromeTabId);
+
+			this.sendMessage({
+				method: 'tabClosed',
+				params:
+					blockingExtensionIds.length > 0
+						? { id, reason: 'blocked_by_extension', blockingExtensionIds }
+						: { id },
+			});
+		} finally {
+			this.foreignFrames.forget(chromeTabId);
+			this.pendingDetachReports--;
 		}
+
+		// Closing drops frames still queued behind us.
+		this.closeIfIdle('debugger_detached');
 	}
 
 	// =========================================================================
@@ -541,7 +574,7 @@ export class RelayConnection {
 		log.debug(`CDP: ${method as string} → targetId=${id} (chromeTabId=${entry.chromeTabId})`);
 
 		// Lazy attach on first CDP command
-		await this.ensureAttached(id);
+		await this.explainDenials(entry.chromeTabId, async () => await this.ensureAttached(id));
 
 		const debuggee = { tabId: entry.chromeTabId };
 
@@ -573,30 +606,48 @@ export class RelayConnection {
 				chrome.debugger.onEvent.addListener(handler);
 			});
 
-			const result = await chrome.debugger.sendCommand(
-				debuggee,
-				method as string,
-				cmdParams as object | undefined,
+			const result = await this.explainDenials(
+				entry.chromeTabId,
+				async () =>
+					await chrome.debugger.sendCommand(
+						debuggee,
+						method as string,
+						cmdParams as object | undefined,
+					),
 			);
 			await contextReady;
 			return result;
 		}
 
-		const result = await Promise.race([
-			chrome.debugger.sendCommand(debuggee, method as string, cmdParams as object | undefined),
-			new Promise<never>((_resolve, reject) => {
-				setTimeout(() => {
-					reject(
-						new Error(
-							`CDP command '${method as string}' timed out after ${CDP_COMMAND_TIMEOUT_MS}ms (${id})`,
-						),
-					);
-				}, CDP_COMMAND_TIMEOUT_MS);
-			}),
-		]);
+		const result = await this.explainDenials(
+			entry.chromeTabId,
+			async () =>
+				await Promise.race([
+					chrome.debugger.sendCommand(debuggee, method as string, cmdParams as object | undefined),
+					new Promise<never>((_resolve, reject) => {
+						setTimeout(() => {
+							reject(
+								new Error(
+									`CDP command '${method as string}' timed out after ${CDP_COMMAND_TIMEOUT_MS}ms (${id})`,
+								),
+							);
+						}, CDP_COMMAND_TIMEOUT_MS);
+					}),
+				]),
+		);
 
 		log.debug(`CDP response: ${method as string} → ${id} OK`);
 		return result;
+	}
+
+	/** Names the extension behind a denial. Wraps attach too — that is denied first. */
+	private async explainDenials<T>(chromeTabId: number, run: () => Promise<T>): Promise<T> {
+		try {
+			return await run();
+		} catch (error) {
+			if (!ForeignFrames.isDenial(error)) throw error;
+			throw await this.foreignFrames.describeDenial(chromeTabId, error);
+		}
 	}
 
 	private async handleCreateTab(params: Record<string, unknown>): Promise<unknown> {
@@ -669,6 +720,7 @@ export class RelayConnection {
 		this.tabs.delete(id);
 		this.chromeTabIdToId.delete(entry.chromeTabId);
 		this.agentCreatedChromeTabIds.delete(entry.chromeTabId);
+		this.foreignFrames.forget(entry.chromeTabId);
 
 		// Close the tab
 		await chrome.tabs.remove(entry.chromeTabId);
@@ -679,9 +731,7 @@ export class RelayConnection {
 			this.primaryId = remaining.length > 0 ? remaining[0] : undefined;
 		}
 
-		if (this.tabs.size === 0) {
-			this.close('extension_disconnected');
-		}
+		this.closeIfIdle('extension_disconnected');
 
 		return { closed: true, id };
 	}
@@ -691,7 +741,8 @@ export class RelayConnection {
 		if (!id) throw new Error('id is required');
 
 		log.debug(`attachTab: ${id}`);
-		await this.ensureAttached(id);
+		const { entry } = this.resolveTab(id);
+		await this.explainDenials(entry.chromeTabId, async () => await this.ensureAttached(id));
 		log.debug(`attachTab: ${id} done`);
 		return { attached: true, id };
 	}

--- a/packages/@n8n/mcp-browser/src/__tests__/cdp-relay.test.ts
+++ b/packages/@n8n/mcp-browser/src/__tests__/cdp-relay.test.ts
@@ -98,7 +98,18 @@ function createFakeExtension(ws: WebSocket) {
 	return { handlers };
 }
 
+const OFFENDING_ID = 'offendingextensionid';
+
 describe('CDPRelayServer', () => {
+	/** An extension connected and ready to serve relay commands. */
+	async function connectedExtension(): Promise<WebSocket> {
+		const ext = connectExtension();
+		await waitForOpen(ext);
+		createFakeExtension(ext);
+		await relay.waitForExtension();
+		return ext;
+	}
+
 	it('should resolve waitForExtension when extension connects', async () => {
 		const ext = connectExtension();
 		await waitForOpen(ext);
@@ -132,6 +143,57 @@ describe('CDPRelayServer', () => {
 		});
 
 		expect(reason).toBe('browser_closed');
+	});
+
+	it('should report a block at once, and again when the session ends', async () => {
+		const ext = await connectedExtension();
+
+		const blocked = new Promise<string[] | undefined>((resolve) => {
+			relay.onTabBlocked = (details) => resolve(details.blockingExtensionIds);
+		});
+		const disconnected = new Promise<{ reason: string; ids?: string[] }>((resolve) => {
+			relay.onExtensionDisconnect = (reason, details) =>
+				resolve({ reason, ids: details?.blockingExtensionIds });
+		});
+
+		ext.send(
+			JSON.stringify({
+				method: 'tabClosed',
+				params: {
+					id: 'tab-1',
+					reason: 'blocked_by_extension',
+					blockingExtensionIds: [OFFENDING_ID],
+				},
+			}),
+		);
+
+		// Arrives while the socket is still open — that immediacy is what cuts short
+		// an in-flight action otherwise waiting on its own timeout.
+		await expect(blocked).resolves.toEqual([OFFENDING_ID]);
+
+		ext.close();
+		await expect(disconnected).resolves.toEqual({
+			reason: 'blocked_by_extension',
+			ids: [OFFENDING_ID],
+		});
+	});
+
+	it('should leave a plain tabClosed unattributed, as older extensions send', async () => {
+		const ext = await connectedExtension();
+		const onTabBlocked = vi.fn();
+		relay.onTabBlocked = onTabBlocked;
+		const disconnected = new Promise<string>((resolve) => {
+			relay.onExtensionDisconnect = (reason) => resolve(reason);
+		});
+
+		ext.send(JSON.stringify({ method: 'tabClosed', params: { id: 'tab-1' } }));
+		// A round-trip proves the frame above was processed: the socket is ordered.
+		await relay.listTabs();
+
+		expect(onTabBlocked).not.toHaveBeenCalled();
+
+		ext.close(1000, 'browser_closed');
+		await expect(disconnected).resolves.toBe('browser_closed');
 	});
 
 	it('should list tabs from extension', async () => {

--- a/packages/@n8n/mcp-browser/src/__tests__/connection.test.ts
+++ b/packages/@n8n/mcp-browser/src/__tests__/connection.test.ts
@@ -1,0 +1,157 @@
+import { BrowserConnection } from '../connection';
+import {
+	ConnectionLostError,
+	ExtensionConflictError,
+	NotConnectedError,
+	type ConnectionLostReason,
+	type McpBrowserError,
+} from '../errors';
+import { configureLogger } from '../logger';
+import type { Adapter, DisconnectDetails } from '../types';
+
+configureLogger({ level: 'silent' });
+
+/**
+ * `connect()` needs a real browser, so drive the connection through the handlers
+ * it installs on its adapter instead — that is the surface a lost session uses.
+ */
+function connectionWithHandlers() {
+	const connection = new BrowserConnection();
+	const adapter = {} as Adapter;
+
+	// Install the real handlers connect() would, so this exercises production wiring.
+	const internals = connection as unknown as {
+		state: unknown;
+		installAdapterHandlers: (adapter: Adapter) => void;
+	};
+	internals.installAdapterHandlers(adapter);
+	internals.state = { adapter, pages: new Map(), activePageId: 'page1' };
+
+	return {
+		connection,
+		disconnect: (reason: ConnectionLostReason, details?: DisconnectDetails) =>
+			adapter.onDisconnect?.(reason, details),
+		block: (details: DisconnectDetails) => adapter.onBlocked?.(details),
+	};
+}
+
+/** The thrown error itself, for assertions on `hint` — `toThrow` only sees the message. */
+function thrownBy(fn: () => unknown): McpBrowserError {
+	try {
+		fn();
+	} catch (e) {
+		return e as McpBrowserError;
+	}
+	throw new Error('expected the call to throw');
+}
+
+describe('BrowserConnection.getConnection', () => {
+	it('reports not connected before anything has happened', () => {
+		expect(() => new BrowserConnection().getConnection()).toThrow(NotConnectedError);
+	});
+
+	it('reports an ordinary loss as a connection loss', () => {
+		const { connection, disconnect } = connectionWithHandlers();
+		disconnect('browser_closed');
+
+		expect(() => connection.getConnection()).toThrow(ConnectionLostError);
+	});
+
+	it('names the extension when a block took the session down', () => {
+		const { connection, disconnect } = connectionWithHandlers();
+		disconnect('blocked_by_extension', { blockingExtensionIds: ['offendingext'] });
+
+		expect(() => connection.getConnection()).toThrow(ExtensionConflictError);
+		expect(() => connection.getConnection()).toThrow(/offendingext/);
+	});
+
+	it('tells a dead session to reconnect before opening a fresh tab', () => {
+		const { connection, disconnect } = connectionWithHandlers();
+		disconnect('blocked_by_extension', { blockingExtensionIds: ['offendingext'] });
+
+		expect(thrownBy(() => connection.getConnection()).hint).toContain('call browser_connect first');
+	});
+});
+
+describe('BrowserConnection.explainFailure', () => {
+	it('passes an ordinary failure straight through', () => {
+		const { connection } = connectionWithHandlers();
+		const failure = new Error('No node with given id');
+
+		expect(connection.explainFailure(failure)).toBe(failure);
+	});
+
+	it('names the extension instead of the timeout the action died on', () => {
+		const { connection, block } = connectionWithHandlers();
+		block({ blockingExtensionIds: ['offendingext'] });
+
+		const explained = connection.explainFailure(new Error('Timeout 30000ms exceeded.'));
+
+		expect(explained).toBeInstanceOf(ExtensionConflictError);
+		expect((explained as ExtensionConflictError).message).toContain('offendingext');
+	});
+
+	it('tells a still-live session to use a fresh tab rather than reconnect', () => {
+		const { connection, block } = connectionWithHandlers();
+		block({ blockingExtensionIds: ['offendingext'] });
+
+		const explained = connection.explainFailure(new Error('boom')) as ExtensionConflictError;
+
+		expect(explained.hint).toContain('do not call browser_connect');
+	});
+
+	it('tells a call whose session died to reconnect, not to open a tab', () => {
+		// A single blocked tab takes the session with it, so the block and the
+		// disconnect land inside the same call.
+		const { connection, block, disconnect } = connectionWithHandlers();
+		block({ blockingExtensionIds: ['offendingext'] });
+		disconnect('blocked_by_extension', { blockingExtensionIds: ['offendingext'] });
+
+		const explained = connection.explainFailure(new Error('Timeout')) as ExtensionConflictError;
+
+		expect(explained.hint).toContain('call browser_connect first');
+		expect(explained.hint).not.toContain('do not call browser_connect');
+	});
+
+	it('reports a dead browser as a lost connection', () => {
+		const { connection } = connectionWithHandlers();
+		const closed = new Error('Target page, context or browser has been closed');
+		closed.name = 'TargetClosedError';
+
+		expect(connection.explainFailure(closed)).toBeInstanceOf(ConnectionLostError);
+	});
+
+	it('blames a block on one failure only', () => {
+		const { connection, block } = connectionWithHandlers();
+		block({ blockingExtensionIds: ['offendingext'] });
+
+		connection.explainFailure(new Error('first'));
+		const second = new Error('second');
+
+		// Otherwise it lands on the fresh tab the agent was told to recover in.
+		expect(connection.explainFailure(second)).toBe(second);
+	});
+});
+
+describe('BrowserConnection extension block', () => {
+	it('drops a block that predates the call asking about it', () => {
+		const { connection, block } = connectionWithHandlers();
+		block({ blockingExtensionIds: ['offendingext'] });
+
+		connection.beginToolCall();
+		const failure = new Error('unrelated');
+
+		expect(connection.explainFailure(failure)).toBe(failure);
+	});
+
+	it('still reports a block that arrives after the call started', () => {
+		const { connection, block } = connectionWithHandlers();
+
+		connection.beginToolCall();
+		block({ blockingExtensionIds: ['offendingext'] });
+
+		expect(connection.explainFailure(new Error('unrelated'))).toBeInstanceOf(
+			ExtensionConflictError,
+		);
+	});
+});

--- a/packages/@n8n/mcp-browser/src/__tests__/errors.test.ts
+++ b/packages/@n8n/mcp-browser/src/__tests__/errors.test.ts
@@ -1,6 +1,8 @@
 import {
 	AlreadyConnectedError,
 	BrowserNotAvailableError,
+	ConnectionLostError,
+	ExtensionConflictError,
 	McpBrowserError,
 	NotConnectedError,
 	PageNotFoundError,
@@ -111,5 +113,54 @@ describe('BrowserNotAvailableError', () => {
 	it('should describe no browsers found when none available', () => {
 		const error = new BrowserNotAvailableError('firefox');
 		expect(error.hint).toContain('No compatible Chromium-based browsers');
+	});
+});
+
+describe('ConnectionLostError', () => {
+	it('should tell the agent to reconnect for ordinary losses', () => {
+		expect(new ConnectionLostError('browser_closed').hint).toContain(
+			'browser_connect to reconnect',
+		);
+	});
+
+	it('should say to reconnect when a block took the session down', () => {
+		// Only renders once the session is gone, so reconnecting is right here.
+		const hint = new ConnectionLostError('blocked_by_extension').hint ?? '';
+		expect(hint).toContain('browser_connect');
+		expect(hint).toContain('fresh tab');
+	});
+});
+
+describe('ExtensionConflictError', () => {
+	const error = ExtensionConflictError.tabLost(['offendingextensionid']);
+
+	it('should name the blocking extension', () => {
+		expect(error.message).toContain('offendingextensionid');
+	});
+
+	it('should steer a still-live session to a fresh tab, not a reconnect', () => {
+		// browser_connect throws AlreadyConnectedError while the session is up.
+		expect(error.hint).toContain('cannot be recovered');
+		expect(error.hint).toContain('browser_tab_open');
+		expect(error.hint).toContain('do not call browser_connect');
+	});
+
+	it('should send a dead session through browser_connect first', () => {
+		const hint = ExtensionConflictError.sessionLost(['abc']).hint ?? '';
+		expect(hint).toContain('call browser_connect first');
+		expect(hint).not.toContain('do not call browser_connect');
+	});
+
+	it('should not route the hand-off through ask-user', () => {
+		// ask-user renders an input field; this hand-off belongs in the reply.
+		expect(error.hint).not.toContain('ask-user');
+	});
+
+	it('should stay readable when no extension could be identified', () => {
+		expect(ExtensionConflictError.tabLost([]).message).toContain('another browser extension');
+	});
+
+	it('should be instanceof McpBrowserError', () => {
+		expect(error).toBeInstanceOf(McpBrowserError);
 	});
 });

--- a/packages/@n8n/mcp-browser/src/adapters/playwright.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/playwright.ts
@@ -39,6 +39,7 @@ import type {
 	SnapshotResult,
 	TypeOptions,
 	WaitOptions,
+	DisconnectDetails,
 } from '../types';
 import { generateId, toError } from '../utils';
 
@@ -87,13 +88,15 @@ export class PlaywrightAdapter {
 	private readonly externalRelay?: CDPRelayServer;
 	private readonly externalCdpEndpoint?: string;
 	private readonly cdpConnectHeaders?: Record<string, string>;
-	/** The embedder's extension-disconnect handler, chained in remote mode. */
-	private previousOnExtensionDisconnect?: (reason: ConnectionLostReason) => void;
+	/** Puts the embedder's relay handlers back; set while ours are installed. */
+	private restoreRelayHandlers?: () => void;
 	/** Pending activation: set by ensurePage(), consumed by context.on('page'). */
 	private pendingActivation?: { id: string; resolve: (page: Page) => void };
 
 	/** Called when the browser connection is unexpectedly lost. */
-	onDisconnect?: (reason: ConnectionLostReason) => void;
+	onDisconnect?: (reason: ConnectionLostReason, details?: DisconnectDetails) => void;
+
+	onBlocked?: (details: DisconnectDetails) => void;
 
 	constructor(config: ResolvedConfig, options?: PlaywrightAdapterOptions) {
 		this.resolvedConfig = config;
@@ -200,15 +203,23 @@ export class PlaywrightAdapter {
 			this.onDisconnect?.('browser_closed');
 		});
 
-		// Detect extension disconnection via the relay (already a typed reason).
-		// In remote mode the embedder may have installed its own handler,
-		// chain it so connection-state tracking keeps working.
-		this.previousOnExtensionDisconnect = relay.onExtensionDisconnect;
-		const previous = this.previousOnExtensionDisconnect;
-		relay.onExtensionDisconnect = (reason) => {
+		// In remote mode the relay outlives us, so chain onto the embedder's handlers
+		// and restore them on close. One closure so neither can be forgotten.
+		const previousDisconnect = relay.onExtensionDisconnect;
+		const previousBlocked = relay.onTabBlocked;
+		relay.onExtensionDisconnect = (reason, details) => {
 			log.debug('relay: extension disconnected, reason:', reason);
-			previous?.(reason);
-			this.onDisconnect?.(reason);
+			previousDisconnect?.(reason, details);
+			this.onDisconnect?.(reason, details);
+		};
+		relay.onTabBlocked = (details) => {
+			log.debug('relay: tab blocked by', details.blockingExtensionIds);
+			previousBlocked?.(details);
+			this.onBlocked?.(details);
+		};
+		this.restoreRelayHandlers = () => {
+			relay.onExtensionDisconnect = previousDisconnect;
+			relay.onTabBlocked = previousBlocked;
 		};
 
 		log.debug('launch complete, context ready for lazy activation');
@@ -227,10 +238,9 @@ export class PlaywrightAdapter {
 		}
 		if (this.relay) {
 			if (this.relay === this.externalRelay) {
-				// Externally managed relay: restore the embedder's handler and
-				// leave the relay running (its lifecycle is owned by the embedder).
-				this.relay.onExtensionDisconnect = this.previousOnExtensionDisconnect;
-				this.previousOnExtensionDisconnect = undefined;
+				// Externally managed relay: restore handlers, leave it running.
+				this.restoreRelayHandlers?.();
+				this.restoreRelayHandlers = undefined;
 			} else {
 				this.relay.stop();
 			}

--- a/packages/@n8n/mcp-browser/src/cdp-relay-protocol.ts
+++ b/packages/@n8n/mcp-browser/src/cdp-relay-protocol.ts
@@ -73,10 +73,13 @@ export interface ExtensionEvents {
 			url: string;
 		};
 	};
-	/** A tab was closed. */
+	/** A tab was closed, or left our control. */
 	tabClosed: {
 		params: {
 			id: string;
+			/** Absent on extension builds older than this field. */
+			reason?: 'blocked_by_extension';
+			blockingExtensionIds?: string[];
 		};
 	};
 }

--- a/packages/@n8n/mcp-browser/src/cdp-relay.ts
+++ b/packages/@n8n/mcp-browser/src/cdp-relay.ts
@@ -29,6 +29,7 @@ import {
 	type ExtensionNotConnectedPhase,
 } from './errors';
 import { createLogger } from './logger';
+import type { DisconnectDetails } from './types';
 
 const log = createLogger('relay');
 
@@ -89,8 +90,13 @@ export class CDPRelayServer {
 	private extensionConnectedReject?: (error: Error) => void;
 	private extensionConnectedPromise: Promise<void>;
 
+	private blockingExtensionIds: string[] = [];
+
 	/** Called when the extension disconnects with a typed reason. */
-	onExtensionDisconnect?: (reason: ConnectionLostReason) => void;
+	onExtensionDisconnect?: (reason: ConnectionLostReason, details?: DisconnectDetails) => void;
+
+	/** Fired before any teardown, so an in-flight action can fail fast. */
+	onTabBlocked?: (details: DisconnectDetails) => void;
 
 	/** Called when the extension (re)connects. */
 	onExtensionConnect?: () => void;
@@ -630,6 +636,8 @@ export class CDPRelayServer {
 	/** Handle tabOpened event from extension. */
 	private handleTabOpened(id: string, title: string, url: string): void {
 		if (this.tabCache.has(id)) return;
+		// A new tab is the agent recovering; the earlier block is history.
+		this.blockingExtensionIds = [];
 
 		log.debug('tabOpened:', id, url);
 		this.tabCache.set(id, { title, url });
@@ -638,8 +646,21 @@ export class CDPRelayServer {
 	}
 
 	/** Handle tabClosed event from extension. */
-	private handleTabClosed(id: string): void {
-		log.debug('tabClosed:', id);
+	private handleTabClosed(
+		id: string,
+		reason?: 'blocked_by_extension',
+		blockingExtensionIds?: string[],
+	): void {
+		if (reason === 'blocked_by_extension') {
+			log.debug('tabClosed:', id, 'blocked by', blockingExtensionIds);
+			this.blockingExtensionIds = blockingExtensionIds ?? [];
+			this.onTabBlocked?.({ blockingExtensionIds: this.blockingExtensionIds });
+		} else {
+			log.debug('tabClosed:', id);
+			// The session carried on past the block, so stop attributing later
+			// disconnects to it.
+			this.blockingExtensionIds = [];
+		}
 
 		this.tabCache.delete(id);
 		const wasActivated = this.activatedTabs.delete(id);
@@ -694,12 +715,20 @@ export class CDPRelayServer {
 		}
 
 		log.debug('extension connected');
+		// A fresh session must not inherit the previous one's block.
+		this.blockingExtensionIds = [];
 		this.extensionConn = new ExtensionConnection(ws);
 
 		this.extensionConn.onclose = () => {
-			const rawReason = this.extensionConn?.closeReason;
-			log.debug('extension disconnected, reason:', rawReason ?? '(none)');
-			this.onExtensionDisconnect?.(asConnectionLostReason(rawReason));
+			const blockingExtensionIds = this.blockingExtensionIds;
+			// A recorded block outranks the socket's own reason: it says why the tab
+			// went, which the close frame never does.
+			const reason: ConnectionLostReason =
+				blockingExtensionIds.length > 0
+					? 'blocked_by_extension'
+					: asConnectionLostReason(this.extensionConn?.closeReason);
+			log.debug('extension disconnected, reason:', reason);
+			this.onExtensionDisconnect?.(reason, { blockingExtensionIds });
 
 			// Clear extension ref but KEEP tabCache, activatedTabs, and Playwright connection.
 			// Pending requests are already rejected by ExtensionConnection.handleClose.
@@ -827,7 +856,7 @@ export class CDPRelayServer {
 				this.handleTabOpened(p.id, p.title, p.url);
 			} else if (method === 'tabClosed') {
 				const p = params as ExtensionEvents['tabClosed']['params'];
-				this.handleTabClosed(p.id);
+				this.handleTabClosed(p.id, p.reason, p.blockingExtensionIds);
 			}
 		};
 	}
@@ -878,6 +907,7 @@ export class CDPRelayServer {
 		this.activatedTabs.clear();
 		this.primaryTabId = undefined;
 		this.lastCreatedTabId = undefined;
+		this.blockingExtensionIds = [];
 		this.browserContextId = 'n8n-default-context';
 		this.extensionConn = null;
 		this.extensionConnectedPromise = new Promise((resolve, reject) => {
@@ -1081,6 +1111,7 @@ const VALID_REASONS = new Set<ConnectionLostReason>([
 	'browser_closed',
 	'extension_disconnected',
 	'debugger_detached',
+	'blocked_by_extension',
 	'network_error',
 	'heartbeat_timeout',
 ]);

--- a/packages/@n8n/mcp-browser/src/connection.ts
+++ b/packages/@n8n/mcp-browser/src/connection.ts
@@ -4,6 +4,7 @@ import {
 	AlreadyConnectedError,
 	BrowserNotAvailableError,
 	ConnectionLostError,
+	ExtensionConflictError,
 	ExtensionNotConnectedError,
 	NotConnectedError,
 	type ConnectionLostReason,
@@ -38,6 +39,9 @@ export interface BrowserConnectionOptions {
 export class BrowserConnection {
 	private state: ConnectionState | null = null;
 	private disconnectReason: ConnectionLostReason | undefined;
+	private sessionBlockedBy: string[] = [];
+	/** Block seen since the current tool call began; consumed when it fails. */
+	private blockedDuringCall: string[] | undefined;
 	private readonly config: ResolvedConfig;
 	private readonly externalRelay?: CDPRelayServer;
 	private readonly externalCdpEndpoint?: string;
@@ -100,6 +104,11 @@ export class BrowserConnection {
 			this.requireBrowserAvailable(browser);
 		}
 
+		// A reconnect must not inherit the block it was told to escape.
+		this.disconnectReason = undefined;
+		this.sessionBlockedBy = [];
+		this.blockedDuringCall = undefined;
+
 		const connectConfig: ConnectConfig = {
 			browser,
 		};
@@ -108,13 +117,7 @@ export class BrowserConnection {
 		const adapter = this.pendingAdapter ?? (await this.createAdapter());
 		this.pendingAdapter = null;
 
-		// Listen for unexpected disconnections so we can invalidate state immediately
-		adapter.onDisconnect = (reason) => {
-			if (!this.state) return; // already disconnected
-			log.debug('unexpected disconnect, reason:', reason);
-			this.disconnectReason = reason;
-			this.state = null;
-		};
+		this.installAdapterHandlers(adapter);
 
 		try {
 			await adapter.launch(connectConfig);
@@ -143,6 +146,23 @@ export class BrowserConnection {
 		return { browser, pages };
 	}
 
+	private installAdapterHandlers(adapter: Adapter): void {
+		// Listen for unexpected disconnections so we can invalidate state immediately
+		adapter.onDisconnect = (reason, details) => {
+			if (!this.state) return; // already disconnected
+			log.debug('unexpected disconnect, reason:', reason);
+			this.disconnectReason = reason;
+			this.sessionBlockedBy = details?.blockingExtensionIds ?? [];
+			this.state = null;
+		};
+
+		// Not keyed by tab: the relay reports a CDP target id, which does not match
+		// the id an agent-created tab is tracked under.
+		adapter.onBlocked = ({ blockingExtensionIds }) => {
+			this.blockedDuringCall = blockingExtensionIds;
+		};
+	}
+
 	async disconnect(): Promise<void> {
 		const pending = this.pendingAdapter;
 		this.pendingAdapter = null;
@@ -154,6 +174,8 @@ export class BrowserConnection {
 		const { adapter } = this.state;
 		this.state = null;
 		this.disconnectReason = undefined;
+		this.sessionBlockedBy = [];
+		this.blockedDuringCall = undefined;
 
 		try {
 			await adapter.close();
@@ -164,12 +186,41 @@ export class BrowserConnection {
 
 	getConnection(): ConnectionState {
 		if (!this.state) {
+			if (this.disconnectReason === 'blocked_by_extension') {
+				// No state left, so browser_connect is the only way back.
+				throw ExtensionConflictError.sessionLost(this.sessionBlockedBy);
+			}
 			if (this.disconnectReason) {
 				throw new ConnectionLostError(this.disconnectReason);
 			}
 			throw new NotConnectedError();
 		}
 		return this.state;
+	}
+
+	/** Drops any earlier block, so only one arriving during this call explains its failure. */
+	beginToolCall(): void {
+		this.blockedDuringCall = undefined;
+	}
+
+	/** A blocked tab fails as an adapter timeout, which says nothing — so a block wins. */
+	explainFailure(error: unknown): unknown {
+		const blockingExtensionIds = this.blockedDuringCall;
+		this.blockedDuringCall = undefined;
+		if (blockingExtensionIds) {
+			// The only remaining trace of the real failure if this attribution is wrong.
+			log.debug('replacing failure with extension conflict, original:', error);
+			// The block can take the session down inside the very call it interrupts,
+			// so the two hints must not be chosen before checking.
+			return this.state
+				? ExtensionConflictError.tabLost(blockingExtensionIds)
+				: ExtensionConflictError.sessionLost(blockingExtensionIds);
+		}
+
+		if (error instanceof Error && error.name === 'TargetClosedError') {
+			return new ConnectionLostError('browser_closed');
+		}
+		return error;
 	}
 
 	get isConnected(): boolean {

--- a/packages/@n8n/mcp-browser/src/errors.ts
+++ b/packages/@n8n/mcp-browser/src/errors.ts
@@ -41,6 +41,47 @@ export class StaleRefError extends McpBrowserError {
 	}
 }
 
+const RESUME_AFTER_SESSION_LOST =
+	'the session went down with the tab, so call browser_connect first, then redo the step in a fresh tab';
+
+/** Chrome will not re-grant debugger access to this tab; recovery means a fresh one. */
+export class ExtensionConflictError extends McpBrowserError {
+	static tabLost(blockingExtensionIds: string[]): ExtensionConflictError {
+		return new ExtensionConflictError(blockingExtensionIds, true);
+	}
+
+	static sessionLost(blockingExtensionIds: string[]): ExtensionConflictError {
+		return new ExtensionConflictError(blockingExtensionIds, false);
+	}
+
+	private constructor(
+		readonly blockingExtensionIds: string[],
+		sessionAlive: boolean,
+	) {
+		const which =
+			blockingExtensionIds.length > 0
+				? `another browser extension (${blockingExtensionIds.join(', ')})`
+				: 'another browser extension';
+		// Opposite advice per case: reconnecting is rejected while the session is up,
+		// and required once it is down.
+		const resume = sessionAlive
+			? 'open a fresh tab with browser_tab_open and redo the step there — do not call browser_connect, the session is still live'
+			: RESUME_AFTER_SESSION_LOST;
+		super(
+			`This tab can no longer be automated — it was blocked by ${which}`,
+			'Chrome stops automating a tab as soon as another extension opens a frame in it — a ' +
+				'password manager showing its autofill menu does exactly that. This tab cannot be ' +
+				'recovered and anything already typed into it is lost. Dismissing the menu does not ' +
+				'help: it reappears the moment the field is focused again, so a retry fails the same ' +
+				'way. In your reply, explain this and offer the user both ways forward: (1) they ' +
+				`turn that extension off for this site and tell you once done, after which ${resume}; ` +
+				'or (2) they finish this step themselves in the browser. If you were capturing a ' +
+				'credential, (2) means the value never comes back through the page — stop using ' +
+				'browser tools for it and let the user enter it through n8n credential setup instead.',
+		);
+	}
+}
+
 export class UnsupportedOperationError extends McpBrowserError {
 	constructor(
 		readonly operation: string,
@@ -73,6 +114,7 @@ export type ConnectionLostReason =
 	| 'browser_closed'
 	| 'extension_disconnected'
 	| 'debugger_detached'
+	| 'blocked_by_extension'
 	| 'network_error'
 	| 'heartbeat_timeout';
 
@@ -80,15 +122,21 @@ const connectionLostMessages: Record<ConnectionLostReason, string> = {
 	browser_closed: 'The browser was closed',
 	extension_disconnected: 'The browser extension disconnected',
 	debugger_detached: 'The Chrome debugger was detached (banner dismissed or DevTools closed)',
+	blocked_by_extension: 'Another browser extension blocked automation of the tab',
 	network_error: 'The connection to the browser extension was lost',
 	heartbeat_timeout: 'The browser extension stopped responding',
+};
+
+/** Reasons that override the default "just reconnect" hint. */
+const connectionLostHints: Partial<Record<ConnectionLostReason, string>> = {
+	blocked_by_extension: `Another extension blocked that tab — ${RESUME_AFTER_SESSION_LOST}.`,
 };
 
 export class ConnectionLostError extends McpBrowserError {
 	constructor(readonly reason: ConnectionLostReason) {
 		super(
 			`Browser connection lost: ${connectionLostMessages[reason]}`,
-			'Call browser_connect to reconnect.',
+			connectionLostHints[reason] ?? 'Call browser_connect to reconnect.',
 		);
 	}
 }

--- a/packages/@n8n/mcp-browser/src/tools/helpers.ts
+++ b/packages/@n8n/mcp-browser/src/tools/helpers.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod';
 
 import type { BrowserConnection } from '../connection';
 import { createLogger } from '../logger';
+import { buildErrorResponse, enrichResponse, resolvePageContext } from './response-envelope';
 import { redactCallToolResult } from '../redaction/redact';
 import type {
 	AffectedResource,
@@ -10,7 +11,6 @@ import type {
 	ToolContext,
 	ToolDefinition,
 } from '../types';
-import { buildErrorResponse, enrichResponse, resolvePageContext } from './response-envelope';
 
 const log = createLogger('connected-tool');
 

--- a/packages/@n8n/mcp-browser/src/tools/helpers.ts
+++ b/packages/@n8n/mcp-browser/src/tools/helpers.ts
@@ -1,7 +1,6 @@
 import type { z } from 'zod';
 
 import type { BrowserConnection } from '../connection';
-import { ConnectionLostError } from '../errors';
 import { createLogger } from '../logger';
 import { redactCallToolResult } from '../redaction/redact';
 import type {
@@ -97,6 +96,7 @@ export function createConnectedTool<
 			const effectiveOptions: ConnectedToolOptions = args.snapshot
 				? { ...options, autoSnapshot: true, snapshotInteractive: args.snapshot === 'interactive' }
 				: (options ?? {});
+			connection.beginToolCall();
 			try {
 				const { state, pageId } = resolvePageContext(connection, args);
 
@@ -128,20 +128,13 @@ export function createConnectedTool<
 
 				return redactCallToolResult(result);
 			} catch (error) {
-				// Playwright throws TargetClosedError when browser/page dies mid-operation.
-				// Re-throw as our typed error so the AI gets a clear message + hint.
-				if (error instanceof Error && error.name === 'TargetClosedError') {
-					return redactCallToolResult(
-						await buildErrorResponse(
-							new ConnectionLostError('browser_closed'),
-							connection,
-							args,
-							effectiveOptions,
-						),
-					);
-				}
 				return redactCallToolResult(
-					await buildErrorResponse(error, connection, args, effectiveOptions),
+					await buildErrorResponse(
+						connection.explainFailure(error),
+						connection,
+						args,
+						effectiveOptions,
+					),
 				);
 			}
 		},

--- a/packages/@n8n/mcp-browser/src/tools/helpers.ts
+++ b/packages/@n8n/mcp-browser/src/tools/helpers.ts
@@ -1,7 +1,6 @@
 import type { z } from 'zod';
 
 import type { BrowserConnection } from '../connection';
-import { ConnectionLostError } from '../errors';
 import { createLogger } from '../logger';
 import { redactCallToolResult } from '../redaction/redact';
 import type {
@@ -91,6 +90,7 @@ export function createConnectedTool<
 		inputSchema,
 		outputSchema,
 		async execute(args: z.infer<TSchema>, context: ToolContext) {
+			connection.beginToolCall();
 			try {
 				const { state, pageId } = resolvePageContext(connection, args);
 
@@ -122,20 +122,13 @@ export function createConnectedTool<
 
 				return redactCallToolResult(result);
 			} catch (error) {
-				// Playwright throws TargetClosedError when browser/page dies mid-operation.
-				// Re-throw as our typed error so the AI gets a clear message + hint.
-				if (error instanceof Error && error.name === 'TargetClosedError') {
-					return redactCallToolResult(
-						await buildErrorResponse(
-							new ConnectionLostError('browser_closed'),
-							connection,
-							args,
-							options ?? {},
-						),
-					);
-				}
 				return redactCallToolResult(
-					await buildErrorResponse(error, connection, args, options ?? {}),
+					await buildErrorResponse(
+						connection.explainFailure(error),
+						connection,
+						args,
+						options ?? {},
+					),
 				);
 			}
 		},

--- a/packages/@n8n/mcp-browser/src/tools/interaction.test.ts
+++ b/packages/@n8n/mcp-browser/src/tools/interaction.test.ts
@@ -167,6 +167,36 @@ describe('createInteractionTools', () => {
 				expect(data.text).toBe('hello');
 				expect(data.ref).toBe('e1');
 			});
+
+			it('routes a failure through the connection so it can be explained', async () => {
+				// The wrapper stays out of the error taxonomy; BrowserConnection owns it.
+				const failure = new Error('locator.pressSequentially: Timeout 30000ms exceeded.');
+				mockConnection.adapter.type.mockRejectedValue(failure);
+				const explainFailure = mockConnection.connection.explainFailure as unknown as ReturnType<
+					typeof vi.fn
+				>;
+				explainFailure.mockReturnValueOnce(new Error('explained'));
+
+				const result = await getTool().execute(
+					{ element: { ref: 'e1' }, text: 'hello' },
+					TOOL_CONTEXT,
+				);
+
+				expect(explainFailure).toHaveBeenCalledWith(failure);
+				expect(structuredOf(result).error).toBe('explained');
+			});
+
+			it('opens the call before acting, so an earlier block is not blamed on it', async () => {
+				const beginToolCall = mockConnection.connection.beginToolCall as unknown as ReturnType<
+					typeof vi.fn
+				>;
+
+				await getTool().execute({ element: { ref: 'e1' }, text: 'hello' }, TOOL_CONTEXT);
+
+				expect(beginToolCall.mock.invocationCallOrder[0]).toBeLessThan(
+					mockConnection.adapter.type.mock.invocationCallOrder[0],
+				);
+			});
 		});
 	});
 

--- a/packages/@n8n/mcp-browser/src/tools/test-helpers.ts
+++ b/packages/@n8n/mcp-browser/src/tools/test-helpers.ts
@@ -141,6 +141,8 @@ export function createMockConnection(adapter?: MockAdapter) {
 			pages: [{ id: 'page1', title: 'Test Page', url: 'http://test.com' }],
 		}),
 		disconnect: vi.fn().mockResolvedValue(undefined),
+		beginToolCall: vi.fn(),
+		explainFailure: vi.fn((error: unknown) => error),
 		isConnected: true,
 	} as unknown as BrowserConnection;
 

--- a/packages/@n8n/mcp-browser/src/types.ts
+++ b/packages/@n8n/mcp-browser/src/types.ts
@@ -59,8 +59,19 @@ export interface PageInfo {
 	url: string;
 }
 
+export interface DisconnectDetails {
+	/** Other extensions owning a frame in the tab. Empty when none could be named. */
+	blockingExtensionIds: string[];
+}
+
 export interface Adapter {
-	onDisconnect?: (reason: ConnectionLostReason) => void;
+	onDisconnect?: (reason: ConnectionLostReason, details?: DisconnectDetails) => void;
+	/**
+	 * Another extension blocked automation; the session may still be alive.
+	 * Playwright adapter only. `agent-browser` never fires this and drops the
+	 * disconnect details, so there a block is reported without naming the extension.
+	 */
+	onBlocked?: (details: DisconnectDetails) => void;
 	launch(config: ConnectConfig): Promise<void>;
 	close(): Promise<void>;
 	// Tabs


### PR DESCRIPTION
## Summary

Chromium refuses `chrome.debugger` access to a tab while **any** frame in it belongs to a *different* extension, and rechecks on every command. A password manager rendering its autofill menu therefore revokes our session mid-interaction — and Chrome's error and detach reason never name the culprit.

Browser Use had no way to see this. The in-flight action died on its own 30s timeout, every later call failed the same way, and the agent kept retrying a tab that could never come back. In the reported run the agent typed an API key name, only `n8` landed, and the session was gone from there on.

What this changes:

- **The extension works out who did it.** It tracks which other extensions hold a frame in each tab, keyed by frame id so a menu that has since closed can't be blamed for a later failure. Frame events are the primary source because `getAllFrames` reports `about:blank` for a frame that is still committing — which is exactly when the menu opens under us. The frame tree is the fallback for a frame that predates our attach (the attach-time denial).
- **That reaches the client.** `tabClosed` gains an optional `reason` + `blockingExtensionIds`, and the relay signals the block immediately rather than waiting for teardown, so an action already waiting on its timeout is cut short.
- **The agent gets one terminal error.** `ExtensionConflictError` names the extension and says the tab is unrecoverable, with different advice depending on whether the session survived — a fresh tab via `browser_tab_open` if it did, `browser_connect` first if it didn't. Getting that backwards leaves the agent with no working move, so both directions are pinned by tests.

Deliberately **not** in this PR: `agent-browser` is left unwired and preventing the interference in the first place is the sibling ticket.

## How to test

The extension half only takes effect from a locally built, unpacked extension

1. `pnpm --filter @n8n/mcp-browser build && pnpm --filter @n8n/mcp-browser-extension build`
2. `chrome://extensions` → **Load unpacked** → `packages/@n8n/mcp-browser-extension/dist`
3. Have a password manager enabled (1Password reproduces it reliably), start n8n, and run an AI credential setup that types into a provider console e.g. anthropic
4. When the autofill menu appears mid-typing, the tool call should come back **once**, naming the blocking extension, instead of hanging 30s and then failing on everything after.

<img width="847" height="648" alt="Bildschirmfoto 2026-08-11 um 08 45 10" src="https://github.com/user-attachments/assets/cb93e0bb-e9b4-4f54-94b1-be1991b7a65e" />

Old extension + new server is a supported combination: the server tolerates a `tabClosed` with no `reason` and simply behaves as it does today.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5725

Parent: https://linear.app/n8n/issue/NODE-5554
Follow-up split out of this work: https://linear.app/n8n/issue/NODE-5607

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

