### PR TITLE
test(editor): Add failing cover for autosave on read-only preview canvases

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -1,5 +1,13 @@
+import { computed, defineComponent, h, provide } from 'vue';
+import { mount } from '@vue/test-utils';
 import { useUIStore } from '@/app/stores/ui.store';
-import { AutoSaveState, MODAL_CANCEL, MODAL_CONFIRM, VIEWS } from '@/app/constants';
+import { AutoSaveState, DEBOUNCE_TIME, MODAL_CANCEL, MODAL_CONFIRM, VIEWS } from '@/app/constants';
+import {
+	EditorEnabledFeaturesKey,
+	WorkflowIdKey,
+	type EditorEnabledFeatures,
+} from '@/app/constants/injectionKeys';
+import { getDebounceTime } from '@n8n/composables/useDebounce';
 import { useWorkflowSaving } from './useWorkflowSaving';
 import router from '@/app/router';
 import { createTestingPinia } from '@pinia/testing';
@@ -1323,6 +1331,145 @@ describe('useWorkflowSaving', () => {
 
 			// State should be Scheduled
 			expect(autosaveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
+		});
+	});
+
+	describe('autosave on a read-only preview canvas', () => {
+		// Preview hosts (template, workflow history, execution) mount the real
+		// NodeView and supersede the editor context with `readOnly: true`. Opening a
+		// node there auto-selects a credential, which marks the document dirty and
+		// reaches this composable — so the read-only signal has to stop the write.
+		// Regression cover for ADO-5764.
+		const PREVIEW_FEATURES: EditorEnabledFeatures = {
+			readOnly: true,
+			expandGroups: 'all',
+			aiAssistant: false,
+			aiBuilder: false,
+			askAi: false,
+			executionSuccessToasts: false,
+			executionErrorToasts: false,
+		};
+
+		const probe: { current: ReturnType<typeof useWorkflowSaving> | null } = { current: null };
+
+		const AutosaveProbe = defineComponent({
+			name: 'AutosaveProbe',
+			setup() {
+				probe.current = useWorkflowSaving({ router });
+				return () => h('div');
+			},
+		});
+
+		// Mirrors how WorkflowPreviewHost/ExecutionPreviewHost scope the subtree:
+		// the host provides, the child (NodeView in production) injects.
+		const PreviewHostStub = defineComponent({
+			name: 'PreviewHostStub',
+			props: {
+				workflowId: { type: String, required: true },
+				readOnly: { type: Boolean, required: true },
+			},
+			setup(props) {
+				provide(
+					WorkflowIdKey,
+					computed(() => props.workflowId),
+				);
+				provide(
+					EditorEnabledFeaturesKey,
+					computed<EditorEnabledFeatures>(() => ({
+						...PREVIEW_FEATURES,
+						readOnly: props.readOnly,
+					})),
+				);
+				return () => h(AutosaveProbe);
+			},
+		});
+
+		function takeProbe(): ReturnType<typeof useWorkflowSaving> {
+			const current = probe.current;
+			if (!current) throw new Error('AutosaveProbe did not initialise');
+			return current;
+		}
+
+		function mountPreview(workflowId: string, readOnly: boolean) {
+			probe.current = null;
+			mount(PreviewHostStub, { props: { workflowId, readOnly } });
+			return takeProbe();
+		}
+
+		/** Drains the autosave debounce plus the in-flight save promise. */
+		async function flushAutoSave() {
+			await vi.advanceTimersByTimeAsync(
+				getDebounceTime(DEBOUNCE_TIME.API.AUTOSAVE_MAX_WAIT) + 1000,
+			);
+		}
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			mockedStore(useSettingsStore).isAutosaveEnabled = true;
+			useWorkflowSaveStore().reset();
+			useUIStore().markStateDirty();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+			probe.current = null;
+		});
+
+		it('issues no create request when a preview with no stored workflow goes dirty', async () => {
+			// Template preview: the id is not in the list store, so the save path
+			// falls through to "save as new" and POSTs a nameless workflow.
+			const createSpy = vi
+				.spyOn(workflowsStore, 'createNewWorkflow')
+				.mockResolvedValue(createTestWorkflow({ id: 'created' }));
+
+			const { autoSaveWorkflow } = mountPreview('template-11754', true);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(createSpy).not.toHaveBeenCalled();
+		});
+
+		it('issues no update request when a preview of a stored workflow goes dirty', async () => {
+			// Workflow history and execution previews resolve to the live workflow id,
+			// so the save path PATCHes the real record.
+			const workflow = createTestWorkflow({
+				id: 'w-preview',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+			});
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+			const updateSpy = vi
+				.spyOn(workflowsStore, 'updateWorkflow')
+				.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+			const { autoSaveWorkflow } = mountPreview(workflow.id, true);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(updateSpy).not.toHaveBeenCalled();
+		});
+
+		it('still saves when the same host is not read-only', async () => {
+			// Control: proves the two assertions above fail for the right reason
+			// rather than because this harness never reaches the request.
+			const workflow = createTestWorkflow({
+				id: 'w-editable',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+			});
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+			const updateSpy = vi
+				.spyOn(workflowsStore, 'updateWorkflow')
+				.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+			const { autoSaveWorkflow } = mountPreview(workflow.id, false);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(updateSpy).toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Gate 1 of ADO-5764: the failing test that the fix will turn green. **No product code is changed here** — this PR is evidence only.

Preview hosts (`WorkflowPreviewHost`, `ExecutionPreviewHost`) mount the real `NodeView` and supersede the editor context with `readOnly: true` via `EditorEnabledFeaturesKey`. Opening a node auto-selects a credential (`NodeCredentials.vue`), which marks the document dirty. `NodeView.vue` watches `uiStore.dirtyStateSetCount` and calls `workflowSaving.autoSaveWorkflow()` — that watcher checks `isDemoRoute` and `builderStore.streaming`, but never the read-only signal. Nothing downstream in `useWorkflowSaving` consults it either.

Reproduced on all three preview surfaces converted in 2.28.0, on `master` at 2.34.0.

## Tests added

Three cases in `useWorkflowSaving.test.ts`, mounting a host that provides the same read-only editor context the preview hosts do:

| Case | Asserts | On master |
| -- | -- | -- |
| preview with no stored workflow | no create request | **fails** — 4 calls |
| preview of a stored workflow | no update request | **fails** — 1 call |
| same host, not read-only | still saves | passes |

The third case is a control: it proves the first two fail because of the missing gate, not because the harness never reaches the request.

The call-count asymmetry (4 vs 1) mirrors the retry-cadence difference measured in the browser: the no-stored-workflow path routes to `saveAsNewWorkflow`, whose `catch` shows a toast without touching the retry counters, so the debounced rescheduler re-fires every ~1.5s with no backoff. The stored-workflow path routes to the update branch, which does increment the backoff.

## Where the assertion sits

The gate is asserted at the save layer rather than in the `NodeView` watcher. That is the single choke point all preview hosts funnel through — including `InstanceAiWorkflowPreview`, a fourth consumer of the same read-only signal — so a future preview host cannot reintroduce the write by bypassing a view-level check. If the fix instead gates only in `NodeView`, these assertions need to move; that is a deliberate coordination point with the fix plan, not an accident.

## Review notes

Verification: `pnpm typecheck` clean; `useWorkflowSaving.test.ts` → 33 passed, 2 failed (the two intended failures). Test files are eslint-ignored in this package.

https://linear.app/n8n/issue/ADO-5764


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

