### PR TITLE
build(editor): Add the `@n8n/frontend-vite-config` package (no-changelog)

### DIFF
--- a/packages/@n8n/frontend-vite-config/aliases.ts
+++ b/packages/@n8n/frontend-vite-config/aliases.ts
@@ -1,0 +1,61 @@
+import { resolve } from 'node:path';
+import type { Alias } from 'vite';
+
+import { frontendModuleAliases, frontendSourceAliases } from './source-packages.js';
+
+/**
+ * Workspace-resolution exceptions: packages reached *transitively*, so they are not declared
+ * dependencies of anyone and cannot sit in the source-packages table.
+ *
+ * `n8n-workflow`'s expression-sandboxing imports `astVisit` from `@n8n/tournament`, whose dist is
+ * CJS. Linked workspace packages skip optimizeDeps, so the dev server serves that file verbatim and
+ * the browser fails to parse a named export out of it; the build survives because rolldown interops
+ * CJS, but pays ~397 kB in defeated tree-shaking. Resolving to src avoids both.
+ */
+export const transitiveWorkspaceAliases = (packagesDir: string): Alias[] => [
+	{ find: '@n8n/tournament', replacement: resolve(packagesDir, '@n8n', 'tournament', 'src') },
+];
+
+/**
+ * Rewrites for third-party specifiers, unrelated to how workspace packages resolve.
+ *
+ * **Shell-only, deliberately out of `frontendAliases`:** these replacements are bare specifiers
+ * resolved from the consumer's own `node_modules`, and only editor-ui declares `lodash` and
+ * `stream-browserify`. Shared with a module's vitest, a value import of `stream` anywhere in its
+ * graph fails to resolve — latent today only because `n8n-workflow` imports `stream` as a type.
+ */
+export const vendorAliases = (): Alias[] => [
+	...['orderBy', 'camelCase', 'cloneDeep', 'startCase'].map((name) => ({
+		find: new RegExp(`^lodash.${name}$`, 'i'),
+		replacement: `lodash/${name}`,
+	})),
+	{ find: /^lodash\.(.+)$/, replacement: 'lodash/$1' },
+	// `n8n-workflow` reaches Node's `stream` in a browser graph.
+	{ find: 'stream', replacement: 'stream-browserify' },
+];
+
+/**
+ * Everything a frontend Vite or vitest config needs that is *not* specific to one package: the
+ * platform source mapping plus the transitive workspace exceptions. Every entry here rewrites to an
+ * absolute path under `packages/`, which is what makes the set safe to share from any directory —
+ * `aliases.test.ts` holds that line.
+ *
+ * Sibling modules are deliberately absent — `frontendModuleAliases` is exported separately because
+ * only the shell may resolve them. A module aliasing its siblings would let an accidental
+ * cross-module import resolve at test time, which is the boundary the module tsconfig base holds.
+ */
+export const frontendAliases = (packagesDir: string): Alias[] => [
+	...frontendSourceAliases(packagesDir),
+	...transitiveWorkspaceAliases(packagesDir),
+];
+
+/**
+ * The shell's full set: the shared aliases, the module mapping only it may resolve, and the vendor
+ * rewrites only it can resolve. Vendor rewrites stay last, where they sat before this package
+ * existed, so the shell's resolution order is unchanged by the move.
+ */
+export const shellAliases = (packagesDir: string): Alias[] => [
+	...frontendAliases(packagesDir),
+	...frontendModuleAliases(packagesDir),
+	...vendorAliases(),
+];

--- a/packages/@n8n/frontend-vite-config/biome.jsonc
+++ b/packages/@n8n/frontend-vite-config/biome.jsonc
@@ -1,0 +1,4 @@
+{
+	"$schema": "../../../node_modules/@biomejs/biome/configuration_schema.json",
+	"extends": ["../../../biome.jsonc"]
+}

--- a/packages/@n8n/frontend-vite-config/index.ts
+++ b/packages/@n8n/frontend-vite-config/index.ts
@@ -1,0 +1,14 @@
+export {
+	frontendAliases,
+	shellAliases,
+	transitiveWorkspaceAliases,
+	vendorAliases,
+} from './aliases.js';
+
+export {
+	frontendModuleAliases,
+	frontendSourceAliases,
+	// The tables themselves, for the guard test that checks them against tsconfig `paths`.
+	modulePackages,
+	sourcePackages,
+} from './source-packages.js';

--- a/packages/@n8n/frontend-vite-config/package.json
+++ b/packages/@n8n/frontend-vite-config/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@n8n/frontend-vite-config",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "peerDependencies": {
+    "vite": "catalog:"
+  },
+  "devDependencies": {
+    "@n8n/typescript-config": "workspace:*",
+    "typescript": "catalog:typescript",
+    "vite": "catalog:"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "clean": "rimraf dist .turbo",
+    "dev": "pnpm watch",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -p tsconfig.build.json",
+    "build:unchecked": "tsc -p tsconfig.build.json --noCheck",
+    "format": "biome format --write .",
+    "format:check": "biome ci .",
+    "watch": "tsc -p tsconfig.build.json --watch"
+  },
+  "license": "LicenseRef-n8n-sustainable-use"
+}

--- a/packages/@n8n/frontend-vite-config/source-packages.ts
+++ b/packages/@n8n/frontend-vite-config/source-packages.ts
@@ -1,0 +1,80 @@
+import { resolve } from 'node:path';
+import type { Alias } from 'vite';
+
+/**
+ * Workspace packages the frontend consumes from source rather than from `dist`, so that an edit in
+ * one of them hot-reloads the editor without a rebuild.
+ *
+ * Hand-maintained — a list you read and edit, not one derived from the filesystem. It has to stay
+ * in step with editor-ui's tsconfig `paths` and with `tsconfig.frontend-module.json`: when those
+ * disagreed, vue-tsc typechecked a package from `src` while the bundle was built from its `dist`.
+ * `editor-ui/vite/aliases.test.ts` fails when they diverge; add a package here and it will tell you
+ * what else to update. `dir` is relative to `packages/`.
+ *
+ * It lives in this package rather than in editor-ui because editor-ui is not its only consumer:
+ * every `packages/modules/<name>/frontend` needs the same mapping for its own vitest run, and a
+ * module cannot import from the shell it plugs into. The cost is one declared dependency per
+ * consumer — accepted deliberately over the earlier home inside `@n8n/vitest-config`, which needed
+ * no new edge but put frontend Vite resolution inside a test-config package.
+ *
+ * `entry: false` marks packages with no `src/index.ts`. Their `exports` map has no `.`, so a bare
+ * import of them does not resolve at all and must not be aliased.
+ */
+export const sourcePackages = [
+	{ name: '@n8n/api-types', dir: '@n8n/api-types' },
+	{ name: '@n8n/chat', dir: 'frontend/@n8n/chat' },
+	{ name: '@n8n/chat-hub', dir: '@n8n/chat-hub' },
+	{ name: '@n8n/composables', dir: 'frontend/@n8n/composables', entry: false },
+	{ name: '@n8n/constants', dir: '@n8n/constants' },
+	{ name: '@n8n/design-system', dir: 'frontend/@n8n/design-system' },
+	{ name: '@n8n/frontend-constants', dir: 'frontend/@n8n/frontend-constants', entry: false },
+	{ name: '@n8n/frontend-module-sdk', dir: 'frontend/@n8n/frontend-module-sdk' },
+	{ name: '@n8n/frontend-utils', dir: 'frontend/@n8n/frontend-utils', entry: false },
+	{ name: '@n8n/i18n', dir: 'frontend/@n8n/i18n' },
+	{ name: '@n8n/rest-api-client', dir: 'frontend/@n8n/rest-api-client' },
+	{ name: '@n8n/stores', dir: 'frontend/@n8n/stores' },
+	{ name: '@n8n/telemetry', dir: '@n8n/telemetry' },
+	{ name: '@n8n/utils', dir: '@n8n/utils', entry: false },
+];
+
+/**
+ * Feature module packages, appended by `n8n-module-sdk create`. Kept separate from the table
+ * above because only the shell resolves them: a module aliasing its siblings would let an
+ * accidental cross-module import resolve at test time, which is the boundary the module tsconfig
+ * base is there to hold.
+ *
+ * Empty until the first module lands under `packages/modules/`.
+ */
+export const modulePackages: Array<{ name: string; dir: string; entry?: boolean }> = [];
+
+const escapeForRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Each package gets a slash-delimited, anchored pair — `^@n8n/chat$` and `^@n8n/chat/(.+)$`. One
+ * open-ended `^@n8n/chat(.+)$` would match `@n8n/chat-hub/…` as well, and would leave the bare
+ * `@n8n/chat` unmatched: `(.+)` needs a character after the package name, which is how 115 bare
+ * `@n8n/stores` imports used to fall through to `dist`.
+ *
+ * Shared for the same reason the table is: twenty-eight regexes hand-written per consumer is
+ * twenty-eight chances to reintroduce that hole.
+ */
+const expand = (packagesDir: string, packages: typeof modulePackages): Alias[] =>
+	packages.flatMap(({ name, dir, entry = true }) => {
+		const src = resolve(packagesDir, dir, 'src');
+		const pattern = escapeForRegExp(name);
+
+		return [
+			...(entry
+				? [{ find: new RegExp(`^${pattern}$`), replacement: resolve(src, 'index.ts') }]
+				: []),
+			{ find: new RegExp(`^${pattern}/(.+)$`), replacement: `${src}/$1` },
+		];
+	});
+
+/** The platform mapping. Every frontend consumer needs this one, modules included. */
+export const frontendSourceAliases = (packagesDir: string): Alias[] =>
+	expand(packagesDir, sourcePackages);
+
+/** The module mapping. Only the shell needs this one. */
+export const frontendModuleAliases = (packagesDir: string): Alias[] =>
+	expand(packagesDir, modulePackages);

--- a/packages/@n8n/frontend-vite-config/tsconfig.build.json
+++ b/packages/@n8n/frontend-vite-config/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"extends": ["./tsconfig.json", "@n8n/typescript-config/tsconfig.build.go.json"],
+	"compilerOptions": {
+		"composite": true,
+		"rootDir": ".",
+		"outDir": "dist"
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["dist", "**/*.test.ts"]
+}

--- a/packages/@n8n/frontend-vite-config/tsconfig.json
+++ b/packages/@n8n/frontend-vite-config/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@n8n/typescript-config/tsconfig.common.go.json",
+	"compilerOptions": {
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler"
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2572,6 +2572,18 @@ importers:
         specifier: 'catalog:'
         version: 3.23.3(zod@3.25.76)
 
+  packages/@n8n/frontend-vite-config:
+    devDependencies:
+      '@n8n/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: catalog:typescript
+        version: 7.0.2
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)
+
   packages/@n8n/imap:
     dependencies:
       iconv-lite:


### PR DESCRIPTION
## Summary

Stage 2 of 6 re-landing #35642 as independently mergeable PRs. Nothing here is new work — every line is carved from `cat-3691-add-frontend-module-scaffolder-guide-and-shared-alias-helper`, which stays open as the reference until the chain lands. Stage 1 was #35957.

This stage adds the package that owns frontend Vite resolution. **Nothing imports it yet** — its first consumer is editor-ui in stage 3, and `packages/modules/*/frontend` follows in stage 4.

| File | Why |
| --- | --- |
| `source-packages.ts` | The hand-maintained table of workspace packages the frontend consumes from `src` instead of `dist`, and the regex expansion that turns it into aliases. |
| `aliases.ts` | The three sets built on top of it: the shared platform set, the transitive `@n8n/tournament` exception, and the shell-only vendor rewrites. |
| `index.ts` | The public surface — the alias factories plus the raw tables, which stage 3's drift guard reads. |
| `package.json`, `tsconfig*.json`, `biome.jsonc` | Standard config-package scaffold, same shape as `@n8n/vitest-config`. |
| `pnpm-lock.yaml` | The importer entry, 12 lines. |

It lives in its own package rather than inside editor-ui because editor-ui is not its only consumer: every `packages/modules/<name>/frontend` needs the same mapping for its own vitest run, and a module cannot import from the shell it plugs into.

## `private` vs `files: ["dist"]` — answering the open question

**Chose `private: true`.**

Both settle the symptom raised in review: with neither field, a publish packs `index.ts`, `aliases.ts` and `source-packages.ts` alongside the `dist` the single export actually points at. Only `private` settles the rest.

1. **Nothing outside the workspace consumes it.** Every consumer takes it as a **devDependency** — editor-ui in stage 3, each module package in stage 4+. `scripts/check-workspace-private-deps.mjs` only inspects runtime `dependencies`, so it stays satisfied (verified below).
2. **Leaving it public has a live cost.** `release-publish.yml` runs `.github/scripts/detect-new-packages.mjs` as a hard step, and it exits 1 for any non-private package npm has never seen. `HEAD https://registry.npmjs.org/@n8n%2Ffrontend-vite-config` returns **404**, so as a public package it would block the next release until someone manually first-publishes it and configures Trusted Publishing. `ci-detect-new-packages.yml` would also page `@release-captain` on merge — its own message says *"If a package is not intended for npm, set `"private": true`"*.
3. **`private` subsumes `files`.** A private package is never packed, so there is no `files` list to drift later — which is how `@n8n/vitest-config`'s list broke. That one is tracked separately and deliberately not copied here.

Precedent: `@n8n/eslint-config`, `@n8n/stylelint-config` and `@n8n/storybook` — the repo's other build-time config packages — are all `private: true`.

## One deviation from the reference branch

`modulePackages` ships **empty**. On the reference branch it is seeded with `@n8n/frontend-module-instance-registry` → `modules/instance-registry/frontend`, a package that does not exist until stage 4. Shipping that entry now would name a package that isn't there, and it would not stay contained: stage 3's drift guard iterates `[...sourcePackages, ...modulePackages]` and requires a matching `paths` entry, so `editor-ui/tsconfig.json` would have to point at the missing directory too. The one-line entry belongs with the module it names — **stage 4 adds it** next to `packages/modules/instance-registry/frontend/**`.

## How to test

Everything below was run on this branch.

```bash
pnpm install --frozen-lockfile
pnpm turbo build typecheck format:check --filter=@n8n/frontend-vite-config
node scripts/check-workspace-private-deps.mjs   # OK
node scripts/check-boundaries.mjs               # 160 issues vs baseline 169 — pass
```

The built `dist` loads and resolves as intended:

```
exports: frontendAliases, frontendModuleAliases, frontendSourceAliases, modulePackages,
         shellAliases, sourcePackages, transitiveWorkspaceAliases, vendorAliases

@n8n/stores        -> packages/frontend/@n8n/stores/src/index.ts   # bare specifier, not dist
@n8n/stores/useX   -> packages/frontend/@n8n/stores/src/useX
@n8n/chat-hub/api  -> packages/@n8n/chat-hub/src/api               # not swallowed by @n8n/chat
@n8n/tournament    -> packages/@n8n/tournament/src                 # transitive exception
@n8n/composables   -> UNMATCHED                                    # entry: false, no src/index.ts

shared set: 25 entries, 0 of them escaping packagesDir
shell set:  31 entries — the 6 vendor rewrites (`stream`, `lodash.*`) exist only here
```

Those last two lines are the invariants stage 3's `aliases.test.ts` locks down; the test arrives with its consumer.

**Carve hazard:** the reference branch predates master and its `pnpm-workspace.yaml` reverts `electron` 41.10.3 → 41.9.1, so stage 1 took hunks rather than whole files. This stage adds seven files that do not exist on master and edits no shared source file. The only shared file in the diff is `pnpm-lock.yaml`, regenerated by `pnpm install` rather than checked out — its delta is the 12-line importer entry and nothing else.

Counted size: **211 additions** (the gate excludes `pnpm-lock.yaml` and markdown). No `/size-limit-override` needed.

## Related Linear tickets, Github issues, and Community forum posts

Stage 2 of 6. Follows #35957. Parent: #35642, which stays open as the reference implementation until stage 6 merges.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- The module guide lands in stage 6. -->
- [x] Tests included. <!-- Consumer-free; the alias drift guard that covers this table arrives with its consumer in stage 3. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

