### PR TITLE
test(cli): Remove clock race from flaky scheduled-task re-claim test

### DIFF
--- a/packages/cli/test/integration/scheduling/executor-repository.test.ts
+++ b/packages/cli/test/integration/scheduling/executor-repository.test.ts
@@ -461,6 +461,7 @@ describe('ScheduledTaskRepository executor methods', () => {
 		it('bumps the epoch again on re-claim after a reschedule', async () => {
 			const { id, epoch } = await claimOne();
 			await taskRepository.rescheduleTask({ host: HOST_A, id, claimedEpoch: epoch }, 0, 'retry');
+			await taskRepository.update(id, { runAt: past() });
 
 			const [reclaimed] = await taskRepository.claimDueTasks(claimOpts({ host: HOST_B }));
 			expect(reclaimed.id).toBe(id);


### PR DESCRIPTION
## Summary

`executor-repository.test.ts`'s `'bumps the epoch again on re-claim after a reschedule'` flakes on CI:

```
TypeError: Cannot read properties of undefined (reading 'id')
 ❯ test/integration/scheduling/executor-repository.test.ts:466:21
```

`claimDueTasks` returned `[]`, so the destructure produced `undefined`.

The test rescheduled with `backoffMs: 0`, which makes `rescheduleTask` stamp `runAt` at the database's current timestamp, and then claimed with `claimOpts()`'s default `lookaheadMs: 0`. The two timestamps come from separate round-trips and the dialects round them differently (Postgres `CURRENT_TIMESTAMP(3)` rounds, SQLite `STRFTIME('%f')` truncates), so `runAt <= now()` could miss by a millisecond and the claim take nothing. It was the only test in the file using an exactly-zero window; every other one dates `runAt` into the past via the `past()` helper.

The fix does the same here: date `runAt` into the past before claiming, so the test turns on the epoch bump it is named for rather than on the database clock.

Test-only. No product code changed.

## Related tickets

https://linear.app/n8n/issue/CAT-4033

## Review / Merge checklist

- [x] PR title and description are follow [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md).
- [x] Tests included.

## How to test

```bash
cd packages/cli
pnpm test:integration test/integration/scheduling/executor-repository.test.ts
pnpm test:postgres:tc test/integration/scheduling/executor-repository.test.ts
```

Verified locally: 68/68 on SQLite (and 20 consecutive runs, 0 failures) and 68/68 on Postgres via testcontainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

