### PR TITLE
test(editor): Add failing cover for preview autosave on reconnect

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -1501,5 +1501,55 @@ describe('useWorkflowSaving', () => {
 
 			expect(saveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
 		});
+
+		// The read-only signal is read through `inject`, so it only reaches instances
+		// built inside a preview host's subtree. `builder.store.ts` and the
+		// `executionFinished` push handler build this composable out-of-tree, where a
+		// host's provide is invisible — and every instance owns a reconnect watcher
+		// that reads the app-wide dirty flag a preview sets. Cover from the observable
+		// end: no request leaves a preview when the connection returns, whatever else
+		// holds an instance.
+		describe('with the composable also built out-of-tree', () => {
+			it('issues no create request when the connection returns on a preview', async () => {
+				const createSpy = vi
+					.spyOn(workflowsStore, 'createNewWorkflow')
+					.mockResolvedValue(createTestWorkflow({ id: 'created' }));
+
+				backendConnectionStore.setOnline(false);
+				useWorkflowSaving({ router });
+				mountPreview('template-11754', true);
+				useUIStore().markStateDirty();
+
+				backendConnectionStore.setOnline(true);
+				await nextTick();
+				await flushAutoSave();
+
+				expect(createSpy).not.toHaveBeenCalled();
+			});
+
+			it('issues no update request when the connection returns on a preview of a stored workflow', async () => {
+				const workflow = createTestWorkflow({
+					id: 'w-reconnect',
+					nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+				});
+				workflowsListStore.workflowsById = { [workflow.id]: workflow };
+				useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+				mockRoute.params = { workflowId: workflow.id };
+				const updateSpy = vi
+					.spyOn(workflowsStore, 'updateWorkflow')
+					.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+				backendConnectionStore.setOnline(false);
+				useWorkflowSaving({ router });
+				mountPreview(workflow.id, true);
+				useUIStore().markStateDirty();
+
+				backendConnectionStore.setOnline(true);
+				await nextTick();
+				await flushAutoSave();
+
+				expect(updateSpy).not.toHaveBeenCalled();
+			});
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, provide } from 'vue';
+import { computed, defineComponent, h, nextTick, provide } from 'vue';
 import { mount } from '@vue/test-utils';
 import { useUIStore } from '@/app/stores/ui.store';
 import { AutoSaveState, DEBOUNCE_TIME, MODAL_CANCEL, MODAL_CONFIRM, VIEWS } from '@/app/constants';
@@ -1470,6 +1470,36 @@ describe('useWorkflowSaving', () => {
 			await flushAutoSave();
 
 			expect(updateSpy).toHaveBeenCalled();
+		});
+
+		it('does not re-arm a dirty preview when the connection comes back', async () => {
+			// The reconnect watcher lives inside this composable, so it is the one
+			// autosave entry point a view-level guard cannot cover.
+			const saveStore = useWorkflowSaveStore();
+
+			backendConnectionStore.setOnline(false);
+			mountPreview('template-11754', true);
+			useUIStore().markStateDirty();
+
+			backendConnectionStore.setOnline(true);
+			await nextTick();
+
+			expect(saveStore.autoSaveState).toBe(AutoSaveState.Idle);
+		});
+
+		it('re-arms a dirty canvas when the host lifts read-only', async () => {
+			// Instance AI locks the canvas while its agent edits and then releases
+			// it; without this the agent's changes would sit unsaved.
+			const saveStore = useWorkflowSaveStore();
+
+			const wrapper = mount(PreviewHostStub, {
+				props: { workflowId: 'w-rearm', readOnly: true },
+			});
+			useUIStore().markStateDirty();
+
+			await wrapper.setProps({ readOnly: false });
+
+			expect(saveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -1,5 +1,13 @@
+import { computed, defineComponent, h, provide } from 'vue';
+import { mount } from '@vue/test-utils';
 import { useUIStore } from '@/app/stores/ui.store';
-import { AutoSaveState, MODAL_CANCEL, MODAL_CONFIRM, VIEWS } from '@/app/constants';
+import { AutoSaveState, DEBOUNCE_TIME, MODAL_CANCEL, MODAL_CONFIRM, VIEWS } from '@/app/constants';
+import {
+	EditorEnabledFeaturesKey,
+	WorkflowIdKey,
+	type EditorEnabledFeatures,
+} from '@/app/constants/injectionKeys';
+import { getDebounceTime } from '@n8n/composables/useDebounce';
 import { useWorkflowSaving } from './useWorkflowSaving';
 import router from '@/app/router';
 import { createTestingPinia } from '@pinia/testing';
@@ -1323,6 +1331,145 @@ describe('useWorkflowSaving', () => {
 
 			// State should be Scheduled
 			expect(autosaveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
+		});
+	});
+
+	describe('autosave on a read-only preview canvas', () => {
+		// Preview hosts (template, workflow history, execution) mount the real
+		// NodeView and supersede the editor context with `readOnly: true`. Opening a
+		// node there auto-selects a credential, which marks the document dirty and
+		// reaches this composable — so the read-only signal has to stop the write.
+		// Regression cover for ADO-5764.
+		const PREVIEW_FEATURES: EditorEnabledFeatures = {
+			readOnly: true,
+			expandGroups: 'all',
+			aiAssistant: false,
+			aiBuilder: false,
+			askAi: false,
+			executionSuccessToasts: false,
+			executionErrorToasts: false,
+		};
+
+		const probe: { current: ReturnType<typeof useWorkflowSaving> | null } = { current: null };
+
+		const AutosaveProbe = defineComponent({
+			name: 'AutosaveProbe',
+			setup() {
+				probe.current = useWorkflowSaving({ router });
+				return () => h('div');
+			},
+		});
+
+		// Mirrors how WorkflowPreviewHost/ExecutionPreviewHost scope the subtree:
+		// the host provides, the child (NodeView in production) injects.
+		const PreviewHostStub = defineComponent({
+			name: 'PreviewHostStub',
+			props: {
+				workflowId: { type: String, required: true },
+				readOnly: { type: Boolean, required: true },
+			},
+			setup(props) {
+				provide(
+					WorkflowIdKey,
+					computed(() => props.workflowId),
+				);
+				provide(
+					EditorEnabledFeaturesKey,
+					computed<EditorEnabledFeatures>(() => ({
+						...PREVIEW_FEATURES,
+						readOnly: props.readOnly,
+					})),
+				);
+				return () => h(AutosaveProbe);
+			},
+		});
+
+		function takeProbe(): ReturnType<typeof useWorkflowSaving> {
+			const current = probe.current;
+			if (!current) throw new Error('AutosaveProbe did not initialise');
+			return current;
+		}
+
+		function mountPreview(workflowId: string, readOnly: boolean) {
+			probe.current = null;
+			mount(PreviewHostStub, { props: { workflowId, readOnly } });
+			return takeProbe();
+		}
+
+		/** Drains the autosave debounce plus the in-flight save promise. */
+		async function flushAutoSave() {
+			await vi.advanceTimersByTimeAsync(
+				getDebounceTime(DEBOUNCE_TIME.API.AUTOSAVE_MAX_WAIT) + 1000,
+			);
+		}
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			mockedStore(useSettingsStore).isAutosaveEnabled = true;
+			useWorkflowSaveStore().reset();
+			useUIStore().markStateDirty();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+			probe.current = null;
+		});
+
+		it('issues no create request when a preview with no stored workflow goes dirty', async () => {
+			// Template preview: the id is not in the list store, so the save path
+			// falls through to "save as new" and POSTs a nameless workflow.
+			const createSpy = vi
+				.spyOn(workflowsStore, 'createNewWorkflow')
+				.mockResolvedValue(createTestWorkflow({ id: 'created' }));
+
+			const { autoSaveWorkflow } = mountPreview('template-11754', true);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(createSpy).not.toHaveBeenCalled();
+		});
+
+		it('issues no update request when a preview of a stored workflow goes dirty', async () => {
+			// Workflow history and execution previews resolve to the live workflow id,
+			// so the save path PATCHes the real record.
+			const workflow = createTestWorkflow({
+				id: 'w-preview',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+			});
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+			const updateSpy = vi
+				.spyOn(workflowsStore, 'updateWorkflow')
+				.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+			const { autoSaveWorkflow } = mountPreview(workflow.id, true);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(updateSpy).not.toHaveBeenCalled();
+		});
+
+		it('still saves when the same host is not read-only', async () => {
+			// Control: proves the two assertions above fail for the right reason
+			// rather than because this harness never reaches the request.
+			const workflow = createTestWorkflow({
+				id: 'w-editable',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+			});
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+			const updateSpy = vi
+				.spyOn(workflowsStore, 'updateWorkflow')
+				.mockResolvedValue({ ...workflow, checksum: 'test-checksum' });
+
+			const { autoSaveWorkflow } = mountPreview(workflow.id, false);
+
+			autoSaveWorkflow();
+			await flushAutoSave();
+
+			expect(updateSpy).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -1,7 +1,8 @@
 import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { LocationQuery, NavigationGuardNext, useRouter } from 'vue-router';
-import { watch } from 'vue';
+import { computed, hasInjectionContext, inject, watch } from 'vue';
+import { EditorEnabledFeaturesKey } from '@/app/constants/injectionKeys';
 import { useMessage } from './useMessage';
 import { useI18n } from '@n8n/i18n';
 import { getDebounceTime } from '@n8n/composables/useDebounce';
@@ -69,6 +70,14 @@ export function useWorkflowSaving({
 	const settingsStore = useSettingsStore();
 	const workflowId = useWorkflowId();
 	const { removeInvalidNodeGroups } = useInvalidNodeGroupCleanup();
+
+	// Preview hosts scope their subtree read-only through the editor context. This
+	// composable is instantiated out-of-tree too (Pinia stores, push handlers),
+	// where `inject()` is unavailable — guard it the way `useWorkflowId` does.
+	const editorEnabledFeatures = hasInjectionContext()
+		? inject(EditorEnabledFeaturesKey, null)
+		: null;
+	const isReadOnlyCanvas = computed(() => editorEnabledFeatures?.value?.readOnly === true);
 
 	async function promptSaveUnsavedWorkflowChanges(
 		next: NavigationGuardNext,
@@ -603,6 +612,12 @@ export function useWorkflowSaving({
 	);
 
 	const scheduleAutoSave = () => {
+		// Don't schedule on a read-only canvas. Every autosave entry point funnels
+		// through here, so previews never write whatever marked them dirty.
+		if (isReadOnlyCanvas.value) {
+			return;
+		}
+
 		// Don't schedule if autosave is disabled via environment variable
 		if (!settingsStore.isAutosaveEnabled) {
 			return;
@@ -634,6 +649,15 @@ export function useWorkflowSaving({
 		}
 		saveStore.setAutoSaveState(AutoSaveState.Idle);
 	};
+
+	// Re-arm when a host lifts read-only with changes still pending — the Instance
+	// AI preview locks the canvas while its agent edits, and nothing else would
+	// save what the agent wrote. Mirrors the AI-builder re-arm in NodeView.
+	watch(isReadOnlyCanvas, (isReadOnly, wasReadOnly) => {
+		if (wasReadOnly && !isReadOnly && uiStore.stateIsDirty) {
+			scheduleAutoSave();
+		}
+	});
 
 	// Watch for network coming back online
 	watch(


### PR DESCRIPTION
## Summary

Failing regression cover for a gap found while verifying #36023 (the read-only autosave gate).

The gate on `scheduleAutoSave()` reads `EditorEnabledFeaturesKey` through `inject`, so it only covers composable instances built inside a preview host's subtree. `builder.store.ts` and the `executionFinished` push handler build the composable out-of-tree, where a host's provide is invisible — and every instance owns a reconnect watcher that fires `scheduleAutoSave()` when the backend health check flips offline and back while the app-wide dirty flag is set. A preview sets that flag (credential auto-select).

Result on `ado-5764-preview-autosave-readonly-gate`: a template preview resumes the nameless-`POST` retry loop after any reconnect, and an execution preview issues an accepted `PATCH` against the live workflow record.

Two cases, asserting the observable rather than a fix shape:

- a preview issues no create request when the connection returns
- a preview of a stored workflow issues no update request when the connection returns

Both fail on the gate branch: 4 create calls on the template shape, 1 update call on a stored workflow. Test-only — no product code.

Base branch is `ado-5764-preview-autosave-readonly-gate` so the red is visible against the gate, not against master.

## Related tickets

https://linear.app/n8n/issue/ADO-5764

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Tests included. *(These are the tests; they are expected to be red until the gap is closed.)*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

