### PR TITLE
feat(core): Restrict end-user credential creation to team projects

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -118,7 +118,7 @@ describe('CredentialsController', () => {
 		// stubbed by default: the project-type check needs real project data that unit tests don't wire up
 		ensureEndUserCredentialAllowedInProjectSpy = vi
 			.spyOn(credentialsService, 'ensureEndUserCredentialAllowedInProject')
-			.mockResolvedValue(undefined);
+			.mockReturnValue(undefined);
 		// stubbed by default: backed by connectionStatusProxy, which unit tests don't wire up
 		vi.spyOn(credentialsService, 'populateConnectedByMe').mockResolvedValue(undefined);
 		findCredentialOwningProjectSpy = sharedCredentialsRepository.findCredentialOwningProject;

--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -77,6 +77,7 @@ describe('CredentialsController', () => {
 	let updateSpy: MockInstance;
 	let createUnmanagedCredentialSpy: MockInstance;
 	let ensureCanManageEndUserCredentialSpy: MockInstance;
+	let ensureEndUserCredentialAllowedInProjectSpy: MockInstance;
 	let findCredentialOwningProjectSpy: MockInstance;
 	let emitSpy: MockInstance;
 
@@ -113,6 +114,10 @@ describe('CredentialsController', () => {
 		// stubbed by default: the scope check needs real role/project data that unit tests don't wire up
 		ensureCanManageEndUserCredentialSpy = vi
 			.spyOn(credentialsService, 'ensureCanManageEndUserCredential')
+			.mockResolvedValue(undefined);
+		// stubbed by default: the project-type check needs real project data that unit tests don't wire up
+		ensureEndUserCredentialAllowedInProjectSpy = vi
+			.spyOn(credentialsService, 'ensureEndUserCredentialAllowedInProject')
 			.mockResolvedValue(undefined);
 		// stubbed by default: backed by connectionStatusProxy, which unit tests don't wire up
 		vi.spyOn(credentialsService, 'populateConnectedByMe').mockResolvedValue(undefined);
@@ -711,6 +716,8 @@ describe('CredentialsController', () => {
 
 			// ASSERT
 			expect(ensureCanManageEndUserCredentialSpy).toHaveBeenCalledTimes(1);
+			// switching to end-user must also clear the personal-project gate
+			expect(ensureEndUserCredentialAllowedInProjectSpy).toHaveBeenCalledTimes(1);
 			expect(updateSpy).toHaveBeenCalledWith(
 				credentialId,
 				expect.objectContaining({
@@ -719,6 +726,42 @@ describe('CredentialsController', () => {
 				expect.any(Object),
 				expect.any(Object),
 			);
+		});
+
+		it('should not apply the personal-project gate when switching back to fixed', async () => {
+			// ARRANGE
+			const ownerReq = {
+				user: { id: 'owner-id', role: GLOBAL_OWNER_ROLE },
+				params: { credentialId },
+				body: {
+					name: 'Updated Credential',
+					type: 'apiKey',
+					data: { apiKey: 'updated-key' },
+					isResolvable: false,
+				},
+			} as unknown as CredentialRequest.Update;
+
+			const existingCredentialWithResolvable = mock<CredentialsEntity>({
+				...existingCredential,
+				isResolvable: true,
+			});
+
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(
+				existingCredentialWithResolvable,
+			);
+			createEncryptedDataSpy.mockResolvedValue(getEncryptedCredential(false));
+			updateSpy.mockResolvedValue({
+				...existingCredentialWithResolvable,
+				name: 'Updated Credential',
+				isResolvable: false,
+			});
+
+			// ACT
+			await credentialsController.updateCredentials(ownerReq);
+
+			// ASSERT
+			expect(ensureCanManageEndUserCredentialSpy).toHaveBeenCalledTimes(1);
+			expect(ensureEndUserCredentialAllowedInProjectSpy).not.toHaveBeenCalled();
 		});
 
 		it('should keep existing isResolvable value when not provided', async () => {

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -1096,32 +1096,24 @@ describe('CredentialsService', () => {
 	});
 
 	describe('ensureEndUserCredentialAllowedInProject', () => {
-		it('throws when the project is personal', async () => {
-			projectRepository.findOneBy.mockResolvedValue(
-				mock<Project>({ id: 'project-id', type: 'personal' }),
-			);
-
-			await expect(service.ensureEndUserCredentialAllowedInProject('project-id')).rejects.toThrow(
-				ForbiddenError,
-			);
+		it('throws when the project is personal', () => {
+			expect(() =>
+				service.ensureEndUserCredentialAllowedInProject(
+					mock<Project>({ id: 'project-id', type: 'personal' }),
+				),
+			).toThrow(ForbiddenError);
 		});
 
-		it('allows a team project', async () => {
-			projectRepository.findOneBy.mockResolvedValue(
-				mock<Project>({ id: 'project-id', type: 'team' }),
-			);
-
-			await expect(
-				service.ensureEndUserCredentialAllowedInProject('project-id'),
-			).resolves.toBeUndefined();
+		it('allows a team project', () => {
+			expect(() =>
+				service.ensureEndUserCredentialAllowedInProject(
+					mock<Project>({ id: 'project-id', type: 'team' }),
+				),
+			).not.toThrow();
 		});
 
-		it('does nothing when no project id is given', async () => {
-			await expect(
-				service.ensureEndUserCredentialAllowedInProject(undefined),
-			).resolves.toBeUndefined();
-
-			expect(projectRepository.findOneBy).not.toHaveBeenCalled();
+		it('does nothing when no project is given', () => {
+			expect(() => service.ensureEndUserCredentialAllowedInProject(undefined)).not.toThrow();
 		});
 	});
 

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -4,6 +4,7 @@ import type {
 	ICredentialsDb,
 	InstanceCredentialAssignmentRepository,
 	SharedCredentialsRepository,
+	Project,
 	ProjectRepository,
 	UserRepository,
 	User,
@@ -34,6 +35,7 @@ import type { InstanceCredentialUseRegistry } from '@/credentials/instance-crede
 import * as validation from '@/credentials/validation';
 import type { CredentialsHelper } from '@/credentials-helper';
 import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { ExternalHooks } from '@/external-hooks';
 import type { ExternalSecretsConfig } from '@/modules/external-secrets.ee/external-secrets.config';
 import type { SecretsProviderAccessCheckService } from '@/modules/external-secrets.ee/secret-provider-access-check.service.ee';
@@ -1090,6 +1092,36 @@ describe('CredentialsService', () => {
 				id: instanceCredential.id,
 				usageScope: 'instance',
 			});
+		});
+	});
+
+	describe('ensureEndUserCredentialAllowedInProject', () => {
+		it('throws when the project is personal', async () => {
+			projectRepository.findOneBy.mockResolvedValue(
+				mock<Project>({ id: 'project-id', type: 'personal' }),
+			);
+
+			await expect(service.ensureEndUserCredentialAllowedInProject('project-id')).rejects.toThrow(
+				ForbiddenError,
+			);
+		});
+
+		it('allows a team project', async () => {
+			projectRepository.findOneBy.mockResolvedValue(
+				mock<Project>({ id: 'project-id', type: 'team' }),
+			);
+
+			await expect(
+				service.ensureEndUserCredentialAllowedInProject('project-id'),
+			).resolves.toBeUndefined();
+		});
+
+		it('does nothing when no project id is given', async () => {
+			await expect(
+				service.ensureEndUserCredentialAllowedInProject(undefined),
+			).resolves.toBeUndefined();
+
+			expect(projectRepository.findOneBy).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -290,7 +290,7 @@ export class CredentialsController {
 			const owningProject =
 				await this.sharedCredentialsRepository.findCredentialOwningProject(credentialId);
 			if (isTogglingToPrivate) {
-				await this.credentialsService.ensureEndUserCredentialAllowedInProject(owningProject?.id);
+				this.credentialsService.ensureEndUserCredentialAllowedInProject(owningProject);
 			}
 			await this.credentialsService.ensureCanManageEndUserCredential(req.user, owningProject?.id);
 		}

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -289,6 +289,9 @@ export class CredentialsController {
 		if (isTogglingToPrivate || isTogglingToStatic) {
 			const owningProject =
 				await this.sharedCredentialsRepository.findCredentialOwningProject(credentialId);
+			if (isTogglingToPrivate) {
+				await this.credentialsService.ensureEndUserCredentialAllowedInProject(owningProject?.id);
+			}
 			await this.credentialsService.ensureCanManageEndUserCredential(req.user, owningProject?.id);
 		}
 

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -227,9 +227,10 @@ export class EnterpriseCredentialsService {
 			);
 		}
 
-		// Transferring an end-user credential into a project is equivalent to creating
-		// one there, so it must clear the same createEndUser gate.
+		// Transferring an end-user credential into a project is equivalent to
+		// creating one there: same createEndUser gate, no personal projects.
 		if (credential.isResolvable) {
+			await this.credentialsService.ensureEndUserCredentialAllowedInProject(destinationProject.id);
 			await this.credentialsService.ensureCanManageEndUserCredential(user, destinationProject.id);
 		}
 

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -230,7 +230,7 @@ export class EnterpriseCredentialsService {
 		// Transferring an end-user credential into a project is equivalent to
 		// creating one there: same createEndUser gate, no personal projects.
 		if (credential.isResolvable) {
-			await this.credentialsService.ensureEndUserCredentialAllowedInProject(destinationProject.id);
+			this.credentialsService.ensureEndUserCredentialAllowedInProject(destinationProject);
 			await this.credentialsService.ensureCanManageEndUserCredential(user, destinationProject.id);
 		}
 

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -1818,6 +1818,19 @@ export class CredentialsService {
 	}
 
 	/**
+	 * End-user credentials can only live in team projects: creating, switching
+	 * to, or transferring one into a personal project is rejected for every
+	 * role. Deleting or switching back to fixed stays allowed for cleanup.
+	 */
+	async ensureEndUserCredentialAllowedInProject(projectId?: string) {
+		if (!projectId) return;
+		const project = await this.projectRepository.findOneBy({ id: projectId });
+		if (project?.type === 'personal') {
+			throw new ForbiddenError('End-user credentials are not available in personal projects');
+		}
+	}
+
+	/**
 	 * The end-user (resolvable) credential lifecycle — creating one, switching a
 	 * credential to or from end-user, deleting or transferring one — is limited
 	 * to roles holding `credential:createEndUser` on the owning project
@@ -1847,6 +1860,7 @@ export class CredentialsService {
 		const targetProjectId = await this.resolveOwningProjectIdForNewCredential(user, opts.projectId);
 
 		if (opts.isResolvable === true) {
+			await this.ensureEndUserCredentialAllowedInProject(targetProjectId);
 			await this.ensureCanManageEndUserCredential(user, targetProjectId);
 		}
 

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -1822,9 +1822,7 @@ export class CredentialsService {
 	 * to, or transferring one into a personal project is rejected for every
 	 * role. Deleting or switching back to fixed stays allowed for cleanup.
 	 */
-	async ensureEndUserCredentialAllowedInProject(projectId?: string) {
-		if (!projectId) return;
-		const project = await this.projectRepository.findOneBy({ id: projectId });
+	ensureEndUserCredentialAllowedInProject(project?: Pick<Project, 'type'> | null) {
 		if (project?.type === 'personal') {
 			throw new ForbiddenError('End-user credentials are not available in personal projects');
 		}
@@ -1860,7 +1858,8 @@ export class CredentialsService {
 		const targetProjectId = await this.resolveOwningProjectIdForNewCredential(user, opts.projectId);
 
 		if (opts.isResolvable === true) {
-			await this.ensureEndUserCredentialAllowedInProject(targetProjectId);
+			const targetProject = await this.projectRepository.findOneBy({ id: targetProjectId });
+			this.ensureEndUserCredentialAllowedInProject(targetProject);
 			await this.ensureCanManageEndUserCredential(user, targetProjectId);
 		}
 

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
@@ -166,17 +166,17 @@ const credentialsHandlers: CredentialsHandlers = {
 				req.body.isResolvable !== undefined &&
 				req.body.isResolvable !== Boolean(existingCredential.isResolvable)
 			) {
-				const owningProjectId = existingCredential.shared?.find(
+				const ownerSharing = existingCredential.shared?.find(
 					(sharing) => sharing.role === 'credential:owner',
-				)?.projectId;
+				);
 				if (req.body.isResolvable) {
-					await Container.get(CredentialsService).ensureEndUserCredentialAllowedInProject(
-						owningProjectId,
+					Container.get(CredentialsService).ensureEndUserCredentialAllowedInProject(
+						ownerSharing?.project,
 					);
 				}
 				await Container.get(CredentialsService).ensureCanManageEndUserCredential(
 					req.user,
-					owningProjectId,
+					ownerSharing?.projectId,
 				);
 			}
 

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
@@ -169,6 +169,11 @@ const credentialsHandlers: CredentialsHandlers = {
 				const owningProjectId = existingCredential.shared?.find(
 					(sharing) => sharing.role === 'credential:owner',
 				)?.projectId;
+				if (req.body.isResolvable) {
+					await Container.get(CredentialsService).ensureEndUserCredentialAllowedInProject(
+						owningProjectId,
+					);
+				}
 				await Container.get(CredentialsService).ensureCanManageEndUserCredential(
 					req.user,
 					owningProjectId,

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -17,6 +17,7 @@ import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import type { ICredentialConnectionStatusProvider } from '@/credentials/credential-connection-status-provider.interface';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import type { AgentChatAttachmentService } from '@/modules/agents/agent-chat-attachment.service';
 import type { AgentExecutionService } from '@/modules/agents/agent-execution.service';
 import type { AgentKnowledgeService } from '@/modules/agents/agent-knowledge.service';
@@ -652,6 +653,87 @@ describe('ProjectService', () => {
 			expect(agentKnowledgeService.destroySandbox).toHaveBeenCalledWith(project.id, 'agent-2');
 			expect(agentExecutionService.deleteExecutionLogsForAgent).toHaveBeenCalledWith('agent-1');
 			expect(agentExecutionService.deleteExecutionLogsForAgent).toHaveBeenCalledWith('agent-2');
+		});
+
+		describe('migrating end-user credentials', () => {
+			// all scopes deleteProject needs, so both project lookups short-circuit on global scope
+			const migratingUser = {
+				id: 'user-1',
+				role: {
+					scopes: [
+						{ slug: 'project:delete' },
+						{ slug: 'credential:create' },
+						{ slug: 'workflow:create' },
+						{ slug: 'dataTable:create' },
+					],
+				},
+			} as any;
+			const project = mock<Project>({ id: 'project-1', type: 'team' });
+			const endUserCredential = mock<SharedCredentials>({
+				credentialsId: 'credential-1',
+				credentials: mock<SharedCredentials['credentials']>({
+					id: 'credential-1',
+					name: 'End-user credential',
+					isResolvable: true,
+				}),
+			});
+
+			beforeEach(() => {
+				Object.defineProperty(projectService, 'connectionStatusProxy', {
+					configurable: true,
+					get: async () => mock<ICredentialConnectionStatusProvider>(),
+				});
+				// reset first: `vi.clearAllMocks()` leaves any unconsumed `...Once` queues behind
+				manager.findOne.mockReset();
+				sharedWorkflowRepository.find.mockReset();
+				sharedCredentialsRepository.find.mockReset();
+				projectRelationRepository.findBy.mockReset();
+				projectRepository.remove.mockResolvedValue(project);
+				sharedWorkflowRepository.find.mockResolvedValue([]);
+				sharedCredentialsRepository.find.mockResolvedValue([endUserCredential]);
+				moduleRegistry.isActive.mockReturnValue(false);
+				projectRelationRepository.findBy.mockResolvedValue([]);
+			});
+
+			it('rejects a migration into a personal project before anything is migrated', async () => {
+				// ARRANGE — source team project, target personal project
+				manager.findOne
+					.mockResolvedValueOnce(project)
+					.mockResolvedValueOnce(mock<Project>({ id: 'personal-1', type: 'personal' }));
+
+				// ACT
+				const deletion = projectService.deleteProject(migratingUser, project.id, {
+					migrateToProject: 'personal-1',
+				});
+
+				// ASSERT — rejected, naming the offending credential
+				await expect(deletion).rejects.toThrow(BadRequestError);
+				await expect(deletion).rejects.toThrow('"End-user credential"');
+
+				// nothing moved, project still there
+				expect(sharedWorkflowRepository.makeOwner).not.toHaveBeenCalled();
+				expect(sharedCredentialsRepository.makeOwner).not.toHaveBeenCalled();
+				expect(projectRepository.remove).not.toHaveBeenCalled();
+			});
+
+			it('migrates end-user credentials into a team project', async () => {
+				// ARRANGE — source and target are both team projects
+				manager.findOne
+					.mockResolvedValueOnce(project)
+					.mockResolvedValueOnce(mock<Project>({ id: 'team-2', type: 'team' }));
+
+				// ACT
+				await projectService.deleteProject(migratingUser, project.id, {
+					migrateToProject: 'team-2',
+				});
+
+				// ASSERT
+				expect(sharedCredentialsRepository.makeOwner).toHaveBeenCalledWith(
+					['credential-1'],
+					'team-2',
+				);
+				expect(projectRepository.remove).toHaveBeenCalledWith(project);
+			});
 		});
 
 		it('destroys agent sandboxes even when knowledge file cleanup fails', async () => {

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -177,6 +177,24 @@ export class ProjectService {
 			);
 		}
 
+		const ownedCredentials = await this.sharedCredentialsRepository.find({
+			where: { projectId: project.id, role: 'credential:owner' },
+			relations: { credentials: true },
+		});
+
+		// End-user credentials can't live in personal projects, so reject the whole
+		// migration before anything moves — deleteProject is a sequence of awaits,
+		// not a transaction.
+		if (targetProject?.type === 'personal') {
+			const endUserCredentials = ownedCredentials.filter((sc) => sc.credentials.isResolvable);
+			if (endUserCredentials.length > 0) {
+				const names = endUserCredentials.map((sc) => `"${sc.credentials.name}"`).join(', ');
+				throw new BadRequestError(
+					`Can't migrate end-user credentials (${names}) to a personal project. Switch them back to fixed credentials, move them to another team project, or delete this project without migrating.`,
+				);
+			}
+		}
+
 		// 1. delete or migrate workflows owned by this project
 		const ownedSharedWorkflows = await this.sharedWorkflowRepository.find({
 			where: { projectId: project.id, role: 'workflow:owner' },
@@ -194,11 +212,6 @@ export class ProjectService {
 		}
 
 		// 2. delete credentials owned by this project
-		const ownedCredentials = await this.sharedCredentialsRepository.find({
-			where: { projectId: project.id, role: 'credential:owner' },
-			relations: { credentials: true },
-		});
-
 		if (targetProject) {
 			await this.sharedCredentialsRepository.makeOwner(
 				ownedCredentials.map((sc) => sc.credentialsId),

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -1570,9 +1570,11 @@ describe('PATCH /credentials/:id', () => {
 	});
 
 	test('should create credential with isResolvable set to true', async () => {
+		// End-user credentials are only available in team projects
+		const teamProject = await createTeamProject(undefined, owner);
 		const response = await authOwnerAgent
 			.post('/credentials')
-			.send({ ...randomCredentialPayload(), isResolvable: true });
+			.send({ ...randomCredentialPayload(), isResolvable: true, projectId: teamProject.id });
 
 		expect(response.statusCode).toBe(200);
 
@@ -1610,8 +1612,10 @@ describe('PATCH /credentials/:id', () => {
 	});
 
 	test('should allow updating isResolvable field', async () => {
+		// End-user credentials are only available in team projects
+		const teamProject = await createTeamProject(undefined, owner);
 		const savedCredential = await saveCredential(randomCredentialPayload({ isResolvable: false }), {
-			user: owner,
+			project: teamProject,
 			role: 'credential:owner',
 		});
 

--- a/packages/cli/test/integration/credentials/credentials.resolvable.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.resolvable.api.test.ts
@@ -1,5 +1,6 @@
 import {
 	createTeamProject,
+	getPersonalProject,
 	linkUserToProject,
 	mockInstance,
 	randomCredentialPayload,
@@ -25,7 +26,7 @@ import {
 	saveCredential,
 	shareCredentialWithProjects,
 } from '../shared/db/credentials';
-import { createAdmin, createMember } from '../shared/db/users';
+import { createAdmin, createMember, createOwner } from '../shared/db/users';
 import * as utils from '../shared/utils';
 import { setupTestServer } from '../shared/utils';
 
@@ -590,12 +591,31 @@ describe('POST /credentials — end-user credential creation is role-restricted'
 			.expect(200);
 	});
 
-	test('member can create an end-user credential in their personal project', async () => {
+	test('member cannot create an end-user credential in their personal project', async () => {
 		await testServer
 			.authAgentFor(memberB)
 			.post('/credentials')
 			.send({ ...randomCredentialPayload(), isResolvable: true })
-			.expect(200);
+			.expect(403);
+	});
+
+	test('instance owner cannot create an end-user credential in their personal project', async () => {
+		const owner = await createOwner();
+		await testServer
+			.authAgentFor(owner)
+			.post('/credentials')
+			.send({ ...randomCredentialPayload(), isResolvable: true })
+			.expect(403);
+	});
+
+	test('instance owner cannot create an end-user credential in another personal project by id', async () => {
+		const owner = await createOwner();
+		const personalProject = await getPersonalProject(memberB);
+		await testServer
+			.authAgentFor(owner)
+			.post('/credentials')
+			.send({ ...randomCredentialPayload(), isResolvable: true, projectId: personalProject.id })
+			.expect(403);
 	});
 });
 
@@ -659,6 +679,35 @@ describe('PATCH /credentials/:id — switching to end-user is role-restricted', 
 			})
 			.expect(200);
 	});
+
+	test('member cannot switch their personal credential to end-user', async () => {
+		const staticCred = await saveCredential(randomCredentialPayload(), {
+			user: memberB,
+			role: 'credential:owner',
+		});
+		await testServer
+			.authAgentFor(memberB)
+			.patch(`/credentials/${staticCred.id}`)
+			.send({ name: staticCred.name, type: staticCred.type, data: {}, isResolvable: true })
+			.expect(403);
+	});
+
+	test('member can switch an existing personal end-user credential back to fixed', async () => {
+		const resolvableCred = await saveCredential(randomCredentialPayload({ isResolvable: true }), {
+			user: memberB,
+			role: 'credential:owner',
+		});
+		await testServer
+			.authAgentFor(memberB)
+			.patch(`/credentials/${resolvableCred.id}`)
+			.send({
+				name: resolvableCred.name,
+				type: resolvableCred.type,
+				data: {},
+				isResolvable: false,
+			})
+			.expect(200);
+	});
 });
 
 describe('PUT /credentials/:id/transfer — end-user credentials are role-restricted', () => {
@@ -700,6 +749,17 @@ describe('PUT /credentials/:id/transfer — end-user credentials are role-restri
 			.send({ destinationProjectId: teamProject.id })
 			.expect(200);
 	});
+
+	test('project admin cannot transfer an end-user credential into their personal project', async () => {
+		const resolvable = await saveResolvableCredential();
+		const personalProject = await getPersonalProject(memberA);
+
+		await testServer
+			.authAgentFor(memberA)
+			.put(`/credentials/${resolvable.id}/transfer`)
+			.send({ destinationProjectId: personalProject.id })
+			.expect(403);
+	});
 });
 
 describe('DELETE /credentials/:id — end-user credentials are role-restricted', () => {
@@ -716,5 +776,13 @@ describe('DELETE /credentials/:id — end-user credentials are role-restricted',
 	test('project admin can delete an end-user credential', async () => {
 		const resolvableCred = await saveResolvableCredential();
 		await testServer.authAgentFor(memberA).delete(`/credentials/${resolvableCred.id}`).expect(200);
+	});
+
+	test('member can delete an existing end-user credential in their personal project', async () => {
+		const resolvableCred = await saveCredential(randomCredentialPayload({ isResolvable: true }), {
+			user: memberB,
+			role: 'credential:owner',
+		});
+		await testServer.authAgentFor(memberB).delete(`/credentials/${resolvableCred.id}`).expect(200);
 	});
 });

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -36,6 +36,7 @@ import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.serv
 import { createFolder } from '@test-integration/db/folders';
 
 import {
+	createCredentials,
 	getCredentialById,
 	saveCredential,
 	shareCredentialWithProjects,
@@ -1490,6 +1491,52 @@ describe('DELETE /project/:projectId', () => {
 		expect(foldersInTargetProject.map((f) => f.name)).toEqual(
 			expect.arrayContaining(['folder1', 'folder1', 'folder2']),
 		);
+	});
+
+	test('does not migrate end-user credentials to a personal project', async () => {
+		//
+		// ARRANGE
+		//
+		const member = await createMember();
+		const projectToBeDeleted = await createTeamProject(undefined, member);
+		const personalProject = await getPersonalProject(member);
+
+		const endUserCredential = await createCredentials(
+			{ name: 'End-user credential', type: 'test', data: '', isResolvable: true },
+			projectToBeDeleted,
+		);
+		const ownedWorkflow = await createWorkflow({}, projectToBeDeleted);
+
+		//
+		// ACT
+		//
+		const response = await testServer
+			.authAgentFor(member)
+			.delete(`/projects/${projectToBeDeleted.id}`)
+			.query({ transferId: personalProject.id })
+			//
+			// ASSERT
+			//
+			.expect(400);
+
+		expect(response.body.message).toContain('"End-user credential"');
+
+		// the project is still there, with nothing migrated out of it
+		await expect(findProject(projectToBeDeleted.id)).resolves.toBeDefined();
+		await expect(
+			Container.get(SharedWorkflowRepository).findOneByOrFail({
+				workflowId: ownedWorkflow.id,
+				projectId: projectToBeDeleted.id,
+				role: 'workflow:owner',
+			}),
+		).resolves.toBeDefined();
+		await expect(
+			Container.get(SharedCredentialsRepository).findOneByOrFail({
+				credentialsId: endUserCredential.id,
+				projectId: projectToBeDeleted.id,
+				role: 'credential:owner',
+			}),
+		).resolves.toBeDefined();
 	});
 
 	// This test is testing behavior that is explicitly not enabled right now,

--- a/packages/cli/test/integration/public-api/credentials.test.ts
+++ b/packages/cli/test/integration/public-api/credentials.test.ts
@@ -191,6 +191,8 @@ describe('POST /credentials', () => {
 	});
 
 	test('should create credential with isResolvable set to true', async () => {
+		// End-user credentials are only available in team projects
+		const project = await createTeamProject();
 		const payload = {
 			name: 'test credential',
 			type: 'githubApi',
@@ -200,6 +202,7 @@ describe('POST /credentials', () => {
 				server: 'testServer',
 			},
 			isResolvable: true,
+			projectId: project.id,
 		};
 
 		const response = await authOwnerAgent.post('/credentials').send(payload);
@@ -211,6 +214,24 @@ describe('POST /credentials', () => {
 
 		const credential = await Container.get(CredentialsRepository).findOneByOrFail({ id });
 		expect(credential.isResolvable).toBe(true);
+	});
+
+	test('should not allow creating an end-user credential in a personal project', async () => {
+		const payload = {
+			name: 'test credential',
+			type: 'githubApi',
+			data: {
+				accessToken: 'abcdefghijklmnopqrstuvwxyz',
+				user: 'test',
+				server: 'testServer',
+			},
+			isResolvable: true,
+			// no projectId — the credential would land in the owner's personal project
+		};
+
+		const response = await authOwnerAgent.post('/credentials').send(payload);
+
+		expect(response.statusCode).toBe(403);
 	});
 
 	test('should create credential with isResolvable set to false', async () => {
@@ -904,7 +925,9 @@ describe('PATCH /credentials/:id', () => {
 	});
 
 	test('should update isResolvable field', async () => {
-		const savedCredential = await saveCredential(dbCredential(), { user: owner });
+		// End-user credentials are only available in team projects
+		const project = await createTeamProject();
+		const savedCredential = await saveCredential(dbCredential(), { project });
 
 		const updatePayload = {
 			isResolvable: true,
@@ -935,8 +958,9 @@ describe('PATCH /credentials/:id', () => {
 		expect(response.statusCode).toBe(403);
 	});
 
-	test('should allow the owner to switch a credential to end-user via the public API', async () => {
-		const credential = await saveCredential(dbCredential(), { user: owner });
+	test('should allow the owner to switch a team credential to end-user via the public API', async () => {
+		const project = await createTeamProject();
+		const credential = await saveCredential(dbCredential(), { project });
 
 		const response = await authOwnerAgent
 			.patch(`/credentials/${credential.id}`)
@@ -944,6 +968,30 @@ describe('PATCH /credentials/:id', () => {
 
 		expect(response.statusCode).toBe(200);
 		expect(response.body.isResolvable).toBe(true);
+	});
+
+	test('should not allow switching a personal credential to end-user via the public API', async () => {
+		const credential = await saveCredential(dbCredential(), { user: owner });
+
+		const response = await authOwnerAgent
+			.patch(`/credentials/${credential.id}`)
+			.send({ isResolvable: true });
+
+		expect(response.statusCode).toBe(403);
+	});
+
+	test('should allow switching a personal end-user credential back to fixed via the public API', async () => {
+		const credential = await saveCredential(
+			{ ...dbCredential(), isResolvable: true },
+			{ user: owner },
+		);
+
+		const response = await authOwnerAgent
+			.patch(`/credentials/${credential.id}`)
+			.send({ isResolvable: false });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.isResolvable).toBe(false);
 	});
 
 	test('should not allow a project editor to switch an end-user credential to fixed via the public API', async () => {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.test.ts
@@ -13,6 +13,7 @@ import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import type { ComponentProps } from 'vue-component-type-helpers';
 import { ResourceType } from '../projects.utils';
+import { ProjectTypes } from '../projects.types';
 import type { ProjectSharingData } from 'n8n-workflow';
 import type { ICredentialsResponse } from '@/features/credentials/credentials.types';
 
@@ -308,6 +309,50 @@ describe('ProjectMoveResourceModal', () => {
 			await vi.waitFor(() => expect(projectsStore.searchProjects).toHaveBeenCalled());
 
 			expect(queryByTestId('project-move-resource-modal-resolvable-warning')).toBeNull();
+		});
+
+		describe('destination filter', () => {
+			const personalProject = createProjectListItem(ProjectTypes.Personal);
+			const teamProject = {
+				...createProjectListItem(ProjectTypes.Team),
+				name: 'Team destination',
+			};
+
+			beforeEach(() => {
+				projectsStore.searchProjects.mockResolvedValue({
+					count: 2,
+					data: [personalProject, teamProject],
+				});
+			});
+
+			it('hides personal projects for a resolvable credential', async () => {
+				const { getByTestId } = renderComponent({ props: props(true) });
+
+				const dropdownItems = await getDropdownItems(getByTestId('project-sharing-select'));
+
+				expect(dropdownItems).toHaveLength(1);
+				expect(dropdownItems[0]).toHaveTextContent('Team destination');
+			});
+
+			it('hides personal projects even when private credentials are disabled', async () => {
+				// the backend rejects the move on `isResolvable` alone, regardless of the module
+				isPrivateCredentialsEnabled.value = false;
+
+				const { getByTestId } = renderComponent({ props: props(true) });
+
+				const dropdownItems = await getDropdownItems(getByTestId('project-sharing-select'));
+
+				expect(dropdownItems).toHaveLength(1);
+				expect(dropdownItems[0]).toHaveTextContent('Team destination');
+			});
+
+			it('keeps personal projects for a non-resolvable credential', async () => {
+				const { getByTestId } = renderComponent({ props: props(false) });
+
+				const dropdownItems = await getDropdownItems(getByTestId('project-sharing-select'));
+
+				expect(dropdownItems).toHaveLength(2);
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
@@ -93,9 +93,6 @@ const homeProjectName = computed(
 	() => processProjectName(props.data.resource.homeProject?.name ?? '') ?? '',
 );
 
-const projectFilterFn = (p: ProjectListItem): boolean =>
-	!p.scopes || !!getResourcePermissions(p.scopes)[props.data.resourceType].create;
-
 const isResourceInTeamProject = computed(() => isHomeProjectTeam(props.data.resource));
 const isResourceWorkflow = computed(() => props.data.resourceType === ResourceType.Workflow);
 
@@ -105,6 +102,12 @@ const isResolvableCredential = computed(
 		props.data.resourceType === ResourceType.Credential &&
 		(props.data.resource as ICredentialsResponse).isResolvable === true,
 );
+
+const projectFilterFn = (p: ProjectListItem): boolean => {
+	// End-user credentials can't move into personal projects
+	if (isResolvableCredential.value && p.type === ProjectTypes.Personal) return false;
+	return !p.scopes || !!getResourcePermissions(p.scopes)[props.data.resourceType].create;
+};
 const targetProjectName = computed(() => {
 	return getTruncatedProjectName(selectedProject.value?.name);
 });

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectMoveResourceModal.vue
@@ -96,16 +96,21 @@ const homeProjectName = computed(
 const isResourceInTeamProject = computed(() => isHomeProjectTeam(props.data.resource));
 const isResourceWorkflow = computed(() => props.data.resourceType === ResourceType.Workflow);
 
-const isResolvableCredential = computed(
+// What the credential is — the backend rejects the move on `isResolvable` alone,
+// so the destination filter must not depend on module/license state.
+const isEndUserCredential = computed(
 	() =>
-		privateCredentials.isEnabled.value &&
 		props.data.resourceType === ResourceType.Credential &&
 		(props.data.resource as ICredentialsResponse).isResolvable === true,
+);
+// What we surface about it — gated on the module being enabled.
+const isResolvableCredential = computed(
+	() => privateCredentials.isEnabled.value && isEndUserCredential.value,
 );
 
 const projectFilterFn = (p: ProjectListItem): boolean => {
 	// End-user credentials can't move into personal projects
-	if (isResolvableCredential.value && p.type === ProjectTypes.Personal) return false;
+	if (isEndUserCredential.value && p.type === ProjectTypes.Personal) return false;
 	return !p.scopes || !!getResourcePermissions(p.scopes)[props.data.resourceType].create;
 };
 const targetProjectName = computed(() => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.test.ts
@@ -188,6 +188,33 @@ describe('CredentialConfig', () => {
 	});
 
 	describe('Dynamic Credentials Section', () => {
+		// Seeds the credentials store with a stored credential so the component can
+		// resolve its home project type (used for edit-mode cases).
+		const createPiniaWithStoredCredential = (projectType: 'personal' | 'team') =>
+			createTestingPinia({
+				initialState: {
+					[STORES.SETTINGS]: {
+						settings: {
+							enterprise: {
+								sharing: false,
+								externalSecrets: false,
+							},
+						},
+					},
+					[STORES.CREDENTIALS]: {
+						state: {
+							credentialTypes: {},
+							credentials: {
+								'cred-1': {
+									id: 'cred-1',
+									homeProject: { id: 'project-1', type: projectType },
+								},
+							},
+						},
+					},
+				},
+			});
+
 		it('should not display dynamic credentials section when isPrivateCredentialsEnabled is false', async () => {
 			renderComponent({
 				props: {
@@ -304,6 +331,7 @@ describe('CredentialConfig', () => {
 					isOAuthType: true,
 					isNewCredential: true,
 					isResolvable: false,
+					newCredentialProjectType: 'team',
 					credentialPermissions: {
 						create: true,
 						createEndUser: true,
@@ -323,12 +351,14 @@ describe('CredentialConfig', () => {
 
 		it('should display dynamic credentials section when all conditions are met for existing credential', async () => {
 			renderComponent({
+				pinia: createPiniaWithStoredCredential('team'),
 				props: {
 					isManaged: false,
 					mode: 'edit',
 					credentialType: mockCredentialType,
 					credentialProperties: [],
 					credentialData: {} as ICredentialDataDecryptedObject,
+					credentialId: 'cred-1',
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
 					isNewCredential: false,
@@ -352,12 +382,14 @@ describe('CredentialConfig', () => {
 
 		it('should keep the credential type selector enabled when the credential is already shared', async () => {
 			renderComponent({
+				pinia: createPiniaWithStoredCredential('team'),
 				props: {
 					isManaged: false,
 					mode: 'edit',
 					credentialType: mockCredentialType,
 					credentialProperties: [],
 					credentialData: {} as ICredentialDataDecryptedObject,
+					credentialId: 'cred-1',
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
 					isNewCredential: false,
@@ -473,6 +505,95 @@ describe('CredentialConfig', () => {
 					credentialType: mockCredentialType,
 					credentialProperties: [],
 					credentialData: {} as ICredentialDataDecryptedObject,
+					isPrivateCredentialsEnabled: true,
+					isOAuthType: true,
+					isNewCredential: false,
+					isResolvable: true,
+					credentialPermissions: {
+						create: false,
+						createEndUser: true,
+						update: true,
+						read: true,
+						delete: false,
+						share: false,
+						list: true,
+						move: false,
+					},
+				},
+			});
+
+			expect(screen.getByTestId('credential-type-selector')).toBeInTheDocument();
+		});
+
+		it('should hide the type selector for a new credential in a personal project', async () => {
+			renderComponent({
+				props: {
+					isManaged: false,
+					mode: 'new',
+					credentialType: mockCredentialType,
+					credentialProperties: [],
+					credentialData: {} as ICredentialDataDecryptedObject,
+					isPrivateCredentialsEnabled: true,
+					isOAuthType: true,
+					isNewCredential: true,
+					isResolvable: false,
+					newCredentialProjectType: 'personal',
+					credentialPermissions: {
+						create: true,
+						createEndUser: true,
+						update: false,
+						read: true,
+						delete: false,
+						share: false,
+						list: true,
+						move: false,
+					},
+				},
+			});
+
+			expect(screen.queryByTestId('credential-type-selector')).not.toBeInTheDocument();
+		});
+
+		it('should hide the type selector for an existing fixed credential in a personal project', async () => {
+			renderComponent({
+				pinia: createPiniaWithStoredCredential('personal'),
+				props: {
+					isManaged: false,
+					mode: 'edit',
+					credentialType: mockCredentialType,
+					credentialProperties: [],
+					credentialData: {} as ICredentialDataDecryptedObject,
+					credentialId: 'cred-1',
+					isPrivateCredentialsEnabled: true,
+					isOAuthType: true,
+					isNewCredential: false,
+					isResolvable: false,
+					credentialPermissions: {
+						create: false,
+						createEndUser: true,
+						update: true,
+						read: true,
+						delete: false,
+						share: false,
+						list: true,
+						move: false,
+					},
+				},
+			});
+
+			expect(screen.queryByTestId('credential-type-selector')).not.toBeInTheDocument();
+		});
+
+		it('should show the type selector for an existing end-user credential in a personal project', async () => {
+			renderComponent({
+				pinia: createPiniaWithStoredCredential('personal'),
+				props: {
+					isManaged: false,
+					mode: 'edit',
+					credentialType: mockCredentialType,
+					credentialProperties: [],
+					credentialData: {} as ICredentialDataDecryptedObject,
+					credentialId: 'cred-1',
 					isPrivateCredentialsEnabled: true,
 					isOAuthType: true,
 					isNewCredential: false,

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -58,6 +58,7 @@ import QuickConnectButton from '../../quickConnect/components/QuickConnectButton
 import QuickConnectBanner from '../../quickConnect/components/QuickConnectBanner.vue';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
+import type { ProjectType } from '@/features/collaboration/projects/projects.types';
 
 type Props = {
 	mode: string;
@@ -79,6 +80,8 @@ type Props = {
 	isResolvable?: boolean;
 	connectedByMe?: boolean;
 	isNewCredential?: boolean;
+	/** Type of the project a new credential will be created in. */
+	newCredentialProjectType?: ProjectType;
 	managedOauthAvailable?: boolean;
 	useCustomOauth?: boolean;
 	isQuickConnectMode?: boolean;
@@ -288,6 +291,14 @@ const canWrite = computed(() => {
 const canSelectEndUserType = computed(
 	() => canWrite.value && !!props.credentialPermissions.createEndUser,
 );
+
+// Only in team projects; an existing end-user credential keeps the selector
+// so it can be switched back to fixed.
+const isEndUserTypeAvailable = computed(() => {
+	if (props.isResolvable) return true;
+	if (props.isNewCredential) return props.newCredentialProjectType === ProjectTypes.Team;
+	return isHomeTeamProject.value;
+});
 
 // Connecting an existing private credential only needs the `connect` capability
 // (no edit rights); shared/static credentials store the token on the shared
@@ -582,7 +593,9 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 						isOAuthType &&
 						// Only users who can manage end-user credentials see the selector at all;
 						// it's disabled for them when they lack edit access to the credential.
-						!!credentialPermissions.createEndUser
+						!!credentialPermissions.createEndUser &&
+						// End-user credentials are not available in personal projects.
+						isEndUserTypeAvailable
 					"
 					:model-value="Boolean(isResolvable)"
 					:disabled="!canSelectEndUserType"

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -1584,6 +1584,16 @@ describe('CredentialEdit', () => {
 				[googleBigQueryOAuth2Api.name]: googleBigQueryOAuth2Api,
 			};
 
+			// The type selector needs a team home project, resolved from the store
+			credentialsStore.state.credentials = {
+				'cred-banner': {
+					id: 'cred-banner',
+					name: 'Google BigQuery account',
+					type: 'googleBigQueryOAuth2Api',
+					homeProject: { id: 'project-1', type: 'team' },
+				} as ICredentialsResponse,
+			};
+
 			return credentialsStore;
 		};
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1419,6 +1419,7 @@ const { width } = useElementSize(credNameRef);
 							:is-resolvable="isResolvable"
 							:connected-by-me="connectedByMe"
 							:is-new-credential="isNewCredential"
+							:new-credential-project-type="homeProject?.type"
 							:managed-oauth-available="managedOAuthAvailable"
 							:use-custom-oauth="useCustomOAuth"
 							:is-quick-connect-mode="isQuickConnectMode"

--- a/packages/testing/playwright/services/workflow-api-helper.ts
+++ b/packages/testing/playwright/services/workflow-api-helper.ts
@@ -338,6 +338,7 @@ export class WorkflowApiHelper {
 			webhookPrefix?: string;
 			idLength?: number;
 			makeUnique?: boolean;
+			projectId?: string;
 			transform?: (workflow: Partial<IWorkflowBase>) => Partial<IWorkflowBase>;
 		},
 	): Promise<WorkflowImportResult> {
@@ -355,7 +356,12 @@ export class WorkflowApiHelper {
 
 	async importWorkflowFromDefinition(
 		workflowDefinition: Partial<IWorkflowBase>,
-		options?: { webhookPrefix?: string; idLength?: number; makeUnique?: boolean },
+		options?: {
+			webhookPrefix?: string;
+			idLength?: number;
+			makeUnique?: boolean;
+			projectId?: string;
+		},
 	): Promise<WorkflowImportResult> {
 		const result = await this.createWorkflowFromDefinition(workflowDefinition, options);
 

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/execution-status.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/execution-status.spec.ts
@@ -54,36 +54,46 @@ test.describe(
 				},
 			});
 
+			// End-user credentials can only live in team projects
+			await api.enableFeature('projectRole:admin');
+			await api.enableFeature('projectRole:editor');
+			await api.setMaxTeamProjectsQuota(-1);
+			const project = await api.projects.createProject('Dynamic Credentials');
+
 			// Create an OAuth2 credential flagged as resolvable (no static data needed)
 			const credential = await api.credentials.createCredential({
 				name: `Resolvable OAuth2 Credential ${nanoid()}`,
 				type: 'oAuth2Api',
 				data: { grantType: 'authorizationCode' },
 				isResolvable: true,
+				projectId: project.id,
 			});
 
 			// Create a workflow that uses that credential, with the resolver as workflow-level fallback
-			const workflow = await api.workflows.createWorkflow({
-				name: `Dynamic Credential Workflow ${nanoid()}`,
-				nodes: [
-					{
-						id: nanoid(),
-						name: 'HTTP Request',
-						type: 'n8n-nodes-base.httpRequest',
-						typeVersion: 4.2,
-						position: [0, 0] as [number, number],
-						parameters: {},
-						credentials: {
-							oAuth2Api: { id: credential.id, name: credential.name },
+			const workflow = await api.workflows.createWorkflow(
+				{
+					name: `Dynamic Credential Workflow ${nanoid()}`,
+					nodes: [
+						{
+							id: nanoid(),
+							name: 'HTTP Request',
+							type: 'n8n-nodes-base.httpRequest',
+							typeVersion: 4.2,
+							position: [0, 0] as [number, number],
+							parameters: {},
+							credentials: {
+								oAuth2Api: { id: credential.id, name: credential.name },
+							},
 						},
+					],
+					connections: {},
+					settings: {
+						// Workflow-level resolver used as fallback for all resolvable credentials
+						credentialResolverId: resolver.id,
 					},
-				],
-				connections: {},
-				settings: {
-					// Workflow-level resolver used as fallback for all resolvable credentials
-					credentialResolverId: resolver.id,
 				},
-			});
+				project.id,
+			);
 
 			// Obtain a real access token for the Keycloak test user via ROPC (no browser needed)
 			const accessToken = await keycloak.getAccessToken(
@@ -152,6 +162,12 @@ test.describe(
 				},
 			});
 
+			// End-user credentials can only live in team projects
+			await api.enableFeature('projectRole:admin');
+			await api.enableFeature('projectRole:editor');
+			await api.setMaxTeamProjectsQuota(-1);
+			const project = await api.projects.createProject('Dynamic Credentials');
+
 			// Create a properly-configured oAuth2Api credential pointing at Keycloak.
 			// The credential is resolvable — its tokens are stored per-user by the resolver.
 			const credential = await api.credentials.createCredential({
@@ -167,29 +183,33 @@ test.describe(
 					ignoreSSLIssues: true,
 				},
 				isResolvable: true,
+				projectId: project.id,
 			});
 
 			// Create a workflow that uses that credential
-			const workflow = await api.workflows.createWorkflow({
-				name: `Configured Credential Workflow ${nanoid()}`,
-				nodes: [
-					{
-						id: nanoid(),
-						name: 'HTTP Request',
-						type: 'n8n-nodes-base.httpRequest',
-						typeVersion: 4.2,
-						position: [0, 0] as [number, number],
-						parameters: {},
-						credentials: {
-							oAuth2Api: { id: credential.id, name: credential.name },
+			const workflow = await api.workflows.createWorkflow(
+				{
+					name: `Configured Credential Workflow ${nanoid()}`,
+					nodes: [
+						{
+							id: nanoid(),
+							name: 'HTTP Request',
+							type: 'n8n-nodes-base.httpRequest',
+							typeVersion: 4.2,
+							position: [0, 0] as [number, number],
+							parameters: {},
+							credentials: {
+								oAuth2Api: { id: credential.id, name: credential.name },
+							},
 						},
+					],
+					connections: {},
+					settings: {
+						credentialResolverId: resolver.id,
 					},
-				],
-				connections: {},
-				settings: {
-					credentialResolverId: resolver.id,
 				},
-			});
+				project.id,
+			);
 
 			// Complete the OAuth2 authorization code flow for the test user.
 			// This stores the user's Keycloak tokens in the dynamic_credential_entry table.

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/external-user-trigger.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/external-user-trigger.spec.ts
@@ -63,6 +63,12 @@ test.describe(
 				},
 			});
 
+			// End-user credentials can only live in team projects
+			await api.enableFeature('projectRole:admin');
+			await api.enableFeature('projectRole:editor');
+			await api.setMaxTeamProjectsQuota(-1);
+			const project = await api.projects.createProject('Dynamic Credentials');
+
 			// Create a properly-configured oAuth2Api credential pointing at Keycloak.
 			// The credential is resolvable — its tokens are stored per-user by the resolver.
 			const credential = await api.credentials.createCredential({
@@ -78,65 +84,69 @@ test.describe(
 					ignoreSSLIssues: true,
 				},
 				isResolvable: true,
+				projectId: project.id,
 			});
 
 			// Build a workflow: webhook trigger → HTTP Request (calls Keycloak userinfo with credential)
 			// The workflow is created BEFORE authorization so we can obtain the authorizationUrl
 			// from the execution-status endpoint (the real flow a marketplace user would follow).
 			const { workflowId, webhookPath, createdWorkflow } =
-				await api.workflows.createWorkflowFromDefinition({
-					name: `Dynamic Credential HTTP Webhook Workflow ${nanoid()}`,
-					nodes: [
-						{
-							id: nanoid(),
-							name: 'Webhook',
-							type: 'n8n-nodes-base.webhook',
-							typeVersion: 2,
-							position: [0, 0] as [number, number],
-							parameters: {
-								httpMethod: 'GET',
-								path: 'placeholder',
-								responseMode: 'onReceived', // Respond immediately; execution runs async
-								// Configure the execution context hook to extract the bearer token
-								// from the Authorization header. Without this, the dynamic credential
-								// resolver can't identify the user during execution.
-								executionsHooksVersion: 1,
-								contextEstablishmentHooks: {
-									hooks: [
-										{
-											hookName: 'BearerTokenExtractor',
-											isAllowedToFail: false,
-										},
-									],
+				await api.workflows.createWorkflowFromDefinition(
+					{
+						name: `Dynamic Credential HTTP Webhook Workflow ${nanoid()}`,
+						nodes: [
+							{
+								id: nanoid(),
+								name: 'Webhook',
+								type: 'n8n-nodes-base.webhook',
+								typeVersion: 2,
+								position: [0, 0] as [number, number],
+								parameters: {
+									httpMethod: 'GET',
+									path: 'placeholder',
+									responseMode: 'onReceived', // Respond immediately; execution runs async
+									// Configure the execution context hook to extract the bearer token
+									// from the Authorization header. Without this, the dynamic credential
+									// resolver can't identify the user during execution.
+									executionsHooksVersion: 1,
+									contextEstablishmentHooks: {
+										hooks: [
+											{
+												hookName: 'BearerTokenExtractor',
+												isAllowedToFail: false,
+											},
+										],
+									},
 								},
 							},
-						},
-						{
-							id: nanoid(),
-							name: 'HTTP Request',
-							type: 'n8n-nodes-base.httpRequest',
-							typeVersion: 4.2,
-							position: [200, 0] as [number, number],
-							parameters: {
-								// Keycloak userinfo endpoint — accepts Bearer tokens and returns user info (200)
-								url: `${internalBase}/protocol/openid-connect/userinfo`,
-								authentication: 'predefinedCredentialType',
-								nodeCredentialType: 'oAuth2Api',
+							{
+								id: nanoid(),
+								name: 'HTTP Request',
+								type: 'n8n-nodes-base.httpRequest',
+								typeVersion: 4.2,
+								position: [200, 0] as [number, number],
+								parameters: {
+									// Keycloak userinfo endpoint — accepts Bearer tokens and returns user info (200)
+									url: `${internalBase}/protocol/openid-connect/userinfo`,
+									authentication: 'predefinedCredentialType',
+									nodeCredentialType: 'oAuth2Api',
+								},
+								credentials: {
+									oAuth2Api: { id: credential.id, name: credential.name },
+								},
 							},
-							credentials: {
-								oAuth2Api: { id: credential.id, name: credential.name },
+						],
+						connections: {
+							Webhook: {
+								main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]],
 							},
 						},
-					],
-					connections: {
-						Webhook: {
-							main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]],
+						settings: {
+							credentialResolverId: resolver.id,
 						},
 					},
-					settings: {
-						credentialResolverId: resolver.id,
-					},
-				});
+					{ projectId: project.id },
+				);
 
 			// Obtain a Keycloak access token for the test user (ROPC — no browser needed).
 			// This token is used as the user identity throughout the flow.

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/mcp-trigger-credential-gate.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/mcp-trigger-credential-gate.spec.ts
@@ -61,6 +61,12 @@ async function provisionGatedWorkflow(
 		'',
 	);
 
+	// End-user credentials can only live in team projects
+	await api.enableFeature('projectRole:admin');
+	await api.enableFeature('projectRole:editor');
+	await api.setMaxTeamProjectsQuota(-1);
+	const project = await api.projects.createProject('Dynamic Credentials');
+
 	// A resolvable OAuth2 credential — resolved per-user by the seeded `system-n8n`
 	// resolver. The caller has NOT connected it, so the gate reports it missing and
 	// hands back the Keycloak authorization URL to connect it.
@@ -77,11 +83,13 @@ async function provisionGatedWorkflow(
 			ignoreSSLIssues: true,
 		},
 		isResolvable: true,
+		projectId: project.id,
 	});
 
 	const { workflowId, createdWorkflow } = await api.workflows.importWorkflowFromFile(
 		'mcp-trigger/mcp-trigger-n8n-oauth2-private-cred.json',
 		{
+			projectId: project.id,
 			transform: (wf) => {
 				// Attach the resolvable credential to the Private API node so the
 				// workflow carries an unconnected private credential.

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/webhook-trigger-private-credential.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/webhook-trigger-private-credential.spec.ts
@@ -60,6 +60,12 @@ test.describe(
 				'',
 			);
 
+			// End-user credentials can only live in team projects
+			await api.enableFeature('projectRole:admin');
+			await api.enableFeature('projectRole:editor');
+			await api.setMaxTeamProjectsQuota(-1);
+			const project = await api.projects.createProject('Dynamic Credentials');
+
 			// Resolvable: the seeded `system-n8n` resolver stores its tokens per n8n user.
 			const credential = await api.credentials.createCredential({
 				name: `Webhook Private OAuth2 ${nanoid()}`,
@@ -74,49 +80,53 @@ test.describe(
 					ignoreSSLIssues: true,
 				},
 				isResolvable: true,
+				projectId: project.id,
 			});
 
 			const { workflowId, webhookPath, createdWorkflow } =
-				await api.workflows.createWorkflowFromDefinition({
-					name: `Webhook n8nOAuth2 Private Credential ${nanoid()}`,
-					nodes: [
-						{
-							id: nanoid(),
-							name: 'Webhook',
-							type: 'n8n-nodes-base.webhook',
-							typeVersion: 2.1,
-							position: [0, 0] as [number, number],
-							parameters: {
-								httpMethod: 'POST',
-								path: 'placeholder', // replaced with a unique value on create
-								authentication: 'n8nOAuth2',
-								// Any authenticated user may mint a token, so the member can call
-								// the trigger without being granted workflow:execute.
-								requireExecuteAccess: false,
-								options: {},
+				await api.workflows.createWorkflowFromDefinition(
+					{
+						name: `Webhook n8nOAuth2 Private Credential ${nanoid()}`,
+						nodes: [
+							{
+								id: nanoid(),
+								name: 'Webhook',
+								type: 'n8n-nodes-base.webhook',
+								typeVersion: 2.1,
+								position: [0, 0] as [number, number],
+								parameters: {
+									httpMethod: 'POST',
+									path: 'placeholder', // replaced with a unique value on create
+									authentication: 'n8nOAuth2',
+									// Any authenticated user may mint a token, so the member can call
+									// the trigger without being granted workflow:execute.
+									requireExecuteAccess: false,
+									options: {},
+								},
 							},
+							{
+								id: nanoid(),
+								name: 'HTTP Request',
+								type: 'n8n-nodes-base.httpRequest',
+								typeVersion: 4.2,
+								position: [200, 0] as [number, number],
+								parameters: {
+									// Keycloak userinfo accepts the resolved Bearer token and returns 200
+									url: `${internalBase}/protocol/openid-connect/userinfo`,
+									authentication: 'predefinedCredentialType',
+									nodeCredentialType: 'oAuth2Api',
+								},
+								credentials: {
+									oAuth2Api: { id: credential.id, name: credential.name },
+								},
+							},
+						],
+						connections: {
+							Webhook: { main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]] },
 						},
-						{
-							id: nanoid(),
-							name: 'HTTP Request',
-							type: 'n8n-nodes-base.httpRequest',
-							typeVersion: 4.2,
-							position: [200, 0] as [number, number],
-							parameters: {
-								// Keycloak userinfo accepts the resolved Bearer token and returns 200
-								url: `${internalBase}/protocol/openid-connect/userinfo`,
-								authentication: 'predefinedCredentialType',
-								nodeCredentialType: 'oAuth2Api',
-							},
-							credentials: {
-								oAuth2Api: { id: credential.id, name: credential.name },
-							},
-						},
-					],
-					connections: {
-						Webhook: { main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]] },
 					},
-				});
+					{ projectId: project.id },
+				);
 
 			await api.workflows.activate(workflowId, createdWorkflow.versionId as string);
 


### PR DESCRIPTION
## Summary

End-user credentials are no longer available in **personal projects** — they are meant for team projects, and offering two credential types in the personal space confused end users (enterprise customer request).

- Creating an end-user credential in a personal project, switching a fixed credential to end-user there, or transferring an end-user credential into a personal project now returns **403** — for every role, including instance owners/admins. Enforced centrally in `CredentialsService.ensureEndUserCredentialAllowedInProject()`, applied on internal REST and the public API.
- **Escape hatches stay open:** existing end-user credentials in personal projects can still be switched back to fixed or deleted.
- **UI:** the Fixed/End-user type selector is hidden in personal projects (still shown on existing end-user credentials so they can be switched back), and personal projects are excluded as move destinations for end-user credentials.

No role/scope changes, no migrations.

### Screenshots

Project space
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/dddc5f37-f342-4899-8985-3e8688b7c138" />


Personal space
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/1e5511d7-a32a-4a38-b442-a2e5138f1a6f" />

Existing end-user credential in Personal space (selector are visible and user can convert back to fixed credential)
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/a9f366a2-8307-44b1-8dd4-2a081a052a9a" />


## How to test

Requires the `dynamic-credentials` module (licensed `feat:dynamicCredentials`) and a team project.

1. **Personal → Create credential** (any OAuth2 type): the credential type selector is gone; `POST /rest/credentials` with `isResolvable: true` and no `projectId` returns 403 (also as instance owner).
2. **Team project → same modal**: the selector is present and creating an end-user credential works as before.
3. **Move** that end-user credential: personal projects are not offered as destinations; transferring one into a personal project via API returns 403.
4. **Existing end-user credential in a personal project** (created before this change): the selector is still visible — switching it back to fixed and deleting it both work.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-1196

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

