### PR TITLE
test(ai-builder): Let a case declare a credential already broken before the conversation started (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/build-workflow-seed-cleanup.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/build-workflow-seed-cleanup.test.ts
@@ -153,4 +153,28 @@ describe('buildWorkflow declared credentials', () => {
 			['cred-seeded'],
 		);
 	});
+
+	it('filters an already-broken credential out of the connection-test bypass list', async () => {
+		const setThreadCredentialAllowlist = vi.fn().mockResolvedValue(undefined);
+		const createCredential = vi
+			.fn()
+			.mockResolvedValueOnce({ id: 'cred-working' })
+			.mockResolvedValueOnce({ id: 'cred-broken' });
+		const client = makeClient({ setThreadCredentialAllowlist, createCredential });
+
+		const build = await buildWorkflow({
+			client,
+			...baseConfig,
+			credentials: [{ type: 'slackApi' }, { type: 'notionApi', valid: false }],
+		});
+
+		expect(build.success).toBe(true);
+		// Both credentials are created for real and visible to the build (2nd arg) —
+		// only the one NOT marked already-broken bypasses its connection test (3rd arg).
+		expect(setThreadCredentialAllowlist).toHaveBeenCalledWith(
+			expect.any(String),
+			['cred-working', 'cred-broken'],
+			['cred-working'],
+		);
+	});
 });

--- a/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/build-workflow.ts
@@ -425,11 +425,22 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 			nameCounts: credentialNameCounts,
 		});
 		const seededCredentialIds = createdCredentials.map((c) => c.id);
+		// `createDeclaredCredentials` returns one entry per `declaredCredentials`, in
+		// the same order — index-zip to find which seeded ids the case marked
+		// already-broken (`valid: false`) and must NOT bypass, so their real
+		// connection test runs and fails.
+		const bypassCredentialTestIds = createdCredentials
+			.filter((_, i) => declaredCredentials[i]?.valid !== false)
+			.map((c) => c.id);
 		try {
 			// A seeded credential models one the user already has connected, so its
 			// connection test resolves as passing — same as one set up on a card
 			// during the run. Both carry a placeholder token that would really fail.
-			await client.setThreadCredentialAllowlist(threadId, seededCredentialIds, seededCredentialIds);
+			await client.setThreadCredentialAllowlist(
+				threadId,
+				seededCredentialIds,
+				bypassCredentialTestIds,
+			);
 		} catch (error: unknown) {
 			// Only a missing endpoint (older backend) may degrade to the legacy
 			// unpinned view, and only for cases that declared nothing — any other
@@ -598,7 +609,7 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 				...(credentialViewPinned
 					? {
 							allowlistedCredentialIds: seededCredentialIds,
-							bypassCredentialTestIds: seededCredentialIds,
+							bypassCredentialTestIds,
 							createdCredentialIds: config.createdCredentialIds,
 							credentialNameCounts,
 						}

--- a/packages/@n8n/instance-ai/evaluations/harness/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/schema.ts
@@ -166,6 +166,7 @@ const evalTestCaseObjectSchema = z
 							message: `unknown credential type — add a template to evaluations/credentials/seeder.ts (supported: ${[...SUPPORTED_CREDENTIAL_TYPES].join(', ')})`,
 						}),
 					name: z.string().min(1).optional(),
+					valid: z.boolean().optional(),
 				}),
 			)
 			.optional(),

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -210,6 +210,12 @@ export interface TestCaseCredential {
 	type: string;
 	/** Display name; defaults to the template's name, auto-suffixed on duplicates. */
 	name?: string;
+	/** Defaults to true. false models a credential that was already broken before
+	 *  the conversation started (expired/revoked/scope-changed) — left off the
+	 *  connection-test bypass list, so its real test runs and fails. Distinct from
+	 *  a credential set up on a card mid-conversation (UserProxyLlm), which always
+	 *  passes. */
+	valid?: boolean;
 }
 
 export interface WorkflowTestCase {


### PR DESCRIPTION
## Summary

Follow-up to #35675, which made every seeded credential (`credentials[]`) pass its connection test — matching a credential the simulated user sets up on a card. That left no way to model a credential that was already broken *before* the conversation started (expired/revoked/scope changed) — a real production situation, and a different one from the card path (which models a token that just stopped working mid-conversation).

`credentials[].valid` defaults to `true`. A `false` entry is still created for real (so the build sees it, same as any declared credential), but it's left off the connection-test bypass list, so its real connection test runs and fails.

- `evaluations/types.ts` — `valid?: boolean` on `TestCaseCredential`
- `evaluations/harness/schema.ts` — `valid: z.boolean().optional()` beside `name`
- `evaluations/harness/build-workflow.ts` — index-zip `createdCredentials` against `declaredCredentials` (same order) to build a `bypassCredentialTestIds` list that excludes anything marked `valid: false`, used at both call sites (the initial pin and the multi-turn config passed through for mid-run credential creation)

Sibling lang-tracer PR (the harness only matters once the authoring side can actually carry `valid` through instead of dropping it): https://github.com/n8n-io/lang-tracer/pull/131

## How to test

```
cd packages/@n8n/instance-ai
pnpm test evaluations/__tests__/build-workflow-seed-cleanup.test.ts
```

The new test declares two credentials, one default (`valid` omitted) and one `valid: false`, and asserts `setThreadCredentialAllowlist` is called with both ids in the allowlist (2nd arg) but only the valid one in the bypass list (3rd arg).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-397

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- eval-harness authoring doc (.agents/skills/create-instance-ai-eval/case-shapes.md) update deferred to a follow-up, per the sibling lang-tracer design doc -->
- [x] Tests included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

