### PR TITLE
feat(API): Add endpoint to create role-mapping rules

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -193,6 +193,7 @@ export {
 	RoleListQueryPublicDto,
 } from './roles/role-public.dto';
 export { CreateRoleMappingRuleDto } from './roles/create-role-mapping-rule.dto';
+export { RoleMappingRulePublicDto } from './roles/role-mapping-rule-public.dto';
 export {
 	PatchRoleMappingRuleDto,
 	type PatchRoleMappingRuleInput,

--- a/packages/@n8n/api-types/src/dto/roles/role-mapping-rule-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/role-mapping-rule-public.dto.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+export class RoleMappingRulePublicDto extends Z.class({
+	id: z.string(),
+	expression: z.string(),
+	role: z.string(),
+	type: z.enum(['instance', 'project']),
+	order: z.number().int(),
+	projectIds: z.array(z.string()),
+	createdAt: z.string().datetime(),
+	updatedAt: z.string().datetime(),
+}) {}

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -112,6 +112,7 @@ export const API_KEY_RESOURCES = {
 	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	insights: ['read'] as const,
 	role: ['manage', 'manageProject', 'list'] as const,
+	roleMappingRule: ['create'] as const,
 } as const;
 
 export const GLOBAL_OWNER_ROLE_SLUG = 'global:owner';

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -90,6 +90,7 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'insights:read',
 	'role:manage',
 	'role:list',
+	'roleMappingRule:create',
 ];
 
 export const ADMIN_API_KEY_SCOPES: ApiKeyScope[] = OWNER_API_KEY_SCOPES;

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.controller.ee.test.ts
@@ -109,7 +109,7 @@ describe('RoleMappingRuleController', () => {
 			const result = await controller.create(req, res, body);
 
 			expect(result).toEqual(created);
-			expect(roleMappingRuleService.create).toHaveBeenCalledWith(body);
+			expect(roleMappingRuleService.create).toHaveBeenCalledWith(body, req.user);
 		});
 	});
 

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-mapping-rule.service.ee.test.ts
@@ -5,6 +5,8 @@ import { RoleMappingRuleService } from '@/modules/provisioning.ee/role-mapping-r
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { EventService } from '@/events/event.service';
+import type { UserLike } from '@/events/maps/relay.event-map';
 import type {
 	Project,
 	ProjectRepository,
@@ -17,12 +19,16 @@ import type {
 const roleMappingRuleRepository = mock<RoleMappingRuleRepository>();
 const roleRepository = mock<RoleRepository>();
 const projectRepository = mock<ProjectRepository>();
+const eventService = mock<EventService>();
 
 const service = new RoleMappingRuleService(
 	roleMappingRuleRepository,
 	roleRepository,
 	projectRepository,
+	eventService,
 );
+
+const testUser: UserLike = { id: 'user-1', email: 'user@example.com' };
 
 const globalRole: Role = {
 	slug: 'global:member',
@@ -78,34 +84,43 @@ describe('RoleMappingRuleService', () => {
 	describe('create', () => {
 		it('should reject project type without projectIds', async () => {
 			await expect(
-				service.create({
-					expression: 'true',
-					role: 'project:editor',
-					type: 'project',
-					order: 0,
-				}),
+				service.create(
+					{
+						expression: 'true',
+						role: 'project:editor',
+						type: 'project',
+						order: 0,
+					},
+					testUser,
+				),
 			).rejects.toThrow(BadRequestError);
 
 			await expect(
-				service.create({
-					expression: 'true',
-					role: 'project:editor',
-					type: 'project',
-					order: 0,
-					projectIds: [],
-				}),
+				service.create(
+					{
+						expression: 'true',
+						role: 'project:editor',
+						type: 'project',
+						order: 0,
+						projectIds: [],
+					},
+					testUser,
+				),
 			).rejects.toThrow(BadRequestError);
 		});
 
 		it('should reject instance type with non-empty projectIds', async () => {
 			await expect(
-				service.create({
-					expression: 'true',
-					role: 'global:member',
-					type: 'instance',
-					order: 0,
-					projectIds: ['proj-1'],
-				}),
+				service.create(
+					{
+						expression: 'true',
+						role: 'global:member',
+						type: 'instance',
+						order: 0,
+						projectIds: ['proj-1'],
+					},
+					testUser,
+				),
 			).rejects.toThrow(BadRequestError);
 		});
 
@@ -113,12 +128,15 @@ describe('RoleMappingRuleService', () => {
 			roleRepository.findOne.mockResolvedValue(null);
 
 			await expect(
-				service.create({
-					expression: 'true',
-					role: 'global:missing',
-					type: 'instance',
-					order: 0,
-				}),
+				service.create(
+					{
+						expression: 'true',
+						role: 'global:missing',
+						type: 'instance',
+						order: 0,
+					},
+					testUser,
+				),
 			).rejects.toThrow(NotFoundError);
 		});
 
@@ -126,12 +144,15 @@ describe('RoleMappingRuleService', () => {
 			roleRepository.findOne.mockResolvedValue(projectRole);
 
 			await expect(
-				service.create({
-					expression: 'true',
-					role: 'project:editor',
-					type: 'instance',
-					order: 0,
-				}),
+				service.create(
+					{
+						expression: 'true',
+						role: 'project:editor',
+						type: 'instance',
+						order: 0,
+					},
+					testUser,
+				),
 			).rejects.toThrow(BadRequestError);
 		});
 
@@ -139,13 +160,16 @@ describe('RoleMappingRuleService', () => {
 			roleRepository.findOne.mockResolvedValue(globalRole);
 
 			await expect(
-				service.create({
-					expression: 'true',
-					role: 'global:member',
-					type: 'project',
-					order: 0,
-					projectIds: ['p1'],
-				}),
+				service.create(
+					{
+						expression: 'true',
+						role: 'global:member',
+						type: 'project',
+						order: 0,
+						projectIds: ['p1'],
+					},
+					testUser,
+				),
 			).rejects.toThrow(BadRequestError);
 		});
 
@@ -154,13 +178,16 @@ describe('RoleMappingRuleService', () => {
 			projectRepository.findBy.mockResolvedValue([{ id: 'p1' } as Project]);
 
 			await expect(
-				service.create({
-					expression: 'true',
-					role: 'project:editor',
-					type: 'project',
-					order: 0,
-					projectIds: ['p1', 'p2'],
-				}),
+				service.create(
+					{
+						expression: 'true',
+						role: 'project:editor',
+						type: 'project',
+						order: 0,
+						projectIds: ['p1', 'p2'],
+					},
+					testUser,
+				),
 			).rejects.toThrow(BadRequestError);
 		});
 
@@ -191,12 +218,15 @@ describe('RoleMappingRuleService', () => {
 
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(loadedRule);
 
-			const result = await service.create({
-				expression: savedRule.expression,
-				role: globalRole.slug,
-				type: 'instance',
-				order: 2,
-			});
+			const result = await service.create(
+				{
+					expression: savedRule.expression,
+					role: globalRole.slug,
+					type: 'instance',
+					order: 2,
+				},
+				testUser,
+			);
 
 			expect(result).toEqual({
 				id: savedRule.id,
@@ -211,6 +241,13 @@ describe('RoleMappingRuleService', () => {
 
 			expect(roleMappingRuleRepository.save).toHaveBeenCalledTimes(1);
 			expect(projectRepository.findBy).not.toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledWith('role-mapping-rule-created', {
+				user: { id: testUser.id, email: testUser.email },
+				ruleId: savedRule.id,
+				ruleType: 'instance',
+				expression: savedRule.expression,
+				role: globalRole.slug,
+			});
 		});
 
 		it('should create a project rule linked to projects', async () => {
@@ -237,13 +274,16 @@ describe('RoleMappingRuleService', () => {
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
 
 			const projectIds = [projA.id, projB.id];
-			const result = await service.create({
-				expression: 'true',
-				role: projectRole.slug,
-				type: 'project',
-				order: 1,
-				projectIds,
-			});
+			const result = await service.create(
+				{
+					expression: 'true',
+					role: projectRole.slug,
+					type: 'project',
+					order: 1,
+					projectIds,
+				},
+				testUser,
+			);
 
 			expect(result.projectIds).toEqual(expect.arrayContaining(projectIds));
 			expect(result.projectIds).toHaveLength(2);
@@ -273,13 +313,16 @@ describe('RoleMappingRuleService', () => {
 			} as unknown as RoleMappingRule);
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
 
-			const result = await service.create({
-				expression: 'true',
-				role: projectRole.slug,
-				type: 'project',
-				order: 1,
-				projectIds: [projA.id, projA.id],
-			});
+			const result = await service.create(
+				{
+					expression: 'true',
+					role: projectRole.slug,
+					type: 'project',
+					order: 1,
+					projectIds: [projA.id, projA.id],
+				},
+				testUser,
+			);
 
 			expect(result.projectIds).toEqual([projA.id]);
 			expect(projectRepository.findBy).toHaveBeenCalledTimes(1);
@@ -309,11 +352,14 @@ describe('RoleMappingRuleService', () => {
 			}));
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
 
-			await service.create({
-				expression: 'claims.c',
-				role: globalRole.slug,
-				type: 'instance',
-			});
+			await service.create(
+				{
+					expression: 'claims.c',
+					role: globalRole.slug,
+					type: 'instance',
+				},
+				testUser,
+			);
 
 			// applyOrder should renumber [rule-a, rule-b, rule-c] to [0, 1, 2]
 			expect(defaultUpdateSpy).toHaveBeenCalledWith(
@@ -357,12 +403,15 @@ describe('RoleMappingRuleService', () => {
 			}));
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
 
-			await service.create({
-				expression: 'claims.new',
-				role: globalRole.slug,
-				type: 'instance',
-				order: 0,
-			});
+			await service.create(
+				{
+					expression: 'claims.new',
+					role: globalRole.slug,
+					type: 'instance',
+					order: 0,
+				},
+				testUser,
+			);
 
 			// applyOrder should renumber [rule-new, rule-a, rule-b] to [0, 1, 2]
 			expect(defaultUpdateSpy).toHaveBeenCalledWith(
@@ -416,11 +465,14 @@ describe('RoleMappingRuleService', () => {
 				.mockResolvedValueOnce(savedRule);
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
 
-			await service.create({
-				expression: 'claims.new',
-				role: globalRole.slug,
-				type: 'instance',
-			});
+			await service.create(
+				{
+					expression: 'claims.new',
+					role: globalRole.slug,
+					type: 'instance',
+				},
+				testUser,
+			);
 
 			expect(roleMappingRuleRepository.find).toHaveBeenCalledTimes(2);
 			expect(roleMappingRuleRepository.save).toHaveBeenCalledTimes(2);
@@ -459,12 +511,15 @@ describe('RoleMappingRuleService', () => {
 			}));
 			roleMappingRuleRepository.findOneOrFail.mockResolvedValue(savedRule);
 
-			await service.create({
-				expression: 'claims.new',
-				role: globalRole.slug,
-				type: 'instance',
-				order: 999,
-			});
+			await service.create(
+				{
+					expression: 'claims.new',
+					role: globalRole.slug,
+					type: 'instance',
+					order: 999,
+				},
+				testUser,
+			);
 
 			// Clamped to end: [rule-a, rule-new] → orders [0, 1]
 			expect(defaultUpdateSpy).toHaveBeenCalledWith(

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.controller.ee.ts
@@ -60,17 +60,7 @@ export class RoleMappingRuleController {
 			return res.status(403).json({ message: 'Provisioning is not licensed' });
 		}
 
-		const result = await this.roleMappingRuleService.create(body);
-
-		this.eventService.emit('role-mapping-rule-created', {
-			user: { id: req.user.id, email: req.user.email },
-			ruleId: result.id,
-			ruleType: result.type,
-			expression: result.expression,
-			role: result.role,
-		});
-
-		return result;
+		return await this.roleMappingRuleService.create(body, req.user);
 	}
 
 	@Post('/:id/move')

--- a/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-mapping-rule.service.ee.ts
@@ -17,6 +17,8 @@ import type { z } from 'zod';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { EventService } from '@/events/event.service';
+import type { UserLike } from '@/events/maps/relay.event-map';
 
 import {
 	assertAndNormalizeProjectIdsForRuleType,
@@ -47,6 +49,7 @@ export class RoleMappingRuleService {
 		private readonly roleMappingRuleRepository: RoleMappingRuleRepository,
 		private readonly roleRepository: RoleRepository,
 		private readonly projectRepository: ProjectRepository,
+		private readonly eventService: EventService,
 	) {}
 
 	async list(query: ListRoleMappingRuleQueryInput): Promise<RoleMappingRuleListResponse> {
@@ -80,7 +83,7 @@ export class RoleMappingRuleService {
 		};
 	}
 
-	async create(dto: CreateRoleMappingRuleInput): Promise<RoleMappingRuleResponse> {
+	async create(dto: CreateRoleMappingRuleInput, user: UserLike): Promise<RoleMappingRuleResponse> {
 		const uniqueProjectIds = assertAndNormalizeProjectIdsForRuleType(dto.type, dto.projectIds, []);
 
 		const role = await this.roleRepository.findOne({ where: { slug: dto.role } });
@@ -106,7 +109,17 @@ export class RoleMappingRuleService {
 			relations: ['projects', 'role'],
 		});
 
-		return this.toResponse(loaded);
+		const result = this.toResponse(loaded);
+
+		this.eventService.emit('role-mapping-rule-created', {
+			user: { id: user.id, email: user.email },
+			ruleId: result.id,
+			ruleType: result.type,
+			expression: result.expression,
+			role: result.role,
+		});
+
+		return result;
 	}
 
 	private async saveWithOrderRetry(

--- a/packages/cli/src/public-api/v1/controllers/index.ts
+++ b/packages/cli/src/public-api/v1/controllers/index.ts
@@ -3,6 +3,7 @@
  * decorator metadata is registered before PublicApiControllerRegistry /
  * scope-parity / discover run.
  */
+import './role-mapping-rules.public.controller';
 import './roles.public.controller';
 import './tags.public.controller';
 import './workflows.public.controller';

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -15,7 +15,6 @@ import {
 import type { Response } from 'express';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { EventService } from '@/events/event.service';
 import { RoleMappingRuleService } from '@/modules/provisioning.ee/role-mapping-rule.service.ee';
 
 @PublicApiController('/role-mapping-rules')
@@ -23,7 +22,6 @@ export class RoleMappingRulesPublicController {
 	constructor(
 		private readonly roleMappingRuleService: RoleMappingRuleService,
 		private readonly licenseState: LicenseState,
-		private readonly eventService: EventService,
 	) {}
 
 	@Post('/')
@@ -44,15 +42,7 @@ export class RoleMappingRulesPublicController {
 			throw new ForbiddenError('Provisioning is not licensed');
 		}
 
-		const rule = await this.roleMappingRuleService.create(body);
-
-		this.eventService.emit('role-mapping-rule-created', {
-			user: { id: req.user.id, email: req.user.email },
-			ruleId: rule.id,
-			ruleType: rule.type,
-			expression: rule.expression,
-			role: rule.role,
-		});
+		const rule = await this.roleMappingRuleService.create(body, req.user);
 
 		return {
 			id: rule.id,

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -35,7 +35,6 @@ export class RoleMappingRulesPublicController {
 	@ApiTags(['RoleMappingRule'])
 	@ApiResponse(201, RoleMappingRulePublicDto)
 	@ApiErrorResponse(404)
-	@ApiErrorResponse(409)
 	async createRoleMappingRule(
 		req: AuthenticatedRequest,
 		_res: Response,

--- a/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/role-mapping-rules.public.controller.ts
@@ -1,0 +1,69 @@
+import { CreateRoleMappingRuleDto, RoleMappingRulePublicDto } from '@n8n/api-types';
+import { LicenseState } from '@n8n/backend-common';
+import { AuthenticatedRequest } from '@n8n/db';
+import {
+	ApiDescription,
+	ApiErrorResponse,
+	ApiKeyScope,
+	ApiResponse,
+	ApiSummary,
+	ApiTags,
+	Body,
+	Post,
+	PublicApiController,
+} from '@n8n/decorators';
+import type { Response } from 'express';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { EventService } from '@/events/event.service';
+import { RoleMappingRuleService } from '@/modules/provisioning.ee/role-mapping-rule.service.ee';
+
+@PublicApiController('/role-mapping-rules')
+export class RoleMappingRulesPublicController {
+	constructor(
+		private readonly roleMappingRuleService: RoleMappingRuleService,
+		private readonly licenseState: LicenseState,
+		private readonly eventService: EventService,
+	) {}
+
+	@Post('/')
+	@ApiKeyScope('roleMappingRule:create')
+	@ApiSummary('Create a role-mapping rule')
+	@ApiDescription(
+		'Creates a rule that maps an identity-provider claim expression to a role. Set `type` to `instance` for a rule granting a global role, or `project` for a rule granting a project role on the projects named in `projectIds`. Omitting `order` appends the rule to the end of the evaluation order for its type.',
+	)
+	@ApiTags(['RoleMappingRule'])
+	@ApiResponse(201, RoleMappingRulePublicDto)
+	@ApiErrorResponse(404)
+	@ApiErrorResponse(409)
+	async createRoleMappingRule(
+		req: AuthenticatedRequest,
+		_res: Response,
+		@Body body: CreateRoleMappingRuleDto,
+	): Promise<RoleMappingRulePublicDto> {
+		if (!this.licenseState.isProvisioningLicensed()) {
+			throw new ForbiddenError('Provisioning is not licensed');
+		}
+
+		const rule = await this.roleMappingRuleService.create(body);
+
+		this.eventService.emit('role-mapping-rule-created', {
+			user: { id: req.user.id, email: req.user.email },
+			ruleId: rule.id,
+			ruleType: rule.type,
+			expression: rule.expression,
+			role: rule.role,
+		});
+
+		return {
+			id: rule.id,
+			expression: rule.expression,
+			role: rule.role,
+			type: rule.type,
+			order: rule.order,
+			projectIds: rule.projectIds,
+			createdAt: rule.createdAt,
+			updatedAt: rule.updatedAt,
+		};
+	}
+}

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/createRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/createRoleMappingRule.generated.yml
@@ -84,5 +84,3 @@ responses:
     $ref: ../../../../shared/spec/responses/forbidden.yml
   '404':
     $ref: ../../../../shared/spec/responses/notFound.yml
-  '409':
-    $ref: ../../../../shared/spec/responses/conflict.yml

--- a/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/createRoleMappingRule.generated.yml
+++ b/packages/cli/src/public-api/v1/handlers/role-mapping-rules/spec/paths/createRoleMappingRule.generated.yml
@@ -1,0 +1,88 @@
+operationId: createRoleMappingRule
+tags:
+  - RoleMappingRule
+summary: Create a role-mapping rule
+description: Creates a rule that maps an identity-provider claim expression to a role. Set `type` to `instance` for a rule granting a global role, or `project` for a rule granting a project role on the projects named in `projectIds`. Omitting `order` appends the rule to the end of the evaluation order for its type.
+x-required-scope: roleMappingRule:create
+x-eov-operation-id: unreachable
+x-eov-operation-handler: v1/handlers/decorator-routed.handler
+x-decorator-routed: true
+requestBody:
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          expression:
+            type: string
+            minLength: 1
+          role:
+            type: string
+            minLength: 1
+            maxLength: 128
+          type:
+            type: string
+            enum:
+              - instance
+              - project
+          order:
+            type: integer
+            minimum: 0
+          projectIds:
+            type: array
+            items:
+              type: string
+        required:
+          - expression
+          - role
+          - type
+responses:
+  '201':
+    description: Operation successful.
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            id:
+              type: string
+            expression:
+              type: string
+            role:
+              type: string
+            type:
+              type: string
+              enum:
+                - instance
+                - project
+            order:
+              type: integer
+            projectIds:
+              type: array
+              items:
+                type: string
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+          required:
+            - id
+            - expression
+            - role
+            - type
+            - order
+            - projectIds
+            - createdAt
+            - updatedAt
+  '400':
+    $ref: ../../../../shared/spec/responses/badRequest.yml
+  '401':
+    $ref: ../../../../shared/spec/responses/unauthorized.yml
+  '403':
+    $ref: ../../../../shared/spec/responses/forbidden.yml
+  '404':
+    $ref: ../../../../shared/spec/responses/notFound.yml
+  '409':
+    $ref: ../../../../shared/spec/responses/conflict.yml

--- a/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
+++ b/packages/cli/src/public-api/v1/openapi.decorator-routes.generated.yml
@@ -3,6 +3,9 @@ info:
   title: decorator-routes
   version: 0.0.0
 paths:
+  /role-mapping-rules:
+    post:
+      $ref: ./handlers/role-mapping-rules/spec/paths/createRoleMappingRule.generated.yml
   /roles:
     get:
       $ref: ./handlers/roles/spec/paths/getAllRoles.generated.yml

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -49,6 +49,8 @@ tags:
     description: Operations about projects
   - name: Role
     description: Operations about roles
+  - name: RoleMappingRule
+    description: Operations about identity-provider role-mapping rules
   - name: SecurityPolicy
     description: Operations about the instance security policy settings
   - name: SettingsLdap

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -1,0 +1,202 @@
+import { createTeamProject, testDb } from '@n8n/backend-test-utils';
+import { RoleMappingRuleRepository, type Project, type User } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { createOwnerWithApiKey } from '@test-integration/db/users';
+import { setupTestServer } from '@test-integration/utils';
+
+describe('Role mapping rules in Public API', () => {
+	let owner: User;
+	let teamProject: Project;
+
+	const testServer = setupTestServer({
+		endpointGroups: ['publicApi'],
+		enabledFeatures: ['feat:saml'],
+	});
+
+	const validInstancePayload = {
+		expression: 'claims.group === "admins"',
+		role: 'global:member',
+		type: 'instance' as const,
+		order: 0,
+	};
+
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['RoleMappingRule', 'Project', 'User']);
+		owner = await createOwnerWithApiKey();
+		teamProject = await createTeamProject(undefined, owner);
+	});
+
+	describe('POST /role-mapping-rules', () => {
+		it('creates an instance rule and returns 201', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send(validInstancePayload);
+
+			expect(response.status).toBe(201);
+			// Full-shape assertion also proves no extra fields leak from the entity.
+			expect(response.body).toEqual({
+				id: expect.any(String),
+				expression: validInstancePayload.expression,
+				role: 'global:member',
+				type: 'instance',
+				order: 0,
+				projectIds: [],
+				createdAt: expect.any(String),
+				updatedAt: expect.any(String),
+			});
+
+			const stored = await Container.get(RoleMappingRuleRepository).findOne({
+				where: { id: response.body.id },
+				relations: ['projects', 'role'],
+			});
+			expect(stored).not.toBeNull();
+			expect(stored!.expression).toBe(validInstancePayload.expression);
+			expect(stored!.role.slug).toBe('global:member');
+			expect(stored!.projects).toHaveLength(0);
+		});
+
+		it('creates a project rule linked to the given projects and returns 201', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send({
+					expression: 'claims.project === "alpha"',
+					role: 'project:editor',
+					type: 'project',
+					projectIds: [teamProject.id],
+				});
+
+			expect(response.status).toBe(201);
+			expect(response.body.type).toBe('project');
+			expect(response.body.projectIds).toEqual([teamProject.id]);
+		});
+
+		it('appends the rule when order is omitted', async () => {
+			const agent = testServer.publicApiAgentFor(owner);
+
+			const { expression, role, type } = validInstancePayload;
+			await agent.post('/role-mapping-rules').send(validInstancePayload).expect(201);
+
+			const appended = await agent
+				.post('/role-mapping-rules')
+				.send({ expression: `${expression} || false`, role, type });
+
+			expect(appended.status).toBe(201);
+			expect(appended.body.order).toBe(1);
+		});
+
+		it('rejects a malformed body with 400', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send({ ...validInstancePayload, expression: '' });
+
+			expect(response.status).toBe(400);
+		});
+
+		it('rejects a project rule without projectIds with 400', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send({ expression: 'true', role: 'project:editor', type: 'project' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('projectIds');
+		});
+
+		it('rejects an instance rule carrying projectIds with 400', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send({ ...validInstancePayload, projectIds: [teamProject.id] });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('projectIds must be omitted or empty');
+		});
+
+		it('rejects a role incompatible with the rule type with 400', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send({ ...validInstancePayload, role: 'project:editor' });
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('must use a global role');
+		});
+
+		it('rejects an unknown project id with 400', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send({
+					expression: 'true',
+					role: 'project:editor',
+					type: 'project',
+					projectIds: ['does-not-exist'],
+				});
+
+			expect(response.status).toBe(400);
+			expect(response.body.message).toContain('projects were not found');
+		});
+
+		it('rejects an unknown role slug with 404', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send({ ...validInstancePayload, role: 'global:nonexistent-role-slug-xyz' });
+
+			expect(response.status).toBe(404);
+			expect(response.body.message).toContain('Could not find role');
+		});
+
+		it('rejects with 401 without an API key', async () => {
+			const response = await testServer
+				.publicApiAgentWithoutApiKey()
+				.post('/role-mapping-rules')
+				.send(validInstancePayload);
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 401 with an invalid API key', async () => {
+			const response = await testServer
+				.publicApiAgentWithApiKey('invalid-key')
+				.post('/role-mapping-rules')
+				.send(validInstancePayload);
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 403 when the key lacks roleMappingRule:create', async () => {
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['user:read'] });
+
+			const response = await testServer
+				.publicApiAgentFor(scopedOwner)
+				.post('/role-mapping-rules')
+				.send(validInstancePayload);
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects with 403 when provisioning is not licensed', async () => {
+			testServer.license.disable('feat:saml');
+			testServer.license.disable('feat:oidc');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/role-mapping-rules')
+				.send(validInstancePayload);
+
+			expect(response.status).toBe(403);
+			expect(response.body.message).toBe('Provisioning is not licensed');
+
+			testServer.license.enable('feat:saml');
+		});
+	});
+});

--- a/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
+++ b/packages/cli/test/integration/public-api/role-mapping-rules.test.ts
@@ -1,6 +1,7 @@
 import { createTeamProject, testDb } from '@n8n/backend-test-utils';
 import { RoleMappingRuleRepository, type Project, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
+import assert from 'node:assert';
 
 import { createOwnerWithApiKey } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
@@ -39,7 +40,6 @@ describe('Role mapping rules in Public API', () => {
 				.send(validInstancePayload);
 
 			expect(response.status).toBe(201);
-			// Full-shape assertion also proves no extra fields leak from the entity.
 			expect(response.body).toEqual({
 				id: expect.any(String),
 				expression: validInstancePayload.expression,
@@ -55,10 +55,12 @@ describe('Role mapping rules in Public API', () => {
 				where: { id: response.body.id },
 				relations: ['projects', 'role'],
 			});
-			expect(stored).not.toBeNull();
-			expect(stored!.expression).toBe(validInstancePayload.expression);
-			expect(stored!.role.slug).toBe('global:member');
-			expect(stored!.projects).toHaveLength(0);
+
+			assert(stored, 'Rule should be stored in the database');
+
+			expect(stored.expression).toBe(validInstancePayload.expression);
+			expect(stored.role.slug).toBe('global:member');
+			expect(stored.projects).toHaveLength(0);
 		});
 
 		it('creates a project rule linked to the given projects and returns 201', async () => {
@@ -98,6 +100,7 @@ describe('Role mapping rules in Public API', () => {
 				.send({ ...validInstancePayload, expression: '' });
 
 			expect(response.status).toBe(400);
+			expect(response.body.message).toBe('String must contain at least 1 character(s)');
 		});
 
 		it('rejects a project rule without projectIds with 400', async () => {
@@ -107,7 +110,7 @@ describe('Role mapping rules in Public API', () => {
 				.send({ expression: 'true', role: 'project:editor', type: 'project' });
 
 			expect(response.status).toBe(400);
-			expect(response.body.message).toContain('projectIds');
+			expect(response.body.message).toBe('projectIds is required when type is project');
 		});
 
 		it('rejects an instance rule carrying projectIds with 400', async () => {
@@ -117,7 +120,9 @@ describe('Role mapping rules in Public API', () => {
 				.send({ ...validInstancePayload, projectIds: [teamProject.id] });
 
 			expect(response.status).toBe(400);
-			expect(response.body.message).toContain('projectIds must be omitted or empty');
+			expect(response.body.message).toBe(
+				'projectIds must be omitted or empty when type is instance',
+			);
 		});
 
 		it('rejects a role incompatible with the rule type with 400', async () => {
@@ -127,7 +132,7 @@ describe('Role mapping rules in Public API', () => {
 				.send({ ...validInstancePayload, role: 'project:editor' });
 
 			expect(response.status).toBe(400);
-			expect(response.body.message).toContain('must use a global role');
+			expect(response.body.message).toBe('Instance mapping rules must use a global role');
 		});
 
 		it('rejects an unknown project id with 400', async () => {
@@ -142,7 +147,7 @@ describe('Role mapping rules in Public API', () => {
 				});
 
 			expect(response.status).toBe(400);
-			expect(response.body.message).toContain('projects were not found');
+			expect(response.body.message).toBe('One or more projects were not found');
 		});
 
 		it('rejects an unknown role slug with 404', async () => {
@@ -152,7 +157,9 @@ describe('Role mapping rules in Public API', () => {
 				.send({ ...validInstancePayload, role: 'global:nonexistent-role-slug-xyz' });
 
 			expect(response.status).toBe(404);
-			expect(response.body.message).toContain('Could not find role');
+			expect(response.body.message).toBe(
+				'Could not find role with slug "global:nonexistent-role-slug-xyz"',
+			);
 		});
 
 		it('rejects with 401 without an API key', async () => {

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -11,6 +11,9 @@
 		"POST /roles": {
 			"status": "gap"
 		},
+		"POST /role-mapping-rules": {
+			"status": "gap"
+		},
 		"GET /settings/security-policy": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

* Adds Public API endpoint `POST /api/v1/role-mapping-rules` aligned with the Internal API version in anticipation of future migration of the `editor-ui`.
  * This is a thin `@PublicApiController` wrapper over the existing `RoleMappingRuleService.create` method which is the same method we use in the Internal API
  * Requires the provisioning licence (`feat:saml` or `feat:oidc`)  as with the Internal API
* Add `roleMappingRule:create` to `API_KEY_RESOURCES` and `OWNER_API_KEY_SCOPES

## How to test

```bash
curl -X POST http://localhost:5678/api/v1/role-mapping-rules \
  -H "X-N8N-API-KEY: $KEY" -H 'Content-Type: application/json' \
  -d '{"expression":"claims.group === \"admins\"","role":"global:member","type":"instance"}'
```

To fully test on a fresh instance, its worth creating the following:
* A new Project
* A Project Role

This will allow you to exercise the `type: project` branch of this endpoint.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-44

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

