### PR TITLE
fix: correct "seperate(d)" typo in node field descriptions

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/document/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/document/analyze.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the document(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the document(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/image/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/image/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the image(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the image(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the audio(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the audio(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/transcribe.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/transcribe.operation.ts
@@ -50,7 +50,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the audio(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the audio(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/document/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/document/analyze.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the document(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the document(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/video/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/video/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the video(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the video(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
+++ b/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
@@ -69,7 +69,7 @@ export const responderFields: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-boolean-without-whether
-		description: 'Choose between providing JSON object or seperated attributes',
+		description: 'Choose between providing JSON object or separated attributes',
 		displayOptions: {
 			show: {
 				resource: ['responder'],

--- a/packages/nodes-base/nodes/Keap/EmailDescription.ts
+++ b/packages/nodes-base/nodes/Keap/EmailDescription.ts
@@ -308,7 +308,7 @@ export const emailFields: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'Contact IDs to receive the email. Multiple can be added seperated by comma.',
+		description: 'Contact IDs to receive the email. Multiple can be added separated by comma.',
 	},
 	{
 		displayName: 'Subject',


### PR DESCRIPTION
## Summary
- Fixes a recurring spelling mistake ("seperate"/"seperated" → "separate"/"separated") in user-facing description text shown in the n8n UI
- Affects parameter descriptions in the Cortex, Keap, Google Gemini, and Anthropic vendor nodes

## Test plan
- [x] Text-only change, no logic affected
- [x] Verified via grep that no remaining occurrences of "seperate(d)" exist in the touched packages

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

