### PR TITLE
fix(Kafka Trigger Node): Refuse activation when the topic does not exist

### DIFF
--- a/packages/nodes-base/nodes/Kafka/test/mocks/confluent-kafka.ts
+++ b/packages/nodes-base/nodes/Kafka/test/mocks/confluent-kafka.ts
@@ -42,7 +42,21 @@ export interface FakeConsumer {
 	};
 }
 
+/** The admin client `assertTopicExists` uses to verify the topic. */
+export interface FakeAdmin {
+	connect: Mock;
+	fetchTopicMetadata: Mock;
+	disconnect: Mock;
+}
+
+/** librdkafka's code for a topic the broker does not know, as the real library exposes it. */
+export const UNKNOWN_TOPIC_OR_PART = 3;
+
+/** librdkafka's code for a topic name the broker rejects outright (also used for patterns). */
+export const TOPIC_EXCEPTION = 17;
+
 const consumers: FakeConsumer[] = [];
+const admins: FakeAdmin[] = [];
 const clientConfigs: KafkaJS.CommonConstructorConfig[] = [];
 
 /** Joined by default, so the startup join wait costs the suites nothing. */
@@ -57,6 +71,67 @@ export function setFakeConsumerAssignment(
 	assignment: () => Array<{ topic: string; partition: number }>,
 ): void {
 	nextAssignment = assignment;
+}
+
+/**
+ * How the next call(s) to `fetchTopicMetadata` answer, one entry consumed per
+ * call across every fake admin. A test that needs a missing topic (or an
+ * inconclusive check) queues outcomes before acting; once the queue is empty,
+ * calls resolve with a healthy topic.
+ */
+const metadataOutcomeQueue: Array<() => Promise<unknown>> = [];
+
+/** How the next fake admin answers `disconnect()`. */
+let nextDisconnectError: Error | undefined;
+
+/**
+ * Makes the next `fetchTopicMetadata` call reject with `error`. Queue it more
+ * than once to fail several calls in a row, e.g. across a retry.
+ */
+export function failNextTopicMetadata(error: Error): void {
+	metadataOutcomeQueue.push(async () => {
+		throw error;
+	});
+}
+
+/** Makes the next admin's `disconnect()` reject with `error`. */
+export function failNextAdminDisconnect(error: Error): void {
+	nextDisconnectError = error;
+}
+
+/** An error shaped like the library's rejection for a topic the broker does not know. */
+export function unknownTopicError(): Error & { code: number } {
+	return Object.assign(new Error('Broker: Unknown topic or partition'), {
+		name: 'KafkaJSProtocolError',
+		code: UNKNOWN_TOPIC_OR_PART,
+	});
+}
+
+/** An error shaped like the library's rejection for a topic name the broker rejects outright. */
+export function invalidTopicNameError(): Error & { code: number } {
+	return Object.assign(new Error('Broker: Invalid topic'), {
+		name: 'KafkaJSProtocolError',
+		code: TOPIC_EXCEPTION,
+	});
+}
+
+function createFakeAdmin(): FakeAdmin {
+	const disconnectError = nextDisconnectError;
+	nextDisconnectError = undefined;
+
+	const admin: FakeAdmin = {
+		connect: vi.fn(async () => {}),
+		fetchTopicMetadata: vi.fn(async () => {
+			const outcome = metadataOutcomeQueue.shift();
+			return outcome ? await outcome() : [{ name: 'test-topic', partitions: [{ partitionId: 0 }] }];
+		}),
+		disconnect: vi.fn(async () => {
+			if (disconnectError) throw disconnectError;
+		}),
+	};
+
+	admins.push(admin);
+	return admin;
 }
 
 function createFakeConsumer(config: KafkaJS.ConsumerConstructorConfig): FakeConsumer {
@@ -135,7 +210,7 @@ function fakeKafkaClient(config?: KafkaJS.CommonConstructorConfig) {
 			disconnect: vi.fn(),
 		})),
 		consumer: vi.fn(createFakeConsumer),
-		admin: vi.fn(),
+		admin: vi.fn(createFakeAdmin),
 	};
 }
 
@@ -147,6 +222,10 @@ export function confluentKafkaModuleMock(): { readonly KafkaJS: unknown } {
 			return {
 				Kafka: vi.fn(fakeKafkaClient),
 				logLevel: { NOTHING: 0, ERROR: 1, WARN: 2, INFO: 3, DEBUG: 4 },
+				ErrorCodes: {
+					ERR_UNKNOWN_TOPIC_OR_PART: UNKNOWN_TOPIC_OR_PART,
+					ERR_TOPIC_EXCEPTION: TOPIC_EXCEPTION,
+				},
 			};
 		},
 	};
@@ -165,6 +244,11 @@ export function getFakeConsumers(): FakeConsumer[] {
 	return consumers;
 }
 
+/** Admin clients created through the fake, in creation order. */
+export function getFakeAdmins(): FakeAdmin[] {
+	return admins;
+}
+
 /** Configs passed to the fake `Kafka` constructor, in creation order. */
 export function getFakeClientConfigs(): KafkaJS.CommonConstructorConfig[] {
 	return clientConfigs;
@@ -173,6 +257,9 @@ export function getFakeClientConfigs(): KafkaJS.CommonConstructorConfig[] {
 /** Clears the recorded consumers and client configs (not the access count). */
 export function resetConfluentKafkaRecordings(): void {
 	consumers.length = 0;
+	admins.length = 0;
 	clientConfigs.length = 0;
 	nextAssignment = joinedAssignment;
+	metadataOutcomeQueue.length = 0;
+	nextDisconnectError = undefined;
 }

--- a/packages/nodes-base/nodes/Kafka/test/mocks/confluent-kafka.ts
+++ b/packages/nodes-base/nodes/Kafka/test/mocks/confluent-kafka.ts
@@ -39,8 +39,68 @@ export interface FakeConsumer {
 	};
 }
 
+/** The admin client `assertTopicExists` uses to verify the topic. */
+export interface FakeAdmin {
+	connect: Mock;
+	fetchTopicMetadata: Mock;
+	disconnect: Mock;
+}
+
+/** librdkafka's code for a topic the broker does not know, as the real library exposes it. */
+export const UNKNOWN_TOPIC_OR_PART = 3;
+
 const consumers: FakeConsumer[] = [];
+const admins: FakeAdmin[] = [];
 const clientConfigs: KafkaJS.CommonConstructorConfig[] = [];
+
+/**
+ * How the next fake admin answers `fetchTopicMetadata`. A test that needs a
+ * missing topic (or an inconclusive check) sets this before acting.
+ */
+let nextMetadataOutcome: (() => Promise<unknown>) | undefined;
+
+/** How the next fake admin answers `disconnect()`. */
+let nextDisconnectError: Error | undefined;
+
+/** Makes the next `fetchTopicMetadata` reject with `error`. */
+export function failNextTopicMetadata(error: Error): void {
+	nextMetadataOutcome = async () => {
+		throw error;
+	};
+}
+
+/** Makes the next admin's `disconnect()` reject with `error`. */
+export function failNextAdminDisconnect(error: Error): void {
+	nextDisconnectError = error;
+}
+
+/** An error shaped like the library's rejection for a topic the broker does not know. */
+export function unknownTopicError(): Error & { code: number } {
+	return Object.assign(new Error('Broker: Unknown topic or partition'), {
+		name: 'KafkaJSProtocolError',
+		code: UNKNOWN_TOPIC_OR_PART,
+	});
+}
+
+function createFakeAdmin(): FakeAdmin {
+	const outcome = nextMetadataOutcome;
+	nextMetadataOutcome = undefined;
+	const disconnectError = nextDisconnectError;
+	nextDisconnectError = undefined;
+
+	const admin: FakeAdmin = {
+		connect: vi.fn(async () => {}),
+		fetchTopicMetadata: vi.fn(async () =>
+			outcome ? await outcome() : [{ name: 'test-topic', partitions: [{ partitionId: 0 }] }],
+		),
+		disconnect: vi.fn(async () => {
+			if (disconnectError) throw disconnectError;
+		}),
+	};
+
+	admins.push(admin);
+	return admin;
+}
 
 function createFakeConsumer(config: KafkaJS.ConsumerConstructorConfig): FakeConsumer {
 	let eachBatch: EachBatchHandler | undefined;
@@ -117,7 +177,7 @@ function fakeKafkaClient(config?: KafkaJS.CommonConstructorConfig) {
 			disconnect: vi.fn(),
 		})),
 		consumer: vi.fn(createFakeConsumer),
-		admin: vi.fn(),
+		admin: vi.fn(createFakeAdmin),
 	};
 }
 
@@ -129,6 +189,7 @@ export function confluentKafkaModuleMock(): { readonly KafkaJS: unknown } {
 			return {
 				Kafka: vi.fn(fakeKafkaClient),
 				logLevel: { NOTHING: 0, ERROR: 1, WARN: 2, INFO: 3, DEBUG: 4 },
+				ErrorCodes: { ERR_UNKNOWN_TOPIC_OR_PART: UNKNOWN_TOPIC_OR_PART },
 			};
 		},
 	};
@@ -147,6 +208,11 @@ export function getFakeConsumers(): FakeConsumer[] {
 	return consumers;
 }
 
+/** Admin clients created through the fake, in creation order. */
+export function getFakeAdmins(): FakeAdmin[] {
+	return admins;
+}
+
 /** Configs passed to the fake `Kafka` constructor, in creation order. */
 export function getFakeClientConfigs(): KafkaJS.CommonConstructorConfig[] {
 	return clientConfigs;
@@ -155,5 +221,8 @@ export function getFakeClientConfigs(): KafkaJS.CommonConstructorConfig[] {
 /** Clears the recorded consumers and client configs (not the access count). */
 export function resetConfluentKafkaRecordings(): void {
 	consumers.length = 0;
+	admins.length = 0;
 	clientConfigs.length = 0;
+	nextMetadataOutcome = undefined;
+	nextDisconnectError = undefined;
 }

--- a/packages/nodes-base/nodes/Kafka/test/v2/KafkaTriggerV2.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/KafkaTriggerV2.node.test.ts
@@ -16,9 +16,12 @@ import {
 } from '../../v2/TriggerSettings';
 import {
 	confluentKafkaModuleMock,
+	failNextTopicMetadata,
+	getFakeAdmins,
 	getFakeConsumers,
 	resetConfluentKafkaRecordings,
 	setFakeConsumerAssignment,
+	unknownTopicError,
 	type FakeConsumer,
 } from '../mocks/confluent-kafka';
 
@@ -506,6 +509,66 @@ describe('KafkaTriggerV2 Node', () => {
 
 		await close();
 		expect(consumer.disconnect).toHaveBeenCalled();
+	});
+
+	describe('a topic that does not exist', () => {
+		it('fails activation instead of publishing a workflow that consumes nothing', async () => {
+			failNextTopicMetadata(unknownTopicError());
+			failNextTopicMetadata(unknownTopicError());
+
+			await expect(startTrigger('v2-missing-topic')).rejects.toThrow(
+				'Kafka topic "test-topic" does not exist',
+			);
+		});
+
+		it('never starts a consumer, so nothing is left connected', async () => {
+			failNextTopicMetadata(unknownTopicError());
+			failNextTopicMetadata(unknownTopicError());
+
+			await expect(startTrigger('v2-missing-topic-no-consumer')).rejects.toThrow();
+
+			expect(getFakeConsumers()).toHaveLength(0);
+			expect(consumeTopicSpy).not.toHaveBeenCalled();
+		});
+
+		it('fails a manual test run too, rather than listening forever', async () => {
+			// A manual run starts the consumer from `manualTriggerFunction`, so the
+			// check runs there rather than during trigger() itself.
+			const { manualTriggerFunction } = await testTriggerNode(new KafkaTriggerV2(baseDescription), {
+				mode: 'manual',
+				node: {
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'v2-missing-topic-manual',
+						useSchemaRegistry: false,
+					},
+				},
+				credential,
+			});
+
+			failNextTopicMetadata(unknownTopicError());
+			failNextTopicMetadata(unknownTopicError());
+
+			await expect(manualTriggerFunction?.()).rejects.toThrow(
+				'Kafka topic "test-topic" does not exist',
+			);
+			expect(getFakeConsumers()).toHaveLength(0);
+		});
+
+		it('starts normally when the broker confirms the topic', async () => {
+			const { close } = await startTrigger('v2-topic-exists');
+
+			const admin = getFakeAdmins().at(-1);
+			expect(admin?.fetchTopicMetadata).toHaveBeenCalledWith({
+				topics: ['test-topic'],
+				timeout: 3_000,
+			});
+			// Checked with a throwaway client that does not outlive the check.
+			expect(admin?.disconnect).toHaveBeenCalledTimes(1);
+			expect(getFakeConsumers()).toHaveLength(1);
+
+			await close();
+		});
 	});
 
 	describe('Batch Size', () => {

--- a/packages/nodes-base/nodes/Kafka/test/v2/KafkaTriggerV2.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/KafkaTriggerV2.node.test.ts
@@ -557,7 +557,7 @@ describe('KafkaTriggerV2 Node', () => {
 			const admin = getFakeAdmins().at(-1);
 			expect(admin?.fetchTopicMetadata).toHaveBeenCalledWith({
 				topics: ['test-topic'],
-				timeout: 10_000,
+				timeout: 3_000,
 			});
 			// Checked with a throwaway client that does not outlive the check.
 			expect(admin?.disconnect).toHaveBeenCalledTimes(1);

--- a/packages/nodes-base/nodes/Kafka/test/v2/KafkaTriggerV2.node.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/KafkaTriggerV2.node.test.ts
@@ -16,8 +16,11 @@ import {
 } from '../../v2/TriggerSettings';
 import {
 	confluentKafkaModuleMock,
+	failNextTopicMetadata,
+	getFakeAdmins,
 	getFakeConsumers,
 	resetConfluentKafkaRecordings,
+	unknownTopicError,
 	type FakeConsumer,
 } from '../mocks/confluent-kafka';
 
@@ -505,6 +508,63 @@ describe('KafkaTriggerV2 Node', () => {
 
 		await close();
 		expect(consumer.disconnect).toHaveBeenCalled();
+	});
+
+	describe('a topic that does not exist', () => {
+		it('fails activation instead of publishing a workflow that consumes nothing', async () => {
+			failNextTopicMetadata(unknownTopicError());
+
+			await expect(startTrigger('v2-missing-topic')).rejects.toThrow(
+				'Kafka topic "test-topic" does not exist',
+			);
+		});
+
+		it('never starts a consumer, so nothing is left connected', async () => {
+			failNextTopicMetadata(unknownTopicError());
+
+			await expect(startTrigger('v2-missing-topic-no-consumer')).rejects.toThrow();
+
+			expect(getFakeConsumers()).toHaveLength(0);
+			expect(consumeTopicSpy).not.toHaveBeenCalled();
+		});
+
+		it('fails a manual test run too, rather than listening forever', async () => {
+			// A manual run starts the consumer from `manualTriggerFunction`, so the
+			// check runs there rather than during trigger() itself.
+			const { manualTriggerFunction } = await testTriggerNode(new KafkaTriggerV2(baseDescription), {
+				mode: 'manual',
+				node: {
+					parameters: {
+						topic: 'test-topic',
+						groupId: 'v2-missing-topic-manual',
+						useSchemaRegistry: false,
+					},
+				},
+				credential,
+			});
+
+			failNextTopicMetadata(unknownTopicError());
+
+			await expect(manualTriggerFunction?.()).rejects.toThrow(
+				'Kafka topic "test-topic" does not exist',
+			);
+			expect(getFakeConsumers()).toHaveLength(0);
+		});
+
+		it('starts normally when the broker confirms the topic', async () => {
+			const { close } = await startTrigger('v2-topic-exists');
+
+			const admin = getFakeAdmins().at(-1);
+			expect(admin?.fetchTopicMetadata).toHaveBeenCalledWith({
+				topics: ['test-topic'],
+				timeout: 10_000,
+			});
+			// Checked with a throwaway client that does not outlive the check.
+			expect(admin?.disconnect).toHaveBeenCalledTimes(1);
+			expect(getFakeConsumers()).toHaveLength(1);
+
+			await close();
+		});
 	});
 
 	describe('Batch Size', () => {

--- a/packages/nodes-base/nodes/Kafka/test/v2/kafka.integration.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/kafka.integration.test.ts
@@ -33,6 +33,7 @@ import type { KafkaCredentials } from '../../utils';
 import { KafkaTriggerV1 } from '../../v1/KafkaTriggerV1.node';
 import { consumeTopic, type KafkaConsumerHandle } from '../../v2/consumer/ConsumeTopic';
 import { createMessageParser } from '../../v2/consumer/MessageParser';
+import { assertTopicExists } from '../../v2/transport/admin';
 import { createKafkaClient } from '../../v2/transport/client';
 import { createKafkaConsumer } from '../../v2/transport/consumer';
 import { createLibraryLogger } from '../../v2/transport/LibraryLogger';
@@ -401,6 +402,41 @@ describe('library logging against a real broker', () => {
 			// Measured at ~19s against a broker that never answered, which is why the
 			// production close path bounds disconnect rather than awaiting it plain.
 			await withDeadline(consumer.disconnect(), 5000, 'disconnect').catch(() => undefined);
+		}
+	}, 60_000);
+});
+
+describe('a missing topic against a real broker', () => {
+	it('refuses activation, naming the topic', async () => {
+		const topic = uniqueTopic('never-created');
+
+		await expect(assertTopicExists(credentials, topic, logger)).rejects.toThrow(
+			`Kafka topic "${topic}" does not exist`,
+		);
+	});
+
+	it('lets an existing topic through', async () => {
+		const topic = uniqueTopic('exists');
+		await createTopic(topic);
+
+		await expect(assertTopicExists(credentials, topic, logger)).resolves.toBeUndefined();
+	});
+
+	it('is the only thing that catches it: subscribe and run both resolve', async () => {
+		// The behaviour the check exists for. Without it the trigger reaches "started"
+		// on a topic the broker does not have, and only a swallowed retry log says so.
+		const topic = uniqueTopic('silent-start');
+		const consumer = await createKafkaConsumer(credentials, {
+			groupId: `${topic}-group`,
+			fromBeginning: true,
+		});
+
+		try {
+			await consumer.connect();
+			await expect(consumer.subscribe({ topics: [topic] })).resolves.toBeUndefined();
+			await expect(consumer.run({ eachBatch: async () => {} })).resolves.toBeUndefined();
+		} finally {
+			await withDeadline(consumer.disconnect(), 30_000, 'disconnect').catch(() => undefined);
 		}
 	}, 60_000);
 });

--- a/packages/nodes-base/nodes/Kafka/test/v2/kafka.integration.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/kafka.integration.test.ts
@@ -32,6 +32,7 @@ import type { KafkaCredentials } from '../../utils';
 import { KafkaTriggerV1 } from '../../v1/KafkaTriggerV1.node';
 import { consumeTopic, type KafkaConsumerHandle } from '../../v2/consumer/ConsumeTopic';
 import { createMessageParser } from '../../v2/consumer/MessageParser';
+import { assertTopicExists } from '../../v2/transport/admin';
 import { createKafkaClient } from '../../v2/transport/client';
 import { createKafkaConsumer } from '../../v2/transport/consumer';
 import { createLibraryLogger } from '../../v2/transport/LibraryLogger';
@@ -330,6 +331,41 @@ describe('library logging against a real broker', () => {
 			// Measured at ~19s against a broker that never answered, which is why the
 			// production close path bounds disconnect rather than awaiting it plain.
 			await withDeadline(consumer.disconnect(), 5000, 'disconnect').catch(() => undefined);
+		}
+	}, 60_000);
+});
+
+describe('a missing topic against a real broker', () => {
+	it('refuses activation, naming the topic', async () => {
+		const topic = uniqueTopic('never-created');
+
+		await expect(assertTopicExists(credentials, topic, logger)).rejects.toThrow(
+			`Kafka topic "${topic}" does not exist`,
+		);
+	});
+
+	it('lets an existing topic through', async () => {
+		const topic = uniqueTopic('exists');
+		await createTopic(topic);
+
+		await expect(assertTopicExists(credentials, topic, logger)).resolves.toBeUndefined();
+	});
+
+	it('is the only thing that catches it: subscribe and run both resolve', async () => {
+		// The behaviour the check exists for. Without it the trigger reaches "started"
+		// on a topic the broker does not have, and only a swallowed retry log says so.
+		const topic = uniqueTopic('silent-start');
+		const consumer = await createKafkaConsumer(credentials, {
+			groupId: `${topic}-group`,
+			fromBeginning: true,
+		});
+
+		try {
+			await consumer.connect();
+			await expect(consumer.subscribe({ topics: [topic] })).resolves.toBeUndefined();
+			await expect(consumer.run({ eachBatch: async () => {} })).resolves.toBeUndefined();
+		} finally {
+			await withDeadline(consumer.disconnect(), 30_000, 'disconnect').catch(() => undefined);
 		}
 	}, 60_000);
 });

--- a/packages/nodes-base/nodes/Kafka/test/v2/transport/admin.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/transport/admin.test.ts
@@ -1,0 +1,176 @@
+import type { Logger } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { KafkaCredentials } from '../../../utils';
+import { assertTopicExists } from '../../../v2/transport/admin';
+import {
+	confluentKafkaModuleMock,
+	failNextAdminDisconnect,
+	failNextTopicMetadata,
+	getFakeAdmins,
+	getFakeClientConfigs,
+	invalidTopicNameError,
+	resetConfluentKafkaRecordings,
+	unknownTopicError,
+} from '../../mocks/confluent-kafka';
+
+vi.mock('@confluentinc/kafka-javascript', () => confluentKafkaModuleMock());
+vi.mock('@n8n/utils/sleep', () => ({ sleep: vi.fn(async () => {}) }));
+
+const credentials: KafkaCredentials = {
+	clientId: 'n8n-test',
+	brokers: 'localhost:9092',
+	ssl: false,
+	authentication: false,
+};
+
+const logger = mock<Logger>();
+
+beforeEach(() => {
+	resetConfluentKafkaRecordings();
+	vi.clearAllMocks();
+});
+
+const lastAdmin = () => {
+	const admin = getFakeAdmins().at(-1);
+	if (!admin) throw new Error('the fake recorded no admin client');
+	return admin;
+};
+
+describe('assertTopicExists', () => {
+	it('asks the broker only about the topic the trigger will subscribe to', async () => {
+		await assertTopicExists(credentials, 'my-topic', logger);
+
+		expect(lastAdmin().fetchTopicMetadata).toHaveBeenCalledWith({
+			topics: ['my-topic'],
+			timeout: 3_000,
+		});
+	});
+
+	it('builds the admin client from the same converted credential as the consumer', async () => {
+		await assertTopicExists(credentials, 'my-topic', logger);
+
+		expect(getFakeClientConfigs()).toStrictEqual([
+			{
+				kafkaJS: {
+					brokers: ['localhost:9092'],
+					clientId: 'n8n-test',
+					ssl: false,
+					logLevel: 1,
+				},
+			},
+		]);
+	});
+
+	it('resolves quietly when the topic exists', async () => {
+		await expect(assertTopicExists(credentials, 'my-topic', logger)).resolves.toBeUndefined();
+
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('fails when the broker still does not know the topic after a retry, naming it and how to recover', async () => {
+		failNextTopicMetadata(unknownTopicError());
+		failNextTopicMetadata(unknownTopicError());
+
+		const assertion = assertTopicExists(credentials, 'missing-topic', logger);
+
+		await expect(assertion).rejects.toThrow(UserError);
+		await expect(assertion).rejects.toThrow('Kafka topic "missing-topic" does not exist');
+		expect(lastAdmin().fetchTopicMetadata).toHaveBeenCalledTimes(2);
+	});
+
+	it('recovers when the second answer finds the topic, since one unknown-topic answer can be stale', async () => {
+		// The broker can call a topic unknown while metadata is still propagating
+		// (e.g. just created); the admin path retries once before it verdicts.
+		failNextTopicMetadata(unknownTopicError());
+
+		await expect(assertTopicExists(credentials, 'my-topic', logger)).resolves.toBeUndefined();
+
+		expect(lastAdmin().fetchTopicMetadata).toHaveBeenCalledTimes(2);
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('puts the fix in the message, which is the only part a failed publish shows', async () => {
+		// n8n's activation path drops the description of a NodeOperationError, so
+		// guidance that lives only there never reaches the user.
+		failNextTopicMetadata(unknownTopicError());
+		failNextTopicMetadata(unknownTopicError());
+
+		await expect(assertTopicExists(credentials, 'missing-topic', logger)).rejects.toThrow(
+			'Create the topic on the broker, or correct the Topic field, then publish the workflow again',
+		);
+	});
+
+	it('proceeds on an inconclusive check rather than blocking activation', async () => {
+		// A broker that cannot be reached is not proof of a missing topic, and the
+		// consumer's own connect reports it with a better message a moment later.
+		failNextTopicMetadata(new Error('Local: Broker transport failure'));
+
+		await expect(assertTopicExists(credentials, 'my-topic', logger)).resolves.toBeUndefined();
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Kafka topic could not be verified before starting the consumer',
+			expect.objectContaining({ topic: 'my-topic' }),
+		);
+	});
+
+	it('skips the check for a pattern topic, without asking the broker at all', async () => {
+		// A Topic of `^orders-.*` is a working pattern subscription on v2. Asking
+		// the broker would only get "invalid topic" (17), always inconclusive, so
+		// it never changes the outcome — it would just log a warning on every
+		// activation of an otherwise healthy pattern.
+		await expect(assertTopicExists(credentials, '^orders-.*', logger)).resolves.toBeUndefined();
+
+		expect(getFakeAdmins()).toHaveLength(0);
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('fails activation when the broker rejects the name outright, since no wait fixes that', async () => {
+		failNextTopicMetadata(invalidTopicNameError());
+
+		const assertion = assertTopicExists(credentials, 'bad topic ', logger);
+
+		await expect(assertion).rejects.toThrow(UserError);
+		await expect(assertion).rejects.toThrow('is not a valid Kafka topic name');
+		// Deterministic, not propagation-dependent: unlike "unknown topic", one
+		// answer is the verdict, so there is no retry to ask twice for.
+		expect(lastAdmin().fetchTopicMetadata).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not treat some other error code as a missing topic', async () => {
+		failNextTopicMetadata(
+			Object.assign(new Error('Broker: Group authorization failed'), { code: 30 }),
+		);
+
+		await expect(assertTopicExists(credentials, 'my-topic', logger)).resolves.toBeUndefined();
+	});
+
+	it('disconnects the admin client on every path', async () => {
+		await assertTopicExists(credentials, 'my-topic', logger);
+		expect(lastAdmin().disconnect).toHaveBeenCalledTimes(1);
+
+		failNextTopicMetadata(unknownTopicError());
+		failNextTopicMetadata(unknownTopicError());
+		await expect(assertTopicExists(credentials, 'missing-topic', logger)).rejects.toThrow(
+			UserError,
+		);
+		expect(lastAdmin().disconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports the missing topic even if the admin disconnect then fails', async () => {
+		failNextTopicMetadata(unknownTopicError());
+		failNextTopicMetadata(unknownTopicError());
+		failNextAdminDisconnect(new Error('disconnect timed out'));
+
+		await expect(assertTopicExists(credentials, 'missing-topic', logger)).rejects.toThrow(
+			'Kafka topic "missing-topic" does not exist',
+		);
+	});
+
+	it('works without a logger', async () => {
+		failNextTopicMetadata(new Error('Local: Broker transport failure'));
+
+		await expect(assertTopicExists(credentials, 'my-topic')).resolves.toBeUndefined();
+	});
+});

--- a/packages/nodes-base/nodes/Kafka/test/v2/transport/admin.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/transport/admin.test.ts
@@ -1,0 +1,128 @@
+import type { Logger } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { KafkaCredentials } from '../../../utils';
+import { assertTopicExists } from '../../../v2/transport/admin';
+import {
+	confluentKafkaModuleMock,
+	failNextAdminDisconnect,
+	failNextTopicMetadata,
+	getFakeAdmins,
+	getFakeClientConfigs,
+	resetConfluentKafkaRecordings,
+	unknownTopicError,
+} from '../../mocks/confluent-kafka';
+
+vi.mock('@confluentinc/kafka-javascript', () => confluentKafkaModuleMock());
+
+const credentials: KafkaCredentials = {
+	clientId: 'n8n-test',
+	brokers: 'localhost:9092',
+	ssl: false,
+	authentication: false,
+};
+
+const logger = mock<Logger>();
+
+beforeEach(() => {
+	resetConfluentKafkaRecordings();
+	vi.clearAllMocks();
+});
+
+const lastAdmin = () => {
+	const admin = getFakeAdmins().at(-1);
+	if (!admin) throw new Error('the fake recorded no admin client');
+	return admin;
+};
+
+describe('assertTopicExists', () => {
+	it('asks the broker only about the topic the trigger will subscribe to', async () => {
+		await assertTopicExists(credentials, 'my-topic', logger);
+
+		expect(lastAdmin().fetchTopicMetadata).toHaveBeenCalledWith({
+			topics: ['my-topic'],
+			timeout: 10_000,
+		});
+	});
+
+	it('builds the admin client from the same converted credential as the consumer', async () => {
+		await assertTopicExists(credentials, 'my-topic', logger);
+
+		expect(getFakeClientConfigs()).toStrictEqual([
+			{
+				kafkaJS: {
+					brokers: ['localhost:9092'],
+					clientId: 'n8n-test',
+					ssl: false,
+					logLevel: 1,
+				},
+			},
+		]);
+	});
+
+	it('resolves quietly when the topic exists', async () => {
+		await expect(assertTopicExists(credentials, 'my-topic', logger)).resolves.toBeUndefined();
+
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('fails when the broker does not know the topic, naming it and how to recover', async () => {
+		failNextTopicMetadata(unknownTopicError());
+
+		const assertion = assertTopicExists(credentials, 'missing-topic', logger);
+
+		await expect(assertion).rejects.toThrow(UserError);
+		await expect(assertion).rejects.toThrow('Kafka topic "missing-topic" does not exist');
+		await expect(assertion).rejects.toMatchObject({
+			description: expect.stringContaining('publish the workflow again'),
+		});
+	});
+
+	it('proceeds on an inconclusive check rather than blocking activation', async () => {
+		// A broker that cannot be reached is not proof of a missing topic, and the
+		// consumer's own connect reports it with a better message a moment later.
+		failNextTopicMetadata(new Error('Local: Broker transport failure'));
+
+		await expect(assertTopicExists(credentials, 'my-topic', logger)).resolves.toBeUndefined();
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Kafka topic could not be verified before starting the consumer',
+			expect.objectContaining({ topic: 'my-topic' }),
+		);
+	});
+
+	it('does not treat some other error code as a missing topic', async () => {
+		failNextTopicMetadata(
+			Object.assign(new Error('Broker: Group authorization failed'), { code: 30 }),
+		);
+
+		await expect(assertTopicExists(credentials, 'my-topic', logger)).resolves.toBeUndefined();
+	});
+
+	it('disconnects the admin client on every path', async () => {
+		await assertTopicExists(credentials, 'my-topic', logger);
+		expect(lastAdmin().disconnect).toHaveBeenCalledTimes(1);
+
+		failNextTopicMetadata(unknownTopicError());
+		await expect(assertTopicExists(credentials, 'missing-topic', logger)).rejects.toThrow(
+			UserError,
+		);
+		expect(lastAdmin().disconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it('reports the missing topic even if the admin disconnect then fails', async () => {
+		failNextTopicMetadata(unknownTopicError());
+		failNextAdminDisconnect(new Error('disconnect timed out'));
+
+		await expect(assertTopicExists(credentials, 'missing-topic', logger)).rejects.toThrow(
+			'Kafka topic "missing-topic" does not exist',
+		);
+	});
+
+	it('works without a logger', async () => {
+		failNextTopicMetadata(new Error('Local: Broker transport failure'));
+
+		await expect(assertTopicExists(credentials, 'my-topic')).resolves.toBeUndefined();
+	});
+});

--- a/packages/nodes-base/nodes/Kafka/test/v2/transport/admin.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/transport/admin.test.ts
@@ -42,7 +42,7 @@ describe('assertTopicExists', () => {
 
 		expect(lastAdmin().fetchTopicMetadata).toHaveBeenCalledWith({
 			topics: ['my-topic'],
-			timeout: 10_000,
+			timeout: 3_000,
 		});
 	});
 
@@ -74,9 +74,16 @@ describe('assertTopicExists', () => {
 
 		await expect(assertion).rejects.toThrow(UserError);
 		await expect(assertion).rejects.toThrow('Kafka topic "missing-topic" does not exist');
-		await expect(assertion).rejects.toMatchObject({
-			description: expect.stringContaining('publish the workflow again'),
-		});
+	});
+
+	it('puts the fix in the message, which is the only part a failed publish shows', async () => {
+		// n8n's activation path drops the description of a NodeOperationError, so
+		// guidance that lives only there never reaches the user.
+		failNextTopicMetadata(unknownTopicError());
+
+		await expect(assertTopicExists(credentials, 'missing-topic', logger)).rejects.toThrow(
+			'Create the topic on the broker, or correct the Topic field, then publish the workflow again',
+		);
 	});
 
 	it('proceeds on an inconclusive check rather than blocking activation', async () => {

--- a/packages/nodes-base/nodes/Kafka/test/v2/transport/admin.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/v2/transport/admin.test.ts
@@ -99,6 +99,21 @@ describe('assertTopicExists', () => {
 		);
 	});
 
+	it('lets a pattern topic activate, which the broker calls an invalid topic', async () => {
+		// A Topic of `^orders-.*` is a working pattern subscription on v2. The broker
+		// answers the metadata request with "invalid topic" (17) rather than "unknown
+		// topic" (3), so it must stay on the inconclusive path. Widening the check
+		// would stop every pattern subscription from activating.
+		failNextTopicMetadata(
+			Object.assign(new Error('Broker: Invalid topic'), {
+				name: 'KafkaJSProtocolError',
+				code: 17,
+			}),
+		);
+
+		await expect(assertTopicExists(credentials, '^orders-.*', logger)).resolves.toBeUndefined();
+	});
+
 	it('does not treat some other error code as a missing topic', async () => {
 		failNextTopicMetadata(
 			Object.assign(new Error('Broker: Group authorization failed'), { code: 30 }),

--- a/packages/nodes-base/nodes/Kafka/v2/KafkaTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/KafkaTriggerV2.node.ts
@@ -12,7 +12,7 @@ import { setSchemaRegistry, type KafkaCredentials } from '../utils';
 import { consumeTopic, createDataEmitter, createMessageParser } from './consumer';
 import type { KafkaConsumerHandle } from './consumer';
 import { versionDescription } from './KafkaTriggerV2Description';
-import { createKafkaConsumer } from './transport';
+import { assertTopicExists, createKafkaConsumer } from './transport';
 import { explainManualRunGroupDenial, getSettings } from './TriggerSettings';
 
 export class KafkaTriggerV2 implements INodeType {
@@ -72,6 +72,10 @@ export class KafkaTriggerV2 implements INodeType {
 			void startupFailure.catch(() => {});
 
 			try {
+				// Before the consumer, so a missing topic fails activation instead of
+				// leaving a Published workflow that silently consumes nothing.
+				await assertTopicExists(credentials, settings.topic, this.logger);
+
 				const consumer = await createKafkaConsumer(credentials, settings.consumer, {
 					logger: this.logger,
 					// v1 routes non-restartable consumer crashes to emitError so n8n

--- a/packages/nodes-base/nodes/Kafka/v2/KafkaTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/KafkaTriggerV2.node.ts
@@ -13,7 +13,7 @@ import { consumeTopic, createDataEmitter, createMessageParser } from './consumer
 import type { KafkaConsumerHandle } from './consumer';
 import { versionDescription } from './KafkaTriggerV2Description';
 import { explainManualRunGroupDenial, getSettings } from './TriggerSettings';
-import { createKafkaConsumer } from './transport';
+import { assertTopicExists, createKafkaConsumer } from './transport';
 
 export class KafkaTriggerV2 implements INodeType {
 	description: INodeTypeDescription;
@@ -62,6 +62,10 @@ export class KafkaTriggerV2 implements INodeType {
 
 		const startConsumerOnce = async () => {
 			try {
+				// Before the consumer, so a missing topic fails activation instead of
+				// leaving a Published workflow that silently consumes nothing.
+				await assertTopicExists(credentials, settings.topic, this.logger);
+
 				const consumer = await createKafkaConsumer(credentials, settings.consumer, {
 					logger: this.logger,
 					// v1 routes non-restartable consumer crashes to emitError so n8n

--- a/packages/nodes-base/nodes/Kafka/v2/transport/admin.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/transport/admin.ts
@@ -1,0 +1,117 @@
+import { sleep } from '@n8n/utils/sleep';
+import type { Logger } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+
+import { createKafkaClient, getKafkaLibrary } from './client';
+import { createLibraryLogger } from './LibraryLogger';
+import type { KafkaCredentials } from '../../utils';
+
+/**
+ * Bounds the metadata request so an unreachable broker can't stall
+ * activation: `admin.connect()` resolves without reaching the broker, so the
+ * whole wait for a dead broker lands here.
+ */
+const METADATA_TIMEOUT_MS = 3_000;
+
+/**
+ * "Unknown topic" is retriable, not final: a topic just created can still be
+ * reported unknown while metadata propagates, and the admin path (unlike v1's
+ * kafkajs consumer) does not retry that on its own. One retry, once, is
+ * enough to tell a stale answer from a real one without adding much delay.
+ */
+const UNKNOWN_TOPIC_RETRY_DELAY_MS = 500;
+
+/**
+ * Fails activation when the topic does not exist, since neither `subscribe()`
+ * nor `run()` reject for a missing topic: the workflow would otherwise show
+ * as Published while silently consuming nothing until the next broker
+ * metadata refresh, 5 minutes out by default.
+ *
+ * Two verdicts block activation: "unknown topic", and "invalid topic" for a
+ * non-pattern name. Both are as final as each other — a name Kafka rejects
+ * (trailing space, a comma-joined list pasted as one topic, over 249 chars)
+ * never becomes valid by waiting, so letting it through would activate into
+ * the same silent, nothing-consumed state this check exists to prevent.
+ * Anything else is inconclusive and left for the consumer's own connect to
+ * report.
+ *
+ * Skips the check entirely for a pattern topic (leading `^`): the broker
+ * answers those with "invalid topic" too, but that verdict only means
+ * "not a valid literal name," which a pattern was never meant to be — asking
+ * would only log a misleading warning on every activation of a healthy
+ * pattern.
+ * @param credentials - The decrypted Kafka credential
+ * @param topic - The topic the trigger is about to subscribe to
+ * @param logger - Records an inconclusive check, which is not an error
+ */
+export async function assertTopicExists(
+	credentials: KafkaCredentials,
+	topic: string,
+	logger?: Logger,
+): Promise<void> {
+	if (topic.startsWith('^')) return;
+
+	const { ErrorCodes } = await getKafkaLibrary();
+	const kafka = await createKafkaClient(credentials);
+	const admin = kafka.admin({
+		// Without this the library's own logger writes ERROR-and-above straight
+		// to stdout, bypassing n8n's logger; there is no fatal-error handler here
+		// since this admin client is short-lived and has no run loop to abort.
+		...(logger ? { kafkaJS: { logger: createLibraryLogger(logger) } } : {}),
+	});
+
+	try {
+		await admin.connect();
+
+		try {
+			await admin.fetchTopicMetadata({ topics: [topic], timeout: METADATA_TIMEOUT_MS });
+			return;
+		} catch (error) {
+			if (!hasErrorCode(error, ErrorCodes.ERR_UNKNOWN_TOPIC_OR_PART)) throw error;
+			await sleep(UNKNOWN_TOPIC_RETRY_DELAY_MS);
+			await admin.fetchTopicMetadata({ topics: [topic], timeout: METADATA_TIMEOUT_MS });
+		}
+	} catch (error) {
+		if (hasErrorCode(error, ErrorCodes.ERR_UNKNOWN_TOPIC_OR_PART)) {
+			// The description is dropped on a failed publish, so the fix instruction
+			// must be in the message; the description still renders elsewhere.
+			throw new UserError(
+				`Kafka topic "${topic}" does not exist. Create the topic on the broker, or correct the Topic field, then publish the workflow again.`,
+				{
+					level: 'warning',
+					description:
+						'Publishing anyway would leave the workflow showing as published while consuming nothing, because a topic created later is only picked up at the next broker metadata refresh, minutes away.',
+					cause: error instanceof Error ? error : undefined,
+				},
+			);
+		}
+
+		// A pattern topic never reaches here (it returns above), so this is always
+		// a literal name Kafka's own naming rules reject outright, not a
+		// propagation delay — no amount of waiting fixes it.
+		if (hasErrorCode(error, ErrorCodes.ERR_TOPIC_EXCEPTION)) {
+			throw new UserError(
+				`Kafka topic "${topic}" is not a valid Kafka topic name. Correct the Topic field, then publish the workflow again.`,
+				{ level: 'warning', cause: error instanceof Error ? error : undefined },
+			);
+		}
+
+		logger?.warn('Kafka topic could not be verified before starting the consumer', {
+			topic,
+			error,
+		});
+	} finally {
+		// This call is synchronous.
+		await admin.disconnect().catch(() => {});
+	}
+}
+
+/**
+ * Whether the broker's error matches the given code. Checked by code, not
+ * message: the admin path preserves the broker's error code, unlike the
+ * consumer's log stream.
+ */
+function hasErrorCode(error: unknown, code: number): boolean {
+	if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+	return error.code === code;
+}

--- a/packages/nodes-base/nodes/Kafka/v2/transport/admin.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/transport/admin.ts
@@ -43,6 +43,17 @@ const METADATA_TIMEOUT_MS = 3_000;
  * An admin metadata request does not create the topic, even on a broker with
  * `auto.create.topics.enable=true`: auto-creation is driven by the consumer's
  * own `allow.auto.create.topics`, which the library leaves off.
+ *
+ * A Topic starting with `^` is a pattern subscription, and it keeps working: it
+ * needs no special case here because the broker answers a pattern with "invalid
+ * topic" rather than "unknown topic", which is inconclusive and lets the trigger
+ * start. Both halves verified against a real broker: `^prefix-.*` consumed from a
+ * topic created to match, and the metadata request for it returned
+ * `ERR_INVALID_TOPIC_EXCEPTION` (17), not (3). librdkafka reads a leading `^` as
+ * a regex; v1 could not do this, since kafkajs only treated an actual `RegExp`
+ * object as a pattern and the node always passed a string. So widening the check
+ * below beyond the single "unknown topic" code would silently stop patterns from
+ * activating.
  * @param credentials - The decrypted Kafka credential
  * @param topic - The topic the trigger is about to subscribe to
  * @param logger - Records an inconclusive check, which is not an error

--- a/packages/nodes-base/nodes/Kafka/v2/transport/admin.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/transport/admin.ts
@@ -1,0 +1,84 @@
+import type { Logger } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
+
+import { createKafkaClient, getKafkaLibrary } from './client';
+import type { KafkaCredentials } from '../../utils';
+
+/** Bounds the metadata request so a slow broker cannot stall activation. */
+const METADATA_TIMEOUT_MS = 10_000;
+
+/**
+ * Fails activation when the topic does not exist on the broker.
+ *
+ * Neither `subscribe()` nor `run()` rejects for a missing topic: librdkafka
+ * resolves the subscription from metadata it does not have yet, so both resolve,
+ * n8n reports the workflow as Published, and the fetch loop then logs
+ * "Broker: Unknown topic or partition" on a retry the library never surfaces
+ * (`_consumer.js:1532` swallows it because `restartOnFailure` is always true).
+ * Until the subscription resolves, the consumer does not even join its group.
+ *
+ * It recovers on its own, but only at the next metadata refresh, which
+ * `topic.metadata.refresh.interval.ms` puts 5 minutes out by default. Measured
+ * against a real broker: a topic created 15s after activation was first consumed
+ * 4m45s later, exactly 5 minutes after subscribe. So a Published workflow
+ * consumes nothing for minutes, with no signal outside a debug log, and the wait
+ * restarts if the topic appears after that window. v1 could not reach that
+ * state: kafkajs resolved the subscription eagerly and refused to activate.
+ *
+ * Only an explicit "unknown topic" verdict blocks activation. Anything else
+ * (broker unreachable, metadata denied, request timed out) is inconclusive
+ * rather than proof of a missing topic, and the consumer's own connect reports
+ * those with a better message a moment later, so the check stays out of the way.
+ *
+ * An admin metadata request does not create the topic, even on a broker with
+ * `auto.create.topics.enable=true`: auto-creation is driven by the consumer's
+ * own `allow.auto.create.topics`, which the library leaves off.
+ * @param credentials - The decrypted Kafka credential
+ * @param topic - The topic the trigger is about to subscribe to
+ * @param logger - Records an inconclusive check, which is not an error
+ */
+export async function assertTopicExists(
+	credentials: KafkaCredentials,
+	topic: string,
+	logger?: Logger,
+): Promise<void> {
+	const { ErrorCodes } = await getKafkaLibrary();
+	const kafka = await createKafkaClient(credentials);
+	const admin = kafka.admin();
+
+	try {
+		await admin.connect();
+		await admin.fetchTopicMetadata({ topics: [topic], timeout: METADATA_TIMEOUT_MS });
+	} catch (error) {
+		if (isUnknownTopic(error, ErrorCodes.ERR_UNKNOWN_TOPIC_OR_PART)) {
+			throw new UserError(`Kafka topic "${topic}" does not exist`, {
+				level: 'warning',
+				description:
+					'A topic that is not on the broker yet would leave this workflow published but consuming nothing for several minutes. Create the topic (or correct the Topic field), then publish the workflow again.',
+				cause: error instanceof Error ? error : undefined,
+			});
+		}
+
+		logger?.warn('Kafka topic could not be verified before starting the consumer', {
+			topic,
+			error,
+		});
+	} finally {
+		// Best effort: the verdict above is the useful outcome, and a failing
+		// disconnect on a short-lived admin client must not mask it.
+		await admin.disconnect().catch(() => {});
+	}
+}
+
+/**
+ * Whether the broker said the topic is unknown.
+ *
+ * Checked by code rather than message: the library's admin path preserves the
+ * librdkafka code on the error it rejects with (verified against a real broker:
+ * `KafkaJSProtocolError` with `code: 3`), unlike the consumer's log stream,
+ * where the code is gone by the time it reaches a logger.
+ */
+function isUnknownTopic(error: unknown, unknownTopicCode: number): boolean {
+	if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+	return error.code === unknownTopicCode;
+}

--- a/packages/nodes-base/nodes/Kafka/v2/transport/admin.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/transport/admin.ts
@@ -4,8 +4,18 @@ import { UserError } from 'n8n-workflow';
 import { createKafkaClient, getKafkaLibrary } from './client';
 import type { KafkaCredentials } from '../../utils';
 
-/** Bounds the metadata request so a slow broker cannot stall activation. */
-const METADATA_TIMEOUT_MS = 10_000;
+/**
+ * Bounds the metadata request so a slow broker cannot stall activation.
+ *
+ * Deliberately short, because an unreachable broker pays it in full and there is
+ * no earlier failure to cut it off: `admin.connect()` resolves without reaching
+ * the broker at all (measured at 10ms against a dead one), so the whole wait
+ * lands here. Startup activates one workflow at a time by default
+ * (`N8N_WORKFLOW_ACTIVATION_BATCH_SIZE`), so every Kafka trigger pointing at a
+ * down broker adds this much to how long the instance takes to come up. 3s is
+ * still ample for a metadata round trip against a broker that is answering.
+ */
+const METADATA_TIMEOUT_MS = 3_000;
 
 /**
  * Fails activation when the topic does not exist on the broker.
@@ -51,12 +61,21 @@ export async function assertTopicExists(
 		await admin.fetchTopicMetadata({ topics: [topic], timeout: METADATA_TIMEOUT_MS });
 	} catch (error) {
 		if (isUnknownTopic(error, ErrorCodes.ERR_UNKNOWN_TOPIC_OR_PART)) {
-			throw new UserError(`Kafka topic "${topic}" does not exist`, {
-				level: 'warning',
-				description:
-					'A topic that is not on the broker yet would leave this workflow published but consuming nothing for several minutes. Create the topic (or correct the Topic field), then publish the workflow again.',
-				cause: error instanceof Error ? error : undefined,
-			});
+			// The fix belongs in the message, not the description: the activation path
+			// only carries a description off a NodeApiError (`workflows/utils.ts`,
+			// getErrorDescription), and this arrives as a NodeOperationError, so on a
+			// failed publish the description is dropped and the message is all the user
+			// sees. The description still renders on surfaces that show the node error
+			// itself, so it carries the reasoning rather than repeating the instruction.
+			throw new UserError(
+				`Kafka topic "${topic}" does not exist. Create the topic on the broker, or correct the Topic field, then publish the workflow again.`,
+				{
+					level: 'warning',
+					description:
+						'Publishing anyway would leave the workflow showing as published while consuming nothing, because a topic created later is only picked up at the next broker metadata refresh, minutes away.',
+					cause: error instanceof Error ? error : undefined,
+				},
+			);
 		}
 
 		logger?.warn('Kafka topic could not be verified before starting the consumer', {

--- a/packages/nodes-base/nodes/Kafka/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Kafka/v2/transport/index.ts
@@ -1,5 +1,6 @@
 export { toKafkaJSConfig } from './config';
 export { getKafkaLibrary, createKafkaClient } from './client';
+export { assertTopicExists } from './admin';
 export { createKafkaProducer, type KafkaProducerOptions } from './producer';
 export {
 	createKafkaConsumer,


### PR DESCRIPTION
## Summary

Kafka Trigger version 2 activated against a topic that did not exist, reported the workflow as Published, and then consumed nothing. Version 1.3 refused to activate in the same situation and said why.

Neither `subscribe()` nor `run()` rejects for a missing topic: librdkafka resolves the subscription from metadata it does not have yet, so both resolve and the workflow goes active. The fetch loop then hits `Broker: Unknown topic or partition` on a retry the library only logs (`_consumer.js` swallows it because `restartOnFailure` is always true), so nothing reaches n8n, and the consumer never joins its group.

Worth correcting one detail in the ticket: it does recover on its own, but only at the next metadata refresh, which `topic.metadata.refresh.interval.ms` puts 5 minutes out by default. Measured against a real broker, a topic created 15s after activation was first consumed 4m45s later, exactly 5 minutes after subscribe. So it is not "never", it is "silent for minutes", and the wait restarts if the topic appears after that window.

This adds a topic check before the consumer starts, restoring the v1.3 contract:

```
Kafka topic "orders" does not exist. Create the topic on the broker,
or correct the Topic field, then publish the workflow again.
```

Deliberately narrow. Only an explicit unknown-topic verdict from the broker (librdkafka code 3) blocks activation. An unreachable broker, denied metadata, or a timed-out request is inconclusive rather than proof of a missing topic, so it logs a warning and lets the consumer's own connect report the real problem a moment later.

Notes for reviewers:

- The guidance is in the error **message**, not the description. The activation path only carries a description off a `NodeApiError` (`getErrorDescription` in `workflows/utils.ts`), and this arrives as a `NodeOperationError`, so a description would be dropped and never seen on a failed publish. Verified against a running instance.
- The metadata timeout is 3s. `admin.connect()` resolves without reaching the broker (measured at 10ms against a dead one), so an unreachable broker pays the timeout in full, and startup activates one workflow at a time by default.
- A metadata request does not create the topic, even on a broker with `auto.create.topics.enable=true`. Auto-creation is driven by the consumer's own `allow.auto.create.topics`, which the library leaves off. Verified against a real broker.
- A Topic starting with `^` is a pattern subscription in v2, since librdkafka reads the caret as a regex, and it keeps working: the broker answers a pattern with "invalid topic" (17) rather than "unknown topic" (3), which is inconclusive and lets the trigger start. A pattern that matches no topics still activates silently, so this fix does not cover that path. Left as-is deliberately and captured in the docs ticket rather than changed here.

Version 1 is untouched. Version 2 is edited in place rather than gaining a new version: `defaultVersion` is 1.3 so v2 is opt-in, and the change restores what 1.3 already did.

## How to test

Needs a Kafka broker. The `packages/testing/containers` Kafka service or the ENT-46 docker-compose setup both work.

1. Add a Kafka Trigger on **typeVersion 2** pointing at a topic that does not exist.
2. Publish it. Before this PR it activated and showed Published; now activation fails with the topic named and the fix in the message.
3. Create the topic, publish again. It activates and consumes normally.
4. With the broker stopped, publish. Activation still fails with the broker's own transport error rather than a misleading "topic does not exist", proving the check stays out of the way when it cannot get an answer.

Real-broker coverage lives in the integration suite, which normal CI skips:

```
pnpm --filter n8n-nodes-base test:integration:skip kafka
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-354

Same shape as https://linear.app/n8n/issue/ENT-340, and the pattern-topic behavior noted above is captured in https://linear.app/n8n/issue/ENT-229.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/36044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

