### PR TITLE
fix(editor): Never autosave a read-only preview canvas

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, provide } from 'vue';
+import { computed, defineComponent, h, nextTick, provide } from 'vue';
 import { mount } from '@vue/test-utils';
 import { useUIStore } from '@/app/stores/ui.store';
 import { AutoSaveState, DEBOUNCE_TIME, MODAL_CANCEL, MODAL_CONFIRM, VIEWS } from '@/app/constants';
@@ -1470,6 +1470,36 @@ describe('useWorkflowSaving', () => {
 			await flushAutoSave();
 
 			expect(updateSpy).toHaveBeenCalled();
+		});
+
+		it('does not re-arm a dirty preview when the connection comes back', async () => {
+			// The reconnect watcher lives inside this composable, so it is the one
+			// autosave entry point a view-level guard cannot cover.
+			const saveStore = useWorkflowSaveStore();
+
+			backendConnectionStore.setOnline(false);
+			mountPreview('template-11754', true);
+			useUIStore().markStateDirty();
+
+			backendConnectionStore.setOnline(true);
+			await nextTick();
+
+			expect(saveStore.autoSaveState).toBe(AutoSaveState.Idle);
+		});
+
+		it('re-arms a dirty canvas when the host lifts read-only', async () => {
+			// Instance AI locks the canvas while its agent edits and then releases
+			// it; without this the agent's changes would sit unsaved.
+			const saveStore = useWorkflowSaveStore();
+
+			const wrapper = mount(PreviewHostStub, {
+				props: { workflowId: 'w-rearm', readOnly: true },
+			});
+			useUIStore().markStateDirty();
+
+			await wrapper.setProps({ readOnly: false });
+
+			expect(saveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -1,5 +1,13 @@
+import { computed, defineComponent, h, provide } from 'vue';
+import { mount } from '@vue/test-utils';
 import { useUIStore } from '@/app/stores/ui.store';
-import { AutoSaveState, MODAL_CANCEL, MODAL_CONFIRM, VIEWS } from '@/app/constants';
+import { AutoSaveState, DEBOUNCE_TIME, MODAL_CANCEL, MODAL_CONFIRM, VIEWS } from '@/app/constants';
+import {
+	EditorEnabledFeaturesKey,
+	WorkflowIdKey,
+	type EditorEnabledFeatures,
+} from '@/app/constants/injectionKeys';
+import { getDebounceTime } from '@n8n/composables/useDebounce';
 import { useWorkflowSaving } from './useWorkflowSaving';
 import router from '@/app/router';
 import { createTestingPinia } from '@pinia/testing';
@@ -1323,6 +1331,145 @@ describe('useWorkflowSaving', () => {
 
 			// State should be Scheduled
 			expect(autosaveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
+		});
+	});
+
+	describe('autosave on a read-only preview canvas', () => {
+		// Preview hosts (template, workflow history, execution) mount the real
+		// NodeView and supersede the editor context with `readOnly: true`. Opening a
+		// node there auto-selects a credential, which marks the document dirty and
+		// reaches this composable — so the read-only signal has to stop the write.
+		// Regression cover for ADO-5764.
+		const PREVIEW_FEATURES: EditorEnabledFeatures = {
+			readOnly: true,
+			expandGroups: 'all',
+			aiAssistant: false,
+			aiBuilder: false,
+			askAi: false,
+			executionSuccessToasts: false,
+			executionErrorToasts: false,
+		};
+
+		const probe: { current: ReturnType<typeof useWorkflowSaving> | null } = { current: null };
+
+		const AutosaveProbe = defineComponent({
+			name: 'AutosaveProbe',
+			setup() {
+				probe.current = useWorkflowSaving({ router });
+				return () => h('div');
+			},
+		});
+
+		// Mirrors how WorkflowPreviewHost/ExecutionPreviewHost scope the subtree:
+		// the host provides, the child (NodeView in production) injects.
+		const PreviewHostStub = defineComponent({
+			name: 'PreviewHostStub',
+			props: {
+				workflowId: { type: String, required: true },
+				readOnly: { type: Boolean, required: true },
+			},
+			setup(props) {
+				provide(
+					WorkflowIdKey,
+					computed(() => props.workflowId),
+				);
+				provide(
+					EditorEnabledFeaturesKey,
+					computed<EditorEnabledFeatures>(() => ({
+						...PREVIEW_FEATURES,
+						readOnly: props.readOnly,
+					})),
+				);
+				return () => h(AutosaveProbe);
+			},
+		});
+
+		function takeProbe(): ReturnType<typeof useWorkflowSaving> {
+			const current = probe.current;
+			if (!current) throw new Error('AutosaveProbe did not initialise');
+			return current;
+		}
+
+		function mountPreview(workflowId: string, readOnly: boolean) {
+			probe.current = null;
+			mount(PreviewHostStub, { props: { workflowId, readOnly } });
+			return takeProbe();
+		}
+
+		/** Drains the autosave debounce plus the in-flight save promise. */
+		async function flushAutoSave() {
+			await vi.advanceTimersByTimeAsync(
+				getDebounceTime(DEBOUNCE_TIME.API.AUTOSAVE_MAX_WAIT) + 1000,
+			);
+		}
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			mockedStore(useSettingsStore).isAutosaveEnabled = true;
+			useWorkflowSaveStore().reset();
+			useUIStore().markStateDirty();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+			probe.current = null;
+		});
+
+		it('issues no create request when a preview with no stored workflow goes dirty', async () => {
+			// Template preview: the id is not in the list store, so the save path
+			// falls through to "save as new" and POSTs a nameless workflow.
+			const createSpy = vi
+				.spyOn(workflowsStore, 'createNewWorkflow')
+				.mockResolvedValue(createTestWorkflow({ id: 'created' }));
+
+			const { autoSaveWorkflow } = mountPreview('template-11754', true);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(createSpy).not.toHaveBeenCalled();
+		});
+
+		it('issues no update request when a preview of a stored workflow goes dirty', async () => {
+			// Workflow history and execution previews resolve to the live workflow id,
+			// so the save path PATCHes the real record.
+			const workflow = createTestWorkflow({
+				id: 'w-preview',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+			});
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+			const updateSpy = vi
+				.spyOn(workflowsStore, 'updateWorkflow')
+				.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+			const { autoSaveWorkflow } = mountPreview(workflow.id, true);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(updateSpy).not.toHaveBeenCalled();
+		});
+
+		it('still saves when the same host is not read-only', async () => {
+			// Control: proves the two assertions above fail for the right reason
+			// rather than because this harness never reaches the request.
+			const workflow = createTestWorkflow({
+				id: 'w-editable',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+			});
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+			const updateSpy = vi
+				.spyOn(workflowsStore, 'updateWorkflow')
+				.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+			const { autoSaveWorkflow } = mountPreview(workflow.id, false);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(updateSpy).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -768,7 +768,7 @@ describe('useWorkflowSaving', () => {
 			const mockPendingSave = new Promise<boolean>(() => {});
 			saveStore.setPendingSave(mockPendingSave);
 
-			const { autoSaveWorkflow } = useWorkflowSaving({ router });
+			const { autoSaveWorkflow } = useWorkflowSaving({ router, ownsAutoSave: true });
 
 			// Try to schedule autosave
 			autoSaveWorkflow();
@@ -784,7 +784,7 @@ describe('useWorkflowSaving', () => {
 			saveStore.reset();
 			expect(saveStore.autoSaveState).toBe(AutoSaveState.Idle);
 
-			const { autoSaveWorkflow } = useWorkflowSaving({ router });
+			const { autoSaveWorkflow } = useWorkflowSaving({ router, ownsAutoSave: true });
 
 			// Schedule autosave
 			autoSaveWorkflow();
@@ -890,7 +890,10 @@ describe('useWorkflowSaving', () => {
 			const saveStore = useWorkflowSaveStore();
 			saveStore.reset();
 
-			const { saveCurrentWorkflow, autoSaveWorkflow } = useWorkflowSaving({ router });
+			const { saveCurrentWorkflow, autoSaveWorkflow } = useWorkflowSaving({
+				router,
+				ownsAutoSave: true,
+			});
 
 			// Dirty workflow with an armed autosave timer, then a manual save
 			// (e.g. save-then-navigate flows). Without the disarm, the timer
@@ -1288,7 +1291,7 @@ describe('useWorkflowSaving', () => {
 			backendConnectionStore.setOnline(false);
 			saveStore.reset();
 
-			const { autoSaveWorkflow } = useWorkflowSaving({ router });
+			const { autoSaveWorkflow } = useWorkflowSaving({ router, ownsAutoSave: true });
 
 			autoSaveWorkflow();
 
@@ -1305,7 +1308,7 @@ describe('useWorkflowSaving', () => {
 			autosaveStore.reset();
 			expect(autosaveStore.autoSaveState).toBe(AutoSaveState.Idle);
 
-			const { autoSaveWorkflow } = useWorkflowSaving({ router });
+			const { autoSaveWorkflow } = useWorkflowSaving({ router, ownsAutoSave: true });
 
 			// Try to schedule autosave while disabled
 			autoSaveWorkflow();
@@ -1324,7 +1327,7 @@ describe('useWorkflowSaving', () => {
 			autosaveStore.reset();
 			expect(autosaveStore.autoSaveState).toBe(AutoSaveState.Idle);
 
-			const { autoSaveWorkflow } = useWorkflowSaving({ router });
+			const { autoSaveWorkflow } = useWorkflowSaving({ router, ownsAutoSave: true });
 
 			// Schedule autosave
 			autoSaveWorkflow();
@@ -1355,7 +1358,8 @@ describe('useWorkflowSaving', () => {
 		const AutosaveProbe = defineComponent({
 			name: 'AutosaveProbe',
 			setup() {
-				probe.current = useWorkflowSaving({ router });
+				// Stands in for NodeView: the canvas the host wraps, so it owns autosave.
+				probe.current = useWorkflowSaving({ router, ownsAutoSave: true });
 				return () => h('div');
 			},
 		});
@@ -1500,6 +1504,82 @@ describe('useWorkflowSaving', () => {
 			await wrapper.setProps({ readOnly: false });
 
 			expect(saveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
+		});
+
+		// The read-only signal is injected, so it only reaches an instance built
+		// inside a preview host's subtree. `builder.store.ts` and the
+		// `executionFinished` push handler build this composable out-of-tree, where
+		// a host's provide is invisible — and every instance used to own a reconnect
+		// watcher reading the app-wide dirty flag a preview sets. Cover from the
+		// observable end: no request leaves a preview when the connection returns,
+		// whatever else holds an instance.
+		describe('with the composable also built out-of-tree', () => {
+			it('issues no create request when the connection returns on a preview', async () => {
+				const createSpy = vi
+					.spyOn(workflowsStore, 'createNewWorkflow')
+					.mockResolvedValue(createTestWorkflow({ id: 'created' }));
+
+				backendConnectionStore.setOnline(false);
+				useWorkflowSaving({ router });
+				mountPreview('template-11754', true);
+				useUIStore().markStateDirty();
+
+				backendConnectionStore.setOnline(true);
+				await nextTick();
+				await flushAutoSave();
+
+				expect(createSpy).not.toHaveBeenCalled();
+			});
+
+			it('issues no update request when the connection returns on a preview of a stored workflow', async () => {
+				const workflow = createTestWorkflow({
+					id: 'w-reconnect',
+					nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+				});
+				workflowsListStore.workflowsById = { [workflow.id]: workflow };
+				useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+				mockRoute.params = { workflowId: workflow.id };
+				const updateSpy = vi
+					.spyOn(workflowsStore, 'updateWorkflow')
+					.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+				backendConnectionStore.setOnline(false);
+				useWorkflowSaving({ router });
+				mountPreview(workflow.id, true);
+				useUIStore().markStateDirty();
+
+				backendConnectionStore.setOnline(true);
+				await nextTick();
+				await flushAutoSave();
+
+				expect(updateSpy).not.toHaveBeenCalled();
+			});
+
+			it('still saves an editable canvas when the connection returns', async () => {
+				// Control for the two above, and the regression risk of arming the
+				// reconnect watcher on the canvas owner alone: offline edits still land.
+				const workflow = createTestWorkflow({
+					id: 'w-reconnect-editable',
+					nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+				});
+				workflowsListStore.workflowsById = { [workflow.id]: workflow };
+				useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+				mockRoute.params = { workflowId: workflow.id };
+				const updateSpy = vi
+					.spyOn(workflowsStore, 'updateWorkflow')
+					.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+				backendConnectionStore.setOnline(false);
+				useWorkflowSaving({ router });
+				mountPreview(workflow.id, false);
+				useUIStore().markStateDirty();
+
+				backendConnectionStore.setOnline(true);
+				await nextTick();
+				await flushAutoSave();
+
+				expect(updateSpy).toHaveBeenCalled();
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -1,7 +1,8 @@
 import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { LocationQuery, NavigationGuardNext, useRouter } from 'vue-router';
-import { watch } from 'vue';
+import { computed, hasInjectionContext, inject, watch } from 'vue';
+import { EditorEnabledFeaturesKey } from '@/app/constants/injectionKeys';
 import { useMessage } from './useMessage';
 import { useI18n } from '@n8n/i18n';
 import { getDebounceTime } from '@n8n/composables/useDebounce';
@@ -69,6 +70,14 @@ export function useWorkflowSaving({
 	const settingsStore = useSettingsStore();
 	const workflowId = useWorkflowId();
 	const { removeInvalidNodeGroups } = useInvalidNodeGroupCleanup();
+
+	// Preview hosts scope their subtree read-only through the editor context. This
+	// composable is instantiated out-of-tree too (Pinia stores, push handlers),
+	// where `inject()` is unavailable — guard it the way `useWorkflowId` does.
+	const editorEnabledFeatures = hasInjectionContext()
+		? inject(EditorEnabledFeaturesKey, null)
+		: null;
+	const isReadOnlyCanvas = computed(() => editorEnabledFeatures?.value?.readOnly === true);
 
 	async function promptSaveUnsavedWorkflowChanges(
 		next: NavigationGuardNext,
@@ -603,6 +612,12 @@ export function useWorkflowSaving({
 	);
 
 	const scheduleAutoSave = () => {
+		// Don't schedule on a read-only canvas. Every autosave entry point funnels
+		// through here, so previews never write whatever marked them dirty.
+		if (isReadOnlyCanvas.value) {
+			return;
+		}
+
 		// Don't schedule if autosave is disabled via environment variable
 		if (!settingsStore.isAutosaveEnabled) {
 			return;
@@ -634,6 +649,15 @@ export function useWorkflowSaving({
 		}
 		saveStore.setAutoSaveState(AutoSaveState.Idle);
 	};
+
+	// Re-arm when a host lifts read-only with changes still pending — the Instance
+	// AI preview locks the canvas while its agent edits, and nothing else would
+	// save what the agent wrote. Mirrors the AI-builder re-arm in NodeView.
+	watch(isReadOnlyCanvas, (isReadOnly, wasReadOnly) => {
+		if (wasReadOnly && !isReadOnly && uiStore.stateIsDirty) {
+			scheduleAutoSave();
+		}
+	});
 
 	// Watch for network coming back online
 	watch(

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -1,8 +1,8 @@
 import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { LocationQuery, NavigationGuardNext, useRouter } from 'vue-router';
-import { computed, hasInjectionContext, inject, watch } from 'vue';
-import { EditorEnabledFeaturesKey } from '@/app/constants/injectionKeys';
+import { computed, getCurrentInstance, watch } from 'vue';
+import { useEditorContext } from '@/app/composables/useEditorContext';
 import { useMessage } from './useMessage';
 import { useI18n } from '@n8n/i18n';
 import { getDebounceTime } from '@n8n/composables/useDebounce';
@@ -46,9 +46,19 @@ import { useInvalidNodeGroupCleanup } from '@/app/composables/useInvalidNodeGrou
 export function useWorkflowSaving({
 	router,
 	onSaved,
+	ownsAutoSave = false,
 }: {
 	router: ReturnType<typeof useRouter>;
 	onSaved?: (isFirstSave: boolean) => void;
+	/**
+	 * Whether this instance drives the canvas's autosave. Only the component
+	 * rendering the canvas passes `true`: it sits inside the host that scopes the
+	 * editor context, so it is the only one that can tell a preview from an
+	 * editable canvas. Everyone else — dialogs, a Pinia store, a push handler —
+	 * builds this composable for its explicit save calls, and an autosave engine
+	 * there would react to app-wide signals from outside any canvas.
+	 */
+	ownsAutoSave?: boolean;
 }) {
 	const uiStore = useUIStore();
 	const npsSurveyStore = useNpsSurveyStore();
@@ -71,13 +81,12 @@ export function useWorkflowSaving({
 	const workflowId = useWorkflowId();
 	const { removeInvalidNodeGroups } = useInvalidNodeGroupCleanup();
 
-	// Preview hosts scope their subtree read-only through the editor context. This
-	// composable is instantiated out-of-tree too (Pinia stores, push handlers),
-	// where `inject()` is unavailable — guard it the way `useWorkflowId` does.
-	const editorEnabledFeatures = hasInjectionContext()
-		? inject(EditorEnabledFeaturesKey, null)
-		: null;
-	const isReadOnlyCanvas = computed(() => editorEnabledFeatures?.value?.readOnly === true);
+	// Preview hosts (template, workflow history, execution) render the real canvas
+	// and scope their subtree read-only through the editor context. The context is
+	// injected, so it only resolves inside a component — fall back to no context
+	// for the out-of-tree callers, the way `useRunWorkflow` does for the same key.
+	const editorContext = getCurrentInstance() ? useEditorContext() : undefined;
+	const canAutoSave = computed(() => ownsAutoSave && editorContext?.readOnly.value !== true);
 
 	async function promptSaveUnsavedWorkflowChanges(
 		next: NavigationGuardNext,
@@ -612,9 +621,10 @@ export function useWorkflowSaving({
 	);
 
 	const scheduleAutoSave = () => {
-		// Don't schedule on a read-only canvas. Every autosave entry point funnels
-		// through here, so previews never write whatever marked them dirty.
-		if (isReadOnlyCanvas.value) {
+		// Don't schedule from a read-only canvas, or from an instance that doesn't
+		// own one. Every autosave entry point funnels through here, so a preview
+		// never writes whatever marked it dirty.
+		if (!canAutoSave.value) {
 			return;
 		}
 
@@ -650,26 +660,34 @@ export function useWorkflowSaving({
 		saveStore.setAutoSaveState(AutoSaveState.Idle);
 	};
 
-	// Re-arm when a host lifts read-only with changes still pending — the Instance
-	// AI preview locks the canvas while its agent edits, and nothing else would
-	// save what the agent wrote. Mirrors the AI-builder re-arm in NodeView.
-	watch(isReadOnlyCanvas, (isReadOnly, wasReadOnly) => {
-		if (wasReadOnly && !isReadOnly && uiStore.stateIsDirty) {
-			scheduleAutoSave();
-		}
-	});
-
-	// Watch for network coming back online
-	watch(
-		() => backendConnectionStore.isOnline,
-		(isOnline, wasOnline) => {
-			if (isOnline && !wasOnline) {
-				if (uiStore.stateIsDirty) {
-					scheduleAutoSave();
-				}
+	// These watchers write on their own, off app-wide signals, so only the canvas's
+	// owner arms them. A non-owner instance armed them too, and outside a canvas
+	// host there is no read-only scope to consult — which is how a preview still
+	// issued a save when the connection returned. They are also unstopped, so the
+	// push handler that builds this composable per message would leak one apiece.
+	if (ownsAutoSave) {
+		// Re-arm when a host lifts read-only with changes still pending — the
+		// Instance AI preview locks the canvas while its agent edits, and nothing
+		// else would save what the agent wrote. Mirrors the AI-builder re-arm in
+		// NodeView.
+		watch(canAutoSave, (allowed, wasAllowed) => {
+			if (allowed && !wasAllowed && uiStore.stateIsDirty) {
+				scheduleAutoSave();
 			}
-		},
-	);
+		});
+
+		// Watch for network coming back online
+		watch(
+			() => backendConnectionStore.isOnline,
+			(isOnline, wasOnline) => {
+				if (isOnline && !wasOnline) {
+					if (uiStore.stateIsDirty) {
+						scheduleAutoSave();
+					}
+				}
+			},
+		);
+	}
 
 	return {
 		promptSaveUnsavedWorkflowChanges,

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -175,6 +175,9 @@ const message = useMessage();
 const documentTitle = useDocumentTitle();
 const workflowSaving = useWorkflowSaving({
 	router,
+	// This is the canvas, so this instance drives autosave — and a preview host
+	// wrapping it can scope it read-only, which no other consumer can see.
+	ownsAutoSave: true,
 	onSaved: (isFirstSave) => {
 		canvasEventBus.emit('saved:workflow', { isFirstSave });
 	},


### PR DESCRIPTION
## Summary

Preview hosts — template, workflow history and execution — scope their subtree read-only through the editor context, but the autosave path never consulted that signal. Opening a node on a preview auto-selects a credential, which marks the document dirty and reaches the save layer, so a **read-only canvas issued a workflow write**:

| Surface | Request | Name in payload | Response | Persisted |
| --- | --- | --- | --- | --- |
| Template preview | `POST /rest/workflows` every ~1.5s | `""` | 400 | No — stopped only by name validation |
| Workflow history preview | `PATCH /rest/workflows/{id}` | `""` | 400 | No — same accidental barrier |
| Execution preview | `PATCH /rest/workflows/{id}` | real name | **200** | **Yes** — version bumped, history entry burned |

This gates `scheduleAutoSave()` on the read-only signal. Every autosave entry point funnels through that function — the `NodeView` dirty watcher, the retry rescheduler, and the reconnect watcher inside the composable — so a preview cannot write whatever marked it dirty, no matter which one fires. Gating a single view-level watcher instead would leave the reconnect path open.

A symmetric watcher re-arms autosave when a host lifts read-only with changes still pending. `InstanceAiWorkflowPreview` sets `readOnly` dynamically as an editing lock while its agent works; without the re-arm, the agent's changes would sit unsaved until the next mutation. This mirrors the AI-builder re-arm already in `NodeView`.

The read-only signal reaches this composable through `inject`, so it only resolves for an instance built inside a preview host's subtree — and `useWorkflowSaving` is also built out of the component tree, in `builder.store.ts` and in the per-message `executionFinished` push handler. Those instances armed their own reconnect watcher, which reads the app-wide dirty flag a preview sets, so a preview stayed silent while idle and then wrote as soon as the health check flipped back online.

Autosave is therefore owned by the component that renders the canvas: `NodeView` passes `ownsAutoSave: true`. It is the only consumer of `autoSaveWorkflow` and the only one inside the host that scopes the editor context, so it is the only one that can tell a preview from an editable canvas. Non-owners keep the explicit save API and arm no watchers, which also stops the push handler from leaking one per message. The read-only read reuses `useEditorContext().readOnly` rather than re-implementing it, guarded by `getCurrentInstance()` the way `useRunWorkflow` guards the same key.

Scope note: this does not change general autosave retry policy for permanent 4xx errors. Worth passing to that work separately — the create path carries no backoff at all, so its `catch` never touches the retry counters and the 1.5s debounce reschedules each failure as a fresh save.

Commits: the first is the failing regression cover (also open as #36020, which this supersedes); the second gates the read; the third scopes the gate to the canvas owner and folds in the out-of-tree cover from #36027, which this supersedes.

## How to test

Needs one credential of a type used by a node on the preview, so the auto-select has something to select (e.g. an OpenAI credential with a throwaway key).

1. **Template preview** — open `/templates/11754`, double-click an OpenAI node. The credential auto-selects and the field renders disabled. Expected: **no** `POST /rest/workflows` in the network tab, no error toast. On master, a nameless `POST` fires roughly every 1.5s.
2. **Execution preview** — run any workflow containing a node whose credential is unset, open the execution, double-click that node. Expected: **no** `PATCH /rest/workflows/{id}`. Confirm by direct API read that `versionId` and `updatedAt` are unchanged; on master both move and a history version is cut.
3. **Workflow history preview** — open `/workflow/{id}/history/{versionId}` and repeat. Expected: no `PATCH`.
4. **Control** — open the same workflow on the normal editable canvas and double-click the node. Autosave must still fire: `PATCH /rest/workflows/{id}` → 200, credential persisted.

5. **Reconnect** — on any preview, open a node, then restart the backend (the health check polls every 10s). Expected: no request when the connection returns. Before this commit the template preview resumed a nameless `POST` storm and the execution preview's `PATCH` was accepted.

Unit cover: `pnpm --filter n8n-editor-ui test src/app/composables/useWorkflowSaving.test.ts` — 40 passed. Reverting only the product-code change turns 6 of them red.

Content note for the changelog: a preview persists the preview canvas's *normalized* document. Harmless for workflows built in the editor, lossy for imported, API-created or older-schema ones.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5764

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


